### PR TITLE
rgw: require MFA on versioned multi-object delete

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -8363,7 +8363,7 @@ void RGWDeleteMultiObj::execute(optional_yield y)
     bool has_versioned = false;
     for (auto object : multi_delete->objects) {
       const string& instance = object.get_version_id();
-      if (instance.empty()) {
+      if (!instance.empty()) {
         has_versioned = true;
         break;
       }


### PR DESCRIPTION
## Description

On a bucket with MFA-delete enabled, `RGWDeleteMultiObj` decided whether a
request contained a versioned delete by checking whether the per-object
version id was *empty*. That is backwards: a versioned delete carries a
non-empty version id. The inverted test flipped the MFA guard in both
directions:

- A multi-object delete that permanently removes specific object versions
  (exactly what MFA-delete is meant to protect) skipped the MFA check.
- A plain delete of the current version wrongly required MFA.

This is a regression from 55f5b762c6 ("RGW | fix conditional Delete and
MultiDelete"), which rewrote the loop and changed the original
`!instance.empty()` test to `instance.empty()`. It shipped in v20.2.1 and
v20.2.2. Reef and Squid are not affected.

The fix restores the correct condition so a version-specific multi-object
delete is gated by MFA.

## Testing

Reproduced and verified on a vstart cluster with a TOTP token and a
versioned bucket with MFA-delete enabled:

- versioned multi-delete without MFA -> 403 (rejected, was allowed before)
- versioned multi-delete with a valid MFA code -> succeeds
- plain multi-delete without MFA -> succeeds (was wrongly rejected before)

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes bug reproducer

Tracker: https://tracker.ceph.com/issues/77869
