### PR TITLE
mgr/cephadm: add rotate-key support for smb

### DIFF
--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_basic.yaml
@@ -113,6 +113,22 @@ tasks:
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U user1%t3stP4ss1 //{{'host.c'|role_to_remote|attr('ip_address')}}/share1 -c ls"
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U user2%t3stP4ss2 //{{'host.c'|role_to_remote|attr('ip_address')}}/share2 -c ls"
 
+- smb.workunit:
+    admin_node: host.a
+    smb_nodes: [host.a, host.b, host.c]
+    smb_shares:
+      - share1
+      - share2
+    smb_users:
+      - username: user1
+        password: t3stP4ss1
+      - username: user2
+        password: t3stP4ss2
+    timeout: 1h
+    clients:
+      client.0:
+        - [key_rotation]
+
 - cephadm.shell:
     host.a:
       - cmd: ceph smb apply -i -

--- a/qa/workunits/smb/tests/pytest.ini
+++ b/qa/workunits/smb/tests/pytest.ini
@@ -7,3 +7,4 @@ markers =
     rate_limiting: Rate limit tests
     ceph_smb_ctl_local: Local/container test of ceph-smb-ctl tool
     domain: Domain integration tests
+    key_rotation: cephx daemon key rotation tests

--- a/qa/workunits/smb/tests/test_key_rotation.py
+++ b/qa/workunits/smb/tests/test_key_rotation.py
@@ -1,0 +1,98 @@
+import time
+
+import pytest
+
+import cephutil
+import smbutil
+
+
+def _smb_daemon_names(smb_cfg):
+    jres = cephutil.cephadm_shell_cmd(
+        smb_cfg,
+        ['ceph', 'orch', 'ps', '--daemon-type', 'smb'],
+        load_json=True,
+    )
+    assert jres.returncode == 0
+    assert jres.obj
+    return [d['daemon_name'] for d in jres.obj]
+
+
+def _auth_entity(daemon_name):
+    _, daemon_id = daemon_name.split('.', 1)
+    return f'client.smb.config.{daemon_id}'
+
+
+def _get_key(smb_cfg, entity):
+    res = cephutil.cephadm_shell_cmd(
+        smb_cfg,
+        ['ceph', 'auth', 'get-key', entity],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0, f'failed to get key for {entity}: {res.stderr}'
+    return res.stdout.strip()
+
+
+def _get_caps(smb_cfg, entity):
+    res = cephutil.cephadm_shell_cmd(
+        smb_cfg,
+        ['ceph', 'auth', 'get', entity],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0, f'failed to get auth for {entity}: {res.stderr}'
+    return sorted(ln.strip() for ln in res.stdout.splitlines() if 'caps' in ln)
+
+
+def _rotate_key(smb_cfg, daemon_name, timeout=300, interval=5):
+    entity = _auth_entity(daemon_name)
+    before = _get_key(smb_cfg, entity)
+
+    res = cephutil.cephadm_shell_cmd(
+        smb_cfg,
+        ['ceph', 'orch', 'daemon', 'rotate-key', daemon_name],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0, (
+        f'rotate-key failed for {daemon_name}: {res.stderr}'
+    )
+
+    after = before
+    waited = 0
+    while after == before and waited < timeout:
+        time.sleep(interval)
+        waited += interval
+        after = _get_key(smb_cfg, entity)
+
+    assert after != before, (
+        f'key for {entity} did not rotate within {timeout}s'
+    )
+    return before, after
+
+
+@pytest.mark.key_rotation
+class TestSMBKeyRotation:
+    def test_rotate_all_daemons(self, smb_cfg):
+        """Rotate the cephx key for every smb daemon and confirm the
+        cluster keeps serving shares afterwards."""
+        daemon_names = _smb_daemon_names(smb_cfg)
+        assert daemon_names, 'no smb daemons found'
+
+        for daemon_name in daemon_names:
+            _rotate_key(smb_cfg, daemon_name)
+
+        share_name = smbutil.get_shares(smb_cfg)[0]['name']
+        with smbutil.connection(smb_cfg, share_name) as sharep:
+            sharep.listdir()
+
+    def test_rotate_preserves_caps(self, smb_cfg):
+        """Rotating a daemon's key should not alter its cephx caps."""
+        daemon_name = _smb_daemon_names(smb_cfg)[0]
+        entity = _auth_entity(daemon_name)
+
+        before_caps = _get_caps(smb_cfg, entity)
+        _rotate_key(smb_cfg, daemon_name)
+        after_caps = _get_caps(smb_cfg, entity)
+
+        assert before_caps == after_caps

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3140,7 +3140,7 @@ Then run the following:
 
         if action == 'rotate-key':
             if d.daemon_type not in ['mgr', 'osd', 'mds',
-                                     'rgw', 'crash', 'nfs', 'rbd-mirror', 'iscsi']:
+                                     'rgw', 'crash', 'nfs', 'rbd-mirror', 'iscsi', 'smb']:
                 raise OrchestratorError(
                     f'key rotation not supported for {d.daemon_type}'
                 )

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -71,6 +71,8 @@ def get_auth_entity(daemon_type: str, daemon_id: str, host: str = "") -> AuthEnt
         return AuthEntity('mon.')
     elif daemon_type in ['mgr', 'osd', 'mds']:
         return AuthEntity(f'{daemon_type}.{daemon_id}')
+    elif daemon_type == 'smb':
+        return AuthEntity(f'client.smb.config.{daemon_id}')
     else:
         raise OrchestratorError(f"unknown daemon type {daemon_type}")
 


### PR DESCRIPTION
Adds smb to the daemon rotate-key action allow list and maps it to its corresponding cephx entity in `get_auth_entity()`, 
so `ceph orch daemon rotate-key smb.<id>` works like it already does for rgw/nfs/crash/etc..


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
