### PR TITLE
rbd-mirror: take MirrorStatusUpdater lock by value in queue_update_task

### DIFF
--- a/src/tools/rbd_mirror/MirrorStatusUpdater.cc
+++ b/src/tools/rbd_mirror/MirrorStatusUpdater.cc
@@ -277,7 +277,7 @@ void MirrorStatusUpdater<I>::handle_timer_task(int r) {
 
 template <typename I>
 void MirrorStatusUpdater<I>::queue_update_task(
-  std::unique_lock<ceph::mutex>&& locker) {
+  std::unique_lock<ceph::mutex> locker) {
   if (!m_initialized) {
     return;
   }

--- a/src/tools/rbd_mirror/MirrorStatusUpdater.h
+++ b/src/tools/rbd_mirror/MirrorStatusUpdater.h
@@ -105,7 +105,7 @@ private:
   void schedule_timer_task();
   void handle_timer_task(int r);
 
-  void queue_update_task(std::unique_lock<ceph::mutex>&& locker);
+  void queue_update_task(std::unique_lock<ceph::mutex> locker);
   void update_task(int r);
   void handle_update_task(int r);
 


### PR DESCRIPTION
`queue_update_task()` took `locker` by rvalue reference, so its early
returns never released the lock. In `handle_update_task()` that left
`m_lock` held across the `on_finish->complete()` calls; during shutdown a
completion can re-enter `try_remove_mirror_image_status()` and re-lock
`m_lock`, deadlocking.

Fixes: https://tracker.ceph.com/issues/78047

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
