### PR TITLE
umbrella: qa: fixing failures in TestShellOpts

### DIFF
--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -1109,6 +1109,17 @@ class TestShellOpts(TestCephFSShell):
     Contains tests for shell options from conf file and shell prompt.
     """
 
+    def extract_set_editor_output(self, out):
+        res = None
+        for line in out.splitlines():
+            line_parts = line.split()
+            if len(line_parts) > 4 and line_parts[0] == "editor":
+                res = line_parts
+                break
+
+        self.assertIsNotNone(res, f"didn't find editor output in: {out}")
+        return res[1]
+
     def setUp(self):
         super(type(self), self).setUp()
 
@@ -1119,9 +1130,8 @@ class TestShellOpts(TestCephFSShell):
         # ====================================================================================================
         # editor  ?                               Program used by 'edit'
         self.editor_val = self.get_cephfs_shell_cmd_output(
-            'set editor ?, set editor').split('\n')[4]
-        self.editor_val = self.editor_val.split()[1].strip(). \
-            replace("'", "", 2)
+            'set editor ?, set editor')
+        self.editor_val = self.extract_set_editor_output(self.editor_val)
 
     def write_tempconf(self, confcontents):
         self.tempconfpath = self.mount_a.client_remote.mktemp(
@@ -1139,9 +1149,7 @@ class TestShellOpts(TestCephFSShell):
         # editor  ???                             Program used by 'edit'
         final_editor_val = self.get_cephfs_shell_cmd_output(
             cmd='set editor', shell_conf_path=self.tempconfpath)
-        final_editor_val = final_editor_val.split('\n')[2]
-        final_editor_val = final_editor_val.split()[1].strip(). \
-            replace("'", "", 2)
+        final_editor_val = self.extract_set_editor_output(final_editor_val)
 
         self.assertNotEqual(self.editor_val, final_editor_val)
 
@@ -1159,9 +1167,7 @@ class TestShellOpts(TestCephFSShell):
         # editor  ?                               Program used by 'edit'
         final_editor_val = self.get_cephfs_shell_cmd_output(
             cmd='set editor', shell_conf_path=self.tempconfpath)
-        final_editor_val = final_editor_val.split('\n')[2]
-        final_editor_val = final_editor_val.split()[1].strip(). \
-            replace("'", "", 2)
+        final_editor_val = self.extract_set_editor_output(final_editor_val)
 
         self.assertEqual(self.editor_val, final_editor_val)
 
@@ -1177,8 +1183,6 @@ class TestShellOpts(TestCephFSShell):
         final_editor_val = self.get_cephfs_shell_cmd_output(
             cmd='set editor %s, set editor' % self.editor_val,
             shell_conf_path=self.tempconfpath)
-        final_editor_val = final_editor_val.split('\n')[4]
-        final_editor_val = final_editor_val.split()[1].strip(). \
-            replace("'", "", 2)
+        final_editor_val = self.extract_set_editor_output(final_editor_val)
 
         self.assertEqual(self.editor_val, final_editor_val)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78197

---

backport of https://github.com/ceph/ceph/pull/69031
parent tracker: https://tracker.ceph.com/issues/71795

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh