### PR TITLE
doc/cephadm: note custom_configs masking by service directory mounts

### DIFF
--- a/doc/cephadm/services/index.rst
+++ b/doc/cephadm/services/index.rst
@@ -746,6 +746,17 @@ applying a YAML spec with custom config files specified and having cephadm
 redeploy the daemons for which the config files are specified, these files will
 be mounted within the daemon's container at the specified location.
 
+.. note::
+
+   If the chosen ``mount_path`` lies inside a directory that cephadm already
+   deploys as a whole-directory bind mount for that service (for example,
+   ``/etc/ganesha/`` for the ``nfs`` service), the custom config file will be
+   silently masked: the file is written to the daemon directory on the host,
+   but the service's directory mount covers it inside the container. Choose a
+   ``mount_path`` outside the service's auto-managed directories (for
+   example, ``/etc/ganesha-override.conf`` rather than
+   ``/etc/ganesha/override.conf``).
+
 Example service spec:
 
 .. code-block:: yaml


### PR DESCRIPTION
The `custom_configs` documentation doesn't mention that a `mount_path` inside a directory the service already bind-mounts wholesale is silently masked.

Hit in production while overriding `ganesha.conf` for a cephadm-managed NFS service on 20.2.x: a custom config at `/etc/ganesha/...` was written to the daemon directory on the host but never appeared inside the container, because cephadm mounts the daemon's `/etc/ganesha/` directory over it. Moving the file to `/etc/ganesha-override.conf` (outside the auto-managed directory) behaves as expected.

This adds a note to the Custom Config Files section documenting the behavior and recommending paths outside the service's auto-managed directories.

## Checklist
- Tracker: docs-only clarification of existing behavior
- Documentation change only — no code, no tests affected