### PR TITLE
[DNM] doc: build with newer Sphinx

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ formats: []
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.12"
   apt_packages:
     - ditaa
     - graphviz

--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -1,5 +1,5 @@
-# RTD theme does not work with >= 7 https://github.com/readthedocs/readthedocs.org/issues/10279
-Sphinx < 7
+# Sphinx 8 dropped Python 3.9 support
+Sphinx > 8,<9
 sphinx-ditaa@git+https://github.com/ceph/sphinx-ditaa.git@py3
 funcparserlib@git+https://github.com/vlasovskikh/funcparserlib.git
 breathe >= 4.20.0,!=4.33
@@ -18,4 +18,4 @@ sphinxcontrib-openapi
 # m2r2 replaces mistune https://github.com/CrossNox/m2r2?tab=readme-ov-file#m2r-the-original
 m2r2
 natsort
-docutils < 0.20
+docutils

--- a/doc/_ext/substitution_prompt.py
+++ b/doc/_ext/substitution_prompt.py
@@ -1,0 +1,31 @@
+import sphinx.application
+import sphinx_prompt
+from docutils import nodes
+from docutils.statemachine import StringList
+from docutils.parsers.rst import directives
+
+
+class SubstitutionPrompt(sphinx_prompt.PromptDirective):
+    optional_arguments = 3
+    option_spec = (sphinx_prompt.PromptDirective.option_spec or {}).copy()
+    option_spec["substitutions"] = directives.flag
+    has_content = True
+
+    def run(self) -> list[nodes.raw]:
+        self.assert_has_content()
+
+        if "substitutions" in self.options:
+            substitution_defs = self.state.document.substitution_defs
+            new_content = []
+            for item in self.content:
+                for name, value in substitution_defs.items():
+                    item = item.replace(f"|{name}|", value.astext())
+                new_content.append(item)
+            self.content = StringList(new_content)
+        return super().run()
+
+
+def setup(app: sphinx.application.Sphinx) -> dict[str, bool]:
+    app.setup_extension("sphinx-prompt")
+    directives.register_directive("prompt", SubstitutionPrompt)
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/doc/_ext/substitution_prompt.py
+++ b/doc/_ext/substitution_prompt.py
@@ -1,0 +1,31 @@
+import sphinx.application
+import sphinx_prompt
+from docutils import nodes
+from docutils.statemachine import StringList
+from docutils.parsers.rst import directives
+
+
+class SubstitutionPrompt(sphinx_prompt.PromptDirective):
+    optional_arguments = 3
+    option_spec = (sphinx_prompt.PromptDirective.option_spec or {}).copy()
+    option_spec["substitutions"] = directives.flag
+    has_content = True
+
+    def run(self) -> list[nodes.raw]:
+        self.assert_has_content()
+
+        if "substitutions" in self.options:
+            substitution_defs = self.state.document.substitution_defs
+            new_content = []
+            for item in self.content:
+                for name, value in substitution_defs.items():
+                    item = item.replace(f"|{name}|", value.astext())
+                new_content.append(item)
+            self.content = StringList(new_content)
+        return super().run()
+
+
+def setup(app: sphinx.application.Sphinx) -> dict[str, bool]:
+    app.setup_extension("sphinx-prompt")
+    app.add_directive("subsprompt", SubstitutionPrompt)
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/doc/_themes/ceph/layout.html
+++ b/doc/_themes/ceph/layout.html
@@ -20,7 +20,9 @@
   {% endblock %}
 
   {# CSS #}
+  {%- for style in styles %}
   <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
+  {%- endfor %}
   <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
   {%- for css in css_files %}
     {%- if css|attr("rel") %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -91,7 +91,7 @@ html_css_files = ['css/custom.css']
 
 # general configuration
 templates_path = ['_templates']
-source_suffix = '.rst'
+source_suffix = {'.rst': 'restructuredtext'}
 exclude_patterns = ['**/.#*',
                     '**/*~',
                     'start/quick-common.rst',
@@ -139,6 +139,7 @@ extensions = [
     'ceph_commands',
     'ceph_releases',
     'ceph_confval',
+    'substitution_prompt',
     'sphinxcontrib.mermaid',
     'sphinxcontrib.openapi',
 ]


### PR DESCRIPTION
Testing Read the Docs build with newer Sphinx versions.

Currently docs are built with Sphinx 6 from 2023. Previously the holdup was `sphinx_rtd_theme` which as of the currently used 3.1.0 supports Sphinx 9 & docutils 0.22 (latest: 0.23).

- Sphinx 7 needs a trivial change in the `ceph` theme. (done, seems web docs are working / man pages ???)
- Sphinx 8
  - Needs Python >3.9
  - `sphinx_substitution_extensions` has dropped support for substitutions in the `prompt` directive. Vendor the feature.
  - toctree entries must be unique. Remove multiple toctree references to the same file.
- Sphinx 9 needs Python >3.11 + ???.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
