### PR TITLE
[WIP] certmgr vault integration

### DIFF
--- a/src/pybind/mgr/cephadm/cert_issuer.py
+++ b/src/pybind/mgr/cephadm/cert_issuer.py
@@ -1,0 +1,92 @@
+from typing import TYPE_CHECKING, Dict
+import logging
+
+from cephadm.ssl_cert_utils import SSLConfigException
+from cephadm.tlsobject_types import Cert, TLSObjectManager
+
+if TYPE_CHECKING:
+    from cephadm.cert_mgr import CertInfo, CertMgr
+
+logger = logging.getLogger(__name__)
+
+
+class CertificateIssuer:
+    """Base interface for certmgr certificate lifecycle issuers.
+
+    Issuers are responsible for renewing certificates owned by a specific
+    TLSObjectManager. Only issuers that return True from supports_auto_fix()
+    are allowed to participate in certmgr's automatic fix path.
+    """
+
+    managed_by: TLSObjectManager
+
+    def __init__(self, managed_by: TLSObjectManager) -> None:
+        self.managed_by = managed_by
+
+    def supports_auto_fix(self) -> bool:
+        return False
+
+    def renew(self, cert_mgr: 'CertMgr', cert_info: 'CertInfo', cert_obj: Cert) -> bool:
+        return False
+
+
+class UnsupportedCertificateIssuer(CertificateIssuer):
+    """Placeholder issuer for lifecycle owners that are not implemented yet."""
+
+    def renew(self, cert_mgr: 'CertMgr', cert_info: 'CertInfo', cert_obj: Cert) -> bool:
+        logger.debug(
+            'Certificate issuer %s does not support automatic renewal for %s',
+            self.managed_by,
+            cert_info.cert_name,
+        )
+        return False
+
+
+class CephadmCertificateIssuer(CertificateIssuer):
+    """Issuer implementation for cephadm-managed self-signed certificates."""
+
+    def __init__(self) -> None:
+        super().__init__(TLSObjectManager.CEPHADM)
+
+    def supports_auto_fix(self) -> bool:
+        return True
+
+    def renew(self, cert_mgr: 'CertMgr', cert_info: 'CertInfo', cert_obj: Cert) -> bool:
+        try:
+            logger.info(f'Renewing cephadm-signed certificate for {cert_info.cert_name}')
+            new_cert, new_key = cert_mgr.ssl_certs.renew_cert(
+                cert_obj.cert,
+                cert_mgr.mgr.certificate_duration_days,
+            )
+            tlsobj_target = cert_mgr.cert_store.determine_tlsobject_target(
+                cert_info.cert_name,
+                cert_info.target,
+            )
+            cert_mgr.cert_store.save_tlsobject(
+                cert_info.cert_name,
+                new_cert,
+                service_name=tlsobj_target.service,
+                host=tlsobj_target.host,
+                managed_by=TLSObjectManager.CEPHADM,
+            )
+            key_name = cert_info.cert_name.replace('_cert', '_key')
+            cert_mgr.key_store.save_tlsobject(
+                key_name,
+                new_key,
+                service_name=tlsobj_target.service,
+                host=tlsobj_target.host,
+                managed_by=TLSObjectManager.CEPHADM,
+            )
+            return True
+        except SSLConfigException as e:
+            logger.error(f'Error while trying to renew cephadm-signed certificate for {cert_info.cert_name}: {e}')
+            return False
+
+
+def build_certificate_issuers() -> Dict[TLSObjectManager, CertificateIssuer]:
+    return {
+        TLSObjectManager.CEPHADM: CephadmCertificateIssuer(),
+        TLSObjectManager.USER: UnsupportedCertificateIssuer(TLSObjectManager.USER),
+        TLSObjectManager.VAULT: UnsupportedCertificateIssuer(TLSObjectManager.VAULT),
+        TLSObjectManager.ACME: UnsupportedCertificateIssuer(TLSObjectManager.ACME),
+    }

--- a/src/pybind/mgr/cephadm/cert_issuer.py
+++ b/src/pybind/mgr/cephadm/cert_issuer.py
@@ -1,8 +1,9 @@
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING, Dict, Optional, Tuple
 import logging
 
 from cephadm.ssl_cert_utils import SSLConfigException
-from cephadm.tlsobject_types import Cert, TLSObjectManager
+from cephadm.tlsobject_types import Cert, TLSObjectException, TLSObjectManager, TLSObjectScope
+from cephadm.vault import VaultClientError, VaultPKIClient
 
 if TYPE_CHECKING:
     from cephadm.cert_mgr import CertInfo, CertMgr
@@ -83,10 +84,82 @@ class CephadmCertificateIssuer(CertificateIssuer):
             return False
 
 
+class VaultCertificateIssuer(CertificateIssuer):
+    """Issuer implementation for Vault-managed certificates."""
+
+    def __init__(self) -> None:
+        super().__init__(TLSObjectManager.VAULT)
+
+    def supports_auto_fix(self) -> bool:
+        return True
+
+    def _storage_target(self, scope: TLSObjectScope, target: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+        if scope == TLSObjectScope.SERVICE:
+            return target, None
+        if scope == TLSObjectScope.HOST:
+            return None, target
+        return None, None
+
+    def renew(self, cert_mgr: 'CertMgr', cert_info: 'CertInfo', cert_obj: Cert) -> bool:
+        metadata = cert_mgr.vault_cert_metadata_store.get(cert_info.cert_name, cert_info.target)
+        if not metadata:
+            logger.error(
+                'Cannot renew Vault-managed certificate %s: missing Vault renewal metadata',
+                cert_info,
+            )
+            return False
+
+        try:
+            logger.info('Renewing Vault-managed certificate for %s', cert_info.cert_name)
+            client = VaultPKIClient(cert_mgr.get_vault_issuer_config(), cert_mgr.get_vault_token())
+            creds = client.issue_certificate(
+                common_name=metadata.common_name,
+                alt_names=metadata.alt_names,
+                ip_sans=metadata.ip_sans,
+                ttl=metadata.ttl,
+                mount=metadata.pki_mount,
+                role=metadata.role,
+            )
+            service_name, host = self._storage_target(metadata.scope, metadata.target)
+            cert_mgr.cert_store.save_tlsobject(
+                metadata.cert_name,
+                creds.cert,
+                service_name=service_name,
+                host=host,
+                managed_by=TLSObjectManager.VAULT,
+                editable=False,
+            )
+            cert_mgr.key_store.save_tlsobject(
+                metadata.key_name,
+                creds.key,
+                service_name=service_name,
+                host=host,
+                managed_by=TLSObjectManager.VAULT,
+                editable=False,
+            )
+            if metadata.ca_cert_name and creds.ca_cert:
+                cert_mgr.cert_store.save_tlsobject(
+                    metadata.ca_cert_name,
+                    creds.ca_cert,
+                    service_name=service_name,
+                    host=host,
+                    managed_by=TLSObjectManager.VAULT,
+                    editable=False,
+                )
+            return True
+        except (VaultClientError, TLSObjectException, SSLConfigException) as e:
+            logger.error(
+                'Error while trying to renew Vault-managed certificate for %s: %s',
+                cert_info.cert_name,
+                e,
+            )
+            return False
+
+
 def build_certificate_issuers() -> Dict[TLSObjectManager, CertificateIssuer]:
     return {
         TLSObjectManager.CEPHADM: CephadmCertificateIssuer(),
         TLSObjectManager.USER: UnsupportedCertificateIssuer(TLSObjectManager.USER),
-        TLSObjectManager.VAULT: UnsupportedCertificateIssuer(TLSObjectManager.VAULT),
+        TLSObjectManager.VAULT: VaultCertificateIssuer(),
         TLSObjectManager.ACME: UnsupportedCertificateIssuer(TLSObjectManager.ACME),
     }

--- a/src/pybind/mgr/cephadm/cert_metadata.py
+++ b/src/pybind/mgr/cephadm/cert_metadata.py
@@ -1,0 +1,237 @@
+from dataclasses import dataclass, field
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from cephadm.tlsobject_types import TLSObjectException, TLSObjectManager, TLSObjectScope
+
+
+logger = logging.getLogger(__name__)
+
+
+VAULT_CERT_METADATA_STORE_PREFIX = 'cert_store.vault_metadata.'
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    value = str(value).strip()
+    return value or None
+
+
+def _string_list(value: Any, field_name: str) -> List[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise TLSObjectException(f'Expected {field_name} in Vault certificate metadata to be a list')
+    values: List[str] = []
+    for item in value:
+        item_str = _optional_str(item)
+        if item_str:
+            values.append(item_str)
+    return values
+
+
+@dataclass(frozen=True)
+class VaultCertificateMetadata:
+    """Metadata needed to renew a Vault-managed certificate.
+
+    The TLS object store contains the current certificate/key PEM material. This
+    metadata stores the issuer inputs that cannot be reconstructed reliably from
+    PEM alone and are therefore required to issue a replacement certificate from
+    Vault later.
+    """
+
+    cert_name: str
+    key_name: str
+    scope: TLSObjectScope
+    common_name: str
+    target: Optional[str] = None
+    pki_mount: Optional[str] = None
+    role: Optional[str] = None
+    ttl: Optional[str] = None
+    alt_names: List[str] = field(default_factory=list)
+    ip_sans: List[str] = field(default_factory=list)
+    ca_cert_name: Optional[str] = None
+    managed_by: TLSObjectManager = TLSObjectManager.VAULT
+
+    @property
+    def store_target(self) -> str:
+        return self.target or ''
+
+    def __post_init__(self) -> None:
+        try:
+            object.__setattr__(self, 'scope', TLSObjectScope(self.scope))
+        except ValueError as e:
+            raise TLSObjectException(f'Invalid Vault certificate metadata scope: {self.scope}') from e
+
+        try:
+            object.__setattr__(self, 'managed_by', TLSObjectManager(self.managed_by))
+        except ValueError as e:
+            raise TLSObjectException(f'Invalid Vault certificate metadata managed_by: {self.managed_by}') from e
+
+        if self.managed_by != TLSObjectManager.VAULT:
+            raise TLSObjectException('Vault certificate metadata must be managed_by=vault')
+        if not _optional_str(self.cert_name):
+            raise TLSObjectException('Vault certificate metadata requires cert_name')
+        if not _optional_str(self.key_name):
+            raise TLSObjectException('Vault certificate metadata requires key_name')
+        if not _optional_str(self.common_name):
+            raise TLSObjectException('Vault certificate metadata requires common_name')
+        if self.scope in (TLSObjectScope.SERVICE, TLSObjectScope.HOST) and not _optional_str(self.target):
+            raise TLSObjectException(f'Vault certificate metadata with scope={self.scope.value} requires target')
+        if self.scope == TLSObjectScope.GLOBAL and _optional_str(self.target):
+            raise TLSObjectException('Vault certificate metadata with scope=global must not set target')
+
+        object.__setattr__(self, 'cert_name', _optional_str(self.cert_name) or '')
+        object.__setattr__(self, 'key_name', _optional_str(self.key_name) or '')
+        object.__setattr__(self, 'common_name', _optional_str(self.common_name) or '')
+        object.__setattr__(self, 'target', _optional_str(self.target))
+        object.__setattr__(self, 'pki_mount', _optional_str(self.pki_mount))
+        object.__setattr__(self, 'role', _optional_str(self.role))
+        object.__setattr__(self, 'ttl', _optional_str(self.ttl))
+        object.__setattr__(self, 'ca_cert_name', _optional_str(self.ca_cert_name))
+        object.__setattr__(self, 'alt_names', _string_list(self.alt_names, 'alt_names'))
+        object.__setattr__(self, 'ip_sans', _string_list(self.ip_sans, 'ip_sans'))
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            'cert_name': self.cert_name,
+            'key_name': self.key_name,
+            'ca_cert_name': self.ca_cert_name,
+            'managed_by': self.managed_by.value,
+            'scope': self.scope.value,
+            'target': self.target,
+            'pki_mount': self.pki_mount,
+            'role': self.role,
+            'ttl': self.ttl,
+            'common_name': self.common_name,
+            'alt_names': list(self.alt_names),
+            'ip_sans': list(self.ip_sans),
+        }
+
+    @classmethod
+    def from_json(cls, data: Dict[str, Any]) -> 'VaultCertificateMetadata':
+        if not isinstance(data, dict):
+            raise TLSObjectException('Vault certificate metadata must be a JSON object')
+        allowed = {
+            'cert_name',
+            'key_name',
+            'ca_cert_name',
+            'managed_by',
+            'scope',
+            'target',
+            'pki_mount',
+            'role',
+            'ttl',
+            'common_name',
+            'alt_names',
+            'ip_sans',
+        }
+        unknown = set(data.keys()) - allowed
+        if unknown:
+            raise TLSObjectException(f'Got unknown field(s) for Vault certificate metadata: {sorted(unknown)}')
+        return cls(
+            cert_name=str(data.get('cert_name', '')),
+            key_name=str(data.get('key_name', '')),
+            ca_cert_name=_optional_str(data.get('ca_cert_name')),
+            managed_by=data.get('managed_by', TLSObjectManager.VAULT.value),
+            scope=data.get('scope', TLSObjectScope.UNKNOWN.value),
+            target=_optional_str(data.get('target')),
+            pki_mount=_optional_str(data.get('pki_mount')),
+            role=_optional_str(data.get('role')),
+            ttl=_optional_str(data.get('ttl')),
+            common_name=str(data.get('common_name', '')),
+            alt_names=_string_list(data.get('alt_names', []), 'alt_names'),
+            ip_sans=_string_list(data.get('ip_sans', []), 'ip_sans'),
+        )
+
+
+class VaultCertificateMetadataStore:
+    """Store scoped Vault certificate renewal metadata in mgr KV."""
+
+    def __init__(self, mgr: Any) -> None:
+        self.mgr = mgr
+        self.metadata_by_cert: Dict[str, Dict[str, VaultCertificateMetadata]] = {}
+
+    def _kv_key(self, cert_name: str) -> str:
+        return VAULT_CERT_METADATA_STORE_PREFIX + cert_name
+
+    def _set_store(self, cert_name: str, payload: Optional[Dict[str, Any]]) -> None:
+        self.mgr.set_store(self._kv_key(cert_name), json.dumps(payload) if payload is not None else None)
+
+    def save(self, metadata: VaultCertificateMetadata) -> None:
+        self.metadata_by_cert.setdefault(metadata.cert_name, {})[metadata.store_target] = metadata
+        self._persist_cert(metadata.cert_name)
+
+    def get(self, cert_name: str, target: Optional[str] = None) -> Optional[VaultCertificateMetadata]:
+        return self.metadata_by_cert.get(cert_name, {}).get(target or '')
+
+    def remove(self, cert_name: str, target: Optional[str] = None) -> bool:
+        target_key = target or ''
+        if cert_name not in self.metadata_by_cert or target_key not in self.metadata_by_cert[cert_name]:
+            return False
+        del self.metadata_by_cert[cert_name][target_key]
+        self._persist_cert(cert_name)
+        return True
+
+    def list(self) -> List[VaultCertificateMetadata]:
+        metadata: List[VaultCertificateMetadata] = []
+        for targets in self.metadata_by_cert.values():
+            metadata.extend(targets.values())
+        return metadata
+
+    def _persist_cert(self, cert_name: str) -> None:
+        targets = self.metadata_by_cert.get(cert_name, {})
+        if not targets:
+            self.metadata_by_cert.pop(cert_name, None)
+            self._set_store(cert_name, None)
+            return
+        payload = {
+            target: metadata.to_json()
+            for target, metadata in targets.items()
+        }
+        self._set_store(cert_name, payload)
+
+    def load(self) -> None:
+        self.metadata_by_cert = {}
+        for key, raw in self.mgr.get_store_prefix(VAULT_CERT_METADATA_STORE_PREFIX).items():
+            cert_name = key[len(VAULT_CERT_METADATA_STORE_PREFIX):]
+            if not raw:
+                continue
+            try:
+                targets = json.loads(raw)
+            except json.JSONDecodeError as e:
+                logger.warning('VaultCertificateMetadataStore: cannot parse JSON for %r: %r', cert_name, e)
+                continue
+            if not isinstance(targets, dict):
+                logger.warning(
+                    'VaultCertificateMetadataStore: invalid data for %r. Expected dict but got %s',
+                    cert_name,
+                    type(targets).__name__,
+                )
+                continue
+            for target, payload in targets.items():
+                try:
+                    metadata = VaultCertificateMetadata.from_json(payload)
+                    self.metadata_by_cert.setdefault(metadata.cert_name, {})[metadata.store_target] = metadata
+                    if metadata.cert_name != cert_name:
+                        logger.warning(
+                            'VaultCertificateMetadataStore: metadata cert_name %r does not match store key %r',
+                            metadata.cert_name,
+                            cert_name,
+                        )
+                    if metadata.store_target != target:
+                        logger.warning(
+                            'VaultCertificateMetadataStore: metadata target %r does not match store target %r for %r',
+                            metadata.store_target,
+                            target,
+                            cert_name,
+                        )
+                except Exception as e:
+                    logger.warning(
+                        'VaultCertificateMetadataStore: failed to decode metadata for %r target %r: %r',
+                        cert_name,
+                        target,
+                        e,
+                    )

--- a/src/pybind/mgr/cephadm/cert_mgr.py
+++ b/src/pybind/mgr/cephadm/cert_mgr.py
@@ -397,10 +397,10 @@ class CertMgr:
                                 ttl: Optional[str] = None) -> TLSCredentials:
         """Issue a certificate from Vault PKI and store it in certmgr.
 
-        This is the manual Vault enrollment path. It intentionally stores the
-        resulting cert/key as non-editable and managed_by=vault so existing
-        services can consume the material through certificate_source=reference.
-        Renewal is not enabled here; later commits use the persisted metadata.
+        This stores the resulting cert/key as non-editable and
+        managed_by=vault. It is used by both the manual Vault enrollment path
+        and services using certificate_source=vault. The persisted metadata is
+        consumed by the periodic Vault renewal path.
         """
         scope, target = self._ensure_vault_issue_target(cert_name, key_name, service_name, host)
         self._ensure_vault_ca_scope(ca_cert_name, scope)

--- a/src/pybind/mgr/cephadm/cert_mgr.py
+++ b/src/pybind/mgr/cephadm/cert_mgr.py
@@ -14,6 +14,7 @@ from cephadm.tlsobject_types import (Cert,
                                      TLSCredentials,
                                      TLSObjectManager)
 from cephadm.tlsobject_store import TLSObjectStore
+from cephadm.vault import VaultIssuerConfig
 
 if TYPE_CHECKING:
     from cephadm.module import CephadmOrchestrator
@@ -185,6 +186,7 @@ class CertMgr:
 
     CEPHADM_CERT_ERROR = 'CEPHADM_CERT_ERROR'
     CEPHADM_CERT_WARNING = 'CEPHADM_CERT_WARNING'
+    VAULT_TOKEN_STORE_KEY = 'certmgr/vault/token'
 
     CEPHADM_SIGNED = 'cephadm-signed'
     LABEL_SEPARATOR = "__lbl__"
@@ -269,6 +271,19 @@ class CertMgr:
 
     def get_root_ca(self) -> str:
         return self.ssl_certs.get_root_cert()
+
+    def get_vault_issuer_config(self) -> VaultIssuerConfig:
+        return VaultIssuerConfig.from_mgr(self.mgr)
+
+    def get_vault_token(self) -> Optional[str]:
+        token = self.mgr.get_store(self.VAULT_TOKEN_STORE_KEY)
+        return token.strip() if token else None
+
+    def set_vault_token(self, token: Optional[str]) -> None:
+        self.mgr.set_store(self.VAULT_TOKEN_STORE_KEY, token.strip() if token else None)
+
+    def rm_vault_token(self) -> None:
+        self.set_vault_token(None)
 
     def register_self_signed_cert_key_pair(self, service_name: str, label: Optional[str] = None) -> None:
         """

--- a/src/pybind/mgr/cephadm/cert_mgr.py
+++ b/src/pybind/mgr/cephadm/cert_mgr.py
@@ -15,6 +15,7 @@ from cephadm.tlsobject_types import (Cert,
                                      TLSObjectManager)
 from cephadm.tlsobject_store import TLSObjectStore
 from cephadm.vault import VaultIssuerConfig
+from cephadm.cert_metadata import VaultCertificateMetadata, VaultCertificateMetadataStore
 from cephadm.cert_issuer import CertificateIssuer, build_certificate_issuers
 
 if TYPE_CHECKING:
@@ -211,6 +212,7 @@ class CertMgr:
             TLSObjectScope.GLOBAL: {},
         }
         self.certificate_issuers: Dict[TLSObjectManager, CertificateIssuer] = build_certificate_issuers()
+        self.vault_cert_metadata_store = VaultCertificateMetadataStore(self.mgr)
 
     def is_cephadm_signed_object(self, object_name: str) -> bool:
         return object_name.startswith(self.CEPHADM_SIGNED)
@@ -244,6 +246,7 @@ class CertMgr:
         self.cert_store.load()
         self.key_store = TLSObjectStore(self.mgr, PrivKey, self.known_keys, self.is_cephadm_signed_object)
         self.key_store.load()
+        self.vault_cert_metadata_store.load()
         self._initialize_root_ca(self.mgr.get_mgr_ip())
 
     def load(self) -> None:
@@ -286,6 +289,29 @@ class CertMgr:
 
     def rm_vault_token(self) -> None:
         self.set_vault_token(None)
+
+
+    def _vault_metadata_target(self, cert_name: str, service_name: Optional[str] = None,
+                               host: Optional[str] = None) -> Optional[str]:
+        scope = self.get_cert_scope(cert_name)
+        if scope == TLSObjectScope.SERVICE:
+            return service_name
+        if scope == TLSObjectScope.HOST:
+            return host
+        return None
+
+    def save_vault_certificate_metadata(self, metadata: VaultCertificateMetadata) -> None:
+        self.vault_cert_metadata_store.save(metadata)
+
+    def get_vault_certificate_metadata(self, cert_name: str, service_name: Optional[str] = None,
+                                       host: Optional[str] = None) -> Optional[VaultCertificateMetadata]:
+        target = self._vault_metadata_target(cert_name, service_name, host)
+        return self.vault_cert_metadata_store.get(cert_name, target)
+
+    def rm_vault_certificate_metadata(self, cert_name: str, service_name: Optional[str] = None,
+                                      host: Optional[str] = None) -> bool:
+        target = self._vault_metadata_target(cert_name, service_name, host)
+        return self.vault_cert_metadata_store.remove(cert_name, target)
 
     def register_self_signed_cert_key_pair(self, service_name: str, label: Optional[str] = None) -> None:
         """
@@ -492,7 +518,10 @@ class CertMgr:
                 logger.info("Skipping CA cert removal for %r — exists but is not inline-saved (editable=True) (%s)", ca_cert_name, context)
 
     def rm_cert(self, cert_name: str, service_name: Optional[str] = None, host: Optional[str] = None) -> bool:
-        return self.cert_store.rm_tlsobject(cert_name, service_name, host)
+        removed = self.cert_store.rm_tlsobject(cert_name, service_name, host)
+        if removed:
+            self.rm_vault_certificate_metadata(cert_name, service_name, host)
+        return removed
 
     def rm_key(self, key_name: str, service_name: Optional[str] = None, host: Optional[str] = None) -> bool:
         return self.key_store.rm_tlsobject(key_name, service_name, host)

--- a/src/pybind/mgr/cephadm/cert_mgr.py
+++ b/src/pybind/mgr/cephadm/cert_mgr.py
@@ -15,6 +15,7 @@ from cephadm.tlsobject_types import (Cert,
                                      TLSObjectManager)
 from cephadm.tlsobject_store import TLSObjectStore
 from cephadm.vault import VaultIssuerConfig
+from cephadm.cert_issuer import CertificateIssuer, build_certificate_issuers
 
 if TYPE_CHECKING:
     from cephadm.module import CephadmOrchestrator
@@ -209,6 +210,7 @@ class CertMgr:
             TLSObjectScope.HOST: {},
             TLSObjectScope.GLOBAL: {},
         }
+        self.certificate_issuers: Dict[TLSObjectManager, CertificateIssuer] = build_certificate_issuers()
 
     def is_cephadm_signed_object(self, object_name: str) -> bool:
         return object_name.startswith(self.CEPHADM_SIGNED)
@@ -804,30 +806,22 @@ class CertMgr:
 
         return problematics_certs
 
-    def _renew_self_signed_certificate(self, cert_info: CertInfo, cert_obj: Cert) -> bool:
-        try:
-            logger.info(f'Renewing cephadm-signed certificate for {cert_info.cert_name}')
-            new_cert, new_key = self.ssl_certs.renew_cert(cert_obj.cert, self.mgr.certificate_duration_days)
-            tlsobj_target = self.cert_store.determine_tlsobject_target(cert_info.cert_name, cert_info.target)
-            self.cert_store.save_tlsobject(
-                cert_info.cert_name,
-                new_cert,
-                service_name=tlsobj_target.service,
-                host=tlsobj_target.host,
-                managed_by=TLSObjectManager.CEPHADM,
-            )
-            key_name = cert_info.cert_name.replace('_cert', '_key')
-            self.key_store.save_tlsobject(
-                key_name,
-                new_key,
-                service_name=tlsobj_target.service,
-                host=tlsobj_target.host,
-                managed_by=TLSObjectManager.CEPHADM,
-            )
-            return True
-        except SSLConfigException as e:
-            logger.error(f'Error while trying to renew cephadm-signed certificate for {cert_info.cert_name}: {e}')
+    def _get_certificate_issuer(self, managed_by: TLSObjectManager) -> CertificateIssuer:
+        return self.certificate_issuers[managed_by]
+
+    def _supports_auto_fix(self, cert_obj: Cert) -> bool:
+        """Return whether certmgr currently knows how to fix this manager type."""
+        return self._get_certificate_issuer(cert_obj.managed_by).supports_auto_fix()
+
+    def _renew_certificate(self, cert_info: CertInfo, cert_obj: Cert) -> bool:
+        issuer = self._get_certificate_issuer(cert_obj.managed_by)
+        if not issuer.supports_auto_fix():
             return False
+        return issuer.renew(self, cert_info, cert_obj)
+
+    def _renew_self_signed_certificate(self, cert_info: CertInfo, cert_obj: Cert) -> bool:
+        """Compatibility wrapper for cephadm-managed self-signed renewal."""
+        return self._get_certificate_issuer(TLSObjectManager.CEPHADM).renew(self, cert_info, cert_obj)
 
     def check_services_certificates(self, fix_issues: bool = False) -> Tuple[List[str], List[CertInfo]]:
         """
@@ -839,26 +833,22 @@ class CertMgr:
             - List of certificates that require manual intervention.
         """
 
-        def supports_auto_fix(cert_obj: Cert) -> bool:
-            """Return whether certmgr currently knows how to fix this manager type."""
-            return cert_obj.managed_by == TLSObjectManager.CEPHADM
-
         def requires_user_intervention(cert_info: CertInfo, cert_obj: Cert) -> bool:
             """Determines if a certificate requires manual user intervention."""
             if cert_info.is_operationally_valid():
                 return False
             if not self.mgr.certificate_automated_rotation_enabled:
                 return True
-            return not supports_auto_fix(cert_obj)
+            return not self._supports_auto_fix(cert_obj)
 
         def trigger_auto_fix(cert_info: CertInfo, cert_obj: Cert) -> bool:
             """Attempts to automatically fix certificate issues if possible."""
             if not self.mgr.certificate_automated_rotation_enabled:
                 return False
-            if not supports_auto_fix(cert_obj):
+            if not self._supports_auto_fix(cert_obj):
                 return False
 
-            # This is a cephadm-managed certificate, let's try to fix it
+            # This certificate is managed by an issuer that supports auto-fix.
             if not cert_info.is_valid:
                 # Remove the invalid certificate to force regeneration
                 tlsobj_target = self.cert_store.determine_tlsobject_target(cert_info.cert_name, cert_info.target)
@@ -869,7 +859,7 @@ class CertMgr:
                 self.cert_store.rm_tlsobject(cert_info.cert_name, tlsobj_target.service, tlsobj_target.host)
                 return True
             elif cert_info.is_close_to_expiration:
-                return self._renew_self_signed_certificate(cert_info, cert_obj)
+                return self._renew_certificate(cert_info, cert_obj)
             else:
                 return False
 

--- a/src/pybind/mgr/cephadm/cert_mgr.py
+++ b/src/pybind/mgr/cephadm/cert_mgr.py
@@ -25,6 +25,7 @@ class CertFilterOption(str, Enum):
     NAME = 'name'
     STATUS = 'status'
     SIGNED_BY = 'signed-by'
+    MANAGED_BY = 'managed-by'
     SCOPE = 'scope'
     SERVICE = 'service'
 
@@ -508,22 +509,17 @@ class CertMgr:
                 include_details: bool = False,
                 include_cephadm_signed: bool = False) -> Dict:
         """
-        signed-by filtering behavior in `cert_ls`:
+        lifecycle-owner filtering behavior in `cert_ls`:
 
         Defaults:
-        - If `include_cephadm_signed` is False and no explicit `signed-by=` is provided,
-          we auto-filter to show only user-made certs (and always include the root CA).
-        - If the caller explicitly filters by `signed-by=...`, that explicit filter wins.
+        - If `include_cephadm_signed` is False and no explicit `signed-by=` or
+          `managed-by=` selector is provided, we auto-filter to show only
+          user-made certs (and always include the root CA).
+        - If the caller explicitly filters by `signed-by=...` or
+          `managed-by=...`, that explicit filter wins.
 
-        Behavior matrix:
-          +------------------------+-----------------------------+----------------------------------------------+
-          | include_cephadm_signed | 'signed-by=' in filter_by?  | Effective behavior on signed-by               |
-          +------------------------+-----------------------------+----------------------------------------------+
-          | False                  | No                          | Auto-filter: signed-by=user  + root CA        |
-          | False                  | Yes                         | Use user's explicit selector                  |
-          | True                   | No                          | No auto filter (include user + cephadm)       |
-          | True                   | Yes                         | Use user's explicit selector                  |
-          +------------------------+-----------------------------+----------------------------------------------+
+        `signed-by` is kept as a compatibility alias for the lifecycle owner;
+        new callers should prefer `managed-by`.
         """
 
         def _lhs(expr: str) -> str:
@@ -536,6 +532,7 @@ class CertMgr:
                 CertFilterOption.NAME: cert_info.cert_name,
                 CertFilterOption.STATUS: cert_info.status,
                 CertFilterOption.SIGNED_BY: cert_info.signed_by,
+                CertFilterOption.MANAGED_BY: cert_info.managed_by.value,
                 CertFilterOption.SCOPE: scope,
                 CertFilterOption.SERVICE: svc,
             }
@@ -553,7 +550,12 @@ class CertMgr:
             if key in (CertFilterOption.NAME, CertFilterOption.SERVICE):
                 return lambda cert_ctx: fnmatch(cert_ctx.get(key, ''), value)
 
-            if key in (CertFilterOption.SCOPE, CertFilterOption.STATUS, CertFilterOption.SIGNED_BY):
+            if key in (
+                CertFilterOption.SCOPE,
+                CertFilterOption.STATUS,
+                CertFilterOption.SIGNED_BY,
+                CertFilterOption.MANAGED_BY,
+            ):
                 return lambda cert_ctx: cert_ctx.get(key) == value
 
             # Default: unknown field selector -> nop filter (don't exclude)
@@ -564,12 +566,16 @@ class CertMgr:
             cert_filters = [_field_filter(expr) for expr in filter_exprs]
             # By default: filter out cephadm-signed certs unless explicitly included
             # with the exception of the cephadm root CA cert (CEPHADM_ROOT_CA_CERT) as
-            # technically the user may be interested in adding it to his CA trust chain
-            explicit_signed_by = any(_lhs(e) == str(CertFilterOption.SIGNED_BY) for e in filter_exprs)
-            if not include_cephadm_signed and not explicit_signed_by:
+            # technically the user may be interested in adding it to his CA trust chain.
+            # An explicit signed-by= or managed-by= selector disables this auto-filter.
+            explicit_manager_filter = any(
+                _lhs(e) in (str(CertFilterOption.SIGNED_BY), str(CertFilterOption.MANAGED_BY))
+                for e in filter_exprs
+            )
+            if not include_cephadm_signed and not explicit_manager_filter:
                 cert_filters.append(
                     lambda cert_ctx:
-                    cert_ctx.get(CertFilterOption.SIGNED_BY) == 'user'
+                    cert_ctx.get(CertFilterOption.MANAGED_BY) == TLSObjectManager.USER.value
                     or cert_ctx[CertFilterOption.NAME] == self.CEPHADM_ROOT_CA_CERT
                 )
             return cert_filters

--- a/src/pybind/mgr/cephadm/cert_mgr.py
+++ b/src/pybind/mgr/cephadm/cert_mgr.py
@@ -6,7 +6,13 @@ from enum import Enum
 from cephadm.ssl_cert_utils import SSLCerts, SSLConfigException
 from mgr_util import verify_tls, certificate_days_to_expire, ServerConfigException
 from cephadm.ssl_cert_utils import get_certificate_info, get_private_key_info
-from cephadm.tlsobject_types import Cert, PrivKey, TLSObjectScope, TLSObjectException, TLSObjectProtocol, TLSCredentials
+from cephadm.tlsobject_types import (Cert,
+                                     PrivKey,
+                                     TLSObjectScope,
+                                     TLSObjectException,
+                                     TLSObjectProtocol,
+                                     TLSCredentials,
+                                     TLSObjectManager)
 from cephadm.tlsobject_store import TLSObjectStore
 
 if TYPE_CHECKING:
@@ -357,12 +363,30 @@ class CertMgr:
         return TLSCredentials(cert=cert, key=key, ca_cert=ca_cert)
 
     def save_cert(self, cert_name: str, cert: str, service_name: Optional[str] = None, host: Optional[str] = None,
-                  user_made: bool = False, editable: bool = False) -> None:
-        self.cert_store.save_tlsobject(cert_name, cert, service_name, host, user_made, editable)
+                  user_made: Optional[bool] = None, editable: bool = False,
+                  managed_by: Optional[Union[TLSObjectManager, str]] = None) -> None:
+        self.cert_store.save_tlsobject(
+            cert_name,
+            cert,
+            service_name=service_name,
+            host=host,
+            user_made=user_made,
+            editable=editable,
+            managed_by=managed_by,
+        )
 
     def save_key(self, key_name: str, key: str, service_name: Optional[str] = None, host: Optional[str] = None,
-                 user_made: bool = False, editable: bool = False) -> None:
-        self.key_store.save_tlsobject(key_name, key, service_name, host, user_made, editable)
+                 user_made: Optional[bool] = None, editable: bool = False,
+                 managed_by: Optional[Union[TLSObjectManager, str]] = None) -> None:
+        self.key_store.save_tlsobject(
+            key_name,
+            key,
+            service_name=service_name,
+            host=host,
+            user_made=user_made,
+            editable=editable,
+            managed_by=managed_by,
+        )
 
     def save_self_signed_cert_key_pair(self, service_name: str, tls_creds: TLSCredentials, host: str,
                                        label: Optional[str] = None) -> None:

--- a/src/pybind/mgr/cephadm/cert_mgr.py
+++ b/src/pybind/mgr/cephadm/cert_mgr.py
@@ -766,9 +766,21 @@ class CertMgr:
             logger.info(f'Renewing cephadm-signed certificate for {cert_info.cert_name}')
             new_cert, new_key = self.ssl_certs.renew_cert(cert_obj.cert, self.mgr.certificate_duration_days)
             tlsobj_target = self.cert_store.determine_tlsobject_target(cert_info.cert_name, cert_info.target)
-            self.cert_store.save_tlsobject(cert_info.cert_name, new_cert, service_name=tlsobj_target.service, host=tlsobj_target.host)
+            self.cert_store.save_tlsobject(
+                cert_info.cert_name,
+                new_cert,
+                service_name=tlsobj_target.service,
+                host=tlsobj_target.host,
+                managed_by=TLSObjectManager.CEPHADM,
+            )
             key_name = cert_info.cert_name.replace('_cert', '_key')
-            self.key_store.save_tlsobject(key_name, new_key, service_name=tlsobj_target.service, host=tlsobj_target.host)
+            self.key_store.save_tlsobject(
+                key_name,
+                new_key,
+                service_name=tlsobj_target.service,
+                host=tlsobj_target.host,
+                managed_by=TLSObjectManager.CEPHADM,
+            )
             return True
         except SSLConfigException as e:
             logger.error(f'Error while trying to renew cephadm-signed certificate for {cert_info.cert_name}: {e}')
@@ -784,18 +796,26 @@ class CertMgr:
             - List of certificates that require manual intervention.
         """
 
+        def supports_auto_fix(cert_obj: Cert) -> bool:
+            """Return whether certmgr currently knows how to fix this manager type."""
+            return cert_obj.managed_by == TLSObjectManager.CEPHADM
+
         def requires_user_intervention(cert_info: CertInfo, cert_obj: Cert) -> bool:
             """Determines if a certificate requires manual user intervention."""
-            close_to_expiry = (not cert_info.is_operationally_valid() and not self.mgr.certificate_automated_rotation_enabled)
-            user_made_and_invalid = cert_obj.user_made and not cert_info.is_operationally_valid()
-            return close_to_expiry or user_made_and_invalid
+            if cert_info.is_operationally_valid():
+                return False
+            if not self.mgr.certificate_automated_rotation_enabled:
+                return True
+            return not supports_auto_fix(cert_obj)
 
         def trigger_auto_fix(cert_info: CertInfo, cert_obj: Cert) -> bool:
             """Attempts to automatically fix certificate issues if possible."""
-            if not self.mgr.certificate_automated_rotation_enabled or cert_obj.user_made:
+            if not self.mgr.certificate_automated_rotation_enabled:
+                return False
+            if not supports_auto_fix(cert_obj):
                 return False
 
-            # This is a cephadm-signed certificate, let's try to fix it
+            # This is a cephadm-managed certificate, let's try to fix it
             if not cert_info.is_valid:
                 # Remove the invalid certificate to force regeneration
                 tlsobj_target = self.cert_store.determine_tlsobject_target(cert_info.cert_name, cert_info.target)

--- a/src/pybind/mgr/cephadm/cert_mgr.py
+++ b/src/pybind/mgr/cephadm/cert_mgr.py
@@ -255,8 +255,16 @@ class CertMgr:
                 raise SSLConfigException("Cannot load cephadm root CA certificates.") from e
         else:
             self.ssl_certs.generate_root_cert(addr=ip)
-            self.cert_store.save_tlsobject(self.CEPHADM_ROOT_CA_CERT, self.ssl_certs.get_root_cert())
-            self.key_store.save_tlsobject(self.CEPHADM_ROOT_CA_KEY, self.ssl_certs.get_root_key())
+            self.cert_store.save_tlsobject(
+                self.CEPHADM_ROOT_CA_CERT,
+                self.ssl_certs.get_root_cert(),
+                managed_by=TLSObjectManager.CEPHADM,
+            )
+            self.key_store.save_tlsobject(
+                self.CEPHADM_ROOT_CA_KEY,
+                self.ssl_certs.get_root_key(),
+                managed_by=TLSObjectManager.CEPHADM,
+            )
 
     def get_root_ca(self) -> str:
         return self.ssl_certs.get_root_cert()
@@ -408,12 +416,26 @@ class CertMgr:
                                        label: Optional[str] = None) -> None:
         ss_cert_name = self.self_signed_cert(service_name, label)
         ss_key_name = self.self_signed_key(service_name, label)
-        self.cert_store.save_tlsobject(ss_cert_name, tls_creds.cert, host=host, user_made=False)
-        self.key_store.save_tlsobject(ss_key_name, tls_creds.key, host=host, user_made=False)
+        self.cert_store.save_tlsobject(
+            ss_cert_name,
+            tls_creds.cert,
+            host=host,
+            managed_by=TLSObjectManager.CEPHADM,
+        )
+        self.key_store.save_tlsobject(
+            ss_key_name,
+            tls_creds.key,
+            host=host,
+            managed_by=TLSObjectManager.CEPHADM,
+        )
 
     def _is_inline_saved_tlsobject(self, obj: Optional[TLSObjectProtocol]) -> bool:
-        # Inline-saved credentials are persisted as user_made=True but editable=False.
-        return bool(obj and getattr(obj, 'user_made', False) and not getattr(obj, 'editable', True))
+        # Inline-saved credentials are persisted as managed_by=user but editable=False.
+        return bool(
+            obj
+            and getattr(obj, 'managed_by', TLSObjectManager.CEPHADM) == TLSObjectManager.USER
+            and not getattr(obj, 'editable', True)
+        )
 
     def rm_inline_saved_cert_key_pair(
         self,

--- a/src/pybind/mgr/cephadm/cert_mgr.py
+++ b/src/pybind/mgr/cephadm/cert_mgr.py
@@ -44,6 +44,7 @@ class CertStatus(str, Enum):
 
 class CertInfo:
     """
+      - managed_by: owner of the certificate lifecycle.
       - is_valid: True if the certificate is valid.
       - is_close_to_expiration: True if the certificate is close to expiration.
       - days_to_expiration: Number of days until expiration.
@@ -51,12 +52,18 @@ class CertInfo:
     """
     def __init__(self, cert_name: str,
                  target: Optional[str],
-                 user_made: bool = False,
+                 user_made: Optional[bool] = None,
                  is_valid: bool = False,
                  is_close_to_expiration: bool = False,
                  days_to_expiration: int = 0,
-                 error_info: str = ''):
-        self.user_made = user_made
+                 error_info: str = '',
+                 managed_by: Optional[Union[TLSObjectManager, str]] = None):
+        if managed_by is not None:
+            self.managed_by = TLSObjectManager(managed_by)
+        elif user_made is not None:
+            self.managed_by = TLSObjectManager.USER if user_made else TLSObjectManager.CEPHADM
+        else:
+            self.managed_by = TLSObjectManager.CEPHADM
         self.cert_name = cert_name
         self.target = target or ''
         self.is_valid = is_valid
@@ -65,8 +72,12 @@ class CertInfo:
         self.error_info = error_info
 
     @property
+    def user_made(self) -> bool:
+        return self.managed_by == TLSObjectManager.USER
+
+    @property
     def signed_by(self) -> str:
-        return "user" if self.user_made else "cephadm"
+        return self.managed_by.value
 
     @property
     def status(self) -> CertStatus:
@@ -84,7 +95,12 @@ class CertInfo:
         return self.is_valid and not self.is_close_to_expiration
 
     def get_status_description(self) -> str:
-        cert_source = 'user-made' if self.user_made else 'cephadm-signed'
+        cert_source = {
+            TLSObjectManager.USER: 'user-made',
+            TLSObjectManager.CEPHADM: 'cephadm-signed',
+            TLSObjectManager.VAULT: 'vault-managed',
+            TLSObjectManager.ACME: 'acme-managed',
+        }[self.managed_by]
         cert_target = f' ({self.target})' if self.target else ''
         cert_details = f"'{self.cert_name}{cert_target}' ({cert_source})"
         if not self.is_valid:
@@ -694,9 +710,9 @@ class CertMgr:
         try:
             days_to_expiration = verify_tls(cert.cert, key.key) if key else certificate_days_to_expire(cert.cert)
             is_close_to_expiration = days_to_expiration < self.mgr.certificate_renewal_threshold_days
-            return CertInfo(cert_name, target, cert.user_made, True, is_close_to_expiration, days_to_expiration, "")
+            return CertInfo(cert_name, target, is_valid=True, is_close_to_expiration=is_close_to_expiration, days_to_expiration=days_to_expiration, error_info="", managed_by=cert.managed_by)
         except ServerConfigException as e:
-            return CertInfo(cert_name, target, cert.user_made, False, False, 0, str(e))
+            return CertInfo(cert_name, target, is_valid=False, is_close_to_expiration=False, days_to_expiration=0, error_info=str(e), managed_by=cert.managed_by)
 
     def get_problematic_certificates(self) -> List[Tuple[CertInfo, Cert]]:
 
@@ -732,7 +748,7 @@ class CertMgr:
             elif any(key_name in ks for ks in self.known_keys.values()) or self.is_cephadm_signed_object(key_name):
                 # certificate is supposed to have a key but it's missing
                 logger.error(f"Key '{key_name}' is missing for certificate '{cert_name}'.")
-                cert_info = CertInfo(cert_name, target, cert_obj.user_made, False, False, 0, "missing key")
+                cert_info = CertInfo(cert_name, target, is_valid=False, is_close_to_expiration=False, days_to_expiration=0, error_info="missing key", managed_by=cert_obj.managed_by)
             else:
                 # certificate has no associated key
                 cert_info = self._check_certificate_state(cert_name, target, cert_obj)

--- a/src/pybind/mgr/cephadm/cert_mgr.py
+++ b/src/pybind/mgr/cephadm/cert_mgr.py
@@ -14,7 +14,7 @@ from cephadm.tlsobject_types import (Cert,
                                      TLSCredentials,
                                      TLSObjectManager)
 from cephadm.tlsobject_store import TLSObjectStore
-from cephadm.vault import VaultIssuerConfig
+from cephadm.vault import VaultIssuerConfig, VaultPKIClient
 from cephadm.cert_metadata import VaultCertificateMetadata, VaultCertificateMetadataStore
 from cephadm.cert_issuer import CertificateIssuer, build_certificate_issuers
 
@@ -312,6 +312,140 @@ class CertMgr:
                                       host: Optional[str] = None) -> bool:
         target = self._vault_metadata_target(cert_name, service_name, host)
         return self.vault_cert_metadata_store.remove(cert_name, target)
+
+
+    def _ensure_vault_issue_target(self, cert_name: str, key_name: str,
+                                   service_name: Optional[str] = None,
+                                   host: Optional[str] = None) -> Tuple[TLSObjectScope, Optional[str]]:
+        cert_scope = self.get_cert_scope(cert_name)
+        key_scope = self.get_key_scope(key_name)
+        if cert_scope == TLSObjectScope.UNKNOWN:
+            raise TLSObjectException(f"Unknown certificate '{cert_name}'. Cannot issue it from Vault.")
+        if key_scope == TLSObjectScope.UNKNOWN:
+            raise TLSObjectException(f"Unknown key '{key_name}'. Cannot issue certificate '{cert_name}' from Vault.")
+        if cert_scope != key_scope:
+            raise TLSObjectException(
+                f"Certificate '{cert_name}' and key '{key_name}' must have the same scope to be issued from Vault. "
+                f"Got cert scope '{cert_scope.value}' and key scope '{key_scope.value}'."
+            )
+        if cert_scope == TLSObjectScope.SERVICE:
+            if not service_name:
+                raise TLSObjectException(f"Vault-managed certificate '{cert_name}' is service-scoped. Please specify service_name.")
+            return cert_scope, service_name
+        if cert_scope == TLSObjectScope.HOST:
+            if not host:
+                raise TLSObjectException(f"Vault-managed certificate '{cert_name}' is host-scoped. Please specify host.")
+            return cert_scope, host
+        return cert_scope, None
+
+    def _ensure_vault_ca_scope(self, ca_cert_name: Optional[str], scope: TLSObjectScope) -> None:
+        if not ca_cert_name:
+            return
+        ca_scope = self.get_cert_scope(ca_cert_name)
+        if ca_scope == TLSObjectScope.UNKNOWN:
+            raise TLSObjectException(f"Unknown CA certificate '{ca_cert_name}'. Cannot save Vault issuing CA.")
+        if ca_scope != scope:
+            raise TLSObjectException(
+                f"CA certificate '{ca_cert_name}' must have the same scope as the Vault-managed certificate. "
+                f"Got CA scope '{ca_scope.value}' and certificate scope '{scope.value}'."
+            )
+
+    def _ensure_vault_overwrite_allowed(self, cert_name: str, key_name: str,
+                                        service_name: Optional[str] = None,
+                                        host: Optional[str] = None,
+                                        ca_cert_name: Optional[str] = None) -> None:
+        objects = [
+            ('certificate', cert_name, self.cert_store.get_tlsobject_if_exists(cert_name, service_name, host)),
+            ('key', key_name, self.key_store.get_tlsobject_if_exists(key_name, service_name, host)),
+        ]
+        if ca_cert_name:
+            objects.append(
+                ('CA certificate', ca_cert_name, self.cert_store.get_tlsobject_if_exists(ca_cert_name, service_name, host))
+            )
+        for obj_type, obj_name, obj in objects:
+            if not obj:
+                continue
+            if not getattr(obj, 'editable', True) and getattr(obj, 'managed_by', TLSObjectManager.CEPHADM) != TLSObjectManager.VAULT:
+                raise TLSObjectException(
+                    f"Cannot overwrite non-editable {obj_type} '{obj_name}' with Vault-managed material."
+                )
+
+    def issue_vault_certificate(self,
+                                cert_name: str,
+                                key_name: str,
+                                common_name: str,
+                                service_name: Optional[str] = None,
+                                host: Optional[str] = None,
+                                ca_cert_name: Optional[str] = None,
+                                alt_names: Optional[List[str]] = None,
+                                ip_sans: Optional[List[str]] = None,
+                                pki_mount: Optional[str] = None,
+                                role: Optional[str] = None,
+                                ttl: Optional[str] = None) -> TLSCredentials:
+        """Issue a certificate from Vault PKI and store it in certmgr.
+
+        This is the manual Vault enrollment path. It intentionally stores the
+        resulting cert/key as non-editable and managed_by=vault so existing
+        services can consume the material through certificate_source=reference.
+        Renewal is not enabled here; later commits use the persisted metadata.
+        """
+        scope, target = self._ensure_vault_issue_target(cert_name, key_name, service_name, host)
+        self._ensure_vault_ca_scope(ca_cert_name, scope)
+        self._ensure_vault_overwrite_allowed(cert_name, key_name, service_name, host, ca_cert_name)
+
+        config = self.get_vault_issuer_config()
+        client = VaultPKIClient(config, self.get_vault_token())
+        creds = client.issue_certificate(
+            common_name=common_name,
+            alt_names=alt_names or [],
+            ip_sans=ip_sans or [],
+            ttl=ttl,
+            mount=pki_mount,
+            role=role,
+        )
+
+        self.save_cert(
+            cert_name,
+            creds.cert,
+            service_name=service_name,
+            host=host,
+            managed_by=TLSObjectManager.VAULT,
+            editable=False,
+        )
+        self.save_key(
+            key_name,
+            creds.key,
+            service_name=service_name,
+            host=host,
+            managed_by=TLSObjectManager.VAULT,
+            editable=False,
+        )
+        if ca_cert_name and creds.ca_cert:
+            self.save_cert(
+                ca_cert_name,
+                creds.ca_cert,
+                service_name=service_name,
+                host=host,
+                managed_by=TLSObjectManager.VAULT,
+                editable=False,
+            )
+
+        resolved_config = self.get_vault_issuer_config()
+        metadata = VaultCertificateMetadata(
+            cert_name=cert_name,
+            key_name=key_name,
+            ca_cert_name=ca_cert_name if creds.ca_cert else None,
+            scope=scope,
+            target=target,
+            pki_mount=pki_mount or resolved_config.pki_mount,
+            role=role or resolved_config.role,
+            ttl=ttl or resolved_config.ttl,
+            common_name=common_name,
+            alt_names=alt_names or [],
+            ip_sans=ip_sans or [],
+        )
+        self.save_vault_certificate_metadata(metadata)
+        return creds
 
     def register_self_signed_cert_key_pair(self, service_name: str, label: Optional[str] = None) -> None:
         """

--- a/src/pybind/mgr/cephadm/cert_mgr.py
+++ b/src/pybind/mgr/cephadm/cert_mgr.py
@@ -290,7 +290,6 @@ class CertMgr:
     def rm_vault_token(self) -> None:
         self.set_vault_token(None)
 
-
     def _vault_metadata_target(self, cert_name: str, service_name: Optional[str] = None,
                                host: Optional[str] = None) -> Optional[str]:
         scope = self.get_cert_scope(cert_name)
@@ -313,6 +312,20 @@ class CertMgr:
         target = self._vault_metadata_target(cert_name, service_name, host)
         return self.vault_cert_metadata_store.remove(cert_name, target)
 
+    def _vault_metadata_matches_target(self, metadata: VaultCertificateMetadata,
+                                       service_name: Optional[str] = None,
+                                       host: Optional[str] = None) -> bool:
+        if metadata.scope == TLSObjectScope.SERVICE:
+            return service_name is not None and metadata.target == service_name
+        if metadata.scope == TLSObjectScope.HOST:
+            return host is not None and metadata.target == host
+        return service_name is None and host is None
+
+    def rm_vault_certificate_metadata_by_key(self, key_name: str, service_name: Optional[str] = None,
+                                             host: Optional[str] = None) -> None:
+        for metadata in list(self.vault_cert_metadata_store.list()):
+            if metadata.key_name == key_name and self._vault_metadata_matches_target(metadata, service_name, host):
+                self.vault_cert_metadata_store.remove(metadata.cert_name, metadata.target)
 
     def _ensure_vault_issue_target(self, cert_name: str, key_name: str,
                                    service_name: Optional[str] = None,
@@ -430,16 +443,15 @@ class CertMgr:
                 editable=False,
             )
 
-        resolved_config = self.get_vault_issuer_config()
         metadata = VaultCertificateMetadata(
             cert_name=cert_name,
             key_name=key_name,
             ca_cert_name=ca_cert_name if creds.ca_cert else None,
             scope=scope,
             target=target,
-            pki_mount=pki_mount or resolved_config.pki_mount,
-            role=role or resolved_config.role,
-            ttl=ttl or resolved_config.ttl,
+            pki_mount=pki_mount or config.pki_mount,
+            role=role or config.role,
+            ttl=ttl or config.ttl,
             common_name=common_name,
             alt_names=alt_names or [],
             ip_sans=ip_sans or [],
@@ -658,7 +670,10 @@ class CertMgr:
         return removed
 
     def rm_key(self, key_name: str, service_name: Optional[str] = None, host: Optional[str] = None) -> bool:
-        return self.key_store.rm_tlsobject(key_name, service_name, host)
+        removed = self.key_store.rm_tlsobject(key_name, service_name, host)
+        if removed:
+            self.rm_vault_certificate_metadata_by_key(key_name, service_name, host)
+        return removed
 
     def rm_self_signed_cert_key_pair(self, service_name: str, host: str, label: Optional[str] = None) -> None:
         self.rm_cert(self.self_signed_cert(service_name, label), service_name, host)
@@ -1011,9 +1026,11 @@ class CertMgr:
             if not self._supports_auto_fix(cert_obj):
                 return False
 
-            # This certificate is managed by an issuer that supports auto-fix.
-            if not cert_info.is_valid:
-                # Remove the invalid certificate to force regeneration
+            # Cephadm-managed invalid certs are removed to force regeneration by
+            # the existing service certificate path. External issuers such as
+            # Vault must never remove old material before a replacement has been
+            # issued successfully, so they renew in-place instead.
+            if not cert_info.is_valid and cert_obj.managed_by == TLSObjectManager.CEPHADM:
                 tlsobj_target = self.cert_store.determine_tlsobject_target(cert_info.cert_name, cert_info.target)
                 logger.info(
                     f'Removing invalid certificate for {cert_info.cert_name} to trigger regeneration '
@@ -1021,7 +1038,7 @@ class CertMgr:
                 )
                 self.cert_store.rm_tlsobject(cert_info.cert_name, tlsobj_target.service, tlsobj_target.host)
                 return True
-            elif cert_info.is_close_to_expiration:
+            elif not cert_info.is_valid or cert_info.is_close_to_expiration:
                 return self._renew_certificate(cert_info, cert_obj)
             else:
                 return False
@@ -1047,20 +1064,27 @@ class CertMgr:
                 certs_with_issues.append(cert_info)
                 continue
 
-            if fix_issues and trigger_auto_fix(cert_info, cert_obj):
-                svc = self.get_associated_service(cert_info)
-                if svc:
-                    services_to_reconfig.add(svc)
-                else:
-                    logger.error(f'Cannot find the service associated with the certificate {cert_info.cert_name}')
+            if fix_issues:
+                if trigger_auto_fix(cert_info, cert_obj):
+                    svc = self.get_associated_service(cert_info)
+                    if svc:
+                        services_to_reconfig.add(svc)
+                    else:
+                        logger.error(f'Cannot find the service associated with the certificate {cert_info.cert_name}')
+                elif not cert_info.is_operationally_valid():
+                    # Auto-fix was possible in principle but failed (for example,
+                    # Vault was unreachable or renewal metadata is missing). Keep
+                    # the old material and report the problem so the user is warned
+                    # and certmgr retries on the next periodic check.
+                    certs_with_issues.append(cert_info)
 
         # Clear previously reported issues as we are newly checking all the certificates
         self.certificates_health_report = []
 
         # All problematic certificates have been processed. certs_with_issues now only
-        # contains certificates that couldn't be fixed either because they are user-made
-        # or automated rotation is disabled. In these cases, health warning or error
-        # is raised to notify the user.
+        # contains certificates that couldn't be fixed either because they are not
+        # auto-fixable, because issuer renewal failed, or automated rotation is disabled.
+        # In these cases, health warning or error is raised to notify the user.
         self._notify_certificates_health_status(certs_with_issues)
 
         return list(services_to_reconfig), certs_with_issues

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -25,6 +25,7 @@ from ceph.utils import str_to_datetime, datetime_to_str, datetime_now
 from orchestrator import OrchestratorError, HostSpec, OrchestratorEvent, service_to_daemon_types
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 from mgr_util import parse_combined_pem_file
+from cephadm.tlsobject_types import TLSObjectManager
 
 from .utils import get_node_proxy_status_value, resolve_ip, SpecialHostLabels
 from .migrations import queue_migrate_nfs_spec, queue_migrate_rgw_spec
@@ -411,12 +412,12 @@ class SpecStore():
                         'rgw_ssl_cert',
                         cert,
                         service_name=rgw_spec.service_name(),
-                        user_made=True)
+                        managed_by=TLSObjectManager.USER)
                     self.mgr.cert_mgr.save_key(
                         'rgw_ssl_key',
                         key,
                         service_name=rgw_spec.service_name(),
-                        user_made=True)
+                        managed_by=TLSObjectManager.USER)
                 else:
                     logger.error(f'Cannot parse the rgw certificate {cert_str}.')
         elif spec.service_type == 'iscsi':
@@ -426,13 +427,13 @@ class SpecStore():
                     'iscsi_ssl_cert',
                     iscsi_spec.ssl_cert,
                     service_name=iscsi_spec.service_name(),
-                    user_made=True)
+                    managed_by=TLSObjectManager.USER)
             if iscsi_spec.ssl_key:
                 self.mgr.cert_mgr.save_key(
                     'iscsi_ssl_key',
                     iscsi_spec.ssl_key,
                     service_name=iscsi_spec.service_name(),
-                    user_made=True)
+                    managed_by=TLSObjectManager.USER)
         elif spec.service_type == 'ingress':
             ingress_spec = cast(IngressSpec, spec)
             if ingress_spec.ssl_cert:
@@ -440,13 +441,13 @@ class SpecStore():
                     'ingress_ssl_cert',
                     ingress_spec.ssl_cert,
                     service_name=ingress_spec.service_name(),
-                    user_made=True)
+                    managed_by=TLSObjectManager.USER)
             if ingress_spec.ssl_key:
                 self.mgr.cert_mgr.save_key(
                     'ingress_ssl_key',
                     ingress_spec.ssl_key,
                     service_name=ingress_spec.service_name(),
-                    user_made=True)
+                    managed_by=TLSObjectManager.USER)
         elif spec.service_type == 'nvmeof':
             nvmeof_spec = cast(NvmeofServiceSpec, spec)
             for cert_attr in [
@@ -460,7 +461,7 @@ class SpecStore():
                         f'nvmeof_{cert_attr}',
                         cert,
                         service_name=nvmeof_spec.service_name(),
-                        user_made=True)
+                        managed_by=TLSObjectManager.USER)
             for key_attr in [
                 'server_key',
                 'client_key',
@@ -472,7 +473,7 @@ class SpecStore():
                         f'nvmeof_{key_attr}',
                         key,
                         service_name=nvmeof_spec.service_name(),
-                        user_made=True)
+                        managed_by=TLSObjectManager.USER)
 
     def rm(self, service_name: str, force_delete_data: bool = False) -> bool:
         if service_name not in self._specs:

--- a/src/pybind/mgr/cephadm/migrations.py
+++ b/src/pybind/mgr/cephadm/migrations.py
@@ -8,6 +8,7 @@ from cephadm.schedule import HostAssignment
 from cephadm.utils import SpecialHostLabels
 import rados
 from mgr_util import get_cert_issuer_info
+from cephadm.tlsobject_types import TLSObjectManager
 
 from mgr_module import NFS_POOL_NAME
 from orchestrator import OrchestratorError, DaemonDescription
@@ -450,8 +451,20 @@ class Migrations:
                 if org != 'Ceph':
                     logger.info(f'Migrating {grafana_daemon.name()}/{hostname} cert/key to cert store (as custom-certs)')
                     grafana_cephadm_signed_certs = False
-                    self.mgr.cert_mgr.save_cert('grafana_ssl_cert', grafana_cert, host=hostname, user_made=True, editable=True)
-                    self.mgr.cert_mgr.save_key('grafana_ssl_key', grafana_key, host=hostname, user_made=True, editable=True)
+                    self.mgr.cert_mgr.save_cert(
+                        'grafana_ssl_cert',
+                        grafana_cert,
+                        host=hostname,
+                        managed_by=TLSObjectManager.USER,
+                        editable=True,
+                    )
+                    self.mgr.cert_mgr.save_key(
+                        'grafana_ssl_key',
+                        grafana_key,
+                        host=hostname,
+                        managed_by=TLSObjectManager.USER,
+                        editable=True,
+                    )
 
         if not grafana_cephadm_signed_certs:
             # Update the spec to specify the right certificate source

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -4161,6 +4161,69 @@ Then run the following:
         )
         return f'Key for {key_name} set correctly'
 
+
+    @handle_orch_error
+    def cert_store_vault_issue(
+        self,
+        consumer: str,
+        common_name: str,
+        cert_name: str = "",
+        service_name: str = "",
+        hostname: str = "",
+        ca_cert_name: str = "",
+        alt_names: Optional[List[str]] = None,
+        ip_sans: Optional[List[str]] = None,
+        pki_mount: Optional[str] = None,
+        role: Optional[str] = None,
+        ttl: Optional[str] = None,
+    ) -> str:
+        """Issue a Vault-managed certificate/key pair into the certmgr store."""
+        if consumer not in self.cert_mgr.list_consumers():
+            raise OrchestratorError(
+                f"Invalid service: {consumer}. Please use 'ceph orch certmgr bindings ls' to list valid bindings."
+            )
+
+        if not cert_name:
+            cert_names = self.cert_mgr.list_consumer_known_certificates(consumer)
+            if len(cert_names) == 1:
+                cert_name = cert_names[0]
+            elif len(cert_names) > 1:
+                raise OrchestratorError(
+                    f"Service '{consumer}' has many certificates, please use the --cert-name argument "
+                    f"to specify which one from the list: {cert_names}"
+                )
+            else:
+                raise OrchestratorError(f"Service '{consumer}' has no registered certificate bindings")
+
+        scope_errors = {
+            TLSObjectScope.HOST: "Certificate is bound to a host. Please specify the host using --hostname.",
+            TLSObjectScope.SERVICE: "Certificate is bound to a service. Please specify the service using --service-name.",
+            TLSObjectScope.UNKNOWN: f"Unknown certificate '{cert_name}'. Use 'ceph orch certmgr cert ls' to list supported certificates.",
+        }
+        scope = self.cert_mgr.get_cert_scope(cert_name)
+        if (scope == TLSObjectScope.HOST and not hostname) or (scope == TLSObjectScope.SERVICE and not service_name):
+            raise OrchestratorError(scope_errors[scope])
+        if scope == TLSObjectScope.UNKNOWN:
+            raise OrchestratorError(scope_errors[scope])
+
+        key_name = cert_name.replace('_cert', '_key')
+        self.cert_mgr.issue_vault_certificate(
+            cert_name=cert_name,
+            key_name=key_name,
+            common_name=common_name,
+            service_name=service_name or None,
+            host=hostname or None,
+            ca_cert_name=ca_cert_name or None,
+            alt_names=alt_names or [],
+            ip_sans=ip_sans or [],
+            pki_mount=pki_mount,
+            role=role,
+            ttl=ttl,
+        )
+        target = service_name or hostname
+        target_info = f" for {target}" if target else ""
+        return f"Vault-managed certificate/key pair for {cert_name}{target_info} issued correctly"
+
     @handle_orch_error
     def cert_store_rm_cert(
         self,

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -4161,7 +4161,6 @@ Then run the following:
         )
         return f'Key for {key_name} set correctly'
 
-
     @handle_orch_error
     def cert_store_vault_token_set(self, token: str) -> str:
         token = token.strip()
@@ -4495,6 +4494,19 @@ Then run the following:
                     f"certificate_source changed from '{old_source}' to '{new_source}' "
                     f"for service '{spec.service_name()}'. This will trigger a service "
                     f"reconfiguration."
+                )
+
+        if getattr(spec, 'certificate_source', None) == CertificateSource.VAULT.value:
+            vault_config = self.cert_mgr.get_vault_issuer_config()
+            missing_fields = vault_config.missing_required_fields()
+            if missing_fields:
+                raise OrchestratorError(
+                    f"SSL is configured with '{CertificateSource.VAULT.value}', but Vault issuer config is incomplete. "
+                    f"Missing: {', '.join(missing_fields)}."
+                )
+            if not self.cert_mgr.get_vault_token():
+                raise OrchestratorError(
+                    f"SSL is configured with '{CertificateSource.VAULT.value}', but no Vault token is configured."
                 )
 
         if spec.is_using_certificates_source(CertificateSource.REFERENCE):

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -18,6 +18,7 @@ from threading import Event
 from ceph.deployment.service_spec import PrometheusSpec
 from cephadm.cert_mgr import CertMgr
 from cephadm.tlsobject_store import TLSObjectScope, TLSObjectException
+from cephadm.tlsobject_types import TLSObjectManager
 
 import string
 from typing import List, Dict, Optional, Callable, Tuple, TypeVar, \
@@ -4054,8 +4055,22 @@ Then run the following:
             self._raise_non_editable_cert_error(cert_name, consumer, service_name, hostname)
 
         key_name = cert_name.replace('_cert', '_key')
-        self.cert_mgr.save_cert(cert_name, cert, service_name, hostname, user_made=True, editable=True)
-        self.cert_mgr.save_key(key_name, key, service_name, hostname, user_made=True, editable=True)
+        self.cert_mgr.save_cert(
+            cert_name,
+            cert,
+            service_name,
+            hostname,
+            managed_by=TLSObjectManager.USER,
+            editable=True,
+        )
+        self.cert_mgr.save_key(
+            key_name,
+            key,
+            service_name,
+            hostname,
+            managed_by=TLSObjectManager.USER,
+            editable=True,
+        )
         return "Certificate/key pair set correctly"
 
     @handle_orch_error
@@ -4077,7 +4092,14 @@ Then run the following:
             if not cert_info.is_operationally_valid():
                 raise OrchestratorError(cert_info.get_status_description())
 
-        self.cert_mgr.save_cert(cert_name, cert, service_name, hostname, user_made=True, editable=True)
+        self.cert_mgr.save_cert(
+            cert_name,
+            cert,
+            service_name,
+            hostname,
+            managed_by=TLSObjectManager.USER,
+            editable=True,
+        )
         return f'Certificate for {cert_name} set correctly'
 
     @handle_orch_error
@@ -4088,7 +4110,13 @@ Then run the following:
         service_name: Optional[str] = None,
         hostname: Optional[str] = None,
     ) -> str:
-        self.cert_mgr.save_key(key_name, key, service_name, hostname, True)
+        self.cert_mgr.save_key(
+            key_name,
+            key,
+            service_name,
+            hostname,
+            managed_by=TLSObjectManager.USER,
+        )
         return f'Key for {key_name} set correctly'
 
     @handle_orch_error

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -4163,6 +4163,19 @@ Then run the following:
 
 
     @handle_orch_error
+    def cert_store_vault_token_set(self, token: str) -> str:
+        token = token.strip()
+        if not token:
+            raise OrchestratorError('Vault token cannot be empty')
+        self.cert_mgr.set_vault_token(token)
+        return 'Vault token set correctly'
+
+    @handle_orch_error
+    def cert_store_vault_token_rm(self) -> str:
+        self.cert_mgr.rm_vault_token()
+        return 'Vault token removed correctly'
+
+    @handle_orch_error
     def cert_store_vault_issue(
         self,
         consumer: str,

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -501,6 +501,42 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             max=90
         ),
         Option(
+            'certmgr_vault_addr',
+            type='str',
+            default=None,
+            desc='Vault server address used by certmgr for Vault-managed certificates.',
+        ),
+        Option(
+            'certmgr_vault_pki_mount',
+            type='str',
+            default=None,
+            desc='Vault PKI secrets engine mount used by certmgr for Vault-managed certificates.',
+        ),
+        Option(
+            'certmgr_vault_role',
+            type='str',
+            default=None,
+            desc='Default Vault PKI role used by certmgr for Vault-managed certificates.',
+        ),
+        Option(
+            'certmgr_vault_ttl',
+            type='str',
+            default=None,
+            desc='Default Vault certificate TTL requested by certmgr for Vault-managed certificates.',
+        ),
+        Option(
+            'certmgr_vault_cacert',
+            type='str',
+            default=None,
+            desc='CA certificate path or PEM used to verify the Vault server TLS certificate.',
+        ),
+        Option(
+            'certmgr_vault_verify_tls',
+            type='bool',
+            default=True,
+            desc='Whether certmgr should verify the Vault server TLS certificate.',
+        ),
+        Option(
             'secure_monitoring_stack',
             type='bool',
             default=False,
@@ -669,6 +705,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.certificate_automated_rotation_enabled = False
             self.certificate_check_debug_mode = False
             self.certificate_check_period = 0
+            self.certmgr_vault_addr: Optional[str] = None
+            self.certmgr_vault_pki_mount: Optional[str] = None
+            self.certmgr_vault_role: Optional[str] = None
+            self.certmgr_vault_ttl: Optional[str] = None
+            self.certmgr_vault_cacert: Optional[str] = None
+            self.certmgr_vault_verify_tls = True
             self.cephadm_binary_logging_level = 'debug'
 
         self.notify(NotifyType.mon_map, None)

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -42,7 +42,12 @@ from ceph.cephadm.d3n_types import (
 )
 from cephadm.services.rgw_d3n import D3NDevicePlanner
 from .service_registry import register_cephadm_service
-from cephadm.tlsobject_types import TLSObjectScope, TLSCredentials, EMPTY_TLS_CREDENTIALS
+from cephadm.tlsobject_types import (
+    TLSObjectScope,
+    TLSCredentials,
+    EMPTY_TLS_CREDENTIALS,
+    TLSObjectManager,
+)
 from cephadm.ssl_cert_utils import extract_ips_and_fqdns_from_cert
 
 if TYPE_CHECKING:
@@ -490,10 +495,28 @@ class CephadmService(metaclass=ABCMeta):
         # Save TLS credentials
         if needs_ca:
             assert ca_cert_name and ca_cert
-            self.mgr.cert_mgr.save_cert(ca_cert_name, ca_cert, service_name, host, user_made=True)
+            self.mgr.cert_mgr.save_cert(
+                ca_cert_name,
+                ca_cert,
+                service_name,
+                host,
+                managed_by=TLSObjectManager.USER,
+            )
         assert cert and key
-        self.mgr.cert_mgr.save_cert(cert_name, cert, service_name, host, user_made=True)
-        self.mgr.cert_mgr.save_key(key_name, key, service_name, host, user_made=True)
+        self.mgr.cert_mgr.save_cert(
+            cert_name,
+            cert,
+            service_name,
+            host,
+            managed_by=TLSObjectManager.USER,
+        )
+        self.mgr.cert_mgr.save_key(
+            key_name,
+            key,
+            service_name,
+            host,
+            managed_by=TLSObjectManager.USER,
+        )
         return TLSCredentials(cert=cert, key=key, ca_cert=ca_cert)
 
     def _get_certificates_from_certmgr_store(
@@ -625,8 +648,8 @@ class CephadmService(metaclass=ABCMeta):
         svc_name = spec.service_name()
         host = daemon_spec.host
 
-        # Inline-saved certs/keys are persisted in the certmgr store as user_made=True
-        # but editable=False. These should be garbage-collected once the service no
+        # Inline-saved certs/keys are persisted in the certmgr store as
+        # managed_by=user but editable=False. These should be garbage-collected once the service no
         # longer uses INLINE.
         if cert_source in (CertificateSource.REFERENCE.value, CertificateSource.CEPHADM_SIGNED.value):
             self.mgr.cert_mgr.rm_inline_saved_cert_key_pair(

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
 ServiceSpecs = TypeVar('ServiceSpecs', bound=ServiceSpec)
 AuthEntity = NewType('AuthEntity', str)
 
@@ -447,6 +448,17 @@ class CephadmService(metaclass=ABCMeta):
             return self._get_certificates_from_certmgr_store(svc_spec, fqdns, cert_name, key_name, ca_cert_name)
         elif cert_source == CertificateSource.CEPHADM_SIGNED.value:
             return self._get_cephadm_signed_certificates(svc_spec, daemon_spec, ips, fqdns, custom_sans)
+        elif cert_source == CertificateSource.VAULT.value:
+            return self._get_vault_certificates(
+                svc_spec,
+                daemon_spec,
+                ips,
+                fqdns,
+                custom_sans,
+                cert_name,
+                key_name,
+                ca_cert_name,
+            )
         else:
             logger.error(f'Invalid cert_source: {cert_source}')
             return EMPTY_TLS_CREDENTIALS
@@ -538,6 +550,83 @@ class CephadmService(metaclass=ABCMeta):
             return TLSCredentials(cert=cert, key=key, ca_cert=ca_cert)
         else:
             logger.error(f'Failed to get cert/key {cert_name} for service {svc_spec.service_name()} host: {host} from the certmgr store.')
+            return EMPTY_TLS_CREDENTIALS
+
+    def _get_vault_certificates(
+        self,
+        svc_spec: ServiceSpec,
+        daemon_spec: CephadmDaemonDeploySpec,
+        ips: List[str],
+        fqdns: List[str],
+        custom_sans: List[str],
+        cert_name: str,
+        key_name: str,
+        ca_cert_name: Optional[str] = None,
+    ) -> TLSCredentials:
+        """Return Vault-managed certs for a service, issuing them on first use.
+
+        The first deployment with certificate_source=vault enrolls the service's
+        known cert/key pair into certmgr by calling the Vault issue path. Later
+        deployments reuse the stored Vault-managed material and leave renewal to
+        certmgr's periodic check.
+        """
+        service_name = svc_spec.service_name()
+        host = daemon_spec.host
+        cert_obj = self.mgr.cert_mgr.cert_store.get_tlsobject_if_exists(cert_name, service_name, host)
+        key_obj = self.mgr.cert_mgr.key_store.get_tlsobject_if_exists(key_name, service_name, host)
+        ca_obj = (
+            self.mgr.cert_mgr.cert_store.get_tlsobject_if_exists(ca_cert_name, service_name, host)
+            if ca_cert_name else None
+        )
+
+        if cert_obj and key_obj:
+            if (
+                getattr(cert_obj, 'managed_by', TLSObjectManager.CEPHADM) == TLSObjectManager.VAULT
+                and getattr(key_obj, 'managed_by', TLSObjectManager.CEPHADM) == TLSObjectManager.VAULT
+            ):
+                if ca_cert_name and not ca_obj:
+                    logger.error(
+                        f'certificate_source=vault for {service_name} requires CA cert {ca_cert_name}, '
+                        f'but it is missing from the certmgr store.'
+                    )
+                    return EMPTY_TLS_CREDENTIALS
+                if ca_obj and getattr(ca_obj, 'managed_by', TLSObjectManager.CEPHADM) != TLSObjectManager.VAULT:
+                    logger.error(
+                        f'certificate_source=vault for {service_name} found CA cert {ca_cert_name} '
+                        f'that is not Vault-managed.'
+                    )
+                    return EMPTY_TLS_CREDENTIALS
+                return TLSCredentials(
+                    cert=cert_obj.cert,
+                    key=key_obj.key,
+                    ca_cert=ca_obj.cert if ca_obj else None,
+                )
+            logger.error(
+                f'certificate_source=vault for {service_name} found existing cert/key '
+                f'{cert_name}/{key_name} that are not Vault-managed.'
+            )
+            return EMPTY_TLS_CREDENTIALS
+
+        host_fqdn = self.mgr.get_fqdn(host)
+        common_name = host_fqdn or (fqdns[0] if fqdns else (custom_sans[0] if custom_sans else ''))
+        sans = sorted({san for san in fqdns + custom_sans + ([common_name] if common_name else []) if san})
+        if not common_name:
+            logger.error(f'Cannot issue Vault certificate for {service_name}: no common_name could be resolved')
+            return EMPTY_TLS_CREDENTIALS
+
+        try:
+            return self.mgr.cert_mgr.issue_vault_certificate(
+                cert_name=cert_name,
+                key_name=key_name,
+                ca_cert_name=ca_cert_name,
+                service_name=service_name,
+                host=host,
+                common_name=common_name,
+                alt_names=sans,
+                ip_sans=ips,
+            )
+        except Exception as e:
+            logger.error(f'Failed to issue Vault certificate for {service_name}: {e}')
             return EMPTY_TLS_CREDENTIALS
 
     def _get_cephadm_signed_certificates(
@@ -651,7 +740,7 @@ class CephadmService(metaclass=ABCMeta):
         # Inline-saved certs/keys are persisted in the certmgr store as
         # managed_by=user but editable=False. These should be garbage-collected once the service no
         # longer uses INLINE.
-        if cert_source in (CertificateSource.REFERENCE.value, CertificateSource.CEPHADM_SIGNED.value):
+        if cert_source in (CertificateSource.REFERENCE.value, CertificateSource.CEPHADM_SIGNED.value, CertificateSource.VAULT.value):
             self.mgr.cert_mgr.rm_inline_saved_cert_key_pair(
                 self.cert_name,
                 self.key_name,
@@ -922,11 +1011,12 @@ class CephadmService(metaclass=ABCMeta):
                     ca_cert_name=self.ca_cert_name,
                 )
 
-            if cert_source == CertificateSource.REFERENCE.value:
-                # It's a reference cert/key to the certmgr so we must keep them as user may want to use them later
+            if cert_source in (CertificateSource.REFERENCE.value, CertificateSource.VAULT.value):
+                # Reference and Vault certs live in the certmgr store and should be kept
+                # on daemon removal. Certmgr rotation/cleanup owns Vault-managed material.
                 logger.info(
-                    "Certificate source is 'reference'; user-provided certmgr entries (if present) will be kept for service: %s, host: %s",
-                    svc_name, host
+                    "Certificate source is '%s'; certmgr entries (if present) will be kept for service: %s, host: %s",
+                    cert_source, svc_name, host
                 )
 
         assert daemon.daemon_type is not None

--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -94,7 +94,7 @@ class NvmeofService(CephService):
             tls_creds = self.get_self_signed_certificates_with_label(
                 spec, daemon_spec, NVMEOF_CLIENT_CERT_LABEL
             )
-        elif spec.certificate_source in [CertificateSource.REFERENCE.value, CertificateSource.INLINE.value]:
+        elif spec.certificate_source in [CertificateSource.REFERENCE.value, CertificateSource.INLINE.value, CertificateSource.VAULT.value]:
             tls_creds = self.get_certificates_generic(
                 svc_spec=spec,
                 daemon_spec=daemon_spec,
@@ -428,7 +428,7 @@ class NvmeofService(CephService):
                 client_key = getattr(spec, 'client_key', '') or ''
 
         # -------- REFERENCE --------
-        elif cert_source == CertificateSource.REFERENCE.value:
+        elif cert_source in (CertificateSource.REFERENCE.value, CertificateSource.VAULT.value):
             server_cert = cert_mgr.get_cert(self.cert_name, service_name=service_name) or ''
             server_key = cert_mgr.get_key(self.key_name, service_name=service_name) or ''
             ca_cert = cert_mgr.get_cert(self.ca_cert_name, service_name=service_name) or ''

--- a/src/pybind/mgr/cephadm/services/smb.py
+++ b/src/pybind/mgr/cephadm/services/smb.py
@@ -34,7 +34,7 @@ from .cephadmservice import (
     CephadmDaemonDeploySpec,
     simplified_keyring,
 )
-from ..tlsobject_types import TLSCredentials, EMPTY_TLS_CREDENTIALS
+from ..tlsobject_types import TLSCredentials, EMPTY_TLS_CREDENTIALS, TLSObjectManager
 from ..schedule import DaemonPlacement
 
 if TYPE_CHECKING:
@@ -284,11 +284,29 @@ class SMBService(CephService):
                         'smb', cert_name, key_name, self.SCOPE, ca_cert_name
                     )
                     if cert_pem:
-                        self.mgr.cert_mgr.save_cert(cert_name, cert_pem, svc_name, host, user_made=True)
+                        self.mgr.cert_mgr.save_cert(
+                            cert_name,
+                            cert_pem,
+                            svc_name,
+                            host,
+                            managed_by=TLSObjectManager.USER,
+                        )
                     if key_pem:
-                        self.mgr.cert_mgr.save_key(key_name, key_pem, svc_name, host, user_made=True)
+                        self.mgr.cert_mgr.save_key(
+                            key_name,
+                            key_pem,
+                            svc_name,
+                            host,
+                            managed_by=TLSObjectManager.USER,
+                        )
                     if ca_pem:
-                        self.mgr.cert_mgr.save_cert(ca_cert_name, ca_pem, svc_name, host, user_made=True)
+                        self.mgr.cert_mgr.save_cert(
+                            ca_cert_name,
+                            ca_pem,
+                            svc_name,
+                            host,
+                            managed_by=TLSObjectManager.USER,
+                        )
         for ext_cluster in smb_spec.ceph_cluster_configs or []:
             files = config_blobs.setdefault('files', {})
             c_name = f'{ext_cluster.alias}.ceph.conf'

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -314,6 +314,11 @@ TLSOBJECT_STORE_KEY_PREFIX = f'{TLSOBJECT_STORE_PREFIX}key.'
 
 class TestCertificateSourceVaultServiceSupport:
 
+    class VaultTestService(CephadmService):
+        @property
+        def TYPE(self) -> str:
+            return 'rgw'
+
     def _service(self):
         mgr = mock.MagicMock()
         mgr.inventory.get_addr.return_value = '10.0.0.10'
@@ -321,7 +326,7 @@ class TestCertificateSourceVaultServiceSupport:
         mgr.cert_mgr = mock.MagicMock()
         mgr.cert_mgr.cert_store.get_tlsobject_if_exists.return_value = None
         mgr.cert_mgr.key_store.get_tlsobject_if_exists.return_value = None
-        return CephadmService(mgr)
+        return self.VaultTestService(mgr)
 
     def _spec(self):
         spec = mock.MagicMock()
@@ -361,7 +366,7 @@ class TestCertificateSourceVaultServiceSupport:
             ca_cert_name='rgw_ssl_ca_cert',
             service_name='rgw.foo',
             host='host1',
-            common_name='rgw.alt.example.com',
+            common_name='rgw.example.com',
             alt_names=['rgw.alt.example.com', 'rgw.example.com'],
             ip_sans=['10.0.0.10'],
         )
@@ -1069,6 +1074,8 @@ class TestCertMgr(object):
                     )
                     for key_name, (target, key_value, scope) in chain(keys.items(), unknown_keys.items())
                 }
+            elif key == VAULT_CERT_METADATA_STORE_PREFIX:
+                return {}
             else:
                 raise Exception(f'Unexpected key access in store: {key}')
 
@@ -1155,6 +1162,9 @@ class TestCertMgr(object):
                     "-----BEGIN PRIVATE KEY-----\nSNIP\n-----END PRIVATE KEY-----"  # raw PEM
                 )
                 return store
+
+            if prefix == VAULT_CERT_METADATA_STORE_PREFIX:
+                return {}
 
             raise Exception(f'Unexpected key access in store: {prefix}')
 
@@ -1273,6 +1283,9 @@ class TestCertMgr(object):
                     f'{TLSOBJECT_STORE_KEY_PREFIX}totally_unknown_key_global': _dump_key(None, 'ignored-key-3', TLSObjectScope.GLOBAL),
                 }
                 return store
+
+            if prefix == VAULT_CERT_METADATA_STORE_PREFIX:
+                return {}
 
             raise Exception(f'Unexpected key access in store: {prefix}')
 

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -319,6 +319,54 @@ class TestCertMgr(object):
     def test_user_made_from_managed_by(self, managed_by, user_made):
         assert user_made_from_managed_by(managed_by) == user_made
 
+    def test_certinfo_legacy_user_made_sets_managed_by(self):
+        cert_info = CertInfo('rgw_ssl_cert', 'rgw.foo', user_made=True)
+
+        assert cert_info.managed_by == TLSObjectManager.USER
+        assert cert_info.user_made is True
+        assert cert_info.signed_by == 'user'
+
+    def test_certinfo_managed_by_takes_precedence_over_user_made(self):
+        cert_info = CertInfo(
+            'rgw_ssl_cert',
+            'rgw.foo',
+            user_made=True,
+            managed_by=TLSObjectManager.VAULT,
+        )
+
+        assert cert_info.managed_by == TLSObjectManager.VAULT
+        assert cert_info.user_made is False
+        assert cert_info.signed_by == 'vault'
+
+    @pytest.mark.parametrize('managed_by, description', [
+        (TLSObjectManager.USER, 'user-made'),
+        (TLSObjectManager.CEPHADM, 'cephadm-signed'),
+        (TLSObjectManager.VAULT, 'vault-managed'),
+        (TLSObjectManager.ACME, 'acme-managed'),
+    ])
+    def test_certinfo_status_description_uses_managed_by(self, managed_by, description):
+        cert_info = CertInfo(
+            'rgw_ssl_cert',
+            'rgw.foo',
+            is_valid=False,
+            error_info='invalid format',
+            managed_by=managed_by,
+        )
+
+        assert f"({description})" in cert_info.get_status_description()
+
+    @mock.patch('cephadm.cert_mgr.certificate_days_to_expire')
+    def test_check_certificate_state_carries_managed_by(self, cert_days_mock, cephadm_module: CephadmOrchestrator):
+        cert_days_mock.return_value = 100
+        cert_info = cephadm_module.cert_mgr._check_certificate_state(
+            'rgw_ssl_cert',
+            'rgw.foo',
+            Cert('cert-data', managed_by=TLSObjectManager.VAULT),
+        )
+
+        assert cert_info.managed_by == TLSObjectManager.VAULT
+        assert cert_info.signed_by == 'vault'
+
     @pytest.mark.parametrize('tlsobject_cls, field_name, payload_value', [
         (Cert, 'cert', 'fake-cert'),
         (PrivKey, 'key', 'fake-key'),

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -2462,6 +2462,173 @@ class TestVaultCertificateMetadata(unittest.TestCase):
         assert cm.get_vault_certificate_metadata('rgw_ssl_cert', service_name='rgw.foo') is None
 
 
+
+class TestVaultManualIssue(unittest.TestCase):
+
+    def _cert_mgr(self) -> CertMgr:
+        mgr = MockCephadmOrchestrator()
+        mgr.certmgr_vault_addr = 'https://vault.example.com:8200'
+        mgr.certmgr_vault_pki_mount = 'pki'
+        mgr.certmgr_vault_role = 'ceph-rgw'
+        mgr.certmgr_vault_ttl = '720h'
+        mgr.certmgr_vault_cacert = None
+        mgr.certmgr_vault_verify_tls = True
+        cm = CertMgr(mgr)
+        cm.register_cert_key_pair(
+            'rgw',
+            'rgw_ssl_cert',
+            'rgw_ssl_key',
+            TLSObjectScope.SERVICE,
+            ca_cert_name='rgw_ssl_ca_cert',
+        )
+        cm.cert_store = TLSObjectStore(mgr, Cert, cm.known_certs, cm.is_cephadm_signed_object)
+        cm.key_store = TLSObjectStore(mgr, PrivKey, cm.known_keys, cm.is_cephadm_signed_object)
+        cm.vault_cert_metadata_store = VaultCertificateMetadataStore(mgr)
+        cm.set_vault_token('s.vault-token')
+        return cm
+
+    @mock.patch('cephadm.cert_mgr.VaultPKIClient')
+    def test_issue_vault_certificate_stores_cert_key_ca_and_metadata(self, m_client_cls):
+        cm = self._cert_mgr()
+        m_client = m_client_cls.return_value
+        m_client.issue_certificate.return_value = TLSCredentials(
+            cert='---VAULT CERT---',
+            key='---VAULT KEY---',
+            ca_cert='---VAULT CA---',
+        )
+
+        creds = cm.issue_vault_certificate(
+            cert_name='rgw_ssl_cert',
+            key_name='rgw_ssl_key',
+            ca_cert_name='rgw_ssl_ca_cert',
+            service_name='rgw.foo',
+            common_name='rgw.example.com',
+            alt_names=['rgw.example.com', 'rgw.internal'],
+            ip_sans=['10.0.0.10'],
+            pki_mount='pki-int',
+            role='ceph-rgw-int',
+            ttl='24h',
+        )
+
+        assert creds.cert == '---VAULT CERT---'
+        m_client_cls.assert_called_once_with(cm.get_vault_issuer_config(), 's.vault-token')
+        m_client.issue_certificate.assert_called_once_with(
+            common_name='rgw.example.com',
+            alt_names=['rgw.example.com', 'rgw.internal'],
+            ip_sans=['10.0.0.10'],
+            ttl='24h',
+            mount='pki-int',
+            role='ceph-rgw-int',
+        )
+
+        cert_obj = cm.cert_store.get_tlsobject('rgw_ssl_cert', service_name='rgw.foo')
+        key_obj = cm.key_store.get_tlsobject('rgw_ssl_key', service_name='rgw.foo')
+        ca_obj = cm.cert_store.get_tlsobject('rgw_ssl_ca_cert', service_name='rgw.foo')
+        assert cert_obj.cert == '---VAULT CERT---'
+        assert key_obj.key == '---VAULT KEY---'
+        assert ca_obj.cert == '---VAULT CA---'
+        assert cert_obj.managed_by == TLSObjectManager.VAULT
+        assert key_obj.managed_by == TLSObjectManager.VAULT
+        assert ca_obj.managed_by == TLSObjectManager.VAULT
+        assert cert_obj.editable is False
+        assert key_obj.editable is False
+        assert ca_obj.editable is False
+
+        metadata = cm.get_vault_certificate_metadata('rgw_ssl_cert', service_name='rgw.foo')
+        assert metadata == VaultCertificateMetadata(
+            cert_name='rgw_ssl_cert',
+            key_name='rgw_ssl_key',
+            ca_cert_name='rgw_ssl_ca_cert',
+            scope=TLSObjectScope.SERVICE,
+            target='rgw.foo',
+            pki_mount='pki-int',
+            role='ceph-rgw-int',
+            ttl='24h',
+            common_name='rgw.example.com',
+            alt_names=['rgw.example.com', 'rgw.internal'],
+            ip_sans=['10.0.0.10'],
+        )
+
+    @mock.patch('cephadm.cert_mgr.VaultPKIClient')
+    def test_issue_vault_certificate_uses_global_config_defaults_in_metadata(self, m_client_cls):
+        cm = self._cert_mgr()
+        m_client_cls.return_value.issue_certificate.return_value = TLSCredentials(
+            cert='---VAULT CERT---',
+            key='---VAULT KEY---',
+            ca_cert='',
+        )
+
+        cm.issue_vault_certificate(
+            cert_name='rgw_ssl_cert',
+            key_name='rgw_ssl_key',
+            service_name='rgw.foo',
+            common_name='rgw.example.com',
+        )
+
+        metadata = cm.get_vault_certificate_metadata('rgw_ssl_cert', service_name='rgw.foo')
+        assert metadata.pki_mount == 'pki'
+        assert metadata.role == 'ceph-rgw'
+        assert metadata.ttl == '720h'
+        assert metadata.ca_cert_name is None
+
+    def test_issue_vault_certificate_validates_scope_and_registered_names(self):
+        cm = self._cert_mgr()
+
+        with pytest.raises(TLSObjectException, match='service-scoped'):
+            cm.issue_vault_certificate(
+                cert_name='rgw_ssl_cert',
+                key_name='rgw_ssl_key',
+                common_name='rgw.example.com',
+            )
+
+        with pytest.raises(TLSObjectException, match='Unknown certificate'):
+            cm.issue_vault_certificate(
+                cert_name='unknown_cert',
+                key_name='rgw_ssl_key',
+                service_name='rgw.foo',
+                common_name='rgw.example.com',
+            )
+
+        with pytest.raises(TLSObjectException, match='Unknown key'):
+            cm.issue_vault_certificate(
+                cert_name='rgw_ssl_cert',
+                key_name='unknown_key',
+                service_name='rgw.foo',
+                common_name='rgw.example.com',
+            )
+
+    @mock.patch('cephadm.cert_mgr.VaultPKIClient')
+    def test_issue_vault_certificate_failure_preserves_existing_material(self, m_client_cls):
+        cm = self._cert_mgr()
+        cm.save_cert('rgw_ssl_cert', 'old-cert', service_name='rgw.foo', managed_by=TLSObjectManager.USER, editable=True)
+        cm.save_key('rgw_ssl_key', 'old-key', service_name='rgw.foo', managed_by=TLSObjectManager.USER, editable=True)
+        m_client_cls.return_value.issue_certificate.side_effect = VaultClientError('Vault unavailable')
+
+        with pytest.raises(VaultClientError, match='Vault unavailable'):
+            cm.issue_vault_certificate(
+                cert_name='rgw_ssl_cert',
+                key_name='rgw_ssl_key',
+                service_name='rgw.foo',
+                common_name='rgw.example.com',
+            )
+
+        assert cm.get_cert('rgw_ssl_cert', service_name='rgw.foo') == 'old-cert'
+        assert cm.get_key('rgw_ssl_key', service_name='rgw.foo') == 'old-key'
+        assert cm.get_vault_certificate_metadata('rgw_ssl_cert', service_name='rgw.foo') is None
+
+    def test_issue_vault_certificate_rejects_non_editable_non_vault_overwrite(self):
+        cm = self._cert_mgr()
+        cm.save_cert('rgw_ssl_cert', 'inline-cert', service_name='rgw.foo', managed_by=TLSObjectManager.USER, editable=False)
+
+        with pytest.raises(TLSObjectException, match='Cannot overwrite non-editable certificate'):
+            cm.issue_vault_certificate(
+                cert_name='rgw_ssl_cert',
+                key_name='rgw_ssl_key',
+                service_name='rgw.foo',
+                common_name='rgw.example.com',
+            )
+
+
 class TestVaultIssuerConfig(unittest.TestCase):
 
     class MockMgr:

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -319,6 +319,89 @@ class TestCertMgr(object):
     def test_user_made_from_managed_by(self, managed_by, user_made):
         assert user_made_from_managed_by(managed_by) == user_made
 
+    @pytest.mark.parametrize('tlsobject_cls, field_name, payload_value', [
+        (Cert, 'cert', 'fake-cert'),
+        (PrivKey, 'key', 'fake-key'),
+    ])
+    def test_tlsobject_from_json_legacy_user_made(self, tlsobject_cls, field_name, payload_value):
+        tlsobject = tlsobject_cls.from_json({
+            field_name: payload_value,
+            'user_made': True,
+            'editable': True,
+        })
+
+        assert tlsobject.managed_by == TLSObjectManager.USER
+        assert tlsobject.user_made is True
+        assert tlsobject.editable is True
+
+    @pytest.mark.parametrize('tlsobject_cls, field_name, payload_value', [
+        (Cert, 'cert', 'fake-cert'),
+        (PrivKey, 'key', 'fake-key'),
+    ])
+    def test_tlsobject_from_json_legacy_cephadm_managed(self, tlsobject_cls, field_name, payload_value):
+        tlsobject = tlsobject_cls.from_json({
+            field_name: payload_value,
+            'user_made': False,
+            'editable': False,
+        })
+
+        assert tlsobject.managed_by == TLSObjectManager.CEPHADM
+        assert tlsobject.user_made is False
+        assert tlsobject.editable is False
+
+    @pytest.mark.parametrize('tlsobject_cls, field_name, payload_value', [
+        (Cert, 'cert', 'fake-cert'),
+        (PrivKey, 'key', 'fake-key'),
+    ])
+    def test_tlsobject_from_json_managed_by_vault(self, tlsobject_cls, field_name, payload_value):
+        tlsobject = tlsobject_cls.from_json({
+            field_name: payload_value,
+            'managed_by': 'vault',
+            'editable': False,
+        })
+
+        assert tlsobject.managed_by == TLSObjectManager.VAULT
+        assert tlsobject.user_made is False
+        assert tlsobject.editable is False
+
+    @pytest.mark.parametrize('tlsobject_cls, field_name, payload_value', [
+        (Cert, 'cert', 'fake-cert'),
+        (PrivKey, 'key', 'fake-key'),
+    ])
+    def test_tlsobject_from_json_managed_by_precedence(self, tlsobject_cls, field_name, payload_value):
+        tlsobject = tlsobject_cls.from_json({
+            field_name: payload_value,
+            'managed_by': 'vault',
+            'user_made': True,
+            'editable': False,
+        })
+
+        assert tlsobject.managed_by == TLSObjectManager.VAULT
+        assert tlsobject.user_made is False
+
+    @pytest.mark.parametrize('tlsobject_cls, field_name, payload_value', [
+        (Cert, 'cert', 'fake-cert'),
+        (PrivKey, 'key', 'fake-key'),
+    ])
+    def test_tlsobject_from_json_invalid_managed_by(self, tlsobject_cls, field_name, payload_value):
+        with pytest.raises(TLSObjectException):
+            tlsobject_cls.from_json({
+                field_name: payload_value,
+                'managed_by': 'unknown-manager',
+            })
+
+    @pytest.mark.parametrize('tlsobject, payload_key, payload_value', [
+        (Cert('fake-cert', managed_by=TLSObjectManager.VAULT), 'cert', 'fake-cert'),
+        (PrivKey('fake-key', managed_by=TLSObjectManager.ACME), 'key', 'fake-key'),
+    ])
+    def test_tlsobject_to_json_includes_managed_by_and_legacy_user_made(self, tlsobject, payload_key, payload_value):
+        payload = tlsobject.to_json()
+
+        assert payload[payload_key] == payload_value
+        assert payload['managed_by'] == tlsobject.managed_by.value
+        assert payload['user_made'] == tlsobject.user_made
+        assert payload['editable'] is False
+
     @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
     def test_tlsobject_store_save_cert(self, _set_store, cephadm_module: CephadmOrchestrator):
 

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -18,6 +18,7 @@ from cephadm.tlsobject_types import (
 from cephadm.tlsobject_store import TLSOBJECT_STORE_PREFIX, TLSObjectStore, TLSObjectScope
 from cephadm.module import CephadmOrchestrator
 from cephadm.cert_mgr import CertInfo, CertMgr
+from cephadm.vault import VaultIssuerConfig
 
 EXPIRED_CERT = """
 -----BEGIN CERTIFICATE-----
@@ -2255,8 +2256,93 @@ class MockCephadmOrchestrator:
     def set_store(self, key, value):
         self.store[key] = value
 
+    def get_store(self, key):
+        return self.store.get(key)
+
     def get_store_prefix(self, prefix):
         return {k: v for k, v in self.store.items() if k.startswith(prefix)}
+
+
+class TestVaultIssuerConfig(unittest.TestCase):
+
+    class MockMgr:
+        certmgr_vault_addr = 'https://vault.example.com:8200'
+        certmgr_vault_pki_mount = 'pki'
+        certmgr_vault_role = 'ceph-rgw'
+        certmgr_vault_ttl = '720h'
+        certmgr_vault_cacert = '/etc/ceph/vault-ca.pem'
+        certmgr_vault_verify_tls = True
+
+    def test_from_mgr_loads_global_vault_config(self):
+        config = VaultIssuerConfig.from_mgr(self.MockMgr())
+
+        assert config.addr == 'https://vault.example.com:8200'
+        assert config.pki_mount == 'pki'
+        assert config.role == 'ceph-rgw'
+        assert config.ttl == '720h'
+        assert config.ca_cert == '/etc/ceph/vault-ca.pem'
+        assert config.verify_tls is True
+        assert config.is_configured()
+        assert config.missing_required_fields() == []
+
+    def test_from_mgr_normalizes_empty_strings(self):
+        class EmptyMgr:
+            certmgr_vault_addr = '  '
+            certmgr_vault_pki_mount = ''
+            certmgr_vault_role = None
+            certmgr_vault_verify_tls = False
+
+        config = VaultIssuerConfig.from_mgr(EmptyMgr())
+
+        assert config.addr is None
+        assert config.pki_mount is None
+        assert config.role is None
+        assert config.verify_tls is False
+        assert not config.is_configured()
+        assert config.missing_required_fields() == ['addr', 'pki_mount', 'role']
+
+    def test_to_json(self):
+        config = VaultIssuerConfig(
+            addr='https://vault.example.com:8200',
+            pki_mount='pki',
+            role='ceph-rgw',
+            ttl='720h',
+            ca_cert='vault-ca',
+            verify_tls=False,
+        )
+
+        assert config.to_json() == {
+            'addr': 'https://vault.example.com:8200',
+            'pki_mount': 'pki',
+            'role': 'ceph-rgw',
+            'ttl': '720h',
+            'ca_cert': 'vault-ca',
+            'verify_tls': False,
+        }
+
+    def test_cert_mgr_vault_config_and_token_helpers(self):
+        mgr = MockCephadmOrchestrator()
+        mgr.certmgr_vault_addr = 'https://vault.example.com:8200'
+        mgr.certmgr_vault_pki_mount = 'pki'
+        mgr.certmgr_vault_role = 'ceph-rgw'
+        mgr.certmgr_vault_ttl = '720h'
+        mgr.certmgr_vault_cacert = None
+        mgr.certmgr_vault_verify_tls = True
+        cm = CertMgr(mgr)
+
+        config = cm.get_vault_issuer_config()
+        assert config.is_configured()
+        assert config.addr == 'https://vault.example.com:8200'
+        assert config.pki_mount == 'pki'
+        assert config.role == 'ceph-rgw'
+
+        assert cm.get_vault_token() is None
+        cm.set_vault_token('  s.vault-token  ')
+        assert mgr.store[CertMgr.VAULT_TOKEN_STORE_KEY] == 's.vault-token'
+        assert cm.get_vault_token() == 's.vault-token'
+        cm.rm_vault_token()
+        assert mgr.store[CertMgr.VAULT_TOKEN_STORE_KEY] is None
+        assert cm.get_vault_token() is None
 
 
 class TestTLSObjectStore(unittest.TestCase):

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -710,6 +710,13 @@ class TestCertMgr(object):
         assert cm.get_cert(cert_name, host=host) == CEPHADM_SELF_GENERATED_CERT_1
         assert cm.get_key(key_name, host=host) == CEPHADM_SELF_GENERATED_KEY_2048
 
+        cert_obj = cm.cert_store.get_tlsobject(cert_name, host=host)
+        key_obj = cm.key_store.get_tlsobject(key_name, host=host)
+        assert cert_obj is not None
+        assert key_obj is not None
+        assert cert_obj.managed_by == TLSObjectManager.CEPHADM
+        assert key_obj.managed_by == TLSObjectManager.CEPHADM
+
         # Scope detection for cephadm-signed objects should be HOST
         assert cm.get_cert_scope(cert_name) == TLSObjectScope.HOST
         assert cm.get_key_scope(key_name) == TLSObjectScope.HOST

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -19,6 +19,7 @@ from cephadm.tlsobject_store import TLSOBJECT_STORE_PREFIX, TLSObjectStore, TLSO
 from cephadm.module import CephadmOrchestrator
 from cephadm.cert_mgr import CertInfo, CertMgr
 from cephadm.vault import VaultClientError, VaultIssuerConfig, VaultPKIClient
+from cephadm.services.cephadmservice import CephadmService, CERTIFICATE_SOURCE_VAULT
 from cephadm.cert_metadata import (
     VAULT_CERT_METADATA_STORE_PREFIX,
     VaultCertificateMetadata,
@@ -305,6 +306,130 @@ IwuZ9Cw+0P6sn81cI8FaeA==
 
 TLSOBJECT_STORE_CERT_PREFIX = f'{TLSOBJECT_STORE_PREFIX}cert.'
 TLSOBJECT_STORE_KEY_PREFIX = f'{TLSOBJECT_STORE_PREFIX}key.'
+
+
+
+
+class TestCertificateSourceVaultServiceSupport:
+
+    def _service(self):
+        mgr = mock.MagicMock()
+        mgr.inventory.get_addr.return_value = '10.0.0.10'
+        mgr.get_fqdn.return_value = 'rgw.example.com'
+        mgr.cert_mgr = mock.MagicMock()
+        mgr.cert_mgr.cert_store.get_tlsobject_if_exists.return_value = None
+        mgr.cert_mgr.key_store.get_tlsobject_if_exists.return_value = None
+        return CephadmService(mgr)
+
+    def _spec(self):
+        spec = mock.MagicMock()
+        spec.service_name.return_value = 'rgw.foo'
+        spec.certificate_source = CERTIFICATE_SOURCE_VAULT
+        spec.custom_sans = ['rgw.alt.example.com']
+        return spec
+
+    def test_certificate_source_vault_issues_and_stores_certificate_on_first_use(self):
+        svc = self._service()
+        daemon_spec = mock.MagicMock(host='host1')
+        spec = self._spec()
+        svc.mgr.cert_mgr.issue_vault_certificate.return_value = TLSCredentials(
+            cert='vault-cert',
+            key='vault-key',
+            ca_cert='vault-ca',
+        )
+
+        creds = svc.get_certificates_generic(
+            svc_spec=spec,
+            daemon_spec=daemon_spec,
+            cert_source_attr='certificate_source',
+            cert_attr='ssl_cert',
+            cert_name='rgw_ssl_cert',
+            key_attr='ssl_key',
+            key_name='rgw_ssl_key',
+            ca_cert_name='rgw_ssl_ca_cert',
+            ips=['10.0.0.10'],
+            fqdns=['rgw.example.com'],
+            custom_sans=['rgw.alt.example.com'],
+        )
+
+        assert creds.cert == 'vault-cert'
+        svc.mgr.cert_mgr.issue_vault_certificate.assert_called_once_with(
+            cert_name='rgw_ssl_cert',
+            key_name='rgw_ssl_key',
+            ca_cert_name='rgw_ssl_ca_cert',
+            service_name='rgw.foo',
+            host='host1',
+            common_name='rgw.alt.example.com',
+            alt_names=['rgw.alt.example.com', 'rgw.example.com'],
+            ip_sans=['10.0.0.10'],
+        )
+
+    def test_certificate_source_vault_reuses_stored_vault_material(self):
+        svc = self._service()
+        daemon_spec = mock.MagicMock(host='host1')
+        spec = self._spec()
+
+        def get_cert(name, service_name=None, host=None):
+            objects = {
+                'rgw_ssl_cert': Cert('stored-vault-cert', managed_by=TLSObjectManager.VAULT),
+                'rgw_ssl_ca_cert': Cert('stored-vault-ca', managed_by=TLSObjectManager.VAULT),
+            }
+            return objects.get(name)
+
+        svc.mgr.cert_mgr.cert_store.get_tlsobject_if_exists.side_effect = get_cert
+        svc.mgr.cert_mgr.key_store.get_tlsobject_if_exists.return_value = PrivKey(
+            'stored-vault-key',
+            managed_by=TLSObjectManager.VAULT,
+        )
+
+        creds = svc.get_certificates_generic(
+            svc_spec=spec,
+            daemon_spec=daemon_spec,
+            cert_source_attr='certificate_source',
+            cert_attr='ssl_cert',
+            cert_name='rgw_ssl_cert',
+            key_attr='ssl_key',
+            key_name='rgw_ssl_key',
+            ca_cert_name='rgw_ssl_ca_cert',
+            ips=['10.0.0.10'],
+            fqdns=['rgw.example.com'],
+            custom_sans=[],
+        )
+
+        assert creds.cert == 'stored-vault-cert'
+        assert creds.key == 'stored-vault-key'
+        assert creds.ca_cert == 'stored-vault-ca'
+        svc.mgr.cert_mgr.issue_vault_certificate.assert_not_called()
+
+    def test_certificate_source_vault_rejects_non_vault_existing_material(self):
+        svc = self._service()
+        daemon_spec = mock.MagicMock(host='host1')
+        spec = self._spec()
+        svc.mgr.cert_mgr.cert_store.get_tlsobject_if_exists.return_value = Cert(
+            'user-cert',
+            managed_by=TLSObjectManager.USER,
+        )
+        svc.mgr.cert_mgr.key_store.get_tlsobject_if_exists.return_value = PrivKey(
+            'user-key',
+            managed_by=TLSObjectManager.USER,
+        )
+
+        creds = svc.get_certificates_generic(
+            svc_spec=spec,
+            daemon_spec=daemon_spec,
+            cert_source_attr='certificate_source',
+            cert_attr='ssl_cert',
+            cert_name='rgw_ssl_cert',
+            key_attr='ssl_key',
+            key_name='rgw_ssl_key',
+            ips=['10.0.0.10'],
+            fqdns=['rgw.example.com'],
+            custom_sans=[],
+        )
+
+        assert not creds.cert
+        assert not creds.key
+        svc.mgr.cert_mgr.issue_vault_certificate.assert_not_called()
 
 
 class TestCertMgr(object):

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -19,6 +19,11 @@ from cephadm.tlsobject_store import TLSOBJECT_STORE_PREFIX, TLSObjectStore, TLSO
 from cephadm.module import CephadmOrchestrator
 from cephadm.cert_mgr import CertInfo, CertMgr
 from cephadm.vault import VaultClientError, VaultIssuerConfig, VaultPKIClient
+from cephadm.cert_metadata import (
+    VAULT_CERT_METADATA_STORE_PREFIX,
+    VaultCertificateMetadata,
+    VaultCertificateMetadataStore,
+)
 
 EXPIRED_CERT = """
 -----BEGIN CERTIFICATE-----
@@ -2314,6 +2319,147 @@ class MockCephadmOrchestrator:
 
     def get_store_prefix(self, prefix):
         return {k: v for k, v in self.store.items() if k.startswith(prefix)}
+
+
+class TestVaultCertificateMetadata(unittest.TestCase):
+
+    def _metadata(self, **kwargs):
+        values = {
+            'cert_name': 'rgw_ssl_cert',
+            'key_name': 'rgw_ssl_key',
+            'ca_cert_name': 'rgw_ssl_ca_cert',
+            'scope': TLSObjectScope.SERVICE,
+            'target': 'rgw.foo',
+            'pki_mount': 'pki',
+            'role': 'ceph-rgw',
+            'ttl': '720h',
+            'common_name': 'rgw.example.com',
+            'alt_names': ['rgw.example.com', 'rgw.internal'],
+            'ip_sans': ['10.0.0.10'],
+        }
+        values.update(kwargs)
+        return VaultCertificateMetadata(**values)
+
+    def test_vault_metadata_serializes_renewal_inputs(self):
+        metadata = self._metadata()
+
+        assert metadata.managed_by == TLSObjectManager.VAULT
+        assert metadata.store_target == 'rgw.foo'
+        assert metadata.to_json() == {
+            'cert_name': 'rgw_ssl_cert',
+            'key_name': 'rgw_ssl_key',
+            'ca_cert_name': 'rgw_ssl_ca_cert',
+            'managed_by': 'vault',
+            'scope': 'service',
+            'target': 'rgw.foo',
+            'pki_mount': 'pki',
+            'role': 'ceph-rgw',
+            'ttl': '720h',
+            'common_name': 'rgw.example.com',
+            'alt_names': ['rgw.example.com', 'rgw.internal'],
+            'ip_sans': ['10.0.0.10'],
+        }
+
+        loaded = VaultCertificateMetadata.from_json(metadata.to_json())
+        assert loaded == metadata
+
+    def test_vault_metadata_supports_global_scope(self):
+        metadata = self._metadata(
+            cert_name='mgmt_gateway_ssl_cert',
+            key_name='mgmt_gateway_ssl_key',
+            ca_cert_name=None,
+            scope=TLSObjectScope.GLOBAL,
+            target=None,
+        )
+
+        assert metadata.store_target == ''
+        assert metadata.to_json()['target'] is None
+
+    def test_vault_metadata_validates_scope_and_owner(self):
+        with pytest.raises(TLSObjectException, match='requires target'):
+            self._metadata(target=None)
+
+        with pytest.raises(TLSObjectException, match='must not set target'):
+            self._metadata(scope=TLSObjectScope.GLOBAL, target='rgw.foo')
+
+        with pytest.raises(TLSObjectException, match='managed_by=vault'):
+            self._metadata(managed_by=TLSObjectManager.CEPHADM)
+
+        bad = self._metadata().to_json()
+        bad['unexpected'] = True
+        with pytest.raises(TLSObjectException, match='unknown field'):
+            VaultCertificateMetadata.from_json(bad)
+
+    def test_vault_metadata_store_save_load_get_remove(self):
+        mgr = MockCephadmOrchestrator()
+        store = VaultCertificateMetadataStore(mgr)
+        rgw_metadata = self._metadata()
+        global_metadata = self._metadata(
+            cert_name='mgmt_gateway_ssl_cert',
+            key_name='mgmt_gateway_ssl_key',
+            ca_cert_name=None,
+            scope=TLSObjectScope.GLOBAL,
+            target=None,
+            common_name='mgmt.example.com',
+            alt_names=['mgmt.example.com'],
+            ip_sans=[],
+        )
+
+        store.save(rgw_metadata)
+        store.save(global_metadata)
+
+        assert store.get('rgw_ssl_cert', 'rgw.foo') == rgw_metadata
+        assert store.get('mgmt_gateway_ssl_cert') == global_metadata
+        assert json.loads(mgr.store[VAULT_CERT_METADATA_STORE_PREFIX + 'rgw_ssl_cert']) == {
+            'rgw.foo': rgw_metadata.to_json(),
+        }
+
+        reloaded = VaultCertificateMetadataStore(mgr)
+        reloaded.load()
+        assert reloaded.get('rgw_ssl_cert', 'rgw.foo') == rgw_metadata
+        assert reloaded.get('mgmt_gateway_ssl_cert') == global_metadata
+
+        assert reloaded.remove('rgw_ssl_cert', 'rgw.foo')
+        assert reloaded.get('rgw_ssl_cert', 'rgw.foo') is None
+        assert mgr.store[VAULT_CERT_METADATA_STORE_PREFIX + 'rgw_ssl_cert'] is None
+        assert not reloaded.remove('rgw_ssl_cert', 'rgw.foo')
+
+    def test_vault_metadata_store_skips_bad_records(self):
+        mgr = MockCephadmOrchestrator()
+        good = self._metadata()
+        mgr.store[VAULT_CERT_METADATA_STORE_PREFIX + 'rgw_ssl_cert'] = json.dumps({
+            'rgw.foo': good.to_json(),
+            'broken': {'cert_name': 'broken'},
+        })
+        mgr.store[VAULT_CERT_METADATA_STORE_PREFIX + 'bad-json'] = 'not-json'
+
+        store = VaultCertificateMetadataStore(mgr)
+        store.load()
+
+        assert store.get('rgw_ssl_cert', 'rgw.foo') == good
+        assert store.get('broken', 'broken') is None
+
+    def test_cert_mgr_vault_metadata_helpers_and_cert_removal(self):
+        mgr = MockCephadmOrchestrator()
+        cm = CertMgr(mgr)
+        cm.register_cert_key_pair(
+            'rgw',
+            'rgw_ssl_cert',
+            'rgw_ssl_key',
+            TLSObjectScope.SERVICE,
+            ca_cert_name='rgw_ssl_ca_cert',
+        )
+        cm.init_tlsobject_store = mock.Mock()
+        cm.cert_store = mock.Mock()
+        cm.cert_store.rm_tlsobject.return_value = True
+        cm.vault_cert_metadata_store = VaultCertificateMetadataStore(mgr)
+
+        metadata = self._metadata()
+        cm.save_vault_certificate_metadata(metadata)
+
+        assert cm.get_vault_certificate_metadata('rgw_ssl_cert', service_name='rgw.foo') == metadata
+        assert cm.rm_cert('rgw_ssl_cert', service_name='rgw.foo')
+        assert cm.get_vault_certificate_metadata('rgw_ssl_cert', service_name='rgw.foo') is None
 
 
 class TestVaultIssuerConfig(unittest.TestCase):

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -1294,14 +1294,14 @@ class TestCertMgr(object):
             renew_mock.assert_called_once()
 
     @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
-    def test_certificate_issuer_registry_marks_only_cephadm_auto_fixable(
+    def test_certificate_issuer_registry_marks_cephadm_and_vault_auto_fixable(
         self, _set_store, cephadm_module: CephadmOrchestrator
     ):
         cert_mgr = cephadm_module.cert_mgr
 
         assert cert_mgr._supports_auto_fix(Cert('cephadm-cert', managed_by=TLSObjectManager.CEPHADM))
         assert not cert_mgr._supports_auto_fix(Cert('user-cert', managed_by=TLSObjectManager.USER))
-        assert not cert_mgr._supports_auto_fix(Cert('vault-cert', managed_by=TLSObjectManager.VAULT))
+        assert cert_mgr._supports_auto_fix(Cert('vault-cert', managed_by=TLSObjectManager.VAULT))
         assert not cert_mgr._supports_auto_fix(Cert('acme-cert', managed_by=TLSObjectManager.ACME))
 
     @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
@@ -1326,7 +1326,7 @@ class TestCertMgr(object):
         renew_mock.assert_called_once_with(cert_mgr, cert_info, cert_obj)
 
     @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
-    def test_renew_certificate_returns_false_for_unsupported_issuer(
+    def test_renew_certificate_dispatches_to_registered_vault_issuer(
         self, _set_store, cephadm_module: CephadmOrchestrator
     ):
         cert_mgr = cephadm_module.cert_mgr
@@ -1341,13 +1341,34 @@ class TestCertMgr(object):
         cert_obj = Cert('vault-cert', managed_by=TLSObjectManager.VAULT)
         issuer = cert_mgr.certificate_issuers[TLSObjectManager.VAULT]
 
+        with mock.patch.object(issuer, 'renew', return_value=True) as renew_mock:
+            assert cert_mgr._renew_certificate(cert_info, cert_obj)
+
+        renew_mock.assert_called_once_with(cert_mgr, cert_info, cert_obj)
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    def test_renew_certificate_returns_false_for_unsupported_issuer(
+        self, _set_store, cephadm_module: CephadmOrchestrator
+    ):
+        cert_mgr = cephadm_module.cert_mgr
+        cert_info = CertInfo(
+            'rgw_ssl_cert',
+            'rgw.foo',
+            is_valid=True,
+            is_close_to_expiration=True,
+            days_to_expiration=5,
+            managed_by=TLSObjectManager.ACME,
+        )
+        cert_obj = Cert('acme-cert', managed_by=TLSObjectManager.ACME)
+        issuer = cert_mgr.certificate_issuers[TLSObjectManager.ACME]
+
         with mock.patch.object(issuer, 'renew', wraps=issuer.renew) as renew_mock:
             assert not cert_mgr._renew_certificate(cert_info, cert_obj)
 
         renew_mock.assert_not_called()
 
     @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
-    def test_check_services_certificates_renews_only_cephadm_managed(
+    def test_check_services_certificates_renews_auto_fixable_managed_cert(
         self, _set_store, cephadm_module: CephadmOrchestrator
     ):
         cert_mgr = cephadm_module.cert_mgr
@@ -1376,11 +1397,10 @@ class TestCertMgr(object):
 
     @pytest.mark.parametrize('managed_by', [
         TLSObjectManager.USER,
-        TLSObjectManager.VAULT,
         TLSObjectManager.ACME,
     ])
     @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
-    def test_check_services_certificates_does_not_cephadm_renew_non_cephadm_managed(
+    def test_check_services_certificates_does_not_renew_unsupported_managed(
         self, _set_store, cephadm_module: CephadmOrchestrator, managed_by: TLSObjectManager
     ):
         cert_mgr = cephadm_module.cert_mgr
@@ -1402,6 +1422,33 @@ class TestCertMgr(object):
             services_to_reconfig, certs_with_issues = cert_mgr.check_services_certificates(fix_issues=True)
 
         renew_mock.assert_not_called()
+        assert services_to_reconfig == []
+        assert certs_with_issues == [cert_info]
+        notify_mock.assert_called_once_with([cert_info])
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    def test_check_services_certificates_reports_failed_auto_fix(
+        self, _set_store, cephadm_module: CephadmOrchestrator
+    ):
+        cert_mgr = cephadm_module.cert_mgr
+        cephadm_module.certificate_automated_rotation_enabled = True
+
+        cert_info = CertInfo(
+            'rgw_ssl_cert',
+            'rgw.foo',
+            is_valid=True,
+            is_close_to_expiration=True,
+            days_to_expiration=5,
+            managed_by=TLSObjectManager.VAULT,
+        )
+        cert_obj = Cert('vault-cert', managed_by=TLSObjectManager.VAULT)
+
+        with mock.patch.object(cert_mgr, 'get_problematic_certificates', return_value=[(cert_info, cert_obj)]), \
+             mock.patch.object(cert_mgr, '_renew_certificate', return_value=False) as renew_mock, \
+             mock.patch.object(cert_mgr, '_notify_certificates_health_status') as notify_mock:
+            services_to_reconfig, certs_with_issues = cert_mgr.check_services_certificates(fix_issues=True)
+
+        renew_mock.assert_called_once_with(cert_info, cert_obj)
         assert services_to_reconfig == []
         assert certs_with_issues == [cert_info]
         notify_mock.assert_called_once_with([cert_info])
@@ -2627,6 +2674,114 @@ class TestVaultManualIssue(unittest.TestCase):
                 service_name='rgw.foo',
                 common_name='rgw.example.com',
             )
+
+    @mock.patch('cephadm.cert_issuer.VaultPKIClient')
+    def test_vault_issuer_renews_stored_material_from_metadata(self, m_client_cls):
+        cm = self._cert_mgr()
+        cm.save_cert('rgw_ssl_cert', 'old-cert', service_name='rgw.foo', managed_by=TLSObjectManager.VAULT, editable=False)
+        cm.save_key('rgw_ssl_key', 'old-key', service_name='rgw.foo', managed_by=TLSObjectManager.VAULT, editable=False)
+        cm.save_cert('rgw_ssl_ca_cert', 'old-ca', service_name='rgw.foo', managed_by=TLSObjectManager.VAULT, editable=False)
+        cm.save_vault_certificate_metadata(VaultCertificateMetadata(
+            cert_name='rgw_ssl_cert',
+            key_name='rgw_ssl_key',
+            ca_cert_name='rgw_ssl_ca_cert',
+            scope=TLSObjectScope.SERVICE,
+            target='rgw.foo',
+            pki_mount='pki-int',
+            role='ceph-rgw-int',
+            ttl='24h',
+            common_name='rgw.example.com',
+            alt_names=['rgw.example.com'],
+            ip_sans=['10.0.0.10'],
+        ))
+        m_client = m_client_cls.return_value
+        m_client.issue_certificate.return_value = TLSCredentials(
+            cert='new-vault-cert',
+            key='new-vault-key',
+            ca_cert='new-vault-ca',
+        )
+
+        cert_info = CertInfo(
+            'rgw_ssl_cert',
+            'rgw.foo',
+            is_valid=True,
+            is_close_to_expiration=True,
+            days_to_expiration=5,
+            managed_by=TLSObjectManager.VAULT,
+        )
+        cert_obj = cm.cert_store.get_tlsobject('rgw_ssl_cert', service_name='rgw.foo')
+
+        assert cm._renew_certificate(cert_info, cert_obj)
+
+        m_client_cls.assert_called_once_with(cm.get_vault_issuer_config(), 's.vault-token')
+        m_client.issue_certificate.assert_called_once_with(
+            common_name='rgw.example.com',
+            alt_names=['rgw.example.com'],
+            ip_sans=['10.0.0.10'],
+            ttl='24h',
+            mount='pki-int',
+            role='ceph-rgw-int',
+        )
+        cert_obj = cm.cert_store.get_tlsobject('rgw_ssl_cert', service_name='rgw.foo')
+        key_obj = cm.key_store.get_tlsobject('rgw_ssl_key', service_name='rgw.foo')
+        ca_obj = cm.cert_store.get_tlsobject('rgw_ssl_ca_cert', service_name='rgw.foo')
+        assert cert_obj.cert == 'new-vault-cert'
+        assert key_obj.key == 'new-vault-key'
+        assert ca_obj.cert == 'new-vault-ca'
+        assert cert_obj.managed_by == TLSObjectManager.VAULT
+        assert key_obj.managed_by == TLSObjectManager.VAULT
+        assert ca_obj.managed_by == TLSObjectManager.VAULT
+        assert cert_obj.editable is False
+        assert key_obj.editable is False
+        assert ca_obj.editable is False
+
+    @mock.patch('cephadm.cert_issuer.VaultPKIClient')
+    def test_vault_issuer_missing_metadata_preserves_existing_material(self, m_client_cls):
+        cm = self._cert_mgr()
+        cm.save_cert('rgw_ssl_cert', 'old-cert', service_name='rgw.foo', managed_by=TLSObjectManager.VAULT, editable=False)
+        cm.save_key('rgw_ssl_key', 'old-key', service_name='rgw.foo', managed_by=TLSObjectManager.VAULT, editable=False)
+        cert_info = CertInfo(
+            'rgw_ssl_cert',
+            'rgw.foo',
+            is_valid=True,
+            is_close_to_expiration=True,
+            days_to_expiration=5,
+            managed_by=TLSObjectManager.VAULT,
+        )
+        cert_obj = cm.cert_store.get_tlsobject('rgw_ssl_cert', service_name='rgw.foo')
+
+        assert not cm._renew_certificate(cert_info, cert_obj)
+        m_client_cls.assert_not_called()
+        assert cm.get_cert('rgw_ssl_cert', service_name='rgw.foo') == 'old-cert'
+        assert cm.get_key('rgw_ssl_key', service_name='rgw.foo') == 'old-key'
+
+    @mock.patch('cephadm.cert_issuer.VaultPKIClient')
+    def test_vault_issuer_failure_preserves_existing_material(self, m_client_cls):
+        cm = self._cert_mgr()
+        cm.save_cert('rgw_ssl_cert', 'old-cert', service_name='rgw.foo', managed_by=TLSObjectManager.VAULT, editable=False)
+        cm.save_key('rgw_ssl_key', 'old-key', service_name='rgw.foo', managed_by=TLSObjectManager.VAULT, editable=False)
+        cm.save_vault_certificate_metadata(VaultCertificateMetadata(
+            cert_name='rgw_ssl_cert',
+            key_name='rgw_ssl_key',
+            scope=TLSObjectScope.SERVICE,
+            target='rgw.foo',
+            common_name='rgw.example.com',
+        ))
+        m_client_cls.return_value.issue_certificate.side_effect = VaultClientError('Vault unavailable')
+        cert_info = CertInfo(
+            'rgw_ssl_cert',
+            'rgw.foo',
+            is_valid=True,
+            is_close_to_expiration=True,
+            days_to_expiration=5,
+            managed_by=TLSObjectManager.VAULT,
+        )
+        cert_obj = cm.cert_store.get_tlsobject('rgw_ssl_cert', service_name='rgw.foo')
+
+        assert not cm._renew_certificate(cert_info, cert_obj)
+        assert cm.get_cert('rgw_ssl_cert', service_name='rgw.foo') == 'old-cert'
+        assert cm.get_key('rgw_ssl_key', service_name='rgw.foo') == 'old-key'
+
 
 
 class TestVaultIssuerConfig(unittest.TestCase):

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -355,6 +355,72 @@ class TestCertMgr(object):
 
         assert f"({description})" in cert_info.get_status_description()
 
+    def _new_cert_mgr_for_filter_tests(self):
+        cm = CertMgr(mock.Mock())
+        cm.cert_store = mock.Mock()
+        cm.key_store = mock.Mock()
+        cm.known_certs[TLSObjectScope.SERVICE].extend(['rgw_ssl_cert', 'vault_ssl_cert'])
+        return cm
+
+    def _set_filter_test_certs(self, cm):
+        cm.cert_store.list_tlsobjects.return_value = [
+            ('rgw_ssl_cert', Cert('user-cert', managed_by=TLSObjectManager.USER), 'rgw.foo'),
+            ('cephadm-signed_grafana_cert', Cert('cephadm-cert', managed_by=TLSObjectManager.CEPHADM), 'node1'),
+            ('vault_ssl_cert', Cert('vault-cert', managed_by=TLSObjectManager.VAULT), 'rgw.foo'),
+        ]
+
+    @mock.patch('cephadm.cert_mgr.get_certificate_info', return_value={})
+    def test_cert_ls_managed_by_filter_selects_manager(self, _get_cert_info):
+        cm = self._new_cert_mgr_for_filter_tests()
+        self._set_filter_test_certs(cm)
+
+        def check_state(cert_name, target, cert_obj, key_obj=None):
+            return CertInfo(cert_name, target, is_valid=True, managed_by=cert_obj.managed_by)
+
+        with mock.patch.object(cm, '_check_certificate_state', side_effect=check_state):
+            ls = cm.cert_ls(filter_by='managed-by=vault')
+
+        assert set(ls.keys()) == {'vault_ssl_cert'}
+
+    @mock.patch('cephadm.cert_mgr.get_certificate_info', return_value={})
+    def test_cert_ls_signed_by_filter_remains_compat_alias(self, _get_cert_info):
+        cm = self._new_cert_mgr_for_filter_tests()
+        self._set_filter_test_certs(cm)
+
+        def check_state(cert_name, target, cert_obj, key_obj=None):
+            return CertInfo(cert_name, target, is_valid=True, managed_by=cert_obj.managed_by)
+
+        with mock.patch.object(cm, '_check_certificate_state', side_effect=check_state):
+            ls = cm.cert_ls(filter_by='signed-by=vault')
+
+        assert set(ls.keys()) == {'vault_ssl_cert'}
+
+    @mock.patch('cephadm.cert_mgr.get_certificate_info', return_value={})
+    def test_cert_ls_explicit_managed_by_overrides_default_cephadm_filter(self, _get_cert_info):
+        cm = self._new_cert_mgr_for_filter_tests()
+        self._set_filter_test_certs(cm)
+
+        def check_state(cert_name, target, cert_obj, key_obj=None):
+            return CertInfo(cert_name, target, is_valid=True, managed_by=cert_obj.managed_by)
+
+        with mock.patch.object(cm, '_check_certificate_state', side_effect=check_state):
+            ls = cm.cert_ls(filter_by='managed-by=cephadm', include_cephadm_signed=False)
+
+        assert set(ls.keys()) == {'cephadm-signed_grafana_cert'}
+
+    @mock.patch('cephadm.cert_mgr.get_certificate_info', return_value={})
+    def test_cert_ls_default_still_shows_only_user_managed_and_root_ca(self, _get_cert_info):
+        cm = self._new_cert_mgr_for_filter_tests()
+        self._set_filter_test_certs(cm)
+
+        def check_state(cert_name, target, cert_obj, key_obj=None):
+            return CertInfo(cert_name, target, is_valid=True, managed_by=cert_obj.managed_by)
+
+        with mock.patch.object(cm, '_check_certificate_state', side_effect=check_state):
+            ls = cm.cert_ls(include_cephadm_signed=False)
+
+        assert set(ls.keys()) == {'rgw_ssl_cert'}
+
     @mock.patch('cephadm.cert_mgr.certificate_days_to_expire')
     def test_check_certificate_state_carries_managed_by(self, cert_days_mock, cephadm_module: CephadmOrchestrator):
         cert_days_mock.return_value = 100

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -1215,6 +1215,93 @@ class TestCertMgr(object):
             renew_mock.assert_called_once()
 
     @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    def test_check_services_certificates_renews_only_cephadm_managed(
+        self, _set_store, cephadm_module: CephadmOrchestrator
+    ):
+        cert_mgr = cephadm_module.cert_mgr
+        cephadm_module.certificate_automated_rotation_enabled = True
+
+        cert_info = CertInfo(
+            'rgw_ssl_cert',
+            'rgw.foo',
+            is_valid=True,
+            is_close_to_expiration=True,
+            days_to_expiration=5,
+            managed_by=TLSObjectManager.CEPHADM,
+        )
+        cert_obj = Cert('cephadm-cert', managed_by=TLSObjectManager.CEPHADM)
+
+        with mock.patch.object(cert_mgr, 'get_problematic_certificates', return_value=[(cert_info, cert_obj)]), \
+             mock.patch.object(cert_mgr, '_renew_self_signed_certificate', return_value=True) as renew_mock, \
+             mock.patch.object(cert_mgr, 'get_associated_service', return_value='rgw.foo'), \
+             mock.patch.object(cert_mgr, '_notify_certificates_health_status') as notify_mock:
+            services_to_reconfig, certs_with_issues = cert_mgr.check_services_certificates(fix_issues=True)
+
+        renew_mock.assert_called_once_with(cert_info, cert_obj)
+        assert services_to_reconfig == ['rgw.foo']
+        assert certs_with_issues == []
+        notify_mock.assert_called_once_with([])
+
+    @pytest.mark.parametrize('managed_by', [
+        TLSObjectManager.USER,
+        TLSObjectManager.VAULT,
+        TLSObjectManager.ACME,
+    ])
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    def test_check_services_certificates_does_not_cephadm_renew_non_cephadm_managed(
+        self, _set_store, cephadm_module: CephadmOrchestrator, managed_by: TLSObjectManager
+    ):
+        cert_mgr = cephadm_module.cert_mgr
+        cephadm_module.certificate_automated_rotation_enabled = True
+
+        cert_info = CertInfo(
+            'rgw_ssl_cert',
+            'rgw.foo',
+            is_valid=True,
+            is_close_to_expiration=True,
+            days_to_expiration=5,
+            managed_by=managed_by,
+        )
+        cert_obj = Cert('external-cert', managed_by=managed_by)
+
+        with mock.patch.object(cert_mgr, 'get_problematic_certificates', return_value=[(cert_info, cert_obj)]), \
+             mock.patch.object(cert_mgr, '_renew_self_signed_certificate') as renew_mock, \
+             mock.patch.object(cert_mgr, '_notify_certificates_health_status') as notify_mock:
+            services_to_reconfig, certs_with_issues = cert_mgr.check_services_certificates(fix_issues=True)
+
+        renew_mock.assert_not_called()
+        assert services_to_reconfig == []
+        assert certs_with_issues == [cert_info]
+        notify_mock.assert_called_once_with([cert_info])
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    def test_check_services_certificates_rotation_disabled_requires_intervention(
+        self, _set_store, cephadm_module: CephadmOrchestrator
+    ):
+        cert_mgr = cephadm_module.cert_mgr
+        cephadm_module.certificate_automated_rotation_enabled = False
+
+        cert_info = CertInfo(
+            'rgw_ssl_cert',
+            'rgw.foo',
+            is_valid=True,
+            is_close_to_expiration=True,
+            days_to_expiration=5,
+            managed_by=TLSObjectManager.CEPHADM,
+        )
+        cert_obj = Cert('cephadm-cert', managed_by=TLSObjectManager.CEPHADM)
+
+        with mock.patch.object(cert_mgr, 'get_problematic_certificates', return_value=[(cert_info, cert_obj)]), \
+             mock.patch.object(cert_mgr, '_renew_self_signed_certificate') as renew_mock, \
+             mock.patch.object(cert_mgr, '_notify_certificates_health_status') as notify_mock:
+            services_to_reconfig, certs_with_issues = cert_mgr.check_services_certificates(fix_issues=True)
+
+        renew_mock.assert_not_called()
+        assert services_to_reconfig == []
+        assert certs_with_issues == [cert_info]
+        notify_mock.assert_called_once_with([cert_info])
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
     def test_health_errors_appending(self, _set_store, cephadm_module: CephadmOrchestrator):
         """
         With split reporting:

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -699,6 +699,30 @@ class TestCertMgr(object):
         _set_store.assert_has_calls(expected_calls)
 
     @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    def test_cert_mgr_save_cert_and_key_accept_managed_by(self, _set_store, cephadm_module: CephadmOrchestrator):
+        cephadm_module.cert_mgr.save_cert(
+            'nfs_ssl_cert',
+            'vault-cert',
+            service_name='nfs.foo',
+            managed_by=TLSObjectManager.VAULT,
+        )
+        cephadm_module.cert_mgr.save_key(
+            'nfs_ssl_key',
+            'vault-key',
+            service_name='nfs.foo',
+            managed_by=TLSObjectManager.VAULT,
+        )
+
+        cert_obj = cephadm_module.cert_mgr.cert_store.get_tlsobject('nfs_ssl_cert', service_name='nfs.foo')
+        key_obj = cephadm_module.cert_mgr.key_store.get_tlsobject('nfs_ssl_key', service_name='nfs.foo')
+        assert cert_obj is not None
+        assert key_obj is not None
+        assert cert_obj.managed_by == TLSObjectManager.VAULT
+        assert key_obj.managed_by == TLSObjectManager.VAULT
+        assert cert_obj.user_made is False
+        assert key_obj.user_made is False
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
     def test_tlsobject_store_key_ls(self, _set_store, cephadm_module: CephadmOrchestrator):
         expected_ls = {
             'nvmeof_ssl_key': {
@@ -1980,21 +2004,40 @@ class TestCertMgr(object):
 class MockTLSObject(TLSObjectProtocol):
     STORAGE_PREFIX = "mocktls"
 
-    def __init__(self, data: str = "", user_made: bool = False, editable: bool = False):
+    def __init__(self, data: str = "", user_made=None, editable: bool = False, managed_by=None):
         self.data = data
-        self.user_made = user_made
+        if managed_by is not None:
+            self.managed_by = TLSObjectManager(managed_by)
+        elif user_made is not None:
+            self.managed_by = managed_by_from_user_made(user_made)
+        else:
+            self.managed_by = TLSObjectManager.CEPHADM
         self.editable = editable
+
+    @property
+    def user_made(self):
+        return user_made_from_managed_by(self.managed_by)
 
     def __bool__(self):
         return bool(self.data)
 
     @staticmethod
     def to_json(obj):
-        return {"data": obj.data, "user_made": obj.user_made, "editable": obj.editable}
+        return {
+            "data": obj.data,
+            "managed_by": obj.managed_by.value,
+            "user_made": obj.user_made,
+            "editable": obj.editable,
+        }
 
     @staticmethod
     def from_json(json_data):
-        return MockTLSObject(json_data["data"], json_data["user_made"], json_data["editable"])
+        return MockTLSObject(
+            json_data["data"],
+            json_data.get("user_made"),
+            json_data.get("editable", False),
+            json_data.get("managed_by"),
+        )
 
 
 class MockCephadmOrchestrator:
@@ -2027,6 +2070,45 @@ class TestTLSObjectStore(unittest.TestCase):
         obj = self.store.get_tlsobject("per_service1", service_name="my_service")
         self.assertIsNotNone(obj)
         self.assertEqual(obj.data, "my_cert_data")
+
+    def test_save_tlsobject_legacy_user_made_true_sets_user_manager(self):
+        self.store.save_tlsobject("per_service1", "my_cert_data", service_name="my_service", user_made=True)
+        obj = self.store.get_tlsobject("per_service1", service_name="my_service")
+        self.assertIsNotNone(obj)
+        self.assertEqual(obj.managed_by, TLSObjectManager.USER)
+        self.assertTrue(obj.user_made)
+
+    def test_save_tlsobject_legacy_user_made_false_sets_cephadm_manager(self):
+        self.store.save_tlsobject("per_service1", "my_cert_data", service_name="my_service", user_made=False)
+        obj = self.store.get_tlsobject("per_service1", service_name="my_service")
+        self.assertIsNotNone(obj)
+        self.assertEqual(obj.managed_by, TLSObjectManager.CEPHADM)
+        self.assertFalse(obj.user_made)
+
+    def test_save_tlsobject_managed_by_vault(self):
+        self.store.save_tlsobject(
+            "per_service1",
+            "my_cert_data",
+            service_name="my_service",
+            managed_by=TLSObjectManager.VAULT,
+        )
+        obj = self.store.get_tlsobject("per_service1", service_name="my_service")
+        self.assertIsNotNone(obj)
+        self.assertEqual(obj.managed_by, TLSObjectManager.VAULT)
+        self.assertFalse(obj.user_made)
+
+    def test_save_tlsobject_managed_by_takes_precedence_over_user_made(self):
+        self.store.save_tlsobject(
+            "per_service1",
+            "my_cert_data",
+            service_name="my_service",
+            user_made=True,
+            managed_by=TLSObjectManager.VAULT,
+        )
+        obj = self.store.get_tlsobject("per_service1", service_name="my_service")
+        self.assertIsNotNone(obj)
+        self.assertEqual(obj.managed_by, TLSObjectManager.VAULT)
+        self.assertFalse(obj.user_made)
 
     def test_remove_tlsobject(self):
         self.store.save_tlsobject("per_host1", "cert_data", host="my_host")

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -18,7 +18,7 @@ from cephadm.tlsobject_types import (
 from cephadm.tlsobject_store import TLSOBJECT_STORE_PREFIX, TLSObjectStore, TLSObjectScope
 from cephadm.module import CephadmOrchestrator
 from cephadm.cert_mgr import CertInfo, CertMgr
-from cephadm.vault import VaultIssuerConfig
+from cephadm.vault import VaultClientError, VaultIssuerConfig, VaultPKIClient
 
 EXPIRED_CERT = """
 -----BEGIN CERTIFICATE-----
@@ -2343,6 +2343,157 @@ class TestVaultIssuerConfig(unittest.TestCase):
         cm.rm_vault_token()
         assert mgr.store[CertMgr.VAULT_TOKEN_STORE_KEY] is None
         assert cm.get_vault_token() is None
+
+
+class TestVaultPKIClient(unittest.TestCase):
+
+    class FakeResponse:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps(self.payload).encode('utf-8')
+
+    def _config(self, **kwargs):
+        values = {
+            'addr': 'https://vault.example.com:8200/',
+            'pki_mount': 'pki',
+            'role': 'ceph-rgw',
+            'ttl': '720h',
+            'ca_cert': None,
+            'verify_tls': True,
+        }
+        values.update(kwargs)
+        return VaultIssuerConfig(**values)
+
+    @mock.patch('cephadm.vault.urlopen')
+    def test_issue_certificate_posts_to_vault_and_parses_response(self, m_urlopen):
+        m_urlopen.return_value = self.FakeResponse({
+            'data': {
+                'certificate': '---CERT---',
+                'private_key': '---KEY---',
+                'ca_chain': ['---CA1---', '---CA2---'],
+            }
+        })
+        client = VaultPKIClient(self._config(), 's.vault-token')
+
+        creds = client.issue_certificate(
+            common_name='rgw.example.com',
+            alt_names=['rgw.example.com', 'rgw.internal'],
+            ip_sans=['10.0.0.10'],
+        )
+
+        assert creds.cert == '---CERT---'
+        assert creds.key == '---KEY---'
+        assert creds.ca_cert == '---CA1---\n---CA2---'
+        request = m_urlopen.call_args[0][0]
+        assert request.full_url == 'https://vault.example.com:8200/v1/pki/issue/ceph-rgw'
+        assert request.get_method() == 'POST'
+        assert request.get_header('X-vault-token') == 's.vault-token'
+        payload = json.loads(request.data.decode('utf-8'))
+        assert payload == {
+            'common_name': 'rgw.example.com',
+            'ttl': '720h',
+            'alt_names': 'rgw.example.com,rgw.internal',
+            'ip_sans': '10.0.0.10',
+        }
+
+    @mock.patch('cephadm.vault.urlopen')
+    def test_issue_certificate_allows_mount_role_and_ttl_overrides(self, m_urlopen):
+        m_urlopen.return_value = self.FakeResponse({
+            'data': {
+                'certificate': '---CERT---',
+                'private_key': '---KEY---',
+                'issuing_ca': '---CA---',
+            }
+        })
+        client = VaultPKIClient(self._config(), 's.vault-token')
+
+        creds = client.issue_certificate(
+            common_name='dashboard.example.com',
+            ttl='24h',
+            mount='pki-int',
+            role='ceph-dashboard',
+        )
+
+        assert creds.ca_cert == '---CA---'
+        request = m_urlopen.call_args[0][0]
+        assert request.full_url == 'https://vault.example.com:8200/v1/pki-int/issue/ceph-dashboard'
+        payload = json.loads(request.data.decode('utf-8'))
+        assert payload == {
+            'common_name': 'dashboard.example.com',
+            'ttl': '24h',
+        }
+
+    def test_issue_certificate_requires_config_and_token(self):
+        client = VaultPKIClient(self._config(addr=None), 's.vault-token')
+        with pytest.raises(VaultClientError, match='addr'):
+            client.issue_certificate(common_name='rgw.example.com')
+
+        client = VaultPKIClient(self._config(), None)
+        with pytest.raises(VaultClientError, match='token'):
+            client.issue_certificate(common_name='rgw.example.com')
+
+        client = VaultPKIClient(self._config(), 's.vault-token')
+        with pytest.raises(VaultClientError, match='common_name'):
+            client.issue_certificate(common_name='  ')
+
+    @mock.patch('cephadm.vault.urlopen')
+    def test_issue_certificate_rejects_missing_response_fields(self, m_urlopen):
+        client = VaultPKIClient(self._config(), 's.vault-token')
+
+        m_urlopen.return_value = self.FakeResponse({'data': {'private_key': '---KEY---'}})
+        with pytest.raises(VaultClientError, match='certificate'):
+            client.issue_certificate(common_name='rgw.example.com')
+
+        m_urlopen.return_value = self.FakeResponse({'data': {'certificate': '---CERT---'}})
+        with pytest.raises(VaultClientError, match='private_key'):
+            client.issue_certificate(common_name='rgw.example.com')
+
+        m_urlopen.return_value = self.FakeResponse({'no_data': {}})
+        with pytest.raises(VaultClientError, match='data'):
+            client.issue_certificate(common_name='rgw.example.com')
+
+    @mock.patch('cephadm.vault.urlopen')
+    def test_issue_certificate_reports_vault_http_errors(self, m_urlopen):
+        from io import BytesIO
+        from urllib.error import HTTPError
+
+        m_urlopen.side_effect = HTTPError(
+            'https://vault.example.com:8200/v1/pki/issue/ceph-rgw',
+            400,
+            'Bad Request',
+            {},
+            BytesIO(json.dumps({'errors': ['role not allowed']}).encode('utf-8')),
+        )
+        client = VaultPKIClient(self._config(), 's.vault-token')
+
+        with pytest.raises(VaultClientError, match='HTTP 400: role not allowed'):
+            client.issue_certificate(common_name='rgw.example.com')
+
+    @mock.patch('cephadm.vault.urlopen')
+    def test_issue_certificate_reports_invalid_json(self, m_urlopen):
+        class InvalidJsonResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b'not-json'
+
+        m_urlopen.return_value = InvalidJsonResponse()
+        client = VaultPKIClient(self._config(), 's.vault-token')
+
+        with pytest.raises(VaultClientError, match='invalid JSON'):
+            client.issue_certificate(common_name='rgw.example.com')
 
 
 class TestTLSObjectStore(unittest.TestCase):

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -1289,6 +1289,59 @@ class TestCertMgr(object):
             renew_mock.assert_called_once()
 
     @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    def test_certificate_issuer_registry_marks_only_cephadm_auto_fixable(
+        self, _set_store, cephadm_module: CephadmOrchestrator
+    ):
+        cert_mgr = cephadm_module.cert_mgr
+
+        assert cert_mgr._supports_auto_fix(Cert('cephadm-cert', managed_by=TLSObjectManager.CEPHADM))
+        assert not cert_mgr._supports_auto_fix(Cert('user-cert', managed_by=TLSObjectManager.USER))
+        assert not cert_mgr._supports_auto_fix(Cert('vault-cert', managed_by=TLSObjectManager.VAULT))
+        assert not cert_mgr._supports_auto_fix(Cert('acme-cert', managed_by=TLSObjectManager.ACME))
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    def test_renew_certificate_dispatches_to_registered_cephadm_issuer(
+        self, _set_store, cephadm_module: CephadmOrchestrator
+    ):
+        cert_mgr = cephadm_module.cert_mgr
+        cert_info = CertInfo(
+            'rgw_ssl_cert',
+            'rgw.foo',
+            is_valid=True,
+            is_close_to_expiration=True,
+            days_to_expiration=5,
+            managed_by=TLSObjectManager.CEPHADM,
+        )
+        cert_obj = Cert('cephadm-cert', managed_by=TLSObjectManager.CEPHADM)
+        issuer = cert_mgr.certificate_issuers[TLSObjectManager.CEPHADM]
+
+        with mock.patch.object(issuer, 'renew', return_value=True) as renew_mock:
+            assert cert_mgr._renew_certificate(cert_info, cert_obj)
+
+        renew_mock.assert_called_once_with(cert_mgr, cert_info, cert_obj)
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    def test_renew_certificate_returns_false_for_unsupported_issuer(
+        self, _set_store, cephadm_module: CephadmOrchestrator
+    ):
+        cert_mgr = cephadm_module.cert_mgr
+        cert_info = CertInfo(
+            'rgw_ssl_cert',
+            'rgw.foo',
+            is_valid=True,
+            is_close_to_expiration=True,
+            days_to_expiration=5,
+            managed_by=TLSObjectManager.VAULT,
+        )
+        cert_obj = Cert('vault-cert', managed_by=TLSObjectManager.VAULT)
+        issuer = cert_mgr.certificate_issuers[TLSObjectManager.VAULT]
+
+        with mock.patch.object(issuer, 'renew', wraps=issuer.renew) as renew_mock:
+            assert not cert_mgr._renew_certificate(cert_info, cert_obj)
+
+        renew_mock.assert_not_called()
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
     def test_check_services_certificates_renews_only_cephadm_managed(
         self, _set_store, cephadm_module: CephadmOrchestrator
     ):
@@ -1306,7 +1359,7 @@ class TestCertMgr(object):
         cert_obj = Cert('cephadm-cert', managed_by=TLSObjectManager.CEPHADM)
 
         with mock.patch.object(cert_mgr, 'get_problematic_certificates', return_value=[(cert_info, cert_obj)]), \
-             mock.patch.object(cert_mgr, '_renew_self_signed_certificate', return_value=True) as renew_mock, \
+             mock.patch.object(cert_mgr, '_renew_certificate', return_value=True) as renew_mock, \
              mock.patch.object(cert_mgr, 'get_associated_service', return_value='rgw.foo'), \
              mock.patch.object(cert_mgr, '_notify_certificates_health_status') as notify_mock:
             services_to_reconfig, certs_with_issues = cert_mgr.check_services_certificates(fix_issues=True)
@@ -1339,7 +1392,7 @@ class TestCertMgr(object):
         cert_obj = Cert('external-cert', managed_by=managed_by)
 
         with mock.patch.object(cert_mgr, 'get_problematic_certificates', return_value=[(cert_info, cert_obj)]), \
-             mock.patch.object(cert_mgr, '_renew_self_signed_certificate') as renew_mock, \
+             mock.patch.object(cert_mgr, '_renew_certificate') as renew_mock, \
              mock.patch.object(cert_mgr, '_notify_certificates_health_status') as notify_mock:
             services_to_reconfig, certs_with_issues = cert_mgr.check_services_certificates(fix_issues=True)
 
@@ -1366,7 +1419,7 @@ class TestCertMgr(object):
         cert_obj = Cert('cephadm-cert', managed_by=TLSObjectManager.CEPHADM)
 
         with mock.patch.object(cert_mgr, 'get_problematic_certificates', return_value=[(cert_info, cert_obj)]), \
-             mock.patch.object(cert_mgr, '_renew_self_signed_certificate') as renew_mock, \
+             mock.patch.object(cert_mgr, '_renew_certificate') as renew_mock, \
              mock.patch.object(cert_mgr, '_notify_certificates_health_status') as notify_mock:
             services_to_reconfig, certs_with_issues = cert_mgr.check_services_certificates(fix_issues=True)
 

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -18,8 +18,10 @@ from cephadm.tlsobject_types import (
 from cephadm.tlsobject_store import TLSOBJECT_STORE_PREFIX, TLSObjectStore, TLSObjectScope
 from cephadm.module import CephadmOrchestrator
 from cephadm.cert_mgr import CertInfo, CertMgr
-from cephadm.vault import VaultClientError, VaultIssuerConfig, VaultPKIClient
-from cephadm.services.cephadmservice import CephadmService, CERTIFICATE_SOURCE_VAULT
+from cephadm.vault import VaultAuthError, VaultClientError, VaultIssuerConfig, VaultPKIClient
+from ceph.deployment.service_spec import CertificateSource
+from cephadm.services.cephadmservice import CephadmService
+from orchestrator import OrchestratorError
 from cephadm.cert_metadata import (
     VAULT_CERT_METADATA_STORE_PREFIX,
     VaultCertificateMetadata,
@@ -324,7 +326,7 @@ class TestCertificateSourceVaultServiceSupport:
     def _spec(self):
         spec = mock.MagicMock()
         spec.service_name.return_value = 'rgw.foo'
-        spec.certificate_source = CERTIFICATE_SOURCE_VAULT
+        spec.certificate_source = CertificateSource.VAULT.value
         spec.custom_sans = ['rgw.alt.example.com']
         return spec
 
@@ -2633,6 +2635,11 @@ class TestVaultCertificateMetadata(unittest.TestCase):
         assert cm.rm_cert('rgw_ssl_cert', service_name='rgw.foo')
         assert cm.get_vault_certificate_metadata('rgw_ssl_cert', service_name='rgw.foo') is None
 
+        cm.save_vault_certificate_metadata(metadata)
+        cm.key_store = mock.Mock()
+        cm.key_store.rm_tlsobject.return_value = True
+        assert cm.rm_key('rgw_ssl_key', service_name='rgw.foo')
+        assert cm.get_vault_certificate_metadata('rgw_ssl_cert', service_name='rgw.foo') is None
 
 
 class TestVaultManualIssue(unittest.TestCase):
@@ -3124,6 +3131,23 @@ class TestVaultPKIClient(unittest.TestCase):
             client.issue_certificate(common_name='rgw.example.com')
 
     @mock.patch('cephadm.vault.urlopen')
+    def test_issue_certificate_reports_vault_auth_errors(self, m_urlopen):
+        from io import BytesIO
+        from urllib.error import HTTPError
+
+        m_urlopen.side_effect = HTTPError(
+            'https://vault.example.com:8200/v1/pki/issue/ceph-rgw',
+            403,
+            'Forbidden',
+            {},
+            BytesIO(json.dumps({'errors': ['permission denied']}).encode('utf-8')),
+        )
+        client = VaultPKIClient(self._config(), 's.expired-token')
+
+        with pytest.raises(VaultAuthError, match='token may be invalid or expired'):
+            client.issue_certificate(common_name='rgw.example.com')
+
+    @mock.patch('cephadm.vault.urlopen')
     def test_issue_certificate_reports_invalid_json(self, m_urlopen):
         class InvalidJsonResponse:
             def __enter__(self):
@@ -3140,6 +3164,32 @@ class TestVaultPKIClient(unittest.TestCase):
 
         with pytest.raises(VaultClientError, match='invalid JSON'):
             client.issue_certificate(common_name='rgw.example.com')
+
+
+class TestVaultCertSourceValidation:
+
+    def _vault_spec(self):
+        spec = mock.MagicMock()
+        spec.service_name.return_value = 'rgw.foo'
+        spec.service_type = 'rgw'
+        spec.certificate_source = CertificateSource.VAULT.value
+        spec.is_using_certificates_source.return_value = False
+        return spec
+
+    def test_check_cert_source_rejects_vault_when_config_incomplete(self, cephadm_module):
+        spec = self._vault_spec()
+
+        with pytest.raises(OrchestratorError, match='Vault issuer config is incomplete'):
+            cephadm_module._check_cert_source(spec)
+
+    def test_check_cert_source_rejects_vault_when_token_missing(self, cephadm_module):
+        spec = self._vault_spec()
+        cephadm_module.certmgr_vault_addr = 'https://vault.example.com:8200'
+        cephadm_module.certmgr_vault_pki_mount = 'pki'
+        cephadm_module.certmgr_vault_role = 'ceph-rgw'
+
+        with pytest.raises(OrchestratorError, match='no Vault token is configured'):
+            cephadm_module._check_cert_source(spec)
 
 
 class TestTLSObjectStore(unittest.TestCase):

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -5,7 +5,16 @@ import json
 from tests import mock
 import logging
 
-from cephadm.tlsobject_types import Cert, PrivKey, TLSObjectException, TLSObjectProtocol, TLSCredentials
+from cephadm.tlsobject_types import (
+    Cert,
+    PrivKey,
+    TLSObjectException,
+    TLSObjectManager,
+    TLSObjectProtocol,
+    TLSCredentials,
+    managed_by_from_user_made,
+    user_made_from_managed_by,
+)
 from cephadm.tlsobject_store import TLSOBJECT_STORE_PREFIX, TLSObjectStore, TLSObjectScope
 from cephadm.module import CephadmOrchestrator
 from cephadm.cert_mgr import CertInfo, CertMgr
@@ -293,6 +302,22 @@ TLSOBJECT_STORE_KEY_PREFIX = f'{TLSOBJECT_STORE_PREFIX}key.'
 
 
 class TestCertMgr(object):
+
+    @pytest.mark.parametrize('user_made, managed_by', [
+        (True, TLSObjectManager.USER),
+        (False, TLSObjectManager.CEPHADM),
+    ])
+    def test_managed_by_from_user_made(self, user_made, managed_by):
+        assert managed_by_from_user_made(user_made) == managed_by
+
+    @pytest.mark.parametrize('managed_by, user_made', [
+        (TLSObjectManager.USER, True),
+        (TLSObjectManager.CEPHADM, False),
+        (TLSObjectManager.VAULT, False),
+        (TLSObjectManager.ACME, False),
+    ])
+    def test_user_made_from_managed_by(self, managed_by, user_made):
+        assert user_made_from_managed_by(managed_by) == user_made
 
     @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
     def test_tlsobject_store_save_cert(self, _set_store, cephadm_module: CephadmOrchestrator):

--- a/src/pybind/mgr/cephadm/tlsobject_store.py
+++ b/src/pybind/mgr/cephadm/tlsobject_store.py
@@ -5,11 +5,16 @@ from typing import (Any,
                     Optional,
                     TYPE_CHECKING,
                     Type,
-                    Callable)
+                    Callable,
+                    Union)
 import json
 import logging
 
-from cephadm.tlsobject_types import TLSObjectProtocol, TLSObjectException, TLSObjectScope, TLSObjectTarget
+from cephadm.tlsobject_types import (TLSObjectProtocol,
+                                     TLSObjectException,
+                                     TLSObjectScope,
+                                     TLSObjectTarget,
+                                     TLSObjectManager)
 
 
 if TYPE_CHECKING:
@@ -143,11 +148,17 @@ class TLSObjectStore():
                        tlsobject: str,
                        service_name: Optional[str] = None,
                        host: Optional[str] = None,
-                       user_made: bool = False,
-                       editable: bool = False) -> None:
+                       user_made: Optional[bool] = None,
+                       editable: bool = False,
+                       managed_by: Optional[Union[TLSObjectManager, str]] = None) -> None:
 
         self._validate_tlsobject_name(obj_name, service_name, host)
-        tlsobject = self.tlsobject_class(tlsobject, user_made, editable)
+        tlsobject = self.tlsobject_class(
+            tlsobject,
+            user_made=user_made,
+            editable=editable,
+            managed_by=managed_by,
+        )
         scope, target = self.get_tlsobject_scope_and_target(obj_name, service_name, host)
         if scope in (TLSObjectScope.SERVICE, TLSObjectScope.HOST):
             self.objects_by_name[obj_name][target] = tlsobject

--- a/src/pybind/mgr/cephadm/tlsobject_types.py
+++ b/src/pybind/mgr/cephadm/tlsobject_types.py
@@ -51,6 +51,24 @@ def user_made_from_managed_by(managed_by: TLSObjectManager) -> bool:
     return managed_by == TLSObjectManager.USER
 
 
+def _normalize_managed_by(managed_by: Union[TLSObjectManager, str]) -> TLSObjectManager:
+    if isinstance(managed_by, TLSObjectManager):
+        return managed_by
+    try:
+        return TLSObjectManager(managed_by)
+    except ValueError:
+        raise TLSObjectException(f'Got invalid managed_by value for TLS object: {managed_by}')
+
+
+def _resolve_managed_by(user_made: Optional[bool],
+                        managed_by: Optional[Union[TLSObjectManager, str]]) -> TLSObjectManager:
+    if managed_by is not None:
+        return _normalize_managed_by(managed_by)
+    if user_made is not None:
+        return managed_by_from_user_made(user_made)
+    return TLSObjectManager.CEPHADM
+
+
 class TLSCredentials(NamedTuple):
     cert: str
     key: str
@@ -72,13 +90,21 @@ EMPTY_TLS_CREDENTIALS = TLSCredentials('', '', '')
 class TLSObjectProtocol(Protocol):
     STORAGE_PREFIX: str
 
-    def __init__(self, cert: str = '', user_made: bool = False, editable: bool = False) -> None:
+    def __init__(self,
+                 cert: str = '',
+                 user_made: Optional[bool] = None,
+                 editable: bool = False,
+                 managed_by: Optional[Union[TLSObjectManager, str]] = None) -> None:
         ...
 
     def __bool__(self) -> bool:
         ...
 
     def __eq__(self, other: Any) -> bool:
+        ...
+
+    @property
+    def user_made(self) -> bool:
         ...
 
     def to_json(self) -> Dict[str, Union[str, bool]]:
@@ -92,23 +118,32 @@ class TLSObjectProtocol(Protocol):
 class Cert(TLSObjectProtocol):
     STORAGE_PREFIX = 'cert'
 
-    def __init__(self, cert: str = '', user_made: bool = False, editable: bool = False) -> None:
+    def __init__(self,
+                 cert: str = '',
+                 user_made: Optional[bool] = None,
+                 editable: bool = False,
+                 managed_by: Optional[Union[TLSObjectManager, str]] = None) -> None:
         self.cert = cert
-        self.user_made = user_made
+        self.managed_by = _resolve_managed_by(user_made, managed_by)
         self.editable = editable
+
+    @property
+    def user_made(self) -> bool:
+        return user_made_from_managed_by(self.managed_by)
 
     def __bool__(self) -> bool:
         return bool(self.cert)
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Cert):
-            return self.cert == other.cert and self.user_made == other.user_made
+            return self.cert == other.cert and self.managed_by == other.managed_by
         return NotImplemented
 
     def to_json(self) -> Dict[str, Union[str, bool]]:
         if (self):
             return {
                 'cert': self.cert,
+                'managed_by': self.managed_by.value,
                 'user_made': self.user_made,
                 'editable': self.editable
             }
@@ -116,44 +151,54 @@ class Cert(TLSObjectProtocol):
             return {}
 
     @classmethod
-    def from_json(cls, data: Dict[str, Union[str, bool]]) -> 'Cert':
+    def from_json(cls, data: Dict[str, Any]) -> 'Cert':
         if 'cert' not in data:
             return cls()
         cert = data['cert']
         if not isinstance(cert, str):
             raise TLSObjectException('Tried to make Cert object with non-string cert')
-        if any(k not in ['cert', 'user_made', 'editable'] for k in data.keys()):
+        if any(k not in ['cert', 'managed_by', 'user_made', 'editable'] for k in data.keys()):
             raise TLSObjectException(f'Got unknown field for Cert object. Fields: {data.keys()}')
 
         try:
-            user_made = parse_bool(data.get('user_made', False))
+            user_made = parse_bool(data['user_made']) if 'user_made' in data else None
             editable = parse_bool(data.get('editable', False))
         except ValueError as e:
             raise TLSObjectException(f'Expected field in Cert object to be bool but got another type: {e}')
 
-        return cls(cert=cert, user_made=user_made, editable=editable)
+        managed_by = data.get('managed_by')
+        return cls(cert=cert, user_made=user_made, editable=editable, managed_by=managed_by)
 
 
 class PrivKey(TLSObjectProtocol):
     STORAGE_PREFIX = 'key'
 
-    def __init__(self, key: str = '', user_made: bool = False, editable: bool = False) -> None:
+    def __init__(self,
+                 key: str = '',
+                 user_made: Optional[bool] = None,
+                 editable: bool = False,
+                 managed_by: Optional[Union[TLSObjectManager, str]] = None) -> None:
         self.key = key
-        self.user_made = user_made
+        self.managed_by = _resolve_managed_by(user_made, managed_by)
         self.editable = editable
+
+    @property
+    def user_made(self) -> bool:
+        return user_made_from_managed_by(self.managed_by)
 
     def __bool__(self) -> bool:
         return bool(self.key)
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, PrivKey):
-            return self.key == other.key and self.user_made == other.user_made
+            return self.key == other.key and self.managed_by == other.managed_by
         return NotImplemented
 
     def to_json(self) -> Dict[str, Union[str, bool]]:
         if bool(self):
             return {
                 'key': self.key,
+                'managed_by': self.managed_by.value,
                 'user_made': self.user_made,
                 'editable': self.editable
             }
@@ -161,19 +206,20 @@ class PrivKey(TLSObjectProtocol):
             return {}
 
     @classmethod
-    def from_json(cls, data: Dict[str, str]) -> 'PrivKey':
+    def from_json(cls, data: Dict[str, Any]) -> 'PrivKey':
         if 'key' not in data:
             return cls()
         key = data['key']
         if not isinstance(key, str):
             raise TLSObjectException('Tried to make PrivKey object with non-string key')
-        if any(k not in ['key', 'user_made', 'editable'] for k in data.keys()):
+        if any(k not in ['key', 'managed_by', 'user_made', 'editable'] for k in data.keys()):
             raise TLSObjectException(f'Got unknown field for PrivKey object. Fields: {data.keys()}')
 
         try:
-            user_made = parse_bool(data.get('user_made', False))
+            user_made = parse_bool(data['user_made']) if 'user_made' in data else None
             editable = parse_bool(data.get('editable', False))
         except ValueError as e:
             raise TLSObjectException(f'Expected field in PrivKey object to be bool but got another type: {e}')
 
-        return cls(key=key, user_made=user_made, editable=editable)
+        managed_by = data.get('managed_by')
+        return cls(key=key, user_made=user_made, editable=editable, managed_by=managed_by)

--- a/src/pybind/mgr/cephadm/tlsobject_types.py
+++ b/src/pybind/mgr/cephadm/tlsobject_types.py
@@ -33,6 +33,24 @@ class TLSObjectScope(str, Enum):
         return self.value
 
 
+class TLSObjectManager(str, Enum):
+    USER = 'user'
+    CEPHADM = 'cephadm'
+    VAULT = 'vault'
+    ACME = 'acme'
+
+    def __str__(self) -> str:
+        return self.value
+
+
+def managed_by_from_user_made(user_made: bool) -> TLSObjectManager:
+    return TLSObjectManager.USER if user_made else TLSObjectManager.CEPHADM
+
+
+def user_made_from_managed_by(managed_by: TLSObjectManager) -> bool:
+    return managed_by == TLSObjectManager.USER
+
+
 class TLSCredentials(NamedTuple):
     cert: str
     key: str

--- a/src/pybind/mgr/cephadm/vault.py
+++ b/src/pybind/mgr/cephadm/vault.py
@@ -1,5 +1,12 @@
 from dataclasses import dataclass
+import json
+import ssl
 from typing import Any, Dict, List, Optional
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+from cephadm.tlsobject_types import TLSCredentials
 
 
 def _optional_str(value: Any) -> Optional[str]:
@@ -53,3 +60,170 @@ class VaultIssuerConfig:
             'ca_cert': self.ca_cert,
             'verify_tls': self.verify_tls,
         }
+
+
+class VaultClientError(Exception):
+    pass
+
+
+class VaultAuthError(VaultClientError):
+    pass
+
+
+class VaultPKIClient:
+    """Small dependency-free client for Vault's PKI issue endpoint.
+
+    The client is intentionally limited to the API primitive certmgr needs for
+    certificate issuance. It is not wired into certmgr renewal in this commit.
+    """
+
+    def __init__(self,
+                 config: VaultIssuerConfig,
+                 token: Optional[str],
+                 timeout: int = 30) -> None:
+        self.config = config
+        self.token = _optional_str(token)
+        self.timeout = timeout
+
+    def issue_certificate(self,
+                          common_name: str,
+                          alt_names: Optional[List[str]] = None,
+                          ip_sans: Optional[List[str]] = None,
+                          ttl: Optional[str] = None,
+                          mount: Optional[str] = None,
+                          role: Optional[str] = None) -> TLSCredentials:
+        """Issue a certificate from Vault PKI and return the PEM credentials."""
+        self._validate_common_config()
+        common_name = _optional_str(common_name) or ''
+        if not common_name:
+            raise VaultClientError('Vault certificate common_name is required')
+
+        resolved_mount = _optional_str(mount) or self.config.pki_mount
+        resolved_role = _optional_str(role) or self.config.role
+        if not resolved_mount:
+            raise VaultClientError('Vault PKI mount is required')
+        if not resolved_role:
+            raise VaultClientError('Vault PKI role is required')
+
+        payload: Dict[str, str] = {'common_name': common_name}
+        resolved_ttl = _optional_str(ttl) or self.config.ttl
+        if resolved_ttl:
+            payload['ttl'] = resolved_ttl
+        if alt_names:
+            payload['alt_names'] = ','.join(alt_names)
+        if ip_sans:
+            payload['ip_sans'] = ','.join(ip_sans)
+
+        response = self._post_json(
+            self._issue_url(resolved_mount, resolved_role),
+            payload,
+        )
+        return self._parse_issue_response(response)
+
+    def _validate_common_config(self) -> None:
+        missing = self.config.missing_required_fields()
+        if missing:
+            raise VaultClientError(
+                f'Missing required Vault issuer config fields: {", ".join(missing)}'
+            )
+        if not self.token:
+            raise VaultClientError('Vault token is required')
+
+    def _issue_url(self, mount: str, role: str) -> str:
+        assert self.config.addr is not None
+        base = self.config.addr.rstrip('/')
+        quoted_mount = quote(mount.strip('/'), safe='/')
+        quoted_role = quote(role.strip('/'), safe='')
+        return f'{base}/v1/{quoted_mount}/issue/{quoted_role}'
+
+    def _ssl_context(self) -> Optional[ssl.SSLContext]:
+        if not self.config.verify_tls:
+            return ssl._create_unverified_context()
+        context = ssl.create_default_context()
+        if self.config.ca_cert:
+            if 'BEGIN CERTIFICATE' in self.config.ca_cert:
+                context.load_verify_locations(cadata=self.config.ca_cert)
+            else:
+                context.load_verify_locations(cafile=self.config.ca_cert)
+        return context
+
+    def _post_json(self, url: str, payload: Dict[str, str]) -> Dict[str, Any]:
+        assert self.token is not None
+        data = json.dumps(payload).encode('utf-8')
+        request = Request(
+            url,
+            data=data,
+            headers={
+                'Content-Type': 'application/json',
+                'X-Vault-Token': self.token,
+            },
+            method='POST',
+        )
+        try:
+            with urlopen(request, timeout=self.timeout, context=self._ssl_context()) as response:  # nosec
+                raw_body = response.read()
+        except HTTPError as e:
+            message = self._format_http_error(e)
+            if e.code in (401, 403):
+                raise VaultAuthError(message) from e
+            raise VaultClientError(message) from e
+        except URLError as e:
+            raise VaultClientError(f'Vault request failed: {e.reason}') from e
+        except OSError as e:
+            raise VaultClientError(f'Vault request failed: {e}') from e
+
+        try:
+            decoded = raw_body.decode('utf-8')
+            loaded = json.loads(decoded)
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            raise VaultClientError(f'Vault returned invalid JSON: {e}') from e
+        if not isinstance(loaded, dict):
+            raise VaultClientError('Vault returned an unexpected non-object JSON response')
+        return loaded
+
+    def _format_http_error(self, error: HTTPError) -> str:
+        details = ''
+        try:
+            raw_body = error.read()
+            if raw_body:
+                loaded = json.loads(raw_body.decode('utf-8'))
+                if isinstance(loaded, dict) and loaded.get('errors'):
+                    errors = loaded['errors']
+                    if isinstance(errors, list):
+                        details = ': ' + '; '.join(str(e) for e in errors)
+                    else:
+                        details = f': {errors}'
+                else:
+                    details = f': {loaded}'
+        except Exception:
+            details = ''
+        if error.code in (401, 403):
+            return (
+                f'Vault authentication failed with HTTP {error.code}{details}. '
+                'The Vault token may be invalid or expired; set a valid certmgr Vault token.'
+            )
+        return f'Vault request failed with HTTP {error.code}{details}'
+
+    def _parse_issue_response(self, response: Dict[str, Any]) -> TLSCredentials:
+        data = response.get('data')
+        if not isinstance(data, dict):
+            raise VaultClientError('Vault issue response is missing data object')
+
+        cert = _optional_str(data.get('certificate'))
+        key = _optional_str(data.get('private_key'))
+        if not cert:
+            raise VaultClientError('Vault issue response is missing certificate')
+        if not key:
+            raise VaultClientError('Vault issue response is missing private_key')
+
+        ca_cert = self._extract_ca_cert(data)
+        return TLSCredentials(cert=cert, key=key, ca_cert=ca_cert)
+
+    def _extract_ca_cert(self, data: Dict[str, Any]) -> Optional[str]:
+        ca_chain = data.get('ca_chain')
+        if isinstance(ca_chain, list):
+            chain = [_optional_str(ca) for ca in ca_chain]
+            chain = [ca for ca in chain if ca]
+            if chain:
+                return '\n'.join(chain)
+        return _optional_str(data.get('issuing_ca'))

--- a/src/pybind/mgr/cephadm/vault.py
+++ b/src/pybind/mgr/cephadm/vault.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    value = str(value).strip()
+    return value or None
+
+
+@dataclass(frozen=True)
+class VaultIssuerConfig:
+    """Configuration used by certmgr to talk to a Vault PKI issuer.
+
+    This object only models the resolved global Vault configuration. It does not
+    perform any Vault API calls. Per-service overrides and issuance metadata will
+    be layered on top in later commits.
+    """
+
+    addr: Optional[str] = None
+    pki_mount: Optional[str] = None
+    role: Optional[str] = None
+    ttl: Optional[str] = None
+    ca_cert: Optional[str] = None
+    verify_tls: bool = True
+
+    REQUIRED_FIELDS = ('addr', 'pki_mount', 'role')
+
+    @classmethod
+    def from_mgr(cls, mgr: Any) -> 'VaultIssuerConfig':
+        return cls(
+            addr=_optional_str(getattr(mgr, 'certmgr_vault_addr', None)),
+            pki_mount=_optional_str(getattr(mgr, 'certmgr_vault_pki_mount', None)),
+            role=_optional_str(getattr(mgr, 'certmgr_vault_role', None)),
+            ttl=_optional_str(getattr(mgr, 'certmgr_vault_ttl', None)),
+            ca_cert=_optional_str(getattr(mgr, 'certmgr_vault_cacert', None)),
+            verify_tls=bool(getattr(mgr, 'certmgr_vault_verify_tls', True)),
+        )
+
+    def missing_required_fields(self) -> List[str]:
+        return [field for field in self.REQUIRED_FIELDS if not getattr(self, field)]
+
+    def is_configured(self) -> bool:
+        return not self.missing_required_fields()
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            'addr': self.addr,
+            'pki_mount': self.pki_mount,
+            'role': self.role,
+            'ttl': self.ttl,
+            'ca_cert': self.ca_cert,
+            'verify_tls': self.verify_tls,
+        }

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -599,6 +599,28 @@ class Orchestrator(object):
     ) -> OrchResult[str]:
         raise NotImplementedError()
 
+    def cert_store_vault_token_set(self, token: str) -> OrchResult[str]:
+        raise NotImplementedError()
+
+    def cert_store_vault_token_rm(self) -> OrchResult[str]:
+        raise NotImplementedError()
+
+    def cert_store_vault_issue(
+        self,
+        consumer: str,
+        common_name: str,
+        cert_name: str = '',
+        service_name: str = '',
+        hostname: str = '',
+        ca_cert_name: str = '',
+        alt_names: Optional[List[str]] = None,
+        ip_sans: Optional[List[str]] = None,
+        pki_mount: Optional[str] = None,
+        role: Optional[str] = None,
+        ttl: Optional[str] = None,
+    ) -> OrchResult[str]:
+        raise NotImplementedError()
+
     def cert_store_rm_cert(
         self,
         cert_name: str,

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1359,6 +1359,68 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
         output = raise_if_exception(completion)
         return HandleCommandResult(stdout=output)
 
+    @staticmethod
+    def _split_certmgr_csv_values(values: Optional[List[str]]) -> Optional[List[str]]:
+        if values is None:
+            return None
+        result = []
+        for value in values:
+            result.extend(v.strip() for v in value.split(',') if v.strip())
+        return result
+
+    @OrchestratorCLICommand.Write('orch certmgr vault token set')
+    def _cert_store_vault_token_set(
+        self,
+        _end_positional_: int = 0,
+        token: Optional[str] = None,
+        inbuf: Optional[str] = None,
+    ) -> HandleCommandResult:
+        token_content = token or inbuf
+        if not token_content:
+            raise OrchestratorError('This command requires passing a Vault token using --token or "-i <token-file>"')
+
+        completion = self.cert_store_vault_token_set(token_content)
+        output = raise_if_exception(completion)
+        return HandleCommandResult(stdout=output)
+
+    @OrchestratorCLICommand.Write('orch certmgr vault token rm')
+    def _cert_store_vault_token_rm(self) -> HandleCommandResult:
+        completion = self.cert_store_vault_token_rm()
+        output = raise_if_exception(completion)
+        return HandleCommandResult(stdout=output)
+
+    @OrchestratorCLICommand.Write('orch certmgr vault issue')
+    def _cert_store_vault_issue(
+        self,
+        consumer: str,
+        common_name: str,
+        _end_positional_: int = 0,
+        cert_name: str = '',
+        service_name: str = '',
+        hostname: str = '',
+        ca_cert_name: str = '',
+        alt_names: Optional[List[str]] = None,
+        ip_sans: Optional[List[str]] = None,
+        pki_mount: Optional[str] = None,
+        role: Optional[str] = None,
+        ttl: Optional[str] = None,
+    ) -> HandleCommandResult:
+        completion = self.cert_store_vault_issue(
+            consumer,
+            common_name,
+            cert_name,
+            service_name,
+            hostname,
+            ca_cert_name,
+            self._split_certmgr_csv_values(alt_names),
+            self._split_certmgr_csv_values(ip_sans),
+            pki_mount,
+            role,
+            ttl,
+        )
+        output = raise_if_exception(completion)
+        return HandleCommandResult(stdout=output)
+
     @OrchestratorCLICommand.Write('orch certmgr cert rm')
     def _cert_store_rm_cert(
         self,

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -77,6 +77,7 @@ class CertificateSource(Enum):
     INLINE = "inline"
     REFERENCE = "reference"
     CEPHADM_SIGNED = "cephadm-signed"
+    VAULT = "vault"
 
 
 class MonitorCertSource(Enum):
@@ -86,6 +87,7 @@ class MonitorCertSource(Enum):
     INLINE = CertificateSource.INLINE.value
     REFERENCE = CertificateSource.REFERENCE.value
     CEPHADM_SIGNED = CertificateSource.CEPHADM_SIGNED.value
+    VAULT = CertificateSource.VAULT.value
     REUSE_SERVICE_CERT = "reuse_service_cert"
 
 


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
