### PR TITLE
rgw/posix: fix inverted If-None-Match: * check on write

### DIFF
--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -4685,7 +4685,7 @@ int POSIXAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   if (if_nomatch) {
     if (strcmp(if_nomatch, "*") == 0) {
       // test the object is not existing
-      if (!exists) {
+      if (exists) {
 	return -ERR_PRECONDITION_FAILED;
       }
     } else {


### PR DESCRIPTION
## Description

`POSIXAtomicWriter::complete()` evaluated `If-None-Match: *` as
`if (!exists) return -ERR_PRECONDITION_FAILED`, so it failed the write when
the object was *absent* and allowed it when the object already *existed* -
the opposite of the intended semantics. `If-None-Match: *` must return 412
when the object exists and succeed only when it is absent.

On the posix backend this meant "create only if absent" requests silently
overwrote existing objects (defeating overwrite protection), while a
legitimate create of a new object was wrongly rejected with 412.

The bug was introduced in 89a28892365d ("rgw/posix: implement the quota
feature"), which refactored the existence check into a cached `exists`
variable and copied the `If-Match` test (`!exists`) into the `If-None-Match`
branch. The fix restores the correct condition.

## Testing

Verified on a vstart cluster running the posix backend (`--rgw_store posix`):

- PUT a new key with If-None-Match: * -> 200 (was 412 before)
- PUT the same key again with If-None-Match: * -> 412 PreconditionFailed (overwrote before)
- PUT with no header -> 200

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes bug reproducer

Tracker: https://tracker.ceph.com/issues/77871
