### PR TITLE
mgr/rook: don't leak a watcher thread per orchestrator call

### DIFF
--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -107,6 +107,19 @@ def threaded(f: Callable[..., None]) -> Callable[..., threading.Thread]:
     return cast(Callable[..., threading.Thread], wrapper)
 
 
+def fetch_k8s_items(api_func: Callable, **kwargs: Any) -> List[Any]:
+    """One-shot fetch of a kubernetes list resource.
+
+    Unlike KubernetesResource, no watcher thread is spawned, so this is
+    safe for short-lived, per-call use.
+    """
+    response = api_func(**kwargs)
+    if isinstance(response, dict):
+        # the custom-object api returns a plain dict
+        return list(response['items'])
+    return list(response.items)
+
+
 class DefaultFetcher():
     def __init__(self, storage_class_name: str, coreV1_api: 'client.CoreV1Api', rook_env: 'RookEnv'):
         self.storage_class_name = storage_class_name
@@ -115,8 +128,11 @@ class DefaultFetcher():
         self.pvs_in_sc: List[client.V1PersistentVolumeList] = []
 
     def fetch(self) -> None:
-        self.inventory: KubernetesResource[client.V1PersistentVolumeList] = KubernetesResource(self.coreV1_api.list_persistent_volume)
-        self.pvs_in_sc = [i for i in self.inventory.items if i.spec.storage_class_name == self.storage_class_name]
+        # fetchers are created per get_discovered_devices() call, so use
+        # a one-shot fetch: a KubernetesResource watcher thread would
+        # leak on every call
+        self.pvs_in_sc = [i for i in fetch_k8s_items(self.coreV1_api.list_persistent_volume)
+                          if i.spec.storage_class_name == self.storage_class_name]
 
     def convert_size(self, size_str: str) -> int:
         units = ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "", "K", "M", "G", "T", "P", "E")
@@ -171,10 +187,19 @@ class LSOFetcher(DefaultFetcher):
 
     def fetch(self) -> None:
         super().fetch()
-        self.discovery: KubernetesCustomResource = KubernetesCustomResource(self.customObjects_api.list_cluster_custom_object,
-                                                 group="local.storage.openshift.io",
-                                                 version="v1alpha1",
-                                                 plural="localvolumediscoveryresults")
+        # the api call now happens here (fetch_k8s_items is eager), so the
+        # ApiException handling that used to live in devices() -- back when
+        # the fetch was triggered lazily by KubernetesCustomResource.items --
+        # has to move with it
+        try:
+            self.discovery: List[Any] = fetch_k8s_items(
+                self.customObjects_api.list_cluster_custom_object,
+                group="local.storage.openshift.io",
+                version="v1alpha1",
+                plural="localvolumediscoveryresults")
+        except ApiException:
+            log.error("Failed to fetch device metadata")
+            raise
 
     def predicate(self, item: 'client.V1ConfigMapList') -> bool:
             if self.nodenames is not None:
@@ -183,11 +208,7 @@ class LSOFetcher(DefaultFetcher):
                 return True
 
     def devices(self) -> Dict[str, List[Device]]:
-        try:
-            lso_discovery_results = [i for i in self.discovery.items if self.predicate(i)]
-        except ApiException as dummy_e:
-            log.error("Failed to fetch device metadata")
-            raise
+        lso_discovery_results = [i for i in self.discovery if self.predicate(i)]
         self.lso_devices = {}
         for i in lso_discovery_results:
             drives = i['status']['discoveredDevices']
@@ -237,14 +258,14 @@ class PDFetcher(DefaultFetcher):
 
     def fetch(self) -> None:
         """ Collect the devices information from k8s configmaps"""
-        self.dev_cms: KubernetesResource = KubernetesResource(self.coreV1_api.list_namespaced_config_map,
-                                                              namespace=self.rook_env.operator_namespace,
-                                                              label_selector='app=rook-discover')
+        self.dev_cms: List[Any] = fetch_k8s_items(self.coreV1_api.list_namespaced_config_map,
+                                                  namespace=self.rook_env.operator_namespace,
+                                                  label_selector='app=rook-discover')
 
     def devices(self) -> Dict[str, List[Device]]:
         """ Return the list of devices found"""
         node_devices: Dict[str, List[Device]] = {}
-        for i in self.dev_cms.items:
+        for i in self.dev_cms:
             devices_list: List[Device] = []
             for d in json.loads(i.data['devices']):
                 devices_list.append(self.device(d)[1])
@@ -276,6 +297,11 @@ class KubernetesResource(Generic[T]):
         The api fetch and watch methods should be common across resource types,
 
         Exceptions in the runner thread are propagated to the caller.
+
+        Instances own a watcher thread that runs until the watch stream
+        ends, so they must be long-lived: on a short-lived instance the
+        thread outlives it and leaks along with its HTTP connection. For
+        one-shot fetches use fetch_k8s_items() instead.
 
         :param api_func: kubernetes client api function that is passed to the watcher
         :param filter_func: signature: ``(Item) -> bool``.
@@ -497,10 +523,12 @@ class RookCluster(object):
         return discovered_devices
 
     def get_osds(self) -> List:
-        osd_pods: KubernetesResource = KubernetesResource(self.coreV1_api.list_namespaced_pod,
-                                                          namespace=self.rook_env.namespace,
-                                                          label_selector='app=rook-ceph-osd')
-        return list(osd_pods.items)
+        # filter the long-lived rook_pods watch instead of creating a
+        # KubernetesResource per call: each instance spawns a watcher
+        # thread that outlives it, so per-call instances leak a thread
+        # and its HTTP connection on every call
+        return [p for p in self.rook_pods.items
+                if (p.metadata.labels or {}).get('app') == 'rook-ceph-osd']
 
     def get_nfs_conf_url(self, nfs_cluster: str, instance: str) -> Optional[str]:
         #
@@ -859,12 +887,13 @@ class RookCluster(object):
         return f'Removed {objpath}'
 
     def get_resource(self, resource_type: str) -> Iterable:
-        custom_objects: KubernetesCustomResource = KubernetesCustomResource(self.customObjects_api.list_namespaced_custom_object,
-                                                                            group="ceph.rook.io",
-                                                                            version="v1",
-                                                                            namespace=self.rook_env.namespace,
-                                                                            plural=resource_type)
-        return custom_objects.items
+        # called per describe_service() call, so use a one-shot fetch: a
+        # KubernetesCustomResource watcher thread would leak on every call
+        return fetch_k8s_items(self.customObjects_api.list_namespaced_custom_object,
+                               group="ceph.rook.io",
+                               version="v1",
+                               namespace=self.rook_env.namespace,
+                               plural=resource_type)
 
     def can_create_osd(self) -> bool:
         current_cluster = self.rook_api_get(

--- a/src/pybind/mgr/rook/tests/test_rook.py
+++ b/src/pybind/mgr/rook/tests/test_rook.py
@@ -118,3 +118,25 @@ class TestRook(object):
                     assert dds[i].last_deployed == pods[i]['created']
                     assert dds[i].started == pods[i]['started']
                     assert dds[i].last_refresh == pods[i]['refreshed']
+
+
+class TestFetchK8sItems(object):
+    class FakeResponse:
+        def __init__(self, items):
+            self.items = items
+
+    def test_fetch_spawns_no_watcher_thread(self):
+        from rook.rook_cluster import fetch_k8s_items
+        # one-shot fetches must not spawn watcher threads: a watcher
+        # outlives a short-lived caller and leaks the thread and its
+        # connection. Fail deterministically if a thread is constructed
+        # instead of comparing the process-global active_count(), which
+        # is racy against unrelated threads.
+        def _fail_on_thread(*args, **kwargs):
+            raise AssertionError("fetch_k8s_items must not spawn a thread")
+        with patch('rook.rook_cluster.threading.Thread', _fail_on_thread):
+            items = fetch_k8s_items(lambda: self.FakeResponse(['pod0']))
+            assert items == ['pod0']
+            # the custom-object api returns a plain dict
+            items = fetch_k8s_items(lambda: {'items': ['cr0', 'cr1']})
+            assert items == ['cr0', 'cr1']


### PR DESCRIPTION
KubernetesResource spawns a watch thread on the first access to .items, and the thread runs until the watch stream ends. `get_osds()`, `get_resource()` and the device fetchers create a `KubernetesResource` per call, so one `describe_service()` leaks up to five threads, their HTTPS connections to the apiserver, and the item dicts the threads keep updating. Poll the orchestrator every few seconds and the active mgr accumulates threads until it is OOM-killed.

Filter the long-lived rook_pods watch in `get_osds()` the way `describe_pods()` does. Convert the other per-call sites to `fetch_k8s_items()`, a one-shot list call that spawns no watcher. `KubernetesResource` stays watch-only, for the three long-lived caches in `RookCluster`.

Fixes: https://tracker.ceph.com/issues/78589




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
