### PR TITLE
osd/ECUtil: fix offset accumulation in slice_map

### DIFF
--- a/src/osd/ECUtil.cc
+++ b/src/osd/ECUtil.cc
@@ -810,14 +810,15 @@ shard_extent_map_t shard_extent_map_t::slice_map(
     extent_map iemap = emap.intersect(offset, length);
 
     if (!iemap.empty()) {
+      raw_shard_id_t raw_shard = sinfo->get_raw_shard(shard);
       slice.start_offset = min(slice.start_offset, iemap.get_start_off());
-      slice.end_offset = max(slice.start_offset, iemap.get_end_off());
-      slice.ro_start = min(slice.start_offset,
-                           calc_ro_offset(sinfo->get_raw_shard(shard),
-                                          iemap.get_start_off()));
-      slice.ro_end = min(slice.ro_end,
-                         calc_ro_end(sinfo->get_raw_shard(shard),
-                                     iemap.get_end_off()));
+      slice.end_offset = max(slice.end_offset, iemap.get_end_off());
+      if (raw_shard < sinfo->get_k()) {
+        slice.ro_start = min(slice.ro_start,
+                             calc_ro_offset(raw_shard, iemap.get_start_off()));
+        slice.ro_end = max(slice.ro_end,
+                           calc_ro_end(raw_shard, iemap.get_end_off()));
+      }
       slice.extent_maps.emplace(shard, iemap);
     }
   }

--- a/src/test/osd/TestECUtil.cc
+++ b/src/test/osd/TestECUtil.cc
@@ -24,6 +24,17 @@
 using namespace std;
 using namespace ECUtil;
 
+namespace {
+
+void verify_offset_cache(const shard_extent_map_t& sem)
+{
+  shard_extent_map_t cached = sem;
+  cached.compute_ro_range();
+  ASSERT_EQ(cached, sem);
+}
+
+} // anonymous namespace
+
 TEST(ECUtil, stripe_info_t)
 {
   const uint64_t swidth = 4096;
@@ -1051,28 +1062,31 @@ TEST(ECUtil, slice)
   {
     auto slice_map = sem.slice_map(512, 1024);
     ASSERT_EQ(4, slice_map.get_extent_maps().size());
-    ASSERT_EQ(512, slice_map.get_start_offset());
-    ASSERT_EQ(512+1024, slice_map.get_end_offset());
+    verify_offset_cache(slice_map);
+  }
 
-    for (int i=1; i<5; i++) {
-      ASSERT_EQ(512, slice_map.get_extent_map(shard_id_t(i)).get_start_off());
-      ASSERT_EQ(512+1024, slice_map.get_extent_map(shard_id_t(i)).get_end_off());
-    }
+  {
+    shard_extent_map_t single(&sinfo);
+    single.insert_in_shard(shard_id_t(1), 512, bl1k);
+
+    auto slice_map = single.slice_map(512, 1024);
+    ASSERT_EQ(1, slice_map.get_extent_maps().size());
+    verify_offset_cache(slice_map);
+  }
+
+  {
+    shard_extent_map_t single(&sinfo);
+    single.insert_in_shard(shard_id_t(1), 512, bl1k);
+
+    auto slice_map = single.slice_map(0, 4096);
+    ASSERT_EQ(1, slice_map.get_extent_maps().size());
+    verify_offset_cache(slice_map);
   }
 
   {
     auto slice_map = sem.slice_map(0, 4096);
     ASSERT_EQ(4, slice_map.get_extent_maps().size());
-    ASSERT_EQ(5, slice_map.get_start_offset());
-    ASSERT_EQ(4096, slice_map.get_end_offset());
-    ASSERT_EQ(512, slice_map.get_extent_map(shard_id_t(1)).get_start_off());
-    ASSERT_EQ(512 + 1024, slice_map.get_extent_map(shard_id_t(1)).get_end_off());
-    ASSERT_EQ(5, slice_map.get_extent_map(shard_id_t(2)).get_start_off());
-    ASSERT_EQ(4096, slice_map.get_extent_map(shard_id_t(2)).get_end_off());
-    ASSERT_EQ(256, slice_map.get_extent_map(shard_id_t(3)).get_start_off());
-    ASSERT_EQ(4096, slice_map.get_extent_map(shard_id_t(3)).get_end_off());
-    ASSERT_EQ(5, slice_map.get_extent_map(shard_id_t(4)).get_start_off());
-    ASSERT_EQ(4096, slice_map.get_extent_map(shard_id_t(4)).get_end_off());
+    verify_offset_cache(slice_map);
   }
 
   {


### PR DESCRIPTION
slice_map() accumulated the slice bounds with the wrong operands:
end_offset took max() against start_offset instead of the previous
end_offset, ro_start took min() against start_offset instead of
ro_start, and ro_end used min() instead of max()

Introduced by 9e2841ab167 ("osd: Introduce optimized EC").

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests