### PR TITLE
rgw: fix logshard lock leak and infinite loop in process_single_logshard

### DIFF
--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -1743,6 +1743,7 @@ int RGWReshard::process_single_logshard(int logshard_num, const DoutPrefixProvid
       if (logshard_lock.should_renew(now)) {
         ret = logshard_lock.renew(now);
         if (ret < 0) {
+          logshard_lock.unlock();
           return ret;
         }
       }

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -1733,7 +1733,7 @@ int RGWReshard::process_single_logshard(int logshard_num, const DoutPrefixProvid
     if (ret < 0) {
       ldpp_dout(dpp, 10) << "cannot list all reshards in logshard oid=" <<
 	logshard_oid << dendl;
-      continue;
+      break;
     }
 
     for(const auto& entry : entries) { // logshard entries
@@ -1752,7 +1752,7 @@ int RGWReshard::process_single_logshard(int logshard_num, const DoutPrefixProvid
   } while (is_truncated);
 
   logshard_lock.unlock();
-  return 0;
+  return ret;
 }
 
 


### PR DESCRIPTION
**rgw: avoid infinite loop in process_single_logshard on list error**

When `list()` returned an error other than ENOENT, neither `is_truncated`
nor `marker` changed, so the `do/while(is_truncated)` loop spun forever
holding the logshard lock and flooding the log.

**rgw: release logshard lock on renew failure in process_single_logshard**

When `logshard_lock.renew()` failed mid-loop, the function returned early
without calling `logshard_lock.unlock()`, leaking the lock until it
expired on its own.

Fixes: https://tracker.ceph.com/issues/78069
Fixes: https://tracker.ceph.com/issues/78070

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests