### PR TITLE
crimson: fix stack-use-after-return in ConfigProxy::parse_argv

### DIFF
--- a/src/crimson/common/config_proxy.h
+++ b/src/crimson/common/config_proxy.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <ranges>
+#include <type_traits>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/sharded.hh>
 #include "common/config.h"
@@ -47,13 +49,20 @@ class ConfigProxy : public seastar::peering_sharded_service<ConfigProxy>
   // apply changes to all shards
   // @param func a functor which accepts @c "ConfigValues&"
   template<typename Func>
-  seastar::future<> do_change(Func&& func) {
+  auto do_change(Func&& func) {
+    using T = std::invoke_result_t<Func, ConfigValues&>;
     return container().invoke_on(values.get_owner_shard(),
                                  [func = std::move(func)](ConfigProxy& owner) {
       // apply the changes to a copy of the values
       auto new_values = seastar::make_lw_shared(*owner.values);
       new_values->changed.clear();
-      func(*new_values);
+      [[maybe_unused]] std::conditional_t<std::is_void_v<T>,
+                                          std::monostate, T> result{};
+      if constexpr (std::is_void_v<T>) {
+        func(*new_values);
+      } else {
+        result = func(*new_values);
+      }
 
       // always apply the new settings synchronously on the owner shard, to
       // avoid racings with other do_change() calls in parallel.
@@ -73,7 +82,7 @@ class ConfigProxy : public seastar::peering_sharded_service<ConfigProxy>
         (*obs)->handle_conf_change(owner, keys);
       }
 
-      return seastar::parallel_for_each(std::views::iota(1u, seastar::smp::count),
+      auto done = seastar::parallel_for_each(std::views::iota(1u, seastar::smp::count),
                                         [&owner, new_values] (auto cpu) {
         return owner.container().invoke_on(cpu,
           [foreign_values = seastar::make_foreign(new_values)](ConfigProxy& proxy) mutable {
@@ -98,7 +107,15 @@ class ConfigProxy : public seastar::peering_sharded_service<ConfigProxy>
         }).finally([new_values] {
           new_values->changed.clear();
         });
-      });
+
+      if constexpr (std::is_void_v<T>) {
+        return done;
+      } else {
+        return done.then([result = std::move(result)]() mutable {
+          return std::move(result);
+        });
+      }
+    });
   }
 public:
   ConfigProxy(const EntityName& name, std::string_view cluster);
@@ -192,17 +209,14 @@ public:
   }
   void show_config(ceph::Formatter* f) const;
 
-  seastar::future<> parse_argv(std::vector<const char*>& argv) {
-    // we could pass whatever is unparsed to seastar, but seastar::app_template
-    // is used for driving the seastar application, and
-    // crimson::common::ConfigProxy is not available until seastar engine is up
-    // and running, so we have to feed the command line args to app_template
-    // first, then pass them to ConfigProxy.
-    return do_change([&argv, this](ConfigValues& values) {
-      get_config().parse_argv(values,
-			      obs_mgr,
-			      argv,
-			      CONF_CMDLINE);
+  seastar::future<std::vector<std::string>>
+  parse_argv(std::vector<std::string> args) {
+    // Take args by value so the lambda can safely be invoked on another shard
+    return do_change([args = std::move(args), this](ConfigValues& values) {
+      auto argv_view = args | std::views::transform(&std::string::c_str);
+      std::vector<const char*> argv(argv_view.begin(), argv_view.end());
+      get_config().parse_argv(values, obs_mgr, argv, CONF_CMDLINE);
+      return std::vector<std::string>(argv.begin(), argv.end());
     });
   }
 

--- a/src/crimson/common/config_proxy.h
+++ b/src/crimson/common/config_proxy.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <ranges>
+#include <type_traits>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/sharded.hh>
 #include "common/config.h"
@@ -47,58 +49,73 @@ class ConfigProxy : public seastar::peering_sharded_service<ConfigProxy>
   // apply changes to all shards
   // @param func a functor which accepts @c "ConfigValues&"
   template<typename Func>
-  seastar::future<> do_change(Func&& func) {
+  auto do_change(Func&& func) {
+    using T = std::invoke_result_t<Func, ConfigValues&>;
     return container().invoke_on(values.get_owner_shard(),
                                  [func = std::move(func)](ConfigProxy& owner) {
       // apply the changes to a copy of the values
       auto new_values = seastar::make_lw_shared(*owner.values);
       new_values->changed.clear();
-      func(*new_values);
 
       // always apply the new settings synchronously on the owner shard, to
       // avoid racings with other do_change() calls in parallel.
-      ObserverMgr<ConfigObserver>::rev_obs_map rev_obs;
-      owner.values.reset(new_values);
-      std::map<std::string, bool> changes_present;
-      for (const auto& change : owner.values->changed) {
-        std::string dummy;
-        changes_present[change] = owner.get_val(change, &dummy);
-      }
-      owner.obs_mgr.for_each_change(changes_present,
-                                    [&rev_obs](auto obs,
-                                               const std::string &key) {
-                                      rev_obs[obs].insert(key);
-                                    }, nullptr);
-      for (auto& [obs, keys] : rev_obs) {
-        (*obs)->handle_conf_change(owner, keys);
-      }
+      auto apply_and_propagate = [&owner, new_values]() {
+        ObserverMgr<ConfigObserver>::rev_obs_map rev_obs;
+        owner.values.reset(new_values);
+        std::map<std::string, bool> changes_present;
+        for (const auto& change : owner.values->changed) {
+          std::string dummy;
+          changes_present[change] = owner.get_val(change, &dummy);
+        }
+        owner.obs_mgr.for_each_change(changes_present,
+                                      [&rev_obs](auto obs,
+                                                 const std::string &key) {
+                                        rev_obs[obs].insert(key);
+                                      }, nullptr);
+        for (auto& [obs, keys] : rev_obs) {
+          (*obs)->handle_conf_change(owner, keys);
+        }
 
-      return seastar::parallel_for_each(std::views::iota(1u, seastar::this_smp_shard_count()),
-                                        [&owner, new_values] (auto cpu) {
-        return owner.container().invoke_on(cpu,
-          [foreign_values = seastar::make_foreign(new_values)](ConfigProxy& proxy) mutable {
-            proxy.values.reset();
-            proxy.values = std::move(foreign_values);
+        return seastar::parallel_for_each(std::views::iota(1u, seastar::this_smp_shard_count()),
+                                          [&owner, new_values] (auto cpu) {
+          return owner.container().invoke_on(cpu,
+            [foreign_values = seastar::make_foreign(new_values)](ConfigProxy& proxy) mutable {
+              proxy.values.reset();
+              proxy.values = std::move(foreign_values);
 
-            std::map<std::string, bool> changes_present;
-            for (const auto& change : proxy.values->changed) {
-              std::string dummy;
-              changes_present[change] = proxy.get_val(change, &dummy);
-            }
+              std::map<std::string, bool> changes_present;
+              for (const auto& change : proxy.values->changed) {
+                std::string dummy;
+                changes_present[change] = proxy.get_val(change, &dummy);
+              }
 
-            ObserverMgr<ConfigObserver>::rev_obs_map rev_obs;
-            proxy.obs_mgr.for_each_change(changes_present,
-              [&rev_obs](auto obs, const std::string& key) {
-                rev_obs[obs].insert(key);
-              }, nullptr);
-            for (auto& [obs, keys] : rev_obs) {
-              (*obs)->handle_conf_change(proxy, keys);
-            }
+              ObserverMgr<ConfigObserver>::rev_obs_map rev_obs;
+              proxy.obs_mgr.for_each_change(changes_present,
+                [&rev_obs](auto obs, const std::string& key) {
+                  rev_obs[obs].insert(key);
+                }, nullptr);
+              for (auto& [obs, keys] : rev_obs) {
+                (*obs)->handle_conf_change(proxy, keys);
+              }
+            });
+          }).finally([new_values] {
+            new_values->changed.clear();
           });
-        }).finally([new_values] {
-          new_values->changed.clear();
-        });
-      });
+      };
+
+      // Construct the functor result directly so T need not be
+      // default-constructible or assignable.
+      if constexpr (std::is_void_v<T>) {
+        func(*new_values);
+        return apply_and_propagate();
+      } else {
+        auto result = func(*new_values);
+        return apply_and_propagate().then(
+          [result = std::move(result)]() mutable {
+            return std::move(result);
+          });
+      }
+    });
   }
 public:
   ConfigProxy(const EntityName& name, std::string_view cluster);
@@ -192,17 +209,14 @@ public:
   }
   void show_config(ceph::Formatter* f) const;
 
-  seastar::future<> parse_argv(std::vector<const char*>& argv) {
-    // we could pass whatever is unparsed to seastar, but seastar::app_template
-    // is used for driving the seastar application, and
-    // crimson::common::ConfigProxy is not available until seastar engine is up
-    // and running, so we have to feed the command line args to app_template
-    // first, then pass them to ConfigProxy.
-    return do_change([&argv, this](ConfigValues& values) {
-      get_config().parse_argv(values,
-			      obs_mgr,
-			      argv,
-			      CONF_CMDLINE);
+  seastar::future<std::vector<std::string>>
+  parse_argv(std::vector<std::string> args) {
+    // Take args by value so the lambda can safely be invoked on another shard
+    return do_change([args = std::move(args), this](ConfigValues& values) {
+      auto argv_view = args | std::views::transform(&std::string::c_str);
+      std::vector<const char*> argv(argv_view.begin(), argv_view.end());
+      get_config().parse_argv(values, obs_mgr, argv, CONF_CMDLINE);
+      return std::vector<std::string>(argv.begin(), argv.end());
     });
   }
 

--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -90,7 +90,7 @@ int main(int argc, const char* argv[])
   INFO("early config parsed successfully");
 
   auto seastar_n_early_args = early_config.get_early_args();
-  auto config_proxy_args = early_config.get_ceph_args();
+  auto config_proxy_args = early_config.ceph_args;
 
   INFO("initializing seastar app_template");
   seastar::app_template::config app_cfg;
@@ -154,7 +154,7 @@ int main(int argc, const char* argv[])
           DEBUG("parsing config files");
           local_conf().parse_config_files(early_config.conf_file_list).get();
           local_conf().parse_env().get();
-          local_conf().parse_argv(config_proxy_args).get();
+          local_conf().parse_argv(std::move(config_proxy_args)).get();
 
           DEBUG("initializing logger output");
           std::ofstream log_file_stream;

--- a/src/crimson/osd/main_config_bootstrap_helpers.cc
+++ b/src/crimson/osd/main_config_bootstrap_helpers.cc
@@ -178,7 +178,16 @@ _get_early_config(int argc, const char *argv[])
 	auto stop_perf_coll = seastar::deferred_stop(sharded_perf_coll());
 
 	local_conf().parse_env().get();
-	local_conf().parse_argv(early_args).get();
+	auto remaining_args = local_conf().parse_argv(
+	  std::vector<std::string>(early_args.begin(), early_args.end())).get();
+	auto next = remaining_args.begin();
+	std::erase_if(early_args, [&next, &remaining_args](const char* arg) {
+	  if (next != remaining_args.end() && *next == arg) {
+	    ++next;
+	    return false;
+	  }
+	  return true;
+	});
 	local_conf().parse_config_files(ret.conf_file_list).get();
 
 	if (local_conf()->no_mon_config) {

--- a/src/crimson/osd/main_config_bootstrap_helpers.h
+++ b/src/crimson/osd/main_config_bootstrap_helpers.h
@@ -39,10 +39,6 @@ struct early_config_t {
     return to_ptr_vector(early_args);
   }
 
-  std::vector<const char *> get_ceph_args() {
-    return to_ptr_vector(ceph_args);
-  }
-
 private:
   /// Returned pointers are valid only as long as \p in is alive.
   static std::vector<const char *> to_ptr_vector(

--- a/src/crimson/tools/store_bench/store-bench.cc
+++ b/src/crimson/tools/store_bench/store-bench.cc
@@ -883,11 +883,8 @@ int main(int argc, char **argv) {
         co_await crimson::common::local_conf().start();
 
         {
-          std::vector<const char *> cav;
-          std::transform(
-              std::begin(unrecognized_options), std::end(unrecognized_options),
-              std::back_inserter(cav), [](auto &s) { return s.c_str(); });
-          co_await crimson::common::local_conf().parse_argv(cav);
+          co_await crimson::common::local_conf().parse_argv(
+            std::move(unrecognized_options));
         }
 
         auto store = crimson::os::FuturizedStore::create(

--- a/src/test/crimson/test_config.cc
+++ b/src/test/crimson/test_config.cc
@@ -1,8 +1,10 @@
 #include <chrono>
 #include <string>
 #include <numeric>
+#include <vector>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/sharded.hh>
+#include <seastar/core/smp.hh>
 #include "common/ceph_argparse.h"
 #include "common/config_obs.h"
 #include "crimson/common/config_proxy.h"
@@ -83,11 +85,50 @@ static seastar::future<> test_config()
   });
 }
 
+// Regression for cross-shard parse_argv lifetime: args are taken by value and
+// moved into the do_change closure so the owning shard can safely use them
+// after the caller returns. Also verifies unrecognized leftovers are returned.
+static seastar::future<> test_parse_argv()
+{
+  return crimson::common::sharded_conf().start(EntityName{}, "ceph"sv).then([] {
+    return crimson::common::sharded_conf().invoke_on(0, &Config::start);
+  }).then([] {
+    if (seastar::this_smp_shard_count() < 2) {
+      throw std::runtime_error("test_parse_argv requires --smp >= 2");
+    }
+    // Owner shard is 0; invoke from a non-owner shard to exercise invoke_on.
+    return crimson::common::sharded_conf().invoke_on(1, [](Config& conf) {
+      std::vector<std::string> args{
+        "--osd_max_pgls", std::to_string(EXPECTED_VALUE),
+        "--not-a-real-ceph-flag", "xyz",
+      };
+      return conf.parse_argv(std::move(args)).then(
+        [](std::vector<std::string> leftovers) {
+          if (leftovers.size() != 2 ||
+              leftovers[0] != "--not-a-real-ceph-flag" ||
+              leftovers[1] != "xyz") {
+            throw std::runtime_error("unexpected leftover argv from parse_argv");
+          }
+        });
+    });
+  }).then([] {
+    return crimson::common::sharded_conf().invoke_on_all([](Config& config) {
+      if (config.get_val<uint64_t>(test_uint_option) != EXPECTED_VALUE) {
+        throw std::runtime_error("parse_argv setting not applied on all shards");
+      }
+    });
+  }).finally([] {
+    return crimson::common::sharded_conf().stop();
+  });
+}
+
 int main(int argc, char** argv)
 {
   seastar::app_template app{get_smp_opts_from_ctest()};
   return app.run(argc, argv, [&] {
     return test_config().then([] {
+      return test_parse_argv();
+    }).then([] {
       std::cout << "All tests succeeded" << std::endl;
     }).handle_exception([] (auto eptr) {
       std::cout << "Test failure" << std::endl;


### PR DESCRIPTION
Reopens #67464 after branch update (GitHub does not allow reopening a PR whose head branch was force-pushed).

ConfigProxy::parse_argv used to take `std::vector<const char*>&` and capture it by reference in a lambda passed to `do_change()`, which invokes the lambda on another shard via `invoke_on`. By the time the target shard ran the lambda, the caller had returned and the referenced vector was destroyed.

- Change the signature to take `std::vector<std::string>` by value.
- Move the vector into the lambda so the data lives as long as the future.
- Convert to `vector<const char*>` only on the owning shard (using `std::views::transform`).
- Make `do_change` able to return a non-void result from the functor (so leftover/unrecognized args can be returned), constructing that result directly so `T` need not be default-constructible.
- Update call sites, remove unused `get_ceph_args()`, and rebuild `early_args` via ordered matching in bootstrap.
- Add a `unittest-seastar-config` regression that calls `parse_argv` from a non-owner shard and checks applied settings plus leftover args.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [ ] No tests