### PR TITLE
tentacle: rgw/dedup: backport full dedup, throttling, permissions, and versioning support

### DIFF
--- a/doc/radosgw/index.rst
+++ b/doc/radosgw/index.rst
@@ -91,4 +91,4 @@ Cluster with one API and then retrieve that data with the other API.
    Metrics <metrics>
    UADK Acceleration for Compression <uadk-accel>
    Bucket Logging <bucket_logging>
-
+   Full Object Deduplication <s3_objects_dedup>

--- a/doc/radosgw/s3_objects_dedup.rst
+++ b/doc/radosgw/s3_objects_dedup.rst
@@ -1,79 +1,78 @@
-======================
-Full RGW Object Dedup:
-======================
-Add a radosgw-admin command to collect and report deduplication stats
+=====================
+Full RGW Object Dedup
+=====================
+Adds a ``radosgw-admin`` command to collect and report deduplication stats.
 
-.. note:: This utility doesn’t perform dedup and doesn’t make any
+.. note:: This utility doesn't perform dedup and doesn't make any
           change to the existing system and will only collect
           statistics and report them.
 
-----
-
-***************
-Admin commands:
-***************
+**************
+Admin commands
+**************
 - ``radosgw-admin dedup stats``:
-   Collects & displays last dedup statistics
+   Collects & displays last dedup statistics.
 - ``radosgw-admin dedup pause``:
-   Pauses active dedup session (dedup resources are not released)
+   Pauses an active dedup session (dedup resources are not released).
 - ``radosgw-admin dedup resume``:
-   Resumes a paused dedup session
+   Resumes a paused dedup session.
 - ``radosgw-admin dedup abort``:
-   Aborts active dedup session and release all resources used by it
+   Aborts an active dedup session and release all resources used by it.
 - ``radosgw-admin dedup estimate``
-    Starts a new dedup estimate session (aborting first existing session if exists)
+   Starts a new dedup estimate session (aborting first existing session if exists).
 
-----
+***************
+Skipped Objects
+***************
+Dedup Estimate process skips the following objects:
 
-****************
-Skipped Objects:
-****************
-Dedup Estimates skips the following objects:
+- Objects smaller than 4MB (unless they are multipart).
+- Objects with different placement rules.
+- Objects with different pools.
+- Objects with different storage classes.
 
-- Objects smaller than 4MB (unless they are multipart)
-- Objects with different placement rules
-- Objects with different pools
-- Objects with different same storage-classes
-
-The Dedup process itself (which will be released later) will also skip
+The dedup process itself (which will be released in a later Ceph release) will also skip
 **compressed** and **user-encrypted** objects, but the estimate
 process will accept them (since we don't have access to that
-information during the estimate process)
+information during the estimate process).
 
-----
-
-********************
-Estimate Processing:
-********************
+*******************
+Estimate Processing
+*******************
 The Dedup Estimate process collects all the needed information directly from
-the bucket-indices reading one full bucket-index object with 1000's of
+the bucket indices reading one full bucket index object with thousands of
 entries at a time.
 
-The Bucket-Indices objects are sharded between the participating
-members so every bucket-index object is read exactly one time.
-The sharding allow processing to scale almost linearly spliting the
+The bucket indices objects are sharded between the participating
+members so every bucket index object is read exactly one time.
+The sharding allow processing to scale almost linearly splitting the
 load evenly between the participating members.
 
 The Dedup Estimate process does not access the objects themselves
 (data/metadata) which means its processing time won't be affected by
-the underlined media storing the objects (SSD/HDD) since the bucket-indices are
+the underlying media storing the objects (SSD/HDD) since the bucket indices are
 virtually always stored on a fast medium (SSD with heavy memory
-caching)
+caching).
 
-----
-
-*************
-Memory Usage:
-*************
- +---------------++-----------+
- | RGW Obj Count |  Memory    |
- +===============++===========+
- | | ____1M      | | ___8MB   |
- | | ____4M      | | __16MB   |
- | | ___16M      | | __32MB   |
- | | ___64M      | | __64MB   |
- | | __256M      | | _128MB   |
- | | _1024M( 1G) | | _256MB   |
- | | _4096M( 4G) | | _512MB   |
- | | 16384M(16G) | | 1024MB   |
- +---------------+------------+
+************
+Memory Usage
+************
+ +---------------+----------+
+ | RGW Obj Count |  Memory  |
+ +===============+==========+
+ | 1M            | 8 MB     |
+ +---------------+----------+
+ | 4M            | 16 MB    |
+ +---------------+----------+
+ | 16M           | 32 MB    |
+ +---------------+----------+
+ | 64M           | 64 MB    |
+ +---------------+----------+
+ | 256M          | 128 MB   |
+ +---------------+----------+
+ | 1024M (1G)    | 256 MB   |
+ +---------------+----------+
+ | 4096M (4G)    | 512 MB   |
+ +---------------+----------+
+ | 16384M (16G)  | 1024 MB  |
+ +---------------+----------+

--- a/doc/radosgw/s3_objects_dedup.rst
+++ b/doc/radosgw/s3_objects_dedup.rst
@@ -8,11 +8,10 @@ Admin commands
 **************
 - ``radosgw-admin dedup estimate``:
    Starts a new dedup estimate session (aborting first existing session if exists).
-   
    It doesn't make any change to the existing system and will only collect statistics and report them.
-- ``radosgw-admin dedup restart --yes-i-really-mean-it``:
+- ``radosgw-admin dedup exec --yes-i-really-mean-it``:
    Starts a new dedup session (aborting first existing session if exists).
-   It will perfrom a full dedup, finding duplicated tail-objects and removing them.
+   It will perform a full dedup, finding duplicated tail-objects and removing them.
 
   This command can lead to **data-loss** and should not be used on production data!!
 - ``radosgw-admin dedup pause``:
@@ -23,6 +22,12 @@ Admin commands
    Aborts an active dedup session and release all resources used by it.
 - ``radosgw-admin dedup stats``:
    Collects & displays last dedup statistics.
+- ``radosgw-admin dedup estimate``:
+   Starts a new dedup estimate session (aborting first existing session if exists).
+- ``radosgw-admin dedup throttle --max-bucket-index-ops=<count>``:
+   Specify max bucket-index requests per second allowed for a single RGW server during dedup, 0 means unlimited.
+- ``radosgw-admin dedup throttle --stat``:
+   Display dedup throttle setting.
 
 ***************
 Skipped Objects
@@ -53,6 +58,14 @@ The Dedup Estimate process does not access the objects themselves
 the underlying media storing the objects (SSD/HDD) since the bucket indices are
 virtually always stored on a fast medium (SSD with heavy memory
 caching).
+
+The admin can throttle the estimate process by setting a limit to the number of
+bucket-index reads per-second per an RGW server (each read brings 1000 object entries) using:
+
+$ radosgw-admin dedup throttle --max-bucket-index-ops=<count>
+
+A typical RGW server performs about 100 bucket-index reads per second (i.e. 100,000 object entries).
+Setting the count to 50 will typically slow down access by half and so on...
 
 *********************
 Full Dedup Processing

--- a/doc/radosgw/s3_objects_dedup.rst
+++ b/doc/radosgw/s3_objects_dedup.rst
@@ -1,40 +1,40 @@
 =====================
 Full RGW Object Dedup
 =====================
-Adds a ``radosgw-admin`` command to collect and report deduplication stats.
-
-.. note:: This utility doesn't perform dedup and doesn't make any
-          change to the existing system and will only collect
-          statistics and report them.
+Adds ``radosgw-admin`` commands to remove duplicated RGW tail-objects and to collect and report deduplication stats.
 
 **************
 Admin commands
 **************
-- ``radosgw-admin dedup stats``:
-   Collects & displays last dedup statistics.
+- ``radosgw-admin dedup estimate``:
+   Starts a new dedup estimate session (aborting first existing session if exists).
+   
+   It doesn't make any change to the existing system and will only collect statistics and report them.
+- ``radosgw-admin dedup restart --yes-i-really-mean-it``:
+   Starts a new dedup session (aborting first existing session if exists).
+   It will perfrom a full dedup, finding duplicated tail-objects and removing them.
+
+  This command can lead to **data-loss** and should not be used on production data!!
 - ``radosgw-admin dedup pause``:
    Pauses an active dedup session (dedup resources are not released).
 - ``radosgw-admin dedup resume``:
    Resumes a paused dedup session.
 - ``radosgw-admin dedup abort``:
    Aborts an active dedup session and release all resources used by it.
-- ``radosgw-admin dedup estimate``
-   Starts a new dedup estimate session (aborting first existing session if exists).
+- ``radosgw-admin dedup stats``:
+   Collects & displays last dedup statistics.
 
 ***************
 Skipped Objects
 ***************
 Dedup Estimate process skips the following objects:
 
-- Objects smaller than 4MB (unless they are multipart).
+- Objects smaller than 4 MB (unless they are multipart).
 - Objects with different placement rules.
 - Objects with different pools.
 - Objects with different storage classes.
 
-The dedup process itself (which will be released in a later Ceph release) will also skip
-**compressed** and **user-encrypted** objects, but the estimate
-process will accept them (since we don't have access to that
-information during the estimate process).
+The full dedup process skips all the above and it also skips **compressed** and **user-encrypted** objects.
 
 *******************
 Estimate Processing
@@ -53,6 +53,24 @@ The Dedup Estimate process does not access the objects themselves
 the underlying media storing the objects (SSD/HDD) since the bucket indices are
 virtually always stored on a fast medium (SSD with heavy memory
 caching).
+
+*********************
+Full Dedup Processing
+*********************
+The Full Dedup process begins by constructing a dedup table from the bucket indices, similar to the estimate process above.
+
+This table is then scanned linearly to purge objects without duplicates, leaving only dedup candidates.
+
+Next, we iterate through these dedup candidate objects, reading their complete information from the object metadata (a per-object RADOS operation).
+During this step, we filter out **compressed** and **user-encrypted** objects.
+
+Following this, we calculate a strong-hash of the object data, which involves a full-object read and is a resource-intensive operation.
+This strong-hash ensures that the dedup candidates are indeed perfect matches.
+If they are, we proceed with the deduplication:
+
+- incrementing the reference count on the source tail-objects one by one.
+- copying the manifest from the source to the target.
+- removing all tail-objects on the target.
 
 ************
 Memory Usage

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -157,7 +157,7 @@ void usage()
   cout << "  caps rm                          remove user capabilities\n";
   cout << "  dedup stats                      Display dedup statistics from the last run\n";
   cout << "  dedup estimate                   Runs dedup in estimate mode (no changes will be made)\n";
-  cout << "  dedup restart                    Restart dedup\n";
+  cout << "  dedup restart                    Restart dedup; must include --yes-i-really-mean-it to activate\n";
   cout << "  dedup abort                      Abort dedup\n";
   cout << "  dedup pause                      Pause dedup\n";
   cout << "  dedup resume                     Resume paused dedup\n";
@@ -3639,7 +3639,6 @@ int main(int argc, const char **argv)
   int skip_zero_entries = false;  // log show
   int purge_keys = false;
   int yes_i_really_mean_it = false;
-  int tech_preview = false;
   int delete_child_objects = false;
   int fix = false;
   int remove_bad = false;
@@ -4099,8 +4098,6 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_binary_flag(args, i, &purge_keys, NULL, "--purge-keys", (char*)NULL)) {
       // do nothing
     } else if (ceph_argparse_binary_flag(args, i, &yes_i_really_mean_it, NULL, "--yes-i-really-mean-it", (char*)NULL)) {
-      // do nothing
-    } else if (ceph_argparse_binary_flag(args, i, &tech_preview, NULL, "--tech-preview", (char*)NULL)) {
       // do nothing
     } else if (ceph_argparse_binary_flag(args, i, &fix, NULL, "--fix", (char*)NULL)) {
       // do nothing
@@ -9288,12 +9285,6 @@ next:
 	if (!yes_i_really_mean_it) {
 	  cerr << "Full Dedup is dangerous and could lead to data loss!\n"
 	       << "do you really mean it? (requires --yes-i-really-mean-it)"
-	       << std::endl;
-	  return EINVAL;
-	}
-	if (!tech_preview) {
-	  cerr << "Full Dedup is supplied as a tech-preview only and should not be used on production systems!\n"
-	       << "Please acknowledge that you understand this is a tech preview (requires --tech-preview)"
 	       << std::endl;
 	  return EINVAL;
 	}

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -3639,6 +3639,7 @@ int main(int argc, const char **argv)
   int skip_zero_entries = false;  // log show
   int purge_keys = false;
   int yes_i_really_mean_it = false;
+  int tech_preview = false;
   int delete_child_objects = false;
   int fix = false;
   int remove_bad = false;
@@ -4098,6 +4099,8 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_binary_flag(args, i, &purge_keys, NULL, "--purge-keys", (char*)NULL)) {
       // do nothing
     } else if (ceph_argparse_binary_flag(args, i, &yes_i_really_mean_it, NULL, "--yes-i-really-mean-it", (char*)NULL)) {
+      // do nothing
+    } else if (ceph_argparse_binary_flag(args, i, &tech_preview, NULL, "--tech-preview", (char*)NULL)) {
       // do nothing
     } else if (ceph_argparse_binary_flag(args, i, &fix, NULL, "--fix", (char*)NULL)) {
       // do nothing
@@ -9282,6 +9285,18 @@ next:
 	dedup_type = dedup_req_type_t::DEDUP_TYPE_ESTIMATE;
       }
       else {
+	if (!yes_i_really_mean_it) {
+	  cerr << "Full Dedup is dangerous and could lead to data loss!\n"
+	       << "do you really mean it? (requires --yes-i-really-mean-it)"
+	       << std::endl;
+	  return EINVAL;
+	}
+	if (!tech_preview) {
+	  cerr << "Full Dedup is supplied as a tech-preview only and should not be used on production systems!\n"
+	       << "Please acknowledge that you understand this is a tech preview (requires --tech-preview)"
+	       << std::endl;
+	  return EINVAL;
+	}
 	dedup_type = dedup_req_type_t::DEDUP_TYPE_FULL;
 #ifndef FULL_DEDUP_SUPPORT
 	std::cerr << "Only dedup estimate is supported!" << std::endl;

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -157,10 +157,11 @@ void usage()
   cout << "  caps rm                          remove user capabilities\n";
   cout << "  dedup stats                      Display dedup statistics from the last run\n";
   cout << "  dedup estimate                   Runs dedup in estimate mode (no changes will be made)\n";
-  cout << "  dedup restart                    Restart dedup; must include --yes-i-really-mean-it to activate\n";
+  cout << "  dedup exec                       Execute dedup (duplicated tail objects will be deleted); must include --yes-i-really-mean-it to activate\n";
   cout << "  dedup abort                      Abort dedup\n";
   cout << "  dedup pause                      Pause dedup\n";
   cout << "  dedup resume                     Resume paused dedup\n";
+  cout << "  dedup throttle                   Throttle dedup execution\n";
   cout << "  subuser create                   create a new subuser\n" ;
   cout << "  subuser modify                   modify subuser\n";
   cout << "  subuser rm                       remove subuser\n";
@@ -490,6 +491,10 @@ void usage()
   cout << "   --disable-feature                 disable a zone/zonegroup feature\n";
   cout << "\n";
   cout << "<date> := \"YYYY-MM-DD[ hh:mm:ss]\"\n";
+  cout << "\nDedup throttle options:\n";
+  cout << "   --max-bucket-index-ops        specify max bucket-index requests per second allowed for an RGW during dedup, 0 means unlimited\n";
+  cout << "   --max-metadata-ops            specify max metadata requests per second allowed for an RGW during dedup, 0 means unlimited\n";
+  cout << "   --stat                        display dedup throttle setting\n";
   cout << "\nQuota options:\n";
   cout << "   --max-objects                 specify max objects (negative value to disable)\n";
   cout << "   --max-size                    specify max size (in B/K/M/G/T, negative value to disable)\n";
@@ -757,9 +762,10 @@ enum class OPT {
   DEDUP_STATS,
   DEDUP_ESTIMATE,
   DEDUP_ABORT,
-  DEDUP_RESTART,
+  DEDUP_EXEC,
   DEDUP_PAUSE,
   DEDUP_RESUME,
+  DEDUP_THROTTLE,
   GC_LIST,
   GC_PROCESS,
   LC_LIST,
@@ -1011,9 +1017,11 @@ static SimpleCmd::Commands all_cmds = {
   { "dedup stats", OPT::DEDUP_STATS },
   { "dedup estimate", OPT::DEDUP_ESTIMATE },
   { "dedup abort", OPT::DEDUP_ABORT },
-  { "dedup restart", OPT::DEDUP_RESTART },
+  { "dedup restart", OPT::DEDUP_EXEC },
+  { "dedup exec", OPT::DEDUP_EXEC },
   { "dedup pause", OPT::DEDUP_PAUSE },
   { "dedup resume", OPT::DEDUP_RESUME },
+  { "dedup throttle", OPT::DEDUP_THROTTLE },
   { "gc list", OPT::GC_LIST },
   { "gc process", OPT::GC_PROCESS },
   { "lc list", OPT::LC_LIST },
@@ -3639,6 +3647,7 @@ int main(int argc, const char **argv)
   int skip_zero_entries = false;  // log show
   int purge_keys = false;
   int yes_i_really_mean_it = false;
+  int throttle_stat = false;
   int delete_child_objects = false;
   int fix = false;
   int remove_bad = false;
@@ -3691,12 +3700,16 @@ int main(int argc, const char **argv)
   int64_t max_write_ops = 0;
   int64_t max_read_bytes = 0;
   int64_t max_write_bytes = 0;
+  uint32_t max_bucket_index_ops = 0;
+  uint32_t max_metadata_ops = 0;
   bool have_max_objects = false;
   bool have_max_size = false;
   bool have_max_write_ops = false;
   bool have_max_read_ops = false;
   bool have_max_write_bytes = false;
   bool have_max_read_bytes = false;
+  bool have_max_bucket_index_ops = false;
+  bool have_max_metadata_ops = false;
   int include_all = false;
   int allow_unordered = false;
 
@@ -4005,6 +4018,20 @@ int main(int argc, const char **argv)
         return EINVAL;
       }
       have_max_write_bytes = true;
+    } else if (ceph_argparse_witharg(args, i, &val, "--max-bucket-index-ops", (char*)NULL)) {
+      max_bucket_index_ops = (int64_t)strict_strtoll(val.c_str(), 10, &err);
+      if (!err.empty()) {
+	cerr << "ERROR: failed to parse max bucket index ops: " << err << std::endl;
+	return EINVAL;
+      }
+      have_max_bucket_index_ops = true;
+    } else if (ceph_argparse_witharg(args, i, &val, "--max-metadata-ops", (char*)NULL)) {
+      max_metadata_ops = (int64_t)strict_strtoll(val.c_str(), 10, &err);
+      if (!err.empty()) {
+	cerr << "ERROR: failed to parse max metadata ops: " << err << std::endl;
+	return EINVAL;
+      }
+      have_max_metadata_ops = true;
     } else if (ceph_argparse_witharg(args, i, &val, "--date", "--time", (char*)NULL)) {
       date = val;
       if (end_date.empty())
@@ -4098,6 +4125,8 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_binary_flag(args, i, &purge_keys, NULL, "--purge-keys", (char*)NULL)) {
       // do nothing
     } else if (ceph_argparse_binary_flag(args, i, &yes_i_really_mean_it, NULL, "--yes-i-really-mean-it", (char*)NULL)) {
+      // do nothing
+    } else if (ceph_argparse_binary_flag(args, i, &throttle_stat, NULL, "--stat", (char*)NULL)) {
       // do nothing
     } else if (ceph_argparse_binary_flag(args, i, &fix, NULL, "--fix", (char*)NULL)) {
       // do nothing
@@ -4516,9 +4545,10 @@ int main(int argc, const char **argv)
 			 OPT::DEDUP_STATS,
 			 OPT::DEDUP_ESTIMATE,
 			 OPT::DEDUP_ABORT,     // TBD - not READ-ONLY
-			 OPT::DEDUP_RESTART,   // TBD - not READ-ONLY
+			 OPT::DEDUP_EXEC,   // TBD - not READ-ONLY
 			 OPT::DEDUP_PAUSE,
 			 OPT::DEDUP_RESUME,
+			 OPT::DEDUP_THROTTLE,
 			 OPT::GC_LIST,
 			 OPT::LC_LIST,
 			 OPT::ORPHANS_LIST_JOBS,
@@ -9241,7 +9271,8 @@ next:
       opt_cmd == OPT::DEDUP_ABORT    ||
       opt_cmd == OPT::DEDUP_PAUSE    ||
       opt_cmd == OPT::DEDUP_RESUME   ||
-      opt_cmd == OPT::DEDUP_RESTART) {
+      opt_cmd == OPT::DEDUP_THROTTLE ||
+      opt_cmd == OPT::DEDUP_EXEC) {
 
     using namespace rgw::dedup;
     rgw::sal::RadosStore *store = dynamic_cast<rgw::sal::RadosStore*>(driver);
@@ -9262,7 +9293,41 @@ next:
       return ret;
     }
 
-    if (opt_cmd == OPT::DEDUP_ABORT || opt_cmd == OPT::DEDUP_PAUSE || opt_cmd == OPT::DEDUP_RESUME) {
+    if (opt_cmd == OPT::DEDUP_THROTTLE) {
+      bufferlist urgent_msg_bl;
+      urgent_msg_t urgent_msg = URGENT_MSG_THROTTLE;
+      ceph::encode(urgent_msg, urgent_msg_bl);
+      throttle_msg_t throttle_msg;
+
+      if (throttle_stat) {
+	encode(throttle_msg, urgent_msg_bl);
+	return cluster::dedup_control_bl(store, dpp(), urgent_msg, urgent_msg_bl);
+      }
+
+      if (unlikely(!have_max_bucket_index_ops && !have_max_metadata_ops)) {
+	std::cerr << "dedup throttle must set either --max-bucket-index-ops or --max-metadata-ops" << std::endl;
+	return EINVAL;
+      }
+
+      if (have_max_bucket_index_ops) {
+	throttle_action_t action = { .op_type = BUCKET_INDEX_OP,
+				     .limit = max_bucket_index_ops};
+	throttle_msg.vec.push_back(action);
+      }
+
+      if (have_max_metadata_ops) {
+	throttle_action_t action = { .op_type = METADATA_ACCESS_OP,
+				     .limit = max_metadata_ops};
+	throttle_msg.vec.push_back(action);
+      }
+
+      encode(throttle_msg, urgent_msg_bl);
+      return cluster::dedup_control_bl(store, dpp(), urgent_msg, urgent_msg_bl);
+    }
+
+    if (opt_cmd == OPT::DEDUP_ABORT  ||
+	opt_cmd == OPT::DEDUP_PAUSE  ||
+	opt_cmd == OPT::DEDUP_RESUME) {
       urgent_msg_t urgent_msg;
       if (opt_cmd == OPT::DEDUP_ABORT) {
 	urgent_msg = URGENT_MSG_ABORT;
@@ -9276,7 +9341,7 @@ next:
       return cluster::dedup_control(store, dpp(), urgent_msg);
     }
 
-    if (opt_cmd == OPT::DEDUP_RESTART || opt_cmd == OPT::DEDUP_ESTIMATE) {
+    if (opt_cmd == OPT::DEDUP_EXEC || opt_cmd == OPT::DEDUP_ESTIMATE) {
       dedup_req_type_t dedup_type = dedup_req_type_t::DEDUP_TYPE_NONE;
       if (opt_cmd == OPT::DEDUP_ESTIMATE) {
 	dedup_type = dedup_req_type_t::DEDUP_TYPE_ESTIMATE;
@@ -9288,7 +9353,7 @@ next:
 	       << std::endl;
 	  return EINVAL;
 	}
-	dedup_type = dedup_req_type_t::DEDUP_TYPE_FULL;
+	dedup_type = dedup_req_type_t::DEDUP_TYPE_EXEC;
 #ifndef FULL_DEDUP_SUPPORT
 	std::cerr << "Only dedup estimate is supported!" << std::endl;
 	return EPERM;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -89,6 +89,7 @@ using ceph::crypto::MD5;
 #define RGW_ATTR_ETAG RGW_ATTR_PREFIX "etag"
 #define RGW_ATTR_CKSUM          RGW_ATTR_PREFIX "cksum"
 #define RGW_ATTR_SHA256         RGW_ATTR_PREFIX "x-amz-content-sha256"
+#define RGW_ATTR_BLAKE3         RGW_ATTR_PREFIX "blake3"
 #define RGW_ATTR_BUCKETS	RGW_ATTR_PREFIX "buckets"
 #define RGW_ATTR_META_PREFIX	RGW_ATTR_PREFIX RGW_AMZ_META_PREFIX
 #define RGW_ATTR_CONTENT_TYPE	RGW_ATTR_PREFIX "content_type"

--- a/src/rgw/rgw_dedup.cc
+++ b/src/rgw/rgw_dedup.cc
@@ -419,10 +419,11 @@ namespace rgw::dedup {
                                                const rgw::sal::Bucket *p_bucket,
                                                const parsed_etag_t    *p_parsed_etag,
                                                const std::string      &obj_name,
+                                               const std::string      &instance,
                                                uint64_t                obj_size,
                                                const std::string      &storage_class)
   {
-    disk_record_t rec(p_bucket, obj_name, p_parsed_etag, obj_size, storage_class);
+    disk_record_t rec(p_bucket, obj_name, p_parsed_etag, instance, obj_size, storage_class);
     // First pass using only ETAG and size taken from bucket-index
     rec.s.flags.set_fastlane();
 
@@ -683,10 +684,10 @@ namespace rgw::dedup {
   //---------------------------------------------------------------------------
   static int get_ioctx(const DoutPrefixProvider* const dpp,
                        rgw::sal::Driver* driver,
-                       RGWRados* rados,
+                       rgw::sal::RadosStore* store,
                        const disk_record_t *p_rec,
                        librados::IoCtx *p_ioctx,
-                       std::string *oid)
+                       std::string *p_oid)
   {
     unique_ptr<rgw::sal::Bucket> bucket;
     {
@@ -699,23 +700,12 @@ namespace rgw::dedup {
       }
     }
 
-    build_oid(p_rec->bucket_id, p_rec->obj_name, oid);
-    //ldpp_dout(dpp, 0) << __func__ << "::OID=" << oid << " || bucket_id=" << bucket_id << dendl;
-    rgw_pool data_pool;
-    rgw_obj obj{bucket->get_key(), *oid};
-    if (!rados->get_obj_data_pool(bucket->get_placement_rule(), obj, &data_pool)) {
-      ldpp_dout(dpp, 1) << __func__ << "::failed to get data pool for bucket "
-                        << bucket->get_name()  << dendl;
-      return -EIO;
-    }
-    int ret = rgw_init_ioctx(dpp, rados->get_rados_handle(), data_pool, *p_ioctx);
-    if (ret < 0) {
-      ldpp_dout(dpp, 1) << __func__ << "::ERR: failed to get ioctx from data pool:"
-                        << data_pool.to_str() << dendl;
-      return -EIO;
-    }
-
-    return 0;
+    string dummy_locator;
+    const rgw_obj_index_key key(p_rec->obj_name, p_rec->instance);
+    rgw_obj obj(bucket->get_key(), key);
+    get_obj_bucket_and_oid_loc(obj, *p_oid, dummy_locator);
+    RGWBucketInfo& bucket_info = bucket->get_info();
+    return store->get_obj_head_ioctx(dpp, bucket_info, obj, p_ioctx);
   }
 
   //---------------------------------------------------------------------------
@@ -787,8 +777,8 @@ namespace rgw::dedup {
 
     std::string src_oid, tgt_oid;
     librados::IoCtx src_ioctx, tgt_ioctx;
-    int ret1 = get_ioctx(dpp, driver, rados, p_src_rec, &src_ioctx, &src_oid);
-    int ret2 = get_ioctx(dpp, driver, rados, p_tgt_rec, &tgt_ioctx, &tgt_oid);
+    int ret1 = get_ioctx(dpp, driver, store, p_src_rec, &src_ioctx, &src_oid);
+    int ret2 = get_ioctx(dpp, driver, store, p_tgt_rec, &tgt_ioctx, &tgt_oid);
     if (unlikely(ret1 != 0 || ret2 != 0)) {
       ldpp_dout(dpp, 1) << __func__ << "::ERR: failed get_ioctx()" << dendl;
       return (ret1 ? ret1 : ret2);
@@ -1093,7 +1083,7 @@ namespace rgw::dedup {
                          << p_rec->obj_name << ")" << dendl;
       return 0;
     }
-
+    p_obj->set_instance(p_rec->instance);
     d_ctl.metadata_access_throttle.acquire();
     ret = p_obj->get_obj_attrs(null_yield, dpp);
     if (unlikely(ret < 0)) {
@@ -1191,7 +1181,7 @@ namespace rgw::dedup {
   //---------------------------------------------------------------------------
   static int write_blake3_object_attribute(const DoutPrefixProvider* const dpp,
                                            rgw::sal::Driver* driver,
-                                           RGWRados* rados,
+                                           rgw::sal::RadosStore *store,
                                            const disk_record_t *p_rec)
   {
     bufferlist etag_bl;
@@ -1204,7 +1194,7 @@ namespace rgw::dedup {
 
     std::string oid;
     librados::IoCtx ioctx;
-    int ret = get_ioctx(dpp, driver, rados, p_rec, &ioctx, &oid);
+    int ret = get_ioctx(dpp, driver, store, p_rec, &ioctx, &oid);
     if (unlikely(ret != 0)) {
       ldpp_dout(dpp, 5) << __func__ << "::ERR: failed get_ioctx()" << dendl;
       return ret;
@@ -1299,10 +1289,11 @@ namespace rgw::dedup {
                        << "/" << src_rec.obj_name << dendl;
     // verify that SRC and TGT records don't refer to the same physical object
     // This could happen in theory if we read the same objects twice
-    if (src_rec.obj_name == p_tgt_rec->obj_name && src_rec.bucket_name == p_tgt_rec->bucket_name) {
+    if (src_rec.ref_tag == p_tgt_rec->ref_tag) {
       p_stats->duplicate_records++;
-      ldpp_dout(dpp, 10) << __func__ << "::WARN: Duplicate records for object="
-                         << src_rec.obj_name << dendl;
+      ldpp_dout(dpp, 10) << __func__ << "::WARN::REF_TAG::Duplicate records for "
+                         << src_rec.obj_name << "::" << src_rec.ref_tag << "::"
+                         << p_tgt_rec->obj_name << dendl;
       return 0;
     }
 
@@ -1321,11 +1312,11 @@ namespace rgw::dedup {
       ldpp_dout(dpp, 10) << __func__ << "::HASH mismatch" << dendl;
       // TBD: set hash attributes on head objects to save calc next time
       if (src_rec.s.flags.hash_calculated()) {
-        write_blake3_object_attribute(dpp, driver, rados, &src_rec);
+        write_blake3_object_attribute(dpp, driver, store, &src_rec);
         p_stats->set_hash_attrs++;
       }
       if (p_tgt_rec->s.flags.hash_calculated()) {
-        write_blake3_object_attribute(dpp, driver, rados, p_tgt_rec);
+        write_blake3_object_attribute(dpp, driver, store, p_tgt_rec);
         p_stats->set_hash_attrs++;
       }
       return 0;
@@ -1583,8 +1574,8 @@ namespace rgw::dedup {
     }
 
     return add_disk_rec_from_bucket_idx(disk_arr, p_bucket, &parsed_etag,
-                                        entry.key.name, entry.meta.size,
-                                        storage_class);
+                                        entry.key.name, entry.key.instance,
+                                        entry.meta.size, storage_class);
   }
 
   //---------------------------------------------------------------------------
@@ -1683,15 +1674,21 @@ namespace rgw::dedup {
       obj_count += result.dir.m.size();
       for (auto& entry : result.dir.m) {
         const rgw_bucket_dir_entry& dirent = entry.second;
+        // make sure to advance marker in all cases!
+        marker = dirent.key;
+        ldpp_dout(dpp, 20) << __func__ << "::dirent = " << bucket->get_name() << "/"
+                           << marker.name << "::instance=" << marker.instance << dendl;
         if (unlikely((!dirent.exists && !dirent.is_delete_marker()) || !dirent.pending_map.empty())) {
           // TBD: should we bailout ???
-          ldpp_dout(dpp, 1) << __func__ << "::ERR: calling check_disk_state bucket="
-                            << bucket->get_name() << " entry=" << dirent.key << dendl;
-          // make sure we're advancing marker
-          marker = dirent.key;
+          ldpp_dout(dpp, 1) << __func__ << "::ERR: bad dirent::" << bucket->get_name()
+                            << "/" << marker.name << "::instance=" << marker.instance << dendl;
           continue;
         }
-        marker = dirent.key;
+        else if (unlikely(dirent.is_delete_marker())) {
+          ldpp_dout(dpp, 20) << __func__ << "::skip delete_marker::" << bucket->get_name()
+                             << "/" << marker.name << "::instance=" << marker.instance << dendl;
+          continue;
+        }
         ret = ingress_bucket_idx_single_object(disk_arr, bucket, dirent, p_worker_stats);
       }
       // TBD: advance marker only once here!

--- a/src/rgw/rgw_dedup.cc
+++ b/src/rgw/rgw_dedup.cc
@@ -1074,8 +1074,8 @@ namespace rgw::dedup {
                          << cpp_strerror(-ret) << dendl;
       return 0;
     }
-
-    unique_ptr<rgw::sal::Object> p_obj = bucket->get_object(p_rec->obj_name);
+    const rgw_obj_index_key roi_key(p_rec->obj_name, p_rec->instance);
+    unique_ptr<rgw::sal::Object> p_obj = bucket->get_object(roi_key);
     if (unlikely(!p_obj)) {
       // could happen when the object is removed between passes
       p_stats->ingress_failed_get_object++;
@@ -1083,7 +1083,7 @@ namespace rgw::dedup {
                          << p_rec->obj_name << ")" << dendl;
       return 0;
     }
-    p_obj->set_instance(p_rec->instance);
+
     d_ctl.metadata_access_throttle.acquire();
     ret = p_obj->get_obj_attrs(null_yield, dpp);
     if (unlikely(ret < 0)) {

--- a/src/rgw/rgw_dedup.h
+++ b/src/rgw/rgw_dedup.h
@@ -55,6 +55,8 @@ namespace rgw::dedup {
     bool remote_pause_req   = false;
     bool remote_paused      = false;
     bool remote_restart_req = false;
+    Throttle bucket_index_throttle;
+    Throttle metadata_access_throttle;
   };
   std::ostream& operator<<(std::ostream &out, const control_t &ctl);
   void encode(const control_t& ctl, ceph::bufferlist& bl);
@@ -230,9 +232,6 @@ namespace rgw::dedup {
     librados::IoCtx d_dedup_cluster_ioctx;
     utime_t  d_heart_beat_last_update;
     unsigned d_heart_beat_max_elapsed_sec;
-
-    // A pool with 6 billion objects has a  1/(2^64) chance for collison with a 128bit MD5
-    uint64_t d_max_protected_objects   = (6ULL * 1024 * 1024 * 1024);
     uint64_t d_all_buckets_obj_count   = 0;
     uint64_t d_all_buckets_obj_size    = 0;
     // we don't benefit from deduping RGW objects smaller than head-object size

--- a/src/rgw/rgw_dedup.h
+++ b/src/rgw/rgw_dedup.h
@@ -179,7 +179,7 @@ namespace rgw::dedup {
                            remapper_t *remapper);
 
 #ifdef FULL_DEDUP_SUPPORT
-    int calc_object_sha256(const disk_record_t *p_rec, uint8_t *p_sha256);
+    int calc_object_blake3(const disk_record_t *p_rec, uint8_t *p_hash);
     int add_obj_attrs_to_record(rgw_bucket            *p_rb,
                                 disk_record_t         *p_rec,
                                 const rgw::sal::Attrs &attrs,

--- a/src/rgw/rgw_dedup.h
+++ b/src/rgw/rgw_dedup.h
@@ -161,6 +161,7 @@ namespace rgw::dedup {
                                      const rgw::sal::Bucket *p_bucket,
                                      const parsed_etag_t    *p_parsed_etag,
                                      const std::string      &obj_name,
+                                     const std::string      &instance,
                                      uint64_t                obj_size,
                                      const std::string      &storage_class);
 

--- a/src/rgw/rgw_dedup_cluster.cc
+++ b/src/rgw/rgw_dedup_cluster.cc
@@ -898,9 +898,15 @@ namespace rgw::dedup {
     if (!has_incomplete_shards) {
       return;
     }
+    //utime_t now = ceph_clock_now();
     Formatter::ArraySection array_section{*fmt, "incomplete_shards"};
     for (unsigned shard = 0; shard < num_shards; shard++) {
-      if (sp_arr[shard].is_completed() ) {
+      if (sp_arr[shard].is_completed()) {
+        continue;
+      }
+      if (sp_arr[shard].was_not_started() ) {
+        Formatter::ObjectSection object_section{*fmt, "pending shard:"};
+        fmt->dump_unsigned("shard_id", shard);
         continue;
       }
       Formatter::ObjectSection object_section{*fmt, "shard_progress"};
@@ -909,6 +915,8 @@ namespace rgw::dedup {
       fmt->dump_unsigned("progress_a", sp_arr[shard].progress_a);
       fmt->dump_unsigned("progress_b", sp_arr[shard].progress_b);
       fmt->dump_stream("last updated") << sp_arr[shard].update_time;
+      utime_t elapsed = sp_arr[shard].update_time - sp_arr[shard].creation_time;
+      fmt->dump_unsigned("time elapsed (sec)", elapsed.tv.tv_sec);
     }
   }
 
@@ -1184,21 +1192,34 @@ namespace rgw::dedup {
   }
 
   //---------------------------------------------------------------------------
-  // command-line called from radosgw-admin.cc
-  int cluster::dedup_control(rgw::sal::RadosStore *store,
-                             const DoutPrefixProvider *dpp,
-                             urgent_msg_t urgent_msg)
+  static void report_throttle_state(const struct rgw::dedup::control_t &ctl)
   {
-    ldpp_dout(dpp, 10) << __func__ << "::dedup_control req = "
-                       << get_urgent_msg_names(urgent_msg) << dendl;
-    if (urgent_msg != URGENT_MSG_RESUME  &&
-        urgent_msg != URGENT_MSG_PASUE   &&
-        urgent_msg != URGENT_MSG_RESTART &&
-        urgent_msg != URGENT_MSG_ABORT) {
-      ldpp_dout(dpp, 1) << __func__ << "::illegal urgent_msg="<< urgent_msg << dendl;
-      return -EINVAL;
+    if (!ctl.bucket_index_throttle.is_disabled()) {
+      std::cout << "bucket-index throttle="
+                << ctl.bucket_index_throttle.get_max_calls_per_second()
+                << std::endl;
+    }
+    else {
+      std::cout << "bucket-index throttle is disabled" << std::endl;
     }
 
+    if (!ctl.metadata_access_throttle.is_disabled()) {
+      std::cout << "metadata throttle="
+                << ctl.metadata_access_throttle.get_max_calls_per_second()
+                << std::endl;
+    }
+    else {
+      std::cout << "metadata throttle is disabled" << std::endl;
+    }
+  }
+
+  //---------------------------------------------------------------------------
+  // command-line called from radosgw-admin.cc
+  int cluster::dedup_control_bl(rgw::sal::RadosStore *store,
+                                const DoutPrefixProvider *dpp,
+                                urgent_msg_t urgent_msg,
+                                bufferlist urgent_msg_bl)
+  {
     librados::IoCtx ctl_ioctx;
     int ret = get_control_ioctx(store, dpp, ctl_ioctx);
     if (unlikely(ret != 0)) {
@@ -1207,8 +1228,7 @@ namespace rgw::dedup {
 
     // 10 seconds timeout
     const uint64_t timeout_ms = 10*1000;
-    bufferlist reply_bl, urgent_msg_bl;
-    ceph::encode(urgent_msg, urgent_msg_bl);
+    bufferlist reply_bl;
     ret = rgw_rados_notify(dpp, ctl_ioctx, DEDUP_WATCH_OBJ, urgent_msg_bl,
                            timeout_ms, &reply_bl, null_yield);
     if (ret < 0) {
@@ -1234,6 +1254,9 @@ namespace rgw::dedup {
         struct rgw::dedup::control_t ctl;
         decode(ctl, iter);
         ldpp_dout(dpp, 10) << __func__ << "::++ACK::ctl=" << ctl << "::ret=" << ret << dendl;
+        if (urgent_msg == URGENT_MSG_THROTTLE) {
+          report_throttle_state(ctl);
+        }
       } catch (buffer::error& err) {
         ldpp_dout(dpp, 1) << __func__ << "::failed decoding notify acks" << dendl;
         return -EINVAL;
@@ -1244,9 +1267,29 @@ namespace rgw::dedup {
         return ret;
       }
     }
-    ldpp_dout(dpp, 10) << __func__ << "::" << get_urgent_msg_names(urgent_msg)
-                       << " finished successfully!" << dendl;
+    ldpp_dout(dpp, 10) << __func__ << "::finished successfully!" << dendl;
     return 0;
+  }
+
+  //---------------------------------------------------------------------------
+  // command-line called from radosgw-admin.cc
+  int cluster::dedup_control(rgw::sal::RadosStore *store,
+                             const DoutPrefixProvider *dpp,
+                             urgent_msg_t urgent_msg)
+  {
+    ldpp_dout(dpp, 10) << __func__ << "::dedup_control req = "
+                       << get_urgent_msg_names(urgent_msg) << dendl;
+    if (urgent_msg != URGENT_MSG_RESUME  &&
+        urgent_msg != URGENT_MSG_PASUE   &&
+        urgent_msg != URGENT_MSG_RESTART &&
+        urgent_msg != URGENT_MSG_ABORT) {
+      ldpp_dout(dpp, 1) << __func__ << "::illegal urgent_msg="<< urgent_msg << dendl;
+      return -EINVAL;
+    }
+
+    bufferlist urgent_msg_bl;
+    ceph::encode(urgent_msg, urgent_msg_bl);
+    return dedup_control_bl(store, dpp, urgent_msg, urgent_msg_bl);
   }
 
   //---------------------------------------------------------------------------
@@ -1288,7 +1331,7 @@ namespace rgw::dedup {
     ldpp_dout(dpp, 10) << __func__ << dedup_type << dendl;
 #ifdef FULL_DEDUP_SUPPORT
     ceph_assert(dedup_type == dedup_req_type_t::DEDUP_TYPE_ESTIMATE ||
-                dedup_type == dedup_req_type_t::DEDUP_TYPE_FULL);
+                dedup_type == dedup_req_type_t::DEDUP_TYPE_EXEC);
 #else
     ceph_assert(dedup_type == dedup_req_type_t::DEDUP_TYPE_ESTIMATE);
 #endif

--- a/src/rgw/rgw_dedup_cluster.h
+++ b/src/rgw/rgw_dedup_cluster.h
@@ -92,6 +92,10 @@ namespace rgw::dedup {
                             uint64_t notify_id,
                             uint64_t cookie,
                             int status);
+    static int   dedup_control_bl(rgw::sal::RadosStore *store,
+                                  const DoutPrefixProvider *dpp,
+                                  urgent_msg_t urgent_msg,
+                                  bufferlist urgent_msg_bl);
     static int   dedup_control(rgw::sal::RadosStore *store,
                                const DoutPrefixProvider *dpp,
                                urgent_msg_t urgent_msg);

--- a/src/rgw/rgw_dedup_cluster.h
+++ b/src/rgw/rgw_dedup_cluster.h
@@ -43,7 +43,7 @@ namespace rgw::dedup {
 
       //---------------------------------------------------------------------------
       void set_shard(uint16_t shard) {
-        int n = snprintf(this->buff + this->prefix_len, BUFF_SIZE, "%03x", shard);
+        int n = snprintf(this->buff + this->prefix_len, BUFF_SIZE - this->prefix_len, "%03x", shard);
         this->total_len = this->prefix_len + n;
       }
 
@@ -55,7 +55,7 @@ namespace rgw::dedup {
       inline const char* get_buff() { return this->buff; }
       inline unsigned get_buff_size() { return this->total_len; }
     private:
-      static const unsigned BUFF_SIZE = 15;
+      static const unsigned BUFF_SIZE = 16;
       unsigned total_len  = 0;
       unsigned prefix_len = 0;
       char buff[BUFF_SIZE];

--- a/src/rgw/rgw_dedup_store.cc
+++ b/src/rgw/rgw_dedup_store.cc
@@ -616,6 +616,9 @@ namespace rgw::dedup {
     unsigned len = (p_curr_block + 1 - p_arr) * sizeof(disk_block_t);
     bufferlist bl = bufferlist::static_from_mem((char*)p_arr, len);
     int ret = store_slab(ioctx, bl, d_md5_shard, d_worker_id, d_seq_number, dpp);
+    if (unlikely(ret != 0)) {
+      p_stats->write_slab_failure++;
+    }
     // Need to make sure the call to rgw_put_system_obj was fully synchronous
 
     // d_seq_number++ must be called **after** flush!!

--- a/src/rgw/rgw_dedup_store.h
+++ b/src/rgw/rgw_dedup_store.h
@@ -27,6 +27,7 @@
 #include "include/rados/buffer.h"
 #include "include/rados/librados.hpp"
 #include "rgw_dedup_utils.h"
+#include "BLAKE3/c/blake3.h"
 
 namespace rgw::dedup {
   struct key_t;
@@ -171,7 +172,7 @@ namespace rgw::dedup {
       uint8_t       pad[6];
 
       uint64_t      shared_manifest; // 64bit hash of the SRC object manifest
-      uint64_t      sha256[4];       // 4 * 8 Bytes of SHA256
+      uint64_t      hash[4];       // 4 * 8 Bytes of BLAKE3
     }s;
     std::string obj_name;
     // TBD: find pool name making it easier to get ioctx
@@ -182,7 +183,7 @@ namespace rgw::dedup {
     std::string stor_class;
     bufferlist  manifest_bl;
   };
-
+  static_assert(BLAKE3_OUT_LEN == sizeof(disk_record_t::packed_rec_t::hash));
   std::ostream &operator<<(std::ostream &stream, const disk_record_t & rec);
 
   static constexpr unsigned BLOCK_MAGIC = 0xFACE;

--- a/src/rgw/rgw_dedup_store.h
+++ b/src/rgw/rgw_dedup_store.h
@@ -138,6 +138,7 @@ namespace rgw::dedup {
     disk_record_t(const rgw::sal::Bucket *p_bucket,
                   const std::string      &obj_name,
                   const parsed_etag_t    *p_parsed_etag,
+                  const std::string      &instance,
                   uint64_t                obj_size,
                   const std::string      &storage_class);
     disk_record_t() {}
@@ -161,10 +162,10 @@ namespace rgw::dedup {
       uint64_t      md5_high;        // High Bytes of the Object Data MD5
       uint64_t      md5_low;         // Low  Bytes of the Object Data MD5
       uint64_t      obj_bytes_size;
-      uint64_t      object_version;
 
       uint16_t      bucket_id_len;
       uint16_t      tenant_name_len;
+      uint16_t      instance_len;
       uint16_t      stor_class_len;
       uint16_t      ref_tag_len;
 
@@ -180,6 +181,7 @@ namespace rgw::dedup {
     std::string bucket_id;
     std::string tenant_name;
     std::string ref_tag;
+    std::string instance;
     std::string stor_class;
     bufferlist  manifest_bl;
   };

--- a/src/rgw/rgw_dedup_utils.cc
+++ b/src/rgw/rgw_dedup_utils.cc
@@ -432,15 +432,15 @@ namespace rgw::dedup {
     this->skipped_source_record   += other.skipped_source_record;
     this->duplicate_records       += other.duplicate_records;
     this->size_mismatch           += other.size_mismatch;
-    this->sha256_mismatch         += other.sha256_mismatch;
+    this->hash_mismatch           += other.hash_mismatch;
     this->failed_src_load         += other.failed_src_load;
     this->failed_rec_load         += other.failed_rec_load;
     this->failed_block_load       += other.failed_block_load;
 
-    this->valid_sha256_attrs      += other.valid_sha256_attrs;
-    this->invalid_sha256_attrs    += other.invalid_sha256_attrs;
-    this->set_sha256_attrs        += other.set_sha256_attrs;
-    this->skip_sha256_cmp         += other.skip_sha256_cmp;
+    this->valid_hash_attrs        += other.valid_hash_attrs;
+    this->invalid_hash_attrs      += other.invalid_hash_attrs;
+    this->set_hash_attrs          += other.set_hash_attrs;
+    this->skip_hash_cmp           += other.skip_hash_cmp;
 
     this->set_shared_manifest_src += other.set_shared_manifest_src;
     this->loaded_objects          += other.loaded_objects;
@@ -514,15 +514,15 @@ namespace rgw::dedup {
         f->dump_unsigned("Failed Remap Overflow", this->failed_map_overflow);
       }
 
-      f->dump_unsigned("Valid SHA256 attrs", this->valid_sha256_attrs);
-      f->dump_unsigned("Invalid SHA256 attrs", this->invalid_sha256_attrs);
+      f->dump_unsigned("Valid HASH attrs", this->valid_hash_attrs);
+      f->dump_unsigned("Invalid HASH attrs", this->invalid_hash_attrs);
 
-      if (this->set_sha256_attrs) {
-        f->dump_unsigned("Set SHA256", this->set_sha256_attrs);
+      if (this->set_hash_attrs) {
+        f->dump_unsigned("Set HASH", this->set_hash_attrs);
       }
 
-      if (this->skip_sha256_cmp) {
-        f->dump_unsigned("Can't run SHA256 compare", this->skip_sha256_cmp);
+      if (this->skip_hash_cmp) {
+        f->dump_unsigned("Can't run HASH compare", this->skip_hash_cmp);
       }
     }
 
@@ -582,8 +582,8 @@ namespace rgw::dedup {
 
     {
       Formatter::ObjectSection logical_failures(*f, "logical failures");
-      if (this->sha256_mismatch) {
-        f->dump_unsigned("SHA256 mismatch", this->sha256_mismatch);
+      if (this->hash_mismatch) {
+        f->dump_unsigned("HASH mismatch", this->hash_mismatch);
       }
       if (this->duplicate_records) {
         f->dump_unsigned("Duplicate SRC/TGT", this->duplicate_records);
@@ -620,15 +620,15 @@ namespace rgw::dedup {
     encode(m.skipped_source_record, bl);
     encode(m.duplicate_records, bl);
     encode(m.size_mismatch, bl);
-    encode(m.sha256_mismatch, bl);
+    encode(m.hash_mismatch, bl);
     encode(m.failed_src_load, bl);
     encode(m.failed_rec_load, bl);
     encode(m.failed_block_load, bl);
 
-    encode(m.valid_sha256_attrs, bl);
-    encode(m.invalid_sha256_attrs, bl);
-    encode(m.set_sha256_attrs, bl);
-    encode(m.skip_sha256_cmp, bl);
+    encode(m.valid_hash_attrs, bl);
+    encode(m.invalid_hash_attrs, bl);
+    encode(m.set_hash_attrs, bl);
+    encode(m.skip_hash_cmp, bl);
     encode(m.set_shared_manifest_src, bl);
 
     encode(m.loaded_objects, bl);
@@ -670,15 +670,15 @@ namespace rgw::dedup {
     decode(m.skipped_source_record, bl);
     decode(m.duplicate_records, bl);
     decode(m.size_mismatch, bl);
-    decode(m.sha256_mismatch, bl);
+    decode(m.hash_mismatch, bl);
     decode(m.failed_src_load, bl);
     decode(m.failed_rec_load, bl);
     decode(m.failed_block_load, bl);
 
-    decode(m.valid_sha256_attrs, bl);
-    decode(m.invalid_sha256_attrs, bl);
-    decode(m.set_sha256_attrs, bl);
-    decode(m.skip_sha256_cmp, bl);
+    decode(m.valid_hash_attrs, bl);
+    decode(m.invalid_hash_attrs, bl);
+    decode(m.set_hash_attrs, bl);
+    decode(m.skip_hash_cmp, bl);
     decode(m.set_shared_manifest_src, bl);
 
     decode(m.loaded_objects, bl);

--- a/src/rgw/rgw_dedup_utils.cc
+++ b/src/rgw/rgw_dedup_utils.cc
@@ -310,8 +310,14 @@ namespace rgw::dedup {
                          this->non_default_storage_class_objs_bytes);
       }
       else {
-        ceph_assert(this->default_storage_class_objs == this->ingress_obj);
-        ceph_assert(this->default_storage_class_objs_bytes == this->ingress_obj_bytes);
+        if (this->default_storage_class_objs != this->ingress_obj) {
+          f->dump_unsigned("default storage class objs",
+                           this->default_storage_class_objs);
+        }
+        if (this->default_storage_class_objs_bytes != this->ingress_obj_bytes) {
+          f->dump_unsigned("default storage class objs bytes",
+                           this->default_storage_class_objs_bytes);
+        }
       }
     }
 

--- a/src/rgw/rgw_dedup_utils.h
+++ b/src/rgw/rgw_dedup_utils.h
@@ -357,14 +357,6 @@ namespace rgw::dedup {
                                 const DoutPrefixProvider* dpp);
 
   //---------------------------------------------------------------------------
-  static inline void build_oid(const std::string &bucket_id,
-                               const std::string &obj_name,
-                               std::string *oid)
-  {
-    *oid = bucket_id + "_" + obj_name;
-  }
-
-  //---------------------------------------------------------------------------
   static inline uint64_t calc_deduped_bytes(uint64_t head_obj_size,
                                             uint16_t num_parts,
                                             uint64_t size_bytes)

--- a/src/rgw/rgw_dedup_utils.h
+++ b/src/rgw/rgw_dedup_utils.h
@@ -23,7 +23,7 @@
 #include "include/encoding.h"
 #include "common/dout.h"
 
-//#define FULL_DEDUP_SUPPORT
+#define FULL_DEDUP_SUPPORT
 namespace rgw::dedup {
   using work_shard_t   = uint16_t;
   using md5_shard_t    = uint16_t;

--- a/src/rgw/rgw_dedup_utils.h
+++ b/src/rgw/rgw_dedup_utils.h
@@ -63,7 +63,7 @@ namespace rgw::dedup {
   std::ostream& operator<<(std::ostream &out, const dedup_req_type_t& dedup_type);
   struct __attribute__ ((packed)) dedup_flags_t {
   private:
-    static constexpr uint8_t RGW_DEDUP_FLAG_SHA256_CALCULATED = 0x01; // REC
+    static constexpr uint8_t RGW_DEDUP_FLAG_HASH_CALCULATED = 0x01; // REC
     static constexpr uint8_t RGW_DEDUP_FLAG_SHARED_MANIFEST   = 0x02; // REC + TAB
     static constexpr uint8_t RGW_DEDUP_FLAG_OCCUPIED          = 0x04; // TAB
     static constexpr uint8_t RGW_DEDUP_FLAG_FASTLANE          = 0x08; // REC
@@ -72,8 +72,8 @@ namespace rgw::dedup {
     dedup_flags_t() : flags(0) {}
     dedup_flags_t(uint8_t _flags) : flags(_flags) {}
     inline void clear() { this->flags = 0; }
-    inline bool sha256_calculated() const { return ((flags & RGW_DEDUP_FLAG_SHA256_CALCULATED) != 0); }
-    inline void set_sha256_calculated()  { flags |= RGW_DEDUP_FLAG_SHA256_CALCULATED; }
+    inline bool hash_calculated() const { return ((flags & RGW_DEDUP_FLAG_HASH_CALCULATED) != 0); }
+    inline void set_hash_calculated()  { flags |= RGW_DEDUP_FLAG_HASH_CALCULATED; }
     inline bool has_shared_manifest() const { return ((flags & RGW_DEDUP_FLAG_SHARED_MANIFEST) != 0); }
     inline void set_shared_manifest() { flags |= RGW_DEDUP_FLAG_SHARED_MANIFEST; }
     inline bool is_occupied() const {return ((this->flags & RGW_DEDUP_FLAG_OCCUPIED) != 0); }
@@ -158,15 +158,15 @@ namespace rgw::dedup {
     uint64_t skipped_source_record = 0;
     uint64_t duplicate_records = 0;
     uint64_t size_mismatch = 0;
-    uint64_t sha256_mismatch = 0;
+    uint64_t hash_mismatch = 0;
     uint64_t failed_src_load = 0;
     uint64_t failed_rec_load = 0;
     uint64_t failed_block_load = 0;
 
-    uint64_t valid_sha256_attrs = 0;
-    uint64_t invalid_sha256_attrs = 0;
-    uint64_t set_sha256_attrs = 0;
-    uint64_t skip_sha256_cmp = 0;
+    uint64_t valid_hash_attrs = 0;
+    uint64_t invalid_hash_attrs = 0;
+    uint64_t set_hash_attrs = 0;
+    uint64_t skip_hash_cmp = 0;
 
     uint64_t set_shared_manifest_src = 0;
     uint64_t loaded_objects = 0;

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -18,10 +18,11 @@
     caps rm                          remove user capabilities
     dedup stats                      Display dedup statistics from the last run
     dedup estimate                   Runs dedup in estimate mode (no changes will be made)
-    dedup restart                    Restart dedup; must include --yes-i-really-mean-it to activate
+    dedup exec                       Execute dedup (duplicated tail objects will be deleted); must include --yes-i-really-mean-it to activate
     dedup abort                      Abort dedup
     dedup pause                      Pause dedup
     dedup resume                     Resume paused dedup
+    dedup throttle                   Throttle dedup execution
     subuser create                   create a new subuser
     subuser modify                   modify subuser
     subuser rm                       remove subuser
@@ -351,6 +352,11 @@
      --disable-feature                 disable a zone/zonegroup feature
   
   <date> := "YYYY-MM-DD[ hh:mm:ss]"
+  
+  Dedup throttle options:
+     --max-bucket-index-ops        specify max bucket-index requests per second allowed for an RGW during dedup, 0 means unlimited
+     --max-metadata-ops            specify max metadata requests per second allowed for an RGW during dedup, 0 means unlimited
+     --stat                        display dedup throttle setting
   
   Quota options:
      --max-objects                 specify max objects (negative value to disable)

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -18,7 +18,7 @@
     caps rm                          remove user capabilities
     dedup stats                      Display dedup statistics from the last run
     dedup estimate                   Runs dedup in estimate mode (no changes will be made)
-    dedup restart                    Restart dedup
+    dedup restart                    Restart dedup; must include --yes-i-really-mean-it to activate
     dedup abort                      Abort dedup
     dedup pause                      Pause dedup
     dedup resume                     Resume paused dedup

--- a/src/test/rgw/dedup/test_dedup.py
+++ b/src/test/rgw/dedup/test_dedup.py
@@ -35,10 +35,10 @@ class Dedup_Stats:
     skip_src_record: int = 0
     skip_changed_object: int = 0
     corrupted_etag: int = 0
-    sha256_mismatch: int = 0
-    valid_sha256: int = 0
-    invalid_sha256: int = 0
-    set_sha256: int = 0
+    hash_mismatch: int = 0
+    valid_hash: int = 0
+    invalid_hash: int = 0
+    set_hash: int = 0
     total_processed_objects: int = 0
     size_before_dedup: int = 0
     #loaded_objects: int = 0
@@ -594,8 +594,8 @@ def calc_expected_stats(dedup_stats, obj_size, num_copies, config):
     else:
         dedup_stats.skip_src_record += 1
         dedup_stats.set_shared_manifest_src += 1
-        dedup_stats.set_sha256 += num_copies
-        dedup_stats.invalid_sha256 += num_copies
+        dedup_stats.set_hash += num_copies
+        dedup_stats.invalid_hash += num_copies
         dedup_stats.unique_obj += 1
         dedup_stats.duplicate_obj += dups_count
         dedup_stats.deduped_obj += dups_count
@@ -939,10 +939,10 @@ def reset_full_dedup_stats(dedup_stats):
     dedup_stats.skip_singleton_bytes = 0
     dedup_stats.skip_changed_object = 0
     dedup_stats.corrupted_etag = 0
-    dedup_stats.sha256_mismatch = 0
-    dedup_stats.valid_sha256 = 0
-    dedup_stats.invalid_sha256 = 0
-    dedup_stats.set_sha256 = 0
+    dedup_stats.hash_mismatch = 0
+    dedup_stats.valid_hash = 0
+    dedup_stats.invalid_hash = 0
+    dedup_stats.set_hash = 0
 
 
 #-------------------------------------------------------------------------------
@@ -964,11 +964,11 @@ def read_full_dedup_stats(dedup_stats, md5_stats):
         dedup_stats.skip_changed_object = skipped[key]
 
     notify=md5_stats['notify']
-    dedup_stats.valid_sha256 = notify['Valid SHA256 attrs']
-    dedup_stats.invalid_sha256 = notify['Invalid SHA256 attrs']
-    key='Set SHA256'
+    dedup_stats.valid_hash = notify['Valid HASH attrs']
+    dedup_stats.invalid_hash = notify['Invalid HASH attrs']
+    key='Set HASH'
     if key in notify:
-        dedup_stats.set_sha256 = notify[key]
+        dedup_stats.set_hash = notify[key]
 
     sys_failures = md5_stats['system failures']
     key='Corrupted ETAG'
@@ -976,9 +976,9 @@ def read_full_dedup_stats(dedup_stats, md5_stats):
         dedup_stats.corrupted_etag = sys_failures[key]
 
     log_failures = md5_stats['logical failures']
-    key='SHA256 mismatch'
+    key='HASH mismatch'
     if key in log_failures:
-        dedup_stats.sha256_mismatch = log_failures[key]
+        dedup_stats.hash_mismatch = log_failures[key]
 
 
 #-------------------------------------------------------------------------------
@@ -1076,7 +1076,7 @@ def exec_dedup_internal(expected_dedup_stats, dry_run, max_dedup_time):
         result = admin(['dedup', 'estimate'])
         reset_full_dedup_stats(expected_dedup_stats)
     else:
-        result = admin(['dedup', 'restart', '--yes-i-really-mean-it', '--tech-preview'])
+        result = admin(['dedup', 'restart', '--yes-i-really-mean-it'])
 
     assert result[1] == 0
     log.debug("wait for dedup to complete")
@@ -1121,7 +1121,7 @@ def exec_dedup(expected_dedup_stats, dry_run, verify_stats=True):
         log.debug("potential_unique_obj= %d / %d ", dedup_stats.potential_unique_obj,
                   expected_dedup_stats.potential_unique_obj)
 
-    #dedup_stats.set_sha256 = dedup_stats.invalid_sha256
+    #dedup_stats.set_hash = dedup_stats.invalid_hash
     if dedup_stats != expected_dedup_stats:
         log.debug("==================================================")
         print_dedup_stats_diff(dedup_stats, expected_dedup_stats)
@@ -1308,7 +1308,7 @@ def check_full_dedup_state():
     global full_dedup_state_was_checked
     global full_dedup_state_disabled
     log.debug("check_full_dedup_state:: sending FULL Dedup request")
-    result = admin(['dedup', 'restart', '--yes-i-really-mean-it', '--tech-preview'])
+    result = admin(['dedup', 'restart', '--yes-i-really-mean-it'])
     if result[1] == 0:
         log.info("full dedup is enabled!")
         full_dedup_state_disabled = False
@@ -1455,9 +1455,9 @@ def test_dedup_etag_corruption():
             dedup_ratio_actual=ret[3]
 
             if corruption == "no corruption":
-                expected_dedup_stats.valid_sha256=1
-                expected_dedup_stats.invalid_sha256=0
-                expected_dedup_stats.set_sha256=0
+                expected_dedup_stats.valid_hash=1
+                expected_dedup_stats.invalid_hash=0
+                expected_dedup_stats.set_hash=0
 
             s3_bytes_before=expected_dedup_stats.size_before_dedup
             expected_ratio_actual=Dedup_Ratio()
@@ -1527,10 +1527,10 @@ def test_md5_collisions():
         dedup_stats.size_before_dedup=2*BLOCK_SIZE
         # the md5 collision confuses the estimate
         dedup_stats.dedup_bytes_estimate=BLOCK_SIZE
-        # SHA256 check will expose the problem
-        dedup_stats.invalid_sha256=dedup_stats.total_processed_objects
-        dedup_stats.set_sha256=dedup_stats.total_processed_objects
-        dedup_stats.sha256_mismatch=1
+        # HASH check will expose the problem
+        dedup_stats.invalid_hash=dedup_stats.total_processed_objects
+        dedup_stats.set_hash=dedup_stats.total_processed_objects
+        dedup_stats.hash_mismatch=1
         s3_bytes_before=dedup_stats.size_before_dedup
         expected_ratio_actual=Dedup_Ratio()
         expected_ratio_actual.s3_bytes_before=s3_bytes_before
@@ -1544,9 +1544,9 @@ def test_md5_collisions():
 
         assert expected_ratio_actual == dedup_ratio_actual
 
-        dedup_stats.valid_sha256=dedup_stats.total_processed_objects
-        dedup_stats.invalid_sha256=0
-        dedup_stats.set_sha256=0
+        dedup_stats.valid_hash=dedup_stats.total_processed_objects
+        dedup_stats.invalid_hash=0
+        dedup_stats.set_hash=0
 
         log.debug("test_md5_collisions: second call to exec_dedup")
         ret=exec_dedup(dedup_stats, dry_run)
@@ -1657,9 +1657,9 @@ def test_dedup_inc_0_with_tenants():
         dedup_stats2.set_shared_manifest_src=0
         dedup_stats2.deduped_obj=0
         dedup_stats2.deduped_obj_bytes=0
-        dedup_stats2.valid_sha256=dedup_stats.invalid_sha256
-        dedup_stats2.invalid_sha256=0
-        dedup_stats2.set_sha256=0
+        dedup_stats2.valid_hash=dedup_stats.invalid_hash
+        dedup_stats2.invalid_hash=0
+        dedup_stats2.set_hash=0
 
         log.debug("test_dedup_inc_0_with_tenants: incremental dedup:")
         # run dedup again and make sure nothing has changed
@@ -1706,9 +1706,9 @@ def test_dedup_inc_0():
         dedup_stats2.set_shared_manifest_src=0
         dedup_stats2.deduped_obj=0
         dedup_stats2.deduped_obj_bytes=0
-        dedup_stats2.valid_sha256=dedup_stats.invalid_sha256
-        dedup_stats2.invalid_sha256=0
-        dedup_stats2.set_sha256=0
+        dedup_stats2.valid_hash=dedup_stats.invalid_hash
+        dedup_stats2.invalid_hash=0
+        dedup_stats2.set_hash=0
 
         log.debug("test_dedup_inc_0: incremental dedup:")
         # run dedup again and make sure nothing has changed
@@ -1775,9 +1775,9 @@ def test_dedup_inc_1_with_tenants():
         stats_combined.deduped_obj         -= stats_base.deduped_obj
         stats_combined.deduped_obj_bytes   -= stats_base.deduped_obj_bytes
 
-        stats_combined.valid_sha256    = stats_base.set_sha256
-        stats_combined.invalid_sha256 -= stats_base.set_sha256
-        stats_combined.set_sha256     -= stats_base.set_sha256
+        stats_combined.valid_hash    = stats_base.set_hash
+        stats_combined.invalid_hash -= stats_base.set_hash
+        stats_combined.set_hash     -= stats_base.set_hash
 
         log.debug("test_dedup_inc_1_with_tenants: incremental dedup:")
         # run dedup again
@@ -1840,9 +1840,9 @@ def test_dedup_inc_1():
         stats_combined.deduped_obj         -= stats_base.deduped_obj
         stats_combined.deduped_obj_bytes   -= stats_base.deduped_obj_bytes
 
-        stats_combined.valid_sha256    = stats_base.set_sha256
-        stats_combined.invalid_sha256 -= stats_base.set_sha256
-        stats_combined.set_sha256     -= stats_base.set_sha256
+        stats_combined.valid_hash    = stats_base.set_hash
+        stats_combined.invalid_hash -= stats_base.set_hash
+        stats_combined.set_hash     -= stats_base.set_hash
 
         log.debug("test_dedup_inc_1: incremental dedup:")
         # run dedup again
@@ -1918,9 +1918,9 @@ def test_dedup_inc_2_with_tenants():
         stats_combined.deduped_obj         -= stats_base.deduped_obj
         stats_combined.deduped_obj_bytes   -= stats_base.deduped_obj_bytes
 
-        stats_combined.valid_sha256    = stats_base.set_sha256
-        stats_combined.invalid_sha256 -= stats_base.set_sha256
-        stats_combined.set_sha256     -= stats_base.set_sha256
+        stats_combined.valid_hash    = stats_base.set_hash
+        stats_combined.invalid_hash -= stats_base.set_hash
+        stats_combined.set_hash     -= stats_base.set_hash
 
         log.debug("test_dedup_inc_2_with_tenants: incremental dedup:")
         # run dedup again
@@ -1991,9 +1991,9 @@ def test_dedup_inc_2():
         stats_combined.deduped_obj         -= stats_base.deduped_obj
         stats_combined.deduped_obj_bytes   -= stats_base.deduped_obj_bytes
 
-        stats_combined.valid_sha256    = stats_base.set_sha256
-        stats_combined.invalid_sha256 -= stats_base.set_sha256
-        stats_combined.set_sha256     -= stats_base.set_sha256
+        stats_combined.valid_hash    = stats_base.set_hash
+        stats_combined.invalid_hash -= stats_base.set_hash
+        stats_combined.set_hash     -= stats_base.set_hash
 
         log.debug("test_dedup_inc_2: incremental dedup:")
         # run dedup again
@@ -2039,7 +2039,7 @@ def test_dedup_inc_with_remove_multi_tenants():
         # REMOVE some objects and update stats/expected
         src_record=0
         shared_manifest=0
-        valid_sha=0
+        valid_hash=0
         object_keys=[]
         files_sub=[]
         dedup_stats = Dedup_Stats()
@@ -2052,7 +2052,7 @@ def test_dedup_inc_with_remove_multi_tenants():
             log.debug("objects::%s::size=%d, num_copies=%d", filename, obj_size, num_copies_2);
             if num_copies_2:
                 if num_copies_2 > 1 and obj_size > RADOS_OBJ_SIZE:
-                    valid_sha += num_copies_2
+                    valid_hash += num_copies_2
                     src_record += 1
                     shared_manifest += (num_copies_2 - 1)
 
@@ -2076,9 +2076,9 @@ def test_dedup_inc_with_remove_multi_tenants():
         dedup_stats.deduped_obj_bytes=0
         dedup_stats.skip_src_record=src_record
         dedup_stats.skip_shared_manifest=shared_manifest
-        dedup_stats.valid_sha256=valid_sha
-        dedup_stats.invalid_sha256=0
-        dedup_stats.set_sha256=0
+        dedup_stats.valid_hash=valid_hash
+        dedup_stats.invalid_hash=0
+        dedup_stats.set_hash=0
 
         log.debug("test_dedup_inc_with_remove: incremental dedup:")
         dry_run=False
@@ -2119,7 +2119,7 @@ def test_dedup_inc_with_remove():
         # REMOVE some objects and update stats/expected
         src_record=0
         shared_manifest=0
-        valid_sha=0
+        valid_hash=0
         object_keys=[]
         files_sub=[]
         dedup_stats = Dedup_Stats()
@@ -2132,7 +2132,7 @@ def test_dedup_inc_with_remove():
             log.debug("objects::%s::size=%d, num_copies=%d", filename, obj_size, num_copies_2);
             if num_copies_2:
                 if num_copies_2 > 1 and obj_size > RADOS_OBJ_SIZE:
-                    valid_sha += num_copies_2
+                    valid_hash += num_copies_2
                     src_record += 1
                     shared_manifest += (num_copies_2 - 1)
 
@@ -2163,9 +2163,9 @@ def test_dedup_inc_with_remove():
         dedup_stats.deduped_obj_bytes=0
         dedup_stats.skip_src_record=src_record
         dedup_stats.skip_shared_manifest=shared_manifest
-        dedup_stats.valid_sha256=valid_sha
-        dedup_stats.invalid_sha256=0
-        dedup_stats.set_sha256=0
+        dedup_stats.valid_hash=valid_hash
+        dedup_stats.invalid_hash=0
+        dedup_stats.set_hash=0
 
         log.debug("test_dedup_inc_with_remove: incremental dedup:")
         log.debug("stats_base.size_before_dedup=%d", stats_base.size_before_dedup)
@@ -2322,7 +2322,7 @@ def test_dedup_small_multipart():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_large_scale_with_tenants():
-    return
+    #return
 
     if full_dedup_is_disabled():
         return
@@ -2342,7 +2342,7 @@ def test_dedup_large_scale_with_tenants():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_dedup_large_scale():
-    return
+    #return
 
     if full_dedup_is_disabled():
         return
@@ -2362,7 +2362,7 @@ def test_dedup_large_scale():
 #-------------------------------------------------------------------------------
 @pytest.mark.basic_test
 def test_empty_bucket():
-    return
+    #return
 
     if full_dedup_is_disabled():
         return
@@ -2426,9 +2426,9 @@ def inc_step_with_tenants(stats_base, files, conns, bucket_names, config):
     stats_combined.deduped_obj         -= stats_base.deduped_obj
     stats_combined.deduped_obj_bytes   -= stats_base.deduped_obj_bytes
 
-    stats_combined.valid_sha256    = stats_base.set_sha256
-    stats_combined.invalid_sha256 -= stats_base.set_sha256
-    stats_combined.set_sha256     -= stats_base.set_sha256
+    stats_combined.valid_hash    = stats_base.set_hash
+    stats_combined.invalid_hash -= stats_base.set_hash
+    stats_combined.set_hash     -= stats_base.set_hash
 
     log.debug("test_dedup_inc_2_with_tenants: incremental dedup:")
     # run dedup again
@@ -2470,10 +2470,10 @@ def test_dedup_inc_loop_with_tenants():
             files=ret[0]
             stats_last=ret[1]
             stats_base.set_shared_manifest_src += stats_last.set_shared_manifest_src
-            stats_base.dup_head_size       += stats_last.dup_head_size
-            stats_base.deduped_obj         += stats_last.deduped_obj
-            stats_base.deduped_obj_bytes   += stats_last.deduped_obj_bytes
-            stats_base.set_sha256          += stats_last.set_sha256
+            stats_base.dup_head_size     += stats_last.dup_head_size
+            stats_base.deduped_obj       += stats_last.deduped_obj
+            stats_base.deduped_obj_bytes += stats_last.deduped_obj_bytes
+            stats_base.set_hash          += stats_last.set_hash
     finally:
         # cleanup must be executed even after a failure
         cleanup_all_buckets(bucket_names, conns)

--- a/src/test/rgw/dedup/test_dedup.py
+++ b/src/test/rgw/dedup/test_dedup.py
@@ -1076,7 +1076,7 @@ def exec_dedup_internal(expected_dedup_stats, dry_run, max_dedup_time):
         result = admin(['dedup', 'estimate'])
         reset_full_dedup_stats(expected_dedup_stats)
     else:
-        result = admin(['dedup', 'restart'])
+        result = admin(['dedup', 'restart', '--yes-i-really-mean-it', '--tech-preview'])
 
     assert result[1] == 0
     log.debug("wait for dedup to complete")
@@ -1308,14 +1308,14 @@ def check_full_dedup_state():
     global full_dedup_state_was_checked
     global full_dedup_state_disabled
     log.debug("check_full_dedup_state:: sending FULL Dedup request")
-    result = admin(['dedup', 'restart'])
+    result = admin(['dedup', 'restart', '--yes-i-really-mean-it', '--tech-preview'])
     if result[1] == 0:
-        log.debug("full dedup is enabled!")
+        log.info("full dedup is enabled!")
         full_dedup_state_disabled = False
         result = admin(['dedup', 'abort'])
         assert result[1] == 0
     else:
-        log.debug("full dedup is disabled, skip all full dedup tests")
+        log.info("full dedup is disabled, skip all full dedup tests")
         full_dedup_state_disabled = True
 
     full_dedup_state_was_checked = True


### PR DESCRIPTION
  backport tracker: https://tracker.ceph.com/issues/76965
  backport tracker: https://tracker.ceph.com/issues/74197
  backport tracker: https://tracker.ceph.com/issues/73506
  backport tracker: https://tracker.ceph.com/issues/78022
  backport tracker: https://tracker.ceph.com/issues/78024
  backport tracker: https://tracker.ceph.com/issues/78026
  Backport of the following PRs from main to tentacle:
  - https://github.com/ceph/ceph/pull/64271 - rgw/dedup: Tech preview of full dedup support
  - https://github.com/ceph/ceph/pull/65783 - rgw/dedup: Grant dedup process full RGW permissions
  - https://github.com/ceph/ceph/pull/64730 - rgw/dedup: Add throttling mechanism
  - https://github.com/ceph/ceph/pull/66233 - rgw/dedup: Add support for RGW versions
  - https://github.com/ceph/ceph/pull/64526 - doc/radosgw: Small improvements in s3_objects_dedup.rst (dependency)
  Signed-off-by: Gabriel BenHanokh <gbenhano@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
