### PR TITLE
tools/cephfs_mirror: fix re-appearance of removed checkpoints

### DIFF
--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -1475,6 +1475,38 @@ class TestMirroring(CephFSTestCase):
 
         self._teardown_mirroring(dir_path, peer_spec)
 
+    def test_checkpoint_remove_during_sync(self):
+        """Removing a checkpoint during sync must not recreate it on completion."""
+        dir_path = '/cp_remove_sync'
+        snap_name = 'snap0'
+        peer_spec = "client.mirror_remote@ceph"
+
+        self._setup_mirrored_directory(dir_path, mount_b=True)
+        dir_name = dir_path.lstrip('/')
+        self.mount_a.create_n_files(f'{dir_name}/file', 10000, sync=True)
+        for i in range(20):
+            self.mount_a.write_n_mb(os.path.join(dir_name, f'large_file.{i}'), 100)
+        self._add_checkpoint_snapshot(dir_path, snap_name)
+        self.check_checkpoint_status(self.primary_fs_name, dir_path, snap_name, 'created')
+
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec,
+                      self.secondary_fs_name)
+        self.check_peer_snap_in_progress(self.primary_fs_name, self.primary_fs_id,
+                                         peer_spec, dir_path, snap_name)
+
+        self.checkpoint_remove(self.primary_fs_name, dir_path, snap_name)
+        res = self.checkpoint_list(self.primary_fs_name, dir_path)
+        self.assertEqual(res['checkpoints'], [])
+
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, dir_path, snap_name, 1)
+        self.verify_snapshot(dir_name, snap_name)
+
+        res = self.checkpoint_list(self.primary_fs_name, dir_path)
+        self.assertEqual(res['checkpoints'], [])
+
+        self._teardown_mirroring(dir_path, peer_spec)
+
     def test_add_relative_directory_path(self):
         self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
         try:

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -1538,6 +1538,38 @@ class TestMirroring(CephFSTestCase):
 
         self._teardown_mirroring(dir_path, peer_spec)
 
+    def test_checkpoint_remove_during_sync(self):
+        """Removing a checkpoint during sync must not recreate it on completion."""
+        dir_path = '/cp_remove_sync'
+        snap_name = 'snap0'
+        peer_spec = "client.mirror_remote@ceph"
+
+        self._setup_mirrored_directory(dir_path, mount_b=True)
+        dir_name = dir_path.lstrip('/')
+        self.mount_a.create_n_files(f'{dir_name}/file', 10000, sync=True)
+        for i in range(20):
+            self.mount_a.write_n_mb(os.path.join(dir_name, f'large_file.{i}'), 100)
+        self._add_checkpoint_snapshot(dir_path, snap_name)
+        self.check_checkpoint_status(self.primary_fs_name, dir_path, snap_name, 'created')
+
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec,
+                      self.secondary_fs_name)
+        self.check_peer_snap_in_progress(self.primary_fs_name, self.primary_fs_id,
+                                         peer_spec, dir_path, snap_name)
+
+        self.checkpoint_remove(self.primary_fs_name, dir_path, snap_name)
+        res = self.checkpoint_list(self.primary_fs_name, dir_path)
+        self.assertEqual(res['checkpoints'], [])
+
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, dir_path, snap_name, 1)
+        self.verify_snapshot(dir_name, snap_name)
+
+        res = self.checkpoint_list(self.primary_fs_name, dir_path)
+        self.assertEqual(res['checkpoints'], [])
+
+        self._teardown_mirroring(dir_path, peer_spec)
+
     def test_add_relative_directory_path(self):
         self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
         try:

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -13957,6 +13957,13 @@ int Client::get_snap_info(const char *path, const UserPerm &perms, SnapInfo *sna
     return -EINVAL;
   }
 
+  // Snapshot metadata is mutable after creation (PR #66723), so a cached inode
+  // copy may be stale if another client added, updated, or removed metadata
+  // keys.  Refresh from the MDS before returning metadata.
+  if (int rc = _getattr(in, CEPH_CAP_AUTH_SHARED, perms, true); rc < 0) {
+    return rc;
+  }
+
   snap_info->id = in->snapid;
   snap_info->metadata = in->snap_metadata;
   return 0;
