### PR TITLE
mgr/dashboard: add validation for username

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
@@ -20,6 +20,8 @@
         <cds-text-label
           labelInputID="username"
           cdRequiredField="Username"
+          helperText="Username can only contain letters, numbers, '.', '_', '@', '+' or '-'."
+          i18n-helperText
           [invalid]="!userForm.controls.username.valid && userForm.controls.username.dirty"
           [invalidText]="usernameError"
           i18n
@@ -43,6 +45,12 @@
           </span>
           <span *ngIf="userForm.showError('username', formDir, 'notUnique')">
             <ng-container i18n> The username already exists. </ng-container>
+          </span>
+          <span
+            *ngIf="userForm.showError('username', formDir, 'pattern')"
+            i18n
+          >
+            Username can only contain letters, numbers, '.', '_', '&#64;', '+' or '-'.
           </span>
         </ng-template>
       </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
@@ -103,6 +103,12 @@ describe('UserFormComponent', () => {
       formHelper.expectValidChange('username', 'user1');
     });
 
+    it('should reject invalid usernames', () => {
+      formHelper.expectErrorChange('username', '..', 'pattern');
+      formHelper.expectErrorChange('username', '??', 'pattern');
+      formHelper.expectErrorChange('username', 'user/name', 'pattern');
+    });
+
     it('should validate password match', () => {
       formHelper.setValue('password', 'aaa');
       formHelper.expectErrorChange('confirmpassword', 'bbb', 'match');

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
@@ -29,6 +29,8 @@ import { UserFormMode } from './user-form-mode.enum';
 import { UserFormRoleModel } from './user-form-role.model';
 import { UserFormModel } from './user-form.model';
 
+const DASHBOARD_USERNAME_PATTERN = /^(?!\.+$)[a-zA-Z0-9._@+-]+$/;
+
 @Component({
   selector: 'cd-user-form',
   templateUrl: './user-form.component.html',
@@ -88,7 +90,7 @@ export class UserFormComponent extends CdForm implements OnInit {
       {
         username: [
           '',
-          [Validators.required],
+          [Validators.required, Validators.pattern(DASHBOARD_USERNAME_PATTERN)],
           [CdValidators.unique(this.userService.validateUserName, this.userService)]
         ],
         name: [''],

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.ts
@@ -69,7 +69,8 @@ export class UserListComponent implements OnInit {
       permission: 'update',
       icon: Icons.edit,
       routerLink: () =>
-        this.selection.first() && this.urlBuilder.getEdit(this.selection.first().username),
+        this.selection.first() &&
+        this.urlBuilder.getEdit(encodeURIComponent(this.selection.first().username)),
       name: this.actionLabels.EDIT
     };
     const deleteAction: CdTableAction = {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/user.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/user.service.spec.ts
@@ -46,6 +46,12 @@ describe('UserService', () => {
     expect(req.request.method).toBe('DELETE');
   });
 
+  it('should URL-encode username on delete', () => {
+    service.delete('??').subscribe();
+    const req = httpTesting.expectOne('api/user/%3F%3F');
+    expect(req.request.method).toBe('DELETE');
+  });
+
   it('should call update', () => {
     const user = new UserFormModel();
     user.username = 'user0';
@@ -62,6 +68,12 @@ describe('UserService', () => {
   it('should call get', () => {
     service.get('user0').subscribe();
     const req = httpTesting.expectOne('api/user/user0');
+    expect(req.request.method).toBe('GET');
+  });
+
+  it('should URL-encode username on get', () => {
+    service.get('??').subscribe();
+    const req = httpTesting.expectOne('api/user/%3F%3F');
     expect(req.request.method).toBe('GET');
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/user.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/user.service.ts
@@ -17,7 +17,7 @@ export class UserService {
   }
 
   delete(username: string) {
-    return this.http.delete(`api/user/${username}`);
+    return this.http.delete(`api/user/${encodeURIComponent(username)}`);
   }
 
   get(username: string) {
@@ -29,14 +29,14 @@ export class UserService {
   }
 
   update(user: UserFormModel) {
-    return this.http.put(`api/user/${user.username}`, user);
+    return this.http.put(`api/user/${encodeURIComponent(user.username)}`, user);
   }
 
   changePassword(username: string, oldPassword: string, newPassword: string) {
     // Note, the specified user MUST be logged in to be able to change
     // the password. The backend ensures that the password of another
     // user can not be changed, otherwise an error will be thrown.
-    return this.http.post(`api/user/${username}/change_password`, {
+    return this.http.post(`api/user/${encodeURIComponent(username)}/change_password`, {
       old_password: oldPassword,
       new_password: newPassword
     });


### PR DESCRIPTION

mgr/dashboard: add validation for username

Fix : https://tracker.ceph.com/issues/78077

Signed-off-by: Sagar Gopale <sagar.gopale@ibm.com>

PR Description :   
This PR resolves a bug where creating dashboard users with special characters (like `..` or `??`) caused 404 errors and page crashes during edit and delete operations. It introduces strict frontend validation to ensure new usernames only contain safe characters, preventing the issue from occurring. Additionally, it safely handles any pre-existing invalid usernames by properly encoding them so they can still be successfully managed or deleted without breaking the UI.



Screencast : 
[Screencast From 2026-07-09 12-41-58.webm](https://github.com/user-attachments/assets/e1c3b614-49e2-485a-ad0b-33b9612048ea)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
