### PR TITLE
mon: allow CRUSH reweight for down OSDs

### DIFF
--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -1038,6 +1038,25 @@ options:
   services:
   - mon
   with_legacy: true
+- name: mon_osd_down_out_action
+  type: str
+  level: advanced
+  desc: action to take when an OSD has been down longer than mon_osd_down_out_interval
+  long_desc: If set to ``mark_out``, Ceph will mark the OSD out by setting its
+    OSDMap override weight to zero. If set to ``crush_reweight_zero``, Ceph will
+    instead set the OSD's CRUSH weight to zero, which also updates the containing
+    CRUSH bucket weights. The latter action changes the CRUSH map and does not
+    automatically restore the previous CRUSH weight when the OSD returns.
+  default: mark_out
+  enum_values:
+  - mark_out
+  - crush_reweight_zero
+  services:
+  - mon
+  see_also:
+  - mon_osd_down_out_interval
+  - osd_crush_update_weight_set
+  with_legacy: true
 - name: mon_osd_down_out_subtree_limit
   type: str
   level: advanced

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -1038,6 +1038,12 @@ options:
   services:
   - mon
   with_legacy: true
+- name: mon_crush_reweight_zero_on_down_out
+  type: bool
+  level: advanced
+  desc: also reweight OSDs crush weight to zero if they are down_out
+  default: false
+  with_legacy: true
 - name: mon_osd_down_out_subtree_limit
   type: str
   level: advanced

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5368,24 +5368,73 @@ void OSDMonitor::tick()
         // complexity for now.
           down.sec() >= g_conf()->mon_osd_destroyed_out_interval;
         if (down_out || destroyed_out) {
-	  dout(10) << "tick marking osd." << o << " OUT after " << down
-		   << " sec (target " << grace << " = " << orig_grace << " + " << my_grace << ")" << dendl;
-	  pending_inc.new_weight[o] = CEPH_OSD_OUT;
+	  auto down_out_action = g_conf().get_val<string>(
+	    "mon_osd_down_out_action");
+	  bool crush_reweight_zero =
+	    down_out && !destroyed_out &&
+	    down_out_action == "crush_reweight_zero";
+	  bool mark_out = !crush_reweight_zero;
 
-	  // set the AUTOOUT bit.
-	  if (pending_inc.new_state.count(o) == 0)
-	    pending_inc.new_state[o] = 0;
-	  pending_inc.new_state[o] |= CEPH_OSD_AUTOOUT;
+	  if (crush_reweight_zero) {
+	    CrushWrapper newcrush = _get_pending_crush();
+	    int old_weight = newcrush.get_item_weight(o);
+	    if (old_weight < 0) {
+	      derr << "failed to get CRUSH weight for osd." << o
+		   << " after " << down << " sec: "
+		   << cpp_strerror(old_weight)
+		   << "; falling back to marking out" << dendl;
+	      mark_out = true;
+	    } else if (old_weight > 0) {
+	      int r = newcrush.adjust_item_weightf(
+		cct, o, 0.0, g_conf()->osd_crush_update_weight_set);
+	      if (r < 0) {
+		derr << "failed to CRUSH reweight osd." << o
+		     << " to 0 after " << down << " sec: "
+		     << cpp_strerror(r) << dendl;
+		continue;
+	      }
+	      pending_inc.crush.clear();
+	      newcrush.encode(pending_inc.crush, mon.get_quorum_con_features());
+	      do_propose = true;
 
-	  // remember previous weight
-	  if (pending_inc.new_xinfo.count(o) == 0)
-	    pending_inc.new_xinfo[o] = osdmap.osd_xinfo[o];
-	  pending_inc.new_xinfo[o].old_weight = osdmap.osd_weight[o];
+	      mon.clog->info() << "CRUSH reweighting osd." << o
+				<< " to 0 (has been down for "
+				<< int(down.sec()) << " seconds)";
+	    } else {
+	      dout(10) << "tick osd." << o
+		       << " already has CRUSH weight 0 after " << down
+		       << " sec" << dendl;
+	    }
+	  }
 
-	  do_propose = true;
+	  if (mark_out) {
+	    if (down_out_action != "mark_out" &&
+		down_out_action != "crush_reweight_zero") {
+	      dout(1) << "invalid mon_osd_down_out_action '"
+		      << down_out_action << "', falling back to mark_out"
+		      << dendl;
+	    }
+	    dout(10) << "tick marking osd." << o << " OUT after " << down
+		     << " sec (target " << grace << " = " << orig_grace
+		     << " + " << my_grace << ")" << dendl;
+	    pending_inc.new_weight[o] = CEPH_OSD_OUT;
 
-	  mon.clog->info() << "Marking osd." << o << " out (has been down for "
-                            << int(down.sec()) << " seconds)";
+	    // set the AUTOOUT bit.
+	    if (pending_inc.new_state.count(o) == 0)
+	      pending_inc.new_state[o] = 0;
+	    pending_inc.new_state[o] |= CEPH_OSD_AUTOOUT;
+
+	    // remember previous weight
+	    if (pending_inc.new_xinfo.count(o) == 0)
+	      pending_inc.new_xinfo[o] = osdmap.osd_xinfo[o];
+	    pending_inc.new_xinfo[o].old_weight = osdmap.osd_weight[o];
+
+	    do_propose = true;
+
+	    mon.clog->info() << "Marking osd." << o
+			      << " out (has been down for "
+			      << int(down.sec()) << " seconds)";
+	  }
 	} else
 	  continue;
       }

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5371,23 +5371,59 @@ void OSDMonitor::tick()
         // complexity for now.
           down.sec() >= g_conf()->mon_osd_destroyed_out_interval;
         if (down_out || destroyed_out) {
-	  dout(10) << "tick marking osd." << o << " OUT after " << down
-		   << " sec (target " << grace << " = " << orig_grace << " + " << my_grace << ")" << dendl;
-	  pending_inc.new_weight[o] = CEPH_OSD_OUT;
+	  auto crush_reweight_zero = (g_conf().get_val<bool>(
+	    "mon_crush_reweight_zero_on_down_out") && !destroyed_out);
 
-	  // set the AUTOOUT bit.
-	  if (pending_inc.new_state.count(o) == 0)
-	    pending_inc.new_state[o] = 0;
-	  pending_inc.new_state[o] |= CEPH_OSD_AUTOOUT;
+	  if (crush_reweight_zero) {
+	    CrushWrapper newcrush = _get_pending_crush();
+	    int old_weight = newcrush.get_item_weight(o);
+	    if (old_weight < 0) {
+	      derr << "failed to get CRUSH weight for osd." << o
+		   << " after " << down << " sec: "
+		   << cpp_strerror(old_weight)
+		   << "; falling back to marking out" << dendl;
+	    } else if (old_weight > 0) {
+	      int r = newcrush.adjust_item_weightf(
+		cct, o, 0.0, g_conf()->osd_crush_update_weight_set);
+	      if (r < 0) {
+		derr << "failed to CRUSH reweight osd." << o
+		     << " to 0 after " << down << " sec: "
+		     << cpp_strerror(r) << dendl;
+		continue;
+	      }
+	      pending_inc.crush.clear();
+	      newcrush.encode(pending_inc.crush, mon.get_quorum_con_features());
+	      do_propose = true;
 
-	  // remember previous weight
-	  if (pending_inc.new_xinfo.count(o) == 0)
-	    pending_inc.new_xinfo[o] = osdmap.osd_xinfo[o];
-	  pending_inc.new_xinfo[o].old_weight = osdmap.osd_weight[o];
+	      mon.clog->info() << "CRUSH reweighting osd." << o
+				<< " to 0 (has been down for "
+				<< int(down.sec()) << " seconds)";
+	    } else {
+	      dout(10) << "tick osd." << o
+		       << " already has CRUSH weight 0 after " << down
+		       << " sec" << dendl;
+	    }
+	  }
 
-	  do_propose = true;
+          dout(10) << "tick marking osd." << o << " OUT after " << down
+                   << " sec (target " << grace << " = " << orig_grace
+                   << " + " << my_grace << ")" << dendl;
+          pending_inc.new_weight[o] = CEPH_OSD_OUT;
 
-	  mon.clog->info() << "Marking osd." << o << " out (has been down for "
+          // set the AUTOOUT bit.
+          if (pending_inc.new_state.count(o) == 0)
+            pending_inc.new_state[o] = 0;
+          pending_inc.new_state[o] |= CEPH_OSD_AUTOOUT;
+
+          // remember previous weight
+          if (pending_inc.new_xinfo.count(o) == 0)
+            pending_inc.new_xinfo[o] = osdmap.osd_xinfo[o];
+          pending_inc.new_xinfo[o].old_weight = osdmap.osd_weight[o];
+
+          do_propose = true;
+
+          mon.clog->info() << "Marking osd." << o
+                            << " out (has been down for "
                             << int(down.sec()) << " seconds)";
 	} else
 	  continue;


### PR DESCRIPTION
At present, when an OSD is down longer than mon_osd_down_out_interval, the cluster would "out" it. But this "out" only adjust its own override weight to 0, which is different from "crush reweight 0".

According to our online experiences, when an OSD is down longer than mon_osd_down_out_interval, it's probably broken and needs to be kicked out of the cluster, which means reweighting its crush weight to 0. So in our cases, the OSD is first "outted" and then crush-reweighted to 0, which leads to two rounds of data backfill as the two steps produce different weight distribution.

What's more, as "outting" an OSD only affects the override weight of the OSD, its data would only be scattered among the OSDs on the same host; in cases where the cluster's available space is relatively low, this may not be feasible, as the other OSDs on the same host may not have enough space to hold all the data of the "outted" OSD.

This commit gives user the option to do "crush reweight 0" directly on osd down out, which, on one hand, avoids a second round of backfill and, on the other, helps to scatter the "outted" OSD's data to more OSDs avoiding filling other OSDs on the same host.

Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
