### PR TITLE
tentacle: nvmeof: Change the NVMEOF image version to 1.7

### DIFF
--- a/src/python-common/ceph/cephadm/images.py
+++ b/src/python-common/ceph/cephadm/images.py
@@ -32,7 +32,7 @@ class DefaultImages(Enum):
     GRAFANA = _create_image('quay.io/ceph/grafana:12.3.1', 'grafana')
     HAPROXY = _create_image('quay.io/ceph/haproxy:2.3', 'haproxy')
     KEEPALIVED = _create_image('quay.io/ceph/keepalived:2.2.4', 'keepalived')
-    NVMEOF = _create_image('quay.io/ceph/nvmeof:1.6', 'nvmeof')
+    NVMEOF = _create_image('quay.io/ceph/nvmeof:1.7', 'nvmeof')
     SNMP_GATEWAY = _create_image('docker.io/maxwo/snmp-notifier:v1.2.1', 'snmp_gateway')
     ELASTICSEARCH = _create_image('quay.io/omrizeneva/elasticsearch:6.8.23', 'elasticsearch')
     JAEGER_COLLECTOR = _create_image('quay.io/jaegertracing/jaeger-collector:1.29',


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77975

---

backport of https://github.com/ceph/ceph/pull/67467
parent tracker: https://tracker.ceph.com/issues/75097

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh