### PR TITLE
rbd-mirror: return after finishing on unsupported mirror mode

### DIFF
--- a/src/tools/rbd_mirror/image_replayer/PrepareLocalImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/PrepareLocalImageRequest.cc
@@ -153,7 +153,7 @@ void PrepareLocalImageRequest<I>::handle_get_mirror_info(int r) {
     derr << "unsupported mirror image mode " << m_mirror_image.mode << " "
          << "for image " << m_global_image_id << dendl;
     finish(-EOPNOTSUPP);
-    break;
+    return;
   }
 
   dout(10) << "local_image_id=" << m_local_image_id << ", "


### PR DESCRIPTION
The mirror-mode switch default in `handle_get_mirror_info()` calls
`finish(-EOPNOTSUPP)`, which deletes `this`, then `break`s and falls
through to the common code — dereferencing the now-null `*m_state_builder`
and freeing the request a second time.

Fixes: https://tracker.ceph.com/issues/78043

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests