### PR TITLE
crimson/store_bench: plot function for tracked metrics vs avg latency and ios per bucket

### DIFF
--- a/src/crimson/tools/store_bench/plot_bucket_metrics.py
+++ b/src/crimson/tools/store_bench/plot_bucket_metrics.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Turn the bucketed CSV output produced by store-bench.cc's --csv-output flag
+into interactive HTML plots (hover to see raw values), using Plotly.
+
+CSV columns: shard,bucket_index,ios_completed,avg_latency_s,<tracked metric>...
+
+For each tracked metric, compares it (min-max normalized, one axis) against
+a base metric (avg_latency_s or ios_completed), per shard, over buckets.
+Produces two self-contained HTML files: one comparing avg_latency_s, one
+comparing ios_completed.
+
+Grid layout: rows = tracked metric names, columns = shards.
+"""
+
+import argparse
+import csv
+import os
+
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+
+BASE_METRICS = ("avg_latency_s", "ios_completed")
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def read_csv(path):
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        return list(reader)
+
+
+def get_rows_for_shard(rows, shard):
+    return [row for row in rows if row["shard"] == shard]
+
+
+def get_unique_shards(rows):
+    return sorted({row["shard"] for row in rows}, key=int)
+
+
+def get_unique_metric_names(rows):
+    if not rows:
+        return []
+    return [name for name in rows[0].keys() if name not in ("shard", "bucket_index")]
+
+
+def get_tracked_metric_names(rows):
+    return [name for name in get_unique_metric_names(rows) if name not in BASE_METRICS]
+
+
+def get_data_for_metric(shard_rows, metric_name):
+    shard_rows = sorted(shard_rows, key=lambda row: int(row["bucket_index"]))
+    x = [int(row["bucket_index"]) for row in shard_rows]
+    y = [float(row[metric_name]) if row[metric_name] != "" else float("nan")
+         for row in shard_rows]
+    return x, y
+
+
+def normalize(values):
+    finite = [v for v in values if v == v]  # drop NaNs
+    if not finite:
+        return values
+    lo, hi = min(finite), max(finite)
+    if hi == lo:
+        return [0.5 if v == v else v for v in values]
+    return [(v - lo) / (hi - lo) if v == v else v for v in values]
+
+
+def plot_comparison_grid(rows, base_metric_name, output_path):
+    shards = get_unique_shards(rows)
+    metric_names = get_tracked_metric_names(rows)
+
+    fig = make_subplots(
+        rows=len(metric_names), cols=len(shards),
+        subplot_titles=[f"shard {shard}" for shard in shards] * len(metric_names),
+        shared_xaxes=True,
+    )
+
+    for metric_row, metric_name in enumerate(metric_names, start=1):
+        for shard_col, shard in enumerate(shards, start=1):
+            shard_rows = get_rows_for_shard(rows, shard)
+            x, base_y = get_data_for_metric(shard_rows, base_metric_name)
+            _, metric_y = get_data_for_metric(shard_rows, metric_name)
+            show_legend = metric_row == 1 and shard_col == 1
+
+            fig.add_trace(
+                go.Scatter(
+                    x=x, y=normalize(base_y), mode="lines+markers",
+                    name=base_metric_name, legendgroup=base_metric_name,
+                    showlegend=show_legend, marker_color="#2a78d6",
+                    customdata=base_y,
+                    hovertemplate=f"bucket %{{x}}<br>{base_metric_name}: %{{customdata:.6g}}<extra></extra>",
+                ),
+                row=metric_row, col=shard_col,
+            )
+            fig.add_trace(
+                go.Scatter(
+                    x=x, y=normalize(metric_y), mode="lines+markers",
+                    name=metric_name, legendgroup=metric_name,
+                    showlegend=show_legend, marker_color="#1baf7a",
+                    customdata=metric_y,
+                    hovertemplate=f"bucket %{{x}}<br>{metric_name}: %{{customdata:.6g}}<extra></extra>",
+                ),
+                row=metric_row, col=shard_col,
+            )
+            fig.update_yaxes(title_text=metric_name if shard_col == 1 else None,
+                              row=metric_row, col=shard_col)
+            fig.update_xaxes(title_text="bucket_index", row=metric_row, col=shard_col)
+
+    fig.update_layout(
+        height=300 * len(metric_names), width=350 * len(shards),
+        title=f"{base_metric_name} vs tracked metrics (normalized)",
+        hovermode="x unified",
+    )
+    fig.write_html(output_path, include_plotlyjs="inline")
+    print(f"wrote {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("csv_path", help="path to the bucketed CSV file")
+    parser.add_argument(
+        "-o", "--output-prefix", default=os.path.join(SCRIPT_DIR, "bucket_metrics"),
+        help="prefix for the output HTML files (default: bucket_metrics, written "
+             "next to this script)",
+    )
+    args = parser.parse_args()
+
+    rows = read_csv(args.csv_path)
+    plot_comparison_grid(rows, "avg_latency_s", f"{args.output_prefix}_latency.html")
+    plot_comparison_grid(rows, "ios_completed", f"{args.output_prefix}_ios.html")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
… CSV output

Turns the bucketed CSV produced by store-bench.cc's --csv-output flag into self-contained interactive HTML plots (Plotly), comparing each tracked metric against avg_latency_s and ios_completed per shard/bucket.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
