### PR TITLE
smb: add teuthology test case for smb shares with fscrypt and keybridge

### DIFF
--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_keybridge.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_keybridge.yaml
@@ -1,0 +1,180 @@
+roles:
+# Test is for basic smb deployment & functionality. one node cluster is OK
+- - host.a
+  - mon.a
+  - mgr.x
+  - osd.0
+  - osd.1
+  - client.0
+# Reserve a host for acting as a domain controller and kmip server
+- - host.b
+  - cephadm.exclude
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
+tasks:
+- openssl_keys:
+    kbroot:
+      client: client.0
+      cn: kbroot
+      key-type: rsa:4096
+      install: [client.0, host.b]
+    kmip-server:
+      client: host.b
+      ca: kbroot
+      cn: keybridge
+      add-san: true
+      extended_key_usage: "serverAuth, clientAuth"
+      ca_false_ext: true
+    kmip-client:
+      client: client.0
+      ca: kbroot
+      cn: keybridge-client
+      add-san: true
+      extended_key_usage: "serverAuth, clientAuth"
+      ca_false_ext: true
+- smb.deploy_samba_ad_dc:
+    role: host.b
+- smb.deploy_kmip_container:
+    role: host.b
+    generate:
+      - {what: symmetric, policy: teuthology, bits: 256}
+      - {what: symmetric, policy: teuthology, bits: 256}
+- cephadm:
+    single_host_defaults: true
+
+- cephadm.shell:
+    host.a:
+      - ceph fs volume create cephfs
+- cephadm.wait_for_service:
+    service: mds.cephfs
+
+- cephadm.shell:
+    host.a:
+      # add subvolgroup & subvolumes for test
+      - cmd: ceph fs subvolumegroup create cephfs smb
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs spare1 --group-name=smb --mode=0777
+      # set up smb cluster and shares
+      - cmd: ceph mgr module enable smb
+      # TODO: replace sleep with poll of mgr state?
+      - cmd: sleep 30
+      - cmd: ceph smb apply -i -
+        stdin: |
+          # --- Begin Embedded YAML
+          - resource_type: ceph.smb.tls.credential
+            tls_credential_id: kb-cert-1
+            credential_type: cert
+            value: |
+              {{'cert@kmip-client'|openssl_content|indent(4)}}
+          - resource_type: ceph.smb.tls.credential
+            tls_credential_id: kb-key-1
+            credential_type: key
+            value: |
+              {{'key@kmip-client'|openssl_content|indent(4)}}
+          - resource_type: ceph.smb.tls.credential
+            tls_credential_id: kb-ca-cert-1
+            credential_type: cert
+            value: |
+              {{'cert@kbroot'|openssl_content|indent(4)}}
+          - resource_type: ceph.smb.cluster
+            cluster_id: crypted1
+            auth_mode: active-directory
+            domain_settings:
+              realm: DOMAIN1.SINK.TEST
+              join_sources:
+                - source_type: resource
+                  ref: join1-admin
+            custom_dns:
+              - "{{ctx.samba_ad_dc_ip}}"
+            remote_control:
+              locally_enabled: true
+            keybridge:
+              scopes:
+                - name: kmip
+                  kmip_hosts:
+                    - "{{ctx.kmip_server_ip}}"
+                  kmip_port: 5696
+                  kmip_cert: {ref: kb-cert-1}
+                  kmip_key: {ref: kb-key-1}
+                  kmip_ca_cert: {ref: kb-ca-cert-1}
+            placement:
+              count: 1
+          - resource_type: ceph.smb.join.auth
+            auth_id: join1-admin
+            auth:
+              username: Administrator
+              password: Passw0rd
+          - resource_type: ceph.smb.share
+            cluster_id: crypted1
+            share_id: share1
+            cephfs:
+              volume: cephfs
+              subvolumegroup: smb
+              subvolume: sv1
+              path: /
+              fscrypt_key:
+                scope: kmip
+                name: "1"
+          - resource_type: ceph.smb.share
+            cluster_id: crypted1
+            share_id: share2
+            cephfs:
+              volume: cephfs
+              subvolumegroup: smb
+              subvolume: sv2
+              path: /
+              fscrypt_key:
+                scope: kmip
+                name: "2"
+          # --- End Embedded YAML
+# Wait for the smb service to start
+- cephadm.wait_for_service:
+    service: smb.crypted1
+# Check if shares exist
+- template.exec:
+    host.b:
+      - sleep 30
+      - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share1 -c ls"
+      - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share2 -c ls"
+
+- smb.workunit:
+    admin_node: host.a
+    smb_nodes: [host.a]
+    smb_shares:
+      - share1
+      - share2
+    params:
+      kb_fscrypt:
+        cluster_id: crypted1
+        unused_subvolume: "smb/spare1"
+    timeout: 1h
+    clients:
+      client.0:
+        - [default, kb_fscrypt]
+
+- cephadm.shell:
+    host.a:
+      - cmd: ceph smb apply -i -
+        stdin: |
+          # --- Begin Embedded YAML
+          - resource_type: ceph.smb.cluster
+            cluster_id: crypted1
+            intent: removed
+          - resource_type: ceph.smb.join.auth
+            auth_id: join1-admin
+            intent: removed
+          - resource_type: ceph.smb.share
+            cluster_id: crypted1
+            share_id: share1
+            intent: removed
+          - resource_type: ceph.smb.share
+            cluster_id: crypted1
+            share_id: share2
+            intent: removed
+          # --- End Embedded YAML
+# Wait for the smb service to be removed
+- cephadm.wait_for_service_not_present:
+    service: smb.crypted1

--- a/qa/tasks/openssl_keys.py
+++ b/qa/tasks/openssl_keys.py
@@ -146,10 +146,13 @@ class OpenSSLKeys(Task):
 
             if san_ext:
                 remove_files.append(ext)
-                ca_cert.remote.write_file(path=ext,
-                        data='subjectAltName = DNS:{},DNS:*.{},IP:{}'.format(
-                        cn, cn,
-                        config.get('ip', cert.remote.ip_address)))
+                ip = config.get('ip', cert.remote.ip_address)
+                lines = [f'subjectAltName = DNS:{cn},DNS:*.{cn},IP:{ip}']
+                if eku := config.get('extended_key_usage'):
+                    lines.append(f'extendedKeyUsage = {eku}')
+                if config.get('ca_false_ext'):
+                    lines.append('basicConstraints = CA:FALSE')
+                ca_cert.remote.write_file(path=ext, data='\n'.join(lines))
 
             # create the signed certificate
             ca_cert.remote.run(args=['openssl', 'x509', '-req', '-in', csr,

--- a/qa/tasks/smb.py
+++ b/qa/tasks/smb.py
@@ -552,6 +552,7 @@ def workunit(ctx, config):
     _ssh_keys_config = config.get('ssh_keys', {})
     _config['enable_ssh_keys'] = _ssh_keys_config not in (False, None)
     _config['testdir'] = misc.get_testdir(ctx)
+    _config['params'] = config.get('params', {})  # freeform test parameters
     log.info('Passing workunit config: %r', _config)
     with contextlib.ExitStack() as estack:
         if _config['enable_ssh_keys']:
@@ -594,6 +595,8 @@ def write_metadata_file(ctx, config, *, roles=None):
         ]
     if config.get('testdir'):
         obj['testdir'] = config['testdir']
+    if config.get('params'):
+        obj['params'] = config['params']
     data = json.dumps(obj)
     log.debug('smb metadata: %r', obj)
 

--- a/qa/tasks/smb.py
+++ b/qa/tasks/smb.py
@@ -167,13 +167,7 @@ def configure_samba_client_container(ctx, config):
             "you must specify a role to discover container engine / pull image"
         )
     (remote,) = ctx.cluster.only(role).remotes.keys()
-    cengine = 'podman'
-    try:
-        log.info("Testing if podman is available")
-        remote.run(args=['sudo', cengine, '--help'])
-    except CommandFailedError:
-        log.info("Failed to find podman. Using docker")
-        cengine = 'docker'
+    cengine = _cengine(ctx, config, remote)
 
     remote.run(args=['sudo', cengine, 'pull', samba_client_image])
     samba_client_container_cmd = [
@@ -193,6 +187,17 @@ def configure_samba_client_container(ctx, config):
         setattr(ctx, 'samba_client_container_cmd', None)
 
 
+def _cengine(ctx, config, remote):
+    cengine = config.get('container_engine', 'podman')
+    try:
+        log.info("Testing if %s is available", cengine)
+        remote.run(args=['sudo', cengine, '--help'])
+    except CommandFailedError:
+        log.info("Failed to find %s. Using docker", cengine)
+        cengine = 'docker'
+    return cengine
+
+
 @contextlib.contextmanager
 def deploy_samba_ad_dc(ctx, config):
     role = config.get('role')
@@ -209,13 +214,7 @@ def deploy_samba_ad_dc(ctx, config):
         )
     (remote,) = ctx.cluster.only(role).remotes.keys()
     ip = remote.ssh.get_transport().getpeername()[0]
-    cengine = 'podman'
-    try:
-        log.info("Testing if podman is available")
-        remote.run(args=['sudo', cengine, '--help'])
-    except CommandFailedError:
-        log.info("Failed to find podman. Using docker")
-        cengine = 'docker'
+    cengine = _cengine(ctx, config, remote)
     remote.run(args=['sudo', cengine, 'pull', ad_dc_image])
     remote.run(args=['sudo', cengine, 'pull', samba_client_image])
     _disable_systemd_resolved(ctx, remote)
@@ -300,6 +299,182 @@ def deploy_samba_ad_dc(ctx, config):
         _reset_systemd_resolved(ctx, remote)
         setattr(ctx, 'samba_ad_dc_ip', None)
         setattr(ctx, 'samba_client_container_cmd', None)
+
+
+@contextlib.contextmanager
+def deploy_kmip_container(ctx, config):
+    role = config.get('role')
+    image = config.get(
+        'image', 'quay.io/phlogistonjohn/pykmip:test'
+    )
+    if not role:
+        raise ConfigError(
+            "you must specify a role to allocate a host for the KMIP server"
+        )
+    (remote,) = ctx.cluster.only(role).remotes.keys()
+    ip = remote.ssh.get_transport().getpeername()[0]
+
+    cengine = _cengine(ctx, config, remote)
+    remote.run(args=['sudo', cengine, 'pull', image])
+
+    remote.run(
+        args=[
+            'sudo',
+            'rm',
+            '-rf',
+            '/var/lib/pykmip'
+        ]
+    )
+    remote.run(
+        args=[
+            'sudo',
+            'mkdir',
+            '-p',
+            '/var/lib/pykmip/tls',
+            '/var/lib/pykmip/data',
+            '/var/lib/pykmip/data/policy',
+        ]
+    )
+    _configure_kmip_server(
+        ctx,
+        config,
+        remote,
+        tls_dir='/var/lib/pykmip/tls',
+        policy_dir='/var/lib/pykmip/data/policy',
+    )
+    remote.run(
+        args=[
+            'sudo',
+            cengine,
+            'run',
+            '-d',
+            '--name=kmip',
+            '--publish=5696:5696',
+            '--volume=/var/lib/pykmip/data:/var/lib/kmip:z',
+            '--volume=/var/lib/pykmip/tls:/etc/kmip/tls:ro,z',
+            image,
+        ]
+    )
+
+    # let the kmip server start & settle. Sleeping less than 1s causes
+    # consistent errors. Sleep 10s to give server plenty of time to init and
+    # avoid flakes.
+    time.sleep(10)
+
+    setattr(ctx, 'kmip_server_ip', ip)
+    try:
+        _init_kmip(ctx, config, remote, image, cengine=cengine)
+        yield
+    finally:
+        try:
+            remote.run(args=['sudo', cengine, 'stop', 'kmip'])
+        except CommandFailedError:
+            log.error("Failed to stop kmip container")
+        try:
+            remote.run(args=['sudo', cengine, 'rm', 'kmip'])
+        except CommandFailedError:
+            log.error("Failed to remove kmip container")
+        remote.run(
+            args=[
+                'sudo',
+                'rm',
+                '-rf',
+                '/var/lib/pykmip'
+            ]
+        )
+        setattr(ctx, 'kmip_server_ip', None)
+
+
+def _configure_kmip_server(
+    ctx,
+    config,
+    remote,
+    tls_dir=None,
+    policy_dir=None,
+    kmip_cert='kmip-server',
+    kmip_ca='kbroot',
+):
+    default_policy = {
+        "teuthology": {
+            "preset": {
+                "CERTIFICATE": {"GET": "ALLOW_ALL"},
+                "OPAQUE_DATA": {"GET": "ALLOW_ALL"},
+                "PRIVATE_KEY": {"GET": "ALLOW_ALL"},
+                "PUBLIC_KEY": {"GET": "ALLOW_ALL"},
+                "SECRET_DATA": {"GET": "ALLOW_ALL"},
+                "SPLIT_KEY": {"GET": "ALLOW_ALL"},
+                "SYMMETRIC_KEY": {
+                    "GET": "ALLOW_ALL",
+                    "LOCATE": "ALLOW_ALL",
+                },
+            }
+        }
+    }
+    ssl_certificates = getattr(ctx, 'ssl_certificates', None)
+    cert_name = config.get('cert_name', kmip_cert)
+    ca_name = config.get('ca_name', kmip_ca)
+    if tls_dir and ssl_certificates:
+        cert_obj = ssl_certificates[cert_name]
+        ca_obj = ssl_certificates[ca_name]
+        cert_path = f'{tls_dir}/kmip.crt'
+        key_path = f'{tls_dir}/kmip.key'
+        ca_path = f'{tls_dir}/ca.crt'
+        _cfg = [
+            (cert_obj, cert_obj.certificate, cert_path),
+            (cert_obj, cert_obj.key, key_path),
+            (ca_obj, ca_obj.certificate, ca_path),
+        ]
+        for _src, _srcpath, _dest in _cfg:
+            _content = _src.remote.read_file(_srcpath)
+            remote.write_file(path=_dest, data=_content, sudo=True)
+    if tls_dir and not ssl_certificates:
+        log.warning('tls_dir provided but no ssl_certificates found')
+    if policy_dir:
+        policy = config.get('policy_config', default_policy)
+        path = f'{policy_dir}/policy.json'
+        remote.write_file(
+            path=path,
+            data=json.dumps(policy),
+            sudo=True,
+        )
+
+
+def _init_kmip(ctx, config, remote, image, cengine=None):
+    if 'generate' not in config:
+        return
+    if not cengine:
+        cengine = _cengine(ctx, config, remote)
+    ip = remote.ssh.get_transport().getpeername()[0]
+    for gsrc in config['generate']:
+        # symmetric is all we support right now
+        assert gsrc.get('what') == 'symmetric'
+        policy = gsrc.get('policy', 'teuthology')
+        bits = gsrc.get('bits', 256)
+        # NOTE: the key 'name' is reserved for future use if/when we need to
+        # support the kmip *locate* API
+        ktc_args = []
+        if policy:
+            ktc_args.append(f'--policy={policy}')
+        ktc_args.append(f'--create-symmetric-key={bits}')
+        ktc_args.append('--get=.')  # for debugging
+
+        common_args = [
+            'sudo',
+            cengine,
+            'run',
+            '--rm',
+            '--net=host',
+            '--volume=/var/lib/pykmip/tls:/etc/kmip/tls:ro,z',
+            '--entrypoint=python3',
+            image,
+            '/usr/local/bin/ktc.py',
+            '--tls-cert=/etc/kmip/tls/kmip.crt',
+            '--tls-key=/etc/kmip/tls/kmip.key',
+            '--tls-ca-cert=/etc/kmip/tls/ca.crt',
+            f'--host={ip}',
+            '--json',
+        ]
+        remote.run(args=(common_args + ktc_args))
 
 
 def _marks(marks_value):

