### PR TITLE
rgw/es: require both major and minor in ES version parsing

### DIFF
--- a/src/rgw/driver/rados/rgw_sync_module_es.cc
+++ b/src/rgw/driver/rados/rgw_sync_module_es.cc
@@ -136,8 +136,8 @@ struct es_version_decoder {
   int parse_version(const std::string& s) {
     int major, minor;
     int ret = sscanf(s.c_str(), "%d.%d", &major, &minor);
-    if (ret < 0) {
-      return ret;
+    if (ret < 2) {
+      return -EINVAL;
     }
     version = std::make_pair(major,minor);
     return 0;


### PR DESCRIPTION
`parse_version()` only checked `sscanf() < 0` as failure, but sscanf returns
the count of assigned fields, so a partial match leaves `major`/`minor`
uninitialized and pollutes later version checks. Require both fields and
return -EINVAL otherwise.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests