### PR TITLE
mgr/cephadm: use inventory IPs for mgmt-gateway dashboard upstreams

### DIFF
--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -108,9 +108,10 @@ def get_dashboard_endpoints(svc: 'CephadmService') -> Tuple[List[str], Optional[
             if not port:
                 continue
             assert dd.hostname is not None
-            # fqdn may already be a name or numeric address; ensure IPv6
-            # literals are bracketed.
-            addr = svc.mgr.get_fqdn(dd.hostname)
+            # Use daemon/inventory IPs (same as other mgmt-gateway upstreams),
+            # not FQDNs, so nginx can reach the dashboard on the Ceph network
+            # when DNS resolves elsewhere. IPv6 literals are bracketed.
+            addr = dd.ip if dd.ip else svc.mgr.inventory.get_addr(dd.hostname)
             dashboard_endpoints.append(f'{wrap_ipv6(addr)}:{port}')
 
     return dashboard_endpoints, protocol

--- a/src/pybind/mgr/cephadm/tests/services/test_mgmt_gateway.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_mgmt_gateway.py
@@ -10,6 +10,7 @@ from ceph.deployment.service_spec import (
     MgmtGatewaySpec,
     OAuth2ProxySpec
 )
+from cephadm.services.cephadmservice import get_dashboard_endpoints
 from cephadm.services.service_registry import service_registry
 from cephadm.tests.fixtures import with_host, with_service, async_side_effect
 from cephadm.tlsobject_types import TLSCredentials
@@ -43,6 +44,25 @@ class TestMgmtGateway:
         foo_daemons = [DaemonDescription(daemon_type='foo', hostname='f1', ip='fe80::2', ports=[8080])]
         cephadm_module.cache.get_daemons_by_service = lambda name: foo_daemons if name == 'foo' else []
         assert svc.get_service_endpoints('foo') == ['[fe80::2]:8080']
+
+    def test_dashboard_endpoints_use_inventory_ips(self, cephadm_module: CephadmOrchestrator):
+        # nginx dashboard upstreams must use daemon/inventory IPs, not FQDNs,
+        # so mgmt-gateway can reach the dashboard when DNS points elsewhere.
+        svc = service_registry.get_service('mgmt-gateway')
+        mgr_daemons = [
+            DaemonDescription(daemon_type='mgr', daemon_id='a', hostname='h1', ip='10.0.0.1'),
+            DaemonDescription(daemon_type='mgr', daemon_id='b', hostname='h2', ip='fe80::1'),
+            DaemonDescription(daemon_type='mgr', daemon_id='c', hostname='h3'),
+        ]
+        cephadm_module.cache.get_daemons_by_service = lambda name: mgr_daemons if name == 'mgr' else []
+        cephadm_module.inventory.get_addr = lambda hostname: '10.0.0.3' if hostname == 'h3' else hostname
+        cephadm_module.get = lambda key: {
+            'services': {'dashboard': 'https://active.example:8443/'}
+        } if key == 'mgr_map' else {}
+
+        endpoints, scheme = get_dashboard_endpoints(svc)
+        assert scheme == 'https'
+        assert endpoints == ['10.0.0.1:8443', '[fe80::1]:8443', '10.0.0.3:8443']
 
     @patch("cephadm.serve.CephadmServe._run_cephadm")
     @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_service_endpoints")


### PR DESCRIPTION
mgmt-gateway nginx proxies to backends via upstream pools. Grafana, Prometheus, and similar pools already used daemon/inventory IPs (dd.ip / inventory.get_addr). The dashboard pool (dashboard_servers) was built with get_fqdn() instead, so nginx could fail to reach mgr dashboard when the hostname resolves off the Ceph network while inventory still has a reachable IP.

Move dashboard upstream building onto MgmtGatewayService and select addresses like get_service_endpoints(). Still take scheme and port from the mgr_map dashboard URL (only that URL's host is ignored for upstream members). Leave get_dashboard_urls() unchanged for browser-facing links.

Example nginx upstream change:
  Before:  server ceph-node-0:8443;
  After:   server 192.168.100.10:8443;

Changed files:

src/pybind/mgr/cephadm/services/mgmt_gateway.py:
- Add MgmtGatewayService.get_dashboard_endpoints() using dd.ip / inventory.get_addr and wrap_ipv6()
- generate_config() calls this method instead of the old shared helper

src/pybind/mgr/cephadm/services/cephadmservice.py:
- Remove the unused shared get_dashboard_endpoints()
- Keep get_dashboard_urls() as-is

src/pybind/mgr/cephadm/tests/services/test_mgmt_gateway.py:
- Add test_dashboard_endpoints_use_inventory_ips (IPv4, IPv6 brackets, inventory fallback when dd.ip is missing)
- Update @patch targets to MgmtGatewayService.get_dashboard_endpoints after the helper moved from a module function to a class method

Testing:
- Unit: tox -e py3 -- cephadm/tests/services/test_mgmt_gateway.py
- Manual: deploy mgmt-gateway; deploy prometheus, grafana, alertmanager, node-exporter, and ceph-exporter. Open the cluster via the mgmt-gateway URL and confirm each service path redirects and loads correctly. Check nginx upstreams use inventory IPs for backends (especially dashboard_servers), not hostnames that fail on the Ceph network.

Fixes: https://tracker.ceph.com/issues/77782
Signed-off-by: Yael Azulay <yazulay@redhat.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
