### PR TITLE
doc: add ultra-minimal AGENTS.md navigation guides across codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Ceph
 
-C++23, CMake, Python for management.
+C++ (check CMakeLists.txt for version if relevant), CMake, Python for management.
 
 ## Build
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Ceph
+
+C++ (check CMakeLists.txt for version if relevant), CMake, Python for management.
+
+## Build
+
+```
+./install-deps.sh
+./do_cmake.sh
+ cd build && ninja
+```
+If build directory exists, do not re-run install-deps or do-cmake
+
+Never clean the build directory without explicit permission.
+
+Minimal build for vstart uses target "vstart"
+
+## Rules
+
+Read and follow these files — they are the single source of truth:
+- `SubmittingPatches.rst` — commit messages, PR format, backports
+
+Key rules:
+- No Signed-off-by: AI agents MUST NOT add `Signed-off-by` tags. Only humans certify DCO.
+- Assisted-by: all AI-generated commits must include `Assisted-by: <tool>`. Do not use co-authored-by.
+- Minimal diffs: only change lines necessary for the functional change. No whitespace-only, style-only, or include-reordering changes to unmodified code.
+- User-visible changes: update docs in `doc/`. Developer info goes in code comments or `doc/dev/`.
+- Design docs: complex features need a design doc in `doc/dev/`. Never modify an approved design doc during implementation without permission.
+
+Config options are defined in `src/common/options/*.yaml.in`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Ceph
+
+C++23, CMake, Python for management.
+
+## Build
+
+```
+./install-deps.sh
+./do_cmake.sh
+ cd build && ninja
+```
+If build directory exists, do not re-run install-deps or do-cmake
+
+Never clean the build directory without explicit permission.
+
+Minimal build for vstart uses target "vstart"
+
+## Rules
+
+Read and follow these files — they are the single source of truth:
+- `SubmittingPatches.rst` — commit messages, PR format, backports
+
+Key rules:
+- No Signed-off-by: AI agents MUST NOT add `Signed-off-by` tags. Only humans certify DCO.
+- Assisted-by: all AI-generated commits must include `Assisted-by: <tool>`. Do not use co-authored-by.
+- Minimal diffs: only change lines necessary for the functional change. No whitespace-only, style-only, or include-reordering changes to unmodified code.
+- User-visible changes: update docs in `doc/`. Developer info goes in code comments or `doc/dev/`.
+- Design docs: complex features need a design doc in `doc/dev/`. Never modify an approved design doc during implementation without permission.
+
+Config options are defined in `src/common/options/*.yaml.in`.

--- a/doc/AGENTS.md
+++ b/doc/AGENTS.md
@@ -1,0 +1,19 @@
+Documentation is written in **reStructuredText** (`.rst`) and built with Sphinx. See `doc/dev/documenting.rst` for full authoring guidelines.
+
+Do not attempt to build docs locally unless explicitly directed to. Advise the user that github will generate docs 
+automatically and provide link. 
+
+## Structure
+
+- `doc/` — user-facing documentation (published to docs.ceph.com)
+- `doc/dev/` — developer documentation (internals, design docs, workflows)
+
+User-visible changes to Ceph functionality **must** include corresponding updates under `doc/`. Developer internals go under `doc/dev/`.
+
+## Design docs
+
+Complex features need a design doc in `doc/dev/` before or alongside implementation. **Never modify an approved design doc during implementation without explicit permission.**
+
+## Diagrams
+
+Prefer Graphviz (`.dot` files referenced via `.. graphviz::`) for directed graphs. For SVG diagrams created with Inkscape, commit both the `.svg` source and an exported `.png`; reference the `.png` in `.rst` files.

--- a/qa/AGENTS.md
+++ b/qa/AGENTS.md
@@ -1,0 +1,5 @@
+# qa/ — Integration Tests
+
+Two approaches: **Teuthology** (distributed cluster tests, YAML suite definitions in `suites/`, Python tasks in `tasks/`) and **standalone** (shell scripts in `standalone/` using `ceph-helpers.sh` to run vstart clusters).
+
+Unit tests are separate — see `src/test/AGENTS.md`. RGW test logic mostly lives in the external `s3-tests` repo; `qa/` RGW content is orchestration only.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,9 @@
+# Non-obvious directory names
+
+
+`client/` CephFS POSIX client
+`osdc/` Objecter: client-side RADOS request routing
+`kv/` RocksDB/LevelDB wrapper
+`blk/` block device abstraction
+`neorados/` experimental C++20 coroutine-based RADOS API
+`messages/` on-wire message type definitions

--- a/src/cls/AGENTS.md
+++ b/src/cls/AGENTS.md
@@ -1,0 +1,9 @@
+# src/cls/ — RADOS Classes
+
+RADOS classes are **server-side plugins** that execute atomically on OSD nodes. Classes register methods via the `objclass` API (`src/objclass/objclass.h`). Server-side code operates only on the local object — it cannot access the network or other objects.
+
+To create a new class, copy the `hello/` directory. Server-side methods receive `cls_method_context_t hctx` and use `cls_cxx_*` functions to operate on the local object. Methods are registered in `__cls_init()` via `cls_register_cxx_method()`.
+
+The client-side helpers and server-side implementation must use the same encoding format. Keep type definitions in the shared `_types.h` file.
+
+`cls_rbd` manages the full RBD image metadata schema — changes to it affect RBD format compatibility.

--- a/src/common/AGENTS.md
+++ b/src/common/AGENTS.md
@@ -1,0 +1,7 @@
+# src/common/ — Shared Utilities
+
+Core library used by every subsystem (~330 files): config, threading, logging, perf counters, data structures.
+
+Config options defined in `options/*.yaml.in`. `CephContext` (`cct`) is the global context object (config, logging, perf counters) — most classes receive it as a constructor param.
+
+Use `ceph::mutex`/`ceph::make_mutex()` instead of `std::mutex` for lockdep in debug builds. `bufferlist` is in `include/buffer.h`, not here.

--- a/src/crimson/AGENTS.md
+++ b/src/crimson/AGENTS.md
@@ -1,0 +1,13 @@
+# src/crimson/ — Next-Generation Async OSD (Seastar)
+
+Crimson is the next-generation OSD built on **Seastar**: run-to-completion, shard-per-core, no mutexes, no blocking I/O. Not yet production-ready.
+
+**Never add blocking code**: no `std::mutex`, `std::condition_variable`, `sleep()`, blocking I/O, or standard threading headers.
+
+**Errorator** (`common/errorator.h`) is the core error-handling pattern — statically encodes which errors a function can return. Adding a new error type to a signature cascades through many callers.
+
+**Interruptible futures** (`common/interruptible_future.h`) are used for most PG operations (not plain `seastar::future<>`). Using the wrong type causes hangs or missed interruptions.
+
+**AlienStore** wraps classic BlueStore's blocking calls in a separate thread pool — this is the practical storage backend for Crimson testing. **SeaStore** is experimental.
+
+Cross-core communication uses `seastar::submit_to()` — each core has its own copy of state.

--- a/src/crush/AGENTS.md
+++ b/src/crush/AGENTS.md
@@ -1,0 +1,9 @@
+# src/crush/ — CRUSH Placement Algorithm
+
+CRUSH deterministically maps objects to OSDs using a hierarchical cluster topology and configurable placement rules. The core algorithm is in C (`mapper.c`) for performance; `CrushWrapper` is the C++ API.
+
+**Hash stability is critical**: changing `hash.c` changes data placement cluster-wide, causing massive data migration.
+
+CRUSH weights are integer units of 0x10000 (65536 = 1.0 TiB) — not floating point.
+
+`straw2` is the recommended bucket algorithm. `straw` (v1) has known fairness issues with weight changes.

--- a/src/erasure-code/AGENTS.md
+++ b/src/erasure-code/AGENTS.md
@@ -1,0 +1,11 @@
+# src/erasure-code/ — Erasure Coding Framework
+
+Pluggable EC framework. `ErasureCodeInterface.h` defines the interface; plugins live in subdirectories (`jerasure/`, `isa/`, `lrc/`, `clay/`, `shec/`).
+
+EC has two OSD-side implementations switched by `src/osd/ECSwitch.h`:
+- **FastEC** (`src/osd/ECBackend.cc`, `ECCommon.cc`) — active development target. All new work goes here.
+- **Classic/Legacy EC** (`src/osd/ECBackendL.cc`, `ECCommonL.cc`) — frozen, likely to be deleted. Do not add features.
+
+`minimum_to_decode()` is critical for read optimization — it tells the OSD which shards to read to minimize I/O.
+
+ISA-L (`isa/`) requires Intel CPUs. CLAY codes minimize repair bandwidth but have higher CPU cost.

--- a/src/erasure-code/AGENTS.md
+++ b/src/erasure-code/AGENTS.md
@@ -8,4 +8,8 @@ EC has two OSD-side implementations switched by `src/osd/ECSwitch.h`:
 
 `minimum_to_decode()` is critical for read optimization — it tells the OSD which shards to read to minimize I/O.
 
-ISA-L (`isa/`) requires Intel CPUs. CLAY codes minimize repair bandwidth but have higher CPU cost.
+Plugin status:
+- **ISA-L** (`isa/`) — default plugin, expected long-term supported. Requires Intel CPUs.
+- **Jerasure** (`jerasure/`) — previous default, expected long-term supported.
+- **LRC** (`lrc/`) — not supported in FastEC (optimised EC). May never be. Do not assume it will work with FastEC.
+- **Clay** (`clay/`) and **SHEC** (`shec/`) — expected to be deleted in the near future. Do not add features.

--- a/src/erasure-code/AGENTS.md
+++ b/src/erasure-code/AGENTS.md
@@ -1,0 +1,15 @@
+# src/erasure-code/ — Erasure Coding Framework
+
+Pluggable EC framework. `ErasureCodeInterface.h` defines the interface; plugins live in subdirectories (`jerasure/`, `isa/`, `lrc/`, `clay/`, `shec/`).
+
+EC has two OSD-side implementations switched by `src/osd/ECSwitch.h`:
+- **FastEC** (`src/osd/ECBackend.cc`, `ECCommon.cc`) — active development target. All new work goes here.
+- **Classic/Legacy EC** (`src/osd/ECBackendL.cc`, `ECCommonL.cc`) — frozen, likely to be deleted. Do not add features.
+
+`minimum_to_decode()` is critical for read optimization — it tells the OSD which shards to read to minimize I/O.
+
+Plugin status:
+- **ISA-L** (`isa/`) — default plugin, expected long-term supported. Hardware-accelerated on x86-64 (Intel + AMD), ARM NEON, and RISC-V; base C functions work on any architecture.
+- **Jerasure** (`jerasure/`) — previous default, expected long-term supported.
+- **LRC** (`lrc/`) — not supported in FastEC (optimised EC). May never be. Do not assume it will work with FastEC.
+- **Clay** (`clay/`) and **SHEC** (`shec/`) — expected to be deleted in the near future. Do not add features.

--- a/src/include/AGENTS.md
+++ b/src/include/AGENTS.md
@@ -1,0 +1,32 @@
+# src/include/ — Shared Header Files
+
+The fundamental layer that everything depends on.
+
+## Serialization
+
+All on-wire and on-disk structures use versioned encoding from `encoding.h`:
+```cpp
+void encode(bufferlist& bl) const {
+  ENCODE_START(2, 1, bl);
+  encode(field1, bl);
+  encode(field2, bl);   // added in v2
+  ENCODE_FINISH(bl);
+}
+void decode(bufferlist::const_iterator& p) {
+  DECODE_START(2, p);
+  decode(field1, p);
+  if (struct_v >= 2) { decode(field2, p); }  // guard new fields
+  DECODE_FINISH(p);
+}
+WRITE_CLASS_ENCODER(MyType)
+```
+`denc.h` is a newer zero-copy variant for performance-critical types — don't mix both for the same type.
+
+## bufferlist
+
+`bufferlist` is NOT a contiguous buffer. `bl.c_str()` may copy. Use iterators for decoding: `auto it = bl.cbegin(); decode(obj, it)`.
+
+## Gotchas
+
+- Feature bits in `ceph_features.h` are a limited resource. New features should prefer capability negotiation over adding feature bits.
+- `MSG_*` constants must be unique. When adding a new message type, choose the next available number.

--- a/src/librados/AGENTS.md
+++ b/src/librados/AGENTS.md
@@ -1,0 +1,7 @@
+# src/librados/ — RADOS Client Library
+
+`librados` wraps the **Objecter** (`src/osdc/Objecter.h`), which handles the actual OSD communication, OSDMap management, and request routing. The C and C++ APIs are separate wrappers around the same `RadosClient` implementation.
+
+`neorados` is the modern replacement API. New internal Ceph code should prefer it over classic `librados`.
+
+Pool handles (`IoCtx`) are not thread-safe. Create one per thread or protect with external synchronization.

--- a/src/librbd/AGENTS.md
+++ b/src/librbd/AGENTS.md
@@ -2,10 +2,8 @@
 
 RBD images use an **async request + state machine pattern** — operations are `AsyncRequest` subclasses chaining `Context` callbacks. Tracing a single operation requires following `Context::complete()` calls through multiple states.
 
-The journal is optional — only enabled when mirroring is active. When enabled, every write goes through the journal.
+The journal is optional. Journal-based mirroring requires it; snapshot-based mirroring does not. Journaling can also be enabled independently of mirroring. When enabled, every write goes through the journal.
 
 Object map is optional. When enabled, it must be kept in sync with actual object existence.
-
-`ImageCtx` is not thread-safe by itself. Access is coordinated through the exclusive lock and image-level locks.
 
 RBD uses `cls_rbd` heavily for metadata. Client-side helpers are in `cls/rbd/cls_rbd_client.h`.

--- a/src/librbd/AGENTS.md
+++ b/src/librbd/AGENTS.md
@@ -1,0 +1,9 @@
+# src/librbd/ — RBD Client Library
+
+RBD images use an **async request + state machine pattern** — operations are `AsyncRequest` subclasses chaining `Context` callbacks. Tracing a single operation requires following `Context::complete()` calls through multiple states.
+
+The journal is optional. Journal-based mirroring requires it; snapshot-based mirroring does not. Journaling can also be enabled independently of mirroring. When enabled, every write goes through the journal.
+
+Object map is optional. When enabled, it must be kept in sync with actual object existence.
+
+RBD uses `cls_rbd` heavily for metadata. Client-side helpers are in `cls/rbd/cls_rbd_client.h`.

--- a/src/librbd/AGENTS.md
+++ b/src/librbd/AGENTS.md
@@ -1,0 +1,11 @@
+# src/librbd/ — RBD Client Library
+
+RBD images use an **async request + state machine pattern** — operations are `AsyncRequest` subclasses chaining `Context` callbacks. Tracing a single operation requires following `Context::complete()` calls through multiple states.
+
+The journal is optional — only enabled when mirroring is active. When enabled, every write goes through the journal.
+
+Object map is optional. When enabled, it must be kept in sync with actual object existence.
+
+`ImageCtx` is not thread-safe by itself. Access is coordinated through the exclusive lock and image-level locks.
+
+RBD uses `cls_rbd` heavily for metadata. Client-side helpers are in `cls/rbd/cls_rbd_client.h`.

--- a/src/mds/AGENTS.md
+++ b/src/mds/AGENTS.md
@@ -1,0 +1,11 @@
+# src/mds/ — Metadata Server
+
+MDS manages the CephFS namespace: in-memory cache of inodes (`CInode`), dentries (`CDentry`), directory fragments (`CDir`), distributed locking, and journaling.
+
+`MDCache.cc` is ~15K lines — search by function rather than reading linearly.
+
+`frag_t` (directory fragmentation) uses a **bitwise prefix scheme**. Understanding it is required for any work on directory operations.
+
+`Locker.cc` is ~6K lines of cap/lock state transitions. The locking model is intricate and easy to break.
+
+CInode/CDentry/CDir use intrusive reference counting — don't hold raw pointers across async operations.

--- a/src/mgr/AGENTS.md
+++ b/src/mgr/AGENTS.md
@@ -1,0 +1,7 @@
+# src/mgr/ — Manager Daemon
+
+The C++ code here is the **hosting infrastructure only**. Python module implementations (dashboard, cephadm, prometheus, etc.) live in `src/pybind/mgr/`.
+
+**GIL management** is the most critical pattern. Acquire the GIL before calling into Python, release before calling into C++. See `Gil.h` for `SafeThreadState` and `GilGuard`. **GIL deadlocks** are a real risk: the common pattern is holding a C++ lock, acquiring GIL, then calling Python code that tries to call back into C++ and re-acquire the same lock.
+
+Manager has active/standby HA. Only the active manager runs Python modules at full functionality.

