### PR TITLE
qa/tests: fix POOL_FULL ignorelist pattern in upgrade tests

### DIFF
--- a/qa/overrides/upgrade_ignorelist_health.yaml
+++ b/qa/overrides/upgrade_ignorelist_health.yaml
@@ -1,21 +1,21 @@
 overrides:
   ceph:
     log-ignorelist:
-      - \(MDS_ALL_DOWN\)
-      - \(MDS_UP_LESS_THAN_MAX\)
-      - \(OSD_SLOW_PING_TIME
+      - MDS_ALL_DOWN
+      - MDS_UP_LESS_THAN_MAX
+      - OSD_SLOW_PING_TIME
       - reached quota
       - overall HEALTH_
-      - \(CACHE_POOL_NO_HIT_SET\)
+      - CACHE_POOL_NO_HIT_SET
       - POOL_FULL
-      - \(SMALLER_PGP_NUM\)
-      - \(SLOW_OPS\)
-      - \(CACHE_POOL_NEAR_FULL\)
-      - \(POOL_APP_NOT_ENABLED\)
-      - \(PG_AVAILABILITY\)
-      - \(OBJECT_MISPLACED\)
+      - SMALLER_PGP_NUM
+      - SLOW_OPS
+      - CACHE_POOL_NEAR_FULL
+      - POOL_APP_NOT_ENABLED
+      - PG_AVAILABILITY
+      - OBJECT_MISPLACED
       - slow request
-      - \(MON_DOWN\)
+      - MON_DOWN
       - noscrub
       - nodeep-scrub
       - OSD_ROOT_DOWN

--- a/qa/overrides/upgrade_ignorelist_health.yaml
+++ b/qa/overrides/upgrade_ignorelist_health.yaml
@@ -7,7 +7,7 @@ overrides:
       - reached quota
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
-      - \(POOL_FULL\)
+      - POOL_FULL
       - \(SMALLER_PGP_NUM\)
       - \(SLOW_OPS\)
       - \(CACHE_POOL_NEAR_FULL\)


### PR DESCRIPTION
## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

## What this does
`qa/overrides/upgrade_ignorelist_health.yaml` ignorelists `\(POOL_FULL\)`, which
only matches the cluster-log format used for "Health check failed/update"
messages (code wrapped in parens, e.g. `... (POOL_FULL)`). It misses the
"Health check cleared" format, where the code is not parenthesized
(`Health check cleared: POOL_FULL (was: ...)`) — see `src/mon/Monitor.cc`.
So a pool clearing its full state mid-upgrade-test was not ignorelisted,
which can fail the log scan.

Dropping the escaped parens matches both forms, consistent with other
bare entries already in this file (`OSD_ROOT_DOWN`, `MDS_INSUFFICIENT_STANDBY`).

Not a duplicate of #75414/#68325 — those cover different files
(`qa/suites/upgrade/{squid,tentacle}-x/**`), never this shared file. See
discussion on #69791.

Fixes: https://tracker.ceph.com/issues/78149

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] No tests