### PR TITLE
crimson/osd: prime merge participants before map advance

### DIFF
--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -1293,6 +1293,8 @@ seastar::future<> OSD::committed_osd_maps(
     }
     co_await update_heartbeat_peers();
     co_await check_osdmap_features();
+    // Before broadcast: create any missing merge participants
+    co_await pg_shard_manager.prime_merges(first, last);
     // yay!
     INFO("osd.{}: committed_osd_maps: broadcasting osdmaps up"
          " to {} epoch to pgs", whoami, osdmap->get_epoch());

--- a/src/crimson/osd/pg_shard_manager.cc
+++ b/src/crimson/osd/pg_shard_manager.cc
@@ -80,6 +80,84 @@ PGShardManager::get_pg_stats() const
     });
 }
 
+seastar::future<> PGShardManager::prime_merges(epoch_t first, epoch_t last)
+{
+  ceph_assert(seastar::this_shard_id() == PRIMARY_CORE);
+  const int whoami = get_local_state().whoami;
+
+  // Collect every merge participant (target + sources) this OSD is in the
+  // acting set for, keyed to the epoch the merge occurs at.  Derived purely
+  // from the OSDMap (pg_num shrink + CRUSH acting set) so participants are
+  // found even when none are live locally yet -- e.g. a target CRUSH has just
+  // remapped onto this OSD because pgp_num dropped alongside pg_num.
+  std::set<std::pair<spg_t, epoch_t>> merge_pgs;
+
+  // If first-1 was trimmed away, we have no local pre-merge map to compare;
+  // start one epoch later (first itself is in the just-stored range).
+  if (!get_osd_singleton_state().superblock.get_maps().contains(first - 1)) {
+    ++first;
+  }
+  for (epoch_t e = first; e <= last; ++e) {
+    cached_map_t prev = co_await get_shard_services().get_map(e - 1);
+    cached_map_t cur  = co_await get_shard_services().get_map(e);
+
+    for (const auto& [poolid, pool] : cur->get_pools()) {
+      if (!prev->have_pg_pool(poolid)) {
+        continue;
+      }
+      const unsigned old_pg_num = prev->get_pg_num(poolid);
+      const unsigned new_pg_num = pool.get_pg_num();
+      if (!new_pg_num || new_pg_num >= old_pg_num) {
+        continue;  // not a merge step
+      }
+
+      // Each ps in [new_pg_num, old_pg_num) is a merge source; from any one we
+      // derive the surviving target (is_merge_source climbs ancestors until
+      // the seed drops below new_pg_num) and the full sibling source set.
+      //
+      // Replicated pools only (NO_SHARD) for now.  spg_t::is_split() and
+      // is_merge_source() preserve the shard, so classic does not need a
+      // separate EC path: OSDShard::identify_splits_and_merges() seeds
+      // discovery from each live pg_slot, which already carries the real
+      // shard id (e.g. 2.7s2).  We derive participants from the OSDMap alone
+      // (no live-PG walk), so we must synthesize spg_t from pg_t seeds; for
+      // EC that means enumerating each acting shard explicitly (future work).
+      for (unsigned ps = new_pg_num; ps < old_pg_num; ++ps) {
+        spg_t src(pg_t(ps, poolid), shard_id_t::NO_SHARD);
+        spg_t target;
+        if (!src.is_merge_source(old_pg_num, new_pg_num, &target)) {
+          continue;
+        }
+        std::set<spg_t> participants;  // the sibling sources...
+        target.is_split(new_pg_num, old_pg_num, &participants);
+        participants.insert(target);   // ...plus the target
+        for (const auto& p : participants) {
+          if (cur->is_up_acting_osd_shard(p, whoami)) {
+            merge_pgs.emplace(p, e);
+          }
+        }
+      }
+    }
+  }
+
+  logger().debug("PGShardManager::prime_merges: {} participants in e{}..{}",
+                 merge_pgs.size(), first, last);
+
+  // Create an empty placeholder for each participant on the shard its mapping
+  // resolves to.  prime_merge_participant() is a no-op for any already live or
+  // not actually owned here, and registers the rest at (merge_epoch - 1)
+  // WITHOUT advancing; broadcast_map_to_pgs() advances all PGs together
+  // through the merge epoch.
+  for (const auto& [pgid, merge_epoch] : merge_pgs) {
+    auto [core, store_index] = co_await get_pg_to_shard_mapping().get_or_create_pg_mapping(pgid);
+    co_await shard_services.invoke_on(
+      core,
+      [pgid, store_index, merge_epoch](ShardServices& tss) {
+        return tss.prime_merge_participant(pgid, store_index, merge_epoch);
+      });
+  }
+}
+
 seastar::future<> PGShardManager::broadcast_map_to_pgs(epoch_t epoch)
 {
   ceph_assert(seastar::this_shard_id() == PRIMARY_CORE);

--- a/src/crimson/osd/pg_shard_manager.h
+++ b/src/crimson/osd/pg_shard_manager.h
@@ -356,6 +356,29 @@ public:
 
   seastar::future<> broadcast_map_to_pgs(epoch_t epoch);
 
+  /**
+   * prime_merges
+   *
+   * Ensure local merge participants exist for merges in (first, last].
+   *
+   * The crimson analogue of classic OSD::consume_map() -> prime_merges():
+   * for every pool whose pg_num shrinks between consecutive maps in
+   * the range, derive the merge participants (target + sources) this OSD is
+   * in the acting set for and instantiate any that are not already live as
+   * empty placeholders, registered at (merge_epoch - 1) without advancing.
+   * The subsequent broadcast_map_to_pgs() advances them through the merge
+   * epoch and runs PG::merge_from().
+   *
+   * Participants are derived from the OSDMap (pg_num + CRUSH acting set), not
+   * from live PGs, so a target that CRUSH has just remapped onto this OSD
+   * (e.g. because pgp_num dropped alongside pg_num) is found even though it
+   * is not instantiated and has no live sibling here yet.  Without this,
+   * ShardServices::register_merge_source() can find no target PG.
+   *
+   * Must run before broadcast_map_to_pgs().
+   */
+  seastar::future<> prime_merges(epoch_t first, epoch_t last);
+
   template <typename F>
   auto with_pg(spg_t pgid, F &&f) {
     core_id_t core = get_pg_to_shard_mapping().get_pg_mapping(pgid);

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -139,12 +139,88 @@ seastar::future<> ShardServices::register_merge_source(
     [target, source, birth_shard, foreign_pg = std::move(foreign_pg)]
     (ShardServices& target_svc) mutable {
       auto target_pg = target_svc.local_state.pg_map.get_pg(target);
-      // PGAdvanceMap on the target shard is expected to have instantiated
-      // the target PG by this point in the merge protocol.
-      ceph_assert(target_pg);
+      // PGShardManager::prime_merges() is expected to have instantiated the
+      // target PG (as an empty placeholder if needed) before the maps were
+      // broadcast.  It can still be absent if CRUSH moved the target off this
+      // OSD entirely between the source freezing and this handoff.  In that
+      // case do not crash: tell the monitor we are not ready so it backs off
+      // the pg_num decrement, and this source will retry under a later,
+      // consistent map.
+      if (!target_pg) {
+        LOG_PREFIX(ShardServices::register_merge_source);
+        WARN("target {} not present for source {}; backing off merge",
+             target, source);
+        return target_svc.set_not_ready_to_merge_source(source.pgid);
+      }
       target_pg->add_merge_source(
         source, birth_shard, std::move(foreign_pg));
+      return seastar::now();
     });
+}
+
+seastar::future<> ShardServices::prime_merge_participant(
+  spg_t pgid,
+  store_index_t store_index,
+  epoch_t merge_epoch)
+{
+  LOG_PREFIX(ShardServices::prime_merge_participant);
+
+  if (local_state.pg_map.get_pg(pgid)) {
+    co_return;  // already live, nothing to prime
+  }
+
+  const epoch_t create_epoch = merge_epoch - 1;
+  cached_map_t startmap = co_await get_map(create_epoch);
+
+  // Only prime participants this OSD genuinely owns, both at the creation
+  // epoch and in the current map.
+  if (!get_map()->is_up_acting_osd_shard(pgid, local_state.whoami) ||
+      !startmap->is_up_acting_osd_shard(pgid, local_state.whoami)) {
+    DEBUG("{} not in acting set, skip priming", pgid);
+    co_return;
+  }
+  // Could have been created concurrently while we awaited the map.
+  if (local_state.pg_map.get_pg(pgid)) {
+    co_return;
+  }
+
+  Ref<PG> pg = co_await make_pg(startmap, pgid, store_index, /*do_create=*/true);
+  const pg_pool_t *pp = startmap->get_pg_pool(pgid.pool());
+  ceph_assert(pp);
+
+  int up_primary, acting_primary;
+  std::vector<int> up, acting;
+  startmap->pg_to_up_acting_osds(
+    pgid.pgid, &up, &up_primary, &acting, &acting_primary);
+  int role = startmap->calc_pg_role(
+    pg_shard_t(local_state.whoami, pgid.shard), acting);
+
+  PeeringCtx rctx;
+  create_pg_collection(
+    rctx.transaction, pgid, pgid.get_split_bits(pp->get_pg_num()));
+  init_pg_ondisk(rctx.transaction, pgid, pp);
+
+  // Leave history zeroed; PG::merge_from() fills it in once the sources
+  // arrive (mirrors classic OSDShard::prime_merges()).
+  pg_history_t history;
+  co_await pg->init(
+    role, up, up_primary, acting, acting_primary,
+    history, PastIntervals(), rctx.transaction);
+
+  // Initialize peering state and commit the on-disk creation, but DO NOT
+  // advance past create_epoch.  The subsequent broadcast_map_to_pgs() will
+  // start a PGAdvanceMap for this PG (it is registered below) and carry it
+  // through the merge epoch, running merge_from() exactly as for an
+  // already-live target.
+  pg->handle_initialize(rctx);
+  pg->handle_activate_map(rctx);
+  co_await pg->complete_rctx(std::move(rctx));
+
+  // pg_loaded() (rather than pg_created()) because we are registering outside
+  // the pgs_creating bookkeeping; it also wakes any op already parked on this
+  // pgid.
+  local_state.pg_map.pg_loaded(pgid, pg);
+  INFO("primed merge participant {} at epoch {}", pgid, create_epoch);
 }
 
 bool ShardServices::is_seastore_objectstore()

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -680,6 +680,15 @@ public:
   }
 
   seastar::future<Ref<PG>> extract_pg(spg_t pgid);
+
+  // Instantiate an empty placeholder PG for a merge participant that is not
+  // currently live on this shard, registering it at (merge_epoch - 1) WITHOUT
+  // advancing it.  The caller (PGShardManager::prime_merges) runs this before
+  // broadcast_map_to_pgs(), which then advances the placeholder through the
+  // merge epoch and performs the actual merge_from().  No-op if the PG is
+  // already live or this OSD is not in its acting set.
+  seastar::future<> prime_merge_participant(
+    spg_t pgid, store_index_t store_index, epoch_t merge_epoch);
   // Hand the source PG off to the target PG's rendezvous, hopping shards
   // if needed. The consumer side (target PG) waits via
   // PG::collect_merge_sources(); cleanup happens when the target drops the


### PR DESCRIPTION
Classic OSD runs prime_merges() in consume_map() before PGs advance so merge targets exist locally when a source calls register_merge_source().

Crimson lacked this, which could cause an assert or a hang during pg_num shrink when the target PG was not yet loaded in pg_map. This is most likely when pgp_num changes alongside pg_num: CRUSH remaps PG placement per the pool's crush rule, so a merge target can land on this OSD without a local PG object having been created yet.

Derive merge participants from the OSDMap epoch range, create empty placeholders via prime_merge_participant() before broadcast_map_to_pgs(), and back off gracefully when a target is still missing at handoff time.

Fixes: https://tracker.ceph.com/issues/77629





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
