### PR TITLE
tentacle: doc/rbd: clarify mirror resync snapshot behavior

### DIFF
--- a/doc/rbd/rbd-mirroring.rst
+++ b/doc/rbd/rbd-mirroring.rst
@@ -551,6 +551,10 @@ For example::
    local cluster's ``rbd-mirror`` daemon process is responsible for performing
    the resync asynchronously.
 
+.. note:: For snapshot-based mirroring, resync replicates the image contents
+   only up to the most recent mirror-snapshot. Create a new mirror-snapshot on
+   the primary image to sync the latest updates.
+
 Mirror Status
 =============
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78079

---

backport of https://github.com/ceph/ceph/pull/70042
parent tracker: https://tracker.ceph.com/issues/78050

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh