### PR TITLE
cephadm: retry shell on transient runc bind-mount race

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -84,6 +84,7 @@ from cephadmlib.call_wrappers import (
     call,
     call_throws,
     call_timeout,
+    call_timeout_shell,
     concurrent_tasks,
 )
 from cephadmlib.container_engines import (
@@ -3449,7 +3450,7 @@ def command_shell(ctx):
         print(' '.join(shlex.quote(arg) for arg in command))
         return 0
 
-    return call_timeout(ctx, command, ctx.timeout)
+    return call_timeout_shell(ctx, command, ctx.timeout)
 
 ##################################
 

--- a/src/cephadm/cephadmlib/call_wrappers.py
+++ b/src/cephadm/cephadmlib/call_wrappers.py
@@ -6,6 +6,7 @@ import logging
 import os
 import subprocess
 import sys
+import time
 
 from enum import Enum
 from typing import Callable, List, Dict, Optional, Any, Tuple, NoReturn
@@ -311,6 +312,15 @@ def call_throws(
     return out, err, ret
 
 
+SHELL_MOUNT_RACE_MAX_RETRIES = 5
+SHELL_MOUNT_RACE_RETRY_DELAY_SEC = 0.5
+
+
+def is_transient_shell_mount_race_error(stderr: str) -> bool:
+    """True when runc failed to bind-mount a path replaced during container init."""
+    return 'was moved while re-opening' in stderr
+
+
 def call_timeout(
     ctx: CephadmContext, command: List[str], timeout: int
 ) -> int:
@@ -329,3 +339,66 @@ def call_timeout(
         )
     except subprocess.TimeoutExpired:
         raise_timeout(command, timeout)
+
+
+def call_timeout_shell(
+    ctx: CephadmContext, command: List[str], timeout: int
+) -> int:
+    """
+    Like call_timeout, but retry transient runc bind-mount races when cephadm
+    shell starts while mgr-driven deploy-file updates /etc/ceph/* on the host.
+    """
+    logger.debug(
+        'Running shell command (timeout=%s): %s' % (timeout, ' '.join(command))
+    )
+
+    def raise_timeout(command: List[str], timeout: int) -> NoReturn:
+        msg = 'Command `%s` timed out after %s seconds' % (command, timeout)
+        logger.debug(msg)
+        raise TimeoutExpired(msg)
+
+    last_ret = 1
+    last_stderr = ''
+    for attempt in range(1, SHELL_MOUNT_RACE_MAX_RETRIES + 1):
+        logger.debug(
+            'Shell command attempt %s/%s',
+            attempt, SHELL_MOUNT_RACE_MAX_RETRIES)
+        try:
+            result = subprocess.run(
+                command,
+                timeout=timeout,
+                env=os.environ.copy(),
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        except subprocess.TimeoutExpired:
+            raise_timeout(command, timeout)
+
+        last_ret = result.returncode
+        last_stderr = result.stderr or ''
+        if last_ret == 0:
+            if last_stderr:
+                print(last_stderr, file=sys.stderr, end='')
+            return 0
+
+        if (
+            attempt < SHELL_MOUNT_RACE_MAX_RETRIES
+            and is_transient_shell_mount_race_error(last_stderr)
+        ):
+            logger.warning(
+                'Transient container mount race starting shell '
+                '(attempt %s/%s); retrying in %ss',
+                attempt,
+                SHELL_MOUNT_RACE_MAX_RETRIES,
+                SHELL_MOUNT_RACE_RETRY_DELAY_SEC,
+            )
+            time.sleep(SHELL_MOUNT_RACE_RETRY_DELAY_SEC)
+            continue
+
+        if last_stderr:
+            print(last_stderr, file=sys.stderr, end='')
+        return last_ret
+
+    if last_stderr:
+        print(last_stderr, file=sys.stderr, end='')
+    return last_ret

--- a/src/cephadm/tests/test_call_wrappers.py
+++ b/src/cephadm/tests/test_call_wrappers.py
@@ -1,0 +1,79 @@
+from unittest import mock
+
+import subprocess
+
+from cephadmlib.call_wrappers import (
+    SHELL_MOUNT_RACE_MAX_RETRIES,
+    call_timeout_shell,
+    is_transient_shell_mount_race_error,
+)
+from tests.fixtures import with_cephadm_ctx
+
+
+class TestShellMountRace:
+    def test_is_transient_shell_mount_race_error(self):
+        err = (
+            'Error: OCI runtime error: runc: runc create failed: '
+            'error mounting "/etc/ceph/ceph.client.admin.keyring" '
+            'to rootfs at "/etc/ceph/ceph.keyring": reopen mountpoint '
+            'after mount: mountpoint "/etc/ceph/ceph.keyring" was moved '
+            'while re-opening'
+        )
+        assert is_transient_shell_mount_race_error(err)
+        assert not is_transient_shell_mount_race_error('permission denied')
+
+    @mock.patch('cephadmlib.call_wrappers.time.sleep')
+    @mock.patch('cephadmlib.call_wrappers.subprocess.run')
+    def test_call_timeout_shell_retries_then_succeeds(self, mock_run, mock_sleep):
+        mount_err = subprocess.CompletedProcess(
+            args=['podman', 'run'],
+            returncode=126,
+            stderr=(
+                'Error: OCI runtime error: mountpoint "/etc/ceph/ceph.keyring" '
+                'was moved while re-opening'
+            ),
+        )
+        ok = subprocess.CompletedProcess(
+            args=['podman', 'run'],
+            returncode=0,
+            stderr='Inferring config /var/lib/ceph/.../config\n',
+        )
+        mock_run.side_effect = [mount_err, ok]
+
+        with with_cephadm_ctx(['shell']) as ctx:
+            ret = call_timeout_shell(ctx, ['podman', 'run'], timeout=30)
+
+        assert ret == 0
+        assert mock_run.call_count == 2
+        mock_sleep.assert_called_once()
+
+    @mock.patch('cephadmlib.call_wrappers.time.sleep')
+    @mock.patch('cephadmlib.call_wrappers.subprocess.run')
+    def test_call_timeout_shell_gives_up_after_max_retries(self, mock_run, mock_sleep):
+        mount_err = subprocess.CompletedProcess(
+            args=['podman', 'run'],
+            returncode=126,
+            stderr='mountpoint "/etc/ceph/ceph.keyring" was moved while re-opening',
+        )
+        mock_run.return_value = mount_err
+
+        with with_cephadm_ctx(['shell']) as ctx:
+            ret = call_timeout_shell(ctx, ['podman', 'run'], timeout=30)
+
+        assert ret == 126
+        assert mock_run.call_count == SHELL_MOUNT_RACE_MAX_RETRIES
+        assert mock_sleep.call_count == SHELL_MOUNT_RACE_MAX_RETRIES - 1
+
+    @mock.patch('cephadmlib.call_wrappers.subprocess.run')
+    def test_call_timeout_shell_no_retry_on_other_errors(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=['podman', 'run'],
+            returncode=1,
+            stderr='some other failure',
+        )
+
+        with with_cephadm_ctx(['shell']) as ctx:
+            ret = call_timeout_shell(ctx, ['podman', 'run'], timeout=30)
+
+        assert ret == 1
+        mock_run.assert_called_once()


### PR DESCRIPTION
cephadm shell bind-mounts /etc/ceph/* while the mgr may atomically replace those files via deploy-file. runc 1.2+ fails with "mountpoint was moved while re-opening". Retry shell startup a few times before failing.
Fixes: https://tracker.ceph.com/issues/77884
Signed-off-by: Kobi Ginon <kginon@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
