### PR TITLE
mgr/nvmeof: change pool application to nvmeof-meta instead of rbd

### DIFF
--- a/src/pybind/mgr/nvmeof/module.py
+++ b/src/pybind/mgr/nvmeof/module.py
@@ -3,7 +3,6 @@ from typing import Any
 
 from .cli import NVMeoFCLICommand
 from mgr_module import MgrModule
-import rbd
 
 logger = logging.getLogger(__name__)
 
@@ -30,31 +29,21 @@ class NVMeoF(MgrModule):
             self.create_pool(pool_name)
             logger.info(f"Pool '{pool_name}' created.")
         except Exception:
-            logger.error(f"Error creating pool '{pool_name}", exc_info=True)
+            logger.error(f"Error creating pool '{pool_name}'", exc_info=True)
             raise
 
-    def _enable_rbd_application(self, pool_name: str) -> None:
+    def _enable_application(self, pool_name: str, application_name: str) -> None:
         try:
-            self.appify_pool(pool_name, 'rbd')
-            logger.info(f"'rbd' application enabled on pool '{pool_name}'.")
+            self.appify_pool(pool_name, application_name)
+            logger.info(f"'{application_name}' application enabled on pool '{pool_name}'.")
         except Exception:
             logger.error(
-                f"Failed to enable 'rbd' application on '{pool_name}'",
+                f"Failed to enable '{application_name}' application on '{pool_name}'",
                 exc_info=True
             )
-            raise
-
-    def _rbd_pool_init(self, pool_name: str) -> None:
-        try:
-            with self.rados.open_ioctx(pool_name) as ioctx:
-                rbd.RBD().pool_init(ioctx, False)
-            logger.info(f"RBD pool_init completed on '{pool_name}'.")
-        except Exception:
-            logger.error(f"Failed to initialize RBD pool '{pool_name}'", exc_info=True)
             raise
 
     def create_pool_if_not_exists(self) -> None:
         if not self._pool_exists(POOL_NAME):
             self._create_pool(POOL_NAME)
-        self._enable_rbd_application(POOL_NAME)
-        self._rbd_pool_init(POOL_NAME)
+            self._enable_application(POOL_NAME, 'nvmeof-meta')

--- a/src/pybind/mgr/nvmeof/tests/test_nvmeof_module.py
+++ b/src/pybind/mgr/nvmeof/tests/test_nvmeof_module.py
@@ -1,5 +1,3 @@
-
-from contextlib import contextmanager
 from unittest.mock import MagicMock
 
 import nvmeof.module as nvmeof_mod
@@ -8,21 +6,9 @@ import nvmeof.module as nvmeof_mod
 class FakeRados:
     def __init__(self, exists: bool):
         self._exists = exists
-        self.opened_pools = []
 
     def pool_exists(self, pool_name: str) -> bool:
         return self._exists
-
-    @contextmanager
-    def open_ioctx(self, pool_name: str):
-        self.opened_pools.append(pool_name)
-        yield object()
-
-
-def patch_rbd_pool_init(monkeypatch):
-    rbd_instance = MagicMock()
-    monkeypatch.setattr(nvmeof_mod.rbd, "RBD", lambda: rbd_instance)
-    return rbd_instance
 
 
 def make_mgr(mon_handler, exists: bool, monkeypatch):
@@ -37,49 +23,61 @@ def make_mgr(mon_handler, exists: bool, monkeypatch):
     def _pool_exists(self, pool_name: str) -> bool:
         return self._fake_rados.pool_exists(pool_name)
 
-    def _rbd_pool_init(self, pool_name: str):
-        with self._fake_rados.open_ioctx(pool_name) as ioctx:
-            nvmeof_mod.rbd.RBD().pool_init(ioctx, False)
-
     monkeypatch.setattr(nvmeof_mod.NVMeoF, "_pool_exists", _pool_exists, raising=True)
-    monkeypatch.setattr(nvmeof_mod.NVMeoF, "_rbd_pool_init", _rbd_pool_init, raising=True)
 
     return mgr
 
 
-def test_pool_exists_skips_create_calls_enable_and_pool_init(monkeypatch):
+def test_pool_exists_skips_pool_creation(monkeypatch):
     calls = []
 
     def mon_command(cmd, inbuf):
         calls.append(cmd)
         return 0, "", ""
 
-    rbd_instance = patch_rbd_pool_init(monkeypatch)
     mgr = make_mgr(mon_command, exists=True, monkeypatch=monkeypatch)
 
     mgr.create_pool_if_not_exists()
 
     assert not any(c.get("prefix") == "osd pool create" for c in calls)
-    assert any(c.get("prefix") == "osd pool application enable" for c in calls)
 
-    assert mgr._fake_rados.opened_pools == [".nvmeof"]
-    rbd_instance.pool_init.assert_called_once()
+    assert not any(c.get("prefix") == "osd pool application enable" for c in calls)
 
 
-def test_pool_missing_creates_then_enables_then_pool_init(monkeypatch):
+def test_pool_missing_creates_then_enables(monkeypatch):
     calls = []
 
     def mon_command(cmd, inbuf):
         calls.append(cmd)
         return 0, "", ""
 
-    rbd_instance = patch_rbd_pool_init(monkeypatch)
     mgr = make_mgr(mon_command, exists=False, monkeypatch=monkeypatch)
 
     mgr.create_pool_if_not_exists()
 
-    assert any(c.get("prefix") == "osd pool create" for c in calls)
-    assert any(c.get("prefix") == "osd pool application enable" for c in calls)
+    create_calls = [c for c in calls if c.get("prefix") == "osd pool create"]
+    assert len(create_calls) == 1, "Expected one pool create call"
 
-    assert mgr._fake_rados.opened_pools == [".nvmeof"]
-    rbd_instance.pool_init.assert_called_once()
+    assert create_calls[0].get("pool") == ".nvmeof", "Expected pool_name to be '.nvmeof'"
+
+    app_enable_calls = [c for c in calls if c.get("prefix") == "osd pool application enable"]
+    assert len(app_enable_calls) == 1, "Expected one application enable call"
+
+    assert app_enable_calls[0].get("app") == "nvmeof-meta", "Expected 'nvmeof-meta' application to be enabled"
+    assert app_enable_calls[0].get("pool") == ".nvmeof", "Expected pool to be '.nvmeof'"
+
+
+def test_enable_application_with_custom_app_name(monkeypatch):
+    calls = []
+
+    def mon_command(cmd, inbuf):
+        calls.append(cmd)
+        return 0, "", ""
+
+    mgr = make_mgr(mon_command, exists=True, monkeypatch=monkeypatch)
+
+    mgr._enable_application("test-pool", "custom-app")
+
+    custom_enable_calls = [c for c in calls if c.get("prefix") == "osd pool application enable" and c.get("app") == "custom-app"]
+    assert len(custom_enable_calls) == 1, "Expected one 'custom-app' application enable call"
+    assert custom_enable_calls[0].get("pool") == "test-pool"


### PR DESCRIPTION
add application `nvmeof-meta` to `.nvmeof` pool on pool creation.

```
[x@xxx ~]# ceph osd pool application get .nvmeof
{
    "nvmeof-meta": {},
    "rbd": {}
}
```

fixes: https://tracker.ceph.com/issues/77694
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
