### PR TITLE
osd/scrubber: send real reservation nonce in scrub grant

### DIFF
--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -902,7 +902,7 @@ sc::result ReplicaActive::react(const ReserverGranted& ev)
   // notify the primary
   auto grant_msg = make_message<MOSDScrubReserve>(
       spg_t(pg_id.pgid, m_pg->get_primary().shard), reservation.request_epoch,
-      MOSDScrubReserve::GRANT, m_pg->pg_whoami, pending_reservation_nonce);
+      MOSDScrubReserve::GRANT, m_pg->pg_whoami, reservation.nonce);
   m_pg->send_cluster_message(
       m_pg->get_primary().osd, grant_msg, reservation.request_epoch, false);
   return discard_event();


### PR DESCRIPTION
The GRANT was built after pending_reservation_nonce was zeroed, so it
always carried nonce 0, exempt from the primary's staleness check.
Send reservation.nonce instead.

Fixes: https://tracker.ceph.com/issues/78202

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests