### PR TITLE
os/bluestore: Revival no.2 of _deferred_replay fix

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8064,7 +8064,7 @@ int BlueStore::_open_db_and_around(
   if (remove_deferred && !keys_to_remove.empty()) {
     KeyValueDB::Transaction deferred_keys_remove_txn = db->get_transaction();
     for (auto& s : keys_to_remove) {
-      deferred_keys_remove_txn->rmkey(PREFIX_DEFERRED, s);
+      deferred_keys_remove_txn->rm_single_key(PREFIX_DEFERRED, s);
     }
     db->submit_transaction_sync(deferred_keys_remove_txn);
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7967,9 +7967,19 @@ int BlueStore::_is_bluefs(bool create, bool* ret)
 * opens both DB and dependant super_meta, FreelistManager and allocator
 * in the proper order
 */
-int BlueStore::_open_db_and_around(bool read_only, bool to_repair)
+int BlueStore::_open_db_and_around(
+  bool read_only,
+  bool to_repair,
+  bool apply_deferred,
+  bool remove_deferred)
 {
-  dout(5) << __func__ << "::NCB::read_only=" << read_only << ", to_repair=" << to_repair << dendl;
+  dout(5) << __func__ << "read_only=" << read_only
+          << ", to_repair=" << to_repair
+          << ", deferred=" << (apply_deferred?"apply;":"noapply;")
+          << (remove_deferred?"remove":"noremove") << dendl;
+  ceph_assert(remove_deferred == false || apply_deferred == true);
+  ceph_assert(read_only == false || remove_deferred == false);
+  std::vector<std::string> keys_to_remove;
   {
     string type;
     int r = read_meta("type", &type);
@@ -8029,6 +8039,11 @@ int BlueStore::_open_db_and_around(bool read_only, bool to_repair)
   if (bdev_label_multi) {
     _main_bdev_label_try_reserve();
   }
+  // This is the place where we can apply deferred writes
+  // without risk of some interaction with RocksDB allocating.
+  if (apply_deferred) {
+    _deferred_replay(remove_deferred ? &keys_to_remove : nullptr);
+  }
 
   // Re-open in the proper mode(s).
 
@@ -8044,6 +8059,14 @@ int BlueStore::_open_db_and_around(bool read_only, bool to_repair)
 
   if (!read_only) {
     _post_init_alloc();
+  }
+
+  if (remove_deferred && !keys_to_remove.empty()) {
+    KeyValueDB::Transaction deferred_keys_remove_txn = db->get_transaction();
+    for (auto& s : keys_to_remove) {
+      deferred_keys_remove_txn->rmkey(PREFIX_DEFERRED, s);
+    }
+    db->submit_transaction_sync(deferred_keys_remove_txn);
   }
 
   // when function is called in repair mode (to_repair=true) we skip db->open()/create()
@@ -9496,7 +9519,7 @@ int BlueStore::mount_readonly()
     }
   });
 
-  r = _deferred_replay();
+  r = _deferred_replay(nullptr);
   if (r < 0) {
     return r;
   }
@@ -9639,8 +9662,7 @@ int BlueStore::_mount()
     return -EINVAL;
   }
 
-  dout(5) << __func__ << "::NCB::calling open_db_and_around(read/write)" << dendl;
-  int r = _open_db_and_around(false);
+  int r = _open_db_and_around(false, false, true, true);
   if (r < 0) {
     return r;
   }
@@ -9677,11 +9699,6 @@ int BlueStore::_mount()
       _kv_stop();
     }
   });
-
-  r = _deferred_replay();
-  if (r < 0) {
-    return r;
-  }
 
   mempool_thread.init();
 
@@ -11048,7 +11065,7 @@ int BlueStore::_fsck(BlueStore::FSCKDepth depth, bool repair, bluestore_stats_t 
 
   // in deep mode we need R/W write access to be able to replay deferred ops
   const bool read_only = !(repair || depth == FSCK_DEEP);
-  int r = _open_db_and_around(read_only);
+  int r = _open_db_and_around(read_only, false, !read_only, !read_only);
   if (r < 0) {
     return r;
   }
@@ -11074,17 +11091,6 @@ int BlueStore::_fsck(BlueStore::FSCKDepth depth, bool repair, bluestore_stats_t 
     mempool_thread.shutdown();
     _shutdown_cache();
   });
-  // we need finisher and kv_{sync,finalize}_thread *just* for replay
-  // enable in repair or deep mode modes only
-  if (!read_only) {
-    _kv_start();
-    r = _deferred_replay();
-    _kv_stop();
-  }
-
-  if (r < 0) {
-    return r;
-  }
   return _fsck_on_open(depth, repair, store_stats);
 }
 
@@ -15338,6 +15344,7 @@ void BlueStore::_kv_sync_thread()
   deque<DeferredBatch*> deferred_stable_queue; ///< deferred ios done + stable
   std::unique_lock l{kv_lock};
   ceph_assert(!kv_sync_started);
+  ceph_assert(!db_was_opened_read_only);
   kv_sync_started = true;
   kv_cond.notify_all();
 
@@ -15889,7 +15896,7 @@ void BlueStore::_deferred_aio_finish(OpSequencer *osr)
   }
 }
 
-int BlueStore::_deferred_replay()
+int BlueStore::_deferred_replay(std::vector<std::string>* keys_to_remove)
 {
   dout(10) << __func__ << " start" << dendl;
   int count = 0;
@@ -15905,49 +15912,50 @@ int BlueStore::_deferred_replay()
   }
   dtr_deferred_replay_start();
   IOContext ioctx(cct, nullptr);
-  KeyValueDB::Transaction t = db->get_transaction();
   KeyValueDB::Iterator it = db->get_iterator(PREFIX_DEFERRED);
-  for (it->lower_bound(string()); it->valid(); it->next(), ++count) {
+  for (it->lower_bound(string()); it->valid(); /*iterator update outside*/) {
     dout(20) << __func__ << " replay " << pretty_binary_string(it->key())
 	     << dendl;
-    t->rmkey(PREFIX_DEFERRED, it->key());
-    bluestore_deferred_transaction_t *deferred_txn =
-      new bluestore_deferred_transaction_t;
+    if (keys_to_remove) {
+      keys_to_remove->push_back(it->key());
+    }
+    bluestore_deferred_transaction_t deferred_txn;
     bufferlist bl = it->value();
     auto p = bl.cbegin();
     try {
-      decode(*deferred_txn, p);
+      decode(deferred_txn, p);
+
+      bool has_some = _eliminate_outdated_deferred(&deferred_txn, bluefs_extents);
+      if (has_some) {
+        dtr_deferred_replay_track(deferred_txn);
+        for (auto& op: deferred_txn.ops) {
+          dout(10) << __func__ << std::hex << " 0x" << op.data.length()
+            << std::dec << " writing to " << op.extents << dendl;
+          for (auto& e : op.extents) {
+            bufferlist t;
+            op.data.splice(0, e.length, &t);
+            bdev->aio_write(e.offset, t, &ioctx, false);
+          }
+        }
+      } else {
+        dout(10) << __func__ << deferred_txn.seq << " fully eliminated" << dendl;
+      }
     } catch (ceph::buffer::error& e) {
       derr << __func__ << " failed to decode deferred txn "
 	   << pretty_binary_string(it->key()) << dendl;
-      delete deferred_txn;
       r = -EIO;
-      goto out;
     }
-    bool has_some = _eliminate_outdated_deferred(deferred_txn, bluefs_extents);
-    if (has_some) {
-      dtr_deferred_replay_track(*deferred_txn);
-      for (auto& op: deferred_txn->ops) {
-        for (auto& e : op.extents) {
-          bufferlist t;
-          op.data.splice(0, e.length, &t);
-          bdev->aio_write(e.offset, t, &ioctx, false);
-        }
-      }
-    } else {
-      delete deferred_txn;
+    // update loop iteration here, so we can inject action
+    ++count;
+    it->next();
+    if (ioctx.num_pending.load() >= 1 || !it->valid()) {
+      // must submit after each deferred, see https://tracker.ceph.com/issues/70581
+      dout(20) << __func__ << " submitting IO batch" << dendl;
+      bdev->aio_submit(&ioctx);
+      ioctx.aio_wait();
+      dout(20) << __func__ << " wait done" << dendl;
+      ioctx.release_running_aios();
     }
-  }
- out:
-  bdev->aio_submit(&ioctx);
-  dout(20) << __func__ << " waiting to complete IO" << dendl;
-  ioctx.aio_wait();
-  dout(20) << __func__ << " wait done" << dendl;
-  if (!db_was_opened_read_only) {
-    db->submit_transaction_sync(t);
-    dout(20) << __func__ << " removed L keys" << dendl;
-  } else {
-    dout(10) << __func__ << " DB read-only, skipped L keys removal" << dendl;
   }
   dtr_deferred_replay_end();
   dout(10) << __func__ << " completed " << count << " events" << dendl;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7564,7 +7564,7 @@ int BlueStore::_init_alloc()
           << ", free 0x" << alloc->get_free()
           << ", fragmentation " << alloc->get_fragmentation()
           << std::dec << dendl;
-
+  dtr_init_alloc_done();
   return 0;
 }
 
@@ -15911,6 +15911,7 @@ int BlueStore::_deferred_replay()
     fake_ch = true;
   }
   OpSequencer *osr = static_cast<OpSequencer*>(ch->osr.get());
+  dtr_deferred_replay_start();
   KeyValueDB::Iterator it = db->get_iterator(PREFIX_DEFERRED);
   for (it->lower_bound(string()); it->valid(); it->next(), ++count) {
     dout(20) << __func__ << " replay " << pretty_binary_string(it->key())
@@ -15930,6 +15931,7 @@ int BlueStore::_deferred_replay()
     }
     bool has_some = _eliminate_outdated_deferred(deferred_txn, bluefs_extents);
     if (has_some) {
+      dtr_deferred_replay_track(*deferred_txn);
       TransContext *txc = _txc_create(ch.get(), osr,  nullptr);
       txc->deferred_txn = deferred_txn;
       txc->set_state(TransContext::STATE_KV_DONE);
@@ -15942,6 +15944,7 @@ int BlueStore::_deferred_replay()
   dout(20) << __func__ << " draining osr" << dendl;
   _osr_register_zombie(osr);
   _osr_drain_all();
+  dtr_deferred_replay_end();
   if (fake_ch) {
     new_coll_map.clear();
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -15504,7 +15504,7 @@ void BlueStore::_kv_sync_thread()
       auto sync_start = mono_clock::now();
 #endif
       // submit synct synchronously (block and wait for it to commit)
-      int r = db_was_opened_read_only || cct->_conf->bluestore_debug_omit_kv_commit ?
+      int r = cct->_conf->bluestore_debug_omit_kv_commit ?
 	0 : db->submit_transaction_sync(synct);
       ceph_assert(r == 0);
 
@@ -15903,19 +15903,14 @@ int BlueStore::_deferred_replay()
       }
     );
   }
-  CollectionRef ch = _get_collection(coll_t::meta());
-  bool fake_ch = false;
-  if (!ch) {
-    // hmm, replaying initial mkfs?
-    ch = static_cast<Collection*>(create_new_collection(coll_t::meta()).get());
-    fake_ch = true;
-  }
-  OpSequencer *osr = static_cast<OpSequencer*>(ch->osr.get());
   dtr_deferred_replay_start();
+  IOContext ioctx(cct, nullptr);
+  KeyValueDB::Transaction t = db->get_transaction();
   KeyValueDB::Iterator it = db->get_iterator(PREFIX_DEFERRED);
   for (it->lower_bound(string()); it->valid(); it->next(), ++count) {
     dout(20) << __func__ << " replay " << pretty_binary_string(it->key())
 	     << dendl;
+    t->rmkey(PREFIX_DEFERRED, it->key());
     bluestore_deferred_transaction_t *deferred_txn =
       new bluestore_deferred_transaction_t;
     bufferlist bl = it->value();
@@ -15932,22 +15927,29 @@ int BlueStore::_deferred_replay()
     bool has_some = _eliminate_outdated_deferred(deferred_txn, bluefs_extents);
     if (has_some) {
       dtr_deferred_replay_track(*deferred_txn);
-      TransContext *txc = _txc_create(ch.get(), osr,  nullptr);
-      txc->deferred_txn = deferred_txn;
-      txc->set_state(TransContext::STATE_KV_DONE);
-      _txc_state_proc(txc);
+      for (auto& op: deferred_txn->ops) {
+        for (auto& e : op.extents) {
+          bufferlist t;
+          op.data.splice(0, e.length, &t);
+          bdev->aio_write(e.offset, t, &ioctx, false);
+        }
+      }
     } else {
       delete deferred_txn;
     }
   }
  out:
-  dout(20) << __func__ << " draining osr" << dendl;
-  _osr_register_zombie(osr);
-  _osr_drain_all();
-  dtr_deferred_replay_end();
-  if (fake_ch) {
-    new_coll_map.clear();
+  bdev->aio_submit(&ioctx);
+  dout(20) << __func__ << " waiting to complete IO" << dendl;
+  ioctx.aio_wait();
+  dout(20) << __func__ << " wait done" << dendl;
+  if (!db_was_opened_read_only) {
+    db->submit_transaction_sync(t);
+    dout(20) << __func__ << " removed L keys" << dendl;
+  } else {
+    dout(10) << __func__ << " DB read-only, skipped L keys removal" << dendl;
   }
+  dtr_deferred_replay_end();
   dout(10) << __func__ << " completed " << count << " events" << dendl;
   return r;
 }
@@ -15975,7 +15977,7 @@ bool BlueStore::_eliminate_outdated_deferred(bluestore_deferred_transaction_t* d
     PExtentVector new_extents;
     ceph::buffer::list new_data;
     uint32_t data_offset = 0; // this tracks location of extent 'e' inside it->data
-    dout(30) << __func__ << " input extents: " << it->extents << dendl;
+    dout(10) << __func__ << " input extents: " << it->extents << dendl;
     for (auto& e: it->extents) {
       interval_set<uint64_t> region;
       region.insert(e.offset, e.length);
@@ -16006,7 +16008,7 @@ bool BlueStore::_eliminate_outdated_deferred(bluestore_deferred_transaction_t* d
       }
       data_offset += e.length;
     }
-    dout(30) << __func__ << " output extents: " << new_extents << dendl;
+    dout(10) << __func__ << " output extents: " << new_extents << dendl;
     if (it->data.length() != new_data.length()) {
       dout(10) << __func__ << " trimmed deferred extents: " << it->extents << "->" << new_extents << dendl;
     }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8359,6 +8359,16 @@ int BlueStore::_open_db(bool create, bool to_repair_db, bool read_only)
   }
   dout(1) << __func__ << " opened " << kv_backend
 	  << " path " << kv_dir_fn << " options " << options << dendl;
+  KeyValueDB::Iterator it = db->get_iterator(PREFIX_DEFERRED);
+  if (it) {
+    it->seek_to_first();
+    dout(10) << __func__ << " Listing L start" << dendl;
+    while (it->valid()) {
+      dout(10) << __func__ << " " << pretty_binary_string(it->key()) << dendl;
+      it->next();
+    }
+    dout(10) << __func__ << " Listing L end" << dendl;
+  }
   return 0;
 }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8115,7 +8115,7 @@ int BlueStore::_open_db_and_around(
   if (remove_deferred && !keys_to_remove.empty()) {
     KeyValueDB::Transaction deferred_keys_remove_txn = db->get_transaction();
     for (auto& s : keys_to_remove) {
-      deferred_keys_remove_txn->rmkey(PREFIX_DEFERRED, s);
+      deferred_keys_remove_txn->rm_single_key(PREFIX_DEFERRED, s);
     }
     db->submit_transaction_sync(deferred_keys_remove_txn);
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -15611,7 +15611,7 @@ void BlueStore::_kv_sync_thread()
       auto sync_start = mono_clock::now();
 #endif
       // submit synct synchronously (block and wait for it to commit)
-      int r = db_was_opened_read_only || cct->_conf->bluestore_debug_omit_kv_commit ?
+      int r = cct->_conf->bluestore_debug_omit_kv_commit ?
 	0 : db->submit_transaction_sync(synct);
       ceph_assert(r == 0);
 
@@ -16010,19 +16010,14 @@ int BlueStore::_deferred_replay()
       }
     );
   }
-  CollectionRef ch = _get_collection(coll_t::meta());
-  bool fake_ch = false;
-  if (!ch) {
-    // hmm, replaying initial mkfs?
-    ch = static_cast<Collection*>(create_new_collection(coll_t::meta()).get());
-    fake_ch = true;
-  }
-  OpSequencer *osr = static_cast<OpSequencer*>(ch->osr.get());
   dtr_deferred_replay_start();
+  IOContext ioctx(cct, nullptr);
+  KeyValueDB::Transaction t = db->get_transaction();
   KeyValueDB::Iterator it = db->get_iterator(PREFIX_DEFERRED);
   for (it->lower_bound(string()); it->valid(); it->next(), ++count) {
     dout(20) << __func__ << " replay " << pretty_binary_string(it->key())
 	     << dendl;
+    t->rmkey(PREFIX_DEFERRED, it->key());
     bluestore_deferred_transaction_t *deferred_txn =
       new bluestore_deferred_transaction_t;
     bufferlist bl = it->value();
@@ -16039,22 +16034,29 @@ int BlueStore::_deferred_replay()
     bool has_some = _eliminate_outdated_deferred(deferred_txn, bluefs_extents);
     if (has_some) {
       dtr_deferred_replay_track(*deferred_txn);
-      TransContext *txc = _txc_create(ch.get(), osr,  nullptr);
-      txc->deferred_txn = deferred_txn;
-      txc->set_state(TransContext::STATE_KV_DONE);
-      _txc_state_proc(txc);
+      for (auto& op: deferred_txn->ops) {
+        for (auto& e : op.extents) {
+          bufferlist t;
+          op.data.splice(0, e.length, &t);
+          bdev->aio_write(e.offset, t, &ioctx, false);
+        }
+      }
     } else {
       delete deferred_txn;
     }
   }
  out:
-  dout(20) << __func__ << " draining osr" << dendl;
-  _osr_register_zombie(osr);
-  _osr_drain_all();
-  dtr_deferred_replay_end();
-  if (fake_ch) {
-    new_coll_map.clear();
+  bdev->aio_submit(&ioctx);
+  dout(20) << __func__ << " waiting to complete IO" << dendl;
+  ioctx.aio_wait();
+  dout(20) << __func__ << " wait done" << dendl;
+  if (!db_was_opened_read_only) {
+    db->submit_transaction_sync(t);
+    dout(20) << __func__ << " removed L keys" << dendl;
+  } else {
+    dout(10) << __func__ << " DB read-only, skipped L keys removal" << dendl;
   }
+  dtr_deferred_replay_end();
   dout(10) << __func__ << " completed " << count << " events" << dendl;
   return r;
 }
