### PR TITLE
mds: wait snapupdate to finish before notifying to clients

### DIFF
--- a/qa/workunits/fs/snaps/snaptest-snap-rm-cmp.sh
+++ b/qa/workunits/fs/snaps/snaptest-snap-rm-cmp.sh
@@ -7,7 +7,7 @@ wget -q http://download.ceph.com/qa/$file
 
 real=`md5sum $file | awk '{print $1}'`
 
-for f in `seq 1 20`
+for f in `seq 1 100`
 do
     echo $f
     cp $file a

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -148,6 +148,7 @@ std::string_view CInode::pin_name(int p) const
     case PIN_DIRTYRSTAT: return "dirtyrstat";
     case PIN_DIRTYPARENT: return "dirtyparent";
     case PIN_DIRWAITER: return "dirwaiter";
+    case PIN_SNAPUPDATE: return "snapupdate";
     default: return generic_pin_name(p);
   }
 }

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -346,6 +346,7 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   static const int PIN_EXPORTINGCAPS =    22;
   static const int PIN_DIRTYPARENT =      23;
   static const int PIN_DIRWAITER =        24;
+  static const int PIN_SNAPUPDATE =       25;
 
   // -- dump flags --
   static const int DUMP_INODE_STORE_BASE = (1 << 0);
@@ -411,8 +412,9 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   static const uint64_t WAIT_FROZEN      = (1<<1);
   static const uint64_t WAIT_TRUNC       = (1<<2);
   static const uint64_t WAIT_FLOCK       = (1<<3);
-  static const uint64_t WAIT_BITS        = 4;
-  
+  static const uint64_t WAIT_SNAPUPDATE  = (1<<4);
+  static const uint64_t WAIT_BITS        = 5;
+
   static const uint64_t WAIT_ANY_MASK    = ((1ul << WAIT_BITS) - 1);
 
   // misc
@@ -1153,6 +1155,9 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
    */
   int64_t get_backtrace_pool() const;
   inodeno_t get_subvolume_id() const;
+
+  uint32_t snap_update_ref = 0;
+
 protected:
   ceph_lock_state_t *get_fcntl_lock_state() {
     if (!fcntl_locks)

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -1156,7 +1156,7 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   int64_t get_backtrace_pool() const;
   inodeno_t get_subvolume_id() const;
 
-  uint32_t snap_update_ref = 0;
+  std::unordered_set<mds_rank_t> snap_update_ref_set;
 
 protected:
   ceph_lock_state_t *get_fcntl_lock_state() {

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -8359,7 +8359,9 @@ void MDCache::dispatch(const cref_t<Message> &m)
   case MSG_MDS_SNAPUPDATE:
     handle_snap_update(ref_cast<MMDSSnapUpdate>(m));
     break;
-    
+  case MSG_MDS_SNAPUPDATEREPLY:
+    handle_snap_update_reply(ref_cast<MMDSSnapUpdateReply>(m));
+    break;
   default:
     derr << "cache unknown message " << m->get_type() << dendl;
     ceph_abort_msg("cache unknown message");
@@ -10205,7 +10207,8 @@ void MDCache::do_realm_invalidate_and_update_notify(CInode *in, int snapop, bool
     send_snaps(updates);
 }
 
-void MDCache::send_snap_update(CInode *in, version_t stid, int snap_op)
+void MDCache::send_snap_update(const MDRequestRef& mdr, CInode *in, version_t stid,
+                               int snap_op, MDSContext *onfinish)
 {
   dout(10) << __func__ << " " << *in << " stid " << stid << dendl;
   ceph_assert(in->is_auth());
@@ -10227,10 +10230,15 @@ void MDCache::send_snap_update(CInode *in, version_t stid, int snap_op)
       m->snap_blob = snap_blob;
       mds->send_message_mds(m, p);
     }
-  }
 
-  if (stid > 0)
-    notify_global_snaprealm_update(snap_op);
+    if (onfinish) {
+      in->snap_update_ref += mds_set.size();
+      in->get(CInode::PIN_SNAPUPDATE);
+      in->add_waiter(CInode::WAIT_SNAPUPDATE, onfinish);
+    }
+  } else if (onfinish) {
+    onfinish->complete(0);
+  }
 }
 
 void MDCache::handle_snap_update(const cref_t<MMDSSnapUpdate> &m)
@@ -10238,8 +10246,10 @@ void MDCache::handle_snap_update(const cref_t<MMDSSnapUpdate> &m)
   mds_rank_t from = mds_rank_t(m->get_source().num());
   dout(10) << __func__ << " " << *m << " from mds." << from << dendl;
 
+  auto reply = make_message<MMDSSnapUpdateReply>(m->get_ino(), m->get_tid());
   if (mds->get_state() < MDSMap::STATE_RESOLVE &&
       mds->get_want_state() != CEPH_MDS_STATE_RESOLVE) {
+    mds->send_message(reply, m->get_connection());
     return;
   }
 
@@ -10268,6 +10278,29 @@ void MDCache::handle_snap_update(const cref_t<MMDSSnapUpdate> &m)
 	}
       }
       do_realm_invalidate_and_update_notify(in, m->get_snap_op(), notify_clients);
+    }
+  }
+  mds->send_message(reply, m->get_connection());
+}
+
+void MDCache::handle_snap_update_reply(const cref_t<MMDSSnapUpdateReply> &m)
+{
+  mds_rank_t from = mds_rank_t(m->get_source().num());
+  dout(10) << __func__ << " " << *m << " from mds." << from << dendl;
+
+  if (mds->get_state() < MDSMap::STATE_RESOLVE &&
+      mds->get_want_state() != CEPH_MDS_STATE_RESOLVE) {
+    return;
+  }
+
+  CInode *in = get_inode(m->get_ino());
+  if (in) {
+    in->snap_update_ref--;
+    if (!in->snap_update_ref) {
+      MDSContext::vec finished;
+      in->take_waiting(CInode::WAIT_SNAPUPDATE, finished);
+      mds->queue_waiters(finished);
+      in->put(CInode::PIN_SNAPUPDATE);
     }
   }
 }

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -10232,7 +10232,8 @@ void MDCache::send_snap_update(const MDRequestRef& mdr, CInode *in, version_t st
     }
 
     if (onfinish) {
-      in->snap_update_ref += mds_set.size();
+      in->snap_update_ref_set = decltype(in->snap_update_ref_set)(mds_set.begin(), mds_set.end());
+      mds->snap_update_inos.insert(in->ino());
       in->get(CInode::PIN_SNAPUPDATE);
       in->add_waiter(CInode::WAIT_SNAPUPDATE, onfinish);
     }
@@ -10295,8 +10296,8 @@ void MDCache::handle_snap_update_reply(const cref_t<MMDSSnapUpdateReply> &m)
 
   CInode *in = get_inode(m->get_ino());
   if (in) {
-    in->snap_update_ref--;
-    if (!in->snap_update_ref) {
+    if (in->snap_update_ref_set.erase(from) && in->snap_update_ref_set.empty()) {
+      mds->snap_update_inos.erase(m->get_ino());
       MDSContext::vec finished;
       in->take_waiting(CInode::WAIT_SNAPUPDATE, finished);
       mds->queue_waiters(finished);
@@ -14556,6 +14557,29 @@ void MDCache::handle_mdsmap(const MDSMap &mdsmap, const MDSMap &oldmap) {
     while ((1U << n) < (unsigned)want)
       ++n;
     export_ephemeral_dist_frag_bits = n;
+  }
+
+  /* Remove the waiter reference if the corresponding MDS is down */
+  set<mds_rank_t> down_set, old_set, new_set;
+  oldmap.get_mds_set_lower_bound(old_set, MDSMap::STATE_RESOLVE);
+  mdsmap.get_mds_set_lower_bound(new_set, MDSMap::STATE_RESOLVE);
+  std::set_difference(old_set.begin(), old_set.end(),
+                      new_set.begin(), new_set.end(),
+                      std::inserter(down_set, down_set.begin()));
+  for (auto m : down_set) {
+    for (auto ino : mds->snap_update_inos) {
+      CInode *in = get_inode(ino);
+      if (!in)
+        continue;
+
+      if (in->snap_update_ref_set.erase(m) && in->snap_update_ref_set.empty()) {
+        mds->snap_update_inos.erase(ino);
+        MDSContext::vec finished;
+        in->take_waiting(CInode::WAIT_SNAPUPDATE, finished);
+        mds->queue_waiters(finished);
+        in->put(CInode::PIN_SNAPUPDATE);
+      }
+    }
   }
 }
 

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -30,6 +30,32 @@
 #include "include/elist.h"
 #include "include/rados/rados_types.hpp"
 
+#include "messages/MCacheExpire.h"
+#include "messages/MClientQuota.h"
+#include "messages/MClientRequest.h"
+#include "messages/MClientSnap.h"
+#include "messages/MDentryLink.h"
+#include "messages/MDentryUnlink.h"
+#include "messages/MDirUpdate.h"
+#include "messages/MDiscover.h"
+#include "messages/MDiscoverReply.h"
+#include "messages/MGatherCaps.h"
+#include "messages/MGenericMessage.h"
+#include "messages/MInodeFileCaps.h"
+#include "messages/MLock.h"
+#include "messages/MMDSCacheRejoin.h"
+#include "messages/MMDSFindIno.h"
+#include "messages/MMDSFindInoReply.h"
+#include "messages/MMDSFragmentNotify.h"
+#include "messages/MMDSFragmentNotifyAck.h"
+#include "messages/MMDSOpenIno.h"
+#include "messages/MMDSOpenInoReply.h"
+#include "messages/MMDSResolve.h"
+#include "messages/MMDSResolveAck.h"
+#include "messages/MMDSPeerRequest.h"
+#include "messages/MMDSSnapUpdate.h"
+#include "messages/MMDSSnapUpdateReply.h"
+
 #include "osdc/Filer.h"
 #include "CInode.h"
 #include "CDentry.h"
@@ -1057,8 +1083,10 @@ private:
   SnapRealm *get_global_snaprealm() const { return global_snaprealm; }
   void create_global_snaprealm();
   void do_realm_invalidate_and_update_notify(CInode *in, int snapop, bool notify_clients=true);
-  void send_snap_update(CInode *in, version_t stid, int snap_op);
+  void send_snap_update(const MDRequestRef& mdr, CInode *in, version_t stid, int snap_op,
+                        MDSContext *onfinish=nullptr);
   void handle_snap_update(const cref_t<MMDSSnapUpdate> &m);
+  void handle_snap_update_reply(const cref_t<MMDSSnapUpdateReply> &m);
   void notify_global_snaprealm_update(int snap_op);
 
   // -- stray --

--- a/src/mds/MDSCacheObject.h
+++ b/src/mds/MDSCacheObject.h
@@ -79,6 +79,7 @@ class MDSCacheObject {
   const static uint64_t WAIT_ORDERED	 = (1ull<<61);
   const static uint64_t WAIT_SINGLEAUTH  = (1ull<<60);
   const static uint64_t WAIT_UNFREEZE    = (1ull<<59); // pka AUTHPINNABLE
+  const static uint64_t WAIT_SNAPUPDATE  = (1ull<<58);
 
   elist<MDSCacheObject*>::item item_scrub;   // for scrub inode or dir
 

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -436,6 +436,8 @@ class MDSRank {
 
     std::map<ceph_tid_t, std::unique_ptr<MDSMetaRequest>> internal_client_requests;
 
+    std::set<inodeno_t> snap_update_inos;
+
     // The last different state I held before current
     MDSMap::DaemonState last_state = MDSMap::STATE_BOOT;
     // The state assigned to me by the MDSMap

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5292,7 +5292,7 @@ public:
     }
 
     if (adjust_realm) {
-      mds->mdcache->send_snap_update(in, 0, snap_op);
+      mds->mdcache->send_snap_update(mdr, in, 0, snap_op);
       mds->mdcache->do_realm_invalidate_and_update_notify(in, snap_op);
     }
 
@@ -7955,7 +7955,7 @@ void Server::_link_local_finish(const MDRequestRef& mdr, CDentry *dn, CInode *ta
 
   if (adjust_realm) {
     int op = CEPH_SNAP_OP_SPLIT;
-    mds->mdcache->send_snap_update(targeti, 0, op);
+    mds->mdcache->send_snap_update(mdr, targeti, 0, op);
     mds->mdcache->do_realm_invalidate_and_update_notify(targeti, op);
   }
 
@@ -8250,7 +8250,7 @@ void Server::_logged_peer_link(const MDRequestRef& mdr, CInode *targeti, bool ad
 
   if (adjust_realm) {
     int op = CEPH_SNAP_OP_SPLIT;
-    mds->mdcache->send_snap_update(targeti, 0, op);
+    mds->mdcache->send_snap_update(mdr, targeti, 0, op);
     mds->mdcache->do_realm_invalidate_and_update_notify(targeti, op);
   }
 
@@ -11621,6 +11621,28 @@ void Server::handle_client_mksnap(const MDRequestRef& mdr)
   mdlog->flush();
 }
 
+struct C_MDS_mksnap_finish_final : public ServerContext {
+  MDRequestRef mdr;
+  CInode *in;
+  version_t stid;
+  int snap_op;
+
+  C_MDS_mksnap_finish_final(Server *s, const MDRequestRef& m, CInode *i, version_t v, int o) :
+    ServerContext(s), mdr(m), in(i), stid(v), snap_op(o) {}
+  void finish(int r) override {
+    server->_mksnap_finish_final(mdr, in, stid, snap_op);
+  }
+};
+
+void Server::_mksnap_finish_final(MDRequestRef& mdr, CInode *in, version_t stid, int op)
+{
+  if (stid > 0) {
+    mdcache->notify_global_snaprealm_update(op);
+  }
+  mdcache->do_realm_invalidate_and_update_notify(in, op);
+  respond_to_request(mdr, 0);
+}
+
 void Server::_mksnap_finish(const MDRequestRef& mdr, CInode *diri, SnapInfo &info)
 {
   dout(10) << "_mksnap_finish " << *mdr << " " << info << dendl;
@@ -11634,16 +11656,15 @@ void Server::_mksnap_finish(const MDRequestRef& mdr, CInode *diri, SnapInfo &inf
   // create snap
   dout(10) << "snaprealm now " << *diri->snaprealm << dendl;
 
-  // notify other mds
-  mdcache->send_snap_update(diri, mdr->more()->stid, op);
-
-  mdcache->do_realm_invalidate_and_update_notify(diri, op);
-
   // yay
   mdr->in[0] = diri;
   mdr->snapid = info.snapid;
   mdr->tracei = diri;
-  respond_to_request(mdr, 0);
+
+  // notify other mds
+  auto stid = mdr->more()->stid;
+  mdcache->send_snap_update(mdr, diri, stid, op,
+                            new C_MDS_mksnap_finish_final(this, mdr, diri, stid, op));
 }
 
 
@@ -11752,6 +11773,31 @@ void Server::handle_client_rmsnap(const MDRequestRef& mdr)
   mdlog->flush();
 }
 
+struct C_MDS_rmsnap_finish_final : public ServerContext {
+  MDRequestRef mdr;
+  CInode *in;
+  version_t stid;
+  int snap_op;
+
+  C_MDS_rmsnap_finish_final(Server *s, const MDRequestRef& m, CInode *i, version_t v, int o) :
+    ServerContext(s), mdr(m), in(i), stid(v), snap_op(o) {}
+  void finish(int r) override {
+    server->_rmsnap_finish_final(mdr, in, stid, snap_op);
+  }
+};
+
+void Server::_rmsnap_finish_final(MDRequestRef& mdr, CInode *in, version_t stid, int op)
+{
+  if (stid > 0) {
+    mdcache->notify_global_snaprealm_update(op);
+  }
+  mdcache->do_realm_invalidate_and_update_notify(in, op);
+  respond_to_request(mdr, 0);
+
+  // purge snapshot data
+  in->purge_stale_snap_data(in->snaprealm->get_snaps());
+}
+
 void Server::_rmsnap_finish(const MDRequestRef& mdr, CInode *diri, snapid_t snapid)
 {
   dout(10) << "_rmsnap_finish " << *mdr << " " << snapid << dendl;
@@ -11763,19 +11809,15 @@ void Server::_rmsnap_finish(const MDRequestRef& mdr, CInode *diri, snapid_t snap
 
   dout(10) << "snaprealm now " << *diri->snaprealm << dendl;
 
-  // notify other mds
-  mdcache->send_snap_update(diri, mdr->more()->stid, CEPH_SNAP_OP_DESTROY);
-
-  mdcache->do_realm_invalidate_and_update_notify(diri, CEPH_SNAP_OP_DESTROY);
-
   // yay
   mdr->in[0] = diri;
   mdr->tracei = diri;
   mdr->snapid = snapid;
-  respond_to_request(mdr, 0);
 
-  // purge snapshot data
-  diri->purge_stale_snap_data(diri->snaprealm->get_snaps());
+  // notify other mds
+  int op = CEPH_SNAP_OP_DESTROY;
+  mdcache->send_snap_update(mdr, diri, stid, op,
+                            new C_MDS_rmsnap_finish_final(this, mdr, diri, stid, op));
 }
 
 struct C_MDS_renamesnap_finish : public ServerLogContext {
@@ -11895,26 +11937,48 @@ void Server::handle_client_renamesnap(const MDRequestRef& mdr)
   mdlog->flush();
 }
 
+struct C_MDS_renamesnap_finish_final : public ServerContext {
+  MDRequestRef mdr;
+  CInode *in;
+  version_t stid;
+  int snap_op;
+
+  C_MDS_renamesnap_finish_final(Server *s, const MDRequestRef& m, CInode *i, version_t v, int o) :
+    ServerContext(s), mdr(m), in(i), stid(v), snap_op(o) {}
+  void finish(int r) override {
+    server->_renamesnap_finish_final(mdr, in, stid, snap_op);
+  }
+};
+
+void Server::_renamesnap_finish_final(MDRequestRef& mdr, CInode *in, version_t stid, int op)
+{
+  if (stid > 0) {
+    mdcache->notify_global_snaprealm_update(op);
+  }
+  mdcache->do_realm_invalidate_and_update_notify(in, op);
+  respond_to_request(mdr, 0);
+}
+
 void Server::_renamesnap_finish(const MDRequestRef& mdr, CInode *diri, snapid_t snapid)
 {
   dout(10) << "_renamesnap_finish " << *mdr << " " << snapid << dendl;
 
   mdr->apply();
 
-  mds->snapclient->commit(mdr->more()->stid, mdr->ls);
+  auto stid = mdr->more()->stid;
+  mds->snapclient->commit(stid, mdr->ls);
 
   dout(10) << "snaprealm now " << *diri->snaprealm << dendl;
-
-  // notify other mds
-  mdcache->send_snap_update(diri, mdr->more()->stid, CEPH_SNAP_OP_UPDATE);
-
-  mdcache->do_realm_invalidate_and_update_notify(diri, CEPH_SNAP_OP_UPDATE);
 
   // yay
   mdr->in[0] = diri;
   mdr->tracei = diri;
   mdr->snapid = snapid;
-  respond_to_request(mdr, 0);
+
+  // notify other mds
+  int op = CEPH_SNAP_OP_UPDATE;
+  mdcache->send_snap_update(mdr, diri, stid, op,
+                            new C_MDS_renamesnap_finish_final(this, mdr, diri, stid, op));
 }
 
 class C_MDS_file_blockdiff_finish : public ServerContext {

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -344,9 +344,12 @@ public:
   void handle_client_lssnap(const MDRequestRef& mdr);
   void handle_client_mksnap(const MDRequestRef& mdr);
   void _mksnap_finish(const MDRequestRef& mdr, CInode *diri, SnapInfo &info);
+  void _mksnap_finish_final(MDRequestRef& mdr, CInode *in, version_t stid, int op);
   void handle_client_rmsnap(const MDRequestRef& mdr);
+  void _rmsnap_finish_final(MDRequestRef& mdr, CInode *in, version_t stid, int op);
   void _rmsnap_finish(const MDRequestRef& mdr, CInode *diri, snapid_t snapid);
   void handle_client_renamesnap(const MDRequestRef& mdr);
+  void _renamesnap_finish_final(MDRequestRef& mdr, CInode *in, version_t stid, int op);
   void _renamesnap_finish(const MDRequestRef& mdr, CInode *diri, snapid_t snapid);
   void handle_client_readdir_snapdiff(const MDRequestRef& mdr);
   void handle_client_file_blockdiff(const MDRequestRef& mdr);

--- a/src/messages/MMDSSnapUpdateReply.h
+++ b/src/messages/MMDSSnapUpdateReply.h
@@ -1,0 +1,57 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_MMDSSNAPUPDATEREPLY_H
+#define CEPH_MMDSSNAPUPDATEREPLY_H
+
+#include "messages/MMDSOp.h"
+
+class MMDSSnapUpdateReply final : public MMDSOp {
+private:
+  inodeno_t ino;
+
+public:
+  inodeno_t get_ino() const { return ino; }
+
+protected:
+  MMDSSnapUpdateReply() : MMDSOp{MSG_MDS_SNAPUPDATEREPLY} {}
+  MMDSSnapUpdateReply(inodeno_t i, version_t tid) :
+    MMDSOp{MSG_MDS_SNAPUPDATEREPLY}, ino(i) {
+      set_tid(tid);
+    }
+  ~MMDSSnapUpdateReply() final {}
+
+public:
+  std::string_view get_type_name() const override { return "snap_update_reply"; }
+  void print(std::ostream& o) const override {
+    o << "snap_update_reply(" << ino << " table_tid " << get_tid() << ")";
+  }
+
+  void encode_payload(uint64_t features) override {
+    using ceph::encode;
+    encode(ino, payload);
+  }
+  void decode_payload() override {
+    using ceph::decode;
+    auto p = payload.cbegin();
+    decode(ino, p);
+  }
+private:
+  template<class T, typename... Args>
+  friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::make_message(Args&&... args);
+};
+
+#endif

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -148,6 +148,7 @@
 #include "messages/MMDSOpenIno.h"
 #include "messages/MMDSOpenInoReply.h"
 #include "messages/MMDSSnapUpdate.h"
+#include "messages/MMDSSnapUpdateReply.h"
 #include "messages/MMDSScrub.h"
 #include "messages/MMDSScrubStats.h"
 
@@ -782,6 +783,10 @@ Message *decode_message(CephContext *cct,
 
   case MSG_MDS_SNAPUPDATE:
     m = make_message<MMDSSnapUpdate>();
+    break;
+
+  case MSG_MDS_SNAPUPDATEREPLY:
+    m = make_message<MMDSSnapUpdateReply>();
     break;
 
   case MSG_MDS_FRAGMENTNOTIFY:

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -184,6 +184,7 @@
 #define MSG_MDS_OPENINOREPLY       0x210
 #define MSG_MDS_SNAPUPDATE         0x211
 #define MSG_MDS_FRAGMENTNOTIFYACK  0x212
+#define MSG_MDS_SNAPUPDATEREPLY    0x213
 #define MSG_MDS_LOCK               0x300 // 0x3xx are for locker of mds
 #define MSG_MDS_INODEFILECAPS      0x301
 


### PR DESCRIPTION
When making snapshot the MDS will notify the mds first and then the
clients, but the other MDSes may get the notify late and just after
the clients flush the snapcap to them. The MDSes will just drop the
snapcap flush request to floor.

We need to wait for a while and make sure all the other MDSes get
notifications first.

The same with rmsnap and renamesnap ops.

Fixes: https://tracker.ceph.com/issues/56011

The old commit https://github.com/ceph/ceph/pull/46747 was closed and I couldn't reopen. Create a new one to fix it and at the same time fixed all the comments in the old PR.




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
