### PR TITLE
umbrella: python-common: Adding precheck for placement count_per_host in NFSServiceSpec

### DIFF
--- a/src/pybind/mgr/cephadm/tests/services/test_nfs.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nfs.py
@@ -589,6 +589,15 @@ class TestNFS:
                 assert "NFS_RDMA_Port" not in ganesha_conf
 
 
+def test_nfs_placement_count_per_host_rejected():
+    spec = NFSServiceSpec(
+        service_id='mynfs',
+        placement=PlacementSpec(hosts=['h1'], count_per_host=1),
+    )
+    with pytest.raises(SpecValidationError, match="count_per_host.*not supported"):
+        spec.validate()
+
+
 def test_nfs_colocation_ports_validation():
     """Test validation of colocation_ports in NFSServiceSpec"""
     # Valid case: correct number of colocation_ports (count=3, need 2 additional)

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1533,6 +1533,11 @@ class NFSServiceSpec(ServiceSpec):
     def validate(self) -> None:
         super(NFSServiceSpec, self).validate()
 
+        if self.placement is not None and self.placement.count_per_host is not None:
+            raise SpecValidationError(
+                "Placement 'count_per_host' is not supported for nfs service."
+            )
+
         if self.virtual_ip and (self.ip_addrs or self.networks):
             raise SpecValidationError("Invalid NFS spec: Cannot set virtual_ip and "
                                       f"{'ip_addrs' if self.ip_addrs else 'networks'} fields")


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77987

---

backport of https://github.com/ceph/ceph/pull/68890
parent tracker: https://tracker.ceph.com/issues/76579

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh