### PR TITLE
mgr/dashboard: add dashboard review skill and standards

### DIFF
--- a/src/pybind/mgr/dashboard/skills/BOB-SKILL.md
+++ b/src/pybind/mgr/dashboard/skills/BOB-SKILL.md
@@ -1,0 +1,228 @@
+---
+name: dashboard-review
+description: "Review Ceph Manager Dashboard code (frontend and backend) against team standards: shared Angular components, Carbon/CDS patterns, minimal local SCSS, controller/service separation, OpenAPI docs, and test coverage. Use when the user invokes /dashboard-review, asks for a dashboard code review, or wants merge-readiness feedback on dashboard PRs."
+disable-model-invocation: true
+---
+
+# Dashboard Review
+
+Bob review-only skill for [`src/pybind/mgr/dashboard/`](src/pybind/mgr/dashboard/). Do not edit files unless the user explicitly asks to fix findings.
+
+## Purpose
+
+Use this skill to review dashboard changes for:
+- correctness and regressions
+- frontend pattern compliance
+- backend controller/service separation
+- API contract and OpenAPI coverage
+- test coverage, i18n, and accessibility
+
+Primary standards reference: [`src/pybind/mgr/dashboard/STANDARDS.md`](src/pybind/mgr/dashboard/STANDARDS.md)
+
+## Bob operating rules
+
+- Stay in review mode. Do not modify code, tests, docs, or configuration unless the user explicitly asks for fixes.
+- Use Bob tools step by step and wait for confirmation after each tool call.
+- Prefer read-only inspection tools first:
+  - `obtain_git_diff`
+  - `read_file`
+  - `search_files`
+  - `list_code_definition_names`
+- Use `ask_followup_question` only if scope cannot be inferred.
+- Use `submit_review_findings` for concrete issues that should appear in the Bob findings panel.
+- After submitting findings, provide a concise human-readable summary with `attempt_completion`.
+- Flag issues in changed code only, unless the change extends or reinforces a legacy anti-pattern.
+
+## Recommended mode
+
+Use this skill from Ask or Advanced mode when the user wants review feedback without edits.
+
+## Scope selection workflow
+
+Determine scope in this order:
+
+1. If the user names specific files, review only those files and directly related companions.
+2. If the user references a branch, PR, or comparison target, use `obtain_git_diff` against that branch and limit attention to [`src/pybind/mgr/dashboard/`](src/pybind/mgr/dashboard/).
+3. If no explicit scope is given, review current dashboard changes using `obtain_git_diff` for local changes.
+4. If scope is still ambiguous, ask one focused follow-up question. Otherwise default to all dashboard changes in the current work.
+
+## Context gathering workflow
+
+After scope is known:
+
+1. Inspect the diff with `obtain_git_diff`.
+2. Read changed dashboard files with `read_file`.
+3. Read directly related companion files when needed, such as:
+   - frontend specs: `*.spec.ts`
+   - backend tests: `tests/test_*.py`
+   - Cypress coverage for affected user flows
+   - shared API services under `frontend/src/app/shared/api/`
+   - Angular routing/module files if declarations or navigation changed
+   - [`src/pybind/mgr/dashboard/openapi.yaml`](src/pybind/mgr/dashboard/openapi.yaml) when public API controllers change
+4. Use `search_files` or `list_code_definition_names` to compare nearby established patterns when the correct dashboard pattern is unclear.
+5. Do not broaden into unrelated legacy cleanup.
+
+## Optional verification workflow
+
+Run verification commands only if the user asks for them or if the review explicitly needs command evidence.
+
+Preferred commands:
+```bash
+cd src/pybind/mgr/dashboard/frontend && npm run lint && npm run test:ci
+cd src/pybind/mgr/dashboard && tox -e lint,py3
+cd src/pybind/mgr/dashboard && tox -e openapi-check
+```
+
+Rules:
+- Use `execute_command` one command at a time.
+- Report command failures as findings.
+- Do not fix failures unless the user asks for implementation help.
+
+## Review checklist
+
+Apply all relevant rules from [`src/pybind/mgr/dashboard/STANDARDS.md`](src/pybind/mgr/dashboard/STANDARDS.md).
+
+### Frontend checks
+
+- Shared components are used where applicable:
+  - `cd-table`
+  - `cd-table-actions`
+  - `cd-table-key-value`
+  - `cd-tearsheet`
+  - `cd-page-header`
+  - `cds-modal` via `ModalCdsService`
+- No bespoke data tables, custom modal patterns, or direct `HttpClient` inside feature components.
+- New UI follows Carbon/CDS patterns and utilities.
+- New local SCSS is avoided unless justified by a comment explaining the Carbon limitation.
+- Mutations use `TaskWrapperService.wrapTaskAroundCall()`.
+- HTTP access lives in shared API services extending `ApiClient`.
+- Forms use `CdFormGroup`, `CdValidators`, and matching `FormField.key` values.
+- New user-visible strings use `$localize` or HTML i18n attributes.
+- New actions use `ActionLabelsI18n` where applicable.
+- Accessibility is covered for new UI, including translated aria/title attributes where needed.
+- Tests match the change type:
+  - service/util/validator logic -> Jest spec
+  - forms/wizards/conditional UI -> component spec
+  - user flows -> Cypress where the area already has e2e coverage
+  - bug fixes -> regression coverage
+
+### Backend checks
+
+- Controllers remain thin and delegate business logic to services.
+- Controllers do not contain substantial Ceph/orchestrator logic, heavy transformation, or raw exception handling.
+- Router type is correct:
+  - `@APIRouter` for public REST
+  - `@UIRouter` for UI helpers
+  - `@Router` only when appropriate
+- Permissions are present and correct for each endpoint.
+- Async HTTP 202 operations use `@Task(...)`.
+- Public API endpoints include `@APIDoc` and `@EndpointDoc(...)`.
+- Public API changes are reflected in [`src/pybind/mgr/dashboard/openapi.yaml`](src/pybind/mgr/dashboard/openapi.yaml).
+- Errors use `DashboardException` appropriately and avoid leaking internals.
+- Sensitive CRUD fields use `SecretStr` where applicable.
+- Tests match the change type:
+  - unit tests in `tests/test_*.py`
+  - OpenAPI coverage for public endpoints
+  - integration coverage in `qa/tasks/mgr/dashboard/test_*.py` when relevant
+
+## Severity mapping
+
+Map issues using the standards severity guide in [`src/pybind/mgr/dashboard/STANDARDS.md`](src/pybind/mgr/dashboard/STANDARDS.md):
+
+- blocker
+  - missing permissions
+  - wrong router type
+  - missing `@EndpointDoc`
+  - bespoke table instead of `cd-table`
+  - direct `HttpClient` in feature component
+  - missing i18n on new strings
+  - business logic in controller
+- should-fix
+  - missing `TaskWrapperService`
+  - missing component/spec coverage for complex UI
+  - unjustified new SCSS
+- suggestion
+  - better reuse of shared dashboard patterns
+- nit
+  - naming or local consistency issues
+
+## Legacy debt guardrail
+
+Do not flag pre-existing legacy debt unless the current change introduces a new instance or expands the anti-pattern.
+
+Examples that should not be flagged unless newly introduced by the change:
+- existing `NgbModal` or legacy `cd-modal` in untouched files
+- unmodified component SCSS
+- existing Formly Bootstrap `form-control`
+- older docs terminology that says `@ApiController`
+
+## Findings workflow
+
+When you identify actionable issues:
+
+1. Submit formal findings with `submit_review_findings`.
+2. Include:
+   - category
+   - severity
+   - concise title
+   - clear explanation tied to dashboard standards
+   - file path and exact line
+   - suggested fix when possible
+3. Submit only findings you can support from the inspected diff and file context.
+4. If there are no actionable issues, do not submit empty findings.
+
+## Final response format
+
+After reviewing, provide a concise markdown summary in this structure:
+
+```markdown
+# Dashboard Review
+
+**Scope:** [files / branch / local diff]
+**Verdict:** ready | ready-with-nits | needs-changes
+
+## Summary
+[1-3 sentences]
+
+## Blockers
+| File | Issue | Fix |
+|------|-------|-----|
+
+## Should fix
+| File | Issue | Fix |
+|------|-------|-----|
+
+## Suggestions
+- ...
+
+## Nits
+- ...
+
+## Pre-merge checklist
+- [ ] Shared components used
+- [ ] Carbon/CDS patterns followed
+- [ ] No unjustified local SCSS
+- [ ] Shared API services used; mutations wrapped with TaskWrapperService
+- [ ] i18n and accessibility covered for new UI
+- [ ] Backend logic stays in services
+- [ ] Permissions and router type are correct
+- [ ] `@EndpointDoc` and `openapi.yaml` updated if API changed
+- [ ] Tests added for new logic and user flows
+- [ ] Optional lint/test commands reviewed if run
+```
+
+Verdict rules:
+- `needs-changes`: one or more blockers
+- `ready-with-nits`: no blockers, but at least one should-fix, suggestion, or nit
+- `ready`: no blockers and no should-fix items
+
+## Invocation examples
+
+- `/dashboard-review`
+- `/dashboard-review @src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts`
+- `/dashboard-review compare against main`
+- `/dashboard-review include lint and test failures as findings`
+
+## Reference
+
+Full standards and component map: [`src/pybind/mgr/dashboard/STANDARDS.md`](src/pybind/mgr/dashboard/STANDARDS.md)

--- a/src/pybind/mgr/dashboard/skills/CURSOR-SKILL.md
+++ b/src/pybind/mgr/dashboard/skills/CURSOR-SKILL.md
@@ -1,0 +1,124 @@
+---
+name: dashboard-review
+description: >-
+  Review Ceph Manager Dashboard code (frontend and backend) against team standards:
+  shared Angular components, Carbon/CDS patterns, minimal local SCSS, controller/service
+  separation, OpenAPI docs, and test coverage. Use when the user invokes /dashboard-review,
+  asks for a dashboard code review, or wants merge-readiness feedback on dashboard PRs.
+disable-model-invocation: true
+---
+
+# Dashboard Review
+
+Review-only skill for `src/pybind/mgr/dashboard/`. **Do not edit files** unless the user explicitly asks to fix findings.
+
+## How to use
+
+1. **When:** after your feature works and before opening a PR (or after addressing review comments).
+2. **Mode:** use **Ask** so the agent reports findings without editing files.
+3. **Invoke:** type `/dashboard-review` in chat, optionally with scope:
+   - `/dashboard-review` — all dashboard changes on the current branch
+   - `/dashboard-review @path/to/file.ts` — specific files only
+4. **Run checks first** (optional but recommended); ask the skill to include failures as findings:
+   ```bash
+   cd src/pybind/mgr/dashboard/frontend && npm run lint && npm run test:ci
+   cd src/pybind/mgr/dashboard && tox -e lint,py3
+   ```
+5. **Act on output:** fix **Blockers** before requesting human review; re-run until verdict is `ready` or `ready-with-nits`.
+
+Full rules: [STANDARDS.md](STANDARDS.md)
+
+## Workflow
+
+1. **Determine scope**
+   - User-named files → review those
+   - Branch/PR → `git diff <base>...HEAD` limited to `src/pybind/mgr/dashboard/`
+   - Uncommitted → `git diff` + `git diff --cached` for dashboard paths
+   - If scope is unclear, ask once; default to all dashboard changes on the current branch
+
+2. **Gather context** (read-only)
+   - Changed `.ts`, `.html`, `.scss`, `.py` files
+   - Related specs: `*.spec.ts`, `tests/test_*.py`
+   - If API controllers changed: check `openapi.yaml` diff
+   - Skim surrounding unchanged files only when needed to compare patterns
+
+3. **Apply standards**
+   - Follow [STANDARDS.md](STANDARDS.md) for all rules and checklists
+   - Flag only issues in **changed code** unless the PR extends a legacy anti-pattern
+
+4. **Optional verification** (run only if user asks or scope is large)
+   ```bash
+   cd src/pybind/mgr/dashboard/frontend && npm run lint && npm run test:ci
+   cd src/pybind/mgr/dashboard && tox -e lint,py3
+   # API changes:
+   tox -e openapi-check
+   ```
+   Report command failures as findings; do not fix code unless asked.
+
+5. **Produce the review** using the output format below.
+
+## Output format
+
+```markdown
+# Dashboard Review
+
+**Scope:** [files / branch / commit range]
+**Verdict:** ready | ready-with-nits | needs-changes
+
+## Summary
+[1-3 sentences: overall quality and main blockers]
+
+## Blockers
+| File | Issue | Fix |
+|------|-------|-----|
+| ... | ... | Use `cd-table` / move logic to service / add `@EndpointDoc` / ... |
+
+## Should fix
+| File | Issue | Fix |
+|------|-------|-----|
+
+## Suggestions
+- ...
+
+## Nits
+- ...
+
+## Pre-merge checklist
+- [ ] Shared components used (cd-table, tearsheet, cds-modal, page-header)
+- [ ] Carbon/CDS; no unjustified local SCSS
+- [ ] API via shared/api services; mutations use TaskWrapperService
+- [ ] i18n on new user-visible strings
+- [ ] Backend logic in services; permissions + router type correct
+- [ ] @EndpointDoc + openapi.yaml if API changed
+- [ ] Tests for new logic (unit/component; e2e for user flows)
+- [ ] tox -e lint,py3 and npm lint/test:ci (if applicable)
+```
+
+**Severity mapping:** blocker → Blockers | should-fix → Should fix | suggestion → Suggestions | nit → Nits
+
+## Review focus (priority order)
+
+1. **Correctness & regressions** — logic bugs, missing error handling, permission gaps
+2. **Pattern compliance** — shared components, CDS, controller/service split
+3. **API contract** — `@EndpointDoc`, `openapi.yaml`, permissions, `@Task` for async ops
+4. **Tests** — missing coverage for new behavior
+5. **i18n & a11y** — untranslated strings, missing aria labels on new UI
+
+## Do not flag (legacy debt)
+
+Unless the PR **adds new** instances:
+
+- Existing `NgbModal` / `cd-modal` in untouched files
+- Unmodified component `.scss`
+- Formly `form-control` (Bootstrap) in existing formly types
+- Docs saying `@ApiController` (code uses `@APIRouter` / `@UIRouter`)
+
+## Invocation examples
+
+- `/dashboard-review` — review current branch dashboard changes
+- `/dashboard-review @path/to/component.ts` — review specific files
+- `/dashboard-review review only, no edits` — explicit read-only (default)
+
+## Reference
+
+Full rules, component map, and checklists: [STANDARDS.md](STANDARDS.md)

--- a/src/pybind/mgr/dashboard/skills/STANDARDS.md
+++ b/src/pybind/mgr/dashboard/skills/STANDARDS.md
@@ -1,0 +1,163 @@
+# Ceph Dashboard Review Standards
+
+Base path: `src/pybind/mgr/dashboard/`
+
+---
+
+## Frontend
+
+### Reuse shared components
+
+| Need | Use | Path |
+|------|-----|------|
+| Data list | `cd-table` + `cd-table-actions` | `shared/datatable/table/` |
+| Key/value details | `cd-table-key-value` | `shared/datatable/table-key-value/` |
+| Multi-step wizard | `cd-tearsheet` + `cd-tearsheet-step` | `shared/components/tearsheet/` |
+| Page header | `cd-page-header` | `shared/components/page-header/` |
+| Modals | `cds-modal` via `ModalCdsService` | `shared/services/modal-cds.service.ts` |
+| Delete/confirm | `DeleteConfirmationModalComponent`, `ConfirmationModalComponent` | `shared/components/*-modal/` |
+| Form footer | `cd-form-button-panel`, `cd-submit-button`, `cd-back-button` | `shared/components/` |
+| Icons | `cd-icon` + `Icons` enum | `shared/components/icon/`, `shared/enum/icons.enum.ts` |
+| Help | `cd-helper`, `cd-doc` | `shared/components/helper/`, `doc/` |
+
+**Block:** bespoke data `<table>`, custom modals, direct `HttpClient` in feature components, hand-rolled multi-step forms.
+
+### Carbon Design System (CDS) first
+
+- Use `carbon-components-angular`: `cds-modal`, `cds-text-label`, `cds-select`, `cds-checkbox`, `cds-combo-box`, `cds-tabs`, `cds-loading`, `cds-grid`
+- Use utility classes: `cds--type-heading-03`, `cds-mt-3`, `cds-mb-3`
+- Use tokens: `var(--cds-border-subtle-01)`, `var(--cds-text-secondary)`
+- New modals extend `BaseModal`; open via `ModalCdsService`
+
+**Block:** new `NgbModal` / legacy `cd-modal`, Bootstrap grid for new UI, inline `style=""`, Font Awesome instead of `cd-icon`.
+
+### CSS / SCSS
+
+**Default:** no new `.scss` rules.
+
+Priority: (1) Carbon APIs/utilities → (2) global `frontend/src/styles/vendor/_variables.scss` / `_style-overrides.scss` → (3) component SCSS only with a **comment explaining the Carbon limitation**.
+
+**Block:** SCSS for margins/padding/fonts Carbon already provides; hard-coded colors; duplicate shared-component styles.
+
+### API & state
+
+- HTTP in `shared/api/*` extending `ApiClient`
+- `@cdEncode` on services; `toStringEncoded()` for path params
+- `getVersionHeaderValue()` for versioned endpoints
+- Mutations: `TaskWrapperService.wrapTaskAroundCall()`
+- Lists: `ListWithDetails`, `CdTableColumn[]`, `CdTableAction[]`, permission-gated actions
+
+### Forms
+
+- `CdFormGroup`, `CdValidators` (not ad-hoc `Validators.pattern`)
+- `cd-form-button-panel` for footers
+- CRUD: `FormField.key` must match POST/PUT body keys
+
+### i18n
+
+- TS: `$localize\`...\``
+- HTML: `i18n`, `i18n-aria-label`, `i18n-title`
+- Action labels: `ActionLabelsI18n` from `shared/constants/app.constants.ts`
+- One translatable unit per `i18n` block
+
+### Frontend tests
+
+| Change | Test |
+|--------|------|
+| Utils, pipes, validators, services | Jest `*.spec.ts` |
+| Forms, wizards, conditional UI | Component spec |
+| User flow | Cypress e2e (if area has coverage) |
+| Bug fix | Regression test |
+
+---
+
+## Backend
+
+### Controller vs service
+
+**Controllers** (`controllers/`): routing, permissions, delegate to services, serialize, document.
+
+**Services** (`services/`): code that talks to Ceph or external daemons and
+returns dashboard-ready data. Includes:
+- Cluster commands (`CephService.send_command`, mgr maps)
+- Domain logic per feature (`rbd.py`, `cephfs.py`, `orchestrator.py`, …)
+- External API clients (`rgw_client.py`, `nvmeof_client.py`, …)
+- Error wrapping (`DashboardException`, `handle_*_error` context managers)
+Controllers call services; they do not contain multi-step Ceph logic,
+data transformation, or raw rados/rbd exception handling.
+
+**Block:** substantial Ceph/orchestrator logic in controllers.
+
+References:
+- `controllers/auth.py` — thin REST controller; delegates to `services/auth.py`; `@EndpointDoc` + OpenAPI schemas
+- `controllers/rbd.py` — REST + `RbdService`; `handle_*_error` decorators; `@UIRouter` UI companion (`RbdStatus`)
+- `controllers/cephfs.py` — REST + `services/cephfs.py`; `@EndpointDoc` schemas; `@UIRouter` UI helpers
+
+### Routing & permissions
+
+| Decorator | URL | Use |
+|-----------|-----|-----|
+| `@APIRouter('/path', Scope.X)` | `/api/...` | Public REST |
+| `@UIRouter('/path', Scope.X)` | `/ui-api/...` | UI-only helpers |
+| `@Router('/path')` | root | Internal |
+
+**Require:** `Scope`, `@ReadPermission` / `@CreatePermission` / `@UpdatePermission` / `@DeletePermission`, `@Task(...)` for HTTP 202 ops.
+
+### OpenAPI
+
+On `@APIRouter` endpoints:
+
+- `@APIDoc("Description", "Tag")` on class
+- `@EndpointDoc("Summary", parameters={...}, responses={...})` on methods
+
+```python
+"pool_name": (str, "pool name"),
+"options": ({"k": (int, "chunks")}, "options dict"),
+```
+
+**Block:** new/changed public endpoints without docs; API change without `openapi.yaml` update (`tox -e openapi-fix` then `openapi-check`).
+
+### Errors
+
+- `DashboardException` with correct HTTP codes
+- `SecretStr` for sensitive CRUD fields
+- No bare exceptions leaking internals
+
+### Backend tests
+
+| Change | Test |
+|--------|------|
+| Logic | `tests/test_*.py` (`tox -e py3`) |
+| Public endpoint | Unit test + OpenAPI |
+| Cluster integration | `qa/tasks/mgr/dashboard/test_*.py` |
+
+---
+
+## Severity guide
+
+| Level | Examples |
+|-------|----------|
+| **blocker** | Missing permissions, wrong router, no `@EndpointDoc`, bespoke table vs `cd-table`, direct `HttpClient`, missing i18n, logic in controller |
+| **should-fix** | No `TaskWrapperService`, no component test for complex form, SCSS without justification |
+| **suggestion** | Could use `cd-table-key-value`, extract to shared component |
+| **nit** | Naming, consistency with nearby legacy code |
+
+---
+
+## Key paths
+
+```
+frontend/src/app/shared/components/   # reusable UI
+frontend/src/app/shared/datatable/    # cd-table, crud-table
+frontend/src/app/shared/forms/        # CdValidators, crud-form
+frontend/src/app/shared/api/          # HTTP services
+controllers/                          # HTTP layer
+controllers/auth.py                   # thin controller + service delegation
+controllers/rbd.py                    # REST + domain service + UI router
+controllers/cephfs.py                 # REST + cephfs service + UI helpers
+controllers/rgw.py                    # external clients + CRUD endpoints
+services/                             # business logic
+tests/                                # Python unit tests
+qa/tasks/mgr/dashboard/               # API integration tests
+openapi.yaml                          # generated API spec
+```


### PR DESCRIPTION
To make these work:

For Cursor
```
Add CURSOR-SKILL.md as SKILL.md and STANDARDS.md  to `.cursor/skills/dashboard-review/`
 ```

For Bob
```
Add BOB-SKILL.md as SKILL.md and STANDARDS.md to `.bob/skills/dashboard-review/`
```

Add new `skills` folder for BOB-SKILL.md, CURSOR-SKILL.md and STANDARDS.md for local pre-PR review of dashboard frontend and backend changes against shared patterns, CDS, controller/service separation, and OpenAPI documentation.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