--- a/src/mon/AGENTS.md
+++ b/src/mon/AGENTS.md
@@ -1,0 +1,19 @@
+# src/mon/ — Monitor Daemon
+
+Monitors use **Paxos** consensus. Each cluster state type (OSDMap, MDSMap, AuthMap, etc.) is managed by a dedicated **PaxosService** subclass.
+
+## PaxosService lifecycle — follow this for all new commands/state changes
+
+1. **`preprocess_query()`** — read-only check, can answer without Paxos. Return `true` if handled.
+2. **`prepare_update()`** — propose a change through Paxos, stages into a pending buffer.
+3. Paxos commits → `update_from_paxos()` applies committed state on all monitors.
+
+## MonCommands DSL
+
+CLI commands are defined in `MonCommands.h` via a macro-based DSL. The command string format is positional — parameter names and types must match exactly.
+
+## Gotchas
+
+- `PGMap` is populated from OSD reports and aggregated by the monitor. It is **NOT** a Paxos-managed map — updated out-of-band.
+- `OSDMonitor` is by far the largest PaxosService — handles pools, CRUSH rules, OSD state, and device classes all in one.
+- The monitor stores ALL versions of cluster maps. Unbounded disk growth if trimming is misconfigured.

--- a/src/msg/AGENTS.md
+++ b/src/msg/AGENTS.md
@@ -1,0 +1,7 @@
+# src/msg/ — Messaging Layer
+
+Production messenger is `AsyncMessenger` in `async/`. Two wire protocols: v1 (legacy, being phased out — new features target v2 only) and v2 (`ProtocolV2.h/cc`, with encryption and compression).
+
+Messages are reference-counted via `MessageRef`. Use `ref_cast<MType>(m)` to downcast — never `delete` a message.
+
+**Do not block in a dispatch handler** — it blocks the worker thread's event loop. Use Finishers or thread pools for heavy work.

--- a/src/os/AGENTS.md
+++ b/src/os/AGENTS.md
@@ -1,0 +1,7 @@
+# src/os/ — ObjectStore Abstraction
+
+`ObjectStore` is the abstract interface for all OSD on-disk storage. Production implementation is **BlueStore** (`bluestore/`); **MemStore** (`memstore/`) is for tests.
+
+A `coll_t` maps 1:1 to a Placement Group. The `ch` (collection handle) must be obtained via `open_collection()` before use — it caches metadata.
+
+`queue_transaction` is asynchronous. Callbacks fire on a separate thread. FileStore is removed — ignore any old references to it.

--- a/src/os/bluestore/AGENTS.md
+++ b/src/os/bluestore/AGENTS.md
@@ -1,0 +1,11 @@
+# src/os/bluestore/ — BlueStore
+
+BlueStore stores data directly on raw block devices (no filesystem). Uses RocksDB via **BlueFS** for metadata.
+
+Object model: `Onode` (metadata in RocksDB) → `Blob` (data chunk, possibly compressed) → `PExtent` (physical offset+length on disk).
+
+`BlueStore.cc` is ~30K lines — search by function name. A bug in allocation or extent mapping can corrupt all data on the device.
+
+**Deferred writes** handle small overwrites (writes to WAL first, applied later). Small and large writes have different code paths.
+
+BlueFS and BlueStore share the same block device but manage different regions.

--- a/src/osd/AGENTS.md
+++ b/src/osd/AGENTS.md
@@ -1,0 +1,11 @@
+# src/osd/ — Object Storage Daemon
+
+Core storage daemon. Manages Placement Groups (PGs), replication, erasure coding, peering, recovery, scrubbing.
+
+Entry points: `OSD.h/cc` (daemon), `PrimaryLogPG.cc` (`do_op()`/`do_osd_ops()` for client I/O), `PeeringState.h` (state machine).
+
+EC has two implementations switched by `ECSwitch.h`: FastEC (`ECBackend.cc`) is the active target; legacy (`ECBackendL.cc`) is frozen — do not add features to it.
+
+`OSDMap.h` is used cluster-wide (mon, mds, clients), not just by OSD.
+
+See `scrubber/AGENTS.md` for scrubbing subsystem.

--- a/src/osd/scrubber/AGENTS.md
+++ b/src/osd/scrubber/AGENTS.md
@@ -1,0 +1,7 @@
+# src/osd/scrubber/ — Scrubbing Subsystem
+
+Scrubbing verifies data integrity by comparing object replicas (or EC shards) across OSDs. Two modes: **shallow** (metadata only) and **deep** (reads and checksums all data). Lifecycle managed by a **boost::statechart state machine** (`scrub_machine.h/cc`).
+
+Before scrubbing, the primary must reserve slots on all replica OSDs (`scrub_reservations.h/cc`) — prevents scrub storms but can delay necessary scrubs.
+
+The state machine is complex with many states and transitions. Changes to scrub timing interact with recovery, backfill, and client I/O — easy to affect cluster performance inadvertently.

--- a/src/pybind/mgr/AGENTS.md
+++ b/src/pybind/mgr/AGENTS.md
@@ -1,0 +1,13 @@
+# src/pybind/mgr/ — Python Manager Modules
+
+50+ modules. Each is a directory with a `module.py` defining a class inheriting `MgrModule` (defined in `mgr_module.py`). Use `hello/` as a template.
+
+The C++ hosting infrastructure is in `src/mgr/`.
+
+## Key patterns
+
+- **Continuous service**: implement `serve()` using `self.event.wait()` — never `time.sleep()` (not interruptible).
+- **Commands**: use `@CLICommand` decorator (preferred over `COMMANDS` class attribute).
+- **Config**: persists in the monitor store, visible cluster-wide.
+
+**Dashboard** is a sub-project with its own Angular frontend and build system — treat it separately.

--- a/src/rgw/AGENTS.md
+++ b/src/rgw/AGENTS.md
@@ -1,0 +1,7 @@
+# src/rgw/ — RADOS Gateway
+
+S3/Swift-compatible HTTP object storage API on RADOS. Largest subsystem (~360 files).
+
+Architecture: HTTP frontend (Beast/Asio) → REST routing (`rgw_rest.cc`) → `RGWOp` handlers (`rgw_op.cc`) → SAL interface (`rgw_sal.h`) → backend driver (`driver/rados/`).
+
+New code must use the SAL interface, not talk to RADOS directly. `radosgw-admin` CLI is in `radosgw-admin/`. Most RGW tests are in the separate `s3-tests` repo.

--- a/src/test/AGENTS.md
+++ b/src/test/AGENTS.md
@@ -1,0 +1,10 @@
+# src/test/ — C++ Unit Tests
+
+GTest/GMock. Test files mirror source structure. Register in `CMakeLists.txt` via `add_ceph_unittest()`.
+
+```bash
+cd build && ninja unittest_foo && ./bin/unittest_foo
+GTEST_FILTER="Suite.Name" ./bin/unittest_foo
+```
+
+`run-make-check.sh` builds everything and runs all tests — slow. For iteration, build and run individual tests directly.

--- a/src/tools/AGENTS.md
+++ b/src/tools/AGENTS.md
@@ -1,0 +1,7 @@
+# src/tools/ — CLI Tools
+
+`ceph-objectstore-tool` opens the OSD's ObjectStore directly. The **OSD must be stopped first** — running it on a live OSD corrupts data.
+
+`ceph-dencoder` is used in encoding compatibility tests. Adding a new encoded type requires registering it with the dencoder.
+
+`rbd-mirror` (`rbd_mirror/`) is a long-running daemon, not just a CLI tool, despite living in `tools/`.


### PR DESCRIPTION
AGENTS.md files were generated by AI analysis of the source code to capture non-obvious facts that aid navigation. They were then audited using a simple test: before reading each file, guess what it says based solely on the directory name and general knowledge of the codebase. Any content that matched the guess was deleted.

The test for "non-obvious": if an agent working in the repo could infer the content without the file — from the directory listing, file names, or general knowledge of the subsystem — it is not worth the context tokens.

What was excluded from the final files:
- Purpose/overview sections (every agent knows what src/mds/ or src/crush/ is)
- Key files tables (discoverable by ls or grep)
- Directory structure tables (mirrors what is on disk)
- Navigation hints ("to understand X, read Y.cc" — just grep)
- Dependency sections ("uses common/, msg/" — obvious from includes)

What was kept:
- Non-standard rules that are easy to get wrong (e.g. no Signed-off-by, Assisted-by tag required, never clean the build dir)
- Critical gotchas with real consequences (e.g. ceph-objectstore-tool corrupts a live OSD, BlueStore.cc is 30K lines, hash.c changes cause cluster-wide data migration)
- Non-obvious architectural facts (e.g. PGMap is NOT Paxos-managed, FastEC is the target and legacy EC is frozen, GIL deadlock pattern in mgr)
- Project-specific conventions that differ from the norm (e.g. use ceph::mutex not std::mutex, interruptible_future not seastar::future)

The initial AI-generated drafts were ~17,900 tokens; the audited files are ~4,600 tokens — a 74% reduction while retaining only content that cannot be inferred from the source tree alone.

Assisted-by: IBM Bob





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
