### PR TITLE
crimson: add asok commands for seastar task profiling

### DIFF
--- a/src/crimson/admin/osd_admin.cc
+++ b/src/crimson/admin/osd_admin.cc
@@ -7,7 +7,9 @@
 
 #include <fmt/format.h>
 #include <seastar/core/do_with.hh>
+#include <seastar/core/fstream.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/task_profiler.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/scollectd_api.hh>
 
@@ -664,5 +666,59 @@ private:
 };
 template std::unique_ptr<AdminSocketHook>
 make_asok_hook<StoreShardNumsHook>(crimson::osd::ShardServices& shard_services);
+
+class TaskProfilerHook : public AdminSocketHook {
+public:
+  TaskProfilerHook() :
+    AdminSocketHook("task_profiler",
+                    "name=cmd,type=CephChoices,strings=start|stop "
+                    "name=sample_interval_ms,type=CephInt,range=1,req=false "
+                    "name=output_prefix,type=CephString,req=false",
+                    "start/stop profiling by collecting samples of task traces "
+                    "from the seastar scheduler. Sample interval can be given "
+                    "when starting, output_prefix is used when stopping, "
+                    "producing one file per shard")
+  {}
+  seastar::future<tell_result_t> call(const cmdmap_t& cmdmap,
+                                      std::string_view format,
+                                      ceph::bufferlist&& input) const final
+  {
+    LOG_PREFIX(AdminSocketHook::TaskProfilerHook);
+    DEBUG("");
+    int64_t sample_interval_ms = cmd_getval_or<int64_t>(cmdmap, "sample_interval_ms", 10);
+    if (sample_interval_ms <= 0) {
+      co_return tell_result_t(-EINVAL, "sample_interval_ms must be > 0");
+    }
+    std::string cmd, file_prefix;
+    cmd_getval(cmdmap, "cmd", cmd);
+    cmd_getval(cmdmap, "output_prefix", file_prefix);
+    if (file_prefix.empty())
+      file_prefix = "task_profiler";
+    auto interval = std::chrono::milliseconds(sample_interval_ms);
+    co_await crimson::invoke_on_all_seq([&cmd, &interval, &file_prefix] -> seastar::future<> {
+      if (cmd == "start") {
+        seastar::task_profiler::start(interval);
+      } else {
+        auto shard_id = seastar::this_shard_id();
+        auto raw_file_path = fmt::format("{}.{}.raw", file_prefix, shard_id);
+        auto norm_file_path = fmt::format("{}.{}.norm", file_prefix, shard_id);
+        auto flags = seastar::open_flags::create |
+          seastar::open_flags::truncate |
+          seastar::open_flags::wo;
+        seastar::file raw_file = co_await seastar::open_file_dma(raw_file_path, flags);
+        seastar::file norm_file = co_await seastar::open_file_dma(norm_file_path, flags);
+        seastar::output_stream<char> raw_stream = co_await seastar::make_file_output_stream(raw_file);
+        seastar::output_stream<char> norm_stream = co_await seastar::make_file_output_stream(norm_file);
+        co_await seastar::task_profiler::stop(raw_stream, norm_stream);
+        co_await raw_stream.flush();
+        co_await norm_stream.flush();
+        co_await raw_stream.close();
+        co_await norm_stream.close();
+      }
+    });
+    co_return tell_result_t();
+  }
+};
+template std::unique_ptr<AdminSocketHook> make_asok_hook<TaskProfilerHook>();
 
 } // namespace crimson::admin

--- a/src/crimson/admin/osd_admin.h
+++ b/src/crimson/admin/osd_admin.h
@@ -25,6 +25,7 @@ class DumpSlowestHistoricOpsHook;
 class DumpRecoveryReservationsHook;
 class DumpReactorBackendHook;
 class StoreShardNumsHook;
+class TaskProfilerHook;
 
 template<class Hook, class... Args>
 std::unique_ptr<AdminSocketHook> make_asok_hook(Args&&... args);

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -833,6 +833,8 @@ seastar::future<> OSD::start_asok_admin()
       make_asok_hook<DumpReactorBackendHook>());
     asok->register_command(
       make_asok_hook<StoreShardNumsHook>(get_shard_services()));
+    asok->register_command(
+      make_asok_hook<TaskProfilerHook>());
   });
 }
 


### PR DESCRIPTION
This tracks suspended coroutines and outputs files readable by flamegraph.pl

I'm not sure how useful this will be yet, it's more a proof-of-concept.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
