### PR TITLE
crimson/os/seastore/transaction: new conflict/no_conflict trans synchronization

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1394,7 +1394,6 @@ record_t Cache::prepare_record(
     }
     if (should_use_no_conflict_publish(t, i->get_type())) {
       i->new_committer(t);
-      i->committer->block_trans(t);
     }
     assert(i->is_exist_mutation_pending() ||
 	   i->prior_instance);
@@ -1675,8 +1674,6 @@ record_t Cache::prepare_record(
       assert(!i->get_prior_instance()->committer);
       i->new_committer(t);
       assert(i->committer);
-      auto &committer = *i->committer;
-      committer.block_trans(t);
       i->get_prior_instance()->set_io_wait(
         CachedExtent::extent_state_t::CLEAN,
         should_use_no_conflict_publish(t, i->get_type()));
@@ -1711,8 +1708,6 @@ record_t Cache::prepare_record(
       i->new_committer(t);
       assert(i->committer);
       i->get_prior_instance()->committer = i->committer;
-      auto &committer = *i->committer;
-      committer.block_trans(t);
       i->get_prior_instance()->set_io_wait(
         CachedExtent::extent_state_t::CLEAN, true);
     }
@@ -2050,7 +2045,6 @@ void Cache::complete_commit(
       }
       touch_extent_fully(prior, &t_src, t.get_cache_hint());
       committer.sync_version();
-      committer.unblock_trans(t);
       prior.complete_io();
       i->committer.reset();
       prior.committer.reset();
@@ -2131,7 +2125,6 @@ void Cache::complete_commit(
       auto &committer = *i->committer;
       committer.commit_state();
       committer.sync_checksum();
-      committer.unblock_trans(t);
       auto &prior = *i->prior_instance;
       prior.pending_for_transaction = TRANS_ID_NULL;
       ceph_assert(prior.is_valid());

--- a/src/crimson/os/seastore/cached_extent.cc
+++ b/src/crimson/os/seastore/cached_extent.cc
@@ -515,24 +515,4 @@ void CachedExtent::new_committer(Transaction &t) {
   prior_instance->committer = committer;
 }
 
-void ExtentCommitter::block_trans(Transaction &t) {
-  LOG_PREFIX(ExtentCommitter::block_trans);
-  auto &prior = *extent.prior_instance;
-  for (auto &item : prior.read_transactions) {
-    TRACET("blocking trans {} for rewriting {}",
-      t, item.t->get_trans_id(), *item.ref);
-    item.t->need_wait_visibility = true;
-  }
-}
-
-void ExtentCommitter::unblock_trans(Transaction &t) {
-  LOG_PREFIX(ExtentCommitter::unblock_trans);
-  auto &prior = *extent.prior_instance;
-  for (auto &item : prior.read_transactions) {
-    TRACET("unblocking trans {} for rewriting {}",
-      t, item.t->get_trans_id(), *item.ref);
-    item.t->need_wait_visibility = false;
-  }
-}
-
 }

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -279,8 +279,6 @@ public:
   ExtentCommitter(CachedExtent &extent, Transaction &t)
     : extent(extent), t(t) {}
 
-  void block_trans(Transaction &);
-  void unblock_trans(Transaction &);
   // commit all extent states to the prior instance,
   // except poffset and extent content
   void commit_state();

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1012,6 +1012,8 @@ private:
 
   void new_committer(Transaction &t);
 
+  seastar::shared_mutex commit_lock;
+
 protected:
   trans_view_set_t mutation_pending_extents;
   trans_view_set_t retired_transactions;

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -444,6 +444,26 @@ public:
     std::for_each(existing_block_list.begin(), existing_block_list.end(), f);
   }
 
+  template <typename F>
+  void for_each_mutated_extent(F &&f) {
+    std::for_each(
+      retired_set.begin(),
+      retired_set.end(),
+      [&f](auto &link) {
+        std::invoke(f, *link.extent);
+      });
+    std::for_each(
+      mutated_block_list.begin(),
+      mutated_block_list.end(),
+      [&f](auto &e) {
+        if (!e->is_valid() ||
+            e->is_exist_mutation_pending()) {
+          return;
+        }
+        std::invoke(f, *e->get_prior_instance());
+      });
+  }
+
   const io_stat_t& get_fresh_block_stats() const {
     return fresh_block_stats;
   }
@@ -971,7 +991,6 @@ constexpr bool should_use_no_conflict_publish(const Transaction &t,
 
   return !t.force_rewrite_conflict && is_rewrite_transaction(t.get_src());
 }
-
 
 }
 

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -547,7 +547,6 @@ public:
     ool_write_stats = {};
     rewrite_stats = {};
     conflicted = false;
-    need_wait_visibility = false;
     force_rewrite_conflict = false;
     assert(backref_entries.empty());
     if (!has_reset) {
@@ -675,7 +674,6 @@ public:
 
   btree_cursor_stats_t cursor_stats;
 
-  bool need_wait_visibility = false;
   bool force_rewrite_conflict = false;
 
   using update_copied_lba_key_func_t =

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -634,9 +634,6 @@ TransactionManager::do_submit_transaction(
   tref.get_phase_durations().prepare_enter +=
     std::chrono::steady_clock::now() - prepare_enter_start;
 
-  while (tref.need_wait_visibility) {
-    co_await trans_intr::make_interruptible(seastar::yield());
-  }
   if (trim_alloc_to && *trim_alloc_to != JOURNAL_SEQ_NULL) {
     SUBTRACET(seastore_t, "trim backref_bufs to {}", tref, *trim_alloc_to);
     cache->trim_backref_bufs(*trim_alloc_to);

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -593,6 +593,43 @@ TransactionManager::update_lba_mappings(
   });
 }
 
+seastar::future<TransactionManager::mutated_extents_locker>
+TransactionManager::lock_mutated_nodes(
+  Transaction &t)
+{
+  mutated_extents_set_t mutated_extents;
+  LOG_PREFIX(TransactionManager::lock_mutated_nodes);
+  t.for_each_mutated_extent(
+    [&mutated_extents](auto &extent) {
+      if (!is_root_type(extent.get_type())) {
+        std::ignore = mutated_extents.emplace(&extent);
+      }
+  });
+  if (unlikely(mutated_extents.empty())) {
+    co_return mutated_extents_locker();
+  }
+  std::vector<std::unique_lock<seastar::shared_mutex>> unique_locks;
+  std::vector<std::shared_lock<seastar::shared_mutex>> shared_locks;
+  if (auto &e = *mutated_extents.begin();
+      should_use_no_conflict_publish(t, e->get_type())) {
+    for (auto &ext : mutated_extents) {
+      assert(should_use_no_conflict_publish(t, ext->get_type()));
+      TRACET("locking {}", t, *ext);
+      auto lock = co_await seastar::get_unique_lock(ext->commit_lock);
+      unique_locks.emplace_back(std::move(lock));
+    }
+  } else {
+    for (auto &ext : mutated_extents) {
+      assert(!should_use_no_conflict_publish(t, ext->get_type()));
+      TRACET("shared locking {}", t, *ext);
+      auto lock = co_await seastar::get_shared_lock(ext->commit_lock);
+      shared_locks.emplace_back(std::move(lock));
+    }
+  }
+  co_return mutated_extents_locker(
+    std::move(mutated_extents), std::move(unique_locks), std::move(shared_locks));
+}
+
 TransactionManager::submit_transaction_direct_ret
 TransactionManager::do_submit_transaction(
   Transaction &tref,
@@ -619,6 +656,18 @@ TransactionManager::do_submit_transaction(
   tref.get_phase_durations().lba_update +=
     std::chrono::steady_clock::now() - lba_start;
 
+  // TODO: For now, we lock mutated extents after delayed ool writes
+  // and lba mappings updating, this is ok because:
+  // 1. at present, only lba/backref nodes might be modified by
+  //    no_conflict trans;
+  // 2. only ool lba/backref extents' persistence needs to be sync'd
+  //
+  // In the future, when no_conflict transactions may also modify
+  // logical extents, we should add something like "lock_logical_mutated_extents"
+  // and invoke it before writing ool extents.
+  auto locker = co_await trans_intr::make_interruptible(
+    lock_mutated_nodes(tref));
+
   auto num_extents = allocated_extents.size();
   SUBTRACET(seastore_t, "process {} allocated extents", tref, num_extents);
   ool_start = std::chrono::steady_clock::now();
@@ -631,6 +680,13 @@ TransactionManager::do_submit_transaction(
   co_await trans_intr::make_interruptible(
     tref.get_handle().enter(write_pipeline.prepare)
   );
+
+  // For conflicting transactions, we can release the lock
+  // now. Because other transactions accessing the same
+  // extents as the current one would be invalidated later
+  // in Cache::prepare_record()
+  locker.release_shared_lock();
+
   tref.get_phase_durations().prepare_enter +=
     std::chrono::steady_clock::now() - prepare_enter_start;
 
@@ -659,7 +715,7 @@ TransactionManager::do_submit_transaction(
     std::move(record),
     tref.get_handle(),
     tref.get_src(),
-    [this, FNAME, &tref](record_locator_t submit_result) {
+    [&locker, this, FNAME, &tref](record_locator_t submit_result) {
     SUBDEBUGT(seastore_t, "committed with {}", tref, submit_result);
     auto start_seq = submit_result.write_result.start_seq;
     journal->get_trimmer().set_journal_head(start_seq);
@@ -667,6 +723,7 @@ TransactionManager::do_submit_transaction(
       tref,
       submit_result.record_block_base,
       start_seq);
+    locker.release_lock();
     journal->get_trimmer().update_journal_tails(
       cache->get_oldest_dirty_from().value_or(start_seq),
       cache->get_oldest_backref_dirty_from().value_or(start_seq));

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -1303,6 +1303,52 @@ private:
     return cache->can_drop_backref();
   }
 
+  // use memory addresses as the key for comparing extents,
+  // this makes sure that mutexes of extents are always
+  // acquired in the same order, avoiding dead locks.
+  struct mem_addr_cmp_t {
+    bool operator()(const CachedExtentRef &lhs,
+                    const CachedExtentRef &rhs) const {
+      return lhs.get() < rhs.get();
+    }
+  };
+
+  using mutated_extents_set_t =
+    std::set<CachedExtentRef, mem_addr_cmp_t>;
+  struct mutated_extents_locker {
+    mutated_extents_set_t mutated_extents;
+    std::vector<std::unique_lock<seastar::shared_mutex>> unique_locks;
+    std::vector<std::shared_lock<seastar::shared_mutex>> shared_locks;
+
+    mutated_extents_locker(
+      mutated_extents_set_t &&mutated_extents,
+      std::vector<std::unique_lock<seastar::shared_mutex>> &&unique_locks,
+      std::vector<std::shared_lock<seastar::shared_mutex>> &&shared_locks)
+      : mutated_extents(mutated_extents),
+        unique_locks(std::move(unique_locks)),
+        shared_locks(std::move(shared_locks)) {}
+    mutated_extents_locker() = default;
+    mutated_extents_locker(mutated_extents_locker&&) = default;
+
+    void release_lock() {
+      unique_locks.clear();
+    }
+
+    void release_shared_lock() {
+      shared_locks.clear();
+    }
+
+    void release() {
+      unique_locks.clear();
+      shared_locks.clear();
+    }
+    ~mutated_extents_locker() {
+      release();
+    }
+  };
+  seastar::future<mutated_extents_locker> lock_mutated_nodes(
+    Transaction &t);
+
   using resolve_cursor_to_mapping_iertr = base_iertr;
   resolve_cursor_to_mapping_iertr::future<LBAMapping>
   resolve_cursor_to_mapping(


### PR DESCRIPTION
Use seastar::shared_mutex to synchronize transactions when committing
no_conflict ones.

Specifically, this commit achieves conflict/no_conflict trans
synchronization by:
1. The no_conflict trans acquires locks on all the stable extents which
   it modifies.
2. The conflicting trans acquires shared locks on all the stable extents
   which it modifies.
3. The no_conflict trans releases the locks after its committing.
4. The conflicting trans releases the shared locks once it enter the
   prepare pipeline phase.

This commits makes sure that:
1. only transactions accessing the extents that the no_conflict trans
   is committing will be blocked.
2. avoid persisting extents that a committing no_conflict trans is
   modified

Compared to the old approach, this commit's strategy is much more
straightforward and understandable.

This commit is more performant as the no_conflict trans only blocks
the trans the modified extent set of which intersects with it, while,
in the old approach, all other transactions will be blocked once a
conflicting trans is blocked because it's blocked after it enters the
prepare pipeline phase

Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
