### PR TITLE
rgw: obi

### DIFF
--- a/README.ordered-bucket-indexes.txt
+++ b/README.ordered-bucket-indexes.txt
@@ -1,0 +1,147 @@
+July 8, 2026
+
+RGW Ordered Bucket Indexes
+
+
+== Quick Start ==
+
+This is an EXPERIMENTAL FEATURE at this point in time. Do NOT use this
+branch for/on critical data. Even if you never try ordered bucket
+indexing, this branch is not considered safe for critical data. This
+branch is STRICTLY intended for early testing.
+
+Newly created buckets start with hashed bucket indexing.
+
+You can reshard a bucket from hashed to ordered bucket indexing with a
+command along the lines of:
+
+    radosgw-admin bucket reshard --bucket-index-type=ordered \
+        --bucket=<bucket> --num-shards=<shard-count> \
+        [--yes-i-really-mean-it] [--debug-rgw=20]
+
+And you can return to hashed indexing with a command along the lines of:
+
+    radosgw-admin bucket reshard --bucket-index-type=hashed \
+        --bucket=<bucket> --num-shards=<shard-count> \
+        [--yes-i-really-mean-it] [--debug-rgw=20]
+
+IMPORTANT: At this time you cannot reshard a bucket from ordered to
+ordered. That is currently being worked on. You can reshard a bucket
+from hashed to hashed, though.
+
+IMPORTANT: Do not use this branch with multisite.
+
+IMPORTANT: Some features have been disabled until they can be fully
+integratred with ordered bucket indexes.
+
+
+== To Do List ==
+
+* Allow ordered bucket index shards to be split manually.
+
+* Allow ordered bucket index shards to be operated on by dynamic
+  resharding.
+
+* Test/fix all functionality that's temporarily turned off.
+
+* Allow ordered bucket index shards to work with multisite.
+
+* Develop new scheme for versioned buckets that would allow us to
+  exceed 49,999 versions of a given object, which is the current
+  limitation with ordered bucket indexes.
+
+
+== Background ==
+
+The bucket indexes contains metadata about the RGW objects in a
+bucket. The data is stored in the OMAP of the index object(s). Since
+RADOS imposes a soft limit of 100,000 OMAP entries per RADOS object, the
+index for a bucket is generally spread across a set of RADOS objects
+referred, and each is referred to as a bucket index shard.
+
+In order to map RGW objects to a specific shard RGW has used a hashing
+mechanism where the name of the RGW object is run through a hashing
+function and we then do a modulo op with the number of shards to come
+up with a shard index. That means that RGW objects are not lexically
+ordered across shards.
+
+That creates challenges when listing a bucket with the entries
+lexically ordered as we must read batches of entries from all shards
+and sort within those batches, and move forward in each shard and so
+forth.
+
+With ordered bucket indexes, each shard contains a lexical slice of
+entry names. In other words, they contain a lexical range. This means
+that to provide a lexically ordered list of RGW objects, we simply
+access the shards sequentially.
+
+
+== Implementation Details ==
+
+In order to know which shard a given RGW object is mapped to, we use
+the OMAP of the bucket instance object. The keys are the "split
+points" that divide the lexical space into the shards.
+
+More specifically, an upper_bound operation is used to find the
+correct OMAP entry. So if the split point for shard N-1 is "pointer"
+and the split point for shard N is "retriever" then entries that are
+greater-than-or-equal to "pointer" and less-than "retriever" are
+stored on shard N.
+
+The final shard has a split point of the empty string (""), so we do
+not need to track the lexically highest entry.
+
+One important added detail -- the split points have a fixed prefix
+that acts as a namespace. In case any other future feature were to
+want to store OMAP entries in the bucket instance object, we need to
+keep the two uses separate, and we'll do that by giving each a unique
+prefix.
+
+For ordered bucket indexes the prefix is "obi1.". The first letters
+"obi" stand for "ordered bucket indexes". The "1" is there in case we
+need to update the scheme and acts as a version number. And the "."
+is used to separate the prefix (namespace) from the actual key.
+
+So returning to the example above, shard N-1 would have the key
+"obi1.pointer", shard N would have "obi1.retriever", and the final
+shard "obi1.".
+
+The values associated with those keys are:
+
+  struct rgw_ordered_bi_omap_value {
+    std::string split;
+    rgw::NestedIndex shard_ident;
+  };
+
+The split is repeated and the NestedIndex is used to generate the oid
+for the shard. With hashed bucket index shards, resharding was an
+operation that replaced all of the shards. But with ordered bucket
+index shards we have the option of splitting a shard into consecutive
+shards or joining consecutive shards into one shard. Because we need
+to potentially insert new shards between existing shards, we need a
+more flexible naming scheme. And that's what NestedIndex does. It's
+declared as:
+
+    using NestedIndex = std::vector<int32_t>;
+
+Each entry in the vector is a level. So if the vector contains {
+64009, 3, 2 } then the oid would be
+".dir.ed9ead10-97bb-46b8-9e40-526eba1e5faf.4179.1.ordered.1.64009.3.2".
+
+Let's focus on "ordered.2.64009.3.2". We "tag" ordered index shards
+with "ordered" (any reason not to? should it be shorter?). Then "2"
+represents a generation number. And "64009.3.2" is the index. If the
+next index is "64009.4" and we need two indexes in between we could
+have "64009.3.3" and "64009.3.4".
+
+Additionally each bucket index object contains the following in its
+data (not its OMAP).
+
+  struct rgw_ordered_bi_shard_data {
+    std::string split;
+    rgw::NestedIndex shard_ident;
+    rgw::NestedIndex prev_shard_ident;
+    rgw::NestedIndex next_shard_ident;
+  };
+
+This allows us to easily figure out what the neighboring shards are.

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -865,7 +865,23 @@ int rgw_bucket_init_index(cls_method_context_t hctx, bufferlist *in, bufferlist 
     return -EINVAL;
   }
 
+  auto in_iter = in->cbegin();
+  rgw::BucketIndexType index_type;
+  bufferlist index_type_data;
+  if (!in_iter.end()) {
+    try {
+      decode(index_type, in_iter);
+      decode(index_type_data, in_iter);
+    } catch (ceph::buffer::error& err) {
+      CLS_LOG(1,
+	      "ERROR: %s: failed to decode index_type or index_type_data", __func__);
+      return -EINVAL;
+    }
+  }
+
   rgw_bucket_dir dir;
+  dir.header.index_type = index_type;
+  dir.header.index_type_data = index_type_data;
 
   return write_bucket_header(hctx, &dir.header);
 }

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -21,6 +21,7 @@ using namespace cls::rgw;
 
 const string BucketIndexShardsManager::KEY_VALUE_SEPARATOR = "#";
 const string BucketIndexShardsManager::SHARDS_SEPARATOR = ",";
+const bufferlist cls_rgw_empty_buffer_list; // no data inside
 
 /**
  * This class represents the bucket index object operation callback context.
@@ -50,15 +51,25 @@ public:
   }
 };
 
-void cls_rgw_bucket_init_index(ObjectWriteOperation& o)
+void cls_rgw_bucket_init_index(ObjectWriteOperation& o,
+			       rgw::BucketIndexType type,
+			       const bufferlist& index_type_data)
 {
   bufferlist in;
+  encode(type, in);
+  encode(index_type_data, in);
+
   o.exec(method::bucket_init_index, in);
 }
 
-void cls_rgw_bucket_init_index2(ObjectWriteOperation& o)
+void cls_rgw_bucket_init_index2(ObjectWriteOperation& o,
+			       rgw::BucketIndexType type,
+			       const bufferlist& index_type_data)
 {
   bufferlist in;
+  encode(type, in);
+  encode(index_type_data, in);
+
   o.exec(method::bucket_init_index2, in);
 }
 

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -16,6 +16,9 @@
 #include "common/ceph_mutex.h"
 
 
+extern const bufferlist cls_rgw_empty_buffer_list;
+
+
 class RGWGetDirHeader_CB : public boost::intrusive_ref_counter<RGWGetDirHeader_CB> {
 public:
   virtual ~RGWGetDirHeader_CB() {}
@@ -126,8 +129,12 @@ public:
 };
 
 /* bucket index */
-void cls_rgw_bucket_init_index(librados::ObjectWriteOperation& o);
-void cls_rgw_bucket_init_index2(librados::ObjectWriteOperation& o);
+void cls_rgw_bucket_init_index(librados::ObjectWriteOperation& o,
+			       rgw::BucketIndexType type = rgw::BucketIndexType::Hashed,
+			       const bufferlist& index_type_data = cls_rgw_empty_buffer_list);
+void cls_rgw_bucket_init_index2(librados::ObjectWriteOperation& o,
+				rgw::BucketIndexType type = rgw::BucketIndexType::Hashed,
+				const bufferlist& index_type_data = cls_rgw_empty_buffer_list);
 
 void cls_rgw_bucket_set_tag_timeout(librados::ObjectWriteOperation& op,
                                     uint64_t timeout);

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -991,7 +991,7 @@ list<cls_rgw_lc_entry> cls_rgw_lc_entry::generate_test_instances()
   return o;
 }
 
-void cls_rgw_lc_obj_head::dump(Formatter *f) const 
+void cls_rgw_lc_obj_head::dump(Formatter *f) const
 {
   encode_json("start_date", start_date, f);
   encode_json("marker", marker, f);
@@ -1022,3 +1022,31 @@ std::ostream& operator<<(std::ostream& out, cls_rgw_reshard_status status) {
 
   return out;
 }
+
+void rgw_ordered_bi_omap_value::dump(Formatter *f) const
+{
+  encode_json("split", split, f);
+  encode_json("shard_ident", shard_ident, f);
+}
+
+std::list<rgw_ordered_bi_omap_value>
+rgw_ordered_bi_omap_value::generate_test_instances()
+{
+  return {};
+}
+
+void rgw_ordered_bi_shard_data::dump(Formatter *f) const
+{
+  encode_json("split", split, f);
+  encode_json("shard_ident", shard_ident, f);
+  encode_json("prev_shard_ident", prev_shard_ident, f);
+  encode_json("next_shard_ident", next_shard_ident, f);
+}
+
+std::list<rgw_ordered_bi_shard_data>
+rgw_ordered_bi_shard_data::generate_test_instances()
+{
+  return {};
+}
+
+

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -858,11 +858,16 @@ struct rgw_bucket_dir_header {
   bool syncstopped;
   uint32_t reshardlog_entries;
 
+  rgw::BucketIndexType index_type;
+  // contains any data a specific index type (e.g., ordered indices)
+  // needs
+  bufferlist index_type_data;
+
   rgw_bucket_dir_header() : tag_timeout(0), ver(0), master_ver(0), syncstopped(false),
                             reshardlog_entries(0) {}
 
   void encode(ceph::buffer::list &bl) const {
-    ENCODE_START(8, 2, bl);
+    ENCODE_START(9, 2, bl);
     encode(stats, bl);
     encode(tag_timeout, bl);
     encode(ver, bl);
@@ -871,10 +876,11 @@ struct rgw_bucket_dir_header {
     encode(new_instance, bl);
     encode(syncstopped,bl);
     encode(reshardlog_entries, bl);
+    encode(index_type_data, bl);
     ENCODE_FINISH(bl);
   }
   void decode(ceph::buffer::list::const_iterator &bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(8, 2, 2, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(9, 2, 2, bl);
     decode(stats, bl);
     if (struct_v > 2) {
       decode(tag_timeout, bl);
@@ -902,6 +908,11 @@ struct rgw_bucket_dir_header {
       decode(reshardlog_entries, bl);
     } else {
       reshardlog_entries = 0;
+    }
+    if (struct_v >= 9) {
+      decode(index_type_data, bl);
+    } else {
+      index_type_data.clear();
     }
     DECODE_FINISH(bl);
   }
@@ -1426,11 +1437,12 @@ struct cls_rgw_reshard_entry
   uint32_t old_num_shards {0};
   uint32_t new_num_shards {0};
   cls_rgw_reshard_initiator initiator {cls_rgw_reshard_initiator::Unknown};
+  std::optional<rgw::BucketIndexType> bucket_index_type;
 
   cls_rgw_reshard_entry() {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(3, 1, bl);
+    ENCODE_START(4, 1, bl);
     encode(time, bl);
     encode(tenant, bl);
     encode(bucket_name, bl);
@@ -1438,11 +1450,12 @@ struct cls_rgw_reshard_entry
     encode(old_num_shards, bl);
     encode(new_num_shards, bl);
     encode(initiator, bl);
+    encode(bucket_index_type, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(3, bl);
+    DECODE_START(4, bl);
     decode(time, bl);
     decode(tenant, bl);
     decode(bucket_name, bl);
@@ -1458,6 +1471,11 @@ struct cls_rgw_reshard_entry
     } else {
       initiator = cls_rgw_reshard_initiator::Unknown;
     }
+    if (struct_v >= 4) {
+      decode(bucket_index_type, bl);
+    } else {
+      bucket_index_type = std::nullopt;
+    }
     DECODE_FINISH(bl);
   }
 
@@ -1468,3 +1486,79 @@ struct cls_rgw_reshard_entry
   void get_key(std::string *key) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_reshard_entry)
+
+
+// the bucket instance object for a bucket using ordered bi shards has
+// omap entries where key is split and this is the value
+struct rgw_ordered_bi_omap_value {
+  std::string split; // entries in shard are less than the split
+  rgw::NestedIndex shard_ident;
+
+  rgw_ordered_bi_omap_value() {}
+
+  void encode(ceph::buffer::list& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(split, bl);
+    encode(shard_ident, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(ceph::buffer::list::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(split, bl);
+    decode(shard_ident, bl);
+    DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const;
+
+  friend std::ostream& operator<<(std::ostream& out, const rgw_ordered_bi_omap_value& v) {
+    return out << "rgw_ordered_bi_omap_value{ split=\"" << v.split <<
+      "\", shard_ident=" << v.shard_ident << " }";
+  }
+
+  static std::list<rgw_ordered_bi_omap_value> generate_test_instances();
+}; // rgw_ordered_bi_omap_value
+WRITE_CLASS_ENCODER(rgw_ordered_bi_omap_value);
+
+
+// this is what's contained in the data block in every orderd bucket
+// index shard
+struct rgw_ordered_bi_shard_data {
+  std::string split; // all entries are after the split
+  rgw::NestedIndex shard_ident;
+  rgw::NestedIndex prev_shard_ident;
+  rgw::NestedIndex next_shard_ident;
+
+  rgw_ordered_bi_shard_data() {}
+
+  void encode(ceph::buffer::list& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(split, bl);
+    encode(shard_ident, bl);
+    encode(prev_shard_ident, bl);
+    encode(next_shard_ident, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(ceph::buffer::list::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(split, bl);
+    decode(shard_ident, bl);
+    decode(prev_shard_ident, bl);
+    decode(next_shard_ident, bl);
+    DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const;
+
+  friend std::ostream& operator<<(std::ostream& out, const rgw_ordered_bi_shard_data& v) {
+    return out << "rgw_ordered_bi_shard_data{ split=\"" << v.split <<
+      "\", shard_ident=" << v.shard_ident <<
+      ", prev_shard_ident=" << v.prev_shard_ident <<
+      ", next_shard_ident=" << v.next_shard_ident << " }";
+  }
+
+  static std::list<rgw_ordered_bi_shard_data> generate_test_instances();
+}; // rgw_ordered_bi_shard_data
+WRITE_CLASS_ENCODER(rgw_ordered_bi_shard_data);

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2156,6 +2156,24 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_bucket_default_index
+  type: str
+  level: advanced
+  desc: Whether new buckets are created w/ "hashed" or "ordered" (currently experimental) indexes
+  long_desc: >-
+    Specifies the bucket indexing scheme when buckets are created. Can
+    be "hashed" and "ordered". They can be resharded between schemes
+    after they're created. WARNING: Ordered is currently in the
+    experimental phase of development.
+  fmt_desc: >-
+    Specifies the bucket indexing scheme when buckets are created. Can
+    be ``hashed`` and ``ordered``. They can be resharded between schemes
+    after they're created. **WARNING**: Ordered is currently in the
+    experimental phase of development.
+  default: hashed
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_relaxed_s3_bucket_names
   type: bool
   level: advanced

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -157,6 +157,7 @@ list(APPEND librgw_common_srcs
 if(WITH_RADOSGW_RADOS)
   list(APPEND librgw_common_srcs
           services/svc_bi_rados.cc
+          services/svc_bindexer_rados.cc
           services/svc_bilog_rados.cc
           services/svc_bucket.cc
           services/svc_bucket_sobj.cc

--- a/src/rgw/driver/rados/rgw_bl_rados.cc
+++ b/src/rgw/driver/rados/rgw_bl_rados.cc
@@ -379,7 +379,7 @@ private:
 
     librados::ObjectWriteOperation op;
     op.assert_exists();
-    rados::cls::lock::unlock(&op, m_lock_name, m_lock_cookie);
+    ::rados::cls::lock::unlock(&op, m_lock_name, m_lock_cookie);
     const auto ret = rgw_rados_operate(this, rados_ioctx, list_obj_name,
                                        std::move(op), yield);
     if (ret == -ENOENT) {
@@ -401,10 +401,10 @@ private:
                          optional_yield y) {
     {
       librados::ObjectWriteOperation op;
-      rados::cls::lock::assert_locked(&op, m_lock_name,
-                                      ClsLockType::EXCLUSIVE,
-                                      m_lock_cookie,
-                                      "" /*no tag*/);
+      ::rados::cls::lock::assert_locked(&op, m_lock_name,
+					ClsLockType::EXCLUSIVE,
+					m_lock_cookie,
+					"" /*no tag*/);
       op.remove();
       auto ret = rgw_rados_operate(this, rados_ioctx, commit_list_name, std::move(op), y);
       if (ret < 0 && ret != -ENOENT) {
@@ -476,10 +476,10 @@ private:
         constexpr auto max_chunk = 1024U;
         std::string start_after;
         bool more = true;
-        rados::cls::lock::assert_locked(&op, m_lock_name,
-                                        ClsLockType::EXCLUSIVE,
-                                        m_lock_cookie,
-                                        "" /*no tag*/);
+        ::rados::cls::lock::assert_locked(&op, m_lock_name,
+					  ClsLockType::EXCLUSIVE,
+					  m_lock_cookie,
+					  "" /*no tag*/);
         op.omap_get_vals2(start_after, max_chunk, &entries, &more, &rval);
         op.getxattr(TEMP_POOL_ATTR.c_str(), &pool_obl, &pool_rval);
         // check ownership and list entries in one batch
@@ -672,10 +672,10 @@ private:
                             << dendl;
         librados::ObjectWriteOperation op;
         op.assert_exists();
-        rados::cls::lock::lock(&op, m_lock_name, ClsLockType::EXCLUSIVE,
-                               m_lock_cookie, "" /*no tag*/,
-                               "" /*no description*/, m_failover_time,
-                               LOCK_FLAG_MAY_RENEW);
+        ::rados::cls::lock::lock(&op, m_lock_name, ClsLockType::EXCLUSIVE,
+				 m_lock_cookie, "" /*no tag*/,
+				 "" /*no description*/, m_failover_time,
+				 LOCK_FLAG_MAY_RENEW);
 
         ret = rgw_rados_operate(this, rados_ioctx, list_obj_name, std::move(op), yield);
         if (ret == -EBUSY) {

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -355,6 +355,10 @@ static int check_bad_index_multipart(rgw::sal::RadosStore* const rados_store,
 				     const int shard,
 				     optional_yield y)
 {
+#if 1
+  // OB: push ordered bucket indexes here
+  return 0;
+#else
   RGWRados* store = rados_store->getRados();
   RGWRados::BucketShard bs(store);
 
@@ -486,6 +490,7 @@ static int check_bad_index_multipart(rgw::sal::RadosStore* const rados_store,
   flusher.flush();
 
   return 0;
+#endif
 } // static ::check_bad_index_multipart
 #endif
 
@@ -516,13 +521,13 @@ int RGWBucket::check_bad_index_multipart(rgw::sal::RadosStore* const rados_store
   formatter->open_array_section("invalid_multipart_entries");
 
   const auto& index_layout = bucket_info.layout.current_index.layout;
-  if (index_layout.type != rgw::BucketIndexType::Normal) {
+  if (index_layout.type != rgw::BucketIndexType::Hashed) {
     ldpp_dout(dpp, 0) << "ERROR: cannot check bucket indices with layouts of type " <<
       current_layout_desc(bucket_info.layout) <<
       " for bad multipart entries" << dendl;
     return -EINVAL;
   }
-  const int num_shards = rgw::num_shards(index_layout.normal);
+  const int num_shards = rgw::num_shards(index_layout.specs);
   int next_shard = 0;
 
   boost::asio::io_context context;
@@ -566,7 +571,7 @@ int RGWBucket::check_bad_index_multipart(rgw::sal::RadosStore* const rados_store
 }
 #endif
 
-int RGWBucket::check_object_index(const DoutPrefixProvider *dpp, 
+int RGWBucket::check_object_index(const DoutPrefixProvider *dpp,
                                   RGWBucketAdminOpState& op_state,
                                   RGWFormatterFlusher& flusher,
                                   optional_yield y,
@@ -630,10 +635,14 @@ static int check_index_olh(rgw::sal::RadosStore* const rados_store,
                            const DoutPrefixProvider *dpp,
                            RGWBucketAdminOpState& op_state,
                            RGWFormatterFlusher& flusher,
-                           const int shard, 
+                           const int shard,
                            uint64_t* const count_out,
                            optional_yield y)
 {
+#if 1
+  // OBI: push ordered bucket indexes here
+  return 0;
+#else
   string marker = BI_OLH_ENTRY_NS_START;
   bool is_truncated = true;
   list<rgw_cls_bi_entry> entries;
@@ -647,7 +656,7 @@ static int check_index_olh(rgw::sal::RadosStore* const rados_store,
     ldpp_dout(dpp, -1) << "ERROR bs.init(bucket=" << bucket << "): " << cpp_strerror(-ret) << dendl;
     return ret;
   }
-  
+
   *count_out = 0;
   do {
     entries.clear();
@@ -709,6 +718,7 @@ static int check_index_olh(rgw::sal::RadosStore* const rados_store,
   } while (is_truncated);
   flusher.flush();
   return 0;
+#endif
 }
 #endif
 
@@ -735,26 +745,26 @@ int RGWBucket::check_index_olh(rgw::sal::RadosStore* const rados_store,
     ldpp_dout(dpp, 0) << "WARNING: this command is only applicable to versioned buckets" << dendl;
     return 0;
   }
-  
+
   Formatter* formatter = flusher.get_formatter();
   if (op_state.dump_keys) {
     formatter->open_array_section("");
   }
 
   const auto& index_layout = bucket_info.layout.current_index.layout;
-  if (index_layout.type != rgw::BucketIndexType::Normal) {
+  if (index_layout.type != rgw::BucketIndexType::Hashed) {
     ldpp_dout(dpp, 0) << "ERROR: cannot check bucket indices with layouts of type " <<
       current_layout_desc(bucket_info.layout) <<
       " for bad OLH entries" << dendl;
     return -EINVAL;
   }
-  const int max_shards = rgw::num_shards(index_layout.normal);
+  const int max_shards = rgw::num_shards(index_layout.specs);
   std::string verb = op_state.will_fix_index() ? "removed" : "found";
   uint64_t count_out = 0;
-  
+
   boost::asio::io_context context;
   int next_shard = 0;
-  
+
   const int max_aio = std::max(1, op_state.get_max_aio());
 
   for (int i=0; i<max_aio; i++) {
@@ -769,7 +779,7 @@ int RGWBucket::check_index_olh(rgw::sal::RadosStore* const rados_store,
         uint64_t shard_count;
         int r = ::check_index_olh(rados_store, &*bucket, dpp, op_state, flusher, shard, &shard_count, y);
         if (r < 0) {
-          ldpp_dout(dpp, -1) << "NOTICE: error processing shard " << shard << 
+          ldpp_dout(dpp, -1) << "NOTICE: error processing shard " << shard <<
             " check_index_olh(): " << r << dendl;
         }
         count_out += shard_count;
@@ -858,10 +868,14 @@ static int check_index_unlinked(rgw::sal::RadosStore* const rados_store,
                                 const DoutPrefixProvider *dpp,
                                 RGWBucketAdminOpState& op_state,
                                 RGWFormatterFlusher& flusher,
-                                const int shard, 
+                                const int shard,
                                 uint64_t* const count_out,
                                 optional_yield y)
 {
+#if 1
+  // OBI: push ordered bucket indexes here
+  return 0;
+#else
   string marker = BI_INSTANCE_ENTRY_NS_START;
   bool is_truncated = true;
   list<rgw_cls_bi_entry> entries;
@@ -878,7 +892,7 @@ static int check_index_unlinked(rgw::sal::RadosStore* const rados_store,
 
   ceph::real_clock::time_point now = ceph::real_clock::now();
   ceph::real_clock::time_point not_after = now - op_state.min_age;
-  
+
   *count_out = 0;
   do {
     entries.clear();
@@ -941,6 +955,7 @@ static int check_index_unlinked(rgw::sal::RadosStore* const rados_store,
   } while (is_truncated);
   flusher.flush();
   return 0;
+#endif
 }
 
 /**
@@ -957,7 +972,7 @@ int RGWBucket::check_index_unlinked(rgw::sal::RadosStore* const rados_store,
     ldpp_dout(dpp, 0) << "WARNING: this command is only applicable to versioned buckets" << dendl;
     return 0;
   }
-  
+
   Formatter* formatter = flusher.get_formatter();
   if (op_state.dump_keys) {
     formatter->open_array_section("");
@@ -966,7 +981,7 @@ int RGWBucket::check_index_unlinked(rgw::sal::RadosStore* const rados_store,
   const int max_shards = rgw::num_shards(bucket_info.layout.current_index);
   std::string verb = op_state.will_fix_index() ? "removed" : "found";
   uint64_t count_out = 0;
-  
+
   int max_aio = std::max(1, op_state.get_max_aio());
   int next_shard = 0;
   boost::asio::io_context context;
@@ -981,7 +996,7 @@ int RGWBucket::check_index_unlinked(rgw::sal::RadosStore* const rados_store,
         uint64_t shard_count = 0;
         int r = ::check_index_unlinked(rados_store, &*bucket, dpp, op_state, flusher, shard, &shard_count, yield);
         if (r < 0) {
-          ldpp_dout(dpp, -1) << "ERROR: error processing shard " << shard << 
+          ldpp_dout(dpp, -1) << "ERROR: error processing shard " << shard <<
             " check_index_unlinked(): " << r << dendl;
         }
         count_out += shard_count;
@@ -1453,17 +1468,17 @@ int RGWBucketAdminOp::check_index(rgw::sal::Driver* driver,
   }
 
   dump_index_check(existing_stats, calculated_stats, formatter);
-  
+
   formatter->close_section();
   flusher.flush();
 
   return 0;
-}
+} // RGWBucketAdminOp::check_index
 #endif
 
 int RGWBucketAdminOp::remove_bucket(rgw::sal::Driver* driver, const rgw::SiteConfig& site,
                                     RGWBucketAdminOpState& op_state,
-				    optional_yield y, const DoutPrefixProvider *dpp, 
+				    optional_yield y, const DoutPrefixProvider *dpp,
                                     bool bypass_gc, bool keep_index_consistent, bool forwarded_request)
 {
   std::unique_ptr<rgw::sal::Bucket> bucket;
@@ -1642,8 +1657,11 @@ static int bucket_stats(rgw::sal::Driver* driver, const rgw::SiteConfig& site,
   ::encode_json("explicit_placement", bucket->get_key().explicit_placement, formatter);
   formatter->dump_string("id", bucket->get_bucket_id());
   formatter->dump_string("marker", bucket->get_marker());
-  formatter->dump_stream("index_type") << index.layout.type;
-  formatter->dump_int("index_generation", index.gen);
+
+  formatter->dump_stream("index_type") << bucket_info.layout.current_index.layout.type;
+  formatter->dump_int("index_generation", bucket_info.layout.current_index.gen);
+  formatter->dump_int("num_shards",
+		      rgw::num_shards(bucket_info.layout.current_index.layout.specs));
   formatter->dump_string("reshard_status", to_string(bucket_info.layout.resharding));
   logrecord_ut.gmtime(formatter->dump_stream("judge_reshard_lock_time"));
   formatter->dump_bool("object_lock_enabled", bucket_info.obj_lock_enabled());
@@ -1683,7 +1701,7 @@ static int bucket_stats(rgw::sal::Driver* driver, const rgw::SiteConfig& site,
     bufferlist::const_iterator piter{&iter->second};
     try {
       tagset.decode(piter);
-      tagset.dump(formatter); 
+      tagset.dump(formatter);
     } catch (buffer::error& err) {
       cerr << "ERROR: caught buffer:error, couldn't decode TagSet" << std::endl;
     }
@@ -1766,7 +1784,7 @@ int RGWBucketAdminOp::limit_check(rgw::sal::Driver* driver,
 	  num_objects += s.second.num_objects;
 	}
 
-	const uint32_t num_shards = rgw::num_shards(index.layout.normal);
+	const uint32_t num_shards = rgw::num_shards(index.layout.specs);
 	uint64_t objs_per_shard =
 	  (num_shards) ? num_objects/num_shards : num_objects;
 	{
@@ -2995,7 +3013,11 @@ int RGWBucketInstanceMetadataHandler::put(std::string& entry, RGWMetadataObject*
   RGWBucketInfo* old_info = (old ? &old->info : nullptr);
   auto mtime = obj->get_mtime();
   ret = svc_bucket->store_bucket_instance_info(entry, bci.info, old_info, false,
-                                               mtime, &bci.attrs, y, dpp);
+                                               mtime,
+					       &bci.attrs,
+// OBI: is nullptr appropriate here?
+					       nullptr,
+					       y, dpp);
   if (ret < 0) {
     return ret;
   }
@@ -3005,31 +3027,54 @@ int RGWBucketInstanceMetadataHandler::put(std::string& entry, RGWMetadataObject*
 }
 #endif
 
-void init_default_bucket_layout(CephContext *cct, rgw::BucketLayout& layout,
+int init_default_bucket_layout(CephContext *cct, rgw::BucketLayout& layout,
 				const RGWZone& zone,
 				std::optional<rgw::BucketIndexType> type,
 				std::optional<uint32_t> shards) {
   layout.current_index.gen = 0;
-  layout.current_index.layout.normal.hash_type = rgw::BucketHashType::Mod;
-
   layout.current_index.layout.type =
-    type.value_or(rgw::BucketIndexType::Normal);
+    type.value_or(rgw::BucketIndexType::Hashed);
 
-  if (shards) {
-    layout.current_index.layout.normal.num_shards = *shards;
-    layout.current_index.layout.normal.min_num_shards = *shards;
-  } else if (cct->_conf->rgw_override_bucket_index_max_shards > 0) {
-    layout.current_index.layout.normal.num_shards =
-      cct->_conf->rgw_override_bucket_index_max_shards;
-  } else {
-    layout.current_index.layout.normal.num_shards =
-      zone.bucket_index_max_shards;
-  }
+  if (layout.current_index.layout.type == rgw::BucketIndexType::Hashed) {
+    rgw::bucket_index_hashed_layout hash_layout;
 
-  if (layout.current_index.layout.type == rgw::BucketIndexType::Normal) {
+    hash_layout.hash_type = rgw::BucketHashType::Mod;
+
+    if (shards) {
+      hash_layout.num_shards = *shards;
+      hash_layout.min_num_shards = *shards;
+    } else if (cct->_conf->rgw_override_bucket_index_max_shards > 0) {
+      hash_layout.num_shards = cct->_conf->rgw_override_bucket_index_max_shards;
+      hash_layout.min_num_shards = cct->_conf->rgw_override_bucket_index_max_shards;
+    } else {
+      hash_layout.num_shards = zone.bucket_index_max_shards;
+      hash_layout.min_num_shards = zone.bucket_index_max_shards;
+    }
+
     layout.logs.push_back(log_layout_from_index(0, layout.current_index));
+
+    layout.current_index.layout.specs = hash_layout;
+  } else if (layout.current_index.layout.type == rgw::BucketIndexType::Ordered) {
+    rgw::bucket_index_ordered_layout ordered_layout;
+
+    if (shards) {
+      ldout(cct, 0) << "WARNING: " << __func__ <<
+        ": suggested number of initial shards for buckets with ordered bucket "
+        "indexes currently ignored" << dendl;
+    }
+    ordered_layout.num_shards = rgw::rados::OrderedBIndexer::get_initial_shard_count();
+
+    layout.current_index.layout.specs = ordered_layout;
+  } else {
+    ldout(cct, 0) << "ERROR: " << __func__ <<
+      " called with unknown BucketIndexType" << dendl;
+
+    return -EINVAL;
   }
-}
+
+  return 0;
+} // init_default_bucket_layout
+
 
 #ifdef WITH_RADOSGW_RADOS
 int RGWBucketInstanceMetadataHandler::put_prepare(
@@ -3047,9 +3092,12 @@ int RGWBucketInstanceMetadataHandler::put_prepare(
     } else {
       // replace peer's layout with default-constructed, then apply our defaults
       bci.info.layout = rgw::BucketLayout{};
-      init_default_bucket_layout(dpp->get_cct(), bci.info.layout,
-				 svc_zone->get_zone(),
-				 std::nullopt, std::nullopt);
+      int ret = init_default_bucket_layout(dpp->get_cct(), bci.info.layout,
+					   svc_zone->get_zone(),
+					   std::nullopt, std::nullopt);
+      if (ret < 0) {
+	return ret;
+      }
     }
   }
 
@@ -3106,9 +3154,9 @@ int RGWBucketInstanceMetadataHandler::put_prepare(
   /* record the read version (if any), store the new version */
   bci.info.objv_tracker.read_version = objv_tracker.read_version;
   bci.info.objv_tracker.write_version = objv_tracker.write_version;
-  
+
   return 0;
-}
+} // RGWBucketInstanceMetadataHandler::put_prepare
 
 int RGWBucketInstanceMetadataHandler::put_post(
     const DoutPrefixProvider* dpp, optional_yield y,
@@ -3116,10 +3164,16 @@ int RGWBucketInstanceMetadataHandler::put_post(
     const std::optional<RGWBucketCompleteInfo>& old_bci,
     RGWObjVersionTracker& objv_tracker)
 {
-  int ret = svc_bi->init_index(dpp, y, bci.info, bci.info.layout.current_index);
+#warning "init_index here"
+  int ret = svc_bi->init_index(dpp, y,
+			       bci.info,
+			       bci.info.layout.current_index,
+			       nullptr);
   if (ret < 0) {
     return ret;
   }
+
+// OBI: do we need to combine attributes?
 
   /* update lc list on changes to lifecyle policy */
   {
@@ -3403,6 +3457,7 @@ int RGWBucketCtl::store_bucket_instance_info(const rgw_bucket& bucket,
                                                 params.exclusive,
                                                 params.mtime,
                                                 params.attrs,
+						params.omap_entries,
                                                 y,
                                                 dpp);
 }
@@ -3438,14 +3493,18 @@ int RGWBucketCtl::do_store_linked_bucket_info(RGWBucketInfo& info,
                                                    info,
                                                    orig_info,
                                                    exclusive,
-                                                   mtime, pattrs,
+                                                   mtime,
+						   pattrs,
+// OBI: is nullptr appropriate here?
+						   nullptr,
 						   y, dpp);
   if (ret < 0) {
     return ret;
   }
 
-  if (!create_head)
+  if (!create_head) {
     return 0; /* done! */
+  }
 
   RGWBucketEntryPoint entry_point;
   entry_point.bucket = info.bucket;

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -1628,7 +1628,7 @@ static int bucket_stats(rgw::sal::Driver* driver, const rgw::SiteConfig& site,
   // - are not indexless
   const bool local_zonegroup = (site.get_zonegroup().id == bucket_info.zonegroup);
   const bool has_index = local_zonegroup &&
-      index.layout.type == rgw::BucketIndexType::Normal;
+      index.layout.type == rgw::BucketIndexType::Hashed;
 
   std::string bucket_ver, master_ver;
   std::string max_marker;
@@ -1669,7 +1669,7 @@ static int bucket_stats(rgw::sal::Driver* driver, const rgw::SiteConfig& site,
   ::encode_json("owner", bucket_info.owner, formatter);
 
   if (has_index) {
-    formatter->dump_int("num_shards", index.layout.normal.num_shards);
+    formatter->dump_int("num_shards", num_shards(index.layout));
     formatter->dump_string("ver", bucket_ver);
     formatter->dump_string("master_ver", master_ver);
     formatter->dump_string("max_marker", max_marker);
@@ -3062,7 +3062,8 @@ int init_default_bucket_layout(CephContext *cct, rgw::BucketLayout& layout,
         ": suggested number of initial shards for buckets with ordered bucket "
         "indexes currently ignored" << dendl;
     }
-    ordered_layout.num_shards = rgw::rados::OrderedBIndexer::get_initial_shard_count();
+    ordered_layout.num_shards =
+                  rgw::rados::OrderedBIndexer::get_default_initial_shard_count();
 
     layout.current_index.layout.specs = ordered_layout;
   } else {

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -3165,14 +3165,22 @@ int RGWBucketInstanceMetadataHandler::put_post(
     const std::optional<RGWBucketCompleteInfo>& old_bci,
     RGWObjVersionTracker& objv_tracker)
 {
-#warning "init_index here"
-  int ret = svc_bi->init_index(dpp, y,
-			       bci.info,
-			       bci.info.layout.current_index,
-			       nullptr);
+  ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
+    ": put_post functionality is temporarily unavailable as ordered "
+    "bucket indexes added" << dendl;
+  return -EINVAL;
+
+  int ret;
+#if 0 // OBI now takes a BIndexer
+  ret = svc_bi->init_index(dpp, y,
+                           bci.info,
+                           bci.info.layout.current_index,
+                           nullptr);
+  // OBI: we'll have new omap entries to process
   if (ret < 0) {
     return ret;
   }
+#endif
 
 // OBI: do we need to combine attributes?
 

--- a/src/rgw/driver/rados/rgw_bucket.h
+++ b/src/rgw/driver/rados/rgw_bucket.h
@@ -44,10 +44,10 @@ struct RGWZoneParams;
 // conforms to the type RGWBucketListNameFilter
 extern bool rgw_bucket_object_check_filter(const std::string& oid);
 
-void init_default_bucket_layout(CephContext *cct, rgw::BucketLayout& layout,
-				const RGWZone& zone,
-				std::optional<rgw::BucketIndexType> type,
-				std::optional<uint32_t> shards);
+int init_default_bucket_layout(CephContext *cct, rgw::BucketLayout& layout,
+			       const RGWZone& zone,
+			       std::optional<rgw::BucketIndexType> type,
+			       std::optional<uint32_t> shards);
 
 struct RGWBucketCompleteInfo {
   RGWBucketInfo info;
@@ -376,7 +376,7 @@ public:
 
   const RGWBucketInfo& get_bucket_info() const { return bucket->get_info(); }
   rgw::sal::User* get_user() { return user.get(); }
-};
+}; // class RGWRbucket
 
 class RGWBucketAdminOp {
 public:
@@ -498,7 +498,7 @@ public:
       RGWObjVersionTracker *objv_tracker{nullptr};
       ceph::real_time mtime;
       bool exclusive{false};
-      const std::map<std::string, bufferlist> *attrs{nullptr};
+      const std::map<std::string, bufferlist>* attrs{nullptr};
 
       PutParams() {}
 
@@ -521,7 +521,7 @@ public:
         attrs = _attrs;
         return *this;
       }
-    };
+};
 
     struct RemoveParams {
       RGWObjVersionTracker *objv_tracker{nullptr};
@@ -576,7 +576,8 @@ public:
                                                    nullptr: orig_info was not found (new bucket instance */
       ceph::real_time mtime;
       bool exclusive{false};
-      const std::map<std::string, bufferlist> *attrs{nullptr};
+      const std::map<std::string, bufferlist>* attrs{nullptr};
+      const std::map<std::string, bufferlist>* omap_entries{nullptr};
       RGWObjVersionTracker *objv_tracker{nullptr};
 
       PutParams() {}
@@ -598,6 +599,11 @@ public:
 
       PutParams& set_attrs(const std::map<std::string, bufferlist> *_attrs) {
         attrs = _attrs;
+        return *this;
+      }
+
+      PutParams& set_omap_entries(const std::map<std::string, bufferlist>* entries) {
+	omap_entries = entries;
         return *this;
       }
 

--- a/src/rgw/driver/rados/rgw_cr_rados.cc
+++ b/src/rgw/driver/rados/rgw_cr_rados.cc
@@ -633,7 +633,10 @@ int RGWAsyncGetBucketInstanceInfo::_send_request(const DoutPrefixProvider *dpp)
 int RGWAsyncPutBucketInstanceInfo::_send_request(const DoutPrefixProvider *dpp)
 {
   auto r = store->getRados()->put_bucket_instance_info(bucket_info, exclusive,
-						       mtime, attrs, dpp, null_yield);
+						       mtime, attrs,
+// OBI: research further to see if nullptr for omap_entries, is OK
+						       nullptr,
+						       dpp, null_yield);
   if (r < 0) {
     ldpp_dout(dpp, 0) << "ERROR: failed to put bucket instance info for "
 		      << bucket_info.bucket << dendl;

--- a/src/rgw/driver/rados/rgw_dedup.cc
+++ b/src/rgw/driver/rados/rgw_dedup.cc
@@ -2503,7 +2503,7 @@ namespace rgw::dedup {
     librados::IoCtx ioctx;
     // objects holding the bucket-listings
     std::map<int, std::string> oids;
-    ret = store->svc()->bi_rados->open_bucket_index(dpp, bucket_info, std::nullopt,
+    ret = store->svc()->bi_rados->open_bucket_index(dpp, bucket_info, rgw::rados::BIndexer::BI_ALL_SHARDS,
                                                     idx_layout, &ioctx, &oids, nullptr);
     if (ret >= 0) {
       // process all the shards in this bucket owned by the worker_id

--- a/src/rgw/driver/rados/rgw_dedup_cluster.cc
+++ b/src/rgw/driver/rados/rgw_dedup_cluster.cc
@@ -623,7 +623,7 @@ namespace rgw::dedup {
       ldpp_dout(dpp, 10) << __func__ << "::try garbbing " << oid << dendl;
       librados::ObjectWriteOperation op;
       op.assert_exists();
-      rados::cls::lock::lock(&op, oid, ClsLockType::EXCLUSIVE, d_lock_cookie,
+      ::rados::cls::lock::lock(&op, oid, ClsLockType::EXCLUSIVE, d_lock_cookie,
                              lock_tag, "dedup_shard_token", lock_duration, lock_flags);
       ret = rgw_rados_operate(dpp, ctl_ioctx, oid, std::move(op), null_yield);
       if (ret == -EBUSY) {

--- a/src/rgw/driver/rados/rgw_notify.cc
+++ b/src/rgw/driver/rados/rgw_notify.cc
@@ -303,7 +303,7 @@ private:
       const auto stale_time = ceph::coarse_real_time::clock::now() - stale_reservations_period;
       librados::ObjectWriteOperation op;
       op.assert_exists();
-      rados::cls::lock::assert_locked(&op, queue_name+"_lock",
+      ::rados::cls::lock::assert_locked(&op, queue_name+"_lock",
         ClsLockType::EXCLUSIVE,
         lock_cookie,
         "" /*no tag*/);
@@ -335,7 +335,7 @@ private:
   int unlock_queue(const std::string& queue_name, boost::asio::yield_context yield) {
     librados::ObjectWriteOperation op;
     op.assert_exists();
-    rados::cls::lock::unlock(&op, queue_name+"_lock", lock_cookie);
+    ::rados::cls::lock::unlock(&op, queue_name+"_lock", lock_cookie);
     auto& rados_ioctx = rados_store->getRados()->get_notif_pool_ctx();
     const auto ret = rgw_rados_operate(this, rados_ioctx, queue_name, std::move(op), yield);
     if (ret == -ENOENT) {
@@ -421,7 +421,7 @@ private:
         op.assert_exists();
         bufferlist obl;
         int rval;
-        rados::cls::lock::assert_locked(&op, queue_name+"_lock", 
+        ::rados::cls::lock::assert_locked(&op, queue_name+"_lock", 
           ClsLockType::EXCLUSIVE,
           lock_cookie, 
           "" /*no tag*/);
@@ -562,7 +562,7 @@ private:
         uint64_t entries_to_remove = index;
         librados::ObjectWriteOperation op;
         op.assert_exists();
-        rados::cls::lock::assert_locked(&op, queue_name+"_lock", 
+        ::rados::cls::lock::assert_locked(&op, queue_name+"_lock", 
           ClsLockType::EXCLUSIVE,
           lock_cookie, 
           "" /*no tag*/);
@@ -710,7 +710,7 @@ private:
         // or if ownership needs to be taken
         librados::ObjectWriteOperation op;
         op.assert_exists();
-        rados::cls::lock::lock(&op, queue_name+"_lock",
+        ::rados::cls::lock::lock(&op, queue_name+"_lock",
               ClsLockType::EXCLUSIVE,
               lock_cookie,
               "" /*no tag*/,

--- a/src/rgw/driver/rados/rgw_object_expirer_core.cc
+++ b/src/rgw/driver/rados/rgw_object_expirer_core.cc
@@ -57,6 +57,7 @@ static string objexp_hint_get_shardname(int shard_num)
 static int objexp_key_shard(const rgw_obj_index_key& key, int num_shards)
 {
   string obj_key = key.name + key.instance;
+  // OBI: need to convert this over to BIShardIdent
   return RGWSI_BucketIndex_RADOS::bucket_shard_index(obj_key, num_shards);
 }
 

--- a/src/rgw/driver/rados/rgw_object_expirer_core.cc
+++ b/src/rgw/driver/rados/rgw_object_expirer_core.cc
@@ -58,7 +58,7 @@ static int objexp_key_shard(const rgw_obj_index_key& key, int num_shards)
 {
   string obj_key = key.name + key.instance;
   // OBI: need to convert this over to BIShardIdent
-  return RGWSI_BucketIndex_RADOS::bucket_shard_index(obj_key, num_shards);
+  return rgw::rados::HashedBIndexer::get_shard_index(obj_key, num_shards);
 }
 
 static string objexp_hint_get_keyext(const string& tenant_name,

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -11899,6 +11899,12 @@ int RGWRados::check_bucket_shards(const RGWBucketInfo& bucket_info,
     return 0;
   }
 
+  if (bucket_info.uses_ordered_index()) {
+    ldpp_dout(dpp, 0) <<
+      "INFO: currently buckets with ordered indexes cannot be resharded dynamically" << dendl;
+    return 0;
+  }
+
   // TODO: consider per-bucket sync policy here?
 
   bool need_resharding = false;

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -1037,7 +1037,7 @@ void RGWIndexCompletionManager::process()
         /* this null_yield can stay for now since we're in our own
          * thread */
         std::ignore = add_datalog_entry(&dpp, store->svc.datalog_rados,
-                                        bucket_info, bs.shard_id,
+                                        bucket_info, *bs.shard_ident,
                                         null_yield);
         /* if there is an error we can ignore it, as a) there's
          * nothing we can do and b) it's already logged in
@@ -1975,8 +1975,7 @@ int RGWRados::Bucket::List::list_objects(const DoutPrefixProvider *dpp, int64_t 
                                          optional_yield y)
 {
   auto bindexer =
-    rgw::rados::BIndexer::create_unique(target->store->cct, dpp,
-                                        target->bucket_info);
+    rgw::rados::BIndexer::create_unique(target->store, dpp, target->bucket_info);
 
   if (bindexer->entries_ordered_by_shard() || params.allow_unordered) {
     return list_objects_by_shard(dpp, max, result, common_prefixes,
@@ -2617,13 +2616,12 @@ int RGWRados::create_bucket(const DoutPrefixProvider* dpp,
       info.quota = *quota;
     }
 
+    auto bindexer = rgw::rados::BIndexer::create_unique(cct, dpp, info);
     std::map<std::string, bufferlist> binfo_map_entries;
 
     if (zone_placement) {
-#warning "init_index here"
       ret = svc.bi->init_index(dpp, y,
-			       info,
-			       info.layout.current_index,
+                               bindexer,
 			       &binfo_map_entries);
       if (ret < 0) {
         return ret;
@@ -3032,7 +3030,7 @@ int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
                                                  *bucket_info_p,
                                                  obj.get_hash_object(),
                                                  &bucket_obj,
-                                                 shard_ident.get());
+                                                 shard_ident);
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
     return ret;
@@ -3054,7 +3052,7 @@ int RGWRados::BucketShard::init(const DoutPrefixProvider *dpp,
                                                          bucket_info,
 							 obj.get_hash_object(),
 							 &bucket_obj,
-							 shard_ident.get());
+							 shard_ident);
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
     return ret;
@@ -3062,16 +3060,6 @@ int RGWRados::BucketShard::init(const DoutPrefixProvider *dpp,
   ldpp_dout(dpp, 20) << " bucket index object: " << bucket_obj << dendl;
 
   return 0;
-}
-
-int RGWRados::BucketShard::init(const DoutPrefixProvider *dpp,
-				const RGWBucketInfo& bucket_info,
-                                const rgw::bucket_index_layout_generation& layout_gen,
-                                rgw::BIShardIndex shard_idx,
-				optional_yield y)
-{
-  rgw::HashedShardIdent shard_ident(shard_idx);
-  return init(dpp, bucket_info, layout_gen, shard_ident, y);
 }
 
 int RGWRados::BucketShard::init(const DoutPrefixProvider *dpp,
@@ -4303,12 +4291,13 @@ int RGWRados::reindex_obj(rgw::sal::Driver* driver,
   }
 
   rgw_rados_ref bucket_ref;
+  std::unique_ptr<rgw::BIShardIdent> shard_ident; // don't need; will ignore
   ret = svc.bi_rados->open_bucket_index_shard(dpp,
                                               svc.bucket_sobj,
 					      bucket_info,
 					      head_obj.get_hash_object(), 
 					      &bucket_ref, 
-					      nullptr);
+					      shard_ident);
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: failed to determine bucket index shard"
                       << dendl;
@@ -10342,6 +10331,9 @@ int RGWRados::try_refresh_bucket_info(RGWBucketInfo& info,
 				      .set_refresh_version(rv));
 }
 
+// for omap_entries, if it's nullptr erase omap, if it's
+// no_change_attrs_omap(), leave alone, and if it's anything else,
+// write those entries
 int RGWRados::put_bucket_instance_info(RGWBucketInfo& info, bool exclusive,
 				       real_time mtime,
 				       const map<string, bufferlist>* pattrs,
@@ -10706,11 +10698,13 @@ int RGWRados::bi_list(BucketShard& bs,
 }
 
 int RGWRados::bi_list(const DoutPrefixProvider *dpp,
-		      const RGWBucketInfo& bucket_info, int shard_id, const string& obj_name_filter, const string& marker, uint32_t max,
+		      const RGWBucketInfo& bucket_info, int shard_idx, const string& obj_name_filter, const string& marker, uint32_t max,
 		      list<rgw_cls_bi_entry> *entries, bool *is_truncated, bool reshardlog, optional_yield y)
 {
   BucketShard bs(this);
 
+  // OBI: temporary work around
+  auto shard_id = rgw::HashedShardIdent(shard_idx);
   int ret = bs.init(dpp, bucket_info,
 		    bucket_info.layout.current_index,
 		    shard_id, y);
@@ -11286,8 +11280,6 @@ int RGWRados::cls_bucket_list_unordered(const DoutPrefixProvider *dpp,
 					RGWBucketListNameFilter force_check_filter)
 {
   const bool bitx = cct->_conf->rgw_bucket_index_transaction_instrumentation;
-  constexpr uint32_t min_req_num_entries = 5;
-  constexpr uint32_t max_req_num_entries = 1005;
 
   ldout_bitx(bitx, dpp, 10) << "ENTERING " << __func__ << ": " << bucket_info.bucket <<
     " start_after=\"" << start_after <<
@@ -11624,6 +11616,7 @@ int RGWRados::remove_objs_from_index(const DoutPrefixProvider *dpp,
   for (const auto& entry_key : entry_key_list) {
     const rgw_obj_key obj_key(entry_key);
     const uint32_t shard = [&obj_key, num_shards]() -> uint32_t {
+      // OBI: need to convert this over to BIShardIdent
       int32_t temp = RGWSI_BucketIndex_RADOS::bucket_shard_index(obj_key, num_shards);
       return (-1 == temp) ? 0 : (uint32_t) temp;
     }();
@@ -11995,6 +11988,7 @@ int RGWRados::get_target_shard_id(const rgw::bucket_index_hashed_layout& layout,
           *shard_id = -1;
         }
       } else {
+        // OBI: need to convert this over to BIShardIdent
         uint32_t sid = svc.bi_rados->bucket_shard_index(obj_key, layout.num_shards);
         if (shard_id) {
           *shard_id = (int)sid;

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -11622,7 +11622,8 @@ int RGWRados::remove_objs_from_index(const DoutPrefixProvider *dpp,
     const rgw_obj_key obj_key(entry_key);
     const uint32_t shard = [&obj_key, num_shards]() -> uint32_t {
       // OBI: need to convert this over to BIShardIdent
-      int32_t temp = RGWSI_BucketIndex_RADOS::bucket_shard_index(obj_key, num_shards);
+      int32_t temp =
+        rgw::rados::HashedBIndexer::get_shard_index(obj_key, num_shards);
       return (-1 == temp) ? 0 : (uint32_t) temp;
     }();
 
@@ -12000,7 +12001,8 @@ int RGWRados::get_target_shard_id(const rgw::bucket_index_hashed_layout& layout,
         }
       } else {
         // OBI: need to convert this over to BIShardIdent
-        uint32_t sid = svc.bi_rados->bucket_shard_index(obj_key, layout.num_shards);
+        uint32_t sid =
+          rgw::rados::HashedBIndexer::get_shard_index(obj_key, layout.num_shards);
         if (shard_id) {
           *shard_id = (int)sid;
         }

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -4104,6 +4104,10 @@ int RGWRados::reindex_obj(rgw::sal::Driver* driver,
 			  const DoutPrefixProvider* dpp,
 			  optional_yield y)
 {
+  ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
+    ": reindex_obj functionality is temporarily unavailable as ordered "
+    "bucket indexes added" << dendl;
+  return -EINVAL; // OBI: need to make sure this works properly with ordered bucket indexes
   // used for trimming pending entries; max value means all versions trimmed
   const uint64_t max_ver = std::numeric_limits<uint64_t>::max();
   // used for linking an olh
@@ -4310,18 +4314,19 @@ int RGWRados::reindex_obj(rgw::sal::Driver* driver,
     ldpp_dout(dpp, 10) << "INFO: bucket index shard " << bucket_ref.obj.oid
                        << " missing, creating..." << dendl;
     std::map<std::string, bufferlist> binfo_map_entries;
-#warning "init_index here"
-    int create_ret = svc.bi_rados->init_index(dpp,
-					      y,
-					      bucket_info,
-					      bucket_info.layout.current_index,
-					      &binfo_map_entries,
-					      false);
+#if 0 // OBI init_index now takes a bindexer
+    create_ret = svc.bi_rados->init_index(dpp,
+                                          y,
+                                          bucket_info,
+                                          bucket_info.layout.current_index,
+                                          &binfo_map_entries,
+                                          false);
 
     if (create_ret < 0) {
       ldpp_dout(dpp, 0) << "ERROR: failed to create bucket index" << dendl;
       return create_ret;
     }
+#endif
   } else if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: failed to stat bucket index shard: "
                       << cpp_strerror(-ret) << dendl;

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -829,19 +829,34 @@ int RGWRados::get_max_chunk_size(const rgw_placement_rule& placement_rule, const
 [[nodiscard]] int add_datalog_entry(const DoutPrefixProvider* dpp,
 				    RGWDataChangesLog* datalog,
 				    const RGWBucketInfo& bucket_info,
-				    uint32_t shard_id, optional_yield y)
+                                    const rgw::BIShardIdent& shard_ident_base,
+				    optional_yield y)
 {
-  const auto& logs = bucket_info.layout.logs;
-  if (logs.empty()) {
-    return 0;
+  // OBI: do we need to intercept this path earlier until multi-site
+  // works with ordered bucket indices?
+  try {
+    // will throw excception if it's a differnt type of shard ident
+    const rgw::HashedShardIdent& shard_ident =
+      dynamic_cast<const rgw::HashedShardIdent&>(shard_ident_base);
+
+    const auto& logs = bucket_info.layout.logs;
+    if (logs.empty()) {
+      return 0;
+    }
+    int r = datalog->add_entry(dpp, bucket_info, logs.back(),
+                               shard_ident.get_index(), y);
+    if (r < 0) {
+      ldpp_dout(dpp, -1) << "ERROR: failed writing data log" << dendl;
+    }
+    // DataLog error *is* fatal so that if we fail to write to the
+    // semaphore set we return an error.
+    return r;
+  } catch (const std::bad_cast& e) {
+    ldpp_dout(dpp, -1) << "ERROR: tried to write an entry with a "
+      "non-hashed shard identifier to data log" << dendl;
+
+    return -EINVAL;
   }
-  int r = datalog->add_entry(dpp, bucket_info, logs.back(), shard_id, y);
-  if (r < 0) {
-    ldpp_dout(dpp, -1) << "ERROR: failed writing data log" << dendl;
-  }
-  // DataLog error *is* fatal so that if we fail to write to the
-  // semaphore set we return an error.
-  return r;
 }
 
 class RGWIndexCompletionManager;
@@ -1030,7 +1045,7 @@ void RGWIndexCompletionManager::process()
       }
     }
   }
-}
+} // RGWIndexCompletionManager::process
 
 void RGWIndexCompletionManager::create_completion(const rgw_obj& obj,
                                                   RGWModifyOp op, string& tag,
@@ -1953,6 +1968,26 @@ int RGWRados::Bucket::update_bucket_id(const string& new_bucket_id, const DoutPr
 }
 
 
+int RGWRados::Bucket::List::list_objects(const DoutPrefixProvider *dpp, int64_t max,
+                                         std::vector<rgw_bucket_dir_entry> *result,
+                                         std::map<std::string, bool> *common_prefixes,
+                                         bool *is_truncated,
+                                         optional_yield y)
+{
+  auto bindexer =
+    rgw::rados::BIndexer::create_unique(target->store->cct, dpp,
+                                        target->bucket_info);
+
+  if (bindexer->entries_ordered_by_shard() || params.allow_unordered) {
+    return list_objects_by_shard(dpp, max, result, common_prefixes,
+                                 is_truncated, y);
+  } else {
+    return list_objects_and_sort(dpp, max, result, common_prefixes,
+                                 is_truncated, y);
+  }
+}
+
+
 /**
  * Get ordered listing of the objects in a bucket.
  *
@@ -1970,7 +2005,7 @@ int RGWRados::Bucket::update_bucket_id(const string& new_bucket_id, const DoutPr
  * is_truncated: if number of objects in the bucket is bigger than
  * max, then truncated.
  */
-int RGWRados::Bucket::List::list_objects_ordered(
+int RGWRados::Bucket::List::list_objects_and_sort(
   const DoutPrefixProvider *dpp,
   int64_t max_p,
   std::vector<rgw_bucket_dir_entry> *result,
@@ -2349,12 +2384,12 @@ done:
  * is_truncated: if number of objects in the bucket is bigger than max, then
  *               truncated.
  */
-int RGWRados::Bucket::List::list_objects_unordered(const DoutPrefixProvider *dpp,
-                                                   int64_t max_p,
-						   std::vector<rgw_bucket_dir_entry>* result,
-						   std::map<std::string, bool>* common_prefixes,
-						   bool* is_truncated,
-                                                   optional_yield y)
+int RGWRados::Bucket::List::list_objects_by_shard(const DoutPrefixProvider *dpp,
+                                                  int64_t max_p,
+                                                  std::vector<rgw_bucket_dir_entry>* result,
+                                                  std::map<std::string, bool>* common_prefixes,
+                                                  bool* is_truncated,
+                                                  optional_yield y)
 {
   RGWRados *store = target->get_store();
   int shard_id = target->get_shard_id();
@@ -2525,7 +2560,7 @@ int RGWRados::create_bucket(const DoutPrefixProvider* dpp,
                             const std::string& zonegroup_id,
                             const rgw_placement_rule& placement_rule,
                             const RGWZonePlacementInfo* zone_placement,
-                            const std::map<std::string, bufferlist>& attrs,
+                            const std::map<std::string, bufferlist>& xattrs,
                             bool obj_lock_enabled,
                             const std::optional<std::string>& swift_ver_location,
                             const std::optional<RGWQuotaInfo>& quota,
@@ -2561,12 +2596,15 @@ int RGWRados::create_bucket(const DoutPrefixProvider* dpp,
       info.flags |= BUCKET_VERSIONED | BUCKET_OBJ_LOCK_ENABLED;
     }
 
-    if (zone_placement) {
-      if (!index_type) {
-        index_type = zone_placement->index_type;
-      }
-      init_default_bucket_layout(cct, info.layout, svc.zone->get_zone(),
-                                 index_type, index_shards);
+    if (zone_placement && !index_type) {
+      // zone placement can override specified
+      index_type = zone_placement->index_type;
+    }
+
+    ret = init_default_bucket_layout(cct, info.layout, svc.zone->get_zone(),
+				     index_type, index_shards);
+    if (ret < 0) {
+      return ret;
     }
 
     info.requester_pays = false;
@@ -2579,15 +2617,24 @@ int RGWRados::create_bucket(const DoutPrefixProvider* dpp,
       info.quota = *quota;
     }
 
+    std::map<std::string, bufferlist> binfo_map_entries;
+
     if (zone_placement) {
-      ret = svc.bi->init_index(dpp, y, info, info.layout.current_index);
+#warning "init_index here"
+      ret = svc.bi->init_index(dpp, y,
+			       info,
+			       info.layout.current_index,
+			       &binfo_map_entries);
       if (ret < 0) {
         return ret;
       }
     }
 
     constexpr bool exclusive = true;
-    ret = put_linked_bucket_info(info, exclusive, ceph::real_time(), pep_objv, &attrs, true, dpp, y);
+    ret = put_linked_bucket_info(info, exclusive, ceph::real_time(), pep_objv,
+				 &xattrs,
+				 &binfo_map_entries,
+				 true, dpp, y);
     if (ret == -ECANCELED) {
       ret = -EEXIST;
     }
@@ -2963,7 +3010,8 @@ int RGWRados::fix_tail_obj_locator(const DoutPrefixProvider *dpp,
 int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
 				const rgw_obj& obj,
 				RGWBucketInfo* bucket_info_out,
-                                const DoutPrefixProvider *dpp, optional_yield y)
+                                const DoutPrefixProvider *dpp,
+                                optional_yield y)
 {
   bucket = _bucket;
 
@@ -2978,7 +3026,13 @@ int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
 
   string oid;
 
-  ret = store->svc.bi_rados->open_bucket_index_shard(dpp, *bucket_info_p, obj.get_hash_object(), &bucket_obj, &shard_id);
+  ret =
+    store->svc.bi_rados->open_bucket_index_shard(dpp,
+                                                 store->svc.bucket_sobj,
+                                                 *bucket_info_p,
+                                                 obj.get_hash_object(),
+                                                 &bucket_obj,
+                                                 shard_ident.get());
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
     return ret;
@@ -2988,15 +3042,19 @@ int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
   return 0;
 }
 
-int RGWRados::BucketShard::init(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info,
-                                const rgw_obj& obj, optional_yield y)
+int RGWRados::BucketShard::init(const DoutPrefixProvider *dpp,
+                                const RGWBucketInfo& bucket_info,
+                                const rgw_obj& obj,
+                                optional_yield y)
 {
   bucket = bucket_info.bucket;
 
-  int ret = store->svc.bi_rados->open_bucket_index_shard(dpp, bucket_info,
+  int ret = store->svc.bi_rados->open_bucket_index_shard(dpp,
+                                                         store->svc.bucket_sobj,
+                                                         bucket_info,
 							 obj.get_hash_object(),
 							 &bucket_obj,
-							 &shard_id);
+							 shard_ident.get());
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
     return ret;
@@ -3008,23 +3066,58 @@ int RGWRados::BucketShard::init(const DoutPrefixProvider *dpp, const RGWBucketIn
 
 int RGWRados::BucketShard::init(const DoutPrefixProvider *dpp,
 				const RGWBucketInfo& bucket_info,
-                                const rgw::bucket_index_layout_generation& index,
-                                int sid, optional_yield y)
+                                const rgw::bucket_index_layout_generation& layout_gen,
+                                rgw::BIShardIndex shard_idx,
+				optional_yield y)
+{
+  rgw::HashedShardIdent shard_ident(shard_idx);
+  return init(dpp, bucket_info, layout_gen, shard_ident, y);
+}
+
+int RGWRados::BucketShard::init(const DoutPrefixProvider *dpp,
+                                const RGWBucketInfo& bucket_info,
+                                const rgw::bucket_index_layout_generation& layout_gen,
+                                const rgw::BIShardIdent& shard_ident,
+                                optional_yield y)
 {
   bucket = bucket_info.bucket;
-  shard_id = sid;
 
-  int ret = store->svc.bi_rados->open_bucket_index_shard(dpp, bucket_info, index,
-                                                         shard_id, &bucket_obj);
+  int ret =
+    store->svc.bi_rados->open_bucket_index_shard(dpp,
+                                                 bucket_info, layout_gen,
+                                                 shard_ident, &bucket_obj);
   if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
+    ldpp_dout(dpp, 0) <<
+      "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
     return ret;
   }
-  ldpp_dout(dpp, 20) << " bucket index object: " << bucket_obj << dendl;
+
+  ldpp_dout(dpp, 20) << "bucket index object: " << bucket_obj << dendl;
 
   return 0;
 }
 
+int RGWRados::BucketShard::init(const DoutPrefixProvider* dpp,
+                                rgw::rados::BIndexer::ShardIterator& shard_it,
+				optional_yield y)
+{
+  bucket = shard_it.get_bindexer()->get_bucket_info().bucket;
+  shard_ident = shard_it.get_ident()->clone();
+
+  int ret =
+    store->svc.bi_rados->open_bucket_index_shard(dpp,
+                                                 shard_it,
+                                                 &bucket_obj);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: open_bucket_index_shard() returned ret=" <<
+      ret << dendl;
+    return ret;
+  }
+
+  ldpp_dout(dpp, 20) << "bucket index object: " << bucket_obj << dendl;
+
+  return 0;
+}
 
 /* Execute @handler on last item in bucket listing for bucket specified
  * in @bucket_info. @obj_prefix and @obj_delim narrow down the listing
@@ -3306,7 +3399,7 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
 
   ObjectWriteOperation op;
 #ifdef WITH_LTTNG
-  const req_state* s =  get_req_state();
+  const req_state* s = get_req_state();
   string req_id;
   if (!s) {
     // fake req_id
@@ -3319,8 +3412,9 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
   RGWObjState *state;
   RGWObjManifest *manifest = nullptr;
   int r = target->get_state(rctx.dpp, &state, &manifest, false, rctx.y, assume_noent);
-  if (r < 0)
+  if (r < 0) {
     return r;
+  }
 
   rgw_obj& obj = target->get_obj();
 
@@ -3331,8 +3425,9 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
 
   rgw_rados_ref ref;
   r = store->get_obj_head_ref(rctx.dpp, target->get_meta_placement_rule(), obj, &ref);
-  if (r < 0)
+  if (r < 0) {
     return r;
+  }
 
   bool is_olh = state->is_olh;
 
@@ -3362,8 +3457,9 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
   bool guard = ((target->manifest) || (target->state->obj_tag.length() != 0)) && (!target->state->fake_tag);
   bool set_attr_id_tag = guard && target->obj.key.instance.empty() && (meta.if_nomatch == nullptr || meta.if_nomatch != "*"sv);
   r = target->prepare_atomic_modification(rctx.dpp, op, reset_obj, ptag, meta.modify_tail, set_attr_id_tag, rctx.y);
-  if (r < 0)
+  if (r < 0) {
     return r;
+  }
 
   if (real_clock::is_zero(meta.set_mtime)) {
     meta.set_mtime = real_clock::now();
@@ -3484,8 +3580,9 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
   decode_restore_index_fields(attrs, nullptr,
                               idx_restore_status, idx_restore_expiry_date);
 
-  if (!op.size())
+  if (!op.size()) {
     return 0;
+  }
 
   uint64_t epoch;
   int64_t poolid;
@@ -3513,8 +3610,9 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
     tracepoint(rgw_rados, prepare_enter, req_id.c_str());
     r = index_op->prepare(rctx.dpp, CLS_RGW_OP_ADD, &state->write_tag, rctx.y);
     tracepoint(rgw_rados, prepare_exit, req_id.c_str());
-    if (r < 0)
+    if (r < 0) {
       return r;
+    }
   }
 
   auto& ioctx = ref.ioctx;
@@ -3567,8 +3665,9 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
 			 meta.user_data, meta.appendable, log_op,
 			 idx_restore_status, idx_restore_expiry_date);
   tracepoint(rgw_rados, complete_exit, req_id.c_str());
-  if (r < 0)
+  if (r < 0) {
     goto done_cancel;
+  }
 
   if (meta.mtime) {
     *meta.mtime = meta.set_mtime;
@@ -4204,8 +4303,9 @@ int RGWRados::reindex_obj(rgw::sal::Driver* driver,
   }
 
   rgw_rados_ref bucket_ref;
-  ret = svc.bi_rados->open_bucket_index_shard(dpp, 
-					      bucket_info, 
+  ret = svc.bi_rados->open_bucket_index_shard(dpp,
+                                              svc.bucket_sobj,
+					      bucket_info,
 					      head_obj.get_hash_object(), 
 					      &bucket_ref, 
 					      nullptr);
@@ -4220,10 +4320,13 @@ int RGWRados::reindex_obj(rgw::sal::Driver* driver,
   if (ret == -ENOENT) {
     ldpp_dout(dpp, 10) << "INFO: bucket index shard " << bucket_ref.obj.oid
                        << " missing, creating..." << dendl;
-    int create_ret = svc.bi_rados->init_index(dpp, 
-					      y, 
-					      bucket_info, 
-					      bucket_info.layout.current_index, 
+    std::map<std::string, bufferlist> binfo_map_entries;
+#warning "init_index here"
+    int create_ret = svc.bi_rados->init_index(dpp,
+					      y,
+					      bucket_info,
+					      bucket_info.layout.current_index,
+					      &binfo_map_entries,
 					      false);
 
     if (create_ret < 0) {
@@ -6121,7 +6224,7 @@ int RGWRados::delete_bucket(RGWBucketInfo& bucket_info, std::map<std::string, bu
   const rgw_bucket& bucket = bucket_info.bucket;
   librados::IoCtx index_pool;
   map<int, string> bucket_objs;
-  int r = svc.bi_rados->open_bucket_index(dpp, bucket_info, std::nullopt, bucket_info.layout.current_index, &index_pool, &bucket_objs, nullptr);
+  int r = svc.bi_rados->open_bucket_index(dpp, bucket_info, rgw::rados::BIndexer::BI_ALL_SHARDS, bucket_info.layout.current_index, &index_pool, &bucket_objs, nullptr);
   if (r < 0)
     return r;
   
@@ -6222,7 +6325,7 @@ int RGWRados::set_bucket_owner(rgw_bucket& bucket, ACLOwner& owner, const DoutPr
 
   info.owner = owner.id;
 
-  r = put_bucket_instance_info(info, false, real_time(), &attrs, dpp, y);
+  r = put_bucket_instance_info(info, false, real_time(), &attrs, nullptr, dpp, y);
   if (r < 0) {
     ldpp_dout(dpp, 0) << "NOTICE: put_bucket_info on bucket=" << bucket.name << " returned err=" << r << dendl;
     return r;
@@ -6260,7 +6363,7 @@ int RGWRados::set_buckets_enabled(vector<rgw_bucket>& buckets, bool enabled, con
       info.flags |= BUCKET_SUSPENDED;
     }
 
-    r = put_bucket_instance_info(info, false, real_time(), &attrs, dpp, y);
+    r = put_bucket_instance_info(info, false, real_time(), &attrs, nullptr, dpp, y);
     if (r < 0) {
       ldpp_dout(dpp, 0) << "NOTICE: put_bucket_info on bucket=" << bucket.name << " returned err=" << r << ", skipping bucket" << dendl;
       ret = r;
@@ -6719,7 +6822,7 @@ int RGWRados::Object::Delete::delete_obj(optional_yield y,
 
     if (add_log) {
       r = add_datalog_entry(dpp, store->svc.datalog_rados,
-			    target->get_bucket_info(), bs->shard_id, y);
+			    target->get_bucket_info(), *bs->shard_ident, y);
       if (r < 0) {
         ldpp_dout(dpp, 0) << "failed to write datalog for object: r=" << r << dendl;
         return r;
@@ -8246,7 +8349,7 @@ int RGWRados::Bucket::UpdateIndex::complete(const DoutPrefixProvider *dpp, int64
   ret = store->cls_obj_complete_add(*bs, obj, optag, poolid, epoch, ent, category, remove_objs, bilog_flags, zones_trace, add_log);
   if (add_log) {
     ret = add_datalog_entry(dpp, store->svc.datalog_rados,
-			    target->bucket_info, bs->shard_id, y);
+			    target->bucket_info, *bs->shard_ident, y);
   }
 
   return ret;
@@ -8277,7 +8380,7 @@ int RGWRados::Bucket::UpdateIndex::complete_del(const DoutPrefixProvider *dpp,
 
   if (add_log) {
     ret = add_datalog_entry(dpp, store->svc.datalog_rados,
-			    target->bucket_info, bs->shard_id, y);
+			    target->bucket_info, *bs->shard_ident, y);
   }
 
   return ret;
@@ -8308,7 +8411,7 @@ int RGWRados::Bucket::UpdateIndex::cancel(const DoutPrefixProvider *dpp,
      * have no way to tell that they're all caught up
      */
     ret = add_datalog_entry(dpp, store->svc.datalog_rados,
-			    target->bucket_info, bs->shard_id, y);
+			    target->bucket_info, *bs->shard_ident, y);
   }
 
   return ret;
@@ -8918,7 +9021,7 @@ int RGWRados::recover_reshard_logrecord(RGWBucketInfo& bucket_info,
       bucket_info.bucket.bucket_id << "; expected if resharding underway" << dendl;
     // update the judge time
     bucket_info.layout.judge_reshard_lock_time = real_clock::now();
-    ret = put_bucket_instance_info(bucket_info, false, real_time(), &bucket_attrs, dpp, y);
+    ret = put_bucket_instance_info(bucket_info, false, real_time(), &bucket_attrs, nullptr, dpp, y);
     if (ret < 0) {
       ldpp_dout(dpp, 0) << "RGWReshard::" << __func__ <<
         " ERROR: error putting bucket instance info: " << cpp_strerror(-ret) << dendl;
@@ -9003,7 +9106,7 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
     const auto gen = bucket_info.layout.logs.empty() ? -1 : bucket_info.layout.logs.back().gen;
     ldpp_dout(dpp, 20) << __func__ <<
       " INFO: refreshed bucket info after reshard at " <<
-      log_tag << ". new shard_id=" << bs->shard_id << ". gen=" << gen << dendl;
+      log_tag << ". new shard_id=" << bs->shard_ident << ". gen=" << gen << dendl;
 
     return 0;
   }; // lambda fetch_new_bucket_info
@@ -9166,7 +9269,7 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
   }
 
   if (log_data_change) {
-    r = add_datalog_entry(dpp, svc.datalog_rados, bucket_info, bs.shard_id, y);
+    r = add_datalog_entry(dpp, svc.datalog_rados, bucket_info, *bs.shard_ident, y);
   }
 
   return r;
@@ -10113,8 +10216,9 @@ int RGWRados::get_bucket_stats(const DoutPrefixProvider *dpp, optional_yield y,
     } else {
       marker_mgr.add(viter->first, iter->max_marker);
     }
-    if (syncstopped != NULL)
+    if (syncstopped != NULL) {
       *syncstopped = iter->syncstopped;
+    }
   }
   ver_mgr.to_string(bucket_ver);
   master_ver_mgr.to_string(master_ver);
@@ -10168,7 +10272,9 @@ public:
 int RGWRados::get_bucket_stats_async(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout, int shard_id, boost::intrusive_ptr<rgw::sal::ReadStatsCB> cb)
 {
   int num_aio = 0;
-  boost::intrusive_ptr headercb = new RGWGetBucketStatsContext(std::move(cb), bucket_info.layout.current_index.layout.normal.num_shards ? : 1);
+  boost::intrusive_ptr headercb =
+    new RGWGetBucketStatsContext(std::move(cb),
+				 rgw::num_shards(bucket_info.layout.current_index.layout.specs) ? : 1);
   int r = cls_bucket_head_async(dpp, bucket_info, idx_layout, shard_id, headercb, &num_aio);
   if (r < 0) {
     if (num_aio) {
@@ -10237,29 +10343,37 @@ int RGWRados::try_refresh_bucket_info(RGWBucketInfo& info,
 }
 
 int RGWRados::put_bucket_instance_info(RGWBucketInfo& info, bool exclusive,
-                              real_time mtime, const map<string, bufferlist> *pattrs,
-                              const DoutPrefixProvider *dpp, optional_yield y)
+				       real_time mtime,
+				       const map<string, bufferlist>* pattrs,
+				       const std::map<std::string, bufferlist>* omap_entries,
+				       const DoutPrefixProvider *dpp, optional_yield y)
 {
   return ctl.bucket->store_bucket_instance_info(info.bucket, info, y, dpp,
 						RGWBucketCtl::BucketInstance::PutParams()
 						.set_exclusive(exclusive)
 						.set_mtime(mtime)
-						.set_attrs(pattrs));
+						.set_attrs(pattrs)
+						.set_omap_entries(omap_entries));
 }
 
 int RGWRados::put_linked_bucket_info(RGWBucketInfo& info, bool exclusive, real_time mtime, obj_version *pep_objv,
-                                     const map<string, bufferlist> *pattrs, bool create_entry_point,
+                                     const map<std::string, bufferlist>* pxattrs,
+                                     const map<std::string, bufferlist>* omap_entries,
+				     bool create_entry_point,
                                      const DoutPrefixProvider *dpp, optional_yield y)
 {
   bool create_head = !info.has_instance_obj || create_entry_point;
 
-  int ret = put_bucket_instance_info(info, exclusive, mtime, pattrs, dpp, y);
+  int ret = put_bucket_instance_info(info, exclusive, mtime,
+				     pxattrs, omap_entries,
+				     dpp, y);
   if (ret < 0) {
     return ret;
   }
 
-  if (!create_head)
+  if (!create_head) {
     return 0; /* done! */
+  }
 
   RGWBucketEntryPoint entry_point;
   entry_point.bucket = info.bucket;
@@ -10275,14 +10389,12 @@ int RGWRados::put_linked_bucket_info(RGWBucketInfo& info, bool exclusive, real_t
       *pep_objv = ot.write_version;
     }
   }
-  ret = ctl.bucket->store_bucket_entrypoint_info(info.bucket, entry_point, y, dpp, RGWBucketCtl::Bucket::PutParams()
-						                          .set_exclusive(exclusive)
-									  .set_objv_tracker(&ot)
-									  .set_mtime(mtime));
-  if (ret < 0)
-    return ret;
-
-  return 0;
+  ret = ctl.bucket->store_bucket_entrypoint_info(info.bucket, entry_point, y, dpp,
+						 RGWBucketCtl::Bucket::PutParams()
+						 .set_exclusive(exclusive)
+						 .set_objv_tracker(&ot)
+						 .set_mtime(mtime));
+  return ret;
 }
 
 int RGWRados::append_async(const DoutPrefixProvider *dpp, rgw_raw_obj& obj, size_t size, bufferlist& bl)
@@ -10575,13 +10687,20 @@ int RGWRados::bi_list(const DoutPrefixProvider *dpp, rgw_bucket& bucket,
   return 0;
 }
 
-int RGWRados::bi_list(BucketShard& bs, const string& obj_name_filter, const string& marker, uint32_t max,
-		      list<rgw_cls_bi_entry> *entries, bool *is_truncated, bool reshardlog, optional_yield y)
+
+int RGWRados::bi_list(BucketShard& bs,
+                      const string& obj_name_filter,
+                      const string& marker, uint32_t max,
+		      list<rgw_cls_bi_entry> *entries,
+                      bool *is_truncated,
+                      bool reshardlog,
+                      optional_yield y)
 {
   auto& ref = bs.bucket_obj;
   int ret = cls_rgw_bi_list(ref.ioctx, ref.obj.oid, obj_name_filter, marker, max, entries, is_truncated, reshardlog);
-  if (ret < 0)
+  if (ret < 0) {
     return ret;
+  }
 
   return 0;
 }
@@ -10591,6 +10710,7 @@ int RGWRados::bi_list(const DoutPrefixProvider *dpp,
 		      list<rgw_cls_bi_entry> *entries, bool *is_truncated, bool reshardlog, optional_yield y)
 {
   BucketShard bs(this);
+
   int ret = bs.init(dpp, bucket_info,
 		    bucket_info.layout.current_index,
 		    shard_id, y);
@@ -10842,7 +10962,8 @@ int RGWRados::cls_bucket_list_ordered(const DoutPrefixProvider *dpp,
   // value - list result for the corresponding oid (shard), it is filled by
   //         the AIO callback
   std::map<int, std::string> shard_oids;
-  int r = svc.bi_rados->open_bucket_index(dpp, bucket_info, shard_id, idx_layout,
+  int r = svc.bi_rados->open_bucket_index(dpp,
+                                          bucket_info, shard_id, idx_layout,
 					  &index_pool, &shard_oids,
 					  nullptr);
   if (r < 0) {
@@ -11162,8 +11283,11 @@ int RGWRados::cls_bucket_list_unordered(const DoutPrefixProvider *dpp,
 					bool *is_truncated,
 					rgw_obj_index_key *last_entry,
                                         optional_yield y,
-					RGWBucketListNameFilter force_check_filter) {
+					RGWBucketListNameFilter force_check_filter)
+{
   const bool bitx = cct->_conf->rgw_bucket_index_transaction_instrumentation;
+  constexpr uint32_t min_req_num_entries = 5;
+  constexpr uint32_t max_req_num_entries = 1005;
 
   ldout_bitx(bitx, dpp, 10) << "ENTERING " << __func__ << ": " << bucket_info.bucket <<
     " start_after=\"" << start_after <<
@@ -11179,27 +11303,22 @@ int RGWRados::cls_bucket_list_unordered(const DoutPrefixProvider *dpp,
   *is_truncated = false;
   librados::IoCtx index_pool;
 
-  std::map<int, std::string> oids;
-  int r = svc.bi_rados->open_bucket_index(dpp, bucket_info, shard_id, idx_layout, &index_pool, &oids, nullptr);
-  if (r < 0) {
-    return r;
-  }
+  int r = svc.bi_rados->open_bucket_index(dpp, bucket_info, &index_pool, nullptr);
 
   auto& ioctx = index_pool;
 
-  const uint32_t num_shards = oids.size();
+  auto bindexer = rgw::rados::BIndexer::create_unique(cct, dpp, bucket_info);
+
+  std::unique_ptr<rgw::BIShardIdent> shard_ident;
+  rgw::rados::BIndexer::ShardIterator shard_it;
 
   rgw_obj_index_key marker = start_after;
-  uint32_t current_shard;
-  if (shard_id >= 0) {
-    current_shard = shard_id;
-  } else if (start_after.empty()) {
-    current_shard = 0u;
+  if (start_after.empty()) {
+    shard_it = bindexer->create_shard_iterator();
   } else {
     // at this point we have a marker (start_after) that has something
     // in it, so we need to get to the bucket shard index, so we can
     // start reading from there
-
 
     // now convert the key (oid) to an rgw_obj_key since that will
     // separate out the namespace, name, and instance
@@ -11214,7 +11333,7 @@ int RGWRados::cls_bucket_list_unordered(const DoutPrefixProvider *dpp,
       // if the name is empty that means the object name came in with
       // a namespace only, and therefore we need to start our scan at
       // the first bucket index shard
-      current_shard = 0u;
+      shard_it = bindexer->create_shard_iterator();
     } else {
       // so now we have the key used to compute the bucket index shard
       // and can extract the specific shard from it
@@ -11224,7 +11343,7 @@ int RGWRados::cls_bucket_list_unordered(const DoutPrefixProvider *dpp,
         // because MultipartMetaFilter only checks .meta suffix, which may
         // exclude data multiparts but include some regular objects with .meta suffix
         // by mistake.
-        string index_hash_source;
+        std::string index_hash_source;
         r = parse_index_hash_source(obj_key.name, &index_hash_source);
         if (r < 0) {
 	  ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
@@ -11232,9 +11351,10 @@ int RGWRados::cls_bucket_list_unordered(const DoutPrefixProvider *dpp,
 	    "\", r=" << r << dendl;
           return r;
         }
-        current_shard = svc.bi_rados->bucket_shard_index(index_hash_source, num_shards);
+
+        shard_it = bindexer->create_shard_iterator(index_hash_source);
       } else {
-        current_shard = svc.bi_rados->bucket_shard_index(obj_key.name, num_shards);
+        shard_it = bindexer->create_shard_iterator(obj_key.name);
       }
     }
   }
@@ -11245,11 +11365,8 @@ int RGWRados::cls_bucket_list_unordered(const DoutPrefixProvider *dpp,
   uint32_t count = 0u;
   std::map<std::string, bufferlist> updates;
   rgw_obj_index_key last_added_entry;
-
-  while (count <= num_entries &&
-	 ((shard_id >= 0 && current_shard == uint32_t(shard_id)) ||
-	  current_shard < num_shards)) {
-    const std::string& oid = oids[current_shard];
+  while (count <= num_entries && shard_it.valid()) {
+    const std::string& oid = shard_it.get_oid();
     rgw_cls_list_ret result;
 
     librados::ObjectReadOperation op;
@@ -11345,8 +11462,9 @@ int RGWRados::cls_bucket_list_unordered(const DoutPrefixProvider *dpp,
     } // entry for loop
 
     if (!result.is_truncated) {
-      // if we reached the end of the shard read next shard
-      ++current_shard;
+      // if there are no more results on this shard, advance shard and
+      // set marker to read from beginning
+      shard_it.next();
       marker = rgw_obj_index_key();
     }
   } // shard loop
@@ -11482,11 +11600,17 @@ int RGWRados::remove_objs_from_index(const DoutPrefixProvider *dpp,
   if (is_layout_indexless(current_index)) {
     return -EINVAL;
   }
-  const uint32_t num_shards = current_index.layout.normal.num_shards;
+
+  auto hash_layout_p = rgw::hashed_layout_ptr(current_index.layout);
+  if (!hash_layout_p) {
+    return -EINVAL;
+  }
+
+  const uint32_t num_shards = hash_layout_p->num_shards;
 
   librados::IoCtx index_pool;
   std::map<int, std::string> index_oids;
-  int r = svc.bi_rados->open_bucket_index(dpp, bucket_info, std::nullopt,
+  int r = svc.bi_rados->open_bucket_index(dpp, bucket_info, rgw::rados::BIndexer::BI_ALL_SHARDS,
 					  bucket_info.layout.current_index,
 					  &index_pool, &index_oids, nullptr);
   if (r < 0) {
@@ -11782,13 +11906,18 @@ int RGWRados::check_bucket_shards(const RGWBucketInfo& bucket_info,
   bool need_resharding = false;
   uint32_t suggested_num_shards = 0;
   const bool is_versioned = bucket_info.versioned();
-  const uint32_t num_source_shards =
-    rgw::current_num_shards(bucket_info.layout);
-  const uint32_t min_layout_shards =
-    rgw::current_min_layout_shards(bucket_info.layout);
+
+  auto hash_layout_p = bucket_info.hashed_layout_ptr();
+  if (!hash_layout_p) {
+    ldpp_dout(dpp, 0) <<
+      "ERROR: tried to perform a hashed layout reshard on a "
+      "bucket with non-hashed layout: " << bucket_info.bucket << dendl;
+    return -EINVAL;
+  }
+  const uint32_t num_source_shards = hash_layout_p->num_shards;
 
   calculate_preferred_shards(dpp, is_versioned, num_objs,
-			     num_source_shards, min_layout_shards,
+			     num_source_shards, hash_layout_p->min_num_shards,
 			     need_resharding, &suggested_num_shards);
   if (! need_resharding) {
     return 0;
@@ -11803,7 +11932,7 @@ int RGWRados::check_bucket_shards(const RGWBucketInfo& bucket_info,
 
   ldpp_dout(dpp, 1) << "RGWRados::" << __func__ <<
     " bucket " << bucket_info.bucket.name <<
-    " needs resharding; current num shards " << num_source_shards <<
+    " needs resharding; current num shards " << hash_layout_p->num_shards <<
     "; new num shards " << suggested_num_shards << dendl;
 
   return add_bucket_to_reshard(dpp, bucket_info, suggested_num_shards, y);
@@ -11855,7 +11984,7 @@ int RGWRados::check_quota(const DoutPrefixProvider *dpp, const rgw_owner& bucket
   return quota_handler->check_quota(dpp, bucket_owner, bucket, quota, 1, obj_size, y);
 }
 
-int RGWRados::get_target_shard_id(const rgw::bucket_index_normal_layout& layout, const string& obj_key,
+int RGWRados::get_target_shard_id(const rgw::bucket_index_hashed_layout& layout, const string& obj_key,
                                   int *shard_id)
 {
   int r = 0;

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -689,16 +689,22 @@ public:
     int init(const DoutPrefixProvider *dpp,
 	     const RGWBucketInfo& bucket_info,
 	     const rgw::bucket_index_layout_generation& layout_gen,
-	     rgw::BIShardIndex _shard_idx,
-	     optional_yield y);
-    int init(const DoutPrefixProvider *dpp,
-	     const RGWBucketInfo& bucket_info,
-	     const rgw::bucket_index_layout_generation& layout_gen,
 	     const rgw::BIShardIdent& _shard_ident,
 	     optional_yield y);
     int init(const DoutPrefixProvider *dpp,
              rgw::rados::BIndexer::ShardIterator& shard_it,
              optional_yield y);
+
+    // OBI: deprecated; keep until we're fully using BIShardIdent
+    // rather than numeric indexes
+    int init(const DoutPrefixProvider *dpp,
+	     const RGWBucketInfo& bucket_info,
+	     const rgw::bucket_index_layout_generation& layout_gen,
+	     rgw::BIShardIndex shard_idx,
+	     optional_yield y) {
+      rgw::HashedShardIdent converted_shard_ident(shard_idx);
+      return init(dpp, bucket_info, layout_gen, converted_shard_ident, y);
+    }
 
     friend std::ostream& operator<<(std::ostream& out, const BucketShard& bs) {
       out << "BucketShard:{ bucket=" << bs.bucket <<
@@ -1519,6 +1525,9 @@ public:
       std::map<RGWObjCategory, RGWStorageStats>& stats, std::string *max_marker, bool* syncstopped = NULL);
   int get_bucket_stats_async(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout, int shard_id, boost::intrusive_ptr<rgw::sal::ReadStatsCB> cb);
 
+// for omap_entries, if it's nullptr erase omap, if it's
+// no_change_attrs_omap(), leave alone, and if it's anything else,
+// write those entries
   int put_bucket_instance_info(RGWBucketInfo& info, bool exclusive, ceph::real_time mtime,
 			       const std::map<std::string, bufferlist>* pattrs,
 			       const std::map<std::string, bufferlist>* omap_entries,

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -35,6 +35,7 @@
 #include "rgw_d3n_cacherequest.h"
 
 #include "services/svc_bi_rados.h"
+#include "services/svc_bindexer_rados.h"
 #include "common/Throttle.h"
 #include "common/ceph_mutex.h"
 #include "rgw_cache.h"
@@ -670,24 +671,42 @@ public:
   struct BucketShard {
     RGWRados *store;
     rgw_bucket bucket;
-    int shard_id;
+    std::unique_ptr<rgw::BIShardIdent> shard_ident;
     rgw_rados_ref bucket_obj;
 
-    explicit BucketShard(RGWRados *_store) : store(_store), shard_id(-1) {}
-    int init(const rgw_bucket& _bucket, const rgw_obj& obj,
-             RGWBucketInfo* out, const DoutPrefixProvider *dpp, optional_yield y);
-    int init(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const rgw_obj& obj, optional_yield y);
+    explicit BucketShard(RGWRados *_store) :
+      store(_store)
+    {}
+
+    int init(const rgw_bucket& _bucket,
+             const rgw_obj& obj,
+             RGWBucketInfo* out,
+             const DoutPrefixProvider *dpp,
+             optional_yield y);
+    int init(const DoutPrefixProvider *dpp,
+             const RGWBucketInfo& bucket_info,
+	     const rgw_obj& obj, optional_yield y);
     int init(const DoutPrefixProvider *dpp,
 	     const RGWBucketInfo& bucket_info,
-	     const rgw::bucket_index_layout_generation& index, int sid, optional_yield y);
+	     const rgw::bucket_index_layout_generation& layout_gen,
+	     rgw::BIShardIndex _shard_idx,
+	     optional_yield y);
+    int init(const DoutPrefixProvider *dpp,
+	     const RGWBucketInfo& bucket_info,
+	     const rgw::bucket_index_layout_generation& layout_gen,
+	     const rgw::BIShardIdent& _shard_ident,
+	     optional_yield y);
+    int init(const DoutPrefixProvider *dpp,
+             rgw::rados::BIndexer::ShardIterator& shard_it,
+             optional_yield y);
 
     friend std::ostream& operator<<(std::ostream& out, const BucketShard& bs) {
       out << "BucketShard:{ bucket=" << bs.bucket <<
-	", shard_id=" << bs.shard_id <<
+	", shard_id=" << bs.shard_ident <<
 	", bucket_obj=" << bs.bucket_obj << "}";
       return out;
     }
-  };
+  }; // BucketShard
 
   class Object {
     RGWRados *store;
@@ -1049,18 +1068,18 @@ public:
       RGWRados::Bucket *target;
       rgw_obj_key next_marker;
 
-      int list_objects_ordered(const DoutPrefixProvider *dpp,
-                               int64_t max,
-			       std::vector<rgw_bucket_dir_entry> *result,
-			       std::map<std::string, bool> *common_prefixes,
-			       bool *is_truncated,
-                               optional_yield y);
-      int list_objects_unordered(const DoutPrefixProvider *dpp,
-                                 int64_t max,
-				 std::vector<rgw_bucket_dir_entry> *result,
-				 std::map<std::string, bool> *common_prefixes,
-				 bool *is_truncated,
-                                 optional_yield y);
+      int list_objects_and_sort(const DoutPrefixProvider *dpp,
+                                int64_t max,
+                                std::vector<rgw_bucket_dir_entry> *result,
+                                std::map<std::string, bool> *common_prefixes,
+                                bool *is_truncated,
+                                optional_yield y);
+      int list_objects_by_shard(const DoutPrefixProvider *dpp,
+                                int64_t max,
+                                std::vector<rgw_bucket_dir_entry> *result,
+                                std::map<std::string, bool> *common_prefixes,
+                                bool *is_truncated,
+                                optional_yield y);
 
     public:
 
@@ -1089,15 +1108,8 @@ public:
 		       std::vector<rgw_bucket_dir_entry> *result,
 		       std::map<std::string, bool> *common_prefixes,
 		       bool *is_truncated,
-                       optional_yield y) {
-	if (params.allow_unordered) {
-	  return list_objects_unordered(dpp, max, result, common_prefixes,
-					is_truncated, y);
-	} else {
-	  return list_objects_ordered(dpp, max, result, common_prefixes,
-				      is_truncated, y);
-	}
-      }
+                       optional_yield y);
+
       rgw_obj_key& get_next_marker() {
         return next_marker;
       }
@@ -1507,7 +1519,10 @@ public:
       std::map<RGWObjCategory, RGWStorageStats>& stats, std::string *max_marker, bool* syncstopped = NULL);
   int get_bucket_stats_async(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout, int shard_id, boost::intrusive_ptr<rgw::sal::ReadStatsCB> cb);
 
-  int put_bucket_instance_info(RGWBucketInfo& info, bool exclusive, ceph::real_time mtime, const std::map<std::string, bufferlist> *pattrs, const DoutPrefixProvider *dpp, optional_yield y);
+  int put_bucket_instance_info(RGWBucketInfo& info, bool exclusive, ceph::real_time mtime,
+			       const std::map<std::string, bufferlist>* pattrs,
+			       const std::map<std::string, bufferlist>* omap_entries,
+			       const DoutPrefixProvider *dpp, optional_yield y);
   /* xxx dang obj_ctx -> svc */
   int get_bucket_instance_info(const std::string& meta_key, RGWBucketInfo& info, ceph::real_time *pmtime, std::map<std::string, bufferlist> *pattrs, optional_yield y, const DoutPrefixProvider *dpp);
   int get_bucket_instance_info(const rgw_bucket& bucket, RGWBucketInfo& info, ceph::real_time *pmtime, std::map<std::string, bufferlist> *pattrs, optional_yield y, const DoutPrefixProvider *dpp);
@@ -1532,7 +1547,9 @@ public:
 			      std::map<std::string, bufferlist> *pattrs = nullptr);
 
   int put_linked_bucket_info(RGWBucketInfo& info, bool exclusive, ceph::real_time mtime, obj_version *pep_objv,
-			     const std::map<std::string, bufferlist> *pattrs, bool create_entry_point,
+			     const std::map<std::string, bufferlist>* pattrs,
+			     const std::map<std::string, bufferlist>* omap_entries,
+			     bool create_entry_point,
                              const DoutPrefixProvider *dpp, optional_yield y);
 
   int cls_obj_prepare_op(const DoutPrefixProvider *dpp, BucketShard& bs, RGWModifyOp op, std::string& tag, rgw_obj& obj,
@@ -1600,10 +1617,23 @@ public:
 	      uint32_t max,
 	      std::list<rgw_cls_bi_entry> *entries,
 	      bool *is_truncated, bool reshardlog, optional_yield y);
-  int bi_list(BucketShard& bs, const std::string& filter_obj, const std::string& marker, uint32_t max, std::list<rgw_cls_bi_entry> *entries,
-              bool *is_truncated, bool reshardlog, optional_yield y);
-  int bi_list(const DoutPrefixProvider *dpp, rgw_bucket& bucket, const std::string& obj_name, const std::string& marker, uint32_t max,
-              std::list<rgw_cls_bi_entry> *entries, bool *is_truncated, bool reshardlog, optional_yield y);
+  int bi_list(BucketShard& bs,
+              const std::string& filter_obj,
+              const std::string& marker,
+              uint32_t max,
+              std::list<rgw_cls_bi_entry> *entries,
+              bool *is_truncated,
+              bool reshardlog,
+              optional_yield y);
+  int bi_list(const DoutPrefixProvider *dpp,
+              rgw_bucket& bucket,
+              const std::string& obj_name,
+              const std::string& marker,
+              uint32_t max,
+              std::list<rgw_cls_bi_entry> *entries,
+              bool *is_truncated,
+              bool reshardlog,
+              optional_yield y);
   int bi_remove(const DoutPrefixProvider *dpp, BucketShard& bs);
 
 
@@ -1615,7 +1645,7 @@ public:
                              uint64_t end_epoch, optional_yield y);
   int cls_obj_usage_log_clear(const DoutPrefixProvider *dpp, std::string& oid, optional_yield y);
 
-  int get_target_shard_id(const rgw::bucket_index_normal_layout& layout, const std::string& obj_key, int *shard_id);
+  int get_target_shard_id(const rgw::bucket_index_hashed_layout& layout, const std::string& obj_key, int *shard_id);
 
   int lock_exclusive(const rgw_pool& pool, const std::string& oid, ceph::timespan& duration, rgw_zone_id& zone_id, std::string& owner_id);
   int unlock(const rgw_pool& pool, const std::string& oid, rgw_zone_id& zone_id, std::string& owner_id);

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -155,7 +155,7 @@ void RGWBucketReshard::calculate_preferred_shards(
 class BucketReshardShard {
   rgw::sal::RadosStore* store;
   const RGWBucketInfo& bucket_info;
-  int shard_id;
+  const rgw::BIShardIdent& shard_id;
   RGWRados::BucketShard bs;
   vector<rgw_cls_bi_entry> entries;
   map<RGWObjCategory, rgw_bucket_category_stats> stats;
@@ -198,12 +198,20 @@ public:
   BucketReshardShard(const DoutPrefixProvider *dpp,
 		     rgw::sal::RadosStore *_store, const RGWBucketInfo& _bucket_info,
                      const rgw::bucket_index_layout_generation& index,
-                     int shard_id, deque<librados::AioCompletion *>& _completions) :
-    store(_store), bucket_info(_bucket_info), shard_id(shard_id),
-    bs(store->getRados()), aio_completions(_completions)
+                     const rgw::BIShardIdent& shard_id,
+                     deque<librados::AioCompletion *>& _completions) :
+    store(_store),
+    bucket_info(_bucket_info),
+    shard_id(shard_id),
+    bs(store->getRados()),
+    aio_completions(_completions)
   {
-#warning "OBI: BucketShard::init with generation"
-    bs.init(dpp, bucket_info, index, shard_id, null_yield);
+    int ret = bs.init(dpp, bucket_info, index, shard_id, null_yield);
+    if (ret < 0) {
+      throw std::runtime_error(
+        std::string("BucketReshardShard constructor could not init RGWRados::BucketShard with error code ") +
+        std::to_string(ret));
+    }
 
     max_aio_completions =
       store->ctx()->_conf.get_val<uint64_t>("rgw_reshard_max_aio");
@@ -211,7 +219,7 @@ public:
       store->ctx()->_conf.get_val<uint64_t>("rgw_reshard_batch_size");
   }
 
-  int get_shard_id() const {
+  const rgw::BIShardIdent& get_shard_id() const {
     return shard_id;
   }
 
@@ -289,25 +297,47 @@ public:
 class BucketReshardManager {
   rgw::sal::RadosStore *store;
   std::deque<librados::AioCompletion *> completions;
-  std::vector<BucketReshardShard> target_shards;
+  std::map<std::unique_ptr<rgw::BIShardIdent>,
+           BucketReshardShard,
+           rgw::BIShardIdent::Comparator> target_shards;
+  const rgw::rados::BIndexer& target_bindexer;
 
 public:
   BucketReshardManager(const DoutPrefixProvider *dpp,
 		       rgw::sal::RadosStore *_store,
 		       const RGWBucketInfo& bucket_info,
-                       const rgw::bucket_index_layout_generation& target)
-    : store(_store)
+                       const rgw::bucket_index_layout_generation& target,
+                       rgw::rados::BIndexer& _target_bindexer)
+    : store(_store),
+      target_bindexer(_target_bindexer)
   {
-    const uint32_t num_shards = rgw::num_shards(target.layout.specs);
-    target_shards.reserve(num_shards);
-    for (uint32_t i = 0; i < num_shards; ++i) {
-      target_shards.emplace_back(dpp, store, bucket_info, target, i, completions);
+    std::vector<std::unique_ptr<rgw::BIShardIdent>> shard_idents;
+    int r = target_bindexer.get_shard_idents(shard_idents);
+    if (r < 0) {
+      throw std::runtime_error("unable to get shard identifiers for "
+                               "bucket in BucketReshardManager constructor");
+    }
+
+    for (const auto& i : shard_idents) {
+#if 1 // this seems safer, but is it necessary?
+      auto ident = i->clone();
+      // the BucketReshardShard that's the value in this map, will
+      // share (refer to) the BIShardIdent in the key of the map
+      target_shards.try_emplace(std::move(ident),
+                                dpp, store, bucket_info, target, *ident, completions);
+#else // this doesn't work and I'm not sure why
+      // since the vector was only created for this purpose, we can move
+      // the idents out of the vector into the map
+      rgw::BIShardIdent& ident = *i; // save the shard ident
+      target_shards.try_emplace(std::move(i),
+                                dpp, store, bucket_info, target, ident, completions);
+#endif
     }
   }
 
   ~BucketReshardManager() {
     for (auto& shard : target_shards) {
-      int ret = shard.wait_all_aio();
+      int ret = shard.second.wait_all_aio();
       if (ret < 0) {
         ldout(store->ctx(), 20) << __func__ <<
 	  ": shard->wait_all_aio() returned ret=" << ret << dendl;
@@ -316,15 +346,19 @@ public:
     target_shards.clear();
   }
 
-  int add_entry(int shard_index,
+  int add_entry(const std::unique_ptr<rgw::BIShardIdent>& shard_ident,
                 rgw_cls_bi_entry& entry, bool account, RGWObjCategory category,
                 const rgw_bucket_category_stats& entry_stats,
-                bool process_log = false) {
-    int ret = target_shards[shard_index].add_entry(entry, account, category,
-						   entry_stats, process_log);
-    if (ret < 0) {
+                bool process_log = false)
+  {
+    try {
+      auto& bucket_reshard_shard = target_shards.at(shard_ident);
+      bucket_reshard_shard.add_entry(entry, account, category,
+                                     entry_stats, process_log);
+    } catch (const std::out_of_range& e) {
+      const int ret = -ENOENT;
       derr << "ERROR: target_shards.add_entry(" << entry.idx <<
-	") returned error: " << cpp_strerror(-ret) << dendl;
+	") returned error: " << cpp_strerror(ret) << dendl;
       return ret;
     }
 
@@ -335,16 +369,16 @@ public:
              const DoutPrefixProvider *dpp = nullptr) {
     int ret = 0;
     for (auto& shard : target_shards) {
-      int r = shard.flush(process_log);
+      int r = shard.second.flush(process_log);
       if (r < 0) {
-        derr << "ERROR: target_shards[" << shard.get_shard_id() << "].flush() returned error: " << cpp_strerror(-r) << dendl;
+        derr << "ERROR: target_shards[" << shard.second.get_shard_id() << "].flush() returned error: " << cpp_strerror(-r) << dendl;
         ret = r;
       }
     }
     for (auto& shard : target_shards) {
-      int r = shard.wait_all_aio();
+      int r = shard.second.wait_all_aio();
       if (r < 0) {
-        derr << "ERROR: target_shards[" << shard.get_shard_id() << "].wait_all_aio() returned error: " << cpp_strerror(-r) << dendl;
+        derr << "ERROR: target_shards[" << shard.second.get_shard_id() << "].wait_all_aio() returned error: " << cpp_strerror(-r) << dendl;
         ret = r;
       }
       if (br != nullptr) {
@@ -385,47 +419,154 @@ static int remove_old_reshard_instance(rgw::sal::RadosStore* store,
   return store->ctl()->bucket->remove_bucket_instance_info(bucket, info, y, dpp);
 }
 
+static int ordered_layout_from_sample(rgw::sal::RadosStore *store,
+                                      const int max_op_entries,
+                                      std::unique_ptr<rgw::rados::BIndexer>& source_bindexer,
+                                      uint32_t& num_shards,
+                                      rgw::rados::OrderedBIndexer::InitialLayout& layout,
+                                      const DoutPrefixProvider* dpp,
+                                      optional_yield y)
+{
+  auto shard_it = source_bindexer->create_shard_iterator();
+  if (! shard_it.valid()) {
+    ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
+      " unable to create a ShardIterator to generate ordered bucket layout" << dendl;
+    return -EIO;
+  }
+
+  // when we have 10X # of desired shards, we can stop sampling early
+  constexpr uint32_t sample_factor = 10;
+  constexpr bool process_log = false;
+
+  std::set<std::string> key_sample;
+
+  std::string marker;
+  std::list<rgw_cls_bi_entry> entries;
+  for ( ;
+        key_sample.size() < sample_factor * num_shards && shard_it.valid();
+        shard_it.next())
+  {
+    marker.clear();
+    RGWRados::BucketShard bs(store->getRados());
+    bs.init(dpp, shard_it, y);
+    bool is_truncated = true;
+    const std::string null_object_filter; // empty string as not filtering at all
+
+    while (is_truncated) {
+      entries.clear();
+
+      int ret = store->getRados()->bi_list(bs, null_object_filter,
+                                           marker, max_op_entries, &entries,
+                                           &is_truncated, process_log, y);
+      if (ret == -ENOENT) {
+        ldpp_dout(dpp, 1) << "WARNING: " << __func__ <<
+          " failed to find shard ident=" << shard_it.get_ident()->to_string() <<
+          ", oid=" << shard_it.get_oid() <<
+          ", skipping" << dendl;
+        // break out of the is_truncated loop and move on to the next shard
+        break;
+      } else if (ret < 0) {
+        derr << "ERROR: bi_list(): " << cpp_strerror(-ret) << dendl;
+        return ret;
+      }
+
+      for (auto iter = entries.begin(); iter != entries.end(); ++iter) {
+        rgw_cls_bi_entry& entry = *iter;
+        marker = entry.idx;
+
+        cls_rgw_obj_key cls_key; // contains key and instance
+        RGWObjCategory category;
+        rgw_bucket_category_stats stats;
+        std::ignore = entry.get_info(&cls_key, &category, &stats);
+
+        rgw_obj_key key(cls_key); // contains name, instance, and namespace
+        if (entry.type == BIIndexType::Plain && key.instance.empty()) {
+          key_sample.insert(key.name);
+        }
+      } // entries loop
+    } // while is truncated
+  } // shard loop
+
+  // uses Bresenham's line algorithm to filter samples so we end up
+  // with the right number of shards
+  if (key_sample.size() > num_shards - 1) {
+    const int dx = key_sample.size() - 1;
+    const int dy = num_shards - 2; // delta is one fewer, and leave room for special last shard
+    int deviance = 2 * dy - dx;
+
+    bool keep_next = true;
+    for (auto it = key_sample.begin(); it != key_sample.end(); ) {
+      if (!keep_next) {
+        it = key_sample.erase(it); // advances it
+      } else {
+        ++it;
+      }
+
+      if (deviance > 0) {
+        keep_next = true;
+        deviance += 2 * (dy - dx);
+      } else {
+        keep_next = false;
+        deviance += 2 * dy;
+      }
+    } // for
+  } // if too many samples
+
+  layout.clear();
+  int index_offset = 0;
+  for (const auto& i : key_sample) {
+    rgw::NestedIndex ni{ rgw::rados::OrderedBIndexer::STARTING_INDEX_ID + index_offset++ };
+    layout.try_emplace(i, i, ni);
+  }
+  rgw::NestedIndex ni{rgw::rados::OrderedBIndexer::STARTING_INDEX_ID + index_offset++ };
+  layout.try_emplace("", "", ni); // special last entry
+
+  return 0;
+} // ordered_layout_from_sample
+
+
 // initialize the new bucket index shard objects
 static int init_target_index(rgw::sal::RadosStore* store,
-                             RGWBucketInfo& bucket_info,
-                             const rgw::bucket_index_layout_generation& index,
+                             std::unique_ptr<rgw::rados::BIndexer>& target_bindexer,
                              ReshardFaultInjector& fault,
                              bool& support_logrecord,
+                             std::map<std::string, bufferlist>& index_omap_entries,
                              const DoutPrefixProvider* dpp,
 			     optional_yield y)
 {
   int ret = 0;
-  std::map<std::string, bufferlist> binfo_map_entries;
   if (ret = fault.check("init_index");
       ret == 0) { // no fault injected, initialize index
-    ret = store->svc()->bi->init_index(dpp, y, bucket_info, index, &binfo_map_entries, true);
+    ret = store->svc()->bi->init_index(dpp, y, target_bindexer, &index_omap_entries, true);
   }
   if (ret == -EOPNOTSUPP) {
     ldpp_dout(dpp, 0) << "WARNING: " << "init_index() does not support logrecord; "
                       << "falling back to block reshard mode." << dendl;
     support_logrecord = false;
-    ret = store->svc()->bi->init_index(dpp, y, bucket_info, index, &binfo_map_entries, false);
+    ret = store->svc()->bi->init_index(dpp, y, target_bindexer, &index_omap_entries, false);
   } else if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: " << __func__ << " failed to initialize "
        "target index shard objects: " << cpp_strerror(ret) << dendl;
     return ret;
   }
 
-  if (!bucket_info.datasync_flag_enabled()) {
+  auto& bucket_info = target_bindexer->get_bucket_info();
+  auto& layout_gen = target_bindexer->get_layout_gen();
+  if (! bucket_info.datasync_flag_enabled()) {
     // if bucket sync is disabled, disable it on each of the new shards too
-    auto log = rgw::log_layout_from_index(0, index);
+    auto log = rgw::log_layout_from_index(0, layout_gen);
     ret = store->svc()->bilog_rados->log_stop(dpp, y, bucket_info, log, -1);
     if (ret < 0) {
       ldpp_dout(dpp, 0) << "ERROR: " << __func__ << " failed to disable "
           "bucket sync on the target index shard objects: "
           << cpp_strerror(ret) << dendl;
-      store->svc()->bi->clean_index(dpp, y, bucket_info, index);
+      store->svc()->bi->clean_index(dpp, y, target_bindexer);
       return ret;
     }
   }
 
   return ret;
-}
+} // init_target_index
 
 // initialize a target index layout, create its bucket index shard objects, and
 // write the target layout to the bucket instance metadata
@@ -433,15 +574,31 @@ static int init_target_layout(rgw::sal::RadosStore* store,
                               RGWBucketInfo& bucket_info,
 			      std::map<std::string, bufferlist>& bucket_attrs,
                               ReshardFaultInjector& fault,
-                              const uint32_t new_num_shards,
+                              const int max_op_entries,
+                              uint32_t& new_num_shards,
 			      rgw::BucketIndexType dest_index_type,
                               bool& support_logrecord,
+                              std::unique_ptr<rgw::rados::BIndexer>& target_bindexer,
+                              std::map<std::string, bufferlist>& index_omap_entries,
                               const DoutPrefixProvider* dpp, optional_yield y)
 {
   auto prev = bucket_info.layout; // make a copy for cleanup
   const auto current = prev.current_index;
 
-  // initialize a new normal target index layout generation
+  rgw::rados::OrderedBIndexer::InitialLayout ordered_layout; // used when destination is ordered
+  if (dest_index_type == rgw::BucketIndexType::Ordered) {
+    auto source_bindexer = rgw::rados::BIndexer::create_unique(store, dpp, bucket_info);
+    int r = ordered_layout_from_sample(store, max_op_entries,
+                                       source_bindexer, new_num_shards, ordered_layout,
+                                       dpp, y);
+    if (r < 0) {
+      return r;
+    }
+    // note: new_num_shards may have been altered in ordered_layout_from_sample
+  }
+
+  // initialize a new target index layout generation
+  // OBI todo: rename target_layout
   rgw::bucket_index_layout_generation target;
 
   int ret = create_layout_generation(current.gen + 1,
@@ -451,8 +608,14 @@ static int init_target_layout(rgw::sal::RadosStore* store,
     return ret;
   }
 
-  auto target_bindexer =
-    rgw::rados::BIndexer::create_unique(store, dpp, bucket_info, target);
+  target_bindexer.reset(rgw::rados::BIndexer::create(store, dpp, bucket_info, target));
+
+  if (dest_index_type == rgw::BucketIndexType::Ordered) {
+    rgw::rados::OrderedBIndexer* obi =
+      dynamic_cast<rgw::rados::OrderedBIndexer*>(target_bindexer.get());
+
+    obi->set_initial_layout(ordered_layout);
+  }
 
   if (! target_bindexer->may_support_log_record()) {
     // if definitely does not support set it to false
@@ -485,7 +648,9 @@ static int init_target_layout(rgw::sal::RadosStore* store,
   }
 
   // create the index shard objects
-  ret = init_target_index(store, bucket_info, target, fault, support_logrecord, dpp, y);
+  ret = init_target_index(store, target_bindexer, fault, support_logrecord,
+                          index_omap_entries,
+                          dpp, y);
   if (ret < 0) {
     return ret;
   }
@@ -495,7 +660,6 @@ static int init_target_layout(rgw::sal::RadosStore* store,
   int tries = 0;
 
   do {
-
     // update resharding state
     bucket_info.layout.target_index = target;
     if (support_logrecord) {
@@ -644,9 +808,12 @@ static int init_reshard(rgw::sal::RadosStore* store,
                         RGWBucketInfo& bucket_info,
 			std::map<std::string, bufferlist>& bucket_attrs,
                         ReshardFaultInjector& fault,
-                        const uint32_t new_num_shards,
+                        const int max_op_entries,
+                        uint32_t& new_num_shards,
 			const std::optional<rgw::BucketIndexType> bindex_type,
                         bool& support_logrecord,
+                        std::unique_ptr<rgw::rados::BIndexer>& target_bindexer,
+                        std::map<std::string, bufferlist>& index_omap_entries,
                         const DoutPrefixProvider *dpp, optional_yield y)
 {
   if (new_num_shards == 0) {
@@ -658,18 +825,31 @@ static int init_reshard(rgw::sal::RadosStore* store,
   if (bindex_type) {
     index_type = *bindex_type;
   } else {
-    index_type = bucket_info.get_current_bucket_index_type();
+    // if destination index type not provided, assume hashed
+    index_type = rgw::BucketIndexType::Hashed;
   }
 
-  int ret = init_target_layout(store, bucket_info, bucket_attrs, fault,
+  // OBI: temporary prohibition
+  if (bucket_info.layout.current_index.layout.type == rgw::BucketIndexType::Ordered &&
+      index_type == rgw::BucketIndexType::Ordered) {
+    ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
+      " currently cannot reshard an index using both from and to ordered "
+      "bucket indexes" << dendl;
+    return -EINVAL;
+  }
+
+  int ret = init_target_layout(store, bucket_info, bucket_attrs, fault, max_op_entries,
 			       new_num_shards, index_type,
-                               support_logrecord, dpp, y);
+                               support_logrecord,
+                               target_bindexer, index_omap_entries,
+                               dpp, y);
   if (ret < 0) {
     return ret;
   }
 
-  // trim the reshard log entries to guarantee that any existing log entries are cleared,
-  // if there are no reshard log entries, this is a no-op that costs little time
+  // trim the reshard log entries to guarantee that any existing log
+  // entries are cleared, if there are no reshard log entries, this is
+  // a no-op that costs little time
   if (support_logrecord) {
     if (ret = fault.check("trim_reshard_log_entries");
         ret == 0) { // no fault injected, trim reshard log entries
@@ -818,8 +998,10 @@ static int cancel_reshard(rgw::sal::RadosStore* store,
 static int commit_target_layout(rgw::sal::RadosStore* store,
                                 RGWBucketInfo& bucket_info,
                                 std::map<std::string, bufferlist>& bucket_attrs,
+                                std::map<std::string, bufferlist>* new_omap,
                                 ReshardFaultInjector& fault,
-                                const DoutPrefixProvider *dpp, optional_yield y)
+                                const DoutPrefixProvider *dpp,
+                                optional_yield y)
 {
   auto& layout = bucket_info.layout;
   const auto next_log_gen = layout.logs.empty() ? 1 :
@@ -843,7 +1025,7 @@ static int commit_target_layout(rgw::sal::RadosStore* store,
     ret = store->getRados()->put_bucket_instance_info(
         bucket_info, false, real_time(),
 	&bucket_attrs,
-	no_change_attrs_omap(), // retain possible omap to access shard info
+        new_omap,
 	dpp, y);
   } else if (ret == -ECANCELED) {
     fault.clear(); // clear the fault so a retry can succeed
@@ -854,6 +1036,7 @@ static int commit_target_layout(rgw::sal::RadosStore* store,
 static int commit_reshard(rgw::sal::RadosStore* store,
                           RGWBucketInfo& bucket_info,
 			  std::map<std::string, bufferlist>& bucket_attrs,
+			  std::map<std::string, bufferlist>* new_omap,
                           ReshardFaultInjector& fault,
                           const DoutPrefixProvider *dpp, optional_yield y)
 {
@@ -864,7 +1047,7 @@ static int commit_reshard(rgw::sal::RadosStore* store,
   int tries = 0;
   int ret = 0;
   do {
-    ret = commit_target_layout(store, bucket_info, bucket_attrs, fault, dpp, y);
+    ret = commit_target_layout(store, bucket_info, bucket_attrs, new_omap, fault, dpp, y);
     if (ret == -ECANCELED) {
       // racing write detected, read the latest bucket info and try again
       int ret2 = store->getRados()->get_bucket_instance_info(
@@ -1083,7 +1266,6 @@ int RGWBucketReshard::calc_target_shard(const RGWBucketInfo& bucket_info,
 					const rgw_obj_key& key,
                                         int& shard,
 					const DoutPrefixProvider* dpp) {
-#warning "fix this"
   auto hash_layout_p = bucket_info.hashed_layout_ptr();
   if (! hash_layout_p) {
     ldpp_dout(dpp, 0) <<
@@ -1114,9 +1296,11 @@ int RGWBucketReshard::calc_target_shard(const RGWBucketInfo& bucket_info,
 
 int RGWBucketReshard::reshard_process(const rgw::bucket_index_layout_generation& current,
                                       int& max_op_entries,
+                                      std::unique_ptr<rgw::rados::BIndexer>& source_bindexer,
                                       BucketReshardManager& target_shards_mgr,
+                                      std::unique_ptr<rgw::rados::BIndexer>& target_bindexer,
                                       bool verbose_json_out,
-                                      ostream *out,
+                                      std::ostream *out,
                                       Formatter *formatter,
 				      rgw::BucketReshardState reshard_stage,
                                       const DoutPrefixProvider* dpp,
@@ -1151,21 +1335,32 @@ int RGWBucketReshard::reshard_process(const rgw::bucket_index_layout_generation&
     (*out) << stage;
   }
 
-  const uint32_t num_source_shards = rgw::num_shards(current.layout.specs);
-  string marker;
-  for (uint32_t i = 0; i < num_source_shards; ++i) {
-    bool is_truncated = true;
+  auto shard_it = source_bindexer->create_shard_iterator();
+  if (! shard_it.valid()) {
+    ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
+      " unable to create a ShardIterator for bucket " << bucket_info.bucket << dendl;
+    return -EIO;
+  }
+
+  std::string marker;
+  for ( ; shard_it.valid(); shard_it.next()) {
     marker.clear();
-    const std::string null_object_filter; // empty string since we're not filtering by object
+    RGWRados::BucketShard bs(store->getRados());
+    bs.init(dpp, shard_it, y);
+    bool is_truncated = true;
+    const std::string null_object_filter; // empty string as not filtering at all
+
     while (is_truncated) {
       entries.clear();
 
-      int ret = store->getRados()->bi_list(dpp, bucket_info, i, null_object_filter,
+      int ret = store->getRados()->bi_list(bs, null_object_filter,
                                            marker, max_op_entries, &entries,
                                            &is_truncated, process_log, y);
       if (ret == -ENOENT) {
-        ldpp_dout(dpp, 1) << "WARNING: " << __func__ << " failed to find shard "
-            << i << ", skipping" << dendl;
+        ldpp_dout(dpp, 1) << "WARNING: " << __func__ <<
+          " failed to find shard ident=" << shard_it.get_ident()->to_string() <<
+          ", oid=" << shard_it.get_oid() <<
+          ", skipping" << dendl;
         // break out of the is_truncated loop and move on to the next shard
         break;
       } else if (ret < 0) {
@@ -1178,7 +1373,7 @@ int RGWBucketReshard::reshard_process(const rgw::bucket_index_layout_generation&
         if (verbose_json_out) {
           formatter->open_object_section("entry");
 
-          encode_json("shard_id", i, formatter);
+          encode_json("shard_ident", shard_it.get_ident()->to_string(), formatter);
           encode_json("num_entry", stage_entries, formatter);
           encode_json("entry", entry, formatter);
         }
@@ -1199,13 +1394,15 @@ int RGWBucketReshard::reshard_process(const rgw::bucket_index_layout_generation&
           continue;
         }
 
-        int shard_index;
-        ret = calc_target_shard(bucket_info, key, shard_index, dpp);
+        std::unique_ptr<rgw::BIShardIdent> shard_ident;
+        ret = target_bindexer->get_bucket_index_object(key.get_index_key_name(),
+                                                       nullptr,
+                                                       shard_ident);
         if (ret < 0) {
           return ret;
         }
 
-        ret = target_shards_mgr.add_entry(shard_index, entry, account,
+        ret = target_shards_mgr.add_entry(shard_ident, entry, account,
                   category, stats, process_log);
         if (ret < 0) {
           return ret;
@@ -1241,10 +1438,11 @@ int RGWBucketReshard::reshard_process(const rgw::bucket_index_layout_generation&
   }
 
   return 0;
-}
+} // reshard_process
 
 int RGWBucketReshard::do_reshard(const rgw::bucket_index_layout_generation& current,
-                                 const rgw::bucket_index_layout_generation& target,
+                                 rgw::bucket_index_layout_generation& target,
+                                 std::unique_ptr<rgw::rados::BIndexer>& target_bindexer,
                                  int max_op_entries, // max num to process per op
                                  bool support_logrecord,
 				 bool verbose,
@@ -1253,7 +1451,6 @@ int RGWBucketReshard::do_reshard(const rgw::bucket_index_layout_generation& curr
                                  ReshardFaultInjector& fault,
                                  const DoutPrefixProvider *dpp, optional_yield y)
 {
-#warning "work on this"
   if (out) {
     (*out) << "tenant: " << bucket_info.bucket.tenant << std::endl;
     (*out) << "bucket name: " << bucket_info.bucket.name << std::endl;
@@ -1265,14 +1462,18 @@ int RGWBucketReshard::do_reshard(const rgw::bucket_index_layout_generation& curr
     return -EINVAL;
   }
 
-  BucketReshardManager target_shards_mgr(dpp, store, bucket_info, target);
-
+  auto source_bindexer =
+    rgw::rados::BIndexer::create_unique(store, dpp, bucket_info);
+  BucketReshardManager target_shards_mgr(dpp, store, bucket_info, target,
+                                         *target_bindexer);
   bool verbose_json_out = verbose && (formatter != nullptr) && (out != nullptr);
 
   if (support_logrecord) {
     // a log is written to shard going with client op at this state
     ceph_assert(bucket_info.layout.resharding == rgw::BucketReshardState::InLogrecord);
-    int ret = reshard_process(current, max_op_entries, target_shards_mgr, verbose_json_out, out,
+    int ret = reshard_process(current, max_op_entries,
+                              source_bindexer, target_shards_mgr, target_bindexer,
+                              verbose_json_out, out,
                               formatter, bucket_info.layout.resharding, dpp, y);
     if (ret < 0) {
       ldpp_dout(dpp, 0) << __func__ << ": failed in logrecord state of reshard ret = " << ret << dendl;
@@ -1286,7 +1487,9 @@ int RGWBucketReshard::do_reshard(const rgw::bucket_index_layout_generation& curr
 
     // block the client op and complete the resharding
     ceph_assert(bucket_info.layout.resharding == rgw::BucketReshardState::InProgress);
-    ret = reshard_process(current, max_op_entries, target_shards_mgr, verbose_json_out, out,
+    ret = reshard_process(current, max_op_entries,
+                          source_bindexer, target_shards_mgr, target_bindexer,
+                          verbose_json_out, out,
 			  formatter, bucket_info.layout.resharding, dpp, y);
     if (ret < 0) {
       ldpp_dout(dpp, 0) << __func__ << ": failed in progress state of reshard ret = " << ret << dendl;
@@ -1295,7 +1498,9 @@ int RGWBucketReshard::do_reshard(const rgw::bucket_index_layout_generation& curr
   } else {
     // setting InProgress state, but doing InLogrecord state
     ceph_assert(bucket_info.layout.resharding == rgw::BucketReshardState::InProgress);
-    int ret = reshard_process(current, max_op_entries, target_shards_mgr, verbose_json_out, out,
+    int ret = reshard_process(current, max_op_entries,
+                              source_bindexer, target_shards_mgr, target_bindexer,
+                              verbose_json_out, out,
                               formatter, rgw::BucketReshardState::InLogrecord, dpp, y);
     if (ret < 0) {
       ldpp_dout(dpp, 0) << __func__ << ": failed in logrecord state of reshard ret = " << ret << dendl;
@@ -1311,7 +1516,7 @@ int RGWBucketReshard::get_status(const DoutPrefixProvider *dpp, optional_yield y
   return store->svc()->bi_rados->get_reshard_status(dpp, y, bucket_info, status);
 }
 
-int RGWBucketReshard::execute(int num_shards,
+int RGWBucketReshard::execute(uint32_t num_shards,
 			      const std::optional<rgw::BucketIndexType> dest_bindex_type,
                               ReshardFaultInjector& fault,
                               int max_op_entries,  // max num to process per op
@@ -1338,20 +1543,31 @@ int RGWBucketReshard::execute(int num_shards,
     }
   }
 
+  // init_reshard will use the target index and other factors to
+  // determine if this should remain true or instead be false
   bool support_logrecord = true;
-  // prepare the target index and add its layout the bucket info
-  ret = init_reshard(store, bucket_info, bucket_attrs, fault,
+
+  std::unique_ptr<rgw::rados::BIndexer> target_bindexer;
+
+  // currently only used for ordered bucket indexes
+  std::map<std::string, bufferlist> index_omap_entries;
+
+  // prepare the target index and add its layout to the bucket info;
+  // num_shards may be altered
+  ret = init_reshard(store, bucket_info, bucket_attrs, fault, max_op_entries,
 		     num_shards, dest_bindex_type,
-                     support_logrecord, dpp, y);
+                     support_logrecord,
+                     target_bindexer, index_omap_entries,
+                     dpp, y);
   if (ret < 0) {
     return ret;
   }
 
   if (ret = fault.check("do_reshard");
       ret == 0) { // no fault injected, do the reshard
-#warning "go into here"
     ret = do_reshard(bucket_info.layout.current_index,
                      *bucket_info.layout.target_index,
+                     target_bindexer,
                      max_op_entries, support_logrecord,
                      verbose, out, formatter, fault, dpp, y);
   }
@@ -1364,12 +1580,28 @@ int RGWBucketReshard::execute(int num_shards,
     return ret;
   }
 
-  auto current_num_shards = rgw::num_shards(bucket_info.layout.current_index);
-  ret = commit_reshard(store, bucket_info, bucket_attrs, fault, dpp, y);
+  std::map<std::string, bufferlist>* new_omap = nullptr;
+  const auto source_type = bucket_info.layout.current_index.layout.type;
+  const auto target_type = bucket_info.layout.target_index->layout.type;
+  if (source_type == rgw::BucketIndexType::Hashed) {
+    if (target_type == rgw::BucketIndexType::Hashed) {
+      new_omap = no_change_attrs_omap();
+    } else if (target_type == rgw::BucketIndexType::Ordered) {
+      new_omap = &index_omap_entries;
+    }
+  } else {
+    // new: we have to keep the omap so we can generate the list of shards
+    // to ultimately delete
+    new_omap = no_change_attrs_omap();
+  }
+
+  ret = commit_reshard(store, bucket_info, bucket_attrs, new_omap,
+                       fault, dpp, y);
   if (ret < 0) {
     return ret;
   }
 
+  const auto current_num_shards = rgw::num_shards(bucket_info.layout.current_index);
   ldpp_dout(dpp, 1) << __func__ << " INFO: reshard of bucket \"" <<
     bucket_info.bucket.name << "\" from " <<
     current_num_shards << " shards to " << num_shards <<
@@ -1384,7 +1616,6 @@ bool RGWBucketReshard::should_zone_reshard_now(const RGWBucketInfo& bucket,
   return !zone_svc->need_to_log_data() ||
     bucket.layout.logs.size() < max_bilog_history;
 }
-
 
 RGWReshard::RGWReshard(rgw::sal::RadosStore* _store, bool _verbose, ostream *_out,
                        Formatter *_formatter) :

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -23,9 +23,12 @@
 #include "services/svc_sys_obj.h"
 #include "services/svc_tier_rados.h"
 #include "services/svc_bilog_rados.h"
+#include "services/svc_bindexer_rados.h"
+
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
+
 
 using namespace std;
 
@@ -199,6 +202,7 @@ public:
     store(_store), bucket_info(_bucket_info), shard_id(shard_id),
     bs(store->getRados()), aio_completions(_completions)
   {
+#warning "OBI: BucketShard::init with generation"
     bs.init(dpp, bucket_info, index, shard_id, null_yield);
 
     max_aio_completions =
@@ -258,7 +262,9 @@ public:
     }
     ret = bs.bucket_obj.aio_operate(c, &op);
     if (ret < 0) {
-      derr << "ERROR: failed to store entries in target bucket shard (bs=" << bs.bucket << "/" << bs.shard_id << ") error=" << cpp_strerror(-ret) << dendl;
+      derr << "ERROR: failed to store entries in target bucket shard (bs=" <<
+        bs.bucket << "/" << bs.shard_ident << ") error=" <<
+        cpp_strerror(-ret) << dendl;
       return ret;
     }
     entries.clear();
@@ -282,8 +288,8 @@ public:
 
 class BucketReshardManager {
   rgw::sal::RadosStore *store;
-  deque<librados::AioCompletion *> completions;
-  vector<BucketReshardShard> target_shards;
+  std::deque<librados::AioCompletion *> completions;
+  std::vector<BucketReshardShard> target_shards;
 
 public:
   BucketReshardManager(const DoutPrefixProvider *dpp,
@@ -292,7 +298,7 @@ public:
                        const rgw::bucket_index_layout_generation& target)
     : store(_store)
   {
-    const uint32_t num_shards = rgw::num_shards(target.layout.normal);
+    const uint32_t num_shards = rgw::num_shards(target.layout.specs);
     target_shards.reserve(num_shards);
     for (uint32_t i = 0; i < num_shards; ++i) {
       target_shards.emplace_back(dpp, store, bucket_info, target, i, completions);
@@ -385,19 +391,20 @@ static int init_target_index(rgw::sal::RadosStore* store,
                              const rgw::bucket_index_layout_generation& index,
                              ReshardFaultInjector& fault,
                              bool& support_logrecord,
-                             const DoutPrefixProvider* dpp, optional_yield y)
+                             const DoutPrefixProvider* dpp,
+			     optional_yield y)
 {
-
   int ret = 0;
+  std::map<std::string, bufferlist> binfo_map_entries;
   if (ret = fault.check("init_index");
       ret == 0) { // no fault injected, initialize index
-    ret = store->svc()->bi->init_index(dpp, y, bucket_info, index, true);
+    ret = store->svc()->bi->init_index(dpp, y, bucket_info, index, &binfo_map_entries, true);
   }
   if (ret == -EOPNOTSUPP) {
-    ldpp_dout(dpp, 0) << "WARNING: " << "init_index() does not supported logrecord, "
+    ldpp_dout(dpp, 0) << "WARNING: " << "init_index() does not support logrecord; "
                       << "falling back to block reshard mode." << dendl;
     support_logrecord = false;
-    ret = store->svc()->bi->init_index(dpp, y, bucket_info, index, false);
+    ret = store->svc()->bi->init_index(dpp, y, bucket_info, index, &binfo_map_entries, false);
   } else if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: " << __func__ << " failed to initialize "
        "target index shard objects: " << cpp_strerror(ret) << dendl;
@@ -427,6 +434,7 @@ static int init_target_layout(rgw::sal::RadosStore* store,
 			      std::map<std::string, bufferlist>& bucket_attrs,
                               ReshardFaultInjector& fault,
                               const uint32_t new_num_shards,
+			      rgw::BucketIndexType dest_index_type,
                               bool& support_logrecord,
                               const DoutPrefixProvider* dpp, optional_yield y)
 {
@@ -435,10 +443,21 @@ static int init_target_layout(rgw::sal::RadosStore* store,
 
   // initialize a new normal target index layout generation
   rgw::bucket_index_layout_generation target;
-  target.layout.type = rgw::BucketIndexType::Normal;
-  target.layout.normal.num_shards = new_num_shards;
-  target.layout.normal.min_num_shards = current.layout.normal.min_num_shards;
-  target.gen = current.gen + 1;
+
+  int ret = create_layout_generation(current.gen + 1,
+				     dest_index_type, new_num_shards,
+				     current.layout, &target);
+  if (ret < 0) {
+    return ret;
+  }
+
+  auto target_bindexer =
+    rgw::rados::BIndexer::create_unique(store, dpp, bucket_info, target);
+
+  if (! target_bindexer->may_support_log_record()) {
+    // if definitely does not support set it to false
+    support_logrecord = false;
+  }
 
   if (bucket_info.reshard_status == cls_rgw_reshard_status::IN_PROGRESS) {
     // backward-compatible cleanup of old reshards, where the target was in a
@@ -466,7 +485,7 @@ static int init_target_layout(rgw::sal::RadosStore* store,
   }
 
   // create the index shard objects
-  int ret = init_target_index(store, bucket_info, target, fault, support_logrecord, dpp, y);
+  ret = init_target_index(store, bucket_info, target, fault, support_logrecord, dpp, y);
   if (ret < 0) {
     return ret;
   }
@@ -490,7 +509,10 @@ static int init_target_layout(rgw::sal::RadosStore* store,
     if (ret = fault.check("set_target_layout");
         ret == 0) { // no fault injected, write the bucket instance metadata
       ret = store->getRados()->put_bucket_instance_info(bucket_info, false,
-                                                        real_time(), &bucket_attrs, dpp, y);
+                                                        real_time(),
+							&bucket_attrs,
+							no_change_attrs_omap(),
+							dpp, y);
     } else if (ret == -ECANCELED) {
       fault.clear(); // clear the fault so a retry can succeed
     }
@@ -571,7 +593,9 @@ static int revert_target_layout(rgw::sal::RadosStore* store,
         ret == 0) { // no fault injected, revert the bucket instance metadata
       ret = store->getRados()->put_bucket_instance_info(bucket_info, false,
                                                         real_time(),
-                                                        &bucket_attrs, dpp, y);
+                                                        &bucket_attrs,
+							no_change_attrs_omap(),
+							dpp, y);
     } else if (ret == -ECANCELED) {
       fault.clear(); // clear the fault so a retry can succeed
     }
@@ -621,6 +645,7 @@ static int init_reshard(rgw::sal::RadosStore* store,
 			std::map<std::string, bufferlist>& bucket_attrs,
                         ReshardFaultInjector& fault,
                         const uint32_t new_num_shards,
+			const std::optional<rgw::BucketIndexType> bindex_type,
                         bool& support_logrecord,
                         const DoutPrefixProvider *dpp, optional_yield y)
 {
@@ -629,7 +654,15 @@ static int init_reshard(rgw::sal::RadosStore* store,
     return -EINVAL;
   }
 
-  int ret = init_target_layout(store, bucket_info, bucket_attrs, fault, new_num_shards,
+  rgw::BucketIndexType index_type;
+  if (bindex_type) {
+    index_type = *bindex_type;
+  } else {
+    index_type = bucket_info.get_current_bucket_index_type();
+  }
+
+  int ret = init_target_layout(store, bucket_info, bucket_attrs, fault,
+			       new_num_shards, index_type,
                                support_logrecord, dpp, y);
   if (ret < 0) {
     return ret;
@@ -695,7 +728,10 @@ static int change_reshard_state(rgw::sal::RadosStore* store,
     if (ret = fault.check("change_reshard_state");
         ret == 0) { // no fault injected, write the bucket instance metadata
       ret = store->getRados()->put_bucket_instance_info(bucket_info, false,
-                                                        real_time(), &bucket_attrs, dpp, y);
+                                                        real_time(),
+							&bucket_attrs,
+							no_change_attrs_omap(),
+							dpp, y);
     } else if (ret == -ECANCELED) {
       fault.clear(); // clear the fault so a retry can succeed
     }
@@ -805,7 +841,10 @@ static int commit_target_layout(rgw::sal::RadosStore* store,
   int ret = fault.check("commit_target_layout");
   if (ret == 0) { // no fault injected, write the bucket instance metadata
     ret = store->getRados()->put_bucket_instance_info(
-        bucket_info, false, real_time(), &bucket_attrs, dpp, y);
+        bucket_info, false, real_time(),
+	&bucket_attrs,
+	no_change_attrs_omap(), // retain possible omap to access shard info
+	dpp, y);
   } else if (ret == -ECANCELED) {
     fault.clear(); // clear the fault so a retry can succeed
   }
@@ -874,12 +913,12 @@ static int commit_reshard(rgw::sal::RadosStore* store,
   }
 
   if (store->svc()->zone->need_to_log_data() && !prev.logs.empty() &&
-      prev.current_index.layout.type == rgw::BucketIndexType::Normal) {
+      prev.current_index.layout.type == rgw::BucketIndexType::Hashed) {
     // write a datalog entry for each shard of the previous index. triggering
     // sync on the old shards will force them to detect the end-of-log for that
     // generation, and eventually transition to the next
     // TODO: use a log layout to support types other than BucketLogType::InIndex
-    for (uint32_t shard_id = 0; shard_id < rgw::num_shards(prev.current_index.layout.normal); ++shard_id) {
+    for (rgw::BIShardIndex shard_id = 0; shard_id < rgw::num_shards(prev.current_index.layout.specs); ++shard_id) {
       // This null_yield can stay, for now, since we're in our own thread
       ret = store->svc()->datalog_rados->add_entry(dpp, bucket_info, prev.logs.back(), shard_id,
 						   null_yield);
@@ -1040,8 +1079,19 @@ int RGWBucketReshard::renew_lock_if_needed(const DoutPrefixProvider *dpp) {
   return 0;
 }
 
-int RGWBucketReshard::calc_target_shard(const RGWBucketInfo& bucket_info, const rgw_obj_key& key,
-                                        int& shard, const DoutPrefixProvider *dpp) {
+int RGWBucketReshard::calc_target_shard(const RGWBucketInfo& bucket_info,
+					const rgw_obj_key& key,
+                                        int& shard,
+					const DoutPrefixProvider* dpp) {
+#warning "fix this"
+  auto hash_layout_p = bucket_info.hashed_layout_ptr();
+  if (! hash_layout_p) {
+    ldpp_dout(dpp, 0) <<
+      "ERROR: tried to calculate the target shard on a bucket with a "
+      "non-hashed layout: " << bucket_info.bucket << dendl;
+    return -EINVAL;
+  }
+
   int target_shard_id, ret;
 
   rgw_obj obj(bucket_info.bucket, key);
@@ -1050,8 +1100,9 @@ int RGWBucketReshard::calc_target_shard(const RGWBucketInfo& bucket_info, const 
     // place the multipart .meta object on the same shard as its head object
     obj.index_hash_source = mp.get_key();
   }
-  ret = store->getRados()->get_target_shard_id(bucket_info.layout.target_index->layout.normal,
-                obj.get_hash_object(), &target_shard_id);
+  ret = store->getRados()->get_target_shard_id(*hash_layout_p,
+					       obj.get_hash_object(),
+					       &target_shard_id);
   if (ret < 0) {
     ldpp_dout(dpp, -1) << "ERROR: get_target_shard_id() returned ret=" << ret << dendl;
     return ret;
@@ -1066,8 +1117,10 @@ int RGWBucketReshard::reshard_process(const rgw::bucket_index_layout_generation&
                                       BucketReshardManager& target_shards_mgr,
                                       bool verbose_json_out,
                                       ostream *out,
-                                      Formatter *formatter, rgw::BucketReshardState reshard_stage,
-                                      const DoutPrefixProvider *dpp, optional_yield y)
+                                      Formatter *formatter,
+				      rgw::BucketReshardState reshard_stage,
+                                      const DoutPrefixProvider* dpp,
+				      optional_yield y)
 {
   list<rgw_cls_bi_entry> entries;
 
@@ -1098,7 +1151,7 @@ int RGWBucketReshard::reshard_process(const rgw::bucket_index_layout_generation&
     (*out) << stage;
   }
 
-  const uint32_t num_source_shards = rgw::num_shards(current.layout.normal);
+  const uint32_t num_source_shards = rgw::num_shards(current.layout.specs);
   string marker;
   for (uint32_t i = 0; i < num_source_shards; ++i) {
     bool is_truncated = true;
@@ -1200,6 +1253,7 @@ int RGWBucketReshard::do_reshard(const rgw::bucket_index_layout_generation& curr
                                  ReshardFaultInjector& fault,
                                  const DoutPrefixProvider *dpp, optional_yield y)
 {
+#warning "work on this"
   if (out) {
     (*out) << "tenant: " << bucket_info.bucket.tenant << std::endl;
     (*out) << "bucket name: " << bucket_info.bucket.name << std::endl;
@@ -1258,6 +1312,7 @@ int RGWBucketReshard::get_status(const DoutPrefixProvider *dpp, optional_yield y
 }
 
 int RGWBucketReshard::execute(int num_shards,
+			      const std::optional<rgw::BucketIndexType> dest_bindex_type,
                               ReshardFaultInjector& fault,
                               int max_op_entries,  // max num to process per op
 			      const cls_rgw_reshard_initiator initiator,
@@ -1285,7 +1340,8 @@ int RGWBucketReshard::execute(int num_shards,
 
   bool support_logrecord = true;
   // prepare the target index and add its layout the bucket info
-  ret = init_reshard(store, bucket_info, bucket_attrs, fault, num_shards,
+  ret = init_reshard(store, bucket_info, bucket_attrs, fault,
+		     num_shards, dest_bindex_type,
                      support_logrecord, dpp, y);
   if (ret < 0) {
     return ret;
@@ -1293,6 +1349,7 @@ int RGWBucketReshard::execute(int num_shards,
 
   if (ret = fault.check("do_reshard");
       ret == 0) { // no fault injected, do the reshard
+#warning "go into here"
     ret = do_reshard(bucket_info.layout.current_index,
                      *bucket_info.layout.target_index,
                      max_op_entries, support_logrecord,
@@ -1587,6 +1644,14 @@ int RGWReshard::process_entry(const cls_rgw_reshard_entry& entry,
     }
   }
 
+  auto hash_layout_p = bucket_info.hashed_layout_ptr();
+  if (!hash_layout_p) {
+    ldpp_dout(dpp, 0) <<
+      "ERROR: tried to process a reshard entry for a bucket without a "
+      "hashed bucket index: " << bucket_info.bucket << dendl;
+    return -EINVAL;
+  }
+
   // if *dynamic* reshard reduction, perform extra sanity checks in
   // part to prevent chasing constantly changing entry count. If
   // *admin*-initiated (or unknown-initiated) reshard reduction, skip
@@ -1615,10 +1680,8 @@ int RGWReshard::process_entry(const cls_rgw_reshard_entry& entry,
     }
 
     const bool is_versioned = bucket_info.versioned();
-    const uint32_t current_shard_count =
-      rgw::current_num_shards(bucket_info.layout);
-    const uint32_t min_layout_shards =
-      rgw::current_min_layout_shards(bucket_info.layout);
+    const uint32_t current_shard_count = hash_layout_p->num_shards;
+    const uint32_t min_layout_shards = hash_layout_p->min_num_shards;
 
     bool needs_resharding { false };
     uint32_t suggested_shard_count { 0 };
@@ -1687,7 +1750,9 @@ int RGWReshard::process_entry(const cls_rgw_reshard_entry& entry,
   RGWBucketReshard br(store, bucket_info, bucket_attrs, nullptr);
 
   ReshardFaultInjector f; // no fault injected
-  ret = br.execute(entry.new_num_shards, f, max_op_entries, entry.initiator,
+  ret = br.execute(entry.new_num_shards,
+		   std::optional<rgw::BucketIndexType>(),
+		   f, max_op_entries, entry.initiator,
 		   dpp, y, false, nullptr, nullptr, this);
   if (ret < 0) {
     ldpp_dout(dpp, 0) <<  __func__ <<

--- a/src/rgw/driver/rados/rgw_reshard.h
+++ b/src/rgw/driver/rados/rgw_reshard.h
@@ -111,7 +111,9 @@ public:
 		   const RGWBucketInfo& _bucket_info,
 		   const std::map<std::string, bufferlist>& _bucket_attrs,
 		   RGWBucketReshardLock* _outer_reshard_lock);
-  int execute(int num_shards, ReshardFaultInjector& f,
+  int execute(int num_shards,
+	      const std::optional<rgw::BucketIndexType> bindex_type,
+	      ReshardFaultInjector& f,
               int max_op_entries, const cls_rgw_reshard_initiator initiator,
 	      const DoutPrefixProvider *dpp, optional_yield y,
               bool verbose = false, std::ostream *out = nullptr,

--- a/src/rgw/driver/rados/rgw_reshard.h
+++ b/src/rgw/driver/rados/rgw_reshard.h
@@ -25,6 +25,7 @@
 
 class RGWReshard;
 
+namespace rgw { namespace rados { class BIndexer; }}
 
 class BucketReshardManager;
 namespace rgw { namespace sal {
@@ -89,14 +90,17 @@ class RGWBucketReshard {
                         int& shard, const DoutPrefixProvider *dpp);
   int reshard_process(const rgw::bucket_index_layout_generation& current,
                       int& max_entries,
+                      std::unique_ptr<rgw::rados::BIndexer>& source_bindexer,
                       BucketReshardManager& target_shards_mgr,
+                      std::unique_ptr<rgw::rados::BIndexer>& target_bindexer,
                       bool verbose_json_out,
                       std::ostream *out,
                       Formatter *formatter, rgw::BucketReshardState reshard_stage,
                       const DoutPrefixProvider *dpp, optional_yield y);
 
   int do_reshard(const rgw::bucket_index_layout_generation& current,
-                 const rgw::bucket_index_layout_generation& target,
+                 rgw::bucket_index_layout_generation& target,
+                 std::unique_ptr<rgw::rados::BIndexer>& target_bindexer,
                  int max_entries, bool support_logrecord,
                  bool verbose,
                  std::ostream *os,
@@ -111,7 +115,7 @@ public:
 		   const RGWBucketInfo& _bucket_info,
 		   const std::map<std::string, bufferlist>& _bucket_attrs,
 		   RGWBucketReshardLock* _outer_reshard_lock);
-  int execute(int num_shards,
+  int execute(uint32_t num_shards,
 	      const std::optional<rgw::BucketIndexType> bindex_type,
 	      ReshardFaultInjector& f,
               int max_op_entries, const cls_rgw_reshard_initiator initiator,

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -2749,6 +2749,7 @@ bool RadosObject::is_sync_completed(const DoutPrefixProvider* dpp,
   bool truncated;
   list<rgw_bi_log_entry> entries;
 
+  // OBI: need to convert this over to BIShardIdent
   const int shard_id = RGWSI_BucketIndex_RADOS::bucket_shard_index(get_key(), shard_count);
 
   int ret = store->svc()->bilog_rados->log_list(dpp, y, bucket_info, log_layout, shard_id,
@@ -4643,7 +4644,7 @@ static void renewal(const DoutPrefixProvider* dpp,
                     rgw::sal::MPSerializer& serializer,
                     librados::IoCtx& ioctx,
                     const std::string& oid,
-                    rados::cls::lock::Lock lock,
+                    ::rados::cls::lock::Lock lock,
                     auto& timer,
                     ceph::timespan dur,
                     boost::asio::yield_context yield)

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -198,8 +198,9 @@ int RadosBucket::create(const DoutPrefixProvider* dpp,
     // prevent re-creation with different index type or shard count
     if ((params.index_type && *params.index_type !=
          info.layout.current_index.layout.type) ||
-        (params.index_shards && *params.index_shards !=
-         info.layout.current_index.layout.normal.num_shards)) {
+        (params.index_shards &&
+	 (rgw::BIShardIndex) (*params.index_shards) !=
+	 rgw::num_shards(info.layout.current_index.layout))) {
       return -ERR_BUCKET_EXISTS;
     }
     ret = 0;
@@ -774,7 +775,8 @@ int RadosBucket::chown(const DoutPrefixProvider* dpp,
 int RadosBucket::put_info(const DoutPrefixProvider* dpp, bool exclusive, ceph::real_time _mtime, optional_yield y)
 {
   mtime = _mtime;
-  return store->getRados()->put_bucket_instance_info(info, exclusive, mtime, &attrs, dpp, y);
+  // OBI: is nullptr OK here?
+  return store->getRados()->put_bucket_instance_info(info, exclusive, mtime, &attrs, nullptr, dpp, y);
 }
 
 int RadosBucket::check_empty(const DoutPrefixProvider* dpp, optional_yield y)
@@ -850,10 +852,11 @@ int RadosBucket::set_tag_timeout(const DoutPrefixProvider *dpp, optional_yield y
 
 int RadosBucket::purge_instance(const DoutPrefixProvider* dpp, optional_yield y)
 {
-  int max_shards = (info.layout.current_index.layout.normal.num_shards > 0 ? info.layout.current_index.layout.normal.num_shards : 1);
+  int max_shards = (rgw::num_shards(info.layout.current_index.layout.specs) > 0 ?
+		    rgw::num_shards(info.layout.current_index.layout.specs) : 1);
   for (int i = 0; i < max_shards; i++) {
     RGWRados::BucketShard bs(store->getRados());
-    int shard_id = (info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
+    int shard_id = (rgw::num_shards(info.layout.current_index.layout.specs) > 0 ? i : -1);
     int ret = bs.init(dpp, info, info.layout.current_index, shard_id, y);
     if (ret < 0) {
       cerr << "ERROR: bs.init(bucket=" << info.bucket << ", shard=" << shard_id
@@ -1294,7 +1297,7 @@ int RadosBucket::set_logging_object_name(const std::string& obj_name,
                                objv_tracker,
                                ceph::real_time::clock::now(),
                                y,
-                               no_change_attrs());
+                               no_change_attrs_omap());
   if (ret == -EEXIST) {
     ldpp_dout(dpp, 20) << "INFO: race detected in initializing '" << obj_name_oid << "' with logging object name:'" << obj_name  << "'. ret = " << ret << dendl;
   } else if (ret == -ECANCELED) {

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -2750,7 +2750,8 @@ bool RadosObject::is_sync_completed(const DoutPrefixProvider* dpp,
   list<rgw_bi_log_entry> entries;
 
   // OBI: need to convert this over to BIShardIdent
-  const int shard_id = RGWSI_BucketIndex_RADOS::bucket_shard_index(get_key(), shard_count);
+  const int shard_id =
+    rgw::rados::HashedBIndexer::get_shard_index(get_key(), shard_count);
 
   int ret = store->svc()->bilog_rados->log_list(dpp, y, bucket_info, log_layout, shard_id,
     marker, 1, entries, &truncated);

--- a/src/rgw/driver/rados/rgw_service.cc
+++ b/src/rgw/driver/rados/rgw_service.cc
@@ -84,7 +84,8 @@ int RGWServices_Def::init(CephContext *cct,
 
   async_processor->start();
   bi_rados->init(zone.get(), driver->getRados()->get_rados_handle(),
-		 bilog_rados.get(), datalog_rados.get());
+		 bilog_rados.get(), datalog_rados.get(), bucket_sobj.get());
+  rgw::rados::BIndexer::init(bucket_sobj.get()); // static init
   bilog_rados->init(bi_rados.get());
   bucket_sobj->init(zone.get(), sysobj.get(), sysobj_cache.get(),
                     bi_rados.get(), mdlog.get(),

--- a/src/rgw/driver/rados/rgw_tools.cc
+++ b/src/rgw/driver/rados/rgw_tools.cc
@@ -150,10 +150,16 @@ std::map<std::string, bufferlist>* no_change_attrs_omap() {
   return &no_change;
 }
 
-int rgw_put_system_obj(const DoutPrefixProvider *dpp, RGWSI_SysObj* svc_sysobj,
-                       const rgw_pool& pool, const string& oid, bufferlist& data, bool exclusive,
-                       RGWObjVersionTracker *objv_tracker, real_time set_mtime, optional_yield y,
-		       const map<string, bufferlist>* pattrs,
+int rgw_put_system_obj(const DoutPrefixProvider *dpp,
+                       RGWSI_SysObj* svc_sysobj,
+                       const rgw_pool& pool,
+                       const string& oid,
+                       bufferlist& data,
+                       bool exclusive,
+                       RGWObjVersionTracker *objv_tracker,
+                       real_time set_mtime,
+                       optional_yield y,
+		       const std::map<std::string, bufferlist>* pattrs,
 		       const std::map<std::string, bufferlist>* omap_entries)
 {
   map<string,bufferlist> no_attrs;
@@ -166,27 +172,49 @@ int rgw_put_system_obj(const DoutPrefixProvider *dpp, RGWSI_SysObj* svc_sysobj,
   RGWSI_SysObj::Obj sysobj = svc_sysobj->get_obj(obj);
   int ret;
 
-  if (pattrs != no_change_attrs()) {
+  if (pattrs != no_change_attrs_omap() && omap_entries != no_change_attrs_omap()) {
+    // we're re-writing everything from scratch, so we'll call write
+    // (rewrites everything) and then add omap vals
     ret = sysobj.wop()
       .set_objv_tracker(objv_tracker)
       .set_exclusive(exclusive)
       .set_mtime(set_mtime)
       .set_attrs(*pattrs)
-      .write(dpp, data, y);
-  } else {
-    ret = sysobj.wop()
-      .set_objv_tracker(objv_tracker)
-      .set_exclusive(exclusive)
-      .set_mtime(set_mtime)
-      .write_data(dpp, data, y);
+      .write(dpp, data, y); // inherently clears omap
+
+    if (ret < 0) {
+      return ret;
+    }
+
+    if (omap_entries) {
+      return sysobj.omap().set(dpp, *omap_entries, y);
+    }
+
+    return 0;
   }
 
-  if (ret || !omap_entries) {
+  ret = sysobj.wop()
+    .set_objv_tracker(objv_tracker)
+    .set_exclusive(exclusive)
+    .set_mtime(set_mtime)
+    .write_data(dpp, data, y);
+  if (ret < 0) {
     return ret;
   }
 
-#warning "update wop to allow omap entries to be added, overwritten, or cleared?"
-  return  sysobj.omap().set(dpp, *omap_entries, y);
+  if (pattrs != no_change_attrs_omap()) {
+    return sysobj.wop().set_attrs(*pattrs).write_attrs(dpp, y);
+  }
+
+  if (! omap_entries) {
+    // nullptr indicates erase
+    return sysobj.omap().clear(dpp, y);
+  } else if (omap_entries != no_change_attrs_omap()) {
+    // add entries
+    return sysobj.omap().set(dpp, *omap_entries, y);
+  }
+
+  return 0;
 }
 
 int rgw_stat_system_obj(const DoutPrefixProvider *dpp, RGWSI_SysObj* svc_sysobj,
@@ -220,6 +248,18 @@ int rgw_read_system_obj_map(const DoutPrefixProvider *dpp,
   auto sysobj = svc_sysobj->get_obj(obj);
   return sysobj.omap().get_vals(dpp, after, prefix, count, default_key,
                                 results, more, y);
+}
+
+
+int rgw_clear_system_obj_map(const DoutPrefixProvider *dpp,
+                            RGWSI_SysObj* svc_sysobj,
+                            const rgw_pool& pool,
+                            const std::string& oid,
+                            optional_yield y)
+{
+  rgw_raw_obj obj(pool, oid);
+  auto sysobj = svc_sysobj->get_obj(obj);
+  return sysobj.omap().clear(dpp, y);
 }
 
 

--- a/src/rgw/driver/rados/rgw_tools.cc
+++ b/src/rgw/driver/rados/rgw_tools.cc
@@ -145,14 +145,16 @@ int rgw_rados_ref::unwatch(const DoutPrefixProvider* dpp, uint64_t handle,
   }
 }
 
-map<string, bufferlist>* no_change_attrs() {
-  static map<string, bufferlist> no_change;
+std::map<std::string, bufferlist>* no_change_attrs_omap() {
+  static std::map<std::string, bufferlist> no_change;
   return &no_change;
 }
 
 int rgw_put_system_obj(const DoutPrefixProvider *dpp, RGWSI_SysObj* svc_sysobj,
                        const rgw_pool& pool, const string& oid, bufferlist& data, bool exclusive,
-                       RGWObjVersionTracker *objv_tracker, real_time set_mtime, optional_yield y, const map<string, bufferlist> *pattrs)
+                       RGWObjVersionTracker *objv_tracker, real_time set_mtime, optional_yield y,
+		       const map<string, bufferlist>* pattrs,
+		       const std::map<std::string, bufferlist>* omap_entries)
 {
   map<string,bufferlist> no_attrs;
   if (!pattrs) {
@@ -161,7 +163,7 @@ int rgw_put_system_obj(const DoutPrefixProvider *dpp, RGWSI_SysObj* svc_sysobj,
 
   rgw_raw_obj obj(pool, oid);
 
-  auto sysobj = svc_sysobj->get_obj(obj);
+  RGWSI_SysObj::Obj sysobj = svc_sysobj->get_obj(obj);
   int ret;
 
   if (pattrs != no_change_attrs()) {
@@ -179,7 +181,12 @@ int rgw_put_system_obj(const DoutPrefixProvider *dpp, RGWSI_SysObj* svc_sysobj,
       .write_data(dpp, data, y);
   }
 
-  return ret;
+  if (ret || !omap_entries) {
+    return ret;
+  }
+
+#warning "update wop to allow omap entries to be added, overwritten, or cleared?"
+  return  sysobj.omap().set(dpp, *omap_entries, y);
 }
 
 int rgw_stat_system_obj(const DoutPrefixProvider *dpp, RGWSI_SysObj* svc_sysobj,
@@ -195,6 +202,24 @@ int rgw_stat_system_obj(const DoutPrefixProvider *dpp, RGWSI_SysObj* svc_sysobj,
                .set_last_mod(pmtime)
                .set_obj_size(psize)
                .stat(y, dpp);
+}
+
+int rgw_read_system_obj_map(const DoutPrefixProvider *dpp,
+                            RGWSI_SysObj* svc_sysobj,
+                            const rgw_pool& pool,
+                            const std::string& oid,
+                            const std::string& after,
+                            const std::string& prefix,
+                            const uint64_t count,
+                            const std::string* default_key, // nullptr indicates none
+                            std::map<std::string, bufferlist>* results,
+                            bool* more,
+                            optional_yield y)
+{
+  rgw_raw_obj obj(pool, oid);
+  auto sysobj = svc_sysobj->get_obj(obj);
+  return sysobj.omap().get_vals(dpp, after, prefix, count, default_key,
+                                results, more, y);
 }
 
 

--- a/src/rgw/driver/rados/rgw_tools.h
+++ b/src/rgw/driver/rados/rgw_tools.h
@@ -128,6 +128,12 @@ int rgw_read_system_obj_map(const DoutPrefixProvider *dpp,
                             bool* more,
                             optional_yield y);
 
+int rgw_clear_system_obj_map(const DoutPrefixProvider *dpp,
+                            RGWSI_SysObj* svc_sysobj,
+                            const rgw_pool& pool,
+                            const std::string& oid,
+                            optional_yield y);
+
 std::string_view rgw_find_mime_by_ext(std::string_view ext);
 
 void rgw_filter_attrset(std::map<std::string, bufferlist>& unfiltered_attrset, const std::string& check_prefix,

--- a/src/rgw/driver/rados/rgw_tools.h
+++ b/src/rgw/driver/rados/rgw_tools.h
@@ -87,7 +87,8 @@ int rgw_put_system_obj(const DoutPrefixProvider *dpp, RGWSI_SysObj* svc_sysobj,
                        bufferlist& data, bool exclusive,
                        RGWObjVersionTracker *objv_tracker,
                        real_time set_mtime, optional_yield y,
-                       const std::map<std::string, bufferlist> *pattrs = nullptr);
+                       const std::map<std::string, bufferlist> *pattrs = nullptr,
+                       const std::map<std::string, bufferlist>* omap_entries = nullptr);
 int rgw_get_system_obj(RGWSI_SysObj* svc_sysobj, const rgw_pool& pool,
                        const std::string& key, bufferlist& bl,
                        RGWObjVersionTracker *objv_tracker, real_time *pmtime,
@@ -104,6 +105,28 @@ int rgw_stat_system_obj(const DoutPrefixProvider *dpp, RGWSI_SysObj* svc_sysobj,
                         RGWObjVersionTracker *objv_tracker,
                         real_time *pmtime, uint64_t *psize, optional_yield y,
                         std::map<std::string, bufferlist> *pattrs = nullptr);
+
+/*
+ * parameters:
+ *   after: returned keys must be greater than after
+ *   prefix: all returned entries must begin with prefix
+ *   max: maximum number to return
+ *   default_key: if using after and prefix nothing matches, then return
+ *                this entry instead
+ *   results: key/value pairs
+ *   more: if true additional entries match
+ */
+int rgw_read_system_obj_map(const DoutPrefixProvider *dpp,
+                            RGWSI_SysObj* svc_sysobj,
+                            const rgw_pool& pool,
+                            const std::string& oid,
+                            const std::string& after,
+                            const std::string& prefix,
+                            const uint64_t count,
+                            const std::string* default_key, // nullptr indicates none
+                            std::map<std::string, bufferlist>* results,
+                            bool* more,
+                            optional_yield y);
 
 std::string_view rgw_find_mime_by_ext(std::string_view ext);
 
@@ -180,13 +203,11 @@ void rgw_tools_cleanup();
 /// calls and error handling.
 void rgw_complete_aio_completion(librados::AioCompletion* c, int r);
 
-/// This returns a static, non-NULL pointer, recognized only by
-/// rgw_put_system_obj(). When supplied instead of the attributes, the
-/// attributes will be unmodified.
-///
-// (Currently providing nullptr will wipe all attributes.)
-
-std::map<std::string, ceph::buffer::list>* no_change_attrs();
+/// These return a static, non-NULL pointer, recognized only by
+/// rgw_put_system_obj(). When supplied instead of the attributes/omap
+/// omap), the attributes and omap will be unmodified. Providing
+/// nullptr will wipe all attributes.
+std::map<std::string, ceph::buffer::list>* no_change_attrs_omap();
 
 bool rgw_check_secure_mon_conn(const DoutPrefixProvider *dpp);
 int rgw_clog_warn(librados::Rados* h, const std::string& msg);

--- a/src/rgw/driver/rados/rgw_trim_bilog.cc
+++ b/src/rgw/driver/rados/rgw_trim_bilog.cc
@@ -782,7 +782,7 @@ int BucketTrimInstanceCR::operate(const DoutPrefixProvider *dpp)
 	yield call(new RGWPutBucketInstanceInfoCR(
 		     store->svc()->async_processor,
 		     store, clean_info->first, false, {},
-		     no_change_attrs(), dpp));
+		     no_change_attrs_omap(), dpp));
 
 	// Raced, try again.
 	if (retcode == -ECANCELED) {
@@ -841,7 +841,7 @@ int BucketTrimInstanceCR::operate(const DoutPrefixProvider *dpp)
 
       // initialize each shard with the maximum marker, which is only used when
       // there are no peers syncing from us
-      min_markers.assign(std::max(1u, rgw::num_shards(totrim.layout.in_index)),
+      min_markers.assign(std::max((rgw::BIShardIndex) 1u, rgw::num_shards(totrim.layout.in_index)),
 			 RGWSyncLogTrimCR::max_marker);
 
       retcode = take_min_status(cct, totrim.gen, peer_status.cbegin(),

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -518,6 +518,9 @@ void usage()
   cout << "   --deny-bucket-list=<file>     file with bucket names to deny in dedup (mutually exclusive with --allow-bucket-list)\n";
   cout << "   --allow-storage-class-list=<file> file with storage class names to allow in dedup (mutually exclusive with --deny-storage-class-list)\n";
   cout << "   --deny-storage-class-list=<file>  file with storage class names to deny in dedup (mutually exclusive with --allow-storage-class-list)\n";
+  cout << "\nReshard options:\n";
+  cout << "   --num-shards                  desired number of shards\n";
+  cout << "   --bucket-index-type           desired bucket index type -- \"hashed\" or \"ordered\" or leave blank to maintain current type\n'";
   cout << "\nQuota options:\n";
   cout << "   --max-objects                 specify max objects (negative value to disable)\n";
   cout << "   --max-size                    specify max size (in B/K/M/G/T, negative value to disable)\n";
@@ -3400,8 +3403,11 @@ int check_reshard_bucket_params(rgw::sal::Driver* driver,
     return -EINVAL;
   }
 
-  if (num_shards > (int)static_cast<rgw::sal::RadosStore*>(driver)->getRados()->get_max_bucket_shards()) {
-    cerr << "ERROR: num_shards too high, max value: " << static_cast<rgw::sal::RadosStore*>(driver)->getRados()->get_max_bucket_shards() << std::endl;
+  if (num_shards >
+      int(static_cast<rgw::sal::RadosStore*>(driver)->getRados()->get_max_bucket_shards())) {
+    cerr << "ERROR: num_shards too high, max value: " <<
+      static_cast<rgw::sal::RadosStore*>(driver)->getRados()->get_max_bucket_shards() <<
+      std::endl;
     return -EINVAL;
   }
 
@@ -3416,21 +3422,24 @@ int check_reshard_bucket_params(rgw::sal::Driver* driver,
     return ret;
   }
 
-  if (! is_layout_reshardable((*bucket)->get_info().layout)) {
+  const RGWBucketInfo& bucket_info = (*bucket)->get_info();
+
+  if (! is_layout_reshardable(bucket_info.layout)) {
     std::cerr << "Bucket '" << (*bucket)->get_name() <<
       "' currently has layout '" <<
-      current_layout_desc((*bucket)->get_info().layout) <<
+      current_layout_desc(bucket_info.layout) <<
       "', which does not support resharding." << std::endl;
     return -EINVAL;
   }
 
-  int num_source_shards = rgw::current_num_shards((*bucket)->get_info().layout);
+  int num_source_shards = rgw::current_num_shards(bucket_info.layout);
 
   if (num_shards <= num_source_shards && !yes_i_really_mean_it) {
     cerr << "num shards is less or equal to current shards count" << std::endl
 	 << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
     return -EINVAL;
   }
+
   return 0;
 }
 
@@ -3923,6 +3932,7 @@ int main(int argc, const char **argv)
   int num_shards = 0;
   bool num_shards_specified = false;
   std::optional<int> bucket_index_max_shards;
+  std::optional<rgw::BucketIndexType> bucket_index_type;
 
   int max_concurrent_ios = 32;
   ceph::timespan min_age = std::chrono::hours(1);
@@ -3950,7 +3960,7 @@ int main(int argc, const char **argv)
   boost::optional<string> data_pool;
   boost::optional<string> data_extra_pool;
 #ifdef WITH_RADOSGW_RADOS
-  rgw::BucketIndexType placement_index_type = rgw::BucketIndexType::Normal;
+  rgw::BucketIndexType placement_index_type = rgw::BucketIndexType::Hashed;
   bool index_type_specified = false;
 #endif
 
@@ -4288,6 +4298,16 @@ int main(int argc, const char **argv)
         cerr << "ERROR: failed to parse bucket-index-max-shards: " << err << std::endl;
         return EINVAL;
       }
+    } else if (ceph_argparse_witharg(args, i, &val, "--bucket-index-type", (char*)NULL)) {
+      parse(val, bucket_index_type);
+      if (! bucket_index_type.has_value()) {
+	std::cerr << "ERROR: --index_type, when specified, must \"hashed\", or \"ordered\"" <<
+	  std::endl;
+	return EINVAL;
+      } else if (bucket_index_type.value() == rgw::BucketIndexType::Indexless) {
+	std::cerr << "ERROR: --index_type cannot be set to Indexless" << std::endl;
+	return EINVAL;
+      }
     } else if (ceph_argparse_witharg(args, i, &val, "--max-concurrent-ios", (char*)NULL)) {
       max_concurrent_ios = (int)strict_strtol(val.c_str(), 10, &err);
       if (!err.empty()) {
@@ -4518,7 +4538,7 @@ int main(int argc, const char **argv)
 #ifdef WITH_RADOSGW_RADOS
     } else if (ceph_argparse_witharg(args, i, &val, "--placement-index-type", (char*)NULL)) {
       if (val == "normal") {
-        placement_index_type = rgw::BucketIndexType::Normal;
+        placement_index_type = rgw::BucketIndexType::Hashed;
       } else if (val == "indexless") {
         placement_index_type = rgw::BucketIndexType::Indexless;
       } else {
@@ -8636,20 +8656,28 @@ next:
       max_entries << ", index=" << index << ", max_shards=" << max_shards <<
       dendl;
 
-    formatter->open_array_section("entries");
+    RGWRados* rados = static_cast<rgw::sal::RadosStore*>(driver)->getRados();
+    auto bindexer = rados->svc.bi_rados->create_bindexer(
+      dpp(), bucket->get_info());
 
-    auto rados = static_cast<rgw::sal::RadosStore*>(driver)->getRados();
-    int i = (specified_shard_id ? shard_id : 0);
-    for (; i < max_shards; i++) {
-      ldpp_dout(dpp(), 20) << "INFO: " << __func__ << ": starting shard=" <<
-	i << dendl;
+    auto shard_iterator =  bindexer->create_shard_iterator();
+    if (!shard_iterator.valid()) {
+      // if not immediately valid indicates an error
+      ldpp_dout(dpp(), 20) << "ERROR: " << __func__ <<
+        ": could not create shard iterator for bucket " << bucket << dendl;
+    }
+
+    formatter->open_array_section("entries");
+    for (; shard_iterator.valid(); shard_iterator.next()) {
       marker.clear();
 
-      RGWRados::BucketShard bs(rados);
-      int ret = bs.init(dpp(), bucket->get_info(), index, i, null_yield);
+      const auto shard_ident_p = shard_iterator.get_ident();
+      RGWRados::BucketShard bs(static_cast<rgw::sal::RadosStore*>(driver)->getRados());
+      int ret = bs.init(dpp(), shard_iterator, null_yield);
       if (ret < 0) {
 	ldpp_dout(dpp(), 0) << "ERROR: bs.init(bucket=" << bucket <<
-	  ", shard=" << i << "): " << cpp_strerror(-ret) << dendl;
+          ", shard=" << *shard_ident_p <<
+	  "): " << cpp_strerror(-ret) << dendl;
         return -ret;
       }
 
@@ -9104,7 +9132,7 @@ next:
     } else if (inject_delay_at) {
       fault.inject(*inject_delay_at, InjectDelay{inject_delay, dpp()});
     }
-    ret = br.execute(num_shards, fault, max_entries,
+    ret = br.execute(num_shards, bucket_index_type, fault, max_entries,
 		     cls_rgw_reshard_initiator::Admin,
 		     dpp(), null_yield,
                      verbose, &cout, formatter.get());
@@ -9134,6 +9162,7 @@ next:
     entry.bucket_id = bucket->get_info().bucket.bucket_id;
     entry.old_num_shards = num_source_shards;
     entry.new_num_shards = num_shards;
+    entry.bucket_index_type = bucket_index_type;
     entry.initiator = cls_rgw_reshard_initiator::Admin;
 
     return reshard.add(dpp(), entry, null_yield);
@@ -9310,19 +9339,26 @@ next:
     }
     auto& bucket_info = bucket->get_info();
 
+    auto hash_layout_p = bucket_info.hashed_layout_ptr();
+
     const rgw::BucketIndexType type =
       bucket_info.layout.current_index.layout.type;
-    if (type != rgw::BucketIndexType::Normal) {
+    if (type != rgw::BucketIndexType::Hashed) {
       cerr << "ERROR: the bucket's layout is type " << type <<
-	" instead of type " << rgw::BucketIndexType::Normal <<
+	" instead of type " << rgw::BucketIndexType::Hashed <<
 	" and therefore does not have a "
 	"minimum number of shards that can be altered" << std::endl;
       return EINVAL;
     }
 
-    uint32_t& min_num_shards =
-      bucket_info.layout.current_index.layout.normal.min_num_shards;
-    min_num_shards = num_shards;
+    if (!hash_layout_p) {
+      cerr << "INTERNAL ERROR: the bucket's layout is type " << type <<
+	" but the data is of a different layout type" << std::endl;
+      return EIO;
+    }
+
+    // copy command-line argument into data structure
+    hash_layout_p->min_num_shards = num_shards;
 
     ret = bucket->put_info(dpp(), false, real_time(), null_yield);
     if (ret < 0) {

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -8070,6 +8070,10 @@ int main(int argc, const char **argv)
       formatter->close_section();
       formatter->flush(cout);
     }
+
+    cerr << "NOTE: The output of this command is only applicable to "
+      "buckets that use hashed bucket index sharding and not buckets "
+      "that use ordered bucket index sharding." << std::endl;
   }
 
   if (opt_cmd == OPT::BUCKET_OBJECT_SHARD) {
@@ -8088,6 +8092,10 @@ int main(int argc, const char **argv)
     encode_json("shard", shard, formatter.get());
     formatter->close_section();
     formatter->flush(cout);
+
+    cerr << "NOTE: The output of this command is only applicable to "
+      "buckets that use hashed bucket index sharding and not buckets "
+      "that use ordered bucket index sharding." << std::endl;
   }
 
 #ifdef WITH_RADOSGW_RADOS

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -8046,7 +8046,7 @@ int main(int argc, const char **argv)
       do {
 	obj = fmt::format("{}{:0>20}", prefix, ctr);
         // OBI: need to convert this over to BIShardIdent
-	shard = RGWSI_BucketIndex_RADOS::bucket_shard_index(obj, num_shards);
+	shard = rgw::rados::HashedBIndexer::get_shard_index(obj, num_shards);
 	++ctr;
       } while (shard != shard_id);
 
@@ -8058,8 +8058,7 @@ int main(int argc, const char **argv)
       std::vector<std::string> objs(num_shards);
       for (uint64_t ctr = 0, shardsleft = num_shards; shardsleft > 0; ++ctr) {
 	auto key = fmt::format("{}{:0>20}", prefix, ctr);
-        // OBI: need to convert this over to BIShardIdent
-	auto shard = RGWSI_BucketIndex_RADOS::bucket_shard_index(key, num_shards);
+	auto shard = rgw::rados::HashedBIndexer::get_shard_index(key, num_shards);
 	if (objs[shard].empty()) {
 	  objs[shard] = std::move(key);
 	  --shardsleft;
@@ -8084,8 +8083,7 @@ int main(int argc, const char **argv)
       return EINVAL;
     }
     // OBI: need to convert this over to BIShardIdent
-    auto shard =
-      RGWSI_BucketIndex_RADOS::bucket_shard_index(object, num_shards);
+    auto shard = rgw::rados::HashedBIndexer::get_shard_index(object, num_shards);
     formatter->open_object_section("obj_shard");
     encode_json("shard", shard, formatter.get());
     formatter->close_section();

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -8042,6 +8042,7 @@ int main(int argc, const char **argv)
       int shard;
       do {
 	obj = fmt::format("{}{:0>20}", prefix, ctr);
+        // OBI: need to convert this over to BIShardIdent
 	shard = RGWSI_BucketIndex_RADOS::bucket_shard_index(obj, num_shards);
 	++ctr;
       } while (shard != shard_id);
@@ -8054,6 +8055,7 @@ int main(int argc, const char **argv)
       std::vector<std::string> objs(num_shards);
       for (uint64_t ctr = 0, shardsleft = num_shards; shardsleft > 0; ++ctr) {
 	auto key = fmt::format("{}{:0>20}", prefix, ctr);
+        // OBI: need to convert this over to BIShardIdent
 	auto shard = RGWSI_BucketIndex_RADOS::bucket_shard_index(key, num_shards);
 	if (objs[shard].empty()) {
 	  objs[shard] = std::move(key);
@@ -8078,6 +8080,7 @@ int main(int argc, const char **argv)
 	num_shards << std::endl;
       return EINVAL;
     }
+    // OBI: need to convert this over to BIShardIdent
     auto shard =
       RGWSI_BucketIndex_RADOS::bucket_shard_index(object, num_shards);
     formatter->open_object_section("obj_shard");

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -4301,11 +4301,11 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_witharg(args, i, &val, "--bucket-index-type", (char*)NULL)) {
       parse(val, bucket_index_type);
       if (! bucket_index_type.has_value()) {
-	std::cerr << "ERROR: --index_type, when specified, must \"hashed\", or \"ordered\"" <<
+	std::cerr << "ERROR: --bucket-index-type, when specified, must \"hashed\", or \"ordered\"" <<
 	  std::endl;
 	return EINVAL;
       } else if (bucket_index_type.value() == rgw::BucketIndexType::Indexless) {
-	std::cerr << "ERROR: --index_type cannot be set to Indexless" << std::endl;
+	std::cerr << "ERROR: --bucket-index-type cannot be set to Indexless" << std::endl;
 	return EINVAL;
       }
     } else if (ceph_argparse_witharg(args, i, &val, "--max-concurrent-ios", (char*)NULL)) {
@@ -4440,7 +4440,10 @@ int main(int argc, const char **argv)
       string index_type_str = val;
       bi_index_type = get_bi_index_type(index_type_str);
       if (bi_index_type == BIIndexType::Invalid) {
-        cerr << "ERROR: invalid bucket index entry type" << std::endl;
+        cerr << "ERROR: invalid bucket index entry type \"" <<
+          index_type_str << "\". Expecting \"plain\", \"instance\", "
+          "\"olh\", or \"resharddeleted\". WARNING: This command-line "
+          "option can be confused with \"--bucket-index-type\"." << std::endl;
         return EINVAL;
       }
     } else if (ceph_argparse_witharg(args, i, &val, "--log-type", (char*)NULL)) {
@@ -9140,7 +9143,7 @@ next:
 		     dpp(), null_yield,
                      verbose, &cout, formatter.get());
     return -ret;
-  }
+  } // BUCKET_RESHARD
 
   if (opt_cmd == OPT::RESHARD_ADD) {
     int ret = check_reshard_bucket_params(driver,
@@ -9169,7 +9172,7 @@ next:
     entry.initiator = cls_rgw_reshard_initiator::Admin;
 
     return reshard.add(dpp(), entry, null_yield);
-  }
+  } // RESHARD_ADD
 
   if (opt_cmd == OPT::RESHARD_LIST) {
     int ret;

--- a/src/rgw/rgw_bucket_layout.cc
+++ b/src/rgw/rgw_bucket_layout.cc
@@ -16,29 +16,50 @@
 #include <boost/algorithm/string.hpp>
 #include "rgw_bucket_layout.h"
 #include "include/utime.h"
+#include "common/versioned_variant.h"
 
 namespace rgw {
+
+const int32_t BIShardIdent::NULL_ID = -1;
+
 
 // BucketIndexType
 std::string_view to_string(const BucketIndexType& t)
 {
   switch (t) {
-  case BucketIndexType::Normal: return "Normal";
+  case BucketIndexType::Hashed: return "Hashed";
   case BucketIndexType::Indexless: return "Indexless";
+  case BucketIndexType::Ordered: return "Ordered";
   default: return "Unknown";
   }
 }
 bool parse(std::string_view str, BucketIndexType& t)
 {
-  if (boost::iequals(str, "Normal")) {
-    t = BucketIndexType::Normal;
+  if (boost::iequals(str, "Hashed") ||
+      boost::iequals(str, "Normal"))
+  {
+    // Normal was used historically up to tentacle
+    t = BucketIndexType::Hashed;
     return true;
   }
   if (boost::iequals(str, "Indexless")) {
     t = BucketIndexType::Indexless;
     return true;
   }
+  if (boost::iequals(str, "Ordered")) {
+    t = BucketIndexType::Ordered;
+    return true;
+  }
   return false;
+}
+void parse(std::string_view str, std::optional<BucketIndexType>& val) {
+  BucketIndexType v;
+  bool result = parse(str, v);
+  if (result) {
+    val = v;
+  } else {
+    val = std::nullopt;
+  }
 }
 void encode_json_impl(const char *name, const BucketIndexType& t, ceph::Formatter *f)
 {
@@ -78,8 +99,8 @@ void decode_json_obj(BucketHashType& t, JSONObj *obj)
   parse(str, t);
 }
 
-// bucket_index_normal_layout
-void encode(const bucket_index_normal_layout& l, bufferlist& bl, uint64_t f)
+// bucket_index_hashed_layout
+void encode(const bucket_index_hashed_layout& l, bufferlist& bl, uint64_t f)
 {
   ENCODE_START(2, 1, bl);
   encode(l.num_shards, bl);
@@ -87,7 +108,7 @@ void encode(const bucket_index_normal_layout& l, bufferlist& bl, uint64_t f)
   encode(l.min_num_shards, bl);
   ENCODE_FINISH(bl);
 }
-void decode(bucket_index_normal_layout& l, bufferlist::const_iterator& bl)
+void decode(bucket_index_hashed_layout& l, bufferlist::const_iterator& bl)
 {
   DECODE_START(2, bl);
   decode(l.num_shards, bl);
@@ -97,7 +118,7 @@ void decode(bucket_index_normal_layout& l, bufferlist::const_iterator& bl)
   }
   DECODE_FINISH(bl);
 }
-void encode_json_impl(const char *name, const bucket_index_normal_layout& l, ceph::Formatter *f)
+void encode_json_impl(const char *name, const bucket_index_hashed_layout& l, ceph::Formatter *f)
 {
   f->open_object_section(name);
   encode_json("num_shards", l.num_shards, f);
@@ -105,7 +126,7 @@ void encode_json_impl(const char *name, const bucket_index_normal_layout& l, cep
   encode_json("min_num_shards", l.min_num_shards, f);
   f->close_section();
 }
-void decode_json_obj(bucket_index_normal_layout& l, JSONObj *obj)
+void decode_json_obj(bucket_index_hashed_layout& l, JSONObj *obj)
 {
   JSONDecoder::decode_json("num_shards", l.num_shards, obj);
   JSONDecoder::decode_json("hash_type", l.hash_type, obj);
@@ -114,44 +135,85 @@ void decode_json_obj(bucket_index_normal_layout& l, JSONObj *obj)
   JSONDecoder::decode_json("min_num_shards", l.min_num_shards, obj, 1);
 }
 
+// bucket_index_hashed_layout
+void encode(const bucket_index_ordered_layout& l, bufferlist& bl, uint64_t f)
+{
+  ENCODE_START(1, 1, bl);
+  encode(l.num_shards, bl);
+  ENCODE_FINISH(bl);
+}
+void decode(bucket_index_ordered_layout& l, bufferlist::const_iterator& bl)
+{
+  DECODE_START(1, bl);
+  decode(l.num_shards, bl);
+  DECODE_FINISH(bl);
+}
+void encode_json_impl(const char *name, const bucket_index_ordered_layout& l, ceph::Formatter *f)
+{
+  f->open_object_section(name);
+  encode_json("num_shards", l.num_shards, f);
+  f->close_section();
+}
+void decode_json_obj(bucket_index_ordered_layout& l, JSONObj *obj)
+{
+  JSONDecoder::decode_json("num_shards", l.num_shards, obj);
+}
+
+
 // bucket_index_layout
 void encode(const bucket_index_layout& l, bufferlist& bl, uint64_t f)
 {
-  ENCODE_START(1, 1, bl);
+  ENCODE_START(2, 1, bl);
   encode(l.type, bl);
-  switch (l.type) {
-  case BucketIndexType::Normal:
-    encode(l.normal, bl);
-    break;
-  case BucketIndexType::Indexless:
-    break;
-  }
+  ceph::converted_variant::encode(l.specs, bl);
   ENCODE_FINISH(bl);
 }
 void decode(bucket_index_layout& l, bufferlist::const_iterator& bl)
 {
-  DECODE_START(1, bl);
+  DECODE_START(2, bl);
   decode(l.type, bl);
-  switch (l.type) {
-  case BucketIndexType::Normal:
-    decode(l.normal, bl);
-    break;
-  case BucketIndexType::Indexless:
-    break;
-  }
+  ceph::converted_variant::decode(l.specs, bl);
   DECODE_FINISH(bl);
 }
 void encode_json_impl(const char *name, const bucket_index_layout& l, ceph::Formatter *f)
 {
   f->open_object_section(name);
   encode_json("type", l.type, f);
-  encode_json("normal", l.normal, f);
+  switch(l.type) {
+  case BucketIndexType::Hashed:
+    encode_json("normal", std::get<bucket_index_hashed_layout>(l.specs), f);
+    break;
+  case BucketIndexType::Ordered:
+    encode_json("normal", std::get<bucket_index_ordered_layout>(l.specs), f);
+    break;
+  case BucketIndexType::Indexless:
+    // empty
+    break;
+  } // switch
   f->close_section();
 }
 void decode_json_obj(bucket_index_layout& l, JSONObj *obj)
 {
   JSONDecoder::decode_json("type", l.type, obj);
-  JSONDecoder::decode_json("normal", l.normal, obj);
+  switch(l.type) {
+  case BucketIndexType::Hashed:
+  {
+    bucket_index_hashed_layout temp;
+    JSONDecoder::decode_json("normal", temp, obj);
+    l.specs = temp;
+  }
+    break;
+  case BucketIndexType::Ordered:
+  {
+    bucket_index_ordered_layout temp;
+    JSONDecoder::decode_json("normal", temp, obj);
+    l.specs = temp;
+  }
+  break;
+  case BucketIndexType::Indexless:
+    // empty
+    break;
+  } // switch
 }
 
 // bucket_index_layout_generation
@@ -219,27 +281,53 @@ void encode(const bucket_index_log_layout& l, bufferlist& bl, uint64_t f)
 {
   ENCODE_START(1, 1, bl);
   encode(l.gen, bl);
-  encode(l.layout, bl);
+  ceph::converted_variant::encode(l.layout, bl);
   ENCODE_FINISH(bl);
 }
 void decode(bucket_index_log_layout& l, bufferlist::const_iterator& bl)
 {
   DECODE_START(1, bl);
   decode(l.gen, bl);
-  decode(l.layout, bl);
+  ceph::converted_variant::decode(l.layout, bl);
   DECODE_FINISH(bl);
 }
 void encode_json_impl(const char *name, const bucket_index_log_layout& l, ceph::Formatter *f)
 {
   f->open_object_section(name);
   encode_json("gen", l.gen, f);
-  encode_json("layout", l.layout, f);
+  if (const bucket_index_hashed_layout* pval = std::get_if<bucket_index_hashed_layout>(&l.layout)) {
+    encode_json("layout_type", BucketIndexType::Hashed, f);
+    encode_json("layout", *pval, f);
+  } else if (const bucket_index_ordered_layout* pval = std::get_if<bucket_index_ordered_layout>(&l.layout)) {
+    encode_json("layout_type", BucketIndexType::Ordered, f);
+    encode_json("layout", *pval, f);
+  } else {
+// OBI: best way to handle?
+    encode_json("layout_type", "unknown", f);
+  }
   f->close_section();
 }
 void decode_json_obj(bucket_index_log_layout& l, JSONObj *obj)
 {
   JSONDecoder::decode_json("gen", l.gen, obj);
-  JSONDecoder::decode_json("layout", l.layout, obj);
+  BucketIndexType index_type;
+  JSONDecoder::decode_json("layout_type", index_type, obj);
+
+  bucket_index_hashed_layout hashed_layout;
+  bucket_index_ordered_layout ordered_layout;
+
+  switch (index_type) {
+  case BucketIndexType::Hashed:
+    JSONDecoder::decode_json("layout", hashed_layout, obj);
+    l.layout = hashed_layout;
+    break;
+  case BucketIndexType::Ordered:
+    JSONDecoder::decode_json("layout", ordered_layout, obj);
+    l.layout = ordered_layout;
+    break;
+  default:
+    throw JSONDecoder::err("unable to decode BucketIndexType");
+  }
 }
 
 // bucket_log_layout
@@ -372,7 +460,7 @@ void decode(BucketLayout& l, bufferlist::const_iterator& bl)
   if (struct_v < 2) {
     l.logs.clear();
     // initialize the log layout to match the current index layout
-    if (l.current_index.layout.type == BucketIndexType::Normal) {
+    if (l.current_index.layout.type == BucketIndexType::Hashed) {
       l.logs.push_back(log_layout_from_index(0, l.current_index));
     }
   } else {
@@ -410,5 +498,223 @@ void decode_json_obj(BucketLayout& l, JSONObj *obj)
   JSONDecoder::decode_json("judge_reshard_lock_time", ut, obj);
   l.judge_reshard_lock_time = ut.to_real_time();
 }
+
+
+std::ostream& operator<<(std::ostream& out, const bucket_index_layout& l) {
+  out << "type=" << to_string(l.type) << ", typed_layout={ ";
+
+  switch (l.type) {
+  case BucketIndexType::Hashed:
+  {
+    const auto* p1 = std::get_if<bucket_index_hashed_layout>(&l.specs);
+    if (p1) {
+      out << *p1;
+    } else {
+      out << "ERROR: MISMATCHED VARIANT";
+    }
+  }
+  break;
+  case BucketIndexType::Ordered:
+  {
+    const auto* p2 = std::get_if<bucket_index_ordered_layout>(&l.specs);
+    if (p2) {
+      out << *p2;
+    } else {
+      out << "ERROR: MISMATCHED VARIANT";
+    }
+  }
+  break;
+  default:
+    out << "ERROR: UNKNOWN VARIANT";
+  }
+  out << " }";
+  return out;
+}
+
+
+BucketIndexType bucket_index_type(const LayoutVariant& l) {
+  if (std::holds_alternative<bucket_index_hashed_layout>(l)) {
+    return BucketIndexType::Hashed;
+  } else if (std::holds_alternative<bucket_index_ordered_layout>(l)) {
+    return BucketIndexType::Ordered;
+  } else {
+    throw std::invalid_argument("unknown layout variant");
+  }
+}
+
+
+std::unique_ptr<BIShardIdent> BIShardIdent::get_null_shard() {
+  return std::make_unique<HashedShardIdent>(NULL_ID);
+}
+
+void BIShardIdent::encode_base(const BIShardIdent* b, bufferlist& bl) {
+  ENCODE_START(1, 1, bl);
+  if (b) {
+    ceph::encode(static_cast<uint8_t>(b->get_type()), bl);
+    b->encode(bl);
+  } else {
+    ceph::encode(static_cast<uint8_t>(Type::NullIdent), bl);
+  }
+  ENCODE_FINISH(bl);
+}
+
+BIShardIdent* BIShardIdent::decode_base(bufferlist::const_iterator& bl) {
+  BIShardIdent* b = nullptr;
+
+  DECODE_START(1, bl);
+  uint8_t type_helper;
+  ceph::decode(type_helper, bl);
+
+  Type type = static_cast<Type>(type_helper);
+  if (type == Type::NullIdent) {
+    return nullptr;
+  }
+        
+  if (type == Type::HashedIdent) {
+    b = new HashedShardIdent();
+  } else if (type == Type::OrderedIdent) {
+    b = new OrderedShardIdent();
+  }
+        
+  if (b) {
+    b->decode(bl);
+  }
+  DECODE_FINISH(bl);
+
+  return b;
+}
+
+std::string HashedShardIdent::to_string() const {
+  const static std::string prefix = "hashed_shard_id:";
+  return prefix + std::to_string(index);
+}
+
+std::size_t HashedShardIdent::get_hash() const {
+  return std::hash<HashedShardIdent>{}(*this);
+}
+
+bool HashedShardIdent::operator==(const BIShardIdent& rhs) const {
+  auto& rhs2 = dynamic_cast<const HashedShardIdent&>(rhs);
+  return index == rhs2.index;
+}
+
+bool HashedShardIdent::operator<(const BIShardIdent& rhs) const {
+  auto& rhs2 = dynamic_cast<const HashedShardIdent&>(rhs);
+  return index < rhs2.index;
+}
+
+void HashedShardIdent::encode(bufferlist& bl) const{
+  ENCODE_START(1, 1, bl);
+  ceph::encode(index, bl);
+  ENCODE_FINISH(bl);
+}
+
+void HashedShardIdent::decode(bufferlist::const_iterator& bl) {
+  DECODE_START(1, bl);
+  ceph::decode(index, bl);
+  DECODE_FINISH(bl);
+}
+
+std::string OrderedShardIdent::to_string() const {
+  std::stringstream ss;
+  ss << "ordered_shard_id:";
+
+  auto i = indices.cbegin();
+  if (i == indices.cend()) {
+    ss << "NULL";
+  } else {
+    ss << *i;
+
+    while (++i != indices.cend()) {
+      ss << "," << *i;
+    }
+  }
+
+  return ss.str();
+}
+
+std::size_t OrderedShardIdent::get_hash() const {
+  return std::hash<OrderedShardIdent>{}(*this);
+}
+
+bool OrderedShardIdent::operator==(const BIShardIdent& rhs) const {
+  auto& rhs2 = dynamic_cast<const OrderedShardIdent&>(rhs);
+
+  if (indices.size() != rhs2.indices.size()) {
+    return false;
+  }
+
+  auto i1 = indices.cbegin();
+  auto i2 = rhs2.indices.cbegin();
+  for ( ; i1 != indices.cend() ; ++i1, ++i2) {
+    if (*i1 != *i2) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool OrderedShardIdent::operator<(const BIShardIdent& rhs) const {
+  const auto& rhs2 = dynamic_cast<const OrderedShardIdent&>(rhs);
+
+  auto i1 = indices.cbegin();
+  auto i2 = rhs2.indices.cbegin();
+  for ( ; i1 != indices.cend() && i2 != rhs2.indices.cend() ; ++i1, ++i2) {
+    if (*i1 < *i2) {
+      return true;
+    } else if (*i2 < *i1) {
+      return false;
+    }
+  }
+
+  // they're the same up to shared length
+
+  return indices.size() < rhs2.indices.size();
+}
+
+void OrderedShardIdent::encode(bufferlist& bl) const{
+  ENCODE_START(1, 1, bl);
+  ceph::encode(indices, bl);
+  ENCODE_FINISH(bl);
+}
+
+void OrderedShardIdent::decode(bufferlist::const_iterator& bl) {
+  DECODE_START(1, bl);
+  ceph::decode(indices, bl);
+  DECODE_FINISH(bl);
+}
+
+int create_layout_generation(
+  int generation,
+  BucketIndexType index_type,
+  int num_shards,
+  const bucket_index_layout& current_layout,
+  bucket_index_layout_generation* result)
+{
+  result->gen = generation;
+  result->layout.type = index_type;
+
+  if (index_type == BucketIndexType::Hashed) {
+    bucket_index_hashed_layout specs;
+    specs.num_shards = num_shards;
+
+    const bucket_index_hashed_layout* old_specs =
+      std::get_if<bucket_index_hashed_layout>(&current_layout.specs);
+    specs.min_num_shards = old_specs ? old_specs->min_num_shards : 11;
+
+    result->layout.specs = specs;
+  } else if (index_type == BucketIndexType::Ordered) {
+    bucket_index_ordered_layout specs;
+    specs.num_shards = num_shards;
+
+    result->layout.specs = specs;
+  } else {
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
 
 } // namespace rgw

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -20,20 +20,171 @@
 
 #pragma once
 
-#include <optional>
 #include <string>
+#include <vector>
+#include <sstream>
+#include <optional>
+
 #include "include/encoding.h"
 #include "common/ceph_json.h"
 
+class RGWBucketInfo;
+
 namespace rgw {
 
+using NestedIndex = std::vector<int32_t>;
+
+// used to indicate an index from 0 up to number of shards, which can
+// be different that the BIShardId for some sharding schemes
+using BIShardIndex = int32_t;
+
+// virtual base class since bucket index shard identifiers can vary
+// depending on sharding scheme
+class BIShardIdent {
+public:
+
+  enum class Type : uint8_t {
+    NullIdent = 0,
+    HashedIdent = 1,
+    OrderedIdent = 2
+  };
+
+  struct Comparator {
+    using is_transparent = void;
+
+    bool operator()(const std::unique_ptr<BIShardIdent>& lhs, const std::unique_ptr<BIShardIdent>& rhs) const {
+      return *lhs < *rhs;
+    }
+
+    bool operator()(const BIShardIdent& lhs, const std::unique_ptr<BIShardIdent>& rhs) const {
+      return lhs < *rhs;
+    }
+
+    bool operator()(const std::unique_ptr<BIShardIdent>& lhs, const BIShardIdent& rhs) const {
+      return *lhs < rhs;
+    }
+  };
+
+  virtual ~BIShardIdent() {}
+
+  virtual std::unique_ptr<BIShardIdent> clone() const = 0;
+
+  virtual std::string to_string() const = 0;
+  virtual bool operator<(const BIShardIdent& rhs) const = 0;
+  virtual bool operator==(const BIShardIdent& rhs) const = 0;
+  virtual std::size_t get_hash() const = 0;
+
+  static const int32_t NULL_ID; // value is -1
+
+  // returns a shard identifer that doesn't (yet?) refer to a shard
+  static std::unique_ptr<BIShardIdent> get_null_shard();
+
+  virtual void encode(bufferlist& bl) const = 0;
+  virtual void decode(bufferlist::const_iterator& bl) = 0;
+  virtual Type get_type() const = 0;
+
+  // helper to encode polymorphic pointer
+  static void encode_base(const BIShardIdent* b, bufferlist& bl);
+
+  // factory method
+  static BIShardIdent* decode_base(bufferlist::const_iterator& bl);
+
+  friend std::ostream& operator<<(std::ostream& out, const BIShardIdent& i) {
+    out << i.to_string();
+    return out;
+  }
+};
+
+class HashedShardIdent : public BIShardIdent {
+  int32_t index;
+
+public:
+
+  HashedShardIdent() :
+    index(-1)
+  { }
+  HashedShardIdent(int32_t _index) :
+    index(_index)
+  { }
+
+  virtual std::unique_ptr<BIShardIdent> clone() const override {
+    return std::make_unique<HashedShardIdent>(index);
+  }
+
+  std::string to_string() const override;
+  std::size_t get_hash() const override;
+  int32_t get_index() const {
+    return index;
+  }
+  Type get_type() const override {
+    return Type::HashedIdent;
+  }
+
+  bool operator<(const BIShardIdent& rhs) const override;
+  bool operator==(const BIShardIdent& rhs) const override;
+  void encode(bufferlist& bl) const override;
+  void decode(bufferlist::const_iterator& bl) override;
+}; // class HashedShardIdent
+
+WRITE_CLASS_ENCODER(HashedShardIdent);
+
+
+class OrderedShardIdent : public BIShardIdent {
+
+  NestedIndex indices;
+
+public:
+
+  OrderedShardIdent()
+  { }
+
+  OrderedShardIdent(int32_t index) :
+    indices(1, index)
+  { }
+
+  OrderedShardIdent(std::initializer_list<int32_t> init_list) :
+    indices(init_list)
+  { }
+
+  OrderedShardIdent(NestedIndex&& from) :
+    indices(from)
+  { }
+
+  OrderedShardIdent(const NestedIndex& from) :
+    indices(from)
+  { }
+
+  virtual std::unique_ptr<BIShardIdent> clone() const override {
+    return std::make_unique<OrderedShardIdent>(indices);
+  }
+
+  std::string to_string() const override;
+  std::size_t get_hash() const override;
+  const NestedIndex& get_indices() const {
+    return indices;
+  }
+  Type get_type() const override {
+    return Type::OrderedIdent;
+  }
+
+  bool operator<(const BIShardIdent& rhs) const override;
+  bool operator==(const BIShardIdent& rhs) const override;
+  void encode(bufferlist& bl) const override;
+  void decode(bufferlist::const_iterator& bl) override;
+}; // class OrderedShardIdent
+
+WRITE_CLASS_ENCODER(OrderedShardIdent);
+
+
 enum class BucketIndexType : uint8_t {
-  Normal, // normal hash-based sharded index layout
-  Indexless, // no bucket index, so listing is unsupported
+  Hashed = 0,    // normal hash-based sharded index layout
+  Indexless = 1, // no bucket index, so listing is unsupported
+  Ordered = 2,   // shards maintain lexical order
 };
 
 std::string_view to_string(const BucketIndexType& t);
 bool parse(std::string_view str, BucketIndexType& t);
+void parse(std::string_view str, std::optional<BucketIndexType>& t);
 void encode_json_impl(const char *name, const BucketIndexType& t, ceph::Formatter *f);
 void decode_json_obj(BucketIndexType& t, JSONObj *obj);
 
@@ -51,7 +202,9 @@ bool parse(std::string_view str, BucketHashType& t);
 void encode_json_impl(const char *name, const BucketHashType& t, ceph::Formatter *f);
 void decode_json_obj(BucketHashType& t, JSONObj *obj);
 
-struct bucket_index_normal_layout {
+
+
+struct bucket_index_hashed_layout {
   uint32_t num_shards = 1;
 
   // the fewest number of shards this bucket layout allows
@@ -59,44 +212,83 @@ struct bucket_index_normal_layout {
 
   BucketHashType hash_type = BucketHashType::Mod;
 
-  friend std::ostream& operator<<(std::ostream& out,
-				  const bucket_index_normal_layout& l) {
-    out << "num_shards=" << l.num_shards << ", min_num_shards=" <<
-      l.min_num_shards << ", hash_type=" << to_string(l.hash_type);
+  std::string to_string() const {
+    std::stringstream ss;
+    ss << "bucket_index_hashed_layout{ num_shards=" << num_shards <<
+      ", min_num_shards=" << min_num_shards <<
+      ", hash_type=" << rgw::to_string(hash_type) << " }";
+    return ss.str();
+  }
+
+  friend std::ostream& operator<<(std::ostream& out, const bucket_index_hashed_layout& l) {
+    out << l.to_string();
     return out;
   }
-};
+}; // struct bucket_index_hashed_layout
 
-inline bool operator==(const bucket_index_normal_layout& l,
-                       const bucket_index_normal_layout& r) {
+inline bool operator==(const bucket_index_hashed_layout& l,
+                       const bucket_index_hashed_layout& r) {
   return l.num_shards == r.num_shards
       && l.hash_type == r.hash_type;
 }
-inline bool operator!=(const bucket_index_normal_layout& l,
-                       const bucket_index_normal_layout& r) {
+inline bool operator!=(const bucket_index_hashed_layout& l,
+                       const bucket_index_hashed_layout& r) {
   return !(l == r);
 }
 
-void encode(const bucket_index_normal_layout& l, bufferlist& bl, uint64_t f=0);
-void decode(bucket_index_normal_layout& l, bufferlist::const_iterator& bl);
-void encode_json_impl(const char *name, const bucket_index_normal_layout& l, ceph::Formatter *f);
-void decode_json_obj(bucket_index_normal_layout& l, JSONObj *obj);
+void encode(const bucket_index_hashed_layout& l, bufferlist& bl, uint64_t f=0);
+void decode(bucket_index_hashed_layout& l, bufferlist::const_iterator& bl);
+void encode_json_impl(const char *name, const bucket_index_hashed_layout& l, ceph::Formatter *f);
+void decode_json_obj(bucket_index_hashed_layout& l, JSONObj *obj);
 
-struct bucket_index_layout {
-  BucketIndexType type = BucketIndexType::Normal;
+struct bucket_index_ordered_layout {
+  uint32_t num_shards = 1;
 
-  // TODO: variant of layout types?
-  bucket_index_normal_layout normal;
+  std::string to_string() const {
+    std::stringstream ss;
+    ss << "bucket_index_ordered_layout:{ num_shards=" << num_shards << " }";
+    return ss.str();
+  }
 
-  friend std::ostream& operator<<(std::ostream& out, const bucket_index_layout& l) {
-    out << "type=" << to_string(l.type) << ", normal=" << l.normal;
+  friend std::ostream& operator<<(std::ostream& out, const bucket_index_ordered_layout& l) {
+    out << l.to_string();
     return out;
   }
-};
+}; // struct bucket_index_ordered_layout
+
+inline bool operator==(const bucket_index_ordered_layout& l,
+                       const bucket_index_ordered_layout& r) {
+  return l.num_shards == r.num_shards;
+}
+
+inline bool operator!=(const bucket_index_ordered_layout& l,
+                       const bucket_index_ordered_layout& r) {
+  return !(l == r);
+}
+
+void encode(const bucket_index_ordered_layout& l, bufferlist& bl, uint64_t f=0);
+void decode(bucket_index_ordered_layout& l, bufferlist::const_iterator& bl);
+void encode_json_impl(const char *name, const bucket_index_ordered_layout& l, ceph::Formatter *f);
+void decode_json_obj(bucket_index_ordered_layout& l, JSONObj *obj);
+
+
+using LayoutVariant = std::variant<bucket_index_hashed_layout,bucket_index_ordered_layout>;
+
+BucketIndexType bucket_index_type(const LayoutVariant& l);
+
+
+struct bucket_index_layout {
+  BucketIndexType type;
+
+  LayoutVariant specs;
+
+  BucketIndexType get_index_type() const { return bucket_index_type(specs); }
+  friend std::ostream& operator<<(std::ostream& out, const bucket_index_layout& l);
+}; // struct bucket_index_layout
 
 inline bool operator==(const bucket_index_layout& l,
                        const bucket_index_layout& r) {
-  return l.type == r.type && l.normal == r.normal;
+  return l.type == r.type && l.specs == r.specs;
 }
 inline bool operator!=(const bucket_index_layout& l,
                        const bucket_index_layout& r) {
@@ -112,11 +304,22 @@ struct bucket_index_layout_generation {
   uint64_t gen = 0;
   bucket_index_layout layout;
 
+  BucketIndexType get_index_type() const { return layout.get_index_type(); }
+
   friend std::ostream& operator<<(std::ostream& out, const bucket_index_layout_generation& g) {
-    out << "gen=" << g.gen;
+    out << "bucket_index_layout_generation{ gen=" << g.gen << ", layout=" << g.layout << " }";
     return out;
   }
 };
+
+
+int create_layout_generation(
+  int generation,
+  BucketIndexType index_type,
+  int num_shards,
+  const bucket_index_layout& current_layout,
+  bucket_index_layout_generation* result);
+
 
 inline bool operator==(const bucket_index_layout_generation& l,
                        const bucket_index_layout_generation& r) {
@@ -158,12 +361,14 @@ inline std::ostream& operator<<(std::ostream& out, const BucketLogType &log_type
 
 struct bucket_index_log_layout {
   uint64_t gen = 0;
-  bucket_index_normal_layout layout;
+
+  LayoutVariant layout;
+
   operator bucket_index_layout_generation() const {
     bucket_index_layout_generation bilg;
     bilg.gen = gen;
-    bilg.layout.type = BucketIndexType::Normal;
-    bilg.layout.normal = layout;
+    bilg.layout.type = bucket_index_type(bilg.layout.specs);
+    bilg.layout.specs = layout;
     return bilg;
   }
 };
@@ -208,7 +413,7 @@ void decode_json_obj(bucket_log_layout_generation& l, JSONObj *obj);
 inline bucket_log_layout_generation log_layout_from_index(
     uint64_t gen, const bucket_index_layout_generation& index)
 {
-  return {gen, {BucketLogType::InIndex, {index.gen, index.layout.normal}}};
+  return { gen, { BucketLogType::InIndex, { index.gen, index.layout.specs }}};
 }
 
 inline auto matches_gen(uint64_t gen)
@@ -220,7 +425,7 @@ inline bucket_index_layout_generation log_to_index_layout(const bucket_log_layou
 {
   bucket_index_layout_generation index;
   index.gen = log_layout.layout.in_index.gen;
-  index.layout.normal = log_layout.layout.in_index.layout;
+  index.layout.specs = log_layout.layout.in_index.layout;
   return index;
 }
 
@@ -274,29 +479,32 @@ void encode_json_impl(const char *name, const BucketLayout& l, ceph::Formatter *
 void decode_json_obj(BucketLayout& l, JSONObj *obj);
 
 
-inline uint32_t num_shards(const bucket_index_normal_layout& index) {
+inline BIShardIndex num_shards(const bucket_index_hashed_layout& index) {
   // old buckets used num_shards=0 to mean 1
   return index.num_shards > 0 ? index.num_shards : 1;
 }
-inline uint32_t num_shards(const bucket_index_layout& index) {
-  ceph_assert(index.type == BucketIndexType::Normal);
-  return num_shards(index.normal);
+inline BIShardIndex num_shards(const bucket_index_ordered_layout& index) {
+  return index.num_shards;
 }
-inline uint32_t num_shards(const bucket_index_layout_generation& index) {
+inline BIShardIndex num_shards(const LayoutVariant& index) {
+  return std::visit([](const auto& arg) -> uint32_t { return num_shards(arg); }, index);
+}
+inline BIShardIndex num_shards(const bucket_index_layout& index) {
+  return num_shards(index.specs);
+}
+inline BIShardIndex num_shards(const bucket_index_layout_generation& index) {
   return num_shards(index.layout);
 }
 
-inline uint32_t current_num_shards(const BucketLayout& layout) {
+inline BIShardIndex current_num_shards(const BucketLayout& layout) {
   return num_shards(layout.current_index);
-}
-inline uint32_t current_min_layout_shards(const BucketLayout& layout) {
-  return layout.current_index.layout.normal.min_num_shards;
 }
 inline bool is_layout_indexless(const bucket_index_layout_generation& layout) {
   return layout.layout.type == BucketIndexType::Indexless;
 }
 inline bool is_layout_reshardable(const bucket_index_layout_generation& layout) {
-  return layout.layout.type == BucketIndexType::Normal;
+  return layout.layout.type == BucketIndexType::Hashed ||
+    layout.layout.type == BucketIndexType::Ordered;
 }
 inline bool is_layout_reshardable(const BucketLayout& layout) {
   return is_layout_reshardable(layout.current_index);
@@ -305,4 +513,61 @@ inline std::string_view current_layout_desc(const BucketLayout& layout) {
   return rgw::to_string(layout.current_index.layout.type);
 }
 
+inline bucket_index_hashed_layout* hashed_layout_ptr(LayoutVariant& specs) {
+  return std::get_if<rgw::bucket_index_hashed_layout>(&specs);
+}
+inline const bucket_index_hashed_layout* hashed_layout_ptr(const LayoutVariant& specs) {
+  return std::get_if<rgw::bucket_index_hashed_layout>(&specs);
+}
+inline bucket_index_hashed_layout* hashed_layout_ptr(bucket_index_layout& layout) {
+  return hashed_layout_ptr(layout.specs);
+}
+inline const bucket_index_hashed_layout* hashed_layout_ptr(const bucket_index_layout& layout) {
+  return hashed_layout_ptr(layout.specs);
+}
+inline bucket_index_ordered_layout* ordered_layout_ptr(bucket_index_layout& layout) {
+  return std::get_if<rgw::bucket_index_ordered_layout>(&layout.specs);
+}
+inline const bucket_index_ordered_layout* ordered_layout_ptr(const bucket_index_layout& layout) {
+  return std::get_if<rgw::bucket_index_ordered_layout>(&layout.specs);
+}
+
 } // namespace rgw
+
+namespace std {
+
+template<>
+struct hash<rgw::BIShardIdent>
+{
+  std::size_t operator ()(const rgw::BIShardIdent& bs) const noexcept {
+    return bs.get_hash();
+  }
+};
+
+template<>
+struct hash<rgw::HashedShardIdent>
+{
+  std::size_t operator ()(const rgw::HashedShardIdent& i) const noexcept {
+    return std::hash<int32_t>{}(i.get_index());
+  }
+};
+
+template<>
+struct hash<rgw::OrderedShardIdent>
+{
+  // algorithm adapted from:
+  // https://stackoverflow.com/questions/20511347/a-good-hash-function-for-a-vector
+  std::size_t operator ()(const rgw::OrderedShardIdent& i) const noexcept {
+    auto& v = i.get_indices();
+
+    std::size_t seed = v.size();
+    for(auto e : v) {
+      auto e_hash = std::hash<int32_t>{}(e);
+      seed ^= e_hash + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    }
+
+    return seed;
+  }
+};
+
+} // namespace std

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -38,6 +38,9 @@ using NestedIndex = std::vector<int32_t>;
 // be different that the BIShardId for some sharding schemes
 using BIShardIndex = int32_t;
 
+// same as BIShardIndex, but named differently to avoid confusion in code
+using BIShardCount = BIShardIndex;
+
 // virtual base class since bucket index shard identifiers can vary
 // depending on sharding scheme
 class BIShardIdent {
@@ -479,24 +482,24 @@ void encode_json_impl(const char *name, const BucketLayout& l, ceph::Formatter *
 void decode_json_obj(BucketLayout& l, JSONObj *obj);
 
 
-inline BIShardIndex num_shards(const bucket_index_hashed_layout& index) {
+inline BIShardCount num_shards(const bucket_index_hashed_layout& index) {
   // old buckets used num_shards=0 to mean 1
   return index.num_shards > 0 ? index.num_shards : 1;
 }
-inline BIShardIndex num_shards(const bucket_index_ordered_layout& index) {
+inline BIShardCount num_shards(const bucket_index_ordered_layout& index) {
   return index.num_shards;
 }
-inline BIShardIndex num_shards(const LayoutVariant& index) {
+inline BIShardCount num_shards(const LayoutVariant& index) {
   return std::visit([](const auto& arg) -> uint32_t { return num_shards(arg); }, index);
 }
-inline BIShardIndex num_shards(const bucket_index_layout& index) {
+inline BIShardCount num_shards(const bucket_index_layout& index) {
   return num_shards(index.specs);
 }
-inline BIShardIndex num_shards(const bucket_index_layout_generation& index) {
+inline BIShardCount num_shards(const bucket_index_layout_generation& index) {
   return num_shards(index.layout);
 }
 
-inline BIShardIndex current_num_shards(const BucketLayout& layout) {
+inline BIShardCount current_num_shards(const BucketLayout& layout) {
   return num_shards(layout.current_index);
 }
 inline bool is_layout_indexless(const bucket_index_layout_generation& layout) {

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -34,6 +34,7 @@
 
 #define dout_context g_ceph_context
 
+
 static constexpr auto dout_subsys = ceph_subsys_rgw;
 
 using rgw::ARN;
@@ -43,6 +44,14 @@ using rgw::IAM::Policy;
 using rgw::IAM::PolicyPrincipal;
 
 const uint32_t RGWBucketInfo::NUM_SHARDS_BLIND_BUCKET(UINT32_MAX);
+
+// helper for std::visit
+template<class... Ts>
+struct overloaded : Ts... { using Ts::operator()...; };
+// explicit deduction guide (not needed as of C++20)
+template<class... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
+
 
 rgw_http_errors rgw_http_s3_errors({
     { 0, {200, "" }},
@@ -2338,31 +2347,51 @@ void RGWBucketInfo::decode(bufferlist::const_iterator& bl) {
     decode(s, bl);
     user.from_str(s);
   }
-  if (struct_v >= 3)
+  if (struct_v >= 3) {
     decode(flags, bl);
-  if (struct_v >= 5)
+  }
+  if (struct_v >= 5) {
     decode(zonegroup, bl);
+  }
   if (struct_v >= 6) {
     uint64_t ct;
     decode(ct, bl);
-    if (struct_v < 17)
+    if (struct_v < 17) {
       creation_time = ceph::real_clock::from_time_t((time_t)ct);
+    }
   }
-  if (struct_v >= 7)
+  if (struct_v >= 7) {
     decode(placement_rule, bl);
-  if (struct_v >= 8)
+  }
+  if (struct_v >= 8) {
     decode(has_instance_obj, bl);
-  if (struct_v >= 9)
+  }
+  if (struct_v >= 9) {
     decode(quota, bl);
+  }
+
   static constexpr uint8_t new_layout_v = 22;
-  if (struct_v >= 10 && struct_v < new_layout_v)
-    decode(layout.current_index.layout.normal.num_shards, bl);
-  if (struct_v >= 11 && struct_v < new_layout_v)
-    decode(layout.current_index.layout.normal.hash_type, bl);
-  if (struct_v >= 12)
+
+
+  // read in the layout for older versions
+  if (struct_v >= 10 && struct_v < new_layout_v) {
+    rgw::bucket_index_hashed_layout new_layout;
+
+    decode(new_layout.num_shards, bl); // if struct_v >= 10 && struct_v < new_layout_v
+
+    if (struct_v >= 11) { // and if struct_v < new_layout_v
+      decode(new_layout.hash_type, bl);
+    }
+
+    layout.current_index.layout.specs = new_layout;
+  }
+
+  if (struct_v >= 12) {
     decode(requester_pays, bl);
-  if (struct_v >= 13)
+  }
+  if (struct_v >= 13) {
     decode(user.tenant, bl);
+  }
   if (struct_v >= 14) {
     decode(has_website, bl);
     if (has_website) {
@@ -2376,7 +2405,7 @@ void RGWBucketInfo::decode(bufferlist::const_iterator& bl) {
     decode(it, bl);
     layout.current_index.layout.type = (rgw::BucketIndexType)it;
   } else {
-    layout.current_index.layout.type = rgw::BucketIndexType::Normal;
+    layout.current_index.layout.type = rgw::BucketIndexType::Hashed;
   }
   swift_versioning = false;
   swift_ver_location.clear();
@@ -2384,7 +2413,7 @@ void RGWBucketInfo::decode(bufferlist::const_iterator& bl) {
     decode(swift_versioning, bl);
     if (swift_versioning) {
       decode(swift_ver_location, bl);
-   }
+    }
   }
   if (struct_v >= 17) {
     decode(creation_time, bl);
@@ -2415,7 +2444,7 @@ void RGWBucketInfo::decode(bufferlist::const_iterator& bl) {
   }
 
   if (layout.logs.empty() &&
-      layout.current_index.layout.type == rgw::BucketIndexType::Normal) {
+      layout.current_index.layout.type == rgw::BucketIndexType::Hashed) {
     layout.logs.push_back(rgw::log_layout_from_index(0, layout.current_index));
   }
   DECODE_FINISH(bl);
@@ -2509,9 +2538,11 @@ list<RGWBucketInfo> RGWBucketInfo::generate_test_instances()
   // round-trip properly.
   auto gen_layout = [](rgw::BucketLayout& l) {
     l.current_index.gen = 0;
-    l.current_index.layout.normal.hash_type = rgw::BucketHashType::Mod;
-    l.current_index.layout.type = rgw::BucketIndexType::Normal;
-    l.current_index.layout.normal.num_shards = 11;
+    rgw::bucket_index_hashed_layout prep_layout;
+    prep_layout.num_shards = 11;
+    prep_layout.hash_type = rgw::BucketHashType::Mod;
+    l.current_index.layout.type = rgw::BucketIndexType::Hashed;
+    l.current_index.layout.specs = prep_layout;
     l.logs.push_back(log_layout_from_index(
                        l.current_index.gen,
                        l.current_index));
@@ -2541,8 +2572,19 @@ void RGWBucketInfo::dump(Formatter *f) const
   encode_json("placement_rule", placement_rule, f);
   encode_json("has_instance_obj", has_instance_obj, f);
   encode_json("quota", quota, f);
-  encode_json("num_shards", layout.current_index.layout.normal.num_shards, f);
-  encode_json("bi_shard_hash_type", (uint32_t)layout.current_index.layout.normal.hash_type, f);
+  encode_json("index_type", (uint32_t)layout.current_index.layout.type, f);
+
+  std::visit(overloaded {
+      [f](rgw::bucket_index_hashed_layout arg) {
+	encode_json("num_shards", arg.num_shards, f);
+	encode_json("bi_shard_hash_type", (uint32_t) arg.hash_type, f);
+	encode_json("min_num_shards", arg.min_num_shards, f);
+      },
+      [f](rgw::bucket_index_ordered_layout arg) {
+	encode_json("num_shards", arg.num_shards, f);
+      }
+  }, layout.current_index.layout.specs);
+
   encode_json("requester_pays", requester_pays, f);
   encode_json("has_website", has_website, f);
   if (has_website) {
@@ -2550,7 +2592,6 @@ void RGWBucketInfo::dump(Formatter *f) const
   }
   encode_json("swift_versioning", swift_versioning, f);
   encode_json("swift_ver_location", swift_ver_location, f);
-  encode_json("index_type", (uint32_t)layout.current_index.layout.type, f);
   encode_json("mdsearch_config", mdsearch_config, f);
   encode_json("reshard_status", (int)reshard_status, f);
   encode_json("new_bucket_instance_id", new_bucket_instance_id, f);
@@ -2579,10 +2620,7 @@ void RGWBucketInfo::decode_json(JSONObj *obj) {
   placement_rule.from_str(pr);
   JSONDecoder::decode_json("has_instance_obj", has_instance_obj, obj);
   JSONDecoder::decode_json("quota", quota, obj);
-  JSONDecoder::decode_json("num_shards", layout.current_index.layout.normal.num_shards, obj);
-  uint32_t hash_type;
-  JSONDecoder::decode_json("bi_shard_hash_type", hash_type, obj);
-  layout.current_index.layout.normal.hash_type = static_cast<rgw::BucketHashType>(hash_type);
+
   JSONDecoder::decode_json("requester_pays", requester_pays, obj);
   JSONDecoder::decode_json("has_website", has_website, obj);
   if (has_website) {
@@ -2603,10 +2641,56 @@ void RGWBucketInfo::decode_json(JSONObj *obj) {
   if (!sp.empty()) {
     set_sync_policy(std::move(sp));
   }
+
   if (obj_lock_enabled()) {
     JSONDecoder::decode_json("obj_lock", obj_lock, obj);
   }
-}
+
+  // piece together the layout
+
+  uint32_t num_shards;
+  if (! JSONDecoder::decode_json("num_shards", num_shards, obj)) {
+    throw JSONDecoder::err("failed to parse RGWBucketInfo; num_shards not specified");
+  }
+
+  uint32_t min_num_shards = 1;
+  JSONDecoder::decode_json("min_num_shards", min_num_shards, obj);
+
+  rgw::BucketHashType hash_type;
+  {
+    uint32_t hash_type_val;
+    if (JSONDecoder::decode_json("bi_shard_hash_type", hash_type_val, obj)) {
+      hash_type = static_cast<rgw::BucketHashType>(hash_type_val);
+    } else {
+      hash_type = rgw::BucketHashType::Mod;
+    }
+  }
+
+  {
+    rgw::BucketIndexType index_type;
+    uint32_t index_type_val;
+    if (JSONDecoder::decode_json("bi_type", index_type_val, obj)) {
+      index_type = static_cast<rgw::BucketIndexType>(index_type_val);
+    } else {
+      index_type = rgw::BucketIndexType::Hashed;
+    }
+
+    rgw::bucket_index_hashed_layout normal;
+    rgw::bucket_index_ordered_layout ordered;
+    switch (index_type) {
+    case rgw::BucketIndexType::Hashed:
+      normal = rgw::bucket_index_hashed_layout { num_shards, min_num_shards, hash_type };
+      layout.current_index.layout.specs = normal;
+      break;
+    case rgw::BucketIndexType::Ordered:
+      ordered = rgw::bucket_index_ordered_layout { num_shards };
+      layout.current_index.layout.specs = ordered;
+      break;
+    default:
+      throw JSONDecoder::err("failed to parse RGWBucketInfo; bi_type unknown");
+    }
+  } // scope
+} // RGWBucketInfo::decode_json
 
 list<RGWUserInfo> RGWUserInfo::generate_test_instances()
 {

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -71,6 +71,11 @@ struct RGWProcessEnv;
 
 using ceph::crypto::MD5;
 
+// used for version 1 of ordered bucket indexes, where shard
+// cut-points are stored as keys in the omap for bucket instance
+// object (aka bucket_info)
+#define RGW_ATTR_OBI1_KEY_PREFIX "obi1."
+
 #define RGW_ATTR_PREFIX  "user.rgw."
 
 #define RGW_HTTP_RGWX_ATTR_PREFIX "RGWX_ATTR_"
@@ -1167,6 +1172,27 @@ struct RGWBucketInfo {
   }
   rgw::bucket_index_layout_generation& get_current_index() {
     return layout.current_index;
+  }
+
+  const rgw::bucket_index_hashed_layout* hashed_layout_ptr() const {
+    return rgw::hashed_layout_ptr(layout.current_index.layout);
+  }
+  rgw::bucket_index_hashed_layout* hashed_layout_ptr() {
+    return rgw::hashed_layout_ptr(layout.current_index.layout);
+  }
+  const rgw::bucket_index_ordered_layout* ordered_layout_ptr() const {
+    return rgw::ordered_layout_ptr(layout.current_index.layout);
+  }
+  rgw::bucket_index_ordered_layout* ordered_layout_ptr() {
+    return rgw::ordered_layout_ptr(layout.current_index.layout);
+  }
+
+  rgw::BucketIndexType get_current_bucket_index_type() const {
+    return layout.current_index.layout.type;
+  }
+
+  const rgw::LayoutVariant& get_current_layout_variant() const {
+    return layout.current_index.layout.specs;
   }
 
   RGWBucketInfo();

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1164,9 +1164,6 @@ struct RGWBucketInfo {
 
   bool empty_sync_policy() const;
 
-  bool is_indexless() const {
-    return rgw::is_layout_indexless(layout.current_index);
-  }
   const rgw::bucket_index_layout_generation& get_current_index() const {
     return layout.current_index;
   }
@@ -1189,6 +1186,18 @@ struct RGWBucketInfo {
 
   rgw::BucketIndexType get_current_bucket_index_type() const {
     return layout.current_index.layout.type;
+  }
+
+  bool is_indexless() const {
+    return rgw::is_layout_indexless(layout.current_index);
+  }
+
+  bool uses_hashed_index() const {
+    return get_current_bucket_index_type() == rgw::BucketIndexType::Hashed;
+  }
+
+  bool uses_ordered_index() const {
+    return get_current_bucket_index_type() == rgw::BucketIndexType::Ordered;
   }
 
   const rgw::LayoutVariant& get_current_layout_variant() const {

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -454,9 +454,11 @@ static bool pass_object_lock_check(rgw::sal::Driver* driver, rgw::sal::Object* o
  * excess OSD requests
  */
 static bool should_list_unordered(const rgw::bucket_index_layout_generation& current_index, uint64_t threshold) {
-  return current_index.layout.type == rgw::BucketIndexType::Normal
-    && rgw::num_shards(current_index.layout.normal) > threshold;
+  return current_index.layout.type == rgw::BucketIndexType::Hashed &&
+    rgw::num_shards(current_index) > (rgw::BIShardIndex) threshold;
 }
+
+
 class LCObjsLister {
   rgw::sal::Driver* driver;
   rgw::sal::Bucket* bucket;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4163,7 +4163,7 @@ void RGWCreateBucket::execute(optional_yield y)
     if ((createparams.index_type && *createparams.index_type !=
          info.layout.current_index.layout.type) ||
         (createparams.index_shards && *createparams.index_shards !=
-         info.layout.current_index.layout.normal.num_shards)) {
+         current_num_shards(info.layout))) {
       s->err.message =
           "Cannot modify existing bucket's index type or shard count";
       op_ret = -EEXIST;
@@ -4266,6 +4266,8 @@ void RGWCreateBucket::execute(optional_yield y)
     createparams.quota = master_info.quota;
     createparams.creation_time = master_info.creation_time;
   }
+
+  createparams.index_type = rgw::BucketIndexType::Hashed;
 
   ldpp_dout(this, 10) << "user=" << s->user << " bucket=" << s->bucket << dendl;
   op_ret = s->bucket->create(this, createparams, y);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4267,7 +4267,26 @@ void RGWCreateBucket::execute(optional_yield y)
     createparams.creation_time = master_info.creation_time;
   }
 
-  createparams.index_type = rgw::BucketIndexType::Hashed;
+  {
+    constexpr char* index_config = "rgw_bucket_default_index";
+
+    const std::string& default_bucket_index =
+      s->cct->_conf.get_val<std::string>(index_config);
+
+    createparams.index_type = rgw::BucketIndexType::Hashed; // default
+    if (default_bucket_index == "ordered") {
+      createparams.index_type = rgw::BucketIndexType::Ordered;
+    } else if (default_bucket_index != "hashed") {
+      ldpp_dout(this, 0) << "ERROR: configuration option " <<
+        index_config << " is set to an unknown value \"" <<
+        default_bucket_index << "\"; using the default of \"hashed\"" <<
+        dendl;
+    }
+
+    ldpp_dout(this, 20) << "INFO: configuration option " <<
+      index_config << " set to " << createparams.index_type <<
+      dendl;
+  }
 
   ldpp_dout(this, 10) << "user=" << s->user << " bucket=" << s->bucket << dendl;
   op_ret = s->bucket->create(this, createparams, y);

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2761,7 +2761,7 @@ int RGWCreateBucket_ObjStore_S3::get_params(optional_yield y)
       createparams.index_type = type;
 
       if (config->index->num_shards) {
-        if (type != rgw::BucketIndexType::Normal) {
+        if (type != rgw::BucketIndexType::Hashed) {
           s->err.message = "NumShards requires Type to be Normal";
           return -EINVAL;
         }

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -518,7 +518,7 @@ list<RGWZonePlacementInfo> RGWZonePlacementInfo::generate_test_instances()
   o.back().index_pool = rgw_pool("rgw.buckets.index");
   
   o.back().data_extra_pool = rgw_pool("rgw.buckets.non-ec");
-  o.back().index_type = rgw::BucketIndexType::Normal;
+  o.back().index_type = rgw::BucketIndexType::Hashed;
   o.back().inline_data = false;
   return o;
 }

--- a/src/rgw/rgw_zone_types.h
+++ b/src/rgw/rgw_zone_types.h
@@ -222,7 +222,7 @@ struct RGWZonePlacementInfo {
   rgw::BucketIndexType index_type;
   bool inline_data;
 
-  RGWZonePlacementInfo() : index_type(rgw::BucketIndexType::Normal), inline_data(true) {}
+  RGWZonePlacementInfo() : index_type(rgw::BucketIndexType::Hashed), inline_data(true) {}
 
   void encode(bufferlist& bl) const {
     ENCODE_START(8, 1, bl);

--- a/src/rgw/services/svc_bi.h
+++ b/src/rgw/services/svc_bi.h
@@ -22,6 +22,8 @@
 class RGWBucketInfo;
 struct RGWBucketEnt;
 
+namespace rgw { namespace rados { class BIndexer; } }
+
 
 class RGWSI_BucketIndex : public RGWServiceInstance
 {
@@ -30,13 +32,16 @@ public:
   virtual ~RGWSI_BucketIndex() {}
 
   virtual int init_index(const DoutPrefixProvider *dpp, optional_yield y,
-                         const RGWBucketInfo& bucket_info,
-                         const rgw::bucket_index_layout_generation& idx_layout,
+                         std::unique_ptr<rgw::rados::BIndexer>& bindexer,
                          std::map<std::string, bufferlist>* binfo_map_data,
                          bool judge_support_logrecord = false) = 0;
+#if 1 // OBI deprecate??
   virtual int clean_index(const DoutPrefixProvider *dpp, optional_yield y,
                           const RGWBucketInfo& bucket_info,
                           const rgw::bucket_index_layout_generation& idx_layout) = 0;
+#endif
+  virtual int clean_index(const DoutPrefixProvider *dpp, optional_yield y,
+                          std::unique_ptr<rgw::rados::BIndexer>& bindexer) = 0;
 
   virtual int read_stats(const DoutPrefixProvider *dpp,
                          const RGWBucketInfo& bucket_info,

--- a/src/rgw/services/svc_bi.h
+++ b/src/rgw/services/svc_bi.h
@@ -32,6 +32,7 @@ public:
   virtual int init_index(const DoutPrefixProvider *dpp, optional_yield y,
                          const RGWBucketInfo& bucket_info,
                          const rgw::bucket_index_layout_generation& idx_layout,
+                         std::map<std::string, bufferlist>* binfo_map_data,
                          bool judge_support_logrecord = false) = 0;
   virtual int clean_index(const DoutPrefixProvider *dpp, optional_yield y,
                           const RGWBucketInfo& bucket_info,

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -960,11 +960,3 @@ int RGWSI_BucketIndex_RADOS::handle_overwrite(const DoutPrefixProvider *dpp,
 
   return ret;
 }
-
-// OBI: this should be converted into returning an index object name
-// and be based on index type
-int32_t RGWSI_BucketIndex_RADOS::bucket_shard_index(const rgw_obj_key& obj_key,
-						    int num_shards)
-{
-  return rgw::rados::HashedBIndexer::get_shard_index(obj_key, num_shards);
-}

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -19,26 +19,31 @@
 #include "common/async/blocked_completion.h"
 #include "common/errno.h"
 
+
 #define dout_subsys ceph_subsys_rgw
 
 using namespace std;
 using rgwrados::shard_io::Result;
 
-static string dir_oid_prefix = ".dir.";
 
-RGWSI_BucketIndex_RADOS::RGWSI_BucketIndex_RADOS(CephContext *cct) : RGWSI_BucketIndex(cct)
+RGWSI_BucketIndex_RADOS::RGWSI_BucketIndex_RADOS(CephContext *cct) :
+  RGWSI_BucketIndex(cct)
 {
+  // empty
 }
 
 void RGWSI_BucketIndex_RADOS::init(RGWSI_Zone *zone_svc,
 				   librados::Rados* rados_,
 				   RGWSI_BILog_RADOS *bilog_svc,
-				   RGWDataChangesLog *datalog_rados_svc)
+				   RGWDataChangesLog *datalog_rados_svc,
+                                   RGWSI_Bucket_SObj *bucket_sobj)
+
 {
   svc.zone = zone_svc;
   rados = rados_;
   svc.bilog = bilog_svc;
   svc.datalog_rados = datalog_rados_svc;
+  svc.bucket_sobj = bucket_sobj;
 }
 
 int RGWSI_BucketIndex_RADOS::open_pool(const DoutPrefixProvider *dpp,
@@ -79,28 +84,6 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index_pool(const DoutPrefixProvider *dp
   return 0;
 }
 
-int RGWSI_BucketIndex_RADOS::open_bucket_index_base(const DoutPrefixProvider *dpp,
-                                                    const RGWBucketInfo& bucket_info,
-                                                    librados::IoCtx* index_pool,
-                                                    string *bucket_oid_base)
-{
-  const rgw_bucket& bucket = bucket_info.bucket;
-  int r = open_bucket_index_pool(dpp, bucket_info, index_pool);
-  if (r < 0)
-    return r;
-
-  if (bucket.bucket_id.empty()) {
-    ldpp_dout(dpp, 0) << "ERROR: empty bucket_id for bucket operation" << dendl;
-    return -EIO;
-  }
-
-  *bucket_oid_base = dir_oid_prefix;
-  bucket_oid_base->append(bucket.bucket_id);
-
-  return 0;
-
-}
-
 int RGWSI_BucketIndex_RADOS::open_bucket_index(const DoutPrefixProvider *dpp,
                                                const RGWBucketInfo& bucket_info,
                                                librados::IoCtx* index_pool,
@@ -119,217 +102,146 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index(const DoutPrefixProvider *dpp,
     return -EIO;
   }
 
-  *bucket_oid = dir_oid_prefix;
-  bucket_oid->append(bucket.bucket_id);
+  if (bucket_oid) {
+    *bucket_oid = dir_oid_prefix;
+    bucket_oid->append(bucket.bucket_id);
+  }
 
   return 0;
 }
 
-namespace {
-inline std::string
-bucket_obj_with_generation(
-    std::string_view bucket_oid_base,
-    uint64_t gen_id,
-    uint32_t shard_id)
-{
-  return fmt::format("{}.{}.{}", bucket_oid_base, gen_id, shard_id);
-}
-
-inline std::string
-bucket_obj_without_generation(std::string_view bucket_oid_base, uint32_t shard_id)
-{
-  return fmt::format("{}.{}", bucket_oid_base, shard_id);
-}
-} // namespace
-
-static void get_bucket_index_objects(const string& bucket_oid_base,
-                                     uint32_t num_shards, uint64_t gen_id,
-                                     map<int, string> *_bucket_objects,
-                                     int shard_id = -1)
-{
-  auto& bucket_objects = *_bucket_objects;
-  if (!num_shards) {
-    bucket_objects[0] = bucket_oid_base;
-  } else {
-    if (shard_id < 0) {
-      for (uint32_t i = 0; i < num_shards; ++i) {
-        if (gen_id) {
-          bucket_objects[i] = bucket_obj_with_generation(bucket_oid_base, gen_id, i);
-        } else {
-          bucket_objects[i] = bucket_obj_without_generation(bucket_oid_base, i);
-        }
-      }
-    } else {
-      if (std::cmp_greater(shard_id, num_shards)) {
-        return;
-      } else {
-        if (gen_id) {
-          bucket_objects[shard_id] =
-              bucket_obj_with_generation(bucket_oid_base, gen_id, shard_id);
-        } else {
-          // for backward compatibility, gen_id(0) will not be added in the object name
-          bucket_objects[shard_id] =
-              bucket_obj_without_generation(bucket_oid_base, shard_id);
-        }
-      }
-    }
-  }
-}
-
-static void get_bucket_instance_ids(const RGWBucketInfo& bucket_info,
-                                    int num_shards, int shard_id,
-                                    map<int, string> *result)
-{
-  const rgw_bucket& bucket = bucket_info.bucket;
-  string plain_id = bucket.name + ":" + bucket.bucket_id;
-
-  if (!num_shards) {
-    (*result)[0] = plain_id;
-  } else {
-    char buf[16];
-    if (shard_id < 0) {
-      for (int i = 0; i < num_shards; ++i) {
-        snprintf(buf, sizeof(buf), ":%d", i);
-        (*result)[i] = plain_id + buf;
-      }
-    } else {
-      if (shard_id > num_shards) {
-        return;
-      }
-      snprintf(buf, sizeof(buf), ":%d", shard_id);
-      (*result)[shard_id] = plain_id + buf;
-    }
-  }
-}
 
 int RGWSI_BucketIndex_RADOS::open_bucket_index(const DoutPrefixProvider *dpp,
                                                const RGWBucketInfo& bucket_info,
-                                               std::optional<int> _shard_id,
+                                               rgw::BIShardIndex shard_index,
                                                const rgw::bucket_index_layout_generation& idx_layout,
                                                librados::IoCtx* index_pool,
                                                map<int, string> *bucket_objs,
                                                map<int, string> *bucket_instance_ids)
 {
-  int shard_id = _shard_id.value_or(-1);
-  string bucket_oid_base;
-  int ret = open_bucket_index_base(dpp, bucket_info, index_pool, &bucket_oid_base);
+  int ret = open_bucket_index_pool(dpp, bucket_info, index_pool);
+  if (ret < 0) {
+    return ret;
+  }
   if (ret < 0) {
     ldpp_dout(dpp, 20) << __func__ << ": open_bucket_index_pool() returned "
                    << ret << dendl;
     return ret;
   }
 
-  get_bucket_index_objects(bucket_oid_base, idx_layout.layout.normal.num_shards,
-                           idx_layout.gen, bucket_objs, shard_id);
-  if (bucket_instance_ids) {
-    get_bucket_instance_ids(bucket_info, idx_layout.layout.normal.num_shards,
-                            shard_id, bucket_instance_ids);
-  }
-  return 0;
-}
+  auto bindexer =
+    rgw::rados::BIndexer::create_unique(cct, dpp, bucket_info);
 
+  bindexer->get_bucket_index_objects(shard_index, bucket_objs);
+
+  if (bucket_instance_ids) {
+    bindexer->get_bucket_instance_ids(num_shards(idx_layout),
+				      shard_index,
+				      bucket_instance_ids);
+  }
+
+  return 0;
+} // open_bucket_index
+
+#if 0
 void RGWSI_BucketIndex_RADOS::get_bucket_index_object(
     const std::string& bucket_oid_base,
-    const rgw::bucket_index_normal_layout& normal,
+    const rgw::LayoutVariant& specs,
     uint64_t gen_id, int shard_id,
     std::string* bucket_obj)
 {
-  if (!normal.num_shards) {
-    // By default with no sharding, we use the bucket oid as itself
-    (*bucket_obj) = bucket_oid_base;
-  } else {
-    if (gen_id) {
-      (*bucket_obj) =
-        bucket_obj_with_generation(bucket_oid_base, gen_id, shard_id);
-      ldout(cct, 10) << "bucket_obj is " << (*bucket_obj) << dendl;
-    } else {
-      // for backward compatibility, gen_id(0) will not be added in the object name
-      (*bucket_obj) = bucket_obj_without_generation(bucket_oid_base, shard_id);
-    }
-  }
+#warning need bucket_info here
+  auto bindexer = rgw::rados::BIndexer::create_unique(cct, specs);
+  bindexer->get_bucket_index_object(bucket_oid_base, gen_id, shard_id, bucket_obj);
 }
 
 int RGWSI_BucketIndex_RADOS::get_bucket_index_object(
     const std::string& bucket_oid_base,
-    const rgw::bucket_index_normal_layout& normal,
-    uint64_t gen_id, const std::string& obj_key,
-    std::string* bucket_obj, int* shard_id)
+    const rgw::LayoutVariant& specs,
+    uint64_t gen_id,
+    const std::string& obj_key,
+    std::string* bucket_obj,
+    int* shard_id)
 {
-  int r = 0;
-  switch (normal.hash_type) {
-    case rgw::BucketHashType::Mod:
-      if (!normal.num_shards) {
-        // By default with no sharding, we use the bucket oid as itself
-        (*bucket_obj) = bucket_oid_base;
-        if (shard_id) {
-          *shard_id = -1;
-        }
-      } else {
-        uint32_t sid = bucket_shard_index(obj_key, normal.num_shards);
-        if (gen_id) {
-          (*bucket_obj) =
-              bucket_obj_with_generation(bucket_oid_base, gen_id, sid);
-        } else {
-          (*bucket_obj) = bucket_obj_without_generation(bucket_oid_base, sid);
-        }
-        if (shard_id) {
-          *shard_id = (int)sid;
-        }
-      }
-      break;
-    default:
-      r = -ENOTSUP;
-  }
-  return r;
+#warning need bucket_info here
+  auto bindexer = rgw::rados::BIndexer::create_unique(cct, specs);
+  return bindexer->get_bucket_index_object(bucket_oid_base, gen_id, obj_key,
+					   bucket_obj, shard_id);
 }
+#endif
 
-int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const DoutPrefixProvider *dpp,
-                                                     const RGWBucketInfo& bucket_info,
-                                                     const string& obj_key,
-                                                     rgw_rados_ref* bucket_obj,
-                                                     int *shard_id)
+int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(
+  const DoutPrefixProvider *dpp,
+  RGWSI_Bucket_SObj* bucket_sobj,
+  const RGWBucketInfo& bucket_info,
+  const string& obj_key,
+  rgw_rados_ref* bucket_ref,
+  rgw::BIShardIdent* shard_id)
 {
-  string bucket_oid_base;
+#warning "TRACE 127"
+  auto bindexer =
+    rgw::rados::BIndexer::create_unique(cct, dpp, bucket_info);
 
-  int ret = open_bucket_index_base(dpp, bucket_info, &bucket_obj->ioctx, &bucket_oid_base);
+  bindexer->get_bucket_index_object(obj_key,
+                                    &bucket_ref->obj.oid, shard_id);
+
+  int ret = open_bucket_index_pool(dpp, bucket_info, &bucket_ref->ioctx);
   if (ret < 0) {
     ldpp_dout(dpp, 20) << __func__ << ": open_bucket_index_pool() returned "
                    << ret << dendl;
     return ret;
   }
 
-  const auto& current_index = bucket_info.layout.current_index;
-  ret = get_bucket_index_object(bucket_oid_base, current_index.layout.normal,
-                                current_index.gen, obj_key,
-				&bucket_obj->obj.oid, shard_id);
-  if (ret < 0) {
-    ldpp_dout(dpp, 10) << "get_bucket_index_object() returned ret=" << ret << dendl;
-    return ret;
-  }
-
   return 0;
 }
 
-int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const DoutPrefixProvider *dpp,
-                                                     const RGWBucketInfo& bucket_info,
-                                                     const rgw::bucket_index_layout_generation& index,
-                                                     int shard_id,
-                                                     rgw_rados_ref* bucket_obj)
+int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(
+  const DoutPrefixProvider *dpp,
+  const RGWBucketInfo& bucket_info,
+  const rgw::bucket_index_layout_generation& layout_gen,
+  const rgw::BIShardIdent& shard_ident,
+  rgw_rados_ref* bucket_obj)
 {
-  string bucket_oid_base;
-  int ret = open_bucket_index_base(dpp, bucket_info, &bucket_obj->ioctx,
-				   &bucket_oid_base);
+#warning "OBI: for now force this to be a HashedBucketIndex"
+  try {
+    auto hashed_shard_ident = dynamic_cast<const rgw::HashedShardIdent&>(shard_ident);
+    int32_t shard_idx = hashed_shard_ident.get_index();
+
+    int ret = open_bucket_index_pool(dpp, bucket_info, &bucket_obj->ioctx);
+    if (ret < 0) {
+      ldpp_dout(dpp, 20) << __func__ << ": open_bucket_index_pool() returned " <<
+        ret << dendl;
+      return ret;
+    }
+
+    auto bindexer = rgw::rados::BIndexer::create_unique(cct, dpp, bucket_info);
+    bindexer->get_bucket_index_object(layout_gen.gen, shard_idx, &bucket_obj->obj.oid);
+
+    return 0;
+  } catch (const std::bad_cast& b) {
+    return -EINVAL;
+  }
+}
+
+int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(
+  const DoutPrefixProvider *dpp,
+  const rgw::rados::BIndexer::ShardIterator& shard_it,
+  rgw_rados_ref* bucket_obj)
+{
+  int ret = open_bucket_index_pool(dpp,
+                                   shard_it.get_bindexer()->get_bucket_info(),
+                                   &bucket_obj->ioctx);
   if (ret < 0) {
-    ldpp_dout(dpp, 20) << __func__ << ": open_bucket_index_pool() returned "
-                   << ret << dendl;
+    ldpp_dout(dpp, 20) << __func__ << ": open_bucket_index_pool() returned " <<
+      ret << dendl;
     return ret;
   }
 
-  get_bucket_index_object(bucket_oid_base, index.layout.normal,
-                          index.gen, shard_id, &bucket_obj->obj.oid);
+  bucket_obj->obj.oid = shard_it.get_oid();
 
   return 0;
 }
+
 
 struct IndexHeadReader : rgwrados::shard_io::RadosReader {
   std::map<int, bufferlist>& buffers;
@@ -360,16 +272,17 @@ struct IndexHeadReader : rgwrados::shard_io::RadosReader {
 int RGWSI_BucketIndex_RADOS::cls_bucket_head(const DoutPrefixProvider *dpp,
                                              const RGWBucketInfo& bucket_info,
                                              const rgw::bucket_index_layout_generation& idx_layout,
-                                             int shard_id,
-                                             vector<rgw_bucket_dir_header> *headers,
-                                             map<int, string> *bucket_instance_ids,
+                                             rgw::BIShardIndex shard_id,
+                                             std::vector<rgw_bucket_dir_header>* headers,
+                                             std::map<int, std::string>* bucket_instance_ids,
                                              optional_yield y)
 {
   librados::IoCtx index_pool;
-  map<int, string> oids;
+  std::map<int, std::string> oids;
   int r = open_bucket_index(dpp, bucket_info, shard_id, idx_layout, &index_pool, &oids, bucket_instance_ids);
-  if (r < 0)
+  if (r < 0) {
     return r;
+  }
 
   // read omap headers into bufferlists
   std::map<int, bufferlist> buffers;
@@ -415,28 +328,43 @@ int RGWSI_BucketIndex_RADOS::cls_bucket_head(const DoutPrefixProvider *dpp,
 // we undo the creation of others. RevertibleWriter provides these semantics
 struct IndexInitWriter : rgwrados::shard_io::RadosRevertibleWriter {
   bool judge_support_logrecord;
+  rgw::BucketIndexType index_type;
+  const std::map<int,bufferlist>& per_shard_index_type_data;
 
   IndexInitWriter(const DoutPrefixProvider& dpp,
                   boost::asio::any_io_executor ex,
                   librados::IoCtx& ioctx,
-                  bool judge_support_logrecord)
+                  bool judge_support_logrecord,
+		  rgw::BucketIndexType index_type,
+		  const std::map<int,bufferlist>& per_shard_index_type_data)
     : RadosRevertibleWriter(dpp, std::move(ex), ioctx),
-      judge_support_logrecord(judge_support_logrecord)
+      judge_support_logrecord(judge_support_logrecord),
+      index_type(index_type),
+      per_shard_index_type_data(per_shard_index_type_data)
   {}
+
   void prepare_write(int shard, librados::ObjectWriteOperation& op) override {
+    static const bufferlist empty_buffer_list;
+    auto data_it = per_shard_index_type_data.find(shard);
+    const bufferlist& shard_data = (data_it == per_shard_index_type_data.cend()) ?
+      empty_buffer_list : data_it->second;
+
     // don't overwrite. fail with EEXIST if a shard already exists
     op.create(true);
+
     if (judge_support_logrecord) {
       // fail with EOPNOTSUPP if the osd doesn't support the reshard log
-      cls_rgw_bucket_init_index2(op);
+      cls_rgw_bucket_init_index2(op, index_type, shard_data);
     } else {
-      cls_rgw_bucket_init_index(op);
+      cls_rgw_bucket_init_index(op, index_type, shard_data);
     }
   }
+
   void prepare_revert(int shard, librados::ObjectWriteOperation& op) override {
     // on failure, remove any of the shards we successfully created
     op.remove();
   }
+
   Result on_complete(int, boost::system::error_code ec) override {
     // ignore EEXIST
     if (ec && ec != boost::system::errc::file_exists) {
@@ -445,52 +373,57 @@ struct IndexInitWriter : rgwrados::shard_io::RadosRevertibleWriter {
       return Result::Success;
     }
   }
+
   void add_prefix(std::ostream& out) const override {
     out << "init index shards: ";
   }
-};
+}; // class InitIndexWriter
 
 int RGWSI_BucketIndex_RADOS::init_index(const DoutPrefixProvider *dpp,
                                         optional_yield y,
                                         const RGWBucketInfo& bucket_info,
                                         const rgw::bucket_index_layout_generation& idx_layout,
+					std::map<std::string, bufferlist>* binfo_map_data,
                                         bool judge_support_logrecord)
 {
-  if (idx_layout.layout.type != rgw::BucketIndexType::Normal) {
-    return 0;
-  }
-
   librados::IoCtx index_pool;
-
-  string dir_oid = dir_oid_prefix;
   int r = open_bucket_index_pool(dpp, bucket_info, &index_pool);
   if (r < 0) {
     return r;
   }
 
-  dir_oid.append(bucket_info.bucket.bucket_id);
+  auto bindexer =
+    rgw::rados::BIndexer::create_unique(cct, dpp, bucket_info, idx_layout);
 
-  map<int, string> bucket_objs;
-  get_bucket_index_objects(dir_oid, idx_layout.layout.normal.num_shards, idx_layout.gen, &bucket_objs);
+  std::map<int, std::string> shard_oids;
+  std::map<int, bufferlist> per_shard_data;
+  bindexer->get_initial_bucket_index_objects(shard_oids, per_shard_data, binfo_map_data);
 
   const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
   boost::system::error_code ec;
+
   if (y) {
     // run on the coroutine's executor and suspend until completion
     auto yield = y.get_yield_context();
     auto ex = yield.get_executor();
-    auto writer = IndexInitWriter{*dpp, ex, index_pool, judge_support_logrecord};
+    auto writer = IndexInitWriter{ *dpp, ex, index_pool, judge_support_logrecord,
+				   bindexer->get_index_type(),
+				   per_shard_data };
 
-    rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio, yield[ec]);
+    rgwrados::shard_io::async_writes(writer, shard_oids, max_aio,
+				     yield[ec]);
   } else {
     // run a strand on the system executor and block on a condition variable
     auto ex = boost::asio::make_strand(boost::asio::system_executor{});
-    auto writer = IndexInitWriter{*dpp, ex, index_pool, judge_support_logrecord};
+    auto writer = IndexInitWriter{ *dpp, ex, index_pool, judge_support_logrecord,
+				   bindexer->get_index_type(),
+				   per_shard_data };
 
     maybe_warn_about_blocking(dpp);
-    rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio,
+    rgwrados::shard_io::async_writes(writer, shard_oids, max_aio,
                                      ceph::async::use_blocked[ec]);
   }
+
   return ceph::from_error_code(ec);
 }
 
@@ -521,7 +454,7 @@ int RGWSI_BucketIndex_RADOS::clean_index(const DoutPrefixProvider *dpp,
                                          const RGWBucketInfo& bucket_info,
                                          const rgw::bucket_index_layout_generation& idx_layout)
 {
-  if (idx_layout.layout.type != rgw::BucketIndexType::Normal) {
+  if (idx_layout.layout.type != rgw::BucketIndexType::Hashed) {
     return 0;
   }
 
@@ -536,8 +469,13 @@ int RGWSI_BucketIndex_RADOS::clean_index(const DoutPrefixProvider *dpp,
   dir_oid.append(bucket_info.bucket.bucket_id);
 
   std::map<int, std::string> bucket_objs;
-  get_bucket_index_objects(dir_oid, idx_layout.layout.normal.num_shards,
-                           idx_layout.gen, &bucket_objs);
+  auto bindexer =
+    rgw::rados::BIndexer::create_unique(cct, dpp, bucket_info);
+  bindexer->get_bucket_index_objects(rgw::rados::BIndexer::BI_ALL_SHARDS,
+#if 0
+				     idx_layout.gen,
+#endif
+				     &bucket_objs);
 
   const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
   boost::system::error_code ec;
@@ -573,9 +511,9 @@ int RGWSI_BucketIndex_RADOS::read_stats(const DoutPrefixProvider *dpp,
     return r;
   }
 
-  result->count = 0; 
-  result->size = 0; 
-  result->size_rounded = 0; 
+  result->count = 0;
+  result->size = 0;
+  result->size_rounded = 0;
 
   auto hiter = headers.begin();
   for (; hiter != headers.end(); ++hiter) {
@@ -630,7 +568,7 @@ int RGWSI_BucketIndex_RADOS::get_reshard_status(const DoutPrefixProvider *dpp,
   librados::IoCtx index_pool;
 
   int r = open_bucket_index(dpp, bucket_info,
-                            std::nullopt,
+                            rgw::rados::BIndexer::BI_ALL_SHARDS,
                             bucket_info.layout.current_index,
                             &index_pool,
                             &bucket_objs,
@@ -701,7 +639,7 @@ int RGWSI_BucketIndex_RADOS::set_reshard_status(const DoutPrefixProvider *dpp,
   librados::IoCtx index_pool;
   map<int, string> bucket_objs;
 
-  int r = open_bucket_index(dpp, bucket_info, std::nullopt, bucket_info.layout.current_index, &index_pool, &bucket_objs, nullptr);
+  int r = open_bucket_index(dpp, bucket_info, rgw::rados::BIndexer::BI_ALL_SHARDS, bucket_info.layout.current_index, &index_pool, &bucket_objs, nullptr);
   if (r < 0) {
     ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
       ": unable to open bucket index, r=" << r << " (" <<
@@ -757,7 +695,7 @@ int RGWSI_BucketIndex_RADOS::trim_reshard_log(const DoutPrefixProvider* dpp,
   librados::IoCtx index_pool;
   map<int, string> bucket_objs;
 
-  int r = open_bucket_index(dpp, bucket_info, std::nullopt, bucket_info.layout.current_index, &index_pool, &bucket_objs, nullptr);
+  int r = open_bucket_index(dpp, bucket_info, rgw::rados::BIndexer::BI_ALL_SHARDS, bucket_info.layout.current_index, &index_pool, &bucket_objs, nullptr);
   if (r < 0) {
     return r;
   }
@@ -807,7 +745,7 @@ int RGWSI_BucketIndex_RADOS::set_tag_timeout(const DoutPrefixProvider* dpp,
   librados::IoCtx index_pool;
   map<int, string> bucket_objs;
 
-  int r = open_bucket_index(dpp, bucket_info, std::nullopt, bucket_info.layout.current_index, &index_pool, &bucket_objs, nullptr);
+  int r = open_bucket_index(dpp, bucket_info, rgw::rados::BIndexer::BI_ALL_SHARDS, bucket_info.layout.current_index, &index_pool, &bucket_objs, nullptr);
   if (r < 0) {
     return r;
   }
@@ -858,7 +796,7 @@ int RGWSI_BucketIndex_RADOS::check_index(const DoutPrefixProvider *dpp, optional
   librados::IoCtx index_pool;
   std::map<int, std::string> bucket_objs;
 
-  int r = open_bucket_index(dpp, bucket_info, std::nullopt, bucket_info.layout.current_index, &index_pool, &bucket_objs, nullptr);
+  int r = open_bucket_index(dpp, bucket_info, rgw::rados::BIndexer::BI_ALL_SHARDS, bucket_info.layout.current_index, &index_pool, &bucket_objs, nullptr);
   if (r < 0) {
     return r;
   }
@@ -901,7 +839,7 @@ int RGWSI_BucketIndex_RADOS::rebuild_index(const DoutPrefixProvider *dpp,
   librados::IoCtx index_pool;
   map<int, string> bucket_objs;
 
-  int r = open_bucket_index(dpp, bucket_info, std::nullopt, bucket_info.layout.current_index, &index_pool, &bucket_objs, nullptr);
+  int r = open_bucket_index(dpp, bucket_info, rgw::rados::BIndexer::BI_ALL_SHARDS, bucket_info.layout.current_index, &index_pool, &bucket_objs, nullptr);
   if (r < 0) {
     return r;
   }
@@ -1045,4 +983,21 @@ int RGWSI_BucketIndex_RADOS::handle_overwrite(const DoutPrefixProvider *dpp,
   }
 
   return ret;
+}
+
+
+int32_t RGWSI_BucketIndex_RADOS::bucket_shard_index(const std::string& key,
+						    int num_shards)
+{
+// OBI: this should be converted into returning an index object name
+// and be based on index type
+  return rgw::rados::HashedBIndexer::get_shard_index(key, num_shards);
+}
+
+
+int32_t RGWSI_BucketIndex_RADOS::bucket_shard_index(const rgw_obj_key& obj_key,
+						    int num_shards)
+{
+#warning "OBI: this should be converted into returning an index object name and be based on index type"
+  return rgw::rados::HashedBIndexer::get_shard_index(obj_key, num_shards);
 }

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -9,6 +9,7 @@
 #include "svc_bi_rados.h"
 #include "svc_bilog_rados.h"
 #include "svc_zone.h"
+#include "svc_bucket_sobj.h"
 
 #include "rgw_asio_thread.h"
 #include "rgw_zone.h"
@@ -143,32 +144,6 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index(const DoutPrefixProvider *dpp,
   return 0;
 } // open_bucket_index
 
-#if 0
-void RGWSI_BucketIndex_RADOS::get_bucket_index_object(
-    const std::string& bucket_oid_base,
-    const rgw::LayoutVariant& specs,
-    uint64_t gen_id, int shard_id,
-    std::string* bucket_obj)
-{
-#warning need bucket_info here
-  auto bindexer = rgw::rados::BIndexer::create_unique(cct, specs);
-  bindexer->get_bucket_index_object(bucket_oid_base, gen_id, shard_id, bucket_obj);
-}
-
-int RGWSI_BucketIndex_RADOS::get_bucket_index_object(
-    const std::string& bucket_oid_base,
-    const rgw::LayoutVariant& specs,
-    uint64_t gen_id,
-    const std::string& obj_key,
-    std::string* bucket_obj,
-    int* shard_id)
-{
-#warning need bucket_info here
-  auto bindexer = rgw::rados::BIndexer::create_unique(cct, specs);
-  return bindexer->get_bucket_index_object(bucket_oid_base, gen_id, obj_key,
-					   bucket_obj, shard_id);
-}
-#endif
 
 int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(
   const DoutPrefixProvider *dpp,
@@ -176,14 +151,10 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(
   const RGWBucketInfo& bucket_info,
   const string& obj_key,
   rgw_rados_ref* bucket_ref,
-  rgw::BIShardIdent* shard_id)
+  std::unique_ptr<rgw::BIShardIdent>& shard_ident)
 {
-#warning "TRACE 127"
-  auto bindexer =
-    rgw::rados::BIndexer::create_unique(cct, dpp, bucket_info);
-
-  bindexer->get_bucket_index_object(obj_key,
-                                    &bucket_ref->obj.oid, shard_id);
+  auto bindexer = rgw::rados::BIndexer::create_unique(cct, dpp, bucket_info);
+  bindexer->get_bucket_index_object(obj_key, &bucket_ref->obj.oid, shard_ident);
 
   int ret = open_bucket_index_pool(dpp, bucket_info, &bucket_ref->ioctx);
   if (ret < 0) {
@@ -202,25 +173,21 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(
   const rgw::BIShardIdent& shard_ident,
   rgw_rados_ref* bucket_obj)
 {
-#warning "OBI: for now force this to be a HashedBucketIndex"
-  try {
-    auto hashed_shard_ident = dynamic_cast<const rgw::HashedShardIdent&>(shard_ident);
-    int32_t shard_idx = hashed_shard_ident.get_index();
-
-    int ret = open_bucket_index_pool(dpp, bucket_info, &bucket_obj->ioctx);
-    if (ret < 0) {
-      ldpp_dout(dpp, 20) << __func__ << ": open_bucket_index_pool() returned " <<
-        ret << dendl;
-      return ret;
-    }
-
-    auto bindexer = rgw::rados::BIndexer::create_unique(cct, dpp, bucket_info);
-    bindexer->get_bucket_index_object(layout_gen.gen, shard_idx, &bucket_obj->obj.oid);
-
-    return 0;
-  } catch (const std::bad_cast& b) {
-    return -EINVAL;
+  int ret = open_bucket_index_pool(dpp, bucket_info, &bucket_obj->ioctx);
+  if (ret < 0) {
+    ldpp_dout(dpp, 20) << __func__ << ": open_bucket_index_pool() returned " <<
+      ret << dendl;
+    return ret;
   }
+
+  auto bindexer = rgw::rados::BIndexer::create_unique(cct, dpp, bucket_info, layout_gen);
+  ret = bindexer->get_bucket_index_object(layout_gen.gen, shard_ident, &bucket_obj->obj.oid);
+  if (ret < 0) {
+    ldpp_dout(dpp, 20) << __func__ << ": get_bucket_index_object returned " <<
+      ret << dendl;
+  }
+
+  return ret;
 }
 
 int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(
@@ -381,23 +348,23 @@ struct IndexInitWriter : rgwrados::shard_io::RadosRevertibleWriter {
 
 int RGWSI_BucketIndex_RADOS::init_index(const DoutPrefixProvider *dpp,
                                         optional_yield y,
-                                        const RGWBucketInfo& bucket_info,
-                                        const rgw::bucket_index_layout_generation& idx_layout,
+                                        std::unique_ptr<rgw::rados::BIndexer>& bindexer,
 					std::map<std::string, bufferlist>* binfo_map_data,
                                         bool judge_support_logrecord)
 {
+  const RGWBucketInfo& bucket_info = bindexer->get_bucket_info();
+  const rgw::bucket_index_layout_generation& idx_layout = bindexer->get_layout_gen();
+
   librados::IoCtx index_pool;
   int r = open_bucket_index_pool(dpp, bucket_info, &index_pool);
   if (r < 0) {
     return r;
   }
 
-  auto bindexer =
-    rgw::rados::BIndexer::create_unique(cct, dpp, bucket_info, idx_layout);
-
   std::map<int, std::string> shard_oids;
   std::map<int, bufferlist> per_shard_data;
-  bindexer->get_initial_bucket_index_objects(shard_oids, per_shard_data, binfo_map_data);
+  bindexer->get_initial_bucket_index_objects(idx_layout.gen, rgw::num_shards(idx_layout),
+                                             shard_oids, per_shard_data, binfo_map_data);
 
   const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
   boost::system::error_code ec;
@@ -425,7 +392,7 @@ int RGWSI_BucketIndex_RADOS::init_index(const DoutPrefixProvider *dpp,
   }
 
   return ceph::from_error_code(ec);
-}
+} // init_index
 
 struct IndexCleanWriter : rgwrados::shard_io::RadosWriter {
   IndexCleanWriter(const DoutPrefixProvider& dpp,
@@ -449,32 +416,30 @@ struct IndexCleanWriter : rgwrados::shard_io::RadosWriter {
   }
 };
 
+#if 1 // OBI: depcrecate??
 int RGWSI_BucketIndex_RADOS::clean_index(const DoutPrefixProvider *dpp,
                                          optional_yield y,
                                          const RGWBucketInfo& bucket_info,
                                          const rgw::bucket_index_layout_generation& idx_layout)
 {
-  if (idx_layout.layout.type != rgw::BucketIndexType::Hashed) {
-    return 0;
-  }
+  auto bindexer =
+    rgw::rados::BIndexer::create_unique(cct, dpp, bucket_info, idx_layout);
+  return clean_index(dpp, y, bindexer);
+}
+#endif
 
+int RGWSI_BucketIndex_RADOS::clean_index(const DoutPrefixProvider *dpp,
+                                         optional_yield y,
+                                         std::unique_ptr<rgw::rados::BIndexer>& bindexer)
+{
   librados::IoCtx index_pool;
-
-  std::string dir_oid = dir_oid_prefix;
-  int r = open_bucket_index_pool(dpp, bucket_info, &index_pool);
+  int r = open_bucket_index_pool(dpp, bindexer->get_bucket_info(), &index_pool);
   if (r < 0) {
     return r;
   }
 
-  dir_oid.append(bucket_info.bucket.bucket_id);
-
   std::map<int, std::string> bucket_objs;
-  auto bindexer =
-    rgw::rados::BIndexer::create_unique(cct, dpp, bucket_info);
   bindexer->get_bucket_index_objects(rgw::rados::BIndexer::BI_ALL_SHARDS,
-#if 0
-				     idx_layout.gen,
-#endif
 				     &bucket_objs);
 
   const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
@@ -495,8 +460,19 @@ int RGWSI_BucketIndex_RADOS::clean_index(const DoutPrefixProvider *dpp,
     rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio,
                                      ceph::async::use_blocked[ec]);
   }
-  return ceph::from_error_code(ec);
-}
+
+  r = ceph::from_error_code(ec);
+  if (r < 0) {
+    return r;
+  }
+
+  // if index being cleaned was ordered, we need to clear the omap too
+  if (bindexer->get_index_type() == rgw::BucketIndexType::Ordered) {
+    r = svc.bucket_sobj->clear_bucket_info_map(bindexer->get_bucket_info().bucket.get_key(), y, dpp);
+  }
+
+  return r;
+} // RGWSI_BucketIndex_RADOS::clean_index
 
 int RGWSI_BucketIndex_RADOS::read_stats(const DoutPrefixProvider *dpp,
                                         const RGWBucketInfo& bucket_info,
@@ -985,19 +961,10 @@ int RGWSI_BucketIndex_RADOS::handle_overwrite(const DoutPrefixProvider *dpp,
   return ret;
 }
 
-
-int32_t RGWSI_BucketIndex_RADOS::bucket_shard_index(const std::string& key,
-						    int num_shards)
-{
 // OBI: this should be converted into returning an index object name
 // and be based on index type
-  return rgw::rados::HashedBIndexer::get_shard_index(key, num_shards);
-}
-
-
 int32_t RGWSI_BucketIndex_RADOS::bucket_shard_index(const rgw_obj_key& obj_key,
 						    int num_shards)
 {
-#warning "OBI: this should be converted into returning an index object name and be based on index type"
   return rgw::rados::HashedBIndexer::get_shard_index(obj_key, num_shards);
 }

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -89,11 +89,6 @@ public:
     return rgw_shard_id(key, max_shards);
   }
 
-// OBI: this should be converted into returning an index object name
-// and be based on index type
-  static int32_t bucket_shard_index(const rgw_obj_key& obj_key,
-				    int num_shards);
-
   int init_index(const DoutPrefixProvider *dpp, optional_yield y,
                  std::unique_ptr<rgw::rados::BIndexer>& bindexer,
 		 std::map<std::string, bufferlist>* binfo_map_data,

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -23,6 +23,8 @@
 
 #include "svc_bi.h"
 #include "svc_tier_rados.h"
+#include "svc_bindexer_rados.h"
+
 
 struct rgw_bucket_dir_header;
 struct rgw_cls_list_ret;
@@ -51,23 +53,25 @@ class RGWSI_BucketIndex_RADOS : public RGWSI_BucketIndex
                              librados::IoCtx* index_pool,
                              std::string *bucket_oid_base);
 
+#if 0
   // return the index oid for the given shard id
   void get_bucket_index_object(const std::string& bucket_oid_base,
-                               const rgw::bucket_index_normal_layout& normal,
+                               const rgw::LayoutVariant& specs,
                                uint64_t gen_id, int shard_id,
                                std::string* bucket_obj);
   // return the index oid and shard id for the given object name
   int get_bucket_index_object(const std::string& bucket_oid_base,
-                              const rgw::bucket_index_normal_layout& normal,
+                              const rgw::LayoutVariant& specs,
                               uint64_t gen_id, const std::string& obj_key,
                               std::string* bucket_obj, int* shard_id);
+#endif
 
 public:
 
   int cls_bucket_head(const DoutPrefixProvider *dpp,
 		      const RGWBucketInfo& bucket_info,
                       const rgw::bucket_index_layout_generation& idx_layout,
-                      int shard_id,
+                      rgw::BIShardIndex shard_id,
                       std::vector<rgw_bucket_dir_header> *headers,
                       std::map<int, std::string> *bucket_instance_ids,
                       optional_yield y);
@@ -78,6 +82,7 @@ public:
     RGWSI_Zone *zone{nullptr};
     RGWSI_BILog_RADOS *bilog{nullptr};
     RGWDataChangesLog *datalog_rados{nullptr};
+    RGWSI_Bucket_SObj* bucket_sobj{nullptr};
   } svc;
 
   RGWSI_BucketIndex_RADOS(CephContext *cct);
@@ -85,7 +90,9 @@ public:
   void init(RGWSI_Zone *zone_svc,
             librados::Rados* rados_,
             RGWSI_BILog_RADOS *bilog_svc,
-            RGWDataChangesLog *datalog_rados_svc);
+            RGWDataChangesLog *datalog_rados_svc,
+            RGWSI_Bucket_SObj *bucket_sobj
+    );
 
   static int shards_max() {
     return RGW_SHARDS_PRIME_1;
@@ -96,30 +103,14 @@ public:
   }
 
   static int32_t bucket_shard_index(const std::string& key,
-				    int num_shards) {
-    uint32_t sid = ceph_str_hash_linux(key.c_str(), key.size());
-    uint32_t sid2 = sid ^ ((sid & 0xFF) << 24);
-    return rgw_shards_mod(sid2, num_shards);
-  }
-
+				    int num_shards);
   static int32_t bucket_shard_index(const rgw_obj_key& obj_key,
-				    int num_shards)
-  {
-    std::string sharding_key;
-    if (obj_key.ns == RGW_OBJ_NS_MULTIPART) {
-      RGWMPObj mp;
-      mp.from_meta(obj_key.name);
-      sharding_key = mp.get_key();
-    } else {
-      sharding_key = obj_key.name;
-    }
-
-    return bucket_shard_index(sharding_key, num_shards);
-  }
+				    int num_shards);
 
   int init_index(const DoutPrefixProvider *dpp, optional_yield y,
                  const RGWBucketInfo& bucket_info,
                  const rgw::bucket_index_layout_generation& idx_layout,
+		 std::map<std::string, bufferlist>* binfo_map_data,
                  bool judge_support_logrecord = false) override;
   int clean_index(const DoutPrefixProvider *dpp, optional_yield y,
                   const RGWBucketInfo& bucket_info,
@@ -166,15 +157,19 @@ public:
 		       optional_yield y) override;
 
   int open_bucket_index_shard(const DoutPrefixProvider *dpp,
+                              RGWSI_Bucket_SObj* bucket_sobj,
                               const RGWBucketInfo& bucket_info,
                               const std::string& obj_key,
                               rgw_rados_ref* bucket_obj,
-                              int *shard_id);
-
+                              rgw::BIShardIdent* shard_ident);
   int open_bucket_index_shard(const DoutPrefixProvider *dpp,
                               const RGWBucketInfo& bucket_info,
-                              const rgw::bucket_index_layout_generation& index,
-                              int shard_id, rgw_rados_ref* bucket_obj);
+                              const rgw::bucket_index_layout_generation& layout_gen,
+                              const rgw::BIShardIdent& shard_ident,
+			      rgw_rados_ref* bucket_obj);
+  int open_bucket_index_shard(const DoutPrefixProvider *dpp,
+                              const rgw::rados::BIndexer::ShardIterator& shard_it,
+                              rgw_rados_ref* bucket_obj);
 
   int open_bucket_index(const DoutPrefixProvider *dpp,
                         const RGWBucketInfo& bucket_info,
@@ -183,9 +178,16 @@ public:
 
   int open_bucket_index(const DoutPrefixProvider *dpp,
                         const RGWBucketInfo& bucket_info,
-                        std::optional<int> shard_id,
+                        rgw::BIShardIndex shard_id,
                         const rgw::bucket_index_layout_generation& idx_layout,
                         librados::IoCtx* index_pool,
                         std::map<int, std::string> *bucket_objs,
                         std::map<int, std::string> *bucket_instance_ids);
+
+  std::unique_ptr<rgw::rados::BIndexer> create_bindexer(
+    const DoutPrefixProvider* dpp,
+    const RGWBucketInfo& bucket_info)
+  {
+    return rgw::rados::BIndexer::create_unique(cct, dpp, bucket_info);
+  }
 };

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -53,19 +53,6 @@ class RGWSI_BucketIndex_RADOS : public RGWSI_BucketIndex
                              librados::IoCtx* index_pool,
                              std::string *bucket_oid_base);
 
-#if 0
-  // return the index oid for the given shard id
-  void get_bucket_index_object(const std::string& bucket_oid_base,
-                               const rgw::LayoutVariant& specs,
-                               uint64_t gen_id, int shard_id,
-                               std::string* bucket_obj);
-  // return the index oid and shard id for the given object name
-  int get_bucket_index_object(const std::string& bucket_oid_base,
-                              const rgw::LayoutVariant& specs,
-                              uint64_t gen_id, const std::string& obj_key,
-                              std::string* bucket_obj, int* shard_id);
-#endif
-
 public:
 
   int cls_bucket_head(const DoutPrefixProvider *dpp,
@@ -102,19 +89,23 @@ public:
     return rgw_shard_id(key, max_shards);
   }
 
-  static int32_t bucket_shard_index(const std::string& key,
-				    int num_shards);
+// OBI: this should be converted into returning an index object name
+// and be based on index type
   static int32_t bucket_shard_index(const rgw_obj_key& obj_key,
 				    int num_shards);
 
   int init_index(const DoutPrefixProvider *dpp, optional_yield y,
-                 const RGWBucketInfo& bucket_info,
-                 const rgw::bucket_index_layout_generation& idx_layout,
+                 std::unique_ptr<rgw::rados::BIndexer>& bindexer,
 		 std::map<std::string, bufferlist>* binfo_map_data,
                  bool judge_support_logrecord = false) override;
+
+#if 1 // OBI deprecate??
   int clean_index(const DoutPrefixProvider *dpp, optional_yield y,
                   const RGWBucketInfo& bucket_info,
                   const rgw::bucket_index_layout_generation& idx_layout) override;
+#endif
+  int clean_index(const DoutPrefixProvider *dpp, optional_yield y,
+                  std::unique_ptr<rgw::rados::BIndexer>& bindexer) override;
 
   /* RADOS specific */
 
@@ -161,7 +152,7 @@ public:
                               const RGWBucketInfo& bucket_info,
                               const std::string& obj_key,
                               rgw_rados_ref* bucket_obj,
-                              rgw::BIShardIdent* shard_ident);
+                              std::unique_ptr<rgw::BIShardIdent>& shard_ident);
   int open_bucket_index_shard(const DoutPrefixProvider *dpp,
                               const RGWBucketInfo& bucket_info,
                               const rgw::bucket_index_layout_generation& layout_gen,

--- a/src/rgw/services/svc_bindexer_rados.cc
+++ b/src/rgw/services/svc_bindexer_rados.cc
@@ -1,0 +1,830 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2025 IBM Corporation
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+
+#include "common/ceph_context.h"
+#include "common/dout.h"
+#include "services/svc_bi_rados.h"
+#include "services/svc_bucket_sobj.h"
+#include "svc_bindexer_rados.h"
+
+// OBI: remove once things stabilize
+#if 1
+#include "common/BackTrace.h"
+#endif
+
+#define dout_subsys ceph_subsys_rgw
+
+namespace rgw::rados {
+
+/******************** BIndexer ********************/
+
+RGWSI_Bucket_SObj* BIndexer::bucket_sobj = nullptr; // until init() run
+
+void BIndexer::init(RGWSI_Bucket_SObj* _bucket_sobj) {
+  bucket_sobj = _bucket_sobj;
+}
+
+
+// OBI: temporary for  use while actively being worked on
+void BIndexer::throw_unimplemented(const std::string& type_name,
+				   const char* func_name,
+				   const char* msg) const {
+  std::string message;
+  if (msg && strlen(msg) != 0) {
+    message = std::string(" message:\"") + std::string(msg) + std::string("\"");
+  }
+
+  ldpp_dout(dpp, 0) << "ERROR: UNIMPLEMENTED BIndexer function " <<
+    type_name << "::" << func_name << message <<
+    "; backtrace: " << ClibBackTrace(0) << dendl;
+
+  throw unimplemented_bindexer_error(type_name +
+				     std::string("::") +
+				     std::string(func_name) +
+				     message);
+}
+
+
+BIndexer* BIndexer::create(CephContext* cct,
+			   const DoutPrefixProvider* dpp,
+			   const RGWBucketInfo& bucket_info,
+			   const LayoutVariant& layout) {
+  const auto* nl = std::get_if<bucket_index_hashed_layout>(&layout);
+  if (nl) {
+    return new HashedBIndexer(cct, dpp, bucket_info, *nl);
+  }
+
+  const auto* ol = std::get_if<bucket_index_ordered_layout>(&layout);
+  if (ol) {
+    return new OrderedBIndexer(cct, dpp, bucket_info, *ol);
+  }
+
+  return nullptr;
+}
+
+
+/******************** HashedBIndexer ********************/
+
+BIndexer::ShardIterator HashedBIndexer::create_shard_iterator() const {
+  return ShardIterator(new HashedShardIterator(*this));
+}
+
+BIndexer::ShardIterator HashedBIndexer::create_shard_iterator(
+  const std::string& start_at) const
+{
+  BIShardIndex index;
+  shard_of(start_at, &index);
+  return ShardIterator(new HashedShardIterator(*this, index));
+}
+
+std::string HashedBIndexer::index_shard_oid(
+  const std::string& bucket_oid_base,
+  uint32_t shard_id,
+  uint64_t gen_id)
+{
+  std::stringstream ss;
+
+  ss << bucket_oid_base;
+  if (gen_id) {
+    ss << '.' << gen_id;
+  }
+  ss << '.' << shard_id;
+
+  return ss.str();
+}
+
+std::string HashedBIndexer::index_shard_oid(
+  uint32_t shard_id,
+  uint64_t gen_id) const
+{
+  return index_shard_oid(get_bucket_oid_base(), shard_id, gen_id);
+}
+
+std::string HashedBIndexer::index_shard_oid(uint32_t shard_id) const
+{
+  return index_shard_oid(get_bucket_oid_base(), shard_id, layout_gen.gen);
+}
+
+std::unique_ptr<BIShardIdent> HashedBIndexer::shard_of(const std::string& obj_key) const {
+  return std::make_unique<HashedShardIdent>(
+    get_shard_index(obj_key, get_actual_num_shards()));
+}
+
+std::unique_ptr<BIShardIdent> HashedBIndexer::shard_of(const rgw_obj_key& obj_key) const {
+  return std::make_unique<HashedShardIdent>(
+    get_shard_index(obj_key, get_actual_num_shards()));
+}
+
+void HashedBIndexer::shard_of(const std::string& obj_key, BIShardIndex* index) const {
+  get_shard_index(obj_key, get_actual_num_shards());
+}
+
+int HashedBIndexer::get_bucket_index_objects(
+  BIShardIndex shard_index,
+  std::map<BIShardIndex, std::string>* shard_oids) const
+{
+  const std::string bucket_oid_base = get_bucket_oid_base();
+  const auto gen_id = layout_gen.gen;
+
+  if (shard_index != BI_ALL_SHARDS) {
+    (*shard_oids)[shard_index] = index_shard_oid(bucket_oid_base, shard_index, gen_id);
+  } else {
+    const BIShardIndex shard_count = (BIShardIndex) num_shards(layout_gen);
+    for (BIShardIndex s = 0; s < shard_count; ++s) {
+      (*shard_oids)[s] = index_shard_oid(bucket_oid_base, s, gen_id);
+    }
+  }
+
+  return 0;
+}
+
+void HashedBIndexer::get_bucket_instance_ids(
+  int num_shards,
+  BIShardIndex shard_index,
+  std::map<int, std::string>* result) const
+{
+  const rgw_bucket& bucket = bucket_info.bucket;
+  std::string plain_id = bucket.name + ":" + bucket.bucket_id;
+
+  if (!num_shards) {
+    (*result)[0] = plain_id;
+  } else {
+    char buf[16];
+    if (shard_index == BIndexer::BI_ALL_SHARDS) {
+      for (int i = 0; i < num_shards; ++i) {
+        snprintf(buf, sizeof(buf), ":%d", i);
+        (*result)[i] = plain_id + buf;
+      }
+    } else {
+      if (shard_index > num_shards) {
+        return;
+      }
+      snprintf(buf, sizeof(buf), ":%d", shard_index);
+      (*result)[shard_index] = plain_id + buf;
+    }
+  }
+}
+
+int HashedBIndexer::get_bucket_index_object(
+  const std::string& obj_key,
+  std::string* bucket_obj,
+  BIShardIndex* shard_index) const
+{
+  std::string bucket_oid_base = dir_oid_prefix;
+  bucket_oid_base.append(bucket_info.bucket.bucket_id);
+  const auto gen_id = layout_gen.gen;
+
+  if (! layout.num_shards) {
+    // by default with no sharding, we use the bucket oid as itself
+    *bucket_obj = bucket_oid_base;
+    if (shard_index) {
+      *shard_index = -1;
+    }
+  } else {
+    uint32_t sid = get_shard_index(obj_key, layout.num_shards);
+    if (bucket_obj) {
+      *bucket_obj = index_shard_oid(bucket_oid_base, sid, gen_id);
+    }
+    if (shard_index) {
+      *shard_index = int(sid);
+    }
+  }
+
+  return 0;
+}
+
+
+int HashedBIndexer::get_bucket_index_object(
+  const std::string& obj_key,
+  std::string* bucket_obj,
+  BIShardIdent* shard_id) const
+{
+  BIShardIndex index;
+
+  int ret = get_bucket_index_object(obj_key, bucket_obj, &index);
+  if (ret < 0) {
+    return ret;
+  }
+
+  *shard_id = HashedShardIdent(index);
+  return 0;
+}
+
+
+int HashedBIndexer::get_bucket_index_object(
+  const std::string& obj_key,
+  std::string* bucket_obj,
+  std::unique_ptr<BIShardIdent>& shard_id) const
+{
+  BIShardIndex index;
+
+  int ret = get_bucket_index_object(obj_key, bucket_obj, &index);
+  if (ret < 0) {
+    return ret;
+  }
+
+  shard_id = std::make_unique<HashedShardIdent>(index);
+  return 0;
+}
+
+
+void HashedBIndexer::get_bucket_index_object(
+  uint64_t gen_id,
+  BIShardIndex shard_id,
+  std::string* bucket_obj) const
+{
+  const std::string oid_base = get_bucket_oid_base();
+  *bucket_obj = index_shard_oid(oid_base, shard_id, gen_id);
+}
+
+void HashedBIndexer::get_initial_bucket_index_objects(
+  std::map<int, std::string>& shard_oids,
+  std::map<int, bufferlist>& per_shard_data,
+  std::map<std::string, bufferlist>* binfo_map_data) const
+{
+  const std::string bucket_oid_base = get_bucket_oid_base();
+  const BIShardIndex shard_count = num_shards(layout_gen);
+
+  const auto gen_id = layout_gen.gen;
+
+  for (BIShardIndex i = 0; i < shard_count; ++i) {
+    shard_oids.emplace(
+      std::make_pair(int(i), index_shard_oid(bucket_oid_base, i, gen_id)));
+  }
+}
+
+
+/******************** OrderedBIndexer ********************/
+
+
+BIndexer::ShardIterator OrderedBIndexer::create_shard_iterator() const {
+  try {
+    return ShardIterator(new OrderedShardIterator(*this));
+  } catch (std::runtime_error& e) {
+    return ShardIterator(new ErrorShardIterator());
+  }
+}
+
+BIndexer::ShardIterator OrderedBIndexer::create_shard_iterator(
+  const std::string& start_from) const
+{
+  try {
+    return ShardIterator(new OrderedShardIterator(*this, start_from));
+  } catch (std::runtime_error& e) {
+    return ShardIterator(new ErrorShardIterator());
+  }
+}
+
+std::string OrderedBIndexer::index_shard_oid(
+  const std::string& bucket_oid_base,
+  const NestedIndex& shard_ident,
+  uint64_t gen_id)
+{
+  std::stringstream ss;
+  ss << bucket_oid_base <<
+    ".ordered" << // this is to make the oids parseable in the opposite direction
+    '.' << gen_id;
+  for (const auto& i : shard_ident) {
+    ss << '.' << i;
+  }
+  return ss.str();
+}
+
+std::string OrderedBIndexer::index_shard_oid(
+  const NestedIndex& shard_ident,
+  uint64_t gen_id) const
+{
+  return index_shard_oid(get_bucket_oid_base(), shard_ident, gen_id);
+}
+
+std::string OrderedBIndexer::index_shard_oid(
+  const NestedIndex& shard_ident) const
+{
+  return index_shard_oid(get_bucket_oid_base(), shard_ident, layout_gen.gen);
+}
+
+std::unique_ptr<BIShardIdent> OrderedBIndexer::shard_of(const std::string& obj_key) const {
+  UNIMPLEMENTED();
+  return std::make_unique<OrderedShardIdent>(64000);
+}
+
+std::unique_ptr<BIShardIdent> OrderedBIndexer::shard_of(const rgw_obj_key& obj_key) const {
+  UNIMPLEMENTED();
+  return std::make_unique<OrderedShardIdent>(64000);
+}
+
+const std::vector<std::pair<std::string, NestedIndex>>&
+OrderedBIndexer::get_initial_shard_data()
+{
+  // initially we'll create 3 shards, the first designed to capture
+  // names that begin with "/", the seconds with upper-case letters,
+  // and the third for for the rest, which includes lower-case letters
+  // and non-ASCII. Please note that all entries in a shard are LESS
+  // THAN the cut-off. The shard with an empty-string cut-off is the
+  // last shard
+  static const std::vector<std::pair<std::string, NestedIndex>> fixed_data =
+  {
+#if 0
+      { "_", { 0 + STARTING_INDEX_ID } },
+      { "~", { 1 + STARTING_INDEX_ID, 7 } },
+      { "", { 2 + STARTING_INDEX_ID, 13, 17 } }
+#else
+      { "C", { -5 + STARTING_INDEX_ID } },
+      { "E", { 0 + STARTING_INDEX_ID, 2 } },
+      { "J", { 0 + STARTING_INDEX_ID, 99 } },
+      { "_", { 1 + STARTING_INDEX_ID, 8 } },
+      { "e", { 1 + STARTING_INDEX_ID, 8, 1, 2, 4 } },
+      { "i", { 1 + STARTING_INDEX_ID, 99 } },
+      { "q", { 2 + STARTING_INDEX_ID } },
+      { "~", { 2 + STARTING_INDEX_ID, 7 } },
+      { "Æ", { 7 + STARTING_INDEX_ID, 12 } },
+      { "Ü", { 50 + STARTING_INDEX_ID } },
+      { "", { 51 + STARTING_INDEX_ID, 13, 17 } }
+#endif
+    };
+  return fixed_data;
+}
+
+void OrderedBIndexer::get_initial_bucket_index_objects(
+    std::map<int, std::string>& shard_oids,
+    std::map<int, bufferlist>& per_shard_data,
+    std::map<std::string, bufferlist>* binfo_map_data) const
+{
+  const std::string bucket_oid_base = get_bucket_oid_base();
+
+  const auto gen_id = layout_gen.gen;
+
+  const auto& fixed_data = get_initial_shard_data();
+
+  if (binfo_map_data) {
+    for (const auto& p : fixed_data) {
+      rgw_ordered_bi_omap_value v;
+      v.split = p.first;
+      v.shard_ident = p.second;
+      bufferlist bl;
+      v.encode(bl);
+      const std::string key = OMAP_KEY_PREFIX + v.split;
+      (*binfo_map_data)[key] = bl;
+    }
+  }
+
+  const NestedIndex empty_index;
+
+  std::vector<rgw_ordered_bi_shard_data> per_shard;
+  NestedIndex prev_ident = empty_index;
+  for (const auto& p : fixed_data) {
+    rgw_ordered_bi_shard_data d;
+    d.split = p.first;
+    d.shard_ident = p.second;
+    d.prev_shard_ident = prev_ident;
+    prev_ident = p.second;
+    per_shard.push_back(d);
+  }
+
+  NestedIndex next_ident = empty_index;
+  for (auto d = per_shard.rbegin(); d != per_shard.rend(); ++d) {
+    d->next_shard_ident = next_ident;
+    next_ident = d->shard_ident;
+  }
+
+  int idx = 0;
+  for (auto d : per_shard) {
+    bufferlist bl;
+    d.encode(bl);
+    shard_oids.insert(std::pair{
+	idx,
+	index_shard_oid(bucket_oid_base, d.shard_ident, gen_id)
+      });
+    per_shard_data.insert(std::pair{ idx, bl });
+    ++idx;
+  }
+}
+
+#warning "ERIC work on this NEXT"
+int OrderedBIndexer::get_bucket_index_object(
+  const std::string& obj_key,
+  std::string* bucket_obj,
+  BIShardIndex* shard_index) const
+{
+#warning "TRACE 127"
+  UNIMPLEMENTED();
+  return -1;
+}
+
+int OrderedBIndexer::get_bucket_index_object(
+  const std::string& obj_key,
+  std::string* bucket_obj,
+  BIShardIdent* shard_id) const
+{
+  const std::string oid_base = get_bucket_oid_base();
+  const auto gen_id = layout_gen.gen;
+
+  std::map<std::string, bufferlist> results;
+
+  const std::string prefixed_key = OMAP_KEY_PREFIX + obj_key;
+  int r = bucket_sobj->read_bucket_info_map(bucket_info.bucket.get_key(),
+					    prefixed_key, OMAP_KEY_PREFIX, 1, &OMAP_KEY_PREFIX,
+					    &results, nullptr, null_yield, dpp);
+  if (r < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
+      ": call to read_bucket_info_map returned " << r << dendl;
+    return r;
+  }
+
+  if (results.empty()) {
+    ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
+      ": no map results to determine shard" << dendl;
+    return -ENOENT;
+  }
+
+  if (results.size() > 1) {
+    ldpp_dout(dpp, 0) << "INTERNAL ERROR: " << __func__ <<
+      ": received more map results than requested" << dendl;
+    throw std::logic_error("expected 1 result, but got " +
+			   std::to_string(results.size()));
+  }
+
+  rgw_ordered_bi_omap_value value;
+  auto it = results.cbegin()->second.cbegin();
+  value.decode(it);
+
+  if (bucket_obj) {
+    *bucket_obj = index_shard_oid(oid_base, value.shard_ident, gen_id);
+  }
+
+  if (shard_id) {
+    *shard_id = OrderedShardIdent(std::move(value.shard_ident));
+  }
+
+  return 0;
+}
+
+int OrderedBIndexer::get_bucket_index_object(
+  const std::string& obj_key,
+  std::string* bucket_obj,
+  std::unique_ptr<BIShardIdent>& shard_id) const
+{
+  const std::string oid_base = get_bucket_oid_base();
+  const auto gen_id = layout_gen.gen;
+  static const std::string default_key = "";
+
+  std::map<std::string, bufferlist> results;
+
+  const std::string prefixed_key = OMAP_KEY_PREFIX + obj_key;
+  int r =
+    bucket_sobj->read_bucket_info_map(bucket_info.bucket.get_key(),
+				      prefixed_key, OMAP_KEY_PREFIX, 1, &default_key,
+				      &results, nullptr,
+				      null_yield, dpp);
+  if (r < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
+      ": call to read_bucket_info_map returned " << r << dendl;
+    return r;
+  }
+
+  if (results.empty()) {
+    ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
+      ": no map results to determine shard" << dendl;
+    return -ENOENT;
+  }
+
+  if (results.size() > 1) {
+    ldpp_dout(dpp, 0) << "INTERNAL ERROR: " << __func__ <<
+      ": received more map results than requested" << dendl;
+    throw std::logic_error("expected 1 result, but got " +
+			   std::to_string(results.size()));
+  }
+
+  rgw_ordered_bi_omap_value value;
+  auto it = results.cbegin()->second.cbegin();
+  value.decode(it);
+
+  if (bucket_obj) {
+    *bucket_obj = index_shard_oid(oid_base, value.shard_ident, gen_id);
+  }
+
+#warning "is this implemented correctly?"
+  shard_id.reset(new OrderedShardIdent(value.shard_ident));
+
+  return 0;
+}
+
+void OrderedBIndexer::get_bucket_index_object(
+  uint64_t gen_id,
+  BIShardIndex shard_id,
+  std::string* bucket_obj) const
+{
+  UNIMPLEMENTED();
+}
+
+// OBI: priority to work on
+void OrderedBIndexer::get_bucket_instance_ids(
+  int num_shards,
+  BIShardIndex shard_index,
+  std::map<int, std::string>* result) const
+{
+  UNIMPLEMENTED();
+}
+
+int OrderedBIndexer::get_bucket_index_objects(
+  BIShardIndex shard_index,
+  std::map<BIShardIndex, std::string>* shard_oids) const
+{
+  // we need to convert this over to BIShardIdent
+  const std::string oid_base = get_bucket_oid_base();
+  const uint64_t gen_id = layout_gen.gen;
+
+  if (shard_index != BI_ALL_SHARDS) {
+    UNIMPLEMENTED();
+    // (*shard_oids)[shard_index] = index_shard_oid(oid_base, shard_index, gen_id);
+  } else {
+    std::string marker = "";
+    bool more = true;
+    BIShardIndex counter = 0;
+    while (more) {
+      std::map<std::string, bufferlist> results;
+      int r = bucket_sobj->read_bucket_info_map(bucket_info.bucket.get_key(),
+						marker, OMAP_KEY_PREFIX, 1, nullptr,
+						&results, &more, null_yield, dpp);
+      if (r < 0) {
+	ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
+	  ": call to read_bucket_info_map returned " << r << dendl;
+	return r;
+      }
+
+      for (const auto& i : results) {
+	rgw_ordered_bi_omap_value value;
+	auto it = i.second.cbegin();
+	value.decode(it);
+	const std::string oid = index_shard_oid(oid_base, value.shard_ident, gen_id);
+	(*shard_oids)[counter++] = oid;
+      }
+    } // while
+  }
+  return 0;
+}
+
+bool HashedBIndexer::HashedShardIterator::valid() const {
+  return index < (BIShardIndex) bindexer.get_actual_num_shards();
+}
+
+int HashedBIndexer::HashedShardIterator::next() {
+  ++index;
+  return 0;
+}
+
+std::unique_ptr<BIShardIdent> HashedBIndexer::HashedShardIterator::get_ident() const {
+  return std::make_unique<HashedShardIdent>(index);
+}
+
+std::string HashedBIndexer::HashedShardIterator::get_oid() const {
+  return bindexer.index_shard_oid(index);
+}
+
+OrderedBIndexer::OrderedShardIterator::OrderedShardIterator(
+  const OrderedBIndexer& b) :
+  bindexer(b),
+  status(Status::pre_read)
+{
+  init("");
+}
+
+OrderedBIndexer::OrderedShardIterator::OrderedShardIterator(
+  const OrderedBIndexer& b, const std::string& start_from) :
+  bindexer(b),
+  status(Status::pre_read)
+{
+  init(start_from);
+}
+
+void OrderedBIndexer::OrderedShardIterator::init(const std::string& start_from) {
+  bool has_more;
+
+  int r = load_batch(OMAP_KEY_PREFIX + start_from, &has_more);
+  if (r < 0) {
+    status = Status::error;
+  } else {
+    status = has_more ? Status::batch_incomplete : Status::batch_with_last_shard;
+  }
+}
+
+int OrderedBIndexer::OrderedShardIterator::next() {
+  int r = 0;
+  bool has_more;
+
+  switch (status) {
+  case Status::pre_read:
+    ldpp_dout(bindexer.dpp, 0) <<
+      "ERROR: OrderedBIndexer::OrderedShardIterator next() called "
+      "before any read" << dendl;
+    return -EINVAL;
+
+  case Status::batch_incomplete:
+    ++batch_it;
+
+    // if at end of this batch, load more starting after split of last
+    // shard in batch
+    if (batch_it == batch.cend()) {
+      r = load_batch(batch.crbegin()->first, &has_more);
+      if (r < 0) {
+	status = Status::error;
+	ldpp_dout(bindexer.dpp, 0) <<
+	  "ERROR: OrderedBIndexer::OrderedShardIterator::load_batch() returned r=" <<
+	  r << dendl;
+	return r;
+      }
+
+      if (! has_more) {
+	status = Status::batch_with_last_shard;
+      }
+    }
+
+    return 0;
+
+  case Status::batch_with_last_shard:
+    ++batch_it;
+    if (batch_it == batch.cend()) {
+      status = Status::complete;
+    }
+
+    return 0;
+
+  case Status::complete:
+    ldpp_dout(bindexer.dpp, 0) <<
+      "ERROR: OrderedBIndexer::OrderedShardIterator next() called "
+      "in complete status" << dendl;
+    return -EINVAL;
+
+  case Status::error:
+    return -EINVAL;
+
+  default:
+    status = Status::error;
+    ldpp_dout(bindexer.dpp, 0) <<
+      "ERROR: OrderedBIndexer::OrderedShardIterator in unknown status" << dendl;
+    return -EINVAL;
+  };
+
+  // all paths have a return above, so no return necessary here
+}
+
+bool OrderedBIndexer::OrderedShardIterator::valid() const {
+  return status == Status::batch_incomplete ||
+    status == Status::batch_with_last_shard;
+}
+
+std::unique_ptr<BIShardIdent> OrderedBIndexer::OrderedShardIterator::get_ident() const {
+  if (valid()) {
+    return std::make_unique<OrderedShardIdent>(get_nested_index());
+  } else {
+    return std::make_unique<OrderedShardIdent>();
+  }
+}
+
+std::string OrderedBIndexer::OrderedShardIterator::get_oid() const {
+  if (valid()) {
+    return bindexer.index_shard_oid(get_nested_index());
+  } else {
+    return "";
+  }
+}
+
+/*
+ * we can expect one of three types of values for start_from:
+ *   * the cut point from a previous shard entry (starts with
+ *     OMAP_KEY_PREFIX)
+ *   * a marker from an incomplete previous cycle (will already have
+ *     OMAP_KEY_PREFIX)
+ *   * a special value just before OMAP_KEY_PREFIX specifically to
+ *     retrieve the final shard at OMAP_KEY_PREFIX
+ *
+ */
+int OrderedBIndexer::OrderedShardIterator::load_batch(
+  const std::string& start_from, // will already have prefix if needed
+  bool* has_more_p)
+{
+  constexpr uint16_t default_batch_size = 20;
+
+  batch.clear();
+
+  // optimize in case we're seeking out the last shard, let's only
+  // retrieve one
+  uint16_t batch_size = start_from < OMAP_KEY_PREFIX ? 1 : default_batch_size;
+
+  int r;
+  std::map<std::string, bufferlist> intermediate; // intermediate results
+
+  r = bindexer.bucket_sobj->read_bucket_info_map(bindexer.bucket_info.bucket.get_key(),
+						 start_from,
+						 OMAP_KEY_PREFIX,
+						 batch_size,
+						 &OMAP_KEY_PREFIX,
+						 &intermediate,
+						 nullptr, // has_more
+						 null_yield,
+						 bindexer.dpp);
+  if (r < 0) {
+    ldpp_dout(bindexer.dpp, 0) << "ERROR: " << __func__ <<
+      ": call to read_bucket_info_map returned " << r << dendl;
+    return r;
+  }
+
+  // our has_more logic is different than that of
+  // read_bucket_info_map; has_more is true until the batch contains
+  // the last shard
+  *has_more_p = true;
+
+  // decode and transfer retrieved items; if we hit the last shard, we
+  // stop
+  for (const auto& i : intermediate) {
+    rgw_ordered_bi_omap_value value;
+    auto it = i.second.cbegin();
+    value.decode(it);
+    batch[i.first] = value;
+    if (i.first == OMAP_KEY_PREFIX) {
+      *has_more_p = false;
+      break;
+    }
+  }
+
+  // if we did not retrieve anything, we ran out of main line shards
+  // and must retrieve the last shard
+  if (batch.empty()) {
+    // set up a "marker" that will guarantee we get the last shard,
+    // which is keyed by just OMAP_KEY_PREFIX; this is because
+    // read_bucket_info gets entries starting *after* the marker
+    std::string preprefix = OMAP_KEY_PREFIX;
+    preprefix.replace(preprefix.end() - 1, preprefix.end(), "-");
+
+    r = bindexer.bucket_sobj->read_bucket_info_map(bindexer.bucket_info.bucket.get_key(),
+						   preprefix,
+						   OMAP_KEY_PREFIX,
+						   1,
+						   nullptr, // default key
+						   &intermediate,
+						   nullptr, // has_more
+						   null_yield,
+						   bindexer.dpp);
+    if (r < 0) {
+      ldpp_dout(bindexer.dpp, 0) << "ERROR: " << __func__ <<
+	" call to read_bucket_info_map returned " << r << dendl;
+    }
+
+    // sanity check 1
+    if (intermediate.size() != 1) {
+      ldpp_dout(bindexer.dpp, 0) << "ERROR: " << __func__ <<
+	" when loading last shard expected one entry but got " <<
+	intermediate.size() << dendl;
+      return -ENOENT;
+    }
+
+    // sanity check 2
+    auto i = intermediate.cbegin();
+    if (i->first != OMAP_KEY_PREFIX) {
+      ldpp_dout(bindexer.dpp, 0) << "ERROR: " << __func__ <<
+	" when loading last shard expected the key to be \"" << OMAP_KEY_PREFIX <<
+	"\" but it was instead \"" << i->first << "\"" << dendl;
+      return -ENOENT;
+    }
+
+    // decode and transfer the last shard's data to batch
+    auto it = i->second.cbegin();
+    rgw_ordered_bi_omap_value value;
+    value.decode(it);
+    batch[i->first] = value;
+    *has_more_p = false;
+  }
+
+  batch_it = batch.cbegin();
+
+  return 0;
+}
+
+std::ostream& operator<<(std::ostream& out,
+			 const OrderedBIndexer::OrderedShardIterator& i)
+{
+  out << "OrderedShardIterator:{ status=" << static_cast<int>(i.status) <<
+    ", batch.size=" << i.batch.size() <<
+    ", (batch_it == end)=" << (i.batch_it == i.batch.cend() ? "true" : "false");
+  if (i.batch_it != i.batch.cend()) {
+    out << ", split=" << i.get_split() <<
+      ", nested_index=" << i.get_nested_index();
+  }
+  out << " }";
+
+  return out;
+}
+
+} // namespace rgw::rados

--- a/src/rgw/services/svc_bindexer_rados.cc
+++ b/src/rgw/services/svc_bindexer_rados.cc
@@ -18,6 +18,8 @@
 #include "services/svc_bi_rados.h"
 #include "services/svc_bucket_sobj.h"
 #include "svc_bindexer_rados.h"
+#include "driver/rados/rgw_rados.h"
+#include "driver/rados/rgw_sal_rados.h"
 
 // OBI: remove once things stabilize
 #if 1
@@ -60,22 +62,97 @@ void BIndexer::throw_unimplemented(const std::string& type_name,
 BIndexer* BIndexer::create(CephContext* cct,
 			   const DoutPrefixProvider* dpp,
 			   const RGWBucketInfo& bucket_info,
-			   const LayoutVariant& layout) {
-  const auto* nl = std::get_if<bucket_index_hashed_layout>(&layout);
+			   const bucket_index_layout_generation& idx_gen)
+{
+  const auto* nl = std::get_if<bucket_index_hashed_layout>(&idx_gen.layout.specs);
   if (nl) {
-    return new HashedBIndexer(cct, dpp, bucket_info, *nl);
+    auto result = new HashedBIndexer(cct, dpp, bucket_info, idx_gen);
+    return result;
   }
 
-  const auto* ol = std::get_if<bucket_index_ordered_layout>(&layout);
+  const auto* ol = std::get_if<bucket_index_ordered_layout>(&idx_gen.layout.specs);
   if (ol) {
-    return new OrderedBIndexer(cct, dpp, bucket_info, *ol);
+    auto result = new OrderedBIndexer(cct, dpp, bucket_info, idx_gen);
+    return result;
   }
 
   return nullptr;
 }
 
+BIndexer* BIndexer::create(RGWRados* rados,
+			   const DoutPrefixProvider* dpp,
+			   const RGWBucketInfo& bucket_info,
+			   const bucket_index_layout_generation& idx_gen) {
+  return create(rados->ctx(), dpp, bucket_info, idx_gen);
+}
+
+BIndexer* BIndexer::create(rgw::sal::RadosStore* store,
+			   const DoutPrefixProvider* dpp,
+			   const RGWBucketInfo& bucket_info,
+			   const bucket_index_layout_generation& idx_gen) {
+  return create(store->getRados()->ctx(), dpp, bucket_info, idx_gen);
+}
+
+std::unique_ptr<BIndexer> BIndexer::create_unique(RGWRados* rados,
+						  const DoutPrefixProvider* dpp,
+						  const RGWBucketInfo& info) {
+  return create_unique(rados->ctx(), dpp, info);
+}
+
+std::unique_ptr<BIndexer> BIndexer::create_unique(rgw::sal::RadosStore* store,
+						  const DoutPrefixProvider* dpp,
+						  const RGWBucketInfo& info) {
+  return create_unique(store->getRados()->ctx(), dpp, info);
+}
+
+std::unique_ptr<BIndexer> BIndexer::create_unique(RGWRados* rados,
+						  const DoutPrefixProvider* dpp,
+						  const RGWBucketInfo& info,
+						  const bucket_index_layout_generation& idx_layout) {
+  return create_unique(rados->ctx(), dpp, info, idx_layout);
+}
+
+std::unique_ptr<BIndexer> BIndexer::create_unique(rgw::sal::RadosStore* store,
+						  const DoutPrefixProvider* dpp,
+						  const RGWBucketInfo& info,
+						  const bucket_index_layout_generation& idx_layout) {
+  return create_unique(store->getRados()->ctx(), dpp, info, idx_layout);
+}
+
+std::string BIndexer::calc_preprefix(const std::string& prefix) {
+  if (prefix.empty()) {
+    return prefix;
+  }
+
+  const char last = prefix[prefix.size() - 1];
+  const std::string new_ending{ char(last - 1), '\xFF' };
+  std::string result = prefix;
+  result.replace(result.end() - 1, result.end(), new_ending);
+  return result;
+}
+
+
+std::ostream& operator<<(std::ostream& o, const BIndexer& b) {
+    return o << b.to_string();
+  }
+
+std::ostream& operator<<(std::ostream& o, const std::unique_ptr<BIndexer>& b) {
+  if (b) {
+    return o << b->to_string();
+  } else {
+    return o << "std::unique_ptr<BIndexer> has no managed object";
+  }
+}
+
 
 /******************** HashedBIndexer ********************/
+
+std::string HashedBIndexer::to_string() const {
+  std::stringstream ss;
+  ss << "HashedBIndexer: { bucket: " << bucket_info.bucket <<
+    ", layout: { " << layout_gen << " } }";
+  return ss.str();
+}
 
 BIndexer::ShardIterator HashedBIndexer::create_shard_iterator() const {
   return ShardIterator(new HashedShardIterator(*this));
@@ -84,8 +161,7 @@ BIndexer::ShardIterator HashedBIndexer::create_shard_iterator() const {
 BIndexer::ShardIterator HashedBIndexer::create_shard_iterator(
   const std::string& start_at) const
 {
-  BIShardIndex index;
-  shard_of(start_at, &index);
+  BIShardIndex index = get_shard_index(start_at, get_actual_num_shards());
   return ShardIterator(new HashedShardIterator(*this, index));
 }
 
@@ -115,20 +191,6 @@ std::string HashedBIndexer::index_shard_oid(
 std::string HashedBIndexer::index_shard_oid(uint32_t shard_id) const
 {
   return index_shard_oid(get_bucket_oid_base(), shard_id, layout_gen.gen);
-}
-
-std::unique_ptr<BIShardIdent> HashedBIndexer::shard_of(const std::string& obj_key) const {
-  return std::make_unique<HashedShardIdent>(
-    get_shard_index(obj_key, get_actual_num_shards()));
-}
-
-std::unique_ptr<BIShardIdent> HashedBIndexer::shard_of(const rgw_obj_key& obj_key) const {
-  return std::make_unique<HashedShardIdent>(
-    get_shard_index(obj_key, get_actual_num_shards()));
-}
-
-void HashedBIndexer::shard_of(const std::string& obj_key, BIShardIndex* index) const {
-  get_shard_index(obj_key, get_actual_num_shards());
 }
 
 int HashedBIndexer::get_bucket_index_objects(
@@ -180,94 +242,83 @@ void HashedBIndexer::get_bucket_instance_ids(
 int HashedBIndexer::get_bucket_index_object(
   const std::string& obj_key,
   std::string* bucket_obj,
-  BIShardIndex* shard_index) const
+  std::unique_ptr<BIShardIdent>& shard_id) const
 {
   std::string bucket_oid_base = dir_oid_prefix;
   bucket_oid_base.append(bucket_info.bucket.bucket_id);
   const auto gen_id = layout_gen.gen;
+  int32_t shard_idx = -1;
 
-  if (! layout.num_shards) {
+  if (! num_shards(layout_gen)) {
     // by default with no sharding, we use the bucket oid as itself
-    *bucket_obj = bucket_oid_base;
-    if (shard_index) {
-      *shard_index = -1;
-    }
-  } else {
-    uint32_t sid = get_shard_index(obj_key, layout.num_shards);
     if (bucket_obj) {
-      *bucket_obj = index_shard_oid(bucket_oid_base, sid, gen_id);
+      *bucket_obj = bucket_oid_base;
     }
-    if (shard_index) {
-      *shard_index = int(sid);
+
+    shard_idx = -1;
+  } else {
+    shard_idx = get_shard_index(obj_key, num_shards(layout_gen));
+
+    if (bucket_obj) {
+      *bucket_obj = index_shard_oid(bucket_oid_base, shard_idx, gen_id);
     }
   }
 
+  shard_id.reset(new HashedShardIdent(shard_idx));
+
   return 0;
 }
-
 
 int HashedBIndexer::get_bucket_index_object(
-  const std::string& obj_key,
-  std::string* bucket_obj,
-  BIShardIdent* shard_id) const
-{
-  BIShardIndex index;
-
-  int ret = get_bucket_index_object(obj_key, bucket_obj, &index);
-  if (ret < 0) {
-    return ret;
-  }
-
-  *shard_id = HashedShardIdent(index);
-  return 0;
-}
-
-
-int HashedBIndexer::get_bucket_index_object(
-  const std::string& obj_key,
-  std::string* bucket_obj,
-  std::unique_ptr<BIShardIdent>& shard_id) const
-{
-  BIShardIndex index;
-
-  int ret = get_bucket_index_object(obj_key, bucket_obj, &index);
-  if (ret < 0) {
-    return ret;
-  }
-
-  shard_id = std::make_unique<HashedShardIdent>(index);
-  return 0;
-}
-
-
-void HashedBIndexer::get_bucket_index_object(
   uint64_t gen_id,
-  BIShardIndex shard_id,
+  const BIShardIdent& shard_ident,
   std::string* bucket_obj) const
 {
+  if (shard_ident.get_type() != BIShardIdent::Type::HashedIdent) {
+    return -EINVAL;
+  }
+
   const std::string oid_base = get_bucket_oid_base();
-  *bucket_obj = index_shard_oid(oid_base, shard_id, gen_id);
+  const auto& hashed_ident = dynamic_cast<const HashedShardIdent&>(shard_ident);
+  *bucket_obj = index_shard_oid(oid_base, hashed_ident.get_index(), gen_id);
+
+  return 0;
 }
 
+
 void HashedBIndexer::get_initial_bucket_index_objects(
+  uint64_t gen,
+  BIShardCount num_shards,
   std::map<int, std::string>& shard_oids,
   std::map<int, bufferlist>& per_shard_data,
-  std::map<std::string, bufferlist>* binfo_map_data) const
+  std::map<std::string, bufferlist>* binfo_map_data)
 {
   const std::string bucket_oid_base = get_bucket_oid_base();
-  const BIShardIndex shard_count = num_shards(layout_gen);
 
-  const auto gen_id = layout_gen.gen;
-
-  for (BIShardIndex i = 0; i < shard_count; ++i) {
-    shard_oids.emplace(
-      std::make_pair(int(i), index_shard_oid(bucket_oid_base, i, gen_id)));
+  for (BIShardIndex i = 0; i < num_shards; ++i) {
+    shard_oids.emplace(std::make_pair(int(i),
+				      index_shard_oid(bucket_oid_base, i, gen)));
   }
 }
 
+int HashedBIndexer::get_shard_idents(std::vector<std::unique_ptr<BIShardIdent>>& result) const {
+  for (uint32_t i = 0; i < get_actual_num_shards(); ++i) {
+    result.push_back(std::make_unique<HashedShardIdent>(i));
+  }
+  return 0;
+}
 
 /******************** OrderedBIndexer ********************/
 
+
+std::string OrderedBIndexer::to_string() const {
+  std::stringstream ss;
+  ss << "OrderedBIndexer: { bucket: " << bucket_info.bucket <<
+    ", layout: { " << layout_gen <<
+    " }, initial_layout:" << (bool(initial_layout) ? "exists" : "empty") <<
+    " }";
+  return ss.str();
+}
 
 BIndexer::ShardIterator OrderedBIndexer::create_shard_iterator() const {
   try {
@@ -315,53 +366,61 @@ std::string OrderedBIndexer::index_shard_oid(
   return index_shard_oid(get_bucket_oid_base(), shard_ident, layout_gen.gen);
 }
 
-std::unique_ptr<BIShardIdent> OrderedBIndexer::shard_of(const std::string& obj_key) const {
-  UNIMPLEMENTED();
-  return std::make_unique<OrderedShardIdent>(64000);
-}
-
-std::unique_ptr<BIShardIdent> OrderedBIndexer::shard_of(const rgw_obj_key& obj_key) const {
-  UNIMPLEMENTED();
-  return std::make_unique<OrderedShardIdent>(64000);
-}
-
-const std::vector<std::pair<std::string, NestedIndex>>&
-OrderedBIndexer::get_initial_shard_data()
+// The default ordered shard layout. The shard with an empty-string
+// cut-off is the last shard
+const OrderedBIndexer::InitialLayout OrderedBIndexer::default_initial_layout =
 {
-  // initially we'll create 3 shards, the first designed to capture
-  // names that begin with "/", the seconds with upper-case letters,
-  // and the third for for the rest, which includes lower-case letters
-  // and non-ASCII. Please note that all entries in a shard are LESS
-  // THAN the cut-off. The shard with an empty-string cut-off is the
-  // last shard
-  static const std::vector<std::pair<std::string, NestedIndex>> fixed_data =
-  {
-#if 0
-      { "_", { 0 + STARTING_INDEX_ID } },
-      { "~", { 1 + STARTING_INDEX_ID, 7 } },
-      { "", { 2 + STARTING_INDEX_ID, 13, 17 } }
-#else
-      { "C", { -5 + STARTING_INDEX_ID } },
-      { "E", { 0 + STARTING_INDEX_ID, 2 } },
-      { "J", { 0 + STARTING_INDEX_ID, 99 } },
-      { "_", { 1 + STARTING_INDEX_ID, 8 } },
-      { "e", { 1 + STARTING_INDEX_ID, 8, 1, 2, 4 } },
-      { "i", { 1 + STARTING_INDEX_ID, 99 } },
-      { "q", { 2 + STARTING_INDEX_ID } },
-      { "~", { 2 + STARTING_INDEX_ID, 7 } },
-      { "Æ", { 7 + STARTING_INDEX_ID, 12 } },
-      { "Ü", { 50 + STARTING_INDEX_ID } },
-      { "", { 51 + STARTING_INDEX_ID, 13, 17 } }
-#endif
-    };
-  return fixed_data;
+  // OBI: we should make this better so there's no room for error
+  // (mismatching keys, out of order keys, out of order indexes)
+  { ".", ShardLayout( ".", { 0 + STARTING_INDEX_ID } ) },
+  { "A", ShardLayout( "A", { 1 + STARTING_INDEX_ID } ) },
+  { "E", ShardLayout( "E", { 2 + STARTING_INDEX_ID } ) },
+  { "U", ShardLayout( "U", { 3 + STARTING_INDEX_ID } ) },
+  { "a", ShardLayout( "a", { 4 + STARTING_INDEX_ID } ) },
+  { "e", ShardLayout( "e", { 5 + STARTING_INDEX_ID } ) },
+  { "u", ShardLayout( "u", { 6 + STARTING_INDEX_ID } ) },
+  { "À", ShardLayout( "À", { 7 + STARTING_INDEX_ID } ) },
+  { "É", ShardLayout( "É", { 8 + STARTING_INDEX_ID } ) },
+  { "Ü", ShardLayout( "Ü", { 9 + STARTING_INDEX_ID } ) },
+  { "à", ShardLayout( "à", { 10 + STARTING_INDEX_ID } ) },
+  { "é", ShardLayout( "é", { 11 + STARTING_INDEX_ID } ) },
+  { "ü", ShardLayout( "ü", { 12 + STARTING_INDEX_ID } ) },
+  { "",  ShardLayout( "",  { 13 + STARTING_INDEX_ID } ) }
+};
+
+// OBI: does this need to return anything?
+const OrderedBIndexer::InitialLayout& OrderedBIndexer::make_initial_layout()
+{
+  initial_layout = default_initial_layout;
+  bucket_index_ordered_layout newspec{ (uint32_t) default_initial_layout.size() };
+  layout_gen.layout.specs = newspec;
+  return *initial_layout;
+}
+
+void OrderedBIndexer::set_initial_layout(const OrderedBIndexer::InitialLayout& layout) {
+  // OBI: try to protect from having too few shards; is this good?
+  if (layout.size() <= default_initial_layout.size() / 2) {
+    // use our default layout if there are too few shards in this layout
+    std::ignore = make_initial_layout();
+    return;
+  }
+
+  initial_layout = layout;
+  bucket_index_ordered_layout newspec{ (uint32_t) layout.size() };
+  layout_gen.layout.specs = newspec;
 }
 
 void OrderedBIndexer::get_initial_bucket_index_objects(
+    uint64_t gen,
+    BIShardCount num_shards,
     std::map<int, std::string>& shard_oids,
     std::map<int, bufferlist>& per_shard_data,
-    std::map<std::string, bufferlist>* binfo_map_data) const
+    std::map<std::string, bufferlist>* binfo_map_data)
 {
+  if (! initial_layout) {
+    std::ignore = make_initial_layout();
+  }
+
   const std::string bucket_oid_base = get_bucket_oid_base();
 
   const auto gen_id = layout_gen.gen;
@@ -369,10 +428,10 @@ void OrderedBIndexer::get_initial_bucket_index_objects(
   const auto& fixed_data = get_initial_shard_data();
 
   if (binfo_map_data) {
-    for (const auto& p : fixed_data) {
+    for (const auto& p : *fixed_data) {
       rgw_ordered_bi_omap_value v;
       v.split = p.first;
-      v.shard_ident = p.second;
+      v.shard_ident = p.second.index_id;
       bufferlist bl;
       v.encode(bl);
       const std::string key = OMAP_KEY_PREFIX + v.split;
@@ -384,12 +443,12 @@ void OrderedBIndexer::get_initial_bucket_index_objects(
 
   std::vector<rgw_ordered_bi_shard_data> per_shard;
   NestedIndex prev_ident = empty_index;
-  for (const auto& p : fixed_data) {
+  for (const auto& p : *fixed_data) {
     rgw_ordered_bi_shard_data d;
     d.split = p.first;
-    d.shard_ident = p.second;
+    d.shard_ident = p.second.index_id;
     d.prev_shard_ident = prev_ident;
-    prev_ident = p.second;
+    prev_ident = p.second.index_id;
     per_shard.push_back(d);
   }
 
@@ -412,122 +471,86 @@ void OrderedBIndexer::get_initial_bucket_index_objects(
   }
 }
 
-#warning "ERIC work on this NEXT"
 int OrderedBIndexer::get_bucket_index_object(
   const std::string& obj_key,
   std::string* bucket_obj,
-  BIShardIndex* shard_index) const
-{
-#warning "TRACE 127"
-  UNIMPLEMENTED();
-  return -1;
-}
-
-int OrderedBIndexer::get_bucket_index_object(
-  const std::string& obj_key,
-  std::string* bucket_obj,
-  BIShardIdent* shard_id) const
+  std::unique_ptr<BIShardIdent>& shard_ident) const
 {
   const std::string oid_base = get_bucket_oid_base();
-  const auto gen_id = layout_gen.gen;
+  const auto& gen_id = layout_gen.gen;
 
-  std::map<std::string, bufferlist> results;
+  NestedIndex index;
 
-  const std::string prefixed_key = OMAP_KEY_PREFIX + obj_key;
-  int r = bucket_sobj->read_bucket_info_map(bucket_info.bucket.get_key(),
-					    prefixed_key, OMAP_KEY_PREFIX, 1, &OMAP_KEY_PREFIX,
-					    &results, nullptr, null_yield, dpp);
-  if (r < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
-      ": call to read_bucket_info_map returned " << r << dendl;
-    return r;
+  if (initial_layout) {
+    auto it = initial_layout->upper_bound(obj_key);
+    if (it == initial_layout->end()) {
+      it = initial_layout->find("");
+      if (it == initial_layout->upper_bound(obj_key)) {
+	ldpp_dout(dpp, 0) << "INTERNAL ERROR: " << __func__ <<
+	  ": received initial_layout exists but does not have an entry keyed by "
+	  "the empty string" << dendl;
+	return -ENOENT;
+      }
+    }
+    index = it->second.index_id;
+  } else {
+    std::map<std::string, bufferlist> results;
+
+    const std::string prefixed_key = OMAP_KEY_PREFIX + obj_key;
+    int r = bucket_sobj->read_bucket_info_map(bucket_info.bucket.get_key(),
+					      prefixed_key, OMAP_KEY_PREFIX, 1, &OMAP_KEY_PREFIX,
+					      &results, nullptr, null_yield, dpp);
+    if (r < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
+	": call to read_bucket_info_map returned " << r << dendl;
+      return r;
+    }
+
+    if (results.empty()) {
+      ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
+	": no map results to determine shard" << dendl;
+      return -ENOENT;
+    }
+
+    if (results.size() > 1) {
+      ldpp_dout(dpp, 0) << "INTERNAL ERROR: " << __func__ <<
+	": received more map results than requested" << dendl;
+      throw std::logic_error("expected 1 result, but got " +
+			     std::to_string(results.size()));
+    }
+
+    rgw_ordered_bi_omap_value value;
+    auto it = results.cbegin()->second.cbegin();
+    value.decode(it);
+
+    index = value.shard_ident;
   }
-
-  if (results.empty()) {
-    ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
-      ": no map results to determine shard" << dendl;
-    return -ENOENT;
-  }
-
-  if (results.size() > 1) {
-    ldpp_dout(dpp, 0) << "INTERNAL ERROR: " << __func__ <<
-      ": received more map results than requested" << dendl;
-    throw std::logic_error("expected 1 result, but got " +
-			   std::to_string(results.size()));
-  }
-
-  rgw_ordered_bi_omap_value value;
-  auto it = results.cbegin()->second.cbegin();
-  value.decode(it);
 
   if (bucket_obj) {
-    *bucket_obj = index_shard_oid(oid_base, value.shard_ident, gen_id);
+    *bucket_obj = index_shard_oid(oid_base, index, gen_id);
   }
 
-  if (shard_id) {
-    *shard_id = OrderedShardIdent(std::move(value.shard_ident));
-  }
+  shard_ident.reset(new OrderedShardIdent(std::move(index)));
 
   return 0;
 }
 
 int OrderedBIndexer::get_bucket_index_object(
-  const std::string& obj_key,
-  std::string* bucket_obj,
-  std::unique_ptr<BIShardIdent>& shard_id) const
-{
-  const std::string oid_base = get_bucket_oid_base();
-  const auto gen_id = layout_gen.gen;
-  static const std::string default_key = "";
-
-  std::map<std::string, bufferlist> results;
-
-  const std::string prefixed_key = OMAP_KEY_PREFIX + obj_key;
-  int r =
-    bucket_sobj->read_bucket_info_map(bucket_info.bucket.get_key(),
-				      prefixed_key, OMAP_KEY_PREFIX, 1, &default_key,
-				      &results, nullptr,
-				      null_yield, dpp);
-  if (r < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
-      ": call to read_bucket_info_map returned " << r << dendl;
-    return r;
-  }
-
-  if (results.empty()) {
-    ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
-      ": no map results to determine shard" << dendl;
-    return -ENOENT;
-  }
-
-  if (results.size() > 1) {
-    ldpp_dout(dpp, 0) << "INTERNAL ERROR: " << __func__ <<
-      ": received more map results than requested" << dendl;
-    throw std::logic_error("expected 1 result, but got " +
-			   std::to_string(results.size()));
-  }
-
-  rgw_ordered_bi_omap_value value;
-  auto it = results.cbegin()->second.cbegin();
-  value.decode(it);
-
-  if (bucket_obj) {
-    *bucket_obj = index_shard_oid(oid_base, value.shard_ident, gen_id);
-  }
-
-#warning "is this implemented correctly?"
-  shard_id.reset(new OrderedShardIdent(value.shard_ident));
-
-  return 0;
-}
-
-void OrderedBIndexer::get_bucket_index_object(
   uint64_t gen_id,
-  BIShardIndex shard_id,
+  const BIShardIdent& shard_ident,
   std::string* bucket_obj) const
 {
-  UNIMPLEMENTED();
+  if (shard_ident.get_type() != BIShardIdent::Type::OrderedIdent) {
+    return -EINVAL;
+  }
+
+  const std::string oid_base = get_bucket_oid_base();
+  const auto& ordered_ident = dynamic_cast<const OrderedShardIdent&>(shard_ident);
+  *bucket_obj = index_shard_oid(oid_base, ordered_ident.get_indices(), gen_id);
+
+  return 0;
 }
+
 
 // OBI: priority to work on
 void OrderedBIndexer::get_bucket_instance_ids(
@@ -550,9 +573,56 @@ int OrderedBIndexer::get_bucket_index_objects(
     UNIMPLEMENTED();
     // (*shard_oids)[shard_index] = index_shard_oid(oid_base, shard_index, gen_id);
   } else {
-    std::string marker = "";
+    std::string marker = calc_preprefix(OMAP_KEY_PREFIX);
     bool more = true;
     BIShardIndex counter = 0;
+    std::string saved_final_oid;
+    constexpr uint64_t batch_size = 1000;
+
+    while (more) {
+      std::map<std::string, bufferlist> results;
+      // note: the following does not update the marker
+      int r = bucket_sobj->read_bucket_info_map(bucket_info.bucket.get_key(),
+						marker, OMAP_KEY_PREFIX, batch_size, &OMAP_KEY_PREFIX,
+						&results, &more, null_yield, dpp);
+      if (r < 0) {
+	ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
+	  ": call to read_bucket_info_map returned " << r << dendl;
+	return r;
+      }
+
+      for (const auto& i : results) {
+	rgw_ordered_bi_omap_value value;
+	auto it = i.second.cbegin();
+	value.decode(it);
+	const std::string oid = index_shard_oid(oid_base, value.shard_ident, gen_id);
+	if (i.first == OMAP_KEY_PREFIX) {
+	  saved_final_oid = oid;
+	} else {
+	  (*shard_oids)[counter++] = oid;
+	}
+      }
+
+      if (more) {
+	marker = results.crbegin()->first;
+      }
+    } // while
+
+    if (! saved_final_oid.empty()) {
+      (*shard_oids)[counter++] = saved_final_oid;
+    }
+  }
+  return 0;
+}
+
+int OrderedBIndexer::get_shard_idents(std::vector<std::unique_ptr<BIShardIdent>>& result) const {
+  if (initial_layout) {
+    for (const auto& i : *initial_layout) {
+      result.push_back(std::make_unique<OrderedShardIdent>(i.second.index_id));
+    }
+  } else {
+    std::string marker = "";
+    bool more = true;
     while (more) {
       std::map<std::string, bufferlist> results;
       int r = bucket_sobj->read_bucket_info_map(bucket_info.bucket.get_key(),
@@ -568,13 +638,14 @@ int OrderedBIndexer::get_bucket_index_objects(
 	rgw_ordered_bi_omap_value value;
 	auto it = i.second.cbegin();
 	value.decode(it);
-	const std::string oid = index_shard_oid(oid_base, value.shard_ident, gen_id);
-	(*shard_oids)[counter++] = oid;
+	result.push_back(std::make_unique<OrderedShardIdent>(std::move(value.shard_ident)));
       }
     } // while
-  }
+  } // if
+
   return 0;
 }
+
 
 bool HashedBIndexer::HashedShardIterator::valid() const {
   return index < (BIShardIndex) bindexer.get_actual_num_shards();
@@ -765,8 +836,7 @@ int OrderedBIndexer::OrderedShardIterator::load_batch(
     // set up a "marker" that will guarantee we get the last shard,
     // which is keyed by just OMAP_KEY_PREFIX; this is because
     // read_bucket_info gets entries starting *after* the marker
-    std::string preprefix = OMAP_KEY_PREFIX;
-    preprefix.replace(preprefix.end() - 1, preprefix.end(), "-");
+    std::string preprefix = calc_preprefix(OMAP_KEY_PREFIX);
 
     r = bindexer.bucket_sobj->read_bucket_info_map(bindexer.bucket_info.bucket.get_key(),
 						   preprefix,
@@ -826,5 +896,18 @@ std::ostream& operator<<(std::ostream& out,
 
   return out;
 }
+
+std::ostream& operator<<(std::ostream& out, const OrderedBIndexer::InitialLayout& layout)
+{
+  out << "InitialLayout:{ ";
+  for (const auto& i : layout) {
+    out << i.first << ":{ " << i.second.split_point <<
+      ", " << i.second.index_id << " }, ";
+  }
+  out << " }";
+
+  return out;
+}
+
 
 } // namespace rgw::rados

--- a/src/rgw/services/svc_bindexer_rados.h
+++ b/src/rgw/services/svc_bindexer_rados.h
@@ -402,10 +402,8 @@ public:
   int get_shard_idents(std::vector<std::unique_ptr<BIShardIdent>>&) const override;
 
 
-protected:
-
   static BIShardIndex get_shard_index(const std::string& key,
-				 int num_shards)
+				      int num_shards)
   {
     uint32_t sid = ceph_str_hash_linux(key.c_str(), key.size());
     uint32_t sid2 = sid ^ ((sid & 0xFF) << 24);
@@ -426,6 +424,8 @@ protected:
 
     return get_shard_index(sharding_key, num_shards);
   }
+
+protected:
 
   void get_initial_bucket_index_objects(
     uint64_t gen,

--- a/src/rgw/services/svc_bindexer_rados.h
+++ b/src/rgw/services/svc_bindexer_rados.h
@@ -1,0 +1,640 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+:* Copyright (C) 2025 IBM Corporation
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+/*
+ * With the introduction of a second rados bucket index type, we need
+ * a way to allow the two types to co-exist. So the idea is to use a
+ * virtual base class and a derived class to represet and hold the
+ * logic of each type of bucket index.
+ */
+
+
+#pragma once
+
+
+#include "rgw_bucket_layout.h"
+
+
+class CephContext;
+
+static const std::string dir_oid_prefix = ".dir.";
+
+namespace rgw {
+
+/*
+ * Defined Bucket Index Namespaces
+ */
+#define RGW_OBJ_NS_MULTIPART "multipart"
+#define RGW_OBJ_NS_SHADOW    "shadow"
+
+namespace rados {
+
+class unimplemented_bindexer_error : public std::runtime_error {
+
+public:
+
+  unimplemented_bindexer_error(const std::string& what_arg) :
+    runtime_error(what_arg)
+  { }
+
+  unimplemented_bindexer_error(const char* what_arg) :
+    runtime_error(what_arg)
+  { }
+};
+
+
+#define UNIMPLEMENTED() throw_unimplemented(typeid(*this).name(), __func__)
+#define UNIMPLEMENTED_MSG(msg) throw_unimplemented(typeid(*this).name(), __func__, msg)
+
+
+class BIndexer {
+
+protected:
+
+  static RGWSI_Bucket_SObj* bucket_sobj;
+
+  CephContext* cct;
+  const DoutPrefixProvider* dpp;
+  const RGWBucketInfo& bucket_info;
+  const bucket_index_layout_generation& layout_gen;
+
+  std::string get_bucket_oid_base() const {
+    std::string bucket_oid_base = dir_oid_prefix;
+    bucket_oid_base.append(bucket_info.bucket.bucket_id);
+    return bucket_oid_base;
+  }
+
+  // throws the exception after documenting the unimplemented function
+  // in the log, including a backtrace
+  void throw_unimplemented(const std::string& type_name,
+			   const char* func_name,
+			   const char* msg = nullptr) const;
+
+public:
+
+  static const BIShardIndex BI_ALL_SHARDS = -1;
+
+  BIndexer(CephContext* _cct,
+	   const DoutPrefixProvider* _dpp,
+	   const RGWBucketInfo& _bucket_info) :
+    cct(_cct),
+    dpp(_dpp),
+    bucket_info(_bucket_info),
+    layout_gen(bucket_info.layout.current_index)
+  { }
+
+  BIndexer(CephContext* _cct,
+	   const DoutPrefixProvider* _dpp,
+	   const RGWBucketInfo& _bucket_info,
+	   const bucket_index_layout_generation _layout_gen) :
+    cct(_cct),
+    dpp(_dpp),
+    bucket_info(_bucket_info),
+    layout_gen(_layout_gen)
+  { }
+
+  virtual ~BIndexer()
+  { }
+
+  static void init(RGWSI_Bucket_SObj* _bucket_sobj);
+
+  const RGWBucketInfo& get_bucket_info() const {
+    return bucket_info;
+  }
+
+  const bucket_index_layout_generation& get_layout_gen() const {
+    return layout_gen;
+  }
+
+  virtual bool entries_ordered_by_shard() const = 0;
+
+  virtual BucketIndexType get_index_type() const = 0;
+
+  virtual uint32_t get_actual_num_shards() const = 0;
+  virtual uint32_t get_stored_num_shards() const = 0;
+
+  virtual std::unique_ptr<BIShardIdent> shard_of(
+    const std::string& obj_key) const = 0;
+  virtual std::unique_ptr<BIShardIdent> shard_of(
+    const rgw_obj_key& obj_key) const = 0;
+
+
+#if 1 // we want to deprecate this
+  virtual int get_bucket_index_object(
+    const std::string& obj_key,
+    std::string* bucket_obj,
+    BIShardIndex* shard_index) const
+  {
+    UNIMPLEMENTED();
+    return -1;
+  }
+#endif
+
+  virtual int get_bucket_index_object(
+    const std::string& obj_key,
+    std::string* bucket_obj,
+    BIShardIdent* shard_ident) const
+  {
+    UNIMPLEMENTED();
+    return -1;
+  }
+
+  virtual int get_bucket_index_object(
+    const std::string& obj_key,
+    std::string* bucket_obj,
+    std::unique_ptr<BIShardIdent>& shard_ident) const
+  {
+    UNIMPLEMENTED();
+    return -1;
+  }
+
+#if 0
+  virtual int get_bucket_index_object(
+    const std::string& bucket_oid_base,
+    uint64_t gen_id,
+    const std::string& obj_key,
+    std::string* bucket_index_obj) const
+  {
+    UNIMPLEMENTED();
+    return -1;
+  }
+#endif
+
+  virtual void get_bucket_index_object(
+    uint64_t gen_id,
+    BIShardIndex shard_idx,
+    std::string* bucket_obj) const
+  {
+    UNIMPLEMENTED();
+  }
+
+  // retrieve specific shard or all shards if shard_index is -1
+  virtual int get_bucket_index_objects(
+    BIShardIndex shard_index,
+    std::map<BIShardIndex, std::string>* shard_oids) const
+  {
+    UNIMPLEMENTED();
+    return -1;
+  }
+
+  /**
+   * shard_oids maps: arbitrary int ids to shard oids
+
+   * per_shard_data: parallel to shard_oids, using the same ids, but
+   * provides data to be stored in the omap heads of the shards in the
+   * index-specific area
+
+   * binfo_map_data: key-value pairs for the bucket instance (bucket
+   * info) objects; optional and nullptr means don't fill; may already
+   * have data in it, so do not clear before adding key/value pairs
+   */
+  virtual void get_initial_bucket_index_objects(
+    std::map<int, std::string>& shard_oids,
+    std::map<int, bufferlist>& per_shard_data,
+    std::map<std::string, bufferlist>* binfo_map_data) const
+  {
+    UNIMPLEMENTED();
+  }
+
+  virtual void get_bucket_instance_ids(
+    int num_shards,
+    BIShardIndex shard_index,
+    std::map<int, std::string>* result) const
+  {
+    UNIMPLEMENTED();
+  }
+
+#if 0
+  static std::unique_ptr<BIndexer> create_unique(CephContext* cct, const LayoutVariant& layout) {
+    return std::unique_ptr<BIndexer>(create(cct, layout));
+  }
+#endif
+
+  static std::unique_ptr<BIndexer> create_unique(CephContext* cct,
+						 const DoutPrefixProvider* dpp,
+						 const RGWBucketInfo& info)
+  {
+    return std::unique_ptr<BIndexer>(create(cct, dpp,
+					    info, info.get_current_layout_variant()));
+  }
+
+  static std::unique_ptr<BIndexer> create_unique(CephContext* cct,
+						 const DoutPrefixProvider* dpp,
+						 const RGWBucketInfo& info,
+						 LayoutVariant& layout)
+  {
+    return std::unique_ptr<BIndexer>(create(cct, dpp, info, layout));
+  }
+
+#if 0
+  static std::shared_ptr<BIndexer> create_shared(CephContext* cct, const LayoutVariant& layout) {
+    return std::shared_ptr<BIndexer>(create(cct, layout));
+  }
+#endif
+
+  static std::shared_ptr<BIndexer> create_shared(CephContext* cct,
+						 const DoutPrefixProvider* dpp,
+						 const RGWBucketInfo& info)
+  {
+    return std::shared_ptr<BIndexer>(create(cct, dpp,
+					    info, info.get_current_layout_variant()));
+  }
+
+  static std::shared_ptr<BIndexer> create_shared(CephContext* cct,
+						 const DoutPrefixProvider* dpp,
+						 const RGWBucketInfo& info,
+						 const LayoutVariant& layout)
+  {
+    return std::shared_ptr<BIndexer>(create(cct, dpp, info, layout));
+  }
+
+  protected:
+
+  static BIndexer* create(CephContext* cct,
+			  const DoutPrefixProvider* dpp,
+			  const RGWBucketInfo& bucket_info,
+			  const LayoutVariant& layout);
+
+  class InteriorShardIterator {
+  public:
+    virtual ~InteriorShardIterator() { }
+    virtual const BIndexer* get_bindexer() const = 0;
+    virtual bool valid() const = 0;
+    virtual int next() = 0;
+    virtual std::unique_ptr<BIShardIdent> get_ident() const = 0;
+    virtual std::string get_oid() const = 0;
+  };
+
+  class ErrorShardIterator : public InteriorShardIterator {
+    const BIndexer* get_bindexer() const override { return nullptr; }
+    bool valid() const override { return false; }
+    int next() override { return -ENOENT; }
+    std::unique_ptr<BIShardIdent> get_ident() const { return nullptr; }
+    std::string get_oid() const override { return ""; }
+  };
+
+public:
+
+  // acts as a wrapper around a pointer iterator that can employ
+  // inheritance polymorphism
+  class ShardIterator {
+    std::unique_ptr<InteriorShardIterator> interior;
+
+  public:
+    // allows us to declare and later assign
+    ShardIterator() : interior(std::make_unique<ErrorShardIterator>()) {}
+
+    ShardIterator(InteriorShardIterator* i) : interior(i) {}
+
+    ShardIterator(ShardIterator&& other) {
+      std::swap(interior, other.interior);
+    }
+
+    ShardIterator& operator=(ShardIterator&& rhs) {
+      std::swap(interior, rhs.interior);
+      return *this;
+    }
+
+    const BIndexer* get_bindexer() const { return interior->get_bindexer(); }
+    bool valid() { return interior->valid(); }
+    int next() { return interior->next(); }
+    std::unique_ptr<BIShardIdent> get_ident() const {
+      return interior->get_ident();
+    }
+    std::string get_oid() const { return interior->get_oid(); }
+  }; // class BIndexer::ShardIterator
+
+  virtual ShardIterator create_shard_iterator() const = 0;
+  virtual ShardIterator create_shard_iterator(const std::string& start_at) const = 0;
+}; // class BIndexer
+
+
+class HashedBIndexer : public BIndexer {
+
+  friend RGWSI_BucketIndex_RADOS;
+
+protected:
+
+  bucket_index_hashed_layout layout;
+
+public:
+
+  HashedBIndexer(CephContext* cct,
+		 const DoutPrefixProvider* dpp,
+		 const RGWBucketInfo& bucket_info,
+		 const bucket_index_hashed_layout& _layout) :
+    BIndexer(cct, dpp, bucket_info),
+    layout(_layout)
+  { }
+
+  ShardIterator create_shard_iterator() const override;
+  ShardIterator create_shard_iterator(const std::string& start_at) const override;
+
+  BucketIndexType get_index_type() const override {
+    return BucketIndexType::Hashed;
+  }
+
+  bool entries_ordered_by_shard() const override {
+    return false;
+  }
+
+  uint32_t get_actual_num_shards() const override {
+    if (layout.num_shards == 0) {
+      return 1;
+    } else {
+      return layout.num_shards;
+    }
+  }
+
+  uint32_t get_stored_num_shards() const override {
+    return layout.num_shards;
+  }
+
+  std::unique_ptr<BIShardIdent> shard_of(
+    const std::string& obj_key) const override;
+  std::unique_ptr<BIShardIdent> shard_of(
+    const rgw_obj_key& obj_key) const override;
+
+  // convenience method
+  void shard_of(const std::string& obj_key, BIShardIndex* index) const;
+
+  static std::string index_shard_oid(
+    const std::string& bucket_oid_base,
+    uint32_t shard_id,
+    uint64_t gen_id = 0);
+
+  std::string index_shard_oid(
+    uint32_t shard_id,
+    uint64_t gen_id) const;
+
+  std::string index_shard_oid(uint32_t shard_id) const;
+
+  // retrieve specific shard or all shards if shard_index is -1
+  int get_bucket_index_objects(
+    BIShardIndex shard_index,
+    std::map<int, std::string>* shard_oids) const override;
+
+  int get_bucket_index_object(
+    const std::string& obj_key,
+    std::string* bucket_obj,
+    BIShardIndex* shard_index) const override;
+
+  int get_bucket_index_object(
+    const std::string& obj_key,
+    std::string* bucket_obj,
+    BIShardIdent* shard_ident) const override;
+
+  int get_bucket_index_object(
+    const std::string& obj_key,
+    std::string* bucket_obj,
+    std::unique_ptr<BIShardIdent>& shard_ident) const override;
+
+  void get_bucket_index_object(
+    uint64_t gen_id,
+    BIShardIndex shard_id,
+    std::string* bucket_obj) const override;
+
+  void get_bucket_instance_ids(
+    int num_shards,
+    BIShardIndex shard_index,
+    std::map<int, std::string>* result) const override;
+
+protected:
+
+  static int32_t get_shard_index(const std::string& key,
+				 int num_shards)
+  {
+    uint32_t sid = ceph_str_hash_linux(key.c_str(), key.size());
+    uint32_t sid2 = sid ^ ((sid & 0xFF) << 24);
+    return rgw_shards_mod(sid2, num_shards);
+  }
+
+  static int32_t get_shard_index(const rgw_obj_key& obj_key,
+				 int num_shards)
+  {
+    std::string sharding_key;
+    if (obj_key.ns == RGW_OBJ_NS_MULTIPART) {
+      RGWMPObj mp;
+      mp.from_meta(obj_key.name);
+      sharding_key = mp.get_key();
+    } else {
+      sharding_key = obj_key.name;
+    }
+
+    return get_shard_index(sharding_key, num_shards);
+  }
+
+  void get_initial_bucket_index_objects(
+    std::map<int, std::string>& shard_oids,
+    std::map<int, bufferlist>& per_shard_data,
+    std::map<std::string, bufferlist>* binfo_map_data) const override;
+
+public:
+
+  class HashedShardIterator : public InteriorShardIterator{
+
+    const HashedBIndexer& bindexer;
+    BIShardIndex index;
+
+  public:
+
+    HashedShardIterator(const HashedBIndexer& b) :
+      bindexer(b),
+      index(0)
+    { }
+
+    HashedShardIterator(const HashedBIndexer& b, BIShardIndex i) :
+      bindexer(b),
+      index(i)
+    { }
+
+    ~HashedShardIterator()
+    { }
+
+    const BIndexer* get_bindexer() const {
+      return &bindexer;
+    }
+
+    bool valid() const override;
+    int next() override;
+    std::unique_ptr<BIShardIdent> get_ident() const override;
+    std::string get_oid() const override;
+  }; // class HashedShardIterator
+
+};  // class HashedBIndexer
+
+
+class OrderedBIndexer : public BIndexer {
+
+  friend RGWSI_BucketIndex_RADOS;
+
+protected:
+
+  static constexpr int STARTING_INDEX_ID = 64000;
+  static constexpr std::string OMAP_KEY_PREFIX = std::string(RGW_ATTR_OBI1_KEY_PREFIX);
+
+  bucket_index_ordered_layout layout;
+
+public:
+
+  OrderedBIndexer(CephContext* cct,
+		  const DoutPrefixProvider* dpp,
+		  const RGWBucketInfo& bucket_info,
+		  const bucket_index_ordered_layout& _layout) :
+    BIndexer(cct, dpp, bucket_info),
+    layout(_layout)
+  { }
+
+  ShardIterator create_shard_iterator() const override;
+  ShardIterator create_shard_iterator(const std::string& start_at) const override;
+
+  BucketIndexType get_index_type() const override {
+    return BucketIndexType::Ordered;
+  }
+
+  bool entries_ordered_by_shard() const override {
+    return true;
+  }
+
+  uint32_t get_actual_num_shards() const override {
+    return layout.num_shards;
+  }
+
+  uint32_t get_stored_num_shards() const override {
+    return layout.num_shards;
+  }
+
+  static std::string index_shard_oid(
+    const std::string& bucket_oid_base,
+    const NestedIndex& index_hierarchy,
+    uint64_t gen_id = 0);
+
+  std::string index_shard_oid(
+    const NestedIndex& index_hierarchy,
+    uint64_t gen_id) const;
+
+  std::string index_shard_oid(
+    const NestedIndex& index_hierarchy) const;
+
+  std::unique_ptr<BIShardIdent> shard_of(const std::string& obj_key) const override;
+  std::unique_ptr<BIShardIdent> shard_of(const rgw_obj_key& obj_key) const override;
+
+  static const std::vector<std::pair<std::string, NestedIndex>>& get_initial_shard_data();
+
+  static uint32_t get_initial_shard_count() {
+    return get_initial_shard_data().size();
+  }
+
+  void get_initial_bucket_index_objects(
+    std::map<int, std::string>& shard_oids,
+    std::map<int, bufferlist>& per_shard_data,
+    std::map<std::string, bufferlist>* binfo_map_data) const override;
+
+  // retrieve specific shard or all shards if shard_index is -1
+  int get_bucket_index_objects(
+    BIShardIndex shard_index,
+    std::map<int, std::string>* shard_oids) const override;
+
+  int get_bucket_index_object(
+    const std::string& obj_key,
+    std::string* bucket_obj,
+    BIShardIndex* shard_index) const override;
+
+  int get_bucket_index_object(
+    const std::string& obj_key,
+    std::string* bucket_obj,
+    BIShardIdent* shard_id) const override;
+
+  int get_bucket_index_object(
+    const std::string& obj_key,
+    std::string* bucket_obj,
+    std::unique_ptr<BIShardIdent>& shard_ident) const;
+
+  void get_bucket_index_object(
+    uint64_t gen_id,
+    BIShardIndex shard_id,
+    std::string* bucket_obj) const override;
+
+  void get_bucket_instance_ids(
+    int num_shards,
+    BIShardIndex shard_index,
+    std::map<int, std::string>* result) const override;
+
+
+  class OrderedShardIterator : public InteriorShardIterator{
+
+    const OrderedBIndexer& bindexer;
+    std::map<std::string, rgw_ordered_bi_omap_value> batch;
+    std::map<std::string, rgw_ordered_bi_omap_value>::const_iterator batch_it;
+
+    enum class Status {
+      pre_read, // before any read
+      batch_incomplete, // read a batch, there are more shards
+      batch_with_last_shard, // read up to and including last shard
+      complete, // completed
+      error // error status
+    } status;
+
+  protected:
+
+    void init(const std::string& start_from);
+
+    int load_batch(
+      const std::string& start_from, // should include prefix if necessary
+      bool* has_more);
+
+  public:
+
+    OrderedShardIterator(const OrderedBIndexer& b);
+    OrderedShardIterator(const OrderedBIndexer& b, const std::string& start_from);
+
+    ~OrderedShardIterator()
+    { }
+
+    const BIndexer* get_bindexer() const {
+      return &bindexer;
+    }
+
+    const std::string& get_split() const {
+      if (valid() && batch_it != batch.cend()) {
+	return batch_it->first;
+      } else {
+	throw std::runtime_error(
+	  "OrderedBIndexer::OrderedShardIterator::get_split() "
+	  "called with invaid data");
+      }
+    }
+
+    const NestedIndex& get_nested_index() const {
+      if (valid() && batch_it != batch.cend()) {
+	return batch_it->second.shard_ident;
+      } else {
+	throw std::runtime_error(
+	  "OrderedBIndexer::OrderedShardIterator::get_nested_index() "
+	  "called with invaid data");
+      }
+    }
+
+    bool valid() const override;
+    int next() override;
+    std::unique_ptr<BIShardIdent> get_ident() const override;
+    std::string get_oid() const override;
+
+    friend std::ostream& operator<<(std::ostream&, const OrderedShardIterator&);
+  }; // class OrderedShardIterator
+
+}; // class OrderedBIndexer
+
+} // namespace rados
+} // namespace rgw

--- a/src/rgw/services/svc_bindexer_rados.h
+++ b/src/rgw/services/svc_bindexer_rados.h
@@ -23,6 +23,7 @@
 #pragma once
 
 
+#include <ostream>
 #include "rgw_bucket_layout.h"
 
 
@@ -67,7 +68,7 @@ protected:
   CephContext* cct;
   const DoutPrefixProvider* dpp;
   const RGWBucketInfo& bucket_info;
-  const bucket_index_layout_generation& layout_gen;
+  bucket_index_layout_generation layout_gen;
 
   std::string get_bucket_oid_base() const {
     std::string bucket_oid_base = dir_oid_prefix;
@@ -80,6 +81,8 @@ protected:
   void throw_unimplemented(const std::string& type_name,
 			   const char* func_name,
 			   const char* msg = nullptr) const;
+
+  static std::string calc_preprefix(const std::string& prefix);
 
 public:
 
@@ -97,7 +100,7 @@ public:
   BIndexer(CephContext* _cct,
 	   const DoutPrefixProvider* _dpp,
 	   const RGWBucketInfo& _bucket_info,
-	   const bucket_index_layout_generation _layout_gen) :
+	   const bucket_index_layout_generation& _layout_gen) :
     cct(_cct),
     dpp(_dpp),
     bucket_info(_bucket_info),
@@ -117,66 +120,25 @@ public:
     return layout_gen;
   }
 
-  virtual bool entries_ordered_by_shard() const = 0;
-
   virtual BucketIndexType get_index_type() const = 0;
+  virtual bool entries_ordered_by_shard() const = 0;
+  virtual bool may_support_log_record() const = 0;
 
   virtual uint32_t get_actual_num_shards() const = 0;
   virtual uint32_t get_stored_num_shards() const = 0;
 
-  virtual std::unique_ptr<BIShardIdent> shard_of(
-    const std::string& obj_key) const = 0;
-  virtual std::unique_ptr<BIShardIdent> shard_of(
-    const rgw_obj_key& obj_key) const = 0;
-
-
-#if 1 // we want to deprecate this
   virtual int get_bucket_index_object(
     const std::string& obj_key,
     std::string* bucket_obj,
-    BIShardIndex* shard_index) const
-  {
-    UNIMPLEMENTED();
-    return -1;
-  }
-#endif
+    std::unique_ptr<BIShardIdent>& shard_ident) const = 0;
 
   virtual int get_bucket_index_object(
-    const std::string& obj_key,
-    std::string* bucket_obj,
-    BIShardIdent* shard_ident) const
-  {
-    UNIMPLEMENTED();
-    return -1;
-  }
-
-  virtual int get_bucket_index_object(
-    const std::string& obj_key,
-    std::string* bucket_obj,
-    std::unique_ptr<BIShardIdent>& shard_ident) const
-  {
-    UNIMPLEMENTED();
-    return -1;
-  }
-
-#if 0
-  virtual int get_bucket_index_object(
-    const std::string& bucket_oid_base,
     uint64_t gen_id,
-    const std::string& obj_key,
-    std::string* bucket_index_obj) const
-  {
-    UNIMPLEMENTED();
-    return -1;
-  }
-#endif
-
-  virtual void get_bucket_index_object(
-    uint64_t gen_id,
-    BIShardIndex shard_idx,
+    const BIShardIdent& shard_ident,
     std::string* bucket_obj) const
   {
     UNIMPLEMENTED();
+    return -EINVAL;
   }
 
   // retrieve specific shard or all shards if shard_index is -1
@@ -200,9 +162,11 @@ public:
    * have data in it, so do not clear before adding key/value pairs
    */
   virtual void get_initial_bucket_index_objects(
+    uint64_t gen,
+    BIShardCount num_shards,
     std::map<int, std::string>& shard_oids,
     std::map<int, bufferlist>& per_shard_data,
-    std::map<std::string, bufferlist>* binfo_map_data) const
+    std::map<std::string, bufferlist>* binfo_map_data)
   {
     UNIMPLEMENTED();
   }
@@ -215,56 +179,86 @@ public:
     UNIMPLEMENTED();
   }
 
-#if 0
-  static std::unique_ptr<BIndexer> create_unique(CephContext* cct, const LayoutVariant& layout) {
-    return std::unique_ptr<BIndexer>(create(cct, layout));
+  virtual int get_shard_idents(std::vector<std::unique_ptr<BIShardIdent>>& result) const
+  {
+    UNIMPLEMENTED();
+    return 0;
   }
-#endif
+
+  // create_unique
 
   static std::unique_ptr<BIndexer> create_unique(CephContext* cct,
 						 const DoutPrefixProvider* dpp,
 						 const RGWBucketInfo& info)
   {
     return std::unique_ptr<BIndexer>(create(cct, dpp,
-					    info, info.get_current_layout_variant()));
+					    info, info.layout.current_index));
   }
 
+  // supply the layout generation in case we want the bindexer to,
+  // say, use the target rather than the current layout generation
   static std::unique_ptr<BIndexer> create_unique(CephContext* cct,
 						 const DoutPrefixProvider* dpp,
 						 const RGWBucketInfo& info,
-						 LayoutVariant& layout)
-  {
-    return std::unique_ptr<BIndexer>(create(cct, dpp, info, layout));
+						 const bucket_index_layout_generation& idx_layout) {
+    return std::unique_ptr<BIndexer>(create(cct, dpp, info, idx_layout));
   }
 
-#if 0
-  static std::shared_ptr<BIndexer> create_shared(CephContext* cct, const LayoutVariant& layout) {
-    return std::shared_ptr<BIndexer>(create(cct, layout));
-  }
-#endif
+  // convenience versions
+
+  static std::unique_ptr<BIndexer> create_unique(RGWRados* rados,
+						 const DoutPrefixProvider* dpp,
+						 const RGWBucketInfo& info);
+  static std::unique_ptr<BIndexer> create_unique(rgw::sal::RadosStore* store,
+						 const DoutPrefixProvider* dpp,
+						 const RGWBucketInfo& info);
+  static std::unique_ptr<BIndexer> create_unique(RGWRados* rados,
+						 const DoutPrefixProvider* dpp,
+						 const RGWBucketInfo& info,
+						 const bucket_index_layout_generation& idx_layout);
+  static std::unique_ptr<BIndexer> create_unique(rgw::sal::RadosStore* store,
+						 const DoutPrefixProvider* dpp,
+						 const RGWBucketInfo& info,
+						 const bucket_index_layout_generation& idx_layout);
+
+  // create_shared
 
   static std::shared_ptr<BIndexer> create_shared(CephContext* cct,
 						 const DoutPrefixProvider* dpp,
-						 const RGWBucketInfo& info)
-  {
+						 const RGWBucketInfo& info) {
     return std::shared_ptr<BIndexer>(create(cct, dpp,
-					    info, info.get_current_layout_variant()));
+					    info, info.layout.current_index));
   }
 
+  // supply the layout generation in case we want the bindexer to,
+  // say, use the target rather than the current layout generation
   static std::shared_ptr<BIndexer> create_shared(CephContext* cct,
 						 const DoutPrefixProvider* dpp,
 						 const RGWBucketInfo& info,
-						 const LayoutVariant& layout)
-  {
-    return std::shared_ptr<BIndexer>(create(cct, dpp, info, layout));
+						 const bucket_index_layout_generation& idx_layout) {
+    return std::shared_ptr<BIndexer>(create(cct, dpp, info, idx_layout));
   }
-
-  protected:
 
   static BIndexer* create(CephContext* cct,
 			  const DoutPrefixProvider* dpp,
 			  const RGWBucketInfo& bucket_info,
-			  const LayoutVariant& layout);
+			  const bucket_index_layout_generation& idx_gen);
+
+  // convenience versions
+
+  static BIndexer* create(RGWRados* rados,
+			  const DoutPrefixProvider* dpp,
+			  const RGWBucketInfo& bucket_info,
+			  const bucket_index_layout_generation& idx_gen);
+
+  static BIndexer* create(rgw::sal::RadosStore* store,
+			  const DoutPrefixProvider* dpp,
+			  const RGWBucketInfo& bucket_info,
+			  const bucket_index_layout_generation& idx_gen);
+
+  virtual std::string to_string() const = 0;
+
+protected:
 
   class InteriorShardIterator {
   public:
@@ -320,23 +314,30 @@ public:
 }; // class BIndexer
 
 
+std::ostream& operator<<(std::ostream&, const BIndexer&);
+std::ostream& operator<<(std::ostream&, const std::unique_ptr<BIndexer>&);
+
+
 class HashedBIndexer : public BIndexer {
 
   friend RGWSI_BucketIndex_RADOS;
-
-protected:
-
-  bucket_index_hashed_layout layout;
 
 public:
 
   HashedBIndexer(CephContext* cct,
 		 const DoutPrefixProvider* dpp,
-		 const RGWBucketInfo& bucket_info,
-		 const bucket_index_hashed_layout& _layout) :
-    BIndexer(cct, dpp, bucket_info),
-    layout(_layout)
+		 const RGWBucketInfo& bucket_info) :
+    BIndexer(cct, dpp, bucket_info)
   { }
+
+  HashedBIndexer(CephContext* cct,
+		 const DoutPrefixProvider* dpp,
+		 const RGWBucketInfo& bucket_info,
+		 const bucket_index_layout_generation& layout_gen) :
+    BIndexer(cct, dpp, bucket_info, layout_gen)
+  { }
+
+  std::string to_string() const override;
 
   ShardIterator create_shard_iterator() const override;
   ShardIterator create_shard_iterator(const std::string& start_at) const override;
@@ -349,25 +350,23 @@ public:
     return false;
   }
 
+  bool may_support_log_record() const override {
+    // might support based on various factors
+    return true;
+  }
+
   uint32_t get_actual_num_shards() const override {
-    if (layout.num_shards == 0) {
+    auto result = get_stored_num_shards();
+    if (0 == result) {
       return 1;
     } else {
-      return layout.num_shards;
+      return result;
     }
   }
 
   uint32_t get_stored_num_shards() const override {
-    return layout.num_shards;
+    return num_shards(layout_gen);
   }
-
-  std::unique_ptr<BIShardIdent> shard_of(
-    const std::string& obj_key) const override;
-  std::unique_ptr<BIShardIdent> shard_of(
-    const rgw_obj_key& obj_key) const override;
-
-  // convenience method
-  void shard_of(const std::string& obj_key, BIShardIndex* index) const;
 
   static std::string index_shard_oid(
     const std::string& bucket_oid_base,
@@ -388,31 +387,24 @@ public:
   int get_bucket_index_object(
     const std::string& obj_key,
     std::string* bucket_obj,
-    BIShardIndex* shard_index) const override;
-
-  int get_bucket_index_object(
-    const std::string& obj_key,
-    std::string* bucket_obj,
-    BIShardIdent* shard_ident) const override;
-
-  int get_bucket_index_object(
-    const std::string& obj_key,
-    std::string* bucket_obj,
     std::unique_ptr<BIShardIdent>& shard_ident) const override;
 
-  void get_bucket_index_object(
+  int get_bucket_index_object(
     uint64_t gen_id,
-    BIShardIndex shard_id,
+    const BIShardIdent& shard_ident,
     std::string* bucket_obj) const override;
 
-  void get_bucket_instance_ids(
+    void get_bucket_instance_ids(
     int num_shards,
     BIShardIndex shard_index,
     std::map<int, std::string>* result) const override;
 
+  int get_shard_idents(std::vector<std::unique_ptr<BIShardIdent>>&) const override;
+
+
 protected:
 
-  static int32_t get_shard_index(const std::string& key,
+  static BIShardIndex get_shard_index(const std::string& key,
 				 int num_shards)
   {
     uint32_t sid = ceph_str_hash_linux(key.c_str(), key.size());
@@ -420,8 +412,8 @@ protected:
     return rgw_shards_mod(sid2, num_shards);
   }
 
-  static int32_t get_shard_index(const rgw_obj_key& obj_key,
-				 int num_shards)
+  static BIShardIndex get_shard_index(const rgw_obj_key& obj_key,
+				      int num_shards)
   {
     std::string sharding_key;
     if (obj_key.ns == RGW_OBJ_NS_MULTIPART) {
@@ -436,9 +428,11 @@ protected:
   }
 
   void get_initial_bucket_index_objects(
+    uint64_t gen,
+    BIShardCount num_shards,
     std::map<int, std::string>& shard_oids,
     std::map<int, bufferlist>& per_shard_data,
-    std::map<std::string, bufferlist>* binfo_map_data) const override;
+    std::map<std::string, bufferlist>* binfo_map_data) override;
 
 public:
 
@@ -479,22 +473,46 @@ class OrderedBIndexer : public BIndexer {
 
   friend RGWSI_BucketIndex_RADOS;
 
+public:
+
+  struct ShardLayout {
+    const std::string split_point;
+    const NestedIndex index_id;
+
+    ShardLayout(const std::string& _split_point,
+		const NestedIndex& _index_id) :
+      split_point(_split_point),
+      index_id(_index_id)
+    { }
+  };
+
+  using InitialLayout = std::map<std::string, ShardLayout>;
+
 protected:
 
-  static constexpr int STARTING_INDEX_ID = 64000;
   static constexpr std::string OMAP_KEY_PREFIX = std::string(RGW_ATTR_OBI1_KEY_PREFIX);
+  static const InitialLayout default_initial_layout;
 
-  bucket_index_ordered_layout layout;
+  std::optional<InitialLayout> initial_layout;
 
 public:
+
+  static constexpr int STARTING_INDEX_ID = 64000;
+
+  OrderedBIndexer(CephContext* cct,
+		  const DoutPrefixProvider* dpp,
+		  const RGWBucketInfo& bucket_info) :
+    BIndexer(cct, dpp, bucket_info)
+  { }
 
   OrderedBIndexer(CephContext* cct,
 		  const DoutPrefixProvider* dpp,
 		  const RGWBucketInfo& bucket_info,
-		  const bucket_index_ordered_layout& _layout) :
-    BIndexer(cct, dpp, bucket_info),
-    layout(_layout)
+		  const bucket_index_layout_generation& layout_gen) :
+    BIndexer(cct, dpp, bucket_info, layout_gen)
   { }
+
+  std::string to_string() const override;
 
   ShardIterator create_shard_iterator() const override;
   ShardIterator create_shard_iterator(const std::string& start_at) const override;
@@ -507,12 +525,17 @@ public:
     return true;
   }
 
+  bool may_support_log_record() const override {
+    // currently does not support
+    return false;
+  }
+
   uint32_t get_actual_num_shards() const override {
-    return layout.num_shards;
+    return get_stored_num_shards();
   }
 
   uint32_t get_stored_num_shards() const override {
-    return layout.num_shards;
+    return num_shards(layout_gen);
   }
 
   static std::string index_shard_oid(
@@ -527,19 +550,24 @@ public:
   std::string index_shard_oid(
     const NestedIndex& index_hierarchy) const;
 
-  std::unique_ptr<BIShardIdent> shard_of(const std::string& obj_key) const override;
-  std::unique_ptr<BIShardIdent> shard_of(const rgw_obj_key& obj_key) const override;
-
-  static const std::vector<std::pair<std::string, NestedIndex>>& get_initial_shard_data();
-
-  static uint32_t get_initial_shard_count() {
-    return get_initial_shard_data().size();
+  const std::optional<InitialLayout>& get_initial_shard_data() const {
+    return initial_layout;
   }
 
+  static uint32_t get_default_initial_shard_count() {
+    return default_initial_layout.size();
+  }
+
+  const InitialLayout& make_initial_layout();
+
+  void set_initial_layout(const InitialLayout& layout);
+
   void get_initial_bucket_index_objects(
+    uint64_t gen,
+    BIShardCount num_shards,
     std::map<int, std::string>& shard_oids,
     std::map<int, bufferlist>& per_shard_data,
-    std::map<std::string, bufferlist>* binfo_map_data) const override;
+    std::map<std::string, bufferlist>* binfo_map_data) override;
 
   // retrieve specific shard or all shards if shard_index is -1
   int get_bucket_index_objects(
@@ -549,21 +577,11 @@ public:
   int get_bucket_index_object(
     const std::string& obj_key,
     std::string* bucket_obj,
-    BIShardIndex* shard_index) const override;
-
-  int get_bucket_index_object(
-    const std::string& obj_key,
-    std::string* bucket_obj,
-    BIShardIdent* shard_id) const override;
-
-  int get_bucket_index_object(
-    const std::string& obj_key,
-    std::string* bucket_obj,
     std::unique_ptr<BIShardIdent>& shard_ident) const;
 
-  void get_bucket_index_object(
+  int get_bucket_index_object(
     uint64_t gen_id,
-    BIShardIndex shard_id,
+    const BIShardIdent& shard_ident,
     std::string* bucket_obj) const override;
 
   void get_bucket_instance_ids(
@@ -571,6 +589,7 @@ public:
     BIShardIndex shard_index,
     std::map<int, std::string>* result) const override;
 
+  int get_shard_idents(std::vector<std::unique_ptr<BIShardIdent>>&) const override;
 
   class OrderedShardIterator : public InteriorShardIterator{
 
@@ -635,6 +654,9 @@ public:
   }; // class OrderedShardIterator
 
 }; // class OrderedBIndexer
+
+std::ostream& operator<<(std::ostream&, const OrderedBIndexer::InitialLayout&);
+
 
 } // namespace rados
 } // namespace rgw

--- a/src/rgw/services/svc_bucket.h
+++ b/src/rgw/services/svc_bucket.h
@@ -1,4 +1,3 @@
-
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 sts=2 expandtab ft=cpp
 
@@ -79,15 +78,16 @@ public:
                        optional_yield y,
                        const DoutPrefixProvider *dpp) = 0;
 
-  virtual int store_bucket_instance_info(const std::string& key,
-                                 RGWBucketInfo& info,
-                                 std::optional<RGWBucketInfo *> orig_info, /* nullopt: orig_info was not fetched,
-                                                                              nullptr: orig_info was not found (new bucket instance */
-                                 bool exclusive,
-                                 real_time mtime,
-                                 const std::map<std::string, bufferlist> *pattrs,
-                                 optional_yield y,
-                                 const DoutPrefixProvider *dpp) = 0;
+    virtual int store_bucket_instance_info(const std::string& key,
+                                           RGWBucketInfo& info,
+                                           std::optional<RGWBucketInfo *> orig_info, /* nullopt: orig_info was not fetched,
+                                                                                        nullptr: orig_info was not found (new bucket instance */
+                                           bool exclusive,
+                                           real_time mtime,
+                                           const std::map<std::string, bufferlist>* pattrs,
+                                           const std::map<std::string, bufferlist>* omap_entries,
+                                           optional_yield y,
+                                           const DoutPrefixProvider *dpp) = 0;
 
   virtual int remove_bucket_instance_info(const std::string& key,
 				  const RGWBucketInfo& bucket_info,

--- a/src/rgw/services/svc_bucket_sobj.cc
+++ b/src/rgw/services/svc_bucket_sobj.cc
@@ -593,7 +593,6 @@ int RGWSI_Bucket_SObj::read_bucket_info_map(const std::string& bucket_meta_key,
   const rgw_pool& pool = svc.zone->get_zone_params().domain_root;
   const std::string oid = instance_meta_key_to_oid(bucket_meta_key);
   bufferlist bl;
-  RGWObjVersionTracker objv;
 
   int ret = rgw_read_system_obj_map(dpp, svc.sysobj, pool, oid,
                                     after, prefix, count, default_key,
@@ -601,6 +600,24 @@ int RGWSI_Bucket_SObj::read_bucket_info_map(const std::string& bucket_meta_key,
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
       "(): rgw_read_system_obj_map returned " << ret << dendl;
+  }
+
+  return ret;
+}
+
+
+int RGWSI_Bucket_SObj::clear_bucket_info_map(const std::string& bucket_meta_key,
+                                             optional_yield y,
+                                             const DoutPrefixProvider* dpp)
+{
+  const rgw_pool& pool = svc.zone->get_zone_params().domain_root;
+  const std::string oid = instance_meta_key_to_oid(bucket_meta_key);
+  bufferlist bl;
+
+  int ret = rgw_clear_system_obj_map(dpp, svc.sysobj, pool, oid, y);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
+      "(): rgw_clear_system_obj_map returned " << ret << dendl;
   }
 
   return ret;

--- a/src/rgw/services/svc_bucket_sobj.cc
+++ b/src/rgw/services/svc_bucket_sobj.cc
@@ -432,7 +432,8 @@ int RGWSI_Bucket_SObj::store_bucket_instance_info(const string& key,
                                                   std::optional<RGWBucketInfo *> orig_info,
                                                   bool exclusive,
                                                   real_time mtime,
-                                                  const map<string, bufferlist> *pattrs,
+                                                  const map<string, bufferlist>* pattrs,
+                                                  const std::map<std::string, bufferlist>* omap_entries,
                                                   optional_yield y,
                                                   const DoutPrefixProvider *dpp)
 {
@@ -473,7 +474,7 @@ int RGWSI_Bucket_SObj::store_bucket_instance_info(const string& key,
   const rgw_pool& pool = svc.zone->get_zone_params().domain_root;
   const std::string oid = instance_meta_key_to_oid(key);
   int ret = rgw_put_system_obj(dpp, svc.sysobj, pool, oid, bl, exclusive,
-                               &info.objv_tracker, mtime, y, pattrs);
+                               &info.objv_tracker, mtime, y, pattrs, omap_entries);
   if (ret >= 0) {
     int r = svc.mdlog->complete_entry(dpp, y, "bucket.instance",
                                       key, &info.objv_tracker);
@@ -576,4 +577,31 @@ int RGWSI_Bucket_SObj::read_buckets_stats(std::vector<RGWBucketEnt>& buckets,
   }
 
   return buckets.size();
+}
+
+
+int RGWSI_Bucket_SObj::read_bucket_info_map(const std::string& bucket_meta_key,
+                                            const std::string& after,
+                                            const std::string& prefix,
+                                            const uint64_t count,
+                                            const std::string* default_key, // nullptr indicates none
+                                            std::map<std::string, bufferlist>* results,
+                                            bool* more,
+                                            optional_yield y,
+                                            const DoutPrefixProvider* dpp)
+{
+  const rgw_pool& pool = svc.zone->get_zone_params().domain_root;
+  const std::string oid = instance_meta_key_to_oid(bucket_meta_key);
+  bufferlist bl;
+  RGWObjVersionTracker objv;
+
+  int ret = rgw_read_system_obj_map(dpp, svc.sysobj, pool, oid,
+                                    after, prefix, count, default_key,
+                                    results, more, y);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
+      "(): rgw_read_system_obj_map returned " << ret << dendl;
+  }
+
+  return ret;
 }

--- a/src/rgw/services/svc_bucket_sobj.h
+++ b/src/rgw/services/svc_bucket_sobj.h
@@ -1,4 +1,3 @@
-
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 sts=2 expandtab ft=cpp
 
@@ -138,7 +137,8 @@ public:
                                                                               nullptr: orig_info was not found (new bucket instance */
                                  bool exclusive,
                                  real_time mtime,
-                                 const std::map<std::string, bufferlist> *pattrs,
+                                 const std::map<std::string, bufferlist>* pattrs,
+                                 const std::map<std::string, bufferlist>* omap_entries,
                                  optional_yield y,
                                  const DoutPrefixProvider *dpp) override;
 
@@ -156,5 +156,25 @@ public:
   int read_buckets_stats(std::vector<RGWBucketEnt>& buckets,
                          optional_yield y,
                          const DoutPrefixProvider *dpp) override;
-};
 
+  /*
+   * parameters:
+   *   after: returned keys must be greater than after
+   *   prefix: all returned entries must begin with prefix
+   *   max: maximum number to return
+   *   default_key: if using after and prefix nothing matches, then return
+   *                this entry instead
+   *   results: key/value pairs
+   *   more: if true additional entries match
+   */
+  int read_bucket_info_map(const std::string& bucket_key,
+                           const std::string& after,
+                           const std::string& prefix,
+                           const uint64_t count,
+                           const std::string* default_key, // nullptr indicates none
+                           std::map<std::string, bufferlist>* results,
+                           bool* more,
+                           optional_yield y,
+                           const DoutPrefixProvider *dpp);
+
+}; // class RGWSI_Bucket_SObj

--- a/src/rgw/services/svc_bucket_sobj.h
+++ b/src/rgw/services/svc_bucket_sobj.h
@@ -177,4 +177,8 @@ public:
                            optional_yield y,
                            const DoutPrefixProvider *dpp);
 
+  int clear_bucket_info_map(const std::string& bucket_key,
+                            optional_yield y,
+                            const DoutPrefixProvider *dpp);
+
 }; // class RGWSI_Bucket_SObj

--- a/src/rgw/services/svc_sys_obj.cc
+++ b/src/rgw/services/svc_sys_obj.cc
@@ -131,14 +131,39 @@ int RGWSI_SysObj::Obj::OmapOp::get_all(const DoutPrefixProvider *dpp, std::map<s
 }
 
 int RGWSI_SysObj::Obj::OmapOp::get_vals(const DoutPrefixProvider *dpp, 
-                                        const string& marker, uint64_t count,
+                                        const string& marker,
+                                        uint64_t count,
                                         std::map<string, bufferlist> *m,
-                                        bool *pmore, optional_yield y)
+                                        bool *pmore,
+                                        optional_yield y)
+{
+  return get_vals(dpp, marker, "", count, nullptr, m, pmore, y);
+}
+
+
+/*
+ * parameters:
+ *   marker: returned keys must be greater than *after*
+ *   prefix: all returned entries must begin with prefix
+ *   count: maximum number to return
+ *   default_key: if using after and prefix nothing matches, then return
+ *                this entry instead
+ *   m: key/value pairs
+ *   pmore: if true additional entries match
+ */
+int RGWSI_SysObj::Obj::OmapOp::get_vals(const DoutPrefixProvider* dpp,
+                                        const std::string& marker,
+                                        const std::string& prefix,
+                                        uint64_t count,
+                                        const std::string* default_key,
+                                        std::map<std::string, bufferlist>* m,
+                                        bool* pmore,
+                                        optional_yield y)
 {
   RGWSI_SysObj_Core *svc = source.core_svc;
   rgw_raw_obj& obj = source.obj;
 
-  return svc->omap_get_vals(dpp, obj, marker, count, m, pmore, y);
+  return svc->omap_get_vals(dpp, obj, marker, prefix, count, default_key, m, pmore, y);
 }
 
 int RGWSI_SysObj::Obj::OmapOp::set(const DoutPrefixProvider *dpp, const std::string& key, bufferlist& bl,

--- a/src/rgw/services/svc_sys_obj.cc
+++ b/src/rgw/services/svc_sys_obj.cc
@@ -192,6 +192,14 @@ int RGWSI_SysObj::Obj::OmapOp::del(const DoutPrefixProvider *dpp, const std::str
   return svc->omap_del(dpp, obj, key, y);
 }
 
+int RGWSI_SysObj::Obj::OmapOp::clear(const DoutPrefixProvider *dpp, optional_yield y)
+{
+  RGWSI_SysObj_Core *svc = source.core_svc;
+  rgw_raw_obj& obj = source.obj;
+
+  return svc->omap_clear(dpp, obj, y);
+}
+
 int RGWSI_SysObj::Obj::WNOp::notify(const DoutPrefixProvider *dpp, bufferlist& bl, uint64_t timeout_ms,
                                     bufferlist *pbl, optional_yield y)
 {

--- a/src/rgw/services/svc_sys_obj.h
+++ b/src/rgw/services/svc_sys_obj.h
@@ -155,12 +155,30 @@ public:
 
       OmapOp(Obj& _source) : source(_source) {}
 
-      int get_all(const DoutPrefixProvider *dpp, std::map<std::string, bufferlist> *m, optional_yield y);
-      int get_vals(const DoutPrefixProvider *dpp, const std::string& marker, uint64_t count,
+      int get_all(const DoutPrefixProvider *dpp,
+                  std::map<std::string, bufferlist> *m,
+                  optional_yield y);
+      int get_vals(const DoutPrefixProvider *dpp,
+                   const std::string& marker,
+                   uint64_t count,
                    std::map<std::string, bufferlist> *m,
-                   bool *pmore, optional_yield y);
-      int set(const DoutPrefixProvider *dpp, const std::string& key, bufferlist& bl, optional_yield y);
-      int set(const DoutPrefixProvider *dpp, const std::map<std::string, bufferlist>& m, optional_yield y);
+                   bool *pmore,
+                   optional_yield y);
+      int get_vals(const DoutPrefixProvider* dpp,
+                   const std::string& marker,
+                   const std::string& prefix,
+                   uint64_t count,
+                   const std::string* default_key,
+                   std::map<std::string, bufferlist>* m,
+                   bool* pmore,
+                   optional_yield y);
+      int set(const DoutPrefixProvider *dpp,
+              const std::string& key,
+              bufferlist& bl,
+              optional_yield y);
+      int set(const DoutPrefixProvider *dpp,
+              const std::map<std::string, bufferlist>& m,
+              optional_yield y);
       int del(const DoutPrefixProvider *dpp, const std::string& key, optional_yield y);
     };
 

--- a/src/rgw/services/svc_sys_obj.h
+++ b/src/rgw/services/svc_sys_obj.h
@@ -180,6 +180,8 @@ public:
               const std::map<std::string, bufferlist>& m,
               optional_yield y);
       int del(const DoutPrefixProvider *dpp, const std::string& key, optional_yield y);
+
+      int clear(const DoutPrefixProvider *dpp, optional_yield y);
     };
 
     struct WNOp {

--- a/src/rgw/services/svc_sys_obj_core.cc
+++ b/src/rgw/services/svc_sys_obj_core.cc
@@ -497,6 +497,23 @@ int RGWSI_SysObj_Core::omap_del(const DoutPrefixProvider *dpp, const rgw_raw_obj
   return r;
 }
 
+int RGWSI_SysObj_Core::omap_clear(const DoutPrefixProvider *dpp, const rgw_raw_obj& obj, optional_yield y)
+{
+  rgw_rados_ref rados_obj;
+  int r = get_rados_obj(dpp, zone_svc, obj, &rados_obj);
+  if (r < 0) {
+    ldpp_dout(dpp, 20) << "get_rados_obj() on obj=" << obj << " returned " << r << dendl;
+    return r;
+  }
+
+  librados::ObjectWriteOperation op;
+
+  op.omap_clear();
+
+  r = rados_obj.operate(dpp, std::move(op), y);
+  return r;
+}
+
 int RGWSI_SysObj_Core::notify(const DoutPrefixProvider *dpp, const rgw_raw_obj& obj, bufferlist& bl,
                               uint64_t timeout_ms, bufferlist *pbl,
                               optional_yield y)

--- a/src/rgw/services/svc_sys_obj_core.cc
+++ b/src/rgw/services/svc_sys_obj_core.cc
@@ -298,38 +298,102 @@ int RGWSI_SysObj_Core::omap_get_vals(const DoutPrefixProvider *dpp,
                                      bool *pmore,
                                      optional_yield y)
 {
+  return omap_get_vals(dpp, obj, marker, "", count, nullptr, m, pmore, y);
+}
+
+/*
+ * parameters:
+ *   marker: returned keys must be greater than *after*; this won't add
+             the prefix to the marker, so if that's expected that the
+             first call will include the prefix with marker
+ *   prefix: all returned entries must begin with prefix
+ *   count: maximum number to return
+ *   default_key: if using after and prefix nothing matches, then return
+ *                this entry instead
+ *   m: key/value pairs
+ *   pmore: if true additional entries match
+ */
+int RGWSI_SysObj_Core::omap_get_vals(const DoutPrefixProvider *dpp, 
+                                     const rgw_raw_obj& obj,
+                                     const string& marker,
+                                     const string& prefix,
+                                     uint64_t count,
+                                     const string* default_key,
+                                     std::map<std::string, bufferlist>* m,
+                                     bool* pmore,
+                                     optional_yield y)
+{
   rgw_rados_ref rados_obj;
   int r = get_rados_obj(dpp, zone_svc, obj, &rados_obj);
   if (r < 0) {
-    ldpp_dout(dpp, 20) << "get_rados_obj() on obj=" << obj << " returned " << r << dendl;
+    ldpp_dout(dpp, 20) << "get_rados_obj() on obj=" << obj <<
+      ", zone_svc=" << zone_svc << ", returned " << r << dendl;
     return r;
   }
 
-  string start_after = marker;
-  bool more;
-
+  std::string start_after = marker;
+  bool more = true;
   do {
     librados::ObjectReadOperation op;
 
-    std::map<string, bufferlist> t;
+    std::map<std::string, bufferlist> vals;
     int rval;
-    op.omap_get_vals2(start_after, count, &t, &more, &rval);
+    op.omap_get_vals2(start_after, prefix, count, &vals, &more, &rval);
   
     r = rados_obj.operate(dpp, std::move(op), nullptr, y);
     if (r < 0) {
       return r;
     }
-    if (t.empty()) {
+    if (vals.empty()) {
       break;
     }
-    count -= t.size();
-    start_after = t.rbegin()->first;
-    m->insert(t.begin(), t.end());
+
+    if (prefix.empty()) {
+      // optimize when there's no prefix
+      count -= vals.size();
+      start_after = vals.rbegin()->first;
+      m->insert(vals.begin(), vals.end());
+    } else {
+      for (const auto& entry : vals) {
+        if (entry.first.starts_with(prefix)) {
+          --count;
+          start_after = entry.first;
+          m->insert(entry);
+        } else {
+          more = false;
+          break;
+        }
+      }
+    }
   } while (more && count > 0);
+
+  // if no results found, then we'll see if we can access the
+  // default_key
+  if (default_key && m->empty()) {
+    librados::ObjectReadOperation op;
+    std::set<std::string> keys;
+    keys.insert(*default_key);
+    std::map<std::string, bufferlist> vals;
+    int rval;
+
+    op.omap_get_vals_by_keys(keys, &vals, &rval);
+    r = rados_obj.operate(dpp, std::move(op), nullptr, y);
+    if (r < 0) {
+      return r;
+    }
+
+    // we expect 0 or 1 result; this works either way
+    for (const auto& entry : vals) {
+      m->insert(entry);
+    }
+
+    more = false; // should already be false if *m is empty
+  }
 
   if (pmore) {
     *pmore = more;
   }
+
   return 0;
 }
 

--- a/src/rgw/services/svc_sys_obj_core.h
+++ b/src/rgw/services/svc_sys_obj_core.h
@@ -111,6 +111,7 @@ protected:
                        optional_yield y);
   virtual int omap_del(const DoutPrefixProvider *dpp, const rgw_raw_obj& obj, const std::string& key,
                        optional_yield y);
+  virtual int omap_clear(const DoutPrefixProvider *dpp, const rgw_raw_obj& obj, optional_yield y);
 
   virtual int notify(const DoutPrefixProvider *dpp, 
                      const rgw_raw_obj& obj, bufferlist& bl,

--- a/src/rgw/services/svc_sys_obj_core.h
+++ b/src/rgw/services/svc_sys_obj_core.h
@@ -82,14 +82,25 @@ protected:
                         RGWObjVersionTracker *objv_tracker,
                         bool exclusive, optional_yield y);
 
-  virtual int omap_get_all(const DoutPrefixProvider *dpp, const rgw_raw_obj& obj, std::map<std::string, bufferlist> *m,
+  virtual int omap_get_all(const DoutPrefixProvider *dpp,
+                           const rgw_raw_obj& obj,
+                           std::map<std::string, bufferlist> *m,
                            optional_yield y);
-  virtual int omap_get_vals(const DoutPrefixProvider *dpp, 
+  virtual int omap_get_vals(const DoutPrefixProvider *dpp,
                             const rgw_raw_obj& obj,
                             const std::string& marker,
                             uint64_t count,
                             std::map<std::string, bufferlist> *m,
                             bool *pmore,
+                            optional_yield y);
+  virtual int omap_get_vals(const DoutPrefixProvider* dpp,
+                            const rgw_raw_obj& obj,
+                            const std::string& marker,
+                            const std::string& prefix,
+                            uint64_t count,
+                            const std::string* default_key,
+                            std::map<std::string, bufferlist>* m,
+                            bool* pmore,
                             optional_yield y);
   virtual int omap_set(const DoutPrefixProvider *dpp, 
                        const rgw_raw_obj& obj, const std::string& key,

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -959,6 +959,8 @@ $CCLIENTDEBUG
         rgw crypt require ssl = false
         rgw sts key = abcdefghijklmnop
         rgw s3 auth use sts = true
+        ;rgw_bucket_default_index = ordered
+        rgw_bucket_default_index = foobar
         ; uncomment the following to set LC days as the value in seconds;
         ; needed for passing lc time based s3-tests (can be verbose)
         ; rgw lc debug interval = 10


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/78858

July 8, 2026

RGW Ordered Bucket Indexes


== Quick Start ==

This is an EXPERIMENTAL FEATURE at this point in time. Do NOT use this
branch for/on critical data. Even if you never try ordered bucket
indexing, this branch is not considered safe for critical data. This
branch is STRICTLY intended for early testing.

Newly created buckets start with hashed bucket indexing.

You can reshard a bucket from hashed to ordered bucket indexing with a
command along the lines of:

    radosgw-admin bucket reshard --bucket-index-type=ordered \
        --bucket=<bucket> --num-shards=<shard-count> \
	[--yes-i-really-mean-it] [--debug-rgw=20]

And you can return to hashed indexing with a command along the lines of:

    radosgw-admin bucket reshard --bucket-index-type=hashed \
        --bucket=<bucket> --num-shards=<shard-count> \
	[--yes-i-really-mean-it] [--debug-rgw=20]

IMPORTANT: At this time you cannot reshard a bucket from ordered to
ordered. That is currently being worked on. You can reshard a bucket
from hashed to hashed, though.

IMPORTANT: Do not use this branch with multisite.

IMPORTANT: Some features have been disabled until they can be fully
integratred with ordered bucket indexes.


== To Do List ==

* Allow ordered bucket index shards to be split manually.

* Allow ordered bucket index shards to be operated on by dynamic
  resharding.

* Test/fix all functionality that's temporarily turned off.

* Allow ordered bucket index shards to work with multisite.

* Develop new scheme for versioned buckets that would allow us to
  exceed 49,999 versions of a given object, which is the current
  limitation with ordered bucket indexes.


== Background ==

The bucket indexes contains metadata about the RGW objects in a
bucket. The data is stored in the OMAP of the index object(s). Since
RADOS imposes a soft limit of 100,000 OMAP entries per RADOS object, the
index for a bucket is generally spread across a set of RADOS objects
referred, and each is referred to as a bucket index shard.

In order to map RGW objects to a specific shard RGW has used a hashing
mechanism where the name of the RGW object is run through a hashing
function and we then do a modulo op with the number of shards to come
up with a shard index. That means that RGW objects are not lexically
ordered across shards.

That creates challenges when listing a bucket with the entries
lexically ordered as we must read batches of entries from all shards
and sort within those batches, and move forward in each shard and so
forth.

With ordered bucket indexes, each shard contains a lexical slice of
entry names. In other words, they contain a lexical range. This means
that to provide a lexically ordered list of RGW objects, we simply
access the shards sequentially.


== Implementation Details ==

In order to know which shard a given RGW object is mapped to, we use
the OMAP of the bucket instance object. The keys are the "split
points" that divide the lexical space into the shards.

More specifically, an upper_bound operation is used to find the
correct OMAP entry. So if the split point for shard N-1 is "pointer"
and the split point for shard N is "retriever" then entries that are
greater-than-or-equal to "pointer" and less-than "retriever" are
stored on shard N.

The final shard has a split point of the empty string (""), so we do
not need to track the lexically highest entry.

One important added detail -- the split points have a fixed prefix
that acts as a namespace. In case any other future feature were to
want to store OMAP entries in the bucket instance object, we need to
keep the two uses separate, and we'll do that by giving each a unique
prefix.

For ordered bucket indexes the prefix is "obi1.". The first letters
"obi" stand for "ordered bucket indexes". The "1" is there in case we
need to update the scheme and acts as a version number. And the "."
is used to separate the prefix (namespace) from the actual key.

So returning to the example above, shard N-1 would have the key
"obi1.pointer", shard N would have "obi1.retriever", and the final
shard "obi1.".

The values associated with those keys are:

  struct rgw_ordered_bi_omap_value {
    std::string split;
    rgw::NestedIndex shard_ident;
  };

The split is repeated and the NestedIndex is used to generate the oid
for the shard. With hashed bucket index shards, resharding was an
operation that replaced all of the shards. But with ordered bucket
index shards we have the option of splitting a shard into consecutive
shards or joining consecutive shards into one shard. Because we need
to potentially insert new shards between existing shards, we need a
more flexible naming scheme. And that's what NestedIndex does. It's
declared as:

    using NestedIndex = std::vector<int32_t>;

Each entry in the vector is a level. So if the vector contains {
64009, 3, 2 } then the oid would be
".dir.ed9ead10-97bb-46b8-9e40-526eba1e5faf.4179.1.ordered.1.64009.3.2".

Let's focus on "ordered.2.64009.3.2". We "tag" ordered index shards
with "ordered" (any reason not to? should it be shorter?). Then "2"
represents a generation number. And "64009.3.2" is the index. If the
next index is "64009.4" and we need two indexes in between we could
have "64009.3.3" and "64009.3.4".

Additionally each bucket index object contains the following in its
data (not its OMAP).

  struct rgw_ordered_bi_shard_data {
    std::string split;
    rgw::NestedIndex shard_ident;
    rgw::NestedIndex prev_shard_ident;
    rgw::NestedIndex next_shard_ident;
  };

This allows us to easily figure out what the neighboring shards are.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
