### PR TITLE
qa: Skip error inject tests when external error inject is happening

### DIFF
--- a/qa/suites/powercycle/osd/tasks/rados_api_tests.yaml
+++ b/qa/suites/powercycle/osd/tasks/rados_api_tests.yaml
@@ -15,4 +15,4 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rados/test.sh
+        - rados/test.sh --external-error-inject

--- a/qa/suites/rados/monthrash/workloads/rados_api_tests.yaml
+++ b/qa/suites/rados/monthrash/workloads/rados_api_tests.yaml
@@ -25,4 +25,4 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rados/test.sh unit_test_scan
+        - rados/test.sh --external-error-inject unit_test_scan

--- a/qa/suites/rados/thrash/workloads/rados_api_tests.yaml
+++ b/qa/suites/rados/thrash/workloads/rados_api_tests.yaml
@@ -26,4 +26,4 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rados/test.sh
+        - rados/test.sh --external-error-inject

--- a/qa/suites/rados/verify/tasks/rados_api_tests.yaml
+++ b/qa/suites/rados/verify/tasks/rados_api_tests.yaml
@@ -36,4 +36,4 @@ tasks:
       ALLOW_TIMEOUTS: "1"
     clients:
       client.0:
-        - rados/test.sh
+        - rados/test.sh --external-error-inject

--- a/qa/suites/smoke/basic/tasks/test/mon_thrash.yaml
+++ b/qa/suites/smoke/basic/tasks/test/mon_thrash.yaml
@@ -36,4 +36,4 @@ tasks:
 - workunit:
     clients:
       client.0:
-      - rados/test.sh
+      - rados/test.sh --external-error-inject

--- a/qa/suites/smoke/basic/tasks/test/rados_api_tests.yaml
+++ b/qa/suites/smoke/basic/tasks/test/rados_api_tests.yaml
@@ -29,4 +29,4 @@ tasks:
 - workunit:
     clients:
       client.0:
-      - rados/test.sh
+      - rados/test.sh --external-error-inject

--- a/qa/workunits/rados/test.sh
+++ b/qa/workunits/rados/test.sh
@@ -36,17 +36,19 @@ VALGRIND_TESTS=(
 # Note on argument ordering: This script processes arguments sequentially,
 # so the order matters. Arguments must be provided in this specific sequence:
 # 1. --serial OR --crimson (optional)
-# 2. --timeout VALUE (optional) (for each test)
-# 3. --vstart (optional)
+# 2. --external-error-inject (optional)
+# 3. --timeout VALUE (optional) (for each test)
+# 4. --vstart (optional)
 #
 # For example:
-# ./test.sh                               # Default: parallel mode, 90-min timeout for each test
-# ./test.sh --serial                      # Serial mode, 90-min timeout for each test
-# ./test.sh --crimson                     # Crimson mode, 90-min timeout for each test
-# ./test.sh --timeout 3600                # Parallel mode, 60-min timeout for each test
-# ./test.sh --serial --timeout 60         # Serial mode, 1-min timeout for each test
-# ./test.sh --crimson --timeout 0         # Crimson mode, no timeout for each test
-# ../qa/workunits/rados/test.sh --vstart  # Run tests locally from `ceph/build` dir
+# ./test.sh                                        # Default: parallel mode, 90-min timeout for each test
+# ./test.sh --serial                               # Serial mode, 90-min timeout for each test
+# ./test.sh --crimson                              # Crimson mode, 90-min timeout for each test
+# ./test.sh --external-error-inject                # Skip all *DoesErrorInject* tests
+# ./test.sh --timeout 3600                         # Parallel mode, 60-min timeout for each test
+# ./test.sh --serial --timeout 60                  # Serial mode, 1-min timeout for each test
+# ./test.sh --crimson --timeout 0                  # Crimson mode, no timeout for each test
+# ../qa/workunits/rados/test.sh --vstart           # Run tests locally from `ceph/build` dir
 
 # First argument must be either --serial or --crimson or nothing
 parallel=1
@@ -57,6 +59,15 @@ if [ "$1" = "--serial" ]; then
 elif [ "$1" = "--crimson" ]; then
     parallel=0
     crimson=1
+    shift
+fi
+
+# After processing the mode flag, check for --external-error-inject
+external_error_inject=0
+gtest_inject_filter=""
+if [ "$1" = "--external-error-inject" ]; then
+    external_error_inject=1
+    gtest_inject_filter="--gtest_filter=-*DoesErrorInject*"
     shift
 fi
 
@@ -127,14 +138,14 @@ do
     if [ $parallel -eq 1 ]; then
         r=`printf '%25s' $f`
         ff=`echo $f | awk '{print $1}'`
-        bash -o pipefail -exc "$executable --gtest_output=xml:$GTEST_OUTPUT_DIR/$f.xml $color 2>&1 | tee ceph_test_rados_$ff.log | sed \"s/^/$r: /\"" &
+        bash -o pipefail -exc "$executable --gtest_output=xml:$GTEST_OUTPUT_DIR/$f.xml $color $gtest_inject_filter 2>&1 | tee ceph_test_rados_$ff.log | sed \"s/^/$r: /\"" &
         pid=$!
         echo "test $f on pid $pid"
 	    pids[$f]=$pid
         test_type["$f"]="rados" # Store test type for later use in parallel mode
     else
         # If running in serial mode, run the test directly
-        if ! timeout $timeout $executable; then
+        if ! timeout $timeout $executable $gtest_inject_filter; then
             echo "ERROR: Test $f timed out after $timeout seconds"
             echo "Check the logs for failures in $f"
             ret=1
@@ -152,7 +163,7 @@ do
     if [ $parallel -eq 1 ]; then
         r=`printf '%25s' $f`
         ff=`echo $f | awk '{print $1}'`
-        bash -o pipefail -exc "$executable --gtest_output=xml:$GTEST_OUTPUT_DIR/neorados_$f.xml $color 2>&1 | tee ceph_test_neorados_$ff.log | sed \"s/^/$r: /\"" &
+        bash -o pipefail -exc "$executable --gtest_output=xml:$GTEST_OUTPUT_DIR/neorados_$f.xml $color $gtest_inject_filter 2>&1 | tee ceph_test_neorados_$ff.log | sed \"s/^/$r: /\"" &
         pid=$!
         echo "test $f on pid $pid"
         pids[$f]=$pid
@@ -165,7 +176,7 @@ do
             fi
         fi
         # If running in serial mode, run the test directly
-        if ! timeout $timeout $executable; then
+        if ! timeout $timeout $executable $gtest_inject_filter; then
             echo "ERROR: Test $f timed out after $timeout seconds"
             echo "Check the logs for failures in $f"
             ret=1
@@ -183,14 +194,14 @@ do
     if [ $parallel -eq 1 ]; then
         r=$(printf '%25s' "$f")
         ff=$(echo "$f" | awk '{print $1}')
-        bash -o pipefail -exc "valgrind $executable --error-exitcode=1 --track-origins=yes --leak-check=yes --log-file=valgrind_$ff.log" &
+        bash -o pipefail -exc "valgrind $executable --error-exitcode=1 --track-origins=yes --leak-check=yes --log-file=valgrind_$ff.log $gtest_inject_filter" &
         pid=$!
         echo "valgrind test $f on pid $pid"
         pids[$f]=$pid
         test_type["$f"]="valgrind" # Store test type for later use in parallel mode
     else
         # If running in serial mode, run the test directly
-        if ! timeout "$timeout" valgrind "$executable" --track-origins=yes --error-exitcode=1 --leak-check=yes; then
+        if ! timeout "$timeout" valgrind "$executable" --track-origins=yes --error-exitcode=1 --leak-check=yes $gtest_inject_filter; then
             echo "ERROR: Test $f timed out after $timeout seconds"
             echo "Check the logs for failures in $f"
             ret=1

--- a/qa/workunits/rados/test.sh
+++ b/qa/workunits/rados/test.sh
@@ -19,6 +19,7 @@ RADOS_TESTS=(
     api_c_write_operations
     api_c_read_operations
     api_omap_pp
+    api_split_op_pp
     list_parallel
     open_pools_parallel
     delete_pools_parallel
@@ -68,6 +69,7 @@ gtest_inject_filter=""
 if [ "$1" = "--external-error-inject" ]; then
     external_error_inject=1
     gtest_inject_filter="--gtest_filter=-*DoesErrorInject*"
+    export CEPH_TEST_EXTERNAL_ERROR_INJECT=1
     shift
 fi
 

--- a/src/test/librados/omap_cxx.cc
+++ b/src/test/librados/omap_cxx.cc
@@ -543,8 +543,7 @@ TEST_P(OmapTest, OmapPreservedAfterTruncateToZero) {
   }
 }
 
-
-TEST_P(OmapTest, OmapRecovery) {
+TEST_P(OmapTest, OmapRecoveryDoesErrorInject) {
   SKIP_IF_CRIMSON();
   turn_balancing_off();
   bufferlist bl_write, omap_val_bl, xattr_val_bl;
@@ -602,7 +601,7 @@ TEST_P(OmapTest, OmapRecovery) {
   turn_balancing_on();
 }
 
-TEST_P(OmapTest, NoOmapRecovery) {
+TEST_P(OmapTest, NoOmapRecoveryDoesErrorInject) {
   SKIP_IF_CRIMSON();
   turn_balancing_off();
   bufferlist bl_write;
@@ -650,7 +649,7 @@ TEST_P(OmapTest, NoOmapRecovery) {
   turn_balancing_on();
 }
 
-TEST_P(OmapTest, LargeOmapRecovery) {
+TEST_P(OmapTest, LargeOmapRecoveryDoesErrorInject) {
   SKIP_IF_CRIMSON();
   turn_balancing_off();
 
@@ -1735,7 +1734,7 @@ TEST_P(OmapTest, OmapCopyFromOverwritesTarget) {
   }
 }
 
-TEST_P(OmapTest, GenerationalObjectRecovery) {
+TEST_P(OmapTest, GenerationalObjectRecoveryDoesErrorInject) {
   SKIP_IF_CRIMSON();
   turn_balancing_off();
   

--- a/src/test/librados/split_op_cxx.cc
+++ b/src/test/librados/split_op_cxx.cc
@@ -1,5 +1,6 @@
 #include <common/perf_counters_collection.h>
 
+#include <fmt/format.h>
 #include "test/librados/test_cxx.h"
 #include "test/librados/testcase_cxx.h"
 #include "crimson_utils.h"
@@ -11,7 +12,18 @@ using namespace librados;
 using namespace cls;
 using namespace rados::cls;
 
-typedef RadosTestPP LibRadosSplitOpPP;
+class LibRadosSplitOpPP : public RadosTestPP {
+public:
+  static void SetUpTestCase() {
+    auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+    pool_name_default = get_temp_pool_name(pool_prefix);
+    std::map<std::string, std::string> config = {{"rados_replica_read_policy", "default"}};
+    ASSERT_EQ("", connect_cluster_pp(s_cluster, config));
+    ASSERT_EQ("", create_pool_pp(pool_name_default, s_cluster, 3));
+    s_cluster.wait_for_latest_osdmap();
+  }
+};
+
 typedef RadosTestECPP LibRadosSplitOpECPP;
 
 // After a write is committed, it isn't necessarily true that the log is

--- a/src/test/librados/test_cxx.cc
+++ b/src/test/librados/test_cxx.cc
@@ -123,22 +123,33 @@ std::string create_one_ec_pool_pp(const std::string &pool_name,
   return err;
 }
 
-std::string create_pool_pp(const std::string &pool_name, Rados &cluster) {
-  int ret = cluster.pool_create(pool_name.c_str());
-  if (ret) {
-    cluster.shutdown();
-    std::ostringstream oss;
-    oss << "cluster.pool_create(" << pool_name << ") failed with error " << ret;
-    return oss.str();
+std::string create_pool_pp(const std::string &pool_name, Rados &cluster, int size) {
+  std::ostringstream oss;
+  int ret;
+  if (size > 0) {
+    ret = cluster.mon_command(
+      "{\"prefix\": \"osd pool create\", \"pool\": \"" + pool_name +
+      "\", \"size\": " + std::to_string(size) + "}",
+      {}, NULL, NULL);
+    if (ret) {
+      oss << "mon_command osd pool create pool:" << pool_name
+          << " size:" << size << " failed with error " << ret;
+      return oss.str();
+    }
+  } else {
+    ret = cluster.pool_create(pool_name.c_str());
+    if (ret) {
+      cluster.shutdown();
+      oss << "cluster.pool_create(" << pool_name << ") failed with error " << ret;
+      return oss.str();
+    }
   }
 
   IoCtx ioctx;
   ret = cluster.ioctx_create(pool_name.c_str(), ioctx);
   if (ret < 0) {
     cluster.shutdown();
-    std::ostringstream oss;
-    oss << "cluster.ioctx_create(" << pool_name << ") failed with error "
-        << ret;
+    oss << "cluster.ioctx_create(" << pool_name << ") failed with error " << ret;
     return oss.str();
   }
   ioctx.application_enable("rados", true);

--- a/src/test/librados/test_cxx.h
+++ b/src/test/librados/test_cxx.h
@@ -20,7 +20,8 @@ std::string create_ec_pool_pp(
   librados::Rados &cluster,
   bool fast_ec = false);
 std::string create_pool_pp(const std::string &pool_name,
-                            librados::Rados &cluster);
+                            librados::Rados &cluster,
+                            int size = 0);
 std::string set_allow_ec_overwrites_pp(const std::string &pool_name,
 				       librados::Rados &cluster, bool allow);
 std::string connect_cluster_pp(librados::Rados &cluster);

--- a/src/test/librados/testcase_cxx.h
+++ b/src/test/librados/testcase_cxx.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstdlib>
 #include <string_view>
 
 #include "gtest/gtest.h"
@@ -94,7 +95,9 @@ protected:
   void ensure_log_committed(const char* oid, uint64_t offset, uint64_t length);
 
   template<typename... Args>
-  ::testing::AssertionResult AssertOperateSplitOp(int split_ios, int rc, Args... args)
+  ::testing::AssertionResult AssertOperateSplitOp(int split_ios, int rc,
+                                                  bool relax_split_check,
+                                                  Args... args)
   {
     auto split_op_stat =  "objecter.split_op_reads"sv;
     auto op_reply_stat =  "objecter.op_reply"sv;
@@ -106,6 +109,13 @@ protected:
     if (ret != rc) {
       return ::testing::AssertionFailure()
              << "ioctx.operate() Incorrect rc " << rc << " != " << ret;
+    }
+
+    // When external error injection is active, split-op counter deltas are
+    // non-deterministic (OSD retries skew the counts). Skip counter checks
+    // for AssertOperateWithSplitOp callers.
+    if (relax_split_check && std::getenv("CEPH_TEST_EXTERNAL_ERROR_INJECT")) {
+      return ::testing::AssertionSuccess();
     }
 
     int64_t actual_count = get_perf_counter_by_path(split_op_stat) - before_count;
@@ -136,15 +146,15 @@ protected:
 
   template<typename... Args>
   ::testing::AssertionResult AssertOperateWithSplitOp(int rc, Args... args) {
-    return AssertOperateSplitOp(1, rc, std::forward<Args>(args)...);
+    return AssertOperateSplitOp(1, rc, true, std::forward<Args>(args)...);
   }
   template<typename... Args>
   ::testing::AssertionResult AssertOperateWithSplitOp(int rc, int split_ios, Args... args) {
-    return AssertOperateSplitOp(split_ios, rc, std::forward<Args>(args)...);
+    return AssertOperateSplitOp(split_ios, rc, true, std::forward<Args>(args)...);
   }
   template<typename... Args>
   ::testing::AssertionResult AssertOperateWithoutSplitOp(int rc, Args... args) {
-    return AssertOperateSplitOp(0, rc, std::forward<Args>(args)...);
+    return AssertOperateSplitOp(0, rc, false, std::forward<Args>(args)...);
   }
 };
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/77808

The recovery tests in omap_cxx.cc change the upmap of a PG, in an attempt to trigger recovery. This does not work correctly when a test suite (such as smoke/basic) is applying error inject at the same time.

This PR uses the string "DoesErrorInject" to specify which rados API tests should be skipped when a test suite is applying external error inject.

This PR also relaxes the AssertOperatesWithSplitOp macro when external error inject is happening, as this may cause split ops to fail (expected behaviour).

Some split ops tests require a pool size >2, so this PR increases the pool size to 3 for this test suite.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
