### PR TITLE
doc: fix Sphinx complaints and some rendering errors

### DIFF
--- a/doc/cephadm/host-management.rst
+++ b/doc/cephadm/host-management.rst
@@ -689,7 +689,7 @@ requires the bare host name when adding a host to the cluster:
 ``ceph orch host add <bare-name>``.
 
 Sudo Hardening
-=============
+==============
 
 Cephadm supports sudo hardening to enhance security by restricting sudo privilege
 escalation for non-root SSH users. When sudo hardening is enabled, cephadm uses the
@@ -697,7 +697,7 @@ escalation for non-root SSH users. When sudo hardening is enabled, cephadm uses 
 privilege escalation.
 
 Enabling Sudo Hardening
-----------------------
+-----------------------
 
 To enable sudo hardening for the entire cluster, use the following command:
 
@@ -730,7 +730,7 @@ You can manually prepare a host for sudo hardening using:
    access will be used for ongoing operations.
 
 Sudo Hardening Workflow
-----------------------
+-----------------------
 
 When sudo hardening is enabled, the following workflow is used:
 
@@ -770,7 +770,7 @@ Sudo hardening provides the following security benefits:
 
 
 Disabling Sudo Hardening
------------------------
+------------------------
 
 To disable sudo hardening:
 

--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -136,7 +136,7 @@ Requirements:
   (same shape as ``ceph_version_short`` in ``ceph osd metadata``).
 * If the Monitors indicate to cephadm that no OSDs in the selected CRUSH bucket
   are okay to upgrade, cephadm will log details and then retry the operation.
-*  If the bucket parameters for a ceph ``osd ok-to-upgrade`` upgrade are not provided,
+* If the bucket parameters for a ceph ``osd ok-to-upgrade`` upgrade are not provided,
   cephadm will fall back to the default ceph osd ok-to-stop gate for OSD upgrades.
 * Bucket-scope upgrades apply only to OSDs. CRUSH buckets do not influence upgrades
   of other daemon types, for example Monitors, Managers, and MDSes.

--- a/doc/dev/crimson/seastore_laddr.rst
+++ b/doc/dev/crimson/seastore_laddr.rst
@@ -201,7 +201,8 @@ after the upgrade finishes.
 
 TODO: fsck/tooling must support scanning and migrating all mappings
 between upgrades.
-             //create tracker after PR merged/ready.
+
+//create tracker after PR merged/ready.
 
 Multi-push Recovery
 -------------------

--- a/doc/dev/osd_internals/erasure_coding/client_support.rst
+++ b/doc/dev/osd_internals/erasure_coding/client_support.rst
@@ -466,7 +466,7 @@ These operations provide the same semantics as in replicated pools, ensuring
 compatibility with existing applications.
 
 Read Operation Flow
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 Read operations follow a simple flow:
 
@@ -906,7 +906,7 @@ Required Settings
 
 To enable the new features, the following OSDMap pool settings are required:
 
-- ``allows_ec_overwrites = true`
+- ``allows_ec_overwrites = true``
 - ``allows_ec_optimizations = true``
 - ``supports_omap = true``
 

--- a/doc/dev/release-process.rst
+++ b/doc/dev/release-process.rst
@@ -88,7 +88,7 @@ Once QE has determined a stopping point in the working (e.g., ``squid``) branch,
 Notify the "Build Lead" that the release branch is ready.
 
 2a. Starting the build
-=====================
+======================
 
 We'll use a stable/regular 19.2.2 release of Squid as an example throughout this document.
 

--- a/doc/man/8/cephadm.rst
+++ b/doc/man/8/cephadm.rst
@@ -458,7 +458,7 @@ Arguments:
 
 
 prepare-host-sudo-hardening
---------------------------
+---------------------------
 
 Prepare a host for sudo hardening by authorizing SSH keys, installing/upgrading
 the cephadm package, and setting up restricted sudoers permissions::

--- a/doc/mgr/ceph_secrets.rst
+++ b/doc/mgr/ceph_secrets.rst
@@ -25,7 +25,7 @@ service spec instead of the plaintext token.  A cephadm integration can then
 resolve the URI at deploy time and write the token only into the daemon files
 that need it.
 
-Secrets are stored in the Mon KV store under the ``secret_store/v1/`` prefix
+Secrets are stored in the Monitor KV store under the ``secret_store/v1/`` prefix
 and are organised by namespace, scope, and name.  Each secret is versioned and
 carries ``created``/``updated`` timestamps.  A per-namespace epoch counter
 is incremented on every ``set`` and on any ``rm`` that actually removes a
@@ -34,7 +34,7 @@ list.
 
 .. note::
 
-   The ``mon`` backend stores secrets in the Mon KV store, which is not an
+   The ``mon`` backend stores secrets in the Monitor KV store, which is not an
    external KMS or vault.  Users and MGR modules with sufficient Ceph
    permissions can still reveal or resolve stored secret values.  Namespaces
    provide logical and storage isolation, not an authorisation boundary.
@@ -429,9 +429,6 @@ Configuration
 .. mgr_module:: ceph_secrets
 .. confval:: secrets_backend
 
-   :type: str
-   :default: ``mon``
-
-   The storage backend used for secrets.  Currently only the Mon KV store
+   The storage backend used for secrets.  Currently only the Monitor KV store
    (``mon``) is supported.  This option is reserved for future backends
    (e.g. HashiCorp Vault).

--- a/doc/rados/troubleshooting/troubleshooting-mon.rst
+++ b/doc/rados/troubleshooting/troubleshooting-mon.rst
@@ -565,7 +565,7 @@ from a service shell), the restored ``kv_backend`` file and the rehydrated
 them.
 
 Restoring a multi-monitor cluster
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Each monitor has its own Paxos state (rank, accepted proposal numbers,
 ``last_committed``), so backups are per-monitor: a backup taken from

--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -2946,7 +2946,7 @@ CLI commands.
 
 To view dedup status, the user must have ``dedup=read`` capability. To
 control dedup operations, the user must have ``dedup=write`` capability.
-See the `Admin Guide`_ for details.
+See the :ref:`radosgw-admin-guide` for details.
 
 Get Dedup Stats
 ~~~~~~~~~~~~~~~

--- a/doc/radosgw/encryption.rst
+++ b/doc/radosgw/encryption.rst
@@ -160,6 +160,7 @@ Secrets are stored using the `Linux Kernel Key Retention Service`_ in
 the RGW processes' process keyring. This is subject to a global quota
 and must be set in accordance with the configured cache size.
 Depending on whether RGW runs as root, these quotas can be managed by adjusting:
+
 - ``/proc/sys/kernel/keys/root_maxkeys`` and ``/proc/sys/kernel/keys/root_maxbytes``
 - ``/proc/sys/kernel/keys/maxkeys`` and ``/proc/sys/kernel/keys/maxbytes``
 
@@ -167,6 +168,7 @@ Exceeding a quota will disable the cache, fail the request with an
 internal error, and log a failure message.
 
 Three different Cache Time-to-Live (TTL) values can be set:
+
 - **Positive TTL**: How long a successfully retrieved secret remains
   in the cache.
 - **Negative TTL**: How long to remember that a key does not exist,
@@ -178,6 +180,7 @@ Metrics
 ---------
 
 The cache exports metrics under the ``kms-cache`` collection.
+
 - ``hit``: Hit counter
 - ``miss``:  Miss counter
 - ``expired``: Number of TTL expired entries
@@ -187,6 +190,7 @@ The cache exports metrics under the ``kms-cache`` collection.
   ``miss``, ``expired``
 
 In addition the ``rgw`` collection has:
+
 - ``kms_fetch_lat``: Average KMS fetch latency. Also includes a
   successful request counter. Each event results in a positive cache
   entry.


### PR DESCRIPTION
Fix 25 criticals, errors, and warnings from Sphinx.  
Some of the changes did not change rendering but most fixed unintended rendering, broken link etc.  

Change Mon to Monitor in ceph-secrets.rst. The remaining "Mon" in the rendered doc requires a `src/common/options/` change.

`doc/cephadm/host-management.rst`: no change rendered

- Original: https://docs.ceph.com/en/latest/cephadm/upgrade/#crush-bucket-scoped-osd-upgrades-osd-ok-to-upgrade
- Rendered PR: https://ceph--70024.org.readthedocs.build/en/70024/cephadm/upgrade/#crush-bucket-scoped-osd-upgrades-osd-ok-to-upgrade
- Original: https://docs.ceph.com/en/latest/dev/crimson/seastore_laddr/#upgrade
- Rendered PR: https://ceph--70024.org.readthedocs.build/en/70024/dev/crimson/seastore_laddr/#upgrade
- Original: https://docs.ceph.com/en/latest/dev/osd_internals/erasure_coding/client_support/#required-settings
- Rendered PR: https://ceph--70024.org.readthedocs.build/en/70024/dev/osd_internals/erasure_coding/client_support/#required-settings

`doc/dev/release-process.rst`: no change rendered
`doc/man/8/cephadm.rst`: no change rendered

- Original: https://docs.ceph.com/en/latest/mgr/ceph_secrets/#configuration
- Rendered PR: https://ceph--70024.org.readthedocs.build/en/70024/mgr/ceph_secrets/#configuration
- Original: https://docs.ceph.com/en/latest/rados/troubleshooting/troubleshooting-mon/#recovery-using-mon-backup
- Rendered PR: https://ceph--70024.org.readthedocs.build/en/70024/rados/troubleshooting/troubleshooting-mon/#recovery-using-mon-backup
- Original: https://docs.ceph.com/en/latest/radosgw/adminops/#dedup
- Rendered PR: https://ceph--70024.org.readthedocs.build/en/70024/radosgw/adminops/#dedup
- Original: https://docs.ceph.com/en/latest/radosgw/encryption/#caching (until the document end)
- Rendered PR: https://ceph--70024.org.readthedocs.build/en/70024/radosgw/encryption/#caching

```console
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/cephadm/host-management.rst:692: WARNING: Title underline too short.
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/cephadm/host-management.rst:700: WARNING: Title underline too short.
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/cephadm/host-management.rst:733: WARNING: Title underline too short.
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/cephadm/host-management.rst:773: WARNING: Title underline too short.
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/cephadm/upgrade.rst:140: WARNING: Bullet list ends without a blank line; unexpected unindent.
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/cephadm/upgrade.rst:141: WARNING: Block quote ends without a blank line; unexpected unindent.
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/dev/crimson/seastore_laddr.rst:204: ERROR: Unexpected indentation.
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/dev/osd_internals/erasure_coding/client_support.rst:469: WARNING: Title underline too short.
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/dev/osd_internals/erasure_coding/client_support.rst:909: WARNING: Inline literal start-string without end-string.
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/dev/release-process.rst:91: WARNING: Title underline too short.
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/man/8/cephadm.rst:461: WARNING: Title underline too short.
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/mgr/ceph_secrets.rst:432: WARNING: Problem in std domain: field is supposed to use role 'class', but that role is not in the domain.
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/rados/troubleshooting/troubleshooting-mon.rst:567: CRITICAL: Title level inconsistent:
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/radosgw/adminops.rst:2947: ERROR: Unknown target name: "admin guide".
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/radosgw/encryption.rst:171: ERROR: Unexpected indentation.
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/radosgw/encryption.rst:172: WARNING: Block quote ends without a blank line; unexpected unindent.
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/radosgw/encryption.rst:187: ERROR: Unexpected indentation.
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/radosgw/encryption.rst:191: ERROR: Unexpected indentation.
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/radosgw/encryption.rst:193: WARNING: Block quote ends without a blank line; unexpected unindent.
```

Three warnings remain that are not simple syntax errors:
```console
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/dev/crimson/pgmerging.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/dev/crimson/seastore_laddr.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/65326/doc/radosgw/s3/s3control.rst: WARNING: document isn't included in any toctree
```




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
