### PR TITLE
mgr/cephadm: support NVMe-oF encryption key sources

### DIFF
--- a/src/pybind/mgr/cephadm/cert_mgr.py
+++ b/src/pybind/mgr/cephadm/cert_mgr.py
@@ -275,6 +275,17 @@ class CertMgr:
     def register_key(self, consumer: str, key_name: str, scope: TLSObjectScope) -> None:
         self._register_tls_object(consumer, key_name, scope, "keys")
 
+    def register_key_object(
+        self,
+        consumer: str,
+        key_name: str,
+        scope: TLSObjectScope,
+    ) -> None:
+        self.register_key(consumer, key_name, scope)
+
+        if hasattr(self, 'key_store') and self.key_store:
+            self.key_store.register_object_name(key_name, scope)
+
     def _register_tls_object(self, consumer: str, obj_name: str, scope: TLSObjectScope, obj_type: str) -> None:
         """
         Registers a TLS-related object (certificate or key) for a given consumer under a specific scope.
@@ -326,6 +337,9 @@ class CertMgr:
         )
         ca_cert = self.mgr.cert_mgr.get_root_ca()
         return TLSCredentials(cert=cert, key=key, ca_cert=ca_cert)
+
+    def generate_private_key(self, key_size: int = 4096) -> str:
+        return self.ssl_certs.generate_private_key(key_size=key_size)
 
     def cert_exists(self, cert_name: str, service_name: Optional[str] = None, host: Optional[str] = None) -> bool:
         cert_obj = self.cert_store.get_tlsobject(cert_name, service_name, host)

--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -6,7 +6,7 @@ from ipaddress import ip_address, IPv6Address
 
 from mgr_module import HandleCommandResult
 from ceph.deployment.service_spec import NvmeofServiceSpec, CertificateSource
-from cephadm.cert_mgr import TLSObjectScope
+from cephadm.tlsobject_types import TLSObjectScope
 
 from orchestrator import (
     OrchestratorError,

--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -6,6 +6,7 @@ from ipaddress import ip_address, IPv6Address
 
 from mgr_module import HandleCommandResult
 from ceph.deployment.service_spec import NvmeofServiceSpec, CertificateSource
+from cephadm.cert_mgr import TLSObjectScope
 
 from orchestrator import (
     OrchestratorError,
@@ -19,6 +20,9 @@ from .. import utils
 
 logger = logging.getLogger(__name__)
 NVMEOF_CLIENT_CERT_LABEL = 'client'
+NVMEOF_ENCRYPTION_KEY = 'nvmeof_encryption_key'
+NVMEOF_ENCRYPTION_KEY_SIZE = 4096
+NVMEOF_ENCRYPTION_KEY_CONTAINER_PATH = '/encryption.key'
 
 
 class NvmeofTLSBundle(NamedTuple):
@@ -116,6 +120,82 @@ class NvmeofService(CephService):
             'root_ca_cert': tls_creds.ca_cert,
         })
 
+    def _get_encryption_key_path(self, spec: NvmeofServiceSpec) -> Optional[str]:
+        source = spec.get_encryption_key_source()
+
+        if source is None:
+            return None
+
+        if source == 'source_file':
+            return spec.encryption_key_path
+
+        return NVMEOF_ENCRYPTION_KEY_CONTAINER_PATH
+
+    def _get_or_create_encryption_key(self, spec: NvmeofServiceSpec) -> Optional[str]:
+        source = spec.get_encryption_key_source()
+        service_name = spec.service_name()
+
+        if source is None:
+            return None
+
+        if source == 'source_file':
+            return None
+
+        if source == 'inline':
+            encryption_key = spec.encryption_key
+            if not encryption_key:
+                raise OrchestratorError(
+                    "encryption_key_source is set to 'inline', but encryption_key is missing"
+                )
+
+            logger.warning(
+                "The nvmeof spec field 'encryption_key' is deprecated because "
+                "it contains secret material. Use encryption_key_source=reference "
+                "or encryption_key_source=source_file instead."
+            )
+            self.mgr.cert_mgr.save_key(
+                NVMEOF_ENCRYPTION_KEY,
+                encryption_key,
+                service_name=service_name,
+                user_made=True,
+                editable=False,
+            )
+            return encryption_key
+
+        key = self.mgr.cert_mgr.get_key(
+            NVMEOF_ENCRYPTION_KEY,
+            service_name=service_name,
+        )
+
+        if source == 'reference':
+            if not key:
+                raise OrchestratorError(
+                    f"NVMe-oF encryption_key_source is set to 'reference', "
+                    f"but certmgr key '{NVMEOF_ENCRYPTION_KEY}' is missing "
+                    f"for service '{service_name}'"
+                )
+            return key
+
+        if source == 'cephadm':
+            if key:
+                return key
+
+            key = self.mgr.cert_mgr.generate_private_key(
+                key_size=NVMEOF_ENCRYPTION_KEY_SIZE
+            )
+            self.mgr.cert_mgr.save_key(
+                NVMEOF_ENCRYPTION_KEY,
+                key,
+                service_name=service_name,
+                user_made=False,
+                editable=False,
+            )
+            return key
+
+        raise OrchestratorError(
+            f"Invalid NVMe-oF encryption_key_source: {source}"
+        )
+
     def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
 
@@ -130,6 +210,12 @@ class NvmeofService(CephService):
 
         super().prepare_certificates(daemon_spec)
         self.mgr.cert_mgr.register_self_signed_cert_key_pair(spec.service_name(), NVMEOF_CLIENT_CERT_LABEL)
+        self.mgr.cert_mgr.register_key_object(
+            self.TYPE,
+            NVMEOF_ENCRYPTION_KEY,
+            TLSObjectScope.SERVICE,
+        )
+
         self.configure_tls(spec, daemon_spec)
 
         # TODO: check if we can force jinja2 to generate dicts with double quotes instead of using json.dumps
@@ -145,6 +231,7 @@ class NvmeofService(CephService):
         self.mgr.log.info(f"gateway address: {addr} from {map_addr=} {spec.addr=} {host_ip=}")
         discovery_addr = map_discovery_addr or spec.discovery_addr or host_ip
         self.mgr.log.info(f"discovery address: {discovery_addr} from {map_discovery_addr=} {spec.discovery_addr=} {host_ip=}")
+        encryption_key_path = self._get_encryption_key_path(spec)
         context = {
             'spec': spec,
             'name': name,
@@ -156,7 +243,8 @@ class NvmeofService(CephService):
             'rpc_socket_name': 'spdk.sock',
             'transport_tcp_options': transport_tcp_options,
             'iobuf_options': iobuf_options,
-            'rados_id': rados_id
+            'rados_id': rados_id,
+            'encryption_key_path': encryption_key_path,
         }
         gw_conf = self.mgr.template.render('services/nvmeof/ceph-nvmeof.conf.j2', context)
 
@@ -177,8 +265,9 @@ class NvmeofService(CephService):
         if spec.enable_dsa_acceleration:
             daemon_spec.extra_files['enable_dsa_acceleration'] = str(spec.enable_dsa_acceleration)
 
-        if spec.encryption_key:
-            daemon_spec.extra_files['encryption_key'] = spec.encryption_key
+        encryption_key = self._get_or_create_encryption_key(spec)
+        if encryption_key:
+            daemon_spec.extra_files['encryption_key'] = encryption_key
 
         daemon_spec.final_config, _ = self.generate_config(daemon_spec)
         daemon_spec.deps = self.get_dependencies(self.mgr, spec, daemon_spec.daemon_type)

--- a/src/pybind/mgr/cephadm/ssl_cert_utils.py
+++ b/src/pybind/mgr/cephadm/ssl_cert_utils.py
@@ -259,6 +259,19 @@ class SSLCerts:
 
         return (cert_str, key_str)
 
+    def generate_private_key(self, key_size: int = 4096) -> str:
+        private_key = rsa.generate_private_key(
+            public_exponent=65537,
+            key_size=key_size,
+            backend=default_backend(),
+        )
+
+        return private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode('utf-8')
+
     def renew_cert(
         self,
         old_cert: str,

--- a/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
@@ -9,7 +9,9 @@ state_update_notify = {{ spec.state_update_notify }}
 state_update_interval_sec = {{ spec.state_update_interval_sec }}
 break_update_interval_sec = {{ spec.break_update_interval_sec }}
 enable_spdk_discovery_controller = {{ spec.enable_spdk_discovery_controller }}
-encryption_key = /encryption.key
+{% if encryption_key_path %}
+encryption_key = {{ encryption_key_path }}
+{% endif %}
 rebalance_period_sec = {{ spec.rebalance_period_sec }}
 max_gws_in_grp = {{ spec.max_gws_in_grp }}
 max_ns_to_change_lb_grp = {{ spec.max_ns_to_change_lb_grp }}

--- a/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
@@ -20,6 +20,19 @@ ceph_generated_cert = """-----BEGIN CERTIFICATE-----\nMIICxjCCAa4CEQDIZSujNBlKaL
 ceph_generated_key = """-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDLIx7gMwD4x5gr\nsEdkwcGrvOOWIQ5w2DGiaNTypt/lRIXsyqt/r7/ztdaqPikLIBbzHRZcSvoDnpr5\nyYFWa36q1YPOXTbRqgh3qUvkSAsufr+QwMIIkur74uD1wSh8xK9xmH6VjZ/7Wn4L\n7TTF6e2ste9cY6KUBlZpB+iNPYGlGc1ZYgVukXCVwquWDYbRwWNXlzWbprTCmxD0\nkc6J6rRK/AKLFqPCrcLABi66JTXCMjigk7gijX6DzIHecfYyj/blICkLExe5eHiQ\nctCv9PjiGqKy8bi4liAoxxIitaPmjbmZyUHIaLVQj+RmQJQRL3iLtn/eKHHgFp3Q\nAyz/23AXAgMBAAECggEAVoTB3Mm8azlPlaQB9GcV3tiXslSn+uYJ1duCf0sV52dV\nBzKW8s5fGiTjpiTNhGCJhchowqxoaew+o47wmGc2TvqbpeRLuecKrjScD0GkCYyQ\neM2wlshEbz4FhIZdgS6gbuh9WaM1dW/oaZoBNR5aTYo7xYTmNNeyLA/jO2zr7+4W\n5yES1lMSBXpKk7bDGKYY4bsX2b5RLr2Grh2u2bp7hoLABCEvuu8tSQdWXLEXWpXo\njwmV3hc6tabypIa0mj2Dmn2Dmt1ppSO0AZWG/WAizN3f4Z0r/u9HnbVrVmh0IEDw\n3uf2LP5o3msG9qKCbzv3lMgt9mMr70HOKnJ8ohMSKQKBgQDLkNb+0nr152HU9AeJ\nvdz8BeMxcwxCG77iwZphZ1HprmYKvvXgedqWtS6FRU+nV6UuQoPUbQxJBQzrN1Qv\nwKSlOAPCrTJgNgF/RbfxZTrIgCPuK2KM8I89VZv92TSGi362oQA4MazXC8RAWjoJ\nSu1/PHzK3aXOfVNSLrOWvIYeZQKBgQD/dgT6RUXKg0UhmXj7ExevV+c7oOJTDlMl\nvLngrmbjRgPO9VxLnZQGdyaBJeRngU/UXfNgajT/MU8B5fSKInnTMawv/tW7634B\nw3v6n5kNIMIjJmENRsXBVMllDTkT9S7ApV+VoGnXRccbTiDapBThSGd0wri/CuwK\nNWK1YFOeywKBgEDyI/XG114PBUJ43NLQVWm+wx5qszWAPqV/2S5MVXD1qC6zgCSv\nG9NLWN1CIMimCNg6dm7Wn73IM7fzvhNCJgVkWqbItTLG6DFf3/DPODLx1wTMqLOI\nqFqMLqmNm9l1Nec0dKp5BsjRQzq4zp1aX21hsfrTPmwjxeqJZdioqy2VAoGAXR5X\nCCdSHlSlUW8RE2xNOOQw7KJjfWT+WAYoN0c7R+MQplL31rRU7dpm1bLLRBN11vJ8\nMYvlT5RYuVdqQSP6BkrX+hLJNBvOLbRlL+EXOBrVyVxHCkDe+u7+DnC4epbn+N8P\nLYpwqkDMKB7diPVAizIKTBxinXjMu5fkKDs5n+sCgYBbZheYKk5M0sIxiDfZuXGB\nkf4mJdEkTI1KUGRdCwO/O7hXbroGoUVJTwqBLi1tKqLLarwCITje2T200BYOzj82\nqwRkCXGtXPKnxYEEUOiFx9OeDrzsZV00cxsEnX0Zdj+PucQ/J3Cvd0dWUspJfLHJ\n39gnaegswnz9KMQAvzKFdg==\n-----END PRIVATE KEY-----\n"""
 
 
