### PR TITLE
mgr/dashboard: set MOTD fails on FIPS enabled systems

### DIFF
--- a/src/pybind/mgr/dashboard/plugins/motd.py
+++ b/src/pybind/mgr/dashboard/plugins/motd.py
@@ -59,9 +59,12 @@ class Motd(SP):
             expires = datetime_to_str(datetime_now() + delta)
         else:
             expires = ''
+
+        # pylint: disable=unexpected-keyword-arg
+        md5 = hashlib.md5(message.encode(), usedforsecurity=False).hexdigest()
         value: str = json.dumps({
             'message': message,
-            'md5': hashlib.md5(message.encode()).hexdigest(),
+            'md5': md5,
             'severity': severity.value,
             'expires': expires
         })

--- a/src/pybind/mgr/dashboard/tests/test_motd.py
+++ b/src/pybind/mgr/dashboard/tests/test_motd.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+
+import hashlib
+import json
+import unittest
+
+from ..plugins.motd import Motd, MotdSeverity
+from . import KVStoreMockMixin  # pylint: disable=no-name-in-module
+
+
+class MotdTest(unittest.TestCase, KVStoreMockMixin):
+    """Unit tests for Motd._set_motd and the helpers it depends on."""
+
+    def setUp(self):
+        self.mock_kv_store()
+        self.plugin = Motd()
+
+    # ------------------------------------------------------------------
+    # _normalize_severity
+    # ------------------------------------------------------------------
+
+    def test_normalize_severity_from_enum(self):
+        result = self.plugin._normalize_severity(MotdSeverity.INFO)
+        self.assertEqual(result, MotdSeverity.INFO)
+
+    def test_normalize_severity_from_valid_string(self):
+        for value, expected in (
+            ('info', MotdSeverity.INFO),
+            ('warning', MotdSeverity.WARNING),
+            ('danger', MotdSeverity.DANGER),
+        ):
+            with self.subTest(value=value):
+                self.assertEqual(self.plugin._normalize_severity(value), expected)
+
+    def test_normalize_severity_invalid_string_returns_none(self):
+        self.assertIsNone(self.plugin._normalize_severity('critical'))
+
+    # ------------------------------------------------------------------
+    # _set_motd — error paths
+    # ------------------------------------------------------------------
+
+    def test_set_motd_invalid_severity_returns_error(self):
+        rc, out, err = self.plugin._set_motd('critical', '0', 'hello')
+        self.assertEqual(rc, 1)
+        self.assertEqual(out, '')
+        self.assertIn('severity', err)
+
+    def test_set_motd_invalid_expires_returns_error(self):
+        rc, out, err = self.plugin._set_motd('info', 'bad-expires', 'hello')
+        self.assertEqual(rc, 1)
+        self.assertEqual(out, '')
+        self.assertIn('expires', err)
+
+    # ------------------------------------------------------------------
+    # _set_motd — happy path: no expiry
+    # ------------------------------------------------------------------
+
+    def test_set_motd_no_expiry_returns_success(self):
+        rc, out, err = self.plugin._set_motd('info', '0', 'hello world')
+        self.assertEqual(rc, 0)
+        self.assertNotEqual(out, '')
+        self.assertEqual(err, '')
+
+    def test_set_motd_no_expiry_stores_expected_fields(self):
+        self.plugin._set_motd('warning', '0', 'test message')
+        raw = self.plugin.get_option(self.plugin.NAME)
+        self.assertIsNotNone(raw)
+        data = json.loads(raw)
+        self.assertEqual(data['message'], 'test message')
+        self.assertEqual(data['severity'], 'warning')
+        self.assertEqual(data['expires'], '')   # '0' → no expiry
+
+    def test_set_motd_stores_correct_md5(self):
+        message = 'checksum test'
+        self.plugin._set_motd('danger', '0', message)
+        data = json.loads(self.plugin.get_option(self.plugin.NAME))
+        expected_md5 = hashlib.md5(  # pylint: disable=unexpected-keyword-arg
+            message.encode(), usedforsecurity=False).hexdigest()
+        self.assertEqual(data['md5'], expected_md5)
+
+    # ------------------------------------------------------------------
+    # _set_motd — happy path: with expiry
+    # ------------------------------------------------------------------
+
+    def test_set_motd_with_expiry_stores_iso_timestamp(self):
+        self.plugin._set_motd('info', '2h', 'expiring message')
+        data = json.loads(self.plugin.get_option(self.plugin.NAME))
+        # expires must be a non-empty ISO 8601 string when a duration is given
+        self.assertTrue(data['expires'], 'expected a non-empty expires value')
+
+    def test_set_motd_accepts_enum_severity(self):
+        rc, _, err = self.plugin._set_motd(MotdSeverity.DANGER, '0', 'enum severity')
+        self.assertEqual(rc, 0)
+        self.assertEqual(err, '')
+        data = json.loads(self.plugin.get_option(self.plugin.NAME))
+        self.assertEqual(data['severity'], 'danger')
+
+    # ------------------------------------------------------------------
+    # Overwrite: second call replaces the stored value
+    # ------------------------------------------------------------------
+
+    def test_set_motd_overwrite(self):
+        self.plugin._set_motd('info', '0', 'first')
+        self.plugin._set_motd('warning', '0', 'second')
+        data = json.loads(self.plugin.get_option(self.plugin.NAME))
+        self.assertEqual(data['message'], 'second')
+        self.assertEqual(data['severity'], 'warning')


### PR DESCRIPTION
Root cause: On FIPS-compliant systems, the OpenSSL provider rejects hashlib.md5() calls that lack the usedforsecurity=False flag, because MD5 is not an approved algorithm for security-sensitive use. This causes the MOTD set command — and the /api/motd create endpoint — to raise a ValueError and crash whenever a new MOTD is saved.

Fix: Pass usedforsecurity=False to hashlib.md5(). This tells the FIPS provider that MD5 is being used only as a non-cryptographic checksum (to detect whether a user has already dismissed a specific MOTD message), which is a legitimate use-case that FIPS allows.

Fixes: https://tracker.ceph.com/issues/78233





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
