### PR TITLE
mgr/rook: probe availability with a single pod

### DIFF
--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -149,7 +149,9 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             return False, "ceph-mgr not running in Rook cluster", {}
 
         try:
-            self.k8s.list_namespaced_pod(self._rook_env.namespace)
+            # reachability probe only; the result is discarded, so don't
+            # fetch (and let the k8s client debug-log) the whole pod list
+            self.k8s.list_namespaced_pod(self._rook_env.namespace, limit=1)
         except ApiException as e:
             return False, "Cannot reach Kubernetes API: {}".format(e), {}
         else:

--- a/src/pybind/mgr/rook/tests/test_rook.py
+++ b/src/pybind/mgr/rook/tests/test_rook.py
@@ -1,7 +1,7 @@
 import orchestrator
 from .fixtures import wait
 import pytest
-from unittest.mock import patch, PropertyMock
+from unittest.mock import patch, MagicMock, PropertyMock
 
 from rook.module import RookOrchestrator
 from rook.rook_cluster import RookCluster
@@ -118,3 +118,25 @@ class TestRook(object):
                     assert dds[i].last_deployed == pods[i]['created']
                     assert dds[i].started == pods[i]['started']
                     assert dds[i].last_refresh == pods[i]['refreshed']
+
+    def test_available_uses_bounded_pod_list(self):
+        # available() must not fetch the entire pod list. This is needlesslyn
+        # expensive, and all we need is availability.
+        ro = RookOrchestrator('rook', None, self)
+        ro._rook_env.namespace = 'rook-ceph'
+
+        fake_k8s = MagicMock()
+        # kubernetes_imported may be False when the optional `kubernetes`
+        # package isn't installed; force it True so this test exercises the
+        # probe rather than short-circuiting at available()'s first guard.
+        with patch('rook.module.kubernetes_imported', True), \
+                patch('rook.RookOrchestrator.k8s',
+                      new_callable=PropertyMock,
+                      return_value=fake_k8s), \
+                patch.object(ro._rook_env, 'has_namespace', return_value=True):
+            avail, why, details = ro.available()
+
+        assert avail is True
+        assert why == ""
+        assert details == {}
+        fake_k8s.list_namespaced_pod.assert_called_once_with('rook-ceph', limit=1)

--- a/src/pybind/mgr/rook/tests/test_rook.py
+++ b/src/pybind/mgr/rook/tests/test_rook.py
@@ -1,7 +1,7 @@
 import orchestrator
 from .fixtures import wait
 import pytest
-from unittest.mock import patch, PropertyMock
+from unittest.mock import patch, MagicMock, PropertyMock
 
 from rook.module import RookOrchestrator
 from rook.rook_cluster import RookCluster
@@ -118,6 +118,28 @@ class TestRook(object):
                     assert dds[i].last_deployed == pods[i]['created']
                     assert dds[i].started == pods[i]['started']
                     assert dds[i].last_refresh == pods[i]['refreshed']
+
+    def test_available_uses_bounded_pod_list(self):
+        # available() must not fetch the entire pod list. This is needlesslyn
+        # expensive, and all we need is availability.
+        ro = RookOrchestrator('rook', None, self)
+        ro._rook_env.namespace = 'rook-ceph'
+
+        fake_k8s = MagicMock()
+        # kubernetes_imported may be False when the optional `kubernetes`
+        # package isn't installed; force it True so this test exercises the
+        # probe rather than short-circuiting at available()'s first guard.
+        with patch('rook.module.kubernetes_imported', True), \
+                patch('rook.RookOrchestrator.k8s',
+                      new_callable=PropertyMock,
+                      return_value=fake_k8s), \
+                patch.object(ro._rook_env, 'has_namespace', return_value=True):
+            avail, why, details = ro.available()
+
+        assert avail is True
+        assert why == ""
+        assert details == {}
+        fake_k8s.list_namespaced_pod.assert_called_once_with('rook-ceph', limit=1)
 
 
 class TestFetchK8sItems(object):


### PR DESCRIPTION
`available()` lists every pod in the rook namespace and discards the result; it only cares whether the API call succeeds.  The prometheus module polls `available()` via `orch_is_available()` on every collect cycle (15 seconds by default), so on a cluster with 137 OSDs each probe was an apiserver range scan returning about 6MB of JSON, which the kubernetes client then logs in full at DEBUG level.

Ask for a single pod instead: same RBAC, same reachability check, about 2KB of response.

Related-to: https://tracker.ceph.com/issues/78165





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