@@ -16082,7 +16084,7 @@ bool BlueStore::_eliminate_outdated_deferred(bluestore_deferred_transaction_t* d
     PExtentVector new_extents;
     ceph::buffer::list new_data;
     uint32_t data_offset = 0; // this tracks location of extent 'e' inside it->data
-    dout(30) << __func__ << " input extents: " << it->extents << dendl;
+    dout(10) << __func__ << " input extents: " << it->extents << dendl;
     for (auto& e: it->extents) {
       interval_set<uint64_t> region;
       region.insert(e.offset, e.length);
@@ -16113,7 +16115,7 @@ bool BlueStore::_eliminate_outdated_deferred(bluestore_deferred_transaction_t* d
       }
       data_offset += e.length;
     }
-    dout(30) << __func__ << " output extents: " << new_extents << dendl;
+    dout(10) << __func__ << " output extents: " << new_extents << dendl;
     if (it->data.length() != new_data.length()) {
       dout(10) << __func__ << " trimmed deferred extents: " << it->extents << "->" << new_extents << dendl;
     }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8015,13 +8015,22 @@ int BlueStore::_is_bluefs(bool create, bool* ret)
 * opens both DB and dependant super_meta, FreelistManager and allocator
 * in the proper order
 */
-int BlueStore::_open_db_and_around(bool read_only, bool to_repair,
-                                   alloc_recovery_policy_t policy)
+int BlueStore::_open_db_and_around(
+  bool read_only,
+  bool to_repair,
+  alloc_recovery_policy_t policy,
+  bool apply_deferred,
+  bool remove_deferred)
 {
+  dout(5) << __func__ << "read_only=" << read_only
+          << ", to_repair=" << to_repair
+          << ", deferred=" << (apply_deferred?"apply;":"noapply;")
+          << (remove_deferred?"remove":"noremove") << dendl;
+  ceph_assert(remove_deferred == false || apply_deferred == true);
+  ceph_assert(read_only == false || remove_deferred == false);
+  std::vector<std::string> keys_to_remove;
   alloc_recovery_policy = policy;
   alloc_recovery_skipped_onodes = 0;
-
-  dout(5) << __func__ << "::NCB::read_only=" << read_only << ", to_repair=" << to_repair << dendl;
   {
     string type;
     int r = read_meta("type", &type);
@@ -8081,6 +8090,11 @@ int BlueStore::_open_db_and_around(bool read_only, bool to_repair,
   if (bdev_label_multi) {
     _main_bdev_label_try_reserve();
   }
+  // This is the place where we can apply deferred writes
+  // without risk of some interaction with RocksDB allocating.
+  if (apply_deferred) {
+    _deferred_replay(remove_deferred ? &keys_to_remove : nullptr);
+  }
 
   // Re-open in the proper mode(s).
 
@@ -8096,6 +8110,14 @@ int BlueStore::_open_db_and_around(bool read_only, bool to_repair,
 
   if (!read_only) {
     _post_init_alloc();
+  }
+
+  if (remove_deferred && !keys_to_remove.empty()) {
+    KeyValueDB::Transaction deferred_keys_remove_txn = db->get_transaction();
+    for (auto& s : keys_to_remove) {
+      deferred_keys_remove_txn->rmkey(PREFIX_DEFERRED, s);
+    }
+    db->submit_transaction_sync(deferred_keys_remove_txn);
   }
 
   // when function is called in repair mode (to_repair=true) we skip db->open()/create()
@@ -9548,7 +9570,7 @@ int BlueStore::mount_readonly()
     }
   });
 
-  r = _deferred_replay();
+  r = _deferred_replay(nullptr);
   if (r < 0) {
     return r;
   }
@@ -9691,8 +9713,7 @@ int BlueStore::_mount()
     return -EINVAL;
   }
 
-  dout(5) << __func__ << "::NCB::calling open_db_and_around(read/write)" << dendl;
-  int r = _open_db_and_around(false);
+  int r = _open_db_and_around(false, false, alloc_recovery_policy_t::strict, true, true);
   if (r < 0) {
     return r;
   }
@@ -9729,11 +9750,6 @@ int BlueStore::_mount()
       _kv_stop();
     }
   });
-
-  r = _deferred_replay();
-  if (r < 0) {
-    return r;
-  }
 
   mempool_thread.init();
 
@@ -11122,10 +11138,11 @@ int BlueStore::_fsck(BlueStore::FSCKDepth depth, bool repair, bluestore_stats_t 
 
   // in deep mode we need R/W write access to be able to replay deferred ops
   const bool read_only = !(repair || depth == FSCK_DEEP);
-  int r = _open_db_and_around(read_only, false,
+  int r = _open_db_and_around(
+    read_only, false,
     read_only ? alloc_recovery_policy_t::tolerate_corrupt_onodes
-              : alloc_recovery_policy_t::strict);
-
+              : alloc_recovery_policy_t::strict,
+    !read_only, !read_only);
   if (r < 0) {
     return r;
   }
@@ -11151,17 +11168,6 @@ int BlueStore::_fsck(BlueStore::FSCKDepth depth, bool repair, bluestore_stats_t 
     mempool_thread.shutdown();
     _shutdown_cache();
   });
-  // we need finisher and kv_{sync,finalize}_thread *just* for replay
-  // enable in repair or deep mode modes only
-  if (!read_only) {
-    _kv_start();
-    r = _deferred_replay();
-    _kv_stop();
-  }
-
-  if (r < 0) {
-    return r;
-  }
   return _fsck_on_open(depth, repair, store_stats);
 }
 
@@ -15445,6 +15451,7 @@ void BlueStore::_kv_sync_thread()
   deque<DeferredBatch*> deferred_stable_queue; ///< deferred ios done + stable
   std::unique_lock l{kv_lock};
   ceph_assert(!kv_sync_started);
+  ceph_assert(!db_was_opened_read_only);
   kv_sync_started = true;
   kv_cond.notify_all();
 
@@ -15996,7 +16003,7 @@ void BlueStore::_deferred_aio_finish(OpSequencer *osr)
   }
 }
 
-int BlueStore::_deferred_replay()
+int BlueStore::_deferred_replay(std::vector<std::string>* keys_to_remove)
 {
   dout(10) << __func__ << " start" << dendl;
   int count = 0;
@@ -16012,49 +16019,50 @@ int BlueStore::_deferred_replay()
   }
   dtr_deferred_replay_start();
   IOContext ioctx(cct, nullptr);
-  KeyValueDB::Transaction t = db->get_transaction();
   KeyValueDB::Iterator it = db->get_iterator(PREFIX_DEFERRED);
-  for (it->lower_bound(string()); it->valid(); it->next(), ++count) {
+  for (it->lower_bound(string()); it->valid(); /*iterator update outside*/) {
     dout(20) << __func__ << " replay " << pretty_binary_string(it->key())
 	     << dendl;
-    t->rmkey(PREFIX_DEFERRED, it->key());
-    bluestore_deferred_transaction_t *deferred_txn =
-      new bluestore_deferred_transaction_t;
+    if (keys_to_remove) {
+      keys_to_remove->push_back(it->key());
+    }
+    bluestore_deferred_transaction_t deferred_txn;
     bufferlist bl = it->value();
     auto p = bl.cbegin();
     try {
-      decode(*deferred_txn, p);
+      decode(deferred_txn, p);
+
+      bool has_some = _eliminate_outdated_deferred(&deferred_txn, bluefs_extents);
+      if (has_some) {
+        dtr_deferred_replay_track(deferred_txn);
+        for (auto& op: deferred_txn.ops) {
+          dout(10) << __func__ << std::hex << " 0x" << op.data.length()
+            << std::dec << " writing to " << op.extents << dendl;
+          for (auto& e : op.extents) {
+            bufferlist t;
+            op.data.splice(0, e.length, &t);
+            bdev->aio_write(e.offset, t, &ioctx, false);
+          }
+        }
+      } else {
+        dout(10) << __func__ << deferred_txn.seq << " fully eliminated" << dendl;
+      }
     } catch (ceph::buffer::error& e) {
       derr << __func__ << " failed to decode deferred txn "
 	   << pretty_binary_string(it->key()) << dendl;
-      delete deferred_txn;
       r = -EIO;
-      goto out;
     }
-    bool has_some = _eliminate_outdated_deferred(deferred_txn, bluefs_extents);
-    if (has_some) {
-      dtr_deferred_replay_track(*deferred_txn);
-      for (auto& op: deferred_txn->ops) {
-        for (auto& e : op.extents) {
-          bufferlist t;
-          op.data.splice(0, e.length, &t);
-          bdev->aio_write(e.offset, t, &ioctx, false);
-        }
-      }
-    } else {
-      delete deferred_txn;
+    // update loop iteration here, so we can inject action
+    ++count;
+    it->next();
+    if (ioctx.num_pending.load() >= 1 || !it->valid()) {
+      // must submit after each deferred, see https://tracker.ceph.com/issues/70581
+      dout(20) << __func__ << " submitting IO batch" << dendl;
+      bdev->aio_submit(&ioctx);
+      ioctx.aio_wait();
+      dout(20) << __func__ << " wait done" << dendl;
+      ioctx.release_running_aios();
     }
-  }
- out:
-  bdev->aio_submit(&ioctx);
-  dout(20) << __func__ << " waiting to complete IO" << dendl;
-  ioctx.aio_wait();
-  dout(20) << __func__ << " wait done" << dendl;
-  if (!db_was_opened_read_only) {
-    db->submit_transaction_sync(t);
-    dout(20) << __func__ << " removed L keys" << dendl;
-  } else {
-    dout(10) << __func__ << " DB read-only, skipped L keys removal" << dendl;
   }
   dtr_deferred_replay_end();
   dout(10) << __func__ << " completed " << count << " events" << dendl;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7577,7 +7577,7 @@ int BlueStore::_init_alloc()
           << ", free 0x" << alloc->get_free()
           << ", fragmentation " << alloc->get_fragmentation()
           << std::dec << dendl;
-
+  dtr_init_alloc_done();
   return 0;
 }
 
@@ -16018,6 +16018,7 @@ int BlueStore::_deferred_replay()
     fake_ch = true;
   }
   OpSequencer *osr = static_cast<OpSequencer*>(ch->osr.get());
+  dtr_deferred_replay_start();
   KeyValueDB::Iterator it = db->get_iterator(PREFIX_DEFERRED);
   for (it->lower_bound(string()); it->valid(); it->next(), ++count) {
     dout(20) << __func__ << " replay " << pretty_binary_string(it->key())
@@ -16037,6 +16038,7 @@ int BlueStore::_deferred_replay()
     }
     bool has_some = _eliminate_outdated_deferred(deferred_txn, bluefs_extents);
     if (has_some) {
+      dtr_deferred_replay_track(*deferred_txn);
       TransContext *txc = _txc_create(ch.get(), osr,  nullptr);
       txc->deferred_txn = deferred_txn;
       txc->set_state(TransContext::STATE_KV_DONE);
@@ -16049,6 +16051,7 @@ int BlueStore::_deferred_replay()
   dout(20) << __func__ << " draining osr" << dendl;
   _osr_register_zombie(osr);
   _osr_drain_all();
+  dtr_deferred_replay_end();
   if (fake_ch) {
     new_coll_map.clear();
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8410,6 +8410,16 @@ int BlueStore::_open_db(bool create, bool to_repair_db, bool read_only)
   }
   dout(1) << __func__ << " opened " << kv_backend
 	  << " path " << kv_dir_fn << " options " << options << dendl;
+  KeyValueDB::Iterator it = db->get_iterator(PREFIX_DEFERRED);
+  if (it) {
+    it->seek_to_first();
+    dout(10) << __func__ << " Listing L start" << dendl;
+    while (it->valid()) {
+      dout(10) << __func__ << " " << pretty_binary_string(it->key()) << dendl;
+      it->next();
+    }
+    dout(10) << __func__ << " Listing L end" << dendl;
+  }
   return 0;
 }
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3646,6 +3646,7 @@ public:
   void debug_set_prefer_deferred_size(uint64_t s) {
     prefer_deferred_size = s;
   }
+
   inline void log_latency(const char* name,
     int idx,
     const ceph::timespan& lat,
@@ -3673,6 +3674,12 @@ public:
     double lat_threshold,
     std::function<std::string (const ceph::timespan& lat)> fn,
     int idx2 = l_bluestore_first);
+
+  debug_point_t<std::function<void()>> dtr_deferred_replay_start;
+  debug_point_t<std::function<void()>> dtr_deferred_replay_end;
+  debug_point_t<std::function<void()>> dtr_init_alloc_done;
+  debug_point_t<std::function<void(const bluestore_deferred_transaction_t&)>>
+    dtr_deferred_replay_track;
 
 private:
   bool _debug_data_eio(const ghobject_t& o) {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2869,7 +2869,11 @@ private:
   * opens both DB and dependant super_meta, FreelistManager and allocator
   * in the proper order
   */
-  int _open_db_and_around(bool read_only, bool to_repair = false);
+  int _open_db_and_around(
+    bool read_only,
+    bool to_repair = false,
+    bool apply_deferred = false,
+    bool remove_deferred = false);
   void _close_db_and_around();
   void _close_around_db();
 
@@ -2993,7 +2997,7 @@ public:
 private:
   void _deferred_submit_unlock(OpSequencer *osr);
   void _deferred_aio_finish(OpSequencer *osr);
-  int _deferred_replay();
+  int _deferred_replay(std::vector<std::string>* keys_to_remove);
   bool _eliminate_outdated_deferred(bluestore_deferred_transaction_t* deferred_txn,
 				    interval_set<uint64_t>& bluefs_extents);
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2882,8 +2882,12 @@ private:
   * opens both DB and dependant super_meta, FreelistManager and allocator
   * in the proper order
   */
-  int _open_db_and_around(bool read_only, bool to_repair = false,
-            alloc_recovery_policy_t policy = alloc_recovery_policy_t::strict);
+  int _open_db_and_around(
+    bool read_only,
+    bool to_repair = false,
+    alloc_recovery_policy_t policy = alloc_recovery_policy_t::strict,
+    bool apply_deferred = false,
+    bool remove_deferred = false);
   void _close_db_and_around();
   void _close_around_db();
 
@@ -3007,7 +3011,7 @@ public:
 private:
   void _deferred_submit_unlock(OpSequencer *osr);
   void _deferred_aio_finish(OpSequencer *osr);
-  int _deferred_replay();
+  int _deferred_replay(std::vector<std::string>* keys_to_remove);
   bool _eliminate_outdated_deferred(bluestore_deferred_transaction_t* deferred_txn,
 				    interval_set<uint64_t>& bluefs_extents);
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3698,6 +3698,12 @@ public:
     std::function<std::string (const ceph::timespan& lat)> fn,
     int idx2 = l_bluestore_first);
 
