### PR TITLE
tentacle: rgw/datalog: Remove use of 'detached' in `rgw_log_backing` watch

### DIFF
--- a/src/rgw/driver/rados/rgw_log_backing.cc
+++ b/src/rgw/driver/rados/rgw_log_backing.cc
@@ -664,7 +664,7 @@ void logback_generations::operator ()(sys::error_code ec,
 				      bufferlist&& bl) {
   co_spawn(rados.get_executor(),
 	   handle_notify(ec, notify_id, cookie, notifier_id, std::move(bl)),
-	   asio::detached);
+	   async::use_blocked);
 }
 
 asio::awaitable<void>


### PR DESCRIPTION
Replace `asio::detached` with `async::use_blocked` in the notify handler. This shouldn't be too much of a problem given that our notify handlers elsewhere use blocking `notify_ack`.

At a later time I plan to do a larger refactor, but this should be a backportable fix for the memory error.

Original tracker: https://tracker.ceph.com/issues/73313
Original PR: https://github.com/ceph/ceph/pull/65722
Backport tracker: https://tracker.ceph.com/issues/76602