### PR TITLE
umbrella: Revert "Reapply "qa/rgw/crypt: disable failing kmip testing""

### DIFF
--- a/qa/suites/rgw/crypt/2-kms/kmip.yaml
+++ b/qa/suites/rgw/crypt/2-kms/kmip.yaml
@@ -1,0 +1,37 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rgw crypt s3 kms backend: kmip
+        rgw crypt kmip ca path: /etc/ceph/kmiproot.crt
+        rgw crypt kmip client cert: /etc/ceph/kmip-client.crt
+        rgw crypt kmip client key: /etc/ceph/kmip-client.key
+        rgw crypt kmip kms key template: pykmip-$keyid
+  rgw:
+    client.0:
+      use-pykmip-role: client.0
+
+tasks:
+- openssl_keys:
+    kmiproot:
+      client: client.0
+      cn: kmiproot
+      key-type: rsa:4096
+    kmip-server:
+      client: client.0
+      ca: kmiproot
+    kmip-client:
+      client: client.0
+      ca: kmiproot
+      cn: rgw-client
+- exec:
+    client.0:
+      - chmod 644 /home/ubuntu/cephtest/ca/kmip-client.key
+- pykmip:
+    client.0:
+      clientca: kmiproot
+      servercert: kmip-server
+      clientcert: kmip-client
+      secrets:
+      - name: pykmip-my-key-1
+      - name: pykmip-my-key-2

--- a/qa/tasks/pykmip.py
+++ b/qa/tasks/pykmip.py
@@ -65,7 +65,7 @@ def download(ctx, config):
 
     for (client, cconf) in config.items():
         branch = cconf.get('force-branch', 'master')
-        repo = cconf.get('force-repo', 'https://github.com/OpenKMIP/PyKMIP')
+        repo = cconf.get('force-repo', 'https://github.com/ceph/PyKMIP')
         sha1 = cconf.get('sha1')
         log.info("Using branch '%s' for pykmip", branch)
         log.info('sha1=%s', sha1)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78112

---

backport of https://github.com/ceph/ceph/pull/69841
parent tracker: https://tracker.ceph.com/issues/77873

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh