### PR TITLE
osd: guard max_element end() deref in get_health_metrics

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8046,7 +8046,8 @@ vector<DaemonHealthMetric> OSD::get_health_metrics()
                                  [](std::pair<uint64_t, int> p1, std::pair<uint64_t, int> p2) {
                                    return p1.second < p2.second;
                                  });
-          if (osdmap->get_pools().find(slow_pool_it->first) != osdmap->get_pools().end()) {
+          if (slow_pool_it != slow_op_pools.end() &&
+              osdmap->get_pools().find(slow_pool_it->first) != osdmap->get_pools().end()) {
             string pool_name = osdmap->get_pool_name(slow_pool_it->first);
             ss << "] most affected pool [ '"
                << pool_name


### PR DESCRIPTION
`slow_op_pools` can be empty (all poolids 0/out-of-range) while
`slow_op_types` is not, making `max_element` return `end()`;
dereferencing it is UB.

Fixes: https://tracker.ceph.com/issues/78184

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests