### PR TITLE
crimson/osd: replace RecoveryCloneLockManager with ObjectContextLoader::Manager

### DIFF
--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -234,12 +234,6 @@ public:
     return lock.is_acquired();
   }
 
-  bool try_get_read_lock() {
-    return lock.try_lock_for_read();
-  }
-  void put_read_lock() {
-    lock.unlock_for_read();
-  }
   bool get_recovery_read() {
     if (lock.try_lock_for_read()) {
       recovery_read_marker = true;

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -60,6 +60,15 @@ public:
 	state = RWState::RWEXCL;
       }
 
+      bool try_lock_for_read() {
+        assert(state == RWState::RWNONE);
+        if (obc->lock.try_lock_for_read()) {
+          state = RWState::RWREAD;
+          return true;
+        }
+        return false;
+      }
+
       void demote_excl_to(RWState::State lock_type) {
 	assert(state == RWState::RWEXCL);
 	switch (lock_type) {
@@ -259,6 +268,23 @@ public:
     Manager ret = get_obc_manager(obc->obs.oi.soid, false);
     ret.set_state_obc(ret.target_state, obc);
     return ret;
+  }
+
+  // Try a non-blocking read lock on an already-cached obc, without
+  // loading it. Returns nullopt if the obc isn't cached or can't be
+  // locked right now.
+  std::optional<Manager> try_lock_cached_obc_for_read(const hobject_t &oid) {
+    auto obc = obc_registry.maybe_get_cached_obc(oid);
+    if (!obc) {
+      return std::nullopt;
+    }
+    Manager manager(*this, oid);
+    manager.options.resolve_clone = false;
+    manager.set_state_obc(manager.target_state, obc);
+    if (!manager.target_state.try_lock_for_read()) {
+      return std::nullopt;
+    }
+    return manager;
   }
 
   Manager get_obc_manager(

--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -60,12 +60,7 @@ void RecoveryBackend::clean_up(ceph::os::Transaction& t,
   replica_push_targets.clear();
 
   for (auto& [soid, recovery_waiter] : recovering) {
-    for (auto& kv : recovery_waiter->pushing) {
-      kv.second.clone_lock_manager.release_locks();
-    }
-    if (recovery_waiter->pull_info) {
-      recovery_waiter->pull_info->clone_lock_manager.release_locks();
-    }
+    recovery_waiter->drop_clone_locks();
     if (recovery_waiter->obc) {
       recovery_waiter->obc->interrupt(
 	  ::crimson::common::actingset_changed(

--- a/src/crimson/osd/recovery_backend.h
+++ b/src/crimson/osd/recovery_backend.h
@@ -10,6 +10,7 @@
 #include "crimson/os/futurized_collection.h"
 #include "crimson/osd/pg_interval_interrupt_condition.h"
 #include "crimson/osd/object_context.h"
+#include "crimson/osd/object_context_loader.h"
 #include "crimson/osd/pg_backend.h"
 #include "crimson/osd/shard_services.h"
 
@@ -23,56 +24,6 @@ namespace crimson::osd {
 class PG;
 
 class PGRecovery;
-
-/// holds read locks on neighbor clones used for clone overlap recovery
-class RecoveryCloneLockManager {
-  std::map<hobject_t, ObjectContextRef> locks;
-
-  void unlock_all() {
-    for (auto& kv : locks) {
-      kv.second->put_read_lock();
-    }
-    locks.clear();
-  }
-public:
-  RecoveryCloneLockManager() = default;
-  RecoveryCloneLockManager(RecoveryCloneLockManager&& o) noexcept
-    : locks(std::move(o.locks)) {}
-  RecoveryCloneLockManager(const RecoveryCloneLockManager&) = delete;
-  RecoveryCloneLockManager& operator=(RecoveryCloneLockManager&& o) noexcept {
-    if (this != &o) {
-      unlock_all();
-      locks = std::move(o.locks);
-    }
-    return *this;
-  }
-  RecoveryCloneLockManager& operator=(const RecoveryCloneLockManager&) = delete;
-
-  bool try_lock_for_read(
-    const hobject_t& hoid,
-    ObjectContextRegistry& registry) {
-    if (locks.count(hoid)) {
-      return false;
-    }
-    auto obc = registry.maybe_get_cached_obc(hoid);
-    if (!obc || !obc->try_get_read_lock()) {
-      return false;
-    }
-    locks.emplace(hoid, std::move(obc));
-    return true;
-  }
-
-  void release_locks() {
-    unlock_all();
-  }
-
-  ~RecoveryCloneLockManager() {
-    // Safe to unlock from the dtor: unlock_for_read() only decrements
-    // and wakes waiters.  Also covers move-assign replacing a non-empty
-    // target without an explicit release_locks() call.
-    unlock_all();
-  }
-};
 
 class RecoveryBackend {
 public:
@@ -171,6 +122,9 @@ public:
 
   seastar::future<> stop() {
     for (auto& [soid, recovery_waiter] : recovering) {
+      // release now: obc_loader is destroyed before this backend, so
+      // the Manager dtors must not run after it
+      recovery_waiter->drop_clone_locks();
       recovery_waiter->stop();
     }
     for (auto& [soid, promise] : unfound) {
@@ -201,7 +155,8 @@ protected:
     crimson::osd::ObjectContextRef head_ctx;
     crimson::osd::ObjectContextRef obc;
     object_stat_sum_t stat;
-    RecoveryCloneLockManager clone_lock_manager;
+    // locks on neighbor clones used as clone-overlap sources
+    std::vector<ObjectContextLoader::Manager> clone_locks;
     bool is_complete() const {
       return recovery_progress.is_complete(recovery_info);
     }
@@ -212,7 +167,8 @@ protected:
     ObjectRecoveryInfo recovery_info;
     crimson::osd::ObjectContextRef obc;
     object_stat_sum_t stat;
-    RecoveryCloneLockManager clone_lock_manager;
+    // locks on neighbor clones used as clone-overlap sources
+    std::vector<ObjectContextLoader::Manager> clone_locks;
   };
 
 public:
@@ -231,6 +187,18 @@ public:
     crimson::osd::ObjectContextRef obc;
     std::optional<pull_info_t> pull_info;
     std::map<pg_shard_t, push_info_t> pushing;
+
+    // Release the clone-overlap locks now. The Manager dtors would
+    // also release them, but only once every intrusive_ptr ref to this
+    // waiter (e.g. a blocked op) drops, which callers here can't rely on.
+    void drop_clone_locks() {
+      for (auto& [shard, push_info] : pushing) {
+        push_info.clone_locks.clear();
+      }
+      if (pull_info) {
+        pull_info->clone_locks.clear();
+      }
+    }
 
     seastar::future<> wait_for_readable() {
       if (!readable) {

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -134,12 +134,7 @@ ReplicatedRecoveryBackend::maybe_push_shards(
     if (recovery.obc) {
       recovery.obc->drop_recovery_read();
     }
-    for (auto& kv : recovery.pushing) {
-      kv.second.clone_lock_manager.release_locks();
-    }
-    if (recovery.pull_info) {
-      recovery.pull_info->clone_lock_manager.release_locks();
-    }
+    recovery.drop_clone_locks();
     recovering.erase(soid);
     return seastar::make_exception_future<>(e);
   });
@@ -391,8 +386,7 @@ ReplicatedRecoveryBackend::prep_push_to_replica(
   auto& recovery_waiter = get_recovering(soid);
   auto& obc = recovery_waiter.obc;
   SnapSet push_info_ss; // only populated if soid is_snap()
-  crimson::osd::subsets_t subsets;
-  RecoveryCloneLockManager clone_lock_manager;
+  clone_overlap_commit_t committed;
   const auto& missing =
     pg.get_shard_missing().find(pg_shard)->second;
 
@@ -407,12 +401,12 @@ ReplicatedRecoveryBackend::prep_push_to_replica(
       DEBUGDPP("missing head {}, pushing raw clone",
 	       pg, head);
       if (obc->obs.oi.size) {
-        subsets.data_subset.insert(0, obc->obs.oi.size);
+        committed.subsets.data_subset.insert(0, obc->obs.oi.size);
       }
       return prep_push(soid,
                        need,
                        pg_shard,
-                       subsets,
+                       committed.subsets,
                        push_info_ss);
     }
     auto ssc = obc->ssc;
@@ -420,35 +414,33 @@ ReplicatedRecoveryBackend::prep_push_to_replica(
     push_info_ss = ssc->snapset;
     DEBUGDPP("snapset is {}", pg, ssc->snapset);
 
-    subsets = commit_clone_overlap_plan(
+    committed = commit_clone_overlap_plan(
       crimson::osd::calc_clone_subsets(
         ssc->snapset, soid,
         missing,
         // get_peer_info() asserts `peer_info` existence.
         pg.get_peering_state().get_peer_info(
-          pg_shard).last_backfill),
-      clone_lock_manager);
+          pg_shard).last_backfill));
   } else if (soid.snap == CEPH_NOSNAP) {
     // pushing head or unversioned object.
     // base this on partially on replica's clones?
     auto ssc = obc->ssc;
     ceph_assert(ssc);
     DEBUGDPP("snapset is {}", pg, ssc->snapset);
-    subsets = commit_clone_overlap_plan(
+    committed = commit_clone_overlap_plan(
       crimson::osd::calc_head_subsets(
         obc->obs.oi.size,
         ssc->snapset, soid,
         missing,
         pg.get_peering_state().get_peer_info(
-          pg_shard).last_backfill),
-      clone_lock_manager);
+          pg_shard).last_backfill));
   }
   return prep_push(soid,
                    need,
                    pg_shard,
-                   subsets,
+                   committed.subsets,
                    push_info_ss,
-                   std::move(clone_lock_manager));
+                   std::move(committed.clone_locks));
 }
 
 RecoveryBackend::interruptible_future<PushOp>
@@ -458,7 +450,7 @@ ReplicatedRecoveryBackend::prep_push(
   pg_shard_t pg_shard,
   const crimson::osd::subsets_t& subsets,
   const SnapSet push_info_ss,
-  RecoveryCloneLockManager&& clone_lock_manager)
+  std::vector<ObjectContextLoader::Manager>&& clone_locks)
 {
   LOG_PREFIX(ReplicatedRecoveryBackend::prep_push);
   DEBUGDPP("{}, {}", pg, soid, need);
@@ -472,7 +464,7 @@ ReplicatedRecoveryBackend::prep_push(
   assert(missing_iter != pmissing_iter->second.get_items().end());
 
   push_info.obc = obc;
-  push_info.clone_lock_manager = std::move(clone_lock_manager);
+  push_info.clone_locks = std::move(clone_locks);
   push_info.recovery_info.size = obc->obs.oi.size;
   push_info.recovery_info.copy_subset = subsets.data_subset;
   push_info.recovery_info.clone_subset = subsets.clone_subsets;
@@ -516,8 +508,10 @@ void ReplicatedRecoveryBackend::prepare_pull(
   assert(iter != locs.end());
   pg_shard_t fromshard = *(iter);
 
-  pull_op.recovery_info =
-    set_recovery_info(soid, head_obc->ssc, pull_info.clone_lock_manager);
+  auto [recovery_info, clone_locks] =
+    set_recovery_info(soid, head_obc->ssc);
+  pull_op.recovery_info = std::move(recovery_info);
+  pull_info.clone_locks = std::move(clone_locks);
   pull_op.soid = soid;
   pull_op.recovery_progress.data_complete = false;
   pull_op.recovery_progress.omap_complete =
@@ -532,24 +526,25 @@ void ReplicatedRecoveryBackend::prepare_pull(
   pull_info.recovery_progress = pull_op.recovery_progress;
 }
 
-ObjectRecoveryInfo ReplicatedRecoveryBackend::set_recovery_info(
+ReplicatedRecoveryBackend::pull_recovery_info_t
+ReplicatedRecoveryBackend::set_recovery_info(
   const hobject_t& soid,
-  const crimson::osd::SnapSetContextRef ssc,
-  RecoveryCloneLockManager& clone_lock_manager)
+  const crimson::osd::SnapSetContextRef ssc)
 {
   LOG_PREFIX(ReplicatedRecoveryBackend::set_recovery_info);
   pg_missing_tracker_t local_missing = pg.get_local_missing();
   const auto missing_iter = local_missing.get_items().find(soid);
   ObjectRecoveryInfo recovery_info;
+  std::vector<ObjectContextLoader::Manager> clone_locks;
   if (soid.is_snap()) {
     assert(!local_missing.is_missing(soid.get_head()));
     assert(ssc);
     recovery_info.ss = ssc->snapset;
-    auto subsets = commit_clone_overlap_plan(
+    auto committed = commit_clone_overlap_plan(
       crimson::osd::calc_clone_subsets(
-        ssc->snapset, soid, local_missing, pg.get_info().last_backfill),
-      clone_lock_manager);
-    crimson::osd::set_subsets(subsets, recovery_info);
+        ssc->snapset, soid, local_missing, pg.get_info().last_backfill));
+    crimson::osd::set_subsets(committed.subsets, recovery_info);
+    clone_locks = std::move(committed.clone_locks);
     DEBUGDPP("pulling {}", pg, recovery_info);
     ceph_assert(ssc->snapset.clone_size.count(soid.snap));
     recovery_info.size = ssc->snapset.clone_size[soid.snap];
@@ -564,7 +559,7 @@ ObjectRecoveryInfo ReplicatedRecoveryBackend::set_recovery_info(
   recovery_info.object_exist =
     missing_iter->second.clean_regions.object_is_exist();
   recovery_info.soid = soid;
-  return recovery_info;
+  return {std::move(recovery_info), std::move(clone_locks)};
 }
 
 RecoveryBackend::interruptible_future<PushOp>
@@ -908,9 +903,7 @@ ReplicatedRecoveryBackend::_handle_pull_response(
 
     if (pull_info.recovery_info.soid.snap &&
 	pull_info.recovery_info.soid.snap < CEPH_NOSNAP) {
-      recalc_subsets(pull_info.recovery_info,
-		     ssc,
-		     pull_info.clone_lock_manager);
+      recalc_subsets(pull_info, ssc);
     }
 
     pull_info.obc = recovery_waiter.obc =
@@ -949,7 +942,9 @@ ReplicatedRecoveryBackend::_handle_pull_response(
 
   if (complete) {
     pull_info.stat.num_objects_recovered++;
-    pull_info.clone_lock_manager.release_locks();
+    // release now: the recovering entry outlives pull completion
+    // while other shards are still being pushed to
+    pull_info.clone_locks.clear();
     auto manager = pg.obc_loader.get_obc_manager(
       recovery_waiter.obc);
     manager.lock_excl_sync(); /* cannot already be locked */
@@ -977,26 +972,26 @@ ReplicatedRecoveryBackend::_handle_pull_response(
 }
 
 void ReplicatedRecoveryBackend::recalc_subsets(
-    ObjectRecoveryInfo& recovery_info,
-    crimson::osd::SnapSetContextRef ssc,
-    RecoveryCloneLockManager& clone_lock_manager)
+    pull_info_t& pull_info,
+    crimson::osd::SnapSetContextRef ssc)
 {
   assert(ssc);
-  clone_lock_manager.release_locks();
-  auto subsets = commit_clone_overlap_plan(
+  // commit before assigning: the new locks are taken while the old
+  // ones are still held, so no writer can slip in between
+  auto committed = commit_clone_overlap_plan(
     crimson::osd::calc_clone_subsets(
-      ssc->snapset, recovery_info.soid, pg.get_local_missing(),
-      pg.get_info().last_backfill),
-    clone_lock_manager);
-  crimson::osd::set_subsets(subsets, recovery_info);
+      ssc->snapset, pull_info.recovery_info.soid, pg.get_local_missing(),
+      pg.get_info().last_backfill));
+  crimson::osd::set_subsets(committed.subsets, pull_info.recovery_info);
+  pull_info.clone_locks = std::move(committed.clone_locks);
 }
 
-subsets_t ReplicatedRecoveryBackend::commit_clone_overlap_plan(
-  clone_overlap_plan_t plan,
-  RecoveryCloneLockManager& clone_lock_manager)
+ReplicatedRecoveryBackend::clone_overlap_commit_t
+ReplicatedRecoveryBackend::commit_clone_overlap_plan(clone_overlap_plan_t plan)
 {
   LOG_PREFIX(ReplicatedRecoveryBackend::commit_clone_overlap_plan);
   subsets_t subsets;
+  std::vector<ObjectContextLoader::Manager> clone_locks;
   subsets.data_subset = std::move(plan.data_subset);
   interval_set<uint64_t> cloning;
 
@@ -1008,13 +1003,16 @@ subsets_t ReplicatedRecoveryBackend::commit_clone_overlap_plan(
         DEBUGDPP("skip candidate {}, now missing", pg, c.clone);
         continue;
       }
-      if (!clone_lock_manager.try_lock_for_read(c.clone, pg.obc_registry)) {
+      auto lock = pg.obc_loader.try_lock_cached_obc_for_read(c.clone);
+      if (!lock) {
         DEBUGDPP("skip candidate {}, cannot lock for read", pg, c.clone);
         continue;
       }
       DEBUGDPP("locked candidate {} overlap {}", pg, c.clone, c.overlap);
-      subsets.clone_subsets[c.clone] = c.overlap;
+      auto [it, inserted] = subsets.clone_subsets.emplace(c.clone, c.overlap);
+      ceph_assert(inserted);
       cloning.union_of(c.overlap);
+      clone_locks.push_back(std::move(*lock));
       return;
     }
   };
@@ -1027,7 +1025,7 @@ subsets_t ReplicatedRecoveryBackend::commit_clone_overlap_plan(
       crimson::common::local_conf().get_val<uint64_t>(
         "osd_recover_clone_overlap_limit")) {
     DEBUGDPP("skipping clone, too many holes", pg);
-    clone_lock_manager.release_locks();
+    clone_locks.clear();
     subsets.clone_subsets.clear();
     cloning.clear();
   }
@@ -1036,7 +1034,7 @@ subsets_t ReplicatedRecoveryBackend::commit_clone_overlap_plan(
   subsets.data_subset.subtract(cloning);
   DEBUGDPP("data_subset {} clone_subsets {}",
            pg, subsets.data_subset, subsets.clone_subsets);
-  return subsets;
+  return {std::move(subsets), std::move(clone_locks)};
 }
 
 RecoveryBackend::interruptible_future<>
@@ -1193,7 +1191,9 @@ ReplicatedRecoveryBackend::_handle_push_reply(
       }).handle_exception_interruptible(
         [recovering_iter, &push_info, peer] (auto e) {
         push_info.recovery_progress.error = true;
-        push_info.clone_lock_manager.release_locks();
+        // release this shard's locks now; the entry stays until the
+        // remaining shards finish
+        push_info.clone_locks.clear();
         recovering_iter->second->set_push_failed(peer, e);
         return seastar::make_ready_future<std::optional<PushOp>>();
       });
@@ -1203,7 +1203,7 @@ ReplicatedRecoveryBackend::_handle_push_reply(
                                                  soid,
                                                  push_info.recovery_info);
     }
-    push_info.clone_lock_manager.release_locks();
+    push_info.clone_locks.clear();
     recovering_iter->second->set_pushed(peer);
     return seastar::make_ready_future<std::optional<PushOp>>();
   }

--- a/src/crimson/osd/replicated_recovery_backend.h
+++ b/src/crimson/osd/replicated_recovery_backend.h
@@ -50,22 +50,27 @@ protected:
     pg_shard_t pg_shard,
     const crimson::osd::subsets_t& subsets,
     const SnapSet push_info_ss,
-    RecoveryCloneLockManager&& clone_lock_manager = {});
+    std::vector<ObjectContextLoader::Manager>&& clone_locks = {});
   void prepare_pull(
     const crimson::osd::ObjectContextRef &head_obc,
     PullOp& pull_op,
     pull_info_t& pull_info,
     const hobject_t& soid,
     eversion_t need);
-  ObjectRecoveryInfo set_recovery_info(
+  struct pull_recovery_info_t {
+    ObjectRecoveryInfo recovery_info;
+    std::vector<ObjectContextLoader::Manager> clone_locks;
+  };
+  pull_recovery_info_t set_recovery_info(
     const hobject_t& soid,
-    const crimson::osd::SnapSetContextRef ssc,
-    RecoveryCloneLockManager& clone_lock_manager);
+    const crimson::osd::SnapSetContextRef ssc);
+  struct clone_overlap_commit_t {
+    subsets_t subsets;
+    std::vector<ObjectContextLoader::Manager> clone_locks;
+  };
   /// Lock the first usable candidate from each preference list and
   /// build final recovery subsets.  Lock policy stays in the backend.
-  subsets_t commit_clone_overlap_plan(
-    clone_overlap_plan_t plan,
-    RecoveryCloneLockManager& clone_lock_manager);
+  clone_overlap_commit_t commit_clone_overlap_plan(clone_overlap_plan_t plan);
   std::vector<pg_shard_t> get_shards_to_push(
     const hobject_t& soid) const;
   interruptible_future<PushOp> build_push_op(
@@ -79,9 +84,8 @@ protected:
     PushOp& push_op,
     PullOp* response);
   void recalc_subsets(
-    ObjectRecoveryInfo& recovery_info,
-    crimson::osd::SnapSetContextRef ssc,
-    RecoveryCloneLockManager& clone_lock_manager);
+    pull_info_t& pull_info,
+    crimson::osd::SnapSetContextRef ssc);
   std::pair<interval_set<uint64_t>, ceph::bufferlist> trim_pushed_data(
     const interval_set<uint64_t> &copy_subset,
     const interval_set<uint64_t> &intervals_received,


### PR DESCRIPTION
`RecoveryCloneLockManager` reimplemented what `ObjectContextLoader::Manager` already provides: RAII release, move, `obc_set_accessing` bookkeeping. It only needed a non-blocking read acquire, so recovery never blocks on a clone snap trim is writing. Add `state_t::try_lock_for_read()` and a loader factory, `try_lock_cached_obc_for_read()`, returning a `Manager` holding the lock, or `nullopt`.

`commit_clone_overlap_plan()` and `set_recovery_info()` now return their Managers instead of accumulating them through reference parameters, so acquiring the locks initializes the object that owns them and no caller has to remember to clear a vector before reusing it. `recalc_subsets()` takes the new locks before the assignment releases the old ones, so no writer can slip in between.

Releasing from a destructor is safe here but not in classic: classic's `ObcLockManager` must release explicitly because unlocking requeues blocked ops, which needs PG context a destructor lacks. A crimson read unlock only decrements the reader count and wakes waiters.

The explicit releases that remain are documented in place: completion boundaries release promptly because the recovering entry outlives them; error and interval-change paths release because `erase()`/`clear()` only drops the map's reference while waiters may keep the infos alive; stop() releases because the PG destroys `obc_loader` before `recovery_backend`.

Remove `RecoveryCloneLockManager` and the `ObjectContext` `try_get_read_lock`/`put_read_lock` helpers it needed.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
