### PR TITLE
mgr/smb: Handling exception for stale share

### DIFF
--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -26,6 +26,7 @@ from ceph.deployment.service_spec import (
     SSLParameters,
 )
 from ceph.fs.earmarking import EarmarkTopScope
+from .fs import CephFSSubvolumeResolutionError
 
 from . import config_store, external, resources, rgw
 from .enums import (
@@ -403,8 +404,13 @@ class ClusterConfigHandler:
             with _store_transaction(staging.destination_store):
                 results = staging.save()
                 staging.prune_linked_entries()
-            with _store_transaction(staging.destination_store):
-                self._sync_modified(results)
+            try:
+                with _store_transaction(staging.destination_store):
+                    self._sync_modified(results)
+            except ValueError as err:
+                if results._contents:
+                    r = results._contents[-1]
+                    r.msg = str(err)
         return results
 
     def cluster_ids(self) -> List[str]:
@@ -1505,7 +1511,16 @@ def _save_pending_config(
     cluster_conf: _ClusterConf,
 ) -> None:
     # generate the cluster configuration and save it in the public store
-    cconfig = _generate_config(cluster_conf)
+    try:
+        cconfig = _generate_config(cluster_conf)
+    except CephFSSubvolumeResolutionError as e:
+        cluster_id = cluster_conf.resource.cluster_id
+        raise ValueError(
+            f"Subvolume issue for cluster '{cluster_id}' with error : {str(e)}. "
+            "This may indicate that one or more shares reference a subvolume that "
+            "no longer exists. Please verify share configurations and remove or "
+            "update any shares with invalid subvolume references."
+        ) from e
     centry = store[external.config_key(cluster_conf.resource.cluster_id)]
     centry.set(cconfig)
     cluster_conf.change_group.cache_updated_entry(centry)


### PR DESCRIPTION
This PR is depends upon https://github.com/ceph/ceph/pull/71108,

A stale share is created when a subvolume associated with an active share is deleted. Consequently, attempting to create or delete a share in this state triggers a `CephFSSubvolumeResolutionError` exception.

We have handled `CephFSSubvolumeResolutionError` exception with debug log messages Failed to resolve cephfs path:

Step to reproduce:

```
ceph smb cluster create smb2 user --define-user-pass testuser%testpassword
ceph fs subvolume create mycephfs sv10
ceph smb share create smb2 share10 mycephfs /  --subvolume sv10
ceph smb share create smb2 share11 mycephfs --path /
ceph fs subvolume rm mycephfs sv10 --force
ceph smb share rm smb2 share11
```

After fix:

```
for success scenario:
----------------------------------
[root@mycephfs21 ~]# ceph smb apply -i smb_yaml_file.yaml 
{
  "results": [
    {
      "resource": {
        "resource_type": "ceph.smb.share",
        "cluster_id": "smb2",
        "share_id": "share14",
        "intent": "present",
        "name": "share14",
        "readonly": false,
        "browseable": true,
        "cephfs": {
          "volume": "mycephfs",
          "path": "/",
          "subvolume": "sv14",
          "provider": "samba-vfs"
        }
      },
      "state": "created",
      "success": true
    }
  ],
  "success": true
}
[root@mycephfs21 ~]# ceph smb share ls smb2
[
  "share13",
  "share14",
  "share12"
]
[root@mycephfs21 ~]# vim smb_share_remove.yaml
[root@mycephfs21 ~]# ceph smb apply -i smb_share_remove.yaml 
{
  "results": [
    {
      "resource": {
        "resource_type": "ceph.smb.share",
        "cluster_id": "smb2",
        "share_id": "share14",
        "intent": "removed"
      },
      "state": "removed",
      "success": true
    }
  ],
  "success": true
}
[root@mycephfs21 ~]# 


For Failed scenario:
------------------------------------
[root@mycephfs21 ~]# ceph smb cluster create smb5 user --define-user-pass testuser%testpassword
{
  "resource": {
    "resource_type": "ceph.smb.cluster",
    "cluster_id": "smb5",
    "auth_mode": "user",
    "intent": "present",
    "user_group_settings": [
      {
        "source_type": "resource",
        "ref": "smb5wedyrinr"
      }
    ],
    "placement": {},
    "public_addrs": []
  },
  "state": "created",
  "additional_results": [
    {
      "resource": {
        "resource_type": "ceph.smb.usersgroups",
        "users_groups_id": "smb5wedyrinr",
        "intent": "present",
        "values": {
          "users": [
            {
              "name": "testuser",
              "password": "testpassword"
            }
          ],
          "groups": []
        },
        "linked_to_cluster": "smb5"
      },
      "state": "created",
      "success": true
    }
  ],
  "msg": "Subvolume issue for cluster 'smb2' with error : \"subvolume 'sv16' does not exist\". This may indicate that one or more shares reference a subvolume that no longer exists. Please verify share configurations and remove or update any shares with invalid subvolume references.",
  "success": true
}

```




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