--- a/qa/workunits/smb/tests/pytest.ini
+++ b/qa/workunits/smb/tests/pytest.ini
@@ -3,8 +3,8 @@
 addopts = -m 'default'
 markers =
     default: Default tests
-    hosts_access: Host access tests
-    rate_limiting: Rate limit tests
     ceph_smb_ctl_local: Local/container test of ceph-smb-ctl tool
     ceph_smb_ctl_remote: Remote access test of ceph-smb-ctl tool
     domain: Domain integration tests
+    hosts_access: Host access tests
+    rate_limiting: Rate limit tests

--- a/qa/workunits/smb/tests/pytest.ini
+++ b/qa/workunits/smb/tests/pytest.ini
@@ -7,4 +7,5 @@ markers =
     ceph_smb_ctl_remote: Remote access test of ceph-smb-ctl tool
     domain: Domain integration tests
     hosts_access: Host access tests
+    kb_fscrypt: Keybridge and FSCrypt tests
     rate_limiting: Rate limit tests

--- a/qa/workunits/smb/tests/smbutil.py
+++ b/qa/workunits/smb/tests/smbutil.py
@@ -94,6 +94,10 @@ class SMBTestConf:
     def testdir(self):
         return self._data.get('testdir') or os.path.expanduser('~/cephtest')
 
+    @property
+    def params(self):
+        return self._data.get('params') or {}
+
 
 @contextlib.contextmanager
 def connection(conf, share):

--- a/qa/workunits/smb/tests/test_kb_fscrypt.py
+++ b/qa/workunits/smb/tests/test_kb_fscrypt.py
@@ -1,0 +1,49 @@
+import pytest
+import smbprotocol
+
+import smbutil
+
+
+@pytest.mark.kb_fscrypt
+def test_invalid_key_uid_share(smb_cfg):
+    """Configure a share for fscrypt but with an invalid KMIP ID.
+    This tests basic error handling in keybridge and validates
+    that when a key can not be fetched that the share is not
+    accessible.
+    """
+    kb_fscrypt = smb_cfg.params["kb_fscrypt"]
+    cluster_id = kb_fscrypt["cluster_id"]
+    unused_subvolume = kb_fscrypt["unused_subvolume"]
+    share_id = kb_fscrypt.get("share_id", "invalidkey1")
+    invalid_key_id = kb_fscrypt.get("invalid_key_id", "9999")
+    filename = "foo.txt"
+
+    new_share = {
+        "resource_type": "ceph.smb.share",
+        "cluster_id": cluster_id,
+        "share_id": share_id,
+        "cephfs": {
+            "volume": "cephfs",
+            "subvolume": unused_subvolume,
+            "path": "/",
+            "fscrypt_key": {
+                "scope": "kmip",
+                "name": invalid_key_id,
+            },
+        },
+    }
+    smbutil.apply_share_config(smb_cfg, new_share)
+
+    try:
+        with pytest.raises(smbprotocol.exceptions.Unsuccessful):
+            with smbutil.connection(smb_cfg, share_id) as sharep:
+                fname = sharep / filename
+                fname.write_text("value: NOPE\n")
+    finally:
+        del_share = {
+            "resource_type": "ceph.smb.share",
+            "cluster_id": cluster_id,
+            "share_id": share_id,
+            "intent": "removed",
+        }
+        smbutil.apply_share_config(smb_cfg, del_share)


### PR DESCRIPTION
Depends on: #69892

Fixes: https://tracker.ceph.com/issues/76677

Add test coverage for the smb features that implement fscrypt (on cephfs shares) as well as the keybridge sidecar fetching keys from a KMIP server.



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [X] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
