### PR TITLE
Fix long toast notifications

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/notification.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/notification.e2e-spec.ts
@@ -54,3 +54,243 @@ describe('Notification page', () => {
     });
   });
 });
+
+describe('Notification panel to page navigation', () => {
+  const notification = new NotificationSidebarPageHelper();
+
+  beforeEach(() => {
+    cy.login();
+    cy.visit('#/');
+    cy.wait(5000);
+  });
+
+  it('should navigate to notifications page via View all', () => {
+    notification.navigateToNotificationsPage();
+    cy.url().should('include', '/notifications');
+    notification.getNotificationsPage().should('exist');
+  });
+
+  it('should navigate from panel notification click to page with pre-selected detail', () => {
+    notification.open();
+    notification.getNotifications().then(($items) => {
+      if ($items.length === 0) {
+        cy.log('No notifications in panel — skipping');
+        return;
+      }
+      notification.getNotifications().first().click();
+      cy.url().should('include', '/notifications');
+      cy.url().should('include', 'id=');
+      notification.getNotificationsPage().should('exist');
+      notification.getNotificationsPageDetail().find('cd-notification-item').should('exist');
+      notification
+        .getNotificationsPageListItems()
+        .first()
+        .should('have.class', 'notifications-page__item--active');
+    });
+  });
+
+  it('should show back button and navigate back', () => {
+    notification.navigateToNotificationsPage();
+    cy.contains('Back').should('be.visible').click();
+    cy.url().should('not.include', '/notifications');
+  });
+});
+
+describe('Notifications page actions', () => {
+  const notification = new NotificationSidebarPageHelper();
+
+  beforeEach(() => {
+    cy.login();
+    cy.visit('#/');
+    cy.wait(3000);
+  });
+
+  it('should show kebab menu with mark all as read and clear all', () => {
+    notification.navigateToNotificationsPage();
+    notification.getKebabMenu().click();
+    notification.getKebabMenuItems().should('have.length', 2);
+    cy.contains('.cds--overflow-menu-options__btn', 'Mark all as read').should('exist');
+    cy.contains('.cds--overflow-menu-options__btn', 'Clear all').should('exist');
+  });
+
+  it('should show empty state when no notifications', () => {
+    notification.open();
+    notification.clearNotifications();
+    notification.getViewAllBtn().click({ force: true });
+    notification.getNotificationsPage().should('exist');
+    cy.contains('No notifications available').should('be.visible');
+  });
+
+  it('should disable kebab actions when no notifications', () => {
+    notification.open();
+    notification.clearNotifications();
+    notification.getViewAllBtn().click({ force: true });
+    notification.getKebabMenu().click();
+    cy.contains('.cds--overflow-menu-options__btn', 'Mark all as read').should('be.disabled');
+    cy.contains('.cds--overflow-menu-options__btn', 'Clear all').should('be.disabled');
+  });
+});
+
+describe('Notification selection and detail', () => {
+  const notification = new NotificationSidebarPageHelper();
+
+  beforeEach(() => {
+    cy.login();
+    cy.visit('#/');
+    cy.wait(5000);
+  });
+
+  it('should select a notification and show detail in right panel', () => {
+    notification.navigateToNotificationsPage();
+    notification.getNotificationsPageListItems().then(($items) => {
+      if ($items.length === 0) {
+        cy.log('No notifications to select — skipping');
+        return;
+      }
+      cy.wrap($items.first()).click();
+      cy.wrap($items.first()).should('have.class', 'notifications-page__item--active');
+      notification.getNotificationsPageDetail().find('cd-notification-item').should('exist');
+      notification
+        .getNotificationsPageDetail()
+        .find('.notifications-page__detail-text')
+        .should('exist');
+    });
+  });
+
+  it('should show occurrences count when notification has duplicates', () => {
+    notification.navigateToNotificationsPage();
+    notification.getNotificationsPageListItems().then(($items) => {
+      if ($items.length === 0) {
+        cy.log('No notifications — skipping');
+        return;
+      }
+      cy.wrap($items.first()).click();
+      notification.getNotificationsPageDetail().then(($detail) => {
+        const hasOccurrences = $detail.find('.notifications-page__occurrences').length > 0;
+        if (hasOccurrences) {
+          cy.get('.notifications-page__occurrences')
+            .should('be.visible')
+            .and('contain', 'Occurrences:');
+        } else {
+          cy.log('First notification has no duplicates — occurrences label correctly hidden');
+        }
+      });
+    });
+  });
+
+  it('should clear all notifications via kebab menu', () => {
+    notification.navigateToNotificationsPage();
+    notification.getNotificationsPageListItems().then(($items) => {
+      if ($items.length === 0) {
+        cy.log('No notifications to clear — skipping');
+        return;
+      }
+      notification.getKebabMenu().click();
+      cy.contains('.cds--overflow-menu-options__btn', 'Clear all').click();
+      cy.contains('No notifications available').should('be.visible');
+    });
+  });
+});
+
+describe('Notification toast deduplication', () => {
+  const notification = new NotificationSidebarPageHelper();
+
+  beforeEach(() => {
+    cy.login();
+    cy.visit('#/');
+  });
+
+  it('should show +N more count on duplicate toasts', () => {
+    cy.wait(8000);
+    cy.get('body').then(($body) => {
+      if ($body.find('.toast-duplicate-count').length > 0) {
+        notification
+          .getToastDuplicateCount()
+          .first()
+          .should('be.visible')
+          .invoke('text')
+          .should('match', /\(\+\d+ more\)/);
+      } else if ($body.find('cds-toast').length > 0) {
+        cy.log('Toasts present but no duplicates yet — only unique errors firing');
+      } else {
+        cy.log('No toasts appeared — skipping');
+      }
+    });
+  });
+
+  it('should show view more link when toast text is truncated', () => {
+    cy.wait(5000);
+    cy.get('body').then(($body) => {
+      if ($body.find('.toast-view-more:visible').length > 0) {
+        notification
+          .getToastViewMoreLink()
+          .first()
+          .should('be.visible')
+          .and('contain', 'View more');
+      } else {
+        cy.log('No truncated toasts with view more — skipping');
+      }
+    });
+  });
+
+  it('should navigate to notifications page and dismiss toasts on view more click', () => {
+    cy.wait(5000);
+    cy.get('body').then(($body) => {
+      if ($body.find('.toast-view-more:visible').length > 0) {
+        notification.getToastViewMoreLink().first().click({ force: true });
+        cy.url().should('include', '/notifications');
+        notification.getNotificationsPage().should('exist');
+        notification.getToasts().should('not.exist');
+      } else {
+        cy.log('No visible view more link — skipping');
+      }
+    });
+  });
+});
+
+describe('Notification read state', () => {
+  const notification = new NotificationSidebarPageHelper();
+
+  beforeEach(() => {
+    cy.login();
+    cy.visit('#/');
+    cy.wait(5000);
+  });
+
+  it('should mark notification as read on selection', () => {
+    notification.navigateToNotificationsPage();
+    notification.getNotificationsPageListItems().then(($items) => {
+      if ($items.length === 0) {
+        cy.log('No notifications — skipping');
+        return;
+      }
+      cy.wrap($items.first()).click();
+      cy.wrap($items.first()).should('not.have.class', 'notifications-page__item--unread');
+    });
+  });
+
+  it('should mark all as read via kebab menu', () => {
+    notification.navigateToNotificationsPage();
+    notification.getNotificationsPageListItems().then(($items) => {
+      if ($items.length === 0) {
+        cy.log('No notifications — skipping');
+        return;
+      }
+      notification.getKebabMenu().click();
+      cy.contains('.cds--overflow-menu-options__btn', 'Mark all as read').click();
+      notification.getNotificationsPageListItems().each(($item) => {
+        cy.wrap($item).should('not.have.class', 'notifications-page__item--unread');
+      });
+    });
+  });
+
+  it('should show unread indicator on bell icon when unread notifications exist', () => {
+    cy.visit('#/');
+    cy.wait(5000);
+    cy.get('[data-testid="header-notification-icon"]').then(($icon) => {
+      const iconType = $icon.find('cd-icon').attr('type');
+      cy.log(`Bell icon type: ${iconType}`);
+      expect(['notification', 'notificationNew']).to.include(iconType);
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/notification.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/notification.po.ts
@@ -1,6 +1,10 @@
 import { PageHelper } from '../page-helper.po';
 
 export class NotificationSidebarPageHelper extends PageHelper {
+  pages = {
+    index: { url: '#/notifications', id: 'cd-notifications-page' }
+  };
+
   getNotificationIcon() {
     return cy.get(`[data-testid='header-notification-icon']`);
   }
@@ -31,6 +35,10 @@ export class NotificationSidebarPageHelper extends PageHelper {
     return cy.get('cd-notification-panel .notification-header__dismiss-btn');
   }
 
+  getViewAllBtn() {
+    return cy.get('.notification-footer__view-all-button');
+  }
+
   open() {
     this.getNotificationIcon().click({ force: true });
     this.getPanel().should('exist');
@@ -47,5 +55,57 @@ export class NotificationSidebarPageHelper extends PageHelper {
 
       this.clearNotifications();
     });
+  }
+
+  // Notifications page helpers
+
+  getNotificationsPage() {
+    return cy.get('.notifications-page');
+  }
+
+  getNotificationsPageList() {
+    return cy.get('.notifications-page__list');
+  }
+
+  getNotificationsPageListItems() {
+    return cy.get('.notifications-page__item');
+  }
+
+  getNotificationsPageDetail() {
+    return cy.get('.notifications-page__detail');
+  }
+
+  getKebabMenu() {
+    return cy.get('.notifications-page__header-menu cds-overflow-menu');
+  }
+
+  getKebabMenuItems() {
+    return cy.get('.cds--overflow-menu-options__btn');
+  }
+
+  getOccurrencesLabel() {
+    return cy.get('.cd-notification-item__occurrences');
+  }
+
+  getToastContainer() {
+    return cy.get('.cds--toast-notification-container');
+  }
+
+  getToasts() {
+    return cy.get('cds-toast');
+  }
+
+  getToastViewMoreLink() {
+    return cy.get('.toast-view-more');
+  }
+
+  getToastDuplicateCount() {
+    return cy.get('.toast-duplicate-count');
+  }
+
+  navigateToNotificationsPage() {
+    this.open();
+    this.getViewAllBtn().click({ force: true });
+    this.getNotificationsPage().should('exist');
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/notification.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/notification.po.ts
@@ -76,7 +76,7 @@ export class NotificationSidebarPageHelper extends PageHelper {
   }
 
   getKebabMenu() {
-    return cy.get('.notifications-page__header-menu cds-overflow-menu');
+    return cy.get('cds-overflow-menu.notifications-page__header-menu');
   }
 
   getKebabMenuItems() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.html
@@ -48,8 +48,12 @@
   >
     <div class="notification-wrapper">
       <div
-        class="notification-item"
+        class="notification-item notification-item--clickable"
         data-testid="notification-item"
+        role="button"
+        tabindex="0"
+        (click)="navigateToNotification(notification)"
+        (keydown.enter)="navigateToNotification(notification)"
       >
         <cd-notification-item
           [type]="notification.type"

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.html
@@ -61,6 +61,7 @@
           [timestamp]="notification.timestamp"
           [message]="notification.message"
           [notificationId]="notification.id"
+          [occurrences]="notification.occurrences"
         >
         </cd-notification-item>
       </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.scss
@@ -5,6 +5,13 @@ cd-notification-area {
   min-block-size: 0;
 }
 
+:host {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-block-size: 0;
+}
+
 .notification-section-heading {
   margin: 0;
   color: var(--cds-text-primary);
@@ -40,7 +47,25 @@ cd-notification-area {
   color: var(--cds-text-primary);
   line-height: 1.25;
   display: block;
+<<<<<<< HEAD
   overflow-wrap: break-word;
+=======
+  word-break: break-word;
+}
+
+.notification-message {
+  @include type.type-style('body-short-01');
+
+  color: $text-helper;
+  margin: 0;
+  line-height: 1.4;
+  margin-top: -$spacing-01;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-word;
+>>>>>>> 8e9c61bcc14 (mgr/dashboard: Fix the footer - view all button css in notification panel)
 }
 
 .notification-empty {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.scss
@@ -5,13 +5,6 @@ cd-notification-area {
   min-block-size: 0;
 }
 
-:host {
-  flex: 1;
-  overflow-y: auto;
-  overflow-x: hidden;
-  min-block-size: 0;
-}
-
 .notification-section-heading {
   margin: 0;
   color: var(--cds-text-primary);
@@ -47,25 +40,7 @@ cd-notification-area {
   color: var(--cds-text-primary);
   line-height: 1.25;
   display: block;
-<<<<<<< HEAD
   overflow-wrap: break-word;
-=======
-  word-break: break-word;
-}
-
-.notification-message {
-  @include type.type-style('body-short-01');
-
-  color: $text-helper;
-  margin: 0;
-  line-height: 1.4;
-  margin-top: -$spacing-01;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  word-break: break-word;
->>>>>>> 8e9c61bcc14 (mgr/dashboard: Fix the footer - view all button css in notification panel)
 }
 
 .notification-empty {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.scss
@@ -59,6 +59,18 @@ cd-notification-area {
   &:last-child {
     padding-bottom: var(--cds-spacing-05);
   }
+
+  > .border-subtle-bottom {
+    margin: 0 calc(-1 * var(--cds-spacing-05));
+  }
+
+  &:has(.notification-item--clickable) {
+    cursor: pointer;
+
+    &:hover {
+      background-color: var(--cds-layer-hover);
+    }
+  }
 }
 
 .notification-item {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.spec.ts
@@ -49,6 +49,7 @@ describe('NotificationAreaComponent', () => {
     mockDataSource = new BehaviorSubject<CdNotification[]>(mockNotifications);
     const spy = {
       remove: jasmine.createSpy('remove'),
+      removeById: jasmine.createSpy('removeById').and.returnValue(true),
       dataSource: mockDataSource,
       data$: mockDataSource.asObservable(),
       getNotificationsSnapshot: () => mockDataSource.getValue()

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.ts
@@ -98,8 +98,10 @@ export class NotificationAreaComponent implements OnInit, OnDestroy {
 
   navigateToNotification(notification: CdNotification) {
     this.notificationService.togglePanel(false);
+    const isAlreadyOnPage = this.router.url.startsWith('/notifications');
     this.router.navigate(['/notifications'], {
-      queryParams: { id: notification.id }
+      queryParams: { id: notification.id },
+      replaceUrl: isAlreadyOnPage
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.ts
@@ -10,6 +10,7 @@ import moment from 'moment';
 import { ExecutingTask } from '~/app/shared/models/executing-task';
 import { TaskMessageService } from '~/app/shared/services/task-message.service';
 import { Icons } from '~/app/shared/enum/icons.enum';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'cd-notification-area',
@@ -30,7 +31,8 @@ export class NotificationAreaComponent implements OnInit, OnDestroy {
   constructor(
     private notificationService: NotificationService,
     private summaryService: SummaryService,
-    private taskMessageService: TaskMessageService
+    private taskMessageService: TaskMessageService,
+    private router: Router
   ) {}
 
   ngOnInit(): void {
@@ -92,5 +94,18 @@ export class NotificationAreaComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.subs.unsubscribe();
+  }
+
+  navigateToNotification(notification: CdNotification) {
+    this.notificationService.togglePanel(false);
+    this.router.navigate(['/notifications'], {
+      queryParams: { id: notification.id }
+    });
+  }
+
+  removeNotification(notification: CdNotification, event: MouseEvent) {
+    event.stopPropagation();
+    event.preventDefault();
+    this.notificationService.removeById(notification.id);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-item/notification-item.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-item/notification-item.component.html
@@ -36,6 +36,14 @@
       </p>
     }
   }
+  @if (occurrences > 1) {
+    <span
+      class="cd-notification-item__occurrences cds--type-label-01"
+      i18n
+    >
+      Occurrences: {{ occurrences }}
+    </span>
+  }
 </div>
 <!-- RIGHT SECTION -->
 <div class="cd-notification-item__right">

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-item/notification-item.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-item/notification-item.component.scss
@@ -83,6 +83,11 @@ cd-notification-item {
   height: 1rem;
 }
 
+.cd-notification-item__occurrences {
+  color: var(--cds-text-secondary);
+  margin: 0;
+}
+
 .cd-notification-item__chevron svg {
   fill: var(--cds-icon-secondary);
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-item/notification-item.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-item/notification-item.component.spec.ts
@@ -9,7 +9,6 @@ import {
 } from '~/app/shared/enum/notification-type.enum';
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { SharedModule } from '~/app/shared/shared.module';
-import { CdNotification, CdNotificationConfig } from '~/app/shared/models/cd-notification';
 
 @Component({
   template: `

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-item/notification-item.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-item/notification-item.component.spec.ts
@@ -162,17 +162,13 @@ describe('NotificationItemComponent', () => {
     expect(appEl).toBeNull();
   });
 
-  it('should call notificationService.remove and emit deleted on delete', () => {
-    const config = new CdNotificationConfig(NotificationType.error, 'Test', 'msg');
-    const notification = new CdNotification(config);
-    notification.id = 'test-1';
-    spyOn(notificationService, 'getNotificationsSnapshot').and.returnValue([notification]);
-    spyOn(notificationService, 'remove');
+  it('should call notificationService.removeById and emit deleted on delete', () => {
+    spyOn(notificationService, 'removeById').and.returnValue(true);
 
     const deleteBtn = fixture.nativeElement.querySelector('.cd-notification-item__delete');
     deleteBtn.click();
 
-    expect(notificationService.remove).toHaveBeenCalledWith(0);
+    expect(notificationService.removeById).toHaveBeenCalledWith('test-1');
     expect(hostComponent.deletedId).toBe('test-1');
   });
 
@@ -209,13 +205,12 @@ describe('NotificationItemComponent', () => {
   });
 
   it('should not emit deleted when notification is not found', () => {
-    spyOn(notificationService, 'getNotificationsSnapshot').and.returnValue([]);
-    spyOn(notificationService, 'remove');
+    spyOn(notificationService, 'removeById').and.returnValue(false);
 
     const deleteBtn = fixture.nativeElement.querySelector('.cd-notification-item__delete');
     deleteBtn.click();
 
-    expect(notificationService.remove).not.toHaveBeenCalled();
+    expect(notificationService.removeById).toHaveBeenCalledWith('test-1');
     expect(hostComponent.deletedId).toBeNull();
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-item/notification-item.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-item/notification-item.component.ts
@@ -46,10 +46,7 @@ export class NotificationItemComponent {
 
   onDelete(event: Event): void {
     event.stopPropagation();
-    const notifications = this.notificationService.getNotificationsSnapshot();
-    const index = notifications.findIndex((n) => n.id === this.notificationId);
-    if (index > -1) {
-      this.notificationService.remove(index);
+    if (this.notificationService.removeById(this.notificationId)) {
       this.deleted.emit(this.notificationId);
     }
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-item/notification-item.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-item/notification-item.component.ts
@@ -1,4 +1,11 @@
-import { Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  ViewEncapsulation,
+  ChangeDetectionStrategy
+} from '@angular/core';
 import {
   NotificationApplication,
   NotificationType
@@ -10,6 +17,7 @@ import { NotificationService } from '~/app/shared/services/notification.service'
   templateUrl: './notification-item.component.html',
   styleUrls: ['./notification-item.component.scss'],
   encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false
 })
 export class NotificationItemComponent {
@@ -29,6 +37,8 @@ export class NotificationItemComponent {
   @Input() showChevron: boolean = false;
   /* Replace severity icon with unread dot */
   @Input() showUnread: boolean = false;
+  /* Number of deduplicated occurrences */
+  @Input() occurrences: number = 1;
   /* Emitted after notification is deleted via the service */
   @Output() deleted = new EventEmitter<string>();
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.html
@@ -19,16 +19,41 @@
     >
       Notifications
     </h4>
-    <a
-      cdsLink
-      class="notifications-page__header-action"
-      tabindex="0"
-      (click)="clearAll()"
-      (keydown.enter)="clearAll()"
-      i18n
+    <cds-overflow-menu
+      class="notifications-page__header-menu"
+      [flip]="true"
+      description=""
+      i18n-description
     >
-      Clear all
-    </a>
+      <li
+        class="cds--overflow-menu-options__option"
+        [class.cds--overflow-menu-options__option--disabled]="allRead() || hasNoNotifications()"
+      >
+        <button
+          class="cds--overflow-menu-options__btn"
+          type="button"
+          [disabled]="allRead() || hasNoNotifications()"
+          (click)="markAllAsRead()"
+          i18n
+        >
+          Mark all as read
+        </button>
+      </li>
+      <li
+        class="cds--overflow-menu-options__option"
+        [class.cds--overflow-menu-options__option--disabled]="hasNoNotifications()"
+      >
+        <button
+          class="cds--overflow-menu-options__btn"
+          type="button"
+          [disabled]="hasNoNotifications()"
+          (click)="clearAll()"
+          i18n
+        >
+          Clear all
+        </button>
+      </li>
+    </cds-overflow-menu>
   </header>
 
   <div class="notifications-page__body">
@@ -84,6 +109,11 @@
           ></cd-notification-item>
         </div>
         <div class="notifications-page__detail-body cds-mt-5">
+          @if (selected.occurrences > 1) {
+            <p class="notifications-page__occurrences cds--type-label-01" i18n>
+              Occurrences: {{ selected.occurrences }}
+            </p>
+          }
           <p class="notifications-page__detail-text cds--type-body-01">
             {{ selected.displayPreview }}
           </p>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.html
@@ -74,6 +74,7 @@
             [timestamp]="notification.timestamp"
             [message]="notification.displayPreview"
             [notificationId]="notification.id"
+            [occurrences]="notification.occurrences"
             [showChevron]="true"
             [showUnread]="!readMap()[notification.id]"
           >
@@ -91,6 +92,12 @@
             i18n
           >
             No notifications available
+          </p>
+          <p
+            class="cds-mt-3 cds--type-helper-text-01"
+            i18n
+          >
+            Notifications are stored locally and cleared on browser reset.
           </p>
         </div>
       }
@@ -110,7 +117,10 @@
         </div>
         <div class="notifications-page__detail-body cds-mt-5">
           @if (selected.occurrences > 1) {
-            <p class="notifications-page__occurrences cds--type-label-01" i18n>
+            <p
+              class="notifications-page__occurrences cds--type-label-01"
+              i18n
+            >
               Occurrences: {{ selected.occurrences }}
             </p>
           }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.scss
@@ -18,10 +18,10 @@
     display: inline-flex;
     align-items: center;
     gap: var(--cds-spacing-02);
+  }
 
-    &:last-child {
-      justify-self: end;
-    }
+  &__header-menu {
+    justify-self: end;
   }
 
   &__header-title {
@@ -77,6 +77,11 @@
       font-weight: var(--cds-heading-compact-02-font-weight);
       line-height: var(--cds-heading-compact-02-line-height);
     }
+  }
+
+  &__occurrences {
+    margin: 0 0 var(--cds-spacing-03) 0;
+    color: var(--cds-text-secondary);
   }
 
   &__detail-text {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.spec.ts
@@ -22,6 +22,7 @@ describe('NotificationsPageComponent', () => {
   let readMapSubject: BehaviorSubject<Record<string, boolean>>;
   let notificationService: any;
   let mockLocation: any;
+  let queryParamsSubject: BehaviorSubject<any>;
 
   const createMockNotificationService = () => {
     dataSourceSubject = new BehaviorSubject<CdNotification[]>([]);
@@ -50,7 +51,8 @@ describe('NotificationsPageComponent', () => {
           readMapSubject.next(updated);
           localStorage.setItem('cdNotificationsRead', JSON.stringify(updated));
         }
-      })
+      }),
+      getNotificationsSnapshot: () => dataSourceSubject.getValue()
     };
   };
 
@@ -118,6 +120,7 @@ describe('NotificationsPageComponent', () => {
     mockLocation = { back: jasmine.createSpy('back') };
     const mockNotificationService = createMockNotificationService();
     notificationService = mockNotificationService;
+    queryParamsSubject = new BehaviorSubject<any>({});
 
     localStorage.removeItem('cdNotificationsRead');
 
@@ -130,7 +133,13 @@ describe('NotificationsPageComponent', () => {
         { provide: PrometheusNotificationService, useValue: mockPrometheusNotificationService },
         { provide: AuthStorageService, useValue: mockAuthStorageService },
         { provide: Location, useValue: mockLocation },
-        { provide: ActivatedRoute, useValue: { snapshot: { queryParams: {} } } }
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { queryParams: {} },
+            queryParams: queryParamsSubject.asObservable()
+          }
+        }
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
@@ -310,13 +319,8 @@ describe('NotificationsPageComponent', () => {
   });
 
   describe('query param pre-selection', () => {
-    it('should pre-select notification from id query param', async () => {
-      const route = TestBed.inject(ActivatedRoute);
-      (route.snapshot.queryParams as any) = { id: '2' };
-
-      fixture = TestBed.createComponent(NotificationsPageComponent);
-      component = fixture.componentInstance;
-      dataSourceSubject.next(mockNotifications);
+    it('should pre-select notification from id query param', () => {
+      queryParamsSubject.next({ id: '2' });
       fixture.detectChanges();
 
       expect(component.selectedNotificationID()).toBe('2');
@@ -324,25 +328,16 @@ describe('NotificationsPageComponent', () => {
     });
 
     it('should not pre-select if id does not match any notification', () => {
-      const route = TestBed.inject(ActivatedRoute);
-      (route.snapshot.queryParams as any) = { id: 'nonexistent' };
-
-      fixture = TestBed.createComponent(NotificationsPageComponent);
-      component = fixture.componentInstance;
-      dataSourceSubject.next(mockNotifications);
+      queryParamsSubject.next({ id: 'nonexistent' });
       fixture.detectChanges();
 
       expect(component.selectedNotificationID()).toBeNull();
     });
 
     it('should not override manual selection on subsequent data emissions', () => {
-      const route = TestBed.inject(ActivatedRoute);
-      (route.snapshot.queryParams as any) = { id: '2' };
-
-      fixture = TestBed.createComponent(NotificationsPageComponent);
-      component = fixture.componentInstance;
-      dataSourceSubject.next(mockNotifications);
+      queryParamsSubject.next({ id: '2' });
       fixture.detectChanges();
+      expect(component.selectedNotificationID()).toBe('2');
 
       component.onNotificationSelect(component.notifications()[0]);
       expect(component.selectedNotificationID()).toBe('1');
@@ -350,6 +345,17 @@ describe('NotificationsPageComponent', () => {
       dataSourceSubject.next(mockNotifications);
       fixture.detectChanges();
       expect(component.selectedNotificationID()).toBe('1');
+    });
+
+    it('should pre-select when navigating from toast view more link', () => {
+      dataSourceSubject.next(mockNotifications);
+      fixture.detectChanges();
+
+      queryParamsSubject.next({ id: '3' });
+      fixture.detectChanges();
+
+      expect(component.selectedNotificationID()).toBe('3');
+      expect(notificationService.markAsRead).toHaveBeenCalledWith('3');
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.spec.ts
@@ -11,6 +11,7 @@ import { PrometheusAlertService } from '~/app/shared/services/prometheus-alert.s
 import { PrometheusNotificationService } from '~/app/shared/services/prometheus-notification.service';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { SharedModule } from '~/app/shared/shared.module';
 
 describe('NotificationsPageComponent', () => {
@@ -33,7 +34,15 @@ describe('NotificationsPageComponent', () => {
         next: (value: CdNotification[]) => dataSourceSubject.next(value)
       },
       remove: jasmine.createSpy('remove'),
+      removeById: jasmine.createSpy('removeById').and.returnValue(true),
       removeAll: jasmine.createSpy('removeAll'),
+      markAllAsRead: jasmine.createSpy('markAllAsRead').and.callFake(() => {
+        const notifications = dataSourceSubject.getValue();
+        const updated = { ...readMapSubject.getValue() };
+        notifications.forEach((n) => (updated[n.id] = true));
+        readMapSubject.next(updated);
+        localStorage.setItem('cdNotificationsRead', JSON.stringify(updated));
+      }),
       markAsRead: jasmine.createSpy('markAsRead').and.callFake((id: string) => {
         const current = readMapSubject.getValue();
         if (!current[id]) {
@@ -120,7 +129,8 @@ describe('NotificationsPageComponent', () => {
         { provide: PrometheusAlertService, useValue: mockPrometheusAlertService },
         { provide: PrometheusNotificationService, useValue: mockPrometheusNotificationService },
         { provide: AuthStorageService, useValue: mockAuthStorageService },
-        { provide: Location, useValue: mockLocation }
+        { provide: Location, useValue: mockLocation },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParams: {} } } }
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
@@ -177,7 +187,7 @@ describe('NotificationsPageComponent', () => {
       } as any;
       component.removeNotification(component.notifications()[0], mockEvent);
       expect(mockEvent.stopPropagation).toHaveBeenCalled();
-      expect(notificationService.remove).toHaveBeenCalledWith(0);
+      expect(notificationService.removeById).toHaveBeenCalledWith('1');
     });
 
     it('should clear selection if removed notification was selected', () => {
@@ -238,6 +248,15 @@ describe('NotificationsPageComponent', () => {
       expect(component.readMap()['2']).toBe(true);
       expect(component.readMap()['1']).toBeFalsy();
     });
+
+    it('should mark all notifications as read', () => {
+      component.markAllAsRead();
+      fixture.detectChanges();
+      expect(notificationService.markAllAsRead).toHaveBeenCalled();
+      expect(component.readMap()['1']).toBe(true);
+      expect(component.readMap()['2']).toBe(true);
+      expect(component.readMap()['3']).toBe(true);
+    });
   });
 
   describe('displayTitle and displayPreview', () => {
@@ -287,6 +306,50 @@ describe('NotificationsPageComponent', () => {
       dataSourceSubject.next([emptyNotification]);
       fixture.detectChanges();
       expect(component.notifications()[0].displayPreview).toBe('');
+    });
+  });
+
+  describe('query param pre-selection', () => {
+    it('should pre-select notification from id query param', async () => {
+      const route = TestBed.inject(ActivatedRoute);
+      (route.snapshot.queryParams as any) = { id: '2' };
+
+      fixture = TestBed.createComponent(NotificationsPageComponent);
+      component = fixture.componentInstance;
+      dataSourceSubject.next(mockNotifications);
+      fixture.detectChanges();
+
+      expect(component.selectedNotificationID()).toBe('2');
+      expect(notificationService.markAsRead).toHaveBeenCalledWith('2');
+    });
+
+    it('should not pre-select if id does not match any notification', () => {
+      const route = TestBed.inject(ActivatedRoute);
+      (route.snapshot.queryParams as any) = { id: 'nonexistent' };
+
+      fixture = TestBed.createComponent(NotificationsPageComponent);
+      component = fixture.componentInstance;
+      dataSourceSubject.next(mockNotifications);
+      fixture.detectChanges();
+
+      expect(component.selectedNotificationID()).toBeNull();
+    });
+
+    it('should not override manual selection on subsequent data emissions', () => {
+      const route = TestBed.inject(ActivatedRoute);
+      (route.snapshot.queryParams as any) = { id: '2' };
+
+      fixture = TestBed.createComponent(NotificationsPageComponent);
+      component = fixture.componentInstance;
+      dataSourceSubject.next(mockNotifications);
+      fixture.detectChanges();
+
+      component.onNotificationSelect(component.notifications()[0]);
+      expect(component.selectedNotificationID()).toBe('1');
+
+      dataSourceSubject.next(mockNotifications);
+      fixture.detectChanges();
+      expect(component.selectedNotificationID()).toBe('1');
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.spec.ts
@@ -347,6 +347,17 @@ describe('NotificationsPageComponent', () => {
       expect(component.selectedNotificationID()).toBe('1');
     });
 
+    it('should re-select when query params change while a notification is already selected', () => {
+      queryParamsSubject.next({ id: '1' });
+      fixture.detectChanges();
+      expect(component.selectedNotificationID()).toBe('1');
+
+      queryParamsSubject.next({ id: '2' });
+      fixture.detectChanges();
+      expect(component.selectedNotificationID()).toBe('2');
+      expect(notificationService.markAsRead).toHaveBeenCalledWith('2');
+    });
+
     it('should pre-select when navigating from toast view more link', () => {
       dataSourceSubject.next(mockNotifications);
       fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.ts
@@ -8,6 +8,7 @@ import {
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { Location } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { CdNotification } from '~/app/shared/models/cd-notification';
@@ -38,6 +39,13 @@ export class NotificationsPageComponent implements OnInit, OnDestroy {
     this.notifications().find((n) => n.id === this.selectedNotificationID())
   );
 
+  hasNoNotifications = computed(() => this.notifications().length === 0);
+
+  allRead = computed(() => {
+    const map = this.readMap();
+    return this.notifications().every((n) => map[n.id]);
+  });
+
   private sub: Subscription;
   private interval: number;
 
@@ -46,7 +54,8 @@ export class NotificationsPageComponent implements OnInit, OnDestroy {
     private prometheusAlertService: PrometheusAlertService,
     private prometheusNotificationService: PrometheusNotificationService,
     private authStorageService: AuthStorageService,
-    private location: Location
+    private location: Location,
+    private route: ActivatedRoute
   ) {
     this.readMap = toSignal(this.notificationService.readMap$, {
       initialValue: {} as Record<string, boolean>
@@ -71,6 +80,15 @@ export class NotificationsPageComponent implements OnInit, OnDestroy {
           })
         )
       );
+
+      const id = this.route.snapshot.queryParams['id'];
+      if (id && !this.selectedNotificationID()) {
+        const match = notifications.find((n) => n.id === id);
+        if (match) {
+          this.selectedNotificationID.set(id);
+          this.notificationService.markAsRead(id);
+        }
+      }
     });
   }
 
@@ -85,6 +103,10 @@ export class NotificationsPageComponent implements OnInit, OnDestroy {
     this.location.back();
   }
 
+  markAllAsRead(): void {
+    this.notificationService.markAllAsRead();
+  }
+
   clearAll(): void {
     this.notificationService.removeAll();
     this.selectedNotificationID.set(null);
@@ -97,9 +119,7 @@ export class NotificationsPageComponent implements OnInit, OnDestroy {
 
   removeNotification(notification: DisplayNotification, event: MouseEvent): void {
     event.stopPropagation();
-    const index = this.notifications().findIndex((n) => n.id === notification.id);
-    if (index > -1) {
-      this.notificationService.remove(index);
+    if (this.notificationService.removeById(notification.id)) {
       if (this.selectedNotificationID() === notification.id) {
         this.selectedNotificationID.set(null);
       }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.ts
@@ -48,6 +48,7 @@ export class NotificationsPageComponent implements OnInit, OnDestroy {
 
   private sub: Subscription;
   private interval: number;
+  private _pendingId: string | null = null;
 
   constructor(
     private notificationService: NotificationService,
@@ -81,15 +82,15 @@ export class NotificationsPageComponent implements OnInit, OnDestroy {
         )
       );
 
-      const id = this.route.snapshot.queryParams['id'];
-      if (id && !this.selectedNotificationID()) {
-        const match = notifications.find((n) => n.id === id);
-        if (match) {
-          this.selectedNotificationID.set(id);
-          this.notificationService.markAsRead(id);
-        }
-      }
+      this._tryPreselect(notifications);
     });
+
+    this.sub.add(
+      this.route.queryParams.subscribe((params) => {
+        this._pendingId = params['id'] || null;
+        this._tryPreselect(this.notificationService.getNotificationsSnapshot());
+      })
+    );
   }
 
   ngOnDestroy(): void {
@@ -129,6 +130,16 @@ export class NotificationsPageComponent implements OnInit, OnDestroy {
   onNotificationDeleted(notificationId: string): void {
     if (this.selectedNotificationID() === notificationId) {
       this.selectedNotificationID.set(null);
+    }
+  }
+
+  private _tryPreselect(notifications: CdNotification[]): void {
+    if (!this._pendingId || this.selectedNotificationID()) return;
+    const match = notifications.find((n) => n.id === this._pendingId);
+    if (match) {
+      this.selectedNotificationID.set(this._pendingId);
+      this.notificationService.markAsRead(this._pendingId);
+      this._pendingId = null;
     }
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.ts
@@ -88,7 +88,7 @@ export class NotificationsPageComponent implements OnInit, OnDestroy {
     this.sub.add(
       this.route.queryParams.subscribe((params) => {
         this._pendingId = params['id'] || null;
-        this._tryPreselect(this.notificationService.getNotificationsSnapshot());
+        this._tryPreselect(this.notificationService.getNotificationsSnapshot(), true);
       })
     );
   }
@@ -133,8 +133,8 @@ export class NotificationsPageComponent implements OnInit, OnDestroy {
     }
   }
 
-  private _tryPreselect(notifications: CdNotification[]): void {
-    if (!this._pendingId || this.selectedNotificationID()) return;
+  private _tryPreselect(notifications: CdNotification[], force = false): void {
+    if (!this._pendingId || (!force && this.selectedNotificationID())) return;
     const match = notifications.find((n) => n.id === this._pendingId);
     if (match) {
       this.selectedNotificationID.set(this._pendingId);

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.html
@@ -1,10 +1,10 @@
-@if (isMuted) {
+@if (isMuted()) {
   <cd-icon
     type="notificationOff"
     [size]="iconSize"
   >
   </cd-icon>
-} @else if (!isMuted && (hasRunningTasks || hasNotifications)) {
+} @else if (hasRunningTasks() || hasNotifications()) {
   <cd-icon
     type="notificationNew"
     [size]="iconSize"

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.spec.ts
@@ -1,44 +1,41 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
-import { CdNotification, CdNotificationConfig } from '~/app/shared/models/cd-notification';
+import { BehaviorSubject } from 'rxjs';
+
 import { ExecutingTask } from '~/app/shared/models/executing-task';
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { SummaryService } from '~/app/shared/services/summary.service';
-import { SharedModule } from '~/app/shared/shared.module';
 import { configureTestBed } from '~/testing/unit-test-helper';
 import { NotificationsComponent } from './notifications.component';
-import { BehaviorSubject } from 'rxjs';
 
 describe('NotificationsComponent', () => {
   let component: NotificationsComponent;
   let fixture: ComponentFixture<NotificationsComponent>;
   let summaryService: SummaryService;
-  let notificationService: NotificationService;
+
   const hasUnreadSource = new BehaviorSubject(false);
+  const muteSource = new BehaviorSubject(false);
 
   const notificationServiceMock = {
-    dataSource: new BehaviorSubject([]),
-    hasUnreadSource,
-    get hasUnread$() {
-      return hasUnreadSource.asObservable();
-    },
-    muteState$: new BehaviorSubject(false)
+    hasUnread$: hasUnreadSource.asObservable(),
+    muteState$: muteSource.asObservable()
   };
 
   configureTestBed({
-    imports: [HttpClientTestingModule, SharedModule, RouterTestingModule],
+    imports: [HttpClientTestingModule],
     declarations: [NotificationsComponent],
-    providers: [{ provide: NotificationService, useValue: notificationServiceMock }]
+    providers: [{ provide: NotificationService, useValue: notificationServiceMock }],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA]
   });
 
   beforeEach(() => {
+    hasUnreadSource.next(false);
+    muteSource.next(false);
     fixture = TestBed.createComponent(NotificationsComponent);
     component = fixture.componentInstance;
     summaryService = TestBed.inject(SummaryService);
-    notificationService = TestBed.inject(NotificationService);
-
     fixture.detectChanges();
   });
 
@@ -46,24 +43,38 @@ describe('NotificationsComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should subscribe and check if there are running tasks', () => {
-    expect(component.hasRunningTasks).toBeFalsy();
+  it('should reflect running tasks from summary service', () => {
+    expect(component.hasRunningTasks()).toBe(false);
 
     const task = new ExecutingTask('task', { name: 'name' });
     summaryService['summaryDataSource'].next({ executing_tasks: [task] });
 
-    expect(component.hasRunningTasks).toBeTruthy();
+    expect(component.hasRunningTasks()).toBe(true);
   });
 
-  it('should show notificationNew icon if there are notifications', () => {
-    const notification = new CdNotification(new CdNotificationConfig());
-    notificationService['dataSource'].next([notification]);
-    notificationService['hasUnreadSource'].next(true);
-
+  it('should show notificationNew icon when unread notifications exist', () => {
+    hasUnreadSource.next(true);
     fixture.detectChanges();
 
     const icon = fixture.debugElement.nativeElement.querySelector('cd-icon');
     expect(icon).toBeTruthy();
     expect(icon.getAttribute('type')).toBe('notificationNew');
+  });
+
+  it('should show notification icon when no unread and no running tasks', () => {
+    fixture.detectChanges();
+
+    const icon = fixture.debugElement.nativeElement.querySelector('cd-icon');
+    expect(icon).toBeTruthy();
+    expect(icon.getAttribute('type')).toBe('notification');
+  });
+
+  it('should show notificationOff icon when muted', () => {
+    muteSource.next(true);
+    fixture.detectChanges();
+
+    const icon = fixture.debugElement.nativeElement.querySelector('cd-icon');
+    expect(icon).toBeTruthy();
+    expect(icon.getAttribute('type')).toBe('notificationOff');
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
-
-import { Subscription } from 'rxjs';
+import { Component, ChangeDetectionStrategy, inject, Signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { map } from 'rxjs/operators';
 
 import { ICON_TYPE, IconSize } from '~/app/shared/enum/icons.enum';
 import { NotificationService } from '~/app/shared/services/notification.service';
@@ -10,42 +10,21 @@ import { SummaryService } from '~/app/shared/services/summary.service';
   selector: 'cd-notifications',
   templateUrl: './notifications.component.html',
   styleUrls: ['./notifications.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false
 })
-export class NotificationsComponent implements OnInit, OnDestroy {
+export class NotificationsComponent {
   icons = ICON_TYPE;
   iconSize = IconSize.size20;
-  hasRunningTasks = false;
-  hasNotifications = false;
-  isMuted = false;
-  private subs = new Subscription();
 
-  constructor(
-    public notificationService: NotificationService,
-    private summaryService: SummaryService
-  ) {}
+  private notificationService = inject(NotificationService);
+  private summaryService = inject(SummaryService);
 
-  ngOnInit() {
-    this.subs.add(
-      this.summaryService.subscribe((summary) => {
-        this.hasRunningTasks = summary.executing_tasks.length > 0;
-      })
-    );
+  hasRunningTasks: Signal<boolean> = toSignal(
+    this.summaryService.summaryData$.pipe(map((summary) => summary?.executing_tasks?.length > 0)),
+    { initialValue: false }
+  );
 
-    this.subs.add(
-      this.notificationService.muteState$.subscribe((isMuted) => {
-        this.isMuted = isMuted;
-      })
-    );
-
-    this.subs.add(
-      this.notificationService.hasUnread$.subscribe(
-        (hasUnread) => (this.hasNotifications = hasUnread)
-      )
-    );
-  }
-
-  ngOnDestroy(): void {
-    this.subs.unsubscribe();
-  }
+  isMuted = toSignal(this.notificationService.muteState$, { initialValue: false });
+  hasNotifications = toSignal(this.notificationService.hasUnread$, { initialValue: false });
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.scss
@@ -1,7 +1,6 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/layer' as *;
-@use '@carbon/styles/scss/type' as *;
 
 .cds--toast-notification-container {
   position: fixed;
@@ -31,7 +30,20 @@
         -webkit-line-clamp: 3;
         -webkit-box-orient: vertical;
         overflow: hidden;
-        word-break: break-word;
+        overflow-wrap: break-word;
+
+        .toast-message {
+          display: -webkit-box;
+          -webkit-line-clamp: 2;
+          -webkit-box-orient: vertical;
+          overflow: hidden;
+        }
+
+        .toast-duplicate-count {
+          display: block;
+          color: $text-secondary;
+          margin-top: $spacing-02;
+        }
       }
 
       .cds--toast-notification__close-button {
@@ -55,6 +67,16 @@
 
       .toast-caption-container .date {
         flex-shrink: 0;
+      }
+
+      .toast-caption-container .toast-view-more {
+        color: $link-primary;
+        text-decoration: none;
+        margin-inline-start: auto;
+
+        &:hover {
+          text-decoration: underline;
+        }
       }
     }
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.scss
@@ -26,6 +26,14 @@
         color: $text-primary;
       }
 
+      .cds--toast-notification__subtitle {
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        word-break: break-word;
+      }
+
       .cds--toast-notification__close-button {
         color: $icon-primary;
       }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Router } from '@angular/router';
 import { of } from 'rxjs';
 import { ToastContent } from 'carbon-components-angular';
 
@@ -11,10 +12,16 @@ describe('ToastComponent', () => {
   let component: ToastComponent;
   let fixture: ComponentFixture<ToastComponent>;
   let mockToasts: ToastContent[];
+  let mockRouter: any;
 
   const mockNotificationService = {
     activeToasts$: of([]),
-    removeToast: jest.fn()
+    removeToast: jest.fn(),
+    clearAllToasts: jest.fn()
+  };
+
+  mockRouter = {
+    navigateByUrl: jest.fn()
   };
 
   configureTestBed({
@@ -24,6 +31,10 @@ describe('ToastComponent', () => {
       {
         provide: NotificationService,
         useValue: mockNotificationService
+      },
+      {
+        provide: Router,
+        useValue: mockRouter
       }
     ]
   });
@@ -67,5 +78,36 @@ describe('ToastComponent', () => {
     const toast = mockToasts[0];
     component.onToastClose(toast);
     expect(mockNotificationService.removeToast).toHaveBeenCalledWith(toast);
+  });
+
+  describe('view more click', () => {
+    it('should navigate and clear toasts when view-more link is clicked', () => {
+      fixture.detectChanges();
+      const link = document.createElement('a');
+      link.classList.add('toast-view-more');
+      link.setAttribute('href', '#/notifications?id=abc123');
+      fixture.nativeElement.appendChild(link);
+
+      const event = new MouseEvent('click', { bubbles: true });
+      const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+      link.dispatchEvent(event);
+
+      expect(preventDefaultSpy).toHaveBeenCalled();
+      expect(mockRouter.navigateByUrl).toHaveBeenCalledWith('/notifications?id=abc123');
+      expect(mockNotificationService.clearAllToasts).toHaveBeenCalled();
+    });
+
+    it('should not navigate for non view-more clicks', () => {
+      fixture.detectChanges();
+      mockRouter.navigateByUrl.mockClear();
+      mockNotificationService.clearAllToasts.mockClear();
+
+      const span = document.createElement('span');
+      fixture.nativeElement.appendChild(span);
+      span.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+      expect(mockRouter.navigateByUrl).not.toHaveBeenCalled();
+      expect(mockNotificationService.clearAllToasts).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.ts
@@ -1,5 +1,12 @@
-import { Component, OnInit } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  AfterViewChecked,
+  HostListener,
+  ElementRef
+} from '@angular/core';
 import { animate, style, transition, trigger } from '@angular/animations';
+import { Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { ToastContent } from 'carbon-components-angular';
 import { NotificationService } from '../../services/notification.service';
@@ -30,13 +37,41 @@ import { NotificationService } from '../../services/notification.service';
   ],
   standalone: false
 })
-export class ToastComponent implements OnInit {
+export class ToastComponent implements OnInit, AfterViewChecked {
   activeToasts$: Observable<ToastContent[]>;
 
-  constructor(private notificationService: NotificationService) {}
+  constructor(
+    private notificationService: NotificationService,
+    private router: Router,
+    private el: ElementRef
+  ) {}
 
   ngOnInit() {
     this.activeToasts$ = this.notificationService.activeToasts$;
+  }
+
+  ngAfterViewChecked() {
+    const toasts = this.el.nativeElement.querySelectorAll('cds-toast');
+    toasts.forEach((toast: HTMLElement) => {
+      const subtitle = toast.querySelector('.cds--toast-notification__subtitle');
+      const viewMore = toast.querySelector('.toast-view-more') as HTMLElement;
+      if (!subtitle || !viewMore) return;
+      const isTruncated = subtitle.scrollHeight > subtitle.clientHeight;
+      viewMore.style.display = isTruncated ? '' : 'none';
+    });
+  }
+
+  @HostListener('click', ['$event'])
+  onViewMoreClick(event: Event) {
+    const target = event.target as HTMLElement;
+    if (target.classList.contains('toast-view-more')) {
+      event.preventDefault();
+      const href = target.getAttribute('href');
+      if (href) {
+        this.router.navigateByUrl(href.replace('#', ''));
+      }
+      this.notificationService.clearAllToasts();
+    }
   }
 
   onToastClose(toast: ToastContent) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.ts
@@ -3,7 +3,8 @@ import {
   OnInit,
   AfterViewChecked,
   HostListener,
-  ElementRef
+  ElementRef,
+  ChangeDetectionStrategy
 } from '@angular/core';
 import { animate, style, transition, trigger } from '@angular/animations';
 import { Router } from '@angular/router';
@@ -15,6 +16,7 @@ import { NotificationService } from '../../services/notification.service';
   selector: 'cd-toast',
   templateUrl: './notification-toast.component.html',
   styleUrls: ['./notification-toast.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   animations: [
     trigger('toastAnimation', [
       transition(
@@ -39,6 +41,7 @@ import { NotificationService } from '../../services/notification.service';
 })
 export class ToastComponent implements OnInit, AfterViewChecked {
   activeToasts$: Observable<ToastContent[]>;
+  private toastsDirty = false;
 
   constructor(
     private notificationService: NotificationService,
@@ -48,15 +51,22 @@ export class ToastComponent implements OnInit, AfterViewChecked {
 
   ngOnInit() {
     this.activeToasts$ = this.notificationService.activeToasts$;
+    this.notificationService.activeToasts$.subscribe(() => {
+      this.toastsDirty = true;
+    });
   }
 
   ngAfterViewChecked() {
+    if (!this.toastsDirty) return;
+    this.toastsDirty = false;
+
     const toasts = this.el.nativeElement.querySelectorAll('cds-toast');
     toasts.forEach((toast: HTMLElement) => {
       const subtitle = toast.querySelector('.cds--toast-notification__subtitle');
       const viewMore = toast.querySelector('.toast-view-more') as HTMLElement;
       if (!subtitle || !viewMore) return;
-      const isTruncated = subtitle.scrollHeight > subtitle.clientHeight;
+      const textEl = subtitle.querySelector('.toast-message') || subtitle;
+      const isTruncated = textEl.scrollHeight > textEl.clientHeight;
       viewMore.style.display = isTruncated ? '' : 'none';
     });
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-notification.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-notification.ts
@@ -52,6 +52,7 @@ export class CdNotification extends CdNotificationConfig {
   iconClass: string;
   duration: number;
   borderClass: string;
+  occurrences = 1;
   alertSilenced = false;
   silenceId?: string;
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.spec.ts
@@ -164,7 +164,7 @@ describe('NotificationService', () => {
       expectSavedNotificationToHave({
         type: NotificationType.error,
         title: '502 - Bad Gateway',
-        message: '<ul><li>Error occurred in path a</li><li>Error occurred in path b</li></ul>'
+        message: 'Error occurred in path a (+1 more)'
       });
       flush();
     }));

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.spec.ts
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import { configureTestBed } from '~/testing/unit-test-helper';
 import { RbdService } from '../api/rbd.service';
 import { NotificationType } from '../enum/notification-type.enum';
-import { CdNotificationConfig } from '../models/cd-notification';
+import { CdNotification, CdNotificationConfig } from '../models/cd-notification';
 import { FinishedTask } from '../models/finished-task';
 import { CdDatePipe } from '../pipes/cd-date.pipe';
 import { NotificationService } from './notification.service';
@@ -157,15 +157,25 @@ describe('NotificationService', () => {
       flush();
     }));
 
-    it('combines different notifications with the same title', fakeAsync(() => {
+    it('deduplicates notifications with the same title, type, and message', fakeAsync(() => {
       service.show(NotificationType.error, '502 - Bad Gateway', 'Error occurred in path a');
-      tick(60);
+      tick(600);
+      service.show(NotificationType.error, '502 - Bad Gateway', 'Error occurred in path a');
+      tick(600);
+      const notifications = service['dataSource'].getValue();
+      expect(notifications.length).toBe(1);
+      expect(notifications[0].title).toBe('502 - Bad Gateway');
+      expect(notifications[0].occurrences).toBe(2);
+      flush();
+    }));
+
+    it('does not deduplicate notifications with different messages', fakeAsync(() => {
+      service.show(NotificationType.error, '502 - Bad Gateway', 'Error occurred in path a');
+      tick(600);
       service.show(NotificationType.error, '502 - Bad Gateway', 'Error occurred in path b');
-      expectSavedNotificationToHave({
-        type: NotificationType.error,
-        title: '502 - Bad Gateway',
-        message: 'Error occurred in path a (+1 more)'
-      });
+      tick(600);
+      const notifications = service['dataSource'].getValue();
+      expect(notifications.length).toBe(2);
       flush();
     }));
 
@@ -285,5 +295,66 @@ describe('NotificationService', () => {
       expect(toasts[0].caption).not.toContain('Prometheus');
       flush();
     }));
+  });
+
+  describe('Active toast limit', () => {
+    it('should show only the latest 2 toasts', fakeAsync(() => {
+      for (let i = 0; i < 5; i++) {
+        service.show(NotificationType.error, `Error ${i}`, `Message ${i}`);
+        tick(600);
+      }
+      const toasts = service['activeToastsSource'].getValue();
+      expect(toasts.length).toBe(2);
+      expect(toasts[0].title).toBe('Error 4');
+      expect(toasts[1].title).toBe('Error 3');
+      flush();
+    }));
+  });
+
+  describe('Read state', () => {
+    it('should mark a notification as read', () => {
+      const config = new CdNotificationConfig(NotificationType.info, 'Test');
+      const notification = new CdNotification(config);
+      service.save(notification);
+
+      expect(service['hasUnreadSource'].getValue()).toBe(true);
+      service.markAsRead(notification.id);
+      expect(service['hasUnreadSource'].getValue()).toBe(false);
+    });
+
+    it('should mark all notifications as read', () => {
+      const n1 = new CdNotification(new CdNotificationConfig(NotificationType.info, 'A'));
+      const n2 = new CdNotification(new CdNotificationConfig(NotificationType.error, 'B'));
+      service.save(n1);
+      service.save(n2);
+
+      expect(service['hasUnreadSource'].getValue()).toBe(true);
+      service.markAllAsRead();
+      expect(service['hasUnreadSource'].getValue()).toBe(false);
+    });
+
+    it('should clear read state when a notification gets a new occurrence', () => {
+      const n1 = new CdNotification(new CdNotificationConfig(NotificationType.error, 'Err', 'msg'));
+      service.save(n1);
+      service.markAsRead(n1.id);
+      expect(service['hasUnreadSource'].getValue()).toBe(false);
+
+      const n2 = new CdNotification(new CdNotificationConfig(NotificationType.error, 'Err', 'msg'));
+      service.save(n2);
+      expect(service['hasUnreadSource'].getValue()).toBe(true);
+      expect(service['dataSource'].getValue()[0].occurrences).toBe(2);
+    });
+
+    it('should remove by id', () => {
+      const n1 = new CdNotification(new CdNotificationConfig(NotificationType.info, 'A'));
+      service.save(n1);
+      expect(service['dataSource'].getValue().length).toBe(1);
+      expect(service.removeById(n1.id)).toBe(true);
+      expect(service['dataSource'].getValue().length).toBe(0);
+    });
+
+    it('should return false when removing non-existent id', () => {
+      expect(service.removeById('nonexistent')).toBe(false);
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.ts
@@ -26,6 +26,8 @@ export class NotificationService {
   private readonly MAX_NOTIFICATIONS = 10;
   private readonly SHOW_DELAY = 10;
   private readonly QUEUE_DELAY = 500;
+  private readonly ERROR_TOAST_DURATION = 10000;
+  private readonly DEFAULT_TOAST_DURATION = 5000;
   private readonly LOCAL_STORAGE_KEY = 'cdNotifications';
   private readonly LOCAL_STORAGE_MUTE_KEY = 'cdNotificationsMuted';
   private readonly LOCAL_STORAGE_READ_KEY = 'cdNotificationsRead';
@@ -129,7 +131,19 @@ export class NotificationService {
    * Saving a shown notification in local storage
    */
   save(notification: CdNotification) {
-    const notifications = [notification, ...this.dataSource.getValue()];
+    const current = this.dataSource.getValue();
+    const existing = current.find(
+      (n) => n.title === notification.title && n.type === notification.type
+    );
+
+    let notifications: CdNotification[];
+    if (existing) {
+      existing.occurrences = (existing.occurrences || 1) + 1;
+      existing.timestamp = notification.timestamp;
+      notifications = [...current];
+    } else {
+      notifications = [notification, ...current];
+    }
 
     const limited = notifications
       .sort((a, b) => (a.timestamp > b.timestamp ? -1 : 1))
@@ -151,6 +165,14 @@ export class NotificationService {
     this._persistNotifications(notifications);
   }
 
+  removeById(id: string): boolean {
+    const notifications = this.dataSource.getValue();
+    const index = notifications.findIndex((n) => n.id === id);
+    if (index === -1) return false;
+    this.remove(index);
+    return true;
+  }
+
   /**
    * Removes all current saved notifications from storage (and any appearing toasts)
    */
@@ -160,7 +182,7 @@ export class NotificationService {
     this.readMapSource.next({});
     this.dataSource.next([]);
     this.hasUnreadSource.next(false);
-    this._clearAllToasts();
+    this.clearAllToasts();
   }
 
   /**
@@ -261,21 +283,39 @@ export class NotificationService {
     const carbonType = this.NOTIFICATION_TYPE_MAP[notification.type] || 'info';
     const lowContrast = notification.options?.lowContrast || false;
 
+    const existing = this.activeToasts.find(
+      (t) => t.title === notification.title && t.type === carbonType
+    );
+    if (existing) {
+      existing.duplicateCount = (existing.duplicateCount || 1) + 1;
+      const count = existing.duplicateCount - 1;
+      existing.subtitle = `<span class="toast-message">${existing.originalSubtitle}</span><span class="toast-duplicate-count">(+${count} more)</span>`;
+      existing.caption = this._renderTimeAndApplicationHtml(notification);
+      this.activeToastsSource.next([...this.activeToasts]);
+      return;
+    }
+
+    const subtitle = notification.message || '';
     const toast: ToastContent = {
       title: notification.title,
-      subtitle: notification.message || '',
+      subtitle,
       caption: this._renderTimeAndApplicationHtml(notification),
       type: carbonType,
       lowContrast: lowContrast,
       showClose: true,
-      duration: notification.options?.timeOut || 5000
+      duration:
+        notification.options?.timeOut ||
+        (notification.type === NotificationType.error
+          ? this.ERROR_TOAST_DURATION
+          : this.DEFAULT_TOAST_DURATION),
+      notificationId: notification.id,
+      duplicateCount: 1,
+      originalSubtitle: subtitle
     };
 
-    // Add new toast to the beginning of the array
     this.activeToasts.unshift(toast);
     this.activeToastsSource.next(this.activeToasts);
 
-    // Handle duration-based auto-dismissal
     if (toast.duration && toast.duration > 0) {
       this.ngZone.runOutsideAngular(() => {
         setTimeout(() => {
@@ -288,14 +328,13 @@ export class NotificationService {
   }
 
   private _renderTimeAndApplicationHtml(notification: CdNotification): string {
-    let html = `<div class="toast-caption-container">
-      <small class="date">${this.cdDatePipe.transform(notification.timestamp)}</small>`;
-
-    html += '</div>';
-    return html;
+    return `<div class="toast-caption-container">
+      <small class="date">${this.cdDatePipe.transform(notification.timestamp)}</small>
+      <a class="toast-view-more cds--type-label-01" href="#/notifications?id=${notification.id}" i18n>View more</a>
+    </div>`;
   }
 
-  private _clearAllToasts() {
+  clearAllToasts() {
     this.activeToasts = [];
     this.activeToastsSource.next(this.activeToasts);
   }
@@ -382,5 +421,14 @@ export class NotificationService {
     this.readMapSource.next(updated);
     this._persistReadMap(updated);
     this._recomputeHasUnread(this.dataSource.getValue());
+  }
+
+  markAllAsRead() {
+    const notifications = this.dataSource.getValue();
+    const updated = { ...this.readMapSource.getValue() };
+    notifications.forEach((n) => (updated[n.id] = true));
+    this.readMapSource.next(updated);
+    this._persistReadMap(updated);
+    this._recomputeHasUnread(notifications);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.ts
@@ -13,6 +13,18 @@ import { FinishedTask } from '../models/finished-task';
 import { CdDatePipe } from '../pipes/cd-date.pipe';
 import { TaskMessageService } from './task-message.service';
 
+// Carbon's cds-toast renders title, subtitle, and caption via [innerHTML].
+// Angular's DomSanitizer only partially protects against XSS in innerHTML bindings,
+// so we escape untrusted input at the source before passing it to Carbon.
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -24,6 +36,7 @@ export class NotificationService {
     [NotificationType.warning]: 'warning'
   };
   private readonly MAX_NOTIFICATIONS = 10;
+  private readonly MAX_ACTIVE_TOASTS = 2;
   private readonly SHOW_DELAY = 10;
   private readonly QUEUE_DELAY = 500;
   private readonly ERROR_TOAST_DURATION = 10000;
@@ -66,9 +79,21 @@ export class NotificationService {
     let notifications: CdNotification[] = [];
     if (_.isString(stringNotifications)) {
       try {
+        const ALLOWED_KEYS = [
+          'id',
+          'title',
+          'message',
+          'type',
+          'timestamp',
+          'application',
+          'prometheusAlert',
+          'isFinishedTask',
+          'alertSilenced',
+          'silenceId'
+        ];
         notifications = JSON.parse(stringNotifications, (_key, value) => {
           if (_.isPlainObject(value)) {
-            return _.assign(new CdNotification(), value);
+            return _.assign(new CdNotification(), _.pick(value, ALLOWED_KEYS));
           }
           return value;
         });
@@ -90,7 +115,17 @@ export class NotificationService {
   }
 
   private _persistReadMap(readMap: Record<string, boolean>) {
-    localStorage.setItem(this.LOCAL_STORAGE_READ_KEY, JSON.stringify(readMap));
+    const ids = new Set(this.dataSource.getValue().map((n) => n.id));
+    const pruned: Record<string, boolean> = {};
+    for (const id of Object.keys(readMap)) {
+      if (ids.has(id)) pruned[id] = true;
+    }
+    try {
+      localStorage.setItem(this.LOCAL_STORAGE_READ_KEY, JSON.stringify(pruned));
+    } catch {
+      // quota exceeded — clear stale read state
+      localStorage.removeItem(this.LOCAL_STORAGE_READ_KEY);
+    }
   }
 
   private _recomputeHasUnread(notifications: CdNotification[]) {
@@ -130,18 +165,30 @@ export class NotificationService {
   /**
    * Saving a shown notification in local storage
    */
-  save(notification: CdNotification) {
+  save(notification: CdNotification): string {
     const current = this.dataSource.getValue();
     const existing = current.find(
-      (n) => n.title === notification.title && n.type === notification.type
+      (n) =>
+        n.title === notification.title &&
+        n.type === notification.type &&
+        n.message === notification.message
     );
 
     let notifications: CdNotification[];
+    let storedId: string;
     if (existing) {
       existing.occurrences = (existing.occurrences || 1) + 1;
       existing.timestamp = notification.timestamp;
+      existing.message = notification.message;
+      storedId = existing.id;
       notifications = [...current];
+
+      const readMap = { ...this.readMapSource.getValue() };
+      delete readMap[existing.id];
+      this.readMapSource.next(readMap);
+      this._persistReadMap(readMap);
     } else {
+      storedId = notification.id;
       notifications = [notification, ...current];
     }
 
@@ -152,6 +199,7 @@ export class NotificationService {
     this.dataSource.next(limited);
     this._recomputeHasUnread(limited);
     this._persistNotifications(limited);
+    return storedId;
   }
 
   /**
@@ -240,42 +288,20 @@ export class NotificationService {
   }
 
   private _showQueued() {
-    this._getUnifiedTitleQueue().forEach((config) => {
+    this.queued.forEach((config) => {
       const notification = new CdNotification(config);
 
       if (!notification.isFinishedTask) {
-        this.save(notification);
+        const storedId = this.save(notification);
+        notification.id = storedId;
       }
       this._showToasty(notification);
     });
     this.queued = [];
   }
 
-  private _getUnifiedTitleQueue(): CdNotificationConfig[] {
-    return Object.values(this._queueShiftByTitle()).map((configs) => {
-      const config = configs[0];
-      if (configs.length > 1) {
-        config.message = '<ul>' + configs.map((c) => `<li>${c.message}</li>`).join('') + '</ul>';
-      }
-      return config;
-    });
-  }
-
-  private _queueShiftByTitle(): { [key: string]: CdNotificationConfig[] } {
-    const byTitle: { [key: string]: CdNotificationConfig[] } = {};
-    let config: CdNotificationConfig;
-    while ((config = this.queued.shift())) {
-      if (!byTitle[config.title]) {
-        byTitle[config.title] = [];
-      }
-      byTitle[config.title].push(config);
-    }
-    return byTitle;
-  }
-
   private _showToasty(notification: CdNotification) {
-    // Exit immediately if no toasty should be displayed.
-    if (this.hideToasties) {
+    if (this.hideToasties || this.panelState.value) {
       return;
     }
 
@@ -283,8 +309,11 @@ export class NotificationService {
     const carbonType = this.NOTIFICATION_TYPE_MAP[notification.type] || 'info';
     const lowContrast = notification.options?.lowContrast || false;
 
+    const escapedTitle = escapeHtml(notification.title || '');
+    const escapedMessage = escapeHtml(notification.message || '');
     const existing = this.activeToasts.find(
-      (t) => t.title === notification.title && t.type === carbonType
+      (t) =>
+        t.title === escapedTitle && t.type === carbonType && t.originalSubtitle === escapedMessage
     );
     if (existing) {
       existing.duplicateCount = (existing.duplicateCount || 1) + 1;
@@ -295,10 +324,9 @@ export class NotificationService {
       return;
     }
 
-    const subtitle = notification.message || '';
     const toast: ToastContent = {
-      title: notification.title,
-      subtitle,
+      title: escapedTitle,
+      subtitle: escapedMessage,
       caption: this._renderTimeAndApplicationHtml(notification),
       type: carbonType,
       lowContrast: lowContrast,
@@ -310,10 +338,13 @@ export class NotificationService {
           : this.DEFAULT_TOAST_DURATION),
       notificationId: notification.id,
       duplicateCount: 1,
-      originalSubtitle: subtitle
+      originalSubtitle: escapedMessage
     };
 
     this.activeToasts.unshift(toast);
+    while (this.activeToasts.length > this.MAX_ACTIVE_TOASTS) {
+      this.activeToasts.pop();
+    }
     this.activeToastsSource.next(this.activeToasts);
 
     if (toast.duration && toast.duration > 0) {
@@ -328,9 +359,11 @@ export class NotificationService {
   }
 
   private _renderTimeAndApplicationHtml(notification: CdNotification): string {
+    const date = escapeHtml(this.cdDatePipe.transform(notification.timestamp) || '');
+    const id = encodeURIComponent(notification.id);
     return `<div class="toast-caption-container">
-      <small class="date">${this.cdDatePipe.transform(notification.timestamp)}</small>
-      <a class="toast-view-more cds--type-label-01" href="#/notifications?id=${notification.id}" i18n>View more</a>
+      <small class="date">${date}</small>
+      <a class="toast-view-more cds--type-label-01" href="#/notifications?id=${id}" i18n>View more</a>
     </div>`;
   }
 
@@ -350,7 +383,7 @@ export class NotificationService {
   }
 
   removeToast(toast: ToastContent) {
-    this.activeToasts = this.activeToasts.filter((t) => !_.isEqual(t, toast));
+    this.activeToasts = this.activeToasts.filter((t) => t.notificationId !== toast.notificationId);
     this.activeToastsSource.next(this.activeToasts);
   }
 
@@ -404,10 +437,12 @@ export class NotificationService {
    */
   togglePanel(isOpen: boolean) {
     this.panelState.next(isOpen);
+    if (isOpen) this.clearAllToasts();
   }
 
   setPanelState(isOpen: boolean) {
     this.panelState.next(isOpen);
+    if (isOpen) this.clearAllToasts();
   }
 
   getPanelState(): boolean {


### PR DESCRIPTION
### Before: 
<img width="430" height="916" alt="image" src="https://github.com/user-attachments/assets/0683b10e-d5aa-4d06-85f5-930228414e01" />


### After

**Adds view more link to toast which takes to view full toast message**
**Duplicated toasts show "<first message> (+n more)"**
**Truncated toast message to 3 lines**
<img width="356" height="191" alt="image" src="https://github.com/user-attachments/assets/1740c0e9-2014-48a8-ab53-af2d5425568f" />

**Allow notifications to be clickable in notification panel taking user to the particular notification**
Also added hover effect.
<img width="358" height="615" alt="image" src="https://github.com/user-attachments/assets/cb198d4b-482f-4379-bb2a-05e8d3e446b2" />

**Maximum 2 visible toasts at a time**
<img width="529" height="758" alt="image" src="https://github.com/user-attachments/assets/f24889ad-ac31-4bac-b2a4-b1401a4250ff" />

**Added kebab action in notifications page with mark all as read**
<img width="303" height="201" alt="image" src="https://github.com/user-attachments/assets/a4f21595-7a7b-45c6-b985-481d788100b0" />

**Changed notification empty text**
<img width="528" height="197" alt="image" src="https://github.com/user-attachments/assets/9f274d9c-1e5b-426b-b5f5-64f6429807d3" />

**Added occurrences for duplicated notifs:**
<img width="552" height="152" alt="image" src="https://github.com/user-attachments/assets/34407495-1f10-4b99-b0d4-3414e85b7354" />
<img width="607" height="129" alt="image" src="https://github.com/user-attachments/assets/2b0ef12c-dcf1-4dd3-88b8-21ea8b5a8175" />
<img width="358" height="148" alt="image" src="https://github.com/user-attachments/assets/04a34bb4-f735-441d-90a2-f87c68f9a4d7" />


- extended duration for error notifications - as per carbon error notifications should persist longer since users need time to read
- added e2e tests and unit tests
- added checks for security concerns and did perf optimizations by using modern Angular features.

**Full demo**

https://github.com/user-attachments/assets/4991fb96-a8a4-429c-af66-c6cc1fd5d845
