### PR TITLE
umbrella: mgr/nfs: read full conf object when removing export URL

### DIFF
--- a/src/pybind/mgr/nfs/rados_utils.py
+++ b/src/pybind/mgr/nfs/rados_utils.py
@@ -72,7 +72,8 @@ class NFSRados:
     def remove_obj(self, obj: str, config_obj: str, should_notify: Optional[bool] = True) -> None:
         with self.rados.open_ioctx(self.pool) as ioctx:
             ioctx.set_namespace(self.namespace)
-            export_urls = ioctx.read(config_obj)
+            size, _ = ioctx.stat(config_obj)
+            export_urls = ioctx.read(config_obj, size)
             url = '%url "{}"\n\n'.format(self._make_rados_url(obj))
             export_urls = export_urls.replace(url.encode('utf-8'), b'')
             ioctx.remove_object(obj)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77986

---

backport of https://github.com/ceph/ceph/pull/69541
parent tracker: https://tracker.ceph.com/issues/77463

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh