### PR TITLE
umbrella: qa/smoke/basic: add log-ignorelist entries for expected smoke test warnings

### DIFF
--- a/qa/suites/smoke/basic/tasks/test/libcephfs_interface_tests.yaml
+++ b/qa/suites/smoke/basic/tasks/test/libcephfs_interface_tests.yaml
@@ -11,6 +11,7 @@ tasks:
 - ceph:
     log-ignorelist:
       - \(POOL_APP_NOT_ENABLED\)
+      - \(FS_DEGRADED\)
 - ceph-fuse:
 - workunit:
     clients:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78067

---

backport of https://github.com/ceph/ceph/pull/69414
parent tracker: https://tracker.ceph.com/issues/77355

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh