### PR TITLE
build: add openRuyi as a containerized build target

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -508,12 +508,15 @@ else
         $SUDO env DEBIAN_FRONTEND=noninteractive apt-get -y remove ceph-build-deps
         if [ "$control" != "debian/control" ] ; then rm $control; fi
         ;;
-    almalinux|rocky|centos|fedora|rhel|ol|virtuozzo)
+    almalinux|rocky|centos|fedora|rhel|ol|virtuozzo|openruyi)
         builddepcmd="dnf -y builddep --allowerasing"
         echo "Using dnf to install dependencies"
         case "$ID" in
             fedora)
                 $SUDO dnf install -y dnf-utils
+                ;;
+            openruyi)
+                rpm --quiet --query dnf5-plugins || $SUDO dnf install -y dnf5-plugins
                 ;;
             almalinux|rocky|centos|rhel|ol|virtuozzo)
                 MAJOR_VERSION="$(echo $VERSION_ID | cut -d. -f1)"

--- a/src/script/build-with-container.py
+++ b/src/script/build-with-container.py
@@ -115,6 +115,7 @@ class DistroKind(StrEnum):
     UBUNTU2604 = "ubuntu26.04"
     DEBIAN12 = "debian12"
     DEBIAN13 = "debian13"
+    OPENRUYI = "openruyi"
 
     @classmethod
     def uses_dnf(cls):
@@ -125,6 +126,7 @@ class DistroKind(StrEnum):
             cls.FEDORA41,
             cls.ROCKY9,
             cls.ROCKY10,
+            cls.OPENRUYI,
         }
 
     @classmethod
@@ -173,6 +175,9 @@ class DistroKind(StrEnum):
             str(cls.DEBIAN13): cls.DEBIAN13,
             "debian-trixie": cls.DEBIAN13,
             "trixie": cls.DEBIAN13,
+            # openruyi
+            str(cls.OPENRUYI): cls.OPENRUYI,
+            "openruyi-creek": cls.OPENRUYI,
         }
 
     @classmethod
@@ -204,6 +209,8 @@ class DefaultImage(StrEnum):
     # debian
     DEBIAN12 = "docker.io/debian:bookworm"
     DEBIAN13 = "docker.io/debian:trixie"
+    # openruyi
+    OPENRUYI = "community-ci.openruyi.cn/openruyi-oci:riscv64"
 
 
 class CommandFailed(Exception):

--- a/src/script/buildcontainer-setup.sh
+++ b/src/script/buildcontainer-setup.sh
@@ -41,6 +41,12 @@ case "${CEPH_BASE_BRANCH}~${DISTRO_KIND}" in
         install_container_deps
         dnf_clean
     ;;
+    # openRuyi's minimal image lacks tar/gzip needed to unpack build tarballs
+    *~*openruyi*)
+        dnf install -y tar gzip /usr/bin/{rpmbuild,wget,curl}
+        install_container_deps
+        dnf_clean
+    ;;
     *~*ubuntu*|*~*debian*)
         apt-get update
         pkgs=(wget reprepro curl lksctp-tools libsctp-dev protobuf-compiler ragel libc-ares-dev)


### PR DESCRIPTION
openRuyi is a Linux distribution (primarily RISC-V, also supporting
x86). Register it as a `-d openruyi` target for build-with-container.py.

The default image is riscv64, the only arch tested.

Verified on openRuyi RISC-V CI: https://github.com/sunyuechi/ceph-ci/actions

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests