### PR TITLE
crimson/osd: fix boot crash when a peer OSD was purged across an osdm…

### DIFF
--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -1243,8 +1243,11 @@ seastar::future<> OSD::committed_osd_maps(
         co_return;
       }
       DEBUG("osd.{}: mark osd.{} down", whoami, osd_id);
+      // osd_id came from old_map->get_all_osds(); if it was purged in the new
+      // osdmap, osdmap->get_cluster_addrs(osd_id) would ceph_assert(exists()).
+      // old_map is guaranteed to contain osd_id and holds its last-known addr.
       co_await cluster_msgr->mark_down(
-        osdmap->get_cluster_addrs(osd_id).front());
+        old_map->get_cluster_addrs(osd_id).front());
     });
 
     co_await pg_shard_manager.update_map(std::move(o));


### PR DESCRIPTION
## Summary

`OSD::committed_osd_maps()` walks the set of peers from the *old* osdmap and, for each peer that transitioned up -> down, marks its cluster messenger address down. The address was looked up in the *new* osdmap via `osdmap->get_cluster_addrs(osd_id)`, but `osd_id` comes from `old_map->get_all_osds()`. 
If that peer was fully purged in the new map (e.g. OSD decommission/reprovision), the new osdmap no longer has an entry for it and `get_cluster_addrs()` hits `ceph_assert(exists())`, aborting the OSD during boot while it replays osdmap epochs.

## Fix

Look the address up in `old_map` instead: it is guaranteed to contain `osd_id` (that's where the id came from) and holds its last-known cluster address, which is exactly what needs to be marked down.