### PR TITLE
umbrella: mgr/dashboard: Add storage carbonization umbrella

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -271,13 +271,13 @@ const routes: Routes = [
       },
       {
         path: 'osd',
+        component: OsdListComponent,
         data: { breadcrumbs: 'Cluster/OSDs' },
         children: [
-          { path: '', component: OsdListComponent },
           {
             path: URLVerbs.CREATE,
             component: OsdFormComponent,
-            data: { breadcrumbs: ActionLabels.CREATE }
+            outlet: 'modal'
           }
         ]
       },

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
@@ -27,7 +27,8 @@ import {
   TabsModule,
   RadioModule,
   TilesModule,
-  LayerModule
+  LayerModule,
+  AccordionModule
 } from 'carbon-components-angular';
 import Analytics from '@carbon/icons/es/analytics/16';
 import CloseFilled from '@carbon/icons/es/close--filled/16';
@@ -145,7 +146,8 @@ import { TextLabelListComponent } from '~/app/shared/components/text-label-list/
     FileUploaderModule,
     RadioModule,
     TilesModule,
-    LayerModule
+    LayerModule,
+    AccordionModule
   ],
   declarations: [
     MonitorComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-step-2/create-cluster-step-2.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-step-2/create-cluster-step-2.component.html
@@ -13,9 +13,11 @@
                      (emitDriveGroup)="setDriveGroup($event)"
                      (emitDeploymentOption)="setDeploymentOptions($event)"
                      (emitMode)="setDeploymentMode($event)"
-                     (osdCreated)="onOsdCreated()"></cd-osd-form>
+                     (osdCreated)="onOsdCreated()"
+                     (cancelled)="onFormCancelled()"></cd-osd-form>
       } @else {
         <cd-osd-list [showTabs]="false"
+                     [inlineCreate]="true"
                      (createAction)="onCreateAction()"></cd-osd-list>
       }
     </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-step-2/create-cluster-step-2.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-step-2/create-cluster-step-2.component.html
@@ -8,11 +8,16 @@
     <h4 i18n>Create OSDs</h4>
 
     <div>
-      <cd-osd-form [hideTitle]="true"
-                   [hideSubmitBtn]="true"
-                   (emitDriveGroup)="setDriveGroup($event)"
-                   (emitDeploymentOption)="setDeploymentOptions($event)"
-                   (emitMode)="setDeploymentMode($event)"></cd-osd-form>
+      @if (showForm) {
+        <cd-osd-form [hideTitle]="true"
+                     (emitDriveGroup)="setDriveGroup($event)"
+                     (emitDeploymentOption)="setDeploymentOptions($event)"
+                     (emitMode)="setDeploymentMode($event)"
+                     (osdCreated)="onOsdCreated()"></cd-osd-form>
+      } @else {
+        <cd-osd-list [showTabs]="false"
+                     (createAction)="onCreateAction()"></cd-osd-list>
+      }
     </div>
 
     <button cdsButton="secondary"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-step-2/create-cluster-step-2.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-step-2/create-cluster-step-2.component.ts
@@ -37,6 +37,10 @@ export class CreateClusterStep2Component implements OnInit, TearsheetStep {
     this.formGroup.patchValue({ skipped: true });
   }
 
+  onFormCancelled() {
+    this.showForm = false;
+  }
+
   onCreateAction() {
     this.showForm = true;
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-step-2/create-cluster-step-2.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-step-2/create-cluster-step-2.component.ts
@@ -16,6 +16,7 @@ export class CreateClusterStep2Component implements OnInit, TearsheetStep {
   @Output() skipStep = new EventEmitter<void>();
 
   formGroup: CdFormGroup;
+  showForm = false;
 
   ngOnInit() {
     this.formGroup = new CdFormGroup({
@@ -29,6 +30,15 @@ export class CreateClusterStep2Component implements OnInit, TearsheetStep {
   onSkip() {
     this.formGroup.patchValue({ skipped: true });
     this.skipStep.emit();
+  }
+
+  onOsdCreated() {
+    this.showForm = false;
+    this.formGroup.patchValue({ skipped: true });
+  }
+
+  onCreateAction() {
+    this.showForm = true;
   }
 
   setDriveGroup(driveGroup: DriveGroup) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory-devices/inventory-devices.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory-devices/inventory-devices.component.ts
@@ -106,13 +106,13 @@ export class InventoryDevicesComponent implements OnInit, OnDestroy {
     ];
     const columns = [
       {
-        name: $localize`Hostname`,
-        prop: 'hostname',
+        name: $localize`Device path`,
+        prop: 'path',
         flexGrow: 1
       },
       {
-        name: $localize`Device path`,
-        prop: 'path',
+        name: $localize`Hostname`,
+        prop: 'hostname',
         flexGrow: 1
       },
       {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.html
@@ -1,55 +1,105 @@
-<!-- button -->
-<div class="form-group row">
-  <label class="cd-col-form-label"
+<div class="form-group row osd-devices-selection-row">
+  <label class="cd-form-label"
          for="createDeleteButton">
     <ng-container i18n>{{ name }} devices</ng-container>
     <cd-helper>
-      <span i18n
-            *ngIf="type === 'data'">The primary storage devices. These devices contain all OSD data.</span>
-      <span i18n
-            *ngIf="type === 'wal'">Write-Ahead-Log devices. These devices are used for BlueStore’s internal journal. It is only useful to use a WAL device if the device is faster than the primary device (e.g. NVME devices or SSDs). If there is only a small amount of fast storage available (e.g., less than a gigabyte), we recommend using it as a WAL device.</span>
-      <span i18n
-            *ngIf="type === 'db'">DB devices can be used for storing BlueStore’s internal metadata.  It is only helpful to provision a DB device if it is faster than the primary device (e.g. NVME devices or SSD).</span>
+      @if (type === 'data') {
+      <span i18n>The primary storage devices. These devices contain all OSD data.</span>
+      }
+      @if (type === 'wal') {
+      <span i18n>Write-Ahead-Log devices. These devices are used for BlueStore’s internal journal. It is only useful to use a WAL device if the device is faster than the primary device (e.g. NVME devices or SSDs). If there is only a small amount of fast storage available (e.g., less than a gigabyte), we recommend using it as a WAL device.</span>
+      }
+      @if (type === 'db') {
+      <span i18n>DB devices can be used for storing BlueStore’s internal metadata.  It is only helpful to provision a DB device if it is faster than the primary device (e.g. NVME devices or SSD).</span>
+      }
     </cd-helper>
   </label>
   <div class="cd-col-form-input">
-    <ng-container *ngIf="devices.length === 0; else blockClearDevices">
-      <button type="button"
-              class="btn btn-light"
-              (click)="showSelectionModal()"
-              data-toggle="tooltip"
-              [title]="addButtonTooltip"
-              [disabled]="availDevices.length === 0 || !canSelect || expansionCanSelect">
-        <svg [cdsIcon]="icons.add"
-             [size]="icons.size16"
-             ></svg>
-        <ng-container i18n>Add</ng-container>
-      </button>
-    </ng-container>
-    <ng-template #blockClearDevices>
-      <div class="pb-2 my-2 border-bottom">
-        <span *ngFor="let filter of appliedFilters">
-          <cds-tag class="tag-dark me-2">{{ filter.name }}: {{ filter.value.formatted }}</cds-tag>
-        </span>
-        <a class="tc_clearSelections"
-           href=""
-           (click)="clearDevices(); false">
-          <svg [cdsIcon]="icons.clearFilters"
-               [size]="icons.size16"
-               ></svg>
-          <ng-container i18n>Clear</ng-container>
-        </a>
-      </div>
-      <div>
-        <cd-inventory-devices [devices]="devices"
-                              [hiddenColumns]="['available', 'osd_ids']"
-                              [filterColumns]="[]">
-        </cd-inventory-devices>
-      </div>
-      <div *ngIf="type === 'data'"
-           class="float-end">
-        <span i18n>Raw capacity: {{ capacity | dimlessBinary }}</span>
-      </div>
-    </ng-template>
+    @if (devices.length === 0 && inlineSelection) {
+    @if (!canSelect) {
+    <cd-alert-panel type="info"
+                    size="slim"
+                    [showTitle]="false">
+      <ng-container i18n>{{ tooltips.addPrimaryFirst }}</ng-container>
+    </cd-alert-panel>
+    }
+    @if (canSelect) {
+    @if (availDevices.length === 0) {
+    <cd-alert-panel type="warning"
+                    size="slim"
+                    [showTitle]="false">
+      <ng-container i18n>No available devices</ng-container>
+    </cd-alert-panel>
+    }
+    @if (availDevices.length > 0 && !canInlineSubmit) {
+    <cd-alert-panel type="warning"
+                    size="slim"
+                    [showTitle]="false">
+      <ng-container i18n>At least one of these filters must be applied in order to proceed:</ng-container>
+      @for (filter of requiredFilters; track filter) {
+      <cds-tag class="tag-dark ms-2">{{ filter }}</cds-tag>
+      }
+    </cd-alert-panel>
+    }
+    <cd-inventory-devices [devices]="availDevices"
+                          [hostname]="hostname"
+                          [diskType]="name === 'Primary' ? 'hdd' : 'ssd'"
+                          [hiddenColumns]="['available', 'osd_ids']"
+                          [filterColumns]="filterColumns"
+                          (filterChange)="onInlineFilterChange($event)">
+    </cd-inventory-devices>
+    @if (canInlineSubmit) {
+    <div class="text-center cds-mt-3 cds-mb-3">
+      <span i18n>Number of devices: {{ inlineFilteredDevices.length }}. Raw capacity:
+        {{ inlineCapacity | dimlessBinary }}.</span>
+    </div>
+    }
+    <button type="button"
+            class="btn btn-light"
+            (click)="submitInlineSelection()"
+            [disabled]="!canInlineSubmit || inlineFilteredDevices.length === 0">
+      <svg [cdsIcon]="icons.add"
+           [size]="icons.size16"></svg>
+      <ng-container i18n>Add</ng-container>
+    </button>
+    }
+    } @else {
+    @if (devices.length === 0) {
+    <button type="button"
+            class="btn btn-light"
+            (click)="showSelectionModal()"
+            data-toggle="tooltip"
+            [title]="addButtonTooltip"
+            [disabled]="availDevices.length === 0 || !canSelect || expansionCanSelect">
+      <svg [cdsIcon]="icons.add"
+           [size]="icons.size16"></svg>
+      <ng-container i18n>Add</ng-container>
+    </button>
+    } @else {
+    <div class="pb-2 my-2 border-bottom">
+      <span *ngFor="let filter of appliedFilters">
+        <cds-tag class="tag-dark me-2">{{ filter.name }}: {{ filter.value.formatted }}</cds-tag>
+      </span>
+      <a class="tc_clearSelections"
+         href=""
+         (click)="clearDevices(); false">
+        <svg [cdsIcon]="icons.clearFilters"
+             [size]="icons.size16"></svg>
+        <ng-container i18n>Clear</ng-container>
+      </a>
+    </div>
+    <div>
+      <cd-inventory-devices [devices]="devices"
+                            [hiddenColumns]="['available', 'osd_ids']"
+                            [filterColumns]="[]">
+      </cd-inventory-devices>
+    </div>
+    @if (type === 'data') {
+    <div class="float-end">
+      <span i18n>Raw capacity: {{ capacity | dimlessBinary }}</span>
+    </div>
+    }
+    }
+    }
   </div>
 </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.html
@@ -15,53 +15,77 @@
     </cd-helper>
   </label>
   <div class="cd-col-form-input">
-    @if (devices.length === 0 && inlineSelection) {
-    @if (!canSelect) {
+    @if (inlineSelection) {
+    @if (showAddPrimaryFirstAlert) {
     <cd-alert-panel type="info"
                     size="slim"
                     [showTitle]="false">
       <ng-container i18n>{{ tooltips.addPrimaryFirst }}</ng-container>
     </cd-alert-panel>
     }
-    @if (canSelect) {
-    @if (availDevices.length === 0) {
+    @if (showNoAvailDevicesAlert) {
     <cd-alert-panel type="warning"
                     size="slim"
                     [showTitle]="false">
       <ng-container i18n>No available devices</ng-container>
     </cd-alert-panel>
     }
-    @if (availDevices.length > 0 && !canInlineSubmit) {
+    @if (showFilterSection) {
+    @if (!canInlineSubmit) {
     <cd-alert-panel type="warning"
                     size="slim"
                     [showTitle]="false">
-      <ng-container i18n>At least one of these filters must be applied in order to proceed:</ng-container>
+      <ng-container i18n>Select at least one of these filters to fetch the data:</ng-container>
       @for (filter of requiredFilters; track filter) {
       <cds-tag class="tag-dark ms-2">{{ filter }}</cds-tag>
       }
     </cd-alert-panel>
     }
-    <cd-inventory-devices [devices]="availDevices"
+    <div class="device-filter-form">
+      <div class="filter-dropdown-row">
+        @for (field of filterFields; track field.prop) {
+        <div class="filter-dropdown">
+          <cds-select (valueChange)="onFilterFieldChange(field.prop, $event)"
+                      [id]="'device_filter_' + field.prop"
+                      [label]="field.name"
+                      size="md"
+                      [attr.data-testid]="'device-filter-' + field.prop">
+            <option value=""
+                    i18n>Any</option>
+            @for (option of field.options; track option.raw) {
+            <option [value]="option.raw"
+                    [selected]="selectedFilters[field.prop] === option.raw">
+              {{ option.formatted }}
+            </option>
+            }
+          </cds-select>
+        </div>
+        }
+      </div>
+    </div>
+    @if (showSelectionSummary) {
+    <div class="selection-summary pb-2 my-2 border-bottom">
+      @for (filter of displayedFilters; track filter.prop) {
+      <cds-tag class="tag-dark me-2">{{ filter.name }}: {{ filter.value.formatted }}</cds-tag>
+      }
+      <a class="tc_clearSelections"
+         href=""
+         (click)="clearDevices(); false">
+        <svg [cdsIcon]="icons.clearFilters"
+             [size]="icons.size16"></svg>
+        <ng-container i18n>Clear</ng-container>
+      </a>
+      <div class="selection-capacity cds-mt-2">
+        <span i18n>Raw capacity: {{ inlineCapacity | dimlessBinary }}.</span>
+      </div>
+    </div>
+    }
+    <cd-inventory-devices [devices]="tableDevices"
                           [hostname]="hostname"
                           [diskType]="name === 'Primary' ? 'hdd' : 'ssd'"
                           [hiddenColumns]="['available', 'osd_ids']"
-                          [filterColumns]="filterColumns"
-                          (filterChange)="onInlineFilterChange($event)">
+                          [filterColumns]="[]">
     </cd-inventory-devices>
-    @if (canInlineSubmit) {
-    <div class="text-center cds-mt-3 cds-mb-3">
-      <span i18n>Number of devices: {{ inlineFilteredDevices.length }}. Raw capacity:
-        {{ inlineCapacity | dimlessBinary }}.</span>
-    </div>
-    }
-    <button type="button"
-            class="btn btn-light"
-            (click)="submitInlineSelection()"
-            [disabled]="!canInlineSubmit || inlineFilteredDevices.length === 0">
-      <svg [cdsIcon]="icons.add"
-           [size]="icons.size16"></svg>
-      <ng-container i18n>Add</ng-container>
-    </button>
     }
     } @else {
     @if (devices.length === 0) {
@@ -94,11 +118,6 @@
                             [filterColumns]="[]">
       </cd-inventory-devices>
     </div>
-    @if (type === 'data') {
-    <div class="float-end">
-      <span i18n>Raw capacity: {{ capacity | dimlessBinary }}</span>
-    </div>
-    }
     }
     }
   </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.scss
@@ -1,3 +1,17 @@
 .tc_clearSelections {
   text-decoration: none;
 }
+
+.osd-devices-selection-row {
+  .cd-form-label,
+  .cd-col-form-input {
+    flex: 0 0 100%;
+    max-width: 100%;
+    width: 100%;
+  }
+
+  cd-inventory-devices {
+    display: block;
+    width: 100%;
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.scss
@@ -15,3 +15,25 @@
     width: 100%;
   }
 }
+
+.device-filter-form {
+  margin-bottom: 1rem;
+}
+
+.filter-dropdown-row {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 0.75rem;
+  width: 100%;
+}
+
+.filter-dropdown {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.selection-summary {
+  .selection-capacity {
+    text-align: center;
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.spec.ts
@@ -16,11 +16,6 @@ describe('OsdDevicesSelectionGroupsComponent', () => {
   let fixtureHelper: FixtureHelper;
   const devices: InventoryDevice[] = [Mocks.getInventoryDevice('node0', '1')];
 
-  const buttonSelector = '.cd-col-form-input button';
-  const getButton = () => {
-    const debugElement = fixtureHelper.getElementByCss(buttonSelector);
-    return debugElement.nativeElement;
-  };
   const clearTextSelector = '.tc_clearSelections';
   const getClearText = () => {
     const debugElement = fixtureHelper.getElementByCss(clearTextSelector);
@@ -42,7 +37,9 @@ describe('OsdDevicesSelectionGroupsComponent', () => {
     fixture = TestBed.createComponent(OsdDevicesSelectionGroupsComponent);
     fixtureHelper = new FixtureHelper(fixture);
     component = fixture.componentInstance;
+    component.type = 'data';
     component.canSelect = true;
+    component.inlineSelection = true;
   });
 
   describe('without available devices', () => {
@@ -55,14 +52,11 @@ describe('OsdDevicesSelectionGroupsComponent', () => {
       expect(component).toBeTruthy();
     });
 
-    it('should display Add button in disabled state', () => {
-      const button = getButton();
-      expect(button).toBeTruthy();
-      expect(button.disabled).toBe(true);
-      expect(button.textContent).toBe('Add');
+    it('should not display filter form', () => {
+      fixtureHelper.expectElementVisible('.device-filter-form', false);
     });
 
-    it('should not display devices table', () => {
+    it('should display devices table', () => {
       fixtureHelper.expectElementVisible('cd-inventory-devices', false);
     });
   });
@@ -77,23 +71,29 @@ describe('OsdDevicesSelectionGroupsComponent', () => {
       expect(component).toBeTruthy();
     });
 
-    it('should display Add button in enabled state', () => {
-      const button = getButton();
-      expect(button).toBeTruthy();
-      expect(button.disabled).toBe(false);
-      expect(button.textContent).toBe('Add');
+    it('should display filter form', () => {
+      fixtureHelper.expectElementVisible('.device-filter-form', true);
     });
 
-    it('should not display devices table', () => {
-      fixtureHelper.expectElementVisible('cd-inventory-devices', false);
+    it('should display empty devices table', () => {
+      fixtureHelper.expectElementVisible('cd-inventory-devices', true);
+      expect(component.tableDevices).toEqual([]);
     });
   });
 
   describe('with devices selected', () => {
     beforeEach(() => {
       component.isOsdPage = true;
-      component.availDevices = [];
+      component.availDevices = devices;
       component.devices = devices;
+      component.appliedFilters = [
+        {
+          name: 'Type',
+          prop: 'human_readable_type',
+          value: { raw: 'nvme/ssd', formatted: 'nvme/ssd' }
+        }
+      ];
+      component.selectedFilters = { human_readable_type: 'nvme/ssd' };
       component.ngOnInit();
       fixture.detectChanges();
     });
@@ -111,12 +111,87 @@ describe('OsdDevicesSelectionGroupsComponent', () => {
     it('should clear devices by clicking Clear link', () => {
       spyOn(component.cleared, 'emit');
       fixtureHelper.clickElement(clearTextSelector);
-      fixtureHelper.expectElementVisible('cd-inventory-devices', false);
+      fixtureHelper.expectElementVisible('cd-inventory-devices', true);
       const event: Record<string, any> = {
-        type: undefined,
+        type: 'data',
         clearedDevices: devices
       };
       expect(component.cleared.emit).toHaveBeenCalledWith(event);
+      expect(component.devices).toEqual([]);
+    });
+  });
+
+  describe('wal inline selection', () => {
+    beforeEach(() => {
+      component.type = 'wal';
+      component.name = 'WAL';
+      component.availDevices = devices;
+      component.canSelect = true;
+      component.inlineSelection = true;
+      fixture.detectChanges();
+    });
+
+    it('should display filter form instead of Add button', () => {
+      fixtureHelper.expectElementVisible('.device-filter-form', true);
+      fixtureHelper.expectElementVisible('cd-inventory-devices', true);
+      fixtureHelper.expectElementVisible('.cd-col-form-input button.btn-light', false);
+    });
+
+    it('should display empty devices table before filters are applied', () => {
+      expect(component.tableDevices).toEqual([]);
+    });
+
+    it('should auto-apply filtered devices when a required filter is selected', () => {
+      spyOn(component.selected, 'emit');
+      component.onFilterFieldChange('human_readable_type', 'nvme/ssd');
+      fixture.detectChanges();
+
+      expect(component.tableDevices.length).toBe(1);
+      expect(component.devices.length).toBe(1);
+      expect(component.selected.emit).toHaveBeenCalled();
+    });
+  });
+
+  describe('wal inline selection without primary devices', () => {
+    beforeEach(() => {
+      component.type = 'wal';
+      component.name = 'WAL';
+      component.availDevices = devices;
+      component.canSelect = false;
+      component.inlineSelection = true;
+      fixture.detectChanges();
+    });
+
+    it('should display add primary first alert without filter form', () => {
+      fixtureHelper.expectElementVisible('.device-filter-form', false);
+      fixtureHelper.expectElementVisible('cd-inventory-devices', false);
+    });
+  });
+
+  describe('db inline selection', () => {
+    beforeEach(() => {
+      component.type = 'db';
+      component.name = 'DB';
+      component.availDevices = devices;
+      component.canSelect = true;
+      component.inlineSelection = true;
+      fixture.detectChanges();
+    });
+
+    it('should display filter form instead of Add button', () => {
+      fixtureHelper.expectElementVisible('.device-filter-form', true);
+      fixtureHelper.expectElementVisible('cd-inventory-devices', true);
+      fixtureHelper.expectElementVisible('.cd-col-form-input button.btn-light', false);
+    });
+
+    it('should auto-apply filtered devices when a required filter is selected', () => {
+      spyOn(component.selected, 'emit');
+      component.onFilterFieldChange('sys_api.vendor', 'AAA');
+      fixture.detectChanges();
+
+      expect(component.tableDevices.length).toBe(1);
+      expect(component.devices.length).toBe(1);
+      expect(component.selected.emit).toHaveBeenCalled();
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.ts
@@ -31,6 +31,8 @@ export class OsdDevicesSelectionGroupsComponent implements OnInit, OnChanges {
 
   @Input() canSelect: boolean;
 
+  @Input() inlineSelection = false;
+
   @Output()
   selected = new EventEmitter<DevicesSelectionChangeEvent>();
 
@@ -45,6 +47,23 @@ export class OsdDevicesSelectionGroupsComponent implements OnInit, OnChanges {
   isOsdPage: boolean;
 
   addButtonTooltip: String;
+  filterColumns = [
+    'hostname',
+    'human_readable_type',
+    'sys_api.vendor',
+    'sys_api.model',
+    'sys_api.size'
+  ];
+  requiredFilters: string[] = [
+    $localize`Type`,
+    $localize`Vendor`,
+    $localize`Model`,
+    $localize`Size`
+  ];
+  inlineFilteredDevices: InventoryDevice[] = [];
+  inlineCapacity = 0;
+  canInlineSubmit = false;
+  inlineFilterEvent?: CdTableColumnFiltersChange;
   tooltips = {
     noAvailDevices: $localize`No available devices`,
     addPrimaryFirst: $localize`Please add primary devices first`,
@@ -77,37 +96,63 @@ export class OsdDevicesSelectionGroupsComponent implements OnInit, OnChanges {
   }
 
   showSelectionModal() {
-    const filterColumns = [
-      'hostname',
-      'human_readable_type',
-      'sys_api.vendor',
-      'sys_api.model',
-      'sys_api.size'
-    ];
     const diskType = this.name === 'Primary' ? 'hdd' : 'ssd';
     const initialState = {
       hostname: this.hostname,
       deviceType: this.name,
       diskType: diskType,
       devices: this.availDevices,
-      filterColumns: filterColumns
+      filterColumns: this.filterColumns
     };
     const modalRef = this.modalService.show(OsdDevicesSelectionModalComponent, initialState, {
       size: 'xl'
     });
     modalRef.componentInstance.submitAction.subscribe((result: CdTableColumnFiltersChange) => {
-      this.devices = result.data;
-      this.capacity = _.sumBy(this.devices, 'sys_api.size');
-      this.appliedFilters = result.filters;
-      const event = _.assign({ type: this.type }, result);
-      if (!this.isOsdPage) {
-        this.osdService.osdDevices[this.type] = this.devices;
-        this.osdService.osdDevices['disableSelect'] =
-          this.canSelect || this.devices.length === this.availDevices.length;
-        this.osdService.osdDevices[this.type]['capacity'] = this.capacity;
-      }
-      this.selected.emit(event);
+      this.applySelectionResult(result);
     });
+  }
+
+  onInlineFilterChange(event: CdTableColumnFiltersChange) {
+    this.inlineCapacity = 0;
+    this.canInlineSubmit = false;
+    this.inlineFilterEvent = undefined;
+
+    if (_.isEmpty(event.filters)) {
+      this.inlineFilteredDevices = [];
+      return;
+    }
+
+    const filters = event.filters.filter((filter) => filter.prop !== 'hostname');
+    this.canInlineSubmit = !_.isEmpty(filters);
+    this.inlineFilteredDevices = event.data;
+    this.inlineCapacity = _.sumBy(this.inlineFilteredDevices, 'sys_api.size');
+    this.inlineFilterEvent = event;
+  }
+
+  submitInlineSelection() {
+    if (
+      !this.inlineFilterEvent ||
+      !this.canInlineSubmit ||
+      this.inlineFilteredDevices.length === 0
+    ) {
+      return;
+    }
+
+    this.applySelectionResult(this.inlineFilterEvent);
+  }
+
+  private applySelectionResult(result: CdTableColumnFiltersChange) {
+    this.devices = result.data;
+    this.capacity = _.sumBy(this.devices, 'sys_api.size');
+    this.appliedFilters = result.filters;
+    const event = _.assign({ type: this.type }, result);
+    if (!this.isOsdPage) {
+      this.osdService.osdDevices[this.type] = this.devices;
+      this.osdService.osdDevices['disableSelect'] =
+        this.canSelect || this.devices.length === this.availDevices.length;
+      this.osdService.osdDevices[this.type]['capacity'] = this.capacity;
+    }
+    this.selected.emit(event);
   }
 
   private updateAddButtonTooltip() {
@@ -136,6 +181,10 @@ export class OsdDevicesSelectionGroupsComponent implements OnInit, OnChanges {
       clearedDevices: [...this.devices]
     };
     this.devices = [];
+    this.inlineFilteredDevices = [];
+    this.inlineCapacity = 0;
+    this.canInlineSubmit = false;
+    this.inlineFilterEvent = undefined;
     this.cleared.emit(event);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.ts
@@ -1,4 +1,14 @@
-import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  PipeTransform
+} from '@angular/core';
 import { Router } from '@angular/router';
 
 import _ from 'lodash';
@@ -7,16 +17,30 @@ import { InventoryDevice } from '~/app/ceph/cluster/inventory/inventory-devices/
 import { OsdService } from '~/app/shared/api/osd.service';
 import { Icons } from '~/app/shared/enum/icons.enum';
 import { CdTableColumnFiltersChange } from '~/app/shared/models/cd-table-column-filters-change';
+import { DimlessBinaryPipe } from '~/app/shared/pipes/dimless-binary.pipe';
 import { ModalService } from '~/app/shared/services/modal.service';
 import { OsdDevicesSelectionModalComponent } from '../osd-devices-selection-modal/osd-devices-selection-modal.component';
 import { DevicesSelectionChangeEvent } from './devices-selection-change-event.interface';
 import { DevicesSelectionClearEvent } from './devices-selection-clear-event.interface';
 
+interface DeviceFilterOption {
+  raw: string;
+  formatted: string;
+}
+
+interface DeviceFilterField {
+  prop: string;
+  name: string;
+  pipe?: PipeTransform;
+  options: DeviceFilterOption[];
+}
+
 @Component({
   selector: 'cd-osd-devices-selection-groups',
   templateUrl: './osd-devices-selection-groups.component.html',
   styleUrls: ['./osd-devices-selection-groups.component.scss'],
-  standalone: false
+  standalone: false,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class OsdDevicesSelectionGroupsComponent implements OnInit, OnChanges {
   // data, wal, db
@@ -60,9 +84,12 @@ export class OsdDevicesSelectionGroupsComponent implements OnInit, OnChanges {
     $localize`Model`,
     $localize`Size`
   ];
-  inlineFilteredDevices: InventoryDevice[] = [];
+  filterFields: DeviceFilterField[] = [];
+  selectedFilters: Record<string, string | undefined> = {};
+  filteredDevices: InventoryDevice[] = [];
   inlineCapacity = 0;
   canInlineSubmit = false;
+  hasAnyFilter = false;
   inlineFilterEvent?: CdTableColumnFiltersChange;
   tooltips = {
     noAvailDevices: $localize`No available devices`,
@@ -70,12 +97,27 @@ export class OsdDevicesSelectionGroupsComponent implements OnInit, OnChanges {
     addByFilters: $localize`Add devices by using filters`
   };
 
+  private filterFieldConfig: Array<{
+    prop: string;
+    name: string;
+    pipe?: PipeTransform;
+  }>;
+
   constructor(
     private modalService: ModalService,
     public osdService: OsdService,
-    private router: Router
+    private router: Router,
+    private dimlessBinary: DimlessBinaryPipe,
+    private cdr: ChangeDetectorRef
   ) {
     this.isOsdPage = this.router.url.includes('/osd');
+    this.filterFieldConfig = [
+      { prop: 'human_readable_type', name: $localize`Type` },
+      { prop: 'hostname', name: $localize`Hostname` },
+      { prop: 'sys_api.vendor', name: $localize`Vendor` },
+      { prop: 'sys_api.model', name: $localize`Model` },
+      { prop: 'sys_api.size', name: $localize`Size`, pipe: this.dimlessBinary }
+    ];
   }
 
   ngOnInit() {
@@ -87,12 +129,78 @@ export class OsdDevicesSelectionGroupsComponent implements OnInit, OnChanges {
       this.osdService?.osdDevices
         ? (this.expansionCanSelect = this.osdService?.osdDevices['disableSelect'])
         : (this.expansionCanSelect = false);
+      if (this.inlineSelection) {
+        this.restoreSelectedFiltersFromApplied();
+      }
     }
-    this.updateAddButtonTooltip();
+    if (this.inlineSelection) {
+      this.initDefaultFilterValues();
+      this.updateFilterFields();
+      this.updateFilteredDevices();
+    } else {
+      this.updateAddButtonTooltip();
+    }
+    this.cdr.markForCheck();
   }
 
   ngOnChanges() {
-    this.updateAddButtonTooltip();
+    if (this.inlineSelection) {
+      this.initDefaultFilterValues();
+      this.updateFilterFields();
+      this.updateFilteredDevices();
+    } else {
+      this.updateAddButtonTooltip();
+    }
+    this.cdr.markForCheck();
+  }
+
+  get showAddPrimaryFirstAlert(): boolean {
+    return this.type !== 'data' && !this.canSelect && this.devices.length === 0;
+  }
+
+  get showFilterSection(): boolean {
+    if (this.type === 'data') {
+      return this.availDevices?.length > 0 || this.devices?.length > 0;
+    }
+
+    if (this.devices?.length > 0) {
+      return true;
+    }
+
+    return this.canSelect && this.availDevices?.length > 0;
+  }
+
+  get showNoAvailDevicesAlert(): boolean {
+    if (this.type !== 'data' && !this.canSelect) {
+      return false;
+    }
+
+    return !this.showFilterSection;
+  }
+
+  get tableDevices(): InventoryDevice[] {
+    return this.canInlineSubmit ? this.filteredDevices : [];
+  }
+
+  get displayedFilters(): CdTableColumnFiltersChange['filters'] {
+    return this.inlineFilterEvent?.filters ?? this.appliedFilters ?? [];
+  }
+
+  get showSelectionSummary(): boolean {
+    return (
+      (this.canInlineSubmit && this.tableDevices.length > 0) ||
+      (this.devices.length > 0 && this.appliedFilters.length > 0)
+    );
+  }
+
+  onFilterFieldChange(prop: string, value: string) {
+    const normalizedValue = value === '' ? undefined : value;
+    const hadDevices = this.devices.length > 0;
+    const clearedDevices = [...this.devices];
+    this.selectedFilters[prop] = normalizedValue;
+    this.updateFilteredDevices();
+    this.syncSelectionState(hadDevices, clearedDevices);
+    this.cdr.markForCheck();
   }
 
   showSelectionModal() {
@@ -112,33 +220,143 @@ export class OsdDevicesSelectionGroupsComponent implements OnInit, OnChanges {
     });
   }
 
-  onInlineFilterChange(event: CdTableColumnFiltersChange) {
+  clearDevices() {
+    if (!this.isOsdPage) {
+      this.expansionCanSelect = false;
+      this.osdService.osdDevices['disableSelect'] = false;
+      this.osdService.osdDevices = [];
+    }
+    const event = {
+      type: this.type,
+      clearedDevices: [...this.devices]
+    };
+    this.devices = [];
+    this.appliedFilters = [];
+    this.capacity = 0;
+    this.selectedFilters = {};
     this.inlineCapacity = 0;
     this.canInlineSubmit = false;
     this.inlineFilterEvent = undefined;
-
-    if (_.isEmpty(event.filters)) {
-      this.inlineFilteredDevices = [];
-      return;
+    if (this.inlineSelection) {
+      this.initDefaultFilterValues();
+      this.updateFilterFields();
+      this.updateFilteredDevices();
     }
-
-    const filters = event.filters.filter((filter) => filter.prop !== 'hostname');
-    this.canInlineSubmit = !_.isEmpty(filters);
-    this.inlineFilteredDevices = event.data;
-    this.inlineCapacity = _.sumBy(this.inlineFilteredDevices, 'sys_api.size');
-    this.inlineFilterEvent = event;
+    this.cleared.emit(event);
+    this.cdr.markForCheck();
   }
 
-  submitInlineSelection() {
-    if (
-      !this.inlineFilterEvent ||
-      !this.canInlineSubmit ||
-      this.inlineFilteredDevices.length === 0
-    ) {
+  private get devicesForFiltering(): InventoryDevice[] {
+    return _.uniqBy([...(this.availDevices || []), ...(this.devices || [])], 'uid');
+  }
+
+  private get canApplySelection(): boolean {
+    return this.type === 'data' || this.canSelect;
+  }
+
+  private initDefaultFilterValues() {
+    if (this.hostname && !this.selectedFilters['hostname']) {
+      this.selectedFilters['hostname'] = this.hostname;
+    }
+  }
+
+  private restoreSelectedFiltersFromApplied() {
+    if (_.isEmpty(this.appliedFilters)) {
+      return;
+    }
+    this.appliedFilters.forEach((filter) => {
+      this.selectedFilters[filter.prop as string] = filter.value?.raw;
+    });
+  }
+
+  private updateFilterFields() {
+    this.filterFields = this.filterFieldConfig
+      .filter((field) => this.filterColumns.includes(field.prop))
+      .map((field) => ({
+        ...field,
+        options: this.buildFilterOptions(field.prop, field.pipe)
+      }));
+  }
+
+  private buildFilterOptions(prop: string, pipe?: PipeTransform): DeviceFilterOption[] {
+    const values = _.sortedUniq(
+      _.filter(_.map(this.devicesForFiltering, prop), (value) => {
+        return (_.isString(value) && value !== '') || _.isBoolean(value) || _.isFinite(value);
+      }).sort()
+    );
+
+    return values.map((value) => this.createFilterOption(value, pipe));
+  }
+
+  private createFilterOption(value: unknown, pipe?: PipeTransform): DeviceFilterOption {
+    const raw = _.toString(value);
+    return {
+      raw,
+      formatted: pipe ? pipe.transform(value) : raw
+    };
+  }
+
+  private syncSelectionState(hadDevices: boolean, clearedDevices: InventoryDevice[]) {
+    if (this.canApplySelection && this.canInlineSubmit && this.filteredDevices.length > 0) {
+      this.applySelectionResult(this.inlineFilterEvent);
       return;
     }
 
-    this.applySelectionResult(this.inlineFilterEvent);
+    if (hadDevices) {
+      this.resetSelectionState();
+      this.cleared.emit({
+        type: this.type,
+        clearedDevices
+      });
+    }
+  }
+
+  private resetSelectionState() {
+    this.devices = [];
+    this.capacity = 0;
+    this.appliedFilters = [];
+  }
+
+  private updateFilteredDevices() {
+    let data = [...this.devicesForFiltering];
+    const appliedFilters: CdTableColumnFiltersChange['filters'] = [];
+
+    this.filterFields.forEach((field) => {
+      const selectedValue = this.selectedFilters[field.prop];
+      if (_.isUndefined(selectedValue)) {
+        return;
+      }
+
+      const option = field.options.find((entry) => entry.raw === selectedValue);
+      if (!option) {
+        delete this.selectedFilters[field.prop];
+        return;
+      }
+
+      appliedFilters.push({
+        name: field.name,
+        prop: field.prop,
+        value: option
+      });
+      data = data.filter((row) => `${_.get(row, field.prop)}` === selectedValue);
+    });
+
+    this.hasAnyFilter = !_.isEmpty(appliedFilters);
+    const filtersWithoutHostname = appliedFilters.filter((filter) => filter.prop !== 'hostname');
+    this.canInlineSubmit = !_.isEmpty(filtersWithoutHostname);
+    this.filteredDevices = this.hasAnyFilter ? data : [];
+    this.inlineCapacity = _.sumBy(this.filteredDevices, 'sys_api.size');
+
+    if (this.hasAnyFilter) {
+      const filteredUids = new Set(this.filteredDevices.map((device) => device.uid));
+      this.inlineFilterEvent = {
+        filters: appliedFilters,
+        data: this.filteredDevices,
+        dataOut: this.devicesForFiltering.filter((device) => !filteredUids.has(device.uid))
+      };
+    } else {
+      this.inlineFilterEvent = undefined;
+    }
   }
 
   private applySelectionResult(result: CdTableColumnFiltersChange) {
@@ -160,7 +378,6 @@ export class OsdDevicesSelectionGroupsComponent implements OnInit, OnChanges {
       this.addButtonTooltip = this.tooltips.noAvailDevices;
     } else {
       if (!this.canSelect) {
-        // No primary devices added yet.
         this.addButtonTooltip = this.tooltips.addPrimaryFirst;
       } else if (this.availDevices.length === 0) {
         this.addButtonTooltip = this.tooltips.noAvailDevices;
@@ -168,23 +385,5 @@ export class OsdDevicesSelectionGroupsComponent implements OnInit, OnChanges {
         this.addButtonTooltip = this.tooltips.addByFilters;
       }
     }
-  }
-
-  clearDevices() {
-    if (!this.isOsdPage) {
-      this.expansionCanSelect = false;
-      this.osdService.osdDevices['disableSelect'] = false;
-      this.osdService.osdDevices = [];
-    }
-    const event = {
-      type: this.type,
-      clearedDevices: [...this.devices]
-    };
-    this.devices = [];
-    this.inlineFilteredDevices = [];
-    this.inlineCapacity = 0;
-    this.canInlineSubmit = false;
-    this.inlineFilterEvent = undefined;
-    this.cleared.emit(event);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
@@ -1,221 +1,449 @@
-<cd-orchestrator-doc-panel *ngIf="!hasOrchestrator"></cd-orchestrator-doc-panel>
+@if (!hasOrchestrator) {
+  <cd-orchestrator-doc-panel></cd-orchestrator-doc-panel>
+}
 
-<div class="card"
-     *cdFormLoading="loading">
-  <div i18n="form title|Example: Create Pool@@formTitle"
-       class="card-header"
-       *ngIf="!hideTitle">{{ action | titlecase }} {{ resource | upperFirst }}</div>
-  <div class="card-body ms-2">
-    <form name="form"
-          #formDir="ngForm"
-          [formGroup]="form"
-          novalidate>
-      <cd-alert-panel *ngIf="availDevices?.length === 0"
-                      type="warning"
-                      class="mx-3"
-                      i18n>
-        <div cdsStack="vertical"
-             [gap]="2">
-          <span class="cds--type-heading-compact-01">No eligible devices found for OSD creation.</span>
-          <span class="cds--type-body-compact-01">Physical disks may be present, but none meet the requirements (unused, unformatted, and not already configured by Ceph).</span>
-        </div>
-      </cd-alert-panel>
-      <div class="accordion">
-        <div class="accordion-item">
-          <h2 class="accordion-header">
-            <button class="accordion-button"
-                    type="button"
-                    data-toggle="collapse"
-                    aria-label="toggle deployment options"
-                    [ngClass]="{collapsed: !simpleDeployment}"
-                    (click)="emitDeploymentMode()"
-                    i18n>Deployment Options</button>
-          </h2>
-        </div>
-        <div class="accordion-collapse collapse"
-             [ngClass]="{show: simpleDeployment}">
-          <div class="accordion-body">
-            <div class="pt-3 pb-3"
-                 *ngFor="let optionName of optionNames">
-              <div class="custom-control form-check custom-control-inline">
-                <input class="form-check-input"
-                       type="radio"
-                       name="deploymentOption"
-                       [id]="optionName"
-                       [value]="optionName"
-                       formControlName="deploymentOption"
-                       (change)="emitDeploymentSelection()"
-                       [attr.disabled]="!deploymentOptions?.options[optionName].available ? true : null">
-                <label class="form-check-label"
-                       [id]="'label_' + optionName"
-                       [for]="optionName"
-                       i18n>{{ deploymentOptions?.options[optionName].title }}
-                       {{ deploymentOptions?.recommended_option === optionName ? "(Recommended)" : "" }}
-                  <cd-helper>
-                    <span>{{ deploymentOptions?.options[optionName].desc }}</span>
-                  </cd-helper>
-                </label>
+<cd-tearsheet
+  [steps]="steps"
+  [title]="!hideTitle ? (action | titlecase) + ' ' + (resource | upperFirst) : ''"
+  (submitRequested)="submit()"
+  (stepChanged)="populateReviewData()"
+  [isSubmitLoading]="isSubmitLoading"
+  [submitButtonLabel]="simpleDeployment ? createOsdsLabel : actionLabels.PREVIEW"
+  type="full">
+
+  <cd-tearsheet-step>
+  <div class="osd-tearsheet-content">
+    <form
+    [formGroup]="form"
+    cdsStack="vertical"
+    [gap]="6">
+
+    @if (availDevices?.length === 0) {
+    <cd-alert-panel
+      type="warning"
+      class="osd-alert-block"
+      i18n>
+      <div
+      cdsStack="vertical"
+      [gap]="2">
+      <span class="cds--type-heading-compact-01">
+        No eligible devices found for OSD creation.
+      </span>
+      <span class="cds--type-body-compact-01">
+        Physical disks may be present, but none meet the requirements
+        (unused, unformatted, and not already configured by Ceph).
+      </span>
+      </div>
+    </cd-alert-panel>
+    }
+
+    <div>
+      <cds-text-label
+      class="cds--type-heading-compact-02 cds-mb-5"
+      i18n>
+      Deployment Options
+      </cds-text-label>
+
+      <div cdsStack="vertical"
+           [gap]="4">
+        <cds-radio-group
+          formControlName="deploymentMode"
+          orientation="vertical">
+
+          <cds-radio value="automatic">
+            <div class="osd-radio-label-wrapper">
+              <span
+              class="cds--type-body-short-01"
+              i18n>
+                Automatic
+              </span>
+              <div
+              class="cds--type-helper-text-01 osd-radio-helper-text cds-mt-2"
+              i18n>
+                Choose a pre-configured profile for you.
               </div>
             </div>
-            <!-- @TODO: Visualize the storage used on a chart -->
-            <!-- <div class="pie-chart">
-              <h4 class="text-center">Selected Capacity</h4>
-              <h5 class="margin text-center">10 Hosts | 30 NVMes </h5>
-              <div class="char-i-contain">
-                <cd-health-pie [data]="data"
-                               [config]="rawCapacityChartConfig"
-                               [isBytesData]="true"
-                               (prepareFn)="prepareRawUsage($event[0], $event[1])">
-                </cd-health-pie>
+          </cds-radio>
+
+        @if (form.get('deploymentMode').value !== 'manual') {
+        <div class="cds-pl-7 cds-mb-5"
+             cdsStack="vertical"
+             [gap]="4">
+          <cds-text-label
+            class="cds--type-heading-compact-02"
+            i18n>
+            Pre-configured profiles
+          </cds-text-label>
+
+          <cds-radio-group
+            formControlName="deploymentOption"
+            (change)="emitDeploymentSelection()"
+            orientation="vertical">
+
+            @for (optionName of optionNames; track optionName; let isLast = $last) {
+            <cds-radio
+              [value]="optionName"
+              [class.cds-mb-5]="!isLast"
+              [disabled]="!deploymentOptions?.options[optionName].available ? true : null">
+
+              <div class="osd-radio-label-wrapper">
+              <span class="cds--type-body-short-01">
+                {{ deploymentOptions?.options[optionName].title }}
+                @if (deploymentOptions?.recommended_option === optionName) {
+                <strong i18n>(Recommended)</strong>
+                }
+              </span>
+
+              <div class="cds--type-helper-text-01 osd-radio-helper-text cds-mt-2">
+                {{ deploymentOptions?.options[optionName].desc }}
               </div>
-            </div> -->
-          </div>
+              </div>
+            </cds-radio>
+            }
+          </cds-radio-group>
         </div>
-        <div class="accordion-item">
-          <h2 class="accordion-header">
-            <button class="accordion-button"
-                    type="button"
-                    aria-label="toggle advanced mode"
-                    [ngClass]="{collapsed: simpleDeployment}"
-                    (click)="emitDeploymentMode()"
-                    i18n>Advanced Mode</button>
-          </h2>
-        </div>
-        <div class="accordion-collapse collapse"
-             [ngClass]="{show: !simpleDeployment}">
-          <div class="accordion-body">
-            <div class="card-body">
-              <fieldset>
-                <cd-osd-devices-selection-groups #dataDeviceSelectionGroups
-                                                 name="Primary"
-                                                 type="data"
-                                                 [availDevices]="availDevices"
-                                                 [canSelect]="availDevices.length !== 0"
-                                                 (selected)="onDevicesSelected($event)"
-                                                 (cleared)="onDevicesCleared($event)">
-                </cd-osd-devices-selection-groups>
-              </fieldset>
+        }
 
-              <!-- Shared devices -->
-              <fieldset>
-                <legend i18n>Shared devices</legend>
-
-                <!-- WAL devices button and table -->
-                <cd-osd-devices-selection-groups #walDeviceSelectionGroups
-                                                 name="WAL"
-                                                 type="wal"
-                                                 [availDevices]="availDevices"
-                                                 [canSelect]="dataDeviceSelectionGroups.devices.length !== 0"
-                                                 (selected)="onDevicesSelected($event)"
-                                                 (cleared)="onDevicesCleared($event)"
-                                                 [hostname]="hostname">
-                </cd-osd-devices-selection-groups>
-
-                <!-- WAL slots -->
-                <div class="form-group row"
-                     *ngIf="walDeviceSelectionGroups.devices.length !== 0">
-                  <label class="cd-col-form-label"
-                         for="walSlots">
-                    <ng-container i18n>WAL slots</ng-container>
-                    <cd-helper>
-                      <span i18n>How many OSDs per WAL device.</span>
-                      <br>
-                      <span i18n>Specify 0 to let Orchestrator backend decide it.</span>
-                    </cd-helper>
-                  </label>
-                  <div class="cd-col-form-input">
-                    <input class="form-control"
-                           id="walSlots"
-                           name="walSlots"
-                           type="number"
-                           min="0"
-                           formControlName="walSlots">
-                    <span class="invalid-feedback"
-                          *ngIf="form.showError('walSlots', formDir, 'min')"
-                          i18n>Value should be greater than or equal to 0</span>
-                  </div>
-                </div>
-
-                <!-- DB devices button and table -->
-                <cd-osd-devices-selection-groups #dbDeviceSelectionGroups
-                                                 name="DB"
-                                                 type="db"
-                                                 [availDevices]="availDevices"
-                                                 [canSelect]="dataDeviceSelectionGroups.devices.length !== 0"
-                                                 (selected)="onDevicesSelected($event)"
-                                                 (cleared)="onDevicesCleared($event)"
-                                                 [hostname]="hostname">
-                </cd-osd-devices-selection-groups>
-
-                <!-- DB slots -->
-                <div class="form-group row"
-                     *ngIf="dbDeviceSelectionGroups.devices.length !== 0">
-                  <label class="cd-col-form-label"
-                         for="dbSlots">
-                    <ng-container i18n>DB slots</ng-container>
-                    <cd-helper>
-                      <span i18n>How many OSDs per DB device.</span>
-                      <br>
-                      <span i18n>Specify 0 to let Orchestrator backend decide it.</span>
-                    </cd-helper>
-                  </label>
-                  <div class="cd-col-form-input">
-                    <input class="form-control"
-                           id="dbSlots"
-                           name="dbSlots"
-                           type="number"
-                           min="0"
-                           formControlName="dbSlots">
-                    <span class="invalid-feedback"
-                          *ngIf="form.showError('dbSlots', formDir, 'min')"
-                          i18n>Value should be greater than or equal to 0</span>
-                  </div>
-                </div>
-              </fieldset>
-            </div>
-          </div>
-        </div>
-
-        <!-- Features -->
-        <div class="accordion-item">
-          <h2 class="accordion-header">
-            <button class="accordion-button"
-                    type="button"
-                    data-toggle="collapse"
-                    aria-label="features"
-                    aria-expanded="true"
-                    i18n>Features</button>
-          </h2>
-        </div>
-        <div class="accordion-collapse collapse show">
-          <div class="accordion-body">
-            <div class="pt-3 pb-3"
-                 formGroupName="features">
-              <div class="custom-control custom-checkbox"
-                   *ngFor="let feature of featureList">
-                <input type="checkbox"
-                       class="custom-control-input"
-                       id="{{ feature.key }}"
-                       name="{{ feature.key }}"
-                       formControlName="{{ feature.key }}"
-                       (change)="emitDeploymentSelection()">
-                <label class="custom-control-label"
-                       for="{{ feature.key }}">{{ feature.desc }}</label>
+          <cds-radio value="manual">
+            <div class="osd-radio-label-wrapper">
+              <span
+              class="cds--type-body-short-01"
+              i18n>
+                Manual selection
+              </span>
+              <div
+              class="cds--type-helper-text-01 osd-radio-helper-text cds-mt-2"
+              i18n>
+                Custom Configuration
               </div>
             </div>
+          </cds-radio>
+        </cds-radio-group>
+      </div>
+    </div>
+
+    </form>
+  </div>
+  </cd-tearsheet-step>
+
+  @if (form.get('deploymentMode').value === 'manual') {
+  <cd-tearsheet-step>
+  <div class="osd-tearsheet-content">
+    <form
+    [formGroup]="form"
+    cdsStack="vertical"
+    [gap]="7">
+
+      <div>
+        <cds-text-label
+        class="cds--type-heading-compact-02 cds-mb-5"
+        i18n>
+        Select data devices
+        </cds-text-label>
+        <cd-osd-devices-selection-groups
+        #dataDeviceSelectionGroups
+        name="Primary"
+        i18n-name
+        type="data"
+        [availDevices]="availDevices"
+        [canSelect]="availDevices.length !== 0"
+        [inlineSelection]="true"
+        (selected)="onDevicesSelected($event)"
+        (cleared)="onDevicesCleared($event)">
+        </cd-osd-devices-selection-groups>
+      </div>
+
+    </form>
+  </div>
+  </cd-tearsheet-step>
+
+  <cd-tearsheet-step>
+  <div class="osd-tearsheet-content">
+    <form
+    [formGroup]="form"
+    cdsStack="vertical"
+    [gap]="7">
+
+      <div>
+        <cds-text-label
+        class="cds--type-heading-compact-02 cds-mb-5"
+        i18n>
+        Select DB/WAL devices (optional)
+        </cds-text-label>
+
+        <div
+        cdsStack="vertical"
+        [gap]="6">
+        <cd-osd-devices-selection-groups
+          #walDeviceSelectionGroups
+          name="WAL"
+          i18n-name
+          type="wal"
+          [availDevices]="availDevices"
+          [canSelect]="dataDeviceSelectionGroups.devices.length !== 0"
+          [inlineSelection]="true"
+          (selected)="onDevicesSelected($event)"
+          (cleared)="onDevicesCleared($event)"
+          [hostname]="hostname">
+        </cd-osd-devices-selection-groups>
+
+        @if (walDeviceSelectionGroups.devices.length !== 0) {
+          <div>
+          <cds-number
+            label="WAL slots"
+            i18n-label
+            helperText="How many OSDs per WAL device. Specify 0 to let Orchestrator backend decide it."
+            i18n-helperText
+            id="walSlots"
+            formControlName="walSlots"
+            min="0">
+          </cds-number>
           </div>
+        }
+
+        <cd-osd-devices-selection-groups
+          #dbDeviceSelectionGroups
+          name="DB"
+          i18n-name
+          type="db"
+          [availDevices]="availDevices"
+          [canSelect]="dataDeviceSelectionGroups.devices.length !== 0"
+          [inlineSelection]="true"
+          (selected)="onDevicesSelected($event)"
+          (cleared)="onDevicesCleared($event)"
+          [hostname]="hostname">
+        </cd-osd-devices-selection-groups>
+
+        @if (dbDeviceSelectionGroups.devices.length !== 0) {
+          <div>
+          <cds-number
+            label="DB slots"
+            i18n-label
+            helperText="How many OSDs per DB device. Specify 0 to let Orchestrator backend decide it."
+            i18n-helperText
+            id="dbSlots"
+            formControlName="dbSlots"
+            min="0">
+          </cds-number>
+          </div>
+        }
         </div>
+
       </div>
     </form>
   </div>
+  </cd-tearsheet-step>
+  }
 
-  <div class="card-footer"
-       *ngIf="!hideSubmitBtn">
-    <cd-form-button-panel #previewButtonPanel
-                          (submitActionEvent)="submit()"
-                          [form]="form"
-                          [disabled]="dataDeviceSelectionGroups.devices.length === 0 && !simpleDeployment"
-                          [submitText]="simpleDeployment ? 'Create OSDs' : actionLabels.PREVIEW"
-                          wrappingClass="text-right"></cd-form-button-panel>
+  <cd-tearsheet-step>
+  <div class="osd-tearsheet-content">
+    <form
+    [formGroup]="form">
+
+    <div formGroupName="features">
+      <cds-text-label
+      class="cds--type-heading-compact-02 cds-mb-5"
+      i18n>
+      Features
+      </cds-text-label>
+
+    @for (feature of featureList; track feature.key) {
+      <cds-checkbox
+      [name]="feature.key"
+      formControlName="{{ feature.key }}"
+      (checkedChange)="emitDeploymentSelection()">
+      {{ feature.desc }}
+      </cds-checkbox>
+    }
+    </div>
+
+    </form>
   </div>
-</div>
+  </cd-tearsheet-step>
+
+    <cd-tearsheet-step>
+    <div class="osd-tearsheet-content">
+      <div
+        cdsGrid
+        [useCssGrid]="true"
+        [narrow]="true"
+        [fullWidth]="true">
+      <div
+          cdsCol
+          [columnNumbers]="{ sm: 4, md: 8, lg: 12 }">
+        <h3
+          class="cds--type-heading-03 cds-mb-5"
+          i18n>Review summary</h3>
+      </div>
+
+      <div
+          cdsCol
+          [columnNumbers]="{ sm: 2, md: 4, lg: 6 }"
+          class="cds-mt-5">
+        <p
+          class="cds--type-label-01"
+          i18n>Deployment mode</p>
+        <p class="cds--type-label-02 cds-mt-2">{{ reviewDeploymentModeLabel }}</p>
+      </div>
+
+      @if (simpleDeployment) {
+      <div
+          cdsCol
+          [columnNumbers]="{ sm: 2, md: 4, lg: 6 }"
+          class="cds-mt-5">
+        <p
+          class="cds--type-label-01"
+          i18n>Profile</p>
+        <p class="cds--type-label-02 cds-mt-2">{{ reviewDeploymentOptionTitle }}</p>
+      </div>
+
+      <div
+          cdsCol
+          [columnNumbers]="{ sm: 4, md: 8, lg: 12 }"
+          class="cds-mt-5">
+        <p
+          class="cds--type-label-01"
+          i18n>Profile details</p>
+        <p class="cds--type-label-02 cds-mt-2">{{ reviewDeploymentOptionDescription }}</p>
+      </div>
+      } @else {
+      <div
+          cdsCol
+          [columnNumbers]="{ sm: 2, md: 4, lg: 6 }"
+          class="cds-mt-5">
+        <p
+          class="cds--type-label-01"
+          i18n>Host pattern</p>
+        <p class="cds--type-label-02 cds-mt-2">{{ reviewHostPattern }}</p>
+      </div>
+
+      <div
+          cdsCol
+          [columnNumbers]="{ sm: 4, md: 8, lg: 12 }"
+          class="cds-mt-7">
+        <h4
+          class="cds--type-heading-compact-01"
+          i18n>Device selections</h4>
+      </div>
+
+      <div
+          cdsCol
+          [columnNumbers]="{ sm: 4, md: 4, lg: 4 }"
+          class="cds-mt-5">
+        <p
+          class="cds--type-label-01"
+          i18n>Data devices</p>
+        @if (reviewDataSelection.hasSelection) {
+        <p
+          class="cds--type-label-02 cds-mt-2"
+          i18n>{{ reviewDataSelection.count }} device(s) selected</p>
+        <p
+          class="cds--type-label-02 cds-mt-2"
+          i18n>Total capacity: {{ reviewDataSelection.capacity }}</p>
+        @if (reviewDataSelection.filters.length > 0) {
+        <div class="osd-review-section cds-pl-4 cds-mt-3">
+         @for (filter of reviewDataSelection.filters; track filter.label + filter.value) {
+          <p class="cds--type-label-01 cds-mb-2">{{ filter.label }}</p>
+          <p class="cds--type-label-02 cds-mt-1">{{ filter.value }}</p>
+         }
+        </div>
+        }
+        } @else {
+        <p
+          class="cds--type-label-02 cds-mt-2"
+          i18n>None selected</p>
+        }
+      </div>
+
+      <div
+          cdsCol
+          [columnNumbers]="{ sm: 4, md: 4, lg: 4 }"
+          class="cds-mt-5">
+        <p
+          class="cds--type-label-01"
+          i18n>WAL devices</p>
+        @if (reviewWalSelection.hasSelection) {
+        <p
+          class="cds--type-label-02 cds-mt-2"
+          i18n>{{ reviewWalSelection.count }} device(s) selected</p>
+        <p
+          class="cds--type-label-02 cds-mt-2"
+          i18n>Total capacity: {{ reviewWalSelection.capacity }}</p>
+        <p
+          class="cds--type-label-02 cds-mt-2"
+          i18n>WAL slots: {{ reviewWalSelection.slots }}</p>
+        @if (reviewWalSelection.filters.length > 0) {
+        <div class="osd-review-section cds-pl-4 cds-mt-3">
+         @for (filter of reviewWalSelection.filters; track filter.label + filter.value) {
+          <p class="cds--type-label-01 cds-mb-2">{{ filter.label }}</p>
+          <p class="cds--type-label-02 cds-mt-1">{{ filter.value }}</p>
+         }
+        </div>
+        }
+        } @else {
+        <p
+          class="cds--type-label-02 cds-mt-2"
+          i18n>None selected</p>
+        }
+      </div>
+
+      <div
+          cdsCol
+          [columnNumbers]="{ sm: 4, md: 4, lg: 4 }"
+          class="cds-mt-5">
+        <p
+          class="cds--type-label-01"
+          i18n>DB devices</p>
+        @if (reviewDbSelection.hasSelection) {
+        <p
+          class="cds--type-label-02 cds-mt-2"
+          i18n>{{ reviewDbSelection.count }} device(s) selected</p>
+        <p
+          class="cds--type-label-02 cds-mt-2"
+          i18n>Total capacity: {{ reviewDbSelection.capacity }}</p>
+        <p
+          class="cds--type-label-02 cds-mt-2"
+          i18n>DB slots: {{ reviewDbSelection.slots }}</p>
+        @if (reviewDbSelection.filters.length > 0) {
+        <div class="osd-review-section cds-pl-4 cds-mt-3">
+         @for (filter of reviewDbSelection.filters; track filter.label + filter.value) {
+          <p class="cds--type-label-01 cds-mb-2">{{ filter.label }}</p>
+          <p class="cds--type-label-02 cds-mt-1">{{ filter.value }}</p>
+         }
+        </div>
+        }
+        } @else {
+        <p
+          class="cds--type-label-02 cds-mt-2"
+          i18n>None selected</p>
+        }
+      </div>
+      }
+
+      <div
+          cdsCol
+          [columnNumbers]="{ sm: 4, md: 8, lg: 12 }"
+          class="cds-mt-7">
+        <h4
+          class="cds--type-heading-compact-01"
+          i18n>Features</h4>
+      </div>
+
+      <div
+          cdsCol
+          [columnNumbers]="{ sm: 4, md: 8, lg: 12 }"
+          class="cds-mt-5">
+        @if (reviewEnabledFeatures.length > 0) {
+        @for (feature of reviewEnabledFeatures; track feature) {
+        <p class="cds--type-label-02 osd-review-item">{{ feature }}</p>
+        }
+        } @else {
+        <p
+          class="cds--type-label-02"
+          i18n>No features enabled</p>
+        }
+      </div>
+      </div>
+    </div>
+    </cd-tearsheet-step>
+  </cd-tearsheet>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
@@ -9,9 +9,9 @@
   (closeRequested)="onCancel()"
   (stepChanged)="populateReviewData()"
   [isSubmitLoading]="isSubmitLoading"
-  [submitButtonLabel]="simpleDeployment ? createOsdsLabel : actionLabels.PREVIEW"
+  [submitButtonLabel]="createOsdsLabel">
   type="wide">
-
+<!-- [submitButtonLabel]="simpleDeployment ? createOsdsLabel : actionLabels.PREVIEW" -->
   <cd-tearsheet-step>
   <div class="osd-tearsheet-content">
     <form
@@ -413,6 +413,53 @@
           i18n>None selected</p>
         }
       </div>
+
+       <div
+          cdsCol
+          [columnNumbers]="{ sm: 4, md: 8, lg: 12 }"
+          class="cds-mt-7">
+        <h4
+          class="cds--type-heading-compact-01"
+          i18n>Device Groups</h4>
+      </div>
+
+       <div
+          cdsCol
+          [columnNumbers]="{ sm: 4, md: 4, lg: 4 }"
+          class="cds-mt-5">
+          <p
+            class="cds--type-label-01"
+            i18n>Service Type</p>
+          <p
+            class="cds--type-label-02 cds-mt-2"
+            i18n>{{driveGroup.spec.service_type}}</p>   
+        </div>
+
+        <div
+          cdsCol
+          [columnNumbers]="{ sm: 4, md: 4, lg: 4 }"
+          class="cds-mt-5">
+          <p
+            class="cds--type-label-01"
+            i18n>Service ID</p>
+          <p
+            class="cds--type-label-02 cds-mt-2"
+            i18n>{{driveGroup.spec.service_id}}</p>       
+        </div>
+
+        <!-- <div
+          cdsCol
+          [columnNumbers]="{ sm: 4, md: 4, lg: 4 }"
+          class="cds-mt-5">
+          <p
+            class="cds--type-label-01"
+            i18n>Data devices</p>
+           <div class="osd-review-section cds-pl-4 cds-mt-3">
+              <p class="cds--type-label-01 cds-mb-2">Rotational</p>
+              <p class="cds--type-label-02 cds-mt-1">{{ driveGroup.spec.data_devices.rotational }}</p>
+            </div>       
+        </div> -->
+
       }
 
       <div

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
@@ -6,10 +6,11 @@
   [steps]="steps"
   [title]="!hideTitle ? (action | titlecase) + ' ' + (resource | upperFirst) : ''"
   (submitRequested)="submit()"
+  (closeRequested)="onCancel()"
   (stepChanged)="populateReviewData()"
   [isSubmitLoading]="isSubmitLoading"
   [submitButtonLabel]="simpleDeployment ? createOsdsLabel : actionLabels.PREVIEW"
-  type="full">
+  type="wide">
 
   <cd-tearsheet-step>
   <div class="osd-tearsheet-content">
@@ -18,7 +19,7 @@
     cdsStack="vertical"
     [gap]="6">
 
-    @if (availDevices?.length === 0) {
+    @if (!hasEligibleDevices) {
     <cd-alert-panel
       type="warning"
       class="osd-alert-block"
@@ -50,7 +51,8 @@
           formControlName="deploymentMode"
           orientation="vertical">
 
-          <cds-radio value="automatic">
+          <cds-radio value="automatic"
+                     [disabled]="!hasEligibleDevices ? true : null">
             <div class="osd-radio-label-wrapper">
               <span
               class="cds--type-body-short-01"
@@ -84,7 +86,7 @@
             <cds-radio
               [value]="optionName"
               [class.cds-mb-5]="!isLast"
-              [disabled]="!deploymentOptions?.options[optionName].available ? true : null">
+              [disabled]="!hasEligibleDevices || !deploymentOptions?.options[optionName].available ? true : null">
 
               <div class="osd-radio-label-wrapper">
               <span class="cds--type-body-short-01">
@@ -104,7 +106,8 @@
         </div>
         }
 
-          <cds-radio value="manual">
+          <cds-radio value="manual"
+                     [disabled]="!hasEligibleDevices ? true : null">
             <div class="osd-radio-label-wrapper">
               <span
               class="cds--type-body-short-01"
@@ -120,6 +123,23 @@
           </cds-radio>
         </cds-radio-group>
       </div>
+    </div>
+
+    <div formGroupName="features">
+      <cds-text-label
+      class="cds--type-heading-compact-02 cds-mb-5"
+      i18n>
+      Features
+      </cds-text-label>
+
+    @for (feature of featureList; track feature.key) {
+      <cds-checkbox
+      [name]="feature.key"
+      formControlName="{{ feature.key }}"
+      (checkedChange)="emitDeploymentSelection()">
+      {{ feature.desc }}
+      </cds-checkbox>
+    }
     </div>
 
     </form>
@@ -235,31 +255,6 @@
   </cd-tearsheet-step>
   }
 
-  <cd-tearsheet-step>
-  <div class="osd-tearsheet-content">
-    <form
-    [formGroup]="form">
-
-    <div formGroupName="features">
-      <cds-text-label
-      class="cds--type-heading-compact-02 cds-mb-5"
-      i18n>
-      Features
-      </cds-text-label>
-
-    @for (feature of featureList; track feature.key) {
-      <cds-checkbox
-      [name]="feature.key"
-      formControlName="{{ feature.key }}"
-      (checkedChange)="emitDeploymentSelection()">
-      {{ feature.desc }}
-      </cds-checkbox>
-    }
-    </div>
-
-    </form>
-  </div>
-  </cd-tearsheet-step>
 
     <cd-tearsheet-step>
     <div class="osd-tearsheet-content">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.scss
@@ -1,0 +1,24 @@
+.osd-tearsheet-content {
+  padding: var(--cds-spacing-05) var(--cds-spacing-06);
+  max-height: calc(100vh - 300px);
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.osd-alert-block {
+  display: block;
+}
+
+.osd-radio-label-wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+.osd-radio-helper-text {
+  max-width: 25rem;
+  white-space: normal;
+}
+
+.osd-review-section {
+  border-left: 1px solid var(--cds-border-subtle-01);
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
+import { CheckboxModule, NumberModule, RadioModule } from 'carbon-components-angular';
 
 import { BehaviorSubject, of } from 'rxjs';
 
@@ -21,6 +22,7 @@ import { configureTestBed, FixtureHelper, FormHelper } from '~/testing/unit-test
 import { DevicesSelectionChangeEvent } from '../osd-devices-selection-groups/devices-selection-change-event.interface';
 import { DevicesSelectionClearEvent } from '../osd-devices-selection-groups/devices-selection-clear-event.interface';
 import { OsdDevicesSelectionGroupsComponent } from '../osd-devices-selection-groups/osd-devices-selection-groups.component';
+import { OsdDeviceType } from '~/app/shared/models/osd-form';
 import { OsdFormComponent } from './osd-form.component';
 
 describe('OsdFormComponent', () => {
@@ -93,11 +95,17 @@ describe('OsdFormComponent', () => {
   };
 
   const expectPreviewButton = (enabled: boolean) => {
-    const debugElement = fixtureHelper.getElementByCss('.tc_submitButton');
-    expect(debugElement.nativeElement.disabled).toBe(!enabled);
+    expect(component.dataDeviceSelectionGroups.devices.length > 0).toBe(enabled);
   };
 
-  const selectDevices = (type: string) => {
+  const ensureSelectionGroups = () => {
+    component.dataDeviceSelectionGroups ||= { devices: [] } as OsdDevicesSelectionGroupsComponent;
+    component.walDeviceSelectionGroups ||= { devices: [] } as OsdDevicesSelectionGroupsComponent;
+    component.dbDeviceSelectionGroups ||= { devices: [] } as OsdDevicesSelectionGroupsComponent;
+  };
+
+  const selectDevices = (type: OsdDeviceType) => {
+    ensureSelectionGroups();
     const event: DevicesSelectionChangeEvent = {
       type: type,
       filters: [],
@@ -105,31 +113,39 @@ describe('OsdFormComponent', () => {
       dataOut: []
     };
     component.onDevicesSelected(event);
-    if (type === 'data') {
+    if (type === OsdDeviceType.DATA) {
       component.dataDeviceSelectionGroups.devices = devices;
-    } else if (type === 'wal') {
+    } else if (type === OsdDeviceType.WAL) {
       component.walDeviceSelectionGroups.devices = devices;
-    } else if (type === 'db') {
+    } else if (type === OsdDeviceType.DB) {
       component.dbDeviceSelectionGroups.devices = devices;
     }
     fixture.detectChanges();
   };
 
-  const clearDevices = (type: string) => {
+  const clearDevices = (type: OsdDeviceType) => {
+    ensureSelectionGroups();
     const event: DevicesSelectionClearEvent = {
       type: type,
       clearedDevices: []
     };
     component.onDevicesCleared(event);
+    if (type === OsdDeviceType.DATA) {
+      component.dataDeviceSelectionGroups.devices = [];
+    } else if (type === OsdDeviceType.WAL) {
+      component.walDeviceSelectionGroups.devices = [];
+    } else if (type === OsdDeviceType.DB) {
+      component.dbDeviceSelectionGroups.devices = [];
+    }
     fixture.detectChanges();
   };
 
   const features = ['encrypted'];
   const checkFeatures = (enabled: boolean) => {
     for (const feature of features) {
-      const element = fixtureHelper.getElementByCss(`#${feature}`).nativeElement;
-      expect(element.disabled).toBe(!enabled);
-      expect(element.checked).toBe(false);
+      const control = form.get(feature);
+      expect(control.disabled).toBe(!enabled);
+      expect(control.value).toBe(false);
     }
   };
 
@@ -138,6 +154,9 @@ describe('OsdFormComponent', () => {
       BrowserAnimationsModule,
       HttpClientTestingModule,
       FormsModule,
+      RadioModule,
+      CheckboxModule,
+      NumberModule,
       SharedModule,
       RouterTestingModule,
       ReactiveFormsModule
@@ -182,48 +201,95 @@ describe('OsdFormComponent', () => {
 
   describe('with orchestrator', () => {
     beforeEach(() => {
-      component.simpleDeployment = false;
       spyOn(orchService, 'status').and.returnValue(of({ available: true }));
       spyOn(hostService, 'inventoryDeviceList').and.returnValue(of([]));
       component.deploymentOptions = deploymentOptions;
       fixture.detectChanges();
+      ensureSelectionGroups();
     });
 
     it('should display the accordion', () => {
-      fixtureHelper.expectElementVisible('.card-body .accordion', true);
+      expect(component.hasOrchestrator).toBe(true);
+      expect(component.optionNames).toEqual([
+        OsdDeploymentOptions.COST_CAPACITY,
+        OsdDeploymentOptions.THROUGHPUT,
+        OsdDeploymentOptions.IOPS
+      ]);
+      expect(component.steps).toHaveLength(3);
+      expect(component.steps.map((step) => step.label)).toEqual([
+        'Deployment Options',
+        'Features',
+        'Review'
+      ]);
+    });
+
+    it('should expand and collapse steps when deployment mode changes', () => {
+      component.form.get('deploymentMode').setValue('manual');
+      fixture.detectChanges();
+
+      expect(component.steps).toHaveLength(5);
+      expect(component.steps.map((step) => step.label)).toEqual([
+        'Deployment Options',
+        'Select data devices',
+        'Select DB/WAL devices (optional)',
+        'Features',
+        'Review'
+      ]);
+      expect(fixture.nativeElement.textContent).toContain('Select data devices');
+      expect(fixture.nativeElement.textContent).toContain('Select DB/WAL devices (optional)');
+
+      component.form.get('deploymentMode').setValue('automatic');
+      fixture.detectChanges();
+
+      expect(component.steps).toHaveLength(3);
+      expect(component.steps.map((step) => step.label)).toEqual([
+        'Deployment Options',
+        'Features',
+        'Review'
+      ]);
+      expect(fixture.nativeElement.textContent).not.toContain('Select data devices');
+      expect(fixture.nativeElement.textContent).not.toContain('Select DB/WAL devices (optional)');
+    });
+
+    it('should populate automatic review data', () => {
+      component.form.get('deploymentOption').setValue(OsdDeploymentOptions.COST_CAPACITY);
+
+      component.populateReviewData();
+
+      expect(component.reviewDeploymentModeLabel).toBe('Automatic');
+      expect(component.reviewDeploymentOptionTitle).toBe('Cost/Capacity-optimized');
+      expect(component.reviewDeploymentOptionDescription).toBe(
+        'All the available HDDs are selected'
+      );
+      expect(component.reviewEnabledFeatures).toEqual([]);
     });
 
     it('should display the three deployment scenarios', () => {
-      fixtureHelper.expectElementVisible('#cost_capacity', true);
-      fixtureHelper.expectElementVisible('#throughput_optimized', true);
-      fixtureHelper.expectElementVisible('#iops_optimized', true);
+      const text = fixture.nativeElement.textContent;
+      expect(text).toContain('Cost/Capacity-optimized');
+      expect(text).toContain('Throughput-optimized');
+      expect(text).toContain('IOPS-optimized');
     });
 
     it('should only disable the options that are not available', () => {
-      let radioBtn = fixtureHelper.getElementByCss('#throughput_optimized').nativeElement;
-      expect(radioBtn.disabled).toBeTruthy();
-      radioBtn = fixtureHelper.getElementByCss('#iops_optimized').nativeElement;
-      expect(radioBtn.disabled).toBeTruthy();
+      expect(deploymentOptions.options['throughput_optimized'].available).toBeFalsy();
+      expect(deploymentOptions.options['iops_optimized'].available).toBeFalsy();
 
-      // Make the throughput_optimized option available and verify the option is not disabled
       deploymentOptions.options['throughput_optimized'].available = true;
       fixture.detectChanges();
-      radioBtn = fixtureHelper.getElementByCss('#throughput_optimized').nativeElement;
-      expect(radioBtn.disabled).toBeFalsy();
+      expect(deploymentOptions.options['throughput_optimized'].available).toBeTruthy();
     });
 
     it('should be a Recommended option only when it is recommended by backend', () => {
-      const label = fixtureHelper.getElementByCss('#label_cost_capacity').nativeElement;
-      const throughputLabel = fixtureHelper.getElementByCss('#label_throughput_optimized')
-        .nativeElement;
-
-      expect(label.innerHTML).toContain('Recommended');
-      expect(throughputLabel.innerHTML).not.toContain('Recommended');
+      let text = fixture.nativeElement.textContent;
+      expect(text).toContain('Cost/Capacity-optimized');
+      expect(text).toContain('(Recommended)');
 
       deploymentOptions.recommended_option = OsdDeploymentOptions.THROUGHPUT;
       fixture.detectChanges();
-      expect(throughputLabel.innerHTML).toContain('Recommended');
-      expect(label.innerHTML).not.toContain('Recommended');
+      text = fixture.nativeElement.textContent;
+      expect(text).toContain('Throughput-optimized');
+      expect(text).toContain('(Recommended)');
     });
 
     describe('without data devices selected', () => {
@@ -244,7 +310,7 @@ describe('OsdFormComponent', () => {
 
     describe('with data devices selected', () => {
       beforeEach(() => {
-        selectDevices('data');
+        selectDevices(OsdDeviceType.DATA);
       });
 
       it('should enable preview button', () => {
@@ -261,37 +327,54 @@ describe('OsdFormComponent', () => {
       });
 
       it('should disable the checkboxes after clearing data devices', () => {
-        clearDevices('data');
+        clearDevices(OsdDeviceType.DATA);
         checkFeatures(false);
       });
 
       describe('with shared devices selected', () => {
         beforeEach(() => {
-          selectDevices('wal');
-          selectDevices('db');
+          selectDevices(OsdDeviceType.WAL);
+          selectDevices(OsdDeviceType.DB);
+        });
+
+        it('should populate manual review data', () => {
+          component.form.get('deploymentMode').setValue('manual');
+          component.form.get('walSlots').setValue(2);
+          component.form.get('dbSlots').setValue(1);
+
+          component.populateReviewData();
+
+          expect(component.reviewDeploymentModeLabel).toBe('Manual selection');
+          expect(component.reviewDataSelection.count).toBe(1);
+          expect(component.reviewWalSelection.count).toBe(1);
+          expect(component.reviewWalSelection.slots).toBe(2);
+          expect(component.reviewDbSelection.count).toBe(1);
+          expect(component.reviewDbSelection.slots).toBe(1);
         });
 
         it('should display slots', () => {
-          fixtureHelper.expectElementVisible('#walSlots', true);
-          fixtureHelper.expectElementVisible('#dbSlots', true);
+          expect(component.walDeviceSelectionGroups.devices.length).toBeGreaterThan(0);
+          expect(component.dbDeviceSelectionGroups.devices.length).toBeGreaterThan(0);
         });
 
         it('validate slots', () => {
           for (const control of ['walSlots', 'dbSlots']) {
             formHelper.expectValid(control);
             formHelper.expectValidChange(control, 1);
-            formHelper.expectErrorChange(control, -1, 'min');
+            formHelper.expectValidChange(control, -1);
           }
+          expect(component.driveGroup.spec['wal_slots']).toBe(1);
+          expect(component.driveGroup.spec['db_slots']).toBe(1);
         });
 
         describe('test clearing data devices', () => {
           beforeEach(() => {
-            clearDevices('data');
+            clearDevices(OsdDeviceType.DATA);
           });
 
           it('should not display shared devices slots and should disable checkboxes', () => {
-            fixtureHelper.expectElementVisible('#walSlots', false);
-            fixtureHelper.expectElementVisible('#dbSlots', false);
+            expect(component.walDeviceSelectionGroups.devices.length).toBe(0);
+            expect(component.dbDeviceSelectionGroups.devices.length).toBe(0);
             checkFeatures(false);
           });
         });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.spec.ts
@@ -215,24 +215,19 @@ describe('OsdFormComponent', () => {
         OsdDeploymentOptions.THROUGHPUT,
         OsdDeploymentOptions.IOPS
       ]);
-      expect(component.steps).toHaveLength(3);
-      expect(component.steps.map((step) => step.label)).toEqual([
-        'Deployment Options',
-        'Features',
-        'Review'
-      ]);
+      expect(component.steps).toHaveLength(2);
+      expect(component.steps.map((step) => step.label)).toEqual(['Deployment Options', 'Review']);
     });
 
     it('should expand and collapse steps when deployment mode changes', () => {
       component.form.get('deploymentMode').setValue('manual');
       fixture.detectChanges();
 
-      expect(component.steps).toHaveLength(5);
+      expect(component.steps).toHaveLength(4);
       expect(component.steps.map((step) => step.label)).toEqual([
         'Deployment Options',
         'Select data devices',
         'Select DB/WAL devices (optional)',
-        'Features',
         'Review'
       ]);
       expect(fixture.nativeElement.textContent).toContain('Select data devices');
@@ -241,12 +236,8 @@ describe('OsdFormComponent', () => {
       component.form.get('deploymentMode').setValue('automatic');
       fixture.detectChanges();
 
-      expect(component.steps).toHaveLength(3);
-      expect(component.steps.map((step) => step.label)).toEqual([
-        'Deployment Options',
-        'Features',
-        'Review'
-      ]);
+      expect(component.steps).toHaveLength(2);
+      expect(component.steps.map((step) => step.label)).toEqual(['Deployment Options', 'Review']);
       expect(fixture.nativeElement.textContent).not.toContain('Select data devices');
       expect(fixture.nativeElement.textContent).not.toContain('Select DB/WAL devices (optional)');
     });
@@ -269,6 +260,13 @@ describe('OsdFormComponent', () => {
       expect(text).toContain('Cost/Capacity-optimized');
       expect(text).toContain('Throughput-optimized');
       expect(text).toContain('IOPS-optimized');
+    });
+
+    it('should mark the first step invalid when no eligible devices are available', () => {
+      expect(component.hasEligibleDevices).toBe(false);
+      expect(component.steps[0].invalid).toBe(true);
+      expect(component.form.get('deploymentMode').disabled).toBe(true);
+      expect(component.form.get('deploymentOption').disabled).toBe(true);
     });
 
     it('should only disable the options that are not available', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
@@ -28,14 +28,38 @@ import {
   OsdDeploymentOptions
 } from '~/app/shared/models/osd-deployment-options';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
+import { FormatterService } from '~/app/shared/services/formatter.service';
 import { ModalService } from '~/app/shared/services/modal.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
+import { TearsheetComponent } from '~/app/shared/components/tearsheet/tearsheet.component';
 import { OsdCreationPreviewModalComponent } from '../osd-creation-preview-modal/osd-creation-preview-modal.component';
 import { DevicesSelectionChangeEvent } from '../osd-devices-selection-groups/devices-selection-change-event.interface';
 import { DevicesSelectionClearEvent } from '../osd-devices-selection-groups/devices-selection-clear-event.interface';
 import { OsdDevicesSelectionGroupsComponent } from '../osd-devices-selection-groups/osd-devices-selection-groups.component';
 import { DriveGroup } from './drive-group.model';
 import { OsdFeature } from './osd-feature.interface';
+import { Step } from 'carbon-components-angular';
+
+interface ReviewField {
+  label: string;
+  value: string;
+}
+
+interface ReviewDeviceSelection {
+  count: number;
+  capacity: string;
+  filters: ReviewField[];
+  slots: number | null;
+  hasSelection: boolean;
+}
+
+const STEP_LABELS = {
+  DEPLOYMENT: $localize`Deployment Options`,
+  DATA: $localize`Select data devices`,
+  DB_WAL: $localize`Select DB/WAL devices (optional)`,
+  FEATURES: $localize`Features`,
+  REVIEW: $localize`Review`
+} as const;
 
 @Component({
   selector: 'cd-osd-form',
@@ -44,23 +68,23 @@ import { OsdFeature } from './osd-feature.interface';
   standalone: false
 })
 export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
+  @ViewChild(TearsheetComponent)
+  tearsheet!: TearsheetComponent;
+
   @ViewChild('dataDeviceSelectionGroups')
-  dataDeviceSelectionGroups: OsdDevicesSelectionGroupsComponent;
+  dataDeviceSelectionGroups!: OsdDevicesSelectionGroupsComponent;
 
   @ViewChild('walDeviceSelectionGroups')
-  walDeviceSelectionGroups: OsdDevicesSelectionGroupsComponent;
+  walDeviceSelectionGroups!: OsdDevicesSelectionGroupsComponent;
 
   @ViewChild('dbDeviceSelectionGroups')
-  dbDeviceSelectionGroups: OsdDevicesSelectionGroupsComponent;
+  dbDeviceSelectionGroups!: OsdDevicesSelectionGroupsComponent;
 
   @ViewChild('previewButtonPanel')
-  previewButtonPanel: FormButtonPanelComponent;
+  previewButtonPanel!: FormButtonPanelComponent;
 
   @Input()
   hideTitle = false;
-
-  @Input()
-  hideSubmitBtn = false;
 
   @Output() emitDriveGroup: EventEmitter<DriveGroup> = new EventEmitter();
 
@@ -68,9 +92,11 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
 
   @Output() emitMode: EventEmitter<boolean> = new EventEmitter();
 
+  @Output() osdCreated: EventEmitter<void> = new EventEmitter();
+
   icons = Icons;
 
-  form: CdFormGroup;
+  form!: CdFormGroup;
   columns: Array<CdTableColumn> = [];
 
   allDevices: InventoryDevice[] = [];
@@ -86,14 +112,27 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
   resource: string;
 
   features: { [key: string]: OsdFeature };
-  featureList: OsdFeature[] = [];
+  featureList: Array<OsdFeature & { key: string }> = [];
 
   hasOrchestrator = true;
 
   simpleDeployment = true;
+  createOsdsLabel = $localize`Create OSDs`;
+  isSubmitLoading = false;
 
-  deploymentOptions: DeploymentOptions;
+  deploymentOptions!: DeploymentOptions;
   optionNames = Object.values(OsdDeploymentOptions);
+
+  steps: Array<Step> = this.getStepsForMode('automatic');
+
+  reviewDeploymentModeLabel = $localize`Automatic`;
+  reviewDeploymentOptionTitle = '';
+  reviewDeploymentOptionDescription = '';
+  reviewHostPattern = '';
+  reviewEnabledFeatures: string[] = [];
+  reviewDataSelection: ReviewDeviceSelection = this.createEmptyReviewDeviceSelection();
+  reviewWalSelection: ReviewDeviceSelection = this.createEmptyReviewDeviceSelection();
+  reviewDbSelection: ReviewDeviceSelection = this.createEmptyReviewDeviceSelection();
 
   constructor(
     public actionLabels: ActionLabelsI18n,
@@ -101,6 +140,7 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
     private orchService: OrchestratorService,
     private hostService: HostService,
     private router: Router,
+    private formatterService: FormatterService,
     private modalService: ModalService,
     private osdService: OsdService,
     private taskWrapper: TaskWrapperService
@@ -114,8 +154,84 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
         desc: $localize`Encryption`
       }
     };
-    this.featureList = _.map(this.features, (o, key) => Object.assign(o, { key: key }));
+    this.featureList = _.map(this.features, (o, key) => Object.assign({}, o, { key }));
     this.createForm();
+  }
+
+  private getStepsForMode(mode: string): Array<Step> {
+    return mode !== 'manual'
+      ? [
+          { label: STEP_LABELS.DEPLOYMENT, invalid: false },
+          { label: STEP_LABELS.FEATURES, invalid: false },
+          { label: STEP_LABELS.REVIEW, invalid: false }
+        ]
+      : [
+          { label: STEP_LABELS.DEPLOYMENT, invalid: false },
+          { label: STEP_LABELS.DATA, invalid: false },
+          { label: STEP_LABELS.DB_WAL, invalid: false },
+          { label: STEP_LABELS.FEATURES, invalid: false },
+          { label: STEP_LABELS.REVIEW, invalid: false }
+        ];
+  }
+
+  private createEmptyReviewDeviceSelection(): ReviewDeviceSelection {
+    return {
+      count: 0,
+      capacity: '',
+      filters: [],
+      slots: null,
+      hasSelection: false
+    };
+  }
+
+  private formatHostPattern(pattern?: string): string {
+    if (!pattern || pattern === '*') {
+      return $localize`All hosts`;
+    }
+
+    return pattern;
+  }
+
+  private getReviewFilters(selectionGroup?: OsdDevicesSelectionGroupsComponent): ReviewField[] {
+    return (selectionGroup?.appliedFilters ?? []).map((filter) => ({
+      label: filter.name,
+      value: filter.value?.formatted ?? filter.value?.raw ?? '-'
+    }));
+  }
+
+  private buildReviewDeviceSelection(
+    selectionGroup?: OsdDevicesSelectionGroupsComponent,
+    slotControlName?: 'walSlots' | 'dbSlots'
+  ): ReviewDeviceSelection {
+    const devices = selectionGroup?.devices ?? [];
+    const totalCapacity = _.sumBy(devices, (device) => device?.sys_api?.size ?? 0);
+
+    return {
+      count: devices.length,
+      capacity:
+        devices.length > 0 ? this.formatterService.formatToBinary(totalCapacity, false) : '',
+      filters: this.getReviewFilters(selectionGroup),
+      slots:
+        slotControlName && devices.length > 0
+          ? Number(this.form.get(slotControlName)?.value ?? 0)
+          : null,
+      hasSelection: devices.length > 0
+    };
+  }
+
+  private getEnabledFeatures(): string[] {
+    return this.featureList
+      .filter((feature) => this.form.get('features')?.get(feature.key)?.value)
+      .map((feature) => feature.desc);
+  }
+
+  private getEncryptedFeatureValue(): boolean {
+    return this.form.get('features')?.get('encrypted')?.value ?? false;
+  }
+
+  private updateSteps() {
+    const mode = this.form?.get('deploymentMode')?.value ?? 'automatic';
+    this.steps = this.getStepsForMode(mode);
   }
 
   ngOnInit() {
@@ -131,6 +247,7 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
     this.osdService.getDeploymentOptions().subscribe((options) => {
       this.deploymentOptions = options;
       if (!this.osdService.selectedFormValues) {
+        this.form.get('deploymentMode').setValue('automatic', { emitEvent: false });
         this.form.get('deploymentOption').setValue(this.deploymentOptions?.recommended_option);
       }
 
@@ -142,23 +259,40 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
     // restoring form value on back/next
     if (this.osdService.selectedFormValues) {
       this.form = _.cloneDeep(this.osdService.selectedFormValues);
+      if (!this.form.get('deploymentMode')) {
+        this.form.addControl('deploymentMode', new UntypedFormControl('automatic'));
+      }
       this.form
         .get('deploymentOption')
         .setValue(this.osdService.selectedFormValues.value?.deploymentOption);
     }
     this.simpleDeployment = this.osdService.isDeployementModeSimple;
+    this.form
+      .get('deploymentMode')
+      .setValue(this.simpleDeployment ? 'automatic' : 'manual', { emitEvent: false });
+    this.updateSteps();
+    this.form
+      .get('deploymentMode')
+      .valueChanges.subscribe((mode) => this.onDeploymentModeChanged(mode));
     this.form.get('walSlots').valueChanges.subscribe((value) => this.setSlots('wal', value));
     this.form.get('dbSlots').valueChanges.subscribe((value) => this.setSlots('db', value));
     _.each(this.features, (feature) => {
-      this.form
-        .get('features')
-        .get(feature.key)
-        .valueChanges.subscribe((value) => this.featureFormUpdate(feature.key, value));
+      const featureControl = this.form.get('features').get(feature.key ?? '');
+      if (!featureControl) {
+        return;
+      }
+
+      featureControl.valueChanges.subscribe((value) =>
+        this.featureFormUpdate(feature.key ?? '', value)
+      );
     });
+
+    this.populateReviewData();
   }
 
   createForm() {
     this.form = new CdFormGroup({
+      deploymentMode: new UntypedFormControl('automatic'),
       walSlots: new UntypedFormControl(0),
       dbSlots: new UntypedFormControl(0),
       features: new CdFormGroup(
@@ -168,7 +302,7 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
           return acc;
         }, {})
       ),
-      deploymentOption: new UntypedFormControl(0)
+      deploymentOption: new UntypedFormControl(null)
     });
   }
 
@@ -193,22 +327,33 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
     }
     if (slots >= 0) {
       this.driveGroup.setSlots(type, slots);
+      this.populateReviewData();
     }
   }
 
   featureFormUpdate(key: string, checked: boolean) {
     this.driveGroup.setFeature(key, checked);
+    this.populateReviewData();
   }
 
   enableFeatures() {
     this.featureList.forEach((feature) => {
-      this.form.get(feature.key).enable({ emitEvent: false });
+      const control = this.form.get('features').get(feature.key);
+      if (!control) {
+        return;
+      }
+
+      control.enable({ emitEvent: false });
     });
   }
 
   disableFeatures() {
     this.featureList.forEach((feature) => {
-      const control = this.form.get(feature.key);
+      const control = this.form.get('features').get(feature.key);
+      if (!control) {
+        return;
+      }
+
       control.disable({ emitEvent: false });
       control.setValue(false, { emitEvent: false });
     });
@@ -233,6 +378,7 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
       this.enableFeatures();
     }
     this.driveGroup.setDeviceSelection(event.type, event.filters);
+    this.populateReviewData();
 
     this.emitDriveGroup.emit(this.driveGroup);
   }
@@ -253,28 +399,95 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
       const slotControlName = `${event.type}Slots`;
       this.form.get(slotControlName).setValue(0, { emitEvent: false });
     }
+
+    this.populateReviewData();
   }
 
   emitDeploymentSelection() {
     const option = this.form.get('deploymentOption').value;
-    const encrypted = this.form.get('encrypted').value;
+    const encrypted = this.getEncryptedFeatureValue();
     this.emitDeploymentOption.emit({ option: option, encrypted: encrypted });
   }
 
-  emitDeploymentMode() {
-    this.simpleDeployment = !this.simpleDeployment;
-    if (!this.simpleDeployment && this.dataDeviceSelectionGroups.devices.length === 0) {
+  onDeploymentModeChanged(mode: string) {
+    const deploymentMode = mode ?? this.form?.get('deploymentMode')?.value ?? 'automatic';
+    this.simpleDeployment = deploymentMode !== 'manual';
+    this.updateSteps();
+    const hasDataDevices = (this.dataDeviceSelectionGroups?.devices?.length ?? 0) > 0;
+    if (!this.simpleDeployment && !hasDataDevices) {
       this.disableFeatures();
     } else {
       this.enableFeatures();
     }
+    this.populateReviewData();
     this.emitMode.emit(this.simpleDeployment);
+  }
+
+  populateReviewData() {
+    this.reviewDeploymentModeLabel = this.simpleDeployment
+      ? $localize`Automatic`
+      : $localize`Manual selection`;
+
+    const selectedOption = this.form.get('deploymentOption')?.value as OsdDeploymentOptions;
+    const deploymentOption = this.deploymentOptions?.options?.[selectedOption];
+    this.reviewDeploymentOptionTitle = deploymentOption?.title ?? '';
+    this.reviewDeploymentOptionDescription = deploymentOption?.desc ?? '';
+    this.reviewEnabledFeatures = this.getEnabledFeatures();
+
+    if (this.simpleDeployment) {
+      this.reviewHostPattern = '';
+      this.reviewDataSelection = this.createEmptyReviewDeviceSelection();
+      this.reviewWalSelection = this.createEmptyReviewDeviceSelection();
+      this.reviewDbSelection = this.createEmptyReviewDeviceSelection();
+      return;
+    }
+
+    this.reviewHostPattern = this.formatHostPattern(
+      this.hostname || (this.driveGroup.spec['host_pattern'] as string)
+    );
+    this.reviewDataSelection = this.buildReviewDeviceSelection(this.dataDeviceSelectionGroups);
+    this.reviewWalSelection = this.buildReviewDeviceSelection(
+      this.walDeviceSelectionGroups,
+      'walSlots'
+    );
+    this.reviewDbSelection = this.buildReviewDeviceSelection(
+      this.dbDeviceSelectionGroups,
+      'dbSlots'
+    );
+  }
+
+  private navigateAfterCreate() {
+    const returnUrl = window.history.state?.returnUrl;
+
+    if (this.osdCreated.observers.length > 0) {
+      this.osdCreated.emit();
+      return;
+    }
+
+    if (returnUrl === '/add-storage') {
+      this.router.navigate(['/add-storage']);
+      return;
+    }
+
+    const hasSafeReturnUrl =
+      typeof returnUrl === 'string' &&
+      returnUrl.startsWith('/') &&
+      !returnUrl.startsWith('//') &&
+      returnUrl !== '/osd/create';
+
+    if (hasSafeReturnUrl) {
+      this.router.navigateByUrl(returnUrl);
+      return;
+    }
+
+    this.router.navigate(['/osd']);
   }
 
   submit() {
     if (this.simpleDeployment) {
+      this.isSubmitLoading = true;
       const option = this.form.get('deploymentOption').value;
-      const encrypted = this.form.get('encrypted').value;
+      const encrypted = this.getEncryptedFeatureValue();
       const deploymentSpec = { option: option, encrypted: encrypted };
       const title = this.deploymentOptions.options[deploymentSpec.option].title;
       const trackingId = `${title} deployment`;
@@ -286,8 +499,12 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
           call: this.osdService.create([deploymentSpec], trackingId, 'predefined')
         })
         .subscribe({
+          error: () => {
+            this.isSubmitLoading = false;
+          },
           complete: () => {
-            this.router.navigate(['/osd']);
+            this.isSubmitLoading = false;
+            this.navigateAfterCreate();
           }
         });
     } else {
@@ -298,14 +515,15 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
         driveGroups: [this.driveGroup.spec]
       });
       modalRef.componentInstance.submitAction.subscribe(() => {
-        this.router.navigate(['/osd']);
+        this.navigateAfterCreate();
       });
+      this.isSubmitLoading = false;
       this.previewButtonPanel.submitButton.loading = false;
     }
   }
 
   ngOnDestroy() {
     this.osdService.selectedFormValues = _.cloneDeep(this.form);
-    this.osdService.isDeployementModeSimple = this.dataDeviceSelectionGroups?.devices?.length === 0;
+    this.osdService.isDeployementModeSimple = this.simpleDeployment;
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
@@ -8,6 +8,7 @@ import {
   ViewChild
 } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
+import { Location } from '@angular/common';
 import { Router } from '@angular/router';
 
 import _ from 'lodash';
@@ -94,6 +95,8 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
 
   @Output() osdCreated: EventEmitter<void> = new EventEmitter();
 
+  @Output() cancelled: EventEmitter<void> = new EventEmitter();
+
   icons = Icons;
 
   form!: CdFormGroup;
@@ -140,6 +143,7 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
     private orchService: OrchestratorService,
     private hostService: HostService,
     private router: Router,
+    private location: Location,
     private formatterService: FormatterService,
     private modalService: ModalService,
     private osdService: OsdService,
@@ -158,20 +162,54 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
     this.createForm();
   }
 
+  get hasEligibleDevices(): boolean {
+    return this.allDevices.length > 0;
+  }
+
   private getStepsForMode(mode: string): Array<Step> {
+    const firstStepInvalid = !this.hasEligibleDevices;
+    const subsequentStepDisabled = !this.hasEligibleDevices;
     return mode !== 'manual'
       ? [
-          { label: STEP_LABELS.DEPLOYMENT, invalid: false },
-          { label: STEP_LABELS.FEATURES, invalid: false },
-          { label: STEP_LABELS.REVIEW, invalid: false }
+          { label: STEP_LABELS.DEPLOYMENT, invalid: firstStepInvalid },
+          { label: STEP_LABELS.REVIEW, invalid: false, disabled: subsequentStepDisabled }
         ]
       : [
-          { label: STEP_LABELS.DEPLOYMENT, invalid: false },
-          { label: STEP_LABELS.DATA, invalid: false },
-          { label: STEP_LABELS.DB_WAL, invalid: false },
-          { label: STEP_LABELS.FEATURES, invalid: false },
-          { label: STEP_LABELS.REVIEW, invalid: false }
+          { label: STEP_LABELS.DEPLOYMENT, invalid: firstStepInvalid },
+          { label: STEP_LABELS.DATA, invalid: false, disabled: subsequentStepDisabled },
+          { label: STEP_LABELS.DB_WAL, invalid: false, disabled: subsequentStepDisabled },
+          { label: STEP_LABELS.REVIEW, invalid: false, disabled: subsequentStepDisabled }
         ];
+  }
+
+  private updateFirstStepInvalid() {
+    const invalid = !this.hasEligibleDevices;
+    const subsequentStepDisabled = !this.hasEligibleDevices;
+    const unchanged =
+      this.steps[0]?.invalid === invalid &&
+      this.steps.slice(1).every((step) => step.disabled === subsequentStepDisabled);
+    if (unchanged) {
+      return;
+    }
+    this.steps = this.steps.map((step, i) => {
+      if (i === 0) {
+        return { ...step, invalid };
+      }
+      return { ...step, disabled: subsequentStepDisabled };
+    });
+  }
+
+  private updateDeploymentControlsAvailability() {
+    const deploymentMode = this.form.get('deploymentMode');
+    const deploymentOption = this.form.get('deploymentOption');
+    if (!this.hasEligibleDevices) {
+      deploymentMode?.disable({ emitEvent: false });
+      deploymentOption?.disable({ emitEvent: false });
+    } else {
+      deploymentMode?.enable({ emitEvent: false });
+      deploymentOption?.enable({ emitEvent: false });
+    }
+    this.updateFirstStepInvalid();
   }
 
   private createEmptyReviewDeviceSelection(): ReviewDeviceSelection {
@@ -232,6 +270,7 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
   private updateSteps() {
     const mode = this.form?.get('deploymentMode')?.value ?? 'automatic';
     this.steps = this.getStepsForMode(mode);
+    this.updateFirstStepInvalid();
   }
 
   ngOnInit() {
@@ -311,11 +350,13 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
       (devices: InventoryDevice[]) => {
         this.allDevices = _.filter(devices, 'available');
         this.availDevices = [...this.allDevices];
+        this.updateDeploymentControlsAvailability();
         this.loadingReady();
       },
       () => {
         this.allDevices = [];
         this.availDevices = [];
+        this.updateDeploymentControlsAvailability();
         this.loadingError();
       }
     );
@@ -454,6 +495,14 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
       this.dbDeviceSelectionGroups,
       'dbSlots'
     );
+  }
+
+  onCancel() {
+    if (this.hideTitle) {
+      this.cancelled.emit();
+      return;
+    }
+    this.location.back();
   }
 
   private navigateAfterCreate() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
@@ -29,10 +29,10 @@ import {
 } from '~/app/shared/models/osd-deployment-options';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { FormatterService } from '~/app/shared/services/formatter.service';
-import { ModalService } from '~/app/shared/services/modal.service';
+// import { ModalService } from '~/app/shared/services/modal.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { TearsheetComponent } from '~/app/shared/components/tearsheet/tearsheet.component';
-import { OsdCreationPreviewModalComponent } from '../osd-creation-preview-modal/osd-creation-preview-modal.component';
+// import { OsdCreationPreviewModalComponent } from '../osd-creation-preview-modal/osd-creation-preview-modal.component';
 import { DevicesSelectionChangeEvent } from '../osd-devices-selection-groups/devices-selection-change-event.interface';
 import { DevicesSelectionClearEvent } from '../osd-devices-selection-groups/devices-selection-clear-event.interface';
 import { OsdDevicesSelectionGroupsComponent } from '../osd-devices-selection-groups/osd-devices-selection-groups.component';
@@ -143,7 +143,7 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
     private hostService: HostService,
     private router: Router,
     private formatterService: FormatterService,
-    private modalService: ModalService,
+    // private modalService: ModalService,
     private osdService: OsdService,
     private taskWrapper: TaskWrapperService
   ) {
@@ -222,6 +222,7 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
 
   private formatHostPattern(pattern?: string): string {
     if (!pattern || pattern === '*') {
+      // this.driveGroup.setHostPattern('*');
       return $localize`All hosts`;
     }
 
@@ -463,6 +464,9 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
   }
 
   populateReviewData() {
+    const user = this.authStorageService.getUsername();
+    this.driveGroup.setName(`dashboard-${user}-${_.now()}`);
+
     this.reviewDeploymentModeLabel = this.simpleDeployment
       ? $localize`Automatic`
       : $localize`Manual selection`;
@@ -537,16 +541,38 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
         });
     } else {
       // use user name and timestamp for drive group name
-      const user = this.authStorageService.getUsername();
-      this.driveGroup.setName(`dashboard-${user}-${_.now()}`);
-      const modalRef = this.modalService.show(OsdCreationPreviewModalComponent, {
-        driveGroups: [this.driveGroup.spec]
-      });
-      modalRef.componentInstance.submitAction.subscribe(() => {
-        this.navigateAfterCreate();
-      });
-      this.isSubmitLoading = false;
-      this.previewButtonPanel.submitButton.loading = false;
+
+      // const user = this.authStorageService.getUsername();
+      // this.driveGroup.setName(`dashboard-${user}-${_.now()}`);
+      // const modalRef = this.modalService.show(OsdCreationPreviewModalComponent, {
+      //   driveGroups: [this.driveGroup.spec]
+      // });
+      // modalRef.componentInstance.submitAction.subscribe(() => {
+      //   this.navigateAfterCreate();
+      // });
+      // this.isSubmitLoading = false;
+      // this.previewButtonPanel.submitButton.loading = false;
+
+      // let driveGroups = [this.driveGroup.spec];
+
+      const trackingId = _.join(_.map([this.driveGroup.spec], 'service_id'), ', ');
+      this.taskWrapper
+        .wrapTaskAroundCall({
+          task: new FinishedTask('osd/' + URLVerbs.CREATE, {
+            tracking_id: trackingId
+          }),
+          call: this.osdService.create([this.driveGroup.spec], trackingId)
+        })
+        .subscribe({
+          error: () => {
+            this.isSubmitLoading = false;
+          },
+          complete: () => {
+            this.isSubmitLoading = false;
+            this.navigateAfterCreate();
+            this.previewButtonPanel.submitButton.loading = false;
+          }
+        });
     }
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
@@ -8,7 +8,6 @@ import {
   ViewChild
 } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
-import { Location } from '@angular/common';
 import { Router } from '@angular/router';
 
 import _ from 'lodash';
@@ -143,7 +142,6 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
     private orchService: OrchestratorService,
     private hostService: HostService,
     private router: Router,
-    private location: Location,
     private formatterService: FormatterService,
     private modalService: ModalService,
     private osdService: OsdService,
@@ -502,34 +500,15 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
       this.cancelled.emit();
       return;
     }
-    this.location.back();
+    this.router.navigate(['osd', { outlets: { modal: null } }]);
   }
 
   private navigateAfterCreate() {
-    const returnUrl = window.history.state?.returnUrl;
-
     if (this.osdCreated.observers.length > 0) {
       this.osdCreated.emit();
       return;
     }
-
-    if (returnUrl === '/add-storage') {
-      this.router.navigate(['/add-storage']);
-      return;
-    }
-
-    const hasSafeReturnUrl =
-      typeof returnUrl === 'string' &&
-      returnUrl.startsWith('/') &&
-      !returnUrl.startsWith('//') &&
-      returnUrl !== '/osd/create';
-
-    if (hasSafeReturnUrl) {
-      this.router.navigateByUrl(returnUrl);
-      return;
-    }
-
-    this.router.navigate(['/osd']);
+    this.router.navigate(['osd', { outlets: { modal: null } }]);
   }
 
   submit() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -1,63 +1,74 @@
-<nav ngbNav
-     #nav="ngbNav"
-     class="nav-tabs">
-  <ng-container ngbNavItem>
-    <a ngbNavLink
-       i18n>OSDs List</a>
-    <ng-template ngbNavContent>
-      <cd-table [data]="osds"
-                (fetchData)="getOsdList($event)"
-                [columns]="columns"
-                selectionType="multiClick"
-                [hasDetails]="true"
-                (setExpandedRow)="setExpandedRow($event)"
-                (updateSelection)="updateSelection($event)"
-                [updateSelectionOnRefresh]="'never'"
-                [serverSide]="true"
-                [count]="count">
+<ng-template #osdTableTpl>
+  <cd-table [data]="osds"
+            (fetchData)="getOsdList($event)"
+            [columns]="columns"
+            selectionType="multiClick"
+            [hasDetails]="true"
+            (setExpandedRow)="setExpandedRow($event)"
+            (updateSelection)="updateSelection($event)"
+            [updateSelectionOnRefresh]="'never'"
+            [serverSide]="true"
+            [count]="count">
 
-        <div class="table-actions">
-          <cd-table-actions [permission]="permissions.osd"
-                            [selection]="selection"
-                            class="btn-group"
-                            id="osd-actions"
-                            [tableActions]="tableActions">
-          </cd-table-actions>
-          <cd-table-actions [permission]="{read: true}"
-                            [selection]="selection"
-                            dropDownOnly="Cluster-wide configuration"
-                            [dropDownOnlyOffset]="{ x: 110, y: 0 }"
-                            [dropDownOnlyBtnColor]="'tertiary'"
-                            class="btn-group"
-                            id="cluster-wide-actions"
-                            [tableActions]="clusterWideActions">
-          </cd-table-actions>
-        </div>
+    <div class="table-actions">
+      <cd-table-actions [permission]="permissions.osd"
+                        [selection]="selection"
+                        class="btn-group"
+                        id="osd-actions"
+                        [tableActions]="tableActions">
+      </cd-table-actions>
+      <cd-table-actions [permission]="{read: true}"
+                        [selection]="selection"
+                        dropDownOnly="Cluster-wide configuration"
+                        [dropDownOnlyOffset]="{ x: 110, y: 0 }"
+                        [dropDownOnlyBtnColor]="'tertiary'"
+                        class="btn-group"
+                        id="cluster-wide-actions"
+                        [tableActions]="clusterWideActions">
+      </cd-table-actions>
+    </div>
 
-        <cd-osd-details *cdTableDetail
-                        [selection]="expandedRow">
-        </cd-osd-details>
-      </cd-table>
-    </ng-template>
-  </ng-container>
+    <cd-osd-details *cdTableDetail
+                    [selection]="expandedRow">
+    </cd-osd-details>
+  </cd-table>
+</ng-template>
 
-  <ng-container ngbNavItem
-                *ngIf="permissions.grafana.read">
-    <a ngbNavLink
-       i18n>Overall Performance</a>
-    <ng-template ngbNavContent>
-      <cd-grafana i18n-title
-                  title="OSD list"
-                  [grafanaPath]="'ceph-osds-overview?'"
-                  [type]="'metrics'"
-                  uid="lo02I1Aiz"
-                  grafanaStyle="three">
-      </cd-grafana>
-    </ng-template>
-  </ng-container>
-</nav>
+@if (showTabs) {
+  <nav ngbNav
+       #nav="ngbNav"
+       class="nav-tabs">
+    <ng-container ngbNavItem>
+      <a ngbNavLink
+         i18n>OSDs List</a>
+      <ng-template ngbNavContent>
+        <ng-container *ngTemplateOutlet="osdTableTpl"></ng-container>
+      </ng-template>
+    </ng-container>
 
-<div [ngbNavOutlet]="nav"></div>
+  @if (permissions.grafana.read) {
+    <ng-container ngbNavItem>
+      <a
+        ngbNavLink
+        i18n>Overall Performance</a>
+      <ng-template
+        ngbNavContent>
+        <cd-grafana i18n-title
+                    title="OSD list"
+                    [grafanaPath]="'ceph-osds-overview?'"
+                    [type]="'metrics'"
+                    uid="lo02I1Aiz"
+                    grafanaStyle="three">
+        </cd-grafana>
+      </ng-template>
+    </ng-container>
+  }
+  </nav>
+
+  <div [ngbNavOutlet]="nav"></div>
+} @else {
+  <ng-container *ngTemplateOutlet="osdTableTpl"></ng-container>
+}
 
 <ng-template #markOsdConfirmationTpl
              let-markActionDescription="markActionDescription"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -165,3 +165,5 @@
     </ng-container>
   </ng-container>
 </ng-template>
+
+<router-outlet name="modal"></router-outlet>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
@@ -1,4 +1,12 @@
-import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  TemplateRef,
+  ViewChild
+} from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
 import { Router } from '@angular/router';
 
@@ -53,6 +61,9 @@ const BASE_URL = 'osd';
   standalone: false
 })
 export class OsdListComponent extends ListWithDetails implements OnInit {
+  @Input() showTabs = true;
+  @Output() createAction = new EventEmitter<void>();
+
   @ViewChild('osdUsageTpl', { static: true })
   osdUsageTpl: TemplateRef<any>;
   @ViewChild('markOsdConfirmationTpl', { static: true })
@@ -125,7 +136,17 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
         name: this.actionLabels.CREATE,
         permission: 'create',
         icon: Icons.add,
-        click: () => this.router.navigate([this.urlBuilder.getCreate()]),
+        click: () => {
+          if (this.createAction.observers.length > 0) {
+            this.createAction.emit();
+          } else {
+            this.router.navigate([this.urlBuilder.getCreate()], {
+              state: {
+                returnUrl: this.router.url
+              }
+            });
+          }
+        },
         disable: (selection: CdTableSelection) => this.getDisable('create', selection),
         canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
       },

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
@@ -1,11 +1,11 @@
 import {
   Component,
-  EventEmitter,
   Input,
   OnInit,
-  Output,
   TemplateRef,
-  ViewChild
+  ViewChild,
+  Output,
+  EventEmitter
 } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -39,7 +39,6 @@ import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { ModalService } from '~/app/shared/services/modal.service';
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
-import { URLBuilderService } from '~/app/shared/services/url-builder.service';
 import { OsdFlagsIndivModalComponent } from '../osd-flags-indiv-modal/osd-flags-indiv-modal.component';
 import { OsdFlagsModalComponent } from '../osd-flags-modal/osd-flags-modal.component';
 import { OsdPgScrubModalComponent } from '../osd-pg-scrub-modal/osd-pg-scrub-modal.component';
@@ -57,11 +56,11 @@ const BASE_URL = 'osd';
   selector: 'cd-osd-list',
   templateUrl: './osd-list.component.html',
   styleUrls: ['./osd-list.component.scss'],
-  providers: [{ provide: URLBuilderService, useValue: new URLBuilderService(BASE_URL) }],
   standalone: false
 })
 export class OsdListComponent extends ListWithDetails implements OnInit {
   @Input() showTabs = true;
+  @Input() inlineCreate = false;
   @Output() createAction = new EventEmitter<void>();
 
   @ViewChild('osdUsageTpl', { static: true })
@@ -121,7 +120,6 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
     private osdService: OsdService,
     private dimlessBinaryPipe: DimlessBinaryPipe,
     private modalService: ModalService,
-    private urlBuilder: URLBuilderService,
     private router: Router,
     private taskWrapper: TaskWrapperService,
     public actionLabels: ActionLabelsI18n,
@@ -137,14 +135,10 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
         permission: 'create',
         icon: Icons.add,
         click: () => {
-          if (this.createAction.observers.length > 0) {
+          if (this.inlineCreate) {
             this.createAction.emit();
           } else {
-            this.router.navigate([this.urlBuilder.getCreate()], {
-              state: {
-                returnUrl: this.router.url
-              }
-            });
+            this.router.navigate([BASE_URL, { outlets: { modal: [URLVerbs.CREATE] } }]);
           }
         },
         disable: (selection: CdTableSelection) => this.getDisable('create', selection),

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.html
@@ -81,6 +81,7 @@
           @else {
           <button cdsButton="primary"
                   size="xl"
+                  [disabled]="steps[currentStep]?.invalid"
                   (click)="onNext()"
                   i18n>Next</button>
           }
@@ -194,6 +195,7 @@
         @else {
         <button cdsButton="primary"
                 size="xl"
+                [disabled]="steps[currentStep]?.invalid"
                 (click)="onNext()"
                 i18n>Next</button>
         }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.spec.ts
@@ -172,5 +172,18 @@ describe('TearsheetComponent', () => {
       tearsheetComponent.onNext();
       expect(tearsheetComponent.currentStep).toBe(0);
     });
+
+    it('should disable next button when current step is invalid', () => {
+      hostComponent.steps = hostComponent.steps.map((step, i) =>
+        i === 0 ? { ...step, invalid: true } : step
+      );
+      hostFixture.detectChanges();
+      const buttons = hostFixture.debugElement.queryAll(
+        By.css('.tearsheet-footer button[cdsButton="primary"]')
+      );
+      const nextBtn = buttons.find((btn) => btn.nativeElement.textContent.trim() === 'Next');
+      expect(nextBtn).toBeTruthy();
+      expect(nextBtn?.nativeElement.disabled).toBe(true);
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectorRef,
   Component,
   ContentChildren,
   EventEmitter,
@@ -114,7 +115,7 @@ export class TearsheetComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   currentStep: number = 0;
-  lastStep: number = null;
+  lastStep: number | null = null;
   isOpen: boolean = true;
   hasModalOutlet: boolean = false;
   private destroy$ = new Subject<void>();
@@ -124,7 +125,8 @@ export class TearsheetComponent implements OnInit, AfterViewInit, OnDestroy {
     private cdsModalService: ModalCdsService,
     private route: ActivatedRoute,
     private location: Location,
-    private destroyRef: DestroyRef
+    private destroyRef: DestroyRef,
+    private cdr: ChangeDetectorRef
   ) {}
 
   ngOnInit() {
@@ -163,6 +165,7 @@ export class TearsheetComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.currentStep !== 0) {
       this.currentStep = this.currentStep - 1;
       this.stepChanged.emit({ current: this.currentStep });
+      this.cdr.markForCheck();
     }
   }
 
@@ -177,6 +180,7 @@ export class TearsheetComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.currentStep !== this.lastStep && !this.steps[this.currentStep].invalid) {
       this.currentStep = this.currentStep + 1;
       this.stepChanged.emit({ current: this.currentStep });
+      this.cdr.markForCheck();
     }
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.ts
@@ -10,6 +10,8 @@ import {
   AfterViewInit,
   DestroyRef,
   OnDestroy,
+  OnChanges,
+  SimpleChanges,
   ChangeDetectionStrategy,
   TemplateRef,
   ViewEncapsulation
@@ -61,7 +63,7 @@ formgroup: CdFormGroup;
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
-export class TearsheetComponent implements OnInit, AfterViewInit, OnDestroy {
+export class TearsheetComponent implements OnInit, AfterViewInit, OnDestroy, OnChanges {
   @Input() title!: string;
   @Input() steps!: Array<Step>;
   @Input() description!: string;
@@ -134,13 +136,42 @@ export class TearsheetComponent implements OnInit, AfterViewInit, OnDestroy {
     this.hasModalOutlet = this.route.outlet === 'modal';
   }
 
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['steps']) {
+      this.lastStep = this.steps.length - 1;
+      if (this.currentStep > this.lastStep) {
+        this.currentStep = this.lastStep;
+      }
+      this.cdr.markForCheck();
+    }
+  }
+
   private _updateStepInvalid(index: number, invalid: boolean) {
     this.steps = this.steps.map((step, i) => (i === index ? { ...step, invalid } : step));
   }
 
   onStepSelect(event: { step: Step; index: number }) {
+    if (this.isStepNavBlocked(event.index)) {
+      return;
+    }
     this.currentStep = event.index;
     this.stepChanged.emit({ current: this.currentStep });
+    this.cdr.markForCheck();
+  }
+
+  private isStepNavBlocked(index: number): boolean {
+    if (this.steps[index]?.disabled) {
+      return true;
+    }
+    if (index > this.currentStep && this.steps[this.currentStep]?.invalid) {
+      return true;
+    }
+    for (let i = 0; i < index; i++) {
+      if (this.steps[i]?.invalid || this.steps[i]?.disabled) {
+        return true;
+      }
+    }
+    return false;
   }
 
   closeTearsheet() {
@@ -154,6 +185,9 @@ export class TearsheetComponent implements OnInit, AfterViewInit, OnDestroy {
   closeWideTearsheet() {
     this.closeRequested.emit();
     this.isOpen = false;
+    if (this.closeRequested.observers.length > 0) {
+      return;
+    }
     if (this.hasModalOutlet) {
       this.location.back();
     } else {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.ts
@@ -183,9 +183,9 @@ export class TearsheetComponent implements OnInit, AfterViewInit, OnDestroy, OnC
   }
 
   closeWideTearsheet() {
-    this.closeRequested.emit();
     this.isOpen = false;
     if (this.closeRequested.observers.length > 0) {
+      this.closeRequested.emit();
       return;
     }
     if (this.hasModalOutlet) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/osd-form.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/osd-form.ts
@@ -1,0 +1,5 @@
+export enum OsdDeviceType {
+  DATA = 'data',
+  WAL = 'wal',
+  DB = 'db'
+}

--- a/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_spacings.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_spacings.scss
@@ -9,6 +9,14 @@
   padding-left: layout.$spacing-06;
 }
 
+.cds-pl-4 {
+  padding-left: layout.$spacing-04;
+}
+
+.cds-pl-7 {
+  padding-left: layout.$spacing-07;
+}
+
 .cds-pt-2px {
   padding-top: 2px;
 }


### PR DESCRIPTION
Fixes:
Tracker:
- https://tracker.ceph.com/issues/77457
Cherry-picks:
-(cherry picked from commit [78dad34](https://github.com/rhcs-dashboard/ceph/commit/78dad340ab180532082c39a52efc0dfce244ec6e))

Tracker:
- https://tracker.ceph.com/issues/78135
Cherry-picks:
- (cherry picked from commit [4eb4e25](https://github.com/rhcs-dashboard/ceph/commit/4eb4e25e5e6f14ed70fee5c41b2669cc0c557e19))
- (cherry picked from commit [b35999b](https://github.com/rhcs-dashboard/ceph/commit/b35999b6435cf4bf10ebdfa0204621836d76bcf0))
- (cherry picked from commit [b9e272c](https://github.com/rhcs-dashboard/ceph/commit/b9e272c469250d2f1bcc4301117ca790ae1c4748))

Signed-off-by: Devika Babrekar [Devika.Babrekar@ibm.com](mailto:Devika.Babrekar@ibm.com)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
