### PR TITLE
rbd-mirror: unlink peer UUIDs from image snapshots during group snapshot peer unlinking

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_group_simple.sh
+++ b/qa/workunits/rbd/rbd_mirror_group_simple.sh
@@ -2739,6 +2739,57 @@ test_force_promote()
   start_mirrors "${secondary_cluster}"
 }
 
+declare -a test_mirror_group_snapshot_unlink_peer_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${image_prefix}" 3 '')
+
+test_mirror_group_snapshot_unlink_peer_scenarios=1
+
+test_mirror_group_snapshot_unlink_peer()
+{
+  local primary_cluster=$1 ; shift
+  local secondary_cluster=$1 ; shift
+  local pool=$1 ; shift
+  local image_prefix=$1 ; shift
+  local image_count=$(($1*"${image_multiplier}")) ; shift
+
+  local group0=test-group-unlink
+  start_mirrors "${primary_cluster}"
+  start_mirrors "${secondary_cluster}"
+
+  local mirror_peer_uuid
+  get_remote_peer_uuid "${primary_cluster}" "${pool}" "${secondary_cluster}" mirror_peer_uuid
+  group_create "${primary_cluster}" "${pool}/${group0}"
+  images_create "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}"
+  for ((i = 0; i < image_count; i++)); do
+    write_image "${primary_cluster}" "${pool}" "${image_prefix}${i}" 10 4096
+  done
+  group_images_add "${primary_cluster}" "${pool}/${group0}" "${pool}/${image_prefix}" "${image_count}"
+
+  mirror_group_enable "${primary_cluster}" "${pool}/${group0}"
+  local group_snap_id
+  get_newest_complete_mirror_group_snapshot_id "${primary_cluster}" "${pool}/${group0}" group_snap_id
+  local group_snap_name
+  get_group_snap_name "${primary_cluster}" "${pool}/${group0}" "${group_snap_id}" group_snap_name
+  wait_for_group_present "${secondary_cluster}" "${pool}" "${group0}" "${image_count}"
+  wait_for_group_replay_started "${secondary_cluster}" "${pool}"/"${group0}" "${image_count}"
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+replaying' "${image_count}"
+  wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+stopped' "${image_count}"
+  wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}"/"${group0}"
+  mirror_group_snapshot "${primary_cluster}" "${pool}/${group0}"
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+replaying' "${image_count}"
+  wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+stopped' "${image_count}"
+  wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}"/"${group0}"
+  wait_for_group_snapshot_uuid_removed "${primary_cluster}" "${pool}/${group0}" "${group_snap_id}" "${mirror_peer_uuid}"
+  test_image_snapshots_uuid_removed "${primary_cluster}" "${pool}/${group0}@${group_snap_name}" "${mirror_peer_uuid}"
+
+  mirror_group_disable "${primary_cluster}" "${pool}/${group0}"
+  group_remove "${primary_cluster}" "${pool}/${group0}"
+  wait_for_group_not_present "${primary_cluster}" "${pool}" "${group0}"
+  wait_for_group_not_present "${secondary_cluster}" "${pool}" "${group0}"
+  images_remove "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}"
+  wait_for_no_keys "${primary_cluster}"
+  stop_mirrors "${primary_cluster}"
+}
+
 declare -a test_force_promote_delete_group_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${image_prefix}" 5 '')
 declare -a test_force_promote_delete_group_2=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${image_prefix}" 5 'disable_reenable_primary')
 
@@ -4116,6 +4167,7 @@ run_all_tests()
   #run_test_all_scenarios test_invalid_actions
   run_test_all_scenarios test_remote_namespace
   run_test_all_scenarios test_create_multiple_groups_do_io
+  run_test_all_scenarios test_mirror_group_snapshot_unlink_peer
 }
 
 if [ -n "${RBD_MIRROR_HIDE_BASH_DEBUGGING}" ]; then

--- a/qa/workunits/rbd/rbd_mirror_group_simple.sh
+++ b/qa/workunits/rbd/rbd_mirror_group_simple.sh
@@ -1195,9 +1195,11 @@ test_remote_namespace()
     local group_id_before
     get_id_from_group_info "${secondary_cluster}" "${secondary_pool_spec}/${group}" group_id_before
     mirror_group_resync "${secondary_cluster}" "${secondary_pool_spec}/${group}"
+    group_resync_marker_exists "${secondary_cluster}" "${secondary_pool_spec}" "${secondary_pool_spec}/${group}" || fail "group resync marker is not set"
     wait_for_group_id_changed "${secondary_cluster}" "${secondary_pool_spec}/${group}" "${group_id_before}"
 
     wait_for_group_synced "${primary_cluster}" "${primary_pool_spec}/${group}" "${secondary_cluster}" "${secondary_pool_spec}/${group}"
+    group_resync_marker_exists "${secondary_cluster}" "${secondary_pool_spec}" "${secondary_pool_spec}/${group}" && fail "group resync marker is still set"
 
     wait_for_group_status_in_pool_dir "${secondary_cluster}" "${secondary_pool_spec}"/"${group}" 'up+replaying' "${image_count}"
     wait_for_group_status_in_pool_dir "${primary_cluster}" "${primary_pool_spec}"/"${group}" 'up+stopped' "${image_count}"
@@ -1319,9 +1321,11 @@ test_empty_group()
   local group_id_before
   get_id_from_group_info "${secondary_cluster}" "${pool}/${group}" group_id_before
   mirror_group_resync "${secondary_cluster}" "${pool}/${group}"
+  group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group}" || fail "group resync marker is not set"
   wait_for_group_id_changed "${secondary_cluster}" "${pool}/${group}" "${group_id_before}"
 
   wait_for_group_synced "${primary_cluster}" "${pool}/${group}" "${secondary_cluster}" "${pool}/${group}"
+  group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group}" && fail "group resync marker is still set"
 
   wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group}" 'up+replaying'
   wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group}" 'up+stopped'
@@ -1491,9 +1495,11 @@ test_empty_groups()
   local group_id_before
   get_id_from_group_info "${secondary_cluster}" "${pool}/${group1}" group_id_before
   mirror_group_resync "${secondary_cluster}" "${pool}/${group1}"
+  group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group1}" || fail "group resync marker is not set"
   wait_for_group_id_changed "${secondary_cluster}" "${pool}/${group1}" "${group_id_before}"
 
   wait_for_group_synced "${primary_cluster}" "${pool}/${group1}" "${secondary_cluster}" "${pool}/${group1}"
+  group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group1}" && fail "group resync marker is still set"
 
   wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group1}" 'up+replaying'
   wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group1}" 'up+stopped'
@@ -2694,6 +2700,7 @@ test_force_promote()
   get_id_from_group_info "${secondary_cluster}" "${pool}/${group0}" group_id_before
 
   mirror_group_resync "${secondary_cluster}" "${pool}/${group0}"
+  group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group0}" || fail "group resync marker is not set"
 
   if [ "${scenario}" != 'no_change_primary_up' ]; then
     start_mirrors "${secondary_cluster}"
@@ -2703,6 +2710,7 @@ test_force_promote()
   wait_for_group_id_changed "${secondary_cluster}" "${pool}/${group0}" "${group_id_before}"
 
   wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}/${group0}"
+  group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group0}" && fail "group resync marker is still set"
 
   compare_image_with_snapshot "${secondary_cluster}" "${pool}/${image_prefix}0" "${secondary_cluster}" "${pool}/${image_prefix}0@${snap0}"
   compare_image_with_snapshot "${secondary_cluster}" "${pool}/${big_image}" "${secondary_cluster}" "${pool}/${big_image}@${snap0}"
@@ -2899,10 +2907,12 @@ test_force_promote_before_initial_sync()
   local group_id_before
   get_id_from_group_info "${secondary_cluster}" "${pool}/${group0}" group_id_before
   mirror_group_resync "${secondary_cluster}" "${pool}/${group0}"
+  group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group0}" || fail "group resync marker is not set"
   start_mirrors "${secondary_cluster}"
   wait_for_group_id_changed "${secondary_cluster}" "${pool}/${group0}" "${group_id_before}"
 
   wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}/${group0}"
+  group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group0}" && fail "group resync marker is still set"
 
   # try another force promote - this time it should work
   stop_mirrors "${secondary_cluster}" '-9'
@@ -2913,10 +2923,12 @@ test_force_promote_before_initial_sync()
 
   get_id_from_group_info "${secondary_cluster}" "${pool}/${group0}" group_id_before
   mirror_group_resync "${secondary_cluster}" "${pool}/${group0}"
+  group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group0}" || fail "group resync marker is not set"
   start_mirrors "${secondary_cluster}"
   wait_for_group_id_changed "${secondary_cluster}" "${pool}/${group0}" "${group_id_before}"
 
   wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}/${group0}"
+  group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group0}" && fail "group resync marker is still set"
 
   # tidy up
   mirror_group_disable "${primary_cluster}" "${pool}/${group0}"
@@ -2990,8 +3002,10 @@ test_resync_after_relocate_and_force_promote()
   local group_id_before_resync
   get_id_from_group_info "${secondary_cluster}" "${pool}/${group0}" group_id_before_resync
   mirror_group_resync "${secondary_cluster}" "${pool}/${group0}"
+  group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group0}" || fail "group resync marker is not set"
   wait_for_group_id_changed  "${secondary_cluster}" "${pool}/${group0}" "${group_id_before_resync}"
   wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}"/"${group0}"
+  group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group0}" && fail "group resync marker is still set"
 
   wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+stopped' ${image_count}
   wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+replaying' ${image_count}
@@ -3320,8 +3334,10 @@ test_odf_failover_failback()
   local group_id_before
   get_id_from_group_info "${primary_cluster}" "${pool}/${group0}" group_id_before
   mirror_group_resync "${primary_cluster}" "${pool}/${group0}" 
+  group_resync_marker_exists "${primary_cluster}" "${pool}" "${pool}/${group0}" || fail "group resync marker is not set"
   wait_for_group_id_changed "${primary_cluster}" "${pool}/${group0}" "${group_id_before}"
   wait_for_group_synced "${secondary_cluster}" "${pool}"/"${group0}" "${primary_cluster}" "${pool}/${group0}" 
+  group_resync_marker_exists "${primary_cluster}" "${pool}" "${pool}/${group0}" && fail "group resync marker is still set"
 
   compare_image_with_snapshot "${primary_cluster}" "${pool}/${image_prefix}0" "${primary_cluster}" "${pool}/${image_prefix}0@${snap0}"
 
@@ -3355,6 +3371,7 @@ test_odf_failover_failback()
   if [ "${scenario}" = 'resync_on_failback' ]; then
     # request resync - won't happen until other site is marked as primary
     mirror_group_resync "${secondary_cluster}" "${pool}/${group0}" 
+    group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group0}" || fail "group resync marker is not set"
   fi  
 
   get_id_from_group_info "${secondary_cluster}" "${pool}/${group0}" group_id_after
@@ -3398,6 +3415,7 @@ test_odf_failover_failback()
     wait_for_group_id_changed "${secondary_cluster}" "${pool}/${group0}" "${group_id_before}"
     get_image_id2 "${secondary_cluster}" "${pool}/${image_prefix}0" image_id_after
     test "${image_id_before}" != "${image_id_after}" || fail "image not recreated by resync"
+    group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group0}" && fail "group resync marker is still set"
   fi  
 
   wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+replaying' "${image_count}"
@@ -3470,6 +3488,7 @@ test_resync_marker()
   # demote primary and request resync on secondary - check that group does not get deleted (due to resync request flag)
   mirror_group_demote "${primary_cluster}" "${pool}/${group0}" 
   mirror_group_resync "${secondary_cluster}" "${pool}/${group0}" 
+  group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group0}" || fail "group resync marker is not set"
   wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+unknown'
 
   get_id_from_group_info "${secondary_cluster}" "${pool}/${group0}" group_id_after
@@ -3478,6 +3497,7 @@ test_resync_marker()
   test "${image_id_before}" = "${image_id_after}" || fail "image recreated with no primary"
 
   mirror_group_promote "${secondary_cluster}" "${pool}/${group0}"
+  group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group0}" && fail "group resync marker is still set"
 
   get_id_from_group_info "${secondary_cluster}" "${pool}/${group0}" group_id_after
   test "${group_id_before}" = "${group_id_after}" || fail "group recreated"
@@ -3499,6 +3519,7 @@ test_resync_marker()
   mirror_group_promote "${primary_cluster}" "${pool}/${group0}"
 
   # confirm that group and image are not recreated - resync flag was cleared
+  group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group0}" && fail "group resync marker is still set"
   get_id_from_group_info "${secondary_cluster}" "${pool}/${group0}" group_id_after
   test "${group_id_before}" = "${group_id_after}" || fail "group recreated"
   get_image_id2 "${secondary_cluster}" "${pool}/${image_prefix}0" image_id_after
@@ -3582,10 +3603,12 @@ test_resync()
   local group_id_before
   get_id_from_group_info "${secondary_cluster}" "${pool}/${group0}" group_id_before
   mirror_group_resync "${secondary_cluster}" "${pool}"/"${group0}"
+  group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group0}" || fail "group resync marker is not set"
   wait_for_group_id_changed  "${secondary_cluster}" "${pool}/${group0}" "${group_id_before}"
 
   # confirm that data on secondary again matches initial snapshot on primary
   wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}"/"${group0}"
+  group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group0}" && fail "group resync marker is still set"
   compare_image_with_snapshot "${secondary_cluster}" "${pool}/${image_prefix}0" "${primary_cluster}" "${pool}/${image_prefix}0@${snap0}"
 
   # Repeat the test this time changing the data on the primary too.
@@ -3608,10 +3631,12 @@ test_resync()
   start_mirrors "${secondary_cluster}"
   get_id_from_group_info "${secondary_cluster}" "${pool}/${group0}" group_id_before
   mirror_group_resync "${secondary_cluster}" "${pool}/${group0}"
+  group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group0}" || fail "group resync marker is not set"
   wait_for_group_id_changed  "${secondary_cluster}" "${pool}/${group0}" "${group_id_before}"
 
   # confirm that data on secondary again matches latest snapshot on primary
   wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}"  "${secondary_cluster}" "${pool}"/"${group0}"
+  group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group0}" && fail "group resync marker is still set"
   wait_for_test_group_snap_present "${secondary_cluster}" "${pool}/${group0}" "${group_snap_id}" 1
   compare_images "${primary_cluster}" "${secondary_cluster}" "${pool}" "${pool}" "${image_prefix}0"
 
@@ -3636,10 +3661,12 @@ test_resync()
   
   get_id_from_group_info "${primary_cluster}" "${pool}/${group0}" group_id_before
   mirror_group_resync "${primary_cluster}" "${pool}/${group0}"
+  group_resync_marker_exists "${primary_cluster}" "${pool}" "${pool}/${group0}" || fail "group resync marker is not set"
   wait_for_group_id_changed  "${primary_cluster}" "${pool}/${group0}" "${group_id_before}"
 
   # confirm that data on secondary again matches latest snapshot on primary
   wait_for_group_synced "${secondary_cluster}" "${pool}"/"${group0}" "${primary_cluster}" "${pool}"/"${group0}"
+  group_resync_marker_exists "${primary_cluster}" "${pool}" "${pool}/${group0}" && fail "group resync marker is still set"
   wait_for_test_group_snap_present "${primary_cluster}" "${pool}/${group0}" "${group_snap_id}" 1
   compare_images "${primary_cluster}" "${secondary_cluster}" "${pool}" "${pool}" "${image_prefix}0"
 
@@ -3881,8 +3908,10 @@ test_rollback_after_add_image()
   local group_id_before_resync
   get_id_from_group_info "${secondary_cluster}" "${pool}/${group0}" group_id_before_resync
   mirror_group_resync "${secondary_cluster}" "${pool}/${group0}"
+  group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group0}" || fail "group resync marker is not set"
   wait_for_group_id_changed  "${secondary_cluster}" "${pool}/${group0}" "${group_id_before_resync}"
   wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}"/"${group0}"
+  group_resync_marker_exists "${secondary_cluster}" "${pool}" "${pool}/${group0}" && fail "group resync marker is still set"
 
   # TEST group membership has 2 images only and the respective groups reflect right mirror status
   wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+stopped' ${image_count}

--- a/qa/workunits/rbd/rbd_mirror_group_simple.sh
+++ b/qa/workunits/rbd/rbd_mirror_group_simple.sh
@@ -3173,6 +3173,64 @@ test_multiple_mirror_group_snapshot_unlink_time()
   fi
 }
 
+declare -a test_group_snap_sync_after_user_snap_removal_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${image_prefix}" 8)
+
+test_group_snap_sync_after_user_snap_removal_scenarios=1
+
+test_group_snap_sync_after_user_snap_removal()
+{
+  local primary_cluster=$1 ; shift
+  local secondary_cluster=$1 ; shift
+  local pool=$1 ; shift
+  local image_prefix=$1 ; shift
+  local image_count=$(($1*"${image_multiplier}")) ; shift
+
+  local group0=test-group0
+  start_mirrors "${primary_cluster}"
+
+  group_create "${primary_cluster}" "${pool}/${group0}"
+  images_create "${primary_cluster}" "${pool}/${image_prefix}" $(("${image_count}"-1))
+  write_image "${primary_cluster}" "${pool}" "${image_prefix}0" 10 4096
+  group_images_add "${primary_cluster}" "${pool}/${group0}" "${pool}/${image_prefix}" $(("${image_count}"-1))
+
+  big_image=test-image-big
+  image_create "${primary_cluster}" "${pool}/${big_image}" 1G
+  group_image_add "${primary_cluster}" "${pool}/${group0}" "${pool}/${big_image}"
+  mirror_group_enable "${primary_cluster}" "${pool}/${group0}"
+  wait_for_group_present "${secondary_cluster}" "${pool}" "${group0}" "${image_count}"
+  wait_for_group_replay_started "${secondary_cluster}" "${pool}"/"${group0}" "${image_count}"
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+replaying' "${image_count}"
+  wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+stopped' "${image_count}"
+  wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}"/"${group0}"
+  for i in $(seq 0 $(("${image_count}"-2))); do
+    write_image "${primary_cluster}" "${pool}" "${image_prefix}$i" 10 4096
+  done;
+  write_image "${primary_cluster}" "${pool}" "${big_image}" 256 4194304
+  snap='regular_snap'
+  group_snap_create "${primary_cluster}" "${pool}/${group0}" "${snap}"
+  check_group_snap_exists "${primary_cluster}" "${pool}/${group0}" "${snap}"
+  local group_snap_id
+  mirror_group_snapshot "${primary_cluster}" "${pool}/${group0}" group_snap_id
+  wait_for_group_snap_present "${secondary_cluster}" "${pool}/${group0}" "${group_snap_id}"
+  # if mirror snapshot is present => user snapshot must be present
+  check_group_snap_exists "${secondary_cluster}" "${pool}/${group0}" "${snap}"
+  group_snap_remove "${primary_cluster}" "${pool}/${group0}" "${snap}"
+  # user group snapshot removed during sync
+  test_group_snap_sync_incomplete "${secondary_cluster}" "${pool}/${group0}" "${group_snap_id}"
+  wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}"/"${group0}"
+  # snapshot sync can be completed only after removal of user snapshot
+  check_group_snap_doesnt_exist "${secondary_cluster}" "${pool}/${group0}" "${snap}"
+
+  mirror_group_disable "${primary_cluster}" "${pool}/${group0}"
+  group_remove "${primary_cluster}" "${pool}/${group0}"
+  wait_for_group_not_present "${primary_cluster}" "${pool}" "${group0}"
+  wait_for_group_not_present "${secondary_cluster}" "${pool}" "${group0}"
+  images_remove "${primary_cluster}" "${pool}/${image_prefix}" $(("${image_count}"-1))
+  image_remove "${primary_cluster}" "${pool}/${big_image}"
+  wait_for_no_keys "${primary_cluster}"
+  stop_mirrors "${primary_cluster}"
+}
+
 # test force promote scenarios
 declare -a test_multiple_mirror_group_snapshot_whilst_stopped_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" 5)
 
@@ -4074,6 +4132,7 @@ run_all_tests()
   run_test_all_scenarios test_group_with_clone_image
   run_test_all_scenarios test_interrupted_sync_restarted_daemon
   run_test_all_scenarios test_interrupted_sync
+  run_test_all_scenarios test_group_snap_sync_after_user_snap_removal
   run_test_all_scenarios test_resync_after_relocate_and_force_promote
   run_test_all_scenarios test_multiple_mirror_group_snapshot_unlink_time
   run_test_all_scenarios test_force_promote_delete_group

--- a/qa/workunits/rbd/rbd_mirror_group_simple.sh
+++ b/qa/workunits/rbd/rbd_mirror_group_simple.sh
@@ -2731,6 +2731,64 @@ test_force_promote()
   start_mirrors "${secondary_cluster}"
 }
 
+declare -a test_mirror_group_snapshot_unlink_peer_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${image_prefix}" 3 '')
+
+test_mirror_group_snapshot_unlink_peer_scenarios=1
+
+test_mirror_group_snapshot_unlink_peer()
+{
+  local primary_cluster=$1 ; shift
+  local secondary_cluster=$1 ; shift
+  local pool=$1 ; shift
+  local image_prefix=$1 ; shift
+  local image_count=$(($1*"${image_multiplier}")) ; shift
+
+  local group0=test-group-unlink
+  start_mirrors "${primary_cluster}"
+
+  local mirror_peer_uuid
+  get_remote_peer_uuid "${primary_cluster}" "${pool}" "${secondary_cluster}" mirror_peer_uuid
+  group_create "${primary_cluster}" "${pool}/${group0}"
+  images_create "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}"
+  for ((i = 0; i < image_count; i++)); do
+    write_image "${primary_cluster}" "${pool}" "${image_prefix}${i}" 10 4096
+  done
+  group_images_add "${primary_cluster}" "${pool}/${group0}" "${pool}/${image_prefix}" "${image_count}"
+
+  mirror_group_enable "${primary_cluster}" "${pool}/${group0}"
+  local group_snap_id group_id_before secondary_group_snap_id
+  get_newest_complete_mirror_group_snapshot_id "${primary_cluster}" "${pool}/${group0}" group_snap_id
+  wait_for_group_present "${secondary_cluster}" "${pool}" "${group0}" "${image_count}"
+  wait_for_group_replay_started "${secondary_cluster}" "${pool}"/"${group0}" "${image_count}"
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+replaying' "${image_count}"
+  wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+stopped' "${image_count}"
+  wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}"/"${group0}"
+  mirror_group_snapshot_and_wait_for_sync_complete "${secondary_cluster}" "${primary_cluster}" "${pool}"/"${group0}"
+  wait_for_group_snapshot_peer_uuid_removed "${primary_cluster}" "${pool}/${group0}" "${group_snap_id}" "${mirror_peer_uuid}"
+  test_group_image_snapshots_peer_uuid_removed "${primary_cluster}" "${pool}/${group0}" "${group_snap_id}" "${mirror_peer_uuid}"
+  get_id_from_group_info "${secondary_cluster}" "${pool}/${group0}" group_id_before
+  mirror_group_resync "${secondary_cluster}" "${pool}/${group0}"
+  wait_for_group_id_changed "${secondary_cluster}" "${pool}/${group0}" "${group_id_before}"
+  wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}/${group0}"
+  get_newest_complete_mirror_group_snapshot_id "${secondary_cluster}" "${pool}/${group0}" secondary_group_snap_id
+  local count
+  count_mirror_group_snaps "${secondary_cluster}" "${pool}"/"${group0}" count
+  test "${count}" -eq 1 || { fail "mirror snap count = ${count}"; return 1; }
+  for ((i = 0; i < image_count; i++)); do
+    # verify that there are no orphan image snapshots present without a associated group snapshot
+    test "$(count_mirror_snaps ${secondary_cluster} ${pool} ${image_prefix}${i})" -eq 1
+    assert_image_snap_present_in_group_snap "${secondary_cluster}" "${pool}" "${group0}" "${image_prefix}${i}" "${secondary_group_snap_id}"
+  done
+
+  mirror_group_disable "${primary_cluster}" "${pool}/${group0}"
+  group_remove "${primary_cluster}" "${pool}/${group0}"
+  wait_for_group_not_present "${primary_cluster}" "${pool}" "${group0}"
+  wait_for_group_not_present "${secondary_cluster}" "${pool}" "${group0}"
+  images_remove "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}"
+  wait_for_no_keys "${primary_cluster}"
+  stop_mirrors "${primary_cluster}"
+}
+
 declare -a test_force_promote_delete_group_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${image_prefix}" 5 '')
 declare -a test_force_promote_delete_group_2=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${image_prefix}" 5 'disable_reenable_primary')
 
@@ -4118,6 +4176,7 @@ run_all_tests()
   run_test_all_scenarios test_create_group_with_images_then_mirror_with_regular_snapshots
   run_test_all_scenarios test_create_group_with_large_image
   run_test_all_scenarios test_create_group_with_multiple_images_do_io
+  run_test_all_scenarios test_mirror_group_snapshot_unlink_peer
   run_test_all_scenarios test_group_and_standalone_images_do_io
   run_test_all_scenarios test_stopped_daemon
   run_test_all_scenarios test_create_group_with_regular_snapshots_then_mirror

--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -2596,6 +2596,17 @@ get_pool_count()
     fi
 }
 
+get_remote_peer_uuid()
+{
+    local local_cluster=$1
+    local pool_name=$2
+    local remote_cluster=$3
+    local -n peer_uuid=$4
+
+    peer_uuid=$(rbd mirror pool info --cluster ${local_cluster} --pool ${pool_name} --format xml | \
+        xmlstarlet sel -t -v "//peers/peer[site_name='${remote_cluster}']/uuid")
+}
+
 get_pool_obj_count()
 {
     local cluster=$1
@@ -2629,6 +2640,57 @@ get_images_from_group_snap_info()
     run_cmd "rbd --cluster=${cluster} group snap info --format xml --pretty-format ${snap_spec}"
     # sed script removes extra path delimiter if namespace field is blank
     _images="$(xmlstarlet sel -t -m "//group_snapshot/images/image" -v "pool_name" -o "/" -v "namespace" -o "/" -v "image_name" -o " " < "$CMD_STDOUT" |  sed s/"\/\/"/"\/"/g )"
+}
+
+wait_for_group_snapshot_uuid_removed()
+{
+    local cluster=$1
+    local group_snap_spec=$2
+    local group_snap_id=$3
+    local mirror_peer_uuid=$4
+
+    # Verify the group snapshot mirror_peer_uuids list does not contain mirror_peer_uuid.
+    for s in 0.1 0.2 0.4 0.8 1 1 2 2 2 4 4 4 8 8 16; do
+        run_cmd "rbd --cluster=${cluster} group snap ls --format xml --pretty-format ${group_snap_spec}"
+
+        if ! xmlstarlet sel -t \
+            -m "//group_snap[id='${group_snap_id}']/namespace/mirror_peer_uuids/peer_uuid" \
+            -v . -n < "$CMD_STDOUT" | grep -Fxq "${mirror_peer_uuid}"; then
+            return 0
+        fi
+
+        sleep "${s}"
+    done
+    return 1
+}
+
+test_image_snapshots_uuid_removed()
+{
+    local cluster=$1
+    local group_snap_spec=$2
+    local mirror_peer_uuid=$3
+
+    # Verify all image snapshots do not contain the mirror_peer_uuid.
+    local images
+    get_images_from_group_snap_info "${cluster}" "${group_snap_spec}" images
+
+    local image
+    for image in ${images}; do
+        local snap_id
+        get_image_snap_id_from_group_snap_info \
+            "${cluster}" "${group_snap_spec}" "${image}" snap_id
+
+        run_cmd "rbd --cluster=${cluster} snap ls --all --format xml --pretty-format ${image}"
+
+        if xmlstarlet sel -t \
+            -m "//snapshot[id='${snap_id}']/namespace/mirror_peer_uuids/peer_uuid" \
+            -v . -n < "$CMD_STDOUT" | grep -Fxq "${mirror_peer_uuid}"; then
+            echo "mirror_peer_uuid ${mirror_peer_uuid} still present in ${image} snapshot ${snap_id}"
+            return 1
+        fi
+    done
+
+    return 0
 }
 
 get_image_snap_complete()

--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -2671,6 +2671,29 @@ mirror_group_resync()
     run_cmd "rbd --cluster=${cluster} mirror group resync ${group_spec}"
 }
 
+group_resync_marker_exists()
+{
+    local cluster=$1 ; shift
+    local pool_spec=$1 ; shift
+    local group_spec=$1 ; shift
+
+    local group_id
+    get_id_from_group_info "${cluster}" "${group_spec}" group_id "run_admin_cmd" || { fail; return 1; }
+
+    local group_header_oid="rbd_group_header.${group_id}"
+
+    # pool_spec may be "pool" or "pool/namespace", rados (unlike rbd) does
+    # not understand the combined pool/namespace spec, so it must be split
+    # and the namespace passed separately via --namespace.
+    local pool="${pool_spec%%/*}"
+    if [[ "${pool_spec}" == */* ]]; then
+        local namespace="${pool_spec#*/}"
+        try_admin_cmd "rados --cluster ${cluster} --pool ${pool} --namespace ${namespace} getomapval ${group_header_oid} metadata_rbd_group_resync >/dev/null"
+    else
+        try_admin_cmd "rados --cluster ${cluster} --pool ${pool} getomapval ${group_header_oid} metadata_rbd_group_resync >/dev/null"
+    fi
+}
+
 test_group_present()
 {
     local cluster=$1

--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -1013,6 +1013,17 @@ get_newest_mirror_snapshot_id_on_primary()
 
 test_snap_present()
 {
+    local cluster=$1
+    local image_spec=$2
+    local snap_id=$3
+    local expected_snap_count=$4
+
+    run_cmd "rbd --cluster ${cluster} snap list -a ${image_spec} --format xml --pretty-format"
+    test "${expected_snap_count}" = "$(xmlstarlet sel -t -v "count(//snapshot[id='${snap_id}'])" < "$CMD_STDOUT")" || { fail; return 1; }
+}
+
+test_secondary_snap_present()
+{
     local secondary_cluster=$1
     local image_spec=$2
     local snap_id=$3
@@ -1043,7 +1054,7 @@ wait_for_test_snap_present()
 
     for s in 0.1 1 2 4 8 8 8 8 8 8 8 8 16 16 32 32; do
         sleep ${s}
-        test_snap_present "${secondary_cluster}" "${image_spec}" "${snap_id}" "${test_snap_count}" && return 0
+        test_secondary_snap_present "${secondary_cluster}" "${image_spec}" "${snap_id}" "${test_snap_count}" && return 0
     done
 
     fail "wait for count of snaps with id ${snap_id} to be ${test_snap_count} failed on ${secondary_cluster}"
@@ -1816,6 +1827,16 @@ count_mirror_snaps()
 
     rbd --cluster ${cluster} snap ls ${pool}/${image} --all |
         grep -c -F " mirror ("
+}
+
+count_mirror_group_snaps()
+{
+    local cluster=$1
+    local group_spec=$2
+    local -n _count=$3
+
+    run_cmd "rbd --cluster ${cluster} group snap ls ${group_spec} --format xml --pretty-format"
+    _count=$(xmlstarlet sel -t -v 'count(/group_snaps/group_snap[namespace/type="mirror"])' < "$CMD_STDOUT")
 }
 
 get_snaps_json()
@@ -2596,6 +2617,17 @@ get_pool_count()
     fi
 }
 
+get_remote_peer_uuid()
+{
+    local local_cluster=$1
+    local pool_name=$2
+    local remote_cluster=$3
+    local -n peer_uuid=$4
+
+    peer_uuid=$(rbd mirror pool info --cluster ${local_cluster} --pool ${pool_name} --format xml | \
+        xmlstarlet sel -t -v "//peers/peer[site_name='${remote_cluster}']/uuid")
+}
+
 get_pool_obj_count()
 {
     local cluster=$1
@@ -2629,6 +2661,86 @@ get_images_from_group_snap_info()
     run_cmd "rbd --cluster=${cluster} group snap info --format xml --pretty-format ${snap_spec}"
     # sed script removes extra path delimiter if namespace field is blank
     _images="$(xmlstarlet sel -t -m "//group_snapshot/images/image" -v "pool_name" -o "/" -v "namespace" -o "/" -v "image_name" -o " " < "$CMD_STDOUT" |  sed s/"\/\/"/"\/"/g )"
+}
+
+wait_for_group_snapshot_peer_uuid_removed()
+{
+    local cluster=$1
+    local group_spec=$2
+    local group_snap_id=$3
+    local mirror_peer_uuid=$4
+
+    test_group_snap_present "${cluster}" "${group_spec}" "${group_snap_id}" 1
+    # Verify the group snapshot mirror_peer_uuids list does not contain mirror_peer_uuid.
+    for s in 0.1 0.2 0.4 0.8 1 1 2 2 2 4 4 4 8 8 16; do
+        run_cmd "rbd --cluster=${cluster} group snap ls --format xml --pretty-format ${group_spec}"
+
+        local mirror_peer_uuids
+        # get multiple UUID's in multiple lines
+        mirror_peer_uuids=$(xmlstarlet sel -t -m "//group_snap[id='${group_snap_id}']/namespace/mirror_peer_uuids/peer_uuid" -v . -n < "$CMD_STDOUT" || true)
+
+        if ! grep -Fxq "${mirror_peer_uuid}" <<< "${mirror_peer_uuids}"; then
+            return 0
+        fi
+
+        sleep "${s}"
+    done
+    return 1
+}
+
+test_group_image_snapshots_peer_uuid_removed()
+{
+    local cluster=$1
+    local group_spec=$2
+    local group_snap_id=$3
+    local mirror_peer_uuid=$4
+
+    local group_snap_name
+    get_group_snap_name "${cluster}" "${group_spec}" "${group_snap_id}" group_snap_name
+    # Verify all image snapshots do not contain the mirror_peer_uuid.
+    local images
+    get_images_from_group_snap_info "${cluster}" "${group_spec}@${group_snap_name}" images
+
+    local image_spec
+    for image_spec in ${images}; do
+        local snap_id
+        get_image_snap_id_from_group_snap_info "${cluster}" "${group_spec}@${group_snap_name}" "${image_spec}" snap_id
+        test_snap_present "${cluster}" "${image_spec}" "${snap_id}" 1
+        run_cmd "rbd --cluster=${cluster} snap ls --all --format xml --pretty-format ${image_spec}"
+
+        local mirror_peer_uuids
+        # get multiple UUID's in multiple lines
+        mirror_peer_uuids=$(xmlstarlet sel -t -m "//snapshot[id='${snap_id}']/namespace/mirror_peer_uuids/peer_uuid" -v . -n < "$CMD_STDOUT" || true)
+
+        if grep -Fxq "${mirror_peer_uuid}" <<< "${mirror_peer_uuids}"; then
+            echo "mirror_peer_uuid ${mirror_peer_uuid} still present in ${image_spec} snapshot ${snap_id}"
+            return 1
+        fi
+    done
+
+    return 0
+}
+
+assert_image_snap_present_in_group_snap()
+{
+    local cluster=$1
+    local pool=$2
+    local group=$3
+    local image=$4
+    local group_snap_id=$5
+
+    local group_snap_name
+    get_group_snap_name "${cluster}" "${pool}/${group}" "${group_snap_id}" group_snap_name
+
+    local snap_id
+    get_image_snap_id_from_group_snap_info "${cluster}" "${pool}/${group}@${group_snap_name}" "${pool}/${image}" snap_id
+
+    if [ -z "${snap_id}" ]; then
+        echo "image ${image} has no snapshot associated with group snap ID ${group_snap_id}"
+        return 1
+    fi
+
+    test_snap_present "${cluster}" "${pool}/${image}" "${snap_id}" 1
 }
 
 get_image_snap_complete()

--- a/src/librbd/mirror/snapshot/GroupUnlinkPeerRequest.cc
+++ b/src/librbd/mirror/snapshot/GroupUnlinkPeerRequest.cc
@@ -174,16 +174,87 @@ void GroupUnlinkPeerRequest<I>::remove_peer_uuid(
                               std::string mirror_peer_uuid) {
   ldout(m_cct, 10) << dendl;
 
-  auto aio_comp = create_rados_callback(
-      new LambdaContext([this, group_snap](int r) {
-        handle_remove_peer_uuid(r, group_snap);
-      }));
+  if (!m_image_ctxs->empty() && m_image_ctx_map.empty()) {
+    for (size_t i = 0; i < m_image_ctxs->size(); ++i) {
+      ImageCtx *ictx = (*m_image_ctxs)[i];
+      m_image_ctx_map[ictx->id] = ictx;
+    }
+  }
+  std::vector<cls::rbd::ImageSnapshotSpec> image_snaps = group_snap.snaps;
+  auto ctx = new LambdaContext([this, group_snap, mirror_peer_uuid](int r) {
+    if (r < 0) {
+      lderr(m_cct) << "failed to remove group snapshot mirror peer: "
+                   << dendl;
+      finish(r);
+      return;
+    }
+    remove_group_snapshot_peer_uuid(group_snap, mirror_peer_uuid);
+  });
 
-  auto ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-    &group_snap.snapshot_namespace);
-  ns->mirror_peer_uuids.erase(mirror_peer_uuid);
+  C_Gather *unlink_gather_ctx = new C_Gather(m_cct, ctx);
+  for (const auto &spec : image_snaps) {
+    if (spec.snap_id == CEPH_NOSNAP) {
+      continue;
+    }
 
+    librados::IoCtx image_io_ctx;
+    if (m_image_ctx_map.find(spec.image_id) != m_image_ctx_map.end()) {
+      image_io_ctx = m_image_ctx_map[spec.image_id]->md_ctx;
+    } else {
+      ldout(m_cct, 10) << "image: " << spec.image_id
+                       << " was removed from the group" << dendl;
+      int r = librbd::util::create_ioctx(m_group_io_ctx, "image",
+                                         spec.pool, {}, &image_io_ctx);
+      if (r < 0) {
+        ldout(m_cct, 10) << "unlink peer failed for removed image snapshot "
+                         << spec.image_id << " snap_id: " << spec.snap_id
+                         << " : pool " << spec.pool
+                         << " inaccessible: " << cpp_strerror(r) << dendl;
+        unlink_gather_ctx->new_sub()->complete(r);
+        continue;
+      }
+    }
+    std::string image_header_oid = librbd::util::header_name(spec.image_id);
+    librados::ObjectWriteOperation op;
+    librbd::cls_client::mirror_image_snapshot_unlink_peer(
+        &op, spec.snap_id, mirror_peer_uuid);
+    auto img_snapshot_unlink = new LambdaContext(
+      [this, spec, new_sub_ctx=unlink_gather_ctx->new_sub()](int r) {
+        if (r == -ENOENT || r == -ERESTART) {
+          r = 0;
+        }
+        if (r < 0) {
+          lderr(m_cct) << "failed to remove peer uuid for image snapshot "
+                       << spec.snap_id << " of image " << spec.image_id
+                       << ": " << cpp_strerror(r) << dendl;
+        }
+        new_sub_ctx->complete(r);
+      });
+    auto aio_comp = create_rados_callback(img_snapshot_unlink);
+    int r = image_io_ctx.aio_operate(image_header_oid, aio_comp, &op);
+    ceph_assert(r == 0);
+    aio_comp->release();
+  }
+
+  unlink_gather_ctx->activate();
+}
+
+template <typename I>
+void GroupUnlinkPeerRequest<I>::remove_group_snapshot_peer_uuid(
+                              cls::rbd::GroupSnapshot group_snap,
+                              std::string mirror_peer_uuid) {
+  ldout(m_cct, 10) << dendl;
+
+  auto &ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
+    group_snap.snapshot_namespace);
+  ns.mirror_peer_uuids.erase(mirror_peer_uuid);
   m_group_snap_id = group_snap.id;
+
+  auto aio_comp = create_rados_callback(
+    new LambdaContext([this, group_snap](int r) {
+      handle_remove_peer_uuid(r, group_snap);
+    }));
+
   librados::ObjectWriteOperation op;
   librbd::cls_client::group_snap_set(&op, group_snap);
   int r = m_group_io_ctx.aio_operate(

--- a/src/librbd/mirror/snapshot/GroupUnlinkPeerRequest.cc
+++ b/src/librbd/mirror/snapshot/GroupUnlinkPeerRequest.cc
@@ -161,29 +161,119 @@ void GroupUnlinkPeerRequest<I>::process_snapshot(cls::rbd::GroupSnapshot group_s
       !is_mirror_group_snapshot_complete(group_snap.state, ns.complete)) {
     remove_group_snapshot(group_snap);
   } else {
-    // Note: avoid calling remove_peer_uuid() for CREATING snapshots as
-    // group_snap_set() returns EEXIST error
-    remove_peer_uuid(group_snap, mirror_peer_uuid);
+    // Note: avoid calling remove_peer_uuid_from_group_snap() for CREATING
+    // snapshots as group_snap_set() returns EEXIST error
+    remove_peer_uuid_from_group_snap(group_snap, mirror_peer_uuid);
   }
 }
 
-
 template <typename I>
-void GroupUnlinkPeerRequest<I>::remove_peer_uuid(
+void GroupUnlinkPeerRequest<I>::remove_peer_uuid_from_group_snap(
                               cls::rbd::GroupSnapshot group_snap,
                               std::string mirror_peer_uuid) {
   ldout(m_cct, 10) << dendl;
 
-  auto aio_comp = create_rados_callback(
-      new LambdaContext([this, group_snap](int r) {
-        handle_remove_peer_uuid(r, group_snap);
-      }));
+  if (!m_image_ctxs->empty() && m_image_ctx_map.empty()) {
+    for (size_t i = 0; i < m_image_ctxs->size(); ++i) {
+      ImageCtx *ictx = (*m_image_ctxs)[i];
+      m_image_ctx_map[ictx->id] = ictx;
+    }
+  }
 
-  auto ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-    &group_snap.snapshot_namespace);
-  ns->mirror_peer_uuids.erase(mirror_peer_uuid);
+  remove_peer_uuid_from_image_snaps(group_snap, mirror_peer_uuid);
+}
 
+template <typename I>
+void GroupUnlinkPeerRequest<I>::remove_peer_uuid_from_image_snaps(
+                              cls::rbd::GroupSnapshot group_snap,
+                              std::string mirror_peer_uuid) {
+  ldout(m_cct, 10) << dendl;
+
+  std::vector<cls::rbd::ImageSnapshotSpec> image_snaps = group_snap.snaps;
+  auto ctx = new LambdaContext([this, group_snap, mirror_peer_uuid](int r) {
+    handle_remove_peer_uuid_from_image_snaps(r, group_snap, mirror_peer_uuid);
+  });
+
+  C_Gather *unlink_gather_ctx = new C_Gather(m_cct, ctx);
+  for (const auto &spec : image_snaps) {
+    if (spec.snap_id == CEPH_NOSNAP) {
+      continue;
+    }
+
+    librados::IoCtx image_io_ctx;
+    if (m_image_ctx_map.find(spec.image_id) != m_image_ctx_map.end()) {
+      image_io_ctx = m_image_ctx_map[spec.image_id]->md_ctx;
+    } else {
+      ldout(m_cct, 10) << "image: " << spec.image_id
+                       << " was removed from the group" << dendl;
+      int r = librbd::util::create_ioctx(m_group_io_ctx, "image",
+                                         spec.pool, {}, &image_io_ctx);
+      if (r < 0) {
+        ldout(m_cct, 10) << "unlink peer failed for removed image snapshot "
+                         << spec.image_id << " snap_id: " << spec.snap_id
+                         << " : pool " << spec.pool
+                         << " inaccessible: " << cpp_strerror(r) << dendl;
+        unlink_gather_ctx->new_sub()->complete(r);
+        continue;
+      }
+    }
+    std::string image_header_oid = librbd::util::header_name(spec.image_id);
+    librados::ObjectWriteOperation op;
+    librbd::cls_client::mirror_image_snapshot_unlink_peer(
+        &op, spec.snap_id, mirror_peer_uuid);
+    auto img_snapshot_unlink = new LambdaContext(
+      [this, spec, new_sub_ctx=unlink_gather_ctx->new_sub()](int r) {
+        if (r == -ENOENT) {
+          r = 0;
+        }
+        if (r < 0) {
+          lderr(m_cct) << "failed to remove peer uuid for image snapshot "
+                       << spec.snap_id << " of image " << spec.image_id
+                       << ": " << cpp_strerror(r) << dendl;
+        }
+        new_sub_ctx->complete(r);
+      });
+    auto aio_comp = create_rados_callback(img_snapshot_unlink);
+    int r = image_io_ctx.aio_operate(image_header_oid, aio_comp, &op);
+    ceph_assert(r == 0);
+    aio_comp->release();
+  }
+
+  unlink_gather_ctx->activate();
+}
+
+template <typename I>
+void GroupUnlinkPeerRequest<I>::handle_remove_peer_uuid_from_image_snaps(
+                              int r, cls::rbd::GroupSnapshot group_snap,
+                              std::string mirror_peer_uuid) {
+  ldout(m_cct, 10) << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to remove group snapshot mirror peer: "
+                 << dendl;
+    finish(r);
+    return;
+  }
+
+  update_peer_uuids_on_group_snap(group_snap, mirror_peer_uuid);
+}
+
+template <typename I>
+void GroupUnlinkPeerRequest<I>::update_peer_uuids_on_group_snap(
+                              cls::rbd::GroupSnapshot group_snap,
+                              std::string mirror_peer_uuid) {
+  ldout(m_cct, 10) << dendl;
+
+  auto &ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
+    group_snap.snapshot_namespace);
+  ns.mirror_peer_uuids.erase(mirror_peer_uuid);
   m_group_snap_id = group_snap.id;
+
+  auto aio_comp = create_rados_callback(
+    new LambdaContext([this, group_snap](int r) {
+      handle_update_peer_uuids_on_group_snap(r, group_snap);
+    }));
+
   librados::ObjectWriteOperation op;
   librbd::cls_client::group_snap_set(&op, group_snap);
   int r = m_group_io_ctx.aio_operate(
@@ -193,7 +283,7 @@ void GroupUnlinkPeerRequest<I>::remove_peer_uuid(
 }
 
 template <typename I>
-void GroupUnlinkPeerRequest<I>::handle_remove_peer_uuid(
+void GroupUnlinkPeerRequest<I>::handle_update_peer_uuids_on_group_snap(
     int r, cls::rbd::GroupSnapshot group_snap) {
   ldout(m_cct, 10) << "r=" << r << dendl;
 

--- a/src/librbd/mirror/snapshot/GroupUnlinkPeerRequest.h
+++ b/src/librbd/mirror/snapshot/GroupUnlinkPeerRequest.h
@@ -72,6 +72,8 @@ private:
 
   void remove_peer_uuid(cls::rbd::GroupSnapshot group_snap,
                         std::string mirror_peer_uuid);
+  void remove_group_snapshot_peer_uuid(cls::rbd::GroupSnapshot group_snap,
+                                       std::string mirror_peer_uuid);
   void handle_remove_peer_uuid(int r, cls::rbd::GroupSnapshot group_snap);
 
   void remove_group_snapshot(cls::rbd::GroupSnapshot group_snap);

--- a/src/librbd/mirror/snapshot/GroupUnlinkPeerRequest.h
+++ b/src/librbd/mirror/snapshot/GroupUnlinkPeerRequest.h
@@ -70,9 +70,16 @@ private:
   void process_snapshot(cls::rbd::GroupSnapshot group_snap,
                         std::string mirror_peer_uuid);
 
-  void remove_peer_uuid(cls::rbd::GroupSnapshot group_snap,
-                        std::string mirror_peer_uuid);
-  void handle_remove_peer_uuid(int r, cls::rbd::GroupSnapshot group_snap);
+  void remove_peer_uuid_from_group_snap(cls::rbd::GroupSnapshot group_snap,
+                                        std::string mirror_peer_uuid);
+  void remove_peer_uuid_from_image_snaps(cls::rbd::GroupSnapshot group_snap,
+                                         std::string mirror_peer_uuid);
+  void handle_remove_peer_uuid_from_image_snaps(int r,
+    cls::rbd::GroupSnapshot group_snap, std::string mirror_peer_uuid);
+  void update_peer_uuids_on_group_snap(cls::rbd::GroupSnapshot group_snap,
+                                       std::string mirror_peer_uuid);
+  void handle_update_peer_uuids_on_group_snap(
+      int r, cls::rbd::GroupSnapshot group_snap);
 
   void remove_group_snapshot(cls::rbd::GroupSnapshot group_snap);
   void handle_remove_group_snapshot(int r);

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -200,12 +200,19 @@ void Replayer<I>::handle_schedule_load_group_snapshots(int r) {
     if (m_state != STATE_REPLAYING) {
       return;
     }
+
+    ceph_assert(m_load_snapshots_task != nullptr);
+    m_load_snapshots_task = nullptr;
+
+    if (m_retry_validate_snap) {
+      m_retry_validate_snap = false;
+      if (!m_local_group_snaps.empty() && !m_check_creating_snaps) {
+        validate_local_group_snapshots(&locker);
+        return;
+      }
+    }
+    load_replayer(&locker);
   }
-
-  ceph_assert(m_load_snapshots_task != nullptr);
-  m_load_snapshots_task = nullptr;
-
-  is_resync_requested();
 }
 
 template <typename I>
@@ -381,17 +388,88 @@ void Replayer<I>::init(Context* on_finish) {
   on_finish->complete(0);
 
   m_update_group_state = true;
-  is_resync_requested();
+  {
+    std::unique_lock locker{m_lock};
+    load_replayer(&locker);
+  }
 }
 
 template <typename I>
-void Replayer<I>::is_resync_requested() {
+void Replayer<I>::validate_local_group_snapshots(
+    std::unique_lock<ceph::mutex>* locker) {
   dout(10) << "m_local_group_id=" << m_local_group_id << dendl;
+
+  if (is_replay_interrupted(locker)) {
+    return;
+  }
+
+  m_in_flight_op_tracker.start_op();
+  locker->unlock();
+
+  // prepare gather context for async operations
+  auto ctx = new LambdaContext([this](int) {
+    std::unique_lock locker{m_lock};
+    m_in_flight_op_tracker.finish_op();
+    load_replayer(&locker);
+  });
+
+  C_Gather *gather_ctx = new C_Gather(g_ceph_context, ctx);
+
+  // process snapshots requiring validation
+  for (auto &local_snap : m_local_group_snaps) {
+    // skip validation for already complete snapshots
+    auto ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
+        &local_snap.snapshot_namespace);
+    if (local_snap.state == cls::rbd::GROUP_SNAPSHOT_STATE_CREATED) {
+      if (ns == nullptr) {
+        // user group snapshot
+        continue;
+      }
+      if (is_mirror_group_snapshot_complete(local_snap.state, ns->complete)) {
+        continue;
+      }
+    }
+
+    // skip validation for primary snapshots
+    if (ns != nullptr && ns->is_primary()) {
+      continue;
+    }
+
+    // setup validation callback
+    Context *sub_ctx = gather_ctx->new_sub();
+    auto ctx = new LambdaContext([sub_ctx](int r) {
+      sub_ctx->complete(r);
+    });
+
+    // validate incomplete non-primary mirror or regular snapshots
+    validate_image_snaps_sync_complete(local_snap, ctx);
+  }
+  gather_ctx->activate();
+}
+
+template <typename I>
+void Replayer<I>::load_replayer(
+    std::unique_lock<ceph::mutex>* locker) {
+  dout(10) << "m_global_group_id=" << m_global_group_id << dendl;
+  if (is_replay_interrupted(locker)) {
+    return;
+  }
+
+  is_resync_requested(locker);
+}
+
+template <typename I>
+void Replayer<I>::is_resync_requested(
+    std::unique_lock<ceph::mutex>* locker) {
+  if (is_replay_interrupted(locker)) {
+    return;
+  }
 
   librados::ObjectReadOperation op;
   librbd::cls_client::metadata_get_start(&op, RBD_GROUP_RESYNC);
 
   m_out_bl.clear();
+  m_resync_requested = false;
 
   std::string group_header_oid = librbd::util::group_header_name(
       m_local_group_id);
@@ -426,125 +504,81 @@ void Replayer<I>::handle_is_resync_requested(int r) {
   } else if (r == 0) {
     dout(10) << "local group resync requested" << dendl;
     m_resync_requested = true;
-    load_remote_group_snapshots();
-    return;
   }
 
-  is_rename_requested();
+  if (m_resync_requested) {
+    load_remote_group_snapshots(&locker);
+    return;
+  }
+  load_local_group_snapshots(&locker);
 }
 
 template <typename I>
-void Replayer<I>::is_rename_requested() {
-  dout(10) << "m_local_group_id=" << m_local_group_id << dendl;
+void Replayer<I>::load_remote_group_snapshots(
+    std::unique_lock<ceph::mutex>* locker) {
+  if (is_replay_interrupted(locker)) {
+    return;
+  }
 
-  librados::ObjectReadOperation op;
-  librbd::cls_client::dir_get_name_start(&op, m_remote_group_id);
-  m_out_bl.clear();
+  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
   m_in_flight_op_tracker.start_op();
-  auto comp = create_rados_callback(
-    new LambdaContext([this](int r) {
-      handle_is_rename_requested(r);
-      m_in_flight_op_tracker.finish_op();
-    }));
-
-  int r = m_remote_io_ctx.aio_operate(RBD_GROUP_DIRECTORY, comp, &op,
-                                      &m_out_bl);
-  ceph_assert(r == 0);
-  comp->release();
-}
-
-template <typename I>
-void Replayer<I>::handle_is_rename_requested(int r) {
-  std::unique_lock locker{m_lock};
-  dout(10) << "r=" << r << dendl;
-
-  if (is_replay_interrupted(&locker)) {
-    return;
-  }
-  std::string remote_group_name;
-  if (r == 0) {
-    auto iter = m_out_bl.cbegin();
-    r = librbd::cls_client::dir_get_name_finish(&iter, &remote_group_name);
-  }
-  if (r < 0) {
-    derr << "failed to retrieve remote group name: " << cpp_strerror(r)
-         << dendl;
-  } else if (r == 0 && m_local_group_ctx &&
-             m_local_group_ctx->name != remote_group_name) {
-    dout(10) << "remote group renamed" << dendl;
-    handle_replay_complete(&locker, 0, "remote group renamed");
-    return;
-  }
+  m_remote_group_snaps.clear();
 
   auto ctx = new LambdaContext(
-    [this](int r) {
-      validate_local_group_snapshots();
+    [this] (int r) {
+      handle_load_remote_group_snapshots(r);
       m_in_flight_op_tracker.finish_op();
-    });
-  m_in_flight_op_tracker.start_op();
-  m_threads->work_queue->queue(ctx, 0);
+  });
+
+  auto req = librbd::group::ListSnapshotsRequest<I>::create(m_remote_io_ctx,
+      m_remote_group_id, true, true, &m_remote_group_snaps, ctx);
+  req->send();
 }
 
 template <typename I>
-void Replayer<I>::validate_local_group_snapshots() {
-  dout(10) << "m_local_group_id=" << m_local_group_id << dendl;
+void Replayer<I>::handle_load_remote_group_snapshots(int r) {
+  dout(10) << "r=" << r << dendl;
 
   std::unique_lock locker{m_lock};
   if (is_replay_interrupted(&locker)) {
     return;
   }
 
-  if (m_local_group_snaps.empty() || m_check_creating_snaps) {
-    load_local_group_snapshots(&locker);
+  if (r < 0) {  // may be remote group is deleted?
+    derr << "error listing remote mirror group snapshots: " << cpp_strerror(r)
+         << dendl;
+    handle_replay_complete(&locker, r, "failed to list remote group snapshots");
     return;
   }
 
-  m_in_flight_op_tracker.start_op();
-  locker.unlock();
-
-  // prepare gather context for async operations
-  auto ctx = new LambdaContext([this](int) {
-    std::unique_lock locker{m_lock};
-    m_in_flight_op_tracker.finish_op();
-    load_local_group_snapshots(&locker);
-  });
-
-  C_Gather *gather_ctx = new C_Gather(g_ceph_context, ctx);
-
-  // process snapshots requiring validation
-  for (auto &local_snap : m_local_group_snaps) {
-    // skip validation for already complete snapshots
-    auto ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-        &local_snap.snapshot_namespace);
-    if (local_snap.state == cls::rbd::GROUP_SNAPSHOT_STATE_CREATED) {
-      if (ns == nullptr) {
-        // user group snapshot
-        continue;
-      }
-      if (is_mirror_group_snapshot_complete(local_snap.state, ns->complete)) {
-        continue;
-      }
-    }
-
-    // skip validation for primary snapshots
-    if (ns != nullptr && ns->is_primary()) {
+  for (auto remote_snap = m_remote_group_snaps.begin();
+       remote_snap != m_remote_group_snaps.end(); ) {
+    auto remote_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
+        &remote_snap->snapshot_namespace);
+    if (remote_snap_ns == nullptr) {
+      ++remote_snap;
       continue;
     }
-
-    // setup validation callback
-    Context *sub_ctx = gather_ctx->new_sub();
-    auto ctx = new LambdaContext([this, sub_ctx](int r) {
-      if (r < 0) {
-        std::unique_lock locker{m_lock};
-        m_retry_validate_snap = true;
-      }
-      sub_ctx->complete(r);
-    });
-
-    // validate incomplete non-primary mirror or regular snapshots
-    validate_image_snaps_sync_complete(local_snap, ctx);
+    if (remote_snap_ns->mirror_peer_uuids.count(m_remote_mirror_peer_uuid) == 0) {
+      dout(10) << "filtering out snapshot " << remote_snap->id
+               << " with no matching mirror_peer_uuid in: "
+               << remote_snap_ns->mirror_peer_uuids << " (expected: "
+               << m_remote_mirror_peer_uuid << ")" << dendl;
+      remote_snap = m_remote_group_snaps.erase(remote_snap);
+    } else {
+      ++remote_snap;
+    }
   }
-  gather_ctx->activate();
+
+  if (m_resync_requested) {
+    if (is_group_primary(m_remote_group_snaps)) { // remote group primary
+      handle_replay_complete(&locker, 0, "resync requested");
+      return;
+    }
+    load_local_group_snapshots(&locker);
+    return;
+  }
+  check_local_group_snapshots(&locker);
 }
 
 template <typename I>
@@ -584,155 +618,145 @@ void Replayer<I>::handle_load_local_group_snapshots(int r) {
     return;
   }
 
+  // We must determine whether the local group is already primary here.
+  // Otherwise, if the remote group snapshots are unavailable for any reason,
+  // replayer will incorrectly report an error status for the local group.
   auto last_local_snap = get_latest_mirror_group_snapshot(m_local_group_snaps);
-  if (!last_local_snap) { // no snaps synced yet
-    m_check_creating_snaps = false;
-    load_remote_group_snapshots();
-    return;
-  }
-
-  const auto& ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
-      last_local_snap->snapshot_namespace);
-  // handle mirror snapshot states
-  if (ns.state != cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY) {
-    if (ns.is_orphan()) {
-      dout(5) << "local group being force promoted" << dendl;
-      handle_replay_complete(&locker, 0, "orphan (force promoting)");
-      return;
-    }
-    if (m_check_creating_snaps) {
-      prune_creating_group_snapshots_if_any(&locker);
-      return;
-    }
-    if (!is_mirror_group_snapshot_complete(last_local_snap->state, ns.complete)) {
-      m_retry_validate_snap = true;
-    }
-  } else {  // primary snapshot
-    if (is_mirror_group_snapshot_complete(last_local_snap->state, ns.complete)) {
+  if (last_local_snap) {
+    const auto& ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
+        last_local_snap->snapshot_namespace);
+    if (ns.state != cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY) {
+      // Remove any stale 'creating' mirror group snapshots that may have been
+      // left behind if the daemon restarted before replay completed. This must
+      // happen here, because before we can go to any scanning of unsynced snaps
+      // it is efficient to be ready, so that, the replay logic sees a clean
+      // local snapshot state and recreates any missing snapshots.
+      if (m_check_creating_snaps) {
+        prune_creating_group_snapshots_if_any(&locker);
+        return;
+      }
+      if (ns.is_orphan()) {
+        dout(5) << "local group being force promoted" << dendl;
+        handle_replay_complete(&locker, 0, "orphan (force promoting)");
+        return;
+      }
+      if (!is_mirror_group_snapshot_complete(last_local_snap->state,
+                                             ns.complete)) {
+        m_retry_validate_snap = true;
+      }
+    } else { // local is primary
       handle_replay_complete(&locker, 0, "local group is primary");
       return;
     }
-    dout(10) << "found incomplete primary group snapshot: "
-             << last_local_snap->id << dendl;
-    m_retry_validate_snap = true;
-  }
-
-  load_remote_group_snapshots();
-}
-
-template <typename I>
-void Replayer<I>::load_remote_group_snapshots() {
-  dout(10) << "m_remote_group_id=" << m_remote_group_id << dendl;
-
-  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
-  m_in_flight_op_tracker.start_op();
-  m_remote_group_snaps.clear();
-
-  auto ctx = new LambdaContext(
-    [this] (int r) {
-      handle_load_remote_group_snapshots(r);
-      m_in_flight_op_tracker.finish_op();
-  });
-
-  auto req = librbd::group::ListSnapshotsRequest<I>::create(m_remote_io_ctx,
-      m_remote_group_id, true, true, &m_remote_group_snaps, ctx);
-  req->send();
-}
-
-template <typename I>
-void Replayer<I>::handle_load_remote_group_snapshots(int r) {
-  dout(10) << "r=" << r << dendl;
-
-  std::unique_lock locker{m_lock};
-  if (is_replay_interrupted(&locker)) {
-    return;
-  }
-
-  if (r < 0) {  // may be remote group is deleted?
-    derr << "error listing remote mirror group snapshots: " << cpp_strerror(r)
-         << dendl;
-    handle_replay_complete(&locker, r, "failed to list remote group snapshots");
-    return;
   }
 
   if (m_resync_requested) {
-    if (is_group_primary(m_remote_group_snaps)) {
-      handle_replay_complete(&locker, 0, "resync requested");
-      return;
-    }
-    dout(10) << "cannot resync as remote is not primary" << dendl;
     m_resync_requested = false;
-    is_rename_requested();
+    check_local_group_snapshots(&locker);
     return;
   }
-
-  if (m_retry_validate_snap) {
-    m_retry_validate_snap = false;
-    locker.unlock();
-    schedule_load_group_snapshots();
-    return;
-  }
-
-  for (auto remote_snap = m_remote_group_snaps.begin();
-       remote_snap != m_remote_group_snaps.end(); ) {
-    auto remote_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-        &remote_snap->snapshot_namespace);
-    if (remote_snap_ns == nullptr) {
-      ++remote_snap;
-      continue;
-    }
-    if (remote_snap_ns->mirror_peer_uuids.count(m_remote_mirror_peer_uuid) == 0) {
-      dout(10) << "filtering out snapshot " << remote_snap->id
-               << " with no matching mirror_peer_uuid in: "
-               << remote_snap_ns->mirror_peer_uuids << " (expected: "
-               << m_remote_mirror_peer_uuid << ")" << dendl;
-      remote_snap = m_remote_group_snaps.erase(remote_snap);
-    } else {
-      ++remote_snap;
-    }
-  }
-  check_local_group_snapshots(&locker);
+  load_remote_group_snapshots(&locker);
 }
 
 template <typename I>
 void Replayer<I>::check_local_group_snapshots(
     std::unique_lock<ceph::mutex>* locker) {
-  if (!m_local_group_snaps.empty()) {
-    prune_group_snapshots(locker);
-    auto last_local_snap = get_latest_group_snapshot(m_local_group_snaps);
-    auto last_local_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-        &last_local_snap->snapshot_namespace);
-    if (last_local_snap_ns &&
-        last_local_snap_ns->state == cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY_DEMOTED &&
-        !m_remote_group_snaps.empty()) {
-      if (last_local_snap->id == m_remote_group_snaps.rbegin()->id) {
-        handle_replay_complete(locker, -EREMOTEIO, "remote group demoted");
-        return;
+  if (m_local_group_snaps.empty()) {
+    m_check_creating_snaps = false;
+    is_rename_requested();
+    return;
+  }
+
+  auto last_local_snap = get_latest_mirror_group_snapshot(m_local_group_snaps);
+  ceph_assert(last_local_snap != nullptr);
+
+  dout(10) << "local mirror snapshot=" << last_local_snap->id << dendl;
+
+  const auto& ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
+      last_local_snap->snapshot_namespace);
+  if (ns.state == cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY_DEMOTED) {
+    bool split_brain = true;
+    for (const auto& remote_snap : m_remote_group_snaps) {
+      if (remote_snap.id != last_local_snap->id) {
+        continue;
       }
-    } else if (last_local_snap_ns &&
-     last_local_snap_ns->state == cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY_DEMOTED) {
-      bool split_brain = true;
-      for (auto it = m_remote_group_snaps.begin();
-           it != m_remote_group_snaps.end(); it++) {
-        auto ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-             &it->snapshot_namespace);
-        if (ns == nullptr ||
-            it->id != last_local_snap->id) {
-          continue;
-        }
-        if (ns->state == cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY_DEMOTED) {
-          split_brain = false;
-          break;
-        }
+      const auto* remote_ns =
+          std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
+              &remote_snap.snapshot_namespace);
+      if (remote_ns != nullptr && remote_ns->state ==
+          cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY_DEMOTED) {
+        split_brain = false;
+        break;
       }
-      if (split_brain) {
-        handle_replay_complete(locker, -EEXIST, "split-brain");
-        return;
-      }
+    }
+    if (split_brain) {
+      handle_replay_complete(locker, -EEXIST, "split-brain");
+      return;
+    }
+    m_check_creating_snaps = false;
+  } else if (ns.state == cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY_DEMOTED) {
+    auto last_remote_snap =
+      get_latest_mirror_group_snapshot(m_remote_group_snaps);
+    if (last_remote_snap != nullptr &&
+        last_local_snap->id == last_remote_snap->id && !m_retry_validate_snap) {
+      handle_replay_complete(locker, -EREMOTEIO, "remote group demoted");
+      return;
     }
   }
 
-  scan_for_unsynced_group_snapshots(locker);
+  if (m_retry_validate_snap) {
+    locker->unlock();
+    schedule_load_group_snapshots();
+    return;
+  }
+  prune_group_snapshots(locker);
+
+  is_rename_requested();
+}
+
+template <typename I>
+void Replayer<I>::is_rename_requested() {
+  dout(10) << "m_local_group_id=" << m_local_group_id << dendl;
+
+  librados::ObjectReadOperation op;
+  librbd::cls_client::dir_get_name_start(&op, m_remote_group_id);
+  m_out_bl.clear();
+  m_in_flight_op_tracker.start_op();
+  auto comp = create_rados_callback(new LambdaContext([this](int r) {
+      handle_is_rename_requested(r);
+      m_in_flight_op_tracker.finish_op();
+    }));
+
+  int r = m_remote_io_ctx.aio_operate(RBD_GROUP_DIRECTORY, comp, &op,
+                                      &m_out_bl);
+  ceph_assert(r == 0);
+  comp->release();
+}
+
+template <typename I>
+void Replayer<I>::handle_is_rename_requested(int r) {
+  std::unique_lock locker{m_lock};
+  dout(10) << "r=" << r << dendl;
+
+  if (is_replay_interrupted(&locker)) {
+    return;
+  }
+  std::string remote_group_name;
+  if (r == 0) {
+    auto iter = m_out_bl.cbegin();
+    r = librbd::cls_client::dir_get_name_finish(&iter, &remote_group_name);
+  }
+  if (r < 0) {
+    derr << "failed to retrieve remote group name: " << cpp_strerror(r)
+         << dendl;
+  } else if (r == 0 && m_local_group_ctx &&
+             m_local_group_ctx->name != remote_group_name) {
+    dout(10) << "remote group renamed" << dendl;
+    handle_replay_complete(&locker, 0, "remote group renamed");
+    return;
+  }
+
+  scan_for_unsynced_group_snapshots(&locker);
 }
 
 template <typename I>
@@ -1040,6 +1064,8 @@ void Replayer<I>::handle_create_mirror_snapshot(
     derr << "failed to create mirror snapshot: " << group_snap_id
          << ", error: " << cpp_strerror(r) << dendl;
   }
+
+  m_retry_validate_snap = true;
 
   on_finish->complete(r);
 }
@@ -1448,6 +1474,8 @@ void Replayer<I>::handle_create_user_snapshot(
     derr << "failed to create user snapshot: " << group_snap_id
          << ", error: " << cpp_strerror(r) << dendl;
   }
+
+  m_retry_validate_snap = true;
 
   on_finish->complete(r);
 }

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -1129,6 +1129,9 @@ void Replayer<I>::mirror_snapshot_complete(
 
   if (itr == m_remote_group_snaps.end()) {
     derr << "remote group snapshot doesn't exist: " << group_snap_id << dendl;
+    // prune the local group snapshot
+    m_prune_group_snap = &(*itl);
+    prune_mirror_group_snapshot(&locker);
     locker.unlock();
     on_finish->complete(-ENOENT);
     return;

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -607,28 +607,47 @@ void Replayer<I>::handle_load_local_group_snapshots(int r) {
     return;
   }
 
+  m_prune_group_snap = nullptr;
   auto prune_creating_group_snaps =
     std::make_shared<std::vector<cls::rbd::GroupSnapshot>>();
   m_last_local_snap = nullptr;
+  const cls::rbd::GroupSnapshot* last_complete_local_snap = nullptr;
   for (const auto& local_snap : m_local_group_snaps) {
-    // latest mirror snapshot (keep updating)
-    if (cls::rbd::get_group_snap_namespace_type(
-          local_snap.snapshot_namespace) ==
-        cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_MIRROR) {
-      m_last_local_snap = &local_snap;
-    }
+    auto mirror_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
+      &local_snap.snapshot_namespace);
 
-    // collect creating snapshots
-    if (local_snap.state == cls::rbd::GROUP_SNAPSHOT_STATE_CREATING) {
-      auto local_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-          &local_snap.snapshot_namespace);
-
-      if (local_snap_ns && local_snap_ns->is_primary()) {
-        continue;
+    // user snaps
+    if (!mirror_ns) {
+      if (m_check_creating_snaps &&
+         local_snap.state == cls::rbd::GROUP_SNAPSHOT_STATE_CREATING) {
+        prune_creating_group_snaps->push_back(local_snap);
       }
-
-      prune_creating_group_snaps->push_back(local_snap);
+      continue;
     }
+    // last mirror snap
+    m_last_local_snap = &local_snap;
+
+    // only non-primary snapshots are prune candidates
+    if (mirror_ns->is_non_primary()) {
+      if (is_mirror_group_snapshot_complete(local_snap.state,
+                                            mirror_ns->complete)) {
+        // complete non-primary snapshot
+        last_complete_local_snap = &local_snap;
+
+        // oldest complete non-primary snapshot
+        if (!m_prune_group_snap) {
+          m_prune_group_snap = &local_snap;
+        }
+      } else if (m_check_creating_snaps &&
+        local_snap.state == cls::rbd::GROUP_SNAPSHOT_STATE_CREATING) {
+        prune_creating_group_snaps->push_back(local_snap);
+      }
+    }
+  }
+
+  // retain newest complete non-primary snapshot
+  if (m_prune_group_snap == last_complete_local_snap) {
+    m_prune_group_snap = nullptr;
   }
 
   // We must determine whether the local group is already primary here.
@@ -644,8 +663,10 @@ void Replayer<I>::handle_load_local_group_snapshots(int r) {
       // happen here, because before we can go to any scanning of unsynced snaps
       // it is efficient to be ready, so that, the replay logic sees a clean
       // local snapshot state and recreates any missing snapshots.
-      if (m_check_creating_snaps) {
-        prune_creating_group_snapshots(&locker, prune_creating_group_snaps);
+      if (!prune_creating_group_snaps->empty()) {
+        m_in_flight_op_tracker.start_op();
+        locker.unlock();
+        prune_creating_group_snapshots(prune_creating_group_snaps);
         return;
       }
       if (ns.is_orphan()) {
@@ -663,6 +684,7 @@ void Replayer<I>::handle_load_local_group_snapshots(int r) {
     }
   }
 
+  m_check_creating_snaps = false;
   if (m_resync_requested) {
     m_resync_requested = false;
     check_local_group_snapshots(&locker);
@@ -719,7 +741,26 @@ void Replayer<I>::check_local_group_snapshots(
     schedule_load_group_snapshots();
     return;
   }
-  prune_group_snapshots(locker);
+
+  int r = prune_group_snapshots(locker);
+  if (r == -EAGAIN) { // retry later
+    m_refresh_snaps = false;
+    locker->unlock();
+    // Allow some time for the ImageReplayer to complete pending prune operations before retrying.
+    schedule_load_group_snapshots();
+    return;
+  }
+
+  if (r < 0) {
+    derr << "failed to prune group snapshots" << cpp_strerror(r) << dendl;
+    // ignore
+  }
+
+  if (m_refresh_snaps) {
+    m_refresh_snaps = false;
+    load_replayer(locker); // immediately reload
+    return;
+  }
 
   is_rename_requested();
 }
@@ -1233,28 +1274,38 @@ void Replayer<I>::post_mirror_snapshot_created(
   }
 
   // Old synced user snap is removed and not yet reflecting locally, wait for it.
-  bool user_snap_found;
-  for (auto local_snap = m_local_group_snaps.begin();
-      local_snap != m_local_group_snaps.end(); ++local_snap) {
+  bool prune_user_snap = false ;
+  std::unordered_set<std::string> remote_snap_ids;
+  remote_snap_ids.reserve(m_remote_group_snaps.size());
+  for (const auto& remote_snap : m_remote_group_snaps) {
+    remote_snap_ids.insert(remote_snap.id);
+  }
+
+  for (auto& local_snap : m_local_group_snaps) {
     auto snap_type = cls::rbd::get_group_snap_namespace_type(
-        local_snap->snapshot_namespace);
-    if (snap_type == cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_USER) {
-      user_snap_found = false;
-      for (auto remote_snap = m_remote_group_snaps.begin();
-          remote_snap != m_remote_group_snaps.end(); ++remote_snap) {
-        if (local_snap->id == remote_snap->id) {
-          user_snap_found = true;
-          break;
-        }
-      }
-      if (!user_snap_found) {
-        prune_user_group_snapshots(&locker);
-        locker.unlock();
-        // there is a user group snap removed on remote, so lets wait for it to removed locally
-        on_finish->complete(-EAGAIN);
-        return;
-      }
+        local_snap.snapshot_namespace);
+    if (snap_type != cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_USER) {
+      continue;
     }
+
+    if (remote_snap_ids.contains(local_snap.id)) {
+      continue;
+    }
+
+    // there is a user group snap removed on remote, so lets wait for it to removed locally
+    prune_user_snap = true;
+    int r = prune_group_snapshot(&local_snap, &locker);
+    if (r != 0) {
+      derr << "failed to remove user group snapshot: " << local_snap.id
+           << ", error: " << cpp_strerror(r) << dendl;
+      // ignore
+    }
+  }
+
+  if (prune_user_snap) {
+    locker.unlock();
+    on_finish->complete(-EAGAIN);
+    return;
   }
 
   // User snap is added and not yet turned created, wait for it.
@@ -1754,9 +1805,18 @@ void Replayer<I>::prune_image_snapshot(ImageReplayer<I>* image_replayer,
   locker.lock();
 }
 
+/*
+ * prune_all_image_snapshots() semantics:
+ *
+ * true:
+ *   all image snapshots already removed
+ *
+ * false:
+ *   async pruning initiated, retry required later
+ */
 template <typename I>
 bool Replayer<I>::prune_all_image_snapshots(
-    cls::rbd::GroupSnapshot *local_snap,
+    const cls::rbd::GroupSnapshot *local_snap,
     std::unique_lock<ceph::mutex>* locker) {
   bool prune_done = true;
   if (!local_snap) {
@@ -1872,17 +1932,8 @@ bool Replayer<I>::prune_all_image_snapshots_by_gsid(
 // and prune them on daemon restart.
 template <typename I>
 void Replayer<I>::prune_creating_group_snapshots(
-    std::unique_lock<ceph::mutex>* locker,
     std::shared_ptr<std::vector<cls::rbd::GroupSnapshot>> prune_creating_group_snaps) {
-
-  if (prune_creating_group_snaps->empty()) {
-    // not found creating snapshots
-    m_check_creating_snaps = false;
-    locker->unlock();
-    schedule_load_group_snapshots();
-    return;
-  }
-  locker->unlock();
+  dout(10) << dendl;
 
   m_out_bl.clear();
   auto local_images =
@@ -1893,7 +1944,9 @@ void Replayer<I>::prune_creating_group_snapshots(
         derr << "failed to list group images: "
              << cpp_strerror(r) << dendl;
         // reload will retry if needed
-        schedule_load_group_snapshots();
+        std::unique_lock locker{m_lock};
+        m_in_flight_op_tracker.finish_op();
+        load_replayer(&locker);
         return;
       }
 
@@ -1910,12 +1963,14 @@ void Replayer<I>::handle_prune_creating_group_snapshots(
     const std::vector<cls::rbd::GroupImageStatus>& local_images,
     const std::vector<cls::rbd::GroupSnapshot>& prune_creating_group_snaps) {
   std::unique_lock locker{m_lock};
+  bool all_pruned = true;
   for (const auto& local_snap : prune_creating_group_snaps) {
     if (!prune_all_image_snapshots_by_gsid(
           local_snap.id, local_images, &locker)) {
       // still pending image snapshots; retry later
       dout(20) << "image snapshots still pending for: "
                << local_snap.id << dendl;
+      all_pruned = false;
       continue;
     }
 
@@ -1928,164 +1983,138 @@ void Replayer<I>::handle_prune_creating_group_snapshots(
       local_snap.id);
 
     if (r < 0) {
+      all_pruned = false;
       derr << "failed to remove group snapshot "
            << local_snap.id << ": "
            << cpp_strerror(r) << dendl;
     }
   }
 
-  m_check_creating_snaps = false;
-  locker.unlock();
-  schedule_load_group_snapshots();
+  if (all_pruned) {
+    m_check_creating_snaps = false;
+  }
+
+  m_in_flight_op_tracker.finish_op();
+
+  load_replayer(&locker);
 }
 
+/* prune_group_snapshots() semantics:
+ *
+ * r == 0 && m_refresh_snaps == true
+ *   One or more group snapshots were successfully removed.
+ *   Reload local and remote snapshots.
+ *
+ * r == 0 && m_refresh_snaps == false
+ *   No snapshot state changes occurred.
+ *   Continue syncing the next snapshots.
+ *
+ * r == -EAGAIN
+ *   Snapshot pruning is still in progress
+ *   (typically waiting for image snapshot pruning).
+ *   Reload local and remote snapshots and retry.
+ *
+ * r < 0 && r != -EAGAIN
+ *   Return the errno to caller.
+ */
+
 template <typename I>
-void Replayer<I>::prune_user_group_snapshots(
+int Replayer<I>::prune_group_snapshots(
     std::unique_lock<ceph::mutex>* locker) {
-  int r;
-  for (auto local_snap = m_local_group_snaps.begin();
-      local_snap != m_local_group_snaps.end(); ++local_snap) {
-    auto snap_type = cls::rbd::get_group_snap_namespace_type(
-        local_snap->snapshot_namespace);
-    if (snap_type == cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_USER) {
-      bool prune_user_snap = true;
-      for (auto &remote_snap : m_remote_group_snaps) {
-        if (remote_snap.id == local_snap->id) {
-          prune_user_snap = false;
-          break;
-        }
-      }
-      if (!prune_user_snap) {
-        continue;
-      }
-      dout(10) << "pruning user group snap in-progress: "
-               << local_snap->name << ", with id: " << local_snap->id << dendl;
-      // prune all the image snaps of the group snap locally
-      if (!prune_all_image_snapshots(&(*local_snap), locker)) {
-        continue;
-      }
-      dout(10) << "all image snaps are pruned, finally pruning user group snap: "
-               << local_snap->id << dendl;
-      r = librbd::cls_client::group_snap_remove(&m_local_io_ctx,
-             librbd::util::group_header_name(m_local_group_id), local_snap->id);
-      if (r < 0) {
-        derr << "failed to remove group snapshot : "
-             << local_snap->id << " : " << cpp_strerror(r) << dendl;
-      }
-    }
+  dout(10) << dendl;
+
+  m_refresh_snaps = false;
+  int r = prune_user_group_snapshots(locker);
+  if (r != 0) {
+    return r;
   }
+
+  return prune_mirror_group_snapshot(locker);
 }
 
 template <typename I>
-void Replayer<I>::prune_mirror_group_snapshots(
+int Replayer<I>::prune_user_group_snapshots(
     std::unique_lock<ceph::mutex>* locker) {
-  int r;
-  bool is_prior_snap_user = false;
-  bool skip_next_snap_check = false;
-  cls::rbd::GroupSnapshot *prune_snap = nullptr;
-  auto last_local_snap_id = m_local_group_snaps.rbegin()->id;
-  for (auto local_snap = m_local_group_snaps.begin();
-      local_snap != m_local_group_snaps.end(); ++local_snap) {
-    auto local_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-            &local_snap->snapshot_namespace);
-    if (local_snap_ns == nullptr) {
-      if (local_snap->state != cls::rbd::GROUP_SNAPSHOT_STATE_CREATED) {
-        break;
-      }
-    } else if (!is_mirror_group_snapshot_complete(local_snap->state,
-                                                  local_snap_ns->complete)) {
-        break;
-    }
+  dout(20) << dendl;
+
+  std::unordered_set<std::string> remote_snap_ids;
+  for (const auto& remote_snap : m_remote_group_snaps) {
+    remote_snap_ids.insert(remote_snap.id);
+  }
+
+  // prune all eligible user snapshots in a single replayer cycle
+  for (auto& local_snap : m_local_group_snaps) {
     auto snap_type = cls::rbd::get_group_snap_namespace_type(
-        local_snap->snapshot_namespace);
-    if (snap_type != cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_MIRROR) {
-      is_prior_snap_user = true;
-      if (prune_snap) { // snapshot before user snap exists ?
-        // delete snap before user snap, only if the user snap has next complete mirror snap
-        auto next_local_snap = std::next(local_snap);
-        if (next_local_snap == m_local_group_snaps.end()) {
-          break; // no next snap.
-        }
-        auto next_local_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-            &next_local_snap->snapshot_namespace);
-        if (next_local_snap_ns == nullptr) {
-          continue; // next snap is user snap again.
-        } else if (
-          !is_mirror_group_snapshot_complete(next_local_snap->state,
-                                             next_local_snap_ns->complete)) {
-          break; // next snap is not complete yet.
-        }
-      }
-      continue;
-    }
-    if (!prune_snap) {
-      prune_snap = &(*local_snap);
-    }
-
-    if (is_prior_snap_user) {
-      is_prior_snap_user = false; // free to continue prune on next iteratation
-      skip_next_snap_check = true; // as we are pruning mirror snap before user snap
+        local_snap.snapshot_namespace);
+    if (snap_type != cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_USER) {
       continue;
     }
 
-    if (!skip_next_snap_check) {
-      auto next_local_snap = std::next(local_snap);
-      // If next local snap is end, or if it is the syncing in-progress snap,
-      // then we still need this group snapshot.
-      if (next_local_snap == m_local_group_snaps.end()) {
-        break;
-      } else if (next_local_snap->id == last_local_snap_id) {
-        auto next_local_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-            &next_local_snap->snapshot_namespace);
-        if (next_local_snap_ns == nullptr) {
-          if (next_local_snap->state != cls::rbd::GROUP_SNAPSHOT_STATE_CREATED) {
-            break;
-          }
-        } else if (!is_mirror_group_snapshot_complete(next_local_snap->state,
-                                                      next_local_snap_ns->complete)) {
-          break;
-        }
-      } else {
-        auto next_snap_type = cls::rbd::get_group_snap_namespace_type(
-            next_local_snap->snapshot_namespace);
-        if (next_snap_type == cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_USER) {
-          continue;
-        }
-      }
-    }
-    mirror_group_snapshot_unlink_peer(prune_snap->id);
-    const auto& ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
-        prune_snap->snapshot_namespace);
-    if (ns.is_primary() ||
-        !prune_all_image_snapshots(prune_snap, locker)) {
-      prune_snap = nullptr;
-      skip_next_snap_check = false;
+    if (remote_snap_ids.contains(local_snap.id)) {
       continue;
     }
-    dout(10) << "all image snaps are pruned, finally pruning mirror group snap: "
-             << prune_snap->id << dendl;
-    r = librbd::cls_client::group_snap_remove(&m_local_io_ctx,
-        librbd::util::group_header_name(m_local_group_id), prune_snap->id);
-    if (r < 0) {
-      derr << "failed to remove group snapshot : "
-           << prune_snap->id << " : " << cpp_strerror(r) << dendl;
+
+    dout(10) << "pruning user group snap in-progress: " << local_snap.name
+             << ", with id: " << local_snap.id << dendl;
+    int r = prune_group_snapshot(&local_snap, locker);
+    if (r != 0) {
+      return r;
     }
-    prune_snap = nullptr;
-    skip_next_snap_check = false;
   }
+
+  return 0;
 }
 
 template <typename I>
-void Replayer<I>::prune_group_snapshots(std::unique_lock<ceph::mutex>* locker) {
-  if (m_local_group_snaps.empty()) {
-    return;
+int Replayer<I>::prune_mirror_group_snapshot(
+    std::unique_lock<ceph::mutex>* locker) {
+  dout(20) << dendl;
+
+  // prune only a single mirror snapshot per replayer cycle
+  if (!m_prune_group_snap) {
+    return 0;
   }
-  prune_user_group_snapshots(locker);
-  prune_mirror_group_snapshots(locker);
+
+  mirror_group_snapshot_unlink_peer(m_prune_group_snap->id);
+
+  dout(10) << "pruning mirror group snap in-progress: "
+           << m_prune_group_snap->name << ", with id: "
+           << m_prune_group_snap->id << dendl;
+
+  return prune_group_snapshot(m_prune_group_snap, locker);
 }
 
 template <typename I>
-std::string Replayer<I>::get_global_image_id( ImageReplayer<I>* image_replayer,
+int Replayer<I>::prune_group_snapshot(
+    const cls::rbd::GroupSnapshot* snap,
+    std::unique_lock<ceph::mutex>* locker) {
+  dout(20) << "snap=" << snap->id << dendl;
+
+  // prune image snapshots first
+  if (!prune_all_image_snapshots(snap, locker)) {
+    dout(20) << "image snapshot pruning still in progress for "
+             << snap->id << dendl;
+    return -EAGAIN;
+  }
+
+  dout(10) << "all image snapshots pruned, removing group snapshot: "
+           << snap->id << dendl;
+  int r = librbd::cls_client::group_snap_remove(&m_local_io_ctx,
+      librbd::util::group_header_name(m_local_group_id), snap->id);
+  if (r < 0 && r != -ENOENT) {
+    derr << "failed to remove group snapshot " << snap->id << ": "
+         << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  // local snapshot state changed
+  m_refresh_snaps = true;
+
+  return 0;
+}
+
+template <typename I>
+std::string Replayer<I>::get_global_image_id(ImageReplayer<I>* image_replayer,
     std::unique_lock<ceph::mutex>& locker) {
 
   if (!image_replayer) {

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -425,14 +425,8 @@ void Replayer<I>::validate_local_group_snapshots(
       continue;
     }
 
-    // setup validation callback
-    Context *sub_ctx = gather_ctx->new_sub();
-    auto ctx = new LambdaContext([sub_ctx](int r) {
-      sub_ctx->complete(r);
-    });
-
     // validate incomplete non-primary mirror or regular snapshots
-    validate_image_snaps_sync_complete(local_snap, ctx);
+    validate_image_snaps_sync_complete(local_snap, gather_ctx->new_sub());
   }
   gather_ctx->activate();
 }
@@ -822,34 +816,47 @@ void Replayer<I>::scan_for_unsynced_group_snapshots(
     return;
   }
 
-  auto last_local_snap = get_latest_group_snapshot(m_local_group_snaps);
-  // check if we have a matching snap on remote to start with it.
-  if (last_local_snap != nullptr) {
-    try_create_group_snapshot(last_local_snap->id, locker);
-  } else { // empty local cluster, started mirroring freshly
-    try_create_group_snapshot("", locker);
-  }
-  locker->unlock();
-
-  schedule_load_group_snapshots();
-}
-
-template <typename I>
-void Replayer<I>::try_create_group_snapshot(
-    std::string prev_snap_id, std::unique_lock<ceph::mutex>* locker) {
   if (m_remote_group_snaps.empty()) {
     dout(10) << "remote snapshots are empty" << dendl;
+    locker->unlock();
+    schedule_load_group_snapshots();
     return;
   }
 
+  auto last_local_snap = get_latest_group_snapshot(m_local_group_snaps);
+  std::string prev_snap_id = "";
+  m_peer_unlink = false;
+  if (last_local_snap != nullptr) {
+    m_peer_unlink = true;
+    prev_snap_id = last_local_snap->id;
+  }
   bool found = false;
+  bool mirror_snap_present = false;
+  m_remote_snap_id_start = "";
+  std::set<std::string> unlink_snap_uuids;
+  std::vector<cls::rbd::GroupSnapshot> user_snapshots;
+  cls::rbd::GroupSnapshot mirror_snapshot;
   auto snap = m_remote_group_snaps.end();
   for (auto remote_snap = m_remote_group_snaps.begin();
       remote_snap != m_remote_group_snaps.end(); ++remote_snap) {
+    if (!found) {
+        auto remote_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
+            &remote_snap->snapshot_namespace);
+      if (remote_snap_ns) {
+        unlink_snap_uuids.insert(remote_snap->id);
+      }
+    }
     if (prev_snap_id.empty() ||
         (found || prev_snap_id == remote_snap->id)) {
       found = true;
       snap = remote_snap; // sync this snapshot
+      if (m_remote_snap_id_start.empty()) {
+        auto remote_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
+            &remote_snap->snapshot_namespace);
+        if (remote_snap_ns) {
+          m_remote_snap_id_start = snap->id;
+        }
+      }
       if (!prev_snap_id.empty()) {
         snap = std::next(remote_snap); // attempt to sync next remote snapshot
       }
@@ -860,7 +867,7 @@ void Replayer<I>::try_create_group_snapshot(
           if (snap->state == cls::rbd::GROUP_SNAPSHOT_STATE_CREATED) {
             dout(10) << "found remote user group snapshot: "
                      << snap->id << dendl;
-            create_group_snapshot(*snap, locker);
+            user_snapshots.push_back(*snap);
             continue;
           }
         } else if (next_remote_snap_ns->is_primary()) {
@@ -868,20 +875,14 @@ void Replayer<I>::try_create_group_snapshot(
                                                 next_remote_snap_ns->complete)) {
             dout(10) << "found primary remote mirror group snapshot: "
                      << snap->id << dendl;
-            create_group_snapshot(*snap, locker);
-            return;
+            mirror_snap_present = true;
+            break;
           }
         } else {
           dout(10) << "skipping non-primary remote group snapshot: "
                    << snap->id << dendl;
           continue;
         }
-      } else {
-        dout(10) << "all remote snaps synced: idling waiting for new snapshot"
-                 << dendl;
-        ceph_assert(m_state == STATE_REPLAYING);
-        m_state = STATE_IDLE;
-        return;
       }
     }
   }
@@ -889,155 +890,72 @@ void Replayer<I>::try_create_group_snapshot(
   if (!prev_snap_id.empty() && !found) {
     dout(10) << "none of the local snaps match remote" << dendl;
     handle_replay_complete(locker, -EEXIST, "split-brain");
+    return;
+  }
+
+  unlink_snap_uuids.erase(m_remote_snap_id_start);
+  if (!unlink_snap_uuids.empty()) {
+    auto remote_snap_id = *unlink_snap_uuids.begin();
+    mirror_group_snapshot_unlink_peer(remote_snap_id);
+    load_replayer(locker);
+    return;
+  }
+
+  if (mirror_snap_present) {
+    auto ctx = new LambdaContext([this](int) {
+      schedule_load_group_snapshots();
+      m_in_flight_op_tracker.finish_op();
+    });
+
+    m_in_flight_op_tracker.start_op();
+    locker->unlock();
+    Context *create_mirror_ctx = new LambdaContext(
+      [this, snap, ctx](int r) {
+        if (r < 0) {
+          dout(10) << "failed to create user snapshots "
+                   << cpp_strerror(r) << dendl;
+          std::unique_lock locker{m_lock};
+          m_in_flight_op_tracker.finish_op();
+          handle_replay_complete(&locker, r, "failed to create user group snapshots");
+          return;
+        }
+
+        create_mirror_snapshot(&(*snap), ctx);
+      });
+
+    auto gather_ctx = new C_Gather(g_ceph_context, create_mirror_ctx);
+    for (auto& user_snap : user_snapshots) {
+      create_user_snapshot(&user_snap, gather_ctx->new_sub());
+    }
+    gather_ctx->activate();
+  } else {
+    dout(10) << "all remote snaps synced: idling waiting for new snapshot"
+             << dendl;
+    ceph_assert(m_state == STATE_REPLAYING);
+    m_state = STATE_IDLE;
+    locker->unlock();
+    schedule_load_group_snapshots();
   }
 }
 
 template <typename I>
-void Replayer<I>::create_group_snapshot(cls::rbd::GroupSnapshot snap,
-                                        std::unique_lock<ceph::mutex>* locker) {
-  dout(10) << snap.id << dendl;
+void Replayer<I>::create_mirror_snapshot(
+    cls::rbd::GroupSnapshot *snap, Context *on_finish) {
+  auto group_snap_id = snap->id;
+  dout(10) << group_snap_id << dendl;
+  std::unique_lock locker{m_lock};
 
   if (m_snapshot_start.is_zero()) {
     m_snapshot_start = ceph_clock_now();
   }
 
-  auto snap_type = cls::rbd::get_group_snap_namespace_type(
-      snap.snapshot_namespace);
-  if (snap_type == cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_MIRROR) {
-    const auto& snap_ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
-        snap.snapshot_namespace);
+  const auto& snap_ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
+      snap->snapshot_namespace);
 
-    if (snap_ns.is_non_primary()) {
-      dout(10) << "remote group snapshot " << snap.id << " is non primary"
-               << dendl;
-      return;
-    }
-
-    auto snap_state =
-      snap_ns.state == cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY ?
-      cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY :
-      cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY_DEMOTED;
-
-    m_in_flight_op_tracker.start_op();
-
-    auto ctx = new LambdaContext([this, snap](int r) mutable {
-      std::unique_lock locker{m_lock};
-      if (r < 0) {
-        dout(10) << "create mirror snapshot failed, will be retried later: "
-                 << cpp_strerror(r) << dendl;
-        m_in_flight_op_tracker.finish_op();
-        return;
-      }
-      if (m_update_group_state) {
-        update_local_group_state(std::move(snap));
-      } else {
-        // if m_replayer in the ImageReplayer is null this cannot be forwarded.
-        // May be we should retry this setting in the validate_image_snaps_sync_complete().
-        // Same for image_replayer->prune_snapshot(); setting actually!!!!
-        set_image_replayer_limits("", &snap, &locker);
-      }
-      m_in_flight_op_tracker.finish_op();
-    });
-
-    create_mirror_snapshot(&snap, snap_state, ctx);
-  } else if (snap_type == cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_USER) {
-    auto itr = std::find_if(
-        m_remote_group_snaps.begin(), m_remote_group_snaps.end(),
-        [&snap](const cls::rbd::GroupSnapshot &s) {
-        return s.id == snap.id;
-        });
-
-    if (itr == m_remote_group_snaps.end()) {
-      dout(10) << "remote group snapshot not found: " << snap.id << dendl;
-      return;
-    }
-
-    auto next_remote_snap = std::next(itr);
-    if (next_remote_snap == m_remote_group_snaps.end()) {
-      return;
-    }
-
-    // check if we have a valid mirror snapshot to proceed
-    bool can_proceed = false;
-    for (; next_remote_snap != m_remote_group_snaps.end(); ++next_remote_snap) {
-      auto next_remote_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-            &next_remote_snap->snapshot_namespace);
-
-      if (next_remote_snap_ns == nullptr) {
-        continue; // skip user snapshots
-      } else if (!is_mirror_group_snapshot_complete(next_remote_snap->state,
-                                                    next_remote_snap_ns->complete)) {
-        dout(10) << "next mirror snapshot is incomplete, waiting: "
-                 << next_remote_snap->id << dendl;
-        return; // wait and try later
-      } else {
-        can_proceed = true; // we have a complete mirror snapshot
-        break;
-      }
-    }
-
-    if (!can_proceed) {
-      dout(10) << "no valid mirror snapshot found after: " << snap.id << dendl;
-      return;
-    }
-
-    dout(10) << "found user snap, snap name: " << snap.name
-             << ", remote group snap id: " << snap.id << dendl;
-
-    m_in_flight_op_tracker.start_op();
-    auto ctx = new LambdaContext([this, snap](int r) mutable {
-      if (r < 0) {
-        dout(10) << "create user snapshot failed, will be retried later: "
-                 << cpp_strerror(r) << dendl;
-      }
-      m_in_flight_op_tracker.finish_op();
-    });
-    create_user_snapshot(&snap, ctx);
-  }
-}
-
-template <typename I>
-void Replayer<I>::update_local_group_state(cls::rbd::GroupSnapshot snap) {
-  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
-  m_in_flight_op_tracker.start_op();
-  auto ctx = new LambdaContext([this, snap](int r) mutable {
-    handle_update_local_group_state(r, std::move(snap));
-    m_in_flight_op_tracker.finish_op();
-  });
-
-  // Set the mirror group state to enabled after the first non-primary
-  // mirror snapshot is created
-  auto req = GroupMirrorStateUpdateRequest<I>::create(m_local_io_ctx,
-                                                      m_local_group_id,
-                                                      m_image_replayers->size(),
-                                                      ctx);
-  req->send();
-}
-
-template <typename I>
-void Replayer<I>::handle_update_local_group_state(int r,
-                                                  cls::rbd::GroupSnapshot snap) {
-  std::unique_lock locker{m_lock};
-  dout(10) << dendl;
-  if (r < 0) {
-    derr << "failed to set group state: " << cpp_strerror(r) << dendl;
-    handle_replay_complete(&locker, r, "failed to set group state to enabled");
-    return;
-  }
-
-  m_update_group_state = false;
-
-  set_image_replayer_limits("", &snap, &locker);
-}
-
-template <typename I>
-void Replayer<I>::create_mirror_snapshot(
-    cls::rbd::GroupSnapshot *snap,
-    const cls::rbd::MirrorSnapshotState &snap_state,
-    Context *on_finish) {
-  auto group_snap_id = snap->id;
-  dout(10) << group_snap_id << dendl;
-  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
+  auto snap_state =
+    snap_ns.state == cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY ?
+    cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY :
+    cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY_DEMOTED;
 
   auto itl = std::find_if(
       m_local_group_snaps.begin(), m_local_group_snaps.end(),
@@ -1048,6 +966,7 @@ void Replayer<I>::create_mirror_snapshot(
   if (itl != m_local_group_snaps.end()) {
     dout(20) << "group snapshot: " << group_snap_id << " already exists"
              << dendl;
+    locker.unlock();
     on_finish->complete(0);
     return;
   }
@@ -1063,6 +982,7 @@ void Replayer<I>::create_mirror_snapshot(
     r = librbd::cls_client::mirror_peer_list(&default_ns_io_ctx, &mirror_peers);
     if (r < 0) {
       derr << "failed to list mirror peers: " << cpp_strerror(r) << dendl;
+      locker.unlock();
       on_finish->complete(r);
       return;
     }
@@ -1081,6 +1001,7 @@ void Replayer<I>::create_mirror_snapshot(
   if (r < 0) {
     derr << "failed to retrieve min OSD release: " << cpp_strerror(r)
          << dendl;
+    locker.unlock();
     on_finish->complete(r);
     return;
   }
@@ -1098,8 +1019,8 @@ void Replayer<I>::create_mirror_snapshot(
                                                          group_snap_id);
 
   auto comp = create_rados_callback(
-      new LambdaContext([this, group_snap_id, on_finish](int r) {
-        handle_create_mirror_snapshot(r, group_snap_id, on_finish);
+      new LambdaContext([this, snap, on_finish](int r) {
+        handle_create_mirror_snapshot(r, snap, on_finish);
         }));
 
   librados::ObjectWriteOperation op;
@@ -1112,16 +1033,64 @@ void Replayer<I>::create_mirror_snapshot(
 
 template <typename I>
 void Replayer<I>::handle_create_mirror_snapshot(
-    int r, const std::string &group_snap_id, Context *on_finish) {
-  dout(10) << "group_snap_id=" << group_snap_id << ", r=" << r << dendl;
+    int r, cls::rbd::GroupSnapshot *snap, Context *on_finish) {
+  dout(10) << "group_snap_id=" << snap->id << ", r=" << r << dendl;
 
   if (r < 0) {
-    derr << "failed to create mirror snapshot: " << group_snap_id
+    derr << "failed to create mirror snapshot: " << snap->id
          << ", error: " << cpp_strerror(r) << dendl;
+    on_finish->complete(r);
+    return;
   }
 
+  std::unique_lock locker{m_lock};
   m_retry_validate_snap = true;
+  if (m_update_group_state) {
+    update_local_group_state(std::move(*snap), on_finish);
+  } else {
+    // if m_replayer in the ImageReplayer is null this cannot be forwarded.
+    // May be we should retry this setting in the validate_image_snaps_sync_complete().
+    // Same for image_replayer->prune_snapshot(); setting actually!!!!
+    set_image_replayer_limits("", snap, &locker);
+    locker.unlock();
+    on_finish->complete(r);
+  }
+}
 
+template <typename I>
+void Replayer<I>::update_local_group_state(cls::rbd::GroupSnapshot snap,
+                                           Context *on_finish) {
+  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
+
+  auto ctx = new LambdaContext([this, snap, on_finish](int r) mutable {
+    handle_update_local_group_state(r, std::move(snap), on_finish);
+  });
+
+  // Set the mirror group state to enabled after the first non-primary
+  // mirror snapshot is created
+  auto req = GroupMirrorStateUpdateRequest<I>::create(m_local_io_ctx,
+                                                      m_local_group_id,
+                                                      m_image_replayers->size(),
+                                                      ctx);
+  req->send();
+}
+
+template <typename I>
+void Replayer<I>::handle_update_local_group_state(int r,
+                            cls::rbd::GroupSnapshot snap, Context *on_finish) {
+  std::unique_lock locker{m_lock};
+  dout(10) << dendl;
+  if (r < 0) {
+    derr << "failed to set group state: " << cpp_strerror(r) << dendl;
+    m_in_flight_op_tracker.finish_op();
+    handle_replay_complete(&locker, r, "failed to set group state to enabled");
+    return;
+  }
+
+  m_update_group_state = false;
+
+  set_image_replayer_limits("", &snap, &locker);
+  locker.unlock();
   on_finish->complete(r);
 }
 
@@ -1485,6 +1454,10 @@ void Replayer<I>::handle_set_mirror_snapshot_complete(
     m_last_snapshot_bytes = last_snapshot_bytes;
   }
 
+  if (m_peer_unlink) {
+    m_peer_unlink = false;
+    mirror_group_snapshot_unlink_peer(m_remote_snap_id_start);
+  }
   on_finish->complete(0);
 }
 
@@ -1494,7 +1467,11 @@ void Replayer<I>::create_user_snapshot(
     Context *on_finish) {
   auto group_snap_id = snap->id;
   dout(10) << group_snap_id << dendl;
-  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
+
+  std::unique_lock locker{m_lock};
+  if (m_snapshot_start.is_zero()) {
+    m_snapshot_start = ceph_clock_now();
+  }
 
   // check if snapshot already exists
   auto itl = std::find_if(
@@ -1506,6 +1483,7 @@ void Replayer<I>::create_user_snapshot(
   if (itl != m_local_group_snaps.end()) {
     dout(20) << "group snapshot: " << group_snap_id << " already exists"
              << dendl;
+    locker.unlock();
     on_finish->complete(0);
     return;
   }
@@ -1539,8 +1517,6 @@ void Replayer<I>::handle_create_user_snapshot(
     derr << "failed to create user snapshot: " << group_snap_id
          << ", error: " << cpp_strerror(r) << dendl;
   }
-
-  m_retry_validate_snap = true;
 
   on_finish->complete(r);
 }
@@ -2078,8 +2054,6 @@ int Replayer<I>::prune_mirror_group_snapshot(
   if (!m_prune_group_snap) {
     return 0;
   }
-
-  mirror_group_snapshot_unlink_peer(m_prune_group_snap->id);
 
   dout(10) << "pruning mirror group snap in-progress: "
            << m_prune_group_snap->name << ", with id: "

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -47,17 +47,6 @@ const cls::rbd::GroupSnapshot* get_latest_group_snapshot(
   return nullptr;
 }
 
-const cls::rbd::GroupSnapshot* get_latest_mirror_group_snapshot(
-    const std::vector<cls::rbd::GroupSnapshot>& gp_snaps) {
-  for (auto it = gp_snaps.rbegin(); it != gp_snaps.rend(); ++it) {
-    if (cls::rbd::get_group_snap_namespace_type(it->snapshot_namespace) ==
-         cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_MIRROR) {
-      return &*it;
-    }
-  }
-  return nullptr;
-}
-
 const cls::rbd::GroupSnapshot* get_latest_complete_mirror_group_snapshot(
     const std::vector<cls::rbd::GroupSnapshot>& gp_snaps) {
   for (auto it = gp_snaps.rbegin(); it != gp_snaps.rend(); ++it) {
@@ -618,13 +607,37 @@ void Replayer<I>::handle_load_local_group_snapshots(int r) {
     return;
   }
 
+  auto prune_creating_group_snaps =
+    std::make_shared<std::vector<cls::rbd::GroupSnapshot>>();
+  m_last_local_snap = nullptr;
+  for (const auto& local_snap : m_local_group_snaps) {
+    // latest mirror snapshot (keep updating)
+    if (cls::rbd::get_group_snap_namespace_type(
+          local_snap.snapshot_namespace) ==
+        cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_MIRROR) {
+      m_last_local_snap = &local_snap;
+    }
+
+    // collect creating snapshots
+    if (local_snap.state == cls::rbd::GROUP_SNAPSHOT_STATE_CREATING) {
+      auto local_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
+          &local_snap.snapshot_namespace);
+
+      if (local_snap_ns && local_snap_ns->is_primary()) {
+        continue;
+      }
+
+      prune_creating_group_snaps->push_back(local_snap);
+    }
+  }
+
   // We must determine whether the local group is already primary here.
   // Otherwise, if the remote group snapshots are unavailable for any reason,
   // replayer will incorrectly report an error status for the local group.
-  auto last_local_snap = get_latest_mirror_group_snapshot(m_local_group_snaps);
-  if (last_local_snap) {
+  m_retry_validate_snap = false;
+  if (m_last_local_snap) {
     const auto& ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
-        last_local_snap->snapshot_namespace);
+        m_last_local_snap->snapshot_namespace);
     if (ns.state != cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY) {
       // Remove any stale 'creating' mirror group snapshots that may have been
       // left behind if the daemon restarted before replay completed. This must
@@ -632,7 +645,7 @@ void Replayer<I>::handle_load_local_group_snapshots(int r) {
       // it is efficient to be ready, so that, the replay logic sees a clean
       // local snapshot state and recreates any missing snapshots.
       if (m_check_creating_snaps) {
-        prune_creating_group_snapshots_if_any(&locker);
+        prune_creating_group_snapshots(&locker, prune_creating_group_snaps);
         return;
       }
       if (ns.is_orphan()) {
@@ -640,7 +653,7 @@ void Replayer<I>::handle_load_local_group_snapshots(int r) {
         handle_replay_complete(&locker, 0, "orphan (force promoting)");
         return;
       }
-      if (!is_mirror_group_snapshot_complete(last_local_snap->state,
+      if (!is_mirror_group_snapshot_complete(m_last_local_snap->state,
                                              ns.complete)) {
         m_retry_validate_snap = true;
       }
@@ -667,17 +680,16 @@ void Replayer<I>::check_local_group_snapshots(
     return;
   }
 
-  auto last_local_snap = get_latest_mirror_group_snapshot(m_local_group_snaps);
-  ceph_assert(last_local_snap != nullptr);
+  ceph_assert(m_last_local_snap != nullptr);
 
-  dout(10) << "local mirror snapshot=" << last_local_snap->id << dendl;
+  dout(10) << "local mirror snapshot=" << m_last_local_snap->id << dendl;
 
   const auto& ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
-      last_local_snap->snapshot_namespace);
+      m_last_local_snap->snapshot_namespace);
   if (ns.state == cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY_DEMOTED) {
     bool split_brain = true;
     for (const auto& remote_snap : m_remote_group_snaps) {
-      if (remote_snap.id != last_local_snap->id) {
+      if (remote_snap.id != m_last_local_snap->id) {
         continue;
       }
       const auto* remote_ns =
@@ -694,11 +706,9 @@ void Replayer<I>::check_local_group_snapshots(
       return;
     }
     m_check_creating_snaps = false;
-  } else if (ns.state == cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY_DEMOTED) {
-    auto last_remote_snap =
-      get_latest_mirror_group_snapshot(m_remote_group_snaps);
-    if (last_remote_snap != nullptr &&
-        last_local_snap->id == last_remote_snap->id && !m_retry_validate_snap) {
+  } else if (ns.state == cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY_DEMOTED &&
+             !m_retry_validate_snap && !m_remote_group_snaps.empty()) {
+    if (m_last_local_snap->id == m_remote_group_snaps.rbegin()->id) {
       handle_replay_complete(locker, -EREMOTEIO, "remote group demoted");
       return;
     }
@@ -1861,25 +1871,11 @@ bool Replayer<I>::prune_all_image_snapshots_by_gsid(
 // Check for non-primary mirror and user group snapshots in CREATING state,
 // and prune them on daemon restart.
 template <typename I>
-void Replayer<I>::prune_creating_group_snapshots_if_any(
-    std::unique_lock<ceph::mutex>* locker) {
-  auto prune_group_snaps =
-    std::make_shared<std::vector<cls::rbd::GroupSnapshot>>();
-  for (const auto& local_snap : m_local_group_snaps) {
-    if (local_snap.state != cls::rbd::GROUP_SNAPSHOT_STATE_CREATING) {
-      continue;
-    }
-    auto local_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-        &local_snap.snapshot_namespace);
-    // skip primary snapshots;
-    // only prune non-primary mirror and user snapshots in CREATING state
-    if (local_snap_ns && local_snap_ns->is_primary()) {
-      continue;
-    }
-    prune_group_snaps->push_back(local_snap);
-  }
+void Replayer<I>::prune_creating_group_snapshots(
+    std::unique_lock<ceph::mutex>* locker,
+    std::shared_ptr<std::vector<cls::rbd::GroupSnapshot>> prune_creating_group_snaps) {
 
-  if (prune_group_snaps->empty()) {
+  if (prune_creating_group_snaps->empty()) {
     // not found creating snapshots
     m_check_creating_snaps = false;
     locker->unlock();
@@ -1892,7 +1888,7 @@ void Replayer<I>::prune_creating_group_snapshots_if_any(
   auto local_images =
     std::make_shared<std::vector<cls::rbd::GroupImageStatus>>();
   auto* ctx = new LambdaContext(
-    [this, local_images, prune_group_snaps](int r) {
+    [this, local_images, prune_creating_group_snaps](int r) {
       if (r < 0) {
         derr << "failed to list group images: "
              << cpp_strerror(r) << dendl;
@@ -1901,8 +1897,8 @@ void Replayer<I>::prune_creating_group_snapshots_if_any(
         return;
       }
 
-      handle_prune_creating_group_snapshots_if_any(
-        *local_images, *prune_group_snaps);
+      handle_prune_creating_group_snapshots(
+        *local_images, *prune_creating_group_snaps);
     });
 
   // initiate image listing
@@ -1910,31 +1906,36 @@ void Replayer<I>::prune_creating_group_snapshots_if_any(
 }
 
 template <typename I>
-void Replayer<I>::handle_prune_creating_group_snapshots_if_any(
+void Replayer<I>::handle_prune_creating_group_snapshots(
     const std::vector<cls::rbd::GroupImageStatus>& local_images,
-    const std::vector<cls::rbd::GroupSnapshot>& prune_group_snaps) {
-  int r = 0;
-  {
-    std::unique_lock locker{m_lock};
-    for (const auto& local_snap : prune_group_snaps) {
-      if (!prune_all_image_snapshots_by_gsid(
-            local_snap.id, local_images, &locker)) {
-        // still pending image snapshots; retry later
-        continue;
-      }
-      dout(10) << "all image snapshots pruned; removing creating group snapshot: "
+    const std::vector<cls::rbd::GroupSnapshot>& prune_creating_group_snaps) {
+  std::unique_lock locker{m_lock};
+  for (const auto& local_snap : prune_creating_group_snaps) {
+    if (!prune_all_image_snapshots_by_gsid(
+          local_snap.id, local_images, &locker)) {
+      // still pending image snapshots; retry later
+      dout(20) << "image snapshots still pending for: "
                << local_snap.id << dendl;
-      r = librbd::cls_client::group_snap_remove(
-          &m_local_io_ctx,
-          librbd::util::group_header_name(m_local_group_id),
-          local_snap.id);
-      if (r < 0) {
-        derr << "failed to remove group snapshot "
-             << local_snap.id << ": "
-             << cpp_strerror(r) << dendl;
-      }
+      continue;
+    }
+
+    dout(10) << "all image snapshots pruned; removing creating group snapshot: "
+             << local_snap.id << dendl;
+
+    int r = librbd::cls_client::group_snap_remove(
+      &m_local_io_ctx,
+      librbd::util::group_header_name(m_local_group_id),
+      local_snap.id);
+
+    if (r < 0) {
+      derr << "failed to remove group snapshot "
+           << local_snap.id << ": "
+           << cpp_strerror(r) << dendl;
     }
   }
+
+  m_check_creating_snaps = false;
+  locker.unlock();
   schedule_load_group_snapshots();
 }
 

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -165,7 +165,7 @@ void Replayer<I>::schedule_load_group_snapshots() {
   std::lock_guard timer_locker{m_threads->timer_lock};
   std::lock_guard locker{m_lock};
 
-  if (m_state != STATE_REPLAYING) {
+  if (m_state != STATE_REPLAYING && m_state != STATE_IDLE) {
     return;
   }
 
@@ -186,9 +186,10 @@ void Replayer<I>::handle_schedule_load_group_snapshots(int r) {
 
   {
     std::unique_lock locker{m_lock};
-    if (m_state != STATE_REPLAYING) {
+    if (m_state != STATE_REPLAYING && m_state != STATE_IDLE) {
       return;
     }
+    m_state = STATE_REPLAYING;
 
     ceph_assert(m_load_snapshots_task != nullptr);
     m_load_snapshots_task = nullptr;
@@ -876,7 +877,10 @@ void Replayer<I>::try_create_group_snapshot(
           continue;
         }
       } else {
-        dout(10) << "all remote snaps synced" << dendl;
+        dout(10) << "all remote snaps synced: idling waiting for new snapshot"
+                 << dendl;
+        ceph_assert(m_state == STATE_REPLAYING);
+        m_state = STATE_IDLE;
         return;
       }
     }
@@ -2253,7 +2257,7 @@ bool Replayer<I>::get_replay_status(std::string* description) {
   dout(10) << dendl;
 
   std::unique_lock locker{m_lock};
-  if (m_state != STATE_REPLAYING) {
+  if (m_state != STATE_REPLAYING && m_state != STATE_IDLE) {
     derr << "replay not running" << dendl;
     return false;
   }

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -896,8 +896,15 @@ void Replayer<I>::scan_for_unsynced_group_snapshots(
   unlink_snap_uuids.erase(m_remote_snap_id_start);
   if (!unlink_snap_uuids.empty()) {
     auto remote_snap_id = *unlink_snap_uuids.begin();
-    mirror_group_snapshot_unlink_peer(remote_snap_id);
-    load_replayer(locker);
+    m_in_flight_op_tracker.start_op();
+    locker->unlock();
+    auto on_unlink = new LambdaContext([this](int r) {
+      std::unique_lock locker{m_lock};
+      m_in_flight_op_tracker.finish_op();
+      load_replayer(&locker);
+      return;
+    });
+    mirror_group_snapshot_unlink_peer(remote_snap_id, on_unlink);
     return;
   }
 
@@ -1456,9 +1463,10 @@ void Replayer<I>::handle_set_mirror_snapshot_complete(
 
   if (m_peer_unlink) {
     m_peer_unlink = false;
-    mirror_group_snapshot_unlink_peer(m_remote_snap_id_start);
+    mirror_group_snapshot_unlink_peer(m_remote_snap_id_start, on_finish);
+  } else {
+    on_finish->complete(0);
   }
-  on_finish->complete(0);
 }
 
 template <typename I>
@@ -1704,7 +1712,11 @@ void Replayer<I>::handle_post_user_snapshot_created(
 }
 
 template <typename I>
-void Replayer<I>::mirror_group_snapshot_unlink_peer(const std::string &snap_id) {
+void Replayer<I>::mirror_group_snapshot_unlink_peer(
+  const std::string &snap_id, Context* on_unlink) {
+  dout(10) << dendl;
+
+  std::unique_lock locker{m_lock};
   auto remote_snap = std::find_if(
       m_remote_group_snaps.begin(), m_remote_group_snaps.end(),
       [snap_id](const cls::rbd::GroupSnapshot &s) {
@@ -1712,6 +1724,8 @@ void Replayer<I>::mirror_group_snapshot_unlink_peer(const std::string &snap_id) 
       });
 
   if (remote_snap == m_remote_group_snaps.end()) {
+    locker.unlock();
+    on_unlink->complete(0);
     return;
   }
 
@@ -1720,36 +1734,95 @@ void Replayer<I>::mirror_group_snapshot_unlink_peer(const std::string &snap_id) 
   if (rns == nullptr) {
     derr << "remote group snapshot is not a mirror snapshot: "
          << snap_id << dendl;
+    locker.unlock();
+    on_unlink->complete(-EINVAL);
     return;
   }
 
   if (rns->mirror_peer_uuids.count(m_remote_mirror_peer_uuid) != 0) {
-    rns->mirror_peer_uuids.erase(m_remote_mirror_peer_uuid);
-    auto comp = create_rados_callback(
-      new LambdaContext([this, snap_id](int r) {
-	handle_mirror_group_snapshot_unlink_peer(r, snap_id);
-      }));
+    // Capture the image snaps list to unlink the peer
+    // from each individual image snapshot first.
+    std::vector<cls::rbd::ImageSnapshotSpec> image_snaps = remote_snap->snaps;
+    if (image_snaps.empty()) {
+      locker.unlock();
+      handle_mirror_group_snapshot_unlink_peer(0, &(*remote_snap), on_unlink);
+      return;
+    }
 
-    librados::ObjectWriteOperation op;
-    librbd::cls_client::group_snap_set(&op, *remote_snap);
-    int r = m_remote_io_ctx.aio_operate(
-      librbd::util::group_header_name(m_remote_group_id), comp, &op);
-    ceph_assert(r == 0);
-    comp->release();
+    auto ctx = new LambdaContext([this, remote_snap, on_unlink](int r) {
+      handle_mirror_group_snapshot_unlink_peer(r, &(*remote_snap), on_unlink);
+    });
+
+    C_Gather *unlink_gather_ctx = new C_Gather(g_ceph_context, ctx);
+    for (const auto &spec : image_snaps) {
+      if (spec.snap_id == CEPH_NOSNAP) {
+        continue;
+      }
+      std::string image_header_oid = librbd::util::header_name(spec.image_id);
+      librados::ObjectWriteOperation op;
+      librbd::cls_client::mirror_image_snapshot_unlink_peer(
+        &op, spec.snap_id, m_remote_mirror_peer_uuid);
+      auto img_snapshot_unlink = new LambdaContext(
+        [this, spec, new_sub_ctx=unlink_gather_ctx->new_sub()](int r) {
+          if (r == -ENOENT || r == -ERESTART) {
+            r = 0;
+          }
+          if (r < 0) {
+            derr << "failed to unlink mirror peer from image snapshot "
+                 << spec.snap_id << " of image " << spec.image_id
+                 << ": " << cpp_strerror(r) << dendl;
+          }
+          new_sub_ctx->complete(r);
+        });
+      auto aio_comp = create_rados_callback(img_snapshot_unlink);
+      int r = m_remote_io_ctx.aio_operate(image_header_oid, aio_comp, &op);
+      ceph_assert(r == 0);
+      aio_comp->release();
+    }
+    unlink_gather_ctx->activate();
+  } else {
+    locker.unlock();
+    on_unlink->complete(0);
   }
 }
 
 template <typename I>
 void Replayer<I>::handle_mirror_group_snapshot_unlink_peer(
-    int r, const std::string &snap_id) {
+    int r, cls::rbd::GroupSnapshot* remote_snap, Context* on_unlink) {
+  auto snap_id = remote_snap->id;
   dout(10) << snap_id << ", r=" << r << dendl;
 
   if (r < 0) {
-    derr << "failed to remove mirror_peer_uuid for snap_id: "
-         << snap_id  << " : " << cpp_strerror(r) << dendl;
+    derr << "failed to remove mirror_peer_uuid for image snapshots"
+         << " of group snapshot snap_id: " << snap_id << dendl;
+    on_unlink->complete(r);
+    return;
   }
 
-  return;
+  dout(10) << "unlinking peer uuid for remote group snapshot: "
+           << snap_id << dendl;
+  std::unique_lock locker{m_lock};
+
+  auto &rns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
+      remote_snap->snapshot_namespace);
+  rns.mirror_peer_uuids.erase(m_remote_mirror_peer_uuid);
+
+  auto comp = create_rados_callback(
+    new LambdaContext([this, snap_id, on_unlink](int r) {
+      if (r < 0) {
+        derr << "failed to remove mirror_peer_uuid for snap_id: "
+             << snap_id  << " : " << cpp_strerror(r) << dendl;
+      }
+      on_unlink->complete(r);
+      return;
+    }));
+
+  librados::ObjectWriteOperation op;
+  librbd::cls_client::group_snap_set(&op, *remote_snap);
+  r = m_remote_io_ctx.aio_operate(
+    librbd::util::group_header_name(m_remote_group_id), comp, &op);
+  ceph_assert(r == 0);
+  comp->release();
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -38,15 +38,6 @@ namespace {
 
 const uint32_t MAX_RETURN = 1024;
 
-const cls::rbd::GroupSnapshot* get_latest_group_snapshot(
-    const std::vector<cls::rbd::GroupSnapshot>& gp_snaps) {
-  auto it = gp_snaps.rbegin();
-  if (it != gp_snaps.rend()) {
-    return &*it;
-  }
-  return nullptr;
-}
-
 const cls::rbd::GroupSnapshot* get_latest_complete_mirror_group_snapshot(
     const std::vector<cls::rbd::GroupSnapshot>& gp_snaps) {
   for (auto it = gp_snaps.rbegin(); it != gp_snaps.rend(); ++it) {
@@ -421,14 +412,8 @@ void Replayer<I>::validate_local_group_snapshots(
       continue;
     }
 
-    // setup validation callback
-    Context *sub_ctx = gather_ctx->new_sub();
-    auto ctx = new LambdaContext([sub_ctx](int r) {
-      sub_ctx->complete(r);
-    });
-
     // validate incomplete non-primary mirror or regular snapshots
-    validate_image_snaps_sync_complete(local_snap, ctx);
+    validate_image_snaps_sync_complete(local_snap, gather_ctx->new_sub());
   }
   gather_ctx->activate();
 }
@@ -528,6 +513,13 @@ void Replayer<I>::handle_load_remote_group_snapshots(int r) {
     derr << "error listing remote mirror group snapshots: " << cpp_strerror(r)
          << dendl;
     handle_replay_complete(&locker, r, "failed to list remote group snapshots");
+    return;
+  }
+
+  if (m_remote_group_snaps.empty()) {
+    dout(10) << "remote snapshots are empty" << dendl;
+    locker.unlock();
+    schedule_load_group_snapshots();
     return;
   }
 
@@ -809,35 +801,25 @@ void Replayer<I>::scan_for_unsynced_group_snapshots(
     return;
   }
 
-  auto last_local_snap = get_latest_group_snapshot(m_local_group_snaps);
-  // check if we have a matching snap on remote to start with it.
+  m_last_synced_remote_snap_id.clear();
+  auto last_local_snap = get_latest_complete_mirror_group_snapshot(
+      m_local_group_snaps);
   if (last_local_snap != nullptr) {
-    try_create_group_snapshot(last_local_snap->id, locker);
-  } else { // empty local cluster, started mirroring freshly
-    try_create_group_snapshot("", locker);
+    m_last_synced_remote_snap_id = last_local_snap->id;
+    m_update_group_state = false;
   }
-  locker->unlock();
-
-  schedule_load_group_snapshots();
-}
-
-template <typename I>
-void Replayer<I>::try_create_group_snapshot(
-    std::string prev_snap_id, std::unique_lock<ceph::mutex>* locker) {
-  if (m_remote_group_snaps.empty()) {
-    dout(10) << "remote snapshots are empty" << dendl;
-    return;
-  }
-
   bool found = false;
+  bool is_mirror_snap_exist = false;
+  std::vector<std::string> unlink_snap_uuids;
+  std::vector<cls::rbd::GroupSnapshot> user_snapshots;
   auto snap = m_remote_group_snaps.end();
   for (auto remote_snap = m_remote_group_snaps.begin();
       remote_snap != m_remote_group_snaps.end(); ++remote_snap) {
-    if (prev_snap_id.empty() ||
-        (found || prev_snap_id == remote_snap->id)) {
+    if (m_last_synced_remote_snap_id.empty() ||
+        (found || m_last_synced_remote_snap_id == remote_snap->id)) {
       found = true;
       snap = remote_snap; // sync this snapshot
-      if (!prev_snap_id.empty()) {
+      if (!m_last_synced_remote_snap_id.empty()) {
         snap = std::next(remote_snap); // attempt to sync next remote snapshot
       }
       if (snap != m_remote_group_snaps.end()) {
@@ -847,7 +829,7 @@ void Replayer<I>::try_create_group_snapshot(
           if (snap->state == cls::rbd::GROUP_SNAPSHOT_STATE_CREATED) {
             dout(10) << "found remote user group snapshot: "
                      << snap->id << dendl;
-            create_group_snapshot(*snap, locker);
+            user_snapshots.push_back(*snap);
             continue;
           }
         } else if (next_remote_snap_ns->is_primary()) {
@@ -855,176 +837,115 @@ void Replayer<I>::try_create_group_snapshot(
                                                 next_remote_snap_ns->complete)) {
             dout(10) << "found primary remote mirror group snapshot: "
                      << snap->id << dendl;
-            create_group_snapshot(*snap, locker);
-            return;
+            is_mirror_snap_exist = true;
+            break;
           }
         } else {
           dout(10) << "skipping non-primary remote group snapshot: "
                    << snap->id << dendl;
           continue;
         }
-      } else {
-        dout(10) << "all remote snaps synced: idling waiting for new snapshot"
-                 << dendl;
-        ceph_assert(m_state == STATE_REPLAYING);
-        m_state = STATE_IDLE;
-        return;
+      }
+    } else {
+      auto remote_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
+          &remote_snap->snapshot_namespace);
+      if (remote_snap_ns) {
+        unlink_snap_uuids.emplace_back(remote_snap->id);
       }
     }
   }
 
-  if (!prev_snap_id.empty() && !found) {
+  if (!m_last_synced_remote_snap_id.empty() && !found) {
     dout(10) << "none of the local snaps match remote" << dendl;
     handle_replay_complete(locker, -EEXIST, "split-brain");
+    return;
+  }
+
+  if (!unlink_snap_uuids.empty()) {
+    // This case occurs when the previous sync cycle was interrupted
+    // (due to a crash or daemon failure) before performing unlink at
+    // the end. Unlinking the peer completes the outstanding cleanup
+    // and the previous interrupted cycle, after which we reload the
+    // replayer to start a new sync cycle.
+    auto remote_snap_id = *unlink_snap_uuids.begin();
+    mirror_group_snapshot_unlink_peer(remote_snap_id);
+    load_replayer(locker);
+    return;
+  }
+
+  if (is_mirror_snap_exist) {
+    if (!user_snapshots.empty()) {
+      create_user_group_snapshots(locker, &(*snap), user_snapshots);
+    } else {
+      create_mirror_group_snapshot(locker, &(*snap));
+    }
+  } else {
+    dout(10) << "all remote mirror snapshots synced: idling waiting for new "
+             << "mirror snapshot" << dendl;
+    ceph_assert(m_state == STATE_REPLAYING);
+    m_state = STATE_IDLE;
+    locker->unlock();
+    schedule_load_group_snapshots();
   }
 }
 
 template <typename I>
-void Replayer<I>::create_group_snapshot(cls::rbd::GroupSnapshot snap,
-                                        std::unique_lock<ceph::mutex>* locker) {
-  dout(10) << snap.id << dendl;
+void Replayer<I>::create_user_group_snapshots(
+    std::unique_lock<ceph::mutex>* locker,
+    cls::rbd::GroupSnapshot* mirror_snap,
+    std::vector<cls::rbd::GroupSnapshot>& user_snapshots) {
+  dout(10) << dendl;
+
+  auto ctx = new LambdaContext([this, mirror_snap](int r) {
+    handle_create_user_group_snapshots(r, mirror_snap);
+    m_in_flight_op_tracker.finish_op();
+  });
+
+  auto gather_ctx = new C_Gather(g_ceph_context, ctx);
+  m_in_flight_op_tracker.start_op();
+  for (auto& user_snap : user_snapshots) {
+    create_user_group_snapshot(&user_snap, gather_ctx->new_sub());
+  }
+  locker->unlock();
+  gather_ctx->activate();
+}
+
+template <typename I>
+void Replayer<I>::handle_create_user_group_snapshots(
+    int r, cls::rbd::GroupSnapshot *mirror_snap) {
+  dout(10) << dendl;
+  std::unique_lock locker{m_lock};
+
+  if (is_replay_interrupted(&locker)) {
+    return;
+  }
+
+  if (r < 0) {
+    dout(10) << "failed to create user snapshots " << cpp_strerror(r) << dendl;
+    handle_replay_complete(&locker, r, "failed to create user group snapshots");
+    return;
+  }
+
+  create_mirror_group_snapshot(&locker, mirror_snap);
+}
+
+template <typename I>
+void Replayer<I>::create_mirror_group_snapshot(
+    std::unique_lock<ceph::mutex>* locker, cls::rbd::GroupSnapshot *snap) {
+  auto group_snap_id = snap->id;
+  dout(10) << group_snap_id << dendl;
 
   if (m_snapshot_start.is_zero()) {
     m_snapshot_start = ceph_clock_now();
   }
 
-  auto snap_type = cls::rbd::get_group_snap_namespace_type(
-      snap.snapshot_namespace);
-  if (snap_type == cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_MIRROR) {
-    const auto& snap_ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
-        snap.snapshot_namespace);
+  const auto& snap_ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
+      snap->snapshot_namespace);
 
-    if (snap_ns.is_non_primary()) {
-      dout(10) << "remote group snapshot " << snap.id << " is non primary"
-               << dendl;
-      return;
-    }
-
-    auto snap_state =
-      snap_ns.state == cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY ?
-      cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY :
-      cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY_DEMOTED;
-
-    m_in_flight_op_tracker.start_op();
-
-    auto ctx = new LambdaContext([this, snap](int r) mutable {
-      std::unique_lock locker{m_lock};
-      if (r < 0) {
-        dout(10) << "create mirror snapshot failed, will be retried later: "
-                 << cpp_strerror(r) << dendl;
-        m_in_flight_op_tracker.finish_op();
-        return;
-      }
-      if (m_update_group_state) {
-        update_local_group_state(std::move(snap));
-      } else {
-        // if m_replayer in the ImageReplayer is null this cannot be forwarded.
-        // May be we should retry this setting in the validate_image_snaps_sync_complete().
-        // Same for image_replayer->prune_snapshot(); setting actually!!!!
-        set_image_replayer_limits("", &snap, &locker);
-      }
-      m_in_flight_op_tracker.finish_op();
-    });
-
-    create_mirror_snapshot(&snap, snap_state, ctx);
-  } else if (snap_type == cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_USER) {
-    auto itr = std::find_if(
-        m_remote_group_snaps.begin(), m_remote_group_snaps.end(),
-        [&snap](const cls::rbd::GroupSnapshot &s) {
-        return s.id == snap.id;
-        });
-
-    if (itr == m_remote_group_snaps.end()) {
-      dout(10) << "remote group snapshot not found: " << snap.id << dendl;
-      return;
-    }
-
-    auto next_remote_snap = std::next(itr);
-    if (next_remote_snap == m_remote_group_snaps.end()) {
-      return;
-    }
-
-    // check if we have a valid mirror snapshot to proceed
-    bool can_proceed = false;
-    for (; next_remote_snap != m_remote_group_snaps.end(); ++next_remote_snap) {
-      auto next_remote_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-            &next_remote_snap->snapshot_namespace);
-
-      if (next_remote_snap_ns == nullptr) {
-        continue; // skip user snapshots
-      } else if (!is_mirror_group_snapshot_complete(next_remote_snap->state,
-                                                    next_remote_snap_ns->complete)) {
-        dout(10) << "next mirror snapshot is incomplete, waiting: "
-                 << next_remote_snap->id << dendl;
-        return; // wait and try later
-      } else {
-        can_proceed = true; // we have a complete mirror snapshot
-        break;
-      }
-    }
-
-    if (!can_proceed) {
-      dout(10) << "no valid mirror snapshot found after: " << snap.id << dendl;
-      return;
-    }
-
-    dout(10) << "found user snap, snap name: " << snap.name
-             << ", remote group snap id: " << snap.id << dendl;
-
-    m_in_flight_op_tracker.start_op();
-    auto ctx = new LambdaContext([this, snap](int r) mutable {
-      if (r < 0) {
-        dout(10) << "create user snapshot failed, will be retried later: "
-                 << cpp_strerror(r) << dendl;
-      }
-      m_in_flight_op_tracker.finish_op();
-    });
-    create_user_snapshot(&snap, ctx);
-  }
-}
-
-template <typename I>
-void Replayer<I>::update_local_group_state(cls::rbd::GroupSnapshot snap) {
-  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
-  m_in_flight_op_tracker.start_op();
-  auto ctx = new LambdaContext([this, snap](int r) mutable {
-    handle_update_local_group_state(r, std::move(snap));
-    m_in_flight_op_tracker.finish_op();
-  });
-
-  // Set the mirror group state to enabled after the first non-primary
-  // mirror snapshot is created
-  auto req = GroupMirrorStateUpdateRequest<I>::create(m_local_io_ctx,
-                                                      m_local_group_id,
-                                                      m_image_replayers->size(),
-                                                      ctx);
-  req->send();
-}
-
-template <typename I>
-void Replayer<I>::handle_update_local_group_state(int r,
-                                                  cls::rbd::GroupSnapshot snap) {
-  std::unique_lock locker{m_lock};
-  dout(10) << dendl;
-  if (r < 0) {
-    derr << "failed to set group state: " << cpp_strerror(r) << dendl;
-    handle_replay_complete(&locker, r, "failed to set group state to enabled");
-    return;
-  }
-
-  m_update_group_state = false;
-
-  set_image_replayer_limits("", &snap, &locker);
-}
-
-template <typename I>
-void Replayer<I>::create_mirror_snapshot(
-    cls::rbd::GroupSnapshot *snap,
-    const cls::rbd::MirrorSnapshotState &snap_state,
-    Context *on_finish) {
-  auto group_snap_id = snap->id;
-  dout(10) << group_snap_id << dendl;
-  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
+  auto snap_state =
+    snap_ns.state == cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY ?
+    cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY :
+    cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY_DEMOTED;
 
   auto itl = std::find_if(
       m_local_group_snaps.begin(), m_local_group_snaps.end(),
@@ -1035,7 +956,8 @@ void Replayer<I>::create_mirror_snapshot(
   if (itl != m_local_group_snaps.end()) {
     dout(20) << "group snapshot: " << group_snap_id << " already exists"
              << dendl;
-    on_finish->complete(0);
+    locker->unlock();
+    schedule_load_group_snapshots();
     return;
   }
 
@@ -1050,7 +972,7 @@ void Replayer<I>::create_mirror_snapshot(
     r = librbd::cls_client::mirror_peer_list(&default_ns_io_ctx, &mirror_peers);
     if (r < 0) {
       derr << "failed to list mirror peers: " << cpp_strerror(r) << dendl;
-      on_finish->complete(r);
+      handle_replay_complete(locker, r, "failed to list mirror peers");
       return;
     }
 
@@ -1068,7 +990,7 @@ void Replayer<I>::create_mirror_snapshot(
   if (r < 0) {
     derr << "failed to retrieve min OSD release: " << cpp_strerror(r)
          << dendl;
-    on_finish->complete(r);
+    handle_replay_complete(locker, r, "failed to retrieve min OSD release");
     return;
   }
 
@@ -1085,10 +1007,12 @@ void Replayer<I>::create_mirror_snapshot(
                                                          group_snap_id);
 
   auto comp = create_rados_callback(
-      new LambdaContext([this, group_snap_id, on_finish](int r) {
-        handle_create_mirror_snapshot(r, group_snap_id, on_finish);
+      new LambdaContext([this, snap](int r) {
+        handle_create_mirror_group_snapshot(r, snap);
+        m_in_flight_op_tracker.finish_op();
         }));
 
+  m_in_flight_op_tracker.start_op();
   librados::ObjectWriteOperation op;
   librbd::cls_client::group_snap_set(&op, local_snap);
   r = m_local_io_ctx.aio_operate(
@@ -1098,18 +1022,74 @@ void Replayer<I>::create_mirror_snapshot(
 }
 
 template <typename I>
-void Replayer<I>::handle_create_mirror_snapshot(
-    int r, const std::string &group_snap_id, Context *on_finish) {
-  dout(10) << "group_snap_id=" << group_snap_id << ", r=" << r << dendl;
+void Replayer<I>::handle_create_mirror_group_snapshot(
+    int r, cls::rbd::GroupSnapshot *snap) {
+  dout(10) << "group_snap_id=" << snap->id << ", r=" << r << dendl;
+  std::unique_lock locker{m_lock};
+
+  if (is_replay_interrupted(&locker)) {
+    return;
+  }
 
   if (r < 0) {
-    derr << "failed to create mirror snapshot: " << group_snap_id
+    derr << "failed to create mirror snapshot: " << snap->id
          << ", error: " << cpp_strerror(r) << dendl;
+    handle_replay_complete(&locker, r, "failed to create mirror snapshot");
+    return;
   }
 
   m_retry_validate_snap = true;
+  update_local_group_state(&locker, snap);
+}
 
-  on_finish->complete(r);
+template <typename I>
+void Replayer<I>::update_local_group_state(std::unique_lock<ceph::mutex>* locker,
+                                           cls::rbd::GroupSnapshot* snap) {
+  dout(10) << dendl;
+  if (!m_update_group_state) {
+    // if m_replayer in the ImageReplayer is null this cannot be forwarded.
+    // May be we should retry this setting in the validate_image_snaps_sync_complete().
+    // Same for image_replayer->prune_snapshot(); setting actually!!!!
+    set_image_replayer_limits("", snap, locker);
+    locker->unlock();
+    schedule_load_group_snapshots();
+    return;
+  }
+
+  auto ctx = new LambdaContext([this, snap](int r) {
+    handle_update_local_group_state(r, snap);
+     m_in_flight_op_tracker.finish_op();
+  });
+
+  // Set the mirror group state to enabled after the first non-primary
+  // mirror snapshot is created
+  m_in_flight_op_tracker.start_op();
+  auto req = GroupMirrorStateUpdateRequest<I>::create(m_local_io_ctx,
+                                                      m_local_group_id,
+                                                      m_image_replayers->size(),
+                                                      ctx);
+  req->send();
+}
+
+template <typename I>
+void Replayer<I>::handle_update_local_group_state(int r,
+    cls::rbd::GroupSnapshot* snap) {
+  std::unique_lock locker{m_lock};
+  dout(10) << dendl;
+  if (is_replay_interrupted(&locker)) {
+    return;
+  }
+
+  if (r < 0) {
+    derr << "failed to set group state: " << cpp_strerror(r) << dendl;
+    handle_replay_complete(&locker, r, "failed to set group state to enabled");
+    return;
+  }
+
+  m_update_group_state = false;
+  set_image_replayer_limits("", snap, &locker);
+  locker.unlock();
+  schedule_load_group_snapshots();
 }
 
 template <typename I>
@@ -1472,16 +1452,22 @@ void Replayer<I>::handle_set_mirror_snapshot_complete(
     m_last_snapshot_bytes = last_snapshot_bytes;
   }
 
+  if (!m_last_synced_remote_snap_id.empty()) {
+    mirror_group_snapshot_unlink_peer(m_last_synced_remote_snap_id);
+  }
   on_finish->complete(0);
 }
 
 template <typename I>
-void Replayer<I>::create_user_snapshot(
-    cls::rbd::GroupSnapshot *snap,
-    Context *on_finish) {
+void Replayer<I>::create_user_group_snapshot(
+    cls::rbd::GroupSnapshot *snap, Context *on_finish) {
   auto group_snap_id = snap->id;
   dout(10) << group_snap_id << dendl;
   ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
+
+  if (m_snapshot_start.is_zero()) {
+    m_snapshot_start = ceph_clock_now();
+  }
 
   // check if snapshot already exists
   auto itl = std::find_if(
@@ -1508,7 +1494,7 @@ void Replayer<I>::create_user_snapshot(
 
   auto comp = create_rados_callback(
       new LambdaContext([this, group_snap_id, on_finish](int r) {
-        handle_create_user_snapshot(r, group_snap_id, on_finish);
+        handle_create_user_group_snapshot(r, group_snap_id, on_finish);
       }));
 
   int r = m_local_io_ctx.aio_operate(
@@ -1518,7 +1504,7 @@ void Replayer<I>::create_user_snapshot(
 }
 
 template <typename I>
-void Replayer<I>::handle_create_user_snapshot(
+void Replayer<I>::handle_create_user_group_snapshot(
     int r, const std::string &group_snap_id, Context *on_finish) {
   dout(10) << "group_snap_id=" << group_snap_id << ", r=" << r << dendl;
 
@@ -1526,8 +1512,6 @@ void Replayer<I>::handle_create_user_snapshot(
     derr << "failed to create user snapshot: " << group_snap_id
          << ", error: " << cpp_strerror(r) << dendl;
   }
-
-  m_retry_validate_snap = true;
 
   on_finish->complete(r);
 }
@@ -2065,8 +2049,6 @@ int Replayer<I>::prune_mirror_group_snapshot(
   if (!m_prune_group_snap) {
     return 0;
   }
-
-  mirror_group_snapshot_unlink_peer(m_prune_group_snap->id);
 
   dout(10) << "pruning mirror group snap in-progress: "
            << m_prune_group_snap->name << ", with id: "

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -868,8 +868,19 @@ void Replayer<I>::scan_for_unsynced_group_snapshots(
     // and the previous interrupted cycle, after which we reload the
     // replayer to start a new sync cycle.
     auto remote_snap_id = *unlink_snap_uuids.begin();
-    mirror_group_snapshot_unlink_peer(remote_snap_id);
-    load_replayer(locker);
+    m_in_flight_op_tracker.start_op();
+    auto on_unlink = new LambdaContext([this](int r) {
+      std::unique_lock locker{m_lock};
+      m_in_flight_op_tracker.finish_op();
+      if (r < 0) {
+        handle_replay_complete(
+          &locker, r, "failed to unlink peer from mirror group snapshot");
+        return;
+      }
+      load_replayer(&locker);
+      return;
+    });
+    mirror_group_snapshot_unlink_peer(locker, remote_snap_id, on_unlink);
     return;
   }
 
@@ -1447,15 +1458,16 @@ void Replayer<I>::handle_set_mirror_snapshot_complete(
     }
   }
 
-  {
-    std::unique_lock locker{m_lock};
-    m_last_snapshot_bytes = last_snapshot_bytes;
-  }
+  std::unique_lock locker{m_lock};
+  m_last_snapshot_bytes = last_snapshot_bytes;
 
   if (!m_last_synced_remote_snap_id.empty()) {
-    mirror_group_snapshot_unlink_peer(m_last_synced_remote_snap_id);
+    mirror_group_snapshot_unlink_peer(
+      &locker, m_last_synced_remote_snap_id, on_finish);
+  } else {
+    locker.unlock();
+    on_finish->complete(0);
   }
-  on_finish->complete(0);
 }
 
 template <typename I>
@@ -1699,7 +1711,11 @@ void Replayer<I>::handle_post_user_snapshot_created(
 }
 
 template <typename I>
-void Replayer<I>::mirror_group_snapshot_unlink_peer(const std::string &snap_id) {
+void Replayer<I>::mirror_group_snapshot_unlink_peer(
+  std::unique_lock<ceph::mutex>* locker,
+  const std::string &snap_id, Context* on_unlink) {
+  dout(10) << dendl;
+
   auto remote_snap = std::find_if(
       m_remote_group_snaps.begin(), m_remote_group_snaps.end(),
       [snap_id](const cls::rbd::GroupSnapshot &s) {
@@ -1707,44 +1723,116 @@ void Replayer<I>::mirror_group_snapshot_unlink_peer(const std::string &snap_id) 
       });
 
   if (remote_snap == m_remote_group_snaps.end()) {
+    locker->unlock();
+    on_unlink->complete(0);
+    return;
+  }
+  ceph_assert(*remote_snap != m_remote_group_snaps.back());
+
+  if (remote_snap->snaps.empty()) {
+    unlink_peer_uuid_from_group_snap(&(*remote_snap), on_unlink);
     return;
   }
 
-  auto rns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-      &remote_snap->snapshot_namespace);
-  if (rns == nullptr) {
-    derr << "remote group snapshot is not a mirror snapshot: "
-         << snap_id << dendl;
-    return;
-  }
-
-  if (rns->mirror_peer_uuids.count(m_remote_mirror_peer_uuid) != 0) {
-    rns->mirror_peer_uuids.erase(m_remote_mirror_peer_uuid);
-    auto comp = create_rados_callback(
-      new LambdaContext([this, snap_id](int r) {
-	handle_mirror_group_snapshot_unlink_peer(r, snap_id);
-      }));
-
-    librados::ObjectWriteOperation op;
-    librbd::cls_client::group_snap_set(&op, *remote_snap);
-    int r = m_remote_io_ctx.aio_operate(
-      librbd::util::group_header_name(m_remote_group_id), comp, &op);
-    ceph_assert(r == 0);
-    comp->release();
-  }
+  unlink_peer_uuid_from_image_snaps(&(*remote_snap), on_unlink);
 }
 
 template <typename I>
-void Replayer<I>::handle_mirror_group_snapshot_unlink_peer(
-    int r, const std::string &snap_id) {
+void Replayer<I>::unlink_peer_uuid_from_image_snaps(
+    cls::rbd::GroupSnapshot* remote_snap, Context* on_unlink) {
+  auto snap_id = remote_snap->id;
+  dout(10) << snap_id << dendl;
+
+  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
+  std::vector<cls::rbd::ImageSnapshotSpec> image_snaps = remote_snap->snaps;
+  auto ctx = new LambdaContext([this, remote_snap, on_unlink](int r) {
+    handle_unlink_peer_uuid_from_image_snaps(r, remote_snap, on_unlink);
+  });
+
+  C_Gather *unlink_gather_ctx = new C_Gather(g_ceph_context, ctx);
+  for (const auto &spec : image_snaps) {
+    if (spec.snap_id == CEPH_NOSNAP) {
+      continue;
+    }
+    std::string image_header_oid = librbd::util::header_name(spec.image_id);
+    librados::ObjectWriteOperation op;
+    librbd::cls_client::mirror_image_snapshot_unlink_peer(
+      &op, spec.snap_id, m_remote_mirror_peer_uuid);
+    auto img_snapshot_unlink = new LambdaContext(
+      [this, spec, new_sub_ctx=unlink_gather_ctx->new_sub()](int r) {
+        if (r == -ENOENT) {
+          r = 0;
+        }
+        if (r < 0) {
+          derr << "failed to unlink mirror peer from image snapshot "
+               << spec.snap_id << " of image " << spec.image_id
+               << ": " << cpp_strerror(r) << dendl;
+        }
+        new_sub_ctx->complete(r);
+      });
+    auto aio_comp = create_rados_callback(img_snapshot_unlink);
+    int r = m_remote_io_ctx.aio_operate(image_header_oid, aio_comp, &op);
+    ceph_assert(r == 0);
+    aio_comp->release();
+  }
+
+  unlink_gather_ctx->activate();
+}
+
+template <typename I>
+void Replayer<I>::handle_unlink_peer_uuid_from_image_snaps(
+    int r, cls::rbd::GroupSnapshot* remote_snap, Context* on_unlink) {
+  std::unique_lock locker{m_lock};
+  auto snap_id = remote_snap->id;
   dout(10) << snap_id << ", r=" << r << dendl;
 
   if (r < 0) {
-    derr << "failed to remove mirror_peer_uuid for snap_id: "
-         << snap_id  << " : " << cpp_strerror(r) << dendl;
+    derr << "failed to remove mirror_peer_uuid for image snapshots"
+         << " of group snapshot snap_id: " << snap_id << dendl;
+    locker.unlock();
+    on_unlink->complete(r);
+    return;
   }
 
-  return;
+  unlink_peer_uuid_from_group_snap(remote_snap, on_unlink);
+}
+
+template <typename I>
+void Replayer<I>::unlink_peer_uuid_from_group_snap(
+  cls::rbd::GroupSnapshot* remote_snap, Context* on_unlink) {
+  auto snap_id = remote_snap->id;
+  dout(10) << "unlinking peer uuid for remote group snapshot: "
+           << snap_id << dendl;
+  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
+
+  auto &rns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
+      remote_snap->snapshot_namespace);
+  rns.mirror_peer_uuids.erase(m_remote_mirror_peer_uuid);
+
+  auto comp = create_rados_callback(
+    new LambdaContext([this, snap_id, on_unlink](int r) {
+      handle_unlink_peer_uuid_from_group_snap(r, snap_id, on_unlink);
+    }));
+
+  librados::ObjectWriteOperation op;
+  librbd::cls_client::group_snap_set(&op, *remote_snap);
+  int r = m_remote_io_ctx.aio_operate(
+    librbd::util::group_header_name(m_remote_group_id), comp, &op);
+  ceph_assert(r == 0);
+  comp->release();
+}
+
+template <typename I>
+void Replayer<I>::handle_unlink_peer_uuid_from_group_snap(
+    int r, const std::string &group_snap_id, Context* on_unlink) {
+  dout(10) << group_snap_id << ", r=" << r << dendl;
+
+  if (r < 0) {
+    derr << "failed to remove mirror_peer_uuid for snap_id: "
+         << group_snap_id  << " : " << cpp_strerror(r) << dendl;
+  }
+
+  on_unlink->complete(r);
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/group_replayer/Replayer.h
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.h
@@ -110,7 +110,7 @@ private:
   std::vector<cls::rbd::GroupSnapshot> m_remote_group_snaps;
   std::vector<std::pair<std::string, ImageReplayer<ImageCtxT> *>> m_replayers_by_image_id;
   const cls::rbd::GroupSnapshot* m_last_local_snap = nullptr;
-
+  const cls::rbd::GroupSnapshot* m_prune_group_snap = nullptr;
   bool m_update_group_state = true;
 
   Context* m_load_snapshots_task = nullptr;
@@ -131,6 +131,7 @@ private:
 
   bool m_check_creating_snaps = true; // check and identify creating snaps just after restart
   bool m_resync_requested = false;
+  bool m_refresh_snaps = false;
 
   bool is_replay_interrupted(std::unique_lock<ceph::mutex>* locker);
 
@@ -249,17 +250,20 @@ private:
       const std::vector<cls::rbd::GroupImageStatus>& local_images,
       std::unique_lock<ceph::mutex>* locker);
   bool prune_all_image_snapshots(
-      cls::rbd::GroupSnapshot *local_snap,
+      const cls::rbd::GroupSnapshot *local_snap,
       std::unique_lock<ceph::mutex>* locker);
-  void prune_user_group_snapshots(std::unique_lock<ceph::mutex>* locker);
-  void prune_mirror_group_snapshots(std::unique_lock<ceph::mutex>* locker);
-  void prune_group_snapshots(std::unique_lock<ceph::mutex>* locker);
+
   void prune_creating_group_snapshots(
-      std::unique_lock<ceph::mutex>* locker,
-      std::shared_ptr<std::vector<cls::rbd::GroupSnapshot>> prune_creating_group_snaps);
+      std::shared_ptr<std::vector<cls::rbd::GroupSnapshot>> prune_creating_snaps);
   void handle_prune_creating_group_snapshots(
       const std::vector<cls::rbd::GroupImageStatus>& local_images,
-      const std::vector<cls::rbd::GroupSnapshot>& prune_creating_group_snaps);
+      const std::vector<cls::rbd::GroupSnapshot>& prune_creating_snaps);
+
+  int prune_group_snapshots(std::unique_lock<ceph::mutex>* locker);
+  int prune_user_group_snapshots(std::unique_lock<ceph::mutex>* locker);
+  int prune_mirror_group_snapshot(std::unique_lock<ceph::mutex>* locker);
+  int prune_group_snapshot(const cls::rbd::GroupSnapshot* snap,
+                           std::unique_lock<ceph::mutex>* locker);
 
   void get_replayers_by_image_id(std::unique_lock<ceph::mutex>* locker);
   std::string get_global_image_id(ImageReplayer<ImageCtxT>* image_replayer,

--- a/src/tools/rbd_mirror/group_replayer/Replayer.h
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.h
@@ -109,6 +109,7 @@ private:
   std::vector<cls::rbd::GroupSnapshot> m_local_group_snaps;
   std::vector<cls::rbd::GroupSnapshot> m_remote_group_snaps;
   std::vector<std::pair<std::string, ImageReplayer<ImageCtxT> *>> m_replayers_by_image_id;
+  const cls::rbd::GroupSnapshot* m_last_local_snap = nullptr;
 
   bool m_update_group_state = true;
 
@@ -253,11 +254,12 @@ private:
   void prune_user_group_snapshots(std::unique_lock<ceph::mutex>* locker);
   void prune_mirror_group_snapshots(std::unique_lock<ceph::mutex>* locker);
   void prune_group_snapshots(std::unique_lock<ceph::mutex>* locker);
-  void prune_creating_group_snapshots_if_any(
-      std::unique_lock<ceph::mutex>* locker);
-  void handle_prune_creating_group_snapshots_if_any(
+  void prune_creating_group_snapshots(
+      std::unique_lock<ceph::mutex>* locker,
+      std::shared_ptr<std::vector<cls::rbd::GroupSnapshot>> prune_creating_group_snaps);
+  void handle_prune_creating_group_snapshots(
       const std::vector<cls::rbd::GroupImageStatus>& local_images,
-      const std::vector<cls::rbd::GroupSnapshot>& prune_group_snaps);
+      const std::vector<cls::rbd::GroupSnapshot>& prune_creating_group_snaps);
 
   void get_replayers_by_image_id(std::unique_lock<ceph::mutex>* locker);
   std::string get_global_image_id(ImageReplayer<ImageCtxT>* image_replayer,

--- a/src/tools/rbd_mirror/group_replayer/Replayer.h
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.h
@@ -153,15 +153,16 @@ private:
   void validate_image_snaps_sync_complete(
     const cls::rbd::GroupSnapshot &local_snap, Context *on_finish);
 
-  void is_resync_requested();
+  void load_replayer(std::unique_lock<ceph::mutex>* locker);
+  void is_resync_requested(std::unique_lock<ceph::mutex>* locker);
   void handle_is_resync_requested(int r);
   void is_rename_requested();
   void handle_is_rename_requested(int r);
-  void validate_local_group_snapshots();
+  void validate_local_group_snapshots(std::unique_lock<ceph::mutex>* locker);
   void load_local_group_snapshots(std::unique_lock<ceph::mutex>* locker);
   void handle_load_local_group_snapshots(int r);
 
-  void load_remote_group_snapshots();
+  void load_remote_group_snapshots(std::unique_lock<ceph::mutex>* locker);
   void handle_load_remote_group_snapshots(int r);
   void check_local_group_snapshots(std::unique_lock<ceph::mutex>* locker);
 

--- a/src/tools/rbd_mirror/group_replayer/Replayer.h
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.h
@@ -160,27 +160,20 @@ private:
  *                   v                                                                     |                               v       |
  *    SCAN_FOR_UNSYNCED_GROUP_SNAPSHOTS                                                    |                HANDLE_REPLAY_COMPLETE |
  *                   |                                                                     |                                       |
- *                   v                                                                     |                                       |
- *        TRY_CREATE_GROUP_SNAPSHOT                                                        |                                       |
  *                   |    if all snaps synced                                              |                                       |
  *                   + --------> m_state = STATE_IDLE                                      |                                       |
  *                   |                                                                     |                                       |
  *                   v                                                                     |                                       |
- *       CREATE_GROUP_SNAPSHOT                                                             |                                       |
+ *        CREATE_USER_SNAPSHOT (if required)                                               |                                       |
  *                   |                                                                     |                                       |
  *                   v                                                                     |                                       |
- *             + --- + --------------- +                                                   |                                       |
- *             |                       |                                                   |                                       |
- *             v                       v                                                   |                                       |
- *    CREATE_MIRROR_SNAPSHOT     CREATE_USER_SNAPSHOT                                      |                                       |
- *             | m_retry_validate_snap | m_retry_validate_snap                             |                                       |
- *             v               = true  |               = true                              |                                       |
- *    UPDATE_LOCAL_GROUP_STATE         |                                                   |                                       |
- *             |                       |                                                   |                                       |
- *             v                       v                                                   |                                       |
- *             + --------- + --------- +                                                   |                                       |
- *                         |                                                               v                                       |
- *                         + ------------------------> + <-------------------------------- +                                     ^ |
+ *        CREATE_MIRROR_SNAPSHOT                                                           |                                       |
+ *                   | m_retry_validate_snap = true                                        |                                       |
+ *                   v                                                                     |                                       |
+ *          UPDATE_LOCAL_GROUP_STATE                                                       |                                       |
+ *                   |                                                                     |                                       |
+ *                   v                                                                     v                                       |
+ *                    +------------------------------> + <-------------------------------- +                                     ^ |
  *                                                     |                                                                         | |
  *                                                     v                             m_retry_validate_snap == false            --+ |
  *                                         SCHEDULE_LOAD_GROUP_SNAPSHOTS --------------------------------------------------------> +
@@ -213,15 +206,18 @@ private:
  *                                 |      CHECK_MIRROR_SNAPSHOT_SYNC_COMPLETE          |                                           |
  *                                 |                         |                         |                                           |
  *                                 |                         v                         |                                           |
- *                                 |            + ---------- + ---------- +            |                                           |
- *                                 |  images    |                         | all image  |                                           |
- *                                 |  syncing   |                         | snapshots  |                                           |
- *                                 |  ( retry   |                         |  sycned    |                                           |
- *                                 |   next     |                         v            |                                           |
- *                                 |   cycle)   |         SET_MIRROR_SNAPSHOT_COMPLETE |                                           |
- *                                 |            |                         |            |                                           |
- *                                 v            v                         v            v                                           |
- *                                 + ---------- + ---------- + ---------- + ---------- +                                         ^ |
+ *                                 |               + ------- + ------- +               |                                           |
+ *                                 |        images |                   | all image     |                                           |
+ *                                 |       syncing |                   | snapshots     |                                           |
+ *                                 |  (retry next  |                   |  sycned       |                                           |
+ *                                 |     cycle)    |                   v               |                                           |
+ *                                 |               |    SET_MIRROR_SNAPSHOT_COMPLETE   |                                           |
+ *                                 |               |                   |               |                                           |
+ *                                 |               |                   v               |                                           |
+ *                                 |               | MIRROR_GROUP_SNAPSHOT_UNLINK_PEER |                                           |
+ *                                 |               |                   |               |                                           |
+ *                                 v               v                   v               v                                           |
+ *                                 + ------------- + ----------------- + ------------- +                                         ^ |
  *                                                           |                                                                   | |
  *                                                           v c_gather waits for all callbacks                                --+ |
  *                                                           + ------------------------------------------------------------------> +
@@ -259,9 +255,6 @@ private:
  *                 |
  *                 v
  *     PRUNE_MIRROR_GROUP_SNAPSHOT
- *                 |
- *                 v
- *    MIRROR_GROUP_SNAPSHOT_UNLINK_PEER
  *                 |
  *                 v
  *        PRUNE_GROUP_SNAPSHOT
@@ -346,6 +339,8 @@ private:
   std::string m_error_description;
 
   bool m_retry_validate_snap = false;
+  std::string m_remote_snap_id_start = "";
+  bool m_peer_unlink = false;
 
   utime_t m_snapshot_start;
   uint64_t m_last_snapshot_complete_seconds = 0;
@@ -393,20 +388,15 @@ private:
 
   void scan_for_unsynced_group_snapshots(std::unique_lock<ceph::mutex>* locker);
 
-  void try_create_group_snapshot(std::string prev_snap_id,
-                                 std::unique_lock<ceph::mutex>* locker);
-  void create_group_snapshot(cls::rbd::GroupSnapshot snap,
-                             std::unique_lock<ceph::mutex>* locker);
-
   void create_mirror_snapshot(
-    cls::rbd::GroupSnapshot *snap,
-    const cls::rbd::MirrorSnapshotState &snap_state,
-    Context *on_finish);
+    cls::rbd::GroupSnapshot *snap, Context *on_finish);
   void handle_create_mirror_snapshot(
-    int r, const std::string &group_snap_id, Context *on_finish);
+    int r, cls::rbd::GroupSnapshot *snap, Context *on_finish);
 
-  void update_local_group_state(cls::rbd::GroupSnapshot snap);
-  void handle_update_local_group_state(int r, cls::rbd::GroupSnapshot snap);
+  void update_local_group_state(cls::rbd::GroupSnapshot snap,
+                                Context *on_finish);
+  void handle_update_local_group_state(int r, cls::rbd::GroupSnapshot snap,
+                                       Context *on_finish);
 
   void mirror_snapshot_complete(
     const std::string &group_snap_id, Context *on_finish);

--- a/src/tools/rbd_mirror/group_replayer/Replayer.h
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.h
@@ -82,6 +82,229 @@ public:
 
 
 private:
+/**
+ * GROUP REPLAYER:
+ * ==============
+ *
+ * At a high level, the Replayer keeps the local mirror group on the secondary
+ * cluster synchronized with the remote primary group. It loads local and
+ * remote group snapshots, validates snapshot synchronization, creates new
+ * group snapshots, waits for image replay and marks group snaps to complete,
+ * updates group state, and prunes snapshots that are no longer needed.
+ *
+ * STATES:
+ * ======
+ *
+ * STATE_INIT: Initial state after construction. No work has been started.
+ * STATE_REPLAYING: Actively loading snapshots, creating new snapshots and wait
+ *             for replays to complete. And prune snapshots no longer needed.
+ * STATE_IDLE: Up to date with the snapshots sync. No work pending. Waiting for
+ *             the scheduler to trigger the next scan.
+ * STATE_COMPLETE: Shutdown has completed. No further work will be scheduled.
+ *
+ *
+ * STATE MACHINE:
+ * =============
+ *
+ * @verbatim
+ *                                             CONSTRUCTOR
+ *                                                 | m_state = STATE_INIT
+ *                                                 v
+ *                                               INIT
+ *                                                 | m_state = STATE_REPLAYING
+ *                                                 v
+ *                                           LOAD_REPLAYER <---------------------------------------------------------------------- +
+ *                                                 |                                                                               ^
+ *                                                 v                                                                               |
+ *                                         IS_RESYNC_REQUESTED                                                                     |
+ *                                                 |  m_resync_requested ?                                                         |
+ *                                   true          v         false                                                                 |
+ *                         + <-------------------- + ------------------------> +                                                   |
+ *                         |                                                   |                                                   |
+ *                         v                                                   v                                                   |
+ *                         + <--------------------------------- +     + -----> +                                                   |
+ *                         |                                    ^     |        |                                                   |
+ *                         v                                    |     |        v                                                   |
+ *             LOAD_REMOTE_GROUP_SNAPSHOTS                      |     | LOAD_LOCAL_GROUP_SNAPSHOTS                                 |
+ *                         |                                    |     |        |                                                   |
+ *                         | m_resync_requested ?               |     |        v role: primary? true                               |
+ *              false      v       true                         |     |        + ----------------------------------------> +     ^ |
+ *           + ----------- + ---------------- +                 |     |  false |     daemon restart one-time check:        |     | |
+ *           |                                |  remote         |     |        v               snaps in creating phase    ╭─╮  --+ |
+ *           + <------------------ +          v  primary? false╭─╮    |        + -----> PRUNE_CREATING_GROUP_SNAPSHOTS ->-╯|╰----> +
+ *           |                     ^          + ------------->-╯|╰--> +        |                                           |       |
+ *           v                     |          | true            |              v  is last group snap orphan ? true         v       |
+ *  CHECK_LOCAL_GROUP_SNAPSHOTS    |          |                 |              + ----------------------------------------> +       |
+ *           |                     |          |                 |        false |  if incomplete mirror snapshot is found,  |       |
+ *  no snaps v                     |          |                 |              |   set m_retry_validate_snap = true        |       |
+ *    + <--- + ----> +             |          |                 + <----------- +                                           |       |
+ *    |              |             |         ╭─╮                      false    | m_resync_requested?                       |       |
+ *    |              |             + <-------╯|╰-<---------------------------- +                                           |       |
+ *    |              |                        |                       true                                                 |       |
+ *    |              |                        |                                                                            |       |
+ *    |              v  demoted/split-brain   v                                                                            v       |
+ *    |              + ---------------------> + -------------------------------------------------------------------------> +       |
+ *    |              |                                                                                                     |       |
+ *    |              v   m_retry_validate_snap == true                                                                     |       |
+ *    |              + ------------------------------------------------------------------> +                               |       |
+ *    |              |                                                                     |                               |       |
+ *    |              v                 r == -EAGAIN? m_refresh_snaps = false               v                               |       |
+ *    |      PRUNE_GROUP_SNAPSHOTS ------------------------------------------------------> +                               |     ^ |
+ *    |              |                                                                     |                               |     | |
+ *    |              v   m_refresh_snaps == true? m_refresh_snaps = false                 ╭─╮                             ╭─╮  --+ |
+ *    |              + ----------------------------------------------------------------->-╯|╰->------------------------->-╯|╰----> +
+ *    |              |                                                                     v                               |       |
+ *    v              v                 true                                               ╭─╮                              v       |
+ *    + -----> IS_RENAME_REQUESTED ----------------------------------------------------->-╯|╰->--------------------------> +       |
+ *                   |                                                                     |                               |       |
+ *                   v                                                                     |                               v       |
+ *    SCAN_FOR_UNSYNCED_GROUP_SNAPSHOTS                                                    |                HANDLE_REPLAY_COMPLETE |
+ *                   |                                                                     |                                       |
+ *                   v                                                                     |                                       |
+ *        TRY_CREATE_GROUP_SNAPSHOT                                                        |                                       |
+ *                   |    if all snaps synced                                              |                                       |
+ *                   + --------> m_state = STATE_IDLE                                      |                                       |
+ *                   |                                                                     |                                       |
+ *                   v                                                                     |                                       |
+ *       CREATE_GROUP_SNAPSHOT                                                             |                                       |
+ *                   |                                                                     |                                       |
+ *                   v                                                                     |                                       |
+ *             + --- + --------------- +                                                   |                                       |
+ *             |                       |                                                   |                                       |
+ *             v                       v                                                   |                                       |
+ *    CREATE_MIRROR_SNAPSHOT     CREATE_USER_SNAPSHOT                                      |                                       |
+ *             | m_retry_validate_snap | m_retry_validate_snap                             |                                       |
+ *             v               = true  |               = true                              |                                       |
+ *    UPDATE_LOCAL_GROUP_STATE         |                                                   |                                       |
+ *             |                       |                                                   |                                       |
+ *             v                       v                                                   |                                       |
+ *             + --------- + --------- +                                                   |                                       |
+ *                         |                                                               v                                       |
+ *                         + ------------------------> + <-------------------------------- +                                     ^ |
+ *                                                     |                                                                         | |
+ *                                                     v                             m_retry_validate_snap == false            --+ |
+ *                                         SCHEDULE_LOAD_GROUP_SNAPSHOTS --------------------------------------------------------> +
+ *                                                     |  m_retry_validate_snap == true : m_retry_validate_snap = false            ^
+ *                                                     v  m_state = STATE_REPLAYING                                                |
+ *                                       VALIDATE_LOCAL_GROUP_SNAPSHOTS                                                            |
+ *                                                     |                                                                           |
+ *                                                     v iterate m_local_group_snaps                                               |
+ *                                 + ----------------- + ---------------- +                                                        |
+ *                snapshot already |                                      | snapshot requires                                      |
+ *                   complete      |                                      v     validation                                         |
+ *                                 |                       VALIDATE_IMAGE_SNAPS_SYNC_COMPLETE                                      |
+ *                                 |                                      |                                                        |
+ *                                 |                                      v                                                        |
+ *                                 |                         + ---------- +----------- +                                           |
+ *                                 |     is mirror snapshot  |                         | is user snapshot                          |
+ *                                 |                         v                         v                                           |
+ *                                 |             MIRROR_SNAPSHOT_COMPLETE      USER_SNAPSHOT_COMPLETE                              |
+ *                                 |                         |                         |                                           |
+ *                                 |                         v                         v                                           |
+ *                                 |         LOCAL_GROUP_IMAGE_LIST_BY_ID      LOCAL_GROUP_IMAGE_LIST_BY_ID                        |
+ *                                 |                         |                         |                                           |
+ *                                 |                         v                         v                                           |
+ *                                 |    HANDLE_MIRROR_SNAPSHOT_IMAGE_LIST      HANDLE_USER_SNAPSHOT_IMAGE_LIST                     |
+ *                                 |                         |                         |                                           |
+ *                                 |                         v                         v                                           |
+ *                                 |         POST_MIRROR_SNAPSHOT_CREATED      POST_USER_SNAPSHOT_CREATED                          |
+ *                                 |                         |                         |                                           |
+ *                                 |                         v                         |                                           |
+ *                                 |      CHECK_MIRROR_SNAPSHOT_SYNC_COMPLETE          |                                           |
+ *                                 |                         |                         |                                           |
+ *                                 |                         v                         |                                           |
+ *                                 |            + ---------- + ---------- +            |                                           |
+ *                                 |  images    |                         | all image  |                                           |
+ *                                 |  syncing   |                         | snapshots  |                                           |
+ *                                 |  ( retry   |                         |  sycned    |                                           |
+ *                                 |   next     |                         v            |                                           |
+ *                                 |   cycle)   |         SET_MIRROR_SNAPSHOT_COMPLETE |                                           |
+ *                                 |            |                         |            |                                           |
+ *                                 v            v                         v            v                                           |
+ *                                 + ---------- + ---------- + ---------- + ---------- +                                         ^ |
+ *                                                           |                                                                   | |
+ *                                                           v c_gather waits for all callbacks                                --+ |
+ *                                                           + ------------------------------------------------------------------> +
+ *
+ *
+ *
+ * PRUNE_CREATING_GROUP_SNAPSHOTS PATH
+ * ===================================
+ *
+ *      PRUNE_CREATING_GROUP_SNAPSHOTS
+ *                 |
+ *                 v                      error
+ *      LOCAL_GROUP_IMAGE_LIST_BY_ID --------------> +
+ *                 |                                 |
+ *                 v                                 |
+ *      PRUNE_ALL_IMAGE_SNAPSHOTS_BY_GSID            |
+ *                 |                                 |
+ *                 v                                 v
+ *        PRUNE_IMAGE_SNAPSHOT                 LOAD_REPLAYER
+ *                 |                                 ^
+ *                 v                                 |
+ *         GROUP_SNAP_REMOVE                         |
+ *                 | if all_pruned == true,          |
+ *                 v m_check_creating_snaps = false  |
+ *                 + ------------------------------> +
+ *
+ *
+ *  PRUNE_GROUP_SNAPSHOTS PATH
+ *  ==========================
+ *
+ *        PRUNE_GROUP_SNAPSHOTS
+ *                 |
+ *                 v
+ *      PRUNE_USER_GROUP_SNAPSHOTS
+ *                 |
+ *                 v
+ *     PRUNE_MIRROR_GROUP_SNAPSHOT
+ *                 |
+ *                 v
+ *    MIRROR_GROUP_SNAPSHOT_UNLINK_PEER
+ *                 |
+ *                 v
+ *        PRUNE_GROUP_SNAPSHOT
+ *                 |
+ *                 v
+ *      PRUNE_ALL_IMAGE_SNAPSHOTS
+ *                 |
+ *                 v             -EAGAIN
+ *        PRUNE_IMAGE_SNAPSHOT -------------> SCHEDULE_LOAD_GROUP_SNAPSHOTS
+ *                 |
+ *                 v              error
+ *        GROUP_SNAP_REMOVE ----------------> IS_RENAME_REQUESTED
+ *                 |
+ *                 v  m_refresh_snaps = true
+ *          LOAD_REPLAYER
+ *
+ *
+ *  SHUTDOWN PATH
+ *  =============
+ *
+ *   SHUT_DOWN
+ *      |
+ *      + -> CANCEL_LOAD_GROUP_SNAPSHOTS
+ *      |
+ *      + -> WAIT_FOR_IN_FLIGHT_OPS
+ *                |
+ *                v
+ *           STATE_COMPLETE
+ *
+ * @endverbatim
+ *
+ * HELPER OPERATIONS (NOT REPRESENTED ABOVE)
+ * =================
+ * GET_REPLAYERS_BY_IMAGE_ID
+ * GET_GLOBAL_IMAGE_ID
+ * SET_IMAGE_REPLAYER_LIMITS
+ * SET_IMAGE_REPLAYER_END_LIMITS
+ * NOTIFY_GROUP_LISTENER
+ * IS_REPLAY_INTERRUPTED
+ * GET_REPLAY_STATUS
+ *
+ */
+
   enum State {
     STATE_INIT,
     STATE_REPLAYING,

--- a/src/tools/rbd_mirror/group_replayer/Replayer.h
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.h
@@ -451,9 +451,10 @@ private:
   void handle_post_user_snapshot_created(
     int r, const std::string &group_snap_id, Context *on_finish);
 
-  void mirror_group_snapshot_unlink_peer(const std::string &snap_id);
+  void mirror_group_snapshot_unlink_peer(const std::string &snap_id,
+                                         Context *on_unlink);
   void handle_mirror_group_snapshot_unlink_peer(
-      int r, const std::string &snap_id);
+      int r, cls::rbd::GroupSnapshot *remote_snap, Context *on_unlink);
 
   void prune_image_snapshot(ImageReplayer<ImageCtxT>* image_replayer,
       uint64_t snap_id,

--- a/src/tools/rbd_mirror/group_replayer/Replayer.h
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.h
@@ -160,27 +160,29 @@ private:
  *                   v                                                                     |                               v       |
  *    SCAN_FOR_UNSYNCED_GROUP_SNAPSHOTS                                                    |                HANDLE_REPLAY_COMPLETE |
  *                   |                                                                     |                                       |
- *                   v                                                                     |                                       |
- *        TRY_CREATE_GROUP_SNAPSHOT                                                        |                                       |
+ *                   | !unlink_peer_uuids.empty()?                                        ╭─╮                                      |
+ *                   + ------------------------>  MIRROR_GROUP_SNAPSHOT_UNLINK_PEER ---->-╯|╰->----------------------------------> +
+ *                   |                                                                     |                                       |
  *                   |    if all snaps synced                                              |                                       |
  *                   + --------> m_state = STATE_IDLE                                      |                                       |
  *                   |                                                                     |                                       |
  *                   v                                                                     |                                       |
- *       CREATE_GROUP_SNAPSHOT                                                             |                                       |
+ *         CREATE_USER_GROUP_SNAPSHOTS                                                     |                                       |
  *                   |                                                                     |                                       |
  *                   v                                                                     |                                       |
- *             + --- + --------------- +                                                   |                                       |
- *             |                       |                                                   |                                       |
- *             v                       v                                                   |                                       |
- *    CREATE_MIRROR_SNAPSHOT     CREATE_USER_SNAPSHOT                                      |                                       |
- *             | m_retry_validate_snap | m_retry_validate_snap                             |                                       |
- *             v               = true  |               = true                              |                                       |
- *    UPDATE_LOCAL_GROUP_STATE         |                                                   |                                       |
- *             |                       |                                                   |                                       |
- *             v                       v                                                   |                                       |
- *             + --------- + --------- +                                                   |                                       |
- *                         |                                                               v                                       |
- *                         + ------------------------> + <-------------------------------- +                                     ^ |
+ *         CREATE_USER_GROUP_SNAPSHOT                                                      |                                       |
+ *                   |                                                                     |                                       |
+ *                   v                                                                     |                                       |
+ *        CREATE_MIRROR_GROUP_SNAPSHOT                                                     |                                       |
+ *                   | m_retry_validate_snap = true                                        |                                       |
+ *                   v                                                                     |                                       |
+ *          UPDATE_LOCAL_GROUP_STATE (skip if group state already enabled)                 |                                       |
+ *                   |                                                                     |                                       |
+ *                   v                                                                     |                                       |
+ *         SET_IMAGE_REPLAYER_LIMITS                                                       |                                       |
+ *                   |                                                                     |                                       |
+ *                   v                                                                     v                                       |
+ *                    +------------------------------> + <-------------------------------- +                                     ^ |
  *                                                     |                                                                         | |
  *                                                     v                             m_retry_validate_snap == false            --+ |
  *                                         SCHEDULE_LOAD_GROUP_SNAPSHOTS --------------------------------------------------------> +
@@ -213,15 +215,18 @@ private:
  *                                 |      CHECK_MIRROR_SNAPSHOT_SYNC_COMPLETE          |                                           |
  *                                 |                         |                         |                                           |
  *                                 |                         v                         |                                           |
- *                                 |            + ---------- + ---------- +            |                                           |
- *                                 |  images    |                         | all image  |                                           |
- *                                 |  syncing   |                         | snapshots  |                                           |
- *                                 |  ( retry   |                         |  sycned    |                                           |
- *                                 |   next     |                         v            |                                           |
- *                                 |   cycle)   |         SET_MIRROR_SNAPSHOT_COMPLETE |                                           |
- *                                 |            |                         |            |                                           |
- *                                 v            v                         v            v                                           |
- *                                 + ---------- + ---------- + ---------- + ---------- +                                         ^ |
+ *                                 |               + ------- + ------- +               |                                           |
+ *                                 |        images |                   | all image     |                                           |
+ *                                 |       syncing |                   | snapshots     |                                           |
+ *                                 |  (retry next  |                   |  synced       |                                           |
+ *                                 |     cycle)    |                   v               |                                           |
+ *                                 |               |    SET_MIRROR_SNAPSHOT_COMPLETE   |                                           |
+ *                                 |               |                   |               |                                           |
+ *                                 |               |                   v               |                                           |
+ *                                 |               | MIRROR_GROUP_SNAPSHOT_UNLINK_PEER |                                           |
+ *                                 |               |                   |               |                                           |
+ *                                 v               v                   v               v                                           |
+ *                                 + ------------- + ----------------- + ------------- +                                         ^ |
  *                                                           |                                                                   | |
  *                                                           v c_gather waits for all callbacks                                --+ |
  *                                                           + ------------------------------------------------------------------> +
@@ -261,9 +266,6 @@ private:
  *     PRUNE_MIRROR_GROUP_SNAPSHOT
  *                 |
  *                 v
- *    MIRROR_GROUP_SNAPSHOT_UNLINK_PEER
- *                 |
- *                 v
  *        PRUNE_GROUP_SNAPSHOT
  *                 |
  *                 v
@@ -297,7 +299,6 @@ private:
  * =================
  * GET_REPLAYERS_BY_IMAGE_ID
  * GET_GLOBAL_IMAGE_ID
- * SET_IMAGE_REPLAYER_LIMITS
  * SET_IMAGE_REPLAYER_END_LIMITS
  * NOTIFY_GROUP_LISTENER
  * IS_REPLAY_INTERRUPTED
@@ -346,6 +347,7 @@ private:
   std::string m_error_description;
 
   bool m_retry_validate_snap = false;
+  std::string m_last_synced_remote_snap_id;
 
   utime_t m_snapshot_start;
   uint64_t m_last_snapshot_complete_seconds = 0;
@@ -392,21 +394,19 @@ private:
   void check_local_group_snapshots(std::unique_lock<ceph::mutex>* locker);
 
   void scan_for_unsynced_group_snapshots(std::unique_lock<ceph::mutex>* locker);
+  void create_user_group_snapshots(std::unique_lock<ceph::mutex>* locker,
+    cls::rbd::GroupSnapshot* mirror_snap,
+    std::vector<cls::rbd::GroupSnapshot>& user_snapshots);
+  void handle_create_user_group_snapshots(
+    int r, cls::rbd::GroupSnapshot* mirror_snap);
+  void create_mirror_group_snapshot(std::unique_lock<ceph::mutex>* locker,
+                                    cls::rbd::GroupSnapshot *snap);
+  void handle_create_mirror_group_snapshot(
+    int r, cls::rbd::GroupSnapshot *snap);
 
-  void try_create_group_snapshot(std::string prev_snap_id,
-                                 std::unique_lock<ceph::mutex>* locker);
-  void create_group_snapshot(cls::rbd::GroupSnapshot snap,
-                             std::unique_lock<ceph::mutex>* locker);
-
-  void create_mirror_snapshot(
-    cls::rbd::GroupSnapshot *snap,
-    const cls::rbd::MirrorSnapshotState &snap_state,
-    Context *on_finish);
-  void handle_create_mirror_snapshot(
-    int r, const std::string &group_snap_id, Context *on_finish);
-
-  void update_local_group_state(cls::rbd::GroupSnapshot snap);
-  void handle_update_local_group_state(int r, cls::rbd::GroupSnapshot snap);
+  void update_local_group_state(std::unique_lock<ceph::mutex>* locker,
+                                cls::rbd::GroupSnapshot* snap);
+  void handle_update_local_group_state(int r, cls::rbd::GroupSnapshot* snap);
 
   void mirror_snapshot_complete(
     const std::string &group_snap_id, Context *on_finish);
@@ -437,10 +437,9 @@ private:
   void handle_set_mirror_snapshot_complete(
     int r, const std::string &group_snap_id, Context *on_finish);
 
-  void create_user_snapshot(
-    cls::rbd::GroupSnapshot *snap,
-    Context *on_finish);
-  void handle_create_user_snapshot(
+  void create_user_group_snapshot(
+    cls::rbd::GroupSnapshot *snap, Context *on_finish);
+  void handle_create_user_group_snapshot(
       int r, const std::string &group_snap_id, Context *on_finish);
 
   void user_snapshot_complete(

--- a/src/tools/rbd_mirror/group_replayer/Replayer.h
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.h
@@ -226,6 +226,12 @@ private:
  *                                 |               | MIRROR_GROUP_SNAPSHOT_UNLINK_PEER |                                           |
  *                                 |               |                   |               |                                           |
  *                                 v               v                   v               v                                           |
+ *                                 |               | UNLINK_PEER_UUID_FROM_IMAGE_SNAPS |                                           |
+ *                                 |               |                   |               |                                           |
+ *                                 |               |                   v               |                                           |
+ *                                 |               | UNLINK_PEER_UUID_FROM_GROUP_SNAP  |                                           |
+ *                                 |               |                   |               |                                           |
+ *                                 v               v                   v               v                                           |
  *                                 + ------------- + ----------------- + ------------- +                                         ^ |
  *                                                           |                                                                   | |
  *                                                           v c_gather waits for all callbacks                                --+ |
@@ -460,9 +466,16 @@ private:
   void handle_post_user_snapshot_created(
     int r, const std::string &group_snap_id, Context *on_finish);
 
-  void mirror_group_snapshot_unlink_peer(const std::string &snap_id);
-  void handle_mirror_group_snapshot_unlink_peer(
-      int r, const std::string &snap_id);
+  void mirror_group_snapshot_unlink_peer(std::unique_lock<ceph::mutex>* locker,
+    const std::string &snap_id, Context *on_unlink);
+  void unlink_peer_uuid_from_image_snaps(
+    cls::rbd::GroupSnapshot* remote_snap, Context* on_unlink);
+  void handle_unlink_peer_uuid_from_image_snaps(
+    int r, cls::rbd::GroupSnapshot* remote_snap, Context* on_unlink);
+  void unlink_peer_uuid_from_group_snap(
+    cls::rbd::GroupSnapshot* remote_snap, Context* on_unlink);
+  void handle_unlink_peer_uuid_from_group_snap(
+    int r, const std::string &group_snap_id, Context* on_unlink);
 
   void prune_image_snapshot(ImageReplayer<ImageCtxT>* image_replayer,
       uint64_t snap_id,


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
