### PR TITLE
umbrella: journal/ObjectPlayer: don't acquire locks in destructor

### DIFF
--- a/src/journal/ObjectPlayer.cc
+++ b/src/journal/ObjectPlayer.cc
@@ -59,12 +59,8 @@ ObjectPlayer::ObjectPlayer(librados::IoCtx &ioctx,
 }
 
 ObjectPlayer::~ObjectPlayer() {
-  {
-    std::lock_guard timer_locker{m_timer_lock};
-    std::lock_guard locker{m_lock};
-    ceph_assert(!m_fetch_in_progress);
-    ceph_assert(m_watch_ctx == nullptr);
-  }
+  ceph_assert(!m_fetch_in_progress);
+  ceph_assert(m_watch_ctx == nullptr);
 }
 
 void ObjectPlayer::fetch(Context *on_finish) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77524

---

backport of https://github.com/ceph/ceph/pull/68613
parent tracker: https://tracker.ceph.com/issues/77496

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh