### PR TITLE
umbrella: qa/workunits: skip unpublished stable repos in test_repos.sh

### DIFF
--- a/qa/workunits/cephadm/test_repos.sh
+++ b/qa/workunits/cephadm/test_repos.sh
@@ -30,16 +30,51 @@ function test_install_uninstall() {
 	      sudo zypper -n remove cephadm )
 }
 
-sudo $CEPHADM -v add-repo --release quincy
-test_install_uninstall
-sudo $CEPHADM -v rm-repo
+function test_release() {
+    local release=$1
+    sudo $CEPHADM -v add-repo --release "$release"
+    test_install_uninstall
+    sudo $CEPHADM -v rm-repo
+}
+
+REPO_URL="${REPO_URL:-https://download.ceph.com}"
+
+function release_published() {
+    local release=$1
+    local base
+
+    if grep -q debian /etc/*-release; then
+        . /etc/os-release
+        base="${REPO_URL}/debian-${release}/dists/${VERSION_CODENAME}"
+        curl -sf -o /dev/null "${base}/InRelease" && return 0
+        curl -sf -o /dev/null "${base}/Release" && return 0
+        return 1
+    elif grep -q rhel /etc/*-release; then
+        . /etc/os-release
+        curl -sf -o /dev/null \
+            "${REPO_URL}/rpm-${release}/el${VERSION_ID%%.*}/noarch/repodata/repomd.xml"
+    else
+        return 1
+    fi
+}
+
+function test_release_if_published() {
+    local release=$1
+    if ! release_published "$release"; then
+        echo "Skipping release $release (not published for this distro)"
+        return 0
+    fi
+    test_release "$release"
+}
 
 sudo $CEPHADM -v add-repo --dev main
 test_install_uninstall
 sudo $CEPHADM -v rm-repo
 
-sudo $CEPHADM -v add-repo --release 17.2.6
-test_install_uninstall
-sudo $CEPHADM -v rm-repo
+test_release_if_published reef
+test_release_if_published 18.2.8
+test_release_if_published squid
+test_release_if_published 19.2.4
+test_release_if_published tentacle
 
 echo OK.


### PR DESCRIPTION
qa/workunits: skip unpublished stable repos in test_repos.sh
Probe download.ceph.com before each stable add-repo and skip releases
that are not published for the current distro. This avoids apt/yum
failures on newer OS versions (e.g. Ubuntu 24.04/noble) where older
stable trees like quincy and reef were never published.

backport tracker: https://tracker.ceph.com/issues/78189
backport of https://github.com/ceph/ceph/pull/69847
parent tracker: https://tracker.ceph.com/issues/77248

Signed-off-by: Yael Azulay <yazulay@redhat.com>
(cherry picked from commit a691404841ae99d96ab0f5578483d3f8c26dac8a)
Conflicts:
	qa/workunits/cephadm/test_repos.sh
	- On umbrella the old script used --release 17.2.6; on main it was 17.2.7.
	- Resolved by keeping the main change: replace the fixed add-repo blocks
	  with test_release_if_published for reef/18.2.8/squid/19.2.4/tentacle.
	
## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
