### PR TITLE
mgr/cephadm: pass svc_spec when persisting mgmt-gateway deps

### DIFF
--- a/src/pybind/mgr/cephadm/services/mgmt_gateway.py
+++ b/src/pybind/mgr/cephadm/services/mgmt_gateway.py
@@ -147,7 +147,7 @@ class MgmtGatewayService(CephadmService):
             daemon_config["files"]["nginx.crt"] = tls_pair.cert
             daemon_config["files"]["nginx.key"] = tls_pair.key
 
-        return daemon_config, sorted(MgmtGatewayService.get_dependencies(self.mgr))
+        return daemon_config, self.sorted_dependencies(self.mgr, svc_spec, daemon_spec.daemon_type)
 
     def post_remove(self, daemon: DaemonDescription, is_failed_deploy: bool) -> None:
         """

--- a/src/pybind/mgr/cephadm/services/oauth2_proxy.py
+++ b/src/pybind/mgr/cephadm/services/oauth2_proxy.py
@@ -83,7 +83,7 @@ class OAuth2ProxyService(CephadmService):
             }
         }
 
-        return daemon_config, sorted(OAuth2ProxyService.get_dependencies(self.mgr))
+        return daemon_config, self.sorted_dependencies(self.mgr, svc_spec, daemon_spec.daemon_type)
 
     def post_remove(self, daemon: DaemonDescription, is_failed_deploy: bool) -> None:
         """

--- a/src/pybind/mgr/cephadm/tests/services/test_mgmt_gateway.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_mgmt_gateway.py
@@ -3,13 +3,17 @@ from textwrap import dedent
 from unittest.mock import patch
 from typing import List
 
+import pytest
+
 from orchestrator._interface import DaemonDescription
 
 from cephadm.module import CephadmOrchestrator
 from ceph.deployment.service_spec import (
+    CertificateSource,
     MgmtGatewaySpec,
-    OAuth2ProxySpec
+    OAuth2ProxySpec,
 )
+from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 from cephadm.services.service_registry import service_registry
 from cephadm.tests.fixtures import with_host, with_service, async_side_effect
 from cephadm.tlsobject_types import TLSCredentials
@@ -815,6 +819,71 @@ class TestMgmtGateway:
                     error_ok=True,
                     use_current_daemon_image=False,
                 )
+
+    @pytest.mark.parametrize(
+        "service_type",
+        [
+            "mgmt-gateway",
+            "oauth2-proxy",
+        ],
+    )
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
+           lambda instance, dspec, ips=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
+    @patch("cephadm.services.oauth2_proxy.OAuth2ProxyService.get_certificates",
+           lambda instance, dspec, ips=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
+    @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_self_signed_certificates_with_label",
+           lambda instance, svc_spec, dspec, label, ip: TLSCredentials(ceph_generated_cert, ceph_generated_key))
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
+    @patch("cephadm.services.mgmt_gateway.get_dashboard_endpoints",
+           lambda _: (["ceph-node-2:8443"], "https"))
+    def test_tls_dependencies_match_reconciliation(
+        self,
+        _run_cephadm,
+        service_type,
+        cephadm_module: CephadmOrchestrator,
+    ):
+        """
+        generate_config() deps (persisted as last_deps) must match
+        sorted_dependencies() (used by reconcile), including TLS deps
+        such as certificate_source.
+        """
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        cert_source = CertificateSource.CEPHADM_SIGNED.value
+
+        if service_type == 'mgmt-gateway':
+            spec = MgmtGatewaySpec(certificate_source=cert_source)
+        else:
+            spec = OAuth2ProxySpec(
+                provider_display_name='my_idp_provider',
+                client_id='my_client_id',
+                client_secret='my_client_secret',
+                oidc_issuer_url='http://192.168.10.10:8888/dex',
+                cookie_secret='kbAEM9opAmuHskQvt0AW8oeJRaOM2BYy5Loba0kZ0SQ=',
+                redirect_url='https://ceph-node:5555/oauth2/callback',
+                certificate_source=cert_source,
+            )
+
+        with with_host(cephadm_module, 'ceph-node'):
+            with with_service(cephadm_module, spec):
+                service = service_registry.get_service(service_type)
+                svc_spec = cephadm_module.spec_store[spec.service_name()].spec
+                daemon_spec = CephadmDaemonDeploySpec(
+                    host='ceph-node',
+                    daemon_id='ceph-node',
+                    service_name=spec.service_name(),
+                    daemon_type=service_type,
+                )
+
+                _, generated_deps = service.generate_config(daemon_spec)
+                expected_deps = service.sorted_dependencies(
+                    cephadm_module,
+                    svc_spec,
+                    daemon_spec.daemon_type,
+                )
+
+                assert generated_deps == expected_deps
+                assert f'certificate_source: {cert_source}' in generated_deps
 
     @patch("cephadm.serve.CephadmServe._run_cephadm")
     def test_mgmt_gateway_default_port_is_443_when_unspecified(


### PR DESCRIPTION
generate_config() builds the dependency list that cephadm persists as last_deps for the daemon. The reconcile path in _check_daemons() then recomputes curr_deps via get_dependencies(mgr, spec) and reconfigures whenever the two lists differ.

For mgmt-gateway and oauth2-proxy, generate_config() called get_dependencies(self.mgr) without the service spec. Parent TLS deps such as certificate_source are only added when spec is provided, so last_deps never included them while curr_deps always did. That permanent mismatch caused an endless reconfigure loop.

Pass svc_spec into get_dependencies() so persisted and reconciled deps match.

* mgmt_gateway.py: pass svc_spec to get_dependencies() in generate_config()
* oauth2_proxy.py: same fix in oauth2-proxy generate_config()
* test_mgmt_gateway.py: regression test that extra serve-loop ticks do not issue further deploys for either service

Testing
-------
Lab: dual-network cluster with ingress and mgmt-gateway. VIP and mgmt-gateway on network1; Ceph daemons on network2. Dual-network was only the environment under test; the failure is the deps mismatch above.

Reproduce (mgmt-gateway):
1. Deploy mgmt-gateway (and ingress) with certificate_source: cephadm-signed and ssl enabled.
2. Observe flapping:
   - Dashboard / VIP access unstable
   - ceph orch ps --daemon-type mgmt-gateway shows AGE resetting
   - cephadm log (ceph log last 200 cephadm) repeats : Reconfigure wanted mgmt-gateway: ... (diff {'certificate_source: cephadm-signed'})
   - journalctl -u 'ceph-$(<ceph fsid>@mgmt-gateway.*' --since '5 min ago' | grep -E 'Starting|Stopped|Started'  shows repeated Starting/Stopped/Started

After the mgmt-gateway fix, the daemon stayed stable. the certificate_source reconfigure spam stopped.

Reproduce (oauth2-proxy), after the mgmt-gateway fix was applied:
1. Deploy oauth2-proxy with certificate_source: cephadm-signed.
2. Without the oauth2-proxy fix, cephadm log repeats: Reconfigure wanted oauth2-proxy: ... (diff {'certificate_source: cephadm-signed'}) Reconfiguring daemon oauth2-proxy...
3. After the oauth2-proxy fix, that certificate_source loop no longer appeared. One-time reconfigs when oauth2-proxy first appears as a dependency of other services (e.g. mgmt-gateway/prometheus) are expected and are not this bug.

Fixes: https://tracker.ceph.com/issues/77242
Signed-off-by: Yael Azulay <yazulay@redhat.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
