### PR TITLE
test/store_test: fix wrong write size for some test cases.

### DIFF
--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -2671,12 +2671,11 @@ TEST_P(StoreTest, AppendDeferredVsTailCache) {
     r = store->queue_transaction(ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  unsigned min_alloc = g_conf()->bluestore_min_alloc_size;
+  unsigned min_alloc = 4096;
   unsigned size = min_alloc / 3;
-  bufferptr bpa(size);
-  memset(bpa.c_str(), 1, bpa.length());
   bufferlist bla;
-  bla.append(bpa);
+  bla.append(std::string(size, 'a'));
+
   {
     ObjectStore::Transaction t;
     t.write(cid, a, 0, bla.length(), bla, 0);
@@ -2693,21 +2692,19 @@ TEST_P(StoreTest, AppendDeferredVsTailCache) {
     ASSERT_EQ(0, r);
     ch = store->open_collection(cid);
   }
+  const PerfCounters* logger = store->get_perf_counters();
 
-  bufferptr bpb(size);
-  memset(bpb.c_str(), 2, bpb.length());
   bufferlist blb;
-  blb.append(bpb);
+  blb.append(std::string(size, 'b'));
+
   {
     ObjectStore::Transaction t;
     t.write(cid, a, bla.length(), blb.length(), blb, 0);
     r = store->queue_transaction(ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  bufferptr bpc(size);
-  memset(bpc.c_str(), 3, bpc.length());
   bufferlist blc;
-  blc.append(bpc);
+  blc.append(std::string(size, 'c'));
   {
     ObjectStore::Transaction t;
     t.write(cid, a, bla.length() + blb.length(), blc.length(), blc, 0);
@@ -2724,6 +2721,7 @@ TEST_P(StoreTest, AppendDeferredVsTailCache) {
 	      store->read(ch, a, 0, final.length(), actual));
     ASSERT_TRUE(bl_eq(final, actual));
   }
+  ASSERT_EQ(logger->get(l_bluestore_write_small), 3u);
   {
     ObjectStore::Transaction t;
     t.remove(cid, a);
@@ -2748,12 +2746,10 @@ TEST_P(StoreTest, AppendZeroTrailingSharedBlock) {
     r = store->queue_transaction(ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  unsigned min_alloc = g_conf()->bluestore_min_alloc_size;
+  unsigned min_alloc = 4096;
   unsigned size = min_alloc / 3;
-  bufferptr bpa(size);
-  memset(bpa.c_str(), 1, bpa.length());
   bufferlist bla;
-  bla.append(bpa);
+  bla.append(std::string(size, 'a'));
   // make sure there is some trailing gunk in the last block
   {
     bufferlist bt;
@@ -2780,10 +2776,8 @@ TEST_P(StoreTest, AppendZeroTrailingSharedBlock) {
   }
 
   // append with implicit zeroing
-  bufferptr bpb(size);
-  memset(bpb.c_str(), 2, bpb.length());
   bufferlist blb;
-  blb.append(bpb);
+  blb.append(std::string(size, 'b'));
   {
     ObjectStore::Transaction t;
     t.write(cid, a, min_alloc * 3, blb.length(), blb, 0);
@@ -2800,10 +2794,10 @@ TEST_P(StoreTest, AppendZeroTrailingSharedBlock) {
   {
     ASSERT_EQ((int)final.length(),
 	      store->read(ch, a, 0, final.length(), actual));
-    final.hexdump(cout);
-    actual.hexdump(cout);
     ASSERT_TRUE(bl_eq(final, actual));
   }
+  const PerfCounters* logger = store->get_perf_counters();
+  ASSERT_EQ(logger->get(l_bluestore_write_small), 2u);
   {
     ObjectStore::Transaction t;
     t.remove(cid, a);

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -2660,6 +2660,8 @@ TEST_P(StoreTest, SmallSkipFront) {
 }
 
 TEST_P(StoreTest, AppendDeferredVsTailCache) {
+  if(string(GetParam()) != "bluestore")
+    return;
   int r;
   coll_t cid;
   ghobject_t a(hobject_t(sobject_t("fooo", CEPH_NOSNAP)));
@@ -2671,12 +2673,11 @@ TEST_P(StoreTest, AppendDeferredVsTailCache) {
     r = store->queue_transaction(ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  unsigned min_alloc = g_conf()->bluestore_min_alloc_size;
+  unsigned min_alloc = 4096;
   unsigned size = min_alloc / 3;
-  bufferptr bpa(size);
-  memset(bpa.c_str(), 1, bpa.length());
   bufferlist bla;
-  bla.append(bpa);
+  bla.append(std::string(size, 'a'));
+
   {
     ObjectStore::Transaction t;
     t.write(cid, a, 0, bla.length(), bla, 0);
@@ -2693,21 +2694,19 @@ TEST_P(StoreTest, AppendDeferredVsTailCache) {
     ASSERT_EQ(0, r);
     ch = store->open_collection(cid);
   }
+  const PerfCounters* logger = store->get_perf_counters();
 
-  bufferptr bpb(size);
-  memset(bpb.c_str(), 2, bpb.length());
   bufferlist blb;
-  blb.append(bpb);
+  blb.append(std::string(size, 'b'));
+
   {
     ObjectStore::Transaction t;
     t.write(cid, a, bla.length(), blb.length(), blb, 0);
     r = store->queue_transaction(ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  bufferptr bpc(size);
-  memset(bpc.c_str(), 3, bpc.length());
   bufferlist blc;
-  blc.append(bpc);
+  blc.append(std::string(size, 'c'));
   {
     ObjectStore::Transaction t;
     t.write(cid, a, bla.length() + blb.length(), blc.length(), blc, 0);
@@ -2724,6 +2723,7 @@ TEST_P(StoreTest, AppendDeferredVsTailCache) {
 	      store->read(ch, a, 0, final.length(), actual));
     ASSERT_TRUE(bl_eq(final, actual));
   }
+  ASSERT_EQ(logger->get(l_bluestore_write_small), 3u);
   {
     ObjectStore::Transaction t;
     t.remove(cid, a);
@@ -2735,6 +2735,8 @@ TEST_P(StoreTest, AppendDeferredVsTailCache) {
 }
 
 TEST_P(StoreTest, AppendZeroTrailingSharedBlock) {
+  if(string(GetParam()) != "bluestore")
+    return;
   int r;
   coll_t cid;
   ghobject_t a(hobject_t(sobject_t("fooo", CEPH_NOSNAP)));
@@ -2748,12 +2750,10 @@ TEST_P(StoreTest, AppendZeroTrailingSharedBlock) {
     r = store->queue_transaction(ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  unsigned min_alloc = g_conf()->bluestore_min_alloc_size;
+  unsigned min_alloc = 4096;
   unsigned size = min_alloc / 3;
-  bufferptr bpa(size);
-  memset(bpa.c_str(), 1, bpa.length());
   bufferlist bla;
-  bla.append(bpa);
+  bla.append(std::string(size, 'a'));
   // make sure there is some trailing gunk in the last block
   {
     bufferlist bt;
@@ -2780,10 +2780,8 @@ TEST_P(StoreTest, AppendZeroTrailingSharedBlock) {
   }
 
   // append with implicit zeroing
-  bufferptr bpb(size);
-  memset(bpb.c_str(), 2, bpb.length());
   bufferlist blb;
-  blb.append(bpb);
+  blb.append(std::string(size, 'b'));
   {
     ObjectStore::Transaction t;
     t.write(cid, a, min_alloc * 3, blb.length(), blb, 0);
@@ -2800,10 +2798,10 @@ TEST_P(StoreTest, AppendZeroTrailingSharedBlock) {
   {
     ASSERT_EQ((int)final.length(),
 	      store->read(ch, a, 0, final.length(), actual));
-    final.hexdump(cout);
-    actual.hexdump(cout);
     ASSERT_TRUE(bl_eq(final, actual));
   }
+  const PerfCounters* logger = store->get_perf_counters();
+  ASSERT_EQ(logger->get(l_bluestore_write_small), 2u);
   {
     ObjectStore::Transaction t;
     t.remove(cid, a);


### PR DESCRIPTION
This includes:
- AppendDeferredVsTailCache
- AppendZeroTrailingSharedBlock

Plus some cleanup around write buffer creation to make it up-to-date.

Fixes: https://tracker.ceph.com/issues/78183





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
