### PR TITLE
librbd: don't load a clone snapshot's object map while parent is live

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -216,6 +216,20 @@
   ``rgw_default_bucket_bilog_type`` configuration option (default:
   ``fifo``). Existing InIndex buckets are unaffected until their next
   reshard, at which point they are automatically migrated to FIFO.
+* RBD: A cloned image's snapshot no longer uses its object map to short-circuit
+  reads while the snapshot still records a non-zero parent overlap. Such an
+  object map is not immutable -- a copyup anywhere in the parent chain can
+  invalidate it, and a read-only client holds no watch and so never learns of
+  it -- which could make reads return zeroes instead of the parent's data once
+  the parent went away. Reads against these snapshots now always go to the OSDs
+  and fall back to the parent, costing an extra round trip for each object that
+  has not been copied up; sparse clone snapshots are the worst case. The object
+  map is used again once the recorded parent overlap drops to zero, which
+  happens when the clone is flattened with the ``deep-flatten`` feature enabled.
+  A clone flattened without ``deep-flatten`` keeps a non-zero parent overlap on
+  its snapshots indefinitely, so those snapshots do not regain the object map.
+  Consumers that read the on-disk object map directly -- ``rbd du``, ``rbd
+  export-diff --whole-object``, deep copy and mirroring -- are unaffected.
 
 >=21.0.0
 

--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -436,6 +436,28 @@ test_clone() {
     rbd flatten clone3
     test "$(rbd ls -l | grep -c rbd2/clone@s1)" = '1'
 
+    # a copy of a clone must contain the data the clone inherits from its
+    # parent, whether the source is the clone itself or a snapshot of it
+    # (test2 is the parent, test3 the clone and test4 each copy in turn)
+    dd if=/dev/urandom bs=1M count=1 | rbd $RBD_CREATE_ARGS import - test2
+    md5sum=$(rbd export test2 - | md5sum)
+    rbd snap create test2@s
+    rbd snap protect test2@s
+    rbd clone test2@s test3
+    rbd snap create test3@s
+    test "$(rbd export test3 - | md5sum)" = "${md5sum}"
+    rbd cp test3 test4
+    test "$(rbd export test4 - | md5sum)" = "${md5sum}"
+    rbd rm test4
+    rbd cp test3@s test4
+    test "$(rbd export test4 - | md5sum)" = "${md5sum}"
+    rbd rm test4
+    rbd snap rm test3@s
+    rbd rm test3
+    rbd snap unprotect test2@s
+    rbd snap rm test2@s
+    rbd rm test2
+
     rbd rm clone2
     rbd snap unprotect rbd2/clone@s1
     rbd snap rm rbd2/clone@s1

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -186,6 +186,7 @@ set(librbd_internal_srcs
   operation/MetadataRemoveRequest.cc
   operation/MetadataSetRequest.cc
   operation/MigrateRequest.cc
+  operation/CheckObjectMapRequest.cc
   operation/ObjectMapIterate.cc
   operation/RebuildObjectMapRequest.cc
   operation/RenameRequest.cc

--- a/src/librbd/Operations.cc
+++ b/src/librbd/Operations.cc
@@ -26,8 +26,8 @@
 #include "librbd/operation/FlattenRequest.h"
 #include "librbd/operation/MetadataRemoveRequest.h"
 #include "librbd/operation/MetadataSetRequest.h"
+#include "librbd/operation/CheckObjectMapRequest.h"
 #include "librbd/operation/MigrateRequest.h"
-#include "librbd/operation/ObjectMapIterate.h"
 #include "librbd/operation/RebuildObjectMapRequest.h"
 #include "librbd/operation/RenameRequest.h"
 #include "librbd/operation/ResizeRequest.h"
@@ -386,18 +386,6 @@ struct C_InvokeAsyncRequest : public Context {
   }
 };
 
-template <typename I>
-bool needs_invalidate(I& image_ctx, uint64_t object_no,
-		     uint8_t current_state, uint8_t new_state) {
-  if ( (current_state == OBJECT_EXISTS ||
-	current_state == OBJECT_EXISTS_CLEAN) &&
-       (new_state == OBJECT_NONEXISTENT ||
-	new_state == OBJECT_PENDING)) {
-    return false;
-  }
-  return true;
-}
-
 } // anonymous namespace
 
 template <typename I>
@@ -627,9 +615,8 @@ int Operations<I>::check_object_map(ProgressContext &prog_ctx) {
 }
 
 template <typename I>
-void Operations<I>::object_map_iterate(ProgressContext &prog_ctx,
-				       operation::ObjectIterateWork<I> handle_mismatch,
-				       Context *on_finish) {
+void Operations<I>::check_object_map(ProgressContext &prog_ctx,
+				     Context *on_finish) {
   ceph_assert(ceph_mutex_is_locked(m_image_ctx.owner_lock));
   ceph_assert(m_image_ctx.exclusive_lock == nullptr ||
               m_image_ctx.exclusive_lock->is_lock_owner());
@@ -639,16 +626,9 @@ void Operations<I>::object_map_iterate(ProgressContext &prog_ctx,
     return;
   }
 
-  operation::ObjectMapIterateRequest<I> *req =
-    new operation::ObjectMapIterateRequest<I>(m_image_ctx, on_finish,
-					      prog_ctx, handle_mismatch);
+  operation::CheckObjectMapRequest<I> *req =
+    new operation::CheckObjectMapRequest<I>(m_image_ctx, on_finish, prog_ctx);
   req->send();
-}
-
-template <typename I>
-void Operations<I>::check_object_map(ProgressContext &prog_ctx,
-				     Context *on_finish) {
-  object_map_iterate(prog_ctx, needs_invalidate, on_finish);
 }
 
 template <typename I>

--- a/src/librbd/Operations.h
+++ b/src/librbd/Operations.h
@@ -5,9 +5,9 @@
 #define CEPH_LIBRBD_OPERATIONS_H
 
 #include "cls/rbd/cls_rbd_types.h"
+#include "common/ceph_mutex.h"
 #include "include/int_types.h"
 #include "librbd/exclusive_lock/Policy.h"
-#include "librbd/operation/ObjectMapIterate.h"
 #include <atomic>
 #include <string>
 #include <list>
@@ -57,10 +57,6 @@ public:
 
   int check_object_map(ProgressContext &prog_ctx);
   void check_object_map(ProgressContext &prog_ctx, Context *on_finish);
-
-  void object_map_iterate(ProgressContext &prog_ctx,
-			  operation::ObjectIterateWork<ImageCtxT> handle_mismatch,
-			  Context* on_finish);
 
   int rename(const char *dstname);
   void execute_rename(const std::string &dest_name, Context *on_finish);

--- a/src/librbd/image/RefreshRequest.cc
+++ b/src/librbd/image/RefreshRequest.cc
@@ -1035,12 +1035,32 @@ Context *RefreshRequest<I>::handle_v2_block_writes(int *result) {
 
 template <typename I>
 void RefreshRequest<I>::send_v2_open_object_map() {
+  auto has_live_snapshot_parent = [&]() {
+    // A snapshot's object map isn't immutable for a cloned image: a
+    // copyup anywhere in the parent chain (e.g. the parent gets
+    // flattened or removed) can invalidate it at any time, and there may
+    // be no watch to ever refresh it (e.g. a read-only open). Avoid
+    // caching the object map while this snapshot still has a live parent
+    // relationship of its own; once its recorded overlap drops to zero
+    // for good, a later refresh will load it safely.
+    if (m_image_ctx.snap_name.empty()) {
+      return false;
+    }
+
+    ParentImageInfo parent_md;
+    MigrationInfo migration_info;
+    int r = get_parent_info(m_image_ctx.snap_id, &parent_md, &migration_info);
+    ceph_assert(r == 0 || r == -ENOENT);
+    return (r == 0 && migration_info.empty() && parent_md.overlap > 0);
+  };
+
   if ((m_features & RBD_FEATURE_OBJECT_MAP) == 0 ||
       m_image_ctx.object_map != nullptr ||
       (m_image_ctx.snap_name.empty() &&
        (m_read_only ||
         m_image_ctx.exclusive_lock == nullptr ||
-        !m_image_ctx.exclusive_lock->is_lock_owner()))) {
+        !m_image_ctx.exclusive_lock->is_lock_owner())) ||
+      has_live_snapshot_parent()) {
     send_v2_open_journal();
     return;
   }

--- a/src/librbd/image/RefreshRequest.cc
+++ b/src/librbd/image/RefreshRequest.cc
@@ -1034,13 +1034,45 @@ Context *RefreshRequest<I>::handle_v2_block_writes(int *result) {
 }
 
 template <typename I>
+bool RefreshRequest<I>::has_live_snapshot_parent() {
+  // A snapshot's object map isn't immutable for a cloned image: a copyup
+  // anywhere in the parent chain (e.g. the parent gets flattened or
+  // removed) can invalidate it at any time, and there may be no watch to
+  // ever refresh it (e.g. a read-only open). Avoid caching the object map
+  // while this snapshot still has a live parent relationship of its own;
+  // once its recorded overlap drops to zero for good, a later refresh will
+  // load it safely. A migration source counts as a parent here -- it goes
+  // away on commit, exactly like a flattened parent does.
+  if (m_image_ctx.snap_name.empty()) {
+    return false;
+  }
+
+  std::shared_lock image_locker{m_image_ctx.image_lock};
+
+  // on the initial open the image context isn't pinned to the snapshot yet,
+  // so this consults the HEAD overlap. That is harmless: SetSnapRequest
+  // runs next and its apply() installs its own (possibly null) object map
+  // unconditionally, so it has the final say for that case.
+  ParentImageInfo parent_md;
+  MigrationInfo migration_info;
+  int r = get_parent_info(m_image_ctx.snap_id, &parent_md, &migration_info);
+  if (r < 0) {
+    // no parent info to go on -- assume the worst and leave it unloaded
+    return true;
+  }
+
+  return (parent_md.overlap > 0);
+}
+
+template <typename I>
 void RefreshRequest<I>::send_v2_open_object_map() {
   if ((m_features & RBD_FEATURE_OBJECT_MAP) == 0 ||
       m_image_ctx.object_map != nullptr ||
       (m_image_ctx.snap_name.empty() &&
        (m_read_only ||
         m_image_ctx.exclusive_lock == nullptr ||
-        !m_image_ctx.exclusive_lock->is_lock_owner()))) {
+        !m_image_ctx.exclusive_lock->is_lock_owner())) ||
+      has_live_snapshot_parent()) {
     send_v2_open_journal();
     return;
   }

--- a/src/librbd/image/RefreshRequest.h
+++ b/src/librbd/image/RefreshRequest.h
@@ -230,6 +230,7 @@ private:
   void send_v2_block_writes();
   Context *handle_v2_block_writes(int *result);
 
+  bool has_live_snapshot_parent();
   void send_v2_open_object_map();
   Context *handle_v2_open_object_map(int *result);
 

--- a/src/librbd/image/SetSnapRequest.cc
+++ b/src/librbd/image/SetSnapRequest.cc
@@ -197,6 +197,15 @@ Context *SetSnapRequest<I>::send_refresh_parent(int *result) {
     parent_md = *parent_info;
     refresh_parent = RefreshParentRequest<I>::is_refresh_required(
         m_image_ctx, parent_md, m_image_ctx.migration_info);
+
+    // A clone snapshot's object map isn't immutable: a copyup anywhere in
+    // the parent chain (e.g. the parent gets flattened or removed) can
+    // invalidate it at any time, with no watch to ever refresh it (e.g. a
+    // read-only open). Avoid loading it while this snapshot still has a
+    // live parent overlap of its own.
+    m_skip_object_map = (m_snap_id != CEPH_NOSNAP &&
+                         parent_md.overlap > 0 &&
+                         m_image_ctx.migration_info.empty());
   }
 
   if (!refresh_parent) {
@@ -252,7 +261,8 @@ Context *SetSnapRequest<I>::handle_refresh_parent(int *result) {
 
 template <typename I>
 Context *SetSnapRequest<I>::send_open_object_map(int *result) {
-  if (!m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP)) {
+  if (!m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP) ||
+      m_skip_object_map) {
     *result = apply();
     if (*result < 0) {
       finalize();

--- a/src/librbd/image/SetSnapRequest.cc
+++ b/src/librbd/image/SetSnapRequest.cc
@@ -197,6 +197,15 @@ Context *SetSnapRequest<I>::send_refresh_parent(int *result) {
     parent_md = *parent_info;
     refresh_parent = RefreshParentRequest<I>::is_refresh_required(
         m_image_ctx, parent_md, m_image_ctx.migration_info);
+
+    // A clone snapshot's object map isn't immutable: a copyup anywhere in
+    // the parent chain (e.g. the parent gets flattened or removed) can
+    // invalidate it at any time, with no watch to ever refresh it (e.g. a
+    // read-only open). Avoid loading it while this snapshot still has a
+    // live parent overlap of its own. A migration source counts as a parent
+    // here -- RefreshRequest::apply() records it as the snapshot's parent and
+    // it goes away on commit, exactly like a flattened parent does.
+    m_skip_object_map = (m_snap_id != CEPH_NOSNAP && parent_md.overlap > 0);
   }
 
   if (!refresh_parent) {
@@ -252,7 +261,8 @@ Context *SetSnapRequest<I>::handle_refresh_parent(int *result) {
 
 template <typename I>
 Context *SetSnapRequest<I>::send_open_object_map(int *result) {
-  if (!m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP)) {
+  if (!m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP) ||
+      m_skip_object_map) {
     *result = apply();
     if (*result < 0) {
       finalize();

--- a/src/librbd/image/SetSnapRequest.h
+++ b/src/librbd/image/SetSnapRequest.h
@@ -86,6 +86,7 @@ private:
   RefreshParentRequest<ImageCtxT> *m_refresh_parent;
 
   bool m_writes_blocked;
+  bool m_skip_object_map = false;
 
   void send_block_writes();
   Context *handle_block_writes(int *result);

--- a/src/librbd/image/SetSnapRequest.h
+++ b/src/librbd/image/SetSnapRequest.h
@@ -47,7 +47,8 @@ private:
    *    |             REFRESH_PARENT (skip if no parent
    *    |                 |           or refresh not needed)
    *    |                 v
-   *    |             OPEN_OBJECT_MAP (skip if map disabled)
+   *    |             OPEN_OBJECT_MAP (skip if map disabled or if the
+   *    |                 |             snapshot has a live parent overlap)
    *    |                 |
    *    |                 v
    *    |              <apply>
@@ -86,6 +87,7 @@ private:
   RefreshParentRequest<ImageCtxT> *m_refresh_parent;
 
   bool m_writes_blocked;
+  bool m_skip_object_map = false;
 
   void send_block_writes();
   Context *handle_block_writes(int *result);

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1328,6 +1328,21 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
     unsigned fadvise_flags = LIBRADOS_OP_FLAG_FADVISE_SEQUENTIAL |
 			     LIBRADOS_OP_FLAG_FADVISE_NOCACHE;
     uint64_t object_id = 0;
+
+    // the object map only tracks the objects that belong to the image itself,
+    // so for a clone everything it still inherits from its parent is marked
+    // as non-existent in it.  Anything the parent overlap covers therefore
+    // has to be read regardless of what the object map says -- use the raw
+    // overlap, which is never smaller than the data one, and fall back to
+    // copying everything if it can't be determined.
+    uint64_t parent_overlap;
+    {
+      std::shared_lock image_locker{src->image_lock};
+      if (src->get_parent_overlap(src->snap_id, &parent_overlap) < 0) {
+        parent_overlap = src_size;
+      }
+    }
+
     for (uint64_t offset = 0; offset < src_size; offset += period) {
       if (throttle.pending_error()) {
         return throttle.wait_for_ret();
@@ -1335,7 +1350,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
 
       {
 	std::shared_lock image_locker{src->image_lock};
-        if (src->object_map != nullptr) {
+        if (src->object_map != nullptr && offset >= parent_overlap) {
           bool skip = true;
           // each period is related to src->stripe_count objects, check them all
           for (uint64_t i=0; i < src->stripe_count; i++) {

--- a/src/librbd/operation/CheckObjectMapRequest.cc
+++ b/src/librbd/operation/CheckObjectMapRequest.cc
@@ -1,0 +1,138 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include "librbd/operation/CheckObjectMapRequest.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "include/rbd/object_map_types.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ObjectMap.h"
+#include "librbd/operation/ObjectMapIterate.h"
+
+#include <shared_mutex> // for std::shared_lock
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::CheckObjectMapRequest: "
+
+namespace librbd {
+namespace operation {
+
+namespace {
+
+template <typename I>
+bool needs_invalidate(I& image_ctx, ObjectMap<I> &object_map,
+		      uint64_t object_no, uint8_t current_state,
+		      uint8_t new_state) {
+  if ( (current_state == OBJECT_EXISTS ||
+	current_state == OBJECT_EXISTS_CLEAN) &&
+       (new_state == OBJECT_NONEXISTENT ||
+	new_state == OBJECT_PENDING)) {
+    return false;
+  }
+  return true;
+}
+
+} // anonymous namespace
+
+template <typename I>
+CheckObjectMapRequest<I>::~CheckObjectMapRequest() {
+  if (m_opened_object_map != nullptr) {
+    m_opened_object_map->put();
+    m_opened_object_map = nullptr;
+  }
+}
+
+template <typename I>
+void CheckObjectMapRequest<I>::send() {
+  uint64_t snap_id;
+  {
+    std::shared_lock image_locker{m_image_ctx.image_lock};
+    m_object_map = m_image_ctx.object_map;
+    snap_id = m_image_ctx.snap_id;
+  }
+
+  if (m_object_map == nullptr) {
+    if (snap_id == CEPH_NOSNAP) {
+      // the HEAD object map is loaded when the exclusive lock is acquired
+      lderr(m_image_ctx.cct) << "object map is not loaded" << dendl;
+      this->async_complete(-EINVAL);
+      return;
+    }
+
+    send_open_object_map(snap_id);
+    return;
+  }
+
+  send_verify_objects();
+}
+
+template <typename I>
+bool CheckObjectMapRequest<I>::should_complete(int r) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 5) << this << " should_complete: " << " r=" << r << dendl;
+
+  std::shared_lock owner_lock{m_image_ctx.owner_lock};
+  switch (m_state) {
+  case STATE_OPEN_OBJECT_MAP:
+    ldout(cct, 5) << "OPEN_OBJECT_MAP" << dendl;
+    if (r == 0) {
+      send_verify_objects();
+      return false;
+    }
+    break;
+
+  case STATE_VERIFY_OBJECTS:
+    ldout(cct, 5) << "VERIFY_OBJECTS" << dendl;
+    break;
+
+  default:
+    ceph_abort();
+    break;
+  }
+
+  if (r < 0) {
+    lderr(cct) << "check object map encountered an error: " << cpp_strerror(r)
+               << dendl;
+  }
+  return true;
+}
+
+template <typename I>
+void CheckObjectMapRequest<I>::send_open_object_map(uint64_t snap_id) {
+  ceph_assert(ceph_mutex_is_locked(m_image_ctx.owner_lock));
+  CephContext *cct = m_image_ctx.cct;
+
+  ldout(cct, 5) << this << " send_open_object_map" << dendl;
+  m_state = STATE_OPEN_OBJECT_MAP;
+
+  // a clone snapshot's object map isn't loaded into the image context while
+  // the snapshot still has a live parent overlap -- it can be invalidated by
+  // a copyup at any time and must not be trusted by the read path.  Open a
+  // private instance for the duration of the operation instead.
+  m_opened_object_map = m_image_ctx.create_object_map(snap_id);
+  m_object_map = m_opened_object_map;
+  m_opened_object_map->open(this->create_callback_context());
+}
+
+template <typename I>
+void CheckObjectMapRequest<I>::send_verify_objects() {
+  ceph_assert(ceph_mutex_is_locked(m_image_ctx.owner_lock));
+  CephContext *cct = m_image_ctx.cct;
+
+  ldout(cct, 5) << this << " send_verify_objects" << dendl;
+  m_state = STATE_VERIFY_OBJECTS;
+
+  ObjectMapIterateRequest<I> *req =
+    new ObjectMapIterateRequest<I>(m_image_ctx,
+				   this->create_callback_context(),
+				   m_prog_ctx, *m_object_map,
+				   needs_invalidate);
+
+  req->send();
+}
+
+} // namespace operation
+} // namespace librbd
+
+template class librbd::operation::CheckObjectMapRequest<librbd::ImageCtx>;

--- a/src/librbd/operation/CheckObjectMapRequest.h
+++ b/src/librbd/operation/CheckObjectMapRequest.h
@@ -1,0 +1,75 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#ifndef CEPH_LIBRBD_OPERATION_CHECK_OBJECT_MAP_REQUEST_H
+#define CEPH_LIBRBD_OPERATION_CHECK_OBJECT_MAP_REQUEST_H
+
+#include "include/int_types.h"
+#include "librbd/AsyncRequest.h"
+
+namespace librbd {
+
+class ImageCtx;
+class ProgressContext;
+template <typename> class ObjectMap;
+
+namespace operation {
+
+template <typename ImageCtxT = ImageCtx>
+class CheckObjectMapRequest : public AsyncRequest<ImageCtxT> {
+public:
+
+  CheckObjectMapRequest(ImageCtxT &image_ctx, Context *on_finish,
+                        ProgressContext &prog_ctx)
+    : AsyncRequest<ImageCtxT>(image_ctx, on_finish), m_image_ctx(image_ctx),
+      m_prog_ctx(prog_ctx)
+  {
+  }
+  ~CheckObjectMapRequest() override;
+
+  void send() override;
+
+protected:
+  bool should_complete(int r) override;
+
+private:
+  /**
+   * Check object map goes through the following state machine to verify
+   * per-object state:
+   *
+   * <start>
+   *    |
+   *    v
+   * STATE_OPEN_OBJECT_MAP (skip if the object map is already loaded)
+   *    |
+   *    v
+   * STATE_VERIFY_OBJECTS
+   *    |
+   *    v
+   * <finish>
+   *
+   * The object map is not loaded into the image context for a snapshot that
+   * still has a live parent overlap, so in that case a private instance is
+   * opened for the duration of the operation.
+   */
+  enum State {
+    STATE_OPEN_OBJECT_MAP,
+    STATE_VERIFY_OBJECTS
+  };
+
+  ImageCtxT &m_image_ctx;
+  ProgressContext &m_prog_ctx;
+  ObjectMap<ImageCtxT> *m_object_map = nullptr;
+  ObjectMap<ImageCtxT> *m_opened_object_map = nullptr;
+  State m_state = STATE_VERIFY_OBJECTS;
+
+  void send_open_object_map(uint64_t snap_id);
+  void send_verify_objects();
+};
+
+} // namespace operation
+} // namespace librbd
+
+extern template class librbd::operation::CheckObjectMapRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_OPERATION_CHECK_OBJECT_MAP_REQUEST_H

--- a/src/librbd/operation/ObjectMapIterate.cc
+++ b/src/librbd/operation/ObjectMapIterate.cc
@@ -32,11 +32,12 @@ template <typename I>
 class C_VerifyObjectCallback : public C_AsyncObjectThrottle<I> {
 public:
   C_VerifyObjectCallback(AsyncObjectThrottle<I> &throttle, I *image_ctx,
-			 uint64_t snap_id, uint64_t object_no,
+			 ObjectMap<I> *object_map, uint64_t snap_id,
+			 uint64_t object_no,
 			 ObjectIterateWork<I> handle_mismatch,
 			 std::atomic_flag *invalidate)
     : C_AsyncObjectThrottle<I>(throttle, *image_ctx),
-    m_snap_id(snap_id), m_object_no(object_no),
+    m_object_map(*object_map), m_snap_id(snap_id), m_object_no(object_no),
     m_oid(image_ctx->get_object_name(m_object_no)),
     m_handle_mismatch(handle_mismatch),
     m_invalidate(invalidate)
@@ -64,6 +65,7 @@ public:
 
 private:
   librados::IoCtx m_io_ctx;
+  ObjectMap<I> &m_object_map;
   uint64_t m_snap_id;
   uint64_t m_object_no;
   std::string m_oid;
@@ -159,9 +161,8 @@ private:
                 image_ctx.exclusive_lock->is_lock_owner());
 
     std::shared_lock image_locker{image_ctx.image_lock};
-    ceph_assert(image_ctx.object_map != nullptr);
 
-    uint8_t state = (*image_ctx.object_map)[m_object_no];
+    uint8_t state = m_object_map[m_object_no];
     ldout(cct, 10) << "C_VerifyObjectCallback::object_map_action"
 		   << " object " << image_ctx.get_object_name(m_object_no)
 		   << " state " << (int)state
@@ -171,7 +172,8 @@ private:
       int r = 0;
 
       ceph_assert(m_handle_mismatch);
-      r = m_handle_mismatch(image_ctx, m_object_no, state, new_state);
+      r = m_handle_mismatch(image_ctx, m_object_map, m_object_no, state,
+			    new_state);
       if (r) {
 	lderr(cct) << "object map error: object "
 		   << image_ctx.get_object_name(m_object_no)
@@ -265,7 +267,7 @@ void ObjectMapIterateRequest<I>::send_verify_objects() {
 
   typename AsyncObjectThrottle<I>::ContextFactory context_factory(
     boost::lambda::bind(boost::lambda::new_ptr<C_VerifyObjectCallback<I> >(),
-			boost::lambda::_1, &m_image_ctx, snap_id,
+			boost::lambda::_1, &m_image_ctx, &m_object_map, snap_id,
 			boost::lambda::_2, m_handle_mismatch, &m_invalidate));
   AsyncObjectThrottle<I> *throttle = new AsyncObjectThrottle<I>(
     this, m_image_ctx, context_factory, this->create_callback_context(),

--- a/src/librbd/operation/ObjectMapIterate.h
+++ b/src/librbd/operation/ObjectMapIterate.h
@@ -15,11 +15,13 @@ namespace librbd {
 
 class ImageCtx;
 class ProgressContext;
+template <typename> class ObjectMap;
 
 namespace operation {
 
 template <typename ImageCtxT = ImageCtx>
 using ObjectIterateWork = bool(*)(ImageCtxT &image_ctx,
+				  ObjectMap<ImageCtxT> &object_map,
 				  uint64_t object_no,
 				  uint8_t current_state,
 				  uint8_t new_state);
@@ -27,11 +29,15 @@ using ObjectIterateWork = bool(*)(ImageCtxT &image_ctx,
 template <typename ImageCtxT = ImageCtx>
 class ObjectMapIterateRequest : public AsyncRequest<ImageCtxT> {
 public:
+  // the object map to verify against is owned by the caller and must stay
+  // valid for the lifetime of the request
   ObjectMapIterateRequest(ImageCtxT &image_ctx, Context *on_finish,
 			  ProgressContext &prog_ctx,
+			  ObjectMap<ImageCtxT> &object_map,
 			  ObjectIterateWork<ImageCtxT> handle_mismatch)
     : AsyncRequest<ImageCtxT>(image_ctx, on_finish), m_image_ctx(image_ctx),
-    m_prog_ctx(prog_ctx), m_handle_mismatch(handle_mismatch)
+    m_prog_ctx(prog_ctx), m_object_map(object_map),
+    m_handle_mismatch(handle_mismatch)
   {
   }
 
@@ -48,6 +54,7 @@ private:
 
   ImageCtxT &m_image_ctx;
   ProgressContext &m_prog_ctx;
+  ObjectMap<ImageCtxT> &m_object_map;
   ObjectIterateWork<ImageCtxT> m_handle_mismatch;
   std::atomic_flag m_invalidate = ATOMIC_FLAG_INIT;
   State m_state = STATE_VERIFY_OBJECTS;

--- a/src/librbd/operation/RebuildObjectMapRequest.cc
+++ b/src/librbd/operation/RebuildObjectMapRequest.cc
@@ -29,8 +29,52 @@ namespace operation {
 using util::create_context_callback;
 
 template <typename I>
+RebuildObjectMapRequest<I>::~RebuildObjectMapRequest() {
+  if (m_opened_object_map != nullptr) {
+    m_opened_object_map->put();
+    m_opened_object_map = nullptr;
+  }
+}
+
+template <typename I>
 void RebuildObjectMapRequest<I>::send() {
+  uint64_t snap_id;
+  {
+    std::shared_lock image_locker{m_image_ctx.image_lock};
+    m_object_map = m_image_ctx.object_map;
+    snap_id = m_image_ctx.snap_id;
+  }
+
+  if (m_object_map == nullptr) {
+    if (snap_id == CEPH_NOSNAP) {
+      // the HEAD object map is loaded when the exclusive lock is acquired
+      lderr(m_image_ctx.cct) << "object map is not loaded" << dendl;
+      this->async_complete(-EINVAL);
+      return;
+    }
+
+    send_open_object_map(snap_id);
+    return;
+  }
+
   send_resize_object_map();
+}
+
+template <typename I>
+void RebuildObjectMapRequest<I>::send_open_object_map(uint64_t snap_id) {
+  ceph_assert(ceph_mutex_is_locked(m_image_ctx.owner_lock));
+  CephContext *cct = m_image_ctx.cct;
+
+  ldout(cct, 5) << this << " send_open_object_map" << dendl;
+  m_state = STATE_OPEN_OBJECT_MAP;
+
+  // a clone snapshot's object map isn't loaded into the image context while
+  // the snapshot still has a live parent overlap -- it can be invalidated by
+  // a copyup at any time and must not be trusted by the read path.  Open a
+  // private instance for the duration of the operation instead.
+  m_opened_object_map = m_image_ctx.create_object_map(snap_id);
+  m_object_map = m_opened_object_map;
+  m_opened_object_map->open(this->create_callback_context());
 }
 
 template <typename I>
@@ -40,6 +84,13 @@ bool RebuildObjectMapRequest<I>::should_complete(int r) {
 
   std::shared_lock owner_lock{m_image_ctx.owner_lock};
   switch (m_state) {
+  case STATE_OPEN_OBJECT_MAP:
+    ldout(cct, 5) << "OPEN_OBJECT_MAP" << dendl;
+    if (r == 0) {
+      send_resize_object_map();
+    }
+    break;
+
   case STATE_RESIZE_OBJECT_MAP:
     ldout(cct, 5) << "RESIZE_OBJECT_MAP" << dendl;
     if (r == -ESTALE && !m_attempted_trim) {
@@ -101,12 +152,12 @@ void RebuildObjectMapRequest<I>::send_resize_object_map() {
   CephContext *cct = m_image_ctx.cct;
 
   m_image_ctx.image_lock.lock_shared();
-  ceph_assert(m_image_ctx.object_map != nullptr);
+  ceph_assert(m_object_map != nullptr);
 
   uint64_t size = get_image_size();
   uint64_t num_objects = Striper::get_num_objects(m_image_ctx.layout, size);
 
-  if (m_image_ctx.object_map->size() == num_objects) {
+  if (m_object_map->size() == num_objects) {
     m_image_ctx.image_lock.unlock_shared();
     send_verify_objects();
     return;
@@ -119,8 +170,8 @@ void RebuildObjectMapRequest<I>::send_resize_object_map() {
   ceph_assert(m_image_ctx.exclusive_lock == nullptr ||
               m_image_ctx.exclusive_lock->is_lock_owner());
 
-  m_image_ctx.object_map->aio_resize(size, OBJECT_NONEXISTENT,
-                                     this->create_callback_context());
+  m_object_map->aio_resize(size, OBJECT_NONEXISTENT,
+                           this->create_callback_context());
   m_image_ctx.image_lock.unlock_shared();
 }
 
@@ -140,11 +191,10 @@ void RebuildObjectMapRequest<I>::send_trim_image() {
   uint64_t orig_size;
   {
     std::shared_lock l{m_image_ctx.image_lock};
-    ceph_assert(m_image_ctx.object_map != nullptr);
+    ceph_assert(m_object_map != nullptr);
 
     new_size = get_image_size();
-    orig_size = m_image_ctx.get_object_size() *
-                m_image_ctx.object_map->size();
+    orig_size = m_image_ctx.get_object_size() * m_object_map->size();
   }
   TrimRequest<I> *req = TrimRequest<I>::create(m_image_ctx,
                                                this->create_callback_context(),
@@ -153,12 +203,13 @@ void RebuildObjectMapRequest<I>::send_trim_image() {
 }
 
 template <typename I>
-bool update_object_map(I& image_ctx, uint64_t object_no, uint8_t current_state,
+bool update_object_map(I& image_ctx, ObjectMap<I> &object_map,
+		      uint64_t object_no, uint8_t current_state,
 		      uint8_t new_state) {
   CephContext *cct = image_ctx.cct;
   uint64_t snap_id = image_ctx.snap_id;
 
-  current_state = (*image_ctx.object_map)[object_no];
+  current_state = object_map[object_no];
   if (current_state == OBJECT_EXISTS && new_state == OBJECT_NONEXISTENT &&
       snap_id == CEPH_NOSNAP) {
     // might be writing object to OSD concurrently
@@ -170,7 +221,7 @@ bool update_object_map(I& image_ctx, uint64_t object_no, uint8_t current_state,
                    << " rebuild updating object map "
                    << static_cast<uint32_t>(current_state) << "->"
                    << static_cast<uint32_t>(new_state) << dendl;
-    image_ctx.object_map->set_state(object_no, new_state, current_state);
+    object_map.set_state(object_no, new_state, current_state);
   }
   return false;
 }
@@ -186,7 +237,8 @@ void RebuildObjectMapRequest<I>::send_verify_objects() {
   ObjectMapIterateRequest<I> *req =
     new ObjectMapIterateRequest<I>(m_image_ctx,
 				   this->create_callback_context(),
-				   m_prog_ctx, update_object_map);
+				   m_prog_ctx, *m_object_map,
+				   update_object_map);
 
   req->send();
 }
@@ -204,8 +256,8 @@ void RebuildObjectMapRequest<I>::send_save_object_map() {
               m_image_ctx.exclusive_lock->is_lock_owner());
 
   std::shared_lock image_locker{m_image_ctx.image_lock};
-  ceph_assert(m_image_ctx.object_map != nullptr);
-  m_image_ctx.object_map->aio_save(this->create_callback_context());
+  ceph_assert(m_object_map != nullptr);
+  m_object_map->aio_save(this->create_callback_context());
 }
 
 template <typename I>

--- a/src/librbd/operation/RebuildObjectMapRequest.h
+++ b/src/librbd/operation/RebuildObjectMapRequest.h
@@ -11,6 +11,7 @@ namespace librbd {
 
 class ImageCtx;
 class ProgressContext;
+template <typename> class ObjectMap;
 
 namespace operation {
 
@@ -24,6 +25,7 @@ public:
       m_prog_ctx(prog_ctx), m_attempted_trim(false)
   {
   }
+  ~RebuildObjectMapRequest() override;
 
   void send() override;
 
@@ -36,6 +38,10 @@ private:
    * verify per-object state:
    *
    * <start>
+   *  .   |
+   *  .   v
+   *  . STATE_OPEN_OBJECT_MAP (skip if the object map is already loaded)
+   *  .   |
    *  .   |               . . . . . . . . . .
    *  .   |               .                 .
    *  .   v               v                 .
@@ -55,6 +61,7 @@ private:
    * only be hit if the resize failed due to an in-use object.
    */
   enum State {
+    STATE_OPEN_OBJECT_MAP,
     STATE_RESIZE_OBJECT_MAP,
     STATE_TRIM_IMAGE,
     STATE_VERIFY_OBJECTS,
@@ -64,9 +71,12 @@ private:
 
   ImageCtxT &m_image_ctx;
   ProgressContext &m_prog_ctx;
+  ObjectMap<ImageCtxT> *m_object_map = nullptr;
+  ObjectMap<ImageCtxT> *m_opened_object_map = nullptr;
   State m_state = STATE_RESIZE_OBJECT_MAP;
   bool m_attempted_trim;
 
+  void send_open_object_map(uint64_t snap_id);
   void send_resize_object_map();
   void send_trim_image();
   void send_verify_objects();

--- a/src/test/librbd/test_fixture.cc
+++ b/src/test/librbd/test_fixture.cc
@@ -81,11 +81,18 @@ void TestFixture::TearDown() {
 }
 
 int TestFixture::open_image(const std::string &image_name,
-			    librbd::ImageCtx **ictx) {
-  *ictx = new librbd::ImageCtx(image_name.c_str(), "", nullptr, m_ioctx, false);
+                            const std::string &snap_name,
+                            librbd::ImageCtx **ictx) {
+  *ictx = new librbd::ImageCtx(image_name.c_str(), {}, snap_name.c_str(),
+                               m_ioctx, false);
   m_ictxs.insert(*ictx);
 
   return (*ictx)->state->open(0);
+}
+
+int TestFixture::open_image(const std::string &image_name,
+			    librbd::ImageCtx **ictx) {
+  return open_image(image_name, {}, ictx);
 }
 
 int TestFixture::snap_create(librbd::ImageCtx &ictx,

--- a/src/test/librbd/test_fixture.h
+++ b/src/test/librbd/test_fixture.h
@@ -24,6 +24,8 @@ public:
   void SetUp() override;
   void TearDown() override;
 
+  int open_image(const std::string &image_name, const std::string &snap_name,
+                 librbd::ImageCtx **ictx);
   int open_image(const std::string &image_name, librbd::ImageCtx **ictx);
   void close_image(librbd::ImageCtx *ictx);
 

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -2025,6 +2025,89 @@ TEST_F(TestInternal, FlattenNoEmptyObjects)
   rados_ioctx_destroy(d_ioctx);
 }
 
+TEST_F(TestInternal, FlattenWhenOpenedSnap)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING | RBD_FEATURE_DEEP_FLATTEN |
+                  RBD_FEATURE_OBJECT_MAP);
+
+  librbd::ImageCtx *parent_ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &parent_ictx));
+
+  bufferlist bl;
+  bl.append(std::string(TEST_IO_SIZE, '1'));
+  ASSERT_EQ(TEST_IO_SIZE, api::Io<>::write(*parent_ictx, 0, bl.length(),
+                                           bufferlist{bl}, 0));
+  ASSERT_EQ(0, flush_writeback_cache(parent_ictx));
+
+  ASSERT_EQ(0, snap_create(*parent_ictx, "parent_snap"));
+  ASSERT_EQ(0, snap_protect(*parent_ictx, "parent_snap"));
+
+  uint64_t features;
+  ASSERT_EQ(0, librbd::get_features(parent_ictx, &features));
+
+  std::string clone_name = get_temp_image_name();
+  int order = parent_ictx->order;
+  ASSERT_EQ(0, librbd::clone(m_ioctx, m_image_name.c_str(), "parent_snap",
+                             m_ioctx, clone_name.c_str(), features, &order, 0,
+                             0));
+
+  TestInternal *parent = this;
+  librbd::ImageCtx *clone_ictx = nullptr;
+  librbd::ImageCtx *snap_ictx = nullptr;
+  BOOST_SCOPE_EXIT( (&m_ioctx) (clone_name) (parent) (&clone_ictx) (&snap_ictx) ) {
+    if (snap_ictx != nullptr) {
+      parent->close_image(snap_ictx);
+    }
+    if (clone_ictx != nullptr) {
+      clone_ictx->operations->snap_remove(cls::rbd::UserSnapshotNamespace(),
+                                          "clone_snap");
+      parent->close_image(clone_ictx);
+    }
+
+    librbd::NoOpProgressContext no_op;
+    ASSERT_EQ(0, librbd::api::Image<>::remove(m_ioctx, clone_name, no_op));
+  } BOOST_SCOPE_EXIT_END;
+
+  ASSERT_EQ(0, open_image(clone_name, &clone_ictx));
+  ASSERT_EQ(0, snap_create(*clone_ictx, "clone_snap"));
+
+  ASSERT_EQ(0, open_image(clone_name, "clone_snap", &snap_ictx));
+  ASSERT_NE(nullptr, snap_ictx->object_map);
+
+  bufferptr read_ptr(bl.length());
+  bufferlist read_bl;
+  read_bl.push_back(read_ptr);
+  librbd::io::ReadResult read_result{&read_bl};
+
+  ASSERT_EQ(TEST_IO_SIZE,
+            api::Io<>::read(*snap_ictx, 0, read_bl.length(),
+                            librbd::io::ReadResult{read_result}, 0));
+  ASSERT_TRUE(bl.contents_equal(read_bl));
+
+  librbd::NoOpProgressContext no_op;
+  ASSERT_EQ(0, clone_ictx->operations->flatten(no_op));
+  // flatten's header-update notification only marks snap_ictx as needing
+  // a refresh; it doesn't reload any state itself, so the explicit
+  // refresh() below is required, not redundant
+  ASSERT_EQ(0, snap_ictx->state->refresh());
+
+  ASSERT_EQ(TEST_IO_SIZE,
+            api::Io<>::read(*snap_ictx, 0, read_bl.length(),
+                            librbd::io::ReadResult{read_result}, 0));
+  ASSERT_TRUE(bl.contents_equal(read_bl));
+
+  librbd::ImageCtx *reopened_snap_ictx;
+  ASSERT_EQ(0, open_image(clone_name, "clone_snap", &reopened_snap_ictx));
+  BOOST_SCOPE_EXIT(parent, reopened_snap_ictx) {
+    parent->close_image(reopened_snap_ictx);
+  } BOOST_SCOPE_EXIT_END;
+
+  ASSERT_EQ(TEST_IO_SIZE,
+            api::Io<>::read(*reopened_snap_ictx, 0, read_bl.length(),
+                            librbd::io::ReadResult{read_result}, 0));
+  ASSERT_TRUE(bl.contents_equal(read_bl));
+}
+
 TEST_F(TestInternal, FlattenInconsistentObjectMap)
 {
   REQUIRE_FEATURE(RBD_FEATURE_LAYERING | RBD_FEATURE_OBJECT_MAP);

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -2072,7 +2072,10 @@ TEST_F(TestInternal, FlattenWhenOpenedSnap)
   ASSERT_EQ(0, snap_create(*clone_ictx, "clone_snap"));
 
   ASSERT_EQ(0, open_image(clone_name, "clone_snap", &snap_ictx));
-  ASSERT_NE(nullptr, snap_ictx->object_map);
+  // the snapshot still has a live parent overlap, so its object map is
+  // intentionally not loaded (it could go stale the moment the parent
+  // is flattened or removed, with no watch to ever refresh it)
+  ASSERT_EQ(nullptr, snap_ictx->object_map);
 
   bufferptr read_ptr(bl.length());
   bufferlist read_bl;
@@ -2091,6 +2094,10 @@ TEST_F(TestInternal, FlattenWhenOpenedSnap)
   // refresh() below is required, not redundant
   ASSERT_EQ(0, snap_ictx->state->refresh());
 
+  // flatten dropped the recorded parent overlap to zero, so it is now
+  // safe to load the object map
+  ASSERT_NE(nullptr, snap_ictx->object_map);
+
   ASSERT_EQ(TEST_IO_SIZE,
             api::Io<>::read(*snap_ictx, 0, read_bl.length(),
                             librbd::io::ReadResult{read_result}, 0));
@@ -2102,6 +2109,7 @@ TEST_F(TestInternal, FlattenWhenOpenedSnap)
     parent->close_image(reopened_snap_ictx);
   } BOOST_SCOPE_EXIT_END;
 
+  ASSERT_NE(nullptr, reopened_snap_ictx->object_map);
   ASSERT_EQ(TEST_IO_SIZE,
             api::Io<>::read(*reopened_snap_ictx, 0, read_bl.length(),
                             librbd::io::ReadResult{read_result}, 0));

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -2073,7 +2073,10 @@ TEST_F(TestInternal, FlattenWhenOpenedSnap)
   ASSERT_EQ(0, snap_create(*clone_ictx, "clone_snap"));
 
   ASSERT_EQ(0, open_image(clone_name, "clone_snap", &snap_ictx));
-  ASSERT_EQ(object_map, snap_ictx->object_map != nullptr);
+  // the snapshot still has a live parent overlap, so its object map is
+  // intentionally not loaded (it could go stale the moment the parent
+  // is flattened or removed, with no watch to ever refresh it)
+  ASSERT_EQ(nullptr, snap_ictx->object_map);
 
   bufferptr read_ptr(bl.length());
   bufferlist read_bl;
@@ -2085,12 +2088,22 @@ TEST_F(TestInternal, FlattenWhenOpenedSnap)
                             librbd::io::ReadResult{read_result}, 0));
   ASSERT_TRUE(bl.contents_equal(read_bl));
 
+  // a refresh while the parent is still live must not load the object map
+  // either -- this exercises RefreshRequest, which SetSnapRequest's skip
+  // above doesn't cover
+  ASSERT_EQ(0, snap_ictx->state->refresh());
+  ASSERT_EQ(nullptr, snap_ictx->object_map);
+
   librbd::NoOpProgressContext no_op;
   ASSERT_EQ(0, clone_ictx->operations->flatten(no_op));
   // flatten's header-update notification only marks snap_ictx as needing
   // a refresh; it doesn't reload any state itself, so the explicit
   // refresh() below is required, not redundant
   ASSERT_EQ(0, snap_ictx->state->refresh());
+
+  // flatten dropped the recorded parent overlap to zero, so it is now
+  // safe to load the object map
+  ASSERT_EQ(object_map, snap_ictx->object_map != nullptr);
 
   ASSERT_EQ(TEST_IO_SIZE,
             api::Io<>::read(*snap_ictx, 0, read_bl.length(),
@@ -2103,6 +2116,7 @@ TEST_F(TestInternal, FlattenWhenOpenedSnap)
     parent->close_image(reopened_snap_ictx);
   } BOOST_SCOPE_EXIT_END;
 
+  ASSERT_EQ(object_map, reopened_snap_ictx->object_map != nullptr);
   ASSERT_EQ(TEST_IO_SIZE,
             api::Io<>::read(*reopened_snap_ictx, 0, read_bl.length(),
                             librbd::io::ReadResult{read_result}, 0));

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -2025,6 +2025,90 @@ TEST_F(TestInternal, FlattenNoEmptyObjects)
   rados_ioctx_destroy(d_ioctx);
 }
 
+TEST_F(TestInternal, FlattenWhenOpenedSnap)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING | RBD_FEATURE_DEEP_FLATTEN);
+
+  bool object_map = is_feature_enabled(RBD_FEATURE_OBJECT_MAP);
+
+  librbd::ImageCtx *parent_ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &parent_ictx));
+
+  bufferlist bl;
+  bl.append(std::string(TEST_IO_SIZE, '1'));
+  ASSERT_EQ(TEST_IO_SIZE, api::Io<>::write(*parent_ictx, 0, bl.length(),
+                                           bufferlist{bl}, 0));
+  ASSERT_EQ(0, flush_writeback_cache(parent_ictx));
+
+  ASSERT_EQ(0, snap_create(*parent_ictx, "parent_snap"));
+  ASSERT_EQ(0, snap_protect(*parent_ictx, "parent_snap"));
+
+  uint64_t features;
+  ASSERT_EQ(0, librbd::get_features(parent_ictx, &features));
+
+  std::string clone_name = get_temp_image_name();
+  int order = parent_ictx->order;
+  ASSERT_EQ(0, librbd::clone(m_ioctx, m_image_name.c_str(), "parent_snap",
+                             m_ioctx, clone_name.c_str(), features, &order, 0,
+                             0));
+
+  TestInternal *parent = this;
+  librbd::ImageCtx *clone_ictx = nullptr;
+  librbd::ImageCtx *snap_ictx = nullptr;
+  BOOST_SCOPE_EXIT( (&m_ioctx) (clone_name) (parent) (&clone_ictx) (&snap_ictx) ) {
+    if (snap_ictx != nullptr) {
+      parent->close_image(snap_ictx);
+    }
+    if (clone_ictx != nullptr) {
+      clone_ictx->operations->snap_remove(cls::rbd::UserSnapshotNamespace(),
+                                          "clone_snap");
+      parent->close_image(clone_ictx);
+    }
+
+    librbd::NoOpProgressContext no_op;
+    ASSERT_EQ(0, librbd::api::Image<>::remove(m_ioctx, clone_name, no_op));
+  } BOOST_SCOPE_EXIT_END;
+
+  ASSERT_EQ(0, open_image(clone_name, &clone_ictx));
+  ASSERT_EQ(0, snap_create(*clone_ictx, "clone_snap"));
+
+  ASSERT_EQ(0, open_image(clone_name, "clone_snap", &snap_ictx));
+  ASSERT_EQ(object_map, snap_ictx->object_map != nullptr);
+
+  bufferptr read_ptr(bl.length());
+  bufferlist read_bl;
+  read_bl.push_back(read_ptr);
+  librbd::io::ReadResult read_result{&read_bl};
+
+  ASSERT_EQ(TEST_IO_SIZE,
+            api::Io<>::read(*snap_ictx, 0, read_bl.length(),
+                            librbd::io::ReadResult{read_result}, 0));
+  ASSERT_TRUE(bl.contents_equal(read_bl));
+
+  librbd::NoOpProgressContext no_op;
+  ASSERT_EQ(0, clone_ictx->operations->flatten(no_op));
+  // flatten's header-update notification only marks snap_ictx as needing
+  // a refresh; it doesn't reload any state itself, so the explicit
+  // refresh() below is required, not redundant
+  ASSERT_EQ(0, snap_ictx->state->refresh());
+
+  ASSERT_EQ(TEST_IO_SIZE,
+            api::Io<>::read(*snap_ictx, 0, read_bl.length(),
+                            librbd::io::ReadResult{read_result}, 0));
+  ASSERT_TRUE(bl.contents_equal(read_bl));
+
+  librbd::ImageCtx *reopened_snap_ictx;
+  ASSERT_EQ(0, open_image(clone_name, "clone_snap", &reopened_snap_ictx));
+  BOOST_SCOPE_EXIT(parent, reopened_snap_ictx) {
+    parent->close_image(reopened_snap_ictx);
+  } BOOST_SCOPE_EXIT_END;
+
+  ASSERT_EQ(TEST_IO_SIZE,
+            api::Io<>::read(*reopened_snap_ictx, 0, read_bl.length(),
+                            librbd::io::ReadResult{read_result}, 0));
+  ASSERT_TRUE(bl.contents_equal(read_bl));
+}
+
 TEST_F(TestInternal, FlattenInconsistentObjectMap)
 {
   REQUIRE_FEATURE(RBD_FEATURE_LAYERING | RBD_FEATURE_OBJECT_MAP);

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -9187,6 +9187,74 @@ TEST_F(TestLibRBD, Flatten)
   ASSERT_PASSED(validate_object_map, clone_image);
 }
 
+TEST_F(TestLibRBD, FlattenWhenOpenedSnap)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING | RBD_FEATURE_DEEP_FLATTEN |
+                  RBD_FEATURE_OBJECT_MAP);
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
+
+  librbd::RBD rbd;
+  std::string parent_name = get_temp_image_name();
+  uint64_t size = 2 << 20;
+  int order = 0;
+  ASSERT_EQ(0, create_image_pp(rbd, ioctx, parent_name.c_str(), size, &order));
+
+  librbd::Image parent_image;
+  ASSERT_EQ(0, rbd.open(ioctx, parent_image, parent_name.c_str(), NULL));
+
+  bufferlist bl;
+  bl.append(std::string(4096, '1'));
+  ASSERT_EQ((ssize_t)bl.length(), parent_image.write(0, bl.length(), bl));
+
+  ASSERT_EQ(0, parent_image.snap_create("snap1"));
+  ASSERT_EQ(0, parent_image.snap_protect("snap1"));
+
+  uint64_t features;
+  ASSERT_EQ(0, parent_image.features(&features));
+
+  std::string clone_name = get_temp_image_name();
+  EXPECT_EQ(0, rbd.clone(ioctx, parent_name.c_str(), "snap1", ioctx,
+       clone_name.c_str(), features, &order));
+
+  librbd::Image clone_image;
+  ASSERT_EQ(0, rbd.open(ioctx, clone_image, clone_name.c_str(), NULL));
+  ASSERT_EQ(0, clone_image.snap_create("clone_snap"));
+
+  // keep a handle open at the clone's snapshot across the parent flatten
+  librbd::Image snap_image;
+  ASSERT_EQ(0, rbd.open(ioctx, snap_image, clone_name.c_str(), "clone_snap"));
+
+  bufferlist read_bl;
+  ASSERT_EQ((ssize_t)bl.length(), snap_image.read(0, bl.length(), read_bl));
+  ASSERT_TRUE(bl.contents_equal(read_bl));
+
+  ASSERT_EQ(0, clone_image.flatten());
+
+  // flatten's watch notification only marks snap_image as needing a
+  // refresh; force the actual reload via any call that checks for one
+  // (e.g. stat), the same way a real client would before its next
+  // operation on the image
+  librbd::image_info_t info;
+  ASSERT_EQ(0, snap_image.stat(info, sizeof(info)));
+
+  read_bl.clear();
+  ASSERT_EQ((ssize_t)bl.length(), snap_image.read(0, bl.length(), read_bl));
+  ASSERT_TRUE(bl.contents_equal(read_bl));
+
+  // a freshly opened handle at the same snapshot should also see the
+  // correct data
+  librbd::Image reopened_snap_image;
+  ASSERT_EQ(0, rbd.open(ioctx, reopened_snap_image, clone_name.c_str(),
+                        "clone_snap"));
+
+  read_bl.clear();
+  ASSERT_EQ((ssize_t)bl.length(),
+            reopened_snap_image.read(0, bl.length(), read_bl));
+  ASSERT_TRUE(bl.contents_equal(read_bl));
+}
+
 TEST_F(TestLibRBD, Sparsify)
 {
   rados_ioctx_t ioctx;

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -9187,6 +9187,73 @@ TEST_F(TestLibRBD, Flatten)
   ASSERT_PASSED(validate_object_map, clone_image);
 }
 
+TEST_F(TestLibRBD, FlattenWhenOpenedSnap)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING | RBD_FEATURE_DEEP_FLATTEN);
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
+
+  librbd::RBD rbd;
+  std::string parent_name = get_temp_image_name();
+  uint64_t size = 2 << 20;
+  int order = 0;
+  ASSERT_EQ(0, create_image_pp(rbd, ioctx, parent_name.c_str(), size, &order));
+
+  librbd::Image parent_image;
+  ASSERT_EQ(0, rbd.open(ioctx, parent_image, parent_name.c_str(), NULL));
+
+  bufferlist bl;
+  bl.append(std::string(4096, '1'));
+  ASSERT_EQ((ssize_t)bl.length(), parent_image.write(0, bl.length(), bl));
+
+  ASSERT_EQ(0, parent_image.snap_create("snap1"));
+  ASSERT_EQ(0, parent_image.snap_protect("snap1"));
+
+  uint64_t features;
+  ASSERT_EQ(0, parent_image.features(&features));
+
+  std::string clone_name = get_temp_image_name();
+  EXPECT_EQ(0, rbd.clone(ioctx, parent_name.c_str(), "snap1", ioctx,
+       clone_name.c_str(), features, &order));
+
+  librbd::Image clone_image;
+  ASSERT_EQ(0, rbd.open(ioctx, clone_image, clone_name.c_str(), NULL));
+  ASSERT_EQ(0, clone_image.snap_create("clone_snap"));
+
+  // keep a handle open at the clone's snapshot across the parent flatten
+  librbd::Image snap_image;
+  ASSERT_EQ(0, rbd.open(ioctx, snap_image, clone_name.c_str(), "clone_snap"));
+
+  bufferlist read_bl;
+  ASSERT_EQ((ssize_t)bl.length(), snap_image.read(0, bl.length(), read_bl));
+  ASSERT_TRUE(bl.contents_equal(read_bl));
+
+  ASSERT_EQ(0, clone_image.flatten());
+
+  // flatten's watch notification only marks snap_image as needing a
+  // refresh; force the actual reload via any call that checks for one
+  // (e.g. stat), the same way a real client would before its next
+  // operation on the image
+  librbd::image_info_t info;
+  ASSERT_EQ(0, snap_image.stat(info, sizeof(info)));
+
+  read_bl.clear();
+  ASSERT_EQ((ssize_t)bl.length(), snap_image.read(0, bl.length(), read_bl));
+  ASSERT_TRUE(bl.contents_equal(read_bl));
+
+  // a freshly opened handle at the same snapshot should also see the
+  // correct data
+  librbd::Image reopened_snap_image;
+  ASSERT_EQ(0, rbd.open(ioctx, reopened_snap_image, clone_name.c_str(),
+                        "clone_snap"));
+
+  read_bl.clear();
+  ASSERT_EQ((ssize_t)bl.length(),
+            reopened_snap_image.read(0, bl.length(), read_bl));
+  ASSERT_TRUE(bl.contents_equal(read_bl));
+}
+
 TEST_F(TestLibRBD, Sparsify)
 {
   rados_ioctx_t ioctx;

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -10479,6 +10479,62 @@ TEST_F(TestLibRBD, CheckObjectMap)
   ASSERT_TRUE((flags & RBD_FLAG_OBJECT_MAP_INVALID) != 0);
 }
 
+TEST_F(TestLibRBD, ObjectMapOnCloneSnap)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING | RBD_FEATURE_OBJECT_MAP);
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
+
+  librbd::RBD rbd;
+  std::string parent_name = get_temp_image_name();
+  uint64_t size = 2 << 20;
+  int order = 0;
+  ASSERT_EQ(0, create_image_pp(rbd, ioctx, parent_name.c_str(), size, &order));
+
+  librbd::Image parent_image;
+  ASSERT_EQ(0, rbd.open(ioctx, parent_image, parent_name.c_str(), NULL));
+
+  bufferlist bl;
+  bl.append(std::string(4096, '1'));
+  ASSERT_EQ((ssize_t)bl.length(), parent_image.write(0, bl.length(), bl));
+
+  ASSERT_EQ(0, parent_image.snap_create("snap1"));
+  ASSERT_EQ(0, parent_image.snap_protect("snap1"));
+
+  uint64_t features;
+  ASSERT_EQ(0, parent_image.features(&features));
+
+  std::string clone_name = get_temp_image_name();
+  ASSERT_EQ(0, rbd.clone(ioctx, parent_name.c_str(), "snap1", ioctx,
+                         clone_name.c_str(), features, &order));
+
+  librbd::Image clone_image;
+  ASSERT_EQ(0, rbd.open(ioctx, clone_image, clone_name.c_str(), NULL));
+
+  // copy up an object so that the snapshot object map has a mix of
+  // existent and non-existent objects to verify
+  bl.clear();
+  bl.append(std::string(4096, '2'));
+  ASSERT_EQ((ssize_t)bl.length(), clone_image.write(0, bl.length(), bl));
+
+  ASSERT_EQ(0, clone_image.snap_create("clone_snap"));
+  ASSERT_EQ(0, clone_image.close());
+
+  // the clone snapshot still has a live parent overlap, so librbd doesn't
+  // load its object map into the image context -- check and rebuild must
+  // still be able to get at the on-disk map
+  librbd::Image snap_image;
+  ASSERT_EQ(0, rbd.open(ioctx, snap_image, clone_name.c_str(), "clone_snap"));
+
+  PrintProgress prog_ctx;
+  ASSERT_EQ(0, snap_image.check_object_map(prog_ctx));
+  ASSERT_PASSED(validate_object_map, snap_image);
+
+  ASSERT_EQ(0, snap_image.rebuild_object_map(prog_ctx));
+  ASSERT_PASSED(validate_object_map, snap_image);
+}
+
 TEST_F(TestLibRBD, BlockingAIO)
 {
   librados::IoCtx ioctx;

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -1576,6 +1576,73 @@ TEST_F(TestLibRBD, TestCopyPP)
   ioctx.close();
 }
 
+TEST_F(TestLibRBD, TestCopyClone)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
+
+  librbd::RBD rbd;
+  std::string parent_name = get_temp_image_name();
+  uint64_t size = 2 << 20;
+  int order = 0;
+  ASSERT_EQ(0, create_image_pp(rbd, ioctx, parent_name.c_str(), size, &order));
+
+  bufferlist bl;
+  bl.append(std::string(4096, '1'));
+  {
+    librbd::Image parent_image;
+    ASSERT_EQ(0, rbd.open(ioctx, parent_image, parent_name.c_str(), NULL));
+    ASSERT_EQ((ssize_t)bl.length(), parent_image.write(0, bl.length(), bl));
+    ASSERT_EQ(0, parent_image.snap_create("snap1"));
+    ASSERT_EQ(0, parent_image.snap_protect("snap1"));
+  }
+
+  uint64_t features;
+  {
+    librbd::Image parent_image;
+    ASSERT_EQ(0, rbd.open(ioctx, parent_image, parent_name.c_str(), NULL));
+    ASSERT_EQ(0, parent_image.features(&features));
+  }
+
+  std::string clone_name = get_temp_image_name();
+  ASSERT_EQ(0, rbd.clone(ioctx, parent_name.c_str(), "snap1", ioctx,
+                         clone_name.c_str(), features, &order));
+
+  std::string copy_name = get_temp_image_name();
+  {
+    librbd::Image clone_image;
+    ASSERT_EQ(0, rbd.open(ioctx, clone_image, clone_name.c_str(), NULL));
+
+    // the object map only tracks objects belonging to the clone itself, so
+    // nothing inherited from the parent is marked as existing in it.  Take
+    // the exclusive lock so that the object map, if any, is loaded before
+    // the copy -- otherwise the copy can't be fooled by it.  With object map
+    // disabled this just exercises the plain copy path.
+    if (is_feature_enabled(RBD_FEATURE_EXCLUSIVE_LOCK)) {
+      ASSERT_EQ(0, clone_image.lock_acquire(RBD_LOCK_MODE_EXCLUSIVE));
+      bool is_owner;
+      ASSERT_EQ(0, clone_image.is_exclusive_lock_owner(&is_owner));
+      ASSERT_TRUE(is_owner);
+    }
+
+    bufferlist clone_bl;
+    ASSERT_EQ((ssize_t)bl.length(), clone_image.read(0, bl.length(), clone_bl));
+    ASSERT_TRUE(bl.contents_equal(clone_bl));
+
+    ASSERT_EQ(0, clone_image.copy(ioctx, copy_name.c_str()));
+  }
+
+  // the copy must carry the data the clone inherited from its parent
+  librbd::Image copy_image;
+  ASSERT_EQ(0, rbd.open(ioctx, copy_image, copy_name.c_str(), NULL));
+
+  bufferlist copy_bl;
+  ASSERT_EQ((ssize_t)bl.length(), copy_image.read(0, bl.length(), copy_bl));
+  ASSERT_TRUE(bl.contents_equal(copy_bl));
+}
+
 TEST_F(TestLibRBD, TestDeepCopy)
 {
   REQUIRE_FORMAT_V2();


### PR DESCRIPTION
When refresh changes an opened snapshot from having parent overlap to having none, force the snapshot object map to be reopened and drop the stale in-memory map.
 
Without this, reads from a snapshot kept open across deep flatten can see objects as missing and fall back to the removed parent path, returning zeroes.

Fixes: https://tracker.ceph.com/issues/74554
Signed-off-by: Mykola Golub <mykola.golub@clyso.com>
Assisted-by: GitHub Copilot (GPT-5.4)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
