### PR TITLE
cmake: fix sccache job limits when dist is unavailable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,13 +117,13 @@ if(WITH_SCCACHE)
         ERROR_VARIABLE sccache_dist_status_error
         GET "${sccache_dist_status}" SchedulerStatus 1 num_cpus
       )
-      string(FIND "${sccache_dist_status}" "disabled" find_result)
-      if(find_result EQUAL -1)
+      if(sccache_dist_status_error)
+        message(WARNING "Using sccache, but it is not configured for distributed "
+          "compilation: ${sccache_dist_status_error}")
+      else()
         message(STATUS "Using sccache with distributed compilation. Effective cores: ${sccache_cores}")
         set(NINJA_MAX_COMPILE_JOBS ${sccache_cores})
         set(NINJA_MAX_LINK_JOBS ${sccache_cores})
-      else()
-        message(WARNING "Using sccache, but it is not configured for distributed complilation")
       endif()
     else()
       message(WARNING "Using sccache, but cannot determine maximum job value since cmake version is <3.19")


### PR DESCRIPTION
The `disabled` search only matches sccache's `Disabled("disabled")` payload,
not `dist-client feature not selected` or `NotConnected`. Those reach the
success branch, so `JOB_POOLS` is left undefined while targets still
reference `heavy_compile_job_pool`, and ninja rejects the manifest.

Key off the JSON lookup's error instead to cover every non-dist state.

Hit in CI: https://github.com/sunyuechi/ceph-ci/actions/runs/29326690098

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests