### PR TITLE
mgr: detect fail slow devices

### DIFF
--- a/doc/dev/osd_internals/fail_slow_osd_detection.rst
+++ b/doc/dev/osd_internals/fail_slow_osd_detection.rst
@@ -1,0 +1,140 @@
+==============================
+Fail-slow OSD Detection Design
+==============================
+
+Background
+==========
+
+Some production clusters have seen severe cluster-wide performance
+degradation caused by a very small number of storage devices with abnormally
+high I/O latency. These devices may still respond within one or two seconds,
+which is slow enough to hurt client workloads but not slow enough for the OSD
+to be marked down.
+
+This is especially impactful for VM workloads because VM data is distributed
+across many OSDs. A single slow device can therefore add latency to requests
+for many VMs.
+
+The goal of this work is to detect OSDs, or physical devices backing OSDs, that
+are likely in a fail-slow state and surface them to the cluster operator. A
+later policy decision may decide whether Ceph should only report these OSDs or
+also take automatic action such as marking them out.
+
+Problem Statement
+=================
+
+A fail-slow detector should identify OSDs whose device-side latency is
+abnormally high compared with similar healthy OSDs. It should avoid flagging
+OSDs that are temporarily slow because of expected internal background work,
+like recovery/backfill/deep-scrub.
+
+The detector should be robust against outliers. A small number of bad OSDs
+should not move the baseline far enough that they stop being detected.
+
+Non-goals
+=========
+
+This design does not try to classify every cause of cluster-wide latency. In
+particular, higher-level background work such as RGW garbage collection,
+cross-site replication, deduplication, or pool migration can affect performance
+without being directly visible to the OSD. Those workloads may need separate
+signals or operator context.
+
+Initial automated remediation policy is also out of scope. The detector should
+first produce a reliable suspicion signal.
+
+Detection Model
+===============
+
+Use a robust reference baseline instead of a simple average or an adaptive
+per-OSD sliding-window baseline.
+
+An adaptive per-OSD baseline has two problems:
+
+* it can include samples collected during recovery, backfill, scrub, or other
+  temporary work;
+* it can adapt to the degraded state and eventually stop flagging the slow OSD.
+
+For each comparison cohort, calculate the median and median absolute deviation
+of the steady-state OSDs, then score each candidate OSD against that cohort:
+
+::
+
+   osd_score = (commit_latency_ms[osd] - cohort_median) / cohort_MAD
+
+``cohort_MAD`` is preferred over standard deviation because standard deviation
+is pulled by extreme outliers.
+
+Comparison Cohorts
+==================
+
+The baseline should not necessarily be global across the entire cluster. A
+cluster may contain very different hardware classes, and it is common for pools
+to use different hardware. Comparing HDD-backed pools directly with NVMe-backed
+pools would produce misleading results.
+
+The preferred comparison is therefore per pool, or per another cohort that maps
+to similar storage hardware. The exact cohort selection should be explicit in
+the implementation so that mixed-hardware clusters do not make healthy slow
+media look anomalous merely because faster media exists elsewhere.
+
+Sample Filtering
+================
+
+Only steady-state OSDs should contribute to the reference statistics. Exclude
+OSDs that are known to be affected by OSD-visible background work, including:
+
+* recovery;
+* backfill;
+* deep scrub;
+* possibly PG split and merge.
+
+The same filtering should be considered when deciding whether a specific OSD is
+a candidate for fail-slow detection. An OSD that is temporarily slow because of
+known background work should not be treated the same way as a steady-state OSD
+with unexpectedly high device latency.
+
+Primary Signal
+==============
+
+For bottom-up OSD or device detection, use device-oriented latency such as
+``commit_latency_ms`` as the primary signal. This keeps the first detector
+focused on storage-device slowness.
+
+Signals such as operation latency or queue-age histograms are still valuable,
+but they are better suited as top-down triggers. They can tell the system that
+clients are experiencing latency, after which the detector can look for a
+device-level explanation.
+
+Physical Device Grouping
+========================
+
+Some deployments run multiple OSDs on the same physical device. After scoring
+individual OSDs, group scores by physical device when that mapping is available
+from OSD metadata.
+
+The primary device-level score should be the median of the already-normalized
+OSD scores for that device:
+
+::
+
+   device_score = median(osd_score[osd] for osd on device)
+
+This helps identify the physical device as the likely failing unit rather than
+treating each affected OSD independently. Since ``osd_score`` is already
+normalized against the comparison cohort, subtracting the median score of OSDs
+not on the device is unnecessary for the primary detector. A leave-one-device-out
+contrast may still be useful as a secondary diagnostic, but it should not be
+the main score used for thresholding.
+
+Failure Classification
+======================
+
+Additional latency metrics can help distinguish storage-device failures from
+network or failure-domain problems. For example, elevated ``subop_w_latency``
+for a rack, host, or OSD may indicate a network issue in that entity or failure
+domain rather than a slow disk.
+
+This classification should be secondary to the first fail-slow detector. The
+initial detector should produce a strong suspicion signal for abnormal storage
+latency; later work can classify the failure domain more precisely.

--- a/src/common/options/mgr.yaml.in
+++ b/src/common/options/mgr.yaml.in
@@ -141,6 +141,62 @@ options:
   default: false
   services:
   - mgr
+- name: mgr_fail_slow_osd_check_period
+  type: int
+  level: basic
+  desc: Period in seconds of checking for fail slow devices
+  long_desc: The detector recomputes device scores at most once per this period.
+    Together with mgr_fail_slow_osd_persistence this sets how long a device must
+    look slow before a warning is raised, i.e. persistence * check_period seconds.
+  see_also:
+    - mgr_fail_slow_osd_persistence
+  default: 10
+  services:
+  - mgr
+  min: 2
+- name: mgr_fail_slow_osd_enabled
+  type: bool
+  level: advanced
+  desc: Enable detection of OSDs with abnormally high commit latency
+  default: true
+  services:
+  - mgr
+- name: mgr_fail_slow_osd_min_osds
+  type: uint
+  level: advanced
+  desc: Minimum steady-state OSDs required in a fail-slow comparison cohort
+  default: 5
+  services:
+  - mgr
+- name: mgr_fail_slow_osd_score_threshold
+  type: float
+  level: advanced
+  desc: Minimum median device score required to report a fail-slow OSD warning
+  default: 10.0
+  services:
+  - mgr
+- name: mgr_fail_slow_osd_min_latency_ms
+  type: float
+  level: advanced
+  desc: Minimum median device commit latency required to report a fail-slow OSD warning
+  default: 100.0
+  services:
+  - mgr
+- name: mgr_fail_slow_osd_mad_floor_ms
+  type: float
+  level: advanced
+  desc: Minimum median absolute deviation used when scoring OSD commit latency
+  default: 1.0
+  services:
+  - mgr
+  min: 1.0
+- name: mgr_fail_slow_osd_persistence
+  type: uint
+  level: advanced
+  desc: Consecutive Manager reports required before reporting a fail-slow OSD warning
+  default: 3
+  services:
+  - mgr
 - name: mgr_max_pg_num_change
   type: int
   level: advanced

--- a/src/common/perf_counters.h
+++ b/src/common/perf_counters.h
@@ -242,9 +242,11 @@ public:
     std::pair<uint64_t, T> cur;
     avg_tracker() : last(0, 0), cur(0, 0) {}
     T current_avg() const {
-      if (cur.first == last.first)
+      auto &[cur_sum, cur_count] = cur;
+      auto &[last_sum, last_count] = last;
+      if (cur_count == last_count)
         return 0;
-      return (cur.second - last.second) / (cur.first - last.first);
+      return (cur_sum - last_sum) / (cur_count - last_count);
     }
     void consume_next(const std::pair<uint64_t, T> &next) {
       last = cur;

--- a/src/mgr/CMakeLists.txt
+++ b/src/mgr/CMakeLists.txt
@@ -17,6 +17,7 @@ if(WITH_MGR)
     DaemonPerfCounters.cc
     DaemonServer.cc
     DaemonState.cc
+    FailSlowOSDDetector.cc
     Gil.cc
     Mgr.cc
     mgr_perf_counters.cc

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -48,14 +48,15 @@
 #include "common/JSONFormatter.h"
 #include "common/pick_address.h"
 #include "common/TextTable.h"
-#include "crush/CrushWrapper.h"
 
 #include <boost/algorithm/string.hpp>
 
 #include <iomanip>
 
+#include <algorithm>
 #include <list>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -1515,6 +1516,34 @@ std::optional<std::string> DaemonServer::get_osd_metadata(
       return p->second;
     }
     return std::nullopt;
+}
+
+std::vector<std::string> DaemonServer::_get_osd_devices(int osd_id)
+{
+  DaemonKey key{"osd", stringify(osd_id)};
+  DaemonStatePtr daemon = daemon_state.get(key);
+  if (!daemon) {
+    return {"osd." + stringify(osd_id)};
+  }
+
+  std::lock_guard l(daemon->lock);
+  std::vector<std::string> devices;
+  devices.reserve(daemon->devices.size());
+  for (const auto& [devid, _] : daemon->devices) {
+    devices.push_back(devid);
+  }
+  if (!devices.empty()) {
+    return devices;
+  }
+
+  auto devices_meta = daemon->metadata.find("devices");
+  if (devices_meta != daemon->metadata.end() && !devices_meta->second.empty()) {
+    std::vector<std::string> devnames;
+    get_str_vec(devices_meta->second, devnames);
+    return devnames;
+  }
+
+  return {"osd." + stringify(osd_id)};
 }
 
 void upgrade_osd_report::dump(Formatter *f) const {
@@ -3244,6 +3273,11 @@ void DaemonServer::send_report()
 
 	  pg_map.get_health_checks(g_ceph_context, osdmap,
 				   &m->health_checks);
+	  fail_slow_detector._check_fail_slow_osds(
+            osdmap, pg_map, &m->health_checks,
+            [this](int osd) {
+              return _get_osd_devices(osd);
+            });
 
 	  dout(10) << m->health_checks.checks.size() << " health checks"
 		   << dendl;

--- a/src/mgr/DaemonServer.h
+++ b/src/mgr/DaemonServer.h
@@ -16,8 +16,10 @@
 #define DAEMON_SERVER_H_
 
 #include "PyModuleRegistry.h"
+#include "FailSlowOSDDetector.h"
 
 #include <map>
+#include <optional>
 #include <set>
 #include <string>
 #include <string_view>
@@ -53,7 +55,7 @@ class CommandContext;
 struct OSDPerfMetricQuery;
 struct MDSPerfMetricQuery;
 class StatsAutotuner;
-
+struct health_check_map_t;
 
 struct offline_pg_report {
   using ContainerType = std::variant<std::vector<int>, std::set<int>>;
@@ -224,6 +226,7 @@ private:
   std::optional<std::string> get_osd_metadata(
     const std::string& name,
     const std::string& osd_id);
+  std::vector<std::string> _get_osd_devices(int osd_id);
   void _update_upgraded_osds(
     const std::vector<int>& orig_osds,
     const std::vector<int>& to_upgrade,
@@ -311,6 +314,7 @@ private:
   // -- op tracking --
   OpTracker op_tracker;
   std::unique_ptr<StatsAutotuner> stats_autotuner;
+  FailSlowOSDDetector fail_slow_detector;
 public:
   int init(uint64_t gid, entity_addrvec_t client_addrs);
 
@@ -459,4 +463,3 @@ public:
   }
 };
 #endif
-

--- a/src/mgr/FailSlowOSDDetector.cc
+++ b/src/mgr/FailSlowOSDDetector.cc
@@ -1,0 +1,417 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#include "mgr/FailSlowOSDDetector.h"
+
+#include "include/ceph_assert.h"
+#include "include/stringify.h"
+#include "crush/CrushWrapper.h"
+#include "mon/PGMap.h"
+#include "osd/OSDMap.h"
+#include "osd/osd_types.h"
+#include "common/debug.h"
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <set>
+#include <boost/algorithm/string.hpp>
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_mgr
+#undef dout_prefix
+#define dout_prefix *_dout << "mgr " << __func__ << " "
+
+namespace {
+constexpr uint64_t FAIL_SLOW_BACKGROUND_PG_STATES =
+  PG_STATE_RECOVERING |
+  PG_STATE_PREMERGE |
+  PG_STATE_DEEP_SCRUB |
+  PG_STATE_BACKFILLING;
+}
+
+std::optional<double>
+FailSlowOSDDetector::median_absolute_deviation(
+  const std::vector<double>& values,
+  double center)
+{
+  std::vector<double> deviations;
+  deviations.reserve(values.size());
+  for (auto value : values) {
+    deviations.push_back(std::abs(value - center));
+  }
+  return median(deviations);
+}
+
+void FailSlowOSDDetector::refresh_osd_crush_root_map(const OSDMap& osdmap)
+{
+  if (!osdmap.crush) {
+    return;
+  }
+  if (auto e = osdmap.get_epoch(); e == or_map.epoch) {
+    return;
+  } else {
+    ceph_assert(e > or_map.epoch);
+    or_map.epoch = e;
+  }
+  std::set<int> roots;
+  osdmap.crush->find_nonshadow_roots(&roots);
+  for (int root : roots) {
+    std::string root_name = osdmap.crush->get_item_name(root);
+    std::list<int> buckets;
+    buckets.push_back(root);
+    while (!buckets.empty()) {
+      int bucket = buckets.front();
+      buckets.pop_front();
+      int size = osdmap.crush->get_bucket_size(bucket);
+      for (int i = 0; i < size; i++) {
+        int item = osdmap.crush->get_bucket_item(bucket, i);
+        if (item >= 0) {
+          // this is an OSD
+          or_map.osd_root_map.emplace(item, root_name);
+        } else {
+          buckets.push_back(item);
+        }
+      }
+    }
+  }
+}
+
+std::string FailSlowOSDDetector::fail_slow_cohort(
+  const OSDMap& osdmap,
+  int osd)
+{
+  std::string_view crush_root = "null";
+  auto it = or_map.osd_root_map.find(osd);
+  if (it != or_map.osd_root_map.end()) {
+    crush_root = it->second;
+  }
+  std::string_view class_name = "unknown";
+  if (osdmap.crush) {
+    if (const char *item_class = osdmap.crush->get_item_class(osd)) {
+      class_name = item_class;
+    }
+  }
+  return fmt::format("{{crush_root:{}, device_class:{}}}",
+    crush_root, class_name);
+}
+
+std::optional<double>
+FailSlowOSDDetector::median(std::vector<double> &values)
+{
+  if (values.empty()) {
+    return std::nullopt;
+  }
+  const std::size_t n = values.size();
+  const auto middle = values.begin() + n / 2;
+
+  std::nth_element(values.begin(), middle, values.end());
+
+  if (n % 2 == 1) {
+    return *middle;
+  }
+
+  const double upper = *middle;
+  const double lower =
+    *std::max_element(values.begin(), middle);
+  return (lower + upper) / 2.0;
+}
+
+/*
+ * find_fail_slow_device works in the following way:
+ *
+ * 1. Find the commit latencies of all OSDs that are NOT under
+ *    background works;
+ * 2. Calculate the scores of all OSDs that are NOT under background
+ *    works, the scores are calculated as:
+ *    osd_score = (commit_latency_ms[osd] - cohort_median) / cohort_MAD
+ * 3. Ground the above OSDs by their under lying devices, and calculate
+ *    each device's score:
+ *    device_score = median(osd_score[osd] for osd on device)
+ * 4. Return the devices whose scores exceeds both score_threshold and
+ *    min_latency_ms
+ */
+std::vector<fail_slow_device_score>
+FailSlowOSDDetector::find_fail_slow_devices(
+  const OSDMap& osdmap,
+  const PGMap& pgmap,
+  const fail_slow_osd_detector_config& config,
+  const std::function<std::vector<std::string>(int)>& get_osd_device,
+  bool all_devices)
+{
+  std::set<int> background_osds;
+  for (const auto& [_, pg_stat] : pgmap.pg_stat) {
+    if ((pg_stat.state & FAIL_SLOW_BACKGROUND_PG_STATES) == 0) {
+      continue;
+    }
+    for (auto osd : pg_stat.acting) {
+      if (osd >= 0) {
+        dout(20) << "found acting osd " << osd << dendl;
+        background_osds.insert(osd);
+      }
+    }
+    for (auto osd : pg_stat.up) {
+      if (osd >= 0) {
+        dout(20) << "found up osd " << osd << dendl;
+        background_osds.insert(osd);
+      }
+    }
+  }
+
+  refresh_osd_crush_root_map(osdmap);
+  std::map<int, double> latency_by_osd;
+  std::map<int, std::string> cohort_by_osd;
+  std::map<std::string, std::vector<double>> latencies_by_cohort;
+  for (const auto& [osd, osd_stat] : pgmap.osd_stat) {
+    if (!osdmap.is_up(osd) ||
+        !osdmap.is_in(osd) ||
+        background_osds.contains(osd)) {
+      continue;
+    }
+
+    auto latency_ms =
+      static_cast<double>(osd_stat.os_perf_stat.os_commit_latency_ns) /
+      1000000.0;
+    if (latency_ms == 0.0) {
+      continue;
+    }
+
+    auto cohort = fail_slow_cohort(osdmap, osd);
+    dout(20) << "osd." << osd << " latency: " << latency_ms
+      << " cohort: " << cohort << dendl;
+    latency_by_osd[osd] = latency_ms;
+    cohort_by_osd[osd] = cohort;
+    latencies_by_cohort[cohort].push_back(latency_ms);
+  }
+
+  struct cohort_stats_t {
+    double median = 0.0;
+    double mad = 0.0;
+  };
+  std::map<std::string, cohort_stats_t> stats_by_cohort;
+  for (auto &[cohort, cohort_latencies] : latencies_by_cohort) {
+    if (cohort_latencies.size() < config.min_osds) {
+      dout(20) << "skipping cohort: " << cohort
+        << ", as too few osds in the cohort" << dendl;
+      continue;
+    }
+
+    auto cohort_median = median(cohort_latencies);
+    if (!cohort_median) {
+      dout(20) << "skipping cohort: " << cohort
+        << ", as can't calc median" << dendl;
+      continue;
+    }
+
+    auto cohort_mad = median_absolute_deviation(
+      cohort_latencies,
+      *cohort_median);
+    if (!cohort_mad) {
+      dout(20) << "skipping cohort: " << cohort
+        << ", as can't calc MAD" << dendl;
+      continue;
+    }
+    *cohort_mad = std::max(*cohort_mad, config.mad_floor_ms);
+    stats_by_cohort.emplace(
+      cohort, cohort_stats_t{*cohort_median, *cohort_mad});
+  }
+
+  std::map<int, fail_slow_osd_score> scored_osds;
+  for (const auto& [osd, latency_ms] : latency_by_osd) {
+    const auto& cohort = cohort_by_osd[osd];
+    auto it = stats_by_cohort.find(cohort);
+    if (it == stats_by_cohort.end()) {
+      dout(20) << "skipping osd." << osd
+        << ", as its cohort has no usable stats" << dendl;
+      continue;
+    }
+    const auto [cohort_median, cohort_mad] = it->second;
+
+    fail_slow_osd_score score;
+    score.osd = osd;
+    score.latency_ms = latency_ms;
+    score.score = (latency_ms - cohort_median) / cohort_mad;
+    dout(20) << "osd." << osd << " score: " << score.score
+      << " cohort_median: " << cohort_median
+      << " cohort_MAD: " << cohort_mad << dendl;
+    score.cohort = cohort;
+    score.cohort_median = cohort_median;
+    score.cohort_mad = cohort_mad;
+    scored_osds[osd] = std::move(score);
+  }
+
+  std::map<std::string, std::vector<fail_slow_osd_score>> osds_by_device;
+  for (const auto& [osd, score] : scored_osds) {
+    auto devices = get_osd_device(osd);
+    for (auto &device : devices) {
+      osds_by_device[device].push_back(score);
+    }
+  }
+
+  std::vector<fail_slow_device_score> devices;
+  for (auto& [device, osds] : osds_by_device) {
+    std::vector<double> scores;
+    std::vector<double> latencies;
+    scores.reserve(osds.size());
+    latencies.reserve(osds.size());
+    for (const auto& osd : osds) {
+      scores.push_back(osd.score);
+      latencies.push_back(osd.latency_ms);
+    }
+
+    auto device_score = median(scores);
+    auto device_latency = median(latencies);
+    if (!device_score || !device_latency) {
+      continue;
+    }
+    if (!all_devices &&
+        (*device_score < config.score_threshold ||
+         *device_latency < config.min_latency_ms)) {
+      continue;
+    }
+
+    std::sort(osds.begin(), osds.end(),
+              [](const auto& lhs, const auto& rhs) {
+                return lhs.osd < rhs.osd;
+              });
+    auto representative = std::max_element(
+      osds.begin(),
+      osds.end(),
+      [](const auto& lhs, const auto& rhs) {
+        return lhs.score < rhs.score;
+      });
+
+    dout(20) << "device: " << device << " score: " << *device_score << dendl;
+    fail_slow_device_score device_score_entry;
+    device_score_entry.device = device;
+    device_score_entry.score = *device_score;
+    device_score_entry.latency_ms = *device_latency;
+    device_score_entry.cohort = representative->cohort;
+    device_score_entry.cohort_median = representative->cohort_median;
+    device_score_entry.cohort_mad = representative->cohort_mad;
+    device_score_entry.osds = std::move(osds);
+    devices.push_back(std::move(device_score_entry));
+  }
+
+  std::sort(devices.begin(), devices.end(),
+            [](const auto& lhs, const auto& rhs) {
+              return lhs.score > rhs.score;
+            });
+  return devices;
+}
+
+std::vector<fail_slow_device_score>
+FailSlowOSDDetector::_find_fail_slow_devices(
+  const OSDMap& osdmap,
+  const PGMap& pgmap,
+  const get_osd_device_func_t &get_osd_device)
+{
+  fail_slow_osd_detector_config config;
+  config.min_osds =
+    g_conf().get_val<uint64_t>("mgr_fail_slow_osd_min_osds");
+  config.score_threshold =
+    g_conf().get_val<double>("mgr_fail_slow_osd_score_threshold");
+  config.min_latency_ms =
+    g_conf().get_val<double>("mgr_fail_slow_osd_min_latency_ms");
+  config.mad_floor_ms =
+    g_conf().get_val<double>("mgr_fail_slow_osd_mad_floor_ms");
+
+  return find_fail_slow_devices(
+    osdmap,
+    pgmap,
+    config,
+    get_osd_device);
+}
+
+void FailSlowOSDDetector::_check_fail_slow_osds(
+  const OSDMap& osdmap,
+  const PGMap& pgmap,
+  health_check_map_t *checks,
+  const get_osd_device_func_t &get_osd_device)
+{
+  dout(20) << "" << dendl;
+  if (!g_conf().get_val<bool>("mgr_fail_slow_osd_enabled")) {
+    fail_slow_device_counts.clear();
+    fail_slow_devices.clear();
+    return;
+  }
+
+  auto now = ceph_clock_now();
+  if (now - last_fail_slow <
+      g_conf().get_val<int64_t>("mgr_fail_slow_osd_check_period")) {
+    dout(20) << "skipped, waiting for fail slow check period" << dendl;
+  } else {
+    last_fail_slow = now;
+
+    auto devices = _find_fail_slow_devices(osdmap, pgmap, get_osd_device);
+    std::set<std::string> current_devices;
+    for (const auto& device : devices) {
+      current_devices.insert(device.device);
+    }
+
+    for (auto p = fail_slow_device_counts.begin();
+         p != fail_slow_device_counts.end(); ) {
+      if (auto found = current_devices.contains(p->first);
+          !found && p->second < 2) {
+        p = fail_slow_device_counts.erase(p);
+      } else {
+        if (!found) {
+          p->second /= 2;
+        }
+        ++p;
+      }
+    }
+    for (const auto& device : current_devices) {
+      ++fail_slow_device_counts[device];
+    }
+    const auto persistence =
+      g_conf().get_val<uint64_t>("mgr_fail_slow_osd_persistence");
+    std::vector<fail_slow_device_score> persistent_devices;
+    for (const auto& device : devices) {
+      if (fail_slow_device_counts[device.device] >= persistence) {
+        persistent_devices.push_back(device);
+      }
+    }
+    fail_slow_devices = std::move(persistent_devices);
+  }
+
+  if (fail_slow_devices.empty()) {
+    return;
+  }
+  auto& check = checks->add(
+    "OSD_FAIL_SLOW",
+    HEALTH_WARN,
+    stringify(fail_slow_devices.size()) +
+    " device(s) with abnormally high OSD commit latency",
+    fail_slow_devices.size());
+
+  for (const auto& device : fail_slow_devices) {
+    std::vector<std::string> osds;
+    osds.reserve(device.osds.size());
+    for (const auto& osd : device.osds) {
+      osds.push_back("osd." + stringify(osd.osd));
+    }
+
+    std::ostringstream ss;
+    ss << std::fixed << std::setprecision(2)
+       << "device " << device.device
+       << " has fail-slow score " << device.score
+       << " after " << fail_slow_device_counts[device.device]
+       << " observations ("
+       << boost::algorithm::join(osds, ",")
+       << "; median commit latency " << device.latency_ms << " ms"
+       << "; " << device.cohort
+       << " median " << device.cohort_median << " ms"
+       << "; MAD " << device.cohort_mad << " ms)";
+    check.detail.push_back(ss.str());
+  }
+}

--- a/src/mgr/FailSlowOSDDetector.cc
+++ b/src/mgr/FailSlowOSDDetector.cc
@@ -1,0 +1,418 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#include "mgr/FailSlowOSDDetector.h"
+
+#include "include/ceph_assert.h"
+#include "include/stringify.h"
+#include "crush/CrushWrapper.h"
+#include "mon/PGMap.h"
+#include "osd/OSDMap.h"
+#include "osd/osd_types.h"
+#include "common/debug.h"
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <set>
+#include <boost/algorithm/string.hpp>
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_mgr
+#undef dout_prefix
+#define dout_prefix *_dout << "mgr " << __func__ << " "
+
+namespace {
+constexpr uint64_t FAIL_SLOW_BACKGROUND_PG_STATES =
+  PG_STATE_RECOVERING |
+  PG_STATE_PREMERGE |
+  PG_STATE_DEEP_SCRUB |
+  PG_STATE_BACKFILLING;
+}
+
+std::optional<double>
+FailSlowOSDDetector::median_absolute_deviation(
+  const std::vector<double>& values,
+  double center)
+{
+  std::vector<double> deviations;
+  deviations.reserve(values.size());
+  for (auto value : values) {
+    deviations.push_back(std::abs(value - center));
+  }
+  return median(deviations);
+}
+
+void FailSlowOSDDetector::refresh_osd_crush_root_map(const OSDMap& osdmap)
+{
+  if (!osdmap.crush) {
+    return;
+  }
+  if (auto e = osdmap.get_epoch(); e == or_map.epoch) {
+    return;
+  } else {
+    ceph_assert(e > or_map.epoch);
+    or_map.epoch = e;
+    or_map.osd_root_map.clear();
+  }
+  std::set<int> roots;
+  osdmap.crush->find_nonshadow_roots(&roots);
+  for (int root : roots) {
+    std::string root_name = osdmap.crush->get_item_name(root);
+    std::list<int> buckets;
+    buckets.push_back(root);
+    while (!buckets.empty()) {
+      int bucket = buckets.front();
+      buckets.pop_front();
+      int size = osdmap.crush->get_bucket_size(bucket);
+      for (int i = 0; i < size; i++) {
+        int item = osdmap.crush->get_bucket_item(bucket, i);
+        if (item >= 0) {
+          // this is an OSD
+          or_map.osd_root_map.emplace(item, root_name);
+        } else {
+          buckets.push_back(item);
+        }
+      }
+    }
+  }
+}
+
+std::string FailSlowOSDDetector::fail_slow_cohort(
+  const OSDMap& osdmap,
+  int osd)
+{
+  std::string_view crush_root = "null";
+  auto it = or_map.osd_root_map.find(osd);
+  if (it != or_map.osd_root_map.end()) {
+    crush_root = it->second;
+  }
+  std::string_view class_name = "unknown";
+  if (osdmap.crush) {
+    if (const char *item_class = osdmap.crush->get_item_class(osd)) {
+      class_name = item_class;
+    }
+  }
+  return fmt::format("{{crush_root:{}, device_class:{}}}",
+    crush_root, class_name);
+}
+
+std::optional<double>
+FailSlowOSDDetector::median(std::vector<double> &values)
+{
+  if (values.empty()) {
+    return std::nullopt;
+  }
+  const std::size_t n = values.size();
+  const auto middle = values.begin() + n / 2;
+
+  std::nth_element(values.begin(), middle, values.end());
+
+  if (n % 2 == 1) {
+    return *middle;
+  }
+
+  const double upper = *middle;
+  const double lower =
+    *std::max_element(values.begin(), middle);
+  return (lower + upper) / 2.0;
+}
+
+/*
+ * find_fail_slow_device works in the following way:
+ *
+ * 1. Find the commit latencies of all OSDs that are NOT under
+ *    background works;
+ * 2. Calculate the scores of all OSDs that are NOT under background
+ *    works, the scores are calculated as:
+ *    osd_score = (commit_latency_ms[osd] - cohort_median) / cohort_MAD
+ * 3. Ground the above OSDs by their under lying devices, and calculate
+ *    each device's score:
+ *    device_score = median(osd_score[osd] for osd on device)
+ * 4. Return the devices whose scores exceeds both score_threshold and
+ *    min_latency_ms
+ */
+std::vector<fail_slow_device_score>
+FailSlowOSDDetector::find_fail_slow_devices(
+  const OSDMap& osdmap,
+  const PGMap& pgmap,
+  const fail_slow_osd_detector_config& config,
+  const std::function<std::vector<std::string>(int)>& get_osd_device,
+  bool all_devices)
+{
+  std::set<int> background_osds;
+  for (const auto& [_, pg_stat] : pgmap.pg_stat) {
+    if ((pg_stat.state & FAIL_SLOW_BACKGROUND_PG_STATES) == 0) {
+      continue;
+    }
+    for (auto osd : pg_stat.acting) {
+      if (osd >= 0) {
+        dout(20) << "found acting osd " << osd << dendl;
+        background_osds.insert(osd);
+      }
+    }
+    for (auto osd : pg_stat.up) {
+      if (osd >= 0) {
+        dout(20) << "found up osd " << osd << dendl;
+        background_osds.insert(osd);
+      }
+    }
+  }
+
+  refresh_osd_crush_root_map(osdmap);
+  std::map<int, double> latency_by_osd;
+  std::map<int, std::string> cohort_by_osd;
+  std::map<std::string, std::vector<double>> latencies_by_cohort;
+  for (const auto& [osd, osd_stat] : pgmap.osd_stat) {
+    if (!osdmap.is_up(osd) ||
+        !osdmap.is_in(osd) ||
+        background_osds.contains(osd)) {
+      continue;
+    }
+
+    auto latency_ms =
+      static_cast<double>(osd_stat.os_perf_stat.os_commit_latency_ns) /
+      1000000.0;
+    if (latency_ms == 0.0) {
+      continue;
+    }
+
+    auto cohort = fail_slow_cohort(osdmap, osd);
+    dout(20) << "osd." << osd << " latency: " << latency_ms
+      << " cohort: " << cohort << dendl;
+    latency_by_osd[osd] = latency_ms;
+    cohort_by_osd[osd] = cohort;
+    latencies_by_cohort[cohort].push_back(latency_ms);
+  }
+
+  struct cohort_stats_t {
+    double median = 0.0;
+    double mad = 0.0;
+  };
+  std::map<std::string, cohort_stats_t> stats_by_cohort;
+  for (auto &[cohort, cohort_latencies] : latencies_by_cohort) {
+    if (cohort_latencies.size() < config.min_osds) {
+      dout(20) << "skipping cohort: " << cohort
+        << ", as too few osds in the cohort" << dendl;
+      continue;
+    }
+
+    auto cohort_median = median(cohort_latencies);
+    if (!cohort_median) {
+      dout(20) << "skipping cohort: " << cohort
+        << ", as can't calc median" << dendl;
+      continue;
+    }
+
+    auto cohort_mad = median_absolute_deviation(
+      cohort_latencies,
+      *cohort_median);
+    if (!cohort_mad) {
+      dout(20) << "skipping cohort: " << cohort
+        << ", as can't calc MAD" << dendl;
+      continue;
+    }
+    *cohort_mad = std::max(*cohort_mad, config.mad_floor_ms);
+    stats_by_cohort.emplace(
+      cohort, cohort_stats_t{*cohort_median, *cohort_mad});
+  }
+
+  std::map<int, fail_slow_osd_score> scored_osds;
+  for (const auto& [osd, latency_ms] : latency_by_osd) {
+    const auto& cohort = cohort_by_osd[osd];
+    auto it = stats_by_cohort.find(cohort);
+    if (it == stats_by_cohort.end()) {
+      dout(20) << "skipping osd." << osd
+        << ", as its cohort has no usable stats" << dendl;
+      continue;
+    }
+    const auto [cohort_median, cohort_mad] = it->second;
+
+    fail_slow_osd_score score;
+    score.osd = osd;
+    score.latency_ms = latency_ms;
+    score.score = (latency_ms - cohort_median) / cohort_mad;
+    dout(20) << "osd." << osd << " score: " << score.score
+      << " cohort_median: " << cohort_median
+      << " cohort_MAD: " << cohort_mad << dendl;
+    score.cohort = cohort;
+    score.cohort_median = cohort_median;
+    score.cohort_mad = cohort_mad;
+    scored_osds[osd] = std::move(score);
+  }
+
+  std::map<std::string, std::vector<fail_slow_osd_score>> osds_by_device;
+  for (const auto& [osd, score] : scored_osds) {
+    auto devices = get_osd_device(osd);
+    for (auto &device : devices) {
+      osds_by_device[device].push_back(score);
+    }
+  }
+
+  std::vector<fail_slow_device_score> devices;
+  for (auto& [device, osds] : osds_by_device) {
+    std::vector<double> scores;
+    std::vector<double> latencies;
+    scores.reserve(osds.size());
+    latencies.reserve(osds.size());
+    for (const auto& osd : osds) {
+      scores.push_back(osd.score);
+      latencies.push_back(osd.latency_ms);
+    }
+
+    auto device_score = median(scores);
+    auto device_latency = median(latencies);
+    if (!device_score || !device_latency) {
+      continue;
+    }
+    if (!all_devices &&
+        (*device_score < config.score_threshold ||
+         *device_latency < config.min_latency_ms)) {
+      continue;
+    }
+
+    std::sort(osds.begin(), osds.end(),
+              [](const auto& lhs, const auto& rhs) {
+                return lhs.osd < rhs.osd;
+              });
+    auto representative = std::max_element(
+      osds.begin(),
+      osds.end(),
+      [](const auto& lhs, const auto& rhs) {
+        return lhs.score < rhs.score;
+      });
+
+    dout(20) << "device: " << device << " score: " << *device_score << dendl;
+    fail_slow_device_score device_score_entry;
+    device_score_entry.device = device;
+    device_score_entry.score = *device_score;
+    device_score_entry.latency_ms = *device_latency;
+    device_score_entry.cohort = representative->cohort;
+    device_score_entry.cohort_median = representative->cohort_median;
+    device_score_entry.cohort_mad = representative->cohort_mad;
+    device_score_entry.osds = std::move(osds);
+    devices.push_back(std::move(device_score_entry));
+  }
+
+  std::sort(devices.begin(), devices.end(),
+            [](const auto& lhs, const auto& rhs) {
+              return lhs.score > rhs.score;
+            });
+  return devices;
+}
+
+std::vector<fail_slow_device_score>
+FailSlowOSDDetector::_find_fail_slow_devices(
+  const OSDMap& osdmap,
+  const PGMap& pgmap,
+  const get_osd_device_func_t &get_osd_device)
+{
+  fail_slow_osd_detector_config config;
+  config.min_osds =
+    g_conf().get_val<uint64_t>("mgr_fail_slow_osd_min_osds");
+  config.score_threshold =
+    g_conf().get_val<double>("mgr_fail_slow_osd_score_threshold");
+  config.min_latency_ms =
+    g_conf().get_val<double>("mgr_fail_slow_osd_min_latency_ms");
+  config.mad_floor_ms =
+    g_conf().get_val<double>("mgr_fail_slow_osd_mad_floor_ms");
+
+  return find_fail_slow_devices(
+    osdmap,
+    pgmap,
+    config,
+    get_osd_device);
+}
+
+void FailSlowOSDDetector::_check_fail_slow_osds(
+  const OSDMap& osdmap,
+  const PGMap& pgmap,
+  health_check_map_t *checks,
+  const get_osd_device_func_t &get_osd_device)
+{
+  dout(20) << "" << dendl;
+  if (!g_conf().get_val<bool>("mgr_fail_slow_osd_enabled")) {
+    fail_slow_device_counts.clear();
+    fail_slow_devices.clear();
+    return;
+  }
+
+  auto now = ceph_clock_now();
+  if (now - last_fail_slow <
+      g_conf().get_val<int64_t>("mgr_fail_slow_osd_check_period")) {
+    dout(20) << "skipped, waiting for fail slow check period" << dendl;
+  } else {
+    last_fail_slow = now;
+
+    auto devices = _find_fail_slow_devices(osdmap, pgmap, get_osd_device);
+    std::set<std::string> current_devices;
+    for (const auto& device : devices) {
+      current_devices.insert(device.device);
+    }
+
+    for (auto p = fail_slow_device_counts.begin();
+         p != fail_slow_device_counts.end(); ) {
+      if (auto found = current_devices.contains(p->first);
+          !found && p->second < 2) {
+        p = fail_slow_device_counts.erase(p);
+      } else {
+        if (!found) {
+          p->second /= 2;
+        }
+        ++p;
+      }
+    }
+    for (const auto& device : current_devices) {
+      ++fail_slow_device_counts[device];
+    }
+    const auto persistence =
+      g_conf().get_val<uint64_t>("mgr_fail_slow_osd_persistence");
+    std::vector<fail_slow_device_score> persistent_devices;
+    for (const auto& device : devices) {
+      if (fail_slow_device_counts[device.device] >= persistence) {
+        persistent_devices.push_back(device);
+      }
+    }
+    fail_slow_devices = std::move(persistent_devices);
+  }
+
+  if (fail_slow_devices.empty()) {
+    return;
+  }
+  auto& check = checks->add(
+    "OSD_FAIL_SLOW",
+    HEALTH_WARN,
+    stringify(fail_slow_devices.size()) +
+    " device(s) with abnormally high OSD commit latency",
+    fail_slow_devices.size());
+
+  for (const auto& device : fail_slow_devices) {
+    std::vector<std::string> osds;
+    osds.reserve(device.osds.size());
+    for (const auto& osd : device.osds) {
+      osds.push_back("osd." + stringify(osd.osd));
+    }
+
+    std::ostringstream ss;
+    ss << std::fixed << std::setprecision(2)
+       << "device " << device.device
+       << " has fail-slow score " << device.score
+       << " after " << fail_slow_device_counts[device.device]
+       << " observations ("
+       << boost::algorithm::join(osds, ",")
+       << "; median commit latency " << device.latency_ms << " ms"
+       << "; " << device.cohort
+       << " median " << device.cohort_median << " ms"
+       << "; MAD " << device.cohort_mad << " ms)";
+    check.detail.push_back(ss.str());
+  }
+}

--- a/src/mgr/FailSlowOSDDetector.h
+++ b/src/mgr/FailSlowOSDDetector.h
@@ -1,0 +1,82 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+#include <optional>
+
+#include "mon/health_check.h"
+#include "include/types.h"
+
+class OSDMap;
+class PGMap;
+
+struct fail_slow_osd_detector_config {
+  uint64_t min_osds = 5;
+  double score_threshold = 10.0;
+  double min_latency_ms = 100.0;
+  double mad_floor_ms = 1.0;
+};
+
+struct fail_slow_osd_score {
+  int osd = -1;
+  double latency_ms = 0.0;
+  double score = 0.0;
+  std::string cohort;
+  double cohort_median = 0.0;
+  double cohort_mad = 0.0;
+};
+
+struct fail_slow_device_score {
+  std::string device;
+  std::vector<fail_slow_osd_score> osds;
+  double score = 0.0;
+  double latency_ms = 0.0;
+  std::string cohort;
+  double cohort_median = 0.0;
+  double cohort_mad = 0.0;
+};
+
+
+class FailSlowOSDDetector {
+public:
+  std::optional<double> median(std::vector<double> &values);
+  using get_osd_device_func_t =
+    std::function<std::vector<std::string>(int)>;
+  std::vector<fail_slow_device_score> find_fail_slow_devices(
+    const OSDMap& osdmap,
+    const PGMap& pgmap,
+    const fail_slow_osd_detector_config& config,
+    const get_osd_device_func_t& get_osd_device,
+    bool all_devices = false // this is for unit tests only
+  );
+  std::vector<fail_slow_device_score> _find_fail_slow_devices(
+    const OSDMap& osdmap,
+    const PGMap& pgmap,
+    const get_osd_device_func_t &get_osd_device);
+  void _check_fail_slow_osds(
+    const OSDMap& osdmap,
+    const PGMap& pgmap,
+    health_check_map_t *checks,
+    const get_osd_device_func_t &get_osd_device);
+private:
+  using osd_crush_root_map_t = std::map<int, std::string>;
+  std::string fail_slow_cohort(
+    const OSDMap& osdmap,
+    int osd);
+  void refresh_osd_crush_root_map(const OSDMap& osdmap);
+  std::optional<double> median_absolute_deviation(
+    const std::vector<double>& values,
+    double center);
+  std::map<std::string, uint64_t> fail_slow_device_counts;
+  utime_t last_fail_slow;
+  std::vector<fail_slow_device_score> fail_slow_devices;
+  struct cached_osd_root_map_t {
+    epoch_t epoch = 0;
+    osd_crush_root_map_t osd_root_map;
+  } or_map;
+};

--- a/src/test/mgr/CMakeLists.txt
+++ b/src/test/mgr/CMakeLists.txt
@@ -34,6 +34,17 @@ target_link_libraries(unittest_mgr_daemonstate
   Python3::Python
 )
 
+# unittest_mgr_fail_slow_osd_detector
+add_executable(unittest_mgr_fail_slow_osd_detector
+  test_fail_slow_osd_detector.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/FailSlowOSDDetector.cc
+)
+add_ceph_unittest(unittest_mgr_fail_slow_osd_detector)
+target_link_libraries(unittest_mgr_fail_slow_osd_detector
+  ceph-common
+  global
+)
+
 # unittest_mgr_mgrcap
 add_executable(unittest_mgr_mgrcap
   test_mgrcap.cc

--- a/src/test/mgr/test_fail_slow_osd_detector.cc
+++ b/src/test/mgr/test_fail_slow_osd_detector.cc
@@ -1,0 +1,300 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#include "mgr/FailSlowOSDDetector.h"
+
+#include "common/common_init.h"
+#include "crush/CrushWrapper.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
+#include "gtest/gtest.h"
+#include "include/ceph_assert.h"
+#include "mon/PGMap.h"
+#include "osd/OSDMap.h"
+#include "osd/osd_types.h"
+
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+constexpr uint64_t NS_PER_MS = 1000000;
+
+fail_slow_osd_detector_config make_config()
+{
+  fail_slow_osd_detector_config config;
+  config.min_osds = 5;
+  config.score_threshold = 10.0;
+  config.min_latency_ms = 100.0;
+  config.mad_floor_ms = 1.0;
+  return config;
+}
+
+std::unique_ptr<OSDMap> make_osdmap(
+  int num_osds,
+  const std::map<int, std::string>& classes = {})
+{
+  auto osdmap = std::make_unique<OSDMap>();
+  uuid_d fsid;
+  osdmap->build_simple(g_ceph_context, 0, fsid, num_osds);
+  OSDMap::Incremental pending_inc(osdmap->get_epoch() + 1);
+  pending_inc.fsid = osdmap->get_fsid();
+  entity_addrvec_t sample_addrs;
+  sample_addrs.v.push_back(entity_addr_t());
+  uuid_d sample_uuid;
+  for (int i = 0; i < num_osds; ++i) {
+    sample_uuid.generate_random();
+    sample_addrs.v[0].nonce = i;
+    pending_inc.new_state[i] = CEPH_OSD_EXISTS | CEPH_OSD_NEW;
+    pending_inc.new_up_client[i] = sample_addrs;
+    pending_inc.new_up_cluster[i] = sample_addrs;
+    pending_inc.new_hb_back_up[i] = sample_addrs;
+    pending_inc.new_hb_front_up[i] = sample_addrs;
+    pending_inc.new_weight[i] = CEPH_OSD_IN;
+    pending_inc.new_uuid[i] = sample_uuid;
+  }
+  osdmap->apply_incremental(pending_inc);
+
+  for (const auto& [osd, device_class] : classes) {
+    ceph_assert(osdmap->crush);
+    ceph_assert(osdmap->crush->set_item_class(osd, device_class) == 0);
+  }
+  return osdmap;
+}
+
+PGMap make_pgmap(const std::vector<uint64_t>& latencies_ms)
+{
+  PGMap pgmap;
+  for (size_t osd = 0; osd < latencies_ms.size(); ++osd) {
+    osd_stat_t stat;
+    stat.os_perf_stat.os_commit_latency_ns = latencies_ms[osd] * NS_PER_MS;
+    pgmap.osd_stat[osd] = stat;
+  }
+  return pgmap;
+}
+
+void move_osds_to_roots(
+  OSDMap *osdmap,
+  const std::map<int, std::string>& roots_by_osd)
+{
+  CrushWrapper newcrush;
+  bufferlist bl;
+  osdmap->crush->encode(bl, CEPH_FEATURES_SUPPORTED_DEFAULT);
+  auto p = bl.cbegin();
+  newcrush.decode(p);
+
+  for (const auto& [osd, root] : roots_by_osd) {
+    std::map<std::string, std::string> loc;
+    loc["root"] = root;
+    ASSERT_GE(
+      newcrush.create_or_move_item(
+        g_ceph_context,
+        osd,
+        0,
+        std::string{"osd."} + std::to_string(osd),
+        loc),
+      0);
+  }
+
+  OSDMap::Incremental pending_inc(osdmap->get_epoch() + 1);
+  pending_inc.fsid = osdmap->get_fsid();
+  newcrush.encode(pending_inc.crush, CEPH_FEATURES_SUPPORTED_DEFAULT);
+  osdmap->apply_incremental(pending_inc);
+}
+
+std::function<std::vector<std::string>(int)> make_device_lookup(
+  std::map<int, std::string> devices)
+{
+  return [devices = std::move(devices)](int osd) -> std::vector<std::string> {
+    auto p = devices.find(osd);
+    if (p != devices.end()) {
+      return {p->second};
+    }
+    return {std::string{"osd."} + std::to_string(osd)};
+  };
+}
+}
+
+TEST(FailSlowOSDDetector, DetectsSingleSlowDevice)
+{
+  auto osdmap = make_osdmap(6);
+  auto pgmap = make_pgmap({10, 11, 12, 12, 13, 500});
+
+  FailSlowOSDDetector detector;
+  auto devices = detector.find_fail_slow_devices(
+    *osdmap,
+    pgmap,
+    make_config(),
+    make_device_lookup({{5, "dev5"}}));
+
+  ASSERT_EQ(1u, devices.size());
+  EXPECT_EQ("dev5", devices[0].device);
+  ASSERT_EQ(1u, devices[0].osds.size());
+  EXPECT_EQ(5, devices[0].osds[0].osd);
+  EXPECT_DOUBLE_EQ(500.0, devices[0].latency_ms);
+  EXPECT_GT(devices[0].score, 400.0);
+}
+
+TEST(FailSlowOSDDetector, ExcludesOSDsWithBackgroundWork)
+{
+  auto osdmap = make_osdmap(6);
+  auto pgmap = make_pgmap({10, 11, 12, 12, 13, 500});
+  pg_stat_t pg_stat;
+  pg_stat.state = PG_STATE_RECOVERING;
+  pg_stat.acting = {5};
+  pgmap.pg_stat[pg_t{1, 1}] = pg_stat;
+
+  FailSlowOSDDetector detector;
+  auto devices = detector.find_fail_slow_devices(
+    *osdmap,
+    pgmap,
+    make_config(),
+    make_device_lookup({{5, "dev5"}}));
+
+  EXPECT_TRUE(devices.empty());
+}
+
+TEST(FailSlowOSDDetector, GroupsOSDsOnSameDevice)
+{
+  auto osdmap = make_osdmap(7);
+  auto pgmap = make_pgmap({10, 11, 12, 12, 13, 500, 510});
+
+  FailSlowOSDDetector detector;
+  auto devices = detector.find_fail_slow_devices(
+    *osdmap,
+    pgmap,
+    make_config(),
+    make_device_lookup({{5, "dev-shared"}, {6, "dev-shared"}}));
+
+  ASSERT_EQ(1u, devices.size());
+  EXPECT_EQ("dev-shared", devices[0].device);
+  ASSERT_EQ(2u, devices[0].osds.size());
+  EXPECT_EQ(5, devices[0].osds[0].osd);
+  EXPECT_EQ(6, devices[0].osds[1].osd);
+  EXPECT_DOUBLE_EQ(505.0, devices[0].latency_ms);
+  EXPECT_GT(devices[0].score, 400.0);
+}
+
+TEST(FailSlowOSDDetector, KeepsDeviceClassesSeparate)
+{
+  std::map<int, std::string> classes;
+  std::vector<uint64_t> latencies;
+  std::vector<double> latencies_ms_ssd;
+  for (int osd = 0; osd < 20; ++osd) {
+    classes[osd] = "ssd";
+    latencies.push_back(10 + osd % 4);
+    latencies_ms_ssd.push_back(10 + osd % 4);
+  }
+  std::vector<double> latencies_ms_hdd;
+  for (int osd = 20; osd < 25; ++osd) {
+    classes[osd] = "hdd";
+    latencies.push_back(500 + osd - 20);
+    latencies_ms_hdd.push_back(500 + osd - 20);
+  }
+
+  auto osdmap = make_osdmap(25, classes);
+  auto pgmap = make_pgmap(latencies);
+
+  std::map<int, std::string> device_lookups;
+  for (int osd = 0; osd < 25; osd++) {
+    device_lookups.emplace(osd, std::string("dev") + std::to_string(osd));
+  }
+  FailSlowOSDDetector detector;
+  auto devices = detector.find_fail_slow_devices(
+    *osdmap,
+    pgmap,
+    make_config(),
+    make_device_lookup(std::move(device_lookups)),
+    true);
+
+  ASSERT_EQ(25u, devices.size());
+  auto lat_median_ssd = detector.median(latencies_ms_ssd);
+  auto lat_median_hdd = detector.median(latencies_ms_hdd);
+  for (int i = 0; i < 25; i++) {
+    ASSERT_EQ(1u, devices[i].osds.size());
+    if (devices[i].osds.front().osd < 20) {
+      ASSERT_EQ(*lat_median_ssd, devices[i].cohort_median);
+      ASSERT_EQ(std::string("{crush_root:default, device_class:ssd}"),
+                devices[i].cohort);
+    } else {
+      ASSERT_EQ(*lat_median_hdd, devices[i].cohort_median);
+      ASSERT_EQ(std::string("{crush_root:default, device_class:hdd}"),
+                devices[i].cohort);
+    }
+  }
+}
+
+TEST(FailSlowOSDDetector, RefreshesCrushRootCacheWhenOSDMapChanges)
+{
+  std::vector<uint64_t> latencies;
+  for (int osd = 0; osd < 20; ++osd) {
+    latencies.push_back(10 + osd % 4);
+  }
+  for (int osd = 20; osd < 25; ++osd) {
+    latencies.push_back(500 + osd - 20);
+  }
+
+  auto osdmap = make_osdmap(25);
+  auto pgmap = make_pgmap(latencies);
+  std::map<int, std::string> device_lookups;
+  for (int osd = 0; osd < 25; ++osd) {
+    device_lookups.emplace(osd, std::string{"dev"} + std::to_string(osd));
+  }
+
+  FailSlowOSDDetector detector;
+  ASSERT_EQ(1u, osdmap->get_epoch());
+  ASSERT_FALSE(detector.find_fail_slow_devices(
+    *osdmap,
+    pgmap,
+    make_config(),
+    make_device_lookup(device_lookups)).empty());
+
+  std::map<int, std::string> roots_by_osd;
+  for (int osd = 0; osd < 20; ++osd) {
+    roots_by_osd.emplace(osd, "fast-root");
+  }
+  for (int osd = 20; osd < 25; ++osd) {
+    roots_by_osd.emplace(osd, "slow-root");
+  }
+  move_osds_to_roots(osdmap.get(), roots_by_osd);
+
+  ASSERT_EQ(2u, osdmap->get_epoch());
+  auto devices = detector.find_fail_slow_devices(
+    *osdmap,
+    pgmap,
+    make_config(),
+    make_device_lookup(device_lookups));
+
+  EXPECT_TRUE(devices.empty());
+}
+
+int main(int argc, char **argv)
+{
+  std::map<std::string, std::string> defaults = {
+    {"osd_pool_default_size", "3"},
+    {"osd_crush_chooseleaf_type", "0"},
+  };
+  std::vector<const char*> args(argv, argv + argc);
+  auto cct = global_init(
+    &defaults,
+    args,
+    CEPH_ENTITY_TYPE_CLIENT,
+    CODE_ENVIRONMENT_UTILITY,
+    CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  common_init_finish(g_ceph_context);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/test/mgr/test_fail_slow_osd_detector.cc
+++ b/src/test/mgr/test_fail_slow_osd_detector.cc
@@ -1,0 +1,227 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#include "mgr/FailSlowOSDDetector.h"
+
+#include "common/common_init.h"
+#include "crush/CrushWrapper.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
+#include "gtest/gtest.h"
+#include "include/ceph_assert.h"
+#include "mon/PGMap.h"
+#include "osd/OSDMap.h"
+#include "osd/osd_types.h"
+
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+constexpr uint64_t NS_PER_MS = 1000000;
+
+fail_slow_osd_detector_config make_config()
+{
+  fail_slow_osd_detector_config config;
+  config.min_osds = 5;
+  config.score_threshold = 10.0;
+  config.min_latency_ms = 100.0;
+  config.mad_floor_ms = 1.0;
+  return config;
+}
+
+std::unique_ptr<OSDMap> make_osdmap(
+  int num_osds,
+  const std::map<int, std::string>& classes = {})
+{
+  auto osdmap = std::make_unique<OSDMap>();
+  uuid_d fsid;
+  osdmap->build_simple(g_ceph_context, 0, fsid, num_osds);
+  OSDMap::Incremental pending_inc(osdmap->get_epoch() + 1);
+  pending_inc.fsid = osdmap->get_fsid();
+  entity_addrvec_t sample_addrs;
+  sample_addrs.v.push_back(entity_addr_t());
+  uuid_d sample_uuid;
+  for (int i = 0; i < num_osds; ++i) {
+    sample_uuid.generate_random();
+    sample_addrs.v[0].nonce = i;
+    pending_inc.new_state[i] = CEPH_OSD_EXISTS | CEPH_OSD_NEW;
+    pending_inc.new_up_client[i] = sample_addrs;
+    pending_inc.new_up_cluster[i] = sample_addrs;
+    pending_inc.new_hb_back_up[i] = sample_addrs;
+    pending_inc.new_hb_front_up[i] = sample_addrs;
+    pending_inc.new_weight[i] = CEPH_OSD_IN;
+    pending_inc.new_uuid[i] = sample_uuid;
+  }
+  osdmap->apply_incremental(pending_inc);
+
+  for (const auto& [osd, device_class] : classes) {
+    ceph_assert(osdmap->crush);
+    ceph_assert(osdmap->crush->set_item_class(osd, device_class) == 0);
+  }
+  return osdmap;
+}
+
+PGMap make_pgmap(const std::vector<uint64_t>& latencies_ms)
+{
+  PGMap pgmap;
+  for (size_t osd = 0; osd < latencies_ms.size(); ++osd) {
+    osd_stat_t stat;
+    stat.os_perf_stat.os_commit_latency_ns = latencies_ms[osd] * NS_PER_MS;
+    pgmap.osd_stat[osd] = stat;
+  }
+  return pgmap;
+}
+
+std::function<std::vector<std::string>(int)> make_device_lookup(
+  std::map<int, std::string> devices)
+{
+  return [devices = std::move(devices)](int osd) -> std::vector<std::string> {
+    auto p = devices.find(osd);
+    if (p != devices.end()) {
+      return {p->second};
+    }
+    return {std::string{"osd."} + std::to_string(osd)};
+  };
+}
+}
+
+TEST(FailSlowOSDDetector, DetectsSingleSlowDevice)
+{
+  auto osdmap = make_osdmap(6);
+  auto pgmap = make_pgmap({10, 11, 12, 12, 13, 500});
+
+  FailSlowOSDDetector detector;
+  auto devices = detector.find_fail_slow_devices(
+    *osdmap,
+    pgmap,
+    make_config(),
+    make_device_lookup({{5, "dev5"}}));
+
+  ASSERT_EQ(1u, devices.size());
+  EXPECT_EQ("dev5", devices[0].device);
+  ASSERT_EQ(1u, devices[0].osds.size());
+  EXPECT_EQ(5, devices[0].osds[0].osd);
+  EXPECT_DOUBLE_EQ(500.0, devices[0].latency_ms);
+  EXPECT_GT(devices[0].score, 400.0);
+}
+
+TEST(FailSlowOSDDetector, ExcludesOSDsWithBackgroundWork)
+{
+  auto osdmap = make_osdmap(6);
+  auto pgmap = make_pgmap({10, 11, 12, 12, 13, 500});
+  pg_stat_t pg_stat;
+  pg_stat.state = PG_STATE_RECOVERING;
+  pg_stat.acting = {5};
+  pgmap.pg_stat[pg_t{1, 1}] = pg_stat;
+
+  FailSlowOSDDetector detector;
+  auto devices = detector.find_fail_slow_devices(
+    *osdmap,
+    pgmap,
+    make_config(),
+    make_device_lookup({{5, "dev5"}}));
+
+  EXPECT_TRUE(devices.empty());
+}
+
+TEST(FailSlowOSDDetector, GroupsOSDsOnSameDevice)
+{
+  auto osdmap = make_osdmap(7);
+  auto pgmap = make_pgmap({10, 11, 12, 12, 13, 500, 510});
+
+  FailSlowOSDDetector detector;
+  auto devices = detector.find_fail_slow_devices(
+    *osdmap,
+    pgmap,
+    make_config(),
+    make_device_lookup({{5, "dev-shared"}, {6, "dev-shared"}}));
+
+  ASSERT_EQ(1u, devices.size());
+  EXPECT_EQ("dev-shared", devices[0].device);
+  ASSERT_EQ(2u, devices[0].osds.size());
+  EXPECT_EQ(5, devices[0].osds[0].osd);
+  EXPECT_EQ(6, devices[0].osds[1].osd);
+  EXPECT_DOUBLE_EQ(505.0, devices[0].latency_ms);
+  EXPECT_GT(devices[0].score, 400.0);
+}
+
+TEST(FailSlowOSDDetector, KeepsDeviceClassesSeparate)
+{
+  std::map<int, std::string> classes;
+  std::vector<uint64_t> latencies;
+  std::vector<double> latencies_ms_ssd;
+  for (int osd = 0; osd < 20; ++osd) {
+    classes[osd] = "ssd";
+    latencies.push_back(10 + osd % 4);
+    latencies_ms_ssd.push_back(10 + osd % 4);
+  }
+  std::vector<double> latencies_ms_hdd;
+  for (int osd = 20; osd < 25; ++osd) {
+    classes[osd] = "hdd";
+    latencies.push_back(500 + osd - 20);
+    latencies_ms_hdd.push_back(500 + osd - 20);
+  }
+
+  auto osdmap = make_osdmap(25, classes);
+  auto pgmap = make_pgmap(latencies);
+
+  std::map<int, std::string> device_lookups;
+  for (int osd = 0; osd < 25; osd++) {
+    device_lookups.emplace(osd, std::string("dev") + std::to_string(osd));
+  }
+  FailSlowOSDDetector detector;
+  auto devices = detector.find_fail_slow_devices(
+    *osdmap,
+    pgmap,
+    make_config(),
+    make_device_lookup(std::move(device_lookups)),
+    true);
+
+  ASSERT_EQ(25u, devices.size());
+  auto lat_median_ssd = detector.median(latencies_ms_ssd);
+  auto lat_median_hdd = detector.median(latencies_ms_hdd);
+  for (int i = 0; i < 25; i++) {
+    ASSERT_EQ(1u, devices[i].osds.size());
+    if (devices[i].osds.front().osd < 20) {
+      ASSERT_EQ(*lat_median_ssd, devices[i].cohort_median);
+      ASSERT_EQ(std::string("{crush_root:default, device_class:ssd}"),
+                devices[i].cohort);
+    } else {
+      ASSERT_EQ(*lat_median_hdd, devices[i].cohort_median);
+      ASSERT_EQ(std::string("{crush_root:default, device_class:hdd}"),
+                devices[i].cohort);
+    }
+  }
+}
+
+int main(int argc, char **argv)
+{
+  std::map<std::string, std::string> defaults = {
+    {"osd_pool_default_size", "3"},
+    {"osd_crush_chooseleaf_type", "0"},
+  };
+  std::vector<const char*> args(argv, argv + argc);
+  auto cct = global_init(
+    &defaults,
+    args,
+    CEPH_ENTITY_TYPE_CLIENT,
+    CODE_ENVIRONMENT_UTILITY,
+    CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  common_init_finish(g_ceph_context);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
