### PR TITLE
mgr/dashboard: add deprecation warning on ns add cli command

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -1263,7 +1263,8 @@ else:
             "nvmeof namespace add",
             model.NamespaceCreation,
             alias="nvmeof ns add",
-            success_message_template="Adding namespace {nsid} to {nqn}: Successful"
+            success_message_template="Adding namespace {nsid} to {nqn}: Successful",
+            deprecated_params={"size": "--size is deprecated, please use --rbd-image-size"}
         )
         @EndpointDoc(
             "Create a new NVMeoF namespace.",

--- a/src/pybind/mgr/dashboard/services/nvmeof_cli.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_cli.py
@@ -349,7 +349,8 @@ class NvmeofCLICommand(DBCLICommand):
                  poll: bool = False,
                  success_message_template: Optional[str] = None,
                  success_message_map: Optional[Dict[str, Any]] = None,
-                 success_message_fn: Optional[Callable[[Dict[str, Any]], str]] = None):
+                 success_message_fn: Optional[Callable[[Dict[str, Any]], str]] = None,
+                 deprecated_params: Optional[Dict[str, str]] = None):
         super().__init__(prefix, perm, poll)
         self._output_formatter = AnnotatedDataTextOutputFormatter()
         self._model = model
@@ -360,6 +361,7 @@ class NvmeofCLICommand(DBCLICommand):
         self._success_message_map = success_message_map or {}
         self._success_message_fn = success_message_fn
         self._func_defaults: Dict[str, Any] = {}
+        self._deprecated_params: Dict[str, str] = deprecated_params or {}
 
     def __call__(self, func):
         resp = super().__call__(func)
@@ -372,6 +374,7 @@ class NvmeofCLICommand(DBCLICommand):
                 success_message_template=self._success_message_template,
                 success_message_map=self._success_message_map,
                 success_message_fn=self._success_message_fn,
+                deprecated_params=self._deprecated_params,
             )
             self._alias_cmd(func)
             self._alias_cmd._func_defaults = self._alias_cmd._compute_func_defaults()
@@ -495,9 +498,16 @@ class NvmeofCLICommand(DBCLICommand):
              mgr: Any,
              cmd_dict: Dict[str, Any],
              inbuf: Optional[str] = None) -> HandleCommandResult:
+        deprecated_warnings = ''
         try:
             out_format = cmd_dict.get('format')
             args_map = self._args_map_from_argspec(cmd_dict, inbuf)
+
+            if out_format == 'plain' or not out_format:
+                for param, msg in self._deprecated_params.items():
+                    if args_map.get(param) is not None:
+                        deprecated_warnings += f"\nWarning: {msg}"
+
             ret = super().call(mgr, cmd_dict, inbuf)
             if ret is None:
                 ret = {}
@@ -519,6 +529,7 @@ class NvmeofCLICommand(DBCLICommand):
                 wrn_msg = ret.get('error_message', '') if isinstance(ret, dict) else ''
                 if wrn_msg:
                     out += f"\nWarning: {wrn_msg}"
+                out += deprecated_warnings
 
             elif out_format == 'json':
                 out = json.dumps(ret, indent=4)
@@ -532,4 +543,4 @@ class NvmeofCLICommand(DBCLICommand):
 
         # pylint: disable=broad-except
         except Exception as e:
-            return HandleCommandResult(-errno.EINVAL, '', str(e))
+            return HandleCommandResult(-errno.EINVAL, '', str(e) + deprecated_warnings)

--- a/src/pybind/mgr/dashboard/tests/test_nvmeof_cli.py
+++ b/src/pybind/mgr/dashboard/tests/test_nvmeof_cli.py
@@ -788,6 +788,519 @@ class TestNvmeofCLICommandSuccessMessage:
         assert test_cmd not in NvmeofCLICommand.COMMANDS
 
 
+class TestNvmeofCLICommandDeprecatedParams:  # pylint: disable=too-many-public-methods
+    @staticmethod
+    def _make_cmd(test_cmd, deprecated_params=None, alias=None):
+        class Model(NamedTuple):
+            status: str
+
+        kwargs = {}
+        if deprecated_params is not None:
+            kwargs['deprecated_params'] = deprecated_params
+        if alias is not None:
+            kwargs['alias'] = alias
+
+        @NvmeofCLICommand(test_cmd, Model, **kwargs)
+        def fn(self, new_param: str,  # pylint: disable=unused-variable,unused-argument
+               old_param: Optional[str] = None):  # pylint: disable=unused-argument
+            return {'status': 'ok'}
+
+        return test_cmd
+
+    @staticmethod
+    def _cleanup(*cmds):
+        for cmd in cmds:
+            NvmeofCLICommand.COMMANDS.pop(cmd, None)
+
+    def test_deprecated_params_stored_on_instance(self):
+        test_cmd = "test deprecated store"
+        mapping = {"old_param": "old_param is deprecated, use new_param"}
+        self._make_cmd(test_cmd, deprecated_params=mapping)
+        try:
+            cmd = NvmeofCLICommand.COMMANDS[test_cmd]
+            assert cmd._deprecated_params == mapping  # pylint: disable=protected-access
+        finally:
+            self._cleanup(test_cmd)
+
+    def test_no_deprecated_params_defaults_to_empty_dict(self):
+        test_cmd = "test deprecated empty"
+        self._make_cmd(test_cmd)
+        try:
+            cmd = NvmeofCLICommand.COMMANDS[test_cmd]
+            assert cmd._deprecated_params == {}  # pylint: disable=protected-access
+        finally:
+            self._cleanup(test_cmd)
+
+    def test_none_deprecated_params_defaults_to_empty_dict(self):
+        test_cmd = "test deprecated none"
+        self._make_cmd(test_cmd, deprecated_params=None)
+        try:
+            cmd = NvmeofCLICommand.COMMANDS[test_cmd]
+            assert cmd._deprecated_params == {}  # pylint: disable=protected-access
+        finally:
+            self._cleanup(test_cmd)
+
+    def test_alias_inherits_deprecated_params(self):
+        test_cmd = "test deprecated alias main"
+        test_alias = "test deprecated alias alias"
+        mapping = {"old_param": "old_param is deprecated, use new_param"}
+        self._make_cmd(test_cmd, deprecated_params=mapping, alias=test_alias)
+        try:
+            cmd = NvmeofCLICommand.COMMANDS[test_alias]
+            assert cmd._deprecated_params == mapping  # pylint: disable=protected-access
+        finally:
+            self._cleanup(test_cmd, test_alias)
+
+    def test_alias_without_deprecated_params_has_empty_dict(self):
+        test_cmd = "test no deprecated alias main"
+        test_alias = "test no deprecated alias alias"
+        self._make_cmd(test_cmd, alias=test_alias)
+        try:
+            cmd = NvmeofCLICommand.COMMANDS[test_alias]
+            assert cmd._deprecated_params == {}  # pylint: disable=protected-access
+        finally:
+            self._cleanup(test_cmd, test_alias)
+
+    def test_warning_emitted_when_deprecated_param_is_supplied(self):
+        test_cmd = "test deprecated warn supplied"
+        self._make_cmd(
+            test_cmd,
+            deprecated_params={"old_param": "--old-param is deprecated, please use --new-param"}
+        )
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(
+                MagicMock(),
+                {"new_param": "foo", "old_param": "bar"}
+            )
+            assert result.retval == 0
+            assert "\nWarning: --old-param is deprecated, please use --new-param" in result.stdout
+        finally:
+            self._cleanup(test_cmd)
+
+    def test_no_warning_when_deprecated_param_is_absent(self):
+        test_cmd = "test deprecated warn absent"
+        self._make_cmd(
+            test_cmd,
+            deprecated_params={"old_param": "--old-param is deprecated, please use --new-param"}
+        )
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(
+                MagicMock(),
+                {"new_param": "foo"}
+            )
+            assert result.retval == 0
+            assert "Warning" not in result.stdout
+        finally:
+            self._cleanup(test_cmd)
+
+    def test_no_warning_when_deprecated_params_is_empty(self):
+        test_cmd = "test no deprecated params"
+        self._make_cmd(test_cmd)
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(
+                MagicMock(),
+                {"new_param": "foo", "old_param": "bar"}
+            )
+            assert result.retval == 0
+            assert "Warning" not in result.stdout
+        finally:
+            self._cleanup(test_cmd)
+
+    def test_multiple_deprecated_params_each_emit_warning(self):
+        test_cmd = "test deprecated multi warn"
+
+        class Model(NamedTuple):
+            status: str
+
+        @NvmeofCLICommand(
+            test_cmd,
+            Model,
+            deprecated_params={
+                "old_a": "--old-a is deprecated, use --new-a",
+                "old_b": "--old-b is deprecated, use --new-b",
+            }
+        )  # pylint: disable=unused-variable
+        def fn(self, new_a: str,  # pylint: disable=unused-argument
+               old_a: Optional[str] = None,  # pylint: disable=unused-argument
+               old_b: Optional[str] = None):  # pylint: disable=unused-argument
+            return {'status': 'ok'}
+
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(
+                MagicMock(),
+                {"new_a": "x", "old_a": "y", "old_b": "z"}
+            )
+            assert result.retval == 0
+            assert "\nWarning: --old-a is deprecated, use --new-a" in result.stdout
+            assert "\nWarning: --old-b is deprecated, use --new-b" in result.stdout
+        finally:
+            self._cleanup(test_cmd)
+
+    def test_only_supplied_deprecated_param_warns(self):
+        test_cmd = "test deprecated partial warn"
+
+        class Model(NamedTuple):
+            status: str
+
+        @NvmeofCLICommand(
+            test_cmd,
+            Model,
+            deprecated_params={
+                "old_a": "--old-a is deprecated, use --new-a",
+                "old_b": "--old-b is deprecated, use --new-b",
+            }
+        )  # pylint: disable=unused-variable
+        def fn(self, new_a: str,  # pylint: disable=unused-argument
+               old_a: Optional[str] = None,  # pylint: disable=unused-argument
+               old_b: Optional[str] = None):  # pylint: disable=unused-argument
+            return {'status': 'ok'}
+
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(
+                MagicMock(),
+                {"new_a": "x", "old_a": "y"}
+            )
+            assert result.retval == 0
+            assert "\nWarning: --old-a is deprecated, use --new-a" in result.stdout
+            assert "--old-b" not in result.stdout
+        finally:
+            self._cleanup(test_cmd)
+
+    def test_warning_not_emitted_for_json_format(self):
+        test_cmd = "test deprecated json no warn"
+        self._make_cmd(
+            test_cmd,
+            deprecated_params={"old_param": "--old-param is deprecated, please use --new-param"}
+        )
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(
+                MagicMock(),
+                {"format": "json", "new_param": "foo", "old_param": "bar"}
+            )
+            assert result.retval == 0
+            assert "Warning" not in result.stdout
+            parsed = json.loads(result.stdout)
+            assert "Warning" not in str(parsed)
+        finally:
+            self._cleanup(test_cmd)
+
+    def test_warning_not_emitted_for_yaml_format(self):
+        test_cmd = "test deprecated yaml no warn"
+        self._make_cmd(
+            test_cmd,
+            deprecated_params={"old_param": "--old-param is deprecated, please use --new-param"}
+        )
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(
+                MagicMock(),
+                {"format": "yaml", "new_param": "foo", "old_param": "bar"}
+            )
+            assert result.retval == 0
+            assert "Warning" not in result.stdout
+        finally:
+            self._cleanup(test_cmd)
+
+    def test_warning_emitted_for_default_format(self):
+        """Default format (no 'format' key) also emits warnings."""
+        test_cmd = "test deprecated default format warn"
+        self._make_cmd(
+            test_cmd,
+            deprecated_params={"old_param": "--old-param is deprecated, please use --new-param"}
+        )
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(
+                MagicMock(),
+                {"new_param": "foo", "old_param": "bar"}
+            )
+            assert result.retval == 0
+            assert "\nWarning: --old-param is deprecated, please use --new-param" in result.stdout
+        finally:
+            self._cleanup(test_cmd)
+
+    def test_warning_emitted_for_explicit_plain_format(self):
+        test_cmd = "test deprecated plain format warn"
+        self._make_cmd(
+            test_cmd,
+            deprecated_params={"old_param": "--old-param is deprecated, please use --new-param"}
+        )
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(
+                MagicMock(),
+                {"format": "plain", "new_param": "foo", "old_param": "bar"}
+            )
+            assert result.retval == 0
+            assert "\nWarning: --old-param is deprecated, please use --new-param" in result.stdout
+        finally:
+            self._cleanup(test_cmd)
+
+    def test_deprecated_warning_and_error_message_warning_both_appear(self):
+        test_cmd = "test deprecated coexist error message"
+
+        class Model(NamedTuple):
+            status: str
+            error_message: str
+
+        @NvmeofCLICommand(
+            test_cmd,
+            Model,
+            deprecated_params={"old_param": "--old-param is deprecated, please use --new-param"}
+        )  # pylint: disable=unused-variable
+        def fn(self, new_param: str,  # pylint: disable=unused-argument
+               old_param: Optional[str] = None):  # pylint: disable=unused-argument
+            return {'status': 'ok', 'error_message': 'something to note from gRPC'}
+
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(
+                MagicMock(),
+                {"new_param": "foo", "old_param": "bar"}
+            )
+            assert result.retval == 0
+            assert "\nWarning: something to note from gRPC" in result.stdout
+            assert "\nWarning: --old-param is deprecated, please use --new-param" in result.stdout
+        finally:
+            self._cleanup(test_cmd)
+
+    def test_error_message_warning_without_deprecated_param(self):
+        test_cmd = "test error message no deprecated"
+
+        class Model(NamedTuple):
+            status: str
+            error_message: str
+
+        @NvmeofCLICommand(test_cmd, Model)
+        def fn(self, new_param: str):  # pylint: disable=unused-variable,unused-argument
+            return {'status': 'ok', 'error_message': 'note from gRPC'}
+
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(
+                MagicMock(),
+                {"new_param": "foo"}
+            )
+            assert result.retval == 0
+            assert "\nWarning: note from gRPC" in result.stdout
+        finally:
+            self._cleanup(test_cmd)
+
+    def test_alias_emits_same_warning_as_main_command(self):
+        test_cmd = "test deprecated alias warn main"
+        test_alias = "test deprecated alias warn alias"
+        self._make_cmd(
+            test_cmd,
+            deprecated_params={"old_param": "--old-param is deprecated, please use --new-param"},
+            alias=test_alias
+        )
+        try:
+            for cmd_key in (test_cmd, test_alias):
+                result = NvmeofCLICommand.COMMANDS[cmd_key].call(
+                    MagicMock(),
+                    {"new_param": "foo", "old_param": "bar"}
+                )
+                assert result.retval == 0, f"failed for {cmd_key}"
+                assert "\nWarning: --old-param is deprecated, please use --new-param" \
+                    in result.stdout, f"warning missing for {cmd_key}"
+        finally:
+            self._cleanup(test_cmd, test_alias)
+
+    def test_alias_also_suppresses_warning_when_param_absent(self):
+        test_cmd = "test deprecated alias no warn main"
+        test_alias = "test deprecated alias no warn alias"
+        self._make_cmd(
+            test_cmd,
+            deprecated_params={"old_param": "--old-param is deprecated, please use --new-param"},
+            alias=test_alias
+        )
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_alias].call(
+                MagicMock(),
+                {"new_param": "foo"}
+            )
+            assert result.retval == 0
+            assert "Warning" not in result.stdout
+        finally:
+            self._cleanup(test_cmd, test_alias)
+
+    def test_warning_emitted_on_failure_when_deprecated_param_supplied(self):
+        test_cmd = "test deprecated warn on failure"
+
+        class Model(NamedTuple):
+            status: str
+
+        @NvmeofCLICommand(
+            test_cmd,
+            Model,
+            deprecated_params={"old_param": "--old-param is deprecated, please use --new-param"}
+        )  # pylint: disable=unused-variable
+        def fn(self, new_param: str,  # pylint: disable=unused-argument
+               old_param: Optional[str] = None):  # pylint: disable=unused-argument
+            raise DashboardException(msg="something went wrong", component="nvmeof",
+                                     http_status_code=500)
+
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(
+                MagicMock(),
+                {"new_param": "foo", "old_param": "bar"}
+            )
+            assert result.retval == -errno.EINVAL
+            assert result.stdout == ''
+            assert "\nWarning: --old-param is deprecated, please use --new-param" in result.stderr
+        finally:
+            self._cleanup(test_cmd)
+
+    def test_no_warning_on_failure_when_deprecated_param_absent(self):
+        test_cmd = "test deprecated no warn on failure absent"
+
+        class Model(NamedTuple):
+            status: str
+
+        @NvmeofCLICommand(
+            test_cmd,
+            Model,
+            deprecated_params={"old_param": "--old-param is deprecated, please use --new-param"}
+        )  # pylint: disable=unused-variable
+        def fn(self, new_param: str,  # pylint: disable=unused-argument
+               old_param: Optional[str] = None):  # pylint: disable=unused-argument
+            raise DashboardException(msg="something went wrong", component="nvmeof",
+                                     http_status_code=500)
+
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(
+                MagicMock(),
+                {"new_param": "foo"}
+            )
+            assert result.retval == -errno.EINVAL
+            assert "Warning" not in result.stderr
+        finally:
+            self._cleanup(test_cmd)
+
+    def test_warning_in_stdout_on_success_and_stderr_on_failure(self):
+        test_cmd_ok = "test deprecated path ok"
+        test_cmd_fail = "test deprecated path fail"
+
+        class Model(NamedTuple):
+            status: str
+
+        @NvmeofCLICommand(
+            test_cmd_ok,
+            Model,
+            deprecated_params={"old_param": "--old-param is deprecated, please use --new-param"}
+        )  # pylint: disable=unused-variable
+        def fn_ok(self, new_param: str,  # pylint: disable=unused-argument
+                  old_param: Optional[str] = None):  # pylint: disable=unused-argument
+            return {'status': 'ok'}
+
+        @NvmeofCLICommand(
+            test_cmd_fail,
+            Model,
+            deprecated_params={"old_param": "--old-param is deprecated, please use --new-param"}
+        )  # pylint: disable=unused-variable
+        def fn_fail(self, new_param: str,  # pylint: disable=unused-argument
+                    old_param: Optional[str] = None):  # pylint: disable=unused-argument
+            raise DashboardException(msg="boom", component="nvmeof", http_status_code=500)
+
+        try:
+            ok_result = NvmeofCLICommand.COMMANDS[test_cmd_ok].call(
+                MagicMock(),
+                {"new_param": "foo", "old_param": "bar"}
+            )
+            assert ok_result.retval == 0
+            assert "\nWarning: --old-param is deprecated, please use --new-param" \
+                in ok_result.stdout
+            assert ok_result.stderr == ''
+
+            fail_result = NvmeofCLICommand.COMMANDS[test_cmd_fail].call(
+                MagicMock(),
+                {"new_param": "foo", "old_param": "bar"}
+            )
+            assert fail_result.retval == -errno.EINVAL
+            assert fail_result.stdout == ''
+            assert "\nWarning: --old-param is deprecated, please use --new-param" \
+                in fail_result.stderr
+        finally:
+            self._cleanup(test_cmd_ok, test_cmd_fail)
+
+    def test_deprecated_warning_appended_after_success_message(self):
+        test_cmd = "test deprecated with success msg"
+
+        class Model(NamedTuple):
+            status: str
+
+        @NvmeofCLICommand(
+            test_cmd,
+            Model,
+            success_message_template="Done: {new_param}",
+            deprecated_params={"old_param": "--old-param is deprecated, please use --new-param"}
+        )  # pylint: disable=unused-variable
+        def fn(self, new_param: str,  # pylint: disable=unused-argument
+               old_param: Optional[str] = None):  # pylint: disable=unused-argument
+            return {'status': 'ok'}
+
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(
+                MagicMock(),
+                {"new_param": "foo", "old_param": "bar"}
+            )
+            assert result.retval == 0
+            assert result.stdout.startswith("Done: foo")
+            assert "\nWarning: --old-param is deprecated, please use --new-param" in result.stdout
+        finally:
+            self._cleanup(test_cmd)
+
+    def test_no_warning_appended_to_success_message_when_param_absent(self):
+        test_cmd = "test deprecated with success msg no warn"
+
+        class Model(NamedTuple):
+            status: str
+
+        @NvmeofCLICommand(
+            test_cmd,
+            Model,
+            success_message_template="Done: {new_param}",
+            deprecated_params={"old_param": "--old-param is deprecated, please use --new-param"}
+        )  # pylint: disable=unused-variable
+        def fn(self, new_param: str,  # pylint: disable=unused-argument
+               old_param: Optional[str] = None):  # pylint: disable=unused-argument
+            return {'status': 'ok'}
+
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(
+                MagicMock(),
+                {"new_param": "foo"}
+            )
+            assert result.retval == 0
+            assert result.stdout == "Done: foo"
+        finally:
+            self._cleanup(test_cmd)
+
+    def test_malformed_arg_in_args_map_returns_handle_command_result_not_uncaught_exception(self):
+        test_cmd = "test argspec throws inside try"
+
+        class Model(NamedTuple):
+            status: str
+
+        @NvmeofCLICommand(
+            test_cmd,
+            Model,
+            deprecated_params={"old_param": "--old-param is deprecated, please use --new-param"}
+        )  # pylint: disable=unused-variable
+        def fn(self, count: int,  # pylint: disable=unused-argument
+               old_param: Optional[str] = None):  # pylint: disable=unused-argument
+            return {'status': 'ok'}
+
+        try:
+            # 'count' is typed as int but we pass a string value to it so
+            # CephArgtype.cast_to raises ValueError inside _args_map_from_argspec
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(
+                MagicMock(),
+                {"count": "not-a-number", "old_param": "bar"}
+            )
+            assert isinstance(result, HandleCommandResult)
+            assert result.retval == -errno.EINVAL
+            assert result.stdout == ''
+            assert result.stderr != ''
+        finally:
+            self._cleanup(test_cmd)
+
+
 class TestNVMeoFConfCLI(unittest.TestCase, CLICommandTestMixin):
     def setUp(self):
         self.mock_kv_store()


### PR DESCRIPTION
The user will now have an indication when using a deprecated parameter.

```
[xxx@xxx ~]# ceph nvmeof namespace add --nqn nqn.2016-06.io.spdk:cnode1.mygroup1 --rbd_pool nvmeof --rbd_image_name image4 --create-image=true --size=10MB
Adding namespace 17 to nqn.2016-06.io.spdk:cnode1.mygroup1: Successful
Warning: --size is deprecated, please use --rbd-image-size


[xxx@xxx ~]# ceph nvmeof namespace add --nqn nqn.2016-06.io.spdk:cnode1.mygroup1 --rbd_pool nvmeof --rbd_image_name image4 --create-image=true --size=10MB
Error EINVAL: RBD image nvmeof/image4 is already used by a namespace with UUID 5fc1327b-efbb-4252-abeb-613276a1685f in subsystem nqn.2016-06.io.spdk:cnode1.mygroup1, group mygroup1, either delete the namespace or use the "force" argument,
you can find the offending namespace by using the "namespace list" CLI command on subsystem nqn.2016-06.io.spdk:cnode1.mygroup1
Warning: --size is deprecated, please use --rbd-image-size
```

Fixes: https://tracker.ceph.com/issues/78228


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
