### PR TITLE
crimson/os/seastore: add OOL write sub-phase latency histograms

### DIFF
--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -66,10 +66,13 @@ SegmentedOolWriter::write_record(
     extent_addr = extent_addr.as_seg_paddr().add_offset(
         extent->get_length());
   }
+  const auto io_start = seastar::lowres_clock::now();
   return std::move(ret.future
   ).safe_then([this, FNAME, &t,
-               record_base=ret.record_base_regardless_md
-              ](record_locator_t ret) {
+               record_base=ret.record_base_regardless_md,
+               io_start](record_locator_t ret) {
+    t.get_phase_durations().ool_write_seg_delayed_io +=
+      seastar::lowres_clock::now() - io_start;
     TRACET("{} finish {}=={}",
            t, segment_allocator.get_name(), ret, record_base);
     // ool won't write metadata, so the paddrs must be equal
@@ -88,9 +91,12 @@ SegmentedOolWriter::do_write(
     DEBUGT("{} extents={} wait ...",
            t, segment_allocator.get_name(),
            extents.size());
+    const auto wait_start = seastar::lowres_clock::now();
     return trans_intr::make_interruptible(
       record_submitter.wait_available()
-    ).si_then([this, &t, &extents] {
+    ).si_then([this, &t, &extents, wait_start] {
+      t.get_phase_durations().ool_write_seg_delayed_wait +=
+        seastar::lowres_clock::now() - wait_start;
       return do_write(t, extents);
     });
   }
@@ -119,9 +125,12 @@ SegmentedOolWriter::do_write(
             t, std::move(record), std::move(pending_extents),
             true/* with_atomic_roll_segment */);
       }
+      const auto roll_start = seastar::lowres_clock::now();
       return trans_intr::make_interruptible(
         record_submitter.roll_segment(
-        ).safe_then([fut_write=std::move(fut_write)]() mutable {
+        ).safe_then([fut_write=std::move(fut_write), &t, roll_start]() mutable {
+          t.get_phase_durations().ool_write_seg_delayed_roll +=
+            seastar::lowres_clock::now() - roll_start;
           return std::move(fut_write);
         })
       ).si_then([this, &t, &extents] {
@@ -1205,6 +1214,7 @@ RandomBlockOolWriter::do_write(
     }
   }
 
+  const auto io_start = seastar::lowres_clock::now();
   return trans_intr::make_interruptible(
     seastar::do_with(std::move(writes),
       [&t, this](auto& writes) {
@@ -1222,7 +1232,10 @@ RandomBlockOolWriter::do_write(
         );
       });
     })
-  );
+  ).si_then([&t, io_start] {
+    t.get_phase_durations().ool_write_rbm_io +=
+      seastar::lowres_clock::now() - io_start;
+  });
 }
 
 }

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -221,6 +221,18 @@ void SeaStore::Shard::register_metrics(store_index_t store_index)
     {txn_stage_t::SUBMIT_TOTAL,          sm::label_instance("stage", "submit_total")},
     {txn_stage_t::SUBMIT_RESERVE,        sm::label_instance("stage", "submit_reserve")},
     {txn_stage_t::SUBMIT_OOL_WRITE,      sm::label_instance("stage", "submit_ool_write")},
+    {txn_stage_t::SUBMIT_OOL_WRITE_SEG_DELAYED,
+     sm::label_instance("stage", "submit_ool_write_seg_delayed")},
+    {txn_stage_t::SUBMIT_OOL_WRITE_SEG_DELAYED_WAIT,
+     sm::label_instance("stage", "submit_ool_write_seg_delayed_wait")},
+    {txn_stage_t::SUBMIT_OOL_WRITE_SEG_DELAYED_ROLL,
+     sm::label_instance("stage", "submit_ool_write_seg_delayed_roll")},
+    {txn_stage_t::SUBMIT_OOL_WRITE_SEG_DELAYED_IO,
+     sm::label_instance("stage", "submit_ool_write_seg_delayed_io")},
+    {txn_stage_t::SUBMIT_OOL_WRITE_RBM,
+     sm::label_instance("stage", "submit_ool_write_rbm")},
+    {txn_stage_t::SUBMIT_OOL_WRITE_RBM_IO,
+     sm::label_instance("stage", "submit_ool_write_rbm_io")},
     {txn_stage_t::SUBMIT_LBA_UPDATE,     sm::label_instance("stage", "submit_lba_update")},
     {txn_stage_t::SUBMIT_PREPARE_ENTER,  sm::label_instance("stage", "submit_prepare_enter")},
     {txn_stage_t::SUBMIT_PREPARE_RECORD, sm::label_instance("stage", "submit_prepare_record")},
@@ -1778,6 +1790,18 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
     auto& pd = ctx.transaction->get_phase_durations();
     add_stage_latency_sample(txn_stage_t::SUBMIT_RESERVE, pd.reserve);
     add_stage_latency_sample(txn_stage_t::SUBMIT_OOL_WRITE, pd.ool_write);
+    add_stage_latency_sample(txn_stage_t::SUBMIT_OOL_WRITE_SEG_DELAYED,
+                             pd.ool_write_seg_delayed);
+    add_stage_latency_sample(txn_stage_t::SUBMIT_OOL_WRITE_SEG_DELAYED_WAIT,
+                             pd.ool_write_seg_delayed_wait);
+    add_stage_latency_sample(txn_stage_t::SUBMIT_OOL_WRITE_SEG_DELAYED_ROLL,
+                             pd.ool_write_seg_delayed_roll);
+    add_stage_latency_sample(txn_stage_t::SUBMIT_OOL_WRITE_SEG_DELAYED_IO,
+                             pd.ool_write_seg_delayed_io);
+    add_stage_latency_sample(txn_stage_t::SUBMIT_OOL_WRITE_RBM,
+                             pd.ool_write_rbm);
+    add_stage_latency_sample(txn_stage_t::SUBMIT_OOL_WRITE_RBM_IO,
+                             pd.ool_write_rbm_io);
     add_stage_latency_sample(txn_stage_t::SUBMIT_LBA_UPDATE, pd.lba_update);
     add_stage_latency_sample(txn_stage_t::SUBMIT_PREPARE_ENTER, pd.prepare_enter);
     add_stage_latency_sample(txn_stage_t::SUBMIT_PREPARE_RECORD, pd.prepare_record);

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -56,6 +56,14 @@ enum class txn_stage_t : uint8_t {
     // Sub-phases of submit_transaction:
     SUBMIT_RESERVE,        // enter(reserve_projected_usage) + epm reserve_projected_usage
     SUBMIT_OOL_WRITE,      // write_delayed + write_preallocated OOL extents (device I/O)
+    // SegmentedOolWriter (segmented device backend):
+    SUBMIT_OOL_WRITE_SEG_DELAYED,      // write_delayed_ool_extents
+    SUBMIT_OOL_WRITE_SEG_DELAYED_WAIT, // RecordSubmitter::wait_available
+    SUBMIT_OOL_WRITE_SEG_DELAYED_ROLL, // RecordSubmitter::roll_segment
+    SUBMIT_OOL_WRITE_SEG_DELAYED_IO,   // SegmentedOolWriter::write_record futures
+    // RandomBlockOolWriter (RBM backend):
+    SUBMIT_OOL_WRITE_RBM,              // write_preallocated_ool_extents
+    SUBMIT_OOL_WRITE_RBM_IO,           // RandomBlockOolWriter::do_write futures
     SUBMIT_LBA_UPDATE,     // update_lba_mappings
     SUBMIT_PREPARE_ENTER,  // enter(prepare) pipeline stage (global OrderedExclusive wait)
     SUBMIT_PREPARE_RECORD, // prepare_record (record encoding)

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -7,6 +7,7 @@
 #include <iostream>
 
 #include <boost/intrusive/list.hpp>
+#include <seastar/core/lowres_clock.hh>
 
 #include "crimson/common/log.h"
 #include "crimson/os/seastore/backref_entry.h"
@@ -475,6 +476,14 @@ public:
   struct phase_durations_t {
     std::chrono::steady_clock::duration reserve{0};         // enter reserve + epm reserve
     std::chrono::steady_clock::duration ool_write{0};       // delayed + preallocated OOL writes
+    // Segmented backend (SegmentedOolWriter) — nested under ool_write:
+    seastar::lowres_clock::duration ool_write_seg_delayed{0};      // write_delayed_ool_extents
+    seastar::lowres_clock::duration ool_write_seg_delayed_wait{0}; // RecordSubmitter::wait_available
+    seastar::lowres_clock::duration ool_write_seg_delayed_roll{0}; // RecordSubmitter::roll_segment
+    seastar::lowres_clock::duration ool_write_seg_delayed_io{0};   // write_record futures
+    // Random-block backend (RandomBlockOolWriter) — nested under ool_write:
+    seastar::lowres_clock::duration ool_write_rbm{0};    // write_preallocated_ool_extents
+    seastar::lowres_clock::duration ool_write_rbm_io{0}; // RBM::write device futures
     std::chrono::steady_clock::duration lba_update{0};      // update_lba_mappings
     std::chrono::steady_clock::duration prepare_enter{0};   // enter(prepare) pipeline stage
     std::chrono::steady_clock::duration prepare_record{0};  // prepare_record

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -606,12 +606,15 @@ TransactionManager::do_submit_transaction(
   );
 
   SUBTRACET(seastore_t, "write delayed ool extents", tref);
-  auto ool_start = std::chrono::steady_clock::now();
+  auto ool_start = seastar::lowres_clock::now();
   co_await epm->write_delayed_ool_extents(
     tref, dispatch_result.alloc_map
   );
-  tref.get_phase_durations().ool_write +=
-    std::chrono::steady_clock::now() - ool_start;
+  {
+    const auto elapsed = seastar::lowres_clock::now() - ool_start;
+    tref.get_phase_durations().ool_write += elapsed;
+    tref.get_phase_durations().ool_write_seg_delayed += elapsed;
+  }
 
   auto allocated_extents = tref.get_valid_pre_alloc_list();
   auto lba_start = std::chrono::steady_clock::now();
@@ -621,10 +624,13 @@ TransactionManager::do_submit_transaction(
 
   auto num_extents = allocated_extents.size();
   SUBTRACET(seastore_t, "process {} allocated extents", tref, num_extents);
-  ool_start = std::chrono::steady_clock::now();
+  ool_start = seastar::lowres_clock::now();
   co_await epm->write_preallocated_ool_extents(tref, allocated_extents);
-  tref.get_phase_durations().ool_write +=
-    std::chrono::steady_clock::now() - ool_start;
+  {
+    const auto elapsed = seastar::lowres_clock::now() - ool_start;
+    tref.get_phase_durations().ool_write += elapsed;
+    tref.get_phase_durations().ool_write_rbm += elapsed;
+  }
 
   SUBTRACET(seastore_t, "entering prepare", tref);
   auto prepare_enter_start = std::chrono::steady_clock::now();


### PR DESCRIPTION
Instrument segmented and random-block OOL writers to break down submit_ool_write into wait, roll, and device-I/O sub-phases, and export them via seastore_do_transaction_stage_lat for investigation purposes.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