@@ -14296,6 +14303,17 @@ int Client::do_snap_md_op(const char* path, const string& md_key,
   ldout(cct, 10) << __func__ << ": making request" << dendl;
   int res = make_request(req, perms, &wdr.target);
   ldout(cct, 10) << __func__ << ": result is " << res << dendl;
+
+  if (res >= 0) {
+    // Snapshot metadata is mutable after creation (PR #66723); keep the
+    // writing client's inode cache consistent with the MDS.
+    auto &md = wdr.target->snap_metadata;
+    if (op_flag == CEPH_SNAP_MD_OP_REMOVE) {
+      md.erase(md_key);
+    } else {
+      md[md_key] = md_val;
+    }
+  }
 
   trim_cache();
 

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -14309,7 +14309,8 @@ int Client::do_snap_md_op(const char* path, const string& md_key,
 {
   if (op_flag != CEPH_SNAP_MD_OP_CREATE &&
       op_flag != (CEPH_SNAP_MD_OP_CREATE | CEPH_SNAP_MD_OP_EXCL) &&
-      op_flag != CEPH_SNAP_MD_OP_REMOVE) {
+      op_flag != CEPH_SNAP_MD_OP_REMOVE &&
+      op_flag != CEPH_SNAP_MD_OP_UPDATE) {
     return -EINVAL;
   }
 

--- a/src/include/cephfs/snap_types.h
+++ b/src/include/cephfs/snap_types.h
@@ -22,4 +22,6 @@ enum {
         // update
 	CEPH_SNAP_MD_OP_EXCL      = (1 << 1),
 	CEPH_SNAP_MD_OP_REMOVE    = (1 << 2),
+        // update only; fails if key is absent
+	CEPH_SNAP_MD_OP_UPDATE    = (1 << 3),
 };

--- a/src/mds/snap.cc
+++ b/src/mds/snap.cc
@@ -104,6 +104,13 @@ bool SnapInfo::will_md_op_succeed(const string& key, const string& val,
                << dendl;
       return false;
     }
+  } else if (op_flag == CEPH_SNAP_MD_OP_UPDATE) {
+    if (metadata.count(key) == 0) {
+      dout(10) << __func__ << " snapshot metadata op will fail: update would "
+               << "be attempted for a non-existing key. op_flag=" << op_flag
+               << dendl;
+      return false;
+    }
   } else {
     // NOTE: in case of wrong mode/op_flag value, client code exits with
     // appropriate error number instead of contacting MDS with wrong
@@ -131,6 +138,8 @@ void SnapInfo::do_md_op(const string& key, const string& val,
     metadata.emplace(key, val);
   } else if (op_flag == CEPH_SNAP_MD_OP_REMOVE) {
     metadata.erase(key);
+  } else if (op_flag == CEPH_SNAP_MD_OP_UPDATE) {
+    metadata.insert_or_assign(key, val);
   }
 }
 

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -94,6 +94,7 @@ cpdef enum:
     CEPH_SNAP_MD_OP_CREATE = (1 << 0)
     CEPH_SNAP_MD_OP_EXCL   = (1 << 1)
     CEPH_SNAP_MD_OP_REMOVE = (1 << 2)
+    CEPH_SNAP_MD_OP_UPDATE = (1 << 3)
 
 
 # XXX: errno definitions, hard-coded numbers here are errnos defined by Linux

--- a/src/test/libcephfs/multiclient.cc
+++ b/src/test/libcephfs/multiclient.cc
@@ -245,3 +245,49 @@ TEST(LibCephFS, SnapMdMutate) {
   ceph_shutdown(cmount);
   ceph_shutdown(cmount2);
 }
+
+// Test that client #2 observes snap metadata removal made by client #1 even
+// when client #2 already cached the snapshot inode.
+TEST(LibCephFS, SnapMdMutateCachedRead) {
+  struct ceph_mount_info *cmount, *cmount2;
+
+  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+  ASSERT_EQ(ceph_conf_parse_env(cmount, NULL), 0);
+  ASSERT_EQ(ceph_mount(cmount, NULL), 0);
+
+  ASSERT_EQ(ceph_create(&cmount2, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount2, NULL), 0);
+  ASSERT_EQ(ceph_conf_parse_env(cmount2, NULL), 0);
+  ASSERT_EQ(ceph_mount(cmount2, NULL), 0);
+
+  char dir_path[64];
+  char snap_name[64];
+  char snap_path[PATH_MAX];
+  sprintf(dir_path, "/dir0_%d-6", getpid());
+  sprintf(snap_name, "snap_%d_6", getpid());
+  sprintf(snap_path, "%s/.snap/%s", dir_path, snap_name);
+
+  ASSERT_EQ(0, ceph_mkdir(cmount, dir_path, 0755));
+  struct snap_metadata snap_meta[] = {{"foo", "bar"}};
+  ASSERT_EQ(0, ceph_mksnap(cmount, dir_path, snap_name, 0755, snap_meta,
+                           std::size(snap_meta)));
+
+  struct snap_info info = {};
+  ASSERT_EQ(0, ceph_get_snap_info(cmount2, snap_path, &info));
+  ASSERT_EQ(info.nr_snap_metadata, 1);
+  ceph_free_snap_info_buffer(&info);
+
+  ASSERT_EQ(0, ceph_do_snap_md_op(cmount, snap_path, "foo", "",
+                                  CEPH_SNAP_MD_OP_REMOVE));
+
+  memset(&info, 0, sizeof(info));
+  ASSERT_EQ(0, ceph_get_snap_info(cmount2, snap_path, &info));
+  ASSERT_EQ(info.nr_snap_metadata, 0);
+  ceph_free_snap_info_buffer(&info);
+
+  ASSERT_EQ(0, ceph_rmsnap(cmount, dir_path, snap_name));
+  ASSERT_EQ(0, ceph_rmdir(cmount, dir_path));
+  ceph_shutdown(cmount);
+  ceph_shutdown(cmount2);
+}

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -2926,6 +2926,44 @@ TEST(LibCephFS, SnapMdCreateUpdates) {
   ceph_shutdown(cmount);
 }
 
+// Test UPDATE-only snap metadata op: update existing key, reject missing key.
+TEST(LibCephFS, SnapMdOpUpdateOnly) {
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+  ASSERT_EQ(ceph_conf_parse_env(cmount, NULL), 0);
+  ASSERT_EQ(do_ceph_mount(cmount, NULL), 0);
+
+  char dir_path[64];
+  char snap_name[64];
+  char snap_path[PATH_MAX];
+  sprintf(dir_path, "/dir0_%d-update", getpid());
+  sprintf(snap_name, "snap_%d_update", getpid());
+  sprintf(snap_path, "%s/.snap/%s", dir_path, snap_name);
+
+  ASSERT_EQ(0, ceph_mkdir(cmount, dir_path, 0755));
+  struct snap_metadata snap_meta[] = {{"foo", "bar"}};
+  ASSERT_EQ(0, ceph_mksnap(cmount, dir_path, snap_name, 0755, snap_meta,
+                           std::size(snap_meta)));
+
+  ASSERT_EQ(0, ceph_do_snap_md_op(cmount, snap_path, "foo", "bar2",
+                                  CEPH_SNAP_MD_OP_UPDATE));
+
+  struct snap_info info;
+  ASSERT_EQ(0, ceph_get_snap_info(cmount, snap_path, &info));
+  ASSERT_EQ(info.nr_snap_metadata, 1);
+  ASSERT_STREQ(info.snap_metadata[0].key, "foo");
+  ASSERT_STREQ(info.snap_metadata[0].value, "bar2");
+  ceph_free_snap_info_buffer(&info);
+
+  ASSERT_EQ(-EINVAL, ceph_do_snap_md_op(cmount, snap_path, "missing", "val",
+                                        CEPH_SNAP_MD_OP_UPDATE));
+
+  ASSERT_EQ(0, ceph_rmsnap(cmount, dir_path, snap_name));
+  ASSERT_EQ(0, ceph_rmdir(cmount, dir_path));
+  ceph_shutdown(cmount);
+}
+
 
 // Test that k-v pair is added successfully by ceph_do_snap_md_op() in
 // EXCL mode.

--- a/src/tools/cephfs_mirror/Checkpoint.cc
+++ b/src/tools/cephfs_mirror/Checkpoint.cc
@@ -7,19 +7,11 @@
 #include "common/strtol.h"
 
 #include <cstdio>
-#include <vector>
 
 namespace cephfs {
 namespace mirror {
 
 namespace {
-
-const std::vector<std::string> CHECKPOINT_METADATA_KEY_LIST = {
-  CHECKPOINT_STATUS_KEY,
-  CHECKPOINT_CREATED_AT_KEY,
-  CHECKPOINT_UPDATED_AT_KEY,
-  CHECKPOINT_ERROR_MSG_KEY,
-};
 
 std::map<std::string, std::string> decode_snap_metadata(snap_metadata *md,
                                                         size_t nr_snap_metadata) {
@@ -128,38 +120,55 @@ int write_checkpoint_metadata(CephContext *cct, MountRef mnt,
   auto snap_path = snapshot_path(cct, dir_root, snap_name);
   auto checkpoint_metadata = info.to_metadata();
 
-  // Write/update checkpoint metadata keys
-  for (const auto &[key, val] : checkpoint_metadata) {
-    // created_at is set by the mgr when the checkpoint is created; mirror
-    // daemon updates must not rewrite it.
-    if (key == CHECKPOINT_CREATED_AT_KEY && snap_metadata.count(key)) {
-      continue;
-    }
-
+  // Mirror daemon only updates existing checkpoints; mgr creates them via
+  // CREATE|EXCL.  UPDATE fails if a key was removed while sync was in progress.
+  auto do_op = [&](const std::string &key, const std::string &val,
+                   unsigned int op_flag) -> int {
     auto it = snap_metadata.find(key);
-    if (it != snap_metadata.end() && it->second == val) {
-      continue;
+    if (op_flag == CEPH_SNAP_MD_OP_UPDATE ||
+        op_flag == CEPH_SNAP_MD_OP_CREATE) {
+      if (it != snap_metadata.end() && it->second == val) {
+        return 0;
+      }
+    } else if (op_flag == CEPH_SNAP_MD_OP_REMOVE) {
+      if (it == snap_metadata.end()) {
+        return 0;
+      }
     }
+    return ceph_do_snap_md_op(mnt, snap_path.c_str(), key.c_str(), val.c_str(),
+                              op_flag);
+  };
 
-    // For updates: use CREATE (allows both create and update)
-    // For new creates: use CREATE | EXCL (create only, reject update)
-    unsigned int op_flag = it != snap_metadata.end() ?
-      CEPH_SNAP_MD_OP_CREATE : (CEPH_SNAP_MD_OP_CREATE | CEPH_SNAP_MD_OP_EXCL);
-    int r = ceph_do_snap_md_op(mnt, snap_path.c_str(), key.c_str(), val.c_str(),
-                               op_flag);
+  int r = do_op(CHECKPOINT_STATUS_KEY,
+                checkpoint_metadata.at(CHECKPOINT_STATUS_KEY),
+                CEPH_SNAP_MD_OP_UPDATE);
+  if (r == -EINVAL) {
+    return 0;
+  }
+  if (r < 0) {
+    return r;
+  }
+
+  r = do_op(CHECKPOINT_UPDATED_AT_KEY,
+            checkpoint_metadata.at(CHECKPOINT_UPDATED_AT_KEY),
+            CEPH_SNAP_MD_OP_UPDATE);
+  if (r == -EINVAL) {
+    return 0;
+  }
+  if (r < 0) {
+    return r;
+  }
+
+  if (!info.error_msg.empty()) {
+    r = do_op(CHECKPOINT_ERROR_MSG_KEY, info.error_msg,
+              CEPH_SNAP_MD_OP_CREATE);
     if (r < 0) {
       return r;
     }
-  }
-
-  // Remove checkpoint metadata keys that are no longer present
-  for (const auto &key : CHECKPOINT_METADATA_KEY_LIST) {
-    if (snap_metadata.count(key) && !checkpoint_metadata.count(key)) {
-      int r = ceph_do_snap_md_op(mnt, snap_path.c_str(), key.c_str(), "",
-                                 CEPH_SNAP_MD_OP_REMOVE);
-      if (r < 0) {
-        return r;
-      }
+  } else {
+    r = do_op(CHECKPOINT_ERROR_MSG_KEY, "", CEPH_SNAP_MD_OP_REMOVE);
+    if (r < 0 && r != -EINVAL) {
+      return r;
     }
   }
 


### PR DESCRIPTION
After snapshot metadata mutation (PR #66723), the mgr can remove a
checkpoint while the mirror daemon is syncing. The mirror daemon may
still see stale inode metadata and recreate checkpoint keys when sync
completes.

Add a new flag CEPH_SNAP_MD_OP_UPDATE to update an existing snap
metadata key and reject the operation when the key is absent.
Use CEPH_SNAP_MD_OP_UPDATE for checkpoint status transitions so the
mirror daemon cannot recreate keys that were removed on the MDS.

Fixes: https://tracker.ceph.com/issues/77992


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
