### PR TITLE
rgw/kafka: Add OAuthbearer support and testing for Kafka bucket notifications

### DIFF
--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -250,6 +250,10 @@ and must be between 1 and 256 characters long. To relax these requirements, use:
    [&Attributes.entry.22.key=sasl-kerberos-service-name&Attributes.entry.22.value=<kerberos-service-name>]
    [&Attributes.entry.23.key=sasl-kerberos-principal&Attributes.entry.23.value=<kerberos-principal>]
    [&Attributes.entry.24.key=sasl-kerberos-keytab&Attributes.entry.24.value=<kerberos-keytab-path>]
+   [&Attributes.entry.25.key=sasl.oauthbearer.token.endpoint.url&Attributes.entry.25.value=<token-endpoint-url>]
+   [&Attributes.entry.26.key=sasl.oauthbearer.client.id&Attributes.entry.26.value=<client-id>]
+   [&Attributes.entry.27.key=sasl.oauthbearer.client.secret&Attributes.entry.27.value=<client-secret>]
+   [&Attributes.entry.28.key=sasl.oauthbearer.scope&Attributes.entry.28.value=<scope>]
 
 Request parameters:
 
@@ -392,6 +396,12 @@ Request parameters:
    The same security considerations in place for this parameter as
    for ``user``/``password``: it should be provided over HTTPS or
    ``rgw_allow_notification_secrets_in_cleartext`` must be set to "true".
+  - ``sasl.oauthbearer.token.endpoint.url``: The token endpoint URL of the
+    identity provider.
+  - ``sasl.oauthbearer.client.id``: The OAuth client identifier.
+  - ``sasl.oauthbearer.client.secret``: The OAuth client secret (sensitive,
+    provide over HTTPS or enable ``rgw_allow_notification_secrets_in_cleartext``).
+  - ``sasl.oauthbearer.scope``: Optional. The OAuth scopes to request.
 
  - ``sasl-kerberos-service-name``: Kerberos service name used with
    ``GSSAPI`` (per-topic override). If not provided, the global
@@ -688,6 +698,14 @@ Valid ``AttributeName`` that can be passed:
 - ``sasl-kerberos-service-name``: Kerberos service name for Kafka SASL/GSSAPI.
 - ``sasl-kerberos-principal``: Kerberos principal for the RGW client when using ``GSSAPI``.
 - ``sasl-kerberos-keytab``: Path to the keytab to use with ``GSSAPI``.
+- ``sasl.oauthbearer.token.endpoint.url``: Token endpoint URL of the
+  identity provider.
+- ``sasl.oauthbearer.client.id``: OAuth client identifier (required for
+  client credential flows).
+- ``sasl.oauthbearer.client.secret``: OAuth client secret (sensitive; provide
+  over HTTPS or enable ``rgw_allow_notification_secrets_in_cleartext``).
+- ``sasl.oauthbearer.scope``: Optional. Space-separated OAuth scopes to
+  request.
 
 Notifications
 ~~~~~~~~~~~~~

--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -249,6 +249,10 @@ and must be between 1 and 256 characters long. To relax these requirements, use:
    [&Attributes.entry.22.key=sasl-kerberos-service-name&Attributes.entry.22.value=<kerberos-service-name>]
    [&Attributes.entry.23.key=sasl-kerberos-principal&Attributes.entry.23.value=<kerberos-principal>]
    [&Attributes.entry.24.key=sasl-kerberos-keytab&Attributes.entry.24.value=<kerberos-keytab-path>]
+   [&Attributes.entry.25.key=sasl-oauthbearer-token-endpoint-url&Attributes.entry.25.value=<token-endpoint-url>]
+   [&Attributes.entry.26.key=sasl-oauthbearer-client-id&Attributes.entry.26.value=<client-id>]
+   [&Attributes.entry.27.key=sasl-oauthbearer-client-secret&Attributes.entry.27.value=<client-secret>]
+   [&Attributes.entry.28.key=sasl-oauthbearer-scope&Attributes.entry.28.value=<scope>]
 
 Request parameters:
 
@@ -391,6 +395,12 @@ Request parameters:
    The same security considerations in place for this parameter as
    for ``user``/``password``: it should be provided over HTTPS or
    ``rgw_allow_notification_secrets_in_cleartext`` must be set to "true".
+ - ``sasl-oauthbearer-token-endpoint-url``: The token endpoint URL of the
+   identity provider.
+ - ``sasl-oauthbearer-client-id``: The OAuth client identifier.
+ - ``sasl-oauthbearer-client-secret``: The OAuth client secret (sensitive,
+   provide over HTTPS or enable ``rgw_allow_notification_secrets_in_cleartext``).
+ - ``sasl-oauthbearer-scope``: Optional. The OAuth scopes to request.
 
  - ``sasl-kerberos-service-name``: Kerberos service name used with
    ``GSSAPI`` (per-topic override). If not provided, the global
@@ -687,6 +697,14 @@ Valid ``AttributeName`` that can be passed:
 - ``sasl-kerberos-service-name``: Kerberos service name for Kafka SASL/GSSAPI.
 - ``sasl-kerberos-principal``: Kerberos principal for the RGW client when using ``GSSAPI``.
 - ``sasl-kerberos-keytab``: Path to the keytab to use with ``GSSAPI``.
+- ``sasl-oauthbearer-token-endpoint-url``: Token endpoint URL of the
+  identity provider.
+- ``sasl-oauthbearer-client-id``: OAuth client identifier (required for
+  client credential flows).
+- ``sasl-oauthbearer-client-secret``: OAuth client secret (sensitive; provide
+  over HTTPS or enable ``rgw_allow_notification_secrets_in_cleartext``).
+- ``sasl-oauthbearer-scope``: Optional. Space-separated OAuth scopes to
+  request.
 
 Notifications
 ~~~~~~~~~~~~~

--- a/qa/suites/rgw/notifications/tasks/kafka/1-dex.yaml
+++ b/qa/suites/rgw/notifications/tasks/kafka/1-dex.yaml
@@ -1,0 +1,3 @@
+tasks:
+- dex:
+    client.0:

--- a/qa/tasks/dex.py
+++ b/qa/tasks/dex.py
@@ -1,0 +1,256 @@
+"""
+Deploy and configure Dex OIDC identity provider for Teuthology.
+"""
+import contextlib
+import logging
+
+from teuthology import misc as teuthology
+from teuthology import contextutil
+from teuthology.orchestra import run
+
+log = logging.getLogger(__name__)
+
+DEX_DEFAULT_VERSION = '2.38.0'
+GO_DEFAULT_VERSION = '1.21.13'
+DEX_PORT = 5556
+DEX_CLIENT_ID = 'rgw-notifications'
+DEX_CLIENT_SECRET = 'client-secret'
+DEX_SCOPE = 'openid'
+
+
+def get_dex_version(config):
+    for client, client_config in config.items():
+        if isinstance(client_config, dict) and 'dex_version' in client_config:
+            return client_config['dex_version']
+    return DEX_DEFAULT_VERSION
+
+
+def get_dex_src_dir(ctx):
+    return '{tdir}/dex-src'.format(tdir=teuthology.get_testdir(ctx))
+
+
+def get_dex_bin(ctx):
+    return '{src}/bin/dex'.format(src=get_dex_src_dir(ctx))
+
+
+@contextlib.contextmanager
+def install_dex(ctx, config):
+    """Clone the Dex repo and build the binary from source using Go."""
+    assert isinstance(config, dict)
+    log.info('Building Dex from source...')
+    testdir = teuthology.get_testdir(ctx)
+    dex_version = get_dex_version(config)
+    go_version = GO_DEFAULT_VERSION
+    go_tarball = 'go{ver}.linux-amd64.tar.gz'.format(ver=go_version)
+    go_url = 'https://go.dev/dl/{tarball}'.format(tarball=go_tarball)
+    go_root = '{tdir}/go'.format(tdir=testdir)
+    dex_src = get_dex_src_dir(ctx)
+
+    for (client, _) in config.items():
+        # Download and extract the Go toolchain
+        ctx.cluster.only(client).run(
+            args=[
+                'wget', '-q', '-O',
+                '{tdir}/{tarball}'.format(tdir=testdir, tarball=go_tarball),
+                go_url,
+            ],
+        )
+        ctx.cluster.only(client).run(
+            args=[
+                'tar', '-C', testdir, '-xzf',
+                '{tdir}/{tarball}'.format(tdir=testdir, tarball=go_tarball),
+            ],
+        )
+
+        # Clone Dex at the specified version tag
+        ctx.cluster.only(client).run(
+            args=[
+                'git', 'clone', '--depth', '1',
+                '--branch', 'v{ver}'.format(ver=dex_version),
+                'https://github.com/dexidp/dex.git',
+                dex_src,
+            ],
+        )
+
+        # Build the dex binary
+        ctx.cluster.only(client).run(
+            args=[
+                'bash', '-c',
+                'cd {src} && PATH={go_root}/bin:$PATH make build'.format(
+                    src=dex_src, go_root=go_root),
+            ],
+        )
+        log.info('Dex binary built at %s/bin/dex', dex_src)
+
+    try:
+        yield
+    finally:
+        log.info('Removing Dex source tree and Go toolchain...')
+        for (client, _) in config.items():
+            ctx.cluster.only(client).run(
+                args=[
+                    'rm', '-rf',
+                    dex_src,
+                    go_root,
+                    '{tdir}/{tarball}'.format(tdir=testdir, tarball=go_tarball),
+                ],
+            )
+
+
+@contextlib.contextmanager
+def configure_dex(ctx, config):
+    """Write the Dex config file and populate ctx.dex_* attributes."""
+    assert isinstance(config, dict)
+    log.info('Configuring Dex...')
+    testdir = teuthology.get_testdir(ctx)
+
+    for (client, _) in config.items():
+        (remote,) = ctx.cluster.only(client).remotes.keys()
+        ip = remote.ip_address
+
+        dex_config = (
+            'issuer: http://{ip}:{port}/dex\n'
+            'storage:\n'
+            '  type: memory\n'
+            'web:\n'
+            '  http: 0.0.0.0:{port}\n'
+            'oauth2:\n'
+            '  grantTypes:\n'
+            '    - client_credentials\n'
+            '  responseTypes:\n'
+            '    - code\n'
+            '  skipApprovalScreen: true\n'
+            'staticClients:\n'
+            '  - id: {client_id}\n'
+            '    secret: {client_secret}\n'
+            '    name: RGW Notifications\n'
+            '    grantTypes:\n'
+            '      - client_credentials\n'
+            'enablePasswordDB: false\n'
+            'connectors:\n'
+            '  - type: mockCallback\n'
+            '    id: mock\n'
+            '    name: Mock\n'
+        ).format(
+            ip=ip,
+            port=DEX_PORT,
+            client_id=DEX_CLIENT_ID,
+            client_secret=DEX_CLIENT_SECRET,
+        )
+
+        remote.write_file(
+            path='{tdir}/dex-config.yaml'.format(tdir=testdir),
+            data=dex_config.encode(),
+        )
+
+        ctx.dex_issuer = 'http://{ip}:{port}/dex'.format(ip=ip, port=DEX_PORT)
+        ctx.dex_jwks_url = 'http://{ip}:{port}/dex/keys'.format(ip=ip, port=DEX_PORT)
+        ctx.dex_token_endpoint = 'http://{ip}:{port}/dex/token'.format(ip=ip, port=DEX_PORT)
+        ctx.dex_client_id = DEX_CLIENT_ID
+        ctx.dex_client_secret = DEX_CLIENT_SECRET
+        ctx.dex_scope = DEX_SCOPE
+
+    try:
+        yield
+    finally:
+        log.info('Removing Dex config...')
+        for (client, _) in config.items():
+            ctx.cluster.only(client).run(
+                args=['rm', '-f', '{tdir}/dex-config.yaml'.format(tdir=testdir)],
+            )
+
+
+@contextlib.contextmanager
+def run_dex(ctx, config):
+    """Start the Dex server, wait for readiness, and fetch an access token."""
+    assert isinstance(config, dict)
+    log.info('Starting Dex...')
+    testdir = teuthology.get_testdir(ctx)
+
+    for (client, _) in config.items():
+        (remote,) = ctx.cluster.only(client).remotes.keys()
+        ip = remote.ip_address
+        dex_bin = get_dex_bin(ctx)
+        config_path = '{tdir}/dex-config.yaml'.format(tdir=testdir)
+
+        ctx.cluster.only(client).run(
+            args=[dex_bin, 'serve', config_path, run.Raw('&'), 'exit'],
+        )
+
+        # Poll until Dex OIDC discovery endpoint responds (up to 30 s)
+        ctx.cluster.only(client).run(
+            args=[
+                'bash', '-c',
+                (
+                    'for i in $(seq 1 30); do '
+                    'curl -sf http://{ip}:{port}/dex/.well-known/openid-configuration '
+                    '&& break; sleep 1; done'
+                ).format(ip=ip, port=DEX_PORT),
+            ],
+        )
+
+        # Fetch an access token for the configured client
+        token = remote.sh([
+            'curl', '-s', '-X', 'POST',
+            'http://{ip}:{port}/dex/token'.format(ip=ip, port=DEX_PORT),
+            '-d', 'grant_type=client_credentials',
+            '-d', 'client_id={}'.format(DEX_CLIENT_ID),
+            '-d', 'client_secret={}'.format(DEX_CLIENT_SECRET),
+            '-d', 'scope={}'.format(DEX_SCOPE),
+            run.Raw('|'),
+            'python3', '-c', "import json,sys; print(json.load(sys.stdin)['access_token'])",
+        ])
+        ctx.dex_access_token = token.strip()
+        log.info('Dex access token acquired')
+
+    try:
+        yield
+    finally:
+        log.info('Stopping Dex...')
+        for (client, _) in config.items():
+            ctx.cluster.only(client).run(
+                args=['bash', '-c', 'pkill -f "dex serve" || true'],
+            )
+
+
+@contextlib.contextmanager
+def task(ctx, config):
+    """
+    Deploy Dex OIDC identity provider for SASL/OAUTHBEARER Kafka tests.
+
+    Example suite YAML usage::
+
+      tasks:
+      - dex:
+          client.0:
+            dex_version: 2.38.0
+      - kafka:
+          client.0:
+            kafka_version: 3.9.2
+      - notification-tests:
+          client.0:
+            extra_attr: ["kafka_test", "kafka_security_test"]
+            rgw_server: client.0
+
+    This task must run before the kafka task so that ctx.dex_* attributes
+    are available when kafka writes server.properties.
+    """
+    assert config is None or isinstance(config, list) \
+        or isinstance(config, dict), \
+        "task dex only supports a list or dictionary for configuration"
+
+    all_clients = ['client.{id}'.format(id=id_)
+                   for id_ in teuthology.all_roles_of_type(ctx.cluster, 'client')]
+    if config is None:
+        config = all_clients
+    if isinstance(config, list):
+        config = dict.fromkeys(config)
+
+    log.debug('Dex config is %s', config)
+
+    with contextutil.nested(
+        lambda: install_dex(ctx=ctx, config=config),
+        lambda: configure_dex(ctx=ctx, config=config),
+        lambda: run_dex(ctx=ctx, config=config),
+    ):
+        yield

--- a/qa/tasks/dex.py
+++ b/qa/tasks/dex.py
@@ -1,0 +1,249 @@
+"""
+Deploy and configure Dex OIDC identity provider for Teuthology.
+"""
+import contextlib
+import logging
+
+from teuthology import misc as teuthology
+from teuthology import contextutil
+from teuthology.orchestra import run
+
+log = logging.getLogger(__name__)
+
+DEX_DEFAULT_VERSION = '2.38.0'
+GO_DEFAULT_VERSION = '1.21.13'
+DEX_PORT = 5556
+DEX_CLIENT_ID = 'rgw-notifications'
+DEX_CLIENT_SECRET = 'client-secret'
+DEX_SCOPE = 'openid'
+
+
+def get_dex_version(config):
+    for client_config in config.values():
+        if isinstance(client_config, dict) and 'dex_version' in client_config:
+            return client_config['dex_version']
+    return DEX_DEFAULT_VERSION
+
+def get_dex_src_dir(ctx):
+    return '{tdir}/dex-src'.format(tdir=teuthology.get_testdir(ctx))
+
+def get_dex_bin(ctx):
+    return '{src}/bin/dex'.format(src=get_dex_src_dir(ctx))
+
+
+@contextlib.contextmanager
+def install_dex(ctx, config):
+    """Clone the Dex repo and build the binary from source using Go."""
+    assert isinstance(config, dict)
+    log.info('Building Dex from source...')
+    testdir = teuthology.get_testdir(ctx)
+    dex_version = get_dex_version(config)
+    go_tarball = 'go{ver}.linux-amd64.tar.gz'.format(ver=GO_DEFAULT_VERSION)
+    go_url = 'https://go.dev/dl/{tarball}'.format(tarball=go_tarball)
+    go_root = '{tdir}/go'.format(tdir=testdir)
+    dex_src = get_dex_src_dir(ctx)
+
+    for (client, _) in config.items():
+        # Download and extract the Go toolchain
+        ctx.cluster.only(client).run(
+            args=[
+                'wget', '-q', '-O',
+                '{tdir}/{tarball}'.format(tdir=testdir, tarball=go_tarball),
+                go_url,
+            ],
+        )
+        ctx.cluster.only(client).run(
+            args=[
+                'tar', '-C', testdir, '-xzf',
+                '{tdir}/{tarball}'.format(tdir=testdir, tarball=go_tarball),
+            ],
+        )
+
+        # Clone Dex at the specified version tag
+        ctx.cluster.only(client).run(
+            args=[
+                'git', 'clone', '--depth', '1',
+                '--branch', 'v{ver}'.format(ver=dex_version),
+                'https://github.com/dexidp/dex.git',
+                dex_src,
+            ],
+        )
+
+        # Build the dex binary
+        ctx.cluster.only(client).run(
+            args=[
+                'bash', '-c',
+                'cd {src} && PATH={go_root}/bin:$PATH make build'.format(
+                    src=dex_src, go_root=go_root),
+            ],
+        )
+        log.info('Dex binary built at %s/bin/dex', dex_src)
+
+    try:
+        yield
+    finally:
+        log.info('Removing Dex source tree and Go toolchain...')
+        for (client, _) in config.items():
+            ctx.cluster.only(client).run(
+                args=[
+                    'rm', '-rf',
+                    dex_src,
+                    go_root,
+                    '{tdir}/{tarball}'.format(tdir=testdir, tarball=go_tarball),
+                ],
+            )
+
+@contextlib.contextmanager
+def configure_dex(ctx, config):
+    """Write the Dex config file and populate ctx.dex_* attributes."""
+    assert isinstance(config, dict)
+    log.info('Configuring Dex...')
+    testdir = teuthology.get_testdir(ctx)
+
+    ctx.dex_client_id = DEX_CLIENT_ID
+    ctx.dex_client_secret = DEX_CLIENT_SECRET
+    ctx.dex_scope = DEX_SCOPE
+
+    for (client, _) in config.items():
+        (remote,) = ctx.cluster.only(client).remotes.keys()
+        ip = remote.ip_address
+
+        dex_config = (
+            'issuer: http://{ip}:{port}/dex\n'
+            'storage:\n'
+            '  type: memory\n'
+            'web:\n'
+            '  http: 0.0.0.0:{port}\n'
+            'oauth2:\n'
+            '  grantTypes:\n'
+            '    - client_credentials\n'
+            '  responseTypes:\n'
+            '    - code\n'
+            '  skipApprovalScreen: true\n'
+            'staticClients:\n'
+            '  - id: {client_id}\n'
+            '    secret: {client_secret}\n'
+            '    name: RGW Notifications\n'
+            '    grantTypes:\n'
+            '      - client_credentials\n'
+            'enablePasswordDB: false\n'
+            'connectors:\n'
+            '  - type: mockCallback\n'
+            '    id: mock\n'
+            '    name: Mock\n'
+        ).format(
+            ip=ip,
+            port=DEX_PORT,
+            client_id=DEX_CLIENT_ID,
+            client_secret=DEX_CLIENT_SECRET,
+        )
+
+        remote.write_file(
+            path='{tdir}/dex-config.yaml'.format(tdir=testdir),
+            data=dex_config.encode(),
+        )
+
+        ctx.dex_issuer = 'http://{ip}:{port}/dex'.format(ip=ip, port=DEX_PORT)
+        ctx.dex_jwks_url = 'http://{ip}:{port}/dex/keys'.format(ip=ip, port=DEX_PORT)
+        ctx.dex_token_endpoint = 'http://{ip}:{port}/dex/token'.format(ip=ip, port=DEX_PORT)
+
+    try:
+        yield
+    finally:
+        log.info('Removing Dex config...')
+        for (client, _) in config.items():
+            ctx.cluster.only(client).run(
+                args=['rm', '-f', '{tdir}/dex-config.yaml'.format(tdir=testdir)],
+            )
+
+@contextlib.contextmanager
+def run_dex(ctx, config):
+    """Start the Dex server, wait for readiness, and fetch an access token."""
+    assert isinstance(config, dict)
+    log.info('Starting Dex...')
+    testdir = teuthology.get_testdir(ctx)
+
+    for (client, _) in config.items():
+        (remote,) = ctx.cluster.only(client).remotes.keys()
+        ip = remote.ip_address
+        dex_bin = get_dex_bin(ctx)
+        config_path = '{tdir}/dex-config.yaml'.format(tdir=testdir)
+
+        ctx.cluster.only(client).run(
+            args=[dex_bin, 'serve', config_path, run.Raw('&'), 'exit'],
+        )
+
+        # poll until Dex OIDC discovery endpoint responds (up to 30 s)
+        ctx.cluster.only(client).run(
+            args=[
+                'bash', '-c',
+                (
+                    'for i in $(seq 1 30); do '
+                    'curl -sf http://{ip}:{port}/dex/.well-known/openid-configuration '
+                    '&& exit 0; sleep 1; done; exit 1'
+                ).format(ip=ip, port=DEX_PORT),
+            ],
+        )
+
+        # fetch an access token for the configured client
+        token = remote.sh([
+            'curl', '-s', '-X', 'POST',
+            'http://{ip}:{port}/dex/token'.format(ip=ip, port=DEX_PORT),
+            '-d', 'grant_type=client_credentials',
+            '-d', 'client_id={}'.format(DEX_CLIENT_ID),
+            '-d', 'client_secret={}'.format(DEX_CLIENT_SECRET),
+            '-d', 'scope={}'.format(DEX_SCOPE),
+            run.Raw('|'),
+            'python3', '-c', "import json,sys; print(json.load(sys.stdin)['access_token'])",
+        ])
+        ctx.dex_access_token = token.strip()
+        log.info('Dex access token acquired')
+
+    try:
+        yield
+    finally:
+        log.info('Stopping Dex...')
+        for (client, _) in config.items():
+            ctx.cluster.only(client).run(
+                args=['bash', '-c', 'pkill -f "dex serve" || true'],
+            )
+
+
+@contextlib.contextmanager
+def task(ctx, config):
+    """
+    Deploy Dex OIDC identity provider for SASL/OAUTHBEARER Kafka tests.
+
+    Example suite YAML usage::
+
+      tasks:
+      - dex:
+          client.0:
+      - kafka:
+          client.0:
+            kafka_version: 3.9.2
+      - notification-tests:
+          client.0:
+            extra_attr: ["kafka_security_test"]
+
+    This task must run before the kafka task so that ctx.dex_* attributes
+    are available when kafka writes server.properties.
+    """
+    assert config is None or isinstance(config, list) or isinstance(config, dict), \
+        "task dex only supports a list or dictionary for configuration"
+
+    all_clients = ['client.{id}'.format(id=id_)
+                   for id_ in teuthology.all_roles_of_type(ctx.cluster, 'client')]
+    if config is None:
+        config = all_clients
+    if isinstance(config, list):
+        config = dict.fromkeys(config)
+
+    log.debug('Dex config is %s', config)
+
+    with contextutil.nested(
+        lambda: install_dex(ctx=ctx, config=config),
+        lambda: configure_dex(ctx=ctx, config=config),
+        lambda: run_dex(ctx=ctx, config=config),
+    ):
+        yield

--- a/qa/tasks/kafka.py
+++ b/qa/tasks/kafka.py
@@ -244,7 +244,7 @@ def broker_conf(ctx, client, kafka_dir, kerberos, kraft):
         "listener.name.mtls.ssl.truststore.location={tdir}/server.truststore.jks\n"
         "listener.name.mtls.ssl.truststore.password=mypassword\n"
         # SASL mechanisms
-        "sasl.enabled.mechanisms=PLAIN,SCRAM-SHA-256,SCRAM-SHA-512,GSSAPI\n"
+        "sasl.enabled.mechanisms=PLAIN,SCRAM-SHA-256,SCRAM-SHA-512,GSSAPI,OAUTHBEARER\n"
         "sasl.mechanism.inter.broker.protocol=PLAIN\n"
         "sasl.kerberos.service.name={service_name}\n"
         'listener.name.sasl_ssl.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \\\n'
@@ -262,6 +262,11 @@ def broker_conf(ctx, client, kafka_dir, kerberos, kraft):
         '  storeKey=true \\\n'
         '  keyTab="{keytab}" \\\n'
         '  principal="{principal}";\n'
+        'listener.name.sasl_ssl.oauthbearer.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;\n'
+        'listener.name.sasl_ssl.oauthbearer.sasl.server.callback.handler.class=org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerValidatorCallbackHandler\n'
+        'listener.name.sasl_ssl.oauthbearer.sasl.oauthbearer.jwks.endpoint.url={jwks}\n'
+        'listener.name.sasl_ssl.oauthbearer.sasl.oauthbearer.expected.audience={oauth_client}\n'
+        'listener.name.sasl_ssl.oauthbearer.sasl.oauthbearer.expected.issuer={issuer}\n'
         'listener.name.sasl_plaintext.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \\\n'
         '  username="admin" \\\n'
         '  password="admin-secret" \\\n'
@@ -277,6 +282,11 @@ def broker_conf(ctx, client, kafka_dir, kerberos, kraft):
         '  storeKey=true \\\n'
         '  keyTab="{keytab}" \\\n'
         '  principal="{principal}";\n'
+        'listener.name.sasl_plaintext.oauthbearer.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;\n'
+        'listener.name.sasl_plaintext.oauthbearer.sasl.server.callback.handler.class=org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerValidatorCallbackHandler\n'
+        'listener.name.sasl_plaintext.oauthbearer.sasl.oauthbearer.jwks.endpoint.url={jwks}\n'
+        'listener.name.sasl_plaintext.oauthbearer.sasl.oauthbearer.expected.audience={oauth_client}\n'
+        'listener.name.sasl_plaintext.oauthbearer.sasl.oauthbearer.expected.issuer={issuer}\n'
     ).format(
         tdir=kafka_dir,
         ip=ip,
@@ -288,6 +298,9 @@ def broker_conf(ctx, client, kafka_dir, kerberos, kraft):
         service_name=kerberos['service_name'] if kerberos else '',
         keytab=kerberos['kafka_keytab'] if kerberos else '',
         principal=kerberos['kafka_principal'] if kerberos else '',
+        jwks=getattr(ctx, 'dex_issuer', None),
+        oauth_client=getattr(ctx, 'dex_client_id', None),
+        issuer=getattr(ctx, 'dex_jwks_url', None)
     )
     file_name = 'server.properties'
     log.info("kafka conf file: %s", file_name)

--- a/qa/tasks/kafka.py
+++ b/qa/tasks/kafka.py
@@ -244,7 +244,7 @@ def broker_conf(ctx, client, kafka_dir, kerberos, kraft):
         "listener.name.mtls.ssl.truststore.location={tdir}/server.truststore.jks\n"
         "listener.name.mtls.ssl.truststore.password=mypassword\n"
         # SASL mechanisms
-        "sasl.enabled.mechanisms=PLAIN,SCRAM-SHA-256,SCRAM-SHA-512,GSSAPI\n"
+        "sasl.enabled.mechanisms=PLAIN,SCRAM-SHA-256,SCRAM-SHA-512,GSSAPI,OAUTHBEARER\n"
         "sasl.mechanism.inter.broker.protocol=PLAIN\n"
         "sasl.kerberos.service.name={service_name}\n"
         'listener.name.sasl_ssl.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \\\n'
@@ -262,6 +262,11 @@ def broker_conf(ctx, client, kafka_dir, kerberos, kraft):
         '  storeKey=true \\\n'
         '  keyTab="{keytab}" \\\n'
         '  principal="{principal}";\n'
+        'listener.name.sasl_ssl.oauthbearer.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;\n'
+        'listener.name.sasl_ssl.oauthbearer.sasl.server.callback.handler.class=org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerValidatorCallbackHandler\n'
+        'listener.name.sasl_ssl.oauthbearer.sasl.oauthbearer.jwks.endpoint.url={jwks}\n'
+        'listener.name.sasl_ssl.oauthbearer.sasl.oauthbearer.expected.audience={oauth_client}\n'
+        'listener.name.sasl_ssl.oauthbearer.sasl.oauthbearer.expected.issuer={issuer}\n'
         'listener.name.sasl_plaintext.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \\\n'
         '  username="admin" \\\n'
         '  password="admin-secret" \\\n'
@@ -277,6 +282,11 @@ def broker_conf(ctx, client, kafka_dir, kerberos, kraft):
         '  storeKey=true \\\n'
         '  keyTab="{keytab}" \\\n'
         '  principal="{principal}";\n'
+        'listener.name.sasl_plaintext.oauthbearer.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;\n'
+        'listener.name.sasl_plaintext.oauthbearer.sasl.server.callback.handler.class=org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerValidatorCallbackHandler\n'
+        'listener.name.sasl_plaintext.oauthbearer.sasl.oauthbearer.jwks.endpoint.url={jwks}\n'
+        'listener.name.sasl_plaintext.oauthbearer.sasl.oauthbearer.expected.audience={oauth_client}\n'
+        'listener.name.sasl_plaintext.oauthbearer.sasl.oauthbearer.expected.issuer={issuer}\n'
     ).format(
         tdir=kafka_dir,
         ip=ip,
@@ -288,6 +298,9 @@ def broker_conf(ctx, client, kafka_dir, kerberos, kraft):
         service_name=kerberos['service_name'] if kerberos else '',
         keytab=kerberos['kafka_keytab'] if kerberos else '',
         principal=kerberos['kafka_principal'] if kerberos else '',
+        jwks=getattr(ctx, 'dex_jwks_url', ''),
+        oauth_client=getattr(ctx, 'dex_client_id', ''),
+        issuer=getattr(ctx, 'dex_issuer', '')
     )
     file_name = 'server.properties'
     log.info("kafka conf file: %s", file_name)

--- a/qa/tasks/notification_tests.py
+++ b/qa/tasks/notification_tests.py
@@ -338,6 +338,16 @@ def task(ctx,config):
                 'kerberos':kerberos_conf
             }
         )
+        if getattr(ctx, 'dex_token_endpoint', None):
+            bntests_conf[client]['oauthbearer'] = {
+                'token_endpoint_url': ctx.dex_token_endpoint,
+                'client_id': ctx.dex_client_id,
+                'client_secret': ctx.dex_client_secret,
+                'access_token': ctx.dex_access_token,
+                'scope': ctx.dex_scope,
+            }
+        else:
+            bntests_conf[client]['oauthbearer'] = {}
 
     with contextutil.nested(
         lambda: download(ctx=ctx, config=config),

--- a/qa/tasks/notification_tests.py
+++ b/qa/tasks/notification_tests.py
@@ -338,6 +338,14 @@ def task(ctx,config):
                 'kerberos':kerberos_conf
             }
         )
+        if getattr(ctx, 'dex_token_endpoint', None):
+            bntests_conf[client]['oauthbearer'] = {
+                'token_endpoint_url': ctx.dex_token_endpoint,
+                'client_id': ctx.dex_client_id,
+                'client_secret': ctx.dex_client_secret,
+                'access_token': ctx.dex_access_token,
+                'scope': ctx.dex_scope,
+            }
 
     with contextutil.nested(
         lambda: download(ctx=ctx, config=config),

--- a/src/rgw/driver/rados/rgw_pubsub_push.cc
+++ b/src/rgw/driver/rados/rgw_pubsub_push.cc
@@ -317,7 +317,11 @@ public:
            args.get_optional("ssl-key-password"),
            args.get_optional("sasl-kerberos-service-name"),
            args.get_optional("sasl-kerberos-principal"),
-           args.get_optional("sasl-kerberos-keytab"))) {
+           args.get_optional("sasl-kerberos-keytab"),
+           args.get_optional("sasl.oauthbearer.token.endpoint.url"),
+           args.get_optional("sasl.oauthbearer.client.id"),
+           args.get_optional("sasl.oauthbearer.client.secret"),
+           args.get_optional("sasl.oauthbearer.scope"))) {
      throw configuration_error("Kafka: failed to create connection to: " +
                                _endpoint);
    }

--- a/src/rgw/driver/rados/rgw_pubsub_push.cc
+++ b/src/rgw/driver/rados/rgw_pubsub_push.cc
@@ -317,7 +317,11 @@ public:
            args.get_optional("ssl-key-password"),
            args.get_optional("sasl-kerberos-service-name"),
            args.get_optional("sasl-kerberos-principal"),
-           args.get_optional("sasl-kerberos-keytab"))) {
+           args.get_optional("sasl-kerberos-keytab"),
+           args.get_optional("sasl-oauthbearer-token-endpoint-url"),
+           args.get_optional("sasl-oauthbearer-client-id"),
+           args.get_optional("sasl-oauthbearer-client-secret"),
+           args.get_optional("sasl-oauthbearer-scope"))) {
      throw configuration_error("Kafka: failed to create connection to: " +
                                _endpoint);
    }

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -892,7 +892,7 @@ int RGWHTTPArgs::parse(const DoutPrefixProvider *dpp)
       }
       string& val = nv.get_val();
       static constexpr std::initializer_list<const char*>
-          sensitive_keyword_list = {"password"};
+          sensitive_keyword_list = {"password", "secret"};
       bool is_sensitive = false;
       for (const auto& key : sensitive_keyword_list) {
         if (name.find(key) != std::string::npos) {

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -45,7 +45,7 @@ namespace {
 using namespace std::string_view_literals;
 
 static constexpr std::array sensitive_keywords = {
-  "password"sv
+  "password"sv, "secret"sv
 };
 
 enum struct http_arg_kind {

--- a/src/rgw/rgw_kafka.cc
+++ b/src/rgw/rgw_kafka.cc
@@ -83,7 +83,11 @@ connection_id_t::connection_id_t(
     const boost::optional<const std::string&>& _ssl_key_password,
     const boost::optional<const std::string&>& _kerberos_service_name,
     const boost::optional<const std::string&>& _kerberos_principal,
-    const boost::optional<const std::string&>& _kerberos_keytab
+    const boost::optional<const std::string&>& _kerberos_keytab,
+    const boost::optional<const std::string&>& _oauthbearer_token_endpoint_url,
+    const boost::optional<const std::string&>& _oauthbearer_client_id,
+    const boost::optional<const std::string&>& _oauthbearer_client_secret,
+    const boost::optional<const std::string&>& _oauthbearer_scope
   )
     : broker(_broker), user(_user), password(_password), ssl(_ssl),
       verify_ssl(_verify_ssl) {
@@ -112,6 +116,18 @@ connection_id_t::connection_id_t(
   if (_kerberos_keytab.has_value()) {
     kerberos_keytab = _kerberos_keytab.get();
   }
+  if (_oauthbearer_token_endpoint_url.has_value()) {
+    oauthbearer_token_endpoint_url = _oauthbearer_token_endpoint_url.get();
+  }
+  if (_oauthbearer_client_id.has_value()) {
+    oauthbearer_client_id = _oauthbearer_client_id.get();
+  }
+  if (_oauthbearer_client_secret.has_value()) {
+    oauthbearer_client_secret = _oauthbearer_client_secret.get();
+  }
+  if (_oauthbearer_scope.has_value()) {
+    oauthbearer_scope = _oauthbearer_scope.get();
+  }
 }
 
 // equality operator and hasher functor are needed
@@ -126,7 +142,11 @@ bool operator==(const connection_id_t& lhs, const connection_id_t& rhs) {
          lhs.ssl_key_password == rhs.ssl_key_password &&
          lhs.kerberos_service_name == rhs.kerberos_service_name &&
          lhs.kerberos_principal == rhs.kerberos_principal &&
-         lhs.kerberos_keytab == rhs.kerberos_keytab;
+         lhs.kerberos_keytab == rhs.kerberos_keytab &&
+         lhs.oauthbearer_token_endpoint_url == rhs.oauthbearer_token_endpoint_url &&
+         lhs.oauthbearer_client_id == rhs.oauthbearer_client_id &&
+         lhs.oauthbearer_client_secret == rhs.oauthbearer_client_secret &&
+         lhs.oauthbearer_scope == rhs.oauthbearer_scope;
 }
 
 struct connection_id_hasher {
@@ -145,6 +165,10 @@ struct connection_id_hasher {
     boost::hash_combine(h, k.kerberos_service_name);
     boost::hash_combine(h, k.kerberos_principal);
     boost::hash_combine(h, k.kerberos_keytab);
+    boost::hash_combine(h, k.oauthbearer_token_endpoint_url);
+    boost::hash_combine(h, k.oauthbearer_client_id);
+    boost::hash_combine(h, k.oauthbearer_client_secret);
+    boost::hash_combine(h, k.oauthbearer_scope);
     return h;
   }
 };
@@ -229,6 +253,10 @@ struct connection_t {
   const boost::optional<std::string> kerberos_service_name;
   const boost::optional<std::string> kerberos_principal;
   const boost::optional<std::string> kerberos_keytab;
+  const boost::optional<std::string> oauthbearer_token_endpoint_url;
+  const boost::optional<std::string> oauthbearer_client_id;
+  const boost::optional<std::string> oauthbearer_client_secret;
+  const boost::optional<std::string> oauthbearer_scope;
   utime_t timestamp = ceph_clock_now();
 
   // cleanup of all internal connection resource
@@ -259,7 +287,7 @@ struct connection_t {
   }
 
   // ctor for setting immutable values
-  connection_t(CephContext* _cct, const std::string& _broker, bool _use_ssl, bool _verify_ssl, 
+  connection_t(CephContext* _cct, const std::string& _broker, bool _use_ssl, bool _verify_ssl,
           const boost::optional<const std::string&>& _ca_location,
           const std::string& _user, const std::string& _password, const boost::optional<const std::string&>& _mechanism,
           const boost::optional<const std::string&>& _ssl_certificate,
@@ -267,10 +295,17 @@ struct connection_t {
           const boost::optional<const std::string&>& _ssl_key_password,
           const boost::optional<const std::string&>& _kerberos_service_name,
           const boost::optional<const std::string&>& _kerberos_principal,
-          const boost::optional<const std::string&>& _kerberos_keytab) :
+          const boost::optional<const std::string&>& _kerberos_keytab,
+          const boost::optional<const std::string&>& _oauthbearer_token_endpoint_url,
+          const boost::optional<const std::string&>& _oauthbearer_client_id,
+          const boost::optional<const std::string&>& _oauthbearer_client_secret,
+          const boost::optional<const std::string&>& _oauthbearer_scope) :
       cct(_cct), broker(_broker), use_ssl(_use_ssl), verify_ssl(_verify_ssl), ca_location(_ca_location), user(_user), password(_password), mechanism(_mechanism),
       ssl_certificate(_ssl_certificate), ssl_key(_ssl_key), ssl_key_password(_ssl_key_password),
-      kerberos_service_name(_kerberos_service_name), kerberos_principal(_kerberos_principal), kerberos_keytab(_kerberos_keytab) {}                                                                                                                                                        
+      kerberos_service_name(_kerberos_service_name), kerberos_principal(_kerberos_principal), kerberos_keytab(_kerberos_keytab),
+      oauthbearer_token_endpoint_url(_oauthbearer_token_endpoint_url),
+      oauthbearer_client_id(_oauthbearer_client_id), oauthbearer_client_secret(_oauthbearer_client_secret),
+      oauthbearer_scope(_oauthbearer_scope) {}
 
   // dtor also destroys the internals
   ~connection_t() {
@@ -337,6 +372,25 @@ void poll_err_callback(rd_kafka_t *rk, int err, const char *reason, void *opaque
 
 using connection_t_ptr = std::unique_ptr<connection_t>;
 
+bool validate_oauthbearer_params(const std::string* token_endpoint_url,
+                                 const std::string* client_id,
+                                 const std::string* client_secret,
+                                 std::string& message) {
+  if (!token_endpoint_url || token_endpoint_url->empty()) {
+    message = "OAUTHBEARER requires sasl.oauthbearer.token.endpoint.url";
+    return false;
+  }
+  if (!client_id || client_id->empty()) {
+    message = "OAUTHBEARER requires sasl.oauthbearer.client.id";
+    return false;
+  }
+  if (!client_secret || client_secret->empty()) {
+    message = "OAUTHBEARER requires sasl.oauthbearer.client.secret";
+    return false;
+  }
+  return true;
+}
+
 // utility function to create a producer, when the connection object already exists
 bool new_producer(connection_t* conn) {
   // reset all status codes
@@ -355,6 +409,31 @@ bool new_producer(connection_t* conn) {
   char errstr[512] = {0};
 
   const bool is_gssapi = conn->mechanism && boost::iequals(*conn->mechanism, "GSSAPI");
+  const bool is_oauthbearer = conn->mechanism && boost::iequals(*conn->mechanism, "OAUTHBEARER");
+  const auto set_oauthbearer_config = [conn, &conf, &errstr]() {
+    std::string err_msg;
+    if (!validate_oauthbearer_params(
+        conn->oauthbearer_token_endpoint_url ? &*conn->oauthbearer_token_endpoint_url : nullptr,
+        conn->oauthbearer_client_id ? &*conn->oauthbearer_client_id : nullptr,
+        conn->oauthbearer_client_secret ? &*conn->oauthbearer_client_secret : nullptr,
+        err_msg)) {
+      ldout(conn->cct, 1) << "Kafka connect: " << err_msg << dendl;
+      return false;
+    }
+    if (rd_kafka_conf_set(conf.get(), "sasl.mechanism", "OAUTHBEARER", errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK ||
+        rd_kafka_conf_set(conf.get(), "sasl.oauthbearer.method", "oidc", errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK ||
+        rd_kafka_conf_set(conf.get(), "sasl.oauthbearer.token.endpoint.url", conn->oauthbearer_token_endpoint_url->c_str(), errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK ||
+        rd_kafka_conf_set(conf.get(), "sasl.oauthbearer.client.id", conn->oauthbearer_client_id->c_str(), errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK ||
+        rd_kafka_conf_set(conf.get(), "sasl.oauthbearer.client.secret", conn->oauthbearer_client_secret->c_str(), errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+      return false;
+    }
+    if (conn->oauthbearer_scope &&
+        rd_kafka_conf_set(conf.get(), "sasl.oauthbearer.scope", conn->oauthbearer_scope->c_str(), errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+      return false;
+    }
+    ldout(conn->cct, 20) << "Kafka connect: successfully configured OAUTHBEARER/OIDC" << dendl;
+    return true;
+  };
 
   // set message timeout
   // according to documentation, value of zero will expire the message based on retries.
@@ -387,11 +466,11 @@ bool new_producer(connection_t* conn) {
     ldout(conn->cct, 20) << "Kafka connect: configured GSSAPI SASL" << dendl;
 
     if (conn->kerberos_service_name) {
-      if (rd_kafka_conf_set(conf.get(), "sasl.kerberos.service.name", conn->kerberos_service_name->c_str(), errstr, 
+      if (rd_kafka_conf_set(conf.get(), "sasl.kerberos.service.name", conn->kerberos_service_name->c_str(), errstr,
                             sizeof(errstr)) != RD_KAFKA_CONF_OK) goto conf_error;
     }
     if (conn->kerberos_principal) {
-      if (rd_kafka_conf_set(conf.get(), "sasl.kerberos.principal", conn->kerberos_principal->c_str(), errstr, 
+      if (rd_kafka_conf_set(conf.get(), "sasl.kerberos.principal", conn->kerberos_principal->c_str(), errstr,
                             sizeof(errstr)) != RD_KAFKA_CONF_OK) goto conf_error;
     }
     if (conn->kerberos_keytab) {
@@ -401,7 +480,13 @@ bool new_producer(connection_t* conn) {
       ldout(conn->cct, 20) << "Kafka connect: GSSAPI without keytab; using ticket cache" << dendl;
     }
   } else if (conn->use_ssl) {
-    if (!conn->user.empty()) {
+    if (is_oauthbearer) {
+      // use SSL+SASL/OAUTHBEARER
+      if (rd_kafka_conf_set(conf.get(), "security.protocol", "SASL_SSL", errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK ||
+          !set_oauthbearer_config()) {
+        goto conf_error;
+      }
+    } else if (!conn->user.empty()) {
       // use SSL+SASL
       if (rd_kafka_conf_set(conf.get(), "security.protocol", "SASL_SSL", errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK ||
           rd_kafka_conf_set(conf.get(), "sasl.username", conn->user.c_str(), errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK ||
@@ -448,6 +533,12 @@ bool new_producer(connection_t* conn) {
     // if (rd_kafka_conf_set(conn->conf, "enable.ssl.certificate.verification", "0", errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) goto conf_error;
 
     ldout(conn->cct, 20) << "Kafka connect: successfully configured security" << dendl;
+  } else if (is_oauthbearer) {
+      // use SASL/OAUTHBEARER+PLAINTEXT
+      if (rd_kafka_conf_set(conf.get(), "security.protocol", "SASL_PLAINTEXT", errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK ||
+          !set_oauthbearer_config()) {
+        goto conf_error;
+      }
   } else if (!conn->user.empty()) {
     // use SASL+PLAINTEXT
     if (rd_kafka_conf_set(conf.get(), "security.protocol", "SASL_PLAINTEXT", errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK ||
@@ -742,7 +833,11 @@ public:
                boost::optional<const std::string&> ssl_key_password,
                boost::optional<const std::string&> topic_kerberos_service_name,
                boost::optional<const std::string&> topic_kerberos_principal,
-               boost::optional<const std::string&> topic_kerberos_keytab) {
+               boost::optional<const std::string&> topic_kerberos_keytab,
+               boost::optional<const std::string&> oauthbearer_token_endpoint_url,
+               boost::optional<const std::string&> oauthbearer_client_id,
+               boost::optional<const std::string&> oauthbearer_client_secret,
+               boost::optional<const std::string&> oauthbearer_scope) {
     if (stopped) {
       ldout(cct, 1) << "Kafka connect: manager is stopped" << dendl;
       return false;
@@ -774,20 +869,36 @@ public:
 
     const bool is_gssapi = mechanism.has_value() && boost::iequals(mechanism.get(), "GSSAPI");
 
+    const bool is_oauthbearer = mechanism && boost::iequals(*mechanism, "OAUTHBEARER");
+
     if (is_gssapi) {
       if (!user.empty() || !password.empty()) {
         ldout(cct, 5) << "Kafka connect: user/password provided with GSSAPI; ignoring" << dendl;
       }
       user.clear();
       password.clear();
-    } else {
-      // this should be validated by the regex in parse_url()
-      ceph_assert(user.empty() == password.empty());
+    }
 
-      if (!user.empty() && !use_ssl && !g_conf().get_val<bool>("rgw_allow_notification_secrets_in_cleartext")) {
-        ldout(cct, 1) << "Kafka connect: user/password are only allowed over secure connection" << dendl;
+    if (is_oauthbearer) {
+      if (!user.empty() || !password.empty() ||
+          topic_user_name.has_value() || topic_password.has_value()) {
+        ldout(cct, 1) << "Kafka connect: OAUTHBEARER does not accept user-name or password" << dendl;
         return false;
       }
+      if (!use_ssl && !g_conf().get_val<bool>("rgw_allow_notification_secrets_in_cleartext")) {
+        ldout(cct, 1) << "Kafka connect: OAUTHBEARER client secrets are only allowed over secure connection" << dendl;
+        return false;
+      }
+    }
+
+    if (!is_gssapi && !is_oauthbearer) {
+      // this should be validated by the regex in parse_url()
+      ceph_assert(user.empty() == password.empty());
+    }
+
+    if (!is_oauthbearer && !user.empty() && !use_ssl && !g_conf().get_val<bool>("rgw_allow_notification_secrets_in_cleartext")) {
+      ldout(cct, 1) << "Kafka connect: user/password are only allowed over secure connection" << dendl;
+      return false;
     }
     
     // ssl_certificate and ssl_key must both be provided for mTLS
@@ -823,7 +934,9 @@ public:
 
     connection_id_t tmp_id(broker_list, user, password, ca_location, mechanism,
                            use_ssl, verify_ssl, ssl_certificate, ssl_key, ssl_key_password,
-                           kerberos_service_name, kerberos_principal, kerberos_keytab);
+                           kerberos_service_name, kerberos_principal, kerberos_keytab,
+                           oauthbearer_token_endpoint_url, oauthbearer_client_id,
+                           oauthbearer_client_secret, oauthbearer_scope);
     std::lock_guard lock(connections_lock);
     const auto it = connections.find(tmp_id);
     // note that ssl vs. non-ssl connection to the same host are two separate connections
@@ -844,7 +957,9 @@ public:
 
     auto conn = std::make_unique<connection_t>(cct, broker_list, use_ssl, verify_ssl, ca_location, user, password,
                                                mechanism, ssl_certificate, ssl_key, ssl_key_password,
-                                               kerberos_service_name, kerberos_principal, kerberos_keytab);
+                                               kerberos_service_name, kerberos_principal, kerberos_keytab,
+                                               oauthbearer_token_endpoint_url, oauthbearer_client_id,
+                                               oauthbearer_client_secret, oauthbearer_scope);
     if (!new_producer(conn.get())) {
       ldout(cct, 10) << "Kafka connect: producer creation failed in new connection" << dendl;
       return false;
@@ -969,13 +1084,19 @@ bool connect(connection_id_t& conn_id,
              boost::optional<const std::string&> ssl_key_password,
              boost::optional<const std::string&> kerberos_service_name,
              boost::optional<const std::string&> kerberos_principal,
-             boost::optional<const std::string&> kerberos_keytab) {
+             boost::optional<const std::string&> kerberos_keytab,
+             boost::optional<const std::string&> oauthbearer_token_endpoint_url,
+             boost::optional<const std::string&> oauthbearer_client_id,
+             boost::optional<const std::string&> oauthbearer_client_secret,
+             boost::optional<const std::string&> oauthbearer_scope) {
   std::shared_lock lock(s_manager_mutex);
   if (!s_manager) return false;
   return s_manager->connect(conn_id, url, use_ssl, verify_ssl, ca_location,
                             mechanism, user_name, password, brokers,
                             ssl_certificate, ssl_key, ssl_key_password,
-                            kerberos_service_name, kerberos_principal, kerberos_keytab);
+                            kerberos_service_name, kerberos_principal, kerberos_keytab,
+                            oauthbearer_token_endpoint_url, oauthbearer_client_id,
+                            oauthbearer_client_secret, oauthbearer_scope);
 }
 
 int publish(const connection_id_t& conn_id,

--- a/src/rgw/rgw_kafka.cc
+++ b/src/rgw/rgw_kafka.cc
@@ -6,6 +6,7 @@
 #include <librdkafka/rdkafka.h>
 #include "include/ceph_assert.h"
 #include <sstream>
+#include <cstdio>
 #include <cstring>
 #include <unordered_map>
 #include <string>
@@ -83,7 +84,11 @@ connection_id_t::connection_id_t(
     const boost::optional<const std::string&>& _ssl_key_password,
     const boost::optional<const std::string&>& _kerberos_service_name,
     const boost::optional<const std::string&>& _kerberos_principal,
-    const boost::optional<const std::string&>& _kerberos_keytab
+    const boost::optional<const std::string&>& _kerberos_keytab,
+    const boost::optional<const std::string&>& _oauthbearer_token_endpoint_url,
+    const boost::optional<const std::string&>& _oauthbearer_client_id,
+    const boost::optional<const std::string&>& _oauthbearer_client_secret,
+    const boost::optional<const std::string&>& _oauthbearer_scope
   )
     : broker(_broker), user(_user), password(_password), ssl(_ssl),
       verify_ssl(_verify_ssl) {
@@ -112,6 +117,18 @@ connection_id_t::connection_id_t(
   if (_kerberos_keytab.has_value()) {
     kerberos_keytab = _kerberos_keytab.get();
   }
+  if (_oauthbearer_token_endpoint_url.has_value()) {
+    oauthbearer_token_endpoint_url = _oauthbearer_token_endpoint_url.get();
+  }
+  if (_oauthbearer_client_id.has_value()) {
+    oauthbearer_client_id = _oauthbearer_client_id.get();
+  }
+  if (_oauthbearer_client_secret.has_value()) {
+    oauthbearer_client_secret = _oauthbearer_client_secret.get();
+  }
+  if (_oauthbearer_scope.has_value()) {
+    oauthbearer_scope = _oauthbearer_scope.get();
+  }
 }
 
 // equality operator and hasher functor are needed
@@ -126,7 +143,11 @@ bool operator==(const connection_id_t& lhs, const connection_id_t& rhs) {
          lhs.ssl_key_password == rhs.ssl_key_password &&
          lhs.kerberos_service_name == rhs.kerberos_service_name &&
          lhs.kerberos_principal == rhs.kerberos_principal &&
-         lhs.kerberos_keytab == rhs.kerberos_keytab;
+         lhs.kerberos_keytab == rhs.kerberos_keytab &&
+         lhs.oauthbearer_token_endpoint_url == rhs.oauthbearer_token_endpoint_url &&
+         lhs.oauthbearer_client_id == rhs.oauthbearer_client_id &&
+         lhs.oauthbearer_client_secret == rhs.oauthbearer_client_secret &&
+         lhs.oauthbearer_scope == rhs.oauthbearer_scope;
 }
 
 struct connection_id_hasher {
@@ -145,6 +166,10 @@ struct connection_id_hasher {
     boost::hash_combine(h, k.kerberos_service_name);
     boost::hash_combine(h, k.kerberos_principal);
     boost::hash_combine(h, k.kerberos_keytab);
+    boost::hash_combine(h, k.oauthbearer_token_endpoint_url);
+    boost::hash_combine(h, k.oauthbearer_client_id);
+    boost::hash_combine(h, k.oauthbearer_client_secret);
+    boost::hash_combine(h, k.oauthbearer_scope);
     return h;
   }
 };
@@ -166,6 +191,15 @@ std::string to_string(const connection_id_t& id) {
   }
   if (!id.kerberos_keytab.empty()) {
     ss << " keytab=" << id.kerberos_keytab;
+  }
+  if (!id.oauthbearer_token_endpoint_url.empty()) {
+    ss << " token_endpoint=" << id.oauthbearer_token_endpoint_url;
+  }
+  if (!id.oauthbearer_client_id.empty()) {
+    ss << " client_id=" << id.oauthbearer_client_id;
+  }
+  if (!id.oauthbearer_scope.empty()) {
+    ss << " scope=" << id.oauthbearer_scope;
   }
   return ss.str();
 }
@@ -229,6 +263,10 @@ struct connection_t {
   const boost::optional<std::string> kerberos_service_name;
   const boost::optional<std::string> kerberos_principal;
   const boost::optional<std::string> kerberos_keytab;
+  const boost::optional<std::string> oauthbearer_token_endpoint_url;
+  const boost::optional<std::string> oauthbearer_client_id;
+  const boost::optional<std::string> oauthbearer_client_secret;
+  const boost::optional<std::string> oauthbearer_scope;
   utime_t timestamp = ceph_clock_now();
 
   // cleanup of all internal connection resource
@@ -259,7 +297,7 @@ struct connection_t {
   }
 
   // ctor for setting immutable values
-  connection_t(CephContext* _cct, const std::string& _broker, bool _use_ssl, bool _verify_ssl, 
+  connection_t(CephContext* _cct, const std::string& _broker, bool _use_ssl, bool _verify_ssl,
           const boost::optional<const std::string&>& _ca_location,
           const std::string& _user, const std::string& _password, const boost::optional<const std::string&>& _mechanism,
           const boost::optional<const std::string&>& _ssl_certificate,
@@ -267,10 +305,17 @@ struct connection_t {
           const boost::optional<const std::string&>& _ssl_key_password,
           const boost::optional<const std::string&>& _kerberos_service_name,
           const boost::optional<const std::string&>& _kerberos_principal,
-          const boost::optional<const std::string&>& _kerberos_keytab) :
+          const boost::optional<const std::string&>& _kerberos_keytab,
+          const boost::optional<const std::string&>& _oauthbearer_token_endpoint_url,
+          const boost::optional<const std::string&>& _oauthbearer_client_id,
+          const boost::optional<const std::string&>& _oauthbearer_client_secret,
+          const boost::optional<const std::string&>& _oauthbearer_scope) :
       cct(_cct), broker(_broker), use_ssl(_use_ssl), verify_ssl(_verify_ssl), ca_location(_ca_location), user(_user), password(_password), mechanism(_mechanism),
       ssl_certificate(_ssl_certificate), ssl_key(_ssl_key), ssl_key_password(_ssl_key_password),
-      kerberos_service_name(_kerberos_service_name), kerberos_principal(_kerberos_principal), kerberos_keytab(_kerberos_keytab) {}                                                                                                                                                        
+      kerberos_service_name(_kerberos_service_name), kerberos_principal(_kerberos_principal), kerberos_keytab(_kerberos_keytab),
+      oauthbearer_token_endpoint_url(_oauthbearer_token_endpoint_url),
+      oauthbearer_client_id(_oauthbearer_client_id), oauthbearer_client_secret(_oauthbearer_client_secret),
+      oauthbearer_scope(_oauthbearer_scope) {}
 
   // dtor also destroys the internals
   ~connection_t() {
@@ -337,6 +382,16 @@ void poll_err_callback(rd_kafka_t *rk, int err, const char *reason, void *opaque
 
 using connection_t_ptr = std::unique_ptr<connection_t>;
 
+// boost::optional<std::string> does not convert to boost::optional<const std::string&>,
+// so the held value has to be re-bound explicitly
+static boost::optional<const std::string&> optional_ref(
+    const boost::optional<std::string>& s) {
+  if (s) {
+    return *s;
+  }
+  return boost::none;
+}
+
 // utility function to create a producer, when the connection object already exists
 bool new_producer(connection_t* conn) {
   // reset all status codes
@@ -355,6 +410,31 @@ bool new_producer(connection_t* conn) {
   char errstr[512] = {0};
 
   const bool is_gssapi = conn->mechanism && boost::iequals(*conn->mechanism, "GSSAPI");
+  const bool is_oauthbearer = conn->mechanism && boost::iequals(*conn->mechanism, "OAUTHBEARER");
+  const auto set_oauthbearer_config = [&conn, &conf, &errstr]() {
+    if (const auto err_msg = validate_oauthbearer_params(
+            optional_ref(conn->oauthbearer_token_endpoint_url),
+            optional_ref(conn->oauthbearer_client_id),
+            optional_ref(conn->oauthbearer_client_secret));
+        !err_msg.empty()) {
+      // report via errstr, so that the caller logs it at the conf_error label
+      std::snprintf(errstr, sizeof(errstr), "%s", err_msg.c_str());
+      return false;
+    }
+    if (rd_kafka_conf_set(conf.get(), "sasl.mechanism", "OAUTHBEARER", errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK ||
+        rd_kafka_conf_set(conf.get(), "sasl.oauthbearer.method", "oidc", errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK ||
+        rd_kafka_conf_set(conf.get(), "sasl.oauthbearer.token.endpoint.url", conn->oauthbearer_token_endpoint_url->c_str(), errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK ||
+        rd_kafka_conf_set(conf.get(), "sasl.oauthbearer.client.id", conn->oauthbearer_client_id->c_str(), errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK ||
+        rd_kafka_conf_set(conf.get(), "sasl.oauthbearer.client.secret", conn->oauthbearer_client_secret->c_str(), errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+      return false;
+    }
+    if (conn->oauthbearer_scope &&
+        rd_kafka_conf_set(conf.get(), "sasl.oauthbearer.scope", conn->oauthbearer_scope->c_str(), errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+      return false;
+    }
+    ldout(conn->cct, 20) << "Kafka connect: successfully configured OAUTHBEARER/OIDC" << dendl;
+    return true;
+  };
 
   // set message timeout
   // according to documentation, value of zero will expire the message based on retries.
@@ -387,11 +467,11 @@ bool new_producer(connection_t* conn) {
     ldout(conn->cct, 20) << "Kafka connect: configured GSSAPI SASL" << dendl;
 
     if (conn->kerberos_service_name) {
-      if (rd_kafka_conf_set(conf.get(), "sasl.kerberos.service.name", conn->kerberos_service_name->c_str(), errstr, 
+      if (rd_kafka_conf_set(conf.get(), "sasl.kerberos.service.name", conn->kerberos_service_name->c_str(), errstr,
                             sizeof(errstr)) != RD_KAFKA_CONF_OK) goto conf_error;
     }
     if (conn->kerberos_principal) {
-      if (rd_kafka_conf_set(conf.get(), "sasl.kerberos.principal", conn->kerberos_principal->c_str(), errstr, 
+      if (rd_kafka_conf_set(conf.get(), "sasl.kerberos.principal", conn->kerberos_principal->c_str(), errstr,
                             sizeof(errstr)) != RD_KAFKA_CONF_OK) goto conf_error;
     }
     if (conn->kerberos_keytab) {
@@ -401,7 +481,13 @@ bool new_producer(connection_t* conn) {
       ldout(conn->cct, 20) << "Kafka connect: GSSAPI without keytab; using ticket cache" << dendl;
     }
   } else if (conn->use_ssl) {
-    if (!conn->user.empty()) {
+    if (is_oauthbearer) {
+      // use SSL+SASL/OAUTHBEARER
+      if (rd_kafka_conf_set(conf.get(), "security.protocol", "SASL_SSL", errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK ||
+          !set_oauthbearer_config()) {
+        goto conf_error;
+      }
+    } else if (!conn->user.empty()) {
       // use SSL+SASL
       if (rd_kafka_conf_set(conf.get(), "security.protocol", "SASL_SSL", errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK ||
           rd_kafka_conf_set(conf.get(), "sasl.username", conn->user.c_str(), errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK ||
@@ -448,6 +534,12 @@ bool new_producer(connection_t* conn) {
     // if (rd_kafka_conf_set(conn->conf, "enable.ssl.certificate.verification", "0", errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) goto conf_error;
 
     ldout(conn->cct, 20) << "Kafka connect: successfully configured security" << dendl;
+  } else if (is_oauthbearer) {
+      // use SASL/OAUTHBEARER+PLAINTEXT
+      if (rd_kafka_conf_set(conf.get(), "security.protocol", "SASL_PLAINTEXT", errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK ||
+          !set_oauthbearer_config()) {
+        goto conf_error;
+      }
   } else if (!conn->user.empty()) {
     // use SASL+PLAINTEXT
     if (rd_kafka_conf_set(conf.get(), "security.protocol", "SASL_PLAINTEXT", errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK ||
@@ -742,7 +834,11 @@ public:
                boost::optional<const std::string&> ssl_key_password,
                boost::optional<const std::string&> topic_kerberos_service_name,
                boost::optional<const std::string&> topic_kerberos_principal,
-               boost::optional<const std::string&> topic_kerberos_keytab) {
+               boost::optional<const std::string&> topic_kerberos_keytab,
+               boost::optional<const std::string&> oauthbearer_token_endpoint_url,
+               boost::optional<const std::string&> oauthbearer_client_id,
+               boost::optional<const std::string&> oauthbearer_client_secret,
+               boost::optional<const std::string&> oauthbearer_scope) {
     if (stopped) {
       ldout(cct, 1) << "Kafka connect: manager is stopped" << dendl;
       return false;
@@ -772,22 +868,32 @@ public:
       password = topic_password.get();
     }
 
-    const bool is_gssapi = mechanism.has_value() && boost::iequals(mechanism.get(), "GSSAPI");
+    const bool is_gssapi = mechanism && boost::iequals(*mechanism, "GSSAPI");
 
-    if (is_gssapi) {
-      if (!user.empty() || !password.empty()) {
-        ldout(cct, 5) << "Kafka connect: user/password provided with GSSAPI; ignoring" << dendl;
-      }
-      user.clear();
-      password.clear();
-    } else {
-      // this should be validated by the regex in parse_url()
-      ceph_assert(user.empty() == password.empty());
+    const bool is_oauthbearer = mechanism && boost::iequals(*mechanism, "OAUTHBEARER");
 
-      if (!user.empty() && !use_ssl && !g_conf().get_val<bool>("rgw_allow_notification_secrets_in_cleartext")) {
-        ldout(cct, 1) << "Kafka connect: user/password are only allowed over secure connection" << dendl;
+    if (is_gssapi || is_oauthbearer) {
+      if (!user.empty() || !password.empty() || topic_user_name.has_value() || topic_password.has_value()) {
+        ldout(cct, 1) << "Kafka connect: " << *mechanism << " does not accept user-name or password" << dendl;
         return false;
       }
+    }
+
+    if (is_oauthbearer) {
+      if (!use_ssl && !g_conf().get_val<bool>("rgw_allow_notification_secrets_in_cleartext")) {
+        ldout(cct, 1) << "Kafka connect: OAUTHBEARER client secrets are only allowed over secure connection" << dendl;
+        return false;
+      }
+    }
+
+    if (!is_gssapi && !is_oauthbearer) {
+      // this should be validated by the regex in parse_url()
+      ceph_assert(user.empty() == password.empty());
+    }
+
+    if (!is_oauthbearer && !user.empty() && !use_ssl && !g_conf().get_val<bool>("rgw_allow_notification_secrets_in_cleartext")) {
+      ldout(cct, 1) << "Kafka connect: user/password are only allowed over secure connection" << dendl;
+      return false;
     }
     
     // ssl_certificate and ssl_key must both be provided for mTLS
@@ -823,7 +929,9 @@ public:
 
     connection_id_t tmp_id(broker_list, user, password, ca_location, mechanism,
                            use_ssl, verify_ssl, ssl_certificate, ssl_key, ssl_key_password,
-                           kerberos_service_name, kerberos_principal, kerberos_keytab);
+                           kerberos_service_name, kerberos_principal, kerberos_keytab,
+                           oauthbearer_token_endpoint_url, oauthbearer_client_id,
+                           oauthbearer_client_secret, oauthbearer_scope);
     std::lock_guard lock(connections_lock);
     const auto it = connections.find(tmp_id);
     // note that ssl vs. non-ssl connection to the same host are two separate connections
@@ -844,7 +952,9 @@ public:
 
     auto conn = std::make_unique<connection_t>(cct, broker_list, use_ssl, verify_ssl, ca_location, user, password,
                                                mechanism, ssl_certificate, ssl_key, ssl_key_password,
-                                               kerberos_service_name, kerberos_principal, kerberos_keytab);
+                                               kerberos_service_name, kerberos_principal, kerberos_keytab,
+                                               oauthbearer_token_endpoint_url, oauthbearer_client_id,
+                                               oauthbearer_client_secret, oauthbearer_scope);
     if (!new_producer(conn.get())) {
       ldout(cct, 10) << "Kafka connect: producer creation failed in new connection" << dendl;
       return false;
@@ -969,13 +1079,19 @@ bool connect(connection_id_t& conn_id,
              boost::optional<const std::string&> ssl_key_password,
              boost::optional<const std::string&> kerberos_service_name,
              boost::optional<const std::string&> kerberos_principal,
-             boost::optional<const std::string&> kerberos_keytab) {
+             boost::optional<const std::string&> kerberos_keytab,
+             boost::optional<const std::string&> oauthbearer_token_endpoint_url,
+             boost::optional<const std::string&> oauthbearer_client_id,
+             boost::optional<const std::string&> oauthbearer_client_secret,
+             boost::optional<const std::string&> oauthbearer_scope) {
   std::shared_lock lock(s_manager_mutex);
   if (!s_manager) return false;
   return s_manager->connect(conn_id, url, use_ssl, verify_ssl, ca_location,
                             mechanism, user_name, password, brokers,
                             ssl_certificate, ssl_key, ssl_key_password,
-                            kerberos_service_name, kerberos_principal, kerberos_keytab);
+                            kerberos_service_name, kerberos_principal, kerberos_keytab,
+                            oauthbearer_token_endpoint_url, oauthbearer_client_id,
+                            oauthbearer_client_secret, oauthbearer_scope);
 }
 
 int publish(const connection_id_t& conn_id,

--- a/src/rgw/rgw_kafka.h
+++ b/src/rgw/rgw_kafka.h
@@ -34,6 +34,10 @@ struct connection_id_t {
   std::string kerberos_service_name;
   std::string kerberos_principal;
   std::string kerberos_keytab;
+  std::string oauthbearer_token_endpoint_url;
+  std::string oauthbearer_client_id;
+  std::string oauthbearer_client_secret;
+  std::string oauthbearer_scope;
   bool ssl = false;
   bool verify_ssl = true;
   connection_id_t() = default;
@@ -49,7 +53,11 @@ struct connection_id_t {
                   const boost::optional<const std::string&>& _ssl_key_password,
                   const boost::optional<const std::string&>& _kerberos_service_name,
                   const boost::optional<const std::string&>& _kerberos_principal,
-                  const boost::optional<const std::string&>& _kerberos_keytab);
+                  const boost::optional<const std::string&>& _kerberos_keytab,
+                  const boost::optional<const std::string&>& _oauthbearer_token_endpoint_url,
+                  const boost::optional<const std::string&>& _oauthbearer_client_id,
+                  const boost::optional<const std::string&>& _oauthbearer_client_secret,
+                  const boost::optional<const std::string&>& _oauthbearer_scope);
 };
 
 std::string to_string(const connection_id_t& id);
@@ -69,7 +77,11 @@ bool connect(connection_id_t& conn_id,
              boost::optional<const std::string&> ssl_key_password,
              boost::optional<const std::string&> kerberos_service_name,
              boost::optional<const std::string&> kerberos_principal,
-             boost::optional<const std::string&> kerberos_keytab);
+             boost::optional<const std::string&> kerberos_keytab,
+             boost::optional<const std::string&> oauthbearer_token_endpoint_url,
+             boost::optional<const std::string&> oauthbearer_client_id,
+             boost::optional<const std::string&> oauthbearer_client_secret,
+             boost::optional<const std::string&> oauthbearer_scope);
 
 // publish a message over a connection that was already created
 int publish(const connection_id_t& conn_id,
@@ -83,6 +95,14 @@ int publish_with_confirm(const connection_id_t& conn_id,
                          const std::string& topic,
                          const std::string& message,
                          reply_callback_t cb);
+
+// validate required OAUTHBEARER parameters; nullptr means "not provided"
+// returns true if all required params are present and non-empty
+// on failure, sets message to a human-readable error string
+bool validate_oauthbearer_params(const std::string* token_endpoint_url,
+                                 const std::string* client_id,
+                                 const std::string* client_secret,
+                                 std::string& message);
 
 // convert the integer status returned from the "publish" function to a string
 std::string status_to_string(int s);

--- a/src/rgw/rgw_kafka.h
+++ b/src/rgw/rgw_kafka.h
@@ -34,6 +34,10 @@ struct connection_id_t {
   std::string kerberos_service_name;
   std::string kerberos_principal;
   std::string kerberos_keytab;
+  std::string oauthbearer_token_endpoint_url;
+  std::string oauthbearer_client_id;
+  std::string oauthbearer_client_secret;
+  std::string oauthbearer_scope;
   bool ssl = false;
   bool verify_ssl = true;
   connection_id_t() = default;
@@ -49,7 +53,11 @@ struct connection_id_t {
                   const boost::optional<const std::string&>& _ssl_key_password,
                   const boost::optional<const std::string&>& _kerberos_service_name,
                   const boost::optional<const std::string&>& _kerberos_principal,
-                  const boost::optional<const std::string&>& _kerberos_keytab);
+                  const boost::optional<const std::string&>& _kerberos_keytab,
+                  const boost::optional<const std::string&>& _oauthbearer_token_endpoint_url,
+                  const boost::optional<const std::string&>& _oauthbearer_client_id,
+                  const boost::optional<const std::string&>& _oauthbearer_client_secret,
+                  const boost::optional<const std::string&>& _oauthbearer_scope);
 };
 
 std::string to_string(const connection_id_t& id);
@@ -69,7 +77,11 @@ bool connect(connection_id_t& conn_id,
              boost::optional<const std::string&> ssl_key_password,
              boost::optional<const std::string&> kerberos_service_name,
              boost::optional<const std::string&> kerberos_principal,
-             boost::optional<const std::string&> kerberos_keytab);
+             boost::optional<const std::string&> kerberos_keytab,
+             boost::optional<const std::string&> oauthbearer_token_endpoint_url,
+             boost::optional<const std::string&> oauthbearer_client_id,
+             boost::optional<const std::string&> oauthbearer_client_secret,
+             boost::optional<const std::string&> oauthbearer_scope);
 
 // publish a message over a connection that was already created
 int publish(const connection_id_t& conn_id,
@@ -83,6 +95,27 @@ int publish_with_confirm(const connection_id_t& conn_id,
                          const std::string& topic,
                          const std::string& message,
                          reply_callback_t cb);
+
+// returns an empty string if all of oauth parameters are present and
+// non-empty, otherwise a human-readable error string naming the first
+// one that is missing.
+// defined inline, so that callers validating topic attributes do not need
+// rgw_kafka.cc, which is only built when WITH_RADOSGW_KAFKA_ENDPOINT is set
+inline std::string validate_oauthbearer_params(
+    const boost::optional<const std::string&>& token_endpoint_url,
+    const boost::optional<const std::string&>& client_id,
+    const boost::optional<const std::string&>& client_secret) {
+  if (!token_endpoint_url || token_endpoint_url->empty()) {
+    return "OAUTHBEARER requires sasl-oauthbearer-token-endpoint-url";
+  }
+  if (!client_id || client_id->empty()) {
+    return "OAUTHBEARER requires sasl-oauthbearer-client-id";
+  }
+  if (!client_secret || client_secret->empty()) {
+    return "OAUTHBEARER requires sasl-oauthbearer-client-secret";
+  }
+  return {};
+}
 
 // convert the integer status returned from the "publish" function to a string
 std::string status_to_string(int s);

--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -2,12 +2,14 @@
 // vim: ts=8 sw=2 sts=2 expandtab
 
 #include <algorithm>
+#include <boost/algorithm/string.hpp>
 #include <boost/tokenizer.hpp>
 #include <optional>
 #include <regex>
 #include "include/function2.hpp"
 #include "rgw_account.h"
 #include "rgw_iam_policy.h"
+#include "rgw_kafka.h"
 #include "rgw_rest_pubsub.h"
 #include "rgw_pubsub.h"
 #include "rgw_op.h"
@@ -32,6 +34,16 @@ bool verify_transport_security(CephContext *cct, const RGWEnv& env) {
   return is_secure;
 }
 
+static bool mark_secret_and_check_transport(rgw_pubsub_dest& dest, CephContext* cct,
+                                             const RGWEnv& env, std::string& message) {
+  dest.stored_secret = true;
+  if (!verify_transport_security(cct, env)) {
+    message = "Topic contains secrets that must be transmitted over a secure transport";
+    return false;
+  }
+  return true;
+}
+
 // make sure that endpoint is a valid URL
 // make sure that if user/password are passed inside URL, it is over secure connection
 // update rgw_pubsub_dest to indicate that a password is stored in the URL
@@ -49,8 +61,35 @@ bool validate_and_update_endpoint_secret(rgw_pubsub_dest& dest, CephContext *cct
   }
 
   const auto& args=ri.args;
+  auto mechanism = args.get_optional("mechanism");
   auto topic_user_name=args.get_optional("user-name");
   auto topic_password=args.get_optional("password");
+  const bool is_oauthbearer = mechanism && boost::iequals(*mechanism, "OAUTHBEARER");
+
+  if (is_oauthbearer && (topic_user_name.has_value() || topic_password.has_value() || !user.empty() || !password.empty())) {
+    message = "OAUTHBEARER does not accept user-name or password";
+    return false;
+  }
+
+  if (is_oauthbearer) {
+    auto oauthbearer_token_endpoint_url = args.get_optional("sasl.oauthbearer.token.endpoint.url");
+    auto oauthbearer_client_id = args.get_optional("sasl.oauthbearer.client.id");
+    auto oauthbearer_client_secret = args.get_optional("sasl.oauthbearer.client.secret");
+    if (!rgw::kafka::validate_oauthbearer_params(
+        oauthbearer_token_endpoint_url ? &*oauthbearer_token_endpoint_url : nullptr,
+        oauthbearer_client_id ? &*oauthbearer_client_id : nullptr,
+        oauthbearer_client_secret ? &*oauthbearer_client_secret : nullptr,
+        message)) {
+      return false;
+    }
+  }
+
+  auto oauthbearer_client_secret = args.get_optional("sasl.oauthbearer.client.secret");
+  if (oauthbearer_client_secret.has_value() && !oauthbearer_client_secret->empty()) {
+    if (!mark_secret_and_check_transport(dest, cct, *ri.env, message)) {
+      return false;
+    }
+  }
 
   // check if username/password was already supplied via topic attributes
   // and if also provided as part of the endpoint URL issue a warning
@@ -70,9 +109,7 @@ bool validate_and_update_endpoint_secret(rgw_pubsub_dest& dest, CephContext *cct
   // this should be verified inside parse_url()
   ceph_assert(user.empty() == password.empty());
   if (!user.empty()) {
-    dest.stored_secret = true;
-    if (!verify_transport_security(cct, *ri.env)) {
-      message = "Topic contains secrets that must be transmitted over a secure transport";
+    if (!mark_secret_and_check_transport(dest, cct, *ri.env, message)) {
       return false;
     }
   }
@@ -80,9 +117,7 @@ bool validate_and_update_endpoint_secret(rgw_pubsub_dest& dest, CephContext *cct
   // check for mTLS key password - also a secret that requires secure transport
   auto ssl_key_password = args.get_optional("ssl-key-password");
   if (ssl_key_password.has_value() && !ssl_key_password->empty()) {
-    dest.stored_secret = true;
-    if (!verify_transport_security(cct, *ri.env)) {
-      message = "Topic contains secrets that must be transmitted over a secure transport";
+    if (!mark_secret_and_check_transport(dest, cct, *ri.env, message)) {
       return false;
     }
   }
@@ -826,9 +861,19 @@ class RGWPSSetTopicAttributesOp : public RGWOp {
           "amqp-exchange", "kafka-ack-level", "mechanism",   "cloudevents",
           "user-name",     "password",
           "ssl-certificate-location", "ssl-key-location", "ssl-key-password",
-          "sasl-kerberos-service-name", "sasl-kerberos-principal", "sasl-kerberos-keytab"};
+          "sasl-kerberos-service-name", "sasl-kerberos-principal", "sasl-kerberos-keytab",
+          "sasl.oauthbearer.token.endpoint.url",
+          "sasl.oauthbearer.client.id",
+          "sasl.oauthbearer.client.secret",
+          "sasl.oauthbearer.scope"};
       if (std::find(args.begin(), args.end(), attribute_name) != args.end()) {
-        replace_str(attribute_name, s->info.args.get("AttributeValue"));
+        const auto& attr_value = s->info.args.get("AttributeValue");
+        replace_str(attribute_name, attr_value);
+        if (attribute_name == "sasl.oauthbearer.client.secret" && !attr_value.empty()) {
+          if (!mark_secret_and_check_transport(dest, s->cct, *s->info.env, s->err.message)) {
+            return -EINVAL;
+          }
+        }
         return 0;
       }
       s->err.message = fmt::format("Invalid value for AttributeName '{}'",
@@ -1702,4 +1747,3 @@ RGWOp* RGWHandler_REST_PSNotifs_S3::create_put_op() {
 RGWOp* RGWHandler_REST_PSNotifs_S3::create_delete_op() {
   return new RGWPSDeleteNotifOp();
 }
-

--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -2,12 +2,14 @@
 // vim: ts=8 sw=2 sts=2 expandtab
 
 #include <algorithm>
+#include <boost/algorithm/string.hpp>
 #include <boost/tokenizer.hpp>
 #include <optional>
 #include <regex>
 #include "include/function2.hpp"
 #include "rgw_account.h"
 #include "rgw_iam_policy.h"
+#include "rgw_kafka.h"
 #include "rgw_rest_pubsub.h"
 #include "rgw_pubsub.h"
 #include "rgw_op.h"
@@ -32,6 +34,16 @@ bool verify_transport_security(CephContext *cct, const RGWEnv& env) {
   return is_secure;
 }
 
+static bool mark_secret_and_check_transport(rgw_pubsub_dest& dest, CephContext* cct,
+                                             const RGWEnv& env, std::string& message) {
+  dest.stored_secret = true;
+  if (!verify_transport_security(cct, env)) {
+    message = "Topic contains secrets that must be transmitted over a secure transport";
+    return false;
+  }
+  return true;
+}
+
 // make sure that endpoint is a valid URL
 // make sure that if user/password are passed inside URL, it is over secure connection
 // update rgw_pubsub_dest to indicate that a password is stored in the URL
@@ -49,8 +61,38 @@ bool validate_and_update_endpoint_secret(rgw_pubsub_dest& dest, CephContext *cct
   }
 
   const auto& args=ri.args;
+  auto mechanism = args.get_optional("mechanism");
   auto topic_user_name=args.get_optional("user-name");
   auto topic_password=args.get_optional("password");
+  const bool is_gssapi = mechanism && boost::iequals(*mechanism, "GSSAPI");
+  const bool is_oauthbearer = mechanism && boost::iequals(*mechanism, "OAUTHBEARER");
+  auto oauthbearer_client_secret = args.get_optional("sasl-oauthbearer-client-secret");
+
+  if ((is_gssapi || is_oauthbearer) &&
+      (topic_user_name.has_value() || topic_password.has_value() || !user.empty() || !password.empty())) {
+    message = is_gssapi ? "GSSAPI does not accept user-name or password"
+                        : "OAUTHBEARER does not accept user-name or password";
+    return false;
+  }
+
+  if (is_oauthbearer) {
+    auto oauthbearer_token_endpoint_url = args.get_optional("sasl-oauthbearer-token-endpoint-url");
+    auto oauthbearer_client_id = args.get_optional("sasl-oauthbearer-client-id");
+    if (auto err_msg = rgw::kafka::validate_oauthbearer_params(
+            oauthbearer_token_endpoint_url,
+            oauthbearer_client_id,
+            oauthbearer_client_secret);
+        !err_msg.empty()) {
+      message = std::move(err_msg);
+      return false;
+    }
+  }
+
+  if (oauthbearer_client_secret.has_value() && !oauthbearer_client_secret->empty()) {
+    if (!mark_secret_and_check_transport(dest, cct, *ri.env, message)) {
+      return false;
+    }
+  }
 
   // check if username/password was already supplied via topic attributes
   // and if also provided as part of the endpoint URL issue a warning
@@ -70,9 +112,7 @@ bool validate_and_update_endpoint_secret(rgw_pubsub_dest& dest, CephContext *cct
   // this should be verified inside parse_url()
   ceph_assert(user.empty() == password.empty());
   if (!user.empty()) {
-    dest.stored_secret = true;
-    if (!verify_transport_security(cct, *ri.env)) {
-      message = "Topic contains secrets that must be transmitted over a secure transport";
+    if (!mark_secret_and_check_transport(dest, cct, *ri.env, message)) {
       return false;
     }
   }
@@ -80,9 +120,7 @@ bool validate_and_update_endpoint_secret(rgw_pubsub_dest& dest, CephContext *cct
   // check for mTLS key password - also a secret that requires secure transport
   auto ssl_key_password = args.get_optional("ssl-key-password");
   if (ssl_key_password.has_value() && !ssl_key_password->empty()) {
-    dest.stored_secret = true;
-    if (!verify_transport_security(cct, *ri.env)) {
-      message = "Topic contains secrets that must be transmitted over a secure transport";
+    if (!mark_secret_and_check_transport(dest, cct, *ri.env, message)) {
       return false;
     }
   }
@@ -811,12 +849,17 @@ class RGWPSSetTopicAttributesOp : public RGWOp {
                                    const std::string& val) {
         auto& push_endpoint_args = dest.push_endpoint_args;
         const std::string replaced_str = param + "=" + val;
-        const auto pos = push_endpoint_args.find(param);
+        const std::string needle = param + "=";
+        auto pos = push_endpoint_args.find(needle);
+        while (pos != std::string::npos && pos != 0 &&
+               push_endpoint_args[pos - 1] != '&') {
+          pos = push_endpoint_args.find(needle, pos + 1);
+        }
         if (pos == std::string::npos) {
-          dest.push_endpoint_args.append("&" + replaced_str);
+          push_endpoint_args.append("&" + replaced_str);
           return;
         }
-        auto end_pos = dest.push_endpoint_args.find("&", pos);
+        auto end_pos = push_endpoint_args.find("&", pos);
         end_pos = end_pos == std::string::npos ? push_endpoint_args.length()
                                                : end_pos;
         push_endpoint_args.replace(pos, end_pos - pos, replaced_str);
@@ -826,9 +869,22 @@ class RGWPSSetTopicAttributesOp : public RGWOp {
           "amqp-exchange", "kafka-ack-level", "mechanism",   "cloudevents",
           "user-name",     "password",
           "ssl-certificate-location", "ssl-key-location", "ssl-key-password",
-          "sasl-kerberos-service-name", "sasl-kerberos-principal", "sasl-kerberos-keytab"};
+          "sasl-kerberos-service-name", "sasl-kerberos-principal", "sasl-kerberos-keytab",
+          "sasl-oauthbearer-token-endpoint-url",
+          "sasl-oauthbearer-client-id",
+          "sasl-oauthbearer-client-secret",
+          "sasl-oauthbearer-scope"};
       if (std::find(args.begin(), args.end(), attribute_name) != args.end()) {
-        replace_str(attribute_name, s->info.args.get("AttributeValue"));
+        static constexpr std::initializer_list<const char*> secret_args = {
+          "password", "ssl-key-password", "sasl-oauthbearer-client-secret"};
+        const auto& attr_value = s->info.args.get("AttributeValue");
+        replace_str(attribute_name, attr_value);
+        if (!attr_value.empty() &&
+            std::find(secret_args.begin(), secret_args.end(), attribute_name) != secret_args.end()) {
+          if (!mark_secret_and_check_transport(dest, s->cct, *s->info.env, s->err.message)) {
+            return -EINVAL;
+          }
+        }
         return 0;
       }
       s->err.message = fmt::format("Invalid value for AttributeName '{}'",

--- a/src/test/rgw/bucket_notification/README.rst
+++ b/src/test/rgw/bucket_notification/README.rst
@@ -135,7 +135,7 @@ Kafka Security Tests
         listener.name.mtls.ssl.truststore.password=mypassword
 
         # SASL mechanisms
-        sasl.enabled.mechanisms=PLAIN,SCRAM-SHA-256,SCRAM-SHA-512,GSSAPI
+        sasl.enabled.mechanisms=PLAIN,SCRAM-SHA-256,SCRAM-SHA-512,GSSAPI,OAUTHBEARER
         sasl.kerberos.service.name=kafka
         sasl.mechanism.inter.broker.protocol=PLAIN
         inter.broker.listener.name=PLAINTEXT
@@ -163,6 +163,14 @@ Kafka Security Tests
         keyTab="/etc/krb5-keytabs/kafka.service.keytab" \
         principal="kafka/192.168.1.100@REALM";
 
+        # SASL over SSL with OAUTHBEARER mechanism
+        listener.name.sasl_ssl.oauthbearer.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;
+        listener.name.sasl_ssl.oauthbearer.sasl.server.callback.handler.class=org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerValidatorCallbackHandler
+        listener.name.sasl_ssl.oauthbearer.sasl.oauthbearer.jwks.endpoint.url=http://127.0.0.1:5556/dex/keys
+        listener.name.sasl_ssl.oauthbearer.sasl.oauthbearer.expected.audience=rgw-notifications
+        listener.name.sasl_ssl.oauthbearer.sasl.oauthbearer.expected.issuer=http://127.0.0.1:5556/dex
+
+
         # PLAINTEXT SASL with PLAIN mechanism
         listener.name.sasl_plaintext.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
         username="admin" \
@@ -186,12 +194,19 @@ Kafka Security Tests
         keyTab="/etc/krb5-keytabs/kafka.service.keytab" \
         principal="kafka/192.168.1.100@REALM";
 
+        # PLAINTEXT SASL with OAUTHBEARER mechanism
+        listener.name.sasl_plaintext.oauthbearer.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;
+        listener.name.sasl_plaintext.oauthbearer.sasl.server.callback.handler.class=org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerValidatorCallbackHandler
+        listener.name.sasl_plaintext.oauthbearer.sasl.oauthbearer.jwks.endpoint.url=http://127.0.0.1:5556/dex/keys
+        listener.name.sasl_plaintext.oauthbearer.sasl.oauthbearer.expected.audience=rgw-notifications
+        listener.name.sasl_plaintext.oauthbearer.sasl.oauthbearer.expected.issuer=http://127.0.0.1:5556/dex
+
 3. Kerberos setup::
 
-   librdkafka (inside RGW) builds the broker SPN (Service Principal Name, basically the 
-   principal that represents the Kafka broker) as ``kafka/<broker-host>@REALM``, 
+   librdkafka (inside RGW) builds the broker SPN (Service Principal Name, basically the
+   principal that represents the Kafka broker) as ``kafka/<broker-host>@REALM``,
    where ``<broker-host>`` is whatever appears in ``advertised.listeners``.
-   Since step 2 uses the broker's IP in ``advertised.listeners``, the 
+   Since step 2 uses the broker's IP in ``advertised.listeners``, the
    broker principal must be tied to that same IP (or hostname — they must match).
 
    The examples below use realm ``REALM.COM`` and broker IP ``192.168.1.100``.
@@ -255,7 +270,7 @@ Kafka Security Tests
               sudo kadmin.local -q "ktadd -k /etc/krb5-keytabs/rgw.service.keytab rgw/192.168.1.100"
 
               sudo chmod 640 /etc/krb5-keytabs/*.keytab
-              sudo chown root:$USER /etc/krb5-keytabs/*.keytab                     # Make keytabs readable by the user that runs the Kafka broker 
+              sudo chown root:$USER /etc/krb5-keytabs/*.keytab                     # Make keytabs readable by the user that runs the Kafka broker
                                                                                    # AND the user that runs vstart (often the same user)
 
    e. Verify the keytabs and get a TGT for the RGW principal::
@@ -267,14 +282,75 @@ Kafka Security Tests
 
    f. Make sure to add the Kafka principal, RGW principal, and keytab to your ``bntests.conf``.
 
-4. Start Zookeeper and Kafka.
+4. Install and configure Dex OIDC provider (for OAUTHBEARER tests)::
 
-5. Start RGW vstart cluster with cleartext parameter set to true::
+   Go 1.21 or later is required to build Dex.
+
+   Clone, build, and install Dex::
+
+        git clone https://github.com/dexidp/dex.git
+        cd dex
+        make build
+        sudo install ./bin/dex /usr/local/bin/
+
+   Create ``/etc/dex/config.yaml``.
+   The ``issuer`` value must exactly match the value set in ``server.properties``::
+
+        sudo mkdir -p /etc/dex
+
+   Write the following content to ``/etc/dex/config.yaml``::
+
+        issuer: http://127.0.0.1:5556/dex
+        storage:
+          type: memory
+        web:
+          http: 0.0.0.0:5556
+        oauth2:
+          grantTypes:
+            - client_credentials
+          responseTypes:
+            - code
+          skipApprovalScreen: true
+        staticClients:
+          - id: rgw-notifications
+            secret: client-secret
+            name: RGW Notifications
+            grantTypes:
+              - client_credentials
+        enablePasswordDB: false
+        connectors:
+          - type: mockCallback
+            id: mock
+            name: Mock
+
+   Start Dex::
+
+        dex serve /etc/dex/config.yaml
+
+   Fetch a test access token for the static consumer used by OAUTHBEARER tests::
+
+        ACCESS_TOKEN=$(curl -s \
+        -X POST http://127.0.0.1:5556/dex/token \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -d grant_type=client_credentials \
+        -d client_id=rgw-notifications \
+        -d client_secret=client-secret \
+        -d scope=openid \
+        | python3 -c "import json,sys;print(json.load(sys.stdin)['access_token'])")
+
+        echo "$ACCESS_TOKEN"
+
+   Put this token in the ``[oauthbearer]`` section of ``bntests.conf`` as
+   ``access_token``.
+
+5. Start Zookeeper and Kafka.
+
+6. Start RGW vstart cluster with cleartext parameter set to true::
 
         cd /path/to/ceph/build
         MON=1 OSD=1 MDS=0 MGR=0 RGW=1 ../src/vstart.sh -n -d -o "rgw_allow_notification_secrets_in_cleartext=true" -o "rgw_kafka_sasl_kerberos_service_name=kafka"
 
-6. Run the tests::
+7. Run the tests::
 
         cd /path/to/ceph
         KAFKA_DIR=/path/to/kafka BNTESTS_CONF=/path/to/bntests.conf python -m pytest -s /path/to/ceph/src/test/rgw/bucket_notification/test_bn.py -v -m 'kafka_security_test'

--- a/src/test/rgw/bucket_notification/__init__.py
+++ b/src/test/rgw/bucket_notification/__init__.py
@@ -4,6 +4,7 @@ import pytest
 from .api import admin
 
 def setup():
+    global cfg
     cfg = configparser.RawConfigParser()
     try:
         path = os.environ['BNTESTS_CONF']
@@ -18,9 +19,6 @@ def setup():
         raise RuntimeError('Your config file is missing the DEFAULT section!')
     if not cfg.has_section("s3 main"):
         raise RuntimeError('Your config file is missing the "s3 main" section!')
-    if not cfg.has_section("kerberos"):
-        raise RuntimeError('Your config file is missing the "kerberos" section!')
-
     defaults = cfg.defaults()
 
     global default_host
@@ -53,13 +51,28 @@ def setup():
     main_secret_key = cfg.get('s3 main',"secret_key")
 
     global kerberos_service_name
-    kerberos_service_name = cfg.get('kerberos', 'service_name')
+    kerberos_service_name = cfg.get('kerberos', 'service_name', fallback=None)
 
     global kerberos_principal
-    kerberos_principal = cfg.get('kerberos', 'principal')
+    kerberos_principal = cfg.get('kerberos', 'principal', fallback=None)
 
     global kerberos_keytab
-    kerberos_keytab = cfg.get('kerberos', 'keytab')
+    kerberos_keytab = cfg.get('kerberos', 'keytab', fallback=None)
+
+    global oauthbearer_token_endpoint_url
+    oauthbearer_token_endpoint_url = cfg.get('oauthbearer', 'token_endpoint_url', fallback=None)
+
+    global oauthbearer_client_id
+    oauthbearer_client_id = cfg.get('oauthbearer', 'client_id', fallback=None)
+
+    global oauthbearer_client_secret
+    oauthbearer_client_secret = cfg.get('oauthbearer', 'client_secret', fallback=None)
+
+    global oauthbearer_access_token
+    oauthbearer_access_token = cfg.get('oauthbearer', 'access_token', fallback=None)
+
+    global oauthbearer_scope
+    oauthbearer_scope = cfg.get('oauthbearer', 'scope', fallback=None)
 
 def get_config_host():
     global default_host
@@ -90,6 +103,16 @@ def get_kerberos_config():
     global kerberos_principal
     global kerberos_keytab
     return kerberos_service_name, kerberos_principal, kerberos_keytab
+
+def get_oauthbearer_config():
+    global oauthbearer_token_endpoint_url
+    global oauthbearer_client_id
+    global oauthbearer_client_secret
+    global oauthbearer_access_token
+    global oauthbearer_scope
+    return (oauthbearer_token_endpoint_url, oauthbearer_client_id,
+            oauthbearer_client_secret, oauthbearer_access_token,
+            oauthbearer_scope)
 
 @pytest.fixture(autouse=True, scope="package")
 def configfile():

--- a/src/test/rgw/bucket_notification/__init__.py
+++ b/src/test/rgw/bucket_notification/__init__.py
@@ -18,9 +18,6 @@ def setup():
         raise RuntimeError('Your config file is missing the DEFAULT section!')
     if not cfg.has_section("s3 main"):
         raise RuntimeError('Your config file is missing the "s3 main" section!')
-    if not cfg.has_section("kerberos"):
-        raise RuntimeError('Your config file is missing the "kerberos" section!')
-
     defaults = cfg.defaults()
 
     global default_host
@@ -53,13 +50,28 @@ def setup():
     main_secret_key = cfg.get('s3 main',"secret_key")
 
     global kerberos_service_name
-    kerberos_service_name = cfg.get('kerberos', 'service_name')
+    kerberos_service_name = cfg.get('kerberos', 'service_name', fallback=None)
 
     global kerberos_principal
-    kerberos_principal = cfg.get('kerberos', 'principal')
+    kerberos_principal = cfg.get('kerberos', 'principal', fallback=None)
 
     global kerberos_keytab
-    kerberos_keytab = cfg.get('kerberos', 'keytab')
+    kerberos_keytab = cfg.get('kerberos', 'keytab', fallback=None)
+
+    global oauthbearer_token_endpoint_url
+    oauthbearer_token_endpoint_url = cfg.get('oauthbearer', 'token_endpoint_url', fallback=None)
+
+    global oauthbearer_client_id
+    oauthbearer_client_id = cfg.get('oauthbearer', 'client_id', fallback=None)
+
+    global oauthbearer_client_secret
+    oauthbearer_client_secret = cfg.get('oauthbearer', 'client_secret', fallback=None)
+
+    global oauthbearer_access_token
+    oauthbearer_access_token = cfg.get('oauthbearer', 'access_token', fallback=None)
+
+    global oauthbearer_scope
+    oauthbearer_scope = cfg.get('oauthbearer', 'scope', fallback=None)
 
 def get_config_host():
     global default_host
@@ -90,6 +102,16 @@ def get_kerberos_config():
     global kerberos_principal
     global kerberos_keytab
     return kerberos_service_name, kerberos_principal, kerberos_keytab
+
+def get_oauthbearer_config():
+    global oauthbearer_token_endpoint_url
+    global oauthbearer_client_id
+    global oauthbearer_client_secret
+    global oauthbearer_access_token
+    global oauthbearer_scope
+    return (oauthbearer_token_endpoint_url, oauthbearer_client_id,
+            oauthbearer_client_secret, oauthbearer_access_token,
+            oauthbearer_scope)
 
 @pytest.fixture(autouse=True, scope="package")
 def configfile():

--- a/src/test/rgw/bucket_notification/bntests.conf.SAMPLE
+++ b/src/test/rgw/bucket_notification/bntests.conf.SAMPLE
@@ -16,3 +16,10 @@ email = tester@ceph.com
 service_name = kafka
 principal = rgw/<broker-fqdn/ip>@REALM.COM
 keytab = /etc/krb5-keytabs/rgw.service.keytab
+
+[oauthbearer]
+token_endpoint_url = http://127.0.0.1:5556/dex/token
+client_id = rgw-notifications
+client_secret = client-secret
+access_token = <access_token>
+scope = openid

--- a/src/test/rgw/bucket_notification/bntests.conf.multisite
+++ b/src/test/rgw/bucket_notification/bntests.conf.multisite
@@ -16,3 +16,10 @@ email =
 service_name = kafka
 principal = rgw/<broker-fqdn/ip>@REALM.COM
 keytab = /etc/krb5-keytabs/rgw.service.keytab
+
+[oauthbearer]
+token_endpoint_url = http://127.0.0.1:5556/dex/token
+client_id = rgw-notifications
+client_secret = client-secret
+access_token = <access_token>
+scope = openid

--- a/src/test/rgw/bucket_notification/requirements.txt
+++ b/src/test/rgw/bucket_notification/requirements.txt
@@ -1,7 +1,7 @@
 pytest
 boto3 >=1.0.0
 configparser >=5.0.0
-kafka-python >=2.0.0
+kafka-python >=2.0.2
 pika
 cloudevents>=1.12.1,<2
 xmltodict

--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -11,6 +11,7 @@ import os
 import io
 import string
 import sys
+from urllib.parse import urlencode
 from botocore.client import Config
 from botocore.exceptions import ClientError
 from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
@@ -32,6 +33,7 @@ from . import(
     get_access_key,
     get_secret_key,
     get_kerberos_config,
+    get_oauthbearer_config,
     )
 
 from .api import PSTopicS3, \
@@ -433,6 +435,47 @@ def get_kerberos_env():
     return service_name, principal, keytab
 
 
+def get_oauthbearer_endpoint_attrs():
+    token_endpoint_url, client_id, client_secret, _, scope = get_oauthbearer_config()
+    missing = []
+    if not token_endpoint_url:
+        missing.append('oauthbearer.token_endpoint_url')
+    if not client_id:
+        missing.append('oauthbearer.client_id')
+    if not client_secret:
+        missing.append('oauthbearer.client_secret')
+    if missing:
+        pytest.skip('missing OAUTHBEARER test config: ' + ', '.join(missing))
+
+    attrs = {
+        'sasl.oauthbearer.token.endpoint.url': token_endpoint_url,
+        'sasl.oauthbearer.client.id': client_id,
+        'sasl.oauthbearer.client.secret': client_secret,
+    }
+    if scope:
+        attrs['sasl.oauthbearer.scope'] = scope
+    return attrs
+
+
+def get_oauthbearer_token_provider():
+    _, _, _, access_token, _ = get_oauthbearer_config()
+    if not access_token:
+        pytest.skip('missing OAUTHBEARER test config: oauthbearer.access_token')
+    try:
+        from kafka.sasl.oauth import AbstractTokenProvider
+    except ImportError:
+        try:
+            from kafka.net.sasl.oauth import AbstractTokenProvider
+        except ImportError:
+            pytest.skip('kafka-python OAUTHBEARER token provider support is not available')
+
+    class StaticTokenProvider(AbstractTokenProvider):
+        def token(self):
+            return access_token
+
+    return StaticTokenProvider()
+
+
 def setup_scram_users_via_kafka_configs(mechanism: str) -> None:
     """to setup SCRAM users using kafka-configs.sh after Kafka is running."""
     if not mechanism.startswith('SCRAM'):
@@ -563,6 +606,8 @@ class KafkaReceiver(object):
                 kerberos_service_name, _, _ = get_kerberos_env()
                 if kerberos_service_name:
                     base_config['sasl_kerberos_service_name'] = kerberos_service_name
+            elif mechanism == 'OAUTHBEARER':
+                base_config['sasl_oauth_token_provider'] = get_oauthbearer_token_provider()
             else:
                 base_config.update({
                     'sasl_plain_username': KAFKA_TEST_USER,
@@ -575,6 +620,8 @@ class KafkaReceiver(object):
                 kerberos_service_name, _, _ = get_kerberos_env()
                 if kerberos_service_name:
                     base_config['sasl_kerberos_service_name'] = kerberos_service_name
+            elif mechanism == 'OAUTHBEARER':
+                base_config['sasl_oauth_token_provider'] = get_oauthbearer_token_provider()
             else:
                 base_config.update({
                     'sasl_plain_username': KAFKA_TEST_USER,
@@ -4762,6 +4809,10 @@ def kafka_security(security_type, mechanism='PLAIN', use_topic_attrs_for_creds=F
             pytest.skip('Missing GSSAPI options in [kerberos] section of BNTESTS_CONF: ' + ', '.join(missing))
         if not os.path.isfile(keytab):
             pytest.skip(f'[kerberos] keytab does not exist: {keytab}')
+    oauthbearer_endpoint_attrs = None
+    if mechanism == 'OAUTHBEARER':
+        oauthbearer_endpoint_attrs = get_oauthbearer_endpoint_attrs()
+        get_oauthbearer_token_provider()
     
     conn = connection()
     zonegroup = get_config_zonegroup()
@@ -4772,7 +4823,7 @@ def kafka_security(security_type, mechanism='PLAIN', use_topic_attrs_for_creds=F
     topic_name = bucket_name+'_topic'
     # create topic
     if security_type == 'SASL_SSL':
-        if mechanism == 'GSSAPI' or use_topic_attrs_for_creds:
+        if mechanism in ('GSSAPI', 'OAUTHBEARER') or use_topic_attrs_for_creds:
             endpoint_address = 'kafka://' + default_kafka_server + ':9094'
         else:
             endpoint_address = 'kafka://alice:alice-secret@' + default_kafka_server + ':9094'
@@ -4782,7 +4833,7 @@ def kafka_security(security_type, mechanism='PLAIN', use_topic_attrs_for_creds=F
         else:
             endpoint_address = 'kafka://' + default_kafka_server + ':9093'
     elif security_type == 'SASL_PLAINTEXT':
-        if mechanism == 'GSSAPI':
+        if mechanism in ('GSSAPI', 'OAUTHBEARER'):
             endpoint_address = 'kafka://' + default_kafka_server + ':9095'
         else:
             endpoint_address = 'kafka://alice:alice-secret@' + default_kafka_server + ':9095'
@@ -4828,6 +4879,9 @@ def kafka_security(security_type, mechanism='PLAIN', use_topic_attrs_for_creds=F
                 f'mTLS client key not found: {ssl_key_path}'
             endpoint_args += '&ssl-certificate-location=' + ssl_cert_path
             endpoint_args += '&ssl-key-location=' + ssl_key_path
+
+    if oauthbearer_endpoint_attrs:
+        endpoint_args += '&' + urlencode(oauthbearer_endpoint_attrs)
 
     topic_conf = PSTopicS3(conn, topic_name, zonegroup, endpoint_args=endpoint_args)
 
@@ -4949,6 +5003,16 @@ def test_notification_kafka_security_ssl_sasl_gssapi():
 def test_notification_kafka_security_ssl_mtls():
     """test mTLS client certificate authentication to Kafka"""
     kafka_security('SSL', use_mtls=True)
+
+
+@pytest.mark.kafka_security_test
+def test_notification_kafka_security_ssl_sasl_oauthbearer():
+    kafka_security('SASL_SSL', mechanism='OAUTHBEARER')
+
+
+@pytest.mark.kafka_security_test
+def test_notification_kafka_security_sasl_oauthbearer():
+    kafka_security('SASL_PLAINTEXT', mechanism='OAUTHBEARER')
 
 
 @pytest.mark.http_test

--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -11,6 +11,7 @@ import os
 import io
 import string
 import sys
+from urllib.parse import urlencode
 from botocore.client import Config
 from botocore.exceptions import ClientError
 from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
@@ -32,6 +33,7 @@ from . import(
     get_access_key,
     get_secret_key,
     get_kerberos_config,
+    get_oauthbearer_config,
     )
 
 from .api import PSTopicS3, \
@@ -432,6 +434,35 @@ def get_kerberos_env():
     service_name, principal, keytab = get_kerberos_config()
     return service_name, principal, keytab
 
+def get_oauthbearer_endpoint_attrs():
+    token_endpoint_url, client_id, client_secret, _, scope = get_oauthbearer_config()
+    # an absent token endpoint means OAUTHBEARER is not part of this run at all
+    if not token_endpoint_url:
+        pytest.skip('OAUTHBEARER not configured: no [oauthbearer] token_endpoint_url')
+    missing = [name for name, value in (('client_id', client_id), ('client_secret', client_secret)) if not value]
+    assert not missing, 'OAUTHBEARER is configured but incomplete: missing [oauthbearer] ' + ', '.join(missing)
+
+    attrs = {
+        'sasl-oauthbearer-token-endpoint-url': token_endpoint_url,
+        'sasl-oauthbearer-client-id': client_id,
+        'sasl-oauthbearer-client-secret': client_secret,
+    }
+    if scope:
+        attrs['sasl-oauthbearer-scope'] = scope
+    return attrs
+
+def get_oauthbearer_token_provider():
+    token_endpoint_url, _, _, access_token, _ = get_oauthbearer_config()
+    if not token_endpoint_url:
+        pytest.skip('OAUTHBEARER not configured: no [oauthbearer] token_endpoint_url')
+    assert access_token, 'OAUTHBEARER is configured but [oauthbearer] access_token is empty'
+    from kafka.sasl.oauth import AbstractTokenProvider
+
+    class StaticTokenProvider(AbstractTokenProvider):
+        def token(self):
+            return access_token
+
+    return StaticTokenProvider()
 
 def setup_scram_users_via_kafka_configs(mechanism: str) -> None:
     """to setup SCRAM users using kafka-configs.sh after Kafka is running."""
@@ -563,6 +594,8 @@ class KafkaReceiver(object):
                 kerberos_service_name, _, _ = get_kerberos_env()
                 if kerberos_service_name:
                     base_config['sasl_kerberos_service_name'] = kerberos_service_name
+            elif mechanism == 'OAUTHBEARER':
+                base_config['sasl_oauth_token_provider'] = get_oauthbearer_token_provider()
             else:
                 base_config.update({
                     'sasl_plain_username': KAFKA_TEST_USER,
@@ -575,6 +608,8 @@ class KafkaReceiver(object):
                 kerberos_service_name, _, _ = get_kerberos_env()
                 if kerberos_service_name:
                     base_config['sasl_kerberos_service_name'] = kerberos_service_name
+            elif mechanism == 'OAUTHBEARER':
+                base_config['sasl_oauth_token_provider'] = get_oauthbearer_token_provider()
             else:
                 base_config.update({
                     'sasl_plain_username': KAFKA_TEST_USER,
@@ -4781,6 +4816,10 @@ def kafka_security(security_type, mechanism='PLAIN', use_topic_attrs_for_creds=F
             pytest.skip('Missing GSSAPI options in [kerberos] section of BNTESTS_CONF: ' + ', '.join(missing))
         if not os.path.isfile(keytab):
             pytest.skip(f'[kerberos] keytab does not exist: {keytab}')
+    oauthbearer_endpoint_attrs = None
+    if mechanism == 'OAUTHBEARER':
+        oauthbearer_endpoint_attrs = get_oauthbearer_endpoint_attrs()
+        get_oauthbearer_token_provider()
     
     conn = connection()
     zonegroup = get_config_zonegroup()
@@ -4791,7 +4830,7 @@ def kafka_security(security_type, mechanism='PLAIN', use_topic_attrs_for_creds=F
     topic_name = bucket_name+'_topic'
     # create topic
     if security_type == 'SASL_SSL':
-        if mechanism == 'GSSAPI' or use_topic_attrs_for_creds:
+        if mechanism in ('GSSAPI', 'OAUTHBEARER') or use_topic_attrs_for_creds:
             endpoint_address = 'kafka://' + default_kafka_server + ':9094'
         else:
             endpoint_address = 'kafka://alice:alice-secret@' + default_kafka_server + ':9094'
@@ -4801,7 +4840,7 @@ def kafka_security(security_type, mechanism='PLAIN', use_topic_attrs_for_creds=F
         else:
             endpoint_address = 'kafka://' + default_kafka_server + ':9093'
     elif security_type == 'SASL_PLAINTEXT':
-        if mechanism == 'GSSAPI':
+        if mechanism in ('GSSAPI', 'OAUTHBEARER'):
             endpoint_address = 'kafka://' + default_kafka_server + ':9095'
         else:
             endpoint_address = 'kafka://alice:alice-secret@' + default_kafka_server + ':9095'
@@ -4829,7 +4868,7 @@ def kafka_security(security_type, mechanism='PLAIN', use_topic_attrs_for_creds=F
                 endpoint_args += '&sasl-kerberos-principal=' + kerberos_principal
             if kerberos_keytab:
                 endpoint_args += '&sasl-kerberos-keytab=' + kerberos_keytab
-        elif use_topic_attrs_for_creds:
+        elif use_topic_attrs_for_creds and mechanism not in ('GSSAPI', 'OAUTHBEARER'):
             endpoint_args += '&user-name=alice&password=alice-secret'
     else:
         kafka_cert_dir = _kafka_cert_dir()
@@ -4847,6 +4886,9 @@ def kafka_security(security_type, mechanism='PLAIN', use_topic_attrs_for_creds=F
                 f'mTLS client key not found: {ssl_key_path}'
             endpoint_args += '&ssl-certificate-location=' + ssl_cert_path
             endpoint_args += '&ssl-key-location=' + ssl_key_path
+
+    if oauthbearer_endpoint_attrs:
+        endpoint_args += '&' + urlencode(oauthbearer_endpoint_attrs)
 
     topic_conf = PSTopicS3(conn, topic_name, zonegroup, endpoint_args=endpoint_args)
 
@@ -4968,6 +5010,16 @@ def test_notification_kafka_security_ssl_sasl_gssapi():
 def test_notification_kafka_security_ssl_mtls():
     """test mTLS client certificate authentication to Kafka"""
     kafka_security('SSL', use_mtls=True)
+
+
+@pytest.mark.kafka_security_test
+def test_notification_kafka_security_ssl_sasl_oauthbearer():
+    kafka_security('SASL_SSL', mechanism='OAUTHBEARER')
+
+
+@pytest.mark.kafka_security_test
+def test_notification_kafka_security_sasl_oauthbearer():
+    kafka_security('SASL_PLAINTEXT', mechanism='OAUTHBEARER')
 
 
 @pytest.mark.http_test


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/74725

## Description

Adds SASL/OAUTHBEARER (OAuth 2.0 Bearer Token) authentication support for RGW Kafka bucket notifications. Includes config options for token endpoints, client credentials, and OAuth scopes; runtime authentication during Kafka connections; and comprehensive Teuthology integration with automatic Dex OIDC provider setup. New tests validate both SASL_PLAINTEXT and SASL_SSL with OAUTHBEARER mechanisms.

### Commit 1: RGW-side Implementation

Extends librdkafka integration with OAUTHBEARER mechanism support, adds four new SASL/OAUTHBEARER Kafka topic attributes (`sasl.oauthbearer.token.endpoint.url`, `client.id`, `client.secret`, `scope`), implements OAUTHBEARER configuration during Kafka producer setup, and adds validation logic to ensure required OAuth credentials are provided and transported securely.

### Commit 2: Testing Framework

Adds OAUTHBEARER config parsing and OAUTHBEARER client support with token provider integration. Includes test infrastructure for token endpoint configuration, two new test functions (`test_notification_kafka_security_ssl_sasl_oauthbearer`, `test_notification_kafka_security_sasl_oauthbearer`), OAUTHBEARER setup documentation, and updated requirements for kafka-python with OAUTHBEARER support.

### Commit 3: Teuthology CI Testing

Implements Dex OIDC provider deployment task (`qa/tasks/dex.py`) with Go toolchain setup, Dex source building, configuration, and access token retrieval. Configures Kafka broker listeners with OAUTHBEARER JAAS config, JWKS endpoint, and issuer validation. Plumbs Dex configuration through test environment via context attributes.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
