### PR TITLE
doc/rgw: propose distributed rate-limit coordination

### DIFF
--- a/doc/dev/radosgw/distributed_rate_limiting.rst
+++ b/doc/dev/radosgw/distributed_rate_limiting.rst
@@ -1,0 +1,310 @@
+=============================
+Distributed RGW Rate Limiting
+=============================
+
+.. warning::
+	This document is a draft, it might not be accurate
+
+This document proposes an optional, eventually consistent rate-limiting
+mode for deployments with more than one RGW instance in a zone. Option
+names and implementation details remain subject to review.
+
+Related discussion: `PR #70008
+<https://github.com/ceph/ceph/pull/70008>`_ and `Tracker #78006
+<http://tracker.ceph.com/issues/78006>`_. User-facing rate-limit behavior
+today is described in :ref:`radosgw-rate-limit-management`.
+
+-------
+Problem
+-------
+
+RGW currently enforces user, bucket, and anonymous rate limits with token
+buckets in each ``radosgw`` process. The configuration is shared, but
+runtime token state is not. Operators therefore divide a desired
+zone-wide limit by the number of active gateways.
+
+This has two undesirable consequences:
+
+* changing the number of gateways changes the effective limit; and
+* uneven request distribution can leave capacity unused on one gateway
+  while another gateway rejects requests.
+
+Persisting and updating one counter in RADOS for every request would
+provide stronger consistency, but it would put distributed I/O on the
+request path. An over-limit client would then consume RGW and OSD
+resources before RGW could reject the request.
+
+Memory pressure and frontend backpressure are separate problems.
+Distributed rate limiting is not intended to control RGW concurrency or
+prevent out-of-memory conditions.
+
+-------------------
+Goals and Non-Goals
+-------------------
+
+Goals:
+
+* keep admission decisions in memory, with no RADOS operation on the
+  HTTP request path;
+* interpret a configured limit as an approximate per-zone limit without
+  requiring operators to divide it by the gateway count;
+* redistribute unused capacity when traffic is not balanced across
+  gateways;
+* retain the current ``RGWRateLimitInfo`` data model, admin commands,
+  request classification, and HTTP error behavior;
+* tolerate gateway joins, leaves, and individual restarts; and
+* remain optional, with the existing local behavior as the default.
+
+Non-goals:
+
+* linearizable counters or billing-grade accounting;
+* a strict upper bound during membership changes or communication
+  failures;
+* cross-zone or cross-zonegroup rate limits;
+* durable runtime state across a simultaneous restart of all gateways;
+* an external Redis or Valkey dependency; and
+* a solution for request concurrency, OSD backpressure, or RGW memory
+  pressure.
+
+--------------------
+Current Request Path
+--------------------
+
+``ActiveRateLimiter`` owns the in-memory maps of ``RateLimiterEntry``
+objects. For each request, ``rate_limit()`` in ``rgw_process.cc``
+selects the effective user and bucket configuration and calls the local
+limiter. Read and write bytes are charged later by ``rgw_rest.cc``. If
+the user check succeeds but the bucket check fails, the user operation
+token is returned.
+
+Keys retain their current forms: ``"u" + uid`` for users, including the
+anonymous user id, and ``"b" + bucket marker`` for buckets. User and
+bucket limits remain independent dimensions of the same request.
+
+The distributed mode preserves these call sites and the existing
+token-bucket behavior. It changes the refill rate and burst capacity
+supplied to each local entry. The configured limit remains the zone-wide
+budget, while a coordinator calculates the local share of that budget.
+
+---------------
+Proposed Design
+---------------
+
+Each gateway runs two independent paths:
+
+* The request path uses only its local token buckets.
+* A background coordinator exchanges membership and demand reports with
+  peer gateways through RADOS watch-notify.
+
+The design uses dedicated objects in the zone's control pool. It follows
+the watch registration, re-registration, sharding, and asynchronous
+callback patterns used by ``RGWSI_Notify``, but does not reuse its
+cache-specific payload or retry behavior. The periodic peer-exchange
+flow is closer to ``rgw::sync_fairness`` and ``RGWRadosNotifyCR`` than
+to cache invalidation.
+
+No notify, read, write, or CLS operation is issued synchronously by a
+request.
+
+Coordination objects
+~~~~~~~~~~~~~~~~~~~~
+
+The coordinator uses:
+
+* one membership object for gateway heartbeats; and
+* a configurable number of demand objects selected by a stable hash of
+  the rate-limit key.
+
+Every participating gateway watches the membership object and all demand
+objects. Sharding limits payload size and allows report processing to
+run in parallel; it does not remove watch-notify fan-out.
+
+The cache notification objects are not reused. Rate-limit messages have
+a different lifetime and failure policy, and
+``RGWSI_Notify::robust_notify()`` may replace a timed-out cache update
+with a cache invalidation. That behavior is not meaningful for demand
+reports.
+
+Membership
+~~~~~~~~~~
+
+Watch registrations alone are not used as the membership protocol. A
+gateway creates a random instance identifier at startup and periodically
+publishes a heartbeat. Peers maintain a soft-state membership table and
+expire an instance after a configurable number of missed report
+intervals.
+
+As a result:
+
+* a restarted process has a new instance identifier;
+* a stale pre-restart instance ages out without requiring a durable
+  identity;
+* adding a gateway reduces the base shares after the heartbeat is
+  observed; and
+* removing a gateway does not immediately expand other shares.
+  Expansion is delayed until the old instance expires.
+
+Membership is local to a zone. Mixed operation, where some gateways use
+the distributed mode and others enforce the full local limit, is not
+supported. Operators must upgrade all gateways in the zone before
+enabling this mode.
+
+Demand reports
+~~~~~~~~~~~~~~
+
+Each local limiter records demand over a short reporting interval.
+Operation demand includes net consumed tokens and requests rejected by
+that limiter because its local allocation was exhausted. Token giveback
+after a bucket rejection is reflected in the net value. Bandwidth demand
+is based on bytes observed by the existing read and write accounting
+hooks.
+
+Only keys with an enabled limit and recent activity are reported.
+Reports are batched by demand-object shard and bounded by entry count
+and encoded size. If a queue or payload limit is reached, the
+coordinator drops demand detail and retains the base allocation
+described below.
+
+Messages use Ceph's versioned ``encode()`` and ``decode()`` conventions
+and include a sender instance identifier, sequence number, reporting
+interval identifier, configuration fingerprint, rate-limit key, and
+per-dimension demand. Receivers ignore duplicate or older sequence
+numbers and do not merge demand from incompatible configuration
+fingerprints.
+
+Allocation
+~~~~~~~~~~
+
+Allocation is calculated independently for each rate-limit key and each
+enabled dimension. Let ``B`` be the configured token budget and ``N``
+the number of live gateway instances.
+
+``B`` retains the semantics of :confval:`rgw_ratelimit_interval`. The
+shorter gossip interval only controls how frequently demand and
+allocations converge; it does not create a second token-bucket window.
+
+Every gateway initially receives a base allocation of ``B / N``. A small
+portion of this base is retained as a reserve for a new request on a
+previously idle gateway. Base and reserve allocations together never
+exceed ``B``.
+
+The allocator then redistributes unused base capacity:
+
+#. Gateways whose reported demand is below their current allocation
+   surrender the unused portion above their reserve.
+#. The surrendered capacity is divided among gateways whose attempted
+   demand exceeds their allocation.
+#. These steps repeat until there is no unused capacity or no
+   unsatisfied demand.
+#. Any remaining capacity is retained as equal burst reserve.
+
+This is a max-min-fair water-filling calculation with a small reserve.
+All gateways use the same ordered membership and demand inputs, so they
+converge on the same result without a leader.
+
+The resulting allocation controls both refill rate and burst capacity of
+the local token bucket. When an allocation shrinks, existing positive
+tokens are clamped to the new capacity. Existing byte debt is preserved.
+
+When membership and reports are stable, the sum of local allocations for
+a key and dimension is at most the configured budget. During startup, a
+network partition, or a membership transition, gateways can temporarily
+admit more than the configured zone-wide rate. Watch-notify messages are
+not persistent: after one gateway restarts, peers retain soft state and
+the restarted gateway converges on later reports. If every gateway
+restarts at the same time, all runtime state is lost, as with the
+current limiter.
+
+----------------
+Failure Behavior
+----------------
+
+The request path never waits for coordination. On notification failure,
+the coordinator keeps its last allocation while peer state is still
+within its expiry period.
+
+After coordination has remained unavailable beyond that period,
+deployments must choose between availability and tighter enforcement:
+
+``local``
+  Return gradually to the full local configured limit. This preserves
+  availability but can multiply the effective limit by the number of
+  gateways. This is the proposed default.
+
+``hold``
+  Keep the last known allocation and do not redistribute expired
+  shares. This avoids expanding the effective limit, but can
+  underutilize capacity after a gateway failure.
+
+Startup before the first membership view follows the same policy. The
+selected policy, current mode, peer count, age of the last successful
+report, and notification errors must be visible in logs and metrics.
+
+-------------
+Configuration
+-------------
+
+The exact option names are provisional. The implementation is expected
+to need options equivalent to:
+
+* ``rgw_ratelimit_backend`` (default ``local``): select ``local`` or the
+  proposed ``distributed`` mode;
+* ``rgw_ratelimit_gossip_interval``: heartbeat and demand-report
+  interval, chosen from testing;
+* ``rgw_ratelimit_gossip_num_shards``: number of dedicated demand
+  objects, chosen from testing; and
+* ``rgw_ratelimit_gossip_failure_mode`` (default ``local``): select
+  ``local`` or ``hold`` after coordination expires.
+
+The existing :confval:`rgw_ratelimit_interval` and all user, bucket, and
+global rate-limit settings remain authoritative. A restart is expected
+when the backend is changed.
+
+---------
+Multisite
+---------
+
+Configuration can continue to replicate through existing RGW metadata
+and period mechanisms. Runtime membership, demand, and allocation do not
+cross zone boundaries. Each zone therefore enforces an independent
+approximation of the configured limit.
+
+-----------------------
+Alternatives Considered
+-----------------------
+
+* **Rate-limit-specific CLS methods:** stronger consistency, but require
+  a distributed write before each admission decision and move
+  RGW-specific policy into the OSD. Not proposed for the request path.
+* **Generic CLS counters:** keep token-bucket policy in RGW, but still
+  require a RADOS operation when used for each request. Possible later
+  for persistence experiments; not required by this design.
+* **External Redis or Valkey:** shared counters and persistence, but
+  normally add a network operation to each request and introduce another
+  operational dependency.
+* **Startup-only counter restore:** reduces the effect of a restart, but
+  does not coordinate gateways while they are running.
+
+-------
+Testing
+-------
+
+Implementation should include:
+
+* allocator unit tests for balanced and skewed demand, idle peers,
+  saturation, rounding, changing membership, and all independently
+  limited operation and byte dimensions;
+* protocol tests for versioning, malformed payloads, duplicate and
+  out-of-order messages, payload bounds, peer expiry, and restart with a
+  new instance identifier;
+* multi-RGW tests that compare aggregate accepted traffic with the
+  configured budget, verify redistribution from idle gateways, exercise
+  join/leave/restart/partition, inject notify timeouts for both failure
+  modes, and verify that local mode is unchanged and that request
+  threads issue no RADOS coordination operations; and
+* scale tests that report request latency and throughput relative to the
+  local limiter, RADOS notification rate and bytes, convergence time,
+  overshoot, underutilization, and coordinator CPU and memory.
+
+The reporting interval and default shard count will be chosen from those
+results.

--- a/doc/dev/radosgw/distributed_rate_limiting.rst
+++ b/doc/dev/radosgw/distributed_rate_limiting.rst
@@ -100,6 +100,15 @@ Each gateway runs two independent paths:
 * A background coordinator exchanges membership and demand reports with
   peer gateways through RADOS watch-notify.
 
+v1 deliberately reuses proven RADOS mechanisms (watch-notify, and CLS
+only if a later optional persistence path needs it) rather than an
+external store. Experience from related RGW work (including d4n
+attempts to move CLS-style logic onto Redis) shows that Redis-style
+shared updates can hit atomicity limits that are hard to solve without
+hurting performance. FoundationDB or another transactional store may be
+evaluated later for membership and demand sharing; that is out of scope
+for the first implementation. See Alternatives below.
+
 The design uses dedicated objects in the zone's control pool. It follows
 the watch registration, re-registration, sharding, and asynchronous
 callback patterns used by ``RGWSI_Notify``, but does not reuse its
@@ -193,9 +202,13 @@ Only keys with an enabled limit and recent activity are reported.
 Reports are batched by demand-object shard and bounded by entry count
 and encoded size. Batching uses an in-process coordinator queue or
 buffer in each RGW; it is not a CLS queue and is not on the HTTP
-admission path. If that in-memory queue or the notify payload limit is
-reached, the coordinator drops demand detail and retains the base
-allocation described below.
+admission path. Before a notify is sent, the coordinator coalesces
+queued reports for the same rate-limit key and dimension: newer demand
+samples replace older ones still waiting in the same batch, so a single
+outbound message carries at most one entry per key rather than a
+history of superseded intervals. If that in-memory queue or the notify
+payload limit is reached, the coordinator drops demand detail and
+retains the base allocation described below.
 
 Messages use Ceph's versioned ``encode()`` and ``decode()`` conventions
 and include a sender instance identifier, sequence number, reporting
@@ -215,28 +228,42 @@ the number of live gateway instances.
 shorter gossip interval only controls how frequently demand and
 allocations converge; it does not create a second token-bucket window.
 
-Every gateway initially receives a base allocation of ``B / N``. A small
-portion of this base is retained as a reserve for a new request on a
-previously idle gateway. Base and reserve allocations together never
-exceed ``B``.
+Every gateway initially receives an equal base allocation of ``B / N``.
+A small portion of this base is retained as a reserve for a new request
+on a previously idle gateway. Base and reserve allocations together
+never exceed ``B``.
 
-The allocator then redistributes unused base capacity:
+The allocator then redistributes unused base capacity. Surplus is not
+simply re-split ``B / N`` again; it is filled in a max-min-fair way:
 
 #. Gateways whose reported demand is below their current allocation
    surrender the unused portion above their reserve.
-#. The surrendered capacity is divided among gateways whose attempted
-   demand exceeds their allocation.
+#. The surrendered capacity is shared equally among gateways that still
+   have unmet demand (demand above their current allocation), raising
+   each such gateway by the same increment until its demand is met or
+   the surplus is exhausted.
 #. These steps repeat until there is no unused capacity or no
    unsatisfied demand.
-#. Any remaining capacity is retained as equal burst reserve.
+#. Any capacity that remains after all reported demand is satisfied is
+   split equally across live members as burst reserve. That reserve is
+   still part of the same budget ``B``; it is not an extra pool on top
+   of ``B``.
 
 This is a max-min-fair water-filling calculation with a small reserve.
+Equal division applies to the initial base and to each filling step
+among the currently unsatisfied set; gateways with higher unmet demand
+receive more only because they remain in the unsatisfied set for more
+steps, not because surplus is proportional to raw demand in one shot.
 All gateways use the same ordered membership and demand inputs, so they
 converge on the same result without a leader.
 
-The resulting allocation controls both refill rate and burst capacity of
-the local token bucket. When an allocation shrinks, existing positive
-tokens are clamped to the new capacity. Existing byte debt is preserved.
+The resulting allocation ``L_i`` controls both refill rate and burst
+capacity of the local token bucket. Burst is therefore bounded by
+``L_i`` for the current gossip interval semantics of ``B``: an idle
+gateway does not accumulate tokens beyond its allocated capacity, and
+when ``L_i`` shrinks, existing positive tokens are clamped to the new
+capacity. There is no separate unbounded burst that grows with idle
+time. Existing byte debt is preserved.
 
 When membership and reports are stable, the sum of local allocations for
 a key and dimension is at most the configured budget. During startup, a
@@ -352,7 +379,14 @@ Alternatives Considered
   research only and does not replace watch-notify coordination.
 * **External Redis or Valkey:** shared counters and persistence, but
   normally add a network operation to each request and introduce another
-  operational dependency.
+  operational dependency. Related RGW work (d4n) also found that
+  expressing CLS-like atomic updates on Redis was difficult to keep both
+  correct and fast; v1 therefore does not depend on Redis.
+* **Non-RADOS coordination (for example FoundationDB):** worth
+  investigating later for membership maps and demand sharing if the
+  project adopts such a store more broadly. v1 stays on RADOS
+  watch-notify so the feature can ship on existing clusters without that
+  dependency.
 * **Startup-only counter restore:** reduces the effect of a restart, but
   does not coordinate gateways while they are running.
 
