### PR TITLE
mds: fix race between strong rejoin and ACK in open_undef_inodes_dirfrags()

### DIFF
--- a/qa/tasks/cephfs/test_failover.py
+++ b/qa/tasks/cephfs/test_failover.py
@@ -1028,3 +1028,70 @@ for killpoint, name in enumerate(SHUTDOWN_KILLPOINTS):
         continue
     test_export_killpoints = TestShutdownKillpoints.make_test_killpoint(killpoint, name)
     setattr(TestShutdownKillpoints, f"test_shutdown_killpoint_{name}", test_export_killpoints)
+
+
+MDS_REJOIN_RESTART_GRACE = 120
+
+class TestRejoinKillpoints(CephFSTestCase):
+    """
+    Test that an MDS killed during rejoin in open_undef_inodes_dirfrags()
+    recovers correctly.  This exercises the fix for
+    https://tracker.ceph.com/issues/77786, where a race between strong
+    rejoin handling and the survivor's ACK could leave a dirfrag in
+    rejoin_undef_dirfrags with a non-zero version, triggering the assert
+      ceph_assert(dir->get_version() == 0).
+    """
+    CLIENTS_REQUIRED = 0
+    MDSS_REQUIRED = 3
+
+    def _test_rejoin_kill(self, killpoint):
+        log.info(f"testing mds_kill_undef_dirfrag_at={killpoint}")
+
+        # Ensure 2 active ranks and 1 standby
+        self.fs.set_max_mds(2)
+        status = self.fs.wait_for_daemons()
+        rank0 = self.fs.get_rank(rank=0, status=status)
+        rank1 = self.fs.get_rank(rank=1, status=status)
+        log.info(f"rank0={rank0['name']}, rank1={rank1['name']}")
+
+        # Set the kill point globally so it persists across daemon restarts.
+        self.fs.run_ceph_cmd("config", "set", "mds", "mds_kill_undef_dirfrag_at", str(killpoint))
+
+        # Freeze rank 1 to prevent automatic failover when it crashes.
+        self.fs.rank_freeze(True, rank=1)
+
+        # Fail and restart rank 1: the daemon will restart, replay its
+        # journal, enter rejoin, and hit the kill point in
+        # open_undef_inodes_dirfrags().
+        self.fs.mds_fail_restart(rank1['name'])
+        log.info("waiting for rank 1 to become laggy (kill point hit)...")
+        self.wait_until_true(
+            lambda: "laggy_since" in self.fs.get_rank(rank=1),
+            timeout=self.fs.beacon_timeout * 2
+        )
+
+        # Clean up the coredump from the kill-point crash.
+        self.delete_mds_coredump(rank1['name'])
+
+        # Remove the global kill point so the next restart succeeds.
+        self.fs.run_ceph_cmd("config", "rm", "mds", "mds_kill_undef_dirfrag_at")
+
+        # Unfreeze so the mon can replace the laggy daemon with a standby.
+        try:
+            self.fs.rank_freeze(False, rank=1)
+        except CommandFailedError:
+            # Rank may already be unfrozen due to state transition
+            log.info("rank_freeze(False) failed, rank may already be unfrozen")
+            self.fs.rank_fail(rank=1)
+        # Restart the daemon that crashed (will become new standby after recovery).
+        self.fs.mds_restart(rank1['name'])
+        self.wait_for_daemon_start([rank1['name']])
+
+        # Wait for the rank to rejoin and become active.
+        self.fs.wait_for_state('up:active', rank=1, timeout=MDS_REJOIN_RESTART_GRACE)
+        status = self.fs.wait_for_daemons()
+        log.info(f"recovery complete: rank1={rank1['name']} is active")
+        self.assertTrue(self.fs.get_rank(rank=1, status=status)['state'] == 'up:active')
+
+    def test_rejoin_killpoint_open_undef(self):
+        self._test_rejoin_kill(1)

--- a/qa/tasks/cephfs/test_failover.py
+++ b/qa/tasks/cephfs/test_failover.py
@@ -1029,3 +1029,70 @@ for killpoint, name in enumerate(SHUTDOWN_KILLPOINTS):
         continue
     test_export_killpoints = TestShutdownKillpoints.make_test_killpoint(killpoint, name)
     setattr(TestShutdownKillpoints, f"test_shutdown_killpoint_{name}", test_export_killpoints)
+
+
+MDS_REJOIN_RESTART_GRACE = 120
+
+class TestRejoinKillpoints(CephFSTestCase):
+    """
+    Test that an MDS killed during rejoin in open_undef_inodes_dirfrags()
+    recovers correctly.  This exercises the fix for
+    https://tracker.ceph.com/issues/77786, where a race between strong
+    rejoin handling and the survivor's ACK could leave a dirfrag in
+    rejoin_undef_dirfrags with a non-zero version, triggering the assert
+      ceph_assert(dir->get_version() == 0).
+    """
+    CLIENTS_REQUIRED = 0
+    MDSS_REQUIRED = 3
+
+    def _test_rejoin_kill(self, killpoint):
+        log.info(f"testing mds_kill_undef_dirfrag_at={killpoint}")
+
+        # Ensure 2 active ranks and 1 standby
+        self.fs.set_max_mds(2)
+        status = self.fs.wait_for_daemons()
+        rank0 = self.fs.get_rank(rank=0, status=status)
+        rank1 = self.fs.get_rank(rank=1, status=status)
+        log.info(f"rank0={rank0['name']}, rank1={rank1['name']}")
+
+        # Set the kill point globally so it persists across daemon restarts.
+        self.fs.run_ceph_cmd("config", "set", "mds", "mds_kill_undef_dirfrag_at", str(killpoint))
+
+        # Freeze rank 1 to prevent automatic failover when it crashes.
+        self.fs.rank_freeze(True, rank=1)
+
+        # Fail and restart rank 1: the daemon will restart, replay its
+        # journal, enter rejoin, and hit the kill point in
+        # open_undef_inodes_dirfrags().
+        self.fs.mds_fail_restart(rank1['name'])
+        log.info("waiting for rank 1 to become laggy (kill point hit)...")
+        self.wait_until_true(
+            lambda: "laggy_since" in self.fs.get_rank(rank=1),
+            timeout=self.fs.beacon_timeout * 2
+        )
+
+        # Clean up the coredump from the kill-point crash.
+        self.delete_mds_coredump(rank1['name'])
+
+        # Remove the global kill point so the next restart succeeds.
+        self.fs.run_ceph_cmd("config", "rm", "mds", "mds_kill_undef_dirfrag_at")
+
+        # Unfreeze so the mon can replace the laggy daemon with a standby.
+        try:
+            self.fs.rank_freeze(False, rank=1)
+        except CommandFailedError:
+            # Rank may already be unfrozen due to state transition
+            log.info("rank_freeze(False) failed, rank may already be unfrozen")
+            self.fs.rank_fail(rank=1)
+        # Restart the daemon that crashed (will become new standby after recovery).
+        self.fs.mds_restart(rank1['name'])
+        self.wait_for_daemon_start([rank1['name']])
+
+        # Wait for the rank to rejoin and become active.
+        self.fs.wait_for_state('up:active', rank=1, timeout=MDS_REJOIN_RESTART_GRACE)
+        status = self.fs.wait_for_daemons()
+        log.info(f"recovery complete: rank1={rank1['name']} is active")
+        self.assertTrue(self.fs.get_rank(rank=1, status=status)['state'] == 'up:active')
+
+    def test_rejoin_killpoint_open_undef(self):
+        self._test_rejoin_kill(1)

--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -1125,6 +1125,15 @@ options:
   fmt_desc: Ceph will inject MDS failure in MDSTable code
     (for developers only).
   with_legacy: true
+- name: mds_kill_undef_dirfrag_at
+  type: int
+  level: dev
+  default: 0
+  services:
+  - mds
+  fmt_desc: Ceph will inject MDS failure when processing undefined
+    dirfrags during rejoin (for developers only).
+  with_legacy: true
 - name: mds_max_export_size
   type: size
   level: dev

--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -1160,6 +1160,15 @@ options:
   fmt_desc: Ceph will inject MDS failure in MDSTable code
     (for developers only).
   with_legacy: true
+- name: mds_kill_undef_dirfrag_at
+  type: int
+  level: dev
+  default: 0
+  services:
+  - mds
+  fmt_desc: Ceph will inject MDS failure when processing undefined
+    dirfrags during rejoin (for developers only).
+  with_legacy: true
 - name: mds_max_export_size
   type: size
   level: dev

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -6061,6 +6061,14 @@ bool MDCache::open_undef_inodes_dirfrags()
 	   << rejoin_undef_inodes.size() << " inodes "
 	   << rejoin_undef_dirfrags.size() << " dirfrags" << dendl;
 
+  // kill point 1: crash at undef dirfrag processing during rejoin.
+  // Before the fix for https://tracker.ceph.com/issues/77786,
+  // recovering from this crash could trigger the assert
+  // dir->get_version() == 0 due to a race between strong rejoin
+  // inventing undef dirfrags and the survivor's ACK populating
+  // their version via _decode_base().
+  ceph_assert(g_conf()->mds_kill_undef_dirfrag_at != 1);
+
   // dirfrag -> (fetch_complete, keys_to_fetch)
   map<CDir*, pair<bool, std::vector<dentry_key_t> > > fetch_queue;
   for (auto it = rejoin_undef_dirfrags.begin(); it != rejoin_undef_dirfrags.end(); ) {

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -5187,6 +5187,13 @@ void MDCache::handle_cache_rejoin_ack(const cref_t<MMDSCacheRejoin> &ack)
     ceph_assert(dir);
     auto q = p.second.cbegin();
     dir->_decode_base(q);
+    // If the dirfrag was invented during strong rejoin processing and is
+    // still in the undef set, remove it now since the survivor's ACK has
+    // fully defined it (both dentries and base were provided).
+    if (dir->state_test(CDir::STATE_REJOINUNDEF)) {
+      dir->state_clear(CDir::STATE_REJOINUNDEF);
+      rejoin_undef_dirfrags.erase(dir);
+    }
     dout(10) << " got dir replica " << *dir << dendl;
   }
 
@@ -6056,9 +6063,20 @@ bool MDCache::open_undef_inodes_dirfrags()
 
   // dirfrag -> (fetch_complete, keys_to_fetch)
   map<CDir*, pair<bool, std::vector<dentry_key_t> > > fetch_queue;
-  for (auto& dir : rejoin_undef_dirfrags) {
-    ceph_assert(dir->get_version() == 0);
+  for (auto it = rejoin_undef_dirfrags.begin(); it != rejoin_undef_dirfrags.end(); ) {
+    CDir *dir = *it;
+    if (dir->get_version() != 0) {
+      // The ACK from a survivor may have already populated this dirfrag
+      // via _decode_base() in handle_cache_rejoin_ack(), setting its
+      // version.  Skip the fetch since it's already fully defined.
+      dout(10) << " dirfrag " << *dir << " already has version " << dir->get_version()
+               << ", skipping fetch" << dendl;
+      dir->state_clear(CDir::STATE_REJOINUNDEF);
+      it = rejoin_undef_dirfrags.erase(it);
+      continue;
+    }
     fetch_queue.emplace(std::piecewise_construct, std::make_tuple(dir), std::make_tuple());
+    ++it;
   }
 
   if (g_conf().get_val<bool>("mds_dir_prefetch")) {

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -6061,6 +6061,14 @@ bool MDCache::open_undef_inodes_dirfrags()
 	   << rejoin_undef_inodes.size() << " inodes "
 	   << rejoin_undef_dirfrags.size() << " dirfrags" << dendl;
 
+  // kill point 1: crash at undef dirfrag processing during rejoin.
+  // Before the fix for https://tracker.ceph.com/issues/77786,
+  // recovering from this crash could trigger the assert
+  // dir->get_version() == 0 due to a race between strong rejoin
+  // inventing undef dirfrags and the survivor's ACK populating
+  // their version via _decode_base().
+  ceph_assert(g_conf()->mds_kill_undef_dirfrag_at != 1);
+
   // dirfrag -> (fetch_complete, keys_to_fetch)
   map<CDir*, pair<bool, std::vector<dentry_key_t> > > fetch_queue;
   int count = 0;

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -5187,6 +5187,13 @@ void MDCache::handle_cache_rejoin_ack(const cref_t<MMDSCacheRejoin> &ack)
     ceph_assert(dir);
     auto q = p.second.cbegin();
     dir->_decode_base(q);
+    // If the dirfrag was invented during strong rejoin processing and is
+    // still in the undef set, remove it now since the survivor's ACK has
+    // fully defined it (both dentries and base were provided).
+    if (dir->state_test(CDir::STATE_REJOINUNDEF)) {
+      dir->state_clear(CDir::STATE_REJOINUNDEF);
+      rejoin_undef_dirfrags.erase(dir);
+    }
     dout(10) << " got dir replica " << *dir << dendl;
   }
 
@@ -6057,11 +6064,22 @@ bool MDCache::open_undef_inodes_dirfrags()
   // dirfrag -> (fetch_complete, keys_to_fetch)
   map<CDir*, pair<bool, std::vector<dentry_key_t> > > fetch_queue;
   int count = 0;
-  for (auto& dir : rejoin_undef_dirfrags) {
-    ceph_assert(dir->get_version() == 0);
+  for (auto it = rejoin_undef_dirfrags.begin(); it != rejoin_undef_dirfrags.end(); ) {
+    CDir *dir = *it;
+    if (dir->get_version() != 0) {
+      // The ACK from a survivor may have already populated this dirfrag
+      // via _decode_base() in handle_cache_rejoin_ack(), setting its
+      // version.  Skip the fetch since it's already fully defined.
+      dout(10) << " dirfrag " << *dir << " already has version " << dir->get_version()
+               << ", skipping fetch" << dendl;
+      dir->state_clear(CDir::STATE_REJOINUNDEF);
+      it = rejoin_undef_dirfrags.erase(it);
+      continue;
+    }
     fetch_queue.emplace(std::piecewise_construct, std::make_tuple(dir), std::make_tuple());
     if (!(++count % mds->heartbeat_reset_grace()))
       mds->heartbeat_reset();
+    ++it;
   }
 
   if (g_conf().get_val<bool>("mds_dir_prefetch")) {


### PR DESCRIPTION
During rejoin, a recovering MDS can hit the assert
  ceph_assert(dir->get_version() == 0)
in open_undef_inodes_dirfrags() due to a race between two
incoming messages from survivors:

1. OP_STRONG (handle_cache_rejoin_strong): invents undef
   dirfrags via rejoin_invent_dirfrag(), setting
   STATE_REJOINUNDEF and adding them to rejoin_undef_dirfrags
   with version == 0.

2. OP_ACK (handle_cache_rejoin_ack): processes dirfrag_bases
   and calls dir->_decode_base(), which decodes the full fnode
   including a non-zero version.  The ACK path clears
   STATE_REJOINING but does NOT clear STATE_REJOINUNDEF or
   remove the dirfrag from the undef set.

If the STRONG rejoin arrives before the ACK, the dirfrag ends
up in rejoin_undef_dirfrags with a non-zero version, and
open_undef_inodes_dirfrags() crashes on the assert.

Fix by:
- Proactively clearing STATE_REJOINUNDEF and removing the
  dirfrag from rejoin_undef_dirfrags in handle_cache_rejoin_ack()
  when _decode_base() has fully defined it (both dentries and
  base are provided by the ACK).
- Replacing the assert in open_undef_inodes_dirfrags() with a
  defensive skip for any dirfrag that already has a non-zero
  version, guarding against any remaining ordering edge cases.

Fixes: https://tracker.ceph.com/issues/77786


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