+TEST_KEY = """-----BEGIN RSA PRIVATE KEY-----
+test-key
+-----END RSA PRIVATE KEY-----"""
+
+CERTMGR_KEY = """-----BEGIN RSA PRIVATE KEY-----
+certmgr-key
+-----END RSA PRIVATE KEY-----"""
+
+GENERATED_KEY = """-----BEGIN RSA PRIVATE KEY-----
+generated-key
+-----END RSA PRIVATE KEY-----"""
+
+
 class FakeInventory:
     def get_addr(self, name: str) -> str:
         return '1.2.3.4'
@@ -106,7 +119,6 @@ state_update_notify = True
 state_update_interval_sec = 5
 break_update_interval_sec = 25
 enable_spdk_discovery_controller = False
-encryption_key = /encryption.key
 rebalance_period_sec = 7
 max_gws_in_grp = 16
 max_ns_to_change_lb_grp = 8
@@ -357,7 +369,6 @@ state_update_notify = True
 state_update_interval_sec = 5
 break_update_interval_sec = 25
 enable_spdk_discovery_controller = False
-encryption_key = /encryption.key
 rebalance_period_sec = 7
 max_gws_in_grp = 16
 max_ns_to_change_lb_grp = 8
@@ -550,7 +561,6 @@ state_update_notify = True
 state_update_interval_sec = 5
 break_update_interval_sec = 25
 enable_spdk_discovery_controller = False
-encryption_key = /encryption.key
 rebalance_period_sec = 7
 max_gws_in_grp = 16
 max_ns_to_change_lb_grp = 8
@@ -697,6 +707,275 @@ timeout = 1.0
                     error_ok=True,
                     use_current_daemon_image=False,
                 )
+
+    def test_nvmeof_encryption_key_source_defaults(self):
+        disabled = NvmeofServiceSpec(
+            service_id='testpool.group1',
+            pool='testpool',
+            group='group1',
+        )
+        assert disabled.get_encryption_key_source() is None
+
+        cephadm = NvmeofServiceSpec(
+            service_id='testpool.group1',
+            pool='testpool',
+            group='group1',
+            enable_encryption=True,
+        )
+        assert cephadm.get_encryption_key_source() == 'cephadm'
+
+        legacy_inline = NvmeofServiceSpec(
+            service_id='testpool.group1',
+            pool='testpool',
+            group='group1',
+            encryption_key=TEST_KEY,
+        )
+        assert legacy_inline.get_encryption_key_source() == 'inline'
+
+        explicit_reference = NvmeofServiceSpec(
+            service_id='testpool.group1',
+            pool='testpool',
+            group='group1',
+            enable_encryption=True,
+            encryption_key_source='reference',
+        )
+        assert explicit_reference.get_encryption_key_source() == 'reference'
+
+        source_file = NvmeofServiceSpec(
+            service_id='testpool.group1',
+            pool='testpool',
+            group='group1',
+            enable_encryption=True,
+            encryption_key_source='source_file',
+            encryption_key_path='/etc/nvmeof/tls/encryption.key',
+        )
+        assert source_file.get_encryption_key_source() == 'source_file'
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            # disabled
+            NvmeofServiceSpec(
+                service_id='testpool.group1',
+                pool='testpool',
+                group='group1',
+            ),
+
+            # implicit cephadm
+            NvmeofServiceSpec(
+                service_id='testpool.group1',
+                pool='testpool',
+                group='group1',
+                enable_encryption=True,
+            ),
+
+            # explicit cephadm
+            NvmeofServiceSpec(
+                service_id='testpool.group1',
+                pool='testpool',
+                group='group1',
+                enable_encryption=True,
+                encryption_key_source='cephadm',
+            ),
+
+            # reference
+            NvmeofServiceSpec(
+                service_id='testpool.group1',
+                pool='testpool',
+                group='group1',
+                enable_encryption=True,
+                encryption_key_source='reference',
+            ),
+
+            # source_file
+            NvmeofServiceSpec(
+                service_id='testpool.group1',
+                pool='testpool',
+                group='group1',
+                enable_encryption=True,
+                encryption_key_source='source_file',
+                encryption_key_path='/etc/nvmeof/tls/encryption.key',
+            ),
+
+            # legacy inline
+            NvmeofServiceSpec(
+                service_id='testpool.group1',
+                pool='testpool',
+                group='group1',
+                encryption_key=TEST_KEY,
+            ),
+
+            # explicit inline
+            NvmeofServiceSpec(
+                service_id='testpool.group1',
+                pool='testpool',
+                group='group1',
+                enable_encryption=True,
+                encryption_key_source='inline',
+                encryption_key=TEST_KEY,
+            ),
+        ],
+    )
+    def test_nvmeof_encryption_key_validation_success(self, spec):
+        spec.validate()
+
+    def test_nvmeof_encryption_key_path_by_source(self, cephadm_module: CephadmOrchestrator):
+        service = NvmeofService(cephadm_module)
+
+        disabled = NvmeofServiceSpec(
+            service_id='testpool.group1',
+            pool='testpool',
+            group='group1',
+        )
+        assert service._get_encryption_key_path(disabled) is None
+
+        cephadm = NvmeofServiceSpec(
+            service_id='testpool.group1',
+            pool='testpool',
+            group='group1',
+            enable_encryption=True,
+        )
+        assert service._get_encryption_key_path(cephadm) == '/encryption.key'
+
+        reference = NvmeofServiceSpec(
+            service_id='testpool.group1',
+            pool='testpool',
+            group='group1',
+            enable_encryption=True,
+            encryption_key_source='reference',
+        )
+        assert service._get_encryption_key_path(reference) == '/encryption.key'
+
+        inline = NvmeofServiceSpec(
+            service_id='testpool.group1',
+            pool='testpool',
+            group='group1',
+            encryption_key=TEST_KEY,
+        )
+        assert service._get_encryption_key_path(inline) == '/encryption.key'
+
+        source_file = NvmeofServiceSpec(
+            service_id='testpool.group1',
+            pool='testpool',
+            group='group1',
+            enable_encryption=True,
+            encryption_key_source='source_file',
+            encryption_key_path='/etc/nvmeof/tls/encryption.key',
+        )
+        assert service._get_encryption_key_path(source_file) == '/etc/nvmeof/tls/encryption.key'
+
+    def test_nvmeof_get_or_create_encryption_key_disabled(
+        self,
+        cephadm_module: CephadmOrchestrator,
+    ):
+        service = NvmeofService(cephadm_module)
+        cephadm_module.cert_mgr = MagicMock()
+
+        spec = NvmeofServiceSpec(
+            service_id='testpool.group1',
+            pool='testpool',
+            group='group1',
+        )
+
+        assert service._get_or_create_encryption_key(spec) is None
+        cephadm_module.cert_mgr.get_key.assert_not_called()
+        cephadm_module.cert_mgr.save_key.assert_not_called()
+        cephadm_module.cert_mgr.generate_private_key.assert_not_called()
+
+    def test_nvmeof_get_or_create_encryption_key_source_file(
+        self,
+        cephadm_module: CephadmOrchestrator,
+    ):
+        service = NvmeofService(cephadm_module)
+        cephadm_module.cert_mgr = MagicMock()
+
+        spec = NvmeofServiceSpec(
+            service_id='testpool.group1',
+            pool='testpool',
+            group='group1',
+            enable_encryption=True,
+            encryption_key_source='source_file',
+            encryption_key_path='/etc/nvmeof/tls/encryption.key',
+        )
+
+        assert service._get_or_create_encryption_key(spec) is None
+        cephadm_module.cert_mgr.get_key.assert_not_called()
+        cephadm_module.cert_mgr.save_key.assert_not_called()
+        cephadm_module.cert_mgr.generate_private_key.assert_not_called()
+
+    def test_nvmeof_get_or_create_encryption_key_inline_imports_key(
+        self,
+        cephadm_module: CephadmOrchestrator,
+    ):
+        service = NvmeofService(cephadm_module)
+        cephadm_module.cert_mgr = MagicMock()
+
+        spec = NvmeofServiceSpec(
+            service_id='testpool.group1',
+            pool='testpool',
+            group='group1',
+            encryption_key=TEST_KEY,
+        )
+
+        assert service._get_or_create_encryption_key(spec) == TEST_KEY
+        cephadm_module.cert_mgr.save_key.assert_called_once_with(
+            'nvmeof_encryption_key',
+            TEST_KEY,
+            service_name='nvmeof.testpool.group1',
+            user_made=True,
+            editable=False,
+        )
+        cephadm_module.cert_mgr.get_key.assert_not_called()
+        cephadm_module.cert_mgr.generate_private_key.assert_not_called()
+
+    def test_nvmeof_get_or_create_encryption_key_reference_success(
+        self,
+        cephadm_module: CephadmOrchestrator,
+    ):
+        service = NvmeofService(cephadm_module)
+        cephadm_module.cert_mgr = MagicMock()
+        cephadm_module.cert_mgr.get_key.return_value = CERTMGR_KEY
+
+        spec = NvmeofServiceSpec(
+            service_id='testpool.group1',
+            pool='testpool',
+            group='group1',
+            enable_encryption=True,
+            encryption_key_source='reference',
+        )
+
+        assert service._get_or_create_encryption_key(spec) == CERTMGR_KEY
+        cephadm_module.cert_mgr.get_key.assert_called_once_with(
+            'nvmeof_encryption_key',
+            service_name='nvmeof.testpool.group1',
+        )
+        cephadm_module.cert_mgr.save_key.assert_not_called()
+        cephadm_module.cert_mgr.generate_private_key.assert_not_called()
+
+    def test_nvmeof_get_or_create_encryption_key_reference_missing_fails(
+        self,
+        cephadm_module: CephadmOrchestrator,
+    ):
+        service = NvmeofService(cephadm_module)
+        cephadm_module.cert_mgr = MagicMock()
+        cephadm_module.cert_mgr.get_key.return_value = None
+
+        spec = NvmeofServiceSpec(
+            service_id='testpool.group1',
+            pool='testpool',
+            group='group1',
+            enable_encryption=True,
+            encryption_key_source='reference',
+        )
+
+        with pytest.raises(
+            OrchestratorError,
+            match="encryption_key_source is set to 'reference'",
+        ):
+            service._get_or_create_encryption_key(spec)
+
+        cephadm_module.cert_mgr.save_key.assert_not_called()
+        cephadm_module.cert_mgr.generate_private_key.assert_not_called()
 
 
 class TestNvmeofTLSBundle:

