### PR TITLE
osd: add storage space usage aware backfill

### DIFF
--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -186,6 +186,12 @@ public:
     return get_acting_recovery_backfill();
   }
 
+  std::optional<backfill_osd_space_usage_t> get_local_osd_space_usage() override {
+    // TODO add device space usage report mechinary so Crimson can also support
+    //      space-usage aware backfill priority
+    return std::nullopt;
+  }
+
   spg_t primary_spg_t() const override {
     return spg_t(get_info().pgid.pgid, get_primary().shard);
   }
@@ -680,7 +686,9 @@ public:
 
 
   bool try_reserve_recovery_space(
-    int64_t primary_num_bytes, int64_t local_num_bytes) final {
+    int64_t primary_num_bytes,
+    int64_t local_num_bytes,
+    backfill_reservation_space_info_t *space_info = nullptr) final {
     // TODO
     return true;
   }

--- a/src/messages/MBackfillReserve.h
+++ b/src/messages/MBackfillReserve.h
@@ -16,13 +16,17 @@
 #ifndef CEPH_MBACKFILL_H
 #define CEPH_MBACKFILL_H
 
+#include <optional>
+#include <utility>
+
 #include "msg/Message.h"
 #include "messages/MOSDPeeringOp.h"
+#include "osd/BackfillReservation.h"
 #include "osd/PGPeeringEvent.h"
 
 class MBackfillReserve : public MOSDPeeringOp {
 private:
-  static constexpr int HEAD_VERSION = 5;
+  static constexpr int HEAD_VERSION = 6;
   static constexpr int COMPAT_VERSION = 4;
 public:
   spg_t pgid;
@@ -40,6 +44,7 @@ public:
   uint32_t priority;
   int64_t primary_num_bytes;
   int64_t shard_num_bytes;
+  std::optional<backfill_reservation_space_info_t> space_info;
 
   spg_t get_spg() const {
     return pgid;
@@ -57,7 +62,11 @@ public:
       return new PGPeeringEvent(
 	query_epoch,
 	query_epoch,
-	RequestBackfillPrio(priority, primary_num_bytes, shard_num_bytes));
+	RequestBackfillPrio(
+	  priority,
+	  primary_num_bytes,
+	  shard_num_bytes,
+	  std::move(space_info)));
     case GRANT:
       return new PGPeeringEvent(
 	query_epoch,
@@ -101,11 +110,22 @@ public:
 		   spg_t pgid,
 		   epoch_t query_epoch, unsigned prio = -1,
 		   int64_t primary_num_bytes = 0,
-                   int64_t shard_num_bytes = 0)
+		   int64_t shard_num_bytes = 0)
     : MOSDPeeringOp{MSG_OSD_BACKFILL_RESERVE, HEAD_VERSION, COMPAT_VERSION},
       pgid(pgid), query_epoch(query_epoch),
       type(type), priority(prio), primary_num_bytes(primary_num_bytes),
       shard_num_bytes(shard_num_bytes) {}
+  MBackfillReserve(int type,
+		   spg_t pgid,
+		   epoch_t query_epoch,
+		   backfill_reservation_space_info_t &&space_info,
+                   unsigned prio = -1,
+		   int64_t primary_num_bytes = 0,
+		   int64_t shard_num_bytes = 0)
+    : MBackfillReserve(type, pgid, query_epoch, prio,
+                       primary_num_bytes, shard_num_bytes) {
+    this->space_info = std::move(space_info);
+  }
 
   std::string_view get_type_name() const override {
     return "MBackfillReserve";
@@ -114,7 +134,10 @@ public:
   void inner_print(std::ostream& out) const override {
     switch (type) {
     case REQUEST:
-      out << "REQUEST";
+      out << "REQUEST prio: " << priority;
+      if (space_info) {
+	out << " space info: " << *space_info;
+      }
       break;
     case GRANT:
       out << "GRANT";
@@ -132,7 +155,6 @@ public:
       out << "REVOKE";
       break;
     }
-    if (type == REQUEST) out << " prio: " << priority;
     return;
   }
 
@@ -150,6 +172,11 @@ public:
     } else {
       primary_num_bytes = 0;
       shard_num_bytes = 0;
+    }
+    if (header.version >= 6) {
+      decode(space_info, p);
+    } else {
+      space_info = std::nullopt;
     }
   }
 
@@ -175,6 +202,7 @@ public:
     encode(pgid.shard, payload);
     encode(primary_num_bytes, payload);
     encode(shard_num_bytes, payload);
+    encode(space_info, payload);
   }
 };
 

--- a/src/messages/MOSDPGInfo2.h
+++ b/src/messages/MOSDPGInfo2.h
@@ -8,7 +8,7 @@
 
 class MOSDPGInfo2 final : public MOSDPeeringOp {
 private:
-  static constexpr int HEAD_VERSION = 1;
+  static constexpr int HEAD_VERSION = 2;
   static constexpr int COMPAT_VERSION = 1;
 
 public:
@@ -18,6 +18,7 @@ public:
   pg_info_t info;
   std::optional<pg_lease_t> lease;
   std::optional<pg_lease_ack_t> lease_ack;
+  std::optional<backfill_osd_space_usage_t> osd_space_usage;
 
   spg_t get_spg() const override {
     return spgid;
@@ -38,7 +39,8 @@ public:
 	info,
 	epoch_sent,
 	lease,
-	lease_ack));
+	lease_ack,
+	osd_space_usage));
   }
 
   MOSDPGInfo2() : MOSDPeeringOp{MSG_OSD_PG_INFO2,
@@ -51,14 +53,16 @@ public:
     epoch_t sent,
     epoch_t min,
     std::optional<pg_lease_t> l,
-    std::optional<pg_lease_ack_t> la)
+    std::optional<pg_lease_ack_t> la,
+    std::optional<backfill_osd_space_usage_t> osd_space_usage = {})
     : MOSDPeeringOp{MSG_OSD_PG_INFO2, HEAD_VERSION, COMPAT_VERSION},
       spgid(s),
       epoch_sent(sent),
       min_epoch(min),
       info(q),
       lease(l),
-      lease_ack(la) {
+      lease_ack(la),
+      osd_space_usage(osd_space_usage) {
     set_priority(CEPH_MSG_PRIO_HIGH);
   }
 
@@ -81,6 +85,7 @@ public:
     encode(info, payload);
     encode(lease, payload);
     encode(lease_ack, payload);
+    encode(osd_space_usage, payload);
   }
   void decode_payload() override {
     using ceph::decode;
@@ -91,6 +96,11 @@ public:
     decode(info, p);
     decode(lease, p);
     decode(lease_ack, p);
+    if (header.version >= 2) {
+      decode(osd_space_usage, p);
+    } else {
+      osd_space_usage = std::nullopt;
+    }
   }
 private:
   template<class T, typename... Args>

--- a/src/messages/MOSDPGNotify2.h
+++ b/src/messages/MOSDPGNotify2.h
@@ -8,12 +8,13 @@
 
 class MOSDPGNotify2 final : public MOSDPeeringOp {
 private:
-  static constexpr int HEAD_VERSION = 1;
+  static constexpr int HEAD_VERSION = 2;
   static constexpr int COMPAT_VERSION = 1;
 
 public:
   spg_t spgid;
   pg_notify_t notify;
+  std::optional<backfill_osd_space_usage_t> osd_space_usage;
 
   spg_t get_spg() const override {
     return spgid;
@@ -38,6 +39,8 @@ public:
 #else
 	get_connection()->get_features()
 #endif
+	,
+	osd_space_usage
       ),
       true,
       new PGCreateInfo(
@@ -54,10 +57,12 @@ public:
   }
   MOSDPGNotify2(
     spg_t s,
-    pg_notify_t n)
+    pg_notify_t n,
+    std::optional<backfill_osd_space_usage_t> osd_space_usage = {})
     : MOSDPeeringOp{MSG_OSD_PG_NOTIFY2, HEAD_VERSION, COMPAT_VERSION},
       spgid(s),
-      notify(n) {
+      notify(n),
+      osd_space_usage(osd_space_usage) {
     set_priority(CEPH_MSG_PRIO_HIGH);
   }
 
@@ -76,12 +81,18 @@ public:
     using ceph::encode;
     encode(spgid, payload);
     encode(notify, payload);
+    encode(osd_space_usage, payload);
   }
   void decode_payload() override {
     using ceph::decode;
     auto p = payload.cbegin();
     decode(spgid, p);
     decode(notify, p);
+    if (header.version >= 2) {
+      decode(osd_space_usage, p);
+    } else {
+      osd_space_usage = std::nullopt;
+    }
   }
 private:
   template<class T, typename... Args>

