### PR TITLE
mon/PG: Add stale bit to PG with empty crush acting

### DIFF
--- a/qa/standalone/mon/mon-pg-no-acting-set.sh
+++ b/qa/standalone/mon/mon-pg-no-acting-set.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+function run() {
+    local dir=$1
+    shift
+
+    export CEPH_MON_A="127.0.0.1:7177" # git grep '\<7177\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+
+    export BASE_CEPH_ARGS=$CEPH_ARGS
+    CEPH_ARGS+="--mon-host=$CEPH_MON_A"
+
+    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        setup $dir || return 1
+        $func $dir || return 1
+        teardown $dir || return 1
+    done
+}
+
+TEST_mon_pg_no_acting_set() {
+    local dir=$1
+    setup $dir || return 1
+
+    run_mon $dir a --public-addr $CEPH_MON_A || return 1
+    run_mgr $dir x || return 1
+    run_osd $dir 0 || return 1
+    run_osd $dir 1 || return 1
+    run_osd $dir 2 || return 1
+    ceph osd pool create testpool 64 || return 1
+    ceph osd pool set testpool size 2 || return 1
+    ceph osd pool set testpool min_size 1 || return 1
+    for i in $(seq 1 20); do
+        echo "data-$i" | rados -p testpool put obj-$i - || return 1
+    done
+
+    sleep 15
+
+    # inject bad crush mapping (OSDs added directly to the root instead of into the appropriate intermediate buckets)
+    ceph osd getcrushmap > $dir/crushmap || return 1
+    cat > $dir/crushmap_modified.txt << EOF
+# begin crush map
+tunable choose_local_tries 0
+tunable choose_local_fallback_tries 0
+tunable choose_total_tries 50
+tunable chooseleaf_descend_once 1
+tunable chooseleaf_vary_r 1
+tunable chooseleaf_stable 1
+tunable straw_calc_version 1
+tunable allowed_bucket_algs 54
+
+device 0 osd.0 class hdd
+device 1 osd.1 class hdd
+device 2 osd.2 class hdd
+
+type 0 osd
+type 1 host
+type 11 root
+
+host ceph-osd0 {
+  id -3
+  alg straw2
+  hash 0
+  item osd.0 weight 0.09769
+}
+host ceph-osd1 {
+  id -5
+  alg straw2
+  hash 0
+  item osd.1 weight 0.09769
+}
+root default {
+  id -1
+  alg straw2
+  hash 0
+  item ceph-osd0 weight 0.09769
+  item ceph-osd1 weight 0.09769
+  item osd.2 weight 0.09769
+}
+
+rule replicated_rule {
+  id 0
+  type replicated
+  step take default
+  step choose firstn 1 type host
+  step chooseleaf firstn 0 type osd
+  step emit
+}
+# end crush map
+EOF
+    crushtool --compile $dir/crushmap_modified.txt -o $dir/crushmap.bin || return 1
+    ceph osd setcrushmap -i $dir/crushmap.bin || return 1
+
+    ceph tell mon.a config set auth_allow_insecure_global_id_reclaim false || return 1
+    ceph config set global mon_warn_on_msgr2_not_enabled false || return 1
+
+    sleep 10
+    echo "=== Health ==="
+    wait_for_health "HEALTH_WARN" || return 1
+
+    ceph -s 2>&1 | grep "stale+active+clean" || return 1
+
+    ceph osd crush set osd.2 0.09769 host=ceph-osd2 || return 1
+    ceph osd crush move ceph-osd2 root=default || return 1
+    sleep 10
+
+    timeout 5 rados -p testpool get obj-4 /dev/null 2>&1 && echo "obj-4: OK" || return 1
+
+    wait_for_health_ok || return 1
+
+    teardown $dir || return 1
+}
+
+main mon-pg-no-acting-set "$@"

--- a/qa/tasks/stretch_mode_disable_enable.py
+++ b/qa/tasks/stretch_mode_disable_enable.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from tasks.mgr.mgr_test_case import MgrTestCase
 
@@ -190,6 +191,29 @@ class TestStretchMode(MgrTestCase):
         for mon in mons:
             self._bring_back_mon(mon)
         super(TestStretchMode, self).tearDown()
