### PR TITLE
crimson/net: handle sender late frame abort instead of ceph_abort("TODO")

### DIFF
--- a/src/crimson/net/FrameAssemblerV2.cc
+++ b/src/crimson/net/FrameAssemblerV2.cc
@@ -380,7 +380,7 @@ template seastar::future<FrameAssemblerV2::read_main_t> FrameAssemblerV2::read_m
 
 template <bool may_cross_core>
 seastar::future<FrameAssemblerV2::read_payload_t*>
-FrameAssemblerV2::read_frame_payload()
+FrameAssemblerV2::read_frame_payload(bool allow_aborted)
 {
   assert(seastar::this_shard_id() == sid);
   rx_segments_data.clear();
@@ -409,7 +409,7 @@ FrameAssemblerV2::read_frame_payload()
     }
   ).then([this] {
     return read_exactly<may_cross_core>(rx_frame_asm.get_epilogue_onwire_len());
-  }).then([this](auto bptr) {
+  }).then([this, allow_aborted](auto bptr) -> read_payload_t* {
     logger().trace("{} RECV({}) frame epilogue", conn, bptr.length());
     bool ok = false;
     try {
@@ -427,13 +427,26 @@ FrameAssemblerV2::read_frame_payload()
     // and abort after putting entire data field on wire. This will be used by
     // the kernel client to avoid unnecessary buffering.
     if (!ok) {
-      ceph_abort_msg("TODO");
+      // The sender aborted the frame late (FRAME_LATE_STATUS_ABORTED).
+      // The full frame including the epilogue has already been read off
+      // the wire (the sender zero-pads the remainder), so the stream is
+      // positioned at the next frame and the aborted frame can simply be
+      // dropped -- see ProtocolV2::_handle_read_frame_epilogue_main() for
+      // the classic messenger equivalent.
+      if (allow_aborted) {
+        logger().info("{} read_frame_payload: late frame abort from the"
+                      " sender, dropping the frame", conn);
+        return nullptr;
+      }
+      logger().warn("{} read_frame_payload: unexpected late frame abort",
+                    conn);
+      throw std::system_error(make_error_code(crimson::net::error::negotiation_failure));
     }
     return &rx_segments_data;
   });
 }
-template seastar::future<FrameAssemblerV2::read_payload_t*> FrameAssemblerV2::read_frame_payload<true>();
-template seastar::future<FrameAssemblerV2::read_payload_t*> FrameAssemblerV2::read_frame_payload<false>();
+template seastar::future<FrameAssemblerV2::read_payload_t*> FrameAssemblerV2::read_frame_payload<true>(bool);
+template seastar::future<FrameAssemblerV2::read_payload_t*> FrameAssemblerV2::read_frame_payload<false>(bool);
 
 void FrameAssemblerV2::log_main_preamble(const ceph::bufferlist &bl)
 {

--- a/src/crimson/net/FrameAssemblerV2.h
+++ b/src/crimson/net/FrameAssemblerV2.h
@@ -128,10 +128,17 @@ public:
   seastar::future<read_main_t> read_main_preamble();
 
   /// may throw negotiation_failure as fault
+  ///
+  /// A sender may legally abort a frame after it has started to put it
+  /// on the wire (FRAME_LATE_STATUS_ABORTED in the epilogue) -- the kernel
+  /// client does this when it revokes an in-flight message (e.g. resending
+  /// an osd op after an osdmap change).  With allow_aborted=true such a
+  /// frame resolves to nullptr so the caller can drop it and keep reading;
+  /// otherwise it throws negotiation_failure (a connection fault).
   using read_payload_t = ceph::msgr::v2::segment_bls_t;
   // FIXME: read_payload_t cannot be no-throw move constructible
   template <bool may_cross_core = true>
-  seastar::future<read_payload_t*> read_frame_payload();
+  seastar::future<read_payload_t*> read_frame_payload(bool allow_aborted = false);
 
   template <class F>
   ceph::bufferlist get_buffer(F &tx_frame) {

--- a/src/crimson/net/io_handler.cc
+++ b/src/crimson/net/io_handler.cc
@@ -997,12 +997,26 @@ IOHandler::read_message(
     utime_t throttle_stamp,
     std::size_t msg_size)
 {
-  return frame_assembler->read_frame_payload<false>(
+  return frame_assembler->read_frame_payload<false>(true
   ).then([this, throttle_stamp, msg_size, &ctx](auto payload) {
     if (unlikely(ctx.get_io_state() != io_state_t::open)) {
       logger().debug("{} triggered {} during read_message()",
                      conn, ctx.get_io_state());
       abort_protocol();
+    }
+
+    if (payload == nullptr) {
+      // The sender aborted the message frame late (e.g. the kernel client
+      // revoking an in-flight osd op to resend it after an osdmap change).
+      // The frame has been consumed from the wire; drop it and release the
+      // policy throttle budget taken for it (the classic messenger does the
+      // same via reset_throttle()).
+      logger().info("{} read_message: message frame aborted by the sender,"
+                    " skipping", conn);
+      if (conn.policy.throttler_bytes && msg_size) {
+        conn.policy.throttler_bytes->put(msg_size);
+      }
+      return seastar::now();
     }
 
     utime_t recv_stamp{seastar::lowres_system_clock::now()};


### PR DESCRIPTION
**Problem**
msgr2 allows a sender to abort a frame after it has started putting it on the wire — it zero-pads the remainder and sets FRAME_LATE_STATUS_ABORTED in the epilogue. The kernel RBD client uses this when it revokes an in-flight message, e.g. ceph_osdc's send_request() resending an osd op after an osdmap change re-targets its PG (a mgr-balancer pg-upmap-items batch is enough to trigger it in practice).

The classic messenger handles this by dropping the frame and continuing (ProtocolV2::_handle_read_frame_epilogue_main(): reset_throttle(); state = READY; CONTINUE(read_frame)). Crimson's receive path for it was never implemented — a literal ceph_abort("TODO") in FrameAssemblerV2::read_frame_payload() — so any late-aborted frame killed the whole OSD. Worse, the resulting osdmap churn caused further revokes on other connections, cascading OSD deaths cluster-wide.

Observed repeatedly on a 40-OSD (8-host) crimson/SeaStore size=5 cluster under sustained kernel-RBD write load: first OSD abort within minutes, then a self-sustaining cascade that only an operator freeze could stop.

**Fix**
Give FrameAssemblerV2::read_frame_payload() an allow_aborted knob (mirroring classic semantics):

The io_handler message path passes allow_aborted=true: a late-aborted message frame resolves to nullptr; the caller drops it and returns the policy-throttle budget (the classic reset_throttle() equivalent), then keeps reading the next frame.
All other callers (handshake/session frames, control frames) keep the default allow_aborted=false, which now surfaces the event as a negotiation_failure connection fault — handled by the existing fault machinery — instead of a process abort.
The aborted frame, including its epilogue, has been fully consumed from the wire (the sender zero-pads the remainder), so the stream stays frame-aligned in both cases.

Only CRC-mode msgr2 sessions are affected (in secure mode the kernel-side revoke is a no-op); this matches the kernel client's default ms_mode=prefer-crc.

Fixes: https://tracker.ceph.com/issues/78119
Signed-off-by: Vitaly Goot [vgoot@akamai.com](mailto:vgoot@akamai.com)