### PR TITLE
rgw: emit structured JSON for sync status --format

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -328,6 +328,13 @@ as follows:
 :command:`data sync run`
   Run data sync for the specified source zone.
 
+:command:`sync status`
+  Show an overall metadata and data sync status summary for the
+  current zone. Default output is human-readable text. With
+  ``--format=json`` (or another formatter), emit a structured
+  summary with typed shard counts, behind-shard lists, and related
+  fields instead of dumping per-shard sync markers.
+
 :command:`sync error list`
   List sync errors.
 

--- a/doc/radosgw/multisite.rst
+++ b/doc/radosgw/multisite.rst
@@ -569,6 +569,12 @@ The output reports the status of synchronization operations. For example:
                           incremental sync: 128/128 shards
                           data is caught up with source
 
+For scripting and monitoring, the same summary is available as structured
+JSON (typed shard counts, behind-shard lists, oldest incremental change,
+recovering shards) without dumping per-shard markers::
+
+   radosgw-admin sync status --format=json
+
 .. note:: Secondary zones accept bucket operations; however, secondary zones
    redirect bucket operations to the master zone and then synchronize with the
    master zone to receive the result of the bucket operations. If the master

--- a/doc/radosgw/multisite.rst
+++ b/doc/radosgw/multisite.rst
@@ -567,6 +567,12 @@ The output reports the status of synchronization operations. For example:
                           incremental sync: 128/128 shards
                           data is caught up with source
 
+For scripting and monitoring, the same summary is available as structured
+JSON (typed shard counts, behind-shard lists, oldest incremental change,
+recovering shards) without dumping per-shard markers::
+
+   radosgw-admin sync status --format=json
+
 .. note:: Secondary zones accept bucket operations; however, secondary zones
    redirect bucket operations to the master zone and then synchronize with the
    master zone to receive the result of the bucket operations. If the master

--- a/qa/suites/rgw/verify/tasks/sync-status-json.yaml
+++ b/qa/suites/rgw/verify/tasks/sync-status-json.yaml
@@ -1,0 +1,5 @@
+tasks:
+- workunit:
+    clients:
+      client.0:
+        - rgw/run-sync-status-json.sh

--- a/qa/workunits/rgw/run-sync-status-json.sh
+++ b/qa/workunits/rgw/run-sync-status-json.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Needs a running cluster (vstart or teuthology). Local example:
+#
+#   cd /var/test/ceph/build-local
+#   ../src/vstart.sh -n -d
+#   export PATH=$PWD/bin:$PATH
+#   export CEPH_CONF=$PWD/ceph.conf
+#   ../qa/workunits/rgw/run-sync-status-json.sh
+#
+# Teuthology sets PATH via the workunit task; no extra setup needed there.
+#
+set -ex
+
+mydir=$(cd "$(dirname "$0")" && pwd)
+repo_root=$(cd "$mydir/../../.." && pwd)
+
+if [ -n "${CEPH_BIN:-}" ]; then
+  export PATH="${CEPH_BIN}:$PATH"
+elif [ -x "$repo_root/build-local/bin/radosgw-admin" ]; then
+  export PATH="$repo_root/build-local/bin:$PATH"
+elif [ -x "$repo_root/build/bin/radosgw-admin" ]; then
+  export PATH="$repo_root/build/bin:$PATH"
+fi
+
+if [ -z "${CEPH_CONF:-}" ]; then
+  for conf in \
+      "$repo_root/build-local/ceph.conf" \
+      "$repo_root/build/ceph.conf" \
+      "$repo_root/build-local/out/ceph.conf" \
+      "$repo_root/build/out/ceph.conf"
+  do
+    if [ -f "$conf" ]; then
+      export CEPH_CONF="$conf"
+      break
+    fi
+  done
+fi
+
+if ! command -v radosgw-admin >/dev/null 2>&1; then
+  echo "ERROR: radosgw-admin not found in PATH." >&2
+  echo "  PATH=$repo_root/build-local/bin:\$PATH $0" >&2
+  exit 1
+fi
+
+python3 "$mydir/test_rgw_sync_status_json.py"
+
+echo OK.

--- a/qa/workunits/rgw/test_rgw_sync_status_json.py
+++ b/qa/workunits/rgw/test_rgw_sync_status_json.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""
+Functional checks for ``radosgw-admin sync status [--format=json]``.
+
+Covers:
+  * single-site / meta-master shape (no metadata sync, empty data_sync)
+  * optional secondary-zone expectations when data_sync sources exist
+  * plaintext default compatibility
+  * structured/parseable JSON fields (counts, behind shards, timestamps)
+  * light performance vs plaintext
+
+JSONFormatter omits the root section name, so fields are at the top level
+(not wrapped in a ``sync_status`` object). Per-shard markers are not dumped.
+"""
+
+import json
+import os
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import time
+import unittest
+
+
+def repo_root():
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.abspath(os.path.join(here, '..', '..', '..'))
+
+
+def find_radosgw_admin():
+    env = os.environ.get('RADOSGW_ADMIN') or os.environ.get('CEPH_BIN')
+    if env:
+        candidate = env
+        if os.path.isdir(candidate):
+            candidate = os.path.join(candidate, 'radosgw-admin')
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    found = shutil.which('radosgw-admin')
+    if found:
+        return found
+    root = repo_root()
+    for sub in ('build-local/bin/radosgw-admin', 'build/bin/radosgw-admin'):
+        candidate = os.path.join(root, sub)
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def find_ceph_conf():
+    if os.environ.get('CEPH_CONF'):
+        path = os.environ['CEPH_CONF']
+        if os.path.isfile(path):
+            return path
+    root = repo_root()
+    candidates = [
+        os.path.join(root, 'build-local', 'ceph.conf'),
+        os.path.join(root, 'build', 'ceph.conf'),
+        os.path.join(root, 'build-local', 'out', 'ceph.conf'),
+        os.path.join(root, 'build', 'out', 'ceph.conf'),
+        '/etc/ceph/ceph.conf',
+    ]
+    conf_path = os.environ.get('CEPH_CONF_PATH')
+    if conf_path:
+        candidates.insert(0, os.path.join(conf_path, 'ceph.conf'))
+    for path in candidates:
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+def parse_sync_status_json(stdout: str) -> dict:
+    """Return the top-level sync-status object (flat JSONFormatter root)."""
+    data = json.loads(stdout)
+    # Be tolerant if a future change wraps under sync_status.
+    if isinstance(data, dict) and 'metadata_sync' in data:
+        return data
+    if isinstance(data, dict) and isinstance(data.get('sync_status'), dict):
+        return data['sync_status']
+    raise AssertionError(f'unexpected sync status JSON shape: {data!r}')
+
+
+def _assert_sync_progress(obj, label):
+    """full_sync / incremental_sync must be typed counts, not prose."""
+    for key in ('full_sync', 'incremental_sync'):
+        assert key in obj, f'{label}: missing {key}'
+        section = obj[key]
+        assert isinstance(section, dict), f'{label}.{key} must be object'
+        assert isinstance(section.get('shards'), int), f'{label}.{key}.shards'
+        assert isinstance(section.get('total_shards'), int), f'{label}.{key}.total_shards'
+        assert 'summary' not in section, f'{label}.{key} must not use string summary'
+
+
+def _assert_behind_fields(obj, label):
+    assert 'caught_up' in obj, f'{label}: missing caught_up'
+    assert isinstance(obj['caught_up'], bool), f'{label}: caught_up must be bool'
+    assert isinstance(obj.get('shards_behind'), int), f'{label}: shards_behind'
+    assert isinstance(obj.get('behind_shards'), list), f'{label}: behind_shards'
+    for shard in obj['behind_shards']:
+        assert isinstance(shard, int), f'{label}: behind_shards entries must be ints'
+    if obj['caught_up']:
+        assert obj['shards_behind'] == 0, f'{label}: caught_up but shards_behind!=0'
+    oldest = obj.get('oldest_incremental_change')
+    if oldest is not None:
+        assert isinstance(oldest, dict), f'{label}: oldest_incremental_change'
+        assert isinstance(oldest.get('shard_id'), int)
+        assert isinstance(oldest.get('timestamp'), str)
+        assert oldest['timestamp'], f'{label}: empty oldest timestamp'
+
+
+class TestSyncStatusFormat(unittest.TestCase):
+    PERF_ITERS = 5
+    CMD_TIMEOUT_SEC = 30
+
+    REQUIRED_KEYS = (
+        'realm_id',
+        'realm_name',
+        'zonegroup_id',
+        'zonegroup_name',
+        'zone_id',
+        'zone_name',
+        'current_time',
+        'metadata_sync',
+        'data_sync',
+    )
+
+    @classmethod
+    def setUpClass(cls):
+        cls.radosgw_admin = find_radosgw_admin()
+        if not cls.radosgw_admin:
+            raise unittest.SkipTest(
+                'radosgw-admin not found; set PATH/CEPH_BIN/RADOSGW_ADMIN'
+            )
+        cls.ceph_conf = find_ceph_conf()
+        try:
+            probe = cls._run_static(['sync', 'status'], check=False)
+        except subprocess.TimeoutExpired as e:
+            raise unittest.SkipTest(
+                f'radosgw-admin timed out after {cls.CMD_TIMEOUT_SEC}s — '
+                'cluster likely incomplete. '
+                f'cmd={e.cmd}'
+            ) from e
+        if probe.returncode != 0:
+            raise unittest.SkipTest(
+                'no usable Ceph cluster for radosgw-admin '
+                f'(ret={probe.returncode}). stderr=\n{probe.stderr}'
+            )
+
+    @classmethod
+    def _run_static(cls, args, check=True):
+        cmd = [cls.radosgw_admin]
+        if cls.ceph_conf:
+            cmd += ['-c', cls.ceph_conf]
+        cmd += args
+        completed = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+            timeout=cls.CMD_TIMEOUT_SEC,
+        )
+        if check and completed.returncode != 0:
+            raise AssertionError(
+                f'command failed: {cmd}\n'
+                f'ret={completed.returncode}\n'
+                f'stdout={completed.stdout}\n'
+                f'stderr={completed.stderr}'
+            )
+        return completed
+
+    def _run(self, args, check=True):
+        return self._run_static(args, check=check)
+
+    def _json_status(self):
+        out = self._run(['sync', 'status', '--format=json']).stdout
+        return parse_sync_status_json(out)
+
+    def test_default_is_plaintext(self):
+        out = self._run(['sync', 'status']).stdout
+        self.assertIn('realm', out)
+        self.assertIn('zonegroup', out)
+        self.assertIn('zone', out)
+        self.assertIn('metadata sync', out)
+        self.assertFalse(
+            out.lstrip().startswith('{'),
+            'default sync status output must remain human-readable plaintext',
+        )
+
+    def test_format_json_is_structured(self):
+        status = self._json_status()
+        for key in self.REQUIRED_KEYS:
+            self.assertIn(key, status, f'missing key {key}')
+        self.assertIsInstance(status['metadata_sync'], dict)
+        self.assertIn('status', status['metadata_sync'])
+        self.assertIsInstance(status['data_sync'], list)
+        self.assertTrue(status['zonegroup_id'])
+        self.assertTrue(status['zone_id'])
+        self.assertTrue(status['current_time'])
+        # Concise structured summary — no per-shard marker dump / prose blobs.
+        md = status['metadata_sync']
+        self.assertNotIn('sync_status', md)
+        self.assertNotIn('messages', md)
+        for src in status['data_sync']:
+            self.assertNotIn('sync_status', src)
+            self.assertNotIn('messages', src)
+
+    def test_pretty_format_json_still_parses(self):
+        out = self._run(
+            ['sync', 'status', '--format=json', '--pretty-format']
+        ).stdout
+        status = parse_sync_status_json(out)
+        self.assertIn('metadata_sync', status)
+        self.assertIn('data_sync', status)
+
+    def test_single_site_or_master_shape(self):
+        """
+        On a single-site / meta-master zone:
+          metadata_sync.status == 'no sync (zone is master)'
+          data_sync is typically empty (no peer sources).
+        """
+        status = self._json_status()
+        md = status['metadata_sync']
+        if md.get('status') != 'no sync (zone is master)':
+            # Likely a secondary zone — covered by secondary-shape test.
+            raise unittest.SkipTest(
+                f'not a meta-master view (metadata_sync={md!r}); '
+                'run against master or use multisite nose tests'
+            )
+        self.assertEqual(md['status'], 'no sync (zone is master)')
+        self.assertNotIn('error', md)
+        self.assertNotIn('full_sync', md)
+        # Single-site default: no connected sources.
+        self.assertIsInstance(status['data_sync'], list)
+        for src in status['data_sync']:
+            self.assertIn('source_zone', src)
+            self.assertTrue('status' in src or 'error' in src)
+
+    def test_secondary_shape_when_present(self):
+        """
+        If this gateway syncs metadata (secondary), JSON must expose typed
+        progress / behind fields for parsers.
+        """
+        status = self._json_status()
+        md = status['metadata_sync']
+        if md.get('status') == 'no sync (zone is master)':
+            raise unittest.SkipTest('single-site / master — no secondary shape')
+
+        self.assertIn(
+            md.get('status'),
+            ('init', 'preparing for full sync', 'syncing', 'unknown'),
+            f'unexpected metadata status: {md!r}',
+        )
+        self.assertNotIn('messages', md)
+        self.assertNotIn('sync_status', md)
+        if 'error' not in md:
+            _assert_sync_progress(md, 'metadata_sync')
+            _assert_behind_fields(md, 'metadata_sync')
+            self.assertIn('period_mismatch', md)
+        if status['data_sync']:
+            for src in status['data_sync']:
+                self.assertIn('source_zone', src)
+                self.assertNotIn('messages', src)
+                self.assertNotIn('sync_status', src)
+                if 'error' not in src and src.get('status') != 'not syncing from zone':
+                    _assert_sync_progress(src, 'data_sync')
+                    _assert_behind_fields(src, 'data_sync')
+                    self.assertIsInstance(src.get('shards_recovering'), int)
+                    self.assertIsInstance(src.get('recovering_shards'), list)
+
+    def test_json_matches_plaintext_identity(self):
+        """Typed JSON counts must agree with plaintext summary lines."""
+        plain = self._run(['sync', 'status']).stdout
+        status = self._json_status()
+        self.assertIn(status['zonegroup_id'], plain)
+        self.assertIn(status['zone_id'], plain)
+        if status['zonegroup_name']:
+            self.assertIn(status['zonegroup_name'], plain)
+        if status['zone_name']:
+            self.assertIn(status['zone_name'], plain)
+
+        md = status['metadata_sync']
+        if md.get('status') != 'no sync (zone is master)' and 'error' not in md:
+            m = re.search(r'full sync:\s*(\d+)/(\d+)\s*shards', plain)
+            self.assertIsNotNone(m, 'plaintext missing metadata full sync line')
+            self.assertEqual(md['full_sync']['shards'], int(m.group(1)))
+            self.assertEqual(md['full_sync']['total_shards'], int(m.group(2)))
+            m = re.search(r'incremental sync:\s*(\d+)/(\d+)\s*shards', plain)
+            self.assertIsNotNone(m, 'plaintext missing metadata incremental line')
+            self.assertEqual(md['incremental_sync']['shards'], int(m.group(1)))
+            self.assertEqual(md['incremental_sync']['total_shards'], int(m.group(2)))
+            if md.get('caught_up'):
+                self.assertIn('metadata is caught up with master', plain)
+            else:
+                self.assertRegex(
+                    plain,
+                    r'metadata is behind on\s+%d\s+shards' % md['shards_behind'],
+                )
+
+        for src in status['data_sync']:
+            if 'error' in src or src.get('status') == 'not syncing from zone':
+                continue
+            source = src['source_zone']
+            self.assertIn(source, plain)
+            # Match the data-sync block for this source (best-effort).
+            block_m = re.search(
+                r'source:\s*' + re.escape(source) + r'.*?(?=source:|\Z)',
+                plain,
+                re.S,
+            )
+            block = block_m.group(0) if block_m else plain
+            m = re.search(r'full sync:\s*(\d+)/(\d+)\s*shards', block)
+            self.assertIsNotNone(m, f'plaintext missing data full sync for {source}')
+            self.assertEqual(src['full_sync']['shards'], int(m.group(1)))
+            self.assertEqual(src['full_sync']['total_shards'], int(m.group(2)))
+            m = re.search(r'incremental sync:\s*(\d+)/(\d+)\s*shards', block)
+            self.assertIsNotNone(m, f'plaintext missing data incremental for {source}')
+            self.assertEqual(src['incremental_sync']['shards'], int(m.group(1)))
+            self.assertEqual(src['incremental_sync']['total_shards'], int(m.group(2)))
+            if src.get('caught_up'):
+                self.assertIn('data is caught up with source', block)
+
+    def test_json_path_performance_comparable(self):
+        def timed(args):
+            times = []
+            for _ in range(self.PERF_ITERS):
+                start = time.perf_counter()
+                completed = self._run(args)
+                elapsed = time.perf_counter() - start
+                times.append(elapsed)
+                self.assertTrue(len(completed.stdout) > 0)
+            return times
+
+        plain = timed(['sync', 'status'])
+        js = timed(['sync', 'status', '--format=json'])
+        plain_mean = statistics.mean(plain)
+        json_mean = statistics.mean(js)
+        print(
+            f'sync status perf: plaintext mean={plain_mean:.4f}s '
+            f'json mean={json_mean:.4f}s '
+            f'(n={self.PERF_ITERS})',
+            file=sys.stderr,
+        )
+        self.assertLessEqual(
+            json_mean,
+            plain_mean * 5.0 + 1.0,
+            f'JSON sync status too slow vs plaintext '
+            f'(json={json_mean:.4f}s plain={plain_mean:.4f}s)',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -2723,10 +2723,395 @@ static auto get_disabled_features(const rgw::zone_features::set& enabled) {
 }
 
 
-static void sync_status(Formatter *formatter)
+static void dump_int_set(Formatter *formatter, const char *name,
+                         const set<int>& values)
+{
+  formatter->open_array_section(name);
+  for (const int id : values) {
+    formatter->dump_int("shard", id);
+  }
+  formatter->close_section();
+}
+
+/*
+ * Structured JSON for the same facts as plaintext `sync status`.
+ * Fields are typed (ints/bools/arrays) for parsers — not prose strings.
+ * Do not dump per-shard markers (huge, not part of the human summary).
+ */
+static void dump_md_sync_status_json(Formatter *formatter)
+{
+  formatter->open_object_section("metadata_sync");
+
+  if (driver->is_meta_master()) {
+    formatter->dump_string("status", "no sync (zone is master)");
+    formatter->close_section();
+    return;
+  }
+
+  RGWMetaSyncStatusManager sync(static_cast<rgw::sal::RadosStore*>(driver),
+                                static_cast<rgw::sal::RadosStore*>(driver)->svc()->async_processor);
+
+  int ret = sync.init(dpp());
+  if (ret < 0) {
+    formatter->dump_string("error",
+                           string("failed to retrieve sync info: sync.init() failed: ") +
+                           cpp_strerror(-ret));
+    formatter->close_section();
+    return;
+  }
+
+  rgw_meta_sync_status sync_status;
+  ret = sync.read_sync_status(dpp(), &sync_status);
+  if (ret < 0) {
+    formatter->dump_string("error",
+                           string("failed to read sync status: ") + cpp_strerror(-ret));
+    formatter->close_section();
+    return;
+  }
+
+  string status_str;
+  switch (sync_status.sync_info.state) {
+    case rgw_meta_sync_info::StateInit:
+      status_str = "init";
+      break;
+    case rgw_meta_sync_info::StateBuildingFullSyncMaps:
+      status_str = "preparing for full sync";
+      break;
+    case rgw_meta_sync_info::StateSync:
+      status_str = "syncing";
+      break;
+    default:
+      status_str = "unknown";
+  }
+
+  formatter->dump_string("status", status_str);
+
+  uint64_t full_total = 0;
+  uint64_t full_complete = 0;
+  int num_full = 0;
+  int num_inc = 0;
+  int total_shards = 0;
+  set<int> shards_behind_set;
+
+  for (auto marker_iter : sync_status.sync_markers) {
+    full_total += marker_iter.second.total_entries;
+    total_shards++;
+    if (marker_iter.second.state == rgw_meta_sync_marker::SyncState::FullSync) {
+      num_full++;
+      full_complete += marker_iter.second.pos;
+      shards_behind_set.insert(marker_iter.first);
+    } else {
+      full_complete += marker_iter.second.total_entries;
+    }
+    if (marker_iter.second.state == rgw_meta_sync_marker::SyncState::IncrementalSync) {
+      num_inc++;
+    }
+  }
+
+  formatter->open_object_section("full_sync");
+  formatter->dump_int("shards", num_full);
+  formatter->dump_int("total_shards", total_shards);
+  formatter->dump_unsigned("total_entries", full_total);
+  formatter->dump_unsigned("complete_entries", full_complete);
+  if (num_full > 0) {
+    formatter->dump_unsigned("entries_to_sync", full_total - full_complete);
+  }
+  formatter->close_section();
+
+  formatter->open_object_section("incremental_sync");
+  formatter->dump_int("shards", num_inc);
+  formatter->dump_int("total_shards", total_shards);
+  formatter->close_section();
+
+  map<int, RGWMetadataLogInfo> master_shards_info;
+  string master_period = static_cast<rgw::sal::RadosStore*>(driver)->svc()->zone->get_current_period_id();
+
+  ret = sync.read_master_log_shards_info(dpp(), master_period, &master_shards_info);
+  if (ret < 0) {
+    formatter->dump_string("error",
+                           string("failed to fetch master sync status: ") + cpp_strerror(-ret));
+    formatter->close_section();
+    return;
+  }
+
+  map<int, string> shards_behind;
+  if (sync_status.sync_info.period != master_period) {
+    formatter->dump_string("master_period", master_period);
+    formatter->dump_string("local_period", sync_status.sync_info.period);
+    formatter->dump_bool("period_mismatch", true);
+  } else {
+    formatter->dump_bool("period_mismatch", false);
+    for (auto local_iter : sync_status.sync_markers) {
+      int shard_id = local_iter.first;
+      auto iter = master_shards_info.find(shard_id);
+      if (iter == master_shards_info.end()) {
+        derr << "ERROR: could not find remote sync shard status for shard_id=" << shard_id << dendl;
+        continue;
+      }
+      auto master_marker = iter->second.marker;
+      if (local_iter.second.state == rgw_meta_sync_marker::SyncState::IncrementalSync &&
+          master_marker > local_iter.second.marker) {
+        shards_behind[shard_id] = local_iter.second.marker;
+        shards_behind_set.insert(shard_id);
+      }
+    }
+  }
+
+  std::optional<std::pair<int, ceph::real_time>> oldest;
+  if (!shards_behind.empty()) {
+    map<int, rgw_mdlog_shard_data> master_pos;
+    ret = sync.read_master_log_shards_next(dpp(), sync_status.sync_info.period,
+                                           shards_behind, &master_pos);
+    if (ret < 0) {
+      derr << "ERROR: failed to fetch master next positions (" << cpp_strerror(-ret) << ")" << dendl;
+    } else {
+      for (auto iter : master_pos) {
+        rgw_mdlog_shard_data& shard_data = iter.second;
+        if (shard_data.entries.empty()) {
+          shards_behind.erase(iter.first);
+          shards_behind_set.erase(iter.first);
+        } else {
+          rgw_mdlog_entry& entry = shard_data.entries.front();
+          if (!oldest) {
+            oldest.emplace(iter.first, entry.timestamp);
+          } else if (!ceph::real_clock::is_zero(entry.timestamp) &&
+                     entry.timestamp < oldest->second) {
+            oldest.emplace(iter.first, entry.timestamp);
+          }
+        }
+      }
+    }
+  }
+
+  int total_behind = shards_behind.size() + (sync_status.sync_info.num_shards - num_inc);
+  formatter->dump_bool("caught_up", total_behind == 0);
+  formatter->dump_int("shards_behind", total_behind);
+  dump_int_set(formatter, "behind_shards", shards_behind_set);
+  if (oldest) {
+    formatter->open_object_section("oldest_incremental_change");
+    formatter->dump_int("shard_id", oldest->first);
+    formatter->dump_string("timestamp",
+                           to_iso_8601(oldest->second, iso_8601_format::YMDhmsn));
+    formatter->close_section();
+  }
+
+  formatter->close_section();
+}
+
+static void dump_data_sync_status_json(const rgw_zone_id& source_zone,
+                                       Formatter *formatter)
+{
+  formatter->open_object_section("source");
+  formatter->dump_string("source_zone", source_zone.id);
+
+  std::unique_ptr<rgw::sal::Zone> sz_sal;
+  if (driver->get_zone()->get_zonegroup().get_zone_by_id(source_zone.id, &sz_sal) == 0) {
+    formatter->dump_string("source_zone_name", sz_sal->get_name());
+  }
+
+  RGWZone *sz;
+  if (!(sz = static_cast<rgw::sal::RadosStore*>(driver)->svc()->zone->find_zone(source_zone))) {
+    formatter->dump_string("error", "zone not found");
+    formatter->close_section();
+    return;
+  }
+
+  if (!static_cast<rgw::sal::RadosStore*>(driver)->svc()->zone->zone_syncs_from(*sz)) {
+    formatter->dump_string("status", "not syncing from zone");
+    formatter->close_section();
+    return;
+  }
+
+  RGWDataSyncStatusManager sync(static_cast<rgw::sal::RadosStore*>(driver),
+                                static_cast<rgw::sal::RadosStore*>(driver)->svc()->async_processor,
+                                source_zone, nullptr);
+
+  int ret = sync.init(dpp());
+  if (ret < 0) {
+    formatter->dump_string("error",
+                           string("failed to retrieve sync info: ") + cpp_strerror(-ret));
+    formatter->close_section();
+    return;
+  }
+
+  rgw_data_sync_status sync_status;
+  ret = sync.read_sync_status(dpp(), &sync_status);
+  if (ret < 0 && ret != -ENOENT) {
+    formatter->dump_string("error",
+                           string("failed read sync status: ") + cpp_strerror(-ret));
+    formatter->close_section();
+    return;
+  }
+
+  set<int> recovering_shards;
+  ret = sync.read_recovering_shards(dpp(), sync_status.sync_info.num_shards, recovering_shards);
+  if (ret < 0 && ret != ENOENT) {
+    formatter->dump_string("error",
+                           string("failed read recovering shards: ") + cpp_strerror(-ret));
+    formatter->close_section();
+    return;
+  }
+
+  string status_str;
+  switch (sync_status.sync_info.state) {
+    case rgw_data_sync_info::StateInit:
+      status_str = "init";
+      break;
+    case rgw_data_sync_info::StateBuildingFullSyncMaps:
+      status_str = "preparing for full sync";
+      break;
+    case rgw_data_sync_info::StateSync:
+      status_str = "syncing";
+      break;
+    default:
+      status_str = "unknown";
+  }
+
+  formatter->dump_string("status", status_str);
+
+  uint64_t full_total = 0;
+  uint64_t full_complete = 0;
+  int num_full = 0;
+  int num_inc = 0;
+  int total_shards = 0;
+  set<int> shards_behind_set;
+
+  for (auto marker_iter : sync_status.sync_markers) {
+    full_total += marker_iter.second.total_entries;
+    total_shards++;
+    if (marker_iter.second.state == rgw_data_sync_marker::SyncState::FullSync) {
+      num_full++;
+      full_complete += marker_iter.second.pos;
+      shards_behind_set.insert(marker_iter.first);
+    } else {
+      full_complete += marker_iter.second.total_entries;
+    }
+    if (marker_iter.second.state == rgw_data_sync_marker::SyncState::IncrementalSync) {
+      num_inc++;
+    }
+  }
+
+  formatter->open_object_section("full_sync");
+  formatter->dump_int("shards", num_full);
+  formatter->dump_int("total_shards", total_shards);
+  formatter->dump_unsigned("total_buckets", full_total);
+  formatter->dump_unsigned("complete_buckets", full_complete);
+  if (num_full > 0) {
+    formatter->dump_unsigned("buckets_to_sync", full_total - full_complete);
+  }
+  formatter->close_section();
+
+  formatter->open_object_section("incremental_sync");
+  formatter->dump_int("shards", num_inc);
+  formatter->dump_int("total_shards", total_shards);
+  formatter->close_section();
+
+  map<int, RGWDataChangesLogInfo> source_shards_info;
+  ret = sync.read_source_log_shards_info(dpp(), &source_shards_info);
+  if (ret < 0) {
+    formatter->dump_string("error",
+                           string("failed to fetch source sync status: ") + cpp_strerror(-ret));
+    formatter->close_section();
+    return;
+  }
+
+  map<int, string> shards_behind;
+  for (auto local_iter : sync_status.sync_markers) {
+    int shard_id = local_iter.first;
+    auto iter = source_shards_info.find(shard_id);
+    if (iter == source_shards_info.end()) {
+      derr << "ERROR: could not find remote sync shard status for shard_id=" << shard_id << dendl;
+      continue;
+    }
+    auto master_marker = iter->second.marker;
+    if (local_iter.second.state == rgw_data_sync_marker::SyncState::IncrementalSync &&
+        master_marker > local_iter.second.marker) {
+      shards_behind[shard_id] = local_iter.second.marker;
+      shards_behind_set.insert(shard_id);
+    }
+  }
+
+  std::optional<std::pair<int, ceph::real_time>> oldest;
+  if (!shards_behind.empty()) {
+    map<int, rgw_datalog_shard_data> master_pos;
+    ret = sync.read_source_log_shards_next(dpp(), shards_behind, &master_pos);
+    if (ret < 0) {
+      derr << "ERROR: failed to fetch next positions (" << cpp_strerror(-ret) << ")" << dendl;
+    } else {
+      for (auto iter : master_pos) {
+        rgw_datalog_shard_data& shard_data = iter.second;
+        if (shard_data.entries.empty()) {
+          shards_behind.erase(iter.first);
+          shards_behind_set.erase(iter.first);
+        } else {
+          rgw_datalog_entry& entry = shard_data.entries.front();
+          if (!oldest) {
+            oldest.emplace(iter.first, entry.timestamp);
+          } else if (!ceph::real_clock::is_zero(entry.timestamp) &&
+                     entry.timestamp < oldest->second) {
+            oldest.emplace(iter.first, entry.timestamp);
+          }
+        }
+      }
+    }
+  }
+
+  int total_behind = shards_behind.size() + (sync_status.sync_info.num_shards - num_inc);
+  int total_recovering = recovering_shards.size();
+
+  formatter->dump_bool("caught_up", total_behind == 0 && total_recovering == 0);
+  formatter->dump_int("shards_behind", total_behind);
+  dump_int_set(formatter, "behind_shards", shards_behind_set);
+  if (oldest) {
+    formatter->open_object_section("oldest_incremental_change");
+    formatter->dump_int("shard_id", oldest->first);
+    formatter->dump_string("timestamp",
+                           to_iso_8601(oldest->second, iso_8601_format::YMDhmsn));
+    formatter->close_section();
+  }
+  formatter->dump_int("shards_recovering", total_recovering);
+  dump_int_set(formatter, "recovering_shards", recovering_shards);
+
+  formatter->close_section();
+}
+
+static void sync_status(Formatter *formatter, bool use_formatter)
 {
   const rgw::sal::ZoneGroup& zonegroup = driver->get_zone()->get_zonegroup();
   rgw::sal::Zone* zone = driver->get_zone();
+
+  const auto& rzg =
+    static_cast<const rgw::sal::RadosZoneGroup&>(zonegroup).get_group();
+  const auto current_time = to_iso_8601(ceph::real_clock::now(),
+                                        iso_8601_format::YMDhms);
+
+  if (use_formatter) {
+    formatter->open_object_section("sync_status");
+    formatter->dump_string("realm_id", zone->get_realm_id());
+    formatter->dump_string("realm_name", zone->get_realm_name());
+    formatter->dump_string("zonegroup_id", zonegroup.get_id());
+    formatter->dump_string("zonegroup_name", zonegroup.get_name());
+    formatter->dump_string("zone_id", zone->get_id());
+    formatter->dump_string("zone_name", zone->get_name());
+    formatter->dump_string("current_time", current_time);
+    encode_json("zonegroup_features_enabled", rzg.enabled_features, formatter);
+    if (auto d = get_disabled_features(rzg.enabled_features); !d.empty()) {
+      encode_json("zonegroup_features_disabled", d, formatter);
+    }
+
+    dump_md_sync_status_json(formatter);
+
+    formatter->open_array_section("data_sync");
+    auto& zone_conn_map = static_cast<rgw::sal::RadosStore*>(driver)->svc()->zone->get_zone_conn_map();
+    for (auto iter : zone_conn_map) {
+      dump_data_sync_status_json(iter.first, formatter);
+    }
+    formatter->close_section();
+
+    formatter->close_section();
+    formatter->flush(cout);
+    return;
+  }
 
   int width = 15;
 
@@ -2734,10 +3119,7 @@ static void sync_status(Formatter *formatter)
   cout << std::setw(width) << "zonegroup" << std::setw(1) << " " << zonegroup.get_id() << " (" << zonegroup.get_name() << ")" << std::endl;
   cout << std::setw(width) << "zone" << std::setw(1) << " " << zone->get_id() << " (" << zone->get_name() << ")" << std::endl;
   cout << std::setw(width) << "current time" << std::setw(1) << " "
-       << to_iso_8601(ceph::real_clock::now(), iso_8601_format::YMDhms) << std::endl;
-
-  const auto& rzg =
-    static_cast<const rgw::sal::RadosZoneGroup&>(zonegroup).get_group();
+       << current_time << std::endl;
 
   cout << std::setw(width) << "zonegroup features enabled: " << rzg.enabled_features << std::endl;
   if (auto d = get_disabled_features(rzg.enabled_features); !d.empty()) {
@@ -10469,7 +10851,7 @@ next:
 
 #ifdef WITH_RADOSGW_RADOS
   if (opt_cmd == OPT::SYNC_STATUS) {
-    sync_status(formatter.get());
+    sync_status(formatter.get(), format_arg_passed);
   }
 
   if (opt_cmd == OPT::METADATA_SYNC_STATUS) {

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -2725,10 +2725,395 @@ static auto get_disabled_features(const rgw::zone_features::set& enabled) {
 }
 
 
-static void sync_status(Formatter *formatter)
+static void dump_int_set(Formatter *formatter, const char *name,
+                         const set<int>& values)
+{
+  formatter->open_array_section(name);
+  for (const int id : values) {
+    formatter->dump_int("shard", id);
+  }
+  formatter->close_section();
+}
+
+/*
+ * Structured JSON for the same facts as plaintext `sync status`.
+ * Fields are typed (ints/bools/arrays) for parsers — not prose strings.
+ * Do not dump per-shard markers (huge, not part of the human summary).
+ */
+static void dump_md_sync_status_json(Formatter *formatter)
+{
+  formatter->open_object_section("metadata_sync");
+
+  if (driver->is_meta_master()) {
+    formatter->dump_string("status", "no sync (zone is master)");
+    formatter->close_section();
+    return;
+  }
+
+  RGWMetaSyncStatusManager sync(static_cast<rgw::sal::RadosStore*>(driver),
+                                static_cast<rgw::sal::RadosStore*>(driver)->svc()->async_processor);
+
+  int ret = sync.init(dpp());
+  if (ret < 0) {
+    formatter->dump_string("error",
+                           string("failed to retrieve sync info: sync.init() failed: ") +
+                           cpp_strerror(-ret));
+    formatter->close_section();
+    return;
+  }
+
+  rgw_meta_sync_status sync_status;
+  ret = sync.read_sync_status(dpp(), &sync_status);
+  if (ret < 0) {
+    formatter->dump_string("error",
+                           string("failed to read sync status: ") + cpp_strerror(-ret));
+    formatter->close_section();
+    return;
+  }
+
+  string status_str;
+  switch (sync_status.sync_info.state) {
+    case rgw_meta_sync_info::StateInit:
+      status_str = "init";
+      break;
+    case rgw_meta_sync_info::StateBuildingFullSyncMaps:
+      status_str = "preparing for full sync";
+      break;
+    case rgw_meta_sync_info::StateSync:
+      status_str = "syncing";
+      break;
+    default:
+      status_str = "unknown";
+  }
+
+  formatter->dump_string("status", status_str);
+
+  uint64_t full_total = 0;
+  uint64_t full_complete = 0;
+  int num_full = 0;
+  int num_inc = 0;
+  int total_shards = 0;
+  set<int> shards_behind_set;
+
+  for (auto marker_iter : sync_status.sync_markers) {
+    full_total += marker_iter.second.total_entries;
+    total_shards++;
+    if (marker_iter.second.state == rgw_meta_sync_marker::SyncState::FullSync) {
+      num_full++;
+      full_complete += marker_iter.second.pos;
+      shards_behind_set.insert(marker_iter.first);
+    } else {
+      full_complete += marker_iter.second.total_entries;
+    }
+    if (marker_iter.second.state == rgw_meta_sync_marker::SyncState::IncrementalSync) {
+      num_inc++;
+    }
+  }
+
+  formatter->open_object_section("full_sync");
+  formatter->dump_int("shards", num_full);
+  formatter->dump_int("total_shards", total_shards);
+  formatter->dump_unsigned("total_entries", full_total);
+  formatter->dump_unsigned("complete_entries", full_complete);
+  if (num_full > 0) {
+    formatter->dump_unsigned("entries_to_sync", full_total - full_complete);
+  }
+  formatter->close_section();
+
+  formatter->open_object_section("incremental_sync");
+  formatter->dump_int("shards", num_inc);
+  formatter->dump_int("total_shards", total_shards);
+  formatter->close_section();
+
+  map<int, RGWMetadataLogInfo> master_shards_info;
+  string master_period = static_cast<rgw::sal::RadosStore*>(driver)->svc()->zone->get_current_period_id();
+
+  ret = sync.read_master_log_shards_info(dpp(), master_period, &master_shards_info);
+  if (ret < 0) {
+    formatter->dump_string("error",
+                           string("failed to fetch master sync status: ") + cpp_strerror(-ret));
+    formatter->close_section();
+    return;
+  }
+
+  map<int, string> shards_behind;
+  if (sync_status.sync_info.period != master_period) {
+    formatter->dump_string("master_period", master_period);
+    formatter->dump_string("local_period", sync_status.sync_info.period);
+    formatter->dump_bool("period_mismatch", true);
+  } else {
+    formatter->dump_bool("period_mismatch", false);
+    for (auto local_iter : sync_status.sync_markers) {
+      int shard_id = local_iter.first;
+      auto iter = master_shards_info.find(shard_id);
+      if (iter == master_shards_info.end()) {
+        derr << "ERROR: could not find remote sync shard status for shard_id=" << shard_id << dendl;
+        continue;
+      }
+      auto master_marker = iter->second.marker;
+      if (local_iter.second.state == rgw_meta_sync_marker::SyncState::IncrementalSync &&
+          master_marker > local_iter.second.marker) {
+        shards_behind[shard_id] = local_iter.second.marker;
+        shards_behind_set.insert(shard_id);
+      }
+    }
+  }
+
+  std::optional<std::pair<int, ceph::real_time>> oldest;
+  if (!shards_behind.empty()) {
+    map<int, rgw_mdlog_shard_data> master_pos;
+    ret = sync.read_master_log_shards_next(dpp(), sync_status.sync_info.period,
+                                           shards_behind, &master_pos);
+    if (ret < 0) {
+      derr << "ERROR: failed to fetch master next positions (" << cpp_strerror(-ret) << ")" << dendl;
+    } else {
+      for (auto iter : master_pos) {
+        rgw_mdlog_shard_data& shard_data = iter.second;
+        if (shard_data.entries.empty()) {
+          shards_behind.erase(iter.first);
+          shards_behind_set.erase(iter.first);
+        } else {
+          rgw_mdlog_entry& entry = shard_data.entries.front();
+          if (!oldest) {
+            oldest.emplace(iter.first, entry.timestamp);
+          } else if (!ceph::real_clock::is_zero(entry.timestamp) &&
+                     entry.timestamp < oldest->second) {
+            oldest.emplace(iter.first, entry.timestamp);
+          }
+        }
+      }
+    }
+  }
+
+  int total_behind = shards_behind.size() + (sync_status.sync_info.num_shards - num_inc);
+  formatter->dump_bool("caught_up", total_behind == 0);
+  formatter->dump_int("shards_behind", total_behind);
+  dump_int_set(formatter, "behind_shards", shards_behind_set);
+  if (oldest) {
+    formatter->open_object_section("oldest_incremental_change");
+    formatter->dump_int("shard_id", oldest->first);
+    formatter->dump_string("timestamp",
+                           to_iso_8601(oldest->second, iso_8601_format::YMDhmsn));
+    formatter->close_section();
+  }
+
+  formatter->close_section();
+}
+
+static void dump_data_sync_status_json(const rgw_zone_id& source_zone,
+                                       Formatter *formatter)
+{
+  formatter->open_object_section("source");
+  formatter->dump_string("source_zone", source_zone.id);
+
+  std::unique_ptr<rgw::sal::Zone> sz_sal;
+  if (driver->get_zone()->get_zonegroup().get_zone_by_id(source_zone.id, &sz_sal) == 0) {
+    formatter->dump_string("source_zone_name", sz_sal->get_name());
+  }
+
+  RGWZone *sz;
+  if (!(sz = static_cast<rgw::sal::RadosStore*>(driver)->svc()->zone->find_zone(source_zone))) {
+    formatter->dump_string("error", "zone not found");
+    formatter->close_section();
+    return;
+  }
+
+  if (!static_cast<rgw::sal::RadosStore*>(driver)->svc()->zone->zone_syncs_from(*sz)) {
+    formatter->dump_string("status", "not syncing from zone");
+    formatter->close_section();
+    return;
+  }
+
+  RGWDataSyncStatusManager sync(static_cast<rgw::sal::RadosStore*>(driver),
+                                static_cast<rgw::sal::RadosStore*>(driver)->svc()->async_processor,
+                                source_zone, nullptr);
+
+  int ret = sync.init(dpp());
+  if (ret < 0) {
+    formatter->dump_string("error",
+                           string("failed to retrieve sync info: ") + cpp_strerror(-ret));
+    formatter->close_section();
+    return;
+  }
+
+  rgw_data_sync_status sync_status;
+  ret = sync.read_sync_status(dpp(), &sync_status);
+  if (ret < 0 && ret != -ENOENT) {
+    formatter->dump_string("error",
+                           string("failed read sync status: ") + cpp_strerror(-ret));
+    formatter->close_section();
+    return;
+  }
+
+  set<int> recovering_shards;
+  ret = sync.read_recovering_shards(dpp(), sync_status.sync_info.num_shards, recovering_shards);
+  if (ret < 0 && ret != ENOENT) {
+    formatter->dump_string("error",
+                           string("failed read recovering shards: ") + cpp_strerror(-ret));
+    formatter->close_section();
+    return;
+  }
+
+  string status_str;
+  switch (sync_status.sync_info.state) {
+    case rgw_data_sync_info::StateInit:
+      status_str = "init";
+      break;
+    case rgw_data_sync_info::StateBuildingFullSyncMaps:
+      status_str = "preparing for full sync";
+      break;
+    case rgw_data_sync_info::StateSync:
+      status_str = "syncing";
+      break;
+    default:
+      status_str = "unknown";
+  }
+
+  formatter->dump_string("status", status_str);
+
+  uint64_t full_total = 0;
+  uint64_t full_complete = 0;
+  int num_full = 0;
+  int num_inc = 0;
+  int total_shards = 0;
+  set<int> shards_behind_set;
+
+  for (auto marker_iter : sync_status.sync_markers) {
+    full_total += marker_iter.second.total_entries;
+    total_shards++;
+    if (marker_iter.second.state == rgw_data_sync_marker::SyncState::FullSync) {
+      num_full++;
+      full_complete += marker_iter.second.pos;
+      shards_behind_set.insert(marker_iter.first);
+    } else {
+      full_complete += marker_iter.second.total_entries;
+    }
+    if (marker_iter.second.state == rgw_data_sync_marker::SyncState::IncrementalSync) {
+      num_inc++;
+    }
+  }
+
+  formatter->open_object_section("full_sync");
+  formatter->dump_int("shards", num_full);
+  formatter->dump_int("total_shards", total_shards);
+  formatter->dump_unsigned("total_buckets", full_total);
+  formatter->dump_unsigned("complete_buckets", full_complete);
+  if (num_full > 0) {
+    formatter->dump_unsigned("buckets_to_sync", full_total - full_complete);
+  }
+  formatter->close_section();
+
+  formatter->open_object_section("incremental_sync");
+  formatter->dump_int("shards", num_inc);
+  formatter->dump_int("total_shards", total_shards);
+  formatter->close_section();
+
+  map<int, RGWDataChangesLogInfo> source_shards_info;
+  ret = sync.read_source_log_shards_info(dpp(), &source_shards_info);
+  if (ret < 0) {
+    formatter->dump_string("error",
+                           string("failed to fetch source sync status: ") + cpp_strerror(-ret));
+    formatter->close_section();
+    return;
+  }
+
+  map<int, string> shards_behind;
+  for (auto local_iter : sync_status.sync_markers) {
+    int shard_id = local_iter.first;
+    auto iter = source_shards_info.find(shard_id);
+    if (iter == source_shards_info.end()) {
+      derr << "ERROR: could not find remote sync shard status for shard_id=" << shard_id << dendl;
+      continue;
+    }
+    auto master_marker = iter->second.marker;
+    if (local_iter.second.state == rgw_data_sync_marker::SyncState::IncrementalSync &&
+        master_marker > local_iter.second.marker) {
+      shards_behind[shard_id] = local_iter.second.marker;
+      shards_behind_set.insert(shard_id);
+    }
+  }
+
+  std::optional<std::pair<int, ceph::real_time>> oldest;
+  if (!shards_behind.empty()) {
+    map<int, rgw_datalog_shard_data> master_pos;
+    ret = sync.read_source_log_shards_next(dpp(), shards_behind, &master_pos);
+    if (ret < 0) {
+      derr << "ERROR: failed to fetch next positions (" << cpp_strerror(-ret) << ")" << dendl;
+    } else {
+      for (auto iter : master_pos) {
+        rgw_datalog_shard_data& shard_data = iter.second;
+        if (shard_data.entries.empty()) {
+          shards_behind.erase(iter.first);
+          shards_behind_set.erase(iter.first);
+        } else {
+          rgw_datalog_entry& entry = shard_data.entries.front();
+          if (!oldest) {
+            oldest.emplace(iter.first, entry.timestamp);
+          } else if (!ceph::real_clock::is_zero(entry.timestamp) &&
+                     entry.timestamp < oldest->second) {
+            oldest.emplace(iter.first, entry.timestamp);
+          }
+        }
+      }
+    }
+  }
+
+  int total_behind = shards_behind.size() + (sync_status.sync_info.num_shards - num_inc);
+  int total_recovering = recovering_shards.size();
+
+  formatter->dump_bool("caught_up", total_behind == 0 && total_recovering == 0);
+  formatter->dump_int("shards_behind", total_behind);
+  dump_int_set(formatter, "behind_shards", shards_behind_set);
+  if (oldest) {
+    formatter->open_object_section("oldest_incremental_change");
+    formatter->dump_int("shard_id", oldest->first);
+    formatter->dump_string("timestamp",
+                           to_iso_8601(oldest->second, iso_8601_format::YMDhmsn));
+    formatter->close_section();
+  }
+  formatter->dump_int("shards_recovering", total_recovering);
+  dump_int_set(formatter, "recovering_shards", recovering_shards);
+
+  formatter->close_section();
+}
+
+static void sync_status(Formatter *formatter, bool use_formatter)
 {
   const rgw::sal::ZoneGroup& zonegroup = driver->get_zone()->get_zonegroup();
   rgw::sal::Zone* zone = driver->get_zone();
+
+  const auto& rzg =
+    static_cast<const rgw::sal::RadosZoneGroup&>(zonegroup).get_group();
+  const auto current_time = to_iso_8601(ceph::real_clock::now(),
+                                        iso_8601_format::YMDhms);
+
+  if (use_formatter) {
+    formatter->open_object_section("sync_status");
+    formatter->dump_string("realm_id", zone->get_realm_id());
+    formatter->dump_string("realm_name", zone->get_realm_name());
+    formatter->dump_string("zonegroup_id", zonegroup.get_id());
+    formatter->dump_string("zonegroup_name", zonegroup.get_name());
+    formatter->dump_string("zone_id", zone->get_id());
+    formatter->dump_string("zone_name", zone->get_name());
+    formatter->dump_string("current_time", current_time);
+    encode_json("zonegroup_features_enabled", rzg.enabled_features, formatter);
+    if (auto d = get_disabled_features(rzg.enabled_features); !d.empty()) {
+      encode_json("zonegroup_features_disabled", d, formatter);
+    }
+
+    dump_md_sync_status_json(formatter);
+
+    formatter->open_array_section("data_sync");
+    auto& zone_conn_map = static_cast<rgw::sal::RadosStore*>(driver)->svc()->zone->get_zone_conn_map();
+    for (auto iter : zone_conn_map) {
+      dump_data_sync_status_json(iter.first, formatter);
+    }
+    formatter->close_section();
+
+    formatter->close_section();
+    formatter->flush(cout);
+    return;
+  }
 
   int width = 15;
 
@@ -2736,10 +3121,7 @@ static void sync_status(Formatter *formatter)
   cout << std::setw(width) << "zonegroup" << std::setw(1) << " " << zonegroup.get_id() << " (" << zonegroup.get_name() << ")" << std::endl;
   cout << std::setw(width) << "zone" << std::setw(1) << " " << zone->get_id() << " (" << zone->get_name() << ")" << std::endl;
   cout << std::setw(width) << "current time" << std::setw(1) << " "
-       << to_iso_8601(ceph::real_clock::now(), iso_8601_format::YMDhms) << std::endl;
-
-  const auto& rzg =
-    static_cast<const rgw::sal::RadosZoneGroup&>(zonegroup).get_group();
+       << current_time << std::endl;
 
   cout << std::setw(width) << "zonegroup features enabled: " << rzg.enabled_features << std::endl;
   if (auto d = get_disabled_features(rzg.enabled_features); !d.empty()) {
@@ -10506,7 +10888,7 @@ next:
        cerr << "Use 'radosgw-admin bucket sync status --bucket=<bucketname>' instead." << std::endl;
        return EINVAL;
     }
-    sync_status(formatter.get());
+    sync_status(formatter.get(), format_arg_passed);
   }
 
   if (opt_cmd == OPT::METADATA_SYNC_STATUS) {

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -683,6 +683,149 @@ def test_bucket_create():
     for zone in zonegroup_conns.zones:
         assert check_all_buckets_exist(zone, buckets)
 
+def _parse_sync_status_json(out):
+    data = json.loads(out)
+    # JSONFormatter drops the root section name; tolerate a wrapped form too.
+    if isinstance(data, dict) and 'metadata_sync' in data:
+        return data
+    if isinstance(data, dict) and isinstance(data.get('sync_status'), dict):
+        return data['sync_status']
+    raise AssertionError('unexpected sync status JSON shape: %r' % (data,))
+
+@attr('sync_status')
+def test_sync_status_json_format():
+    """Validate structured JSON from `radosgw-admin sync status --format=json` on all zones."""
+    zonegroup = realm.master_zonegroup()
+    zonegroup_conns = ZonegroupConns(zonegroup)
+    meta_master = realm.meta_master_zone()
+
+    for zone_conn in zonegroup_conns.zones:
+        zone = zone_conn.zone
+        cmd = ['sync', 'status', '--format=json'] + zone.zone_args()
+        out, ret = zone.cluster.admin(cmd, check_retcode=False, read_only=True)
+        eq(ret, 0)
+        status = _parse_sync_status_json(out)
+        for key in ('realm_id', 'zonegroup_id', 'zone_id', 'current_time',
+                    'metadata_sync', 'data_sync'):
+            assert_true(key in status, 'missing key %s for zone=%s' % (key, zone.name))
+        assert_true(isinstance(status['metadata_sync'], dict))
+        assert_true('status' in status['metadata_sync'])
+        assert_true(isinstance(status['data_sync'], list))
+        assert_true(status['zonegroup_id'])
+        assert_true(status['zone_id'])
+
+        md = status['metadata_sync']
+        assert_true('messages' not in md,
+                    'metadata_sync must use typed fields, not messages, zone=%s' % zone.name)
+        assert_true('sync_status' not in md,
+                    'metadata_sync must not dump per-shard markers for zone=%s' % zone.name)
+        if zone == meta_master:
+            eq(md['status'], 'no sync (zone is master)')
+        else:
+            assert_true(
+                md['status'] in ('init', 'preparing for full sync', 'syncing', 'unknown')
+                or 'error' in md,
+                'unexpected secondary metadata_sync for zone=%s: %r' % (zone.name, md),
+            )
+            # Secondary should expose typed summary detail when sync is healthy.
+            if 'error' not in md:
+                for key in ('full_sync', 'incremental_sync', 'caught_up',
+                            'shards_behind', 'behind_shards'):
+                    assert_true(key in md,
+                                'secondary metadata_sync missing %s for zone=%s: %r'
+                                % (key, zone.name, md))
+                assert_true(isinstance(md['full_sync'].get('shards'), int))
+                assert_true(isinstance(md['full_sync'].get('total_shards'), int))
+                assert_true(isinstance(md['behind_shards'], list))
+                assert_true(isinstance(md['caught_up'], bool))
+
+        for src in status['data_sync']:
+            assert_true('source_zone' in src)
+            assert_true('messages' not in src)
+            assert_true('sync_status' not in src,
+                        'data_sync must not dump per-shard markers')
+            if 'error' in src or src.get('status') == 'not syncing from zone':
+                continue
+            assert_true('status' in src)
+            assert_true('full_sync' in src)
+            assert_true('incremental_sync' in src)
+            assert_true('caught_up' in src)
+            assert_true(isinstance(src['behind_shards'], list))
+            assert_true(isinstance(src.get('shards_recovering'), int))
+            assert_true(isinstance(src.get('recovering_shards'), list))
+
+        # Default (no --format) must stay human-readable; counts agree with JSON.
+        plain, pret = zone.cluster.admin(['sync', 'status'] + zone.zone_args(),
+                                         check_retcode=False, read_only=True)
+        eq(pret, 0)
+        assert_false(plain.lstrip().startswith('{'),
+                     'default sync status must remain plaintext')
+        assert_true(status['zone_id'] in plain)
+        assert_true(status['zonegroup_id'] in plain)
+        if zone != meta_master and 'error' not in md:
+            expected = 'full sync: %d/%d shards' % (
+                md['full_sync']['shards'], md['full_sync']['total_shards'])
+            assert_true(expected in plain,
+                        'JSON full_sync mismatch vs plaintext for zone=%s: expected %r'
+                        % (zone.name, expected))
+            if md.get('caught_up'):
+                assert_true('metadata is caught up with master' in plain)
+
+@attr('sync_status')
+def test_sync_status_json_performance():
+    """JSON path should complete and stay roughly comparable to plaintext."""
+    zone = realm.meta_master_zone()
+    iters = 3
+
+    def mean_runtime(args):
+        times = []
+        for _ in range(iters):
+            start = time.time()
+            out, ret = zone.cluster.admin(args + zone.zone_args(),
+                                          check_retcode=False, read_only=True)
+            elapsed = time.time() - start
+            eq(ret, 0)
+            assert_true(len(out) > 0)
+            times.append(elapsed)
+        return sum(times) / len(times)
+
+    plain_mean = mean_runtime(['sync', 'status'])
+    json_mean = mean_runtime(['sync', 'status', '--format=json'])
+    log.info('sync status perf zone=%s plaintext=%.4fs json=%.4fs (n=%d)',
+             zone.name, plain_mean, json_mean, iters)
+    assert_true(
+        json_mean <= plain_mean * 5.0 + 1.0,
+        'JSON sync status too slow vs plaintext '
+        '(json=%.4fs plain=%.4fs)' % (json_mean, plain_mean),
+    )
+
+@attr('sync_status')
+def test_sync_status_json_secondary_data_sources():
+    """On a non-master zone, data_sync should list at least one source zone."""
+    zonegroup = realm.master_zonegroup()
+    zonegroup_conns = ZonegroupConns(zonegroup)
+    meta_master = realm.meta_master_zone()
+    secondaries = [zc for zc in zonegroup_conns.zones if zc.zone != meta_master]
+    if not secondaries:
+        raise SkipTest('need a secondary zone in the zonegroup')
+
+    for zone_conn in secondaries:
+        zone = zone_conn.zone
+        out, ret = zone.cluster.admin(
+            ['sync', 'status', '--format=json'] + zone.zone_args(),
+            check_retcode=False, read_only=True)
+        eq(ret, 0)
+        status = _parse_sync_status_json(out)
+        assert_true(isinstance(status['data_sync'], list))
+        # Secondary in a multi-zone zonegroup should see sync sources.
+        assert_true(
+            len(status['data_sync']) >= 1,
+            'expected data_sync sources on secondary zone=%s, got %r'
+            % (zone.name, status['data_sync']),
+        )
+        md = status['metadata_sync']
+        assert_true(md.get('status') != 'no sync (zone is master)')
+
 def test_bucket_create_with_tenant():
 
     ''' create a bucket from secondary zone under tenant namespace. check if it successfully syncs

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -698,6 +698,149 @@ def test_bucket_create():
     for zone in zonegroup_conns.zones:
         assert check_all_buckets_exist(zone, buckets)
 
+def _parse_sync_status_json(out):
+    data = json.loads(out)
+    # JSONFormatter drops the root section name; tolerate a wrapped form too.
+    if isinstance(data, dict) and 'metadata_sync' in data:
+        return data
+    if isinstance(data, dict) and isinstance(data.get('sync_status'), dict):
+        return data['sync_status']
+    raise AssertionError('unexpected sync status JSON shape: %r' % (data,))
+
+@attr('sync_status')
+def test_sync_status_json_format():
+    """Validate structured JSON from `radosgw-admin sync status --format=json` on all zones."""
+    zonegroup = realm.master_zonegroup()
+    zonegroup_conns = ZonegroupConns(zonegroup)
+    meta_master = realm.meta_master_zone()
+
+    for zone_conn in zonegroup_conns.zones:
+        zone = zone_conn.zone
+        cmd = ['sync', 'status', '--format=json'] + zone.zone_args()
+        out, ret = zone.cluster.admin(cmd, check_retcode=False, read_only=True)
+        eq(ret, 0)
+        status = _parse_sync_status_json(out)
+        for key in ('realm_id', 'zonegroup_id', 'zone_id', 'current_time',
+                    'metadata_sync', 'data_sync'):
+            assert_true(key in status, 'missing key %s for zone=%s' % (key, zone.name))
+        assert_true(isinstance(status['metadata_sync'], dict))
+        assert_true('status' in status['metadata_sync'])
+        assert_true(isinstance(status['data_sync'], list))
+        assert_true(status['zonegroup_id'])
+        assert_true(status['zone_id'])
+
+        md = status['metadata_sync']
+        assert_true('messages' not in md,
+                    'metadata_sync must use typed fields, not messages, zone=%s' % zone.name)
+        assert_true('sync_status' not in md,
+                    'metadata_sync must not dump per-shard markers for zone=%s' % zone.name)
+        if zone == meta_master:
+            eq(md['status'], 'no sync (zone is master)')
+        else:
+            assert_true(
+                md['status'] in ('init', 'preparing for full sync', 'syncing', 'unknown')
+                or 'error' in md,
+                'unexpected secondary metadata_sync for zone=%s: %r' % (zone.name, md),
+            )
+            # Secondary should expose typed summary detail when sync is healthy.
+            if 'error' not in md:
+                for key in ('full_sync', 'incremental_sync', 'caught_up',
+                            'shards_behind', 'behind_shards'):
+                    assert_true(key in md,
+                                'secondary metadata_sync missing %s for zone=%s: %r'
+                                % (key, zone.name, md))
+                assert_true(isinstance(md['full_sync'].get('shards'), int))
+                assert_true(isinstance(md['full_sync'].get('total_shards'), int))
+                assert_true(isinstance(md['behind_shards'], list))
+                assert_true(isinstance(md['caught_up'], bool))
+
+        for src in status['data_sync']:
+            assert_true('source_zone' in src)
+            assert_true('messages' not in src)
+            assert_true('sync_status' not in src,
+                        'data_sync must not dump per-shard markers')
+            if 'error' in src or src.get('status') == 'not syncing from zone':
+                continue
+            assert_true('status' in src)
+            assert_true('full_sync' in src)
+            assert_true('incremental_sync' in src)
+            assert_true('caught_up' in src)
+            assert_true(isinstance(src['behind_shards'], list))
+            assert_true(isinstance(src.get('shards_recovering'), int))
+            assert_true(isinstance(src.get('recovering_shards'), list))
+
+        # Default (no --format) must stay human-readable; counts agree with JSON.
+        plain, pret = zone.cluster.admin(['sync', 'status'] + zone.zone_args(),
+                                         check_retcode=False, read_only=True)
+        eq(pret, 0)
+        assert_false(plain.lstrip().startswith('{'),
+                     'default sync status must remain plaintext')
+        assert_true(status['zone_id'] in plain)
+        assert_true(status['zonegroup_id'] in plain)
+        if zone != meta_master and 'error' not in md:
+            expected = 'full sync: %d/%d shards' % (
+                md['full_sync']['shards'], md['full_sync']['total_shards'])
+            assert_true(expected in plain,
+                        'JSON full_sync mismatch vs plaintext for zone=%s: expected %r'
+                        % (zone.name, expected))
+            if md.get('caught_up'):
+                assert_true('metadata is caught up with master' in plain)
+
+@attr('sync_status')
+def test_sync_status_json_performance():
+    """JSON path should complete and stay roughly comparable to plaintext."""
+    zone = realm.meta_master_zone()
+    iters = 3
+
+    def mean_runtime(args):
+        times = []
+        for _ in range(iters):
+            start = time.time()
+            out, ret = zone.cluster.admin(args + zone.zone_args(),
+                                          check_retcode=False, read_only=True)
+            elapsed = time.time() - start
+            eq(ret, 0)
+            assert_true(len(out) > 0)
+            times.append(elapsed)
+        return sum(times) / len(times)
+
+    plain_mean = mean_runtime(['sync', 'status'])
+    json_mean = mean_runtime(['sync', 'status', '--format=json'])
+    log.info('sync status perf zone=%s plaintext=%.4fs json=%.4fs (n=%d)',
+             zone.name, plain_mean, json_mean, iters)
+    assert_true(
+        json_mean <= plain_mean * 5.0 + 1.0,
+        'JSON sync status too slow vs plaintext '
+        '(json=%.4fs plain=%.4fs)' % (json_mean, plain_mean),
+    )
+
+@attr('sync_status')
+def test_sync_status_json_secondary_data_sources():
+    """On a non-master zone, data_sync should list at least one source zone."""
+    zonegroup = realm.master_zonegroup()
+    zonegroup_conns = ZonegroupConns(zonegroup)
+    meta_master = realm.meta_master_zone()
+    secondaries = [zc for zc in zonegroup_conns.zones if zc.zone != meta_master]
+    if not secondaries:
+        raise SkipTest('need a secondary zone in the zonegroup')
+
+    for zone_conn in secondaries:
+        zone = zone_conn.zone
+        out, ret = zone.cluster.admin(
+            ['sync', 'status', '--format=json'] + zone.zone_args(),
+            check_retcode=False, read_only=True)
+        eq(ret, 0)
+        status = _parse_sync_status_json(out)
+        assert_true(isinstance(status['data_sync'], list))
+        # Secondary in a multi-zone zonegroup should see sync sources.
+        assert_true(
+            len(status['data_sync']) >= 1,
+            'expected data_sync sources on secondary zone=%s, got %r'
+            % (zone.name, status['data_sync']),
+        )
+        md = status['metadata_sync']
+        assert_true(md.get('status') != 'no sync (zone is master)')
+
 def test_bucket_create_with_tenant():
 
     ''' create a bucket from secondary zone under tenant namespace. check if it successfully syncs


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins test ceph-volume all`
- `jenkins test windows`
- `jenkins test rook e2e`

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>

## Summary
- `radosgw-admin sync status` previously ignored `--format` and always printed plaintext.
- With `--format=json` (or another formatter), emit a **structured summary** aligned with the human-readable output: typed `full_sync` / `incremental_sync` counts, `caught_up`, `shards_behind`, `behind_shards[]`, `oldest_incremental_change`, and data-sync `recovering_*`.
- Default (no `--format`) remains plaintext for compatibility.
- Do **not** dump per-shard marker blobs (those are huge and not part of the plaintext summary).

## Testing
Local (vstart single-site + `test-rgw-multisite.sh` 2 zones + induced lag):

| Scenario | Result |
|----------|--------|
| Single-site | workunit `OK (skipped=1)` — master shape; secondary test skipped |
| Multisite c1 (master) | workunit `OK (skipped=1)` |
| Multisite c2 (secondary) | workunit `OK (skipped=1)`; JSON has typed `full_sync` / `incremental_sync` / `behind_shards` |
| Lag (stop c2 RGW, put objects on c1) | `lag scenario OK` — metadata behind 5 shards, data behind 11 shards, `oldest_incremental_change` present |

Also: smoke asserts no `messages` / no raw `sync_status` markers; plaintext/JSON count parity; light perf comparable (~0.13s both paths).

QA added:
- `qa/workunits/rgw/test_rgw_sync_status_json.py` (+ runner + verify suite yaml)
- Multisite nose `@attr('sync_status')` in `src/test/rgw/rgw_multi/tests.py`

CI: please comment `ok to test` if needed for external contributors, then `jenkins test make check`.
