### PR TITLE
crimson/osd: extend mClock throttle to all op types

### DIFF
--- a/src/common/mclock_common.cc
+++ b/src/common/mclock_common.cc
@@ -143,6 +143,13 @@ const dmc::ClientInfo *ClientRegistry::get_info(
     return (dmc::ClientInfo*)nullptr;
   case SchedulerClass::client:
     return get_external_client(id.client_profile_id);
+#ifdef WITH_CRIMSON
+  case SchedulerClass::repop:
+    // repop uses background_recovery profile for now
+    // TODO: add dedicated repop profile with own R/W/L
+    return &internal_client_infos[
+      static_cast<size_t>(SchedulerClass::background_recovery)];
+#endif
   default:
     ceph_assert(static_cast<size_t>(id.class_id) < internal_client_infos.size());
     return &internal_client_infos[static_cast<size_t>(id.class_id)];

--- a/src/crimson/osd/osd_operations/ecrep_request.cc
+++ b/src/crimson/osd/osd_operations/ecrep_request.cc
@@ -5,11 +5,11 @@
 
 #include "common/Formatter.h"
 
-#include "crimson/osd/ec_backend.h"
 #include "crimson/osd/osd.h"
 #include "crimson/osd/osd_connection_priv.h"
 #include "crimson/osd/osd_operation_external_tracking.h"
 #include "crimson/osd/pg.h"
+#include "osd/PeeringState.h"
 
 namespace {
   seastar::logger& logger() {
@@ -57,6 +57,72 @@ struct overloaded : Ts... { using Ts::operator()...; };
 template<class... Ts>
 overloaded(Ts...) -> overloaded<Ts...>;
 
+ECRepRequest::interruptible_future<>
+ECRepRequest::with_pg_interruptible(
+  ShardServices &shard_services, Ref<PG> pg,
+  ECBackend *ec_backend)
+{
+  // only throttle write/read ops -- replies must never be throttled
+  // to avoid deadlock with the ops waiting for those replies
+  int cost = 1; // irrelevant for immediate class
+  unsigned prio = 0;
+  bool needs_throttle = false;
+  SchedulerClass klass = SchedulerClass::immediate;
+
+  if (auto* write = std::get_if<Ref<MOSDECSubOpWrite>>(&req)) {
+    // classic OSD uses SchedulerClass::immediate for EC write sub-ops
+    // immediate bypasses mClock and goes directly to high_priority queue
+    prio = static_cast<unsigned>((*write)->get_priority());
+    needs_throttle = true;
+  } else if (auto* read = std::get_if<Ref<MOSDECSubOpRead>>(&req)) {
+    // EC reads: distinguish client vs recovery generated via priority
+    // matching classic: priority_to_scheduler_class for recovery EC reads
+    cost = std::max<int>((*read)->get_cost(), 1);
+    prio = static_cast<unsigned>((*read)->get_priority());
+    if (static_cast<int>(prio) <=
+         PeeringState::recovery_msg_priority_t::FORCED) {
+      // recovery-generated EC read
+      klass = (static_cast<int>(prio) >=
+	        PeeringState::recovery_msg_priority_t::DEGRADED)
+	      ? SchedulerClass::background_recovery
+	      : SchedulerClass::background_best_effort;
+    } else {
+      // client-generated EC read → immediate
+      klass = SchedulerClass::immediate;
+    }
+    needs_throttle = true;
+  }
+
+  std::optional<OperationThrottler::ThrottleReleaser> throttle;
+  if (needs_throttle) {
+    auto releaser = co_await interruptor::make_interruptible(
+      shard_services.get_throttle(
+        scheduler::params_t{
+          cost,
+          prio,
+          0,
+          klass}));
+    throttle.emplace(std::move(releaser));
+  }
+  co_await std::visit(overloaded{
+    [pg] (Ref<MOSDECSubOpWrite> concrete_req) {
+      return pg->handle_rep_write_op(std::move(concrete_req));
+    },
+    [pg] (Ref<MOSDECSubOpWriteReply> concrete_req) {
+      return pg->handle_rep_write_reply(std::move(concrete_req));
+    },
+    [pg] (Ref<MOSDECSubOpRead> concrete_req) {
+      return pg->handle_rep_read_op(std::move(concrete_req));
+    },
+    [ec_backend] (Ref<MOSDECSubOpReadReply> concrete_req) {
+      return ec_backend->handle_rep_read_reply(
+        std::move(concrete_req)
+      ).handle_error_interruptible(
+        crimson::ct_error::assert_all("unexpected error"));
+    }}, req);
+  // throttle destructs here if set
+}
+
 seastar::future<> ECRepRequest::with_pg(
   ShardServices &shard_services, Ref<PG> pg)
 {
@@ -64,23 +130,9 @@ seastar::future<> ECRepRequest::with_pg(
 
   IRef ref = this;
   return interruptor::with_interruption(
-    [this, pg, ec_backend=dynamic_cast<ECBackend*>(&pg->get_backend())] {
+    [this, pg, ec_backend=dynamic_cast<ECBackend*>(&pg->get_backend()), &shard_services] {
     assert(ec_backend);
-    return std::visit(overloaded{
-      [pg] (Ref<MOSDECSubOpWrite> concrete_req) {
-        return pg->handle_rep_write_op(std::move(concrete_req));
-      },
-      [pg] (Ref<MOSDECSubOpWriteReply> concrete_req) {
-        return pg->handle_rep_write_reply(std::move(concrete_req));
-      },
-      [pg] (Ref<MOSDECSubOpRead> concrete_req) {
-        return pg->handle_rep_read_op(std::move(concrete_req));
-      },
-      [ec_backend] (Ref<MOSDECSubOpReadReply> concrete_req) {
-        return ec_backend->handle_rep_read_reply(
-	  std::move(concrete_req)
-	).handle_error_interruptible(crimson::ct_error::assert_all("unexpected error"));
-      }}, req);
+    return  with_pg_interruptible(shard_services, pg, ec_backend);
   }, [ref, this](std::exception_ptr) {
     logger().debug("{}: ECRepRequest::exception handling", *this);
     return seastar::now();

--- a/src/crimson/osd/osd_operations/ecrep_request.h
+++ b/src/crimson/osd/osd_operations/ecrep_request.h
@@ -8,6 +8,7 @@
 #include "crimson/net/Connection.h"
 #include "crimson/osd/osdmap_gate.h"
 #include "crimson/osd/osd_operation.h"
+#include "crimson/osd/ec_backend.h"
 #include "crimson/osd/osd_operations/client_request.h"
 #include "crimson/osd/pg_map.h"
 #include "crimson/common/type_helpers.h"
@@ -116,6 +117,10 @@ private:
     Ref<MOSDECSubOpRead>,
     Ref<MOSDECSubOpReadReply>
   > req;
+  interruptible_future<> with_pg_interruptible(
+    ShardServices &shard_services,
+    Ref<PG> pg,
+    ECBackend *ec_backend);
 };
 
 }

--- a/src/crimson/osd/osd_operations/internal_client_request.cc
+++ b/src/crimson/osd/osd_operations/internal_client_request.cc
@@ -62,6 +62,16 @@ InternalClientRequest::with_interruption()
     *obc_orderer,
     get_target_oid());
 
+  // acquire throttle BEFORE entering exclusive obc_pp.process stage
+  // consistent with ClientRequest pattern -- orderer preserves ordering
+  auto throttle = co_await interruptor::make_interruptible(
+    pg->shard_services.get_throttle(
+      scheduler::params_t{
+        1,
+        0,
+        0,
+        SchedulerClass::client}));
+
   co_await enter_stage<interruptor>(obc_orderer->obc_pp().process);
 
   bool unfound = co_await pg->do_recover_missing(
@@ -112,6 +122,7 @@ InternalClientRequest::with_interruption()
 
   DEBUGDPP("{}: complete", *pg, *this);
   co_await interruptor::make_interruptible(handle.complete());
+  // throttle destructs here
   co_return;
 }
 

--- a/src/crimson/osd/osd_operations/logmissing_request.cc
+++ b/src/crimson/osd/osd_operations/logmissing_request.cc
@@ -63,6 +63,40 @@ PGRepopPipeline &LogMissingRequest::repop_pipeline(PG &pg)
   return pg.repop_pipeline;
 }
 
+LogMissingRequest::interruptible_future<>
+LogMissingRequest::with_pg_interruptible(
+  ShardServices &shard_services, Ref<PG> pg)
+{
+  LOG_PREFIX(LogMissingRequest::with_pg_interruptible);
+  DEBUGI("{}: pg present", *this);
+
+  // acquire throttle BEFORE entering exclusive process stage
+  // shared with RepRequest -- don't block it while waiting for slot
+  // uses immediate class so wait is instantaneous (high_priority queue)
+  auto throttle = co_await interruptor::make_interruptible(
+    shard_services.get_throttle(
+      scheduler::params_t{
+        1,
+        static_cast<unsigned>(req->get_priority()),
+        0,
+        SchedulerClass::immediate}));
+
+  co_await this->template enter_stage<interruptor>(
+    repop_pipeline(*pg).process);
+
+  co_await interruptor::make_interruptible(
+  this->template with_blocking_event<
+    PG_OSDMapGate::OSDMapBlocker::BlockingEvent
+  >([this, pg](auto &&trigger) {
+    return pg->osdmap_gate.wait_for_map(
+      std::move(trigger), req->min_epoch);
+  }));
+  co_await pg->do_update_log_missing(req, get_remote_connection());
+  logger().debug("{}: complete", *this);
+  co_await interruptor::make_interruptible(handle.complete());
+  // throttle destructs here
+}
+
 seastar::future<> LogMissingRequest::with_pg(
   ShardServices &shard_services, Ref<PG> pg)
 {
@@ -70,23 +104,9 @@ seastar::future<> LogMissingRequest::with_pg(
   DEBUGI("{}: LogMissingRequest::with_pg", *this);
 
   IRef ref = this;
-  return interruptor::with_interruption([this, pg] {
-    LOG_PREFIX(LogMissingRequest::with_pg);
-    DEBUGI("{}: pg present", *this);
-    return this->template enter_stage<interruptor>(repop_pipeline(*pg).process
-    ).then_interruptible([this, pg] {
-      return this->template with_blocking_event<
-        PG_OSDMapGate::OSDMapBlocker::BlockingEvent
-      >([this, pg](auto &&trigger) {
-        return pg->osdmap_gate.wait_for_map(
-          std::move(trigger), req->min_epoch);
-      });
-    }).then_interruptible([this, pg](auto) {
-      return pg->do_update_log_missing(req, get_remote_connection());
-    }).then_interruptible([this] {
-      logger().debug("{}: complete", *this);
-      return handle.complete();
-    });
+  return interruptor::with_interruption
+    ([this, pg, &shard_services] {
+      return with_pg_interruptible(shard_services, pg);
   }, [](std::exception_ptr) {
     return seastar::now();
   }, pg, pg->get_osdmap_epoch()).finally([this, ref=std::move(ref)] {

--- a/src/crimson/osd/osd_operations/logmissing_request.h
+++ b/src/crimson/osd/osd_operations/logmissing_request.h
@@ -67,6 +67,7 @@ private:
   // must be after `conn` to ensure the ConnectionPipeline's is alive
   PipelineHandle handle;
   Ref<MOSDPGUpdateLogMissing> req;
+  interruptible_future<> with_pg_interruptible(ShardServices &shard_services, Ref<PG> pg);
 };
 
 }

--- a/src/crimson/osd/osd_operations/recovery_subrequest.cc
+++ b/src/crimson/osd/osd_operations/recovery_subrequest.cc
@@ -27,21 +27,54 @@ SET_SUBSYS(osd);
 
 namespace crimson::osd {
 
+RecoverySubRequest::interruptible_future<>
+RecoverySubRequest::with_pg_interruptible(
+  ShardServices &shard_services, Ref<PG> pgref)
+{
+  LOG_PREFIX(RecoverySubRequest::with_pg_interruptible);
+  DEBUGI("{}: {}", "RecoverySubRequest::with_pg", *this);
+
+  // skip throttle for backfill control messages to avoid deadlock:
+  // OP_BACKFILL_FINISH/PROGRESS/ACK must not be throttled since
+  // primary waits for finish_ack which can never arrive if stuck
+  // in throttle queue when crimson_osd_scheduler_concurrency is set.
+  // Only throttle actual data ops (push, pull, delete).
+  const bool needs_throttle =
+    m->get_type() != MSG_OSD_PG_BACKFILL &&
+    m->get_type() != MSG_OSD_PG_BACKFILL_REMOVE &&
+    m->get_type() != MSG_OSD_PG_SCAN;
+
+  std::optional<OperationThrottler::ThrottleReleaser> throttle;
+  if (needs_throttle) {
+    // use message priority matching classic OSD's PGRecoveryMsg::get_scheduler_class()
+    // which calls priority_to_scheduler_class(op->get_req()->get_priority())
+    auto recovery_prio = static_cast<int>(m->get_priority());
+    auto kclass = (recovery_prio >= PeeringState::recovery_msg_priority_t::DEGRADED)
+      ? SchedulerClass::background_recovery
+      : SchedulerClass::background_best_effort;
+    auto releaser = co_await interruptor::make_interruptible(
+      shard_services.get_throttle(
+        scheduler::params_t{
+          std::max<int>(pgref->get_average_object_size(), 1),
+          static_cast<unsigned>(recovery_prio),
+          0,
+          kclass}));
+    throttle.emplace(std::move(releaser));
+  }
+  co_await pgref->get_recovery_backend()->handle_recovery_op(
+    m, get_remote_connection());
+  DEBUGI("{}: complete", *this);
+  co_await interruptor::make_interruptible(handle.complete());
+  // throttle destructs here -> release_throttle()
+}
+
 seastar::future<> RecoverySubRequest::with_pg(
   ShardServices &shard_services, Ref<PG> pgref)
 {
   track_event<StartEvent>();
   IRef opref = this;
-  return interruptor::with_interruption([this, pgref] {
-    LOG_PREFIX(RecoverySubRequest::with_pg);
-    DEBUGI("{}: {}", "RecoverySubRequest::with_pg", *this);
-    return pgref->get_recovery_backend()->handle_recovery_op(
-      m, get_remote_connection()
-    ).then_interruptible([this] {
-      LOG_PREFIX(RecoverySubRequest::with_pg);
-      DEBUGI("{}: complete", *this);
-      return handle.complete();
-    });
+  return interruptor::with_interruption([this, pgref, &shard_services] {
+    return with_pg_interruptible(shard_services, pgref);
   }, [](std::exception_ptr) {
     return seastar::now();
   }, pgref, pgref->get_osdmap_epoch()).finally([this, opref=std::move(opref), pgref] {

--- a/src/crimson/osd/osd_operations/recovery_subrequest.cc
+++ b/src/crimson/osd/osd_operations/recovery_subrequest.cc
@@ -27,21 +27,39 @@ SET_SUBSYS(osd);
 
 namespace crimson::osd {
 
+RecoverySubRequest::interruptible_future<>
+RecoverySubRequest::with_pg_interruptible(
+  ShardServices &shard_services, Ref<PG> pgref)
+{
+  LOG_PREFIX(RecoverySubRequest::with_pg_interruptible);
+  DEBUGI("{}: {}", "RecoverySubRequest::with_pg", *this);
+  // use message priority matching classic OSD's PGRecoveryMsg::get_scheduler_class()
+  // which calls priority_to_scheduler_class(op->get_req()->get_priority())
+  auto recovery_prio = static_cast<int>(m->get_priority());
+  auto kclass = (recovery_prio >= PeeringState::recovery_msg_priority_t::DEGRADED)
+    ? SchedulerClass::background_recovery
+    : SchedulerClass::background_best_effort;
+  auto throttle = co_await interruptor::make_interruptible(
+    shard_services.get_throttle(
+      scheduler::params_t{
+        std::max<int>(pgref->get_average_object_size(), 1),
+        static_cast<unsigned>(recovery_prio),
+        0,
+        kclass}));
+  co_await pgref->get_recovery_backend()->handle_recovery_op(
+    m, get_remote_connection());
+  DEBUGI("{}: complete", *this);
+  co_await interruptor::make_interruptible(handle.complete());
+  // throttle destructs here -> release_throttle()
+}
+
 seastar::future<> RecoverySubRequest::with_pg(
   ShardServices &shard_services, Ref<PG> pgref)
 {
   track_event<StartEvent>();
   IRef opref = this;
-  return interruptor::with_interruption([this, pgref] {
-    LOG_PREFIX(RecoverySubRequest::with_pg);
-    DEBUGI("{}: {}", "RecoverySubRequest::with_pg", *this);
-    return pgref->get_recovery_backend()->handle_recovery_op(
-      m, get_remote_connection()
-    ).then_interruptible([this] {
-      LOG_PREFIX(RecoverySubRequest::with_pg);
-      DEBUGI("{}: complete", *this);
-      return handle.complete();
-    });
+  return interruptor::with_interruption([this, pgref, &shard_services] {
+    return with_pg_interruptible(shard_services, pgref);
   }, [](std::exception_ptr) {
     return seastar::now();
   }, pgref, pgref->get_osdmap_epoch()).finally([this, opref=std::move(opref), pgref] {

--- a/src/crimson/osd/osd_operations/recovery_subrequest.h
+++ b/src/crimson/osd/osd_operations/recovery_subrequest.h
@@ -67,6 +67,8 @@ private:
   // must be after `conn` to ensure the ConnectionPipeline's is alive
   PipelineHandle handle;
   Ref<MOSDFastDispatchOp> m;
+  interruptible_future<> with_pg_interruptible(
+    ShardServices &shard_services, Ref<PG> pgref);
 };
 
 }

--- a/src/crimson/osd/osd_operations/replicated_request.cc
+++ b/src/crimson/osd/osd_operations/replicated_request.cc
@@ -70,6 +70,7 @@ RepRequest::interruptible_future<> RepRequest::with_pg_interruptible(
   LOG_PREFIX(RepRequest::with_pg_interruptible);
   DEBUGI("{}", *this);
   req->finish_decode();
+
   co_await this->template enter_stage<interruptor>(repop_pipeline(*pg).process);
   co_await interruptor::make_interruptible(this->template with_blocking_event<
     PG_OSDMapGate::OSDMapBlocker::BlockingEvent
@@ -82,6 +83,16 @@ RepRequest::interruptible_future<> RepRequest::with_pg_interruptible(
     co_return;
   }
 
+  // acquire throttle AFTER process stage -- ordering preserved by pipeline
+  // process stage serializes repops in correct log entry order
+  // throttle before process stage causes out-of-order log entries (assert v > last_update)
+  auto throttle = co_await interruptor::make_interruptible(
+    pg->shard_services.get_throttle(
+      scheduler::params_t{
+        std::max<int>(req->get_cost(), 1),
+        req->get_priority(),
+        static_cast<uint64_t>(req->from.osd),
+        SchedulerClass::immediate}));
   auto [commit_fut, reply] = co_await pg->handle_rep_op(req);
 
   // Transitions from OrderedExclusive->OrderedConcurrent cannot block
@@ -96,6 +107,7 @@ RepRequest::interruptible_future<> RepRequest::with_pg_interruptible(
     pg->shard_services.send_to_osd(
       req->from.osd, std::move(reply), pg->get_osdmap_epoch())
   );
+  // throttle destructs here -> release_throttle()
 }
 
 seastar::future<> RepRequest::with_pg(

--- a/src/crimson/osd/osd_operations/replicated_request.cc
+++ b/src/crimson/osd/osd_operations/replicated_request.cc
@@ -70,6 +70,17 @@ RepRequest::interruptible_future<> RepRequest::with_pg_interruptible(
   LOG_PREFIX(RepRequest::with_pg_interruptible);
   DEBUGI("{}", *this);
   req->finish_decode();
+
+  // acquire throttle BEFORE entering exclusive process stage
+  // consistent with LogMissingRequest which shares this stage
+  auto throttle = co_await interruptor::make_interruptible(
+    pg->shard_services.get_throttle(
+      scheduler::params_t{
+        std::max<int>(req->get_cost(), 1),
+        req->get_priority(),
+        static_cast<uint64_t>(req->from.osd),
+        SchedulerClass::immediate}));
+
   co_await this->template enter_stage<interruptor>(repop_pipeline(*pg).process);
   co_await interruptor::make_interruptible(this->template with_blocking_event<
     PG_OSDMapGate::OSDMapBlocker::BlockingEvent
@@ -96,6 +107,7 @@ RepRequest::interruptible_future<> RepRequest::with_pg_interruptible(
     pg->shard_services.send_to_osd(
       req->from.osd, std::move(reply), pg->get_osdmap_epoch())
   );
+  // throttle destructs here -> release_throttle()
 }
 
 seastar::future<> RepRequest::with_pg(

--- a/src/crimson/osd/osd_operations/scrub_events.cc
+++ b/src/crimson/osd/osd_operations/scrub_events.cc
@@ -148,6 +148,14 @@ ScrubScan::ifut<> ScrubScan::run(PG &pg)
   ret.valid_through = pg.get_info().last_update;
 
   DEBUGDPP("begin: {}, end: {}", pg, begin, end);
+  using crimson::common::local_conf;
+  auto throttle = co_await interruptor::make_interruptible(
+    pg.shard_services.get_throttle(
+      scheduler::params_t{
+        static_cast<int>(local_conf()->osd_scrub_event_cost),
+        static_cast<unsigned>(local_conf()->osd_scrub_priority),
+        0,
+        SchedulerClass::background_best_effort}));
   auto [objects, _] = co_await pg.backend->list_objects(begin, end);
 
   DEBUGDPP("listed {} objects", pg, objects);

--- a/src/crimson/osd/osd_operations/snaptrim_event.cc
+++ b/src/crimson/osd/osd_operations/snaptrim_event.cc
@@ -401,6 +401,7 @@ SnapTrimObjSubEvent::remove_or_update(
 SnapTrimObjSubEvent::snap_trim_obj_subevent_ret_t
 SnapTrimObjSubEvent::start()
 {
+  using crimson::common::local_conf;
   obc_orderer = pg->obc_loader.get_obc_orderer(
     coid);
 
@@ -412,6 +413,16 @@ SnapTrimObjSubEvent::start()
   });
 
   logger().debug("{}: entering obc pipeline process", *this);
+  // acquire throttle BEFORE entering exclusive obc_pp.process stage
+  // consistent with ClientRequest pattern -- orderer preserves ordering
+  auto throttle = co_await interruptor::make_interruptible(
+    pg->get_shard_services().get_throttle(
+      scheduler::params_t{
+        std::max<int>(pg->get_average_object_size(), 1),
+        static_cast<unsigned>(local_conf()->osd_snap_trim_priority),
+        0,
+        SchedulerClass::background_best_effort}));
+
   co_await enter_stage<interruptor>(
     obc_orderer->obc_pp().process);
 
@@ -470,6 +481,7 @@ SnapTrimObjSubEvent::start()
   co_await std::move(all_completed);
 
   logger().debug("{}: completed", *this);
+  // throttle destructs here after all_completed resolves
 }
 
 void SnapTrimObjSubEvent::print(std::ostream &lhs) const

--- a/src/crimson/osd/scheduler/scheduler.cc
+++ b/src/crimson/osd/scheduler/scheduler.cc
@@ -89,23 +89,44 @@ public:
   }
 
   void enqueue(item_t &&item) final {
-    if (use_strict(item.params.klass))
+     // immediate ops bypass class-based priority -- use message priority directly
+    // matching classic WPQ which uses numeric priority, not SchedulerClass
+    if (item.params.klass == SchedulerClass::immediate) {
+      queue.enqueue_strict(
+        item.params.owner,
+        item.params.priority,  // use message priority directly
+        std::move(item));
+      return;
+    }
+
+    if (use_strict(item.params.klass)) {
       queue.enqueue_strict(
 	item.params.owner, get_priority(item.params.klass), std::move(item));
-    else
+    } else {
       queue.enqueue(
 	item.params.owner, get_priority(item.params.klass),
 	item.params.cost, std::move(item));
+    }
   }
 
   void enqueue_front(item_t &&item) final {
-    if (use_strict(item.params.klass))
+    if (item.params.klass == SchedulerClass::immediate) {
+      // same for enqueue_front
+      queue.enqueue_strict_front(
+        item.params.owner,
+        item.params.priority,
+        std::move(item));
+      return;
+    }
+
+    if (use_strict(item.params.klass)) {
       queue.enqueue_strict_front(
 	item.params.owner, get_priority(item.params.klass), std::move(item));
-    else
+    } else {
       queue.enqueue_front(
 	item.params.owner, get_priority(item.params.klass),
 	item.params.cost, std::move(item));
+    }
   }
 
   bool empty() const final {


### PR DESCRIPTION
For crimson the operations  repop, EC replica ops, recovery sub-requests, log missing,
snap trim, scrub scan, internal client requests, bypass the throttler entirely.

This PR extends get_throttle() to all op types that perform actual SeaStore I/O, acquiring a throttle slot just before
the actual I/O work begins and holding it for the op's lifetime via RAII ThrottleReleaser.

Fixes: https://tracker.ceph.com/issues/78219

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
