### PR TITLE
mgr: forward the root-logger fallback at the record's own level 

### DIFF
--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -299,9 +299,28 @@ PyObject* PyModule::init_ceph_logger()
   return py_logger;
 }
 
+// module-independent sink for the Python root-logger fallback; the Python
+// side filters and formats, this just emits like PyModuleRunner::log()
+static PyObject*
+ceph_mgr_log(PyObject *self, PyObject *args)
+{
+  char *record = nullptr;
+  if (!PyArg_ParseTuple(args, "s:mgr_log", &record)) {
+    return nullptr;
+  }
+#undef dout_prefix
+#define dout_prefix *_dout
+  dout(0) << record << dendl;
+#undef dout_prefix
+#define dout_prefix *_dout << "mgr[py] "
+  Py_RETURN_NONE;
+}
+
 PyObject* PyModule::init_ceph_module()
 {
   static PyMethodDef module_methods[] = {
+    {"mgr_log", ceph_mgr_log, METH_VARARGS,
+     "log a preformatted record to the mgr daemon log"},
     {nullptr, nullptr, 0, nullptr}
   };
   static PyModuleDef ceph_module_def = {

--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -300,17 +300,22 @@ PyObject* PyModule::init_ceph_logger()
 }
 
 // module-independent sink for the Python root-logger fallback; the Python
-// side filters and formats, this just emits like PyModuleRunner::log()
+// side maps the record's level to a ceph debug level, so the usual
+// subsystem gating applies per record
 static PyObject*
 ceph_mgr_log(PyObject *self, PyObject *args)
 {
+  int level = 0;
   char *record = nullptr;
-  if (!PyArg_ParseTuple(args, "s:mgr_log", &record)) {
+  if (!PyArg_ParseTuple(args, "is:mgr_log", &level, &record)) {
     return nullptr;
+  }
+  if (level < 0) {
+    level = 0;
   }
 #undef dout_prefix
 #define dout_prefix *_dout
-  dout(0) << record << dendl;
+  dout(ceph::dout::need_dynamic(level)) << record << dendl;
 #undef dout_prefix
 #define dout_prefix *_dout << "mgr[py] "
   Py_RETURN_NONE;
@@ -320,7 +325,7 @@ PyObject* PyModule::init_ceph_module()
 {
   static PyMethodDef module_methods[] = {
     {"mgr_log", ceph_mgr_log, METH_VARARGS,
-     "log a preformatted record to the mgr daemon log"},
+     "log a preformatted record to the mgr daemon log at a debug level"},
     {nullptr, nullptr, 0, nullptr}
   };
   static PyModuleDef ceph_module_def = {

--- a/src/pybind/mgr/ceph_module.pyi
+++ b/src/pybind/mgr/ceph_module.pyi
@@ -10,6 +10,9 @@ except ImportError:
         pass
 
 
+def mgr_log(record: str) -> None: ...
+
+
 class BasePyOSDMap(object):
     def _get_epoch(self): ...
     def _get_crush_version(self): ...

--- a/src/pybind/mgr/ceph_module.pyi
+++ b/src/pybind/mgr/ceph_module.pyi
@@ -10,7 +10,7 @@ except ImportError:
         pass
 
 
-def mgr_log(record: str) -> None: ...
+def mgr_log(level: int, record: str) -> None: ...
 
 
 class BasePyOSDMap(object):

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -702,15 +702,19 @@ class CPlusPlusHandler(logging.Handler):
             self._module._ceph_log(self.format(record))
 
 
-class MgrRootHandler(CPlusPlusHandler):
-    def __init__(self, module_inst: 'MgrModuleLoggingMixin') -> None:
-        super().__init__(module_inst)
+class MgrRootHandler(logging.Handler):
+    # fallback for third-party libraries logging to the root logger; emits
+    # via the module-independent ceph_module.mgr_log, so it holds no module
+    # reference to go stale.  installed once; its level follows debug_mgr.
+    def __init__(self) -> None:
+        super().__init__()
         self.setFormatter(logging.Formatter(
             "[mgr %(levelname)-4s %(name)s] %(message)s"
         ))
 
-    def set_module(self, module_inst: 'MgrModuleLoggingMixin') -> None:
-        self._module = module_inst
+    def emit(self, record: logging.LogRecord) -> None:
+        if record.levelno >= self.level:
+            ceph_module.mgr_log(self.format(record))
 
 
 class ClusterLogHandler(logging.Handler):
@@ -748,7 +752,6 @@ class FileHandler(logging.FileHandler):
 
 class MgrModuleLoggingMixin(object):
     module_name: str
-    _root_log_handler: Optional[MgrRootHandler] = None
 
     def _configure_logging(self,
                            mgr_level: str,
@@ -771,20 +774,11 @@ class MgrModuleLoggingMixin(object):
         self.log_to_cluster = log_to_cluster
 
         root = logging.getLogger()
-        root_handler = None
-        for handler in root.handlers:
-            if isinstance(handler, MgrRootHandler):
-                root_handler = handler
-                break
-        if root_handler is None:
-            root_handler = MgrRootHandler(self)
-            root.addHandler(root_handler)
-        else:
-            root_handler.set_module(self)
-        self._root_log_handler = root_handler
-        # Module loggers rely on handler thresholds, so keep root permissive
-        # and apply the mgr fallback threshold on MgrRootHandler itself.
-        root.setLevel(logging.NOTSET)
+        if self._mgr_root_handler() is None:
+            # keep root permissive; the fallback handler gates on its own
+            # level, set from debug_mgr in _set_log_level()
+            root.addHandler(MgrRootHandler())
+            root.setLevel(logging.NOTSET)
 
         self._module_logger.addHandler(self._mgr_log_handler)
         if log_to_file:
@@ -807,13 +801,22 @@ class MgrModuleLoggingMixin(object):
         self.log_to_file = False
         self.log_to_cluster = False
 
+    @staticmethod
+    def _mgr_root_handler() -> Optional['MgrRootHandler']:
+        root = logging.getLogger()
+        return next((h for h in root.handlers
+                     if isinstance(h, MgrRootHandler)), None)
+
     def _set_log_level(self,
                        mgr_level: str,
                        module_level: str,
                        cluster_level: str) -> None:
         self._cluster_log_handler.setLevel(cluster_level.upper())
-        if self._root_log_handler is not None:
-            self._root_log_handler.setLevel(self._ceph_log_level_to_python(mgr_level))
+        # set before the early returns below so a debug_mgr change applies
+        # even when the module level is unchanged
+        root_handler = self._mgr_root_handler()
+        if root_handler is not None:
+            root_handler.setLevel(self._ceph_log_level_to_python(mgr_level))
 
         module_level = module_level.upper() if module_level else ''
         if not self._module_level:

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -712,9 +712,23 @@ class MgrRootHandler(logging.Handler):
             "[mgr %(levelname)-4s %(name)s] %(message)s"
         ))
 
+    @staticmethod
+    def _ceph_log_level(levelno: int) -> int:
+        # inverse of _ceph_log_level_to_python.  INFO -> 2 keeps it in the
+        # log file at the default debug_mgr=2/5; DEBUG -> 20 keeps floods
+        # out unless raised, e.g. 2/20 for in-memory capture only.
+        if levelno >= logging.ERROR:
+            return 0
+        if levelno >= logging.WARNING:
+            return 1
+        if levelno >= logging.INFO:
+            return 2
+        return 20
+
     def emit(self, record: logging.LogRecord) -> None:
         if record.levelno >= self.level:
-            ceph_module.mgr_log(self.format(record))
+            ceph_module.mgr_log(self._ceph_log_level(record.levelno),
+                                self.format(record))
 
 
 class ClusterLogHandler(logging.Handler):
@@ -807,6 +821,25 @@ class MgrModuleLoggingMixin(object):
         return next((h for h in root.handlers
                      if isinstance(h, MgrRootHandler)), None)
 
+    @staticmethod
+    def _debug_mgr_gather_to_python(log_level: str) -> str:
+        # records are emitted at their own mapped levels, so forward
+        # everything the C++ side could gather: gate on the higher of the
+        # two debug_mgr levels, not just the file level
+        gather = 0
+        if log_level:
+            try:
+                gather = max(int(level) for level in log_level.split("/", 1))
+            except ValueError:
+                pass
+        if gather >= 20:
+            return "DEBUG"
+        if gather >= 2:
+            return "INFO"
+        if gather >= 1:
+            return "WARNING"
+        return "ERROR"
+
     def _set_log_level(self,
                        mgr_level: str,
                        module_level: str,
@@ -816,7 +849,7 @@ class MgrModuleLoggingMixin(object):
         # even when the module level is unchanged
         root_handler = self._mgr_root_handler()
         if root_handler is not None:
-            root_handler.setLevel(self._ceph_log_level_to_python(mgr_level))
+            root_handler.setLevel(self._debug_mgr_gather_to_python(mgr_level))
 
         module_level = module_level.upper() if module_level else ''
         if not self._module_level:


### PR DESCRIPTION
`ceph_module.mgr_log()` emitted every record at `dout(0)`: a record either passed the Python-side gate and went unconditionally to both the log file and the in-memory recent buffer, or never reached the C++ log at
all.  The two-level debug_mgr semantics (file level / memory level) never applied, so capturing third-party `DEBUG` logs meant sending each record to the log file and a log_max_recent slot; with the kubernetes client logging multi-megabyte HTTP response bodies at DEBUG, the recent buffer alone could grow to tens of gigabytes.

Pass the record's level through `mgr_log()` and emit at the mapped ceph level: 

- `CRITICAL`/`ERROR` at 0, 
- `WARNING` at 1, 
- `INFO` at 2, 
- `DEBUG` at 20. I

so it stays visible in the log file at the default `debug_mgr=2/5`; DEBUG maps to 20 so floods are dropped there, while debug_mgr=2/20 captures third-party DEBUG in the in-memory buffer without touching the log file.  The Python-side gate follows the higher of the two debug_mgr levels so memory-only records still reach the C++ side.

Fixes: https://tracker.ceph.com/issues/77633


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
