### PR TITLE
os/bluestore,osd: add speculative onode prefetcher

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -520,6 +520,13 @@
 
 * NFS: cluster/export delete commands now throw a deprecation warning when
        used and will be removed in V release. 
+* BlueStore/OSD: A new option `bluestore_onode_prefetch` (default: false)
+  speculatively loads an object's onode into the BlueStore cache as soon as the
+  corresponding OSD operation is queued. This hides the onode lookup latency behind
+  the queuing time, so the write path avoids a blocking RocksDB read on a cold-cache
+  miss. A companion option `bluestore_onode_prefetch_max_queue_depth` (default: 64)
+  bounds the number of in-flight prefetch requests; prefetch hints beyond this depth
+  are dropped.
 
 >=19.2.1
 

--- a/doc/rados/configuration/bluestore-config-ref.rst
+++ b/doc/rados/configuration/bluestore-config-ref.rst
@@ -379,6 +379,18 @@ Throttling
 .. confval:: bluestore_throttle_cost_per_io_hdd
 .. confval:: bluestore_throttle_cost_per_io_ssd
 
+Onode Prefetch
+==============
+
+BlueStore can speculatively load an object's onode into its cache as soon as the
+corresponding OSD operation is queued, hiding the onode-lookup latency behind the
+operation's queuing time. This can reduce write latency for workloads that
+overwrite objects whose onodes have fallen out of the cache. The feature is
+disabled by default.
+
+.. confval:: bluestore_onode_prefetch
+.. confval:: bluestore_onode_prefetch_max_queue_depth
+
 SPDK Usage
 ==========
 

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -7054,6 +7054,24 @@ options:
   - bluestore_extent_map_shard_target_size
   - bluestore_debug_onode_segmentation_random
   with_legacy: false
+- name: bluestore_onode_prefetch
+  type: bool
+  level: advanced
+  desc: Speculatively prefetch onodes into cache when operations are enqueued.
+  long_desc: When enabled, BlueStore fetches an onode into its cache as soon as the
+    corresponding OSD operation enters the PG work queue. This hides the onode lookup
+    latency behind the queuing time.
+  default: false
+  with_legacy: false
+- name: bluestore_onode_prefetch_max_queue_depth
+  type: uint
+  level: dev
+  desc: Maximum number of pending onode prefetch requests.
+  long_desc: Caps the depth of the BlueStore onode prefetch queue. When full,
+    new prefetch hints are silently dropped. Tune higher under deep queues
+    or high object-count workloads.
+  default: 64
+  with_legacy: false
 - name: bluestore_debug_onode_segmentation_random
   type: bool
   level: dev

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -624,6 +624,13 @@ public:
 		       std::map<std::string,ceph::buffer::ptr, std::less<>>& aset) = 0;
 
   /**
+   * prefetch_onode -- advisory hint to warm the onode cache for an object.
+   */
+  virtual void prefetch_onode(CollectionHandle& c, const ghobject_t& oid) {}
+  virtual bool prefetch_onode_enabled() const { return false; }
+
+
+  /**
    * getattrs -- get all of the xattrs of an object
    *
    * @param cid collection for object

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5908,6 +5908,7 @@ std::vector<std::string> BlueStore::get_tracked_keys() const noexcept
     "bluestore_warn_on_no_per_pg_omap"s,
     "bluestore_max_defer_interval"s,
     "bluestore_onode_segment_size"s,
+    "bluestore_onode_prefetch"s,
     "bluestore_allocator_lookup_policy"s,
     "bluestore_volume_selection_reserved_factor"s,
     "bluestore_volume_selection_reserved"s,
@@ -5944,6 +5945,10 @@ void BlueStore::handle_conf_change(const ConfigProxy& conf,
   if (changed.count("bluestore_onode_segment_size")) {
     segment_size = (cct->_conf.get_val<Option::size_t>("bluestore_onode_segment_size"));
   }
+  if (changed.count("bluestore_onode_prefetch")) {
+    m_onode_prefetch_enabled = cct->_conf.get_val<bool>("bluestore_onode_prefetch");
+  }
+
   if (changed.count("bluestore_max_blob_size") ||
       changed.count("bluestore_max_blob_size_ssd") ||
       changed.count("bluestore_max_blob_size_hdd")) {
@@ -6565,6 +6570,16 @@ void BlueStore::_init_logger()
   b.add_u64_counter(l_bluestore_onode_misses, "onode_misses",
 		    "Count of onode cache lookup misses",
 		    "o_ms", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_u64_counter(l_bluestore_onode_prefetch_processed, "onode_prefetch_processed",
+		    "Prefetch requests popped from the queue by the prefetch thread");
+  b.add_u64_counter(l_bluestore_onode_prefetch_hits, "onode_prefetch_hits",
+		    "Prefetch requests skipped: onode already cached");
+  b.add_u64_counter(l_bluestore_onode_prefetch_misses, "onode_prefetch_misses",
+		    "Prefetch requests that warmed a cold onode");
+  b.add_u64_counter(l_bluestore_onode_prefetch_enoent, "onode_prefetch_enoent",
+		    "Prefetch requests where no onode existed on disk");
+        b.add_u64_counter(l_bluestore_onode_prefetch_error, "onode_prefetch_error",
+		    "Prefetch requests that failed with an error");
   b.add_u64_counter(l_bluestore_onode_shard_hits, "onode_shard_hits",
 		    "Count of onode shard cache lookups hits");
   b.add_u64_counter(l_bluestore_onode_shard_misses,
@@ -9636,6 +9651,7 @@ int BlueStore::_mount()
     use_write_v2 = rand() % 2;
   }
   segment_size = (cct->_conf.get_val<Option::size_t>("bluestore_onode_segment_size"));
+  m_onode_prefetch_enabled = cct->_conf.get_val<bool>("bluestore_onode_prefetch");  
   if (cct->_conf.get_val<bool>("bluestore_debug_onode_segmentation_random")) {
     srand(time(NULL) * 13 + 5);
     if (rand() % 2) {
@@ -15318,6 +15334,7 @@ void BlueStore::_kv_start()
   finisher.start();
   kv_sync_thread.create("bstore_kv_sync");
   kv_finalize_thread.create("bstore_kv_final");
+  onode_prefetch_thread = std::thread(&BlueStore::_onode_prefetch_thread, this);
 }
 
 void BlueStore::_kv_stop()
@@ -15339,6 +15356,18 @@ void BlueStore::_kv_stop()
     kv_finalize_stop = true;
     kv_finalize_cond.notify_all();
   }
+  {
+    std::lock_guard l(prefetch_lock);
+    prefetch_stop = true;
+    prefetch_cond.notify_all();
+  }
+  if (onode_prefetch_thread.joinable())
+    onode_prefetch_thread.join();
+  {
+    std::lock_guard l(prefetch_lock);
+    prefetch_stop = false;
+    prefetch_queue.clear();
+  }
   kv_sync_thread.join();
   kv_finalize_thread.join();
   ceph_assert(removed_collections.empty());
@@ -15354,6 +15383,82 @@ void BlueStore::_kv_stop()
   finisher.wait_for_empty();
   finisher.stop();
   dout(10) << __func__ << " stopped" << dendl;
+}
+
+void BlueStore::prefetch_onode(CollectionHandle& ch, const ghobject_t& oid)
+{
+  Collection *c = static_cast<Collection*>(ch.get());
+  if (!c->exists)
+    return;
+  // Quick cache check under cache lock — skip if already hot
+  if (c->onode_space.lookup(oid))
+    return;
+  std::lock_guard l(prefetch_lock);
+  if (prefetch_stop ||
+      prefetch_queue.size() >=
+        cct->_conf.get_val<uint64_t>("bluestore_onode_prefetch_max_queue_depth"))
+    return;
+  prefetch_queue.push_back({CollectionRef(c), oid});
+  prefetch_cond.notify_one();
+}
+
+void BlueStore::_onode_prefetch_thread()
+{
+  ceph_pthread_setname("onode_prefetch");
+  dout(10) << __func__ << " start" << dendl;
+  std::unique_lock l(prefetch_lock);
+  while (true) {
+    if (prefetch_queue.empty()) {
+      if (prefetch_stop)
+        break;
+      prefetch_cond.wait(l);
+      continue;
+    }
+    PrefetchItem item = std::move(prefetch_queue.front());
+    prefetch_queue.pop_front();
+    l.unlock();
+    logger->inc(l_bluestore_onode_prefetch_processed);
+    if (item.c->exists) {
+      // Fast cache check — OnodeSpace has its own internal lock; no c->lock needed.
+      if (item.c->onode_space.lookup(item.oid)) {
+        logger->inc(l_bluestore_onode_prefetch_hits);
+      } else {
+        // Read from RocksDB without holding c->lock.  The slow I/O no longer
+        // blocks write ops that need an exclusive lock on the same collection.
+        // Non-existent onodes (new-write workloads) return immediately here.
+        std::string key;
+        get_object_key(cct, item.oid, &key);
+        bufferlist v;
+        int r = db->get(PREFIX_OBJ, key.c_str(), key.size(), &v);
+        dout(20) << __func__ << " oid " << item.oid << " r " << r
+                 << " v.len " << v.length() << dendl;
+        if (r == 0 && v.length() > 0) {
+          // Onode exists on disk: decode and insert into cache.
+          std::shared_lock cl(item.c->lock);
+          if (item.c->exists && !item.c->onode_space.lookup(item.oid)) {
+            Onode *on = Onode::create_decode(
+              item.c.get(), item.oid, key, v, true, segment_size != 0);
+            OnodeRef o;
+            o.reset(on);
+            item.c->onode_space.add_onode(item.oid, o);
+            logger->inc(l_bluestore_onode_prefetch_misses);
+          } else {
+            logger->inc(l_bluestore_onode_prefetch_hits);
+          }
+        } else if (r == -ENOENT || (r == 0 && v.length() == 0)) {
+          // r == -ENOENT or empty value: no onode on disk for this oid.
+          logger->inc(l_bluestore_onode_prefetch_enoent);
+        } else {
+          // Unexpected error from rocksdb
+          dout(1) << __func__ << " unexpected db->get r=" << r
+            << " oid " << item.oid << dendl;
+          logger->inc(l_bluestore_onode_prefetch_error); 
+        }
+      }
+    }
+    l.lock();
+  }
+  dout(10) << __func__ << " stop" << dendl;
 }
 
 void BlueStore::_kv_sync_thread()

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -181,6 +181,11 @@ enum {
   l_bluestore_pinned_onodes,
   l_bluestore_onode_hits,
   l_bluestore_onode_misses,
+  l_bluestore_onode_prefetch_processed,
+  l_bluestore_onode_prefetch_hits,
+  l_bluestore_onode_prefetch_misses,
+  l_bluestore_onode_prefetch_enoent,
+  l_bluestore_onode_prefetch_error,
   l_bluestore_onode_shard_hits,
   l_bluestore_onode_shard_misses,
   l_bluestore_extents,
@@ -2484,6 +2489,17 @@ private:
   std::deque<DeferredBatch*> deferred_stable_to_finalize; ///< pending finalization
   bool kv_finalize_in_progress = false;
 
+  // onode prefetch
+  struct PrefetchItem {
+    CollectionRef c;
+    ghobject_t oid;
+  };
+  ceph::mutex prefetch_lock = ceph::make_mutex("BlueStore::prefetch_lock");
+  ceph::condition_variable prefetch_cond;
+  std::deque<PrefetchItem> prefetch_queue;
+  bool prefetch_stop = false;
+  std::thread onode_prefetch_thread;
+
   PerfCounters *logger = nullptr;
 
   std::list<CollectionRef> removed_collections;
@@ -2985,6 +3001,7 @@ private:
   void _kv_stop();
   void _kv_sync_thread();
   void _kv_finalize_thread();
+  void _onode_prefetch_thread();
 
   bluestore_deferred_op_t *_get_deferred_op(TransContext *txc, uint64_t len);
   void _deferred_queue(TransContext *txc);
@@ -3420,6 +3437,10 @@ public:
 
   int getattr(CollectionHandle &c, const ghobject_t& oid, const char *name,
 	      ceph::buffer::ptr& value) override;
+  void prefetch_onode(CollectionHandle& c, const ghobject_t& oid) override;
+  std::atomic<bool> m_onode_prefetch_enabled = {true};
+  bool prefetch_onode_enabled() const override { return m_onode_prefetch_enabled.load(std::memory_order_relaxed); }
+
 
   int getattrs(CollectionHandle &c, const ghobject_t& oid,
 	       std::map<std::string,ceph::buffer::ptr, std::less<>>& aset) override;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9954,6 +9954,22 @@ void OSD::enqueue_op(spg_t pg, OpRequestRef&& op, epoch_t epoch)
     });
 
   op->mark_queued_for_pg();
+  if (op->get_req()->get_type() == CEPH_MSG_OSD_OP &&
+    store->prefetch_onode_enabled()) {
+    auto m = static_cast<MOSDOp*>(op->get_nonconst_req());
+    // The object identity (oid name, pool, snap) lives in the message's
+    // deferred-decode tail; get_hobj() returns an empty hobject_t until
+    // finish_decode() runs (normally in do_op on the worker thread).  Decode
+    // here so the prefetch targets the real onode key.
+    if (m->finish_decode()) {
+      op->reset_desc();
+      m->clear_payload();
+    }
+    if (ObjectStore::CollectionHandle ch = store->open_collection(coll_t(pg)); ch) {
+      store->prefetch_onode(
+        ch, ghobject_t(m->get_hobj(), ghobject_t::NO_GEN, pg.shard));
+    }
+  }
   logger->tinc(l_osd_op_before_queue_op_lat, latency);
   if (PGRecoveryMsg::is_recovery_msg(op)) {
     op_shardedwq.queue(

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2378,10 +2378,12 @@ void PrimaryLogPG::do_op_impl(OpRequestRef op)
     osd->logger->inc(l_osd_replica_read_served);
   }
 
+  op->mark_event("find_onode_start");
   int r = find_object_context(
     oid, &obc, can_create,
     m->has_flag(CEPH_OSD_FLAG_MAP_SNAP_CLONE),
     &missing_oid);
+  op->mark_event("find_onode_end");
 
   // LIST_SNAPS needs the ssc too
   if (obc &&
@@ -4351,7 +4353,9 @@ void PrimaryLogPG::execute_ctx(OpContext *ctx)
   }
 
 
+  op->mark_event("prepare_transaction_start");
   int result = prepare_transaction(ctx);
+  op->mark_event("prepare_transaction_end");
 
   {
 #ifdef WITH_LTTNG
@@ -11726,6 +11730,7 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
     soid,
     ctx->log,
     ctx->at_version);
+  ctx->op->mark_event("issue_repop");
   pgbackend->submit_transaction(
     soid,
     ctx->delta_stats,

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -672,6 +672,7 @@ void ReplicatedBackend::submit_transaction(
   vector<ObjectStore::Transaction> tls;
   tls.push_back(std::move(op_t));
 
+  if (orig_op) orig_op->mark_event("queue_transactions");
   parent->queue_transactions(tls, op.op);
   if (at_version != eversion_t()) {
     parent->op_applied(at_version);


### PR DESCRIPTION
This PR adds an opt-in onode prefetcher: when an op is enqueued (OSD::enqueue_op), the target object id is queued to a background BlueStore thread that loads the onode into the cache, overlapping the lookup with the op's queue-dwell time.

* When `bluestore_onode_prefetch` is set to true, onode prefetcher will be turned on.
* `finish_decode()` is called at enqueue time to obtain the object id. 
* `bluestore_onode_prefetch_max_queue_depth ` defines the queue depth for prefetch queue. 

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
