### PR TITLE
Improve the performance of Ceph builds and rebuilds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,18 @@ if(WITH_SCCACHE)
   set(CMAKE_CXX_COMPILER_LAUNCHER ${SCCACHE_EXECUTABLE})
 endif(WITH_SCCACHE)
 
+set(CEPH_EXTERNAL_PROJECT_CMAKE_ARGS)
+foreach(language C CXX)
+  if(CMAKE_${language}_COMPILER_LAUNCHER)
+    string(REPLACE ";" "!" compiler_launcher
+      "${CMAKE_${language}_COMPILER_LAUNCHER}")
+    list(APPEND CEPH_EXTERNAL_PROJECT_CMAKE_ARGS
+      -DCMAKE_${language}_COMPILER_LAUNCHER=${compiler_launcher})
+  endif()
+endforeach()
+unset(compiler_launcher)
+unset(language)
+
 option(WITH_MANPAGE "Build man pages." ON)
 if(WITH_MANPAGE)
   find_program(SPHINX_BUILD

--- a/cmake/modules/BuildArrow.cmake
+++ b/cmake/modules/BuildArrow.cmake
@@ -3,6 +3,7 @@
 function(build_arrow)
   # only enable the parquet component
   set(arrow_CMAKE_ARGS -DARROW_PARQUET=ON)
+  list(APPEND arrow_CMAKE_ARGS ${CEPH_EXTERNAL_PROJECT_CMAKE_ARGS})
 
   # only use preinstalled dependencies for arrow, don't fetch/build any
   list(APPEND arrow_CMAKE_ARGS -DARROW_DEPENDENCY_SOURCE=SYSTEM)

--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -83,6 +83,7 @@ function(do_build_boost root_dir version)
     endif()
   endforeach()
   list_replace(boost_with_libs "unit_test_framework" "test")
+  list(REMOVE_DUPLICATES boost_with_libs)
   string(REPLACE ";" "," boost_with_libs "${boost_with_libs}")
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
@@ -112,17 +113,21 @@ function(do_build_boost root_dir version)
   set(user_config ${CMAKE_BINARY_DIR}/user-config.jam)
   # edit the user-config.jam so b2 will be able to use the specified
   # toolset and python
-  file(WRITE ${user_config}
+  set(boost_cxx_command
+    ${CMAKE_CXX_COMPILER_LAUNCHER}
+    ${CMAKE_CXX_COMPILER})
+  string(REPLACE ";" " " boost_cxx_command "${boost_cxx_command}")
+  string(CONCAT user_config_content
     "using ${toolset}"
     " : "
-    " : ${CMAKE_CXX_COMPILER}"
+    " : ${boost_cxx_command}"
     " : <compileflags>-fPIC <compileflags>-w <compileflags>-Wno-everything"
     " ;\n")
   if(with_python_version)
     find_package(Python3 ${with_python_version} QUIET REQUIRED
       COMPONENTS Development)
     string(REPLACE ";" " " python3_includes "${Python3_INCLUDE_DIRS}")
-    file(APPEND ${user_config}
+    string(APPEND user_config_content
       "using python"
       " : ${with_python_version}"
       " : ${Python3_EXECUTABLE}"
@@ -130,6 +135,10 @@ function(do_build_boost root_dir version)
       " : ${Python3_LIBRARIES}"
       " ;\n")
   endif()
+  file(CONFIGURE
+    OUTPUT ${user_config}
+    CONTENT "${user_config_content}"
+    @ONLY)
   list(APPEND b2 --user-config=${user_config})
 
   list(APPEND b2 toolset=${toolset})
@@ -144,7 +153,7 @@ function(do_build_boost root_dir version)
   if(WITH_BOOST_VALGRIND)
     list(APPEND b2 valgrind=on)
   endif()
-  set(b2_targets headers stage)
+  set(b2_targets stage)
   set(b2_install_targets install)
   if(WITH_ASAN)
     list(APPEND b2 context-impl=ucontext)
@@ -162,8 +171,9 @@ function(do_build_boost root_dir version)
     ${b2} ${b2_targets}
     #"--buildid=ceph" # changes lib names--can omit for static
     ${boost_features})
+  # Stage and install must select identical library variants:
   set(install_command
-    ${b2} ${b2_install_targets})
+    ${b2} ${b2_install_targets} ${boost_features})
   if(EXISTS "${PROJECT_SOURCE_DIR}/src/boost/bootstrap.sh")
     check_boost_version("${PROJECT_SOURCE_DIR}/src/boost" ${version})
     set(source_dir
@@ -203,6 +213,13 @@ function(do_build_boost root_dir version)
     DEPENDERS configure
     COMMENT "Building B2 engine.."
     WORKING_DIRECTORY <SOURCE_DIR>)
+  ExternalProject_Add_Step(Boost headers
+    COMMAND ${b2} headers
+    DEPENDEES configure
+    DEPENDERS build
+    COMMENT "Preparing Boost headers"
+    WORKING_DIRECTORY <SOURCE_DIR>)
+  ExternalProject_Add_StepTargets(Boost headers)
 endfunction()
 
 set(Boost_context_DEPENDENCIES thread chrono system date_time)
@@ -217,14 +234,19 @@ macro(build_boost version)
   # target, so we can collect "Boost_LIBRARIES" which is then used by
   # ExternalProject_Add(Boost ...)
   set(install_dir "${CMAKE_BINARY_DIR}/boost")
+  if(EXISTS "${PROJECT_SOURCE_DIR}/src/boost/bootstrap.sh")
+    set(Boost_SOURCE_DIR "${PROJECT_SOURCE_DIR}/src/boost")
+  else()
+    set(Boost_SOURCE_DIR "${install_dir}/src/Boost")
+  endif()
   set(BOOST_ROOT ${install_dir})
-  set(Boost_INCLUDE_DIRS ${install_dir}/include)
-  set(Boost_INCLUDE_DIR ${install_dir}/include)
+  set(Boost_INCLUDE_DIRS ${Boost_SOURCE_DIR})
+  set(Boost_INCLUDE_DIR ${Boost_SOURCE_DIR})
   set(Boost_LIBRARY_DIR_RELEASE ${install_dir}/lib)
   set(Boost_VERSION ${version})
   # create the directory so cmake won't complain when looking at the imported
   # target
-  file(MAKE_DIRECTORY ${Boost_INCLUDE_DIRS})
+  file(MAKE_DIRECTORY ${Boost_SOURCE_DIR})
   cmake_parse_arguments(Boost_BUILD "" "" COMPONENTS ${ARGN})
   foreach(c ${Boost_BUILD_COMPONENTS})
     list(APPEND components ${c})
@@ -234,6 +256,7 @@ macro(build_boost version)
     endif()
   endforeach()
   set(Boost_BUILD_COMPONENTS ${components})
+  list(REMOVE_DUPLICATES Boost_BUILD_COMPONENTS)
   # Remove the `headers` from the list of components to build as
   # `headers` is an interface only target we add later.
   list(REMOVE_ITEM Boost_BUILD_COMPONENTS headers)
@@ -293,7 +316,7 @@ macro(build_boost version)
   add_library(Boost::headers INTERFACE IMPORTED)
   set_target_properties(Boost::headers PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}")
-  add_dependencies(Boost::headers Boost)
+  add_dependencies(Boost::headers Boost-headers)
   find_package_handle_standard_args(Boost DEFAULT_MSG
     Boost_INCLUDE_DIRS Boost_LIBRARIES)
   mark_as_advanced(Boost_LIBRARIES BOOST_INCLUDE_DIRS)

--- a/cmake/modules/BuildOpentelemetry.cmake
+++ b/cmake/modules/BuildOpentelemetry.cmake
@@ -14,6 +14,7 @@ function(build_opentelemetry)
                                -DBUILD_TESTING=OFF
                                -DCMAKE_BUILD_TYPE=Release
                                -DWITH_EXAMPLES=OFF)
+  list(APPEND opentelemetry_CMAKE_ARGS ${CEPH_EXTERNAL_PROJECT_CMAKE_ARGS})
 
   set(opentelemetry_libs
       ${opentelemetry_BINARY_DIR}/sdk/src/trace/libopentelemetry_trace.a
@@ -21,7 +22,6 @@ function(build_opentelemetry)
       ${opentelemetry_BINARY_DIR}/sdk/src/common/libopentelemetry_common.a
       ${opentelemetry_BINARY_DIR}/exporters/jaeger/libopentelemetry_exporter_jaeger_trace.a
       ${opentelemetry_BINARY_DIR}/ext/src/http/client/curl/libopentelemetry_http_client_curl.a
-      ${CURL_LIBRARIES}
   )
   set(opentelemetry_include_dir ${opentelemetry_SOURCE_DIR}/api/include/
                                 ${opentelemetry_SOURCE_DIR}/exporters/jaeger/include/
@@ -67,6 +67,7 @@ function(build_opentelemetry)
     INSTALL_COMMAND ""
     BUILD_BYPRODUCTS ${opentelemetry_libs}
     DEPENDS ${dependencies}
+    LIST_SEPARATOR !
     LOG_BUILD ON)
 
   # CMake doesn't allow to add a list of libraries to the import property, hence

--- a/cmake/modules/BuildRocksDB.cmake
+++ b/cmake/modules/BuildRocksDB.cmake
@@ -1,5 +1,6 @@
 function(build_rocksdb)
   set(rocksdb_CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=ON)
+  list(APPEND rocksdb_CMAKE_ARGS ${CEPH_EXTERNAL_PROJECT_CMAKE_ARGS})
   list(APPEND rocksdb_CMAKE_ARGS -DWITH_GFLAGS=OFF)
 
   # cmake doesn't properly handle arguments containing ";", such as

--- a/cmake/modules/BuildUtf8proc.cmake
+++ b/cmake/modules/BuildUtf8proc.cmake
@@ -1,6 +1,7 @@
 # utf8proc is a dependency of the arrow submodule
 
 function(build_utf8proc)
+  list(APPEND utf8proc_CMAKE_ARGS ${CEPH_EXTERNAL_PROJECT_CMAKE_ARGS})
   # only build static version
   list(APPEND utf8proc_CMAKE_ARGS -DBUILD_SHARED_LIBS=OFF)
 

--- a/cmake/modules/BuildZstd.cmake
+++ b/cmake/modules/BuildZstd.cmake
@@ -7,12 +7,14 @@ function(build_Zstd)
     SOURCE_DIR ${CMAKE_SOURCE_DIR}/src/zstd/build/cmake
     CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+               ${CEPH_EXTERNAL_PROJECT_CMAKE_ARGS}
                -DCMAKE_C_FLAGS=${ZSTD_C_FLAGS}
                -DCMAKE_AR=${CMAKE_AR}
                -DCMAKE_POSITION_INDEPENDENT_CODE=${ENABLE_SHARED}
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/libzstd
     BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --target libzstd_static
     BUILD_BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/libzstd/lib/libzstd.a"
+    LIST_SEPARATOR !
     INSTALL_COMMAND "")
   add_library(Zstd::Zstd STATIC IMPORTED)
   set_target_properties(Zstd::Zstd PROPERTIES

--- a/cmake/modules/Buildc-ares.cmake
+++ b/cmake/modules/Buildc-ares.cmake
@@ -5,11 +5,13 @@ function(build_c_ares)
   ExternalProject_Add(c-ares_ext
     SOURCE_DIR "${C-ARES_SOURCE_DIR}"
     CMAKE_ARGS
-     -DCARES_STATIC=ON
-     -DCARES_SHARED=OFF
-     -DCARES_INSTALL=OFF
+      ${CEPH_EXTERNAL_PROJECT_CMAKE_ARGS}
+      -DCARES_STATIC=ON
+      -DCARES_SHARED=OFF
+      -DCARES_INSTALL=OFF
     BINARY_DIR "${C-ARES_BINARY_DIR}"
     BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR>
+    LIST_SEPARATOR !
     INSTALL_COMMAND "")
   add_library(c-ares::cares STATIC IMPORTED)
   add_dependencies(c-ares::cares c-ares_ext)

--- a/cmake/modules/CephChecks.cmake
+++ b/cmake/modules/CephChecks.cmake
@@ -165,7 +165,10 @@ int main() { std::stable_sort((int *)0, (int*)0); }
 cmake_pop_check_state()
 
 set(version_script_source "v1 { }; v2 { } v1;")
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/version_script.txt "${version_script_source}")
+file(CONFIGURE
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/version_script.txt
+  CONTENT "${version_script_source}"
+  @ONLY)
 cmake_push_check_state(RESET)
 set(CMAKE_REQUIRED_FLAGS "-Werror -Wl,--version-script=${CMAKE_CURRENT_BINARY_DIR}/version_script.txt")
 check_c_source_compiles("

--- a/src/pybind/mgr/dashboard/frontend/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/frontend/CMakeLists.txt
@@ -20,9 +20,11 @@ function(add_npm_command)
   add_custom_command(
     OUTPUT "${NC_OUTPUT}"
     COMMAND ${command}
+    COMMAND ${CMAKE_COMMAND} -E touch "${NC_OUTPUT}"
     DEPENDS ${NC_DEPENDS}
     WORKING_DIRECTORY "${NC_WORKING_DIRECTORY}"
-    COMMENT ${NC_COMMENT})
+    COMMENT ${NC_COMMENT}
+    VERBATIM)
   set_property(DIRECTORY APPEND
     PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "${NC_OUTPUT}")
 endfunction(add_npm_command)
@@ -40,19 +42,25 @@ function(add_npm_options)
       npm config set ${key} ${value} --userconfig ${NC_NODEENV_DIR}/.npmrc &&
       deactivate)
   endforeach()
-  set(npm_config_python ${MGR_PYTHON_EXECUTABLE})
-  add_custom_target(${NC_TARGET}
+  set(npm_config_file ${NC_NODEENV_DIR}/.npmrc)
+  add_custom_command(
+    OUTPUT ${npm_config_file}
     ${commands}
     DEPENDS ${NC_NODEENV_DIR}/bin/npm
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT "dashboard npm options are being configured"
+    VERBATIM)
+  add_custom_target(${NC_TARGET}
+    DEPENDS ${npm_config_file})
 endfunction(add_npm_options)
+
+set(node_modules_stamp
+  ${CMAKE_CURRENT_BINARY_DIR}/node_modules.stamp)
+set(dashboard_frontend_deps ${node_modules_stamp})
 
 if(WITH_SYSTEM_NPM)
   set(mgr-dashboard-nodeenv-dir )
   set(nodeenv "")
-  add_custom_target(mgr-dashboard-frontend-deps
-    DEPENDS node_modules
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 else(WITH_SYSTEM_NPM)
   set(mgr-dashboard-nodeenv-dir ${CMAKE_CURRENT_BINARY_DIR}/node-env)
   set(nodeenv NODEENV)
@@ -75,7 +83,8 @@ else(WITH_SYSTEM_NPM)
     # uid 1000 and running the unpack in a id-mapped namespace (container)
     # that lets tar set the uid to a "bad" uid outside the namespace
     COMMAND bash -c 'chown -R `id -u`:`id -g` ${mgr-dashboard-nodeenv-dir}/src'
-    COMMAND mkdir -p ${npm-cache-dir}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${npm-cache-dir}
+    DEPENDS ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "dashboard nodeenv is being installed")
   if(DEFINED ENV{NPM_REGISTRY})
@@ -86,15 +95,17 @@ else(WITH_SYSTEM_NPM)
     TARGET mgr-dashboard-nodeenv
     OPTION cache=${npm-cache-dir}
     ${npm_registry_opts})
-  add_custom_target(mgr-dashboard-frontend-deps
-    DEPENDS node_modules mgr-dashboard-nodeenv
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  list(APPEND dashboard_frontend_deps mgr-dashboard-nodeenv)
 endif(WITH_SYSTEM_NPM)
 
+add_custom_target(mgr-dashboard-frontend-deps
+  DEPENDS ${dashboard_frontend_deps}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_npm_command(
-  OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/node_modules"
-  COMMAND CYPRESS_CACHE_FOLDER=${CMAKE_SOURCE_DIR}/build/src/pybind/mgr/dashboard/cypress NG_CLI_ANALYTICS=false IBM_TELEMETRY_DISABLED=true npm ci -f ${mgr-dashboard-userconfig}
-  DEPENDS package.json
+  OUTPUT ${node_modules_stamp}
+  COMMAND CYPRESS_CACHE_FOLDER=${CMAKE_BINARY_DIR}/src/pybind/mgr/dashboard/cypress NG_CLI_ANALYTICS=false IBM_TELEMETRY_DISABLED=true npm ci -f ${mgr-dashboard-userconfig}
+  DEPENDS package.json package-lock.json
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMENT "dashboard frontend dependencies are being installed"
   ${nodeenv})
@@ -104,19 +115,20 @@ file(
   GLOB_RECURSE frontend_src
   RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
   src/*.ts
-  src/*.html)
+  src/*.html
+  src/*.scss
+  src/*.css
+  src/*.svg
+  src/*.json
+  src/*.xlf)
 
 # these files are generated during build
 list(REMOVE_ITEM frontend_src
   src/environments/environment.prod.ts
   src/environments/environment.ts)
 
-execute_process(
-    COMMAND bash -c "jq -r .config.locale ${CMAKE_CURRENT_SOURCE_DIR}/package.json"
-    OUTPUT_VARIABLE default_lang
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-
 set(frontend_dist_dir "${CMAKE_CURRENT_BINARY_DIR}/dist")
+set(frontend_dist_stamp "${frontend_dist_dir}/.ceph-built")
 set(npm_args "--output-path ${frontend_dist_dir}")
 if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
   string(APPEND npm_args " --configuration=production --progress=false")
@@ -125,24 +137,39 @@ else()
 endif()
 
 add_npm_command(
-  OUTPUT "${frontend_dist_dir}"
+  OUTPUT ${frontend_dist_stamp}
   COMMAND DASHBOARD_FRONTEND_LANGS="${DASHBOARD_FRONTEND_LANGS}" npm run build:localize -- ${npm_args}
-  DEPENDS ${frontend_src} node_modules
+  DEPENDS
+    ${frontend_src}
+    ${node_modules_stamp}
+    .browserslistrc
+    angular.json
+    babel.config.js
+    cd.js
+    ngcc.config.js
+    package.json
+    tsconfig.app.json
+    tsconfig.json
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMENT "dashboard frontend is being created"
   ${nodeenv})
+
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
+  "${CMAKE_CURRENT_SOURCE_DIR}/node_modules"
+  "${frontend_dist_dir}")
 
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/package.json
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/package.json
   COMMAND ${CMAKE_COMMAND} -E copy_if_different
     ${CMAKE_CURRENT_SOURCE_DIR}/package.json
-    ${CMAKE_CURRENT_BINARY_DIR}/package.json)
+    ${CMAKE_CURRENT_BINARY_DIR}/package.json
+  VERBATIM)
 
 add_custom_target(mgr-dashboard-frontend-build
   ALL
   DEPENDS
-    ${frontend_dist_dir}
+    ${frontend_dist_stamp}
     ${CMAKE_CURRENT_BINARY_DIR}/package.json
     mgr-dashboard-frontend-deps
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/script/lib-build.sh
+++ b/src/script/lib-build.sh
@@ -64,7 +64,8 @@ function get_processors() {
 # and uses the same BUILD_DIR environment variable. It checks for the
 # directory relative to the current working directory.
 function has_build_dir() {
-    ( cd "${BUILD_DIR:=build}" && [[ -f build.ninja || -f Makefile ]] )
+    [[ -d "${BUILD_DIR:=build}" ]] &&
+        ( cd "${BUILD_DIR}" && [[ -f build.ninja || -f Makefile ]] )
 }
 
 # discover_compiler takes one argument, purpose, which may be used


### PR DESCRIPTION
This set of changes tries to improve the incremental build modeling as
well as focus on comparatively "easy wins" hopefully without TOO much
churn. I tried to avoid changing build invocations and focus soley on
CMake alterations.

Initial results were measured on a single machine with 8 cores and a single
SSD (a fairly vanilla desktop). Some targeted expensive compile paths improved
substantially, with a much more modest "actual time" improvement of about 3.4%. 

Assisted-by: Codex:GPT-5

Signed-off-by: Jesse Williamson <jfw@ibm.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
