### PR TITLE
tentacle: osd/PeeringState: add perf counters for PG rebuild times

### DIFF
--- a/qa/standalone/osd/osd-recovery-stats.sh
+++ b/qa/standalone/osd/osd-recovery-stats.sh
@@ -505,6 +505,87 @@ function TEST_recovery_multi() {
     kill_daemons $dir || return 1
 }
 
+# Verify that the rebuild perf counters on the primary OSD increment after a
+# real EC shard recovery.  Kill one non-primary OSD so the PG goes degraded,
+# then let recovery run to completion.  After the PG is clean again:
+#   - pg_rebuild_duration.avgcount must be >= 1
+#   - pg_rebuild_duration.sum must be > 0 (real time elapsed)
+function TEST_rebuild_perf_ec_increments() {
+    local dir=$1
+    local OSDS=4
+    local ecpoolname=ectest
+
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    for osd in $(seq 0 $(expr $OSDS - 1))
+    do
+      run_osd $dir $osd --osd-mclock-skip-benchmark=true || return 1
+    done
+
+    ceph osd erasure-code-profile set ecprofile \
+        plugin=jerasure technique=reed_sol_van k=2 m=1 \
+        crush-failure-domain=osd || return 1
+    ceph osd pool create $ecpoolname 1 1 erasure ecprofile || return 1
+    ceph osd pool set $ecpoolname min_size 2 || return 1
+    wait_for_clean || return 1
+
+    # Write a few objects so the PG has data that must be recovered.
+    for i in $(seq 1 5)
+    do
+      rados -p $ecpoolname put obj$i /etc/hostname || return 1
+    done
+    wait_for_clean || return 1
+
+    local primary
+    primary=$(get_primary $ecpoolname obj1)
+    local replica
+    replica=$(get_not_primary $ecpoolname obj1)
+
+    # Pause recovery so the PG stays degraded long enough for the latch to
+    # fire inside prepare_stats_for_publish before recovery completes.
+    ceph osd set norecover || return 1
+
+    # Kill one non-primary OSD so the PG becomes degraded.
+    kill $(cat $dir/osd.${replica}.pid)
+    ceph osd down osd.${replica} || return 1
+    ceph osd out osd.${replica} || return 1
+
+    # Release the hold and wait for full recovery.
+    ceph osd unset norecover || return 1
+    wait_for_clean || return 1
+
+    # flush_pg_stats triggers publish_stats_to_osd on every OSD, which calls
+    # prepare_stats_for_publish and commits the rebuild counters.
+    flush_pg_stats || return 1
+
+    # The primary may be the same OSD we started with (we only killed a
+    # replica), but re-query in case CRUSH remapped the primary shard.
+    primary=$(get_primary $ecpoolname obj1)
+
+    local dump
+    dump=$(CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${primary}) \
+           perf dump) || return 1
+
+    local rebuild_avgcount
+    rebuild_avgcount=$(jq '.recoverystate_perf.pg_rebuild_duration.avgcount' \
+      <<< "$dump")
+    test "$rebuild_avgcount" -ge 1 || {
+      echo "FAIL: expected pg_rebuild_duration.avgcount>=1, got $rebuild_avgcount"
+      return 1
+    }
+
+    echo "$dump" | \
+      jq -e '.recoverystate_perf.pg_rebuild_duration.sum > 0' > /dev/null || {
+      local rebuild_sum
+      rebuild_sum=$(jq '.recoverystate_perf.pg_rebuild_duration.sum' <<< "$dump")
+      echo "FAIL: expected pg_rebuild_duration.sum>0, got $rebuild_sum"
+      return 1
+    }
+
+    delete_pool $ecpoolname
+    kill_daemons $dir || return 1
+}
+
 main osd-recovery-stats "$@"
 
 # Local Variables:

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -1047,6 +1047,10 @@ void PeeringState::clear_primary_state()
 
   clear_recovery_state();
 
+  rebuild_start_time = utime_t();
+  rebuild_base_recovered = 0;
+  rebuild_had_redundancy_loss = false;
+
   pg_committed_to = eversion_t();
   missing_loc.clear();
   pl->clear_primary_state();
@@ -4409,6 +4413,95 @@ std::optional<pg_stat_t> PeeringState::prepare_stats_for_publish(
       info.stats.last_undegraded = now;
     if ((info.stats.state & PG_STATE_UNDERSIZED) == 0)
       info.stats.last_fullsized = now;
+
+    /**
+     * The following block is an interim solution to aggregate PG rebuild stats
+     * into a set of perf counters. The counterss are set based on the following
+     * existing pg_stat_t fields:
+     *  - last_clean, last_change
+     *  - num_objects_degraded, num_objects_misplaced, num_objects_recovered
+     *
+     * The PG rebuild stats are aggregated into the following recoverystate
+     * perf counters:
+     *  - rs_pg_rebuild_duration: rebuild duration LONGRUNAVG time counter
+     *  - rs_pg_rebuild_max_secs: maximum rebuild duration (secs)
+     *  - rs_pg_rebuild_min_secs: minimum rebuild duration (secs)
+     *
+     * Workflow:
+     *  1. Only the acting primary OSD of the PG executes the logic to
+     *     determine the rebuild stats.
+     *  2. The logic uses rebuild_start_time as a per-PG in-memory latch that
+     *     captures the failure entry point. When a PG is considered vulnerable,
+     *     rebuild_start_time latches info.stats.last_change as the start time,
+     *     provided last_change > last_clean, which ensures only genuine new
+     *     failures after the prior clean interval are tracked.
+     *  3. On recovery, the rebuild duration is computed as
+     *     (now - rebuild_start_time) and is only recorded if delta
+     *     num_objects_recovered > 0 or the PG had confirmed redundancy loss
+     *     at latch time, filtering out spurious state transitions. The latch
+     *     is cleared after each recorded event.
+     *
+     * last_degraded is intentionally not used in the interim solution to
+     * retain compatibility with older Ceph releases where this field doesn't
+     * exist and requires encoding changes. The interim solution is a
+     * close approximation of the PG rebuild time.
+     *
+     * A future simplification can replace the latch with a direct
+     * (last_clean - last_degraded) calculation once last_degraded is
+     * consistently available.
+     */
+    if (is_primary()) {
+      const int64_t num_degraded  = info.stats.stats.sum.num_objects_degraded;
+      const int64_t num_misplaced = info.stats.stats.sum.num_objects_misplaced;
+      const int64_t num_recovered = info.stats.stats.sum.num_objects_recovered;
+      const bool is_vulnerable =
+        (info.stats.state & (PG_STATE_DEGRADED | PG_STATE_UNDERSIZED)) ||
+        num_degraded > 0 || num_misplaced > 0;
+
+      if (is_vulnerable) {
+        // Latch the failure entry point on the first publish after a new
+        // failure; last_change captures when the state transition occurred.
+        if (rebuild_start_time == utime_t()) {
+          const bool new_failure =
+            info.stats.last_clean == utime_t() ||
+            info.stats.last_change > info.stats.last_clean;
+          if (new_failure) {
+            rebuild_start_time = info.stats.last_change;
+            rebuild_base_recovered = num_recovered;
+            rebuild_had_redundancy_loss =
+              (num_degraded > 0 || num_misplaced > 0);
+            psdout(15) << "rebuild-stats: latched failure start for "
+                       << info.pgid << " at " << rebuild_start_time << dendl;
+          }
+        }
+      } else if (rebuild_start_time != utime_t()) {
+        // PG recovered — record rebuild time if this was a genuine event.
+        const int64_t delta_recovered = num_recovered - rebuild_base_recovered;
+        const utime_t rebuild_dur  = now - rebuild_start_time;
+
+        if (rebuild_dur.to_msec() > 0 &&
+            (delta_recovered > 0 || rebuild_had_redundancy_loss)) {
+          PerfCounters &perf = pl->get_peering_perf();
+          perf.tinc(rs_pg_rebuild_duration, rebuild_dur);
+
+          const uint64_t rebuild_secs = (uint64_t)rebuild_dur.sec();
+          if (rebuild_secs > perf.get(rs_pg_rebuild_max_secs)) {
+            perf.set(rs_pg_rebuild_max_secs, rebuild_secs);
+          }
+          const uint64_t cur_min = perf.get(rs_pg_rebuild_min_secs);
+          if (cur_min == 0 || rebuild_secs < cur_min) {
+            perf.set(rs_pg_rebuild_min_secs, rebuild_secs);
+          }
+          psdout(15) << "rebuild-stats: recorded rebuild for " << info.pgid
+                     << " duration=" << rebuild_dur
+                     << " delta_recovered=" << delta_recovered << dendl;
+        }
+        // reset for the next event
+        rebuild_start_time = utime_t();
+        rebuild_base_recovered = 0;
+        rebuild_had_redundancy_loss = false;
+      }
+    }
 
     psdout(15) << "publish_stats_to_osd " << pre_publish.reported_epoch
 	       << ":" << pre_publish.reported_seq << dendl;

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -1579,6 +1579,17 @@ public:
   bool backfill_reserved = false;
   bool backfill_reserving = false;
 
+  /**
+   * Per-PG latch state for rebuild time tracking. Cleared after each
+   * completed rebuild event is recorded in the perf counters.
+   * The state is also cleared in clear_primary_state() so that an interval
+   * change or role transition (primary -> replica) does not carry a stale
+   * start time or baseline recovered count into a future interval.
+   */
+  utime_t rebuild_start_time;
+  int64_t rebuild_base_recovered = 0;
+  bool rebuild_had_redundancy_loss = false;
+
   PeeringMachine machine;
 
   void update_osdmap_ref(OSDMapRef newmap) {
@@ -1678,6 +1689,17 @@ public:
       pool.info.opts.get(pool_opts_t::RECOVERY_OP_PRIORITY, &pri);
       return  pri > 0 ? pri : cct->_conf->osd_recovery_op_priority;
     }
+  }
+
+  // Accessors for the per-PG rebuild latch state.
+  utime_t get_rebuild_start_time() const {
+    return rebuild_start_time;
+  }
+  int64_t get_rebuild_base_recovered() const {
+    return rebuild_base_recovered;
+  }
+  bool get_rebuild_had_redundancy_loss() const {
+    return rebuild_had_redundancy_loss;
   }
 
 private:

--- a/src/osd/osd_perf_counters.cc
+++ b/src/osd/osd_perf_counters.cc
@@ -531,6 +531,15 @@ PerfCounters *build_recoverystate_perf(CephContext *cct) {
   rs_perf.add_time_avg(rs_waitupthru_latency, "waitupthru_latency", "Waitupthru recovery state latency");
   rs_perf.add_time_avg(rs_notrecovering_latency, "notrecovering_latency", "Notrecovering recovery state latency");
   rs_perf.add_u64_counter(rs_stats_invalidated, "stats_invalidated", "Number of times pg stats received invalidations");
+  rs_perf.add_time_avg(rs_pg_rebuild_duration, "pg_rebuild_duration",
+    "Average PG rebuild duration on this OSD (primary role only)",
+    NULL, PerfCountersBuilder::PRIO_USEFUL);
+  rs_perf.add_u64(rs_pg_rebuild_max_secs, "pg_rebuild_max_secs",
+    "Max PG rebuild duration seen on this OSD in seconds (primary role only)",
+    NULL, PerfCountersBuilder::PRIO_USEFUL);
+  rs_perf.add_u64(rs_pg_rebuild_min_secs, "pg_rebuild_min_secs",
+    "Min PG rebuild duration seen on this OSD in seconds (primary role only)",
+    NULL, PerfCountersBuilder::PRIO_USEFUL);
 
   return rs_perf.create_perf_counters();
 }

--- a/src/osd/osd_perf_counters.h
+++ b/src/osd/osd_perf_counters.h
@@ -256,6 +256,9 @@ enum {
   rs_waitupthru_latency,
   rs_notrecovering_latency,
   rs_stats_invalidated,
+  rs_pg_rebuild_duration,
+  rs_pg_rebuild_max_secs,
+  rs_pg_rebuild_min_secs,
   rs_last,
 };
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77956

---

backport of https://github.com/ceph/ceph/pull/69578
parent tracker: https://tracker.ceph.com/issues/77493

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh