### PR TITLE
tentacle: qa/suites/rbd/valgrind: pin to centos_9.stream instead of rpm_latest

### DIFF
--- a/qa/suites/rbd/valgrind/centos_9.stream.yaml
+++ b/qa/suites/rbd/valgrind/centos_9.stream.yaml
@@ -1,0 +1,1 @@
+.qa/distros/all/centos_9.stream.yaml

--- a/qa/suites/rbd/valgrind/rpm_latest.yaml
+++ b/qa/suites/rbd/valgrind/rpm_latest.yaml
@@ -1,1 +1,0 @@
-.qa/distros/supported/rpm_latest.yaml


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77998

---

backport of https://github.com/ceph/ceph/pull/69988
parent tracker: https://tracker.ceph.com/issues/77982