### PR TITLE
common,rgw: remove pre-OpenSSL-1.1 relic code

### DIFF
--- a/src/common/ceph_crypto.cc
+++ b/src/common/ceph_crypto.cc
@@ -13,21 +13,13 @@
  *
  */
 
-#include <vector>
 #include <utility>
 
 #include "common/ceph_context.h"
-#include "common/ceph_mutex.h"
 #include "common/config.h"
 #include "ceph_crypto.h"
 
 #include <openssl/evp.h>
-
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-#  include <openssl/conf.h>
-#  include <openssl/engine.h>
-#  include <openssl/err.h>
-#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -36,139 +28,6 @@
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
 namespace TOPNSPC::crypto::ssl {
-
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-static std::atomic_uint32_t crypto_refs;
-
-
-static auto ssl_mutexes = ceph::make_lock_container<ceph::shared_mutex>(
-  static_cast<size_t>(std::max(CRYPTO_num_locks(), 0)),
-  [](const size_t i) {
-    return ceph::make_shared_mutex(
-      std::string("ssl-mutex-") + std::to_string(i));
-  });
-
-static struct {
-  // we could use e.g. unordered_set instead at the price of providing
-  // std::hash<...> specialization. However, we can live with duplicates
-  // quite well while the benefit is not worth the effort.
-  std::vector<CRYPTO_THREADID> tids;
-  ceph::mutex lock = ceph::make_mutex("crypto::ssl::init_records::lock");;
-} init_records;
-
-static void
-ssl_locking_callback(
-  const int mode,
-  const int mutex_num,
-  [[maybe_unused]] const char *file,
-  [[maybe_unused]] const int line)
-{
-  if (mutex_num < 0 || static_cast<size_t>(mutex_num) >= ssl_mutexes.size()) {
-    ceph_assert_always("openssl passed wrong mutex index" == nullptr);
-  }
-
-  if (mode & CRYPTO_READ) {
-    if (mode & CRYPTO_LOCK) {
-      ssl_mutexes[mutex_num].lock_shared();
-    } else if (mode & CRYPTO_UNLOCK) {
-      ssl_mutexes[mutex_num].unlock_shared();
-    }
-  } else if (mode & CRYPTO_WRITE) {
-    if (mode & CRYPTO_LOCK) {
-      ssl_mutexes[mutex_num].lock();
-    } else if (mode & CRYPTO_UNLOCK) {
-      ssl_mutexes[mutex_num].unlock();
-    }
-  }
-}
-
-static unsigned long
-ssl_get_thread_id(void)
-{
-  static_assert(sizeof(unsigned long) >= sizeof(pthread_t));
-  /* pthread_t may be any data type, so a simple cast to unsigned long
-   * can rise a warning/error, depending on the platform.
-   * Here memcpy is used as an anything-to-anything cast. */
-  unsigned long ret = 0;
-  pthread_t t = pthread_self();
-  memcpy(&ret, &t, sizeof(pthread_t));
-  return ret;
-}
-#endif /* not OPENSSL_VERSION_NUMBER < 0x10100000L */
-
-static void init() {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-  if (++crypto_refs == 1) {
-    // according to
-    // https://wiki.openssl.org/index.php/Library_Initialization#libcrypto_Initialization
-    OpenSSL_add_all_algorithms();
-    ERR_load_crypto_strings();
-
-    // initialize locking callbacks, needed for thread safety.
-    // http://www.openssl.org/support/faq.html#PROG1
-    CRYPTO_set_locking_callback(&ssl_locking_callback);
-    CRYPTO_set_id_callback(&ssl_get_thread_id);
-
-    OPENSSL_config(nullptr);
-  }
-
-  // we need to record IDs of all threads calling the initialization in
-  // order to *manually* free per-thread memory OpenSSL *automagically*
-  // allocated in ERR_get_state().
-  // XXX: this solution/nasty hack is IMPERFECT. A leak will appear when
-  // a client init()ializes the crypto subsystem with one thread and then
-  // uses it from another one in a way that results in ERR_get_state().
-  // XXX: for discussion about another approaches please refer to:
-  // https://www.mail-archive.com/openssl-users@openssl.org/msg59070.html
-  {
-    std::lock_guard l(init_records.lock);
-    CRYPTO_THREADID tmp;
-    CRYPTO_THREADID_current(&tmp);
-    init_records.tids.emplace_back(std::move(tmp));
-  }
-#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
-}
-
-static void shutdown() {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-  if (--crypto_refs != 0) {
-    return;
-  }
-
-  // drop error queue for each thread that called the init() function to
-  // satisfy valgrind.
-  {
-    std::lock_guard l(init_records.lock);
-
-    // NOTE: in OpenSSL 1.0.2g the signature is:
-    //    void ERR_remove_thread_state(const CRYPTO_THREADID *tid);
-    // but in 1.1.0j it has been changed to
-    //    void ERR_remove_thread_state(void *);
-    // We're basing on the OPENSSL_VERSION_NUMBER check to preserve
-    // const-correctness without failing builds on modern envs.
-    for (const auto& tid : init_records.tids) {
-      ERR_remove_thread_state(&tid);
-    }
-  }
-
-  // Shutdown according to
-  // https://wiki.openssl.org/index.php/Library_Initialization#Cleanup
-  // http://stackoverflow.com/questions/29845527/how-to-properly-uninitialize-openssl
-  //
-  // The call to CONF_modules_free() has been introduced after a valgring run.
-  CRYPTO_set_locking_callback(nullptr);
-  CRYPTO_set_id_callback(nullptr);
-  ENGINE_cleanup();
-  CONF_modules_free();
-  CONF_modules_unload(1);
-  ERR_free_strings();
-  EVP_cleanup();
-  CRYPTO_cleanup_all_ex_data();
-
-  // NOTE: don't clear ssl_mutexes as we should be ready for init-deinit-init
-  // sequence.
-#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
-}
 
 void zeroize_for_security(void* const s, const size_t n) {
   OPENSSL_cleanse(s, n);
@@ -179,11 +38,11 @@ void zeroize_for_security(void* const s, const size_t n) {
 
 namespace TOPNSPC::crypto {
 void init() {
-  ssl::init();
+  // OpenSSL >= 1.1.0 self-initializes (OPENSSL_init_crypto) and
+  // registers its own atexit cleanup; nothing to do.
 }
 
 void shutdown([[maybe_unused]] const bool shared) {
-  ssl::shutdown();
 }
 
 void zeroize_for_security(void* const s, const size_t n) {

--- a/src/rgw/rgw_http_client_curl.cc
+++ b/src/rgw/rgw_http_client_curl.cc
@@ -3,103 +3,17 @@
 
 #include "rgw_http_client_curl.h"
 #include <mutex>
-#include <vector>
 #include <curl/curl.h>
 
 #include "rgw_common.h"
-#define dout_context g_ceph_context
-#define dout_subsys ceph_subsys_rgw
-
-#ifdef WITH_CURL_OPENSSL
-#include <openssl/crypto.h>
-#endif
-
-#if defined(WITH_CURL_OPENSSL) && OPENSSL_API_COMPAT < 0x10100000L
-namespace openssl {
-
-class RGWSSLSetup
-{
-  std::vector <std::mutex> locks;
-public:
-  explicit RGWSSLSetup(int n) : locks (n){}
-
-  void set_lock(int id){
-    try {
-      locks.at(id).lock();
-    } catch (std::out_of_range& e) {
-      dout(0) << __func__ << " failed to set locks" << dendl;
-    }
-  }
-
-  void clear_lock(int id){
-    try {
-      locks.at(id).unlock();
-    } catch (std::out_of_range& e) {
-      dout(0) << __func__ << " failed to unlock" << dendl;
-    }
-  }
-};
-
-
-void rgw_ssl_locking_callback(int mode, int id, const char *file, int line)
-{
-  static RGWSSLSetup locks(CRYPTO_num_locks());
-  if (mode & CRYPTO_LOCK)
-    locks.set_lock(id);
-  else
-    locks.clear_lock(id);
-}
-
-unsigned long rgw_ssl_thread_id_callback(){
-  return (unsigned long)pthread_self();
-}
-
-void init_ssl(){
-  CRYPTO_set_id_callback((unsigned long (*) ()) rgw_ssl_thread_id_callback);
-  CRYPTO_set_locking_callback(rgw_ssl_locking_callback);
-}
-
-} /* namespace openssl */
-#endif // WITH_CURL_OPENSSL
-
 
 namespace rgw {
 namespace curl {
 
-#if defined(WITH_CURL_OPENSSL) && OPENSSL_API_COMPAT < 0x10100000L
-void init_ssl() {
-  ::openssl::init_ssl();
-}
-
-bool fe_inits_ssl(boost::optional <const fe_map_t&> m, long& curl_global_flags){
-  if (m) {
-    for (const auto& kv: *m){
-      if (kv.first == "beast"){
-        std::string cert;
-        kv.second->get_val("ssl_certificate","", &cert);
-        if (!cert.empty()){
-         /* TODO this flag is no op for curl > 7.57 */
-          curl_global_flags &= ~CURL_GLOBAL_SSL;
-          return true;
-        }
-      }
-    }
-  }
-  return false;
-}
-#endif // WITH_CURL_OPENSSL
-
 std::once_flag curl_init_flag;
 
-void setup_curl(boost::optional<const fe_map_t&> m) {
-  long curl_global_flags = CURL_GLOBAL_ALL;
-
-  #if defined(WITH_CURL_OPENSSL) && OPENSSL_API_COMPAT < 0x10100000L
-  if (!fe_inits_ssl(m, curl_global_flags))
-    init_ssl();
-  #endif
-
-  std::call_once(curl_init_flag, curl_global_init, curl_global_flags);
+void setup_curl([[maybe_unused]] boost::optional<const fe_map_t&> m) {
+  std::call_once(curl_init_flag, curl_global_init, CURL_GLOBAL_ALL);
   rgw_setup_saved_curl_handles();
 }
 


### PR DESCRIPTION
This removes two blocks of dead pre-OpenSSL-1.1.0 lifecycle code:

* `src/common/ceph_crypto.cc`: the refcounted init/shutdown machinery
  (OpenSSL_add_all_algorithms, ERR_load_crypto_strings, locking/id
  callbacks, OPENSSL_config, and the matching cleanup calls). All of it
  is fenced `OPENSSL_VERSION_NUMBER < 0x10100000L`; OpenSSL >= 1.1.0
  initializes and deinitializes itself (OPENSSL_init_crypto(3)). The
  public `ceph::crypto::init()/shutdown()` entry points stay as empty
  functions, so the existing callers (ceph_context.cc, test/crypto.cc)
  are untouched.

* `src/rgw/rgw_http_client_curl.cc`: the libcurl locking-callback shim.
  Its version fence is broken — it tests `OPENSSL_API_COMPAT <
  0x10100000L`, but Ceph never defines OPENSSL_API_COMPAT, so the
  undefined token evaluates to 0 and the shim compiles on every OpenSSL
  version. Since 1.1.0 the CRYPTO_set_locking_callback family expands
  to no-op macros, so the code does nothing at runtime; this deletes it
  outright rather than fixing the fence.

Per-line no-op justification and the OpenSSL man-page citations are in
the commit messages. The `-Wdeprecated-declarations` pragmas in
ceph_crypto.cc are intentionally left in place: they still suppress
real warnings from the HMAC wrapper on OpenSSL 3 builds, which a
follow-up addresses.

This is the first installment of a tree-wide audit of deprecated and
obsolete OpenSSL API use in Ceph. The motivation is provider-based
FIPS configurations (OpenSSL's fips provider or any third-party
provider): legacy call shapes either bypass or half-bypass provider
dispatch. These two cleanups are behavior-neutral on every supported
build; follow-ups fix sites where the legacy shape is an actual
correctness problem. The same audit also flagged src/cls_crypto.cc and
src/cls_acl.cc, already removed on main by 43cf7eb8.

Testing: these deletions were carried in a downstream 20.2.2-based
package build (full build clean; radosgw brought up and serving, with
no behavior delta observed on the touched paths). The rebase onto main
is textually identical apart from editor modelines. Deletion-only
otherwise; no functional change intended on any supported OpenSSL.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests


<!-- edited to retrigger checklist Verify -->