--- a/src/osd/BackfillReservation.h
+++ b/src/osd/BackfillReservation.h
@@ -1,0 +1,47 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#pragma once
+
+#include <cstdint>
+#include <ostream>
+
+#include "include/encoding.h"
+
+struct backfill_reservation_space_info_t {
+
+  double relieved_usage_before = 0;
+  double relieved_usage_after = 0;
+  double target_usage_before = 0;
+  double target_usage_after = 0;
+
+  void encode(ceph::buffer::list& bl) const {
+    ENCODE_START(1, 1, bl);
+    ceph::encode(relieved_usage_before, bl);
+    ceph::encode(relieved_usage_after, bl);
+    ceph::encode(target_usage_before, bl);
+    ceph::encode(target_usage_after, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(ceph::buffer::list::const_iterator& p) {
+    DECODE_START(1, p);
+    ceph::decode(relieved_usage_before, p);
+    ceph::decode(relieved_usage_after, p);
+    ceph::decode(target_usage_before, p);
+    ceph::decode(target_usage_after, p);
+    DECODE_FINISH(p);
+  }
+};
+WRITE_CLASS_ENCODER(backfill_reservation_space_info_t)
+
+inline std::ostream& operator<<(
+  std::ostream& out,
+  const backfill_reservation_space_info_t& info)
+{
+  return out << "relieved " << info.relieved_usage_before
+	     << "->" << info.relieved_usage_after
+	     << " target " << info.target_usage_before
+	     << "->" << info.target_usage_after
+	     << " ppm";
+}

--- a/src/osd/BackfillReservation.h
+++ b/src/osd/BackfillReservation.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <ostream>
 
@@ -10,10 +11,40 @@
 
 struct backfill_reservation_space_info_t {
 
+  static constexpr uint64_t SCORE_SCALE = 100000000;
+
   double relieved_usage_before = 0;
   double relieved_usage_after = 0;
   double target_usage_before = 0;
   double target_usage_after = 0;
+
+  static double encode_usage_ratio(double ratio) {
+    return std::clamp(ratio, 0.0, 1.0);
+  }
+
+  static double encode_usage_ratio(uint64_t used, uint64_t total) {
+    if (total == 0) {
+      return 0;
+    }
+    return encode_usage_ratio(static_cast<double>(used) / total);
+  }
+
+  double raw_score() const {
+    int64_t scaled_relieved_usage_before = relieved_usage_before * SCORE_SCALE;
+    int64_t scaled_relieved_usage_after = relieved_usage_after * SCORE_SCALE;
+    int64_t scaled_target_usage_after = target_usage_after * SCORE_SCALE;
+    return (double)(scaled_relieved_usage_before -
+      std::max(scaled_relieved_usage_after,
+               scaled_target_usage_after)) / SCORE_SCALE;
+  }
+
+  unsigned priority_boost(unsigned priority_band_remaining) const {
+    const double score = raw_score();
+    if (score <= 0) {
+      return 0;
+    }
+    return static_cast<unsigned>(priority_band_remaining * std::min(score, 1.0));
+  }
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
@@ -34,6 +65,45 @@ struct backfill_reservation_space_info_t {
   }
 };
 WRITE_CLASS_ENCODER(backfill_reservation_space_info_t)
+
+struct backfill_osd_space_usage_t {
+  uint64_t used_bytes = 0;
+  uint64_t total_bytes = 0;
+
+  double usage_ratio() const {
+    return backfill_reservation_space_info_t::encode_usage_ratio(
+      used_bytes, total_bytes);
+  }
+
+  double projected_usage_ratio(int64_t delta_bytes) const {
+    uint64_t projected = used_bytes;
+    if (delta_bytes < 0) {
+      const uint64_t reduction = static_cast<uint64_t>(-delta_bytes);
+      projected = reduction > projected ? 0 : projected - reduction;
+    } else if (delta_bytes > 0) {
+      const uint64_t increase = static_cast<uint64_t>(delta_bytes);
+      projected = total_bytes - projected < increase ?
+	total_bytes : projected + increase;
+    }
+    return backfill_reservation_space_info_t::encode_usage_ratio(
+      projected, total_bytes);
+  }
+
+  void encode(ceph::buffer::list& bl) const {
+    ENCODE_START(1, 1, bl);
+    ceph::encode(used_bytes, bl);
+    ceph::encode(total_bytes, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(ceph::buffer::list::const_iterator& p) {
+    DECODE_START(1, p);
+    ceph::decode(used_bytes, p);
+    ceph::decode(total_bytes, p);
+    DECODE_FINISH(p);
+  }
+};
+WRITE_CLASS_ENCODER(backfill_osd_space_usage_t)
 
 inline std::ostream& operator<<(
   std::ostream& out,

--- a/src/osd/BackfillReservation.h
+++ b/src/osd/BackfillReservation.h
@@ -113,5 +113,5 @@ inline std::ostream& operator<<(
 	     << "->" << info.relieved_usage_after
 	     << " target " << info.target_usage_before
 	     << "->" << info.target_usage_after
-	     << " ppm";
+	     << " ratio";
 }

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1668,11 +1668,25 @@ static int64_t pending_backfill(CephContext *cct, int64_t bf_bytes, int64_t loca
 }
 
 
+std::optional<backfill_osd_space_usage_t> PG::get_local_osd_space_usage()
+{
+  std::lock_guard l{osd->stat_lock};
+  const auto& statfs = osd->osd_stat.statfs;
+  if (statfs.total == 0) {
+    return std::nullopt;
+  }
+  return backfill_osd_space_usage_t{
+    statfs.get_used_raw(),
+    statfs.total};
+}
+
 // We can zero the value of primary num_bytes as just an atomic.
 // However, setting above zero reserves space for backfill and requires
 // the OSDService::stat_lock which protects all OSD usage
 bool PG::try_reserve_recovery_space(
-  int64_t primary_bytes, int64_t local_bytes) {
+  int64_t primary_bytes,
+  int64_t local_bytes,
+  backfill_reservation_space_info_t *space_info) {
   // Use tentative_bacfill_full() to make sure enough
   // space is available to handle target bytes from primary.
 
@@ -1725,6 +1739,15 @@ bool PG::try_reserve_recovery_space(
 	     << dendl;
     return false;
   } else {
+    if (space_info) {
+      float before = 0;
+      const float after = osd->compute_adjusted_ratio(
+	cur_stat, &before, pending_adjustment);
+      space_info->target_usage_before =
+	backfill_reservation_space_info_t::encode_usage_ratio(before);
+      space_info->target_usage_after =
+	backfill_reservation_space_info_t::encode_usage_ratio(after);
+    }
     // Don't reserve space if skipped reservation check, this is used
     // to test the other backfill full check AND in case a corruption
     // of num_bytes requires ignoring that value and trying the

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -910,7 +910,12 @@ public:
     return primary_num_bytes.load() > 0;
   }
 
-  bool try_reserve_recovery_space(int64_t primary, int64_t local) override;
+  std::optional<backfill_osd_space_usage_t>
+  get_local_osd_space_usage() override;
+  bool try_reserve_recovery_space(
+    int64_t primary,
+    int64_t local,
+    backfill_reservation_space_info_t *space_info = nullptr) override;
   void unreserve_recovery_space() override;
 
   // If num_bytes are inconsistent and local_num- goes negative

--- a/src/osd/PGPeeringEvent.h
+++ b/src/osd/PGPeeringEvent.h
@@ -84,11 +84,13 @@ struct MInfoRec : boost::statechart::event< MInfoRec > {
   epoch_t msg_epoch;
   std::optional<pg_lease_t> lease;
   std::optional<pg_lease_ack_t> lease_ack;
+  std::optional<backfill_osd_space_usage_t> osd_space_usage;
   MInfoRec(pg_shard_t from, const pg_info_t &info, epoch_t msg_epoch,
 	   std::optional<pg_lease_t> l = {},
-	   std::optional<pg_lease_ack_t> la = {})
+	   std::optional<pg_lease_ack_t> la = {},
+	   std::optional<backfill_osd_space_usage_t> osd_space_usage = {})
     : from(from), info(info), msg_epoch(msg_epoch),
-      lease(l), lease_ack(la) {}
+      lease(l), lease_ack(la), osd_space_usage(osd_space_usage) {}
   void print(std::ostream *out) const {
     *out << "MInfoRec from " << from << " info: " << info;
     if (lease) {
@@ -112,8 +114,15 @@ struct MNotifyRec : boost::statechart::event< MNotifyRec > {
   pg_shard_t from;
   pg_notify_t notify;
   uint64_t features;
-  MNotifyRec(spg_t p, pg_shard_t from, const pg_notify_t &notify, uint64_t f)
-    : pgid(p), from(from), notify(notify), features(f) {}
+  std::optional<backfill_osd_space_usage_t> osd_space_usage;
+  MNotifyRec(
+    spg_t p,
+    pg_shard_t from,
+    const pg_notify_t &notify,
+    uint64_t f,
+    std::optional<backfill_osd_space_usage_t> osd_space_usage = {})
+    : pgid(p), from(from), notify(notify), features(f),
+      osd_space_usage(osd_space_usage) {}
   void print(std::ostream *out) const {
     *out << "MNotifyRec " << pgid << " from " << from << " notify: " << notify
 	 << " features: 0x" << std::hex << features << std::dec;

--- a/src/osd/PGPeeringEvent.h
+++ b/src/osd/PGPeeringEvent.h
@@ -5,12 +5,15 @@
 
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
+#include <utility>
 
 #include <boost/intrusive_ptr.hpp>
 #include <boost/statechart/event.hpp>
 
+#include "osd/BackfillReservation.h"
 #include "osd/osd_types.h"
 
 class MOSDPGLog;
@@ -171,13 +174,22 @@ struct RequestBackfillPrio : boost::statechart::event< RequestBackfillPrio > {
   unsigned priority;
   int64_t primary_num_bytes;
   int64_t local_num_bytes;
-  explicit RequestBackfillPrio(unsigned prio, int64_t pbytes, int64_t lbytes) :
+  std::optional<backfill_reservation_space_info_t> space_info;
+  explicit RequestBackfillPrio(
+    unsigned prio,
+    int64_t pbytes,
+    int64_t lbytes,
+    std::optional<backfill_reservation_space_info_t> &&space_info) :
     boost::statechart::event< RequestBackfillPrio >(),
-    priority(prio), primary_num_bytes(pbytes), local_num_bytes(lbytes) {}
+    priority(prio), primary_num_bytes(pbytes), local_num_bytes(lbytes),
+    space_info(std::move(space_info)) {}
   void print(std::ostream *out) const {
     *out << "RequestBackfillPrio: priority " << priority
          << " primary bytes " << primary_num_bytes
          << " local bytes " << local_num_bytes;
+    if (space_info) {
+      *out << " space info " << *space_info;
+    }
   }
 };
 

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -59,10 +59,15 @@ BufferedRecoveryMessages::BufferedRecoveryMessages(PeeringCtx &ctx)
   : message_map{std::move(ctx.message_map)}
 {}
 
-void BufferedRecoveryMessages::send_notify(int to, const pg_notify_t &n)
+void BufferedRecoveryMessages::send_notify(
+  int to,
+  const pg_notify_t &n,
+  std::optional<backfill_osd_space_usage_t> osd_space_usage)
 {
   spg_t pgid(n.info.pgid.pgid, n.to);
-  send_osd_message(to, TOPNSPC::make_message<MOSDPGNotify2>(pgid, n));
+  send_osd_message(
+    to,
+    TOPNSPC::make_message<MOSDPGNotify2>(pgid, n, osd_space_usage));
 }
 
 void BufferedRecoveryMessages::send_query(
@@ -80,7 +85,8 @@ void BufferedRecoveryMessages::send_info(
   epoch_t cur_epoch,
   const pg_info_t &info,
   std::optional<pg_lease_t> lease,
-  std::optional<pg_lease_ack_t> lease_ack)
+  std::optional<pg_lease_ack_t> lease_ack,
+  std::optional<backfill_osd_space_usage_t> osd_space_usage)
 {
   send_osd_message(
     to,
@@ -90,7 +96,8 @@ void BufferedRecoveryMessages::send_info(
       cur_epoch,
       min_epoch,
       lease,
-      lease_ack)
+      lease_ack,
+      osd_space_usage)
   );
 }
 
@@ -449,7 +456,10 @@ void PeeringState::update_peer_info(const pg_shard_t &from,
   }
 }
 
-bool PeeringState::proc_replica_notify(const pg_shard_t &from, const pg_notify_t &notify)
+bool PeeringState::proc_replica_notify(
+  const pg_shard_t &from,
+  const pg_notify_t &notify,
+  const std::optional<backfill_osd_space_usage_t> &osd_space_usage)
 {
   const pg_info_t &oinfo = notify.info;
   const epoch_t send_epoch = notify.epoch_sent;
@@ -469,6 +479,11 @@ bool PeeringState::proc_replica_notify(const pg_shard_t &from, const pg_notify_t
 
   psdout(10) << " got osd." << from << " " << oinfo << dendl;
   ceph_assert(is_primary());
+  if (osd_space_usage) {
+    peer_osd_space_usage[from] = *osd_space_usage;
+  } else {
+    peer_osd_space_usage.erase(from);
+  }
   peer_info[from] = oinfo;
   update_peer_info(from, oinfo);
   might_have_unfound.insert(from);
@@ -1050,6 +1065,7 @@ void PeeringState::clear_primary_state()
   peer_missing_requested.clear();
   peer_info.clear();
   peer_bytes.clear();
+  peer_osd_space_usage.clear();
   peer_missing.clear();
   peer_last_complete_ondisk.clear();
   peer_activated.clear();
@@ -1226,6 +1242,129 @@ unsigned PeeringState::get_backfill_priority()
   return static_cast<unsigned>(ret);
 }
 
+unsigned PeeringState::apply_backfill_space_priority(
+  unsigned base_priority,
+  const std::optional<backfill_reservation_space_info_t> &space_info)
+{
+  if (!space_info || base_priority >= OSD_BACKFILL_DEGRADED_PRIORITY_BASE) {
+    return base_priority;
+  }
+
+  const unsigned max_priority =
+    get_max_prio_for_base(OSD_BACKFILL_PRIORITY_BASE);
+  if (base_priority >= max_priority) {
+    return base_priority;
+  }
+
+  const unsigned boost =
+    space_info->priority_boost(max_priority - base_priority);
+  const unsigned priority = base_priority + boost;
+  psdout(20) << "space-aware backfill priority is " << priority
+	     << " base " << base_priority
+	     << " boost " << boost
+	     << " raw_score " << space_info->raw_score()
+	     << " " << *space_info
+	     << dendl;
+  return priority;
+}
+
+std::optional<backfill_reservation_space_info_t>
+PeeringState::get_backfill_reservation_space_info(
+  bool require_target_usage)
+{
+  if ((state & PG_STATE_FORCED_BACKFILL) ||
+      actingset.size() < pool.info.min_size ||
+      is_undersized() ||
+      is_degraded()) {
+    return std::nullopt;
+  }
+
+  auto get_usage = [this](pg_shard_t shard)
+    -> std::optional<backfill_osd_space_usage_t> {
+    if (shard == pg_whoami) {
+      return pl->get_local_osd_space_usage();
+    }
+    auto it = peer_osd_space_usage.find(shard);
+    if (it == peer_osd_space_usage.end()) {
+      return std::nullopt;
+    }
+    return it->second;
+  };
+
+  auto get_shard_bytes = [this](pg_shard_t shard) -> int64_t {
+    if (shard == pg_whoami) {
+      return std::max<int64_t>(0, info.stats.stats.sum.num_bytes);
+    }
+    auto p = peer_bytes.find(shard);
+    if (p != peer_bytes.end()) {
+      return std::max<int64_t>(0, p->second);
+    }
+    auto pi = peer_info.find(shard);
+    if (pi != peer_info.end()) {
+      return std::max<int64_t>(0, pi->second.stats.stats.sum.num_bytes);
+    }
+    return 0;
+  };
+
+  backfill_reservation_space_info_t space_info;
+  bool have_relieved_osd = false;
+  for (const auto& acting : actingset) {
+    if (upset.count(acting)) {
+      continue;
+    }
+    auto usage = get_usage(acting);
+    if (!usage || usage->total_bytes == 0) {
+      psdout(20) << "missing OSD space usage for relieved " << acting << dendl;
+      return std::nullopt;
+    }
+    have_relieved_osd = true;
+    const int64_t shard_bytes = get_shard_bytes(acting);
+    space_info.relieved_usage_before = std::max(
+      space_info.relieved_usage_before,
+      usage->usage_ratio());
+    space_info.relieved_usage_after = std::max(
+      space_info.relieved_usage_after,
+      usage->projected_usage_ratio(-shard_bytes));
+  }
+
+  if (!have_relieved_osd) {
+    return std::nullopt;
+  }
+
+  for (const auto &target : backfill_targets) {
+    auto target_usage = get_usage(target);
+    if (target_usage && target_usage->total_bytes > 0) {
+      const int64_t incoming_bytes = std::max<int64_t>(
+        0,
+        std::max<int64_t>(0, info.stats.stats.sum.num_bytes) -
+        get_shard_bytes(target));
+      space_info.target_usage_before = std::max(
+        space_info.target_usage_before,
+        target_usage->usage_ratio());
+      space_info.target_usage_after = std::max(
+        space_info.target_usage_after,
+        target_usage->projected_usage_ratio(incoming_bytes));
+    } else if (require_target_usage) {
+      psdout(20) << "missing OSD space usage for target " << target << dendl;
+      return std::nullopt;
+    }
+    psdout(20) << "backfill reservation space info for target " << target
+               << " " << space_info << dendl;
+  }
+  return space_info;
+}
+
+unsigned PeeringState::get_space_aware_local_backfill_priority()
+{
+  const unsigned base_priority = get_backfill_priority();
+  unsigned priority = std::max(
+    base_priority,
+    apply_backfill_space_priority(
+      base_priority,
+      get_backfill_reservation_space_info(true)));
+  return priority;
+}
+
 unsigned PeeringState::get_delete_priority()
 {
   auto state = get_osdmap()->get_state(pg_whoami.osd);
@@ -1288,7 +1427,8 @@ bool PeeringState::set_force_backfill(bool b)
   if (did) {
     psdout(20) << "state " << get_current_state()
 	     << dendl;
-    pl->update_local_background_io_priority(get_backfill_priority());
+    pl->update_local_background_io_priority(
+      get_space_aware_local_backfill_priority());
   }
   return did;
 }
@@ -3289,7 +3429,8 @@ void PeeringState::share_pg_info()
 			  get_osdmap_epoch(),
 			  get_osdmap_epoch(),
 			  std::optional<pg_lease_t>{get_lease()},
-			  std::nullopt);
+			  std::nullopt,
+			  pl->get_local_osd_space_usage());
     pl->send_cluster_message(pg_shard.osd, std::move(m), get_osdmap_epoch());
   }
 }
@@ -3727,7 +3868,8 @@ void PeeringState::fulfill_query(const MQuery& query, PeeringCtxWrapper &rctx)
 	get_osdmap_epoch(),
 	notify_info.second,
 	past_intervals,
-	local_pg_acting_features));
+	local_pg_acting_features),
+      pl->get_local_osd_space_usage());
   } else {
     update_history(query.query.history);
     fulfill_log(query.from, query.query, query.query_epoch);
@@ -5376,7 +5518,10 @@ PeeringState::Initial::Initial(my_context ctx)
 boost::statechart::result PeeringState::Initial::react(const MNotifyRec& notify)
 {
   DECLARE_LOCALS;
-  ps->proc_replica_notify(notify.from, notify.notify);
+  ps->proc_replica_notify(
+    notify.from,
+    notify.notify,
+    notify.osd_space_usage);
   ps->set_last_peering_reset();
   return transit< Primary >();
 }
@@ -5620,7 +5765,10 @@ boost::statechart::result PeeringState::Primary::react(const MNotifyRec& notevt)
 {
   DECLARE_LOCALS;
   psdout(7) << "handle_pg_notify from osd." << notevt.from << dendl;
-  ps->proc_replica_notify(notevt.from, notevt.notify);
+  ps->proc_replica_notify(
+    notevt.from,
+    notevt.notify,
+    notevt.osd_space_usage);
   return discard_event();
 }
 
@@ -5943,16 +6091,32 @@ PeeringState::WaitRemoteBackfillReserved::react(const RemoteBackfillReserved &ev
       context< Active >().remote_shards_to_reserve_backfill.end()) {
     // The primary never backfills itself
     ceph_assert(*backfill_osd_it != ps->pg_whoami);
-    pl->send_cluster_message(
-      backfill_osd_it->osd,
-      TOPNSPC::make_message<MBackfillReserve>(
-	MBackfillReserve::REQUEST,
-	spg_t(context< PeeringMachine >().spgid.pgid, backfill_osd_it->shard),
-	ps->get_osdmap_epoch(),
-	ps->get_backfill_priority(),
-        num_bytes,
-        ps->peer_bytes[*backfill_osd_it]),
-      ps->get_osdmap_epoch());
+    auto space_info =
+      ps->get_backfill_reservation_space_info();
+    if (space_info) {
+      pl->send_cluster_message(
+        backfill_osd_it->osd,
+        TOPNSPC::make_message<MBackfillReserve>(
+          MBackfillReserve::REQUEST,
+          spg_t(context< PeeringMachine >().spgid.pgid, backfill_osd_it->shard),
+          ps->get_osdmap_epoch(),
+          std::move(*space_info),
+          ps->get_backfill_priority(),
+          num_bytes,
+          ps->peer_bytes[*backfill_osd_it]),
+        ps->get_osdmap_epoch());
+    } else {
+      pl->send_cluster_message(
+        backfill_osd_it->osd,
+        TOPNSPC::make_message<MBackfillReserve>(
+          MBackfillReserve::REQUEST,
+          spg_t(context< PeeringMachine >().spgid.pgid, backfill_osd_it->shard),
+          ps->get_osdmap_epoch(),
+          ps->get_backfill_priority(),
+          num_bytes,
+          ps->peer_bytes[*backfill_osd_it]),
+        ps->get_osdmap_epoch());
+    }
     ++backfill_osd_it;
   } else {
     ps->peer_bytes.clear();
@@ -6029,7 +6193,7 @@ PeeringState::WaitLocalBackfillReserved::WaitLocalBackfillReserved(my_context ct
 
   ps->state_set(PG_STATE_BACKFILL_WAIT);
   pl->request_local_background_io_reservation(
-    ps->get_backfill_priority(),
+    ps->get_space_aware_local_backfill_priority(),
     std::make_unique<PGPeeringEvent>(
       ps->get_osdmap_epoch(),
       ps->get_osdmap_epoch(),
@@ -6199,8 +6363,10 @@ PeeringState::RepNotRecovering::react(const RequestBackfillPrio &evt)
 
   DECLARE_LOCALS;
 
+  auto space_info = evt.space_info;
   if (!pl->try_reserve_recovery_space(
-	evt.primary_num_bytes, evt.local_num_bytes)) {
+	evt.primary_num_bytes, evt.local_num_bytes,
+	space_info ? &*space_info : nullptr)) {
     post_event(RejectTooFullRemoteReservation());
   } else {
     PGPeeringEventURef preempt;
@@ -6211,8 +6377,11 @@ PeeringState::RepNotRecovering::react(const RequestBackfillPrio &evt)
 	pl->get_osdmap_epoch(),
 	RemoteBackfillPreempted());
     }
-    pl->request_remote_recovery_reservation(
+    const unsigned priority = ps->apply_backfill_space_priority(
       evt.priority,
+      space_info);
+    pl->request_remote_recovery_reservation(
+      priority,
       std::make_unique<PGPeeringEvent>(
 	pl->get_osdmap_epoch(),
 	pl->get_osdmap_epoch(),
@@ -6872,7 +7041,10 @@ boost::statechart::result PeeringState::Active::react(const MNotifyRec& notevt)
     psdout(10) << "Active: got notify from " << notevt.from
 		       << ", calling proc_replica_notify and discover_all_missing"
 		       << dendl;
-    ps->proc_replica_notify(notevt.from, notevt.notify);
+    ps->proc_replica_notify(
+      notevt.from,
+      notevt.notify,
+      notevt.osd_space_usage);
     if (ps->have_unfound() || (ps->is_degraded() && ps->might_have_unfound.count(notevt.from))) {
       ps->discover_all_missing(
 	context<PeeringMachine>().get_recovery_ctx().msgs);
@@ -6909,6 +7081,10 @@ boost::statechart::result PeeringState::Active::react(const MInfoRec& infoevt)
 {
   DECLARE_LOCALS;
   ceph_assert(ps->is_primary());
+
+  if (infoevt.osd_space_usage) {
+    ps->peer_osd_space_usage[infoevt.from] = *infoevt.osd_space_usage;
+  }
 
   ceph_assert(!ps->acting_recovery_backfill.empty());
   if (infoevt.lease_ack) {
@@ -7228,7 +7404,8 @@ boost::statechart::result PeeringState::ReplicaActive::react(
     epoch,
     i,
     {}, /* lease */
-    ps->get_lease_ack());
+    ps->get_lease_ack(),
+    pl->get_local_osd_space_usage());
 
   if (ps->acting_set_writeable()) {
     ps->state_set(PG_STATE_ACTIVE);
@@ -7698,7 +7875,10 @@ boost::statechart::result PeeringState::GetInfo::react(const MNotifyRec& infoevt
   }
 
   epoch_t old_start = ps->info.history.last_epoch_started;
-  if (ps->proc_replica_notify(infoevt.from, infoevt.notify)) {
+  if (ps->proc_replica_notify(
+	infoevt.from,
+	infoevt.notify,
+	infoevt.osd_space_usage)) {
     // we got something new ...
     PastIntervals::PriorSet &prior_set = context< Peering >().prior_set;
     if (old_start < ps->info.history.last_epoch_started) {
@@ -8106,7 +8286,10 @@ boost::statechart::result PeeringState::Incomplete::react(const AdvMap &advmap) 
 boost::statechart::result PeeringState::Incomplete::react(const MNotifyRec& notevt) {
   DECLARE_LOCALS;
   psdout(7) << "handle_pg_notify from osd." << notevt.from << dendl;
-  if (ps->proc_replica_notify(notevt.from, notevt.notify)) {
+  if (ps->proc_replica_notify(
+	notevt.from,
+	notevt.notify,
+	notevt.osd_space_usage)) {
     // We got something new, try again!
     return transit< GetLog >();
   } else {
@@ -8474,5 +8657,4 @@ std::vector<pg_shard_t> PeeringState::get_replica_recovery_order() const
   }
   return ret;
 }
-
 

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -109,13 +109,17 @@ struct BufferedRecoveryMessages {
   void send_osd_message(int target, MsgT&& m) {
     message_map[target].emplace_back(std::forward<MsgT>(m));
   }
-  void send_notify(int to, const pg_notify_t &n);
+  void send_notify(
+    int to,
+    const pg_notify_t &n,
+    std::optional<backfill_osd_space_usage_t> osd_space_usage = {});
   void send_query(int to, spg_t spgid, const pg_query_t &q);
   void send_info(int to, spg_t to_spgid,
 		 epoch_t min_epoch, epoch_t cur_epoch,
 		 const pg_info_t &info,
 		 std::optional<pg_lease_t> lease = {},
-		 std::optional<pg_lease_ack_t> lease_ack = {});
+		 std::optional<pg_lease_ack_t> lease_ack = {},
+		 std::optional<backfill_osd_space_usage_t> osd_space_usage = {});
 };
 
 struct HeartbeatStamps : public RefCountedObject {
@@ -255,8 +259,11 @@ struct PeeringCtxWrapper {
   void send_osd_message(int target, MsgT&& m) {
     msgs.send_osd_message(target, std::forward<MsgT>(m));
   }
-  void send_notify(int to, const pg_notify_t &n) {
-    msgs.send_notify(to, n);
+  void send_notify(
+    int to,
+    const pg_notify_t &n,
+    std::optional<backfill_osd_space_usage_t> osd_space_usage = {}) {
+    msgs.send_notify(to, n, osd_space_usage);
   }
   void send_query(int to, spg_t spgid, const pg_query_t &q) {
     msgs.send_query(to, spgid, q);
@@ -265,9 +272,10 @@ struct PeeringCtxWrapper {
 		 epoch_t min_epoch, epoch_t cur_epoch,
 		 const pg_info_t &info,
 		 std::optional<pg_lease_t> lease = {},
-		 std::optional<pg_lease_ack_t> lease_ack = {}) {
+		 std::optional<pg_lease_ack_t> lease_ack = {},
+		 std::optional<backfill_osd_space_usage_t> osd_space_usage = {}) {
     msgs.send_info(to, to_spgid, min_epoch, cur_epoch, info,
-		   lease, lease_ack);
+		   lease, lease_ack, osd_space_usage);
   }
 };
 
@@ -429,8 +437,12 @@ public:
     virtual void on_recovery_cancelled() = 0;
 
     // ================recovery space accounting ================
+    virtual std::optional<backfill_osd_space_usage_t>
+    get_local_osd_space_usage() = 0;
     virtual bool try_reserve_recovery_space(
-      int64_t primary_num_bytes, int64_t local_num_bytes) = 0;
+      int64_t primary_num_bytes,
+      int64_t local_num_bytes,
+      backfill_reservation_space_info_t *space_info = nullptr) = 0;
     virtual void unreserve_recovery_space() = 0;
 
     // ================== Peering log events ====================
@@ -639,7 +651,7 @@ public:
 
     void send_notify(int to, const pg_notify_t &n) {
       ceph_assert(state->rctx);
-      state->rctx->send_notify(to, n);
+      state->rctx->send_notify(to, n, state->pl->get_local_osd_space_usage());
     }
     void send_query(int to, const pg_query_t &query) {
       state->rctx->send_query(
@@ -1519,6 +1531,7 @@ public:
   std::set<pg_shard_t>    stray_set; ///< non-acting osds that have PG data.
   std::map<pg_shard_t, pg_info_t>    peer_info; ///< info from peers (stray or prior)
   std::map<pg_shard_t, int64_t>    peer_bytes; ///< Peer's num_bytes from peer_info
+  std::map<pg_shard_t, backfill_osd_space_usage_t> peer_osd_space_usage;
   std::set<pg_shard_t> peer_purged; ///< peers purged
   std::map<pg_shard_t, pg_missing_t> peer_missing; ///< peer missing sets
   std::set<pg_shard_t> peer_log_requested; ///< logs i've requested (and start stamps)
@@ -1618,7 +1631,10 @@ public:
     apply_pwlc(pwlc, shard, info, nullptr, log);
   }
   void update_peer_info(const pg_shard_t &from, const pg_info_t &oinfo);
-  bool proc_replica_notify(const pg_shard_t &from, const pg_notify_t &notify);
+  bool proc_replica_notify(
+    const pg_shard_t &from,
+    const pg_notify_t &notify,
+    const std::optional<backfill_osd_space_usage_t> &osd_space_usage);
   void remove_down_peer_info(const OSDMapRef &osdmap);
   void check_recovery_sources(const OSDMapRef& map);
   void set_last_peering_reset();
@@ -1648,6 +1664,13 @@ public:
   unsigned get_recovery_priority();
   /// get backfill reservation priority
   unsigned get_backfill_priority();
+  unsigned apply_backfill_space_priority(
+    unsigned base_priority,
+    const std::optional<backfill_reservation_space_info_t> &space_info);
+  unsigned get_space_aware_local_backfill_priority();
+  std::optional<backfill_reservation_space_info_t>
+  get_backfill_reservation_space_info(
+    bool require_target_usage = false);
   /// get priority for pg deletion
   unsigned get_delete_priority();
 

--- a/src/test/osd/MockPeeringListener.cc
+++ b/src/test/osd/MockPeeringListener.cc
@@ -22,6 +22,7 @@ void MockPeeringListener::request_local_background_io_reservation(
   unsigned priority,
   PGPeeringEventURef on_grant,
   PGPeeringEventURef on_preempt) {
+  last_io_reservation_priority = priority;
   // If the test has configured an event loop (i.e. ECPeeringTestFixture),
   // then use the event loop to run this event, rather than putting it on the queue.
   if (event_loop && fixture) {
@@ -48,6 +49,7 @@ void MockPeeringListener::request_remote_recovery_reservation(
   unsigned priority,
   PGPeeringEventURef on_grant,
   PGPeeringEventURef on_preempt) {
+  last_remote_recovery_reservation_priority = priority;
   // If the test has configured an event loop (i.e. ECPeeringTestFixture),
   // then use the event loop to run this event, rather than putting it on the queue.
   if (event_loop && fixture) {
@@ -138,4 +140,3 @@ void MockPeeringListener::on_activate_complete() {
   }
   activate_complete_called = true;
 }
-

--- a/src/test/osd/MockPeeringListener.h
+++ b/src/test/osd/MockPeeringListener.h
@@ -435,12 +435,17 @@ class MockPeeringListener : public PeeringState::PeeringListener {
 
   bool try_reserve_recovery_space(
     int64_t primary_num_bytes,
-    int64_t local_num_bytes) override {
+    int64_t local_num_bytes,
+    backfill_reservation_space_info_t *space_info = nullptr) override {
     recovery_space_reserved = true;
     if (inject_fail_reserve_recovery_space) {
       return false;
     }
     return true;
+  }
+
+  std::optional<backfill_osd_space_usage_t> get_local_osd_space_usage() override {
+    return std::nullopt;
   }
 
   void unreserve_recovery_space() override {

--- a/src/test/osd/MockPeeringListener.h
+++ b/src/test/osd/MockPeeringListener.h
@@ -95,6 +95,7 @@ class MockPeeringListener : public PeeringState::PeeringListener {
   bool inject_fail_reserve_recovery_space = false;
 
   std::function<int(ObjectStore::Transaction&&)> queue_transaction_callback;
+  std::optional<backfill_osd_space_usage_t> local_osd_space_usage;
 
   MockPeeringListener(OSDMapRef osdmap,
                       int64_t pool_id,
@@ -445,7 +446,7 @@ class MockPeeringListener : public PeeringState::PeeringListener {
   }
 
   std::optional<backfill_osd_space_usage_t> get_local_osd_space_usage() override {
-    return std::nullopt;
+    return local_osd_space_usage;
   }
 
   void unreserve_recovery_space() override {
@@ -583,7 +584,8 @@ class MockPeeringListener : public PeeringState::PeeringListener {
   int events_scheduled = 0;
   int io_reservations_requested = 0;
   int remote_recovery_reservations_requested = 0;
+  std::optional<unsigned> last_io_reservation_priority;
+  std::optional<unsigned> last_remote_recovery_reservation_priority;
   int events_on_commit_scheduled = 0;
   bool first_write_in_interval = false;
 };
-

--- a/src/test/osd/TestPeeringState.cc
+++ b/src/test/osd/TestPeeringState.cc
@@ -1492,6 +1492,110 @@ TEST_F(PeeringStateTest, UpdateStats) {
   EXPECT_EQ(ps->get_info().stats.stats.sum.num_objects, 10u);
 }
 
+TEST_F(PeeringStateTest, SpaceAwareRemoteBackfillReservationPriority) {
+  test_create_peering_state();
+  test_init();
+  test_event_initialize();
+  test_peering();
+
+  backfill_reservation_space_info_t high_relief;
+  high_relief.relieved_usage_before = 0.9;
+  high_relief.relieved_usage_after = 0.7;
+  high_relief.target_usage_before = 0.5;
+  high_relief.target_usage_after = 0.7;
+
+  backfill_reservation_space_info_t low_relief;
+  low_relief.relieved_usage_before = 0.8;
+  low_relief.relieved_usage_after = 0.75;
+  low_relief.target_usage_before = 0.6;
+  low_relief.target_usage_after = 0.7;
+
+  auto request_backfill = [this](
+      int osd,
+      std::optional<backfill_reservation_space_info_t> space_info) {
+    auto evt = std::make_shared<PGPeeringEvent>(
+      osdmap->get_epoch(),
+      osdmap->get_epoch(),
+      RequestBackfillPrio(
+	OSD_BACKFILL_PRIORITY_BASE,
+	200,
+	0,
+	std::move(space_info)));
+    get_ps(osd)->handle_event(evt, get_ctx(osd));
+  };
+
+  request_backfill(acting[1], high_relief);
+  request_backfill(acting[2], low_relief);
+  request_backfill(acting[3], std::nullopt);
+
+  const auto high_priority =
+    get_listener(acting[1])->last_remote_recovery_reservation_priority;
+  const auto low_priority =
+    get_listener(acting[2])->last_remote_recovery_reservation_priority;
+  const auto priority_without_space_info =
+    get_listener(acting[3])->last_remote_recovery_reservation_priority;
+
+  ASSERT_TRUE(high_priority);
+  ASSERT_TRUE(low_priority);
+  ASSERT_TRUE(priority_without_space_info);
+  EXPECT_EQ(
+    *high_priority,
+    OSD_BACKFILL_PRIORITY_BASE + high_relief.priority_boost(39));
+  EXPECT_EQ(
+    *low_priority,
+    OSD_BACKFILL_PRIORITY_BASE + low_relief.priority_boost(39));
+  EXPECT_EQ(*priority_without_space_info, OSD_BACKFILL_PRIORITY_BASE);
+  EXPECT_GT(*high_priority, *low_priority);
+  EXPECT_GT(*low_priority, *priority_without_space_info);
+}
+
+TEST_F(PeeringStateTest, SpaceAwareBackfillPriorityFromOsdUsage) {
+  test_create_peering_state();
+  for (auto osd : acting) {
+    get_listener(osd)->local_osd_space_usage =
+      backfill_osd_space_usage_t{500, 1000};
+  }
+  get_listener(acting[1])->local_osd_space_usage =
+    backfill_osd_space_usage_t{900, 1000};
+
+  test_init();
+  for (auto osd : acting) {
+    get_ps(osd)->update_stats(
+      [](pg_history_t&, pg_stat_t& stats) {
+	stats.stats.sum.num_bytes = 200;
+	return true;
+      });
+  }
+  test_event_initialize();
+
+  test_append_log_entry();
+  test_append_log_entry();
+  test_append_log_entry(
+    shard_id_set(),
+    shard_id_set(),
+    false,
+    true);
+  test_peering();
+
+  modify_up_acting(1, 9);
+  test_create_peering_state(9, 1);
+  get_listener(9)->local_osd_space_usage =
+    backfill_osd_space_usage_t{500, 1000};
+  test_init(9);
+  test_event_initialize(9);
+  test_peering();
+
+  const auto local_priority =
+    get_listener(acting[0])->last_io_reservation_priority;
+  const auto remote_priority =
+    get_listener(9)->last_remote_recovery_reservation_priority;
+
+  ASSERT_TRUE(local_priority);
+  ASSERT_TRUE(remote_priority);
+  EXPECT_EQ(*local_priority, 115u);
+  EXPECT_EQ(*remote_priority, *local_priority);
+}
+
 // ============================================================================
 // Test Stubs - Deletion
 // ============================================================================

--- a/src/test/osd/types.cc
+++ b/src/test/osd/types.cc
@@ -17,6 +17,7 @@
  */
 
 #include "include/types.h"
+#include "osd/BackfillReservation.h"
 #include "osd/osd_types.h"
 #include "osd/OSDMap.h"
 #include "gtest/gtest.h"
@@ -29,6 +30,118 @@
 #include <sstream>
 
 using namespace std;
+
+#define ABS_ERROR 0.000000001
+
+TEST(backfill_reservation_space_info_t, usage_ratio)
+{
+  ASSERT_NEAR(0.0,
+              backfill_reservation_space_info_t::encode_usage_ratio(0, 100), ABS_ERROR);
+  ASSERT_NEAR(0.5,
+              backfill_reservation_space_info_t::encode_usage_ratio(50, 100), ABS_ERROR);
+  ASSERT_NEAR(1.0,
+              backfill_reservation_space_info_t::encode_usage_ratio(100, 100), ABS_ERROR);
+  ASSERT_NEAR(1.0,
+              backfill_reservation_space_info_t::encode_usage_ratio(150, 100), ABS_ERROR);
+  ASSERT_NEAR(0.0,
+              backfill_reservation_space_info_t::encode_usage_ratio(1, 0), ABS_ERROR);
+}
+
+TEST(backfill_osd_space_usage_t, projected_usage_ratio)
+{
+  backfill_osd_space_usage_t usage{800, 1000};
+
+  ASSERT_NEAR(0.8, usage.usage_ratio(), ABS_ERROR);
+  ASSERT_NEAR(0.7, usage.projected_usage_ratio(-100), ABS_ERROR);
+  ASSERT_NEAR(1.0, usage.projected_usage_ratio(300), ABS_ERROR);
+  ASSERT_NEAR(0.0, usage.projected_usage_ratio(-900), ABS_ERROR);
+}
+
+TEST(backfill_reservation_space_info_t, priority_boost)
+{
+  backfill_reservation_space_info_t info;
+  info.relieved_usage_before = 0.8;
+  info.relieved_usage_after = 0.7;
+  info.target_usage_after = 0.65;
+
+  ASSERT_NEAR(0.1, info.raw_score(), ABS_ERROR);
+  ASSERT_EQ(10u, info.priority_boost(100));
+  ASSERT_EQ(0u, info.priority_boost(5));
+  ASSERT_EQ(3u, info.priority_boost(39));
+
+  info.relieved_usage_before = 1.0;
+  info.relieved_usage_after = 0.0;
+  info.target_usage_after = 0.0;
+  ASSERT_NEAR(1.0, info.raw_score(), ABS_ERROR);
+  ASSERT_EQ(17u, info.priority_boost(17));
+
+  info.relieved_usage_before = 0.8;
+  info.relieved_usage_after = 0.7;
+  info.target_usage_after = 0.85;
+  ASSERT_NEAR(-0.05, info.raw_score(), ABS_ERROR);
+  ASSERT_EQ(0u, info.priority_boost(100));
+}
+
+TEST(backfill_reservation_space_info_t, target_usage_limits_priority_boost)
+{
+  backfill_reservation_space_info_t info;
+  info.relieved_usage_before = 0.9;
+  info.relieved_usage_after = 0.6;
+  info.target_usage_after = 0.8;
+
+  ASSERT_NEAR(0.1, info.raw_score(), ABS_ERROR);
+  ASSERT_EQ(3u, info.priority_boost(39));
+
+  info.target_usage_after = 0.9;
+  ASSERT_NEAR(0.0, info.raw_score(), ABS_ERROR);
+  ASSERT_EQ(0u, info.priority_boost(39));
+}
+
+TEST(backfill_reservation_space_info_t, priority_boost_is_bounded)
+{
+  backfill_reservation_space_info_t info;
+  info.relieved_usage_before = 2.0;
+  info.relieved_usage_after = 0.0;
+  info.target_usage_after = 0.0;
+
+  ASSERT_EQ(39u, info.priority_boost(39));
+}
+
+TEST(backfill_reservation_space_info_t, encode_decode)
+{
+  backfill_reservation_space_info_t in;
+  in.relieved_usage_before = 0.81;
+  in.relieved_usage_after = 0.76;
+  in.target_usage_before = 0.3;
+  in.target_usage_after = 0.36;
+
+  bufferlist bl;
+  encode(in, bl);
+
+  auto p = bl.cbegin();
+  backfill_reservation_space_info_t out;
+  decode(out, p);
+
+  ASSERT_NEAR(in.relieved_usage_before, out.relieved_usage_before, ABS_ERROR);
+  ASSERT_NEAR(in.relieved_usage_after, out.relieved_usage_after, ABS_ERROR);
+  ASSERT_NEAR(in.target_usage_before, out.target_usage_before, ABS_ERROR);
+  ASSERT_NEAR(in.target_usage_after, out.target_usage_after, ABS_ERROR);
+}
+
+TEST(backfill_osd_space_usage_t, encode_decode)
+{
+  backfill_osd_space_usage_t in{12345, 67890};
+
+  bufferlist bl;
+  encode(in, bl);
+
+  auto p = bl.cbegin();
+  backfill_osd_space_usage_t out;
+  decode(out, p);
+
+  ASSERT_EQ(in.used_bytes, out.used_bytes);
+  ASSERT_EQ(in.total_bytes, out.total_bytes);
+}
 
 void compare_pg_pool_t(const pg_pool_t l, const pg_pool_t r)
 {


### PR DESCRIPTION
At present, OSDs' backfilling doesn't take the disk space usage into account when deciding the backfill reservations.

This can lead to the following situation: when expanding a cluster, altough the eventual cluster available space will be increased, there can be a temporary period of time when the available cluster space is reduced. Because the data might be backfilled to the highest space used OSDs before those OSDs' data gets backfilled away.

This can cause serious results when the cluster storage space usage is already very high. Although we already have `backfill_toofull` to prevent backfills from filling the cluster, but it's still risky that client writes might fill the cluster if the backfill runs for a relatively long time.

This PR tries to make the backfill reservation process osd-space-usage aware. Specifically, when deciding which backfill is to be reserved, the OSDs tries its best to select those that benefit the cluster space usage reduction, so there won't be the above mentioned period in which the cluster available space is reduced if the eventual cluster available space is to be increased. This is done by adding space usage based backfill priority:

```
relieved_osds: OSDs in which the current pg will be removed after the backfill.
target_osds: OSDs that the current pg is backfilled to.

R_before: the maximum of the storage space usage ratio of the relieved OSDs before the backfill.
R_after: the maximum of the storage space usage ratio of the relieved OSDs after the backfill.
T_after: the maximum of the storage space usage ratio of the target OSDs after the backfill.

raw_score = R_before - max(R_after, T_after)
boost = priority_band_remaining * raw_score
priority = base_priority + boost
```

Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