@@ -360,27 +394,48 @@ Alternatives Considered
 Testing
 -------
 
-Implementation should include:
+Implementation should cover several layers, following existing RGW
+practice:
 
-* allocator unit tests for balanced and skewed demand, idle peers,
-  saturation, rounding, changing membership, and all independently
-  limited operation and byte dimensions;
-* protocol tests for versioning, malformed payloads, duplicate and
-  out-of-order messages, payload bounds, peer expiry, and restart with a
-  new instance identifier;
-* concurrency tests that show request-path demand accounting and
-  allocation updates do not take a write mutex on the admission path;
-* multi-RGW tests that compare aggregate accepted traffic with the
-  configured budget, verify redistribution from idle gateways, exercise
-  join/leave/restart/partition, inject notify timeouts for both failure
-  modes, verify overshoot during join under ``hold``, verify that local
-  mode is unchanged, and verify that request threads issue no RADOS
-  coordination operations;
-* capacity tests that relate shard count and the tracked-key hard cap to
-  payload size and fallback-to-local behavior; and
-* scale tests that report request latency and throughput relative to the
-  local limiter, RADOS notification rate and bytes, convergence time,
-  overshoot, underutilization, and coordinator CPU and memory.
+Unit tests
+  Allocator and protocol logic that needs no cluster: balanced and
+  skewed demand, idle peers, saturation, rounding, changing membership,
+  all independently limited operation and byte dimensions, burst
+  clamping so idle members cannot grow unbounded tokens, versioning,
+  malformed payloads, duplicate and out-of-order messages, payload
+  bounds, coalesced batched reports, peer expiry, and restart with a new
+  instance identifier. Concurrency tests should show request-path demand
+  accounting and allocation updates do not take a write mutex on the
+  admission path.
+
+Coordinator / RADOS tests (between unit and full RGW system tests)
+  Similar in spirit to existing CLS-oriented tests: run against a
+  vstart or teuthology Ceph cluster without necessarily running RGW
+  frontends. Drive multiple coordinator clients against real
+  watch-notify objects to validate membership, demand exchange, and
+  allocation convergence with more control than full HTTP system tests.
+
+Local system tests (vstart)
+  Prefer extending any existing local rate-limiter functional coverage
+  so the same assertions pass with a single RGW under the distributed
+  backend (behavior should match local when ``N = 1``). Add multi-RGW
+  vstart cases for aggregate accepted traffic versus the configured
+  budget, redistribution from idle gateways, join/leave/restart, both
+  failure modes, overshoot during join under ``hold``, unchanged
+  ``local`` mode, and the absence of RADOS coordination on request
+  threads.
+
+Teuthology
+  Run the multi-RGW functional suite under different cluster setups when
+  practical.
+
+Perf / stability
+  There is little shared infrastructure for these today. Document
+  procedure and results for latency and throughput versus the local
+  limiter, RADOS notification rate and bytes, convergence time,
+  overshoot, underutilization, coordinator CPU and memory, and the
+  relationship between shard count, tracked-key cap, and fallback-to-local
+  behavior.
 
 Default gossip interval values will still be refined from those results
 after the capacity model for shards and tracked keys is fixed.

--- a/doc/dev/radosgw/distributed_rate_limiting.rst
+++ b/doc/dev/radosgw/distributed_rate_limiting.rst
@@ -12,7 +12,8 @@ names and implementation details remain subject to review.
 Related discussion: `PR #70008
 <https://github.com/ceph/ceph/pull/70008>`_ and `Tracker #78006
 <http://tracker.ceph.com/issues/78006>`_. User-facing rate-limit behavior
-today is described in :ref:`radosgw-rate-limit-management`.
+today is described in :ref:`radosgw-rate-limit-management`. Zone-feature
+migration follows :ref:`radosgw-zone-features`.
 
 -------
 Problem
@@ -52,8 +53,10 @@ Goals:
   gateways;
 * retain the current ``RGWRateLimitInfo`` data model, admin commands,
   request classification, and HTTP error behavior;
-* tolerate gateway joins, leaves, and individual restarts; and
-* remain optional, with the existing local behavior as the default.
+* tolerate gateway joins, leaves, and individual restarts;
+* remain optional, with the existing local behavior as the default; and
+* enable the distributed mode only through an explicit zone feature after
+  all gateways in the zone support it.
 
 Non-goals:
 
@@ -62,7 +65,8 @@ Non-goals:
   failures;
 * cross-zone or cross-zonegroup rate limits;
 * durable runtime state across a simultaneous restart of all gateways;
-* an external Redis or Valkey dependency; and
+* an external Redis or Valkey dependency;
+* dynamic resharding of demand objects in the first implementation; and
 * a solution for request concurrency, OSD backpressure, or RGW memory
   pressure.
 
@@ -112,8 +116,8 @@ Coordination objects
 The coordinator uses:
 
 * one membership object for gateway heartbeats; and
-* a configurable number of demand objects selected by a stable hash of
-  the rate-limit key.
+* a fixed number of demand objects selected by a stable hash of the
+  rate-limit key.
 
 Every participating gateway watches the membership object and all demand
 objects. Sharding limits payload size and allows report processing to
@@ -125,6 +129,15 @@ a different lifetime and failure policy, and
 with a cache invalidation. That behavior is not meaningful for demand
 reports.
 
+Demand-object shard count is not chosen by trial alone. It is a function
+of the maximum useful notify/omap payload size and the number of active
+user and bucket keys that must be reported. The first implementation
+does not reshard these objects at runtime. The deployment publishes a
+hard cap on the number of concurrently tracked keys in distributed mode.
+When that cap is exceeded, additional keys (or the whole gateway, if the
+cap cannot be applied per key) fall back to local enforcement for those
+keys until operators raise capacity or reduce the tracked set.
+
 Membership
 ~~~~~~~~~~
 
@@ -133,6 +146,17 @@ gateway creates a random instance identifier at startup and periodically
 publishes a heartbeat. Peers maintain a soft-state membership table and
 expire an instance after a configurable number of missed report
 intervals.
+
+Membership leave is soft-state, not a leader-owned delete:
+
+* heartbeats are published to the membership object and delivered through
+  watch-notify;
+* each peer expires a missing instance in its in-memory table after the
+  missed-interval threshold;
+* no single RGW is responsible for removing another instance from the
+  membership object; and
+* optional explicit leave notifies may be added for faster convergence,
+  but expiry remains the source of truth.
 
 As a result:
 
@@ -146,8 +170,8 @@ As a result:
 
 Membership is local to a zone. Mixed operation, where some gateways use
 the distributed mode and others enforce the full local limit, is not
-supported. Operators must upgrade all gateways in the zone before
-enabling this mode.
+supported. Operators enable the mode only through the zone-feature
+procedure described below.
 
 Demand reports
 ~~~~~~~~~~~~~~
@@ -159,11 +183,19 @@ after a bucket rejection is reflected in the net value. Bandwidth demand
 is based on bytes observed by the existing read and write accounting
 hooks.
 
+Hot-path recording must not introduce a write mutex around admission.
+Request threads update demand through atomic counters or a lock-free
+handoff into the coordinator. Applying a new local allocation ``L_i``
+similarly avoids a global lock on the request path (for example atomic
+replacement of per-entry refill and burst parameters).
+
 Only keys with an enabled limit and recent activity are reported.
 Reports are batched by demand-object shard and bounded by entry count
-and encoded size. If a queue or payload limit is reached, the
-coordinator drops demand detail and retains the base allocation
-described below.
+and encoded size. Batching uses an in-process coordinator queue or
+buffer in each RGW; it is not a CLS queue and is not on the HTTP
+admission path. If that in-memory queue or the notify payload limit is
+reached, the coordinator drops demand detail and retains the base
+allocation described below.
 
 Messages use Ceph's versioned ``encode()`` and ``decode()`` conventions
 and include a sender instance identifier, sequence number, reporting
@@ -233,12 +265,42 @@ deployments must choose between availability and tighter enforcement:
 
 ``hold``
   Keep the last known allocation and do not redistribute expired
-  shares. This avoids expanding the effective limit, but can
-  underutilize capacity after a gateway failure.
+  shares. This reduces expansion when a peer disappears, but does not
+  provide a hard global bound. In particular, when a new gateway joins
+  before membership and allocations reconverge, the sum of local shares
+  can temporarily exceed ``B``. ``hold`` also underutilizes capacity
+  after a gateway failure until operators or later intervals correct
+  the membership view.
 
 Startup before the first membership view follows the same policy. The
 selected policy, current mode, peer count, age of the last successful
 report, and notification errors must be visible in logs and metrics.
+
+--------------------------
+Rollout and Zone Feature
+--------------------------
+
+Distributed rate limiting is opt-in. Until the feature is enabled, every
+gateway continues to use the existing local limiter and the existing
+``RGWRateLimitInfo`` configuration without change.
+
+The implementation adds a zone feature (see
+:ref:`radosgw-zone-features`). The intended rollout is:
+
+#. Upgrade all RGWs (and required OSDs, if any new object-class
+   dependency is introduced later) in the zone, then mark the feature
+   supported on the zone.
+#. Keep ``rgw_ratelimit_backend`` at ``local`` so behavior remains
+   unchanged.
+#. When every zone that participates in the zonegroup supports the
+   feature, enable it on the zonegroup and commit a period update.
+#. Only then select the distributed backend on the gateways that should
+   participate, and restart those gateways as required.
+
+Until that enablement completes, local rate limits already configured by
+operators keep working exactly as today. Mixed fleets, where some
+gateways run distributed mode and others still apply the full local
+budget, are not supported.
 
 -------------
 Configuration
@@ -248,11 +310,15 @@ The exact option names are provisional. The implementation is expected
 to need options equivalent to:
 
 * ``rgw_ratelimit_backend`` (default ``local``): select ``local`` or the
-  proposed ``distributed`` mode;
+  proposed ``distributed`` mode. The first shipping step exposes only
+  ``local`` until the zone feature and distributed path are ready;
 * ``rgw_ratelimit_gossip_interval``: heartbeat and demand-report
-  interval, chosen from testing;
-* ``rgw_ratelimit_gossip_num_shards``: number of dedicated demand
-  objects, chosen from testing; and
+  interval;
+* ``rgw_ratelimit_gossip_num_shards``: fixed number of dedicated demand
+  objects, sized from payload limits and the tracked-key cap rather than
+  from ad-hoc testing alone;
+* ``rgw_ratelimit_gossip_max_tracked_keys``: hard cap that triggers
+  per-key or gateway fallback to local enforcement; and
 * ``rgw_ratelimit_gossip_failure_mode`` (default ``local``): select
   ``local`` or ``hold`` after coordination expires.
 
@@ -267,7 +333,9 @@ Multisite
 Configuration can continue to replicate through existing RGW metadata
 and period mechanisms. Runtime membership, demand, and allocation do not
 cross zone boundaries. Each zone therefore enforces an independent
-approximation of the configured limit.
+approximation of the configured limit. Zone-feature support and
+enablement follow the same per-zone and zonegroup rules as other RGW
+features.
 
 -----------------------
 Alternatives Considered
@@ -277,8 +345,11 @@ Alternatives Considered
   a distributed write before each admission decision and move
   RGW-specific policy into the OSD. Not proposed for the request path.
 * **Generic CLS counters:** keep token-bucket policy in RGW, but still
-  require a RADOS operation when used for each request. Possible later
-  for persistence experiments; not required by this design.
+  require a RADOS operation when used for each request. Not proposed for
+  admission. A later experiment may record counters asynchronously after
+  the client response is sent, which would raise cluster IOPS without
+  adding that latency to the request. That path is for persistence
+  research only and does not replace watch-notify coordination.
 * **External Redis or Valkey:** shared counters and persistence, but
   normally add a network operation to each request and introduce another
   operational dependency.
@@ -297,14 +368,19 @@ Implementation should include:
 * protocol tests for versioning, malformed payloads, duplicate and
   out-of-order messages, payload bounds, peer expiry, and restart with a
   new instance identifier;
+* concurrency tests that show request-path demand accounting and
+  allocation updates do not take a write mutex on the admission path;
 * multi-RGW tests that compare aggregate accepted traffic with the
   configured budget, verify redistribution from idle gateways, exercise
   join/leave/restart/partition, inject notify timeouts for both failure
-  modes, and verify that local mode is unchanged and that request
-  threads issue no RADOS coordination operations; and
+  modes, verify overshoot during join under ``hold``, verify that local
+  mode is unchanged, and verify that request threads issue no RADOS
+  coordination operations;
+* capacity tests that relate shard count and the tracked-key hard cap to
+  payload size and fallback-to-local behavior; and
 * scale tests that report request latency and throughput relative to the
   local limiter, RADOS notification rate and bytes, convergence time,
   overshoot, underutilization, and coordinator CPU and memory.
 
-The reporting interval and default shard count will be chosen from those
-results.
+Default gossip interval values will still be refined from those results
+after the capacity model for shards and tracked keys is fixed.

--- a/doc/dev/radosgw/index.rst
+++ b/doc/dev/radosgw/index.rst
@@ -12,3 +12,4 @@
    Admin Ops Nonimplemented <admin/adminops_nonimplemented>
    s3_compliance
    bucket_index
+   distributed_rate_limiting


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Summary

This design document proposes an opt-in, eventually consistent rate-limiting mode for multi-RGW zones.


The current limiter keeps runtime token state in each `radosgw` process, so operators must divide a desired zone-wide limit by the number of gateways. PR #70008 explored shared counter backends, but review correctly pointed out that a distributed write before every request would weaken the cheap rejection path and allow over-limit traffic to consume cluster resources first.

The proposed direction keeps every admission decision in memory. A background coordinator uses dedicated RADOS watch-notify objects to exchange soft membership and bounded demand reports. Each gateway starts with an equal share of the configured budget and can receive unused capacity through deterministic max-min redistribution.

The document makes the consistency boundary explicit:

- no RADOS or CLS operation on the HTTP request path;
- eventual per-zone enforcement, not linearizable accounting;
- bounded in-memory and report queues;
- explicit degraded-mode behavior;
- no claim of durable state after a simultaneous restart of all gateways; and
- performance and convergence acceptance criteria before implementation
  defaults are selected.

This is a design-only change. It does not change current RGW behavior or configuration.

Related:

- https://github.com/ceph/ceph/pull/70008
- http://tracker.ceph.com/issues/78006

## Method

I first traced the current limiter from `RateLimiterEntry` and `ActiveRateLimiter` through `rgw_process.cc` and the byte-accounting hooks in `rgw_rest.cc`. I then reviewed the existing RGW watch-notify patterns in `svc_notify`, the system-object cache, and the realm watcher.

That review changed several parts of my earlier idea. In particular, watch-notify is transport rather than durable state, cache notification retry behavior cannot be reused directly, and accepted consumption alone is not a safe demand signal for allocating capacity. The proposal now uses explicit heartbeat membership, net token consumption plus local rejections, equal base shares, and max-min redistribution.

I also kept the alternatives raised in #70008—generic CLS counters and an external Redis/Valkey service—in the document, but neither is required by the first proposed implementation.

I would appreciate feedback especially on the allocation rule, prolonged coordination-failure policy, and the scale and overshoot targets that should gate an implementation.

## Testing

- Documentation-only proposal; no runtime behavior changes.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
