### PR TITLE
pybind: write Tempita-processed pyx to the build directory

### DIFF
--- a/src/pybind/cephfs/setup.py
+++ b/src/pybind/cephfs/setup.py
@@ -149,7 +149,14 @@ if 'BUILD_DOC' in os.environ or 'READTHEDOCS' in os.environ:
 elif check_sanity():
     ext_args = get_python_flags(['cephfs'])
     cython_constants = dict(BUILD_DOC=False)
-    include_path = [os.path.join(os.path.dirname(__file__), "..", "rados")]
+    # The processed .pyx is written to CYTHON_BUILD_DIR, away from the
+    # binding's own c_*.pxd, so add this source directory to include_path
+    # for cimports to resolve.
+    source_dir = os.path.dirname(os.path.abspath(__file__))
+    include_path = [
+        source_dir,
+        os.path.join(source_dir, "..", "rados"),
+    ]
     cythonize_args = dict(include_path=include_path)
 else:
     sys.exit(1)
@@ -186,9 +193,11 @@ else:
     # Process the template with cython_constants
     processed = Tempita.sub(template_content, **cython_constants)
 
-    # Write processed output to current working directory
-    # (which is the build directory when invoked by CMake)
-    output_pyx = "cephfs_processed.pyx"
+    # Write the processed output to the build directory when invoked by
+    # CMake, which exports CYTHON_BUILD_DIR but runs setup.py from the
+    # source directory; fall back to the current working directory.
+    build_dir = os.environ.get("CYTHON_BUILD_DIR", os.getcwd())
+    output_pyx = os.path.join(build_dir, "cephfs_processed.pyx")
 
     with open(output_pyx, 'w') as f:
         f.write(processed)
@@ -225,7 +234,6 @@ setup(
                 **ext_args
             )
         ],
-        build_dir=os.environ.get("CYTHON_BUILD_DIR", None),
         **cythonize_args
     ),
     classifiers=[

--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -140,9 +140,15 @@ def check_sanity():
 if 'BUILD_DOC' in os.environ or 'READTHEDOCS' in os.environ:
     ext_args = dict(extra_compile_args=['-DBUILD_DOC'])
     cython_constants = dict(BUILD_DOC=True)
+    cythonize_args = dict()
 elif check_sanity():
     ext_args = get_python_flags(['rados'])
     cython_constants = dict(BUILD_DOC=False)
+    # The processed .pyx is written to CYTHON_BUILD_DIR, away from the
+    # binding's own c_*.pxd, so add this source directory to include_path
+    # for cimports to resolve.
+    include_path = [os.path.dirname(os.path.abspath(__file__))]
+    cythonize_args = dict(include_path=include_path)
 else:
     sys.exit(1)
 
@@ -178,9 +184,11 @@ else:
     # Process the template with cython_constants
     processed = Tempita.sub(template_content, **cython_constants)
 
-    # Write processed output to current working directory
-    # (which is the build directory when invoked by CMake)
-    output_pyx = "rados_processed.pyx"
+    # Write the processed output to the build directory when invoked by
+    # CMake, which exports CYTHON_BUILD_DIR but runs setup.py from the
+    # source directory; fall back to the current working directory.
+    build_dir = os.environ.get("CYTHON_BUILD_DIR", os.getcwd())
+    output_pyx = os.path.join(build_dir, "rados_processed.pyx")
 
     with open(output_pyx, 'w') as f:
         f.write(processed)
@@ -216,7 +224,7 @@ setup(
                 **ext_args
             )
         ],
-        build_dir=os.environ.get("CYTHON_BUILD_DIR", None),
+        **cythonize_args
     ),
     classifiers=[
         'Intended Audience :: Developers',

--- a/src/pybind/rbd/setup.py
+++ b/src/pybind/rbd/setup.py
@@ -147,7 +147,14 @@ if 'BUILD_DOC' in os.environ or 'READTHEDOCS' in os.environ:
 elif check_sanity():
     ext_args = get_python_flags(['rados', 'rbd'])
     cython_constants = dict(BUILD_DOC=False)
-    include_path = [os.path.join(os.path.dirname(__file__), "..", "rados")]
+    # The processed .pyx is written to CYTHON_BUILD_DIR, away from the
+    # binding's own c_*.pxd, so add this source directory to include_path
+    # for cimports to resolve.
+    source_dir = os.path.dirname(os.path.abspath(__file__))
+    include_path = [
+        source_dir,
+        os.path.join(source_dir, "..", "rados"),
+    ]
     cythonize_args = dict(include_path=include_path)
 else:
     sys.exit(1)
@@ -185,9 +192,11 @@ else:
     # Process the template with cython_constants
     processed = Tempita.sub(template_content, **cython_constants)
 
-    # Write processed output to current working directory
-    # (which is the build directory when invoked by CMake)
-    source = "rbd_processed.pyx"
+    # Write the processed output to the build directory when invoked by
+    # CMake, which exports CYTHON_BUILD_DIR but runs setup.py from the
+    # source directory; fall back to the current working directory.
+    build_dir = os.environ.get("CYTHON_BUILD_DIR", os.getcwd())
+    source = os.path.join(build_dir, "rbd_processed.pyx")
 
     with open(source, 'w') as f:
         f.write(processed)
@@ -222,7 +231,6 @@ setup(
                 **ext_args
             )
         ],
-        build_dir=os.environ.get("CYTHON_BUILD_DIR", None),
         **cythonize_args
     ),
     classifiers=[

--- a/src/pybind/rgw/setup.py
+++ b/src/pybind/rgw/setup.py
@@ -149,7 +149,14 @@ if 'BUILD_DOC' in os.environ or 'READTHEDOCS' in os.environ:
 elif check_sanity():
     ext_args = get_python_flags(['rados', 'rgw'])
     cython_constants = dict(BUILD_DOC=False)
-    include_path = [os.path.join(os.path.dirname(__file__), "..", "rados")]
+    # The processed .pyx is written to CYTHON_BUILD_DIR, away from the
+    # binding's own c_*.pxd, so add this source directory to include_path
+    # for cimports to resolve.
+    source_dir = os.path.dirname(os.path.abspath(__file__))
+    include_path = [
+        source_dir,
+        os.path.join(source_dir, "..", "rados"),
+    ]
     cythonize_args = dict(include_path=include_path)
 else:
     sys.exit(1)
@@ -186,9 +193,11 @@ else:
     # Process the template with cython_constants
     processed = Tempita.sub(template_content, **cython_constants)
 
-    # Write processed output to current working directory
-    # (which is the build directory when invoked by CMake)
-    output_pyx = "rgw_processed.pyx"
+    # Write the processed output to the build directory when invoked by
+    # CMake, which exports CYTHON_BUILD_DIR but runs setup.py from the
+    # source directory; fall back to the current working directory.
+    build_dir = os.environ.get("CYTHON_BUILD_DIR", os.getcwd())
+    output_pyx = os.path.join(build_dir, "rgw_processed.pyx")
 
     with open(output_pyx, 'w') as f:
         f.write(processed)
@@ -224,7 +233,6 @@ setup(
                 **ext_args
             )
         ],
-        build_dir=os.environ.get("CYTHON_BUILD_DIR", None),
         **cythonize_args
     ),
     classifiers=[


### PR DESCRIPTION
`distutils_add_cython_module()` runs setup.py with WORKING_DIRECTORY set
to the source directory, so every build leaks
`{rados,cephfs,rbd,rgw}_processed.pyx` into the source tree as untracked
files. Write the file to `CYTHON_BUILD_DIR` (already exported by that
CMake function) when set, keeping the cwd fallback for standalone
invocations.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