--- a/src/pybind/mgr/cephadm/tests/test_certmgr.py
+++ b/src/pybind/mgr/cephadm/tests/test_certmgr.py
@@ -1868,6 +1868,36 @@ class TestCertMgr(object):
         assert cm.get_cert('ingress_ssl_cert', service_name=svc) == 'ref-cert'
         assert cm.get_key('ingress_ssl_key', service_name=svc) == 'ref-key'
 
+    def test_register_key_object_registers_existing_key_store(self, cephadm_module: CephadmOrchestrator):
+        cert_mgr = cephadm_module.cert_mgr
+        cert_mgr.key_store = mock.MagicMock()
+
+        cert_mgr.register_key_object(
+            'nvmeof',
+            'nvmeof_encryption_key',
+            TLSObjectScope.SERVICE,
+        )
+
+        cert_mgr.key_store.register_object_name.assert_called_once_with(
+            'nvmeof_encryption_key',
+            TLSObjectScope.SERVICE,
+        )
+
+    def test_generate_private_key(self, cephadm_module: CephadmOrchestrator):
+        cephadm_module._init_cert_mgr()
+
+        key = cephadm_module.cert_mgr.generate_private_key(key_size=2048)
+
+        assert isinstance(key, str)
+        assert (
+            '-----BEGIN RSA PRIVATE KEY-----' in key
+            or '-----BEGIN PRIVATE KEY-----' in key
+        )
+        assert (
+            '-----END RSA PRIVATE KEY-----' in key
+            or '-----END PRIVATE KEY-----' in key
+        )
+
 
 class MockTLSObject(TLSObjectProtocol):
     STORAGE_PREFIX = "mocktls"

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1855,6 +1855,9 @@ class NvmeofServiceSpec(ServiceSpec):
                  port: Optional[int] = None,
                  pool: Optional[str] = None,
                  enable_auth: bool = False,
+                 enable_encryption: bool = False,
+                 encryption_key_source: Optional[str] = None,
+                 encryption_key_path: Optional[str] = None,
                  ssl: Optional[bool] = False,
                  certificate_source: Optional[str] = None,
                  custom_sans: Optional[List[str]] = None,
@@ -1986,6 +1989,12 @@ class NvmeofServiceSpec(ServiceSpec):
         self.group = group or ''
         #: ``enable_auth`` enables user authentication on nvmeof gateway
         self.enable_auth = enable_auth
+        #: ``enable_encryption`` enables NVMe-oF gateway encryption key configuration
+        self.enable_encryption = enable_encryption
+
+        self.encryption_key_source = encryption_key_source
+        self.encryption_key_path = encryption_key_path
+
         self.ssl = ssl or enable_auth  # to force enabling ssl field when auth is enabled
         #: ``state_update_notify`` enables automatic update from OMAP in nvmeof gateway
         self.state_update_notify = state_update_notify
@@ -2239,6 +2248,75 @@ class NvmeofServiceSpec(ServiceSpec):
             raise SpecValidationError('Cannot add NVMEOF: No Pool specified')
 
         verify_boolean(self.enable_auth, "Enable authentication")
+        verify_boolean(self.enable_encryption, "Enable encryption")
+
+        valid_encryption_key_sources = ['inline', 'reference', 'cephadm', 'source_file']
+
+        if self.encryption_key_source is not None:
+            if self.encryption_key_source not in valid_encryption_key_sources:
+                raise SpecValidationError(
+                    f'encryption_key_source must be one of {valid_encryption_key_sources}'
+                )
+
+        encryption_key_source = self.get_encryption_key_source()
+        legacy_inline = bool(self.encryption_key and self.encryption_key_source is None)
+
+        if encryption_key_source is None:
+            if self.encryption_key_path:
+                raise SpecValidationError(
+                    'encryption_key_path requires encryption_key_source=source_file'
+                )
+
+        elif legacy_inline:
+            # old specs with encryption_key and no source.
+            # Treated as implicit inline. No enable_encryption requirement.
+            if self.encryption_key_path:
+                raise SpecValidationError(
+                    'encryption_key_path cannot be set with legacy inline encryption_key'
+                )
+
+        else:
+            if not self.enable_encryption:
+                raise SpecValidationError(
+                    'encryption_key_source requires enable_encryption=true'
+                )
+
+            if encryption_key_source == 'inline':
+                if not self.encryption_key:
+                    raise SpecValidationError(
+                        'encryption_key_source=inline requires encryption_key'
+                    )
+                if self.encryption_key_path:
+                    raise SpecValidationError(
+                        'encryption_key_path cannot be set with encryption_key_source=inline'
+                    )
+
+            elif encryption_key_source in ['reference', 'cephadm']:
+                if self.encryption_key:
+                    raise SpecValidationError(
+                        f'encryption_key cannot be set with '
+                        f'encryption_key_source={encryption_key_source}'
+                    )
+                if self.encryption_key_path:
+                    raise SpecValidationError(
+                        f'encryption_key_path cannot be set with '
+                        f'encryption_key_source={encryption_key_source}'
+                    )
+
+            elif encryption_key_source == 'source_file':
+                if self.encryption_key:
+                    raise SpecValidationError(
+                        'encryption_key cannot be set with encryption_key_source=source_file'
+                    )
+                if not self.encryption_key_path:
+                    raise SpecValidationError(
+                        'encryption_key_source=source_file requires encryption_key_path'
+                    )
+                if not self.encryption_key_path.startswith('/'):
+                    raise SpecValidationError(
+                        'encryption_key_path must be an absolute container path'
+                    )
+
         if self.enable_auth or self.ssl:
             if self.certificate_source == CertificateSource.INLINE.value:
                 if not all([self.server_key, self.server_cert, self.client_key,
@@ -2348,6 +2426,15 @@ class NvmeofServiceSpec(ServiceSpec):
             raise SpecValidationError(
                 '"spdk_mem_size" and "spdk_huge_pages" are mutually exclusive'
                 )
+
+    def get_encryption_key_source(self) -> Optional[str]:
+        if self.encryption_key and not self.encryption_key_source:
+            return 'inline'
+
+        if self.enable_encryption and not self.encryption_key_source:
+            return 'cephadm'
+
+        return self.encryption_key_source
 
 
 yaml.add_representer(NvmeofServiceSpec, ServiceSpec.yaml_representer)


### PR DESCRIPTION
mgr/cephadm: support NVMe-oF encryption key sources

This PR updates NVMe-oF gateway encryption key handling so private key material no longer needs to be stored directly in the service spec.

Previously, users could provide the NVMe-oF gateway encryption key through the encryption_key field. That key could then be exposed through spec/export paths such as:

`ceph orch ls --export nvmeof`

This change introduces explicit encryption key source handling, allowing the key to be managed by cephadm/certmgr, referenced from certmgr, or provided through an externally mounted file path.

**New spec fields**

```
spec:
  enable_encryption: true
  encryption_key_source: cephadm | reference | source_file | inline
  encryption_key_path: /path/inside/container/encryption.key
```

Field roles
`enable_encryption : Enables NVMe-oF gateway encryption-key configuration.`

`encryption_key_source: Defines where the encryption key comes from.`

```
encryption_key_path
  Used only with encryption_key_source: source_file.
  This is the path inside the container where the externally managed key is available.
```

Testing logs:

External Key file used with the spec:

```
[root@ceph-node-0 ~]#  mkdir -p /tmp/nvmeof-test-key
[root@ceph-node-0 ~]# openssl genrsa -out /tmp/nvmeof-test-key/encryption.key 2048
[root@ceph-node-0 ~]# chmod 0400 /tmp/nvmeof-test-key/encryption.key
```

```
[ceph: root@ceph-node-0 ~]# cat > /tmp/nvmeof-source-file.yaml <<'EOF'
service_type: nvmeof
service_id: nvmeof_pool01.group1
placement:
  hosts:
    - ceph-node-0
extra_container_args:
  - --volume=/tmp/nvmeof-test-key:/etc/nvmeof/tls:ro
spec:
  pool: nvmeof_pool01
  group: group1
  enable_encryption: true
  encryption_key_source: source_file
  encryption_key_path: /etc/nvmeof/tls/encryption.key
EOF

ceph orch apply -i /tmp/nvmeof-source-file.yaml
Scheduled nvmeof.nvmeof_pool01.group1 update...

```
```

[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                         PORTS                   RUNNING  REFRESHED  AGE  PLACEMENT    
crash                                                    3/3  8m ago     38m  *            
mgr                                                      2/2  7m ago     38m  count:2      
mon                                                      3/5  8m ago     39m  count:5      
nvmeof.nvmeof_pool01.group1  ?:4420,5500,8009,10008      1/1  7s ago     19s  ceph-node-0  
osd.all-available-devices                                  3  8m ago     38m  *   

[ceph: root@ceph-node-0 ~]# ceph orch ls --export nvmeof
service_type: nvmeof
service_id: nvmeof_pool01.group1
service_name: nvmeof.nvmeof_pool01.group1
placement:
  hosts:
  - ceph-node-0
extra_container_args:
- --volume=/tmp/nvmeof-test-key:/etc/nvmeof/tls:ro
spec:
  abort_discovery_on_errors: true
  abort_on_errors: true
  abort_on_update_error: true
  allowed_consecutive_spdk_ping_failures: 1
  break_update_interval_sec: 25
  cluster_connections: 32
  conn_retries: 10
  degrade_namespace_on_kmip_error: true
  discovery_bind_retries_limit: 10
  discovery_bind_sleep_interval: 0.5
  discovery_port: 8009
  enable_encryption: true
  enable_monitor_client: true
  enable_prometheus_exporter: true
  encryption_key_path: /etc/nvmeof/tls/encryption.key
  encryption_key_source: source_file
  group: group1
  io_stats_enabled: true
  kmip_cert_dir: ./certs/kmip/{server_name}
  log_directory: /var/log/ceph/
  log_files_enabled: true
  log_files_rotation_enabled: true
  log_level: INFO
  max_gws_in_grp: 16
  max_hosts: 2048
  max_hosts_per_namespace: 16
  max_hosts_per_subsystem: 128
  max_log_directory_backups: 10
  max_log_file_size_in_mb: 10
  max_log_files_count: 20
  max_message_length_in_mb: 4
  max_namespaces: 4096
  max_namespaces_per_subsystem: 512
  max_namespaces_with_netmask: 1000
  max_ns_to_change_lb_grp: 8
  max_subsystems: 128
  monitor_timeout: 1.0
  notifications_interval: 60
  omap_file_lock_duration: 40
  omap_file_lock_on_read: true
  omap_file_lock_retries: 30
  omap_file_lock_retry_sleep_interval: 1.0
  omap_file_update_attempts: 500
  omap_file_update_reloads: 10
  pool: nvmeof_pool01
  port: 5500
  prometheus_connection_list_cache_expiration: 60
  prometheus_cycles_to_adjust_speed: 3
  prometheus_frequency_slow_down_factor: 3.0
  prometheus_port: 10008
  prometheus_startup_delay: 240
  prometheus_stats_interval: 10
  rbd_with_crc32c: true
  rebalance_period_sec: 7
  rpc_socket_dir: /var/tmp/
  rpc_socket_name: spdk.sock
  spdk_path: /usr/local/bin/nvmf_tgt
  spdk_ping_interval_in_seconds: 2.0
  spdk_protocol_log_level: WARNING
  spdk_timeout: 60.0
  state_update_interval_sec: 5
  state_update_notify: true
  subsystem_cache_expiration: 30
  tgt_path: /usr/local/bin/nvmf_tgt
  transport_tcp_options:
    in_capsule_data_size: 8192
    max_io_qpairs_per_ctrlr: 7
  transports: tcp
  verbose_log_messages: true
  verify_keys: true
  verify_listener_ip: true
  verify_nqns: true

```


```
[root@ceph-node-0 nvmeof.nvmeof_pool01.group1.ceph-node-0.zyaiwy]# grep -R "encryption.key\|nvmeof-test-key\|/etc/nvmeof/tls" unit.run config-json.json . 2>/dev/null
unit.run:/usr/bin/podman run --rm --ipc=host --stop-signal=SIGTERM --net=host --init --name ceph-fb0f4d9a-7b71-11f1-832c-525400f73baa-nvmeof-nvmeof_pool01-group1-ceph-node-0-zyaiwy --pids-limit=-1 --ulimit memlock=-1:-1 --ulimit nofile=10240 --cap-add=CAP_SYS_NICE --cap-add=SYS_ADMIN -d --log-driver journald --conmon-pidfile /run/ceph-fb0f4d9a-7b71-11f1-832c-525400f73baa@nvmeof.nvmeof_pool01.group1.ceph-node-0.zyaiwy.service-pid --cidfile /run/ceph-fb0f4d9a-7b71-11f1-832c-525400f73baa@nvmeof.nvmeof_pool01.group1.ceph-node-0.zyaiwy.service-cid --cgroups=split --volume=/tmp/nvmeof-test-key:/etc/nvmeof/tls:ro -e CONTAINER_IMAGE=quay.io/ceph/nvmeof:1.9 -e NODE_NAME=ceph-node-0 -v /var/lib/ceph/fb0f4d9a-7b71-11f1-832c-525400f73baa/nvmeof.nvmeof_pool01.group1.ceph-node-0.zyaiwy/config:/etc/ceph/ceph.conf:z -v /var/lib/ceph/fb0f4d9a-7b71-11f1-832c-525400f73baa/nvmeof.nvmeof_pool01.group1.ceph-node-0.zyaiwy/keyring:/etc/ceph/keyring:z -v /var/lib/ceph/fb0f4d9a-7b71-11f1-832c-525400f73baa/nvmeof.nvmeof_pool01.group1.ceph-node-0.zyaiwy/ceph-nvmeof.conf:/src/ceph-nvmeof.conf:z -v /var/lib/ceph/fb0f4d9a-7b71-11f1-832c-525400f73baa/nvmeof.nvmeof_pool01.group1.ceph-node-0.zyaiwy/configfs:/sys/kernel/config -v /var/log/ceph/fb0f4d9a-7b71-11f1-832c-525400f73baa:/var/log/ceph:z -v /dev/hugepages:/dev/hugepages -v /dev/vfio/vfio:/dev/vfio/vfio -v /etc/hosts:/etc/hosts:ro --mount type=bind,source=/lib/modules,destination=/lib/modules,ro=true quay.io/ceph/nvmeof:1.9
./ceph-nvmeof.conf:encryption_key = /etc/nvmeof/tls/encryption.key
./unit.meta:        "--volume=/tmp/nvmeof-test-key:/etc/nvmeof/tls:ro"

./unit.run:/usr/bin/podman run --rm --ipc=host --stop-signal=SIGTERM --net=host --init --name ceph-fb0f4d9a-7b71-11f1-832c-525400f73baa-nvmeof-nvmeof_pool01-group1-ceph-node-0-zyaiwy --pids-limit=-1 --ulimit memlock=-1:-1 --ulimit nofile=10240 --cap-add=CAP_SYS_NICE --cap-add=SYS_ADMIN -d --log-driver journald --conmon-pidfile /run/ceph-fb0f4d9a-7b71-11f1-832c-525400f73baa@nvmeof.nvmeof_pool01.group1.ceph-node-0.zyaiwy.service-pid --cidfile /run/ceph-fb0f4d9a-7b71-11f1-832c-525400f73baa@nvmeof.nvmeof_pool01.group1.ceph-node-0.zyaiwy.service-cid --cgroups=split --volume=/tmp/nvmeof-test-key:/etc/nvmeof/tls:ro -e CONTAINER_IMAGE=quay.io/ceph/nvmeof:1.9 -e NODE_NAME=ceph-node-0 -v /var/lib/ceph/fb0f4d9a-7b71-11f1-832c-525400f73baa/nvmeof.nvmeof_pool01.group1.ceph-node-0.zyaiwy/config:/etc/ceph/ceph.conf:z -v /var/lib/ceph/fb0f4d9a-7b71-11f1-832c-525400f73baa/nvmeof.nvmeof_pool01.group1.ceph-node-0.zyaiwy/keyring:/etc/ceph/keyring:z -v /var/lib/ceph/fb0f4d9a-7b71-11f1-832c-525400f73baa/nvmeof.nvmeof_pool01.group1.ceph-node-0.zyaiwy/ceph-nvmeof.conf:/src/ceph-nvmeof.conf:z -v /var/lib/ceph/fb0f4d9a-7b71-11f1-832c-525400f73baa/nvmeof.nvmeof_pool01.group1.ceph-node-0.zyaiwy/configfs:/sys/kernel/config -v /var/log/ceph/fb0f4d9a-7b71-11f1-832c-525400f73baa:/var/log/ceph:z -v /dev/hugepages:/dev/hugepages -v /dev/vfio/vfio:/dev/vfio/vfio -v /etc/hosts:/etc/hosts:ro --mount type=bind,source=/lib/modules,destination=/lib/modules,ro=true quay.io/ceph/nvmeof:1.9
[root@ceph-node-0 nvmeof.nvmeof_pool01.group1.ceph-node-0.zyaiwy]# cephadm shell
Inferring fsid fb0f4d9a-7b71-11f1-832c-525400f73baa
```

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
