### PR TITLE
umbrella: ceph.spec.in: disable -P in python shebang for cephadm binary

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1993,6 +1993,9 @@ install -m 0644 -D udev/50-rbd.rules %{buildroot}%{_udevrulesdir}/50-rbd.rules
 install -m 0440 -D sudoers.d/ceph-smartctl %{buildroot}%{_sysconfdir}/sudoers.d/ceph-smartctl
 
 %if 0%{?rhel} >= 8 || 0%{?openEuler}
+# Undefine -P flag as it is only supported with python version >= 3.11
+%undefine _py3_shebang_P
+
 %{py3_shebang_fix} %{buildroot}%{_bindir}/* %{buildroot}%{_sbindir}/*
 %endif
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77390

---

backport of https://github.com/ceph/ceph/pull/69421
parent tracker: https://tracker.ceph.com/issues/77340

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh