### PR TITLE
OSD/EC: ECTransaction: mark all data shards in written_shards for non…

### DIFF
--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -832,9 +832,10 @@ ECTransaction::Generate::Generate(PGTransaction &t,
     all_shards_written();
     first_write_in_interval = false;
   } else {
-    // All primary shards must always be written, regardless of the write plan.
-    shards_written(sinfo.get_parity_shards());
-    shard_written(sinfo.get_shard(raw_shard_id_t(0)));
+    // Data shards always receive attr updates, so must always be marked
+    // written. Parity shards are only marked when they have data writes
+    // (tracked via plan.will_write in encode_and_write).
+    shards_written(sinfo.get_data_shards());
   }
 
   written_shards();


### PR DESCRIPTION
…-size-changing writes

Fixing the code on lines 834..838 of ECTransactions.cc: The else branch at line 837 only marked data shard 0 via shard_written(sinfo.get_shard(raw_shard_id_t(0))), omitting data shards 1..k-1. Since attr_updates() unconditionally generates setattrs transactions on all data shards, the validation assert at line 884 ("Written shard not set, but messages present") fires for any modifying operation on an EC pool with k>=2 that does not change object size (e.g. setxattr).

The parity shard addition was also removed from this branch as it was redundant: parity shards that receive data writes are already marked by shard_written() in appends_and_clone_ranges() via plan.will_write, and for xattr-only operations parity shards correctly receive no transactions.

Fixes: https://tracker.ceph.com/issues/78124
