### PR TITLE
mgr/{smb,nfs}: refactor earmarking code a bit 

### DIFF
--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -424,37 +424,6 @@ class CephFSEarmarkResolver:
         self._mgr = mgr
         self._cephfs_client = client or CephfsClient(mgr)
 
-    def _extract_path_component(self, path: str, index: int) -> Optional[str]:
-        """
-        Extracts a specific component from the path based on the given index.
-
-        :param path: The path in the format '/volumes/{subvolumegroup}/{subvolume}/..'
-        :param index: The index of the component to extract (1 for subvolumegroup, 2 for subvolume)
-        :return: The component at the specified index
-        """
-        parts = path.strip('/').split('/')
-        if len(parts) >= 3 and parts[0] == "volumes":
-            return parts[index]
-        return None
-
-    def _fetch_subvolumegroup_from_path(self, path: str) -> Optional[str]:
-        """
-        Extracts and returns the subvolume group name from the given path.
-
-        :param path: The path in the format '/volumes/{subvolumegroup}/{subvolume}/..'
-        :return: The subvolume group name
-        """
-        return self._extract_path_component(path, 1)
-
-    def _fetch_subvolume_from_path(self, path: str) -> Optional[str]:
-        """
-        Extracts and returns the subvolume name from the given path.
-
-        :param path: The path in the format '/volumes/{subvolumegroup}/{subvolume}/..'
-        :return: The subvolume name
-        """
-        return self._extract_path_component(path, 2)
-
     def _manage_earmark(self, path: str, volume: str, operation: str, earmark: Optional[str] = None) -> Optional[str]:
         """
         Manages (get or set) the earmark for a subvolume based on the provided parameters.

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -2,6 +2,7 @@ import os
 
 from ceph.fs.earmarking import (
     CephFSVolumeEarmarking,
+    EarmarkContents,
     EarmarkException,
     EarmarkParseError,
     EarmarkTopScope,
@@ -474,6 +475,24 @@ class CephFSEarmarkResolver:
             return parsed.top == top_level_scope
         except EarmarkParseError:
             return False
+
+    def test_and_set_earmark(
+        self, path: str, volume: str, earmark: EarmarkContents
+    ) -> Tuple[bool, Optional[EarmarkContents]]:
+        """Perform a test-and-set of an earmark given the a path, a cephfs
+        volume, and an earmark object.
+        If the path has no earmark or is upgradable to the given earmark the
+        function will return (True, <new earmark>) otherwise the function may
+        return (False, <old earmark>) or raise an EarmarkConflictError
+        exception.
+        """
+        with self._manager(path, volume) as emgr:
+            changed, current = emgr.test_and_set(earmark)
+        if changed:
+            logger.debug(
+                'Set earmark [%s] on %s in volume %s', current, path, volume
+            )
+        return changed, current
 
 
 class NvmeofMetadataPoolHelper:

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -2,9 +2,9 @@ import os
 
 from ceph.fs.earmarking import (
     CephFSVolumeEarmarking,
+    EarmarkException,
     EarmarkParseError,
     EarmarkTopScope,
-    EarmarkException
 )
 
 if 'UNITTEST' in os.environ:

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -424,39 +424,40 @@ class CephFSEarmarkResolver:
         self._mgr = mgr
         self._cephfs_client = client or CephfsClient(mgr)
 
-    def _manage_earmark(self, path: str, volume: str, operation: str, earmark: Optional[str] = None) -> Optional[str]:
-        """
-        Manages (get or set) the earmark for a subvolume based on the provided parameters.
+    @contextlib.contextmanager
+    def _manager(
+        self, path: str, volume: str, raises: bool = True
+    ) -> Iterator[CephFSVolumeEarmarking]:
+        """Returns a context manager object yielding a earmarking manager.
 
         :param path: The path of the subvolume
         :param volume: The volume name
-        :param earmark: The earmark to set (None if only getting the earmark)
-        :return: The earmark if getting, otherwise None
+        :param raises: If false, EarmarkExceptions will be automatically
+                      supressed
+        :yield: The earmark manager
         """
         with open_filesystem(self._cephfs_client, volume) as fs:
-            earmark_manager = CephFSVolumeEarmarking(fs, path)
             try:
-                if operation == 'set' and earmark is not None:
-                    earmark_manager.set_earmark(earmark)
-                    return None
-                elif operation == 'get':
-                    return earmark_manager.get_earmark()
+                yield CephFSVolumeEarmarking(fs, path)
             except EarmarkException as e:
                 logger.error(f"Failed to manage earmark: {e}")
-                return None
-        return None
+                if raises:
+                    raise
 
     def get_earmark(self, path: str, volume: str) -> Optional[str]:
         """
         Get earmark for a subvolume.
         """
-        return self._manage_earmark(path, volume, 'get')
+        with self._manager(path, volume, raises=False) as emgr:
+            return emgr.get_earmark()
+        return None  # in case ctx manager supresses the error
 
     def set_earmark(self, path: str, volume: str, earmark: str) -> None:
         """
         Set earmark for a subvolume.
         """
-        self._manage_earmark(path, volume, 'set', earmark)
+        with self._manager(path, volume, raises=False) as emgr:
+            emgr.set_earmark(earmark)
 
     def check_earmark(self, earmark: str, top_level_scope: EarmarkTopScope) -> bool:
         """

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -4,8 +4,6 @@ from ceph.fs.earmarking import (
     CephFSVolumeEarmarking,
     EarmarkContents,
     EarmarkException,
-    EarmarkParseError,
-    EarmarkTopScope,
 )
 
 if 'UNITTEST' in os.environ:
@@ -459,22 +457,6 @@ class CephFSEarmarkResolver:
         """
         with self._manager(path, volume, raises=False) as emgr:
             emgr.set_earmark(earmark)
-
-    def check_earmark(self, earmark: str, top_level_scope: EarmarkTopScope) -> bool:
-        """
-        Check if the earmark belongs to the mentioned top level scope.
-
-        :param earmark: The earmark string to check.
-        :param top_level_scope: The expected top level scope.
-        :return: True if the earmark matches the top level scope, False otherwise.
-        """
-        try:
-            parsed = CephFSVolumeEarmarking.parse_earmark(earmark)
-            if parsed is None:
-                return False
-            return parsed.top == top_level_scope
-        except EarmarkParseError:
-            return False
 
     def test_and_set_earmark(
         self, path: str, volume: str, earmark: EarmarkContents

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -13,7 +13,7 @@ from typing import (
     Set,
     cast)
 from os.path import normpath
-from ceph.fs.earmarking import EarmarkTopScope
+from ceph.fs.earmarking import NFSEarmark, EarmarkConflictError
 import cephfs
 
 from mgr_util import CephFSEarmarkResolver
@@ -611,27 +611,13 @@ class ExportMgr:
         log.info(f"Export user created is {json_res[0]['entity']}")
         return json_res[0]['key']
 
-    def _check_earmark(self, earmark_resolver: CephFSEarmarkResolver, path: str,
+    def _apply_earmark(self, earmark_resolver: CephFSEarmarkResolver, path: str,
                        fs_name: str) -> None:
-        earmark = earmark_resolver.get_earmark(
-            path,
-            fs_name,
-        )
-        if not earmark:
-            earmark_resolver.set_earmark(
-                path,
-                fs_name,
-                EarmarkTopScope.NFS.value,
-            )
-        else:
-            if not earmark_resolver.check_earmark(
-                earmark, EarmarkTopScope.NFS
-            ):
-                raise NFSException(
-                    'earmark has already been set by ' + earmark.split('.')[0],
-                    -errno.EAGAIN
-                )
-        return None
+        wanted = NFSEarmark.default()
+        try:
+            earmark_resolver.test_and_set_earmark(path, fs_name, wanted)
+        except EarmarkConflictError as err:
+            raise NFSException(str(err), -errno.EAGAIN) from err
 
     def create_export_from_dict(self,
                                 cluster_id: str,
@@ -664,7 +650,7 @@ class ExportMgr:
 
             # Check if earmark is set for the path, given path is of subvolume
             if earmark_resolver:
-                self._check_earmark(earmark_resolver, path, fs_name)
+                self._apply_earmark(earmark_resolver, path, fs_name)
 
             if fsal["cmount_path"] != "/":
                 _validate_cmount_path(fsal["cmount_path"], path)  # type: ignore

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -25,7 +25,7 @@ from ceph.deployment.service_spec import (
     SMBSpec,
     SSLParameters,
 )
-from ceph.fs.earmarking import EarmarkTopScope
+from ceph.fs.earmarking import EarmarkContents, EarmarkTopScope
 
 from . import config_store, external, resources, rgw
 from .enums import (
@@ -175,6 +175,11 @@ class _FakeEarmarkResolver:
         self, earmark: str, top_level_scope: EarmarkTopScope
     ) -> bool:
         return True
+
+    def test_and_set_earmark(
+        self, path: str, volume: str, earmark: EarmarkContents
+    ) -> Tuple[bool, Optional[EarmarkContents]]:
+        return True, earmark
 
 
 class _FakeAuthorizer:

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -25,7 +25,7 @@ from ceph.deployment.service_spec import (
     SMBSpec,
     SSLParameters,
 )
-from ceph.fs.earmarking import EarmarkContents, EarmarkTopScope
+from ceph.fs.earmarking import EarmarkContents
 
 from . import config_store, external, resources, rgw
 from .enums import (
@@ -167,14 +167,6 @@ class _FakeEarmarkResolver:
 
     def get_earmark(self, path: str, volume: str) -> Optional[str]:
         return None
-
-    def set_earmark(self, path: str, volume: str, earmark: str) -> None:
-        pass
-
-    def check_earmark(
-        self, earmark: str, top_level_scope: EarmarkTopScope
-    ) -> bool:
-        return True
 
     def test_and_set_earmark(
         self, path: str, volume: str, earmark: EarmarkContents

--- a/src/pybind/mgr/smb/proto.py
+++ b/src/pybind/mgr/smb/proto.py
@@ -15,7 +15,7 @@ from typing import (
 import sys
 
 from ceph.deployment.service_spec import SMBSpec
-from ceph.fs.earmarking import EarmarkContents, EarmarkTopScope
+from ceph.fs.earmarking import EarmarkContents
 
 # this uses a version check as opposed to a try/except because this
 # form makes mypy happy and try/except doesn't.
@@ -217,14 +217,6 @@ class EarmarkResolver(Protocol):
     """A protocol for a type that can resolve earmarks for subvolumes."""
 
     def get_earmark(self, path: str, volume: str) -> Optional[str]:
-        ...  # pragma: no cover
-
-    def set_earmark(self, path: str, volume: str, earmark: str) -> None:
-        ...  # pragma: no cover
-
-    def check_earmark(
-        self, earmark: str, top_level_scope: EarmarkTopScope
-    ) -> bool:
         ...  # pragma: no cover
 
     def test_and_set_earmark(

--- a/src/pybind/mgr/smb/proto.py
+++ b/src/pybind/mgr/smb/proto.py
@@ -15,7 +15,7 @@ from typing import (
 import sys
 
 from ceph.deployment.service_spec import SMBSpec
-from ceph.fs.earmarking import EarmarkTopScope
+from ceph.fs.earmarking import EarmarkContents, EarmarkTopScope
 
 # this uses a version check as opposed to a try/except because this
 # form makes mypy happy and try/except doesn't.
@@ -225,4 +225,9 @@ class EarmarkResolver(Protocol):
     def check_earmark(
         self, earmark: str, top_level_scope: EarmarkTopScope
     ) -> bool:
+        ...  # pragma: no cover
+
+    def test_and_set_earmark(
+        self, path: str, volume: str, earmark: EarmarkContents
+    ) -> Tuple[bool, Optional[EarmarkContents]]:
         ...  # pragma: no cover

--- a/src/pybind/mgr/smb/staging.py
+++ b/src/pybind/mgr/smb/staging.py
@@ -13,7 +13,7 @@ import functools
 import logging
 import operator
 
-from ceph.fs.earmarking import EarmarkTopScope
+from ceph.fs.earmarking import EarmarkConflictError, SMBEarmark
 
 from . import config_store, resources, rgw
 from .enums import (
@@ -487,41 +487,13 @@ def _check_share_resource(
             share, msg="path is not a valid directory in volume"
         )
     if earmark_resolver:
-        earmark = earmark_resolver.get_earmark(
-            volpath,
-            share.cephfs.volume,
-        )
-        if not earmark:
-            smb_earmark = (
-                f"{EarmarkTopScope.SMB.value}.cluster.{share.cluster_id}"
+        wanted = SMBEarmark.from_cluster_id(share.cluster_id)
+        try:
+            earmark_resolver.test_and_set_earmark(
+                volpath, share.cephfs.volume, wanted
             )
-            earmark_resolver.set_earmark(
-                volpath,
-                share.cephfs.volume,
-                smb_earmark,
-            )
-        else:
-            parsed_earmark = _parse_earmark(earmark)
-
-            # Check if the top-level scope is not SMB
-            if not earmark_resolver.check_earmark(
-                earmark, EarmarkTopScope.SMB
-            ):
-                raise ErrorResult(
-                    share,
-                    msg=f"earmark has already been set by {parsed_earmark['scope']}",
-                )
-
-            # Check if the earmark is set by a different cluster
-            if (
-                parsed_earmark['cluster_id']
-                and parsed_earmark['cluster_id'] != share.cluster_id
-            ):
-                raise ErrorResult(
-                    share,
-                    msg="earmark has already been set by smb cluster "
-                    f"{parsed_earmark['cluster_id']}",
-                )
+        except EarmarkConflictError as err:
+            raise ErrorResult(share, str(err)) from err
 
     name_used_by = _share_name_in_use(staging, share)
     if name_used_by:

--- a/src/pybind/mgr/tests/test_mgr_util.py
+++ b/src/pybind/mgr/tests/test_mgr_util.py
@@ -64,28 +64,6 @@ class TestCephFsEarmarkResolver:
 
         mock_earmarking.set_earmark.assert_called_once_with("smb.test2")
 
-    @patch('mgr_util.CephFSVolumeEarmarking.parse_earmark')
-    def test_check_earmark(self, mock_parse_earmark, resolver):
-        # Test that an earmark with the 'smb' top-level scope is correctly identified
-        mock_parse_earmark.return_value = MagicMock(top=mgr_util.EarmarkTopScope.SMB)
-        result = resolver.check_earmark("smb.cluster.cluster1", mgr_util.EarmarkTopScope.SMB)
-        assert result is True
-
-        # Test with a different top-level scope, should return False
-        mock_parse_earmark.return_value = MagicMock(top=mgr_util.EarmarkTopScope.SMB)
-        result = resolver.check_earmark("smb.cluster.cluster1", mgr_util.EarmarkTopScope.NFS)
-        assert result is False
-
-        # Test with an invalid earmark (parse_earmark returns None), should return False
-        mock_parse_earmark.return_value = None
-        result = resolver.check_earmark("invalid.test", mgr_util.EarmarkTopScope.SMB)
-        assert result is False
-
-        # Test with an exception raised by parse_earmark, should return False
-        mock_parse_earmark.side_effect = mgr_util.EarmarkParseError
-        result = resolver.check_earmark("error.test", mgr_util.EarmarkTopScope.SMB)
-        assert result is False
-
 
 _SHA256_OK = "a" * 64
 _SHA256_BAD_HEX = "g" * 64

--- a/src/python-common/ceph/fs/earmarking.py
+++ b/src/python-common/ceph/fs/earmarking.py
@@ -16,14 +16,40 @@ Key Features:
 supported top-level scopes.
 """
 
+import sys
 import errno
 import enum
 import logging
-from typing import List, NamedTuple, Optional, Tuple, Protocol
+
+from typing import (
+    Any,
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Protocol,
+    TYPE_CHECKING,
+    Tuple,
+    Type,
+    Union,
+)
+
+if sys.version_info >= (3, 11):  # pragma: no cover
+    from typing import Self
+elif TYPE_CHECKING:  # pragma: no cover
+    from typing_extensions import Self
+else:  # pragma: no cover
+    # fallback type that should be ignored at runtime
+    Self = Any  # type: ignore
 
 log = logging.getLogger(__name__)
 
 XATTR_SUBVOLUME_EARMARK_NAME = 'user.ceph.subvolume.earmark'
+
+
+class EarmarkTopScope(enum.Enum):
+    NFS = "nfs"
+    SMB = "smb"
 
 
 class FSOperations(Protocol):
@@ -38,9 +64,17 @@ class FSOperations(Protocol):
     def getxattr(self, path: str, key: str) -> bytes: ...
 
 
-class EarmarkTopScope(enum.Enum):
-    NFS = "nfs"
-    SMB = "smb"
+class EarmarkContents(Protocol):
+    @property
+    def top(self) -> EarmarkTopScope: ...
+
+    @property
+    def subsections(self) -> List[str]: ...
+
+    def __str__(self) -> str: ...
+
+    @classmethod
+    def parse(cls, value: str) -> Self: ...
 
 
 class EarmarkException(Exception):
@@ -55,13 +89,127 @@ class EarmarkException(Exception):
         return f"{self.errno} ({self.error_str})"
 
 
-class EarmarkContents(NamedTuple):
-    top: 'EarmarkTopScope'
-    subsections: List[str]
-
-
 class EarmarkParseError(ValueError):
     pass
+
+
+class NFSEarmark(NamedTuple):
+    top: EarmarkTopScope
+    # to be backwards compatible we allow freeform subsections in nfs
+    # (for now) but we may want to get stricter about this in the
+    # future since this is never used in practice
+    subsections: List[str]
+
+    def __str__(self) -> str:
+        return f'{self.top.value}'
+
+    @classmethod
+    def parse(cls, value: str) -> Self:
+        parts = value.split('.')
+        if parts[0] != EarmarkTopScope.NFS.value:
+            raise EarmarkParseError(
+                f'wrong top scope for NFS earmark: {value!r}'
+            )
+        for part in parts[1:]:
+            if not part:
+                raise EarmarkParseError(
+                    f'empty subsection in NFS earmark: {value!r}'
+                )
+        return cls(EarmarkTopScope.NFS, parts[1:])
+
+    @classmethod
+    def default(cls) -> Self:
+        return cls(EarmarkTopScope.NFS, [])
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, str):
+            try:
+                _other = self.parse(other)
+            except EarmarkParseError:
+                return False
+        elif isinstance(other, self.__class__):
+            _other = other
+        else:
+            return NotImplemented
+        return (
+            self.top is _other.top and self.subsections == _other.subsections
+        )
+
+
+class SMBEarmark(NamedTuple):
+    top: EarmarkTopScope
+    cluster_id: str
+
+    @property
+    def subsections(self) -> List[str]:
+        return [] if not self.cluster_id else ['cluster', self.cluster_id]
+
+    def __str__(self) -> str:
+        earmark = f'{self.top.value}'
+        if self.cluster_id:
+            earmark = f'{earmark}.cluster.{self.cluster_id}'
+        return earmark
+
+    @classmethod
+    def parse(cls, value: str) -> Self:
+        cid = ''
+        parts = value.split('.')
+        if parts[0] != EarmarkTopScope.SMB.value:
+            raise EarmarkParseError(
+                f'wrong top scope for SMB earmark: {value!r}'
+            )
+        if len(parts) > 3:
+            raise EarmarkParseError(
+                f'too many subsections for SMB earmark: {value!r}'
+            )
+        elif len(parts) == 3:
+            cflag, cid = parts[1:]
+            if cflag != 'cluster' or not cid:
+                raise EarmarkParseError(
+                    f'invalid subsection in SMB earmark: {value!r}'
+                )
+        elif len(parts) == 2:
+            raise EarmarkParseError(
+                f'too few subsections for SMB earmark: {value!r}'
+            )
+        return cls(EarmarkTopScope.SMB, cid)
+
+    @classmethod
+    def from_cluster_id(cls, cluster_id: str) -> Self:
+        return cls(EarmarkTopScope.SMB, cluster_id)
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, str):
+            try:
+                _other = self.parse(other)
+            except EarmarkParseError:
+                return False
+        elif isinstance(other, self.__class__):
+            _other = other
+        else:
+            return NotImplemented
+        return self.top is _other.top and self.cluster_id == _other.cluster_id
+
+
+_earmark_types: Dict[EarmarkTopScope, Type[EarmarkContents]] = {
+    EarmarkTopScope.NFS: NFSEarmark,
+    EarmarkTopScope.SMB: SMBEarmark,
+}
+
+
+def parse_earmark(value: str) -> Optional[EarmarkContents]:
+    """Given an earmark string return an EarmarkContents object from
+    parsing the string. If the value is empty return None.
+    If the value can not be parsed raise EarmarkParseError.
+    """
+    if not value:
+        return None
+    _top = value.split('.', 1)[0]
+    try:
+        top = EarmarkTopScope(_top)
+    except ValueError:
+        raise EarmarkParseError(f"Invalid top-level scope: {_top}")
+    return _earmark_types[top].parse(value)
 
 
 class CephFSVolumeEarmarking:
@@ -101,53 +249,22 @@ class CephFSVolumeEarmarking:
         :param value: The earmark string to parse.
         :return: An EarmarkContents instance if valid, None if empty.
         """
-        if not value:
-            return None
+        return parse_earmark(value)
 
-        parts = value.split('.')
-
-        # Check if the top-level scope is valid
-        if parts[0] not in (scope.value for scope in EarmarkTopScope):
-            raise EarmarkParseError(f"Invalid top-level scope: {parts[0]}")
-
-        # Check if all parts are non-empty to ensure valid dot-separated format
-        if not all(parts):
-            raise EarmarkParseError("Earmark contains empty sections.")
-
-        # Return parsed earmark with top scope and subsections
-        return EarmarkContents(
-            top=EarmarkTopScope(parts[0]), subsections=parts[1:]
-        )
-
-    def _validate_earmark(self, earmark: str) -> bool:
+    def _validate_earmark(self, earmark: Union[str, EarmarkContents]) -> bool:
         """
-        Validates the earmark string further by checking specific conditions for scopes like 'smb'.
+        Validates the earmark. If the earmark is a string, it will be parsed
+        and checked.
 
         :param earmark: The earmark string to validate.
         :return: True if valid, False otherwise.
         """
+        if not isinstance(earmark, str):
+            return True
         try:
-            parsed = self.parse_earmark(earmark)
+            self.parse_earmark(earmark)
         except EarmarkParseError:
             return False
-
-        # If parsed is None, it's considered valid since the earmark is empty
-        if not parsed:
-            return True
-
-        # Specific validation for 'smb' scope
-        if parsed.top == EarmarkTopScope.SMB:
-            # Valid formats: 'smb' or 'smb.cluster.{cluster_id}'
-            if not (
-                len(parsed.subsections) == 0
-                or (
-                    len(parsed.subsections) == 2
-                    and parsed.subsections[0] == 'cluster'
-                    and parsed.subsections[1]
-                )
-            ):
-                return False
-
         return True
 
     def get_earmark(self) -> Optional[str]:

--- a/src/python-common/ceph/fs/earmarking.py
+++ b/src/python-common/ceph/fs/earmarking.py
@@ -121,6 +121,9 @@ class NFSEarmark(NamedTuple):
 
     @classmethod
     def parse(cls, value: str) -> Self:
+        """Given an earmark string, return a new NFSEarmark object or raise an
+        EarmarkParseError if the string is not a valid nfs earmark.
+        """
         parts = value.split('.')
         if parts[0] != EarmarkTopScope.NFS.value:
             raise EarmarkParseError(
@@ -135,9 +138,11 @@ class NFSEarmark(NamedTuple):
 
     @classmethod
     def default(cls) -> Self:
+        """Return a new NFSEarmark with default values."""
         return cls(EarmarkTopScope.NFS, [])
 
     def __eq__(self, other: Any) -> bool:
+        """Equality check."""
         if isinstance(other, str):
             try:
                 _other = self.parse(other)
@@ -152,6 +157,9 @@ class NFSEarmark(NamedTuple):
         )
 
     def upgrades(self, current: EarmarkContents) -> bool:
+        """Returns true if this earmark can be used to upgrade the current
+        earmark value applied to some path.
+        """
         if self.top != current.top:
             raise EarmarkConflictError(
                 f'earmark has already been set by {current.top.value}',
@@ -168,6 +176,7 @@ class SMBEarmark(NamedTuple):
 
     @property
     def subsections(self) -> List[str]:
+        """Return earmark subsections as a list of strings."""
         return [] if not self.cluster_id else ['cluster', self.cluster_id]
 
     def __str__(self) -> str:
@@ -178,6 +187,9 @@ class SMBEarmark(NamedTuple):
 
     @classmethod
     def parse(cls, value: str) -> Self:
+        """Given an earmark string, return a new SMBEarmark object or raise an
+        EarmarkParseError if the string is not a valid smb earmark.
+        """
         cid = ''
         parts = value.split('.')
         if parts[0] != EarmarkTopScope.SMB.value:
@@ -202,9 +214,11 @@ class SMBEarmark(NamedTuple):
 
     @classmethod
     def from_cluster_id(cls, cluster_id: str) -> Self:
+        """Given an smb cluster_id, return a new SMBEarmark object."""
         return cls(EarmarkTopScope.SMB, cluster_id)
 
     def __eq__(self, other: Any) -> bool:
+        """Equality check."""
         if isinstance(other, str):
             try:
                 _other = self.parse(other)
@@ -217,6 +231,9 @@ class SMBEarmark(NamedTuple):
         return self.top is _other.top and self.cluster_id == _other.cluster_id
 
     def upgrades(self, current: EarmarkContents) -> bool:
+        """Returns true if this earmark can be used to upgrade the current
+        earmark value applied to some path.
+        """
         if self.top != current.top:
             raise EarmarkConflictError(
                 f'earmark has already been set by {current.top.value}',
@@ -299,6 +316,9 @@ class CephFSVolumeEarmarking:
         return True
 
     def get_earmark(self) -> Optional[str]:
+        """Get an earmark string or None if no earmark is set on the current
+        path.
+        """
         try:
             earmark_value = self.fs.getxattr(
                 self.path, XATTR_SUBVOLUME_EARMARK_NAME
@@ -308,12 +328,16 @@ class CephFSVolumeEarmarking:
             return self._handle_cephfs_error(e, "getting")
 
     def get_parsed_earmark(self) -> Optional[EarmarkContents]:
+        """Get a parsed earmark object or None if no earmark is set on the
+        current path.
+        """
         earmark_value = self.get_earmark()
         if earmark_value is None:
             return None
         return parse_earmark(earmark_value)
 
     def set_earmark(self, earmark: Union[str, EarmarkContents]) -> None:
+        """Set the given earmark value on the current path."""
         # Validate the earmark before attempting to set it
         if not self._validate_earmark(earmark):
             raise EarmarkException(
@@ -336,11 +360,18 @@ class CephFSVolumeEarmarking:
             self._handle_cephfs_error(e, "setting")
 
     def clear_earmark(self) -> None:
+        """Remove the earmark value from the current path."""
         self.set_earmark("")
 
     def test_and_set(
         self, earmark: EarmarkContents
     ) -> Tuple[bool, Optional[EarmarkContents]]:
+        """Perform a test-and-set operation on the earmark value for the given
+        path. If the new earmark is accepted the function returns (True, <new
+        earmark>), if the earmark does not need updating the function return
+        (False, <current earmark>). If the earmark is not compatible raise an
+        EarmarkConflictError exception.
+        """
         current = self.get_parsed_earmark()
         if not _upgrade_earmark(current, earmark):
             return False, current

--- a/src/python-common/ceph/fs/earmarking.py
+++ b/src/python-common/ceph/fs/earmarking.py
@@ -282,19 +282,6 @@ class CephFSVolumeEarmarking:
                 errno.EFAULT, f"Unexpected error {action} earmark: {e}"
             ) from e
 
-    @staticmethod
-    def parse_earmark(value: str) -> Optional[EarmarkContents]:
-        """
-        Parse an earmark value. Returns None if the value is an empty string.
-        Raises EarmarkParseError if the top-level scope is not valid or the earmark
-        string is not properly structured.
-        Returns an EarmarkContents for valid earmark values.
-
-        :param value: The earmark string to parse.
-        :return: An EarmarkContents instance if valid, None if empty.
-        """
-        return parse_earmark(value)
-
     def _validate_earmark(self, earmark: Union[str, EarmarkContents]) -> bool:
         """
         Validates the earmark. If the earmark is a string, it will be parsed
@@ -306,7 +293,7 @@ class CephFSVolumeEarmarking:
         if not isinstance(earmark, str):
             return True
         try:
-            self.parse_earmark(earmark)
+            parse_earmark(earmark)
         except EarmarkParseError:
             return False
         return True

--- a/src/python-common/ceph/fs/earmarking.py
+++ b/src/python-common/ceph/fs/earmarking.py
@@ -32,6 +32,7 @@ from typing import (
     Tuple,
     Type,
     Union,
+    cast,
 )
 
 if sys.version_info >= (3, 11):  # pragma: no cover
@@ -73,11 +74,17 @@ class EarmarkContents(Protocol):
 
     def __str__(self) -> str: ...
 
+    def upgrades(self, other: 'EarmarkContents') -> bool: ...
+
     @classmethod
     def parse(cls, value: str) -> Self: ...
 
 
-class EarmarkException(Exception):
+class EarmarkError(Exception):
+    pass
+
+
+class EarmarkException(EarmarkError):
     def __init__(self, error_code: int, error_message: str) -> None:
         self.errno = error_code
         self.error_str = error_message
@@ -89,8 +96,17 @@ class EarmarkException(Exception):
         return f"{self.errno} ({self.error_str})"
 
 
-class EarmarkParseError(ValueError):
+class EarmarkParseError(ValueError, EarmarkError):
     pass
+
+
+class EarmarkConflictError(EarmarkError):
+    def __init__(
+        self, msg: str, current: Any = None, wanted: Any = None
+    ) -> None:
+        super().__init__(msg)
+        self.current_earmark = current
+        self.wanted_earmark = wanted
 
 
 class NFSEarmark(NamedTuple):
@@ -134,6 +150,16 @@ class NFSEarmark(NamedTuple):
         return (
             self.top is _other.top and self.subsections == _other.subsections
         )
+
+    def upgrades(self, current: EarmarkContents) -> bool:
+        if self.top != current.top:
+            raise EarmarkConflictError(
+                f'earmark has already been set by {current.top.value}',
+                current,
+                self,
+            )
+        # No need to upgrade nfs at this time
+        return False
 
 
 class SMBEarmark(NamedTuple):
@@ -189,6 +215,24 @@ class SMBEarmark(NamedTuple):
         else:
             return NotImplemented
         return self.top is _other.top and self.cluster_id == _other.cluster_id
+
+    def upgrades(self, current: EarmarkContents) -> bool:
+        if self.top != current.top:
+            raise EarmarkConflictError(
+                f'earmark has already been set by {current.top.value}',
+                current,
+                self,
+            )
+        ce = cast(SMBEarmark, current)
+        if not ce.cluster_id:
+            return True
+        if ce.cluster_id == self.cluster_id:
+            return False
+        raise EarmarkConflictError(
+            f'earmark has already been set by smb cluster {ce.cluster_id}',
+            current,
+            self,
+        )
 
 
 _earmark_types: Dict[EarmarkTopScope, Type[EarmarkContents]] = {
@@ -276,7 +320,13 @@ class CephFSVolumeEarmarking:
         except Exception as e:
             return self._handle_cephfs_error(e, "getting")
 
-    def set_earmark(self, earmark: str) -> None:
+    def get_parsed_earmark(self) -> Optional[EarmarkContents]:
+        earmark_value = self.get_earmark()
+        if earmark_value is None:
+            return None
+        return parse_earmark(earmark_value)
+
+    def set_earmark(self, earmark: Union[str, EarmarkContents]) -> None:
         # Validate the earmark before attempting to set it
         if not self._validate_earmark(earmark):
             raise EarmarkException(
@@ -291,7 +341,7 @@ class CephFSVolumeEarmarking:
             self.fs.setxattr(
                 self.path,
                 XATTR_SUBVOLUME_EARMARK_NAME,
-                earmark.encode('utf-8'),
+                str(earmark).encode('utf-8'),
                 0,
             )
             log.info(f"Earmark '{earmark}' set on {self.path}.")
@@ -300,3 +350,32 @@ class CephFSVolumeEarmarking:
 
     def clear_earmark(self) -> None:
         self.set_earmark("")
+
+    def test_and_set(
+        self, earmark: EarmarkContents
+    ) -> Tuple[bool, Optional[EarmarkContents]]:
+        current = self.get_parsed_earmark()
+        if not _upgrade_earmark(current, earmark):
+            return False, current
+        self.set_earmark(earmark)
+        return True, earmark
+
+
+def _upgrade_earmark(
+    current: Optional[EarmarkContents],
+    wanted: EarmarkContents,
+) -> bool:
+    """Given two earmarks, current and wanted, return True if the wanted
+    earmark is an "upgrade" from the current earmark.
+    If the current earmark is None/falsey then the earmark may be upgraded.
+    If the earmarks are equal they do not need to be upgraded (returns false).
+    Otherwise, the `upgrades` method of the wanted earmark will be passed
+    the current earmark.
+    This function will raise a EarmarkConflictError if the earmarks are
+    totally incompatible.
+    """
+    if not current:
+        return True
+    if current == wanted:
+        return False
+    return wanted.upgrades(current)

--- a/src/python-common/ceph/tests/test_earmarking.py
+++ b/src/python-common/ceph/tests/test_earmarking.py
@@ -6,7 +6,8 @@ from ceph.fs.earmarking import (
     CephFSVolumeEarmarking,
     EarmarkException,
     EarmarkParseError,
-    EarmarkTopScope
+    EarmarkTopScope,
+    parse_earmark,
 )
 
 XATTR_SUBVOLUME_EARMARK_NAME = 'user.ceph.subvolume.earmark'
@@ -24,21 +25,21 @@ class TestCephFSVolumeEarmarking:
 
     def test_parse_earmark_valid(self):
         earmark_value = "nfs.subsection1.subsection2"
-        result = CephFSVolumeEarmarking.parse_earmark(earmark_value)
+        result = parse_earmark(earmark_value)
         assert result.top == EarmarkTopScope.NFS
         assert result.subsections == ["subsection1", "subsection2"]
 
     def test_parse_earmark_empty_string(self):
-        result = CephFSVolumeEarmarking.parse_earmark("")
+        result = parse_earmark("")
         assert result is None
 
     def test_parse_earmark_invalid_scope(self):
         with pytest.raises(EarmarkParseError):
-            CephFSVolumeEarmarking.parse_earmark("invalid.scope")
+            parse_earmark("invalid.scope")
 
     def test_parse_earmark_empty_sections(self):
         with pytest.raises(EarmarkParseError):
-            CephFSVolumeEarmarking.parse_earmark("nfs..section")
+            parse_earmark("nfs..section")
 
     def test_validate_earmark_valid_empty(self, earmarking):
         assert earmarking._validate_earmark("")


### PR DESCRIPTION
In preparation for some future (experimental) work regarding earmarks these changes refactor some of the earmarking code. The gist is to concentrate most of the logic of earmarks in the earmarking.py module and provide high-level types and functions for the code interacting with it to use. We aim to:
* avoid manipulation of earmarks as strings by using structured types
* provide a high-level test_and_set method for updating earmarks
* avoid open-coding earmarking logic in the smb and nfs modules



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] updates tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
