### PR TITLE
rgw/pubsub: return negative error code from remove_notification_v2

### DIFF
--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -12388,6 +12388,10 @@ next:
         ret = b.remove_notification_by_id(dpp(), notification_id, null_yield);
       }
     }
+    if (ret < 0 && ret != -ENOENT) {
+      cerr << "ERROR: could not remove notification: " << cpp_strerror(-ret) << std::endl;
+      return -ret;
+    }
   }
 
 #ifdef WITH_RADOSGW_RADOS

--- a/src/rgw/rgw_pubsub.cc
+++ b/src/rgw/rgw_pubsub.cc
@@ -665,7 +665,7 @@ int remove_notification_v2(const DoutPrefixProvider* dpp,
   rgw_pubsub_bucket_topics bucket_topics;
   auto ret = get_bucket_notifications(dpp, bucket, bucket_topics);
   if (ret < 0) {
-    return -ret;
+    return ret;
   }
   // no notifications on the bucket.
   if (bucket_topics.topics.empty()) {


### PR DESCRIPTION
`remove_notification_v2()` returned `-ret` on a `get_bucket_notifications()`
failure, flipping the negative error to positive so callers saw it as
success. Return `ret` unchanged.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests