### PR TITLE
rgw/cls: Make cmpomap workable for atomic updates with different values

### DIFF
--- a/src/cls/cmpomap/client.cc
+++ b/src/cls/cmpomap/client.cc
@@ -18,7 +18,7 @@
 
 namespace cls::cmpomap {
 
-int cmp_vals(librados::ObjectReadOperation& op,
+int cmp_vals(librados::ObjectOperation& op,
              Mode mode, Op comparison, ComparisonMap values,
              std::optional<ceph::bufferlist> default_value)
 {

--- a/src/cls/cmpomap/client.h
+++ b/src/cls/cmpomap/client.h
@@ -28,7 +28,7 @@ static constexpr uint32_t max_keys = 1000;
 /// comparisons with Mode::U64, failure to decode an input value is reported
 /// as -EINVAL, an empty stored value is compared as 0, and failure to decode
 /// a stored value is reported as -EIO
-[[nodiscard]] int cmp_vals(librados::ObjectReadOperation& op,
+[[nodiscard]] int cmp_vals(librados::ObjectOperation& op,
                            Mode mode, Op comparison, ComparisonMap values,
                            std::optional<ceph::bufferlist> default_value);
 
@@ -38,6 +38,16 @@ static constexpr uint32_t max_keys = 1000;
 /// to decode an input value is reported as -EINVAL. an empty stored value is
 /// compared as 0, while decode failure of a stored value is treated as an
 /// unsuccessful comparison and is not reported as an error
+///
+/// NOTE: This function cannot be used to set different values when Op::EQ
+/// is used. To accomplish this, one may utilize the transactional operation
+/// with librados::ObjectWriteOperation in combination of cmp_vals(). For example,
+///
+///   librados::ObjectWriteOperation op;
+///   // cmp_vals() fails the operation with ECANCELED if any comparison fails
+///   cls::cmpomap::cmp_vals(op, mode, comparison, cmp_values, std::nullopt);
+///   // write new values on success
+///   op.omap_set(set_values);
 [[nodiscard]] int cmp_set_vals(librados::ObjectWriteOperation& writeop,
                                Mode mode, Op comparison, ComparisonMap values,
                                std::optional<ceph::bufferlist> default_value);

--- a/src/cls/cmpomap/client.h
+++ b/src/cls/cmpomap/client.h
@@ -41,10 +41,10 @@ static constexpr uint32_t max_keys = 1000;
 ///
 /// NOTE: This function cannot be used to set different values when Op::EQ
 /// is used. To accomplish this, one may utilize the transactional operation
-/// with librados::ObjectWriteOperation in combination of cmp_vals(). For example,
+/// with librados::ObjectWriteOperation in combination with cmp_vals(). For example,
 ///
 ///   librados::ObjectWriteOperation op;
-///   // cmp_vals() fails the operation with ECANCELED if any comparison fails
+///   // cmp_vals() fails the operation with -ECANCELED if any comparison fails
 ///   cls::cmpomap::cmp_vals(op, mode, comparison, cmp_values, std::nullopt);
 ///   // write new values on success
 ///   op.omap_set(set_values);

--- a/src/cls/cmpomap/client.h
+++ b/src/cls/cmpomap/client.h
@@ -41,10 +41,10 @@ static constexpr uint32_t max_keys = 1000;
 ///
 /// NOTE: This function cannot be used to set different values when Op::EQ
 /// is used. To accomplish this, one may utilize the transactional operation
-/// with librados::ObjectWriteOperation in combination with cmp_vals(). For example,
+/// with librados::ObjectWriteOperation in combination of cmp_vals(). For example,
 ///
 ///   librados::ObjectWriteOperation op;
-///   // cmp_vals() fails the operation with -ECANCELED if any comparison fails
+///   // cmp_vals() fails the operation with ECANCELED if any comparison fails
 ///   cls::cmpomap::cmp_vals(op, mode, comparison, cmp_values, std::nullopt);
 ///   // write new values on success
 ///   op.omap_set(set_values);

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -1,6 +1,12 @@
 add_library(crimson::cflags INTERFACE IMPORTED)
 set(crimson_cflag_definitions "WITH_CRIMSON=1")
 
+option(WITH_CRIMSON_DETAILED_SAMPLING
+  "Enable detailed onode-tree sampling metrics in crimson-seastore" OFF)
+if(WITH_CRIMSON_DETAILED_SAMPLING)
+  list(APPEND crimson_cflag_definitions "CRIMSON_DETAILED_SAMPLING=1")
+endif()
+
 set_target_properties(crimson::cflags PROPERTIES
   INTERFACE_COMPILE_DEFINITIONS "${crimson_cflag_definitions}"
   INTERFACE_LINK_LIBRARIES Seastar::seastar)

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -321,6 +321,9 @@ level_t Node::level() const
 eagain_ifuture<Node::search_result_t> Node::lower_bound(
     context_t c, const key_hobj_t& key)
 {
+#ifdef CRIMSON_DETAILED_SAMPLING
+  ++c.t.get_onode_tree_stats().lookup_count;
+#endif
   return seastar::do_with(
     MatchHistory(), [this, c, &key](auto& history) {
       return lower_bound_tracked(c, key, history);
@@ -334,6 +337,9 @@ eagain_ifuture<std::pair<Ref<tree_cursor_t>, bool>> Node::insert(
     value_config_t vconf,
     Ref<Node>&& this_ref)
 {
+#ifdef CRIMSON_DETAILED_SAMPLING
+  ++c.t.get_onode_tree_stats().lookup_count;
+#endif
   return seastar::do_with(
     MatchHistory(), [this, c, &key, vconf,
                      this_ref = std::move(this_ref)] (auto& history) mutable {
@@ -1267,7 +1273,15 @@ eagain_ifuture<Node::search_result_t>
 InternalNode::lower_bound_tracked(
     context_t c, const key_hobj_t& key, MatchHistory& history)
 {
+#ifdef CRIMSON_DETAILED_SAMPLING
+  auto& tstats = c.t.get_onode_tree_stats();
+  ++tstats.nodes_visited;
+  auto cmp0 = key.ncmp_str;
   auto result = impl->lower_bound(key, history);
+  tstats.string_cmp_count += key.ncmp_str - cmp0;
+#else
+  auto result = impl->lower_bound(key, history);
+#endif
   return get_or_track_child(c, result.position, result.p_value->value
   ).si_then([c, &key, &history](auto child) {
     // XXX(multi-type): pass result.mstat to child
@@ -1956,7 +1970,15 @@ LeafNode::lower_bound_tracked(
     context_t c, const key_hobj_t& key, MatchHistory& history)
 {
   key_view_t index_key;
+#ifdef CRIMSON_DETAILED_SAMPLING
+  auto& tstats = c.t.get_onode_tree_stats();
+  ++tstats.nodes_visited;
+  auto cmp0 = key.ncmp_str;
   auto result = impl->lower_bound(key, history, &index_key);
+  tstats.string_cmp_count += key.ncmp_str - cmp0;
+#else
+  auto result = impl->lower_bound(key, history, &index_key);
+#endif
   Ref<tree_cursor_t> cursor;
   if (result.position.is_end()) {
     assert(!result.p_value);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
@@ -406,6 +406,10 @@ bool is_valid_key(const Key& key);
  */
 class key_hobj_t {
  public:
+  // number of ns/oid comparisons this query key participated in during lookup.
+  // Only incremented under CRIMSON_DETAILED_SAMPLING; otherwise stays zero.
+  mutable uint64_t ncmp_str = 0;
+
   explicit key_hobj_t(const ghobject_t& _ghobj) {
     if (_ghobj.is_max()) {
       ghobj = _MAX_OID();
@@ -920,6 +924,12 @@ auto operator<=>(const T& key, const shard_pool_crush_t& target) {
 
 template <IsFullKey T>
 auto operator<=>(const T& key, const ns_oid_view_t& target) {
+#ifdef CRIMSON_DETAILED_SAMPLING
+  // only key_hobj_t carries the counter
+  if constexpr (requires { key.ncmp_str; }) {
+    ++key.ncmp_str;
+  }
+#endif
   auto ret = key.nspace() <=> string_view_masked_t{target.nspace};
   if (ret != 0)
     return ret;

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -250,6 +250,54 @@ void SeaStore::Shard::register_metrics(store_index_t store_index)
   }
 
   metrics.add_group(
+    "onode_tree",
+    {
+      sm::make_counter(
+        "onode_lookups",
+        [this] { return stats.onode_lookups; },
+        sm::description("onode-tree find + insert search"),
+        {sm::label_instance("shard_store_index", std::to_string(store_index))}
+      ),
+      sm::make_counter(
+        "onode_lookup_nodes",
+        [this] { return stats.onode_lookup_nodes; },
+        sm::description("nodes searched across onode-tree"),
+        {sm::label_instance("shard_store_index", std::to_string(store_index))}
+      ),
+      sm::make_counter(
+        "onode_lookup_str_cmp_count",
+        [this] { return stats.onode_str_cmp_count; },
+        sm::description("ns/oid key comparisons during onode-tree ops"),
+        {sm::label_instance("shard_store_index", std::to_string(store_index))}
+      ),
+      sm::make_counter(
+        "onode_inserts",
+        [this] { return stats.onode_inserts; },
+        sm::description("onode-tree key inserts"),
+        {sm::label_instance("shard_store_index", std::to_string(store_index))}
+      ),
+      sm::make_counter(
+        "onode_updates",
+        [this] { return stats.onode_updates; },
+        sm::description("onode-tree value updates"),
+        {sm::label_instance("shard_store_index", std::to_string(store_index))}
+      ),
+      sm::make_counter(
+        "onode_erases",
+        [this] { return stats.onode_erases; },
+        sm::description("onode-tree key erases"),
+        {sm::label_instance("shard_store_index", std::to_string(store_index))}
+      ),
+      sm::make_gauge(
+        "onode_extents_delta",
+        [this] { return stats.onode_extents_delta; },
+        sm::description("net onode-tree extents added(+)/removed(-)"),
+        {sm::label_instance("shard_store_index", std::to_string(store_index))}
+      ),
+    }
+  );
+
+  metrics.add_group(
     "seastore",
     {
       sm::make_gauge(
@@ -1786,6 +1834,7 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
   add_latency_sample(
     op_type_t::DO_TRANSACTION,
     std::chrono::steady_clock::now() - ctx.begin_timestamp);
+  add_onode_tree_sample(ctx.transaction->get_onode_tree_stats());
 
   throttler.put();
 

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -465,7 +465,24 @@ public:
       std::array<seastar::metrics::histogram, LAT_MAX> op_lat;
       seastar::metrics::histogram conflict_replays;
       std::array<seastar::metrics::histogram, STAGE_MAX> stage_lat;
+      uint64_t onode_lookups = 0;      // tree lookups
+      uint64_t onode_lookup_nodes = 0; // nodes searched (~depth/lookup)
+      uint64_t onode_str_cmp_count = 0;// ns/oid memcmp calls
+      uint64_t onode_inserts = 0;
+      uint64_t onode_updates = 0;
+      uint64_t onode_erases = 0;
+      int64_t  onode_extents_delta = 0;
     } stats;
+
+    void add_onode_tree_sample(const Transaction::tree_stats_t& ts) {
+      stats.onode_lookups        += ts.lookup_count;
+      stats.onode_lookup_nodes   += ts.nodes_visited;
+      stats.onode_str_cmp_count  += ts.string_cmp_count;
+      stats.onode_inserts        += ts.num_inserts;
+      stats.onode_updates        += ts.num_updates;
+      stats.onode_erases         += ts.num_erases;
+      stats.onode_extents_delta  += ts.extents_num_delta;
+    }
 
     seastar::metrics::histogram& get_latency(
       op_type_t op_type) {

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -569,13 +569,19 @@ public:
     uint64_t num_erases = 0;
     uint64_t num_updates = 0;
     int64_t extents_num_delta = 0;
+    uint64_t lookup_count = 0;
+    uint64_t nodes_visited = 0;
+    uint64_t string_cmp_count = 0;
 
     bool is_clear() const {
       return (depth == 0 &&
               num_inserts == 0 &&
               num_erases == 0 &&
               num_updates == 0 &&
-	      extents_num_delta == 0);
+	      extents_num_delta == 0 &&
+              lookup_count == 0 &&
+              nodes_visited == 0 &&
+              string_cmp_count == 0);
     }
   };
   tree_stats_t& get_onode_tree_stats() {

--- a/src/test/cls_cmpomap/test_cls_cmpomap.cc
+++ b/src/test/cls_cmpomap/test_cls_cmpomap.cc
@@ -446,6 +446,55 @@ TEST_F(CmpOmap, cmp_set_vals_str)
   }
 }
 
+TEST_F(CmpOmap, atomic_omap_set_conditional_match)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  const bufferlist value1 = u64_buffer(1);
+  const bufferlist value2 = u64_buffer(42);
+  {
+    std::map<std::string, bufferlist> vals = {
+      {"eq", value1},
+    };
+    ASSERT_EQ(ioctx.omap_set(oid, vals), 0);
+  }
+
+  librados::ObjectWriteOperation op;
+  ASSERT_EQ(cmp_vals(op, Mode::U64, Op::EQ, {{"eq", value1}}, 0), 0);
+  op.omap_set({{"eq", value2}});
+  ASSERT_EQ(ioctx.operate(oid, &op), 0);
+  {
+    std::map<std::string, bufferlist> vals;
+    ASSERT_EQ(get_vals(oid, &vals), 0);
+    ASSERT_EQ(vals.size(), 1);
+    EXPECT_EQ(value2, vals["eq"]);
+  }
+}
+
+TEST_F(CmpOmap, atomic_omap_set_conditional_mismatch)
+{
+  const std::string oid = __PRETTY_FUNCTION__;
+  const bufferlist value1 = u64_buffer(1);
+  const bufferlist value2 = u64_buffer(2);
+  const bufferlist value3 = u64_buffer(42);
+  {
+    std::map<std::string, bufferlist> vals = {
+      {"eq", value1},
+    };
+    ASSERT_EQ(ioctx.omap_set(oid, vals), 0);
+  }
+
+  librados::ObjectWriteOperation op;
+  ASSERT_EQ(cmp_vals(op, Mode::U64, Op::EQ, {{"eq", value2}}, 0), 0);
+  op.omap_set({{"eq", value3}});
+  ASSERT_EQ(ioctx.operate(oid, &op), -ECANCELED);
+  {
+    std::map<std::string, bufferlist> vals;
+    ASSERT_EQ(get_vals(oid, &vals), 0);
+    ASSERT_EQ(vals.size(), 1);
+    EXPECT_EQ(value1, vals["eq"]); // Nothing is changed
+  }
+}
+
 TEST_F(CmpOmap, cmp_set_vals_u64)
 {
   const std::string oid = __PRETTY_FUNCTION__;

--- a/src/test/cls_cmpomap/test_cls_cmpomap.cc
+++ b/src/test/cls_cmpomap/test_cls_cmpomap.cc
@@ -459,7 +459,7 @@ TEST_F(CmpOmap, atomic_omap_set_conditional_match)
   }
 
   librados::ObjectWriteOperation op;
-  ASSERT_EQ(cmp_vals(op, Mode::U64, Op::EQ, {{"eq", value1}}, std::nullopt), 0);
+  ASSERT_EQ(cmp_vals(op, Mode::U64, Op::EQ, {{"eq", value1}}, 0), 0);
   op.omap_set({{"eq", value2}});
   ASSERT_EQ(ioctx.operate(oid, &op), 0);
   {
@@ -484,7 +484,11 @@ TEST_F(CmpOmap, atomic_omap_set_conditional_mismatch)
   }
 
   librados::ObjectWriteOperation op;
+<<<<<<< HEAD
   ASSERT_EQ(cmp_vals(op, Mode::U64, Op::EQ, {{"eq", value2}}, std::nullopt), 0);
+=======
+  ASSERT_EQ(cmp_vals(op, Mode::U64, Op::EQ, {{"eq", value2}}, 0), 0);
+>>>>>>> 30c6492240e (rgw/cls: Make cmpomap workable for atomic updates with different values)
   op.omap_set({{"eq", value3}});
   ASSERT_EQ(ioctx.operate(oid, &op), -ECANCELED);
   {

--- a/src/test/cls_cmpomap/test_cls_cmpomap.cc
+++ b/src/test/cls_cmpomap/test_cls_cmpomap.cc
@@ -459,7 +459,7 @@ TEST_F(CmpOmap, atomic_omap_set_conditional_match)
   }
 
   librados::ObjectWriteOperation op;
-  ASSERT_EQ(cmp_vals(op, Mode::U64, Op::EQ, {{"eq", value1}}, 0), 0);
+  ASSERT_EQ(cmp_vals(op, Mode::U64, Op::EQ, {{"eq", value1}}, std::nullopt), 0);
   op.omap_set({{"eq", value2}});
   ASSERT_EQ(ioctx.operate(oid, &op), 0);
   {
@@ -484,7 +484,7 @@ TEST_F(CmpOmap, atomic_omap_set_conditional_mismatch)
   }
 
   librados::ObjectWriteOperation op;
-  ASSERT_EQ(cmp_vals(op, Mode::U64, Op::EQ, {{"eq", value2}}, 0), 0);
+  ASSERT_EQ(cmp_vals(op, Mode::U64, Op::EQ, {{"eq", value2}}, std::nullopt), 0);
   op.omap_set({{"eq", value3}});
   ASSERT_EQ(ioctx.operate(oid, &op), -ECANCELED);
   {

--- a/src/test/cls_cmpomap/test_cls_cmpomap.cc
+++ b/src/test/cls_cmpomap/test_cls_cmpomap.cc
@@ -459,7 +459,7 @@ TEST_F(CmpOmap, atomic_omap_set_conditional_match)
   }
 
   librados::ObjectWriteOperation op;
-  ASSERT_EQ(cmp_vals(op, Mode::U64, Op::EQ, {{"eq", value1}}, 0), 0);
+  ASSERT_EQ(cmp_vals(op, Mode::U64, Op::EQ, {{"eq", value1}}, std::nullopt), 0);
   op.omap_set({{"eq", value2}});
   ASSERT_EQ(ioctx.operate(oid, &op), 0);
   {
@@ -484,11 +484,7 @@ TEST_F(CmpOmap, atomic_omap_set_conditional_mismatch)
   }
 
   librados::ObjectWriteOperation op;
-<<<<<<< HEAD
   ASSERT_EQ(cmp_vals(op, Mode::U64, Op::EQ, {{"eq", value2}}, std::nullopt), 0);
-=======
-  ASSERT_EQ(cmp_vals(op, Mode::U64, Op::EQ, {{"eq", value2}}, 0), 0);
->>>>>>> 30c6492240e (rgw/cls: Make cmpomap workable for atomic updates with different values)
   op.omap_set({{"eq", value3}});
   ASSERT_EQ(ioctx.operate(oid, &op), -ECANCELED);
   {


### PR DESCRIPTION
1. Make cmp_vals() to take in ObjectOperation to allow it work with ObjectWriteOperation.

2. Add comments for cmp_set_vals() regarding how different omap values may be set.

3. Add unit tests to verify the transactional nature of ObjectWriteOperation used when setting different omap values.

Fixes: https://tracker.ceph.com/issues/76622

Reported-by: Yixin Jin <yjin77@yahoo.ca>
Signed-off-by: Yixin Jin <yjin77@yahoo.ca>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
