### PR TITLE
Extend libfdb to support transaction-versioned timestamps.

### DIFF
--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -59,6 +59,41 @@ if (!lfdb::commit(txn)) {
 }
 ```
 
+## Version Stamps
+
+```cpp
+// Store a value with a versioned key:
+lfdb::versionstamp stamp;
+
+lfdb::set(dbh,
+          lfdb::versioned("person/konrad-zuse/event/", "/created", stamp),
+          "created");
+```
+
+```cpp
+// Store a transaction-versioned value:
+lfdb::versionstamp stamp;
+
+lfdb::set(dbh,
+          "person/barbara-liskov/version",
+          lfdb::versioned("", stamp));
+```
+
+```cpp
+// Get a version stamp from a committed transaction:
+auto txn = lfdb::make_transaction(dbh);
+lfdb::versionstamp stamp;
+
+lfdb::set(txn, "person/alonzo-church/name", "Alonzo Church");
+
+if (lfdb::commit(txn, stamp)) {
+  const auto& version_stamp_bytes = stamp.resolved_bytes();
+}
+```
+
+Note that version stamping a key or a value is strictly an either/or proposition: there is no call
+to set a stamped key and value all at once.
+
 ## Setup
 
 ```cpp

--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -91,8 +91,32 @@ if (lfdb::commit(txn, stamp)) {
 }
 ```
 
+```cpp
+// Use one version stamp for several operations in the same transaction:
+auto txn = lfdb::make_transaction(dbh);
+lfdb::versionstamp stamp;
+
+lfdb::set(txn,
+          lfdb::versioned("person/grace-hopper/event/", "/created", stamp),
+          "created");
+lfdb::set(txn,
+          lfdb::versioned("person/grace-hopper/event/", "/updated", stamp),
+          "updated");
+lfdb::set(txn,
+          "person/grace-hopper/version",
+          lfdb::versioned("", stamp));
+
+if (lfdb::commit(txn) && stamp.is_resolved()) {
+  const auto& version_stamp_bytes = stamp.resolved_bytes();
+}
+```
+
 Note that version stamping a key or a value is strictly an either/or proposition: there is no call
 to set a stamped key and value all at once.
+
+Version stamps become readable and orderable only after commit resolution.
+Trying to read an unresolved stamp is a `std::invalid_argument`; trying to reuse a
+resolved stamp as a new commit output is a `std::invalid_argument`.
 
 ## Setup
 
@@ -410,7 +434,7 @@ txr([](auto& txn) {
 ```
 
 ```cpp
-/* Retryable FoundationDB errors are handled before control returns here. */
+/* Retryable FoundationDB errors may replay the transaction body. */
 auto txr = lfdb::make_transactor(dbh);
 
 try {
@@ -423,9 +447,35 @@ try {
     });
 }
 catch (const lfdb::libfdb_exception& e) {
-    /* FoundationDB reported an error that libfdb could not recover from. */
+    /* libfdb operation failure: FDB status failure, retry exhaustion, decode
+     * failure, or invalid data at the FoundationDB boundary. */
+}
+catch (const std::invalid_argument& e) {
+    /* The caller passed an argument that violates the libfdb API contract. */
 }
 catch (const std::exception& e) {
-    /* Application or system error from user code. */
+    /* Application or other runtime error. */
 }
 ```
+
+## Appendix: Exception Summary
+
+libfdb tries to keep its exception surface small. Ordinary library operation
+failures are reported as `lfdb::libfdb_exception`; direct caller contract
+violations use standard exceptions.
+
+The categories are intentionally coarse: they are meant to be useful to
+callers, not to divide every possible misuse into a separate exception type. For
+example, some versionstamp state violations are treated as `std::invalid_argument`
+to avoid a crazy taxonomy explosion.
+
+| Condition | Exception |
+| --- | --- |
+| FoundationDB C API returns `fdb_error_t` | `lfdb::libfdb_exception` |
+| FoundationDB option setup fails | `lfdb::libfdb_exception` |
+| Retry recovery fails or retry limit is exceeded | `lfdb::libfdb_exception` |
+| zpp_bits cannot decode stored bytes into the requested type | `lfdb::libfdb_exception` |
+| Invalid result at the FoundationDB boundary | `lfdb::libfdb_exception` |
+| Caller uses libfdb after shutdown | `lfdb::libfdb_exception` |
+| Caller passes an impossible selector prefix or invalid versionstamp bytes | `std::invalid_argument` |
+| Caller reads, compares, reuses, or overwrites a versionstamp in the wrong state | `std::invalid_argument` |

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -25,21 +25,26 @@
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
-#include <tuple>
-#include <mutex>
-#include <memory>
 #include <span>
-#include <ranges>
-#include <thread>
+#include <array>
+#include <tuple>
 #include <vector>
-#include <cstdint>
-#include <utility>
 #include <variant>
 #include <optional>
+
+#include <ranges>
 #include <iterator>
-#include <concepts>
 #include <algorithm>
 #include <generator>
+
+#include <mutex>
+#include <thread>
+
+#include <memory>
+#include <cstdint>
+#include <utility>
+#include <compare>
+#include <concepts>
 #include <exception>
 #include <functional>
 #include <filesystem>
@@ -59,6 +64,7 @@
 namespace ceph::libfdb {
 
 struct select;
+struct versionstamp;
 
 class database;
 class transaction;
@@ -69,6 +75,13 @@ using transaction_handle = std::shared_ptr<transaction>;
 extern transaction_handle make_transaction(database_handle dbh);
 
 } // namespace ceph::libfdb
+
+namespace ceph::libfdb::from {
+
+inline void convert(const std::span<const std::uint8_t>& from,
+                    ceph::libfdb::versionstamp& to);
+
+} // namespace ceph::libfdb::from
 
 // MOAR forward declarations-- "pay no attention to that man behind the curtain": 
 namespace ceph::libfdb::detail {
@@ -82,6 +95,7 @@ template <typename ValueT = std::string>
 std::pair<std::string, ValueT> to_decoded_kv_pair(const FDBKeyValue& kv);
 
 inline fdb_error_t do_commit(transaction_handle& txn);
+inline future_value block_until_ready(future_value&& fv);
 
 inline void transaction_set_kv_bytes(const transaction_handle& txn,
                                      std::span<const std::uint8_t> k,
@@ -235,6 +249,144 @@ inline std::string make_range_end_key_for_prefix(std::string_view prefix)
 }
 
 } // namespace ceph::libfdb::detail
+
+struct versionstamp final
+{
+ // FoundationDB versionstamps are 10 bytes: 8 bytes of committed
+ // database version followed by 2 bytes of transaction batch order.
+ using versionstamp_data_t = std::array<std::uint8_t, 10>;
+
+ bool is_resolved() const noexcept
+ {
+  return result->has_value();
+ }
+
+ const versionstamp_data_t& resolved_bytes() const
+ {
+  if (not is_resolved()) {
+   throw libfdb_exception("attempt to access unresolved version stamp");
+  }
+
+  return result->value();
+ }
+
+ bool operator==(const versionstamp& rhs) const
+ {
+  return resolved_bytes() == rhs.resolved_bytes();
+ }
+
+ auto operator<=>(const versionstamp& rhs) const
+ {
+  return resolved_bytes() <=> rhs.resolved_bytes();
+ }
+
+ private:
+ std::shared_ptr<std::optional<versionstamp_data_t>> result =
+  std::make_shared<std::optional<versionstamp_data_t>>();
+
+ void store_result(const std::span<const std::uint8_t> versionstamp_result);
+
+ private:
+ friend class transaction;
+ friend void ceph::libfdb::from::convert(const std::span<const std::uint8_t>&,
+                                         ceph::libfdb::versionstamp&);
+};
+
+// versioned_bytes can only be constructed by calling versioned():
+// It carries data in transaction-correct version stamp encoding:
+struct versioned_bytes final
+{
+ public:
+ versioned_bytes() = delete;
+
+ versioned_bytes(const versioned_bytes&) = default;
+ versioned_bytes(versioned_bytes&&) noexcept = default;
+ versioned_bytes& operator=(const versioned_bytes&) = default;
+ versioned_bytes& operator=(versioned_bytes&&) noexcept = default;
+
+ private:
+ std::vector<std::uint8_t> encoding_buffer;
+ versionstamp stamp;
+
+ versioned_bytes(std::vector<std::uint8_t> encoding_buffer_, versionstamp stamp_)
+  : encoding_buffer(std::move(encoding_buffer_)),
+    stamp(std::move(stamp_))
+ {}
+
+ private:
+ friend class transaction;
+
+ template <concepts::stringview_convertible PrefixT>
+ friend versioned_bytes versioned(const PrefixT& prefix, versionstamp stamp);
+
+ template <concepts::stringview_convertible PrefixT, concepts::stringview_convertible SuffixT>
+ friend versioned_bytes versioned(const PrefixT& prefix, const SuffixT& suffix, versionstamp stamp);
+};
+
+namespace detail {
+
+// FDB version stamp mutations expect the final four bytes to be a little-endian uint32_t offset pointing at the 10-byte placeholder:
+inline void append_little_endian_u32(std::vector<std::uint8_t>& out, const std::uint32_t x)
+{
+ out.push_back(static_cast<std::uint8_t>(x));
+ out.push_back(static_cast<std::uint8_t>(x >> 8));
+ out.push_back(static_cast<std::uint8_t>(x >> 16));
+ out.push_back(static_cast<std::uint8_t>(x >> 24));
+}
+
+inline std::vector<std::uint8_t> make_versioned_encoding(std::string_view prefix, std::string_view suffix)
+{
+ constexpr auto versionstamp_byte_count = std::tuple_size_v<versionstamp::versionstamp_data_t>;
+
+ std::vector<std::uint8_t> out;
+ out.reserve(prefix.size() + versionstamp_byte_count + suffix.size() + sizeof(std::uint32_t));
+
+ std::ranges::copy(prefix, std::back_inserter(out));
+
+ const auto versionstamp_offset = static_cast<std::uint32_t>(out.size());
+ out.resize(out.size() + versionstamp_byte_count);
+
+ std::ranges::copy(suffix, std::back_inserter(out));
+ detail::append_little_endian_u32(out, versionstamp_offset);
+
+ return out;
+}
+
+} // namespace detail
+
+template <concepts::stringview_convertible PrefixT, concepts::stringview_convertible SuffixT>
+versioned_bytes versioned(const PrefixT& prefix, const SuffixT& suffix, versionstamp stamp)
+{
+ return versioned_bytes {
+  detail::make_versioned_encoding(std::string_view(prefix), std::string_view(suffix)),
+  std::move(stamp)
+ };
+}
+
+template <concepts::stringview_convertible PrefixT>
+versioned_bytes versioned(const PrefixT& prefix, versionstamp stamp)
+{
+ return versioned(prefix, std::string_view {}, std::move(stamp));
+}
+
+inline void versionstamp::store_result(const std::span<const std::uint8_t> versionstamp_result)
+{
+ if (versionstamp_result.size() != std::tuple_size_v<versionstamp_data_t>) {
+  throw libfdb_exception("invalid version stamp (size)");
+ }
+
+ versionstamp_data_t result_value;
+ std::ranges::copy(versionstamp_result, std::begin(result_value));
+
+ if (not result->has_value()) {
+  result->emplace(std::move(result_value));
+  return;
+ }
+
+ if (result->value() != result_value) {
+  throw libfdb_exception("attempt to overwrite resolved version stamp");
+ }
+}
 
 struct range_endpoint final
 {
@@ -541,6 +693,8 @@ class transaction final
 
  std::unique_ptr<FDBTransaction, decltype(&fdb_transaction_destroy)> txn_handle;
 
+ std::vector<versionstamp> version_stamps;
+
  private:
  bool get_single_value_from_transaction(const std::span<const std::uint8_t>& key,
                                         std::invocable<std::span<const std::uint8_t>> auto&& write_output_fn);
@@ -571,6 +725,36 @@ class transaction final
     fdb_transaction_set(raw_handle(),
                         (const uint8_t*)k.data(), k.size(),
                         (const uint8_t*)v.data(), v.size());
+ }
+
+ void mark_version(const versionstamp& stamp)
+ {
+  version_stamps.push_back(stamp);
+ }
+
+ template <FDBMutationType MutationKind>
+ void set_versioned_data(std::span<const std::uint8_t> k,
+                         std::span<const std::uint8_t> v,
+                         const versionstamp& stamp)
+ {
+  fdb_transaction_atomic_op(raw_handle(),
+                            (const std::uint8_t*)k.data(), k.size(),
+                            (const std::uint8_t*)v.data(), v.size(),
+                            MutationKind);
+
+  mark_version(stamp);
+ }
+
+ void set(const versioned_bytes& k, std::span<const std::uint8_t> v)
+ {
+  set_versioned_data<FDB_MUTATION_TYPE_SET_VERSIONSTAMPED_KEY>(
+    std::span<const std::uint8_t>(k.encoding_buffer), v, k.stamp);
+ }
+
+ void set(std::span<const std::uint8_t> k, const versioned_bytes& v)
+ {
+  set_versioned_data<FDB_MUTATION_TYPE_SET_VERSIONSTAMPED_VALUE>(
+    k, std::span<const std::uint8_t>(v.encoding_buffer), v.stamp);
  }
 
  // JFW: it's not as easy to wedge an output_range into here as it appears, perhaps
@@ -615,6 +799,10 @@ class transaction final
  friend inline void set(database_handle, std::string_view, const auto&);
  friend inline void set(transaction_handle, std::string_view, const ceph::libfdb::concepts::stringview_convertible auto&, const commit_after_op);
  friend inline void set(database_handle, std::string_view, const ceph::libfdb::concepts::stringview_convertible auto&);
+ friend inline void set(transaction_handle, const versioned_bytes&, const auto&, const commit_after_op);
+ friend inline void set(database_handle, const versioned_bytes&, const auto&);
+ friend inline void set(transaction_handle, std::string_view, const versioned_bytes&, const commit_after_op);
+ friend inline void set(database_handle, std::string_view, const versioned_bytes&);
 
  template <typename OutputTargetOrFnT>
  requires concepts::value_callback<std::remove_reference_t<OutputTargetOrFnT>> ||
@@ -633,6 +821,7 @@ class transaction final
  friend inline bool key_exists(transaction_handle txn, std::string_view k, const commit_after_op commit_after);
 
  friend inline bool commit(transaction_handle& txn);
+ friend inline bool commit(transaction_handle& txn, const versionstamp& stamp);
  friend inline fdb_error_t ceph::libfdb::detail::do_commit(transaction_handle& txn);
  friend inline void ceph::libfdb::detail::transaction_set_kv_bytes(const transaction_handle&,
                                                                    std::span<const std::uint8_t>,
@@ -695,6 +884,12 @@ inline bool ceph::libfdb::transaction::get_single_value_from_transaction(const s
  if (!*this)
   return false;
 
+ std::optional<detail::future_value> versionstamp_future;
+
+ if (not version_stamps.empty()) {
+  versionstamp_future.emplace(fdb_transaction_get_versionstamp(raw_handle()));
+ }
+
  detail::future_value fv(fdb_transaction_commit(raw_handle()));
 
  if (fdb_error_t r = fdb_future_block_until_ready(fv.raw_handle()); 0 != r) {
@@ -719,7 +914,25 @@ inline bool ceph::libfdb::transaction::get_single_value_from_transaction(const s
    *replay_error = r;
   }
 
+  version_stamps.clear();
   return false;
+ }
+
+ if (versionstamp_future) {
+  auto ready = detail::block_until_ready(std::move(*versionstamp_future));
+
+  const uint8_t *out_versionstamp_data = nullptr;
+  int out_versionstamp_size = 0;
+
+  if (fdb_error_t r = fdb_future_get_key(ready.raw_handle(), &out_versionstamp_data, &out_versionstamp_size); 0 != r) {
+   throw libfdb_exception(r);
+  }
+
+  for (auto& stamp : version_stamps) {
+   stamp.store_result(std::span(out_versionstamp_data, out_versionstamp_size));
+  }
+
+  version_stamps.clear();
  }
 
  // Ok:

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -46,6 +46,7 @@
 #include <compare>
 #include <concepts>
 #include <exception>
+#include <stdexcept>
 #include <functional>
 #include <filesystem>
 #include <type_traits>
@@ -161,7 +162,8 @@ inline bool get_value_range_from_transaction(ceph::libfdb::transaction& txn, con
 
 } // namespace ceph::libfdb::detail
 
-// libfdb_exception: How to deal, when Bad Things(TM) happen:
+// libfdb_exception represents libfdb operation failures.
+// Caller contract errors use standard exceptions such as std::invalid_argument.
 namespace ceph::libfdb {
 
 // Should we commit after the (possibly) mutating operation?
@@ -243,7 +245,7 @@ inline std::string make_range_end_key_for_prefix(std::string_view prefix)
  }
 
  if (0xFF == static_cast<unsigned char>(prefix.front())) {
-  throw libfdb_exception("requested prefix has no (finite) end key");
+  throw std::invalid_argument("requested prefix has no finite end key");
  }
 
  auto i = prefix.find_last_not_of(static_cast<char>(0xFF));
@@ -270,12 +272,13 @@ struct versionstamp final
  const versionstamp_data_t& resolved_bytes() const
  {
   if (not is_resolved()) {
-   throw libfdb_exception("attempt to access unresolved version stamp");
+   throw std::invalid_argument("attempt to access unresolved version stamp");
   }
 
   return result->value();
  }
 
+ // Versionstamps become orderable only after commit resolution.
  bool operator==(const versionstamp& rhs) const
  {
   return resolved_bytes() == rhs.resolved_bytes();
@@ -378,7 +381,7 @@ versioned_bytes versioned(const PrefixT& prefix, versionstamp stamp)
 inline void versionstamp::store_result(const std::span<const std::uint8_t> versionstamp_result)
 {
  if (versionstamp_result.size() != std::tuple_size_v<versionstamp_data_t>) {
-  throw libfdb_exception("invalid version stamp (size)");
+  throw std::invalid_argument("invalid version stamp size");
  }
 
  versionstamp_data_t result_value;
@@ -390,7 +393,7 @@ inline void versionstamp::store_result(const std::span<const std::uint8_t> versi
  }
 
  if (result->value() != result_value) {
-  throw libfdb_exception("attempt to overwrite resolved version stamp");
+  throw std::invalid_argument("attempt to overwrite resolved version stamp");
  }
 }
 
@@ -735,6 +738,10 @@ class transaction final
 
  void mark_version(const versionstamp& stamp)
  {
+  if (stamp.is_resolved()) {
+   throw std::invalid_argument("attempt to reuse resolved version stamp");
+  }
+
   version_stamps.push_back(stamp);
  }
 
@@ -937,8 +944,19 @@ inline bool ceph::libfdb::transaction::get_single_value_from_transaction(const s
    throw libfdb_exception(r);
   }
 
+  constexpr auto expected_versionstamp_size =
+   std::tuple_size_v<versionstamp::versionstamp_data_t>;
+
+  if (expected_versionstamp_size != static_cast<std::size_t>(out_versionstamp_size) ||
+      nullptr == out_versionstamp_data) {
+   throw libfdb_exception("invalid version stamp result");
+  }
+
+  const auto versionstamp_result =
+   std::span(out_versionstamp_data, expected_versionstamp_size);
+
   for (auto& stamp : version_stamps) {
-   stamp.store_result(std::span(out_versionstamp_data, out_versionstamp_size));
+   stamp.store_result(versionstamp_result);
   }
 
   version_stamps.clear();

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -25,21 +25,26 @@
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
-#include <tuple>
-#include <mutex>
-#include <memory>
 #include <span>
-#include <ranges>
-#include <thread>
+#include <array>
+#include <tuple>
 #include <vector>
-#include <cstdint>
-#include <utility>
 #include <variant>
 #include <optional>
+
+#include <ranges>
 #include <iterator>
-#include <concepts>
 #include <algorithm>
 #include <generator>
+
+#include <mutex>
+#include <thread>
+
+#include <memory>
+#include <cstdint>
+#include <utility>
+#include <compare>
+#include <concepts>
 #include <exception>
 #include <functional>
 #include <filesystem>
@@ -61,6 +66,7 @@
 namespace ceph::libfdb {
 
 struct select;
+struct versionstamp;
 
 class database;
 class transaction;
@@ -71,6 +77,13 @@ using transaction_handle = std::shared_ptr<transaction>;
 extern transaction_handle make_transaction(database_handle dbh);
 
 } // namespace ceph::libfdb
+
+namespace ceph::libfdb::from {
+
+inline void convert(const std::span<const std::uint8_t>& from,
+                    ceph::libfdb::versionstamp& to);
+
+} // namespace ceph::libfdb::from
 
 namespace ceph::libfdb::concepts {
 
@@ -242,6 +255,144 @@ inline std::string make_range_end_key_for_prefix(std::string_view prefix)
 }
 
 } // namespace ceph::libfdb::detail
+
+struct versionstamp final
+{
+ // FoundationDB versionstamps are 10 bytes: 8 bytes of committed
+ // database version followed by 2 bytes of transaction batch order.
+ using versionstamp_data_t = std::array<std::uint8_t, 10>;
+
+ bool is_resolved() const noexcept
+ {
+  return result->has_value();
+ }
+
+ const versionstamp_data_t& resolved_bytes() const
+ {
+  if (not is_resolved()) {
+   throw libfdb_exception("attempt to access unresolved version stamp");
+  }
+
+  return result->value();
+ }
+
+ bool operator==(const versionstamp& rhs) const
+ {
+  return resolved_bytes() == rhs.resolved_bytes();
+ }
+
+ auto operator<=>(const versionstamp& rhs) const
+ {
+  return resolved_bytes() <=> rhs.resolved_bytes();
+ }
+
+ private:
+ std::shared_ptr<std::optional<versionstamp_data_t>> result =
+  std::make_shared<std::optional<versionstamp_data_t>>();
+
+ void store_result(const std::span<const std::uint8_t> versionstamp_result);
+
+ private:
+ friend class transaction;
+ friend void ceph::libfdb::from::convert(const std::span<const std::uint8_t>&,
+                                         ceph::libfdb::versionstamp&);
+};
+
+// versioned_bytes can only be constructed by calling versioned():
+// It carries data in transaction-correct version stamp encoding:
+struct versioned_bytes final
+{
+ public:
+ versioned_bytes() = delete;
+
+ versioned_bytes(const versioned_bytes&) = default;
+ versioned_bytes(versioned_bytes&&) noexcept = default;
+ versioned_bytes& operator=(const versioned_bytes&) = default;
+ versioned_bytes& operator=(versioned_bytes&&) noexcept = default;
+
+ private:
+ std::vector<std::uint8_t> encoding_buffer;
+ versionstamp stamp;
+
+ versioned_bytes(std::vector<std::uint8_t> encoding_buffer_, versionstamp stamp_)
+  : encoding_buffer(std::move(encoding_buffer_)),
+    stamp(std::move(stamp_))
+ {}
+
+ private:
+ friend class transaction;
+
+ template <concepts::stringview_convertible PrefixT>
+ friend versioned_bytes versioned(const PrefixT& prefix, versionstamp stamp);
+
+ template <concepts::stringview_convertible PrefixT, concepts::stringview_convertible SuffixT>
+ friend versioned_bytes versioned(const PrefixT& prefix, const SuffixT& suffix, versionstamp stamp);
+};
+
+namespace detail {
+
+// FDB version stamp mutations expect the final four bytes to be a little-endian uint32_t offset pointing at the 10-byte placeholder:
+inline void append_little_endian_u32(std::vector<std::uint8_t>& out, const std::uint32_t x)
+{
+ out.push_back(static_cast<std::uint8_t>(x));
+ out.push_back(static_cast<std::uint8_t>(x >> 8));
+ out.push_back(static_cast<std::uint8_t>(x >> 16));
+ out.push_back(static_cast<std::uint8_t>(x >> 24));
+}
+
+inline std::vector<std::uint8_t> make_versioned_encoding(std::string_view prefix, std::string_view suffix)
+{
+ constexpr auto versionstamp_byte_count = std::tuple_size_v<versionstamp::versionstamp_data_t>;
+
+ std::vector<std::uint8_t> out;
+ out.reserve(prefix.size() + versionstamp_byte_count + suffix.size() + sizeof(std::uint32_t));
+
+ std::ranges::copy(prefix, std::back_inserter(out));
+
+ const auto versionstamp_offset = static_cast<std::uint32_t>(out.size());
+ out.resize(out.size() + versionstamp_byte_count);
+
+ std::ranges::copy(suffix, std::back_inserter(out));
+ detail::append_little_endian_u32(out, versionstamp_offset);
+
+ return out;
+}
+
+} // namespace detail
+
+template <concepts::stringview_convertible PrefixT, concepts::stringview_convertible SuffixT>
+versioned_bytes versioned(const PrefixT& prefix, const SuffixT& suffix, versionstamp stamp)
+{
+ return versioned_bytes {
+  detail::make_versioned_encoding(std::string_view(prefix), std::string_view(suffix)),
+  std::move(stamp)
+ };
+}
+
+template <concepts::stringview_convertible PrefixT>
+versioned_bytes versioned(const PrefixT& prefix, versionstamp stamp)
+{
+ return versioned(prefix, std::string_view {}, std::move(stamp));
+}
+
+inline void versionstamp::store_result(const std::span<const std::uint8_t> versionstamp_result)
+{
+ if (versionstamp_result.size() != std::tuple_size_v<versionstamp_data_t>) {
+  throw libfdb_exception("invalid version stamp (size)");
+ }
+
+ versionstamp_data_t result_value;
+ std::ranges::copy(versionstamp_result, std::begin(result_value));
+
+ if (not result->has_value()) {
+  result->emplace(std::move(result_value));
+  return;
+ }
+
+ if (result->value() != result_value) {
+  throw libfdb_exception("attempt to overwrite resolved version stamp");
+ }
+}
 
 struct range_endpoint final
 {
@@ -548,6 +699,8 @@ class transaction final
 
  std::unique_ptr<FDBTransaction, decltype(&fdb_transaction_destroy)> txn_handle;
 
+ std::vector<versionstamp> version_stamps;
+
  private:
  bool get_single_value_from_transaction(const std::span<const std::uint8_t>& key,
                                         std::invocable<std::span<const std::uint8_t>> auto&& write_output_fn);
@@ -578,6 +731,36 @@ class transaction final
     fdb_transaction_set(raw_handle(),
                         (const uint8_t*)k.data(), k.size(),
                         (const uint8_t*)v.data(), v.size());
+ }
+
+ void mark_version(const versionstamp& stamp)
+ {
+  version_stamps.push_back(stamp);
+ }
+
+ template <FDBMutationType MutationKind>
+ void set_versioned_data(std::span<const std::uint8_t> k,
+                         std::span<const std::uint8_t> v,
+                         const versionstamp& stamp)
+ {
+  fdb_transaction_atomic_op(raw_handle(),
+                            (const std::uint8_t*)k.data(), k.size(),
+                            (const std::uint8_t*)v.data(), v.size(),
+                            MutationKind);
+
+  mark_version(stamp);
+ }
+
+ void set(const versioned_bytes& k, std::span<const std::uint8_t> v)
+ {
+  set_versioned_data<FDB_MUTATION_TYPE_SET_VERSIONSTAMPED_KEY>(
+    std::span<const std::uint8_t>(k.encoding_buffer), v, k.stamp);
+ }
+
+ void set(std::span<const std::uint8_t> k, const versioned_bytes& v)
+ {
+  set_versioned_data<FDB_MUTATION_TYPE_SET_VERSIONSTAMPED_VALUE>(
+    k, std::span<const std::uint8_t>(v.encoding_buffer), v.stamp);
  }
 
  // JFW: it's not as easy to wedge an output_range into here as it appears, perhaps
@@ -622,6 +805,10 @@ class transaction final
  friend inline void set(database_handle, std::string_view, const auto&);
  friend inline void set(transaction_handle, std::string_view, const ceph::libfdb::concepts::stringview_convertible auto&, const commit_after_op);
  friend inline void set(database_handle, std::string_view, const ceph::libfdb::concepts::stringview_convertible auto&);
+ friend inline void set(transaction_handle, const versioned_bytes&, const auto&, const commit_after_op);
+ friend inline void set(database_handle, const versioned_bytes&, const auto&);
+ friend inline void set(transaction_handle, std::string_view, const versioned_bytes&, const commit_after_op);
+ friend inline void set(database_handle, std::string_view, const versioned_bytes&);
 
  template <typename OutputTargetOrFnT>
  requires concepts::value_callback<std::remove_reference_t<OutputTargetOrFnT>> ||
@@ -643,6 +830,7 @@ class transaction final
  friend inline bool key_exists(transaction_handle txn, std::string_view k, const commit_after_op commit_after);
 
  friend inline bool commit(transaction_handle& txn);
+ friend inline bool commit(transaction_handle& txn, const versionstamp& stamp);
  friend inline fdb_error_t ceph::libfdb::detail::do_commit(transaction_handle& txn);
  friend inline void ceph::libfdb::detail::transaction_set_kv_bytes(const transaction_handle&,
                                                                    std::span<const std::uint8_t>,
@@ -705,6 +893,12 @@ inline bool ceph::libfdb::transaction::get_single_value_from_transaction(const s
  if (!*this)
   return false;
 
+ std::optional<detail::future_value> versionstamp_future;
+
+ if (not version_stamps.empty()) {
+  versionstamp_future.emplace(fdb_transaction_get_versionstamp(raw_handle()));
+ }
+
  detail::future_value fv(fdb_transaction_commit(raw_handle()));
 
  if (fdb_error_t r = fdb_future_block_until_ready(fv.raw_handle()); 0 != r) {
@@ -729,7 +923,25 @@ inline bool ceph::libfdb::transaction::get_single_value_from_transaction(const s
    *replay_error = r;
   }
 
+  version_stamps.clear();
   return false;
+ }
+
+ if (versionstamp_future) {
+  auto ready = detail::block_until_ready(std::move(*versionstamp_future));
+
+  const uint8_t *out_versionstamp_data = nullptr;
+  int out_versionstamp_size = 0;
+
+  if (fdb_error_t r = fdb_future_get_key(ready.raw_handle(), &out_versionstamp_data, &out_versionstamp_size); 0 != r) {
+   throw libfdb_exception(r);
+  }
+
+  for (auto& stamp : version_stamps) {
+   stamp.store_result(std::span(out_versionstamp_data, out_versionstamp_size));
+  }
+
+  version_stamps.clear();
  }
 
  // Ok:

--- a/src/rgw/fdb/conversion.h
+++ b/src/rgw/fdb/conversion.h
@@ -72,6 +72,11 @@ non-FDB input sources here (or any non-matching user output sources). Do NOT add
 non-owning targets, lest Antevorda be angered!: */
 namespace ceph::libfdb::from {
 
+inline void convert(const std::span<const std::uint8_t>& from, versionstamp& to)
+{
+ to.store_result(from);
+}
+
 inline void convert(const std::span<const std::uint8_t>& from, auto& to)
 {
  zpp::bits::in zpp_in(from);

--- a/src/rgw/fdb/conversion.h
+++ b/src/rgw/fdb/conversion.h
@@ -103,12 +103,9 @@ inline std::pair<std::string, ValueT> to_decoded_kv_pair(const FDBKeyValue& kv)
  try 
   {
      ceph::libfdb::from::convert(std::span<const std::uint8_t>(kv.value, kv.value_length), r.second);
-  }
+ }
  catch (const std::system_error& e) {
-     // Translate from underlying (e.g. zpp_bits) conversion error into the right type:
-     // This is a bit bound to zpp_bits for the moment, but there's not a more direct way to distinguish this
-     // from a different system_error. We could do that, by using zpp_bits' non-throwing modes and throwing a
-     // special type, but this will do for now.
+     // Decode failures still surface as libfdb operation failures to callers.
      throw ceph::libfdb::libfdb_exception(e.what());
   }
 

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -81,6 +81,13 @@ inline transaction_handle make_transaction(database_handle dbh, const transactio
  return txn->commit(); 
 }
 
+[[nodiscard]] inline bool commit(transaction_handle& txn,
+                                 const versionstamp& stamp)
+{
+ txn->mark_version(stamp);
+ return commit(txn);
+}
+
 } // namespace ceph::libfdb
 
 namespace ceph::libfdb::detail {
@@ -209,6 +216,76 @@ inline void set(database_handle dbh,
  return detail::commit_in_new_transaction(dbh,
           [key = detail::as_fdb_span(k), value = std::string_view(v)](const transaction_handle& txn) {
             return txn->set(key, ceph::libfdb::to::convert(value));
+          });
+}
+
+inline void set(transaction_handle txn,
+                const versioned_bytes& k,
+                const auto& v,
+                const commit_after_op commit_after)
+{
+ return detail::commit_noreplay(txn, commit_after,
+          [&k, &v](const transaction_handle& txn) {
+            return txn->set(k, ceph::libfdb::to::convert(v));
+          });
+}
+
+inline void set(transaction_handle txn,
+                const versioned_bytes& k,
+                const auto& v)
+{
+ return set(txn, k, v, commit_after_op::no_commit);
+}
+
+inline void set(database_handle dbh,
+                const versioned_bytes& k,
+                const auto& v)
+{
+ return detail::maybe_commit(make_transaction(dbh), commit_after_op::commit,
+          [&k, &v](const transaction_handle& txn) {
+            return txn->set(k, ceph::libfdb::to::convert(v));
+          });
+}
+
+// Version-stamped keys and values are strictly an either/or choice for a single set():
+inline void set(transaction_handle,
+                const versioned_bytes&,
+                const versioned_bytes&,
+                const commit_after_op) = delete;
+
+inline void set(transaction_handle,
+                const versioned_bytes&,
+                const versioned_bytes&) = delete;
+
+inline void set(database_handle,
+                const versioned_bytes&,
+                const versioned_bytes&) = delete;
+
+inline void set(transaction_handle txn,
+                std::string_view k,
+                const versioned_bytes& v,
+                const commit_after_op commit_after)
+{
+ return detail::commit_noreplay(txn, commit_after,
+          [key = detail::as_fdb_span(k), &v](const transaction_handle& txn) {
+            return txn->set(key, v);
+          });
+}
+
+inline void set(transaction_handle txn,
+                std::string_view k,
+                const versioned_bytes& v)
+{
+ return set(txn, k, v, commit_after_op::no_commit);
+}
+
+inline void set(database_handle dbh,
+                std::string_view k,
+                const versioned_bytes& v)
+{
+ return detail::maybe_commit(make_transaction(dbh), commit_after_op::commit,
+          [key = detail::as_fdb_span(k), &v](const transaction_handle& txn) {
+            return txn->set(key, v);
           });
 }
 

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -72,9 +72,7 @@ inline transaction_handle make_transaction(database_handle dbh, const transactio
 
 // Note: only rarely is a direct call to this needed. You can use transactors or pass database_handles
 // to get automagic.
-// Note: after a transaction is committed, it cannot be used again; but right now, that is NOT
-// an error with respect to the object. So, don't do operations on the object after you've committed
-// it or the behavior could be surprising.
+// Note: after a transaction is committed, it cannot be used again.
 // On false, the client should retry the transaction:
 [[nodiscard]] inline bool commit(transaction_handle& txn)
 {

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -33,12 +33,17 @@
 
 #include <map>
 #include <list>
-#include <chrono>
 #include <vector>
+#include <unordered_map>
+
+#include <chrono>
+#include <cstdint>
+#include <compare>
+#include <utility>
+
 #include <ranges>
 #include <iterator>
 #include <algorithm>
-#include <unordered_map>
 
 using Catch::Matchers::AllMatch;
 
@@ -59,6 +64,11 @@ using namespace std::literals;
 
 // Be nice to Catch2's template-test macros:
 using string_pair = std::pair<std::string, std::string>;
+
+template <typename ...Ts>
+concept can_lfdb_set = requires(Ts&& ...xs) {
+ lfdb::set(std::forward<Ts>(xs)...);
+};
 
 // Collect values in selection to out_values:
 auto key_counter(auto txn, const auto& selector, auto& out_values) -> auto {
@@ -189,6 +199,149 @@ TEST_CASE("fdb simple", "[rgw][fdb]") {
     // ...and now it should be gone again:
     lfdb::erase(lfdb::make_transaction(j), k, lfdb::commit_after_op::commit);
     CHECK_FALSE(lfdb::key_exists(lfdb::make_transaction(j), k, lfdb::commit_after_op::no_commit));
+ }
+}
+
+// Version-stamped keys and values are deliberately mutually exclusive:
+static_assert(can_lfdb_set<lfdb::database_handle,
+                           lfdb::versioned_bytes,
+                           std::string>);
+
+static_assert(can_lfdb_set<lfdb::database_handle,
+                           std::string_view,
+                           lfdb::versioned_bytes>);
+
+static_assert(not can_lfdb_set<lfdb::database_handle,
+                               lfdb::versioned_bytes,
+                               lfdb::versioned_bytes>);
+
+TEST_CASE("version stamps", "[fdb]") {
+ janitor dbh;
+
+ constexpr auto stamp_data = [](const std::uint8_t x) {
+  lfdb::versionstamp::versionstamp_data_t out {};
+  out.back() = x;
+  return out;
+ };
+
+ const auto resolved_stamp = [](const auto& versionstamp_data) {
+  lfdb::versionstamp stamp;
+  lfdb::from::convert(std::span(versionstamp_data), stamp);
+  return stamp;
+ };
+
+ SECTION("accessing unresolved versionstamp throws") {
+  lfdb::versionstamp stamp;
+
+  CHECK_FALSE(stamp.is_resolved());
+  CHECK_THROWS_WITH(stamp.resolved_bytes(),
+                    Catch::Matchers::ContainsSubstring("attempt to access unresolved version stamp"));
+ }
+
+ SECTION("commit resolves explicit version stamp") {
+  auto txn = lfdb::make_transaction(dbh);
+  lfdb::versionstamp stamp;
+
+  lfdb::set(txn, "versionstamp/explicit", "value");
+  REQUIRE(lfdb::commit(txn, stamp));
+
+  CHECK(stamp.is_resolved());
+  CHECK(10 == stamp.resolved_bytes().size());
+ }
+
+ SECTION("versionstamp comparison requires resolved values") {
+  lfdb::versionstamp unresolved;
+  const auto resolved = resolved_stamp(stamp_data(1));
+
+  CHECK_THROWS_WITH((void)(unresolved == resolved),
+                    Catch::Matchers::ContainsSubstring("attempt to access unresolved version stamp"));
+  CHECK_THROWS_WITH((void)(resolved == unresolved),
+                    Catch::Matchers::ContainsSubstring("attempt to access unresolved version stamp"));
+  CHECK_THROWS_WITH((void)(unresolved < resolved),
+                    Catch::Matchers::ContainsSubstring("attempt to access unresolved version stamp"));
+  CHECK_THROWS_WITH((void)(resolved < unresolved),
+                    Catch::Matchers::ContainsSubstring("attempt to access unresolved version stamp"));
+ }
+
+ SECTION("versionstamp comparison algebra") {
+  auto [lhs_version, rhs_version, expected_result] =
+   GENERATE(Catch::Generators::table<std::uint8_t,
+                                     std::uint8_t,
+                                     std::strong_ordering>({
+    { 1, 1, std::strong_ordering::equal },
+    { 1, 2, std::strong_ordering::less },
+    { 2, 1, std::strong_ordering::greater },
+   }));
+
+  const auto lhs = resolved_stamp(stamp_data(lhs_version));
+  const auto rhs = resolved_stamp(stamp_data(rhs_version));
+
+  CHECK((lhs <=> rhs) == expected_result);
+  CHECK((lhs == rhs) == (expected_result == std::strong_ordering::equal));
+  CHECK((lhs != rhs) == (expected_result != std::strong_ordering::equal));
+  CHECK((lhs < rhs) == (expected_result == std::strong_ordering::less));
+  CHECK((lhs <= rhs) == (expected_result != std::strong_ordering::greater));
+  CHECK((lhs > rhs) == (expected_result == std::strong_ordering::greater));
+  CHECK((lhs >= rhs) == (expected_result != std::strong_ordering::less));
+ }
+
+ SECTION("versionstamp key") {
+  lfdb::versionstamp stamp;
+
+  lfdb::set(dbh,
+            lfdb::versioned("versionstamp/key/", "/entry", stamp),
+            "value"s);
+
+  REQUIRE(stamp.is_resolved());
+
+  std::map<std::string, std::string> out;
+  lfdb::get(dbh, lfdb::select { "versionstamp/key/" }, std::inserter(out, out.end()));
+
+  REQUIRE(1 == out.size());
+  CHECK("value" == out.begin()->second);
+ }
+
+ SECTION("versionstamp value") {
+  lfdb::versionstamp stamp;
+
+  lfdb::set(dbh,
+            "versionstamp/value",
+            lfdb::versioned("", stamp));
+
+  REQUIRE(stamp.is_resolved());
+
+  lfdb::versionstamp out;
+  REQUIRE(lfdb::get(dbh, "versionstamp/value", out));
+
+  REQUIRE(out.is_resolved());
+  CHECK(stamp.resolved_bytes() == out.resolved_bytes());
+ }
+
+ SECTION("versionstamp overloads compile and commit") {
+  // As these overloads share call paths, just check that they compile and briefly check output:
+  {
+    auto txn = lfdb::make_transaction(dbh);
+    lfdb::versionstamp stamp;
+
+    lfdb::set(txn,
+              lfdb::versioned("versionstamp/overload/key/", stamp),
+              "value",
+              lfdb::commit_after_op::commit);
+
+    CHECK(stamp.is_resolved());
+  }
+
+  {
+    auto txn = lfdb::make_transaction(dbh);
+    lfdb::versionstamp stamp;
+
+    lfdb::set(txn,
+              "versionstamp/overload/value",
+              lfdb::versioned("value:", stamp),
+              lfdb::commit_after_op::commit);
+
+    CHECK(stamp.is_resolved());
+  }
  }
 }
 

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -39,6 +39,7 @@
 #include <chrono>
 #include <cstdint>
 #include <compare>
+#include <stdexcept>
 #include <utility>
 
 #include <ranges>
@@ -234,8 +235,18 @@ TEST_CASE("version stamps", "[fdb]") {
   lfdb::versionstamp stamp;
 
   CHECK_FALSE(stamp.is_resolved());
-  CHECK_THROWS_WITH(stamp.resolved_bytes(),
-                    Catch::Matchers::ContainsSubstring("attempt to access unresolved version stamp"));
+  CHECK_THROWS_MATCHES(stamp.resolved_bytes(),
+                       std::invalid_argument,
+                       Catch::Matchers::MessageMatches(
+                        Catch::Matchers::ContainsSubstring("attempt to access unresolved version stamp")));
+ }
+
+ SECTION("invalid versionstamp bytes are an API error") {
+  lfdb::versionstamp stamp;
+  const std::array<std::uint8_t, 1> invalid_stamp_bytes {};
+
+  CHECK_THROWS_AS(lfdb::from::convert(std::span(invalid_stamp_bytes), stamp),
+                  std::invalid_argument);
  }
 
  SECTION("commit resolves explicit version stamp") {
@@ -249,18 +260,43 @@ TEST_CASE("version stamps", "[fdb]") {
   CHECK(10 == stamp.resolved_bytes().size());
  }
 
+ SECTION("resolved versionstamp cannot be reused for commit") {
+  lfdb::versionstamp stamp;
+
+  auto txn = lfdb::make_transaction(dbh);
+  lfdb::set(txn, "versionstamp/reuse/first", "value");
+  REQUIRE(lfdb::commit(txn, stamp));
+  REQUIRE(stamp.is_resolved());
+
+  auto reuse_txn = lfdb::make_transaction(dbh);
+  lfdb::set(reuse_txn, "versionstamp/reuse/second", "value");
+
+  CHECK_THROWS_MATCHES(lfdb::commit(reuse_txn, stamp),
+                       std::invalid_argument,
+                       Catch::Matchers::MessageMatches(
+                        Catch::Matchers::ContainsSubstring("attempt to reuse resolved version stamp")));
+ }
+
  SECTION("versionstamp comparison requires resolved values") {
   lfdb::versionstamp unresolved;
   const auto resolved = resolved_stamp(stamp_data(1));
 
-  CHECK_THROWS_WITH((void)(unresolved == resolved),
-                    Catch::Matchers::ContainsSubstring("attempt to access unresolved version stamp"));
-  CHECK_THROWS_WITH((void)(resolved == unresolved),
-                    Catch::Matchers::ContainsSubstring("attempt to access unresolved version stamp"));
-  CHECK_THROWS_WITH((void)(unresolved < resolved),
-                    Catch::Matchers::ContainsSubstring("attempt to access unresolved version stamp"));
-  CHECK_THROWS_WITH((void)(resolved < unresolved),
-                    Catch::Matchers::ContainsSubstring("attempt to access unresolved version stamp"));
+  CHECK_THROWS_MATCHES((void)(unresolved == resolved),
+                       std::invalid_argument,
+                       Catch::Matchers::MessageMatches(
+                        Catch::Matchers::ContainsSubstring("attempt to access unresolved version stamp")));
+  CHECK_THROWS_MATCHES((void)(resolved == unresolved),
+                       std::invalid_argument,
+                       Catch::Matchers::MessageMatches(
+                        Catch::Matchers::ContainsSubstring("attempt to access unresolved version stamp")));
+  CHECK_THROWS_MATCHES((void)(unresolved < resolved),
+                       std::invalid_argument,
+                       Catch::Matchers::MessageMatches(
+                        Catch::Matchers::ContainsSubstring("attempt to access unresolved version stamp")));
+  CHECK_THROWS_MATCHES((void)(resolved < unresolved),
+                       std::invalid_argument,
+                       Catch::Matchers::MessageMatches(
+                        Catch::Matchers::ContainsSubstring("attempt to access unresolved version stamp")));
  }
 
  SECTION("versionstamp comparison algebra") {
@@ -286,6 +322,8 @@ TEST_CASE("version stamps", "[fdb]") {
  }
 
  SECTION("versionstamp key") {
+  lfdb::erase(dbh, lfdb::select { "versionstamp/key/" });
+
   lfdb::versionstamp stamp;
 
   lfdb::set(dbh,
@@ -449,6 +487,11 @@ TEST_CASE("check selectors", "[fdb][rgw]") {
  CHECK("abc" == lfdb::select { "abc" }.begin_key);
  CHECK("abd" == lfdb::select { "abc" }.end_key);
  CHECK("abd" == lfdb::select { std::string("abc\xFF", 4) }.end_key);
+ CHECK_THROWS_AS([] {
+   const auto invalid_prefix = std::string("\xFF", 1);
+   const auto selector = lfdb::select { invalid_prefix };
+   (void)selector;
+ }(), std::invalid_argument);
 
  // Make sure that there's nothing in our test range:
  dbh.drop_test_namespace();

--- a/src/test/rgw/test_fdb_ceph.cc
+++ b/src/test/rgw/test_fdb_ceph.cc
@@ -661,7 +661,7 @@ TEST_CASE("read path benchmarks", "[.benchmark][benchmark]") {
 }
 
 // Note that these are disabled for regular test runs. Use
-//      unittest_fdb_ceph "simple benchmarks"
+//      unittest_fdb_ceph "[benchmark]"
 // ...to run:
 TEST_CASE("simple benchmarks", "[.benchmark][benchmark]") {
 

--- a/src/test/rgw/test_fdb_common.h
+++ b/src/test/rgw/test_fdb_common.h
@@ -19,7 +19,7 @@
 
 namespace lfdb = ceph::libfdb;
 
-constexpr const char* const msg = "Hello, World!";
+constexpr char msg[] = "Hello, World!";
 
 constexpr const char msg_with_null[] = { '\0', 'H', 'i', '\0', ' ', 't', 'h', 'e', 'r', 'e', '!', '\0'};
 


### PR DESCRIPTION
Extend libfdb to support monotonic transaction-versioned timestamps.

Both version-stamped keys and values are supported. Examples updated (in EXAMPLES.md).
    
Assisted-by: Codex:GPT-5
    
Signed-off-by: Jesse Williamson <jfw@ibm.com>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
