### PR TITLE
mgr/cephadm: support host-provided NVMe-oF encryption key

### DIFF
--- a/src/cephadm/cephadmlib/daemons/nvmeof.py
+++ b/src/cephadm/cephadmlib/daemons/nvmeof.py
@@ -16,6 +16,10 @@ from ..deployment_utils import to_deployment_container
 from ..exceptions import Error
 from ..file_utils import makedirs, populate_files
 from ..call_wrappers import call
+from ceph.cephadm.constants import (
+    NVMEOF_ENCRYPTION_KEY_CONTAINER_PATH,
+    NVMEOF_ENCRYPTION_KEY_PATH_FILE,
+)
 
 
 logger = logging.getLogger()
@@ -135,6 +139,7 @@ class CephNvmeof(ContainerDaemonForm):
         mounts.update(self._get_huge_pages_mounts(self.files))
         mounts.update(self._get_dsa_mounts(self.files))
         mounts.update(self._get_tls_cert_key_mounts(data_dir, self.files))
+        mounts.update(self._get_external_encryption_key_mounts(self.files))
 
     def customize_container_binds(
         self, ctx: CephadmContext, binds: List[List[str]]
@@ -294,3 +299,17 @@ class CephNvmeof(ContainerDaemonForm):
                     pass
                 except ValueError:
                     pass
+
+    def _get_external_encryption_key_mounts(
+        self, files: Dict[str, str]
+    ) -> Dict[str, str]:
+        host_path = files.get(NVMEOF_ENCRYPTION_KEY_PATH_FILE)
+        if not host_path:
+            return {}
+
+        if not os.path.isfile(host_path):
+            raise Error(
+                f'NVMe-oF encryption key file does not exist on host: {host_path}'
+            )
+
+        return {host_path: f'{NVMEOF_ENCRYPTION_KEY_CONTAINER_PATH}:ro'}

--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -13,6 +13,10 @@ from orchestrator import (
     DaemonDescriptionStatus,
     HostSpec,
 )
+from ceph.cephadm.constants import (
+    NVMEOF_ENCRYPTION_KEY_CONTAINER_PATH,
+    NVMEOF_ENCRYPTION_KEY_PATH_FILE,
+)
 from .cephadmservice import CephadmDaemonDeploySpec, CephService
 from .service_registry import register_cephadm_service
 from .. import utils
@@ -145,6 +149,7 @@ class NvmeofService(CephService):
         self.mgr.log.info(f"gateway address: {addr} from {map_addr=} {spec.addr=} {host_ip=}")
         discovery_addr = map_discovery_addr or spec.discovery_addr or host_ip
         self.mgr.log.info(f"discovery address: {discovery_addr} from {map_discovery_addr=} {spec.discovery_addr=} {host_ip=}")
+        encryption_key_path = self._get_encryption_key_path(spec)
         context = {
             'spec': spec,
             'name': name,
@@ -156,7 +161,8 @@ class NvmeofService(CephService):
             'rpc_socket_name': 'spdk.sock',
             'transport_tcp_options': transport_tcp_options,
             'iobuf_options': iobuf_options,
-            'rados_id': rados_id
+            'rados_id': rados_id,
+            'encryption_key_path': encryption_key_path,
         }
         gw_conf = self.mgr.template.render('services/nvmeof/ceph-nvmeof.conf.j2', context)
 
@@ -179,6 +185,9 @@ class NvmeofService(CephService):
 
         if spec.encryption_key:
             daemon_spec.extra_files['encryption_key'] = spec.encryption_key
+
+        if spec.enable_encryption and spec.encryption_key_path:
+            daemon_spec.extra_files[NVMEOF_ENCRYPTION_KEY_PATH_FILE] = spec.encryption_key_path
 
         daemon_spec.final_config, _ = self.generate_config(daemon_spec)
         daemon_spec.deps = self.get_dependencies(self.mgr, spec, daemon_spec.daemon_type)
@@ -468,3 +477,9 @@ class NvmeofService(CephService):
                 server_key=server_key,
                 ca_cert=ca_cert
             )
+
+    def _get_encryption_key_path(self, spec: NvmeofServiceSpec) -> Optional[str]:
+        if spec.encryption_key_path or spec.encryption_key:
+            return NVMEOF_ENCRYPTION_KEY_CONTAINER_PATH
+
+        return None

--- a/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
@@ -9,7 +9,9 @@ state_update_notify = {{ spec.state_update_notify }}
 state_update_interval_sec = {{ spec.state_update_interval_sec }}
 break_update_interval_sec = {{ spec.break_update_interval_sec }}
 enable_spdk_discovery_controller = {{ spec.enable_spdk_discovery_controller }}
-encryption_key = /encryption.key
+{% if encryption_key_path %}
+encryption_key = {{ encryption_key_path }}
+{% endif %}
 rebalance_period_sec = {{ spec.rebalance_period_sec }}
 max_gws_in_grp = {{ spec.max_gws_in_grp }}
 max_ns_to_change_lb_grp = {{ spec.max_ns_to_change_lb_grp }}

--- a/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
@@ -19,6 +19,9 @@ ceph_generated_cert = """-----BEGIN CERTIFICATE-----\nMIICxjCCAa4CEQDIZSujNBlKaL
 
 ceph_generated_key = """-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDLIx7gMwD4x5gr\nsEdkwcGrvOOWIQ5w2DGiaNTypt/lRIXsyqt/r7/ztdaqPikLIBbzHRZcSvoDnpr5\nyYFWa36q1YPOXTbRqgh3qUvkSAsufr+QwMIIkur74uD1wSh8xK9xmH6VjZ/7Wn4L\n7TTF6e2ste9cY6KUBlZpB+iNPYGlGc1ZYgVukXCVwquWDYbRwWNXlzWbprTCmxD0\nkc6J6rRK/AKLFqPCrcLABi66JTXCMjigk7gijX6DzIHecfYyj/blICkLExe5eHiQ\nctCv9PjiGqKy8bi4liAoxxIitaPmjbmZyUHIaLVQj+RmQJQRL3iLtn/eKHHgFp3Q\nAyz/23AXAgMBAAECggEAVoTB3Mm8azlPlaQB9GcV3tiXslSn+uYJ1duCf0sV52dV\nBzKW8s5fGiTjpiTNhGCJhchowqxoaew+o47wmGc2TvqbpeRLuecKrjScD0GkCYyQ\neM2wlshEbz4FhIZdgS6gbuh9WaM1dW/oaZoBNR5aTYo7xYTmNNeyLA/jO2zr7+4W\n5yES1lMSBXpKk7bDGKYY4bsX2b5RLr2Grh2u2bp7hoLABCEvuu8tSQdWXLEXWpXo\njwmV3hc6tabypIa0mj2Dmn2Dmt1ppSO0AZWG/WAizN3f4Z0r/u9HnbVrVmh0IEDw\n3uf2LP5o3msG9qKCbzv3lMgt9mMr70HOKnJ8ohMSKQKBgQDLkNb+0nr152HU9AeJ\nvdz8BeMxcwxCG77iwZphZ1HprmYKvvXgedqWtS6FRU+nV6UuQoPUbQxJBQzrN1Qv\nwKSlOAPCrTJgNgF/RbfxZTrIgCPuK2KM8I89VZv92TSGi362oQA4MazXC8RAWjoJ\nSu1/PHzK3aXOfVNSLrOWvIYeZQKBgQD/dgT6RUXKg0UhmXj7ExevV+c7oOJTDlMl\nvLngrmbjRgPO9VxLnZQGdyaBJeRngU/UXfNgajT/MU8B5fSKInnTMawv/tW7634B\nw3v6n5kNIMIjJmENRsXBVMllDTkT9S7ApV+VoGnXRccbTiDapBThSGd0wri/CuwK\nNWK1YFOeywKBgEDyI/XG114PBUJ43NLQVWm+wx5qszWAPqV/2S5MVXD1qC6zgCSv\nG9NLWN1CIMimCNg6dm7Wn73IM7fzvhNCJgVkWqbItTLG6DFf3/DPODLx1wTMqLOI\nqFqMLqmNm9l1Nec0dKp5BsjRQzq4zp1aX21hsfrTPmwjxeqJZdioqy2VAoGAXR5X\nCCdSHlSlUW8RE2xNOOQw7KJjfWT+WAYoN0c7R+MQplL31rRU7dpm1bLLRBN11vJ8\nMYvlT5RYuVdqQSP6BkrX+hLJNBvOLbRlL+EXOBrVyVxHCkDe+u7+DnC4epbn+N8P\nLYpwqkDMKB7diPVAizIKTBxinXjMu5fkKDs5n+sCgYBbZheYKk5M0sIxiDfZuXGB\nkf4mJdEkTI1KUGRdCwO/O7hXbroGoUVJTwqBLi1tKqLLarwCITje2T200BYOzj82\nqwRkCXGtXPKnxYEEUOiFx9OeDrzsZV00cxsEnX0Zdj+PucQ/J3Cvd0dWUspJfLHJ\n39gnaegswnz9KMQAvzKFdg==\n-----END PRIVATE KEY-----\n"""
 
+EXTERNAL_ENCRYPTION_KEY_HOST_PATH = '/tmp/nvmeof-test-key/encryption.key'
+EXTERNAL_ENCRYPTION_KEY_CONTAINER_PATH = '/encryption.key'
+
 
 class FakeInventory:
     def get_addr(self, name: str) -> str:
@@ -106,7 +109,6 @@ state_update_notify = True
 state_update_interval_sec = 5
 break_update_interval_sec = 25
 enable_spdk_discovery_controller = False
-encryption_key = /encryption.key
 rebalance_period_sec = 7
 max_gws_in_grp = 16
 max_ns_to_change_lb_grp = 8
@@ -357,7 +359,6 @@ state_update_notify = True
 state_update_interval_sec = 5
 break_update_interval_sec = 25
 enable_spdk_discovery_controller = False
-encryption_key = /encryption.key
 rebalance_period_sec = 7
 max_gws_in_grp = 16
 max_ns_to_change_lb_grp = 8
@@ -550,7 +551,6 @@ state_update_notify = True
 state_update_interval_sec = 5
 break_update_interval_sec = 25
 enable_spdk_discovery_controller = False
-encryption_key = /encryption.key
 rebalance_period_sec = 7
 max_gws_in_grp = 16
 max_ns_to_change_lb_grp = 8
@@ -697,6 +697,94 @@ timeout = 1.0
                     error_ok=True,
                     use_current_daemon_image=False,
                 )
+
+    def test_nvmeof_encryption_key_path_legacy_inline(
+        self,
+        cephadm_module: CephadmOrchestrator,
+    ):
+        service = NvmeofService(cephadm_module)
+
+        spec = NvmeofServiceSpec(
+            service_id='testpool.group1',
+            pool='testpool',
+            group='group1',
+            encryption_key='inline-key',
+        )
+
+        assert service._get_encryption_key_path(spec) == '/encryption.key'
+
+    def test_nvmeof_encryption_key_path_external_file(
+        self,
+        cephadm_module: CephadmOrchestrator,
+    ):
+        service = NvmeofService(cephadm_module)
+
+        spec = NvmeofServiceSpec(
+            service_id='testpool.group1',
+            pool='testpool',
+            group='group1',
+            enable_encryption=True,
+            encryption_key_path=EXTERNAL_ENCRYPTION_KEY_HOST_PATH,
+        )
+
+        assert service._get_encryption_key_path(spec) == EXTERNAL_ENCRYPTION_KEY_CONTAINER_PATH
+
+    def test_nvmeof_encryption_key_path_not_set(
+        self,
+        cephadm_module: CephadmOrchestrator,
+    ):
+        service = NvmeofService(cephadm_module)
+
+        spec = NvmeofServiceSpec(
+            service_id='testpool.group1',
+            pool='testpool',
+            group='group1',
+        )
+
+        assert service._get_encryption_key_path(spec) is None
+
+    @pytest.mark.parametrize(
+        'spec_kwargs, expected_error',
+        [
+            (
+                {
+                    'enable_encryption': True,
+                    'encryption_key': 'inline-key',
+                    'encryption_key_path': '/tmp/encryption.key',
+                },
+                'encryption_key and encryption_key_path cannot both be set',
+            ),
+            (
+                {
+                    'enable_encryption': True,
+                },
+                'enable_encryption=true requires either encryption_key_path or encryption_key',
+            ),
+            (
+                {
+                    'enable_encryption': True,
+                    'encryption_key_path': 'relative/path/encryption.key',
+                },
+                'encryption_key_path must be an absolute path',
+            ),
+        ],
+    )
+    def test_nvmeof_encryption_validation(
+        self,
+        spec_kwargs,
+        expected_error,
+    ):
+        spec = NvmeofServiceSpec(
+            service_id='nvmeof_pool01.group1',
+            pool='nvmeof_pool01',
+            group='group1',
+            **spec_kwargs,
+        )
+
+        with pytest.raises(Exception) as e:
+            spec.validate()
+
+        assert expected_error in str(e.value)
 
 
 class TestNvmeofTLSBundle:

--- a/src/python-common/ceph/cephadm/constants.py
+++ b/src/python-common/ceph/cephadm/constants.py
@@ -1,0 +1,2 @@
+NVMEOF_ENCRYPTION_KEY_CONTAINER_PATH = '/encryption.key'
+NVMEOF_ENCRYPTION_KEY_PATH_FILE = 'encryption_key_path'

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1989,7 +1989,11 @@ class NvmeofServiceSpec(ServiceSpec):
         #: ``enable_auth`` enables user authentication on nvmeof gateway
         self.enable_auth = enable_auth
 
+        #: ``enable_encryption`` enables encryption for the NVMe-oF gateway
         self.enable_encryption = enable_encryption
+
+        #: ``encryption_key_path`` is the absolute host-side path to an externally
+        #: managed encryption key file used when ``enable_encryption`` is enabled
         self.encryption_key_path = encryption_key_path
         self.ssl = ssl or enable_auth  # to force enabling ssl field when auth is enabled
         #: ``state_update_notify`` enables automatic update from OMAP in nvmeof gateway

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1855,6 +1855,8 @@ class NvmeofServiceSpec(ServiceSpec):
                  port: Optional[int] = None,
                  pool: Optional[str] = None,
                  enable_auth: bool = False,
+                 enable_encryption: bool = False,
+                 encryption_key_path: Optional[str] = None,
                  ssl: Optional[bool] = False,
                  certificate_source: Optional[str] = None,
                  custom_sans: Optional[List[str]] = None,
@@ -1986,6 +1988,9 @@ class NvmeofServiceSpec(ServiceSpec):
         self.group = group or ''
         #: ``enable_auth`` enables user authentication on nvmeof gateway
         self.enable_auth = enable_auth
+
+        self.enable_encryption = enable_encryption
+        self.encryption_key_path = encryption_key_path
         self.ssl = ssl or enable_auth  # to force enabling ssl field when auth is enabled
         #: ``state_update_notify`` enables automatic update from OMAP in nvmeof gateway
         self.state_update_notify = state_update_notify
@@ -2239,6 +2244,27 @@ class NvmeofServiceSpec(ServiceSpec):
             raise SpecValidationError('Cannot add NVMEOF: No Pool specified')
 
         verify_boolean(self.enable_auth, "Enable authentication")
+        verify_boolean(self.enable_encryption, "Enable encryption")
+
+        if self.encryption_key and self.encryption_key_path:
+            raise SpecValidationError(
+                'encryption_key and encryption_key_path cannot both be set'
+            )
+
+        if self.enable_encryption:
+            if not self.encryption_key_path and not self.encryption_key:
+                raise SpecValidationError(
+                    'enable_encryption=true requires either encryption_key_path or encryption_key'
+                )
+            if self.encryption_key_path and not self.encryption_key_path.startswith('/'):
+                raise SpecValidationError(
+                    'encryption_key_path must be an absolute path'
+                )
+        elif self.encryption_key_path:
+            raise SpecValidationError(
+                'encryption_key_path requires enable_encryption=true'
+            )
+
         if self.enable_auth or self.ssl:
             if self.certificate_source == CertificateSource.INLINE.value:
                 if not all([self.server_key, self.server_cert, self.client_key,


### PR DESCRIPTION

Fixes: https://tracker.ceph.com/issues/80694

mgr/cephadm: support host-provided NVMe-oF encryption key

NVMe-oF gateway encryption currently supports legacy inline key material through the service spec. This exposes private key content through service export and does not fit environments where an external system, such as Vault Agent, places the key directly on the host.

Add support for enable_encryption with encryption_key_path as a host-side key file path. When set, cephadm stores only the path marker, bind-mounts the host file read-only into the NVMe-oF container at a stable container path, and renders that container path into ceph-nvmeof.conf.

cephadm does not read, generate, store, or export the private key material. The existing inline encryption_key behavior is preserved for compatibility, and validation rejects specs that set both encryption_key and encryption_key_path.

**Usage note:**

NVMe-oF encryption is enabled only when `enable_encryption: true `is set in the service spec. Once encryption is enabled, the user must provide exactly one key source:

`encryption_key_path`: host-side path to a key file generated or managed externally, for example by Vault Agent. cephadm bind-mounts this file read-only into the container and renders /encryption.key in ceph-nvmeof.conf.
`encryption_key:` legacy inline key material in the service spec. This behavior is preserved for compatibility.

Specs that set both `encryption_key_path` and `encryption_key` are rejected to avoid ambiguity.

Testing logs:

Spec used:
```
[ceph: root@ceph-node-0 ~]# cat nvmeof.yaml 
service_type: nvmeof
service_id: nvmeof_pool01.group1

placement:
  hosts:
    - ceph-node-0
spec:
  pool: nvmeof_pool01
  group: group1
  enable_encryption: true
  encryption_key_path: /tmp/nvmeof-test-key/encryption.key
```
```

[root@ceph-node-0 ~]# sudo mkdir -p /tmp/nvmeof-test-key

sudo openssl genrsa -out /tmp/nvmeof-test-key/encryption.key 2048

sudo chmod 600 /tmp/nvmeof-test-key/encryption.key

sudo ls -l /tmp/nvmeof-test-key/encryption.key

head -1 /tmp/nvmeof-test-key/encryption.key
-rw-------. 1 root root 1704 Jul  9 16:41 /tmp/nvmeof-test-key/encryption.key
-----BEGIN PRIVATE KEY-----

```


```
[ceph: root@ceph-node-0 ~]# ceph orch ps --daemon_type nvmeof
NAME                                            HOST         PORTS                   STATUS         REFRESHED  AGE  MEM USE  MEM LIM  VERSION  IMAGE ID      CONTAINER ID  
nvmeof.nvmeof_pool01.group1.ceph-node-0.oehouk  ceph-node-0  *:5500,4420,8009,10008  running (75s)    50s ago  74s    72.8M        -  1.9.1    d18300ae65e1  ff60c3af80fd  

[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                         PORTS                   RUNNING  REFRESHED  AGE  PLACEMENT    
crash                                                    3/3  66s ago    15m  *            
mgr                                                      2/2  54s ago    15m  count:2      
mon                                                      3/5  66s ago    15m  count:5      
nvmeof.nvmeof_pool01.group1  ?:4420,5500,8009,10008      1/1  54s ago    3m   ceph-node-0  
osd.all-available-devices                                  3  66s ago    14m  *           

```

```
[root@ceph-node-0 nvmeof.nvmeof_pool01.group1.ceph-node-0.oehouk]# podman exec -it ff60c3af80fd bash

[root@ceph-node-0 src]# ls -l
total 144
-rw-r--r--. 1 root root  7377 Jun 25 13:13 LICENSE
-rw-r--r--. 1 root root 23710 Jun 25 13:13 README.md
drwxr-xr-x. 1 root root     8 Jun 25 13:20 __pypackages__
-rw-------. 1  167  167  2888 Jul  9 16:43 ceph-nvmeof.conf
drwxr-xr-x. 1 root root    32 Jul  9 16:44 control
-rw-------. 1 root root  1704 Jul  9 16:41 encryption.key
-rw-r--r--. 1 root root 97294 Jun 25 13:13 pdm.lock
-rw-r--r--. 1 root root    26 Jun 25 13:13 pdm.toml
-rw-r--r--. 1 root root  1779 Jun 25 13:13 pyproject.toml


[root@ceph-node-0 src]# cat encryption.key
-----BEGIN PRIVATE KEY-----
MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDwdRP60+2vMI+F
3qnemSWQFWnCRuhUUCBV5LXw3SlesZY43RmFTAb18lg4o6o/0pwvKr8AtSqOM/+d
M8n2r9gq9ET50RpQMEXT+xuYiFKJW1VB1ZbIAJeo1Yjf9sH1kpXiidK4bLznFfIA
-----END PRIVATE KEY-----
```

```
[ceph: root@ceph-node-0 ~]# cat > /tmp/nvmeof-both-inline-and-path.yaml <<'EOF'
service_type: nvmeof
service_id: nvmeof_pool01.group1
placement:
  hosts:
    - ceph-node-0
spec:
  pool: nvmeof_pool01
  group: group1
  enable_encryption: true
  encryption_key_path: /tmp/nvmeof-test-key/encryption.key
  encryption_key: |
    -----BEGIN PRIVATE KEY-----
    test-inline-key
    -----END PRIVATE KEY-----
EOF

ceph orch apply -i /tmp/nvmeof-both-inline-and-path.yaml
encryption_key and encryption_key_path cannot both be set


```

Non existent path test:
```

2026-07-10T08:38:30.108238+0000 mgr.ceph-node-0.fzjtxo (mgr.14154) 751 : cephadm [ERR] Failed while placing nvmeof.nvmeof_pool01.group1.ceph-node-0.txeanv on ceph-node-0: cephadm exited with an error code: 1, stderr: ['Non-zero exit code 125 from /usr/bin/podman container inspect --format {{.State.Status}} ceph-d98ed86e-7c36-11f1-8aef-525400bebb0c-nvmeof-nvmeof_pool01-group1-ceph-node-0-txeanv\n/usr/bin/podman: stderr Error: no such container ceph-d98ed86e-7c36-11f1-8aef-525400bebb0c-nvmeof-nvmeof_pool01-group1-ceph-node-0-txeanv\nNon-zero exit code 125 from /usr/bin/podman container inspect --format {{.State.Status}} ceph-d98ed86e-7c36-11f1-8aef-525400bebb0c-nvmeof.nvmeof_pool01.group1.ceph-node-0.txeanv\n/usr/bin/podman: stderr Error: no such container ceph-d98ed86e-7c36-11f1-8aef-525400bebb0c-nvmeof.nvmeof_pool01.group1.ceph-node-0.txeanv\nDeploy daemon nvmeof.nvmeof_pool01.group1.ceph-node-0.txeanv ...\nERROR: NVMe-oF encryption key file does not exist on host: /tmp/nvmeof-test-key/does-not-exist.key']
2026-07-10T08:38:30.108541+0000 mgr.ceph-node-0.fzjtxo (mgr.14154) 752 : cephadm [INF] Checking pool "nvmeof_pool01" exists for service nvmeof.nvmeof_pool01.group1
```

Missing path with enable_encryption:

```
[ceph: root@ceph-node-0 ~]# cat > /tmp/nvmeof-invalid-missing-path.yaml <<'EOF'
service_type: nvmeof
service_id: nvmeof_pool01.group1
placement:
  hosts:
    - ceph-node-0
spec:
  pool: nvmeof_pool01
  group: group1
  enable_encryption: true
EOF

ceph orch apply -i /tmp/nvmeof-invalid-missing-path.yaml
enable_encryption=true requires either encryption_key_path or encryption_key

```

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
