### PR TITLE
libfdb: Transaction Triggers

### DIFF
--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -396,3 +396,104 @@ catch (const std::exception& e) {
     /* Application or system error from user code. */
 }
 ```
+
+## Transaction Watches (Triggers)
+
+Transaction watches (watches, triggers) ask FoundationDB to report a change 
+to a key (relative to the transaction that created the watch). If watches are 
+unsupported by the local FoundationDB configuration, or the transaction cannot 
+create watches, waiting on the watch throws `lfdb::libfdb_exception`.
+
+Note that watches do not report the triggering value. If you need the value,
+read it in a separate transaction. For the underlying semantics, see the
+FoundationDB Developer Guide and the C API entry for ``fdb_transaction_watch()``.
+
+See also:
+- https://apple.github.io/foundationdb/developer-guide.html#watches
+- https://apple.github.io/foundationdb/api-c.html#c.fdb_transaction_watch
+
+Here are some illustrative examples using transaction watches:
+
+```cpp
+// Create a one-shot watch that becomes ready when the key changes:
+auto watch = lfdb::make_watch(dbh, "person/jose-capablanca/title");
+
+lfdb::set(dbh, "person/jose-capablanca/title", "World Chess Champion");
+
+if (lfdb::watch_event::changed == watch.wait_for_event()) {
+  handle_title_change();
+}
+```
+
+```cpp
+// Create a watch inside a transaction when it must share that transaction's
+// read version. Commit the transaction before waiting on the watch:
+auto txn = lfdb::make_transaction(dbh);
+auto watch = lfdb::make_watch(txn, "person/jose-capablanca/title");
+
+if (lfdb::commit(txn)) {
+  watch.wait();
+}
+```
+
+```cpp
+// Cancel a watch that is no longer needed:
+auto watch = lfdb::make_watch(dbh, "person/jose-capablanca/title");
+
+watch.cancel();
+
+if (lfdb::watch_event::cancelled == watch.wait_for_event()) {
+  handle_watch_cancelled();
+}
+```
+
+```cpp
+// Let a jthread stop_token cancel a blocked transaction watch wait:
+std::jthread watch_thread {
+  [dbh](std::stop_token stop_token) {
+    auto watch = lfdb::make_watch(dbh, "person/jose-capablanca/title");
+
+    if (lfdb::watch_event::cancelled == watch.wait_for_event(stop_token)) {
+      return;
+    }
+
+    handle_title_change();
+  }
+};
+
+watch_thread.request_stop();
+```
+
+`watched_loop()` is a gadget for repeated watch handling. Its callback takes
+the watched key as a `std::string_view`. The helper blocks; applications should
+own any thread, executor, shutdown, or callback error policy around it:
+
+```cpp
+std::jthread watch_thread {
+  [dbh](std::stop_token stop_token) {
+    lfdb::watched_loop(dbh, "person/jose-capablanca/title", stop_token,
+      [](std::string_view key) {
+        handle_title_change(key);
+      });
+  }
+};
+```
+
+Use a manual approach when you need direct control over each one-shot watch:
+
+```cpp
+// Reset (re-arm) the transaction watch manually after each event:
+std::jthread watch_thread {
+  [dbh](std::stop_token stop_token) {
+    while (not stop_token.stop_requested()) {
+      auto watch = lfdb::make_watch(dbh, "person/jose-capablanca/title");
+
+      if (lfdb::watch_event::cancelled == watch.wait_for_event(stop_token)) {
+        break;
+      }
+
+      handle_title_change();
+    }
+  }
+};
+```

--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -1102,6 +1102,139 @@ The query expression says exactly what should be touched: cache records, minus
 reserved subspaces, further trimmed by a cursor. The scan loop does work; it
 does not reimplement filtering.
 
+## Transaction Watches (Triggers)
+
+Transaction watches (watches, triggers) ask FoundationDB to report a change
+to a key (relative to the transaction that created the watch). If watches are
+unsupported by the local FoundationDB configuration, or the transaction cannot
+create watches, waiting on the watch throws `lfdb::libfdb_exception`.
+
+Note that watches do not report the triggering value. If you need the value,
+read it in a separate transaction. For the underlying semantics, see the
+FoundationDB Developer Guide and the C API entry for ``fdb_transaction_watch()``.
+
+See also:
+- https://apple.github.io/foundationdb/developer-guide.html#watches
+- https://apple.github.io/foundationdb/api-c.html#c.fdb_transaction_watch
+
+Here are some illustrative examples using transaction watches:
+
+```cpp
+// Create a one-shot watch that becomes ready when the key changes:
+auto watch = lfdb::make_watch(dbh, "person/jose-capablanca/title");
+
+lfdb::set(dbh, "person/jose-capablanca/title", "World Chess Champion");
+
+if (lfdb::watch_event::changed == watch.wait_for_event()) {
+  handle_title_change();
+}
+```
+
+```cpp
+// Create a watch inside a transaction when it must share that transaction's
+// read version. Commit the transaction before waiting on the watch:
+auto txn = lfdb::make_transaction(dbh);
+auto watch = lfdb::make_watch(txn, "person/jose-capablanca/title");
+
+if (lfdb::commit(txn)) {
+  watch.wait();
+}
+```
+
+```cpp
+// Cancel a watch that is no longer needed:
+auto watch = lfdb::make_watch(dbh, "person/jose-capablanca/title");
+
+watch.cancel();
+
+if (lfdb::watch_event::cancelled == watch.wait_for_event()) {
+  handle_watch_cancelled();
+}
+```
+
+libfdb exposes watch readiness (`ready()`), explicit cancellation (`cancel()`),
+blocking waits (`wait_for_event()`), and cooperative cancellation
+(`wait_for_event(stop_token)`) so applications can choose the timeout strategy
+that fits their scheduler. The same primitives can support polling, event-loop
+integration, stop-token cancellation, or a dedicated watch thread. You do not
+need to create an extra thread to put a timeout around a watch wait:
+
+```cpp
+bool wait_until_ready(lfdb::watch_handle& watch, auto timeout)
+{
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+
+  while (not watch.ready() && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  return watch.ready();
+}
+
+auto watch = lfdb::make_watch(dbh, "person/jose-capablanca/title");
+
+if (not wait_until_ready(watch, std::chrono::seconds(5))) {
+  watch.cancel();
+  handle_watch_timeout();
+  return;
+}
+
+if (lfdb::watch_event::changed == watch.wait_for_event()) {
+  handle_title_change();
+}
+```
+
+```cpp
+// Let a jthread stop_token cancel a blocked transaction watch wait:
+std::jthread watch_thread {
+  [dbh](std::stop_token stop_token) {
+    auto watch = lfdb::make_watch(dbh, "person/jose-capablanca/title");
+
+    if (lfdb::watch_event::cancelled == watch.wait_for_event(stop_token)) {
+      return;
+    }
+
+    handle_title_change();
+  }
+};
+
+watch_thread.request_stop();
+```
+
+`watched_loop()` is a gadget for repeated watch handling. Its callback takes
+the watched key as a `std::string_view`. The helper blocks; applications should
+own any thread, executor, shutdown, or callback error policy around it:
+
+```cpp
+std::jthread watch_thread {
+  [dbh](std::stop_token stop_token) {
+    lfdb::watched_loop(dbh, "person/jose-capablanca/title", stop_token,
+      [](std::string_view key) {
+        handle_title_change(key);
+      });
+  }
+};
+```
+
+Use a manual approach when you need direct control over each one-shot watch:
+
+```cpp
+// Reset (re-arm) the transaction watch manually after each event:
+std::jthread watch_thread {
+  [dbh](std::stop_token stop_token) {
+    while (not stop_token.stop_requested()) {
+      auto watch = lfdb::make_watch(dbh, "person/jose-capablanca/title");
+
+      if (lfdb::watch_event::cancelled == watch.wait_for_event(stop_token)) {
+        break;
+      }
+
+      handle_title_change();
+    }
+  }
+};
+```
+
 ## Appendix: Exception Summary
 
 libfdb tries to keep its exception surface small. Ordinary library operation

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -42,6 +42,7 @@
 #include <generator>
 #include <exception>
 #include <functional>
+#include <stop_token>
 #include <filesystem>
 #include <type_traits>
 
@@ -59,6 +60,7 @@
 namespace ceph::libfdb {
 
 struct select;
+struct watch_handle;
 
 class database;
 class transaction;
@@ -67,6 +69,7 @@ using database_handle = std::shared_ptr<database>;
 using transaction_handle = std::shared_ptr<transaction>;
 
 extern transaction_handle make_transaction(database_handle dbh);
+[[nodiscard]] inline watch_handle make_watch(transaction_handle txn, std::string_view key);
 
 } // namespace ceph::libfdb
 
@@ -146,6 +149,7 @@ namespace ceph::libfdb {
 
 // Should we commit after the (possibly) mutating operation?
 enum struct commit_after_op { commit, no_commit };
+enum struct watch_event { changed, cancelled };
 
 struct libfdb_exception final : std::runtime_error
 {
@@ -188,6 +192,11 @@ inline bool retryable(const libfdb_exception& e) noexcept
 
 namespace detail {
 
+/* Note: this magic constant is from FoundationDB's public error-code table,
+(flow/include/flow/error_definitions.h). It's distinct from watch_cancelled,
+which is a storage-server watch-limit error: */
+inline constexpr fdb_error_t operation_cancelled_error = 1101;
+
 struct future_value final
 {
  std::unique_ptr<FDBFuture, decltype(&fdb_future_destroy)> future_ptr;
@@ -206,6 +215,95 @@ struct future_value final
  private:
  friend class ceph::libfdb::transaction;
 };
+
+} // namespace detail
+
+// watch_handle can only be constructed by calling make_watch():
+struct watch_handle final
+{
+ public:
+ watch_handle(watch_handle&&) noexcept = default;
+ watch_handle& operator=(watch_handle&&) noexcept = default;
+
+ [[nodiscard]] bool ready() const noexcept
+ {
+  return fdb_future_is_ready(watch_future.raw_handle());
+ }
+
+ void cancel() noexcept
+ {
+  fdb_future_cancel(watch_future.raw_handle());
+ }
+
+ // Block until the watch reports an event:
+ [[nodiscard]] watch_event wait_for_event()
+ {
+  if (auto block_error = fdb_future_block_until_ready(watch_future.raw_handle());
+      0 != block_error) {
+   throw libfdb_exception(block_error);
+  }
+
+  switch (const auto error = fdb_future_get_error(watch_future.raw_handle()))
+   {
+    default: throw libfdb_exception(error);
+    case 0: return watch_event::changed;
+    case detail::operation_cancelled_error: return watch_event::cancelled;
+   }
+ }
+
+ [[nodiscard]] watch_event wait_for_event(std::stop_token stop_token)
+ {
+  if (stop_token.stop_requested()) {
+   cancel();
+
+   return wait_for_event();
+  }
+
+  std::stop_callback cancel_watch_on_stop(stop_token, [this] {
+   cancel();
+  });
+
+  return wait_for_event();
+ }
+
+ // Block until the watched key changes:
+ void wait()
+ {
+  if (watch_event::cancelled == wait_for_event()) {
+   throw libfdb_exception(detail::operation_cancelled_error);
+  }
+ }
+
+ void wait(std::stop_token stop_token)
+ {
+  if (watch_event::cancelled == wait_for_event(stop_token)) {
+   throw libfdb_exception(detail::operation_cancelled_error);
+  }
+ }
+
+ private:
+ detail::future_value watch_future;
+
+ private:
+ explicit watch_handle(detail::future_value watch_future_)
+  : watch_future(std::move(watch_future_))
+ {}
+
+ watch_handle() = delete;
+ watch_handle(const watch_handle&) = delete;
+ watch_handle& operator=(const watch_handle&) = delete;
+
+ private:
+ friend watch_handle make_watch(transaction_handle txn, std::string_view key);
+ friend class transaction;
+};
+
+namespace detail {
+
+inline auto as_fdb_span(const char *s)
+{
+ return std::span<const std::uint8_t>((const std::uint8_t *)s, std::strlen(s));
+}
 
 inline auto as_fdb_span(std::string_view sv)
 { 
@@ -598,6 +696,15 @@ class transaction final
         (const uint8_t *)half_open_range.end_key.data(), half_open_range.end_key.size());
  }
 
+ [[nodiscard]] watch_handle make_watch(std::span<const std::uint8_t> key)
+ {
+  return watch_handle {
+   detail::future_value {
+    fdb_transaction_watch(raw_handle(), key.data(), key.size())
+   }
+  };
+ }
+
  bool key_exists(std::string_view k) {
     return get_single_value_from_transaction(detail::as_fdb_span(k), [](auto) {});
  }
@@ -633,6 +740,7 @@ class transaction final
  friend inline bool key_exists(transaction_handle txn, std::string_view k, const commit_after_op commit_after);
 
  friend inline bool commit(transaction_handle& txn);
+ friend inline watch_handle make_watch(transaction_handle txn, std::string_view key);
  friend inline fdb_error_t ceph::libfdb::detail::do_commit(transaction_handle& txn);
  friend inline void ceph::libfdb::detail::transaction_set_kv_bytes(const transaction_handle&,
                                                                    std::span<const std::uint8_t>,

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -48,6 +48,7 @@
 #include <exception>
 #include <stdexcept>
 #include <functional>
+#include <stop_token>
 #include <filesystem>
 #include <type_traits>
 #include <initializer_list>
@@ -75,6 +76,7 @@ struct interval;
 
 using select = query::interval;
 struct versionstamp;
+struct watch_handle;
 
 class database;
 class transaction;
@@ -83,6 +85,7 @@ using database_handle = std::shared_ptr<database>;
 using transaction_handle = std::shared_ptr<transaction>;
 
 extern transaction_handle make_transaction(database_handle dbh);
+[[nodiscard]] inline watch_handle make_watch(transaction_handle txn, std::string_view key);
 
 } // namespace ceph::libfdb
 
@@ -231,6 +234,7 @@ namespace ceph::libfdb {
 
 // Should we commit after the (possibly) mutating operation?
 enum struct commit_after_op { commit, no_commit };
+enum struct watch_event { changed, cancelled };
 
 struct libfdb_exception final : std::runtime_error
 {
@@ -273,6 +277,11 @@ inline bool retryable(const libfdb_exception& e) noexcept
 
 namespace detail {
 
+/* Note: this magic constant is from FoundationDB's public error-code table,
+(flow/include/flow/error_definitions.h). It's distinct from watch_cancelled,
+which is a storage-server watch-limit error: */
+inline constexpr fdb_error_t operation_cancelled_error = 1101;
+
 struct future_value final
 {
  std::unique_ptr<FDBFuture, decltype(&fdb_future_destroy)> future_ptr;
@@ -285,6 +294,15 @@ struct future_value final
  public:
  FDBFuture *raw_handle() const noexcept { return future_ptr.get(); }
 
+ FDBFuture *raw_ptr_or_throw() const
+ {
+  if (auto *future = raw_handle(); nullptr != future) {
+   return future;
+  }
+
+  throw std::invalid_argument("invalid FDB pointer");
+ }
+
  private:
  void destroy() noexcept { future_ptr.reset(nullptr); }
  
@@ -296,6 +314,95 @@ inline auto as_fdb_span(concepts::libfdb_key_view auto key)
 {
  return std::span<const std::uint8_t>((const std::uint8_t *)key.data(), key.size());
 }
+
+} // namespace detail
+
+// watch_handle can only be constructed by calling make_watch():
+struct watch_handle final
+{
+ public:
+ watch_handle(watch_handle&&) noexcept = default;
+ watch_handle& operator=(watch_handle&&) noexcept = default;
+
+ [[nodiscard]] bool ready() const noexcept
+ {
+  auto *future = watch_future.raw_handle();
+  return nullptr != future && fdb_future_is_ready(future);
+ }
+
+ void cancel() noexcept
+ {
+  if (auto *future = watch_future.raw_handle(); nullptr != future) {
+   fdb_future_cancel(future);
+  }
+ }
+
+ // Block until the watch reports an event:
+ [[nodiscard]] watch_event wait_for_event()
+ {
+  auto *future = watch_future.raw_ptr_or_throw();
+
+  if (auto block_error = fdb_future_block_until_ready(future);
+      0 != block_error) {
+   throw libfdb_exception(block_error);
+  }
+
+  switch (const auto error = fdb_future_get_error(future))
+   {
+    default: throw libfdb_exception(error);
+    case 0: return watch_event::changed;
+    case detail::operation_cancelled_error: return watch_event::cancelled;
+   }
+ }
+
+ [[nodiscard]] watch_event wait_for_event(std::stop_token stop_token)
+ {
+  if (stop_token.stop_requested()) {
+   cancel();
+
+   return wait_for_event();
+  }
+
+  std::stop_callback cancel_watch_on_stop(stop_token, [this] {
+   cancel();
+  });
+
+  return wait_for_event();
+ }
+
+ // Block until the watched key changes:
+ void wait()
+ {
+  if (watch_event::cancelled == wait_for_event()) {
+   throw libfdb_exception(detail::operation_cancelled_error);
+  }
+ }
+
+ void wait(std::stop_token stop_token)
+ {
+  if (watch_event::cancelled == wait_for_event(stop_token)) {
+   throw libfdb_exception(detail::operation_cancelled_error);
+  }
+ }
+
+ private:
+ detail::future_value watch_future;
+
+ private:
+ explicit watch_handle(detail::future_value watch_future_)
+  : watch_future(std::move(watch_future_))
+ {}
+
+ watch_handle() = delete;
+ watch_handle(const watch_handle&) = delete;
+ watch_handle& operator=(const watch_handle&) = delete;
+
+ private:
+ friend watch_handle make_watch(transaction_handle txn, std::string_view key);
+ friend class transaction;
+};
+
+namespace detail {
 
 inline auto as_fdb_span(const concepts::libfdb_key auto& key)
 requires (!concepts::libfdb_key_view<decltype(key)>)
@@ -766,6 +873,15 @@ class transaction final
         (const uint8_t *)half_open_range.end_key.data(), half_open_range.end_key.size());
  }
 
+ [[nodiscard]] watch_handle make_watch(std::span<const std::uint8_t> key)
+ {
+  return watch_handle {
+   detail::future_value {
+    fdb_transaction_watch(raw_handle(), key.data(), key.size())
+   }
+  };
+ }
+
  bool key_exists(std::string_view k) {
     return get_single_value_from_transaction(detail::as_fdb_span(k), [](auto) {});
  }
@@ -810,6 +926,7 @@ class transaction final
 
  friend inline bool commit(transaction_handle& txn);
  friend inline bool commit(transaction_handle& txn, const versionstamp& stamp);
+ friend inline watch_handle make_watch(transaction_handle txn, std::string_view key);
  friend inline fdb_error_t ceph::libfdb::detail::do_commit(transaction_handle& txn);
  friend inline void ceph::libfdb::detail::transaction_set_kv_bytes(const transaction_handle&,
                                                                    std::span<const std::uint8_t>,
@@ -853,12 +970,13 @@ inline bool ceph::libfdb::transaction::get_single_value_from_transaction(const s
                                     raw_handle(),
                                     (const uint8_t *)key.data(), key.size(),
                                     is_snapshot)));
+ auto *future = fv.raw_ptr_or_throw();
  
   fdb_bool_t key_was_found = false;
   const uint8_t *out_buffer = nullptr;
   int out_len = 0;
 
-  if (fdb_error_t r = fdb_future_get_value(fv.raw_handle(), &key_was_found, &out_buffer, &out_len); 0 != r) {
+  if (fdb_error_t r = fdb_future_get_value(future, &key_was_found, &out_buffer, &out_len); 0 != r) {
     throw libfdb_exception(r);
   }
 
@@ -895,12 +1013,13 @@ inline bool ceph::libfdb::transaction::get_single_value_from_transaction(const s
  }
 
  detail::future_value fv(fdb_transaction_commit(raw_handle()));
+ auto *commit_future = fv.raw_ptr_or_throw();
 
- if (fdb_error_t r = fdb_future_block_until_ready(fv.raw_handle()); 0 != r) {
+ if (fdb_error_t r = fdb_future_block_until_ready(commit_future); 0 != r) {
   throw libfdb_exception(r);
  }
 
- if (fdb_error_t r = fdb_future_get_error(fv.raw_handle()); 0 != r) {
+ if (fdb_error_t r = fdb_future_get_error(commit_future); 0 != r) {
   detail::future_value ferror_result = detail::wait_for_on_error(raw_handle(), r);
 
   if (0 != detail::get_future_error(ferror_result)) {
@@ -961,13 +1080,15 @@ namespace ceph::libfdb::detail {
 
 inline future_value block_until_ready(future_value&& fv)
 {
- if (fdb_error_t r = fdb_future_block_until_ready(fv.raw_handle()); 0 != r) {
+ auto *future = fv.raw_ptr_or_throw();
+
+ if (fdb_error_t r = fdb_future_block_until_ready(future); 0 != r) {
   throw libfdb_exception(r);
  }
 
  // Note that fdb_future_block_until_ready() does not by itself check for errors
  // with the value; so, we need to do this separately:
- fdb_error_t r = fdb_future_get_error(fv.raw_handle());
+ fdb_error_t r = fdb_future_get_error(future);
 
  if (0 != r) {
   throw libfdb_exception(r);
@@ -978,7 +1099,7 @@ inline future_value block_until_ready(future_value&& fv)
 
 inline future_value wait_until_ready(future_value&& fv)
 {
- if (fdb_error_t r = fdb_future_block_until_ready(fv.raw_handle()); 0 != r) {
+ if (fdb_error_t r = fdb_future_block_until_ready(fv.raw_ptr_or_throw()); 0 != r) {
   throw libfdb_exception(r);
  }
 
@@ -987,14 +1108,14 @@ inline future_value wait_until_ready(future_value&& fv)
 
 inline fdb_error_t get_future_error(const future_value& fv)
 {
- return fdb_future_get_error(fv.raw_handle());
+ return fdb_future_get_error(fv.raw_ptr_or_throw());
 }
 
 inline future_value wait_for_on_error(FDBTransaction* txn, const fdb_error_t original_error)
 {
  future_value on_error_future(fdb_transaction_on_error(txn, original_error));
 
- if (0 != fdb_future_block_until_ready(on_error_future.raw_handle())) {
+ if (0 != fdb_future_block_until_ready(on_error_future.raw_ptr_or_throw())) {
   throw libfdb_exception(original_error);
  }
 
@@ -1030,7 +1151,7 @@ inline query_window extract_result_pairs(future_value result_owner)
  int out_count = 0;
  const FDBKeyValue *out_kvs = nullptr;
 
- if (fdb_error_t r = fdb_future_get_keyvalue_array(result_owner.raw_handle(),
+ if (fdb_error_t r = fdb_future_get_keyvalue_array(result_owner.raw_ptr_or_throw(),
                                                    &out_kvs,
                                                    &out_count,
                                                    &more_available); 0 != r) {
@@ -1049,7 +1170,7 @@ inline split_point_result extract_split_points(future_value result_owner)
  const FDBKey *result_keys = nullptr;
  int result_count = 0;
 
- const auto error = fdb_future_get_key_array(result_owner.raw_handle(), &result_keys, &result_count);
+ const auto error = fdb_future_get_key_array(result_owner.raw_ptr_or_throw(), &result_keys, &result_count);
 
  return split_point_result {
   .result_owner = std::move(result_owner),

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -81,6 +81,11 @@ inline transaction_handle make_transaction(database_handle dbh, const transactio
  return txn->commit(); 
 }
 
+[[nodiscard]] inline watch_handle make_watch(transaction_handle txn, std::string_view key)
+{
+ return txn->make_watch(detail::as_fdb_span(key));
+}
+
 } // namespace ceph::libfdb
 
 namespace ceph::libfdb::detail {
@@ -127,6 +132,37 @@ auto commit_in_new_transaction(database_handle dbh, FnT&& fn)
  -> operation_result_t<FnT>;
 
 } // namespace ceph::libfdb::detail
+
+namespace ceph::libfdb {
+
+[[nodiscard]] inline watch_handle make_watch(database_handle dbh, std::string_view key)
+{
+ return detail::maybe_commit(make_transaction(dbh), commit_after_op::commit,
+          [key](const transaction_handle& txn) {
+            return make_watch(txn, key);
+          });
+}
+
+template <typename FnT>
+requires std::invocable<FnT&, std::string_view>
+void watched_loop(database_handle dbh, std::string_view key, std::stop_token stop_token, FnT&& fn)
+{
+ std::string watched_key(key);
+
+ while (not stop_token.stop_requested() &&
+        watch_event::changed == make_watch(dbh, watched_key).wait_for_event(stop_token)) {
+  std::invoke(fn, std::string_view(watched_key));
+ }
+}
+
+template <typename FnT>
+requires std::invocable<FnT&, std::string_view>
+void watched_loop(database_handle dbh, std::string_view key, FnT&& fn)
+{
+ return watched_loop(dbh, key, std::stop_token{}, std::forward<FnT>(fn));
+}
+
+} // namespace ceph::libfdb
 
 namespace ceph::libfdb {
 

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -86,6 +86,11 @@ inline transaction_handle make_transaction(database_handle dbh, const transactio
  return commit(txn);
 }
 
+[[nodiscard]] inline watch_handle make_watch(transaction_handle txn, std::string_view key)
+{
+ return txn->make_watch(detail::as_fdb_span(key));
+}
+
 } // namespace ceph::libfdb
 
 namespace ceph::libfdb::detail {
@@ -128,6 +133,40 @@ auto in_transaction(database_handle dbh, FnT&& fn)
  -> operation_result_t<FnT>;
 
 } // namespace ceph::libfdb::detail
+
+namespace ceph::libfdb {
+
+[[nodiscard]] inline watch_handle make_watch(database_handle dbh, std::string_view key)
+{
+ return detail::in_transaction(dbh,
+          [key](transaction_handle& txn) {
+            return make_watch(txn, key);
+          });
+}
+
+template <typename FnT>
+requires std::invocable<FnT&, std::string_view>
+void watched_loop(database_handle dbh, std::string_view key, std::stop_token stop_token, FnT&& fn)
+{
+ std::string watched_key(key);
+
+ while (not stop_token.stop_requested() &&
+        watch_event::changed == make_watch(dbh, watched_key).wait_for_event(stop_token)) {
+  std::invoke(fn, std::string_view(watched_key));
+ }
+}
+
+/* watched_loop() runs until the watch is cancelled or an exception escapes.
+ * For more complex stop behavior, see make_watch(), ready(), cancel(), and
+ * wait_for_event(): */
+template <typename FnT>
+requires std::invocable<FnT&, std::string_view>
+void watched_loop(database_handle dbh, std::string_view key, FnT&& fn)
+{
+ return watched_loop(dbh, key, std::stop_token{}, std::forward<FnT>(fn));
+}
+
+} // namespace ceph::libfdb
 
 namespace ceph::libfdb {
 

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -33,12 +33,18 @@
 
 #include <map>
 #include <list>
-#include <chrono>
 #include <vector>
+#include <unordered_map>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <concepts>
+#include <exception>
+
 #include <ranges>
 #include <iterator>
 #include <algorithm>
-#include <unordered_map>
 
 using Catch::Matchers::AllMatch;
 
@@ -189,6 +195,223 @@ TEST_CASE("fdb simple", "[rgw][fdb]") {
     // ...and now it should be gone again:
     lfdb::erase(lfdb::make_transaction(j), k, lfdb::commit_after_op::commit);
     CHECK_FALSE(lfdb::key_exists(lfdb::make_transaction(j), k, lfdb::commit_after_op::no_commit));
+ }
+}
+
+static_assert(not std::default_initializable<lfdb::watch_handle>);
+static_assert(not std::copy_constructible<lfdb::watch_handle>);
+static_assert(std::move_constructible<lfdb::watch_handle>);
+
+static constexpr std::string_view watch_key = "watch/key";
+
+bool wait_until(std::predicate auto&& predicate,
+                const std::chrono::milliseconds timeout = 5s)
+{
+ const auto expiration_time = std::chrono::steady_clock::now() + timeout;
+ while (!std::invoke(predicate) &&
+        std::chrono::steady_clock::now() < expiration_time) {
+  std::this_thread::sleep_for(10ms);
+ }
+
+ return std::invoke(predicate);
+}
+
+lfdb::watch_event wait_for_watch_event(lfdb::watch_handle& watch,
+                                       const std::chrono::milliseconds timeout = 5s)
+{
+ std::atomic_bool done = false;
+ std::exception_ptr thrown;
+ lfdb::watch_event result = lfdb::watch_event::cancelled;
+
+ std::jthread wait_thread {
+  [&done, &result, &thrown, &watch](std::stop_token stop_token) {
+   try
+   {
+    result = watch.wait_for_event(stop_token);
+   }
+   catch (...)
+   {
+    thrown = std::current_exception();
+   }
+
+   done.store(true, std::memory_order_release);
+  }
+ };
+
+ const auto completed = wait_until([&done] {
+  return done.load(std::memory_order_acquire);
+ }, timeout);
+
+ if (not completed) {
+  wait_thread.request_stop();
+ }
+
+ wait_thread.join();
+
+ if (not completed) {
+  FAIL("watch did not report an event before timeout; check local FoundationDB watch support");
+ }
+
+ if (thrown) {
+  std::rethrow_exception(thrown);
+ }
+
+ return result;
+}
+
+bool trigger_watch_until(lfdb::database_handle dbh,
+                         std::string_view key,
+                         std::atomic_int& callbacks,
+                         const int target,
+                         const std::chrono::milliseconds timeout = 5s)
+{
+ const auto expiration_time = std::chrono::steady_clock::now() + timeout;
+ auto enough_callbacks = [&] {
+  return target <= callbacks.load(std::memory_order_acquire);
+ };
+
+ for (const auto n : std::views::iota(0) |
+                     std::views::take_while([&](auto) {
+                      return not enough_callbacks() &&
+                             std::chrono::steady_clock::now() < expiration_time;
+                     })) {
+  lfdb::set(dbh, key, fmt::format("value-{}", n));
+  wait_until(enough_callbacks, 50ms);
+ }
+
+ return enough_callbacks();
+}
+
+TEST_CASE("transaction watches", "[rgw][fdb]") {
+ janitor dbh;
+
+ SECTION("watch fires after committed key change") {
+  auto txn = lfdb::make_transaction(dbh);
+  auto watch = lfdb::make_watch(txn, watch_key);
+
+  REQUIRE(lfdb::commit(txn));
+  REQUIRE_FALSE(watch.ready());
+
+  lfdb::set(dbh, watch_key, "value");
+
+  CHECK(lfdb::watch_event::changed == wait_for_watch_event(watch));
+  CHECK(watch.ready());
+ }
+
+ SECTION("watch fires after committed key erase") {
+  lfdb::set(dbh, watch_key, "value");
+
+  auto txn = lfdb::make_transaction(dbh);
+  auto watch = lfdb::make_watch(txn, watch_key);
+
+  REQUIRE(lfdb::commit(txn));
+  REQUIRE_FALSE(watch.ready());
+
+  lfdb::erase(dbh, watch_key);
+
+  CHECK(lfdb::watch_event::changed == wait_for_watch_event(watch));
+  CHECK(watch.ready());
+ }
+
+ SECTION("database watch commits its watch transaction") {
+  auto watch = lfdb::make_watch(dbh, watch_key);
+
+  REQUIRE_FALSE(watch.ready());
+
+  lfdb::set(dbh, watch_key, "value");
+
+  CHECK(lfdb::watch_event::changed == wait_for_watch_event(watch));
+  CHECK(watch.ready());
+ }
+
+ SECTION("watch cancellation returns a wait result") {
+  auto watch = lfdb::make_watch(dbh, watch_key);
+
+  REQUIRE_FALSE(watch.ready());
+
+  watch.cancel();
+
+  CHECK(lfdb::watch_event::cancelled == watch.wait_for_event());
+  CHECK(watch.ready());
+ }
+
+ SECTION("throwing wait preserves cancellation as an exception") {
+  auto watch = lfdb::make_watch(dbh, watch_key);
+
+  REQUIRE_FALSE(watch.ready());
+
+  watch.cancel();
+
+  CHECK_THROWS_AS(watch.wait(), lfdb::libfdb_exception);
+  CHECK(watch.ready());
+ }
+
+ SECTION("watch can be rearmed after each key change") {
+  auto watch = lfdb::make_watch(dbh, watch_key);
+
+  lfdb::set(dbh, watch_key, "first-value");
+
+  REQUIRE(lfdb::watch_event::changed == wait_for_watch_event(watch));
+
+  watch = lfdb::make_watch(dbh, watch_key);
+
+  lfdb::set(dbh, watch_key, "second-value");
+
+  CHECK(lfdb::watch_event::changed == wait_for_watch_event(watch));
+  CHECK(watch.ready());
+ }
+
+ SECTION("read-your-writes disabled transactions reject watches") {
+  lfdb::transaction_options opts{
+   { FDB_TR_OPTION_READ_YOUR_WRITES_DISABLE, lfdb::option_flag },
+  };
+
+  auto txn = lfdb::make_transaction(dbh, opts);
+  auto watch = lfdb::make_watch(txn, watch_key);
+
+  CHECK_THROWS_AS(watch.wait_for_event(), lfdb::libfdb_exception);
+  CHECK(watch.ready());
+ }
+
+ SECTION("watch wait can be cancelled by stop token") {
+  lfdb::watch_event result = lfdb::watch_event::changed;
+  std::jthread wait_thread {
+   [&dbh, &result](std::stop_token stop_token) {
+    auto watch = lfdb::make_watch(dbh, watch_key);
+    result = watch.wait_for_event(stop_token);
+   }
+  };
+
+  wait_thread.request_stop();
+  wait_thread.join();
+
+  CHECK(lfdb::watch_event::cancelled == result);
+ }
+
+ SECTION("watch loop re-arms until stopped") {
+  std::atomic_int callbacks = 0;
+  std::atomic_bool wrong_key = false;
+
+  std::jthread watch_thread {
+   [&dbh, &callbacks, &wrong_key](std::stop_token stop_token) {
+    lfdb::watched_loop(dbh, watch_key, stop_token,
+     [&callbacks, &wrong_key](std::string_view key) {
+      if (watch_key != key) {
+       wrong_key.store(true, std::memory_order_release);
+      }
+
+      callbacks.fetch_add(1, std::memory_order_release);
+     });
+   }
+  };
+
+  REQUIRE(trigger_watch_until(dbh, watch_key, callbacks, 1));
+  REQUIRE(trigger_watch_until(dbh, watch_key, callbacks, 2));
+
+  watch_thread.request_stop();
+  watch_thread.join();
+
+  CHECK_FALSE(wrong_key.load(std::memory_order_acquire));
  }
 }
 

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -33,14 +33,18 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <chrono>
 #include <compare>
+#include <concepts>
 #include <cstdint>
+#include <exception>
 #include <iterator>
 #include <list>
 #include <map>
 #include <ranges>
 #include <stdexcept>
+#include <thread>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -458,6 +462,235 @@ TEST_CASE("version stamps", "[fdb]") {
 
     CHECK(stamp.is_resolved());
   }
+ }
+}
+
+static_assert(not std::default_initializable<lfdb::watch_handle>);
+static_assert(not std::copy_constructible<lfdb::watch_handle>);
+static_assert(std::move_constructible<lfdb::watch_handle>);
+
+static constexpr std::string_view watch_key = "watch/key";
+
+bool wait_until(std::predicate auto&& predicate,
+                const std::chrono::milliseconds timeout = 5s)
+{
+ const auto expiration_time = std::chrono::steady_clock::now() + timeout;
+ while (!std::invoke(predicate) &&
+        std::chrono::steady_clock::now() < expiration_time) {
+  std::this_thread::sleep_for(10ms);
+ }
+
+ return std::invoke(predicate);
+}
+
+lfdb::watch_event wait_for_watch_event(lfdb::watch_handle& watch,
+                                       const std::chrono::milliseconds timeout = 5s)
+{
+ std::atomic_bool done = false;
+ std::exception_ptr thrown;
+ lfdb::watch_event result = lfdb::watch_event::cancelled;
+
+ std::jthread wait_thread {
+  [&done, &result, &thrown, &watch](std::stop_token stop_token) {
+   try
+   {
+    result = watch.wait_for_event(stop_token);
+   }
+   catch (...)
+   {
+    thrown = std::current_exception();
+   }
+
+   done.store(true, std::memory_order_release);
+  }
+ };
+
+ const auto completed = wait_until([&done] {
+  return done.load(std::memory_order_acquire);
+ }, timeout);
+
+ if (not completed) {
+  wait_thread.request_stop();
+ }
+
+ wait_thread.join();
+
+ if (not completed) {
+  FAIL("watch did not report an event before timeout; check local FoundationDB watch support");
+ }
+
+ if (thrown) {
+  std::rethrow_exception(thrown);
+ }
+
+ return result;
+}
+
+bool trigger_watch_until(lfdb::database_handle dbh,
+                         std::string_view key,
+                         std::atomic_int& callbacks,
+                         const int target,
+                         const std::chrono::milliseconds timeout = 5s)
+{
+ const auto expiration_time = std::chrono::steady_clock::now() + timeout;
+ auto enough_callbacks = [&] {
+  return target <= callbacks.load(std::memory_order_acquire);
+ };
+
+ for (const auto n : std::views::iota(0) |
+                     std::views::take_while([&](auto) {
+                      return not enough_callbacks() &&
+                             std::chrono::steady_clock::now() < expiration_time;
+                     })) {
+  lfdb::set(dbh, key, fmt::format("value-{}", n));
+  wait_until(enough_callbacks, 50ms);
+ }
+
+ return enough_callbacks();
+}
+
+TEST_CASE("transaction watches", "[rgw][fdb]") {
+ janitor dbh;
+
+ SECTION("watch fires after committed key change") {
+  auto txn = lfdb::make_transaction(dbh);
+  auto watch = lfdb::make_watch(txn, watch_key);
+
+  REQUIRE(lfdb::commit(txn));
+  REQUIRE_FALSE(watch.ready());
+
+  lfdb::set(dbh, watch_key, "value");
+
+  CHECK(lfdb::watch_event::changed == wait_for_watch_event(watch));
+  CHECK(watch.ready());
+ }
+
+ SECTION("watch fires after committed key erase") {
+  lfdb::set(dbh, watch_key, "value");
+
+  auto txn = lfdb::make_transaction(dbh);
+  auto watch = lfdb::make_watch(txn, watch_key);
+
+  REQUIRE(lfdb::commit(txn));
+  REQUIRE_FALSE(watch.ready());
+
+  lfdb::erase(dbh, watch_key);
+
+  CHECK(lfdb::watch_event::changed == wait_for_watch_event(watch));
+  CHECK(watch.ready());
+ }
+
+ SECTION("database watch commits its watch transaction") {
+  auto watch = lfdb::make_watch(dbh, watch_key);
+
+  REQUIRE_FALSE(watch.ready());
+
+  lfdb::set(dbh, watch_key, "value");
+
+  CHECK(lfdb::watch_event::changed == wait_for_watch_event(watch));
+  CHECK(watch.ready());
+ }
+
+ SECTION("watch cancellation returns a wait result") {
+  auto watch = lfdb::make_watch(dbh, watch_key);
+
+  REQUIRE_FALSE(watch.ready());
+
+  watch.cancel();
+
+  CHECK(lfdb::watch_event::cancelled == watch.wait_for_event());
+  CHECK(watch.ready());
+ }
+
+ SECTION("moved-from watch can be probed and cancelled") {
+  auto watch = lfdb::make_watch(dbh, watch_key);
+  auto moved_watch = std::move(watch);
+
+  CHECK_FALSE(watch.ready());
+  CHECK_NOTHROW(watch.cancel());
+  CHECK_THROWS_AS(watch.wait_for_event(), std::invalid_argument);
+
+  moved_watch.cancel();
+  CHECK(lfdb::watch_event::cancelled == moved_watch.wait_for_event());
+ }
+
+ SECTION("throwing wait preserves cancellation as an exception") {
+  auto watch = lfdb::make_watch(dbh, watch_key);
+
+  REQUIRE_FALSE(watch.ready());
+
+  watch.cancel();
+
+  CHECK_THROWS_AS(watch.wait(), lfdb::libfdb_exception);
+  CHECK(watch.ready());
+ }
+
+ SECTION("watch can be rearmed after each key change") {
+  auto watch = lfdb::make_watch(dbh, watch_key);
+
+  lfdb::set(dbh, watch_key, "first-value");
+
+  REQUIRE(lfdb::watch_event::changed == wait_for_watch_event(watch));
+
+  watch = lfdb::make_watch(dbh, watch_key);
+
+  lfdb::set(dbh, watch_key, "second-value");
+
+  CHECK(lfdb::watch_event::changed == wait_for_watch_event(watch));
+  CHECK(watch.ready());
+ }
+
+ SECTION("read-your-writes disabled transactions reject watches") {
+  lfdb::transaction_options opts{
+   { FDB_TR_OPTION_READ_YOUR_WRITES_DISABLE, lfdb::option_flag },
+  };
+
+  auto txn = lfdb::make_transaction(dbh, opts);
+  auto watch = lfdb::make_watch(txn, watch_key);
+
+  CHECK_THROWS_AS(watch.wait_for_event(), lfdb::libfdb_exception);
+  CHECK(watch.ready());
+ }
+
+ SECTION("watch wait can be cancelled by stop token") {
+  lfdb::watch_event result = lfdb::watch_event::changed;
+  std::jthread wait_thread {
+   [&dbh, &result](std::stop_token stop_token) {
+    auto watch = lfdb::make_watch(dbh, watch_key);
+    result = watch.wait_for_event(stop_token);
+   }
+  };
+
+  wait_thread.request_stop();
+  wait_thread.join();
+
+  CHECK(lfdb::watch_event::cancelled == result);
+ }
+
+ SECTION("watch loop re-arms until stopped") {
+  std::atomic_int callbacks = 0;
+  std::atomic_bool wrong_key = false;
+
+  std::jthread watch_thread {
+   [&dbh, &callbacks, &wrong_key](std::stop_token stop_token) {
+    lfdb::watched_loop(dbh, watch_key, stop_token,
+     [&callbacks, &wrong_key](std::string_view key) {
+      if (watch_key != key) {
+       wrong_key.store(true, std::memory_order_release);
+      }
+
+      callbacks.fetch_add(1, std::memory_order_release);
+     });
+   }
+  };
+
+  REQUIRE(trigger_watch_until(dbh, watch_key, callbacks, 1));
+  REQUIRE(trigger_watch_until(dbh, watch_key, callbacks, 2));
+
+  watch_thread.request_stop();
+  watch_thread.join();
+
+  CHECK_FALSE(wrong_key.load(std::memory_order_acquire));
  }
 }
 

--- a/src/test/rgw/test_fdb_ceph.cc
+++ b/src/test/rgw/test_fdb_ceph.cc
@@ -661,7 +661,7 @@ TEST_CASE("read path benchmarks", "[.benchmark][benchmark]") {
 }
 
 // Note that these are disabled for regular test runs. Use
-//      unittest_fdb_ceph "simple benchmarks"
+//      unittest_fdb_ceph "[benchmark]"
 // ...to run:
 TEST_CASE("simple benchmarks", "[.benchmark][benchmark]") {
 


### PR DESCRIPTION
Adds transaction trigger (watch) support to libfdb.

This exposes an interface into FoundationFDB transaction watches: when a key is modified, a
user callback is invoked. In addition to basic support, slightly higher-level machinery like
libfdb::watched_loop() makes handling common use-cases straightforward.

Includes examples and unit tests.

Assisted-by: Codex:GPT-5

Signed-off-by: Jesse Williamson <jfw@ibm.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