+  debug_point_t<std::function<void()>> dtr_deferred_replay_start;
+  debug_point_t<std::function<void()>> dtr_deferred_replay_end;
+  debug_point_t<std::function<void()>> dtr_init_alloc_done;
+  debug_point_t<std::function<void(const bluestore_deferred_transaction_t&)>>
+    dtr_deferred_replay_track;
+
 private:
   bool _debug_data_eio(const ghobject_t& o) {
     if (!cct->_conf->bluestore_debug_inject_read_err) {

--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -149,11 +149,12 @@ if(WITH_BLUESTORE)
   add_ceph_unittest(unittest_bdev)
   target_link_libraries(unittest_bdev os global)
 
-  # test_corrupt_deferred
-  add_executable(test_corrupt_deferred
+  # unittest_deferred
+  add_executable(unittest_deferred
     test_deferred.cc
     )
-  target_link_libraries(test_corrupt_deferred os global)
+  add_ceph_unittest(unittest_deferred)
+  target_link_libraries(unittest_deferred os global)
 
 endif(WITH_BLUESTORE)
 

--- a/src/test/objectstore/test_deferred.cc
+++ b/src/test/objectstore/test_deferred.cc
@@ -133,6 +133,8 @@ void create_deferred_and_terminate() {
 
   // small deferred writes over object
   // and complete overwrite of previous one
+  lgeneric_dout(g_ceph_context, 0) << "starting object IO" << dendl;
+  cout << "starting object IO" << std::endl;
   bufferlist bl_8_bytes;
   bl_8_bytes.append("abcdefgh");
   std::atomic<size_t> deferred_counter{0};
@@ -150,9 +152,11 @@ void create_deferred_and_terminate() {
     ghobject_t hoid_m(hobject_t(oid_m, "", CEPH_NOSNAP, 1, poolid, ""));
     t.write(cid, hoid_m, 4096 * o, bl_64K.length(), bl_64K);
 
-    t.register_on_commit(new C_do_action([&] {
+    t.register_on_commit(new C_do_action([=, &deferred_counter] {
+      lgeneric_dout(g_ceph_context, 0) << "completed id=" << o << dendl;
+      cout << "completed id=" << o << std::endl;
       if (++deferred_counter == object_count) {
-        exit(0);
+        _exit(0);
       }
     }));
     r = store->queue_transaction(ch, std::move(t));
@@ -310,6 +314,10 @@ boost::intrusive_ptr<CephContext> setup_env() {
   return cct;
 }
 
+void say_good_bye() {
+  std::cout << "good bye" << std::endl;
+}
+
 int main(int _argc, char **_argv) {
   argc = _argc;
   argv = _argv;
@@ -317,6 +325,7 @@ int main(int _argc, char **_argv) {
   pid_t first_test = fork();
   if (first_test == 0) {
     std::cout << "1. Testing deletion of deferred (L) entries." << std::endl;
+    atexit(&say_good_bye);
     pid_t child = fork();
     if (child == 0) {
       auto cct = setup_env();
@@ -342,6 +351,7 @@ int main(int _argc, char **_argv) {
     waitpid(first_test, &first_stat, 0);
     ceph_assert(WIFEXITED(first_stat) && WEXITSTATUS(first_stat) == 0);
     std::cout << "2. Testing overwrite of space allocated by BlueFS" << std::endl;
+    atexit(&say_good_bye);
     pid_t child = fork();
     if (child == 0) {
       auto cct = setup_env();

--- a/src/test/objectstore/test_deferred.cc
+++ b/src/test/objectstore/test_deferred.cc
@@ -1,13 +1,21 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 sts=2 expandtab
 
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <iostream>
 #include <memory>
+#include <random>
+#include <string>
 #include <time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 
+#include "common/pretty_binary.h"
+#include "global/global_context.h"
+#include "kv/KeyValueDB.h"
 #include "os/ObjectStore.h"
 #include "os/bluestore/BlueStore.h"
 #include "include/Context.h"
@@ -18,8 +26,11 @@
 #include "common/errno.h"
 #include "common/options.h" // for the size literals
 #include <semaphore.h>
+#include "os/bluestore/Allocator.h"
+#include "os/bluestore/AvlAllocator.h"
 
-
+using namespace std;
+typedef std::mt19937 gen_type;
 
 class C_do_action : public Context {
 public:
@@ -32,24 +43,33 @@ public:
   }
 };
 
+gen_type rng(0);
+uniform_int_distribution<> chargen('a', 'z');
+
+std::string gen_string(size_t size) {
+  std::string s;
+  for (size_t i = 0; i < size; i++) {
+    s.push_back(chargen(rng));
+  }
+  return s;
+}
+
 void create_deferred_and_terminate() {
   std::unique_ptr<ObjectStore> store;
-
-  g_ceph_context->_conf._clear_safe_to_start_threads();
-  g_ceph_context->_conf.set_val_or_die("bluestore_prefer_deferred_size", "4096");
-  g_ceph_context->_conf.set_val_or_die("bluestore_allocator", "bitmap");
-  g_ceph_context->_conf.set_val_or_die("bluestore_block_size", "10240000000");
-  g_ceph_context->_conf.apply_changes(nullptr);
-
   int64_t poolid;
   coll_t cid;
   ghobject_t hoid;
   ObjectStore::CollectionHandle ch;
-  std::string const db_store_dir = "bluestore.test_temp_dir_" + std::to_string(time(NULL));
-  ceph_assert(::mkdir(db_store_dir.c_str(), 0777) == 0);
+  std::string const bluestore_dir = "bluestore.test_temp_dir";
+  {
+    string cmd = string("rm -rf ") + bluestore_dir;
+    int r = ::system(cmd.c_str());
+    ceph_assert(r == 0);
+  }
+  ceph_assert(::mkdir(bluestore_dir.c_str(), 0777) == 0);
   store = ObjectStore::create(g_ceph_context,
                               "bluestore",
-                              db_store_dir.c_str(),
+                              bluestore_dir.c_str(),
                               "store_test_temp_journal");
   ceph_assert(store->mkfs() == 0);
   ceph_assert(store->mount() == 0);
@@ -77,72 +97,271 @@ void create_deferred_and_terminate() {
   }
 
   size_t object_count = 10;
+  size_t keys_per_transaction = 100;
+  size_t omap_push_repeats = 2200;
 
   // initial fill
   bufferlist bl_64K;
   bl_64K.append(std::string(64 * 1024, '-'));
-
-  std::atomic<size_t> prefill_counter{0};
-  sem_t prefill_mutex;
-  sem_init(&prefill_mutex, 0, 0);
-
+  //write objects
   for (size_t o = 0; o < object_count; o++) {
     ObjectStore::Transaction t;
     std::string oid = "object-" + std::to_string(o);
     ghobject_t hoid(hobject_t(oid, "", CEPH_NOSNAP, 1, poolid, ""));
-
     t.write(cid, hoid, 0, bl_64K.length(), bl_64K);
-    t.register_on_commit(new C_do_action([&] {
-      if (++prefill_counter == object_count) {
-	sem_post(&prefill_mutex);
-      }
-    }));
-
     r = store->queue_transaction(ch, std::move(t));
     ceph_assert(r == 0);
   }
-  sem_wait(&prefill_mutex);
+  //spam omap
+  for (size_t q = 0; q < omap_push_repeats; q++) {
+    for (size_t o = 0; o < object_count; o++) {
+      ObjectStore::Transaction t;
+      std::string oid = "object-" + std::to_string(o);
+      ghobject_t hoid(hobject_t(oid, "", CEPH_NOSNAP, 1, poolid, ""));
+
+      std::map<std::string, bufferlist> new_keys;
+      for (size_t m = 0; m < keys_per_transaction; m++) {
+        bufferlist bl;
+        bl.append(gen_string(100));
+        new_keys.emplace(to_string(q)+gen_string(50), bl);
+      }
+      t.omap_setkeys(cid, hoid, new_keys);
+      r = store->queue_transaction(ch, std::move(t));
+      ceph_assert(r == 0);
+    };
+  }
 
   // small deferred writes over object
   // and complete overwrite of previous one
   bufferlist bl_8_bytes;
   bl_8_bytes.append("abcdefgh");
   std::atomic<size_t> deferred_counter{0};
-  for (size_t o = 0; o < object_count - 1; o++) {
+  for (size_t o = 0; o < object_count/* - 1*/; o++) {
     ObjectStore::Transaction t;
 
     // sprinkle deferred writes
-    std::string oid_d = "object-" + std::to_string(o + 1);
+    std::string oid_d = "object-" + std::to_string(o/* + 1*/);
     ghobject_t hoid_d(hobject_t(oid_d, "", CEPH_NOSNAP, 1, poolid, ""));
-
     for(int i = 0; i < 16; i++) {
       t.write(cid, hoid_d, 4096 * i, bl_8_bytes.length(), bl_8_bytes);
     }
-
-    // overwrite previous object
+    // overwrite object content
     std::string oid_m = "object-" + std::to_string(o);
     ghobject_t hoid_m(hobject_t(oid_m, "", CEPH_NOSNAP, 1, poolid, ""));
-    t.write(cid, hoid_m, 0, bl_64K.length(), bl_64K);
+    t.write(cid, hoid_m, 4096 * o, bl_64K.length(), bl_64K);
 
     t.register_on_commit(new C_do_action([&] {
-      if (++deferred_counter == object_count - 1) {
+      if (++deferred_counter == object_count) {
         exit(0);
       }
     }));
     r = store->queue_transaction(ch, std::move(t));
     ceph_assert(r == 0);
   }
-  sleep(10);
+  sleep(100);
   ceph_assert(0 && "should not reach here");
 }
 
-int main(int argc, char **argv) {
+void mount_check_L()
+{
+  std::unique_ptr<ObjectStore> store;
+  store = ObjectStore::create(g_ceph_context,
+    "bluestore", "bluestore.test_temp_dir", "store_test_temp_journal");
+  // this should replay all deferred writes
+  std::cout << "mounting..." << std::endl;
+  ceph_assert(store->mount() == 0);
+  std::cout << "checking for stale deferred (L)..." << std::endl;
+
+  // now there should be no L entries
+  BlueStore* bs = dynamic_cast<BlueStore*>(store.get());
+  ceph_assert(bs);
+  KeyValueDB* db = bs->get_kv();
+  KeyValueDB::Iterator it = db->get_iterator("L");
+  it->seek_to_first();
+  if (it->valid()) {
+    while (it->valid()) {
+      std::cout << pretty_binary_string(it->key()) << std::endl;
+      it->next();
+    }
+    ceph_assert(false && "there are L entries");
+  }
+  it.reset();
+  ceph_assert(store->umount() == 0);
+  std::cout << "all done and good" << std::endl;
+}
+
+
+
+
+/*
+ * The test verifies that its not possible for deferred_replay procedure
+ * to overwrite BlueFS data.
+ * Corruption occurs when:
+ * - BlueFS allocated some space
+ * - deferred wrote over this space
+ * Instead, stronger condition is checked:
+ * - BlueFS allocated any space
+ * - deferred wrote over
+ */
+void mount_check_alloc()
+{
+  std::unique_ptr<ObjectStore> store;
+
+  ObjectStore::CollectionHandle ch;
+  store = ObjectStore::create(g_ceph_context,
+                              "bluestore",
+                              "bluestore.test_temp_dir",
+                              "store_test_temp_journal");
+  // this should replay all deferred writes
+  BlueStore* bs = dynamic_cast<BlueStore*>(store.get());
+  ceph_assert(bs);
+
+  bool called_allocate = false;
+  vector<pair<uint64_t, uint64_t> > captured_allocations;
+  bs->set_tracepoint_debug_deferred_replay_start(
+    [&](){
+      std::cout << "action before deferred replay" << std::endl;
+      Allocator* alloc = bs->debug_get_alloc();
+      alloc->foreach(
+        [&](uint64_t offset, uint64_t length) {
+          captured_allocations.emplace_back(offset, length);
+        });
+      std::cout << "sleeping to give compaction a chance" << std::endl;
+      sleep(10);
+      std::cout << "sleep end" << std::endl;
+    });
+  bs->set_tracepoint_debug_deferred_replay_end(
+    [&](){
+      std::cout << "action after deferred replay" << std::endl;
+      Allocator* alloc = bs->debug_get_alloc();
+      auto ca_it = captured_allocations.begin();
+      alloc->foreach(
+        [&](uint64_t offset, uint64_t length) {
+          if (ca_it == captured_allocations.end()) {
+            called_allocate = true;
+            return;
+          }
+          if (ca_it->first != offset || ca_it->second != length) {
+            called_allocate = true;
+          }
+          ca_it++;
+        });
+      std::cout << "called_allocate=" << called_allocate << std::endl;
+      bs->set_tracepoint_debug_deferred_replay_track(nullptr);
+      bs->set_tracepoint_debug_deferred_replay_start(nullptr);
+      bs->set_tracepoint_debug_deferred_replay_end(nullptr);
+    });
+
+  interval_set<uint64_t> not_onode_allocations;
+  bs->set_tracepoint_debug_init_alloc_done(
+    [&](){
+      Allocator* alloc = bs->debug_get_alloc();
+      alloc->foreach(
+        [&](uint64_t start, uint64_t len) {
+          not_onode_allocations.insert(start, len);
+        });
+      bs->set_tracepoint_debug_init_alloc_done(nullptr);
+    });
+  interval_set<uint64_t> extents_sum;
+  bs->set_tracepoint_debug_deferred_replay_track(
+    [&](const bluestore_deferred_transaction_t& dtxn) {
+      for (auto& op : dtxn.ops) {
+        for (auto& e : op.extents) {
+          extents_sum.insert(e.offset, e.length);
+        }
+      }
+    });
+  std::cout << "mounting..." << std::endl;
+  ceph_assert(store->mount() == 0);
+  std::cout << "mount done" << std::endl;
+  std::cout << std::hex << "disk not used by onodes:" << not_onode_allocations << std::dec << std::endl;
+  std::cout << std::hex << "disk deferred wrote to:" << extents_sum << std::dec << std::endl;
+  std::cout << "allocated_some=" << called_allocate << std::endl;
+  interval_set<uint64_t> wrote_to_not_onodes;
+  wrote_to_not_onodes.intersection_of(extents_sum, not_onode_allocations);
+  std::cout << std::hex << "disk not used by onodes written by deferred="
+            << wrote_to_not_onodes << std::dec << std::endl;
+  bool only_wrote_to_onodes = wrote_to_not_onodes.empty();
+  bs->set_tracepoint_debug_deferred_replay_start(nullptr);
+  ceph_assert(store->umount() == 0);
+
+  ceph_assert(!called_allocate || only_wrote_to_onodes);
+}
+
+
+
+
+int argc;
+char **argv;
+
+boost::intrusive_ptr<CephContext> setup_env() {
   auto args = argv_to_vec(argc, argv);
-  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
-			 CODE_ENVIRONMENT_UTILITY,
-			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  auto cct = global_init(
+    NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+    CODE_ENVIRONMENT_UTILITY,
+    CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);
 
-  create_deferred_and_terminate();
+  g_ceph_context->_conf._clear_safe_to_start_threads();
+  g_ceph_context->_conf.set_val_or_die("bluestore_prefer_deferred_size", "4096");
+  g_ceph_context->_conf.set_val_or_die("bluefs_shared_alloc_size", "4096");
+  g_ceph_context->_conf.set_val_or_die("bluestore_block_size", "10240000000");
+  g_ceph_context->_conf.apply_changes(nullptr);
+  return cct;
+}
+
+int main(int _argc, char **_argv) {
+  argc = _argc;
+  argv = _argv;
+
+  pid_t first_test = fork();
+  if (first_test == 0) {
+    std::cout << "1. Testing deletion of deferred (L) entries." << std::endl;
+    pid_t child = fork();
+    if (child == 0) {
+      auto cct = setup_env();
+      g_ceph_context->_conf->bluestore_allocator = "bitmap";
+      g_ceph_context->_conf->bluestore_rocksdb_options +=
+          ",level0_file_num_compaction_trigger=4";
+      create_deferred_and_terminate();
+      ceph_assert(false && "should exit() earlier");
+    } else {
+      std::cout << "Waiting for fill omap and create deferred..." << std::endl;
+      int stat;
+      waitpid(child, &stat, 0);
+      ceph_assert(WIFEXITED(stat) && WEXITSTATUS(stat) == 0);
+      std::cout << "done and subprocess terminated." << std::endl;
+      auto cct = setup_env();
+      g_ceph_context->_conf->bluestore_allocator = "bitmap";
+      g_ceph_context->_conf->bluestore_rocksdb_options +=
+          ",level0_file_num_compaction_trigger=2";
+      mount_check_L();
+    }
+  } else {
+    int first_stat;
+    waitpid(first_test, &first_stat, 0);
+    ceph_assert(WIFEXITED(first_stat) && WEXITSTATUS(first_stat) == 0);
+    std::cout << "2. Testing overwrite of space allocated by BlueFS" << std::endl;
+    pid_t child = fork();
+    if (child == 0) {
+      auto cct = setup_env();
+      g_ceph_context->_conf->bluestore_allocator = "avl";
+      g_ceph_context->_conf->bluestore_rocksdb_options +=
+          ",level0_file_num_compaction_trigger=4";
+      create_deferred_and_terminate();
+      ceph_assert(false && "should exit() earlier");
+    } else {
+      std::cout << "Waiting for fill omap and create deferred..." << std::endl;
+      int stat;
+      waitpid(child, &stat, 0);
+      ceph_assert(WIFEXITED(stat) && WEXITSTATUS(stat) == 0);
+      std::cout << "done and subprocess terminated." << std::endl;
+      auto cct = setup_env();
+      g_ceph_context->_conf->bluestore_allocator = "avl";
+      g_ceph_context->_conf->bluestore_rocksdb_options +=
+          ",level0_file_num_compaction_trigger=2";
+      mount_check_alloc();
+    }
+  }
   return 0;
 }

--- a/src/test/objectstore/test_deferred.cc
+++ b/src/test/objectstore/test_deferred.cc
@@ -218,7 +218,7 @@ void mount_check_alloc()
 
   bool called_allocate = false;
   vector<pair<uint64_t, uint64_t> > captured_allocations;
-  bs->set_tracepoint_debug_deferred_replay_start(
+  bs->dtr_deferred_replay_start =
     [&](){
       std::cout << "action before deferred replay" << std::endl;
       Allocator* alloc = bs->debug_get_alloc();
@@ -229,8 +229,8 @@ void mount_check_alloc()
       std::cout << "sleeping to give compaction a chance" << std::endl;
       sleep(10);
       std::cout << "sleep end" << std::endl;
-    });
-  bs->set_tracepoint_debug_deferred_replay_end(
+    };
+  bs->dtr_deferred_replay_end =
     [&](){
       std::cout << "action after deferred replay" << std::endl;
       Allocator* alloc = bs->debug_get_alloc();
@@ -247,30 +247,30 @@ void mount_check_alloc()
           ca_it++;
         });
       std::cout << "called_allocate=" << called_allocate << std::endl;
-      bs->set_tracepoint_debug_deferred_replay_track(nullptr);
-      bs->set_tracepoint_debug_deferred_replay_start(nullptr);
-      bs->set_tracepoint_debug_deferred_replay_end(nullptr);
-    });
+      bs->dtr_deferred_replay_track = nullptr;
+      bs->dtr_deferred_replay_start = nullptr;
+      bs->dtr_deferred_replay_end = nullptr;
+    };
 
   interval_set<uint64_t> not_onode_allocations;
-  bs->set_tracepoint_debug_init_alloc_done(
+  bs->dtr_init_alloc_done =
     [&](){
       Allocator* alloc = bs->debug_get_alloc();
       alloc->foreach(
         [&](uint64_t start, uint64_t len) {
           not_onode_allocations.insert(start, len);
         });
-      bs->set_tracepoint_debug_init_alloc_done(nullptr);
-    });
+      bs->dtr_init_alloc_done = nullptr;
+    };
   interval_set<uint64_t> extents_sum;
-  bs->set_tracepoint_debug_deferred_replay_track(
+  bs->dtr_deferred_replay_track =
     [&](const bluestore_deferred_transaction_t& dtxn) {
       for (auto& op : dtxn.ops) {
         for (auto& e : op.extents) {
           extents_sum.insert(e.offset, e.length);
         }
       }
-    });
+    };
   std::cout << "mounting..." << std::endl;
   ceph_assert(store->mount() == 0);
   std::cout << "mount done" << std::endl;
@@ -282,7 +282,7 @@ void mount_check_alloc()
   std::cout << std::hex << "disk not used by onodes written by deferred="
             << wrote_to_not_onodes << std::dec << std::endl;
   bool only_wrote_to_onodes = wrote_to_not_onodes.empty();
-  bs->set_tracepoint_debug_deferred_replay_start(nullptr);
+  bs->dtr_deferred_replay_start = nullptr;
   ceph_assert(store->umount() == 0);
 
   ceph_assert(!called_allocate || only_wrote_to_onodes);


### PR DESCRIPTION
This PR is a revival of #62412
The difference is that previously elusive problem with RocksDB data revival is now solved.

Fixes known problems with deferred write replay.
Based on unittest for deferred writes https://github.com/ceph/ceph/pull/60732
Fixes: https://tracker.ceph.com/issues/68060

Includes observation from https://tracker.ceph.com/issues/70581

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