+    
+    def _pg_active_or_stale_correctly(self):
+            pgs = self.mgr_cluster.mon_manager.get_pg_stats()
+            for pg in pgs:
+                pgid = pg['pgid']
+                state = pg['state']
+                is_active = 'active' in state and 'stale' not in state
+                is_stale = 'stale' in state
+                map_out = self.mgr_cluster.mon_manager.raw_cluster_cmd(
+                    'pg', 'map', pgid, '--format=json')
+                pg_map = json.loads(map_out)
+                acting = pg_map['acting']
+                has_acting_primary = len(acting) > 0
+                if has_acting_primary and not is_active:
+                    log.debug('PG %s acting=%s but not active (state=%s)',
+                              pgid, acting, state)
+                    return False
+                if not has_acting_primary and not is_stale:
+                    log.debug('PG %s acting=[] but not stale (state=%s)',
+                              pgid, state)
+                    return False
+            log.debug('All PGs correclty active or stale')
+            return True
 
     def _kill_osd(self, osd):
         """
@@ -557,9 +581,9 @@ class TestStretchMode(MgrTestCase):
             ))
         # Check if stretch mode is disabled correctly
         self._stretch_mode_disabled_correctly()
-        # all PGs are active
+        # only PGs with empty acting set are stale and rest are active
         self.wait_until_true_and_hold(
-            lambda: self.mgr_cluster.mon_manager.pg_all_active(),
+            lambda: self._pg_active_or_stale_correctly(),
             timeout=self.RECOVERY_PERIOD,
             success_hold_time=self.SUCCESS_HOLD_TIME
         )

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -3936,17 +3936,43 @@ static void _try_mark_pg_stale(
   const pg_stat_t& cur,
   PGMap::Incremental *pending_inc)
 {
-  if ((cur.state & PG_STATE_STALE) == 0 &&
-      cur.acting_primary != -1 &&
-      osdmap.is_down(cur.acting_primary)) {
+  if ((cur.state & PG_STATE_STALE) != 0 || cur.acting_primary == -1) {
+    return;
+  }
+
+  bool primary_is_down = osdmap.is_down(cur.acting_primary);
+  
+  // Only compute CRUSH mapping if primary is up (to check for CRUSH mapping failure)
+  // The current CRUSH acting set and primary may be different from cur which may be stale
+  int crush_acting_primary = -1;
+  if (!primary_is_down) {
+    vector<int> crush_acting;
+    osdmap.pg_to_acting_osds(pgid, &crush_acting, &crush_acting_primary);
+  }
+
+  // Mark PG stale if primary is down OR CRUSH mapping failed
+  if (primary_is_down || crush_acting_primary == -1) {
     pg_stat_t *newstat;
     auto q = pending_inc->pg_stat_updates.find(pgid);
     if (q != pending_inc->pg_stat_updates.end()) {
-      if ((q->second.acting_primary == cur.acting_primary) ||
-	  ((q->second.state & PG_STATE_STALE) == 0 &&
-	   q->second.acting_primary != -1 &&
-	   osdmap.is_down(q->second.acting_primary))) {
-	newstat = &q->second;
+      bool pending_primary_is_down = false;
+      int pending_crush_acting_primary = -1;
+      
+      if (q->second.acting_primary == cur.acting_primary) {
+        newstat = &q->second;
+      } else if ((q->second.state & PG_STATE_STALE) == 0 &&
+                 q->second.acting_primary != -1) {
+        pending_primary_is_down = osdmap.is_down(q->second.acting_primary);
+        if (!pending_primary_is_down) {
+          vector<int> pending_crush_acting;
+          osdmap.pg_to_acting_osds(pgid, &pending_crush_acting, &pending_crush_acting_primary);
+        }
+        if (pending_primary_is_down || pending_crush_acting_primary == -1) {
+          newstat = &q->second;
+        } else {
+          // Pending update has a working primary, don't mark stale
+          return;
+        }
       } else {
 	// pending update is no longer down or already stale
 	return;


### PR DESCRIPTION
Problem: PGs with an empty acting set `(acting=[], acting_primary=-1) ` are invisible to every health check. The PGs becoming empty is caused by a CRUSH map misconfiguration (OSDs added directly to the root instead of into the appropriate intermediate buckets). The PGs cache the previous state so if they were previously active+clean, they remain displayed as active+clean. I/O then hangs on those PGs

Solution: Add stale bit to PGs when they previously had a valid acting set but now have an empty crush acting.

Fixes: https://tracker.ceph.com/issues/75767

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
