### PR TITLE
squid: Revert "Reapply "qa/rgw/crypt: disable failing kmip testing""

### DIFF
--- a/qa/tasks/pykmip.py
+++ b/qa/tasks/pykmip.py
@@ -65,7 +65,7 @@ def download(ctx, config):
 
     for (client, cconf) in config.items():
         branch = cconf.get('force-branch', 'master')
-        repo = cconf.get('force-repo', 'https://github.com/OpenKMIP/PyKMIP')
+        repo = cconf.get('force-repo', 'https://github.com/ceph/PyKMIP')
         sha1 = cconf.get('sha1')
         log.info("Using branch '%s' for pykmip", branch)
         log.info('sha1=%s', sha1)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78113

---

backport of https://github.com/ceph/ceph/pull/69841
parent tracker: https://tracker.ceph.com/issues/77873

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh