### PR TITLE
rgw/sts: fix inverted token code length check in AssumeRole

### DIFF
--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -282,7 +282,7 @@ int AssumeRoleRequest::validate_input(const DoutPrefixProvider *dpp) const
       return -EINVAL;
     }
   }
-  if (! tokenCode.empty() && tokenCode.size() == TOKEN_CODE_SIZE) {
+  if (! tokenCode.empty() && tokenCode.size() != TOKEN_CODE_SIZE) {
     ldpp_dout(dpp, 0) << "Either token code is empty or token code size is invalid: " << tokenCode.size() << dendl;
     return -EINVAL;
   }


### PR DESCRIPTION
## Description

`AssumeRoleRequest::validate_input()` rejected a token code of the *valid*
length and accepted every other length. The guard used
`tokenCode.size() == TOKEN_CODE_SIZE` to return `-EINVAL`, which is the
opposite of the neighbouring `externalId` and `serialNumber` checks that
reject only out-of-range lengths.

As a result an `AssumeRole` call carrying a valid 6-digit MFA token code was
rejected with `-EINVAL`, so MFA-gated role assumption via STS could not
work, while a wrong-length code slipped through. The fix compares with `!=`
so only a token code of the wrong length is rejected.

The check has been inverted since the STS AssumeRole implementation was
added in e2873cdfa6f6. It affects tentacle and squid.

## Testing

Verified on a vstart cluster with STS enabled and a role assumable by the
caller:

- AssumeRole with a valid 6-char TokenCode -> succeeds (rejected with EINVAL before)
- AssumeRole with a 7/8/9-char TokenCode -> 400 InvalidArgument (rejected)
- AssumeRole with no TokenCode -> succeeds

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes bug reproducer

Tracker: https://tracker.ceph.com/issues/77872
