### PR TITLE
cephadm/nfs: add configurable CephFS client logging for Ganesha

### DIFF
--- a/doc/cephadm/services/nfs.rst
+++ b/doc/cephadm/services/nfs.rst
@@ -82,6 +82,49 @@ is met, the default binding will happen on all available network interfaces.
 By default, only the NFSv4 protocol is enabled. NFSv3 can be enabled by setting
 ``enable_nfsv3`` to ``true`` in the service specification.
 
+CephFS client logging
+---------------------
+
+When an NFS export uses the CephFS backend, Ganesha acts as a libcephfs client.
+To troubleshoot CephFS client issues, cephadm can mount a host log directory into
+the Ganesha container and add a ``[client]`` section to the daemon ``ceph.conf``.
+
+This is disabled by default. To enable it, set ``enable_cephfs_client_log: true``
+in the NFS service spec.
+
+Example:
+
+.. code-block:: yaml
+
+    service_type: nfs
+    service_id: mynfs
+    placement:
+      count: 1
+    spec:
+      enable_cephfs_client_log: true
+
+The following optional parameters are also available:
+
+* ``cephfs_client_log_level`` (integer): libcephfs client debug level. Default is
+  ``10`` when logging is enabled.
+* ``cephfs_client_log_dir`` (string): host path to mount into the container at
+  ``/var/log/ceph``. When unset, defaults to ``/var/log/ceph/<cluster-fsid>``.
+
+Example with custom log level and directory:
+
+.. code-block:: yaml
+
+    service_type: nfs
+    service_id: mynfs
+    placement:
+      count: 1
+    spec:
+      enable_cephfs_client_log: true
+      cephfs_client_log_level: 20
+      cephfs_client_log_dir: /var/log/ceph/<fsid>
+
+Client log files appear under the mounted host log directory.
+
 NFS over RDMA
 -------------
 

--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -1076,6 +1076,12 @@ There are two methds for examining NFS-Ganesha logs:
 The NFS log level can be adjusted using the ``nfs cluster config set`` command
 (see :ref:`nfs-cluster-set`).
 
+To enable libcephfs client debug logging for CephFS-backed exports, set
+``enable_cephfs_client_log: true`` in the NFS service spec. See
+:ref:`deploy-cephadm-nfs-ganesha` for details. Client logs are written to the
+host directory ``/var/log/ceph/<cluster-fsid>`` (or a custom path set via
+``cephfs_client_log_dir``).
+
 
 .. _nfs-ganesha-config:
 

--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -1156,6 +1156,13 @@ There are two methods for examining NFS-Ganesha logs:
 The NFS log level can be adjusted using the ``nfs cluster config set`` command
 (see :ref:`nfs-cluster-set`).
 
+To enable libcephfs client debug logging for CephFS-backed exports, set
+``enable_cephfs_client_log: true`` in the NFS service spec. See
+:ref:`deploy-cephadm-nfs-ganesha` for details. Client logs are written to the
+host directory ``/var/log/ceph/<cluster-fsid>`` (or a custom path set via
+``cephfs_client_log_dir``).
+
+
 .. _nfs-ganesha-config:
 
 Manual NFS-Ganesha Deployment

--- a/src/cephadm/cephadmlib/daemons/nfs.py
+++ b/src/cephadm/cephadmlib/daemons/nfs.py
@@ -5,7 +5,7 @@ import re
 from typing import Dict, List, Optional, Tuple, Union
 
 from ..call_wrappers import call, CallVerbosity
-from ..constants import DEFAULT_IMAGE, CEPH_DEFAULT_CONF
+from ..constants import DEFAULT_IMAGE, CEPH_DEFAULT_CONF, LOG_DIR_MODE
 from ..container_daemon_form import ContainerDaemonForm, daemon_to_container
 from ..container_types import CephContainer, extract_uid_gid
 from ..context import CephadmContext
@@ -64,6 +64,12 @@ class NFSGanesha(ContainerDaemonForm):
         self.files = dict_get(config_json, 'files', {})
         self.rgw = dict_get(config_json, 'rgw', {})
         self.enable_rdma = dict_get(config_json, 'enable_rdma', False)
+        self.enable_cephfs_client_log = dict_get(
+            config_json, 'enable_cephfs_client_log', False
+        )
+        self.cephfs_client_log_dir = dict_get(
+            config_json, 'cephfs_client_log_dir', None
+        )
 
         # validate the supplied args
         self.validate()
@@ -101,11 +107,19 @@ class NFSGanesha(ContainerDaemonForm):
             ] = '/var/lib/ceph/radosgw/%s-%s/keyring:z' % (cluster, rgw_user)
         return mounts
 
+    def _get_host_log_dir(self, ctx: CephadmContext) -> str:
+        if self.cephfs_client_log_dir:
+            return self.cephfs_client_log_dir
+        return os.path.join(ctx.log_dir, self.identity.fsid)
+
     def customize_container_mounts(
         self, ctx: CephadmContext, mounts: Dict[str, str]
     ) -> None:
         data_dir = self.identity.data_dir(ctx.data_dir)
         mounts.update(self._get_container_mounts(data_dir))
+        if self.enable_cephfs_client_log:
+            host_log_dir = self._get_host_log_dir(ctx)
+            mounts[host_log_dir] = '/var/log/ceph:z'
 
     @staticmethod
     def get_container_envs():
@@ -243,6 +257,11 @@ set -e
         with write_new(entrypoint_path, owner=(uid, gid)) as f:
             f.write(self.ganesha_entrypoint_script(nfsv3=nfsv3))
         os.chmod(entrypoint_path, 0o700)
+
+        if self.enable_cephfs_client_log:
+            host_log_dir = self._get_host_log_dir(self.ctx)
+            if not os.path.exists(host_log_dir):
+                makedirs(host_log_dir, uid, gid, LOG_DIR_MODE)
 
         # write the RGW keyring
         if self.rgw:

--- a/src/cephadm/cephadmlib/daemons/nfs.py
+++ b/src/cephadm/cephadmlib/daemons/nfs.py
@@ -5,7 +5,7 @@ import re
 from typing import Dict, List, Optional, Tuple, Union
 
 from ..call_wrappers import call, CallVerbosity
-from ..constants import DEFAULT_IMAGE, CEPH_DEFAULT_CONF
+from ..constants import DEFAULT_IMAGE, CEPH_DEFAULT_CONF, LOG_DIR_MODE
 from ..container_daemon_form import ContainerDaemonForm, daemon_to_container
 from ..container_types import CephContainer, extract_uid_gid
 from ..context import CephadmContext
@@ -64,6 +64,12 @@ class NFSGanesha(ContainerDaemonForm):
         self.files = dict_get(config_json, 'files', {})
         self.rgw = dict_get(config_json, 'rgw', {})
         self.enable_rdma = dict_get(config_json, 'enable_rdma', False)
+        self.enable_cephfs_client_log = dict_get(
+            config_json, 'enable_cephfs_client_log', False
+        )
+        self.cephfs_client_log_dir = dict_get(
+            config_json, 'cephfs_client_log_dir', None
+        )
 
         # validate the supplied args
         self.validate()
@@ -101,11 +107,28 @@ class NFSGanesha(ContainerDaemonForm):
             ] = '/var/lib/ceph/radosgw/%s-%s/keyring:z' % (cluster, rgw_user)
         return mounts
 
+    def _get_host_log_dir(self, ctx: CephadmContext) -> str:
+        log_dir = self.cephfs_client_log_dir
+        if not log_dir:
+            return os.path.join(ctx.log_dir, self.identity.fsid)
+
+        resolved = os.path.realpath(log_dir)
+        if not log_dir.startswith('/') or resolved == '/':
+            raise Error('invalid cephfs_client_log_dir: %s' % log_dir)
+        if os.path.exists(resolved) and not os.path.isdir(resolved):
+            raise Error(
+                'cephfs_client_log_dir is not a directory: %s' % log_dir
+            )
+        return resolved
+
     def customize_container_mounts(
         self, ctx: CephadmContext, mounts: Dict[str, str]
     ) -> None:
         data_dir = self.identity.data_dir(ctx.data_dir)
         mounts.update(self._get_container_mounts(data_dir))
+        if self.enable_cephfs_client_log:
+            host_log_dir = self._get_host_log_dir(ctx)
+            mounts[host_log_dir] = '/var/log/ceph:z'
 
     @staticmethod
     def get_container_envs():
@@ -243,6 +266,11 @@ set -e
         with write_new(entrypoint_path, owner=(uid, gid)) as f:
             f.write(self.ganesha_entrypoint_script(nfsv3=nfsv3))
         os.chmod(entrypoint_path, 0o700)
+
+        if self.enable_cephfs_client_log:
+            host_log_dir = self._get_host_log_dir(self.ctx)
+            if not os.path.exists(host_log_dir):
+                makedirs(host_log_dir, uid, gid, LOG_DIR_MODE)
 
         # write the RGW keyring
         if self.rgw:

--- a/src/cephadm/tests/test_deploy.py
+++ b/src/cephadm/tests/test_deploy.py
@@ -73,6 +73,33 @@ def test_deploy_nfs_container(cephadm_fs, funkypatch):
         assert f.read() == 'FAKE'
 
 
+def test_deploy_nfs_container_cephfs_client_log(cephadm_fs, funkypatch):
+    mocks = _common_patches(funkypatch)
+    fsid = 'b01dbeef-701d-9abe-0000-e1e5a47004a7'
+    with with_cephadm_ctx([]) as ctx:
+        ctx.container_engine = mock_podman()
+        ctx.fsid = fsid
+        ctx.name = 'nfs.fun'
+        ctx.image = 'quay.io/ceph/ceph:latest'
+        ctx.reconfig = False
+        ctx.config_blobs = {
+            'pool': 'foo',
+            'files': {
+                'ganesha.conf': 'FAKE',
+                'idmap.conf': 'FAKE',
+            },
+            'config': 'BALONEY',
+            'keyring': 'BUNKUS',
+            'enable_cephfs_client_log': True,
+        }
+        _cephadm._common_deploy(ctx)
+
+    with open(f'/var/lib/ceph/{fsid}/nfs.fun/unit.run') as f:
+        runfile_lines = f.read().splitlines()
+    assert f'-v /var/log/ceph/{fsid}:/var/log/ceph:z' in runfile_lines[-1]
+    assert pathlib.Path(f'/var/log/ceph/{fsid}').is_dir()
+
+
 def test_deploy_snmp_container(cephadm_fs, funkypatch):
     mocks = _common_patches(funkypatch)
     _firewalld = mocks['Firewalld']

--- a/src/cephadm/tests/test_nfs.py
+++ b/src/cephadm/tests/test_nfs.py
@@ -34,6 +34,10 @@ def nfs_json(**kwargs):
             "keyring": "foobar",
             "user": "jsmith",
         }
+    if kwargs.get("enable_cephfs_client_log"):
+        result["enable_cephfs_client_log"] = True
+    if kwargs.get("cephfs_client_log_dir"):
+        result["cephfs_client_log_dir"] = kwargs["cephfs_client_log_dir"]
     return result
 
 
@@ -144,6 +148,40 @@ def test_nfsganesha_container_mounts():
             cmounts["/var/tmp/keyring.rgw"]
             == "/var/lib/ceph/radosgw/ceph-jsmith/keyring:z"
         )
+
+
+def test_nfsganesha_container_mounts_cephfs_client_log():
+    with with_cephadm_ctx([]) as ctx:
+        ctx.log_dir = "/var/log/ceph"
+        nfsg = _cephadm.NFSGanesha(
+            ctx,
+            SAMPLE_UUID,
+            "fred",
+            nfs_json(pool=True, files=True, enable_cephfs_client_log=True),
+        )
+        cmounts = nfsg._get_container_mounts("/var/tmp")
+        assert len(cmounts) == 4
+
+        mounts = {}
+        nfsg.customize_container_mounts(ctx, mounts)
+        assert mounts[f"/var/log/ceph/{SAMPLE_UUID}"] == "/var/log/ceph:z"
+
+    with with_cephadm_ctx([]) as ctx:
+        ctx.log_dir = "/var/log/ceph"
+        nfsg = _cephadm.NFSGanesha(
+            ctx,
+            SAMPLE_UUID,
+            "fred",
+            nfs_json(
+                pool=True,
+                files=True,
+                enable_cephfs_client_log=True,
+                cephfs_client_log_dir="/custom/log/dir",
+            ),
+        )
+        mounts = {}
+        nfsg.customize_container_mounts(ctx, mounts)
+        assert mounts["/custom/log/dir"] == "/var/log/ceph:z"
 
 
 def test_nfsganesha_container_envs():

--- a/src/cephadm/tests/test_nfs.py
+++ b/src/cephadm/tests/test_nfs.py
@@ -34,6 +34,10 @@ def nfs_json(**kwargs):
             "keyring": "foobar",
             "user": "jsmith",
         }
+    if kwargs.get("enable_cephfs_client_log"):
+        result["enable_cephfs_client_log"] = True
+    if kwargs.get("cephfs_client_log_dir"):
+        result["cephfs_client_log_dir"] = kwargs["cephfs_client_log_dir"]
     return result
 
 
@@ -144,6 +148,80 @@ def test_nfsganesha_container_mounts():
             cmounts["/var/tmp/keyring.rgw"]
             == "/var/lib/ceph/radosgw/ceph-jsmith/keyring:z"
         )
+
+
+def test_nfsganesha_container_mounts_cephfs_client_log():
+    with with_cephadm_ctx([]) as ctx:
+        ctx.log_dir = "/var/log/ceph"
+        nfsg = _cephadm.NFSGanesha(
+            ctx,
+            SAMPLE_UUID,
+            "fred",
+            nfs_json(pool=True, files=True, enable_cephfs_client_log=True),
+        )
+        cmounts = nfsg._get_container_mounts("/var/tmp")
+        assert len(cmounts) == 4
+
+        mounts = {}
+        nfsg.customize_container_mounts(ctx, mounts)
+        assert mounts[f"/var/log/ceph/{SAMPLE_UUID}"] == "/var/log/ceph:z"
+
+    with with_cephadm_ctx([]) as ctx:
+        ctx.log_dir = "/var/log/ceph"
+        nfsg = _cephadm.NFSGanesha(
+            ctx,
+            SAMPLE_UUID,
+            "fred",
+            nfs_json(
+                pool=True,
+                files=True,
+                enable_cephfs_client_log=True,
+                cephfs_client_log_dir="/custom/log/dir",
+            ),
+        )
+        mounts = {}
+        nfsg.customize_container_mounts(ctx, mounts)
+        assert mounts["/custom/log/dir"] == "/var/log/ceph:z"
+
+
+def test_nfsganesha_cephfs_client_log_dir_symlink_to_root(cephadm_fs):
+    # a lexically fine path can still alias '/' through a symlink on the host
+    cephadm_fs.create_symlink("/var/log/ceph-link", "/")
+    with with_cephadm_ctx([]) as ctx:
+        ctx.log_dir = "/var/log/ceph"
+        nfsg = _cephadm.NFSGanesha(
+            ctx,
+            SAMPLE_UUID,
+            "fred",
+            nfs_json(
+                pool=True,
+                files=True,
+                enable_cephfs_client_log=True,
+                cephfs_client_log_dir="/var/log/ceph-link",
+            ),
+        )
+        with pytest.raises(_cephadm.Error, match="cephfs_client_log_dir"):
+            nfsg.customize_container_mounts(ctx, {})
+
+
+def test_nfsganesha_cephfs_client_log_dir_not_a_directory(cephadm_fs):
+    log_dir = "/var/log/ceph-file"
+    cephadm_fs.create_file(log_dir, contents="")
+    with with_cephadm_ctx([]) as ctx:
+        ctx.log_dir = "/var/log/ceph"
+        nfsg = _cephadm.NFSGanesha(
+            ctx,
+            SAMPLE_UUID,
+            "fred",
+            nfs_json(
+                pool=True,
+                files=True,
+                enable_cephfs_client_log=True,
+                cephfs_client_log_dir=log_dir,
+            ),
+        )
+        with pytest.raises(_cephadm.Error, match="not a directory"):
+            nfsg.customize_container_mounts(ctx, {})
 
 
 def test_nfsganesha_container_envs():

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -138,6 +138,13 @@ class NFSService(CephService):
             deps.append(f'enable_rdma: {nfs_spec.enable_rdma}')
             if nfs_spec.rdma_port is not None:
                 deps.append(f'rdma_port: {nfs_spec.rdma_port}')
+        # CephFS client logging
+        if nfs_spec.enable_cephfs_client_log:
+            deps.append(f'enable_cephfs_client_log: {nfs_spec.enable_cephfs_client_log}')
+            if nfs_spec.cephfs_client_log_level is not None:
+                deps.append(f'cephfs_client_log_level: {nfs_spec.cephfs_client_log_level}')
+            if nfs_spec.cephfs_client_log_dir is not None:
+                deps.append(f'cephfs_client_log_dir: {nfs_spec.cephfs_client_log_dir}')
         # TLS related
         if nfs_spec.tls_ktls:
             deps.append(f'tls_ktls: {nfs_spec.tls_ktls}')
@@ -160,6 +167,18 @@ class NFSService(CephService):
         if out and service_name in out.split(','):
             return f'{service_name}.{rank}'
         return str(rank)
+
+    @staticmethod
+    def _cephfs_client_log_ceph_conf(spec: NFSServiceSpec) -> Optional[str]:
+        if not spec.enable_cephfs_client_log:
+            return None
+        level = 10 if spec.cephfs_client_log_level is None else spec.cephfs_client_log_level
+        return f'\n[client]\n\tdebug client = {level}\n\tlog file = /var/log/ceph/$name.$pid.log\n'
+
+    def _get_cephfs_client_log_dir(self, spec: NFSServiceSpec) -> str:
+        if spec.cephfs_client_log_dir:
+            return spec.cephfs_client_log_dir
+        return f'/var/log/ceph/{self.mgr._cluster_fsid}'
 
     def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
@@ -329,9 +348,13 @@ class NFSService(CephService):
                 self.get_config_and_keyring(
                     daemon_type, daemon_id,
                     keyring=rados_keyring,
-                    host=host
+                    host=host,
+                    extra_ceph_config=self._cephfs_client_log_ceph_conf(spec),
                 )
             )
+            if spec.enable_cephfs_client_log:
+                config['enable_cephfs_client_log'] = True
+                config['cephfs_client_log_dir'] = self._get_cephfs_client_log_dir(spec)
             config['rgw'] = {
                 'cluster': 'ceph',
                 'user': rgw_user,

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -165,6 +165,13 @@ class NFSService(CephService):
             deps.append(f'enable_rdma: {nfs_spec.enable_rdma}')
             if nfs_spec.rdma_port is not None:
                 deps.append(f'rdma_port: {nfs_spec.rdma_port}')
+        # CephFS client logging
+        if nfs_spec.enable_cephfs_client_log:
+            deps.append(f'enable_cephfs_client_log: {nfs_spec.enable_cephfs_client_log}')
+            if nfs_spec.cephfs_client_log_level is not None:
+                deps.append(f'cephfs_client_log_level: {nfs_spec.cephfs_client_log_level}')
+            if nfs_spec.cephfs_client_log_dir is not None:
+                deps.append(f'cephfs_client_log_dir: {nfs_spec.cephfs_client_log_dir}')
         # TLS related
         if nfs_spec.tls_ktls:
             deps.append(f'tls_ktls: {nfs_spec.tls_ktls}')
@@ -206,6 +213,18 @@ class NFSService(CephService):
         if out and service_name in out.split(','):
             return f'nfs.{daemon_id}'
         return f'{service_name}'
+
+    @staticmethod
+    def _cephfs_client_log_ceph_conf(spec: NFSServiceSpec) -> Optional[str]:
+        if not spec.enable_cephfs_client_log:
+            return None
+        level = 10 if spec.cephfs_client_log_level is None else spec.cephfs_client_log_level
+        return f'\n[client]\n\tdebug client = {level}\n\tlog file = /var/log/ceph/$name.$pid.log\n'
+
+    def _get_cephfs_client_log_dir(self, spec: NFSServiceSpec) -> str:
+        if spec.cephfs_client_log_dir:
+            return spec.cephfs_client_log_dir
+        return f'/var/log/ceph/{self.mgr._cluster_fsid}'
 
     def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
@@ -388,9 +407,13 @@ class NFSService(CephService):
                 self.get_config_and_keyring(
                     daemon_type, daemon_id,
                     keyring=rados_keyring,
-                    host=host
+                    host=host,
+                    extra_ceph_config=self._cephfs_client_log_ceph_conf(spec),
                 )
             )
+            if spec.enable_cephfs_client_log:
+                config['enable_cephfs_client_log'] = True
+                config['cephfs_client_log_dir'] = self._get_cephfs_client_log_dir(spec)
             config['rgw'] = {
                 'cluster': 'ceph',
                 'user': rgw_user,

--- a/src/pybind/mgr/cephadm/tests/services/test_nfs.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nfs.py
@@ -132,6 +132,72 @@ class TestNFS:
                 assert "Bind_addr = 1.2.3.100" in ganesha_conf
 
     @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.services.nfs.NFSService.fence_old_ranks", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.purge", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.create_rados_config_obj", MagicMock())
+    def test_nfs_cephfs_client_log(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test', addr='1.2.3.7'):
+            nfs_spec = NFSServiceSpec(
+                service_id="foo",
+                placement=PlacementSpec(hosts=['test']),
+                enable_cephfs_client_log=True,
+            )
+            with with_service(cephadm_module, nfs_spec) as _:
+                nfs_generated_conf, deps = service_registry.get_service('nfs').generate_config(
+                    CephadmDaemonDeploySpec(
+                        host='test',
+                        daemon_id='foo.test.0.0',
+                        service_name=nfs_spec.service_name(),
+                    )
+                )
+                ceph_conf = nfs_generated_conf['config']
+                assert '[client]' in ceph_conf
+                assert 'debug client = 10' in ceph_conf
+                assert 'log file = /var/log/ceph/$name.$pid.log' in ceph_conf
+                assert nfs_generated_conf['enable_cephfs_client_log'] is True
+                assert nfs_generated_conf['cephfs_client_log_dir'] == (
+                    f'/var/log/ceph/{cephadm_module._cluster_fsid}'
+                )
+
+            nfs_spec = NFSServiceSpec(
+                service_id="bar",
+                placement=PlacementSpec(hosts=['test']),
+                enable_cephfs_client_log=True,
+                cephfs_client_log_level=20,
+                cephfs_client_log_dir='/var/log/ceph/custom',
+            )
+            with with_service(cephadm_module, nfs_spec) as _:
+                nfs_generated_conf, _ = service_registry.get_service('nfs').generate_config(
+                    CephadmDaemonDeploySpec(
+                        host='test',
+                        daemon_id='bar.test.0.0',
+                        service_name=nfs_spec.service_name(),
+                    )
+                )
+                ceph_conf = nfs_generated_conf['config']
+                assert 'debug client = 20' in ceph_conf
+                assert 'log file = /var/log/ceph/$name.$pid.log' in ceph_conf
+                assert nfs_generated_conf['cephfs_client_log_dir'] == '/var/log/ceph/custom'
+
+            nfs_spec = NFSServiceSpec(
+                service_id="baz",
+                placement=PlacementSpec(hosts=['test']),
+            )
+            with with_service(cephadm_module, nfs_spec) as _:
+                nfs_generated_conf, _ = service_registry.get_service('nfs').generate_config(
+                    CephadmDaemonDeploySpec(
+                        host='test',
+                        daemon_id='baz.test.0.0',
+                        service_name=nfs_spec.service_name(),
+                    )
+                )
+                assert '[client]' not in nfs_generated_conf['config']
+                assert 'enable_cephfs_client_log' not in nfs_generated_conf
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
     def test_ingress_without_haproxy_stats(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
         _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
 

--- a/src/pybind/mgr/cephadm/tests/services/test_nfs.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nfs.py
@@ -140,6 +140,72 @@ class TestNFS:
                 assert "Bind_addr = 1.2.3.100" in ganesha_conf
 
     @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.services.nfs.NFSService.fence_old_ranks", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.purge", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.create_rados_config_obj", MagicMock())
+    def test_nfs_cephfs_client_log(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test', addr='1.2.3.7'):
+            nfs_spec = NFSServiceSpec(
+                service_id="foo",
+                placement=PlacementSpec(hosts=['test']),
+                enable_cephfs_client_log=True,
+            )
+            with with_service(cephadm_module, nfs_spec) as _:
+                nfs_generated_conf, deps = service_registry.get_service('nfs').generate_config(
+                    CephadmDaemonDeploySpec(
+                        host='test',
+                        daemon_id='foo.test.0.0',
+                        service_name=nfs_spec.service_name(),
+                    )
+                )
+                ceph_conf = nfs_generated_conf['config']
+                assert '[client]' in ceph_conf
+                assert 'debug client = 10' in ceph_conf
+                assert 'log file = /var/log/ceph/$name.$pid.log' in ceph_conf
+                assert nfs_generated_conf['enable_cephfs_client_log'] is True
+                assert nfs_generated_conf['cephfs_client_log_dir'] == (
+                    f'/var/log/ceph/{cephadm_module._cluster_fsid}'
+                )
+
+            nfs_spec = NFSServiceSpec(
+                service_id="bar",
+                placement=PlacementSpec(hosts=['test']),
+                enable_cephfs_client_log=True,
+                cephfs_client_log_level=20,
+                cephfs_client_log_dir='/var/log/ceph/custom',
+            )
+            with with_service(cephadm_module, nfs_spec) as _:
+                nfs_generated_conf, _ = service_registry.get_service('nfs').generate_config(
+                    CephadmDaemonDeploySpec(
+                        host='test',
+                        daemon_id='bar.test.0.0',
+                        service_name=nfs_spec.service_name(),
+                    )
+                )
+                ceph_conf = nfs_generated_conf['config']
+                assert 'debug client = 20' in ceph_conf
+                assert 'log file = /var/log/ceph/$name.$pid.log' in ceph_conf
+                assert nfs_generated_conf['cephfs_client_log_dir'] == '/var/log/ceph/custom'
+
+            nfs_spec = NFSServiceSpec(
+                service_id="baz",
+                placement=PlacementSpec(hosts=['test']),
+            )
+            with with_service(cephadm_module, nfs_spec) as _:
+                nfs_generated_conf, _ = service_registry.get_service('nfs').generate_config(
+                    CephadmDaemonDeploySpec(
+                        host='test',
+                        daemon_id='baz.test.0.0',
+                        service_name=nfs_spec.service_name(),
+                    )
+                )
+                assert '[client]' not in nfs_generated_conf['config']
+                assert 'enable_cephfs_client_log' not in nfs_generated_conf
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
     def test_ingress_without_haproxy_stats(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
         _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
 

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -42,6 +42,7 @@ from ceph.deployment.hostspec import (
 from ceph.deployment.utils import unwrap_ipv6, valid_addr, verify_non_negative_int
 from ceph.deployment.utils import verify_positive_int, verify_non_negative_number
 from ceph.deployment.utils import verify_boolean, verify_enum, verify_int, verify_non_empty_string
+from ceph.deployment.utils import verify_path
 from ceph.deployment.utils import parse_combined_pem_file, validate_port, validate_unique_ports
 from ceph.cephadm.d3n_types import D3NCacheSpec, D3NCacheError
 from ceph.utils import is_hex
@@ -1425,6 +1426,9 @@ class NFSServiceSpec(ServiceSpec):
                  tls_ciphers: Optional[str] = None,
                  colocation_ports: Optional[List[Dict[str, int]]] = None,
                  enable_nfsv3: bool = False,
+                 enable_cephfs_client_log: bool = False,
+                 cephfs_client_log_level: Optional[int] = None,
+                 cephfs_client_log_dir: Optional[str] = None,
                  ):
         assert service_type == 'nfs'
         super(NFSServiceSpec, self).__init__(
@@ -1454,6 +1458,10 @@ class NFSServiceSpec(ServiceSpec):
         self.cluster_qos_config = cluster_qos_config
         self.cluster_qos_port = cluster_qos_port
         self.enable_nfsv3 = enable_nfsv3
+
+        self.enable_cephfs_client_log = enable_cephfs_client_log
+        self.cephfs_client_log_level = cephfs_client_log_level
+        self.cephfs_client_log_dir = cephfs_client_log_dir
 
         # colocation_ports is a list of port dicts for ADDITIONAL colocated daemons
         # The first daemon always uses port and monitoring_port from the spec
@@ -1584,6 +1592,12 @@ class NFSServiceSpec(ServiceSpec):
                 if key.endswith('iops') and not isinstance(value, int):
                     raise SpecValidationError(
                         f"Invalid NFS spec: IOPS '{key}' should be an integer")
+
+        if self.enable_cephfs_client_log:
+            if self.cephfs_client_log_level is not None:
+                verify_non_negative_int(
+                    self.cephfs_client_log_level, "cephfs_client_log_level")
+            verify_path(self.cephfs_client_log_dir, "cephfs_client_log_dir")
 
         # TLS certificate validation
         if self.ssl and not self.certificate_source:

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -43,6 +43,7 @@ from ceph.deployment.utils import unwrap_ipv6, valid_addr, verify_non_negative_i
 from ceph.deployment.utils import verify_positive_int, verify_non_negative_number
 from ceph.deployment.utils import verify_boolean, verify_enum, verify_int, verify_non_empty_string
 from ceph.deployment.utils import verify_size_with_units, validate_port, validate_unique_ports
+from ceph.deployment.utils import verify_path
 from ceph.cephadm.d3n_types import D3NCacheSpec, D3NCacheError
 from ceph.utils import is_hex
 from ceph.smb import constants as smbconst
@@ -1430,6 +1431,9 @@ class NFSServiceSpec(ServiceSpec):
                  enable_client_object_cache: bool = False,
                  client_object_cache_size: Optional[Union[str, int]] = None,
                  client_object_cache_max_dirty: Optional[Union[str, int]] = None,
+                 enable_cephfs_client_log: bool = False,
+                 cephfs_client_log_level: Optional[int] = None,
+                 cephfs_client_log_dir: Optional[str] = None,
                  ):
         assert service_type == 'nfs'
         super(NFSServiceSpec, self).__init__(
@@ -1466,6 +1470,10 @@ class NFSServiceSpec(ServiceSpec):
         self.enable_client_object_cache = enable_client_object_cache
         self.client_object_cache_size = client_object_cache_size
         self.client_object_cache_max_dirty = client_object_cache_max_dirty
+
+        self.enable_cephfs_client_log = enable_cephfs_client_log
+        self.cephfs_client_log_level = cephfs_client_log_level
+        self.cephfs_client_log_dir = cephfs_client_log_dir
 
         # colocation_ports is a list of port dicts for ADDITIONAL colocated daemons
         # The first daemon always uses port and monitoring_port from the spec
@@ -1613,6 +1621,12 @@ class NFSServiceSpec(ServiceSpec):
                 if key.endswith('iops') and not isinstance(value, int):
                     raise SpecValidationError(
                         f"Invalid NFS spec: IOPS '{key}' should be an integer")
+
+        if self.enable_cephfs_client_log:
+            if self.cephfs_client_log_level is not None:
+                verify_non_negative_int(
+                    self.cephfs_client_log_level, "cephfs_client_log_level")
+            verify_path(self.cephfs_client_log_dir, "cephfs_client_log_dir")
 
         # TLS certificate validation
         if self.ssl and not self.certificate_source:

--- a/src/python-common/ceph/deployment/utils.py
+++ b/src/python-common/ceph/deployment/utils.py
@@ -197,3 +197,18 @@ def verify_non_empty_string(field: Any, field_name: str) -> None:
     # isinstance first so we never call .strip() on None or non-str
     if not isinstance(field, str) or not field.strip():
         raise SpecValidationError(f"Invalid {field_name}: Must be a non-empty string.")
+
+
+def verify_path(field: Any, field_name: str) -> None:
+    """
+    Validate an absolute filesystem path string without touching the host FS.
+    """
+    if field is None:
+        return
+    verify_non_empty_string(field, field_name)
+    if not field.startswith('/'):
+        raise SpecValidationError(
+            f'{field_name} must be an absolute path starting with /, got {field!r}')
+    if field == '/':
+        raise SpecValidationError(
+            f'{field_name} must not be the filesystem root (/), got {field!r}')

--- a/src/python-common/ceph/deployment/utils.py
+++ b/src/python-common/ceph/deployment/utils.py
@@ -1,4 +1,5 @@
 import ipaddress
+import posixpath
 import socket
 from typing import Tuple, Optional, Any, List
 from urllib.parse import urlparse
@@ -197,3 +198,31 @@ def verify_non_empty_string(field: Any, field_name: str) -> None:
     # isinstance first so we never call .strip() on None or non-str
     if not isinstance(field, str) or not field.strip():
         raise SpecValidationError(f"Invalid {field_name}: Must be a non-empty string.")
+
+
+def verify_path(field: Any, field_name: str) -> None:
+    """
+    Validate an absolute filesystem path string without touching the host FS.
+    """
+    if field is None:
+        return
+    verify_non_empty_string(field, field_name)
+    if not field.startswith('/'):
+        raise SpecValidationError(
+            f'{field_name} must be an absolute path starting with /, got {field!r}')
+    if '..' in field.split('/'):
+        raise SpecValidationError(
+            f"{field_name} must not contain '..' path components, got {field!r}")
+    normalized = '/' + posixpath.normpath(field).lstrip('/')
+    if normalized == '/':
+        raise SpecValidationError(
+            f'{field_name} must not be the filesystem root (/), got {field!r}')
+    protected_dirs = frozenset([
+        '/bin', '/boot', '/dev', '/etc', '/home', '/lib', '/lib32', '/lib64',
+        '/libx32', '/log', '/media', '/mnt', '/opt', '/proc', '/root', '/run',
+        '/sbin', '/srv', '/sys', '/tmp', '/usr', '/var',
+    ])
+    if normalized in protected_dirs:
+        raise SpecValidationError(
+            f'{field_name} must not be a protected system directory, '
+            f'got {field!r}. Use a subdirectory of it instead.')

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -651,6 +651,33 @@ def test_nfs_spec_from_json_rdma():
     assert out.get('spec', {}).get('rdma_port') == 1234
 
 
+def test_nfs_spec_cephfs_client_log_dir_path():
+    """cephfs_client_log_dir must be an absolute path and not '/' when set."""
+    spec = NFSServiceSpec(
+        service_id='mynfs',
+        placement=PlacementSpec(count=1),
+        enable_cephfs_client_log=True,
+        cephfs_client_log_dir='/var/log/ceph/custom',
+    )
+    spec.validate()
+
+    with pytest.raises(SpecValidationError, match='absolute path'):
+        NFSServiceSpec(
+            service_id='mynfs',
+            placement=PlacementSpec(count=1),
+            enable_cephfs_client_log=True,
+            cephfs_client_log_dir='relative/log/dir',
+        ).validate()
+
+    with pytest.raises(SpecValidationError, match='filesystem root'):
+        NFSServiceSpec(
+            service_id='mynfs',
+            placement=PlacementSpec(count=1),
+            enable_cephfs_client_log=True,
+            cephfs_client_log_dir='/',
+        ).validate()
+
+
 def test_repr():
     val = """ServiceSpec.from_json(yaml.safe_load('''service_type: crash
 service_name: crash

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -806,6 +806,45 @@ def test_nfs_spec_client_object_cache_validation():
     ).validate()
 
 
+def test_nfs_spec_cephfs_client_log_dir_path():
+    """cephfs_client_log_dir must be an absolute path and not '/' when set."""
+    spec = NFSServiceSpec(
+        service_id='mynfs',
+        placement=PlacementSpec(count=1),
+        enable_cephfs_client_log=True,
+        cephfs_client_log_dir='/var/log/ceph/custom',
+    )
+    spec.validate()
+
+    with pytest.raises(SpecValidationError, match='absolute path'):
+        NFSServiceSpec(
+            service_id='mynfs',
+            placement=PlacementSpec(count=1),
+            enable_cephfs_client_log=True,
+            cephfs_client_log_dir='relative/log/dir',
+        ).validate()
+
+    with pytest.raises(SpecValidationError, match='filesystem root'):
+        NFSServiceSpec(
+            service_id='mynfs',
+            placement=PlacementSpec(count=1),
+            enable_cephfs_client_log=True,
+            cephfs_client_log_dir='/',
+        ).validate()
+
+
+@pytest.mark.parametrize('log_dir', ['//', '/..', '/tmp/..', '/etc', '/var'])
+def test_nfs_spec_cephfs_client_log_dir_rejects_root_aliases(log_dir):
+    """Paths that are, escape to, or name a protected system dir are refused."""
+    with pytest.raises(SpecValidationError):
+        NFSServiceSpec(
+            service_id='mynfs',
+            placement=PlacementSpec(count=1),
+            enable_cephfs_client_log=True,
+            cephfs_client_log_dir=log_dir,
+        ).validate()
+
+
 def test_repr():
     val = """ServiceSpec.from_json(yaml.safe_load('''service_type: crash
 service_name: crash

--- a/src/python-common/ceph/tests/test_utils.py
+++ b/src/python-common/ceph/tests/test_utils.py
@@ -1,6 +1,13 @@
 import pytest
 
-from ceph.deployment.utils import is_ipv6, unwrap_ipv6, wrap_ipv6, valid_addr
+from ceph.deployment.hostspec import SpecValidationError
+from ceph.deployment.utils import (
+    is_ipv6,
+    unwrap_ipv6,
+    wrap_ipv6,
+    valid_addr,
+    verify_path,
+)
 from typing import NamedTuple
 
 
@@ -73,3 +80,18 @@ def test_valid_addr(addr_object: Address):
     valid, description = valid_addr(addr_object.addr)
     assert valid == addr_object.status
     assert description == addr_object.description
+
+
+def test_verify_path():
+    verify_path(None, 'path')
+    verify_path('/var/log/ceph', 'path')
+    verify_path('/var/log/ceph/custom', 'path')
+
+    with pytest.raises(SpecValidationError, match='non-empty string'):
+        verify_path('', 'path')
+    with pytest.raises(SpecValidationError, match='non-empty string'):
+        verify_path('   ', 'path')
+    with pytest.raises(SpecValidationError, match='absolute path'):
+        verify_path('relative/path', 'path')
+    with pytest.raises(SpecValidationError, match='filesystem root'):
+        verify_path('/', 'path')

--- a/src/python-common/ceph/tests/test_utils.py
+++ b/src/python-common/ceph/tests/test_utils.py
@@ -1,6 +1,13 @@
 import pytest
 
-from ceph.deployment.utils import is_ipv6, unwrap_ipv6, wrap_ipv6, valid_addr
+from ceph.deployment.hostspec import SpecValidationError
+from ceph.deployment.utils import (
+    is_ipv6,
+    unwrap_ipv6,
+    wrap_ipv6,
+    valid_addr,
+    verify_path,
+)
 from typing import NamedTuple
 
 
@@ -73,3 +80,34 @@ def test_valid_addr(addr_object: Address):
     valid, description = valid_addr(addr_object.addr)
     assert valid == addr_object.status
     assert description == addr_object.description
+
+
+def test_verify_path():
+    verify_path(None, 'path')
+    verify_path('/var/log/ceph', 'path')
+    verify_path('/var/log/ceph/custom', 'path')
+
+    with pytest.raises(SpecValidationError, match='non-empty string'):
+        verify_path('', 'path')
+    with pytest.raises(SpecValidationError, match='non-empty string'):
+        verify_path('   ', 'path')
+    with pytest.raises(SpecValidationError, match='absolute path'):
+        verify_path('relative/path', 'path')
+    with pytest.raises(SpecValidationError, match='filesystem root'):
+        verify_path('/', 'path')
+
+
+@pytest.mark.parametrize('path', ['/etc', '/var/', '/', '//etc'])
+def test_verify_path_rejects_protected_dirs(path):
+    with pytest.raises(SpecValidationError, match='protected system directory'):
+        verify_path(path, 'path')
+
+
+@pytest.mark.parametrize('path', [
+    '/var/log/ceph/',
+    '//var/log/ceph',
+    '/etc/ceph/logs',
+    '/vary',
+])
+def test_verify_path_accepts_paths_below_protected_dirs(path):
+    verify_path(path, 'path')


### PR DESCRIPTION
When enable_cephfs_client_log is set, cephadm mounts the host log directory into the Ganesha container at /var/log/ceph and adds a [client] section to the daemon ceph.conf with a configurable debug level and a fixed log file path of /var/log/ceph/$name.$pid.log.

New NFSServiceSpec fields:
- enable_cephfs_client_log: enable logging and log dir mount
- cephfs_client_log_level: client debug level (default: 10)
- cephfs_client_log_dir: host mount source (default: /var/log/ceph/<cluster-fsid>)

Fixes: https://tracker.ceph.com/issues/78087
Signed-off-by: Shweta Bhosale <Shweta.Bhosale1@ibm.com>




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
