### PR TITLE
mgr/dashboard: Getting get attrribute 400 error after mirroring on clicking FS -> Subvolume , Subvolume Group Tab

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -890,7 +890,7 @@ class CephFSSubvolume(RESTController):
             )
         subvolumes = json.loads(out)
 
-        if info:
+        if str_to_bool(info):
             for subvolume in subvolumes:
                 params['sub_name'] = subvolume['name']
                 error_code, out, err = mgr.remote('volumes', '_cmd_fs_subvolume_info', None,
@@ -901,10 +901,17 @@ class CephFSSubvolume(RESTController):
                 if error_code == -errno.EAGAIN:
                     pass
                 elif error_code != 0:
-                    raise DashboardException(
-                        f'Failed to get info for subvolume {subvolume["name"]}: {err}'
-                    )
-                if out:
+                    if _is_unmanaged_volume_entry(error_code, err):
+                        subvolume['info'] = _mirrored_subvolume_info()
+                        error_code, out, err = mgr.remote(
+                            'volumes', '_cmd_fs_subvolume_getpath', None, params)
+                        if error_code == 0:
+                            subvolume['info']['path'] = out
+                    else:
+                        raise DashboardException(
+                            f'Failed to get info for subvolume {subvolume["name"]}: {err}'
+                        )
+                elif out:
                     subvolume['info'] = json.loads(out)
         return subvolumes
 
@@ -916,6 +923,13 @@ class CephFSSubvolume(RESTController):
         error_code, out, err = mgr.remote('volumes', '_cmd_fs_subvolume_info', None,
                                           params)
         if error_code != 0:
+            if _is_unmanaged_volume_entry(error_code, err):
+                info = _mirrored_subvolume_info()
+                error_code, out, err = mgr.remote(
+                    'volumes', '_cmd_fs_subvolume_getpath', None, params)
+                if error_code == 0:
+                    info['path'] = out
+                return info
             raise DashboardException(
                 f'Failed to get info for subvolume {subvol_name}: {err}'
             )
@@ -1040,6 +1054,27 @@ class CephFSSubvolume(RESTController):
         return out
 
 
+def _is_unmanaged_volume_entry(error_code: int, err: str) -> bool:
+    return (
+        error_code in (-errno.EINVAL, -errno.ENODATA)
+        and 'getxattr' in (err or '').lower()
+    )
+
+
+def _mirrored_subvolume_info() -> Dict[str, Any]:
+    return {
+        'state': 'mirrored',
+        'bytes_pcent': 'undefined',
+    }
+
+
+def _mirrored_snapshot_info() -> Dict[str, Any]:
+    return {
+        'state': 'mirrored',
+        'has_pending_clones': 'no',
+    }
+
+
 @APIRouter('/cephfs/subvolume/group', Scope.CEPHFS)
 @APIDoc("Cephfs Subvolume Group Management API", "CephfsSubvolumeGroup")
 class CephFSSubvolumeGroups(RESTController):
@@ -1055,12 +1090,20 @@ class CephFSSubvolumeGroups(RESTController):
                 f'Error listing subvolume groups for {vol_name}')
         subvolume_groups = json.loads(out)
 
-        if info:
+        if str_to_bool(info):
             for group in subvolume_groups:
                 error_code, out, err = mgr.remote('volumes', '_cmd_fs_subvolumegroup_info',
                                                   None, {'vol_name': vol_name,
                                                          'group_name': group['name']})
                 if error_code != 0:
+                    if _is_unmanaged_volume_entry(error_code, err):
+                        group['info'] = _mirrored_subvolume_info()
+                        error_code, out, err = mgr.remote(
+                            'volumes', '_cmd_fs_subvolumegroup_getpath',
+                            None, {'vol_name': vol_name, 'group_name': group['name']})
+                        if error_code == 0:
+                            group['info']['path'] = out
+                        continue
                     raise DashboardException(
                         f'Failed to get info for subvolume group {group["name"]}: {err}'
                     )
@@ -1081,6 +1124,14 @@ class CephFSSubvolumeGroups(RESTController):
         error_code, out, err = mgr.remote('volumes', '_cmd_fs_subvolumegroup_info', None, {
             'vol_name': vol_name, 'group_name': group_name})
         if error_code != 0:
+            if _is_unmanaged_volume_entry(error_code, err):
+                group = _mirrored_subvolume_info()
+                error_code, out, err = mgr.remote(
+                    'volumes', '_cmd_fs_subvolumegroup_getpath',
+                    None, {'vol_name': vol_name, 'group_name': group_name})
+                if error_code == 0:
+                    group['path'] = out
+                return group
             raise DashboardException(
                 f'Failed to get info for subvolume group {group_name}: {err}'
 
@@ -1140,7 +1191,7 @@ class CephFSSubvolumeSnapshots(RESTController):
             )
         snapshots = json.loads(out)
 
-        if info:
+        if str_to_bool(info):
             for snapshot in snapshots:
                 params['snap_name'] = snapshot['name']
                 error_code, out, err = mgr.remote('volumes', '_cmd_fs_subvolume_snapshot_info',
@@ -1151,10 +1202,13 @@ class CephFSSubvolumeSnapshots(RESTController):
                 if error_code == -errno.EAGAIN:
                     pass
                 elif error_code != 0:
-                    raise DashboardException(
-                        f'Failed to get info for subvolume snapshot {snapshot["name"]}: {err}'
-                    )
-                if out:
+                    if _is_unmanaged_volume_entry(error_code, err):
+                        snapshot['info'] = _mirrored_snapshot_info()
+                    else:
+                        raise DashboardException(
+                            f'Failed to get info for subvolume snapshot {snapshot["name"]}: {err}'
+                        )
+                elif out:
                     snapshot['info'] = json.loads(out)
         return snapshots
 
@@ -1166,6 +1220,8 @@ class CephFSSubvolumeSnapshots(RESTController):
         error_code, out, err = mgr.remote('volumes', '_cmd_fs_subvolume_snapshot_info', None,
                                           params)
         if error_code != 0:
+            if _is_unmanaged_volume_entry(error_code, err):
+                return _mirrored_snapshot_info()
             raise DashboardException(
                 f'Failed to get info for subvolume snapshot {snap_name}: {err}'
             )

--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -14,6 +14,8 @@ from ..exceptions import DashboardException
 from ..security import Scope
 from ..services.ceph_service import CephService
 from ..services.cephfs import CephFS as CephFS_
+from ..services.cephfs import get_subvolumegroup_path, \
+    is_unmanaged_volume_entry, unmanaged_volume_info
 from ..services.exception import handle_cephfs_error
 from ..tools import ViewCache, str_to_bool
 from . import APIDoc, APIRouter, CreatePermission, DeletePermission, Endpoint, \
@@ -901,8 +903,8 @@ class CephFSSubvolume(RESTController):
                 if error_code == -errno.EAGAIN:
                     pass
                 elif error_code != 0:
-                    if _is_unmanaged_volume_entry(error_code, err):
-                        subvolume['info'] = _mirrored_subvolume_info()
+                    if is_unmanaged_volume_entry(error_code, err):
+                        subvolume['info'] = unmanaged_volume_info()
                         error_code, out, err = mgr.remote(
                             'volumes', '_cmd_fs_subvolume_getpath', None, params)
                         if error_code == 0:
@@ -923,8 +925,8 @@ class CephFSSubvolume(RESTController):
         error_code, out, err = mgr.remote('volumes', '_cmd_fs_subvolume_info', None,
                                           params)
         if error_code != 0:
-            if _is_unmanaged_volume_entry(error_code, err):
-                info = _mirrored_subvolume_info()
+            if is_unmanaged_volume_entry(error_code, err):
+                info = unmanaged_volume_info()
                 error_code, out, err = mgr.remote(
                     'volumes', '_cmd_fs_subvolume_getpath', None, params)
                 if error_code == 0:
@@ -1054,27 +1056,6 @@ class CephFSSubvolume(RESTController):
         return out
 
 
-def _is_unmanaged_volume_entry(error_code: int, err: str) -> bool:
-    return (
-        error_code in (-errno.EINVAL, -errno.ENODATA)
-        and 'getxattr' in (err or '').lower()
-    )
-
-
-def _mirrored_subvolume_info() -> Dict[str, Any]:
-    return {
-        'state': 'mirrored',
-        'bytes_pcent': 'undefined',
-    }
-
-
-def _mirrored_snapshot_info() -> Dict[str, Any]:
-    return {
-        'state': 'mirrored',
-        'has_pending_clones': 'no',
-    }
-
-
 @APIRouter('/cephfs/subvolume/group', Scope.CEPHFS)
 @APIDoc("Cephfs Subvolume Group Management API", "CephfsSubvolumeGroup")
 class CephFSSubvolumeGroups(RESTController):
@@ -1096,27 +1077,15 @@ class CephFSSubvolumeGroups(RESTController):
                                                   None, {'vol_name': vol_name,
                                                          'group_name': group['name']})
                 if error_code != 0:
-                    if _is_unmanaged_volume_entry(error_code, err):
-                        group['info'] = _mirrored_subvolume_info()
-                        error_code, out, err = mgr.remote(
-                            'volumes', '_cmd_fs_subvolumegroup_getpath',
-                            None, {'vol_name': vol_name, 'group_name': group['name']})
-                        if error_code == 0:
-                            group['info']['path'] = out
-                        continue
-                    raise DashboardException(
-                        f'Failed to get info for subvolume group {group["name"]}: {err}'
-                    )
-                group['info'] = json.loads(out)
-
-                error_code, out, err = mgr.remote('volumes', '_cmd_fs_subvolumegroup_getpath',
-                                                  None, {'vol_name': vol_name,
-                                                         'group_name': group['name']})
-                if error_code != 0:
-                    raise DashboardException(
-                        f'Failed to get path for subvolume group {group["name"]}: {err}'
-                    )
-                group['info']['path'] = out
+                    if not is_unmanaged_volume_entry(error_code, err):
+                        raise DashboardException(
+                            f'Failed to get info for subvolume group {group["name"]}: {err}'
+                        )
+                    group['info'] = unmanaged_volume_info()
+                else:
+                    group['info'] = json.loads(out)
+                group['info']['path'] = get_subvolumegroup_path(
+                    vol_name, group['name'])
         return subvolume_groups
 
     @RESTController.Resource('GET')
@@ -1124,26 +1093,14 @@ class CephFSSubvolumeGroups(RESTController):
         error_code, out, err = mgr.remote('volumes', '_cmd_fs_subvolumegroup_info', None, {
             'vol_name': vol_name, 'group_name': group_name})
         if error_code != 0:
-            if _is_unmanaged_volume_entry(error_code, err):
-                group = _mirrored_subvolume_info()
-                error_code, out, err = mgr.remote(
-                    'volumes', '_cmd_fs_subvolumegroup_getpath',
-                    None, {'vol_name': vol_name, 'group_name': group_name})
-                if error_code == 0:
-                    group['path'] = out
-                return group
-            raise DashboardException(
-                f'Failed to get info for subvolume group {group_name}: {err}'
-
-            )
-        group = json.loads(out)
-        error_code, out, err = mgr.remote('volumes', '_cmd_fs_subvolumegroup_getpath', None, {
-            'vol_name': vol_name, 'group_name': group_name})
-        if error_code != 0:
-            raise DashboardException(
-                f'Failed to get path for subvolume group {group_name}: {err}'
-            )
-        group['path'] = out
+            if not is_unmanaged_volume_entry(error_code, err):
+                raise DashboardException(
+                    f'Failed to get info for subvolume group {group_name}: {err}'
+                )
+            group = unmanaged_volume_info()
+        else:
+            group = json.loads(out)
+        group['path'] = get_subvolumegroup_path(vol_name, group_name)
         return group
 
     def create(self, vol_name: str, group_name: str, **kwargs):
@@ -1202,8 +1159,8 @@ class CephFSSubvolumeSnapshots(RESTController):
                 if error_code == -errno.EAGAIN:
                     pass
                 elif error_code != 0:
-                    if _is_unmanaged_volume_entry(error_code, err):
-                        snapshot['info'] = _mirrored_snapshot_info()
+                    if is_unmanaged_volume_entry(error_code, err):
+                        snapshot['info'] = unmanaged_volume_info()
                     else:
                         raise DashboardException(
                             f'Failed to get info for subvolume snapshot {snapshot["name"]}: {err}'
@@ -1220,8 +1177,8 @@ class CephFSSubvolumeSnapshots(RESTController):
         error_code, out, err = mgr.remote('volumes', '_cmd_fs_subvolume_snapshot_info', None,
                                           params)
         if error_code != 0:
-            if _is_unmanaged_volume_entry(error_code, err):
-                return _mirrored_snapshot_info()
+            if is_unmanaged_volume_entry(error_code, err):
+                return unmanaged_volume_info()
             raise DashboardException(
                 f'Failed to get info for subvolume snapshot {snap_name}: {err}'
             )

--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -867,7 +867,7 @@ class CephFSSubvolume(RESTController):
             )
         subvolumes = json.loads(out)
 
-        if info:
+        if str_to_bool(info):
             for subvolume in subvolumes:
                 params['sub_name'] = subvolume['name']
                 error_code, out, err = mgr.remote('volumes', '_cmd_fs_subvolume_info', None,
@@ -878,10 +878,17 @@ class CephFSSubvolume(RESTController):
                 if error_code == -errno.EAGAIN:
                     pass
                 elif error_code != 0:
-                    raise DashboardException(
-                        f'Failed to get info for subvolume {subvolume["name"]}: {err}'
-                    )
-                if out:
+                    if _is_unmanaged_volume_entry(error_code, err):
+                        subvolume['info'] = _mirrored_subvolume_info()
+                        error_code, out, err = mgr.remote(
+                            'volumes', '_cmd_fs_subvolume_getpath', None, params)
+                        if error_code == 0:
+                            subvolume['info']['path'] = out
+                    else:
+                        raise DashboardException(
+                            f'Failed to get info for subvolume {subvolume["name"]}: {err}'
+                        )
+                elif out:
                     subvolume['info'] = json.loads(out)
         return subvolumes
 
@@ -893,6 +900,13 @@ class CephFSSubvolume(RESTController):
         error_code, out, err = mgr.remote('volumes', '_cmd_fs_subvolume_info', None,
                                           params)
         if error_code != 0:
+            if _is_unmanaged_volume_entry(error_code, err):
+                info = _mirrored_subvolume_info()
+                error_code, out, err = mgr.remote(
+                    'volumes', '_cmd_fs_subvolume_getpath', None, params)
+                if error_code == 0:
+                    info['path'] = out
+                return info
             raise DashboardException(
                 f'Failed to get info for subvolume {subvol_name}: {err}'
             )
@@ -1017,6 +1031,27 @@ class CephFSSubvolume(RESTController):
         return out
 
 
+def _is_unmanaged_volume_entry(error_code: int, err: str) -> bool:
+    return (
+        error_code in (-errno.EINVAL, -errno.ENODATA)
+        and 'getxattr' in (err or '').lower()
+    )
+
+
+def _mirrored_subvolume_info() -> Dict[str, Any]:
+    return {
+        'state': 'mirrored',
+        'bytes_pcent': 'undefined',
+    }
+
+
+def _mirrored_snapshot_info() -> Dict[str, Any]:
+    return {
+        'state': 'mirrored',
+        'has_pending_clones': 'no',
+    }
+
+
 @APIRouter('/cephfs/subvolume/group', Scope.CEPHFS)
 @APIDoc("Cephfs Subvolume Group Management API", "CephfsSubvolumeGroup")
 class CephFSSubvolumeGroups(RESTController):
@@ -1032,12 +1067,20 @@ class CephFSSubvolumeGroups(RESTController):
                 f'Error listing subvolume groups for {vol_name}')
         subvolume_groups = json.loads(out)
 
-        if info:
+        if str_to_bool(info):
             for group in subvolume_groups:
                 error_code, out, err = mgr.remote('volumes', '_cmd_fs_subvolumegroup_info',
                                                   None, {'vol_name': vol_name,
                                                          'group_name': group['name']})
                 if error_code != 0:
+                    if _is_unmanaged_volume_entry(error_code, err):
+                        group['info'] = _mirrored_subvolume_info()
+                        error_code, out, err = mgr.remote(
+                            'volumes', '_cmd_fs_subvolumegroup_getpath',
+                            None, {'vol_name': vol_name, 'group_name': group['name']})
+                        if error_code == 0:
+                            group['info']['path'] = out
+                        continue
                     raise DashboardException(
                         f'Failed to get info for subvolume group {group["name"]}: {err}'
                     )
@@ -1058,6 +1101,14 @@ class CephFSSubvolumeGroups(RESTController):
         error_code, out, err = mgr.remote('volumes', '_cmd_fs_subvolumegroup_info', None, {
             'vol_name': vol_name, 'group_name': group_name})
         if error_code != 0:
+            if _is_unmanaged_volume_entry(error_code, err):
+                group = _mirrored_subvolume_info()
+                error_code, out, err = mgr.remote(
+                    'volumes', '_cmd_fs_subvolumegroup_getpath',
+                    None, {'vol_name': vol_name, 'group_name': group_name})
+                if error_code == 0:
+                    group['path'] = out
+                return group
             raise DashboardException(
                 f'Failed to get info for subvolume group {group_name}: {err}'
 
@@ -1117,7 +1168,7 @@ class CephFSSubvolumeSnapshots(RESTController):
             )
         snapshots = json.loads(out)
 
-        if info:
+        if str_to_bool(info):
             for snapshot in snapshots:
                 params['snap_name'] = snapshot['name']
                 error_code, out, err = mgr.remote('volumes', '_cmd_fs_subvolume_snapshot_info',
@@ -1128,10 +1179,13 @@ class CephFSSubvolumeSnapshots(RESTController):
                 if error_code == -errno.EAGAIN:
                     pass
                 elif error_code != 0:
-                    raise DashboardException(
-                        f'Failed to get info for subvolume snapshot {snapshot["name"]}: {err}'
-                    )
-                if out:
+                    if _is_unmanaged_volume_entry(error_code, err):
+                        snapshot['info'] = _mirrored_snapshot_info()
+                    else:
+                        raise DashboardException(
+                            f'Failed to get info for subvolume snapshot {snapshot["name"]}: {err}'
+                        )
+                elif out:
                     snapshot['info'] = json.loads(out)
         return snapshots
 
@@ -1143,6 +1197,8 @@ class CephFSSubvolumeSnapshots(RESTController):
         error_code, out, err = mgr.remote('volumes', '_cmd_fs_subvolume_snapshot_info', None,
                                           params)
         if error_code != 0:
+            if _is_unmanaged_volume_entry(error_code, err):
+                return _mirrored_snapshot_info()
             raise DashboardException(
                 f'Failed to get info for subvolume snapshot {snap_name}: {err}'
             )

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.spec.ts
@@ -299,7 +299,9 @@ describe('CephfsMirroringListComponent', () => {
     component.selection.selected = [
       {
         local_fs_name: 'fs1',
-        remote_cluster_name: 'clusterA',
+        remote_site_name: 'clusterA',
+        fs_name: 'fsA',
+        client_name: 'clientA',
         directory_count: 4,
         peer_uuid: 'peer-uuid',
         failure_count: 0,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-form/cephfs-subvolume-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-form/cephfs-subvolume-form.component.ts
@@ -65,14 +65,15 @@ export class CephfsSubvolumeFormComponent extends CdForm implements OnInit {
     @Optional() @Inject('subVolumeName') public subVolumeName: string,
     @Optional() @Inject('subVolumeGroupName') public subVolumeGroupName: string,
     @Optional() @Inject('pools') public pools: Pool[],
-    @Optional() @Inject('isEdit') public isEdit = false
+    @Optional() @Inject('isEdit') public isEdit = false,
+    @Optional() @Inject('isRecreate') public isRecreate = false
   ) {
     super();
     this.resource = $localize`Subvolume`;
   }
 
   ngOnInit(): void {
-    this.action = this.actionLabels.CREATE;
+    this.action = this.isRecreate ? this.actionLabels.RECREATE : this.actionLabels.CREATE;
     this.columns = [
       {
         prop: 'scope',
@@ -104,8 +105,24 @@ export class CephfsSubvolumeFormComponent extends CdForm implements OnInit {
     this.createForm();
 
     this.loadSnapshotVisibilityConfig().subscribe(() => {
-      this.isEdit ? this.populateForm() : this.loadingReady();
+      if (this.isEdit) {
+        this.populateForm();
+      } else {
+        if (this.isRecreate) {
+          this.prepareRecreateForm();
+        }
+        this.loadingReady();
+      }
     });
+  }
+
+  private prepareRecreateForm() {
+    const nameControl = this.subvolumeForm.get('subvolumeName');
+    nameControl.setValue(this.subVolumeName);
+    nameControl.disable();
+    nameControl.clearAsyncValidators();
+    nameControl.updateValueAndValidity();
+    this.subvolumeForm.get('subvolumeGroupName').disable();
   }
 
   private loadSnapshotVisibilityConfig(): Observable<void> {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-group/cephfs-subvolume-group.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-group/cephfs-subvolume-group.component.html
@@ -27,7 +27,7 @@
   let-row="data.row"
 >
   <cd-usage-bar
-    *ngIf="row.info.bytes_pcent && row.info.bytes_pcent !== 'undefined'; else noLimitTpl"
+    *ngIf="row.info?.bytes_pcent && row.info.bytes_pcent !== 'undefined'; else noLimitTpl"
     [total]="row.info.bytes_quota"
     [used]="row.info.bytes_used"
     [title]="row.name"
@@ -35,13 +35,27 @@
   ></cd-usage-bar>
   <ng-template #noLimitTpl>
     <span
+      *ngIf="row.info?.bytes_pcent === 'undefined'; else missingQuotaTpl"
       ngbTooltip="Quota limit is not set"
-      *ngIf="row.info.bytes_pcent === 'undefined'"
       i18n-ngbTooltip
     >
       {{ row.info.bytes_used | dimlessBinary }}</span
     >
+    <ng-template #missingQuotaTpl>-</ng-template>
   </ng-template>
+</ng-template>
+
+<ng-template
+  #nameTpl
+  let-row="data.row"
+>
+  <span class="fw-bold">{{ row.name }}</span>
+
+  <cd-label
+    [value]="unmanagedState"
+    *ngIf="row?.info?.state === unmanagedState"
+    [tooltipText]="unmanagedHint"
+  ></cd-label>
 </ng-template>
 
 <ng-template

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-group/cephfs-subvolume-group.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-group/cephfs-subvolume-group.component.ts
@@ -21,6 +21,12 @@ import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import _ from 'lodash';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { DeletionImpact } from '~/app/shared/enum/delete-confirmation-modal-impact.enum';
+import {
+  createRecreateAction,
+  getUnmanagedDisable,
+  UNMANAGED_STATE,
+  unmanagedRecreateHint
+} from '../cephfs-utils';
 
 @Component({
   selector: 'cd-cephfs-subvolume-group',
@@ -60,6 +66,9 @@ export class CephfsSubvolumeGroupComponent implements OnInit, OnChanges {
 
   modalRef: NgbModalRef;
 
+  unmanagedState = UNMANAGED_STATE;
+  unmanagedHint = unmanagedRecreateHint($localize`subvolume group`);
+
   constructor(
     private cephfsSubvolumeGroup: CephfsSubvolumeGroupService,
     private actionLabels: ActionLabelsI18n,
@@ -77,7 +86,7 @@ export class CephfsSubvolumeGroupComponent implements OnInit, OnChanges {
         name: $localize`Name`,
         prop: 'name',
         flexGrow: 0.6,
-        cellTransformation: CellTemplate.bold
+        cellTemplate: this.nameTpl
       },
       {
         name: $localize`Data Pool`,
@@ -117,24 +126,30 @@ export class CephfsSubvolumeGroupComponent implements OnInit, OnChanges {
         click: () => this.openModal(),
         canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
       },
+      createRecreateAction(this.actionLabels, () => this.openModal(false, true)),
       {
         name: this.actionLabels.EDIT,
         permission: 'update',
         icon: Icons.edit,
-        click: () => this.openModal(true)
+        click: () => this.openModal(true),
+        disable: (selection: CdTableSelection) =>
+          getUnmanagedDisable(selection, $localize`subvolume group`)
       },
       {
         name: this.actionLabels.NFS_EXPORT,
         permission: 'create',
         icon: Icons.nfsExport,
         routerLink: () => ['/cephfs/nfs/create', this.fsName, this.selection?.first()?.name],
-        disable: () => !this.selection.hasSingleSelection
+        disable: (selection: CdTableSelection) =>
+          getUnmanagedDisable(selection, $localize`subvolume group`)
       },
       {
         name: this.actionLabels.REMOVE,
         permission: 'delete',
         icon: Icons.destroy,
-        click: () => this.removeSubVolumeModal()
+        click: () => this.removeSubVolumeModal(),
+        disable: (selection: CdTableSelection) =>
+          getUnmanagedDisable(selection, $localize`subvolume group`)
       }
     ];
 
@@ -165,12 +180,13 @@ export class CephfsSubvolumeGroupComponent implements OnInit, OnChanges {
     this.selection = selection;
   }
 
-  openModal(edit = false) {
+  openModal(edit = false, recreate = false) {
     this.modalService.show(CephfsSubvolumegroupFormComponent, {
       fsName: this.fsName,
       subvolumegroupName: this.selection?.first()?.name,
       pools: this.pools,
-      isEdit: edit
+      isEdit: edit,
+      isRecreate: recreate
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-list/cephfs-subvolume-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-list/cephfs-subvolume-list.component.html
@@ -39,7 +39,7 @@
   let-row="data.row"
 >
   <cd-usage-bar
-    *ngIf="row.info.bytes_pcent && row.info.bytes_pcent !== 'undefined'; else noLimitTpl"
+    *ngIf="row.info?.bytes_pcent && row.info.bytes_pcent !== 'undefined'; else noLimitTpl"
     [total]="row.info.bytes_quota"
     [used]="row.info.bytes_used"
     [title]="row.name"
@@ -48,12 +48,13 @@
 
   <ng-template #noLimitTpl>
     <span
+      *ngIf="row.info?.bytes_pcent === 'undefined'; else missingQuotaTpl"
       ngbTooltip="Quota limit is not set"
-      *ngIf="row.info.bytes_pcent === 'undefined'"
       i18n-ngbTooltip
     >
       {{ row.info.bytes_used | dimlessBinary }}</span
     >
+    <ng-template #missingQuotaTpl>-</ng-template>
   </ng-template>
 </ng-template>
 
@@ -83,7 +84,7 @@
 >
   <span class="fw-bold">{{ row.name }}</span>
 
-  <span *ngIf="row?.info?.state === 'complete'; else snapshotRetainedTpl">
+  <span *ngIf="row?.info?.state === 'complete'">
     <i
       [ngClass]="[icons.success, icons.size24]"
       ngbTooltip="{{ row.name }} is ready to use"
@@ -91,17 +92,23 @@
     ></i>
   </span>
 
-  <ng-template #snapshotRetainedTpl>
+  <span *ngIf="row?.info?.state === 'snapshot-retained'">
     <i
       [ngClass]="[icons.warning, icons.size24]"
       class="text-warning"
       ngbTooltip="{{ row.name }} is removed after retaining the snapshots"
     ></i>
-  </ng-template>
+  </span>
 
   <cd-label
     [value]="row?.info?.type"
-    *ngIf="row?.info?.type !== 'subvolume'"
+    *ngIf="row?.info?.type && row.info.type !== 'subvolume'"
+  ></cd-label>
+
+  <cd-label
+    [value]="unmanagedState"
+    *ngIf="row?.info?.state === unmanagedState"
+    [tooltipText]="unmanagedHint"
   ></cd-label>
 
   <cd-label

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-list/cephfs-subvolume-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-list/cephfs-subvolume-list.component.ts
@@ -36,6 +36,12 @@ import _ from 'lodash';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { DEFAULT_SUBVOLUME_GROUP } from '~/app/shared/constants/cephfs.constant';
 import { DeletionImpact } from '~/app/shared/enum/delete-confirmation-modal-impact.enum';
+import {
+  createRecreateAction,
+  getUnmanagedDisable,
+  UNMANAGED_STATE,
+  unmanagedRecreateHint
+} from '../cephfs-utils';
 
 @Component({
   selector: 'cd-cephfs-subvolume-list',
@@ -85,6 +91,9 @@ export class CephfsSubvolumeListComponent extends CdForm implements OnInit, OnCh
   subVolumesList: CephfsSubvolume[] = [];
 
   activeGroupName: string = '';
+
+  unmanagedState = UNMANAGED_STATE;
+  unmanagedHint = unmanagedRecreateHint($localize`subvolume`);
 
   constructor(
     private cephfsSubVolumeService: CephfsSubvolumeService,
@@ -150,17 +159,21 @@ export class CephfsSubvolumeListComponent extends CdForm implements OnInit, OnCh
         icon: Icons.add,
         click: () => this.openModal()
       },
+      createRecreateAction(this.actionLabels, () => this.openModal(false, true)),
       {
         name: this.actionLabels.EDIT,
         permission: 'update',
         icon: Icons.edit,
-        click: () => this.openModal(true)
+        click: () => this.openModal(true),
+        disable: (selection: CdTableSelection) =>
+          getUnmanagedDisable(selection, $localize`subvolume`)
       },
       {
         name: this.actionLabels.ATTACH,
         permission: 'read',
         icon: Icons.bars,
-        disable: () => !this.selection?.hasSelection,
+        disable: (selection: CdTableSelection) =>
+          getUnmanagedDisable(selection, $localize`subvolume`),
         click: () => this.showAttachInfo()
       },
       {
@@ -173,13 +186,16 @@ export class CephfsSubvolumeListComponent extends CdForm implements OnInit, OnCh
           _.isEmpty(this.activeGroupName) ? DEFAULT_SUBVOLUME_GROUP : this.activeGroupName,
           { subvolume: this.selection?.first()?.name }
         ],
-        disable: () => !this.selection?.hasSingleSelection
+        disable: (selection: CdTableSelection) =>
+          getUnmanagedDisable(selection, $localize`subvolume`)
       },
       {
         name: this.actionLabels.REMOVE,
         permission: 'delete',
         icon: Icons.destroy,
-        click: () => this.removeSubVolumeModal()
+        click: () => this.removeSubVolumeModal(),
+        disable: (selection: CdTableSelection) =>
+          getUnmanagedDisable(selection, $localize`subvolume`)
       }
     ];
 
@@ -231,13 +247,14 @@ export class CephfsSubvolumeListComponent extends CdForm implements OnInit, OnCh
     });
   }
 
-  openModal(edit = false) {
+  openModal(edit = false, recreate = false) {
     this.modalService.show(CephfsSubvolumeFormComponent, {
       fsName: this.fsName,
       subVolumeName: this.selection?.first()?.name,
       subVolumeGroupName: this.activeGroupName,
       pools: this.pools,
-      isEdit: edit
+      isEdit: edit,
+      isRecreate: recreate
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-snapshots-list/cephfs-subvolume-snapshots-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-snapshots-list/cephfs-subvolume-snapshots-list.component.ts
@@ -28,6 +28,7 @@ import { CdValidators } from '~/app/shared/forms/cd-validators';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { DEFAULT_SUBVOLUME_GROUP } from '~/app/shared/constants/cephfs.constant';
 import { DeletionImpact } from '~/app/shared/enum/delete-confirmation-modal-impact.enum';
+import { getUnmanagedDisable } from '../cephfs-utils';
 
 @Component({
   selector: 'cd-cephfs-subvolume-snapshots-list',
@@ -113,14 +114,16 @@ export class CephfsSubvolumeSnapshotsListComponent implements OnInit, OnChanges 
         name: this.actionLabels.CLONE,
         permission: 'create',
         icon: Icons.clone,
-        disable: () => !this.selection.hasSingleSelection,
+        disable: (selection: CdTableSelection) =>
+          getUnmanagedDisable(selection, $localize`snapshot`),
         click: () => this.cloneModal()
       },
       {
         name: this.actionLabels.REMOVE,
         permission: 'delete',
         icon: Icons.destroy,
-        disable: () => !this.selection.hasSingleSelection,
+        disable: (selection: CdTableSelection) =>
+          getUnmanagedDisable(selection, $localize`snapshot`),
         click: () => this.deleteSnapshot()
       }
     ];

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolumegroup-form/cephfs-subvolumegroup-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolumegroup-form/cephfs-subvolumegroup-form.component.ts
@@ -48,14 +48,15 @@ export class CephfsSubvolumegroupFormComponent extends CdForm implements OnInit 
     @Optional() @Inject('fsName') public fsName: string,
     @Optional() @Inject('subvolumegroupName') public subvolumegroupName: string,
     @Optional() @Inject('pools') public pools: Pool[],
-    @Optional() @Inject('isEdit') public isEdit = false
+    @Optional() @Inject('isEdit') public isEdit = false,
+    @Optional() @Inject('isRecreate') public isRecreate = false
   ) {
     super();
     this.resource = $localize`subvolume group`;
   }
 
   ngOnInit(): void {
-    this.action = this.actionLabels.CREATE;
+    this.action = this.isRecreate ? this.actionLabels.RECREATE : this.actionLabels.CREATE;
     this.columns = [
       {
         prop: 'scope',
@@ -85,7 +86,22 @@ export class CephfsSubvolumegroupFormComponent extends CdForm implements OnInit 
     this.dataPools = this.pools.filter((pool) => pool.type === 'data');
     this.createForm();
 
-    this.isEdit ? this.populateForm() : this.loadingReady();
+    if (this.isEdit) {
+      this.populateForm();
+    } else {
+      if (this.isRecreate) {
+        this.prepareRecreateForm();
+      }
+      this.loadingReady();
+    }
+  }
+
+  private prepareRecreateForm() {
+    const nameControl = this.subvolumegroupForm.get('subvolumegroupName');
+    nameControl.setValue(this.subvolumegroupName);
+    nameControl.disable();
+    nameControl.clearAsyncValidators();
+    nameControl.updateValueAndValidity();
   }
 
   createForm() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-utils.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-utils.spec.ts
@@ -1,0 +1,43 @@
+import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
+import {
+  getUnmanagedDisable,
+  isUnmanagedSelection,
+  unmanagedRecreateHint,
+  UNMANAGED_STATE
+} from './cephfs-utils';
+
+describe('cephfs-utils', () => {
+  const resource = 'subvolume';
+
+  function selectionWith(state?: string): CdTableSelection {
+    const selection = new CdTableSelection();
+    if (state) {
+      selection.selected = [{ name: 'sv1', info: { state } }];
+    }
+    return selection;
+  }
+
+  describe('isUnmanagedSelection', () => {
+    it('should detect unmanaged selections', () => {
+      expect(isUnmanagedSelection(selectionWith(UNMANAGED_STATE))).toBe(true);
+      expect(isUnmanagedSelection(selectionWith('complete'))).toBe(false);
+      expect(isUnmanagedSelection(new CdTableSelection())).toBe(false);
+    });
+  });
+
+  describe('getUnmanagedDisable', () => {
+    it('should disable when there is no single selection', () => {
+      expect(getUnmanagedDisable(new CdTableSelection(), resource)).toBe(true);
+    });
+
+    it('should guide recreate for unmanaged selections', () => {
+      expect(getUnmanagedDisable(selectionWith(UNMANAGED_STATE), resource)).toBe(
+        unmanagedRecreateHint(resource)
+      );
+    });
+
+    it('should allow managed selections', () => {
+      expect(getUnmanagedDisable(selectionWith('complete'), resource)).toBe(false);
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-utils.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-utils.ts
@@ -1,0 +1,45 @@
+import { Icons } from '~/app/shared/enum/icons.enum';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
+import { CdTableAction } from '~/app/shared/models/cd-table-action';
+import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
+
+export const UNMANAGED_STATE = 'unmanaged';
+
+export function isUnmanagedSelection(selection: CdTableSelection): boolean {
+  return Boolean(
+    selection?.hasSingleSelection && selection.first()?.info?.state === UNMANAGED_STATE
+  );
+}
+
+export function unmanagedRecreateHint(resource: string): string {
+  return $localize`Recreate this ${resource} to manage it`;
+}
+
+/**
+ * Disable mutating actions when the selection is missing or unmanaged.
+ */
+export function getUnmanagedDisable(
+  selection: CdTableSelection,
+  resource: string
+): boolean | string {
+  if (!selection?.hasSingleSelection) {
+    return true;
+  }
+  if (isUnmanagedSelection(selection)) {
+    return unmanagedRecreateHint(resource);
+  }
+  return false;
+}
+
+export function createRecreateAction(
+  actionLabels: ActionLabelsI18n,
+  click: () => void
+): CdTableAction {
+  return {
+    name: actionLabels.RECREATE,
+    permission: 'create',
+    icon: Icons.refresh,
+    click,
+    visible: isUnmanagedSelection
+  };
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/workbench-layout/workbench-layout.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/workbench-layout/workbench-layout.component.ts
@@ -111,8 +111,7 @@ export class WorkbenchLayoutComponent implements OnInit, OnDestroy {
 
     const titleFromParamRoute = this.findRouteWithData(route, 'pageHeaderTitleFromParam');
     const titleFromParam = titleFromParamRoute?.routeConfig?.data?.['pageHeaderTitleFromParam'] as
-      | string
-      | undefined;
+      string | undefined;
 
     if (titleFromParam && titleFromParamRoute?.params[titleFromParam]) {
       try {
@@ -126,8 +125,7 @@ export class WorkbenchLayoutComponent implements OnInit, OnDestroy {
     }
 
     const pageHeader = route?.routeConfig?.data?.['pageHeader'] as
-      | { title?: string; subtitle?: string; description?: string }
-      | undefined;
+      { title?: string; subtitle?: string; description?: string } | undefined;
     this.pageHeaderTitle = pageHeader?.title ?? null;
     this.pageHeaderSubtitle = pageHeader?.subtitle ?? null;
     this.pageHeaderDescription = pageHeader?.description ?? null;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
@@ -767,10 +767,13 @@
   let-value="data.value"
 >
   <span
+    *ngIf="value; else missingTimeAgoTpl"
     data-toggle="tooltip"
     [title]="value | cdDate"
-    >{{ value | relativeDate }}</span
   >
+    {{ value | relativeDate }}
+  </span>
+  <ng-template #missingTimeAgoTpl>-</ng-template>
 </ng-template>
 
 <ng-template

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cephfs-subvolume.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cephfs-subvolume.model.ts
@@ -23,8 +23,9 @@ export interface SubvolumeSnapshot {
 }
 
 export interface SubvolumeSnapshotInfo {
-  created_at: string;
-  has_pending_clones: string;
+  created_at?: string;
+  has_pending_clones?: string;
+  state?: string;
 }
 
 export const SNAPSHOT_VISIBILITY_CONFIG_NAME = 'client_respect_subvolume_snapshot_visibility';

--- a/src/pybind/mgr/dashboard/services/cephfs.py
+++ b/src/pybind/mgr/dashboard/services/cephfs.py
@@ -1,15 +1,43 @@
 # -*- coding: utf-8 -*-
 
 import datetime
+import errno
 import logging
 import os
 from contextlib import contextmanager, suppress
+from typing import Any, Dict
 
 import cephfs
 
 from .. import mgr
+from ..exceptions import DashboardException
 
 logger = logging.getLogger(__name__)
+
+
+def is_unmanaged_volume_entry(error_code: int, err: str) -> bool:
+    """
+    Detect entries whose metadata xattrs are missing/unreadable.
+    """
+    return (
+        error_code in (-errno.EINVAL, -errno.ENODATA)
+        and 'getxattr' in (err or '').lower()
+    )
+
+
+def unmanaged_volume_info() -> Dict[str, Any]:
+    return {'state': 'unmanaged'}
+
+
+def get_subvolumegroup_path(vol_name: str, group_name: str) -> str:
+    error_code, out, err = mgr.remote(
+        'volumes', '_cmd_fs_subvolumegroup_getpath',
+        None, {'vol_name': vol_name, 'group_name': group_name})
+    if error_code != 0:
+        raise DashboardException(
+            f'Failed to get path for subvolume group {group_name}: {err}'
+        )
+    return out
 
 
 class CephFS(object):

--- a/src/pybind/mgr/dashboard/tests/test_cephfs.py
+++ b/src/pybind/mgr/dashboard/tests/test_cephfs.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import errno
 import json
 from collections import defaultdict
 
@@ -8,8 +9,26 @@ except ImportError:
     from unittest.mock import Mock, patch
 
 from .. import mgr
-from ..controllers.cephfs import CephFS, CephFSMirror, CephFSMirrorStatus
+from ..controllers.cephfs import (
+    CephFS,
+    CephFSMirror,
+    CephFSMirrorStatus,
+    CephFSSubvolume,
+    CephFSSubvolumeGroups,
+    CephFSSubvolumeSnapshots,
+    _mirrored_snapshot_info,
+    _mirrored_subvolume_info,
+)
 from ..tests import ControllerTestCase
+
+
+UNMANAGED_VOLUME_ERROR = (-errno.EINVAL, '', 'failed to getxattr on subvolume metadata')
+VOL_NAME = 'test_fs'
+SUBVOL_NAME = 'sv1'
+GROUP_NAME = 'g1'
+SNAP_NAME = 'snap1'
+SUBVOL_PATH = '/volumes/_nogroup/sv1'
+GROUP_PATH = '/volumes/g1'
 
 
 class MetaDataMock(object):
@@ -341,6 +360,139 @@ class CephFSMirrorTest(ControllerTestCase):
         self.assertIn(error_message, response.get('detail', ''))
         mgr.remote.assert_called_once_with(
             'mirroring', 'snapshot_mirror_status', fs_name, None, None)
+
+
+class CephFSMirroredVolumeFallbackTest(ControllerTestCase):
+
+    @classmethod
+    def setup_server(cls):
+        cls.setup_controllers([
+            CephFSSubvolume,
+            CephFSSubvolumeGroups,
+            CephFSSubvolumeSnapshots,
+        ])
+
+    def test_subvolume_list_mirrored_fallback(self):
+        def remote_side_effect(module, cmd, *_args, **_kwargs):
+            self.assertEqual(module, 'volumes')
+            if cmd == '_cmd_fs_subvolume_ls':
+                return (0, json.dumps([{'name': SUBVOL_NAME}]), '')
+            if cmd == '_cmd_fs_subvolume_info':
+                return UNMANAGED_VOLUME_ERROR
+            if cmd == '_cmd_fs_subvolume_getpath':
+                return (0, SUBVOL_PATH, '')
+            self.fail(f'unexpected volumes command: {cmd}')
+
+        mgr.remote = Mock(side_effect=remote_side_effect)
+
+        self._get(f'/api/cephfs/subvolume/{VOL_NAME}')
+        self.assertStatus(200)
+        self.assertJsonBody([{
+            'name': SUBVOL_NAME,
+            'info': {
+                **_mirrored_subvolume_info(),
+                'path': SUBVOL_PATH,
+            },
+        }])
+
+    def test_subvolume_info_mirrored_fallback(self):
+        def remote_side_effect(module, cmd, *_args, **_kwargs):
+            self.assertEqual(module, 'volumes')
+            if cmd == '_cmd_fs_subvolume_info':
+                return UNMANAGED_VOLUME_ERROR
+            if cmd == '_cmd_fs_subvolume_getpath':
+                return (0, SUBVOL_PATH, '')
+            self.fail(f'unexpected volumes command: {cmd}')
+
+        mgr.remote = Mock(side_effect=remote_side_effect)
+
+        self._get(
+            f'/api/cephfs/subvolume/{VOL_NAME}/info'
+            f'?subvol_name={SUBVOL_NAME}'
+        )
+        self.assertStatus(200)
+        self.assertJsonBody({
+            **_mirrored_subvolume_info(),
+            'path': SUBVOL_PATH,
+        })
+
+    def test_subvolume_group_list_mirrored_fallback(self):
+        def remote_side_effect(module, cmd, *_args, **_kwargs):
+            self.assertEqual(module, 'volumes')
+            if cmd == '_cmd_fs_subvolumegroup_ls':
+                return (0, json.dumps([{'name': GROUP_NAME}]), '')
+            if cmd == '_cmd_fs_subvolumegroup_info':
+                return UNMANAGED_VOLUME_ERROR
+            if cmd == '_cmd_fs_subvolumegroup_getpath':
+                return (0, GROUP_PATH, '')
+            self.fail(f'unexpected volumes command: {cmd}')
+
+        mgr.remote = Mock(side_effect=remote_side_effect)
+
+        self._get(f'/api/cephfs/subvolume/group/{VOL_NAME}')
+        self.assertStatus(200)
+        self.assertJsonBody([{
+            'name': GROUP_NAME,
+            'info': {
+                **_mirrored_subvolume_info(),
+                'path': GROUP_PATH,
+            },
+        }])
+
+    def test_subvolume_group_info_mirrored_fallback(self):
+        def remote_side_effect(module, cmd, *_args, **_kwargs):
+            self.assertEqual(module, 'volumes')
+            if cmd == '_cmd_fs_subvolumegroup_info':
+                return UNMANAGED_VOLUME_ERROR
+            if cmd == '_cmd_fs_subvolumegroup_getpath':
+                return (0, GROUP_PATH, '')
+            self.fail(f'unexpected volumes command: {cmd}')
+
+        mgr.remote = Mock(side_effect=remote_side_effect)
+
+        self._get(
+            f'/api/cephfs/subvolume/group/{VOL_NAME}/info'
+            f'?group_name={GROUP_NAME}'
+        )
+        self.assertStatus(200)
+        self.assertJsonBody({
+            **_mirrored_subvolume_info(),
+            'path': GROUP_PATH,
+        })
+
+    def test_subvolume_snapshot_list_mirrored_fallback(self):
+        def remote_side_effect(module, cmd, *_args, **_kwargs):
+            self.assertEqual(module, 'volumes')
+            if cmd == '_cmd_fs_subvolume_snapshot_ls':
+                return (0, json.dumps([{'name': SNAP_NAME}]), '')
+            if cmd == '_cmd_fs_subvolume_snapshot_info':
+                return UNMANAGED_VOLUME_ERROR
+            self.fail(f'unexpected volumes command: {cmd}')
+
+        mgr.remote = Mock(side_effect=remote_side_effect)
+
+        self._get(f'/api/cephfs/subvolume/snapshot/{VOL_NAME}/{SUBVOL_NAME}')
+        self.assertStatus(200)
+        self.assertJsonBody([{
+            'name': SNAP_NAME,
+            'info': _mirrored_snapshot_info(),
+        }])
+
+    def test_subvolume_snapshot_info_mirrored_fallback(self):
+        mgr.remote = Mock(return_value=UNMANAGED_VOLUME_ERROR)
+
+        self._get(
+            f'/api/cephfs/subvolume/snapshot/{VOL_NAME}/{SUBVOL_NAME}/info'
+            f'?snap_name={SNAP_NAME}'
+        )
+        self.assertStatus(200)
+        self.assertJsonBody(_mirrored_snapshot_info())
+        mgr.remote.assert_called_once_with(
+            'volumes', '_cmd_fs_subvolume_snapshot_info', None, {
+                'vol_name': VOL_NAME,
+                'sub_name': SUBVOL_NAME,
+                'snap_name': SNAP_NAME,
+            })
 
 
 class CephFSMirrorStatusTest(ControllerTestCase):

--- a/src/pybind/mgr/dashboard/tests/test_cephfs.py
+++ b/src/pybind/mgr/dashboard/tests/test_cephfs.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import errno
 import json
 import urllib.parse
 from collections import defaultdict
@@ -9,8 +10,26 @@ except ImportError:
     from unittest.mock import Mock, patch
 
 from .. import mgr
-from ..controllers.cephfs import CephFS, CephFSMirror, CephFSMirrorStatus
+from ..controllers.cephfs import (
+    CephFS,
+    CephFSMirror,
+    CephFSMirrorStatus,
+    CephFSSubvolume,
+    CephFSSubvolumeGroups,
+    CephFSSubvolumeSnapshots,
+    _mirrored_snapshot_info,
+    _mirrored_subvolume_info,
+)
 from ..tests import ControllerTestCase
+
+
+UNMANAGED_VOLUME_ERROR = (-errno.EINVAL, '', 'failed to getxattr on subvolume metadata')
+VOL_NAME = 'test_fs'
+SUBVOL_NAME = 'sv1'
+GROUP_NAME = 'g1'
+SNAP_NAME = 'snap1'
+SUBVOL_PATH = '/volumes/_nogroup/sv1'
+GROUP_PATH = '/volumes/g1'
 
 
 class MetaDataMock(object):
@@ -558,6 +577,139 @@ class CephFSMirrorTest(ControllerTestCase):  # pylint: disable=too-many-public-m
         self.assertIn(error_message, response.get('detail', ''))
         mgr.remote.assert_called_once_with(
             'mirroring', 'snapshot_mirror_status', fs_name, None, None)
+
+
+class CephFSMirroredVolumeFallbackTest(ControllerTestCase):
+
+    @classmethod
+    def setup_server(cls):
+        cls.setup_controllers([
+            CephFSSubvolume,
+            CephFSSubvolumeGroups,
+            CephFSSubvolumeSnapshots,
+        ])
+
+    def test_subvolume_list_mirrored_fallback(self):
+        def remote_side_effect(module, cmd, *_args, **_kwargs):
+            self.assertEqual(module, 'volumes')
+            if cmd == '_cmd_fs_subvolume_ls':
+                return (0, json.dumps([{'name': SUBVOL_NAME}]), '')
+            if cmd == '_cmd_fs_subvolume_info':
+                return UNMANAGED_VOLUME_ERROR
+            if cmd == '_cmd_fs_subvolume_getpath':
+                return (0, SUBVOL_PATH, '')
+            self.fail(f'unexpected volumes command: {cmd}')
+
+        mgr.remote = Mock(side_effect=remote_side_effect)
+
+        self._get(f'/api/cephfs/subvolume/{VOL_NAME}')
+        self.assertStatus(200)
+        self.assertJsonBody([{
+            'name': SUBVOL_NAME,
+            'info': {
+                **_mirrored_subvolume_info(),
+                'path': SUBVOL_PATH,
+            },
+        }])
+
+    def test_subvolume_info_mirrored_fallback(self):
+        def remote_side_effect(module, cmd, *_args, **_kwargs):
+            self.assertEqual(module, 'volumes')
+            if cmd == '_cmd_fs_subvolume_info':
+                return UNMANAGED_VOLUME_ERROR
+            if cmd == '_cmd_fs_subvolume_getpath':
+                return (0, SUBVOL_PATH, '')
+            self.fail(f'unexpected volumes command: {cmd}')
+
+        mgr.remote = Mock(side_effect=remote_side_effect)
+
+        self._get(
+            f'/api/cephfs/subvolume/{VOL_NAME}/info'
+            f'?subvol_name={SUBVOL_NAME}'
+        )
+        self.assertStatus(200)
+        self.assertJsonBody({
+            **_mirrored_subvolume_info(),
+            'path': SUBVOL_PATH,
+        })
+
+    def test_subvolume_group_list_mirrored_fallback(self):
+        def remote_side_effect(module, cmd, *_args, **_kwargs):
+            self.assertEqual(module, 'volumes')
+            if cmd == '_cmd_fs_subvolumegroup_ls':
+                return (0, json.dumps([{'name': GROUP_NAME}]), '')
+            if cmd == '_cmd_fs_subvolumegroup_info':
+                return UNMANAGED_VOLUME_ERROR
+            if cmd == '_cmd_fs_subvolumegroup_getpath':
+                return (0, GROUP_PATH, '')
+            self.fail(f'unexpected volumes command: {cmd}')
+
+        mgr.remote = Mock(side_effect=remote_side_effect)
+
+        self._get(f'/api/cephfs/subvolume/group/{VOL_NAME}')
+        self.assertStatus(200)
+        self.assertJsonBody([{
+            'name': GROUP_NAME,
+            'info': {
+                **_mirrored_subvolume_info(),
+                'path': GROUP_PATH,
+            },
+        }])
+
+    def test_subvolume_group_info_mirrored_fallback(self):
+        def remote_side_effect(module, cmd, *_args, **_kwargs):
+            self.assertEqual(module, 'volumes')
+            if cmd == '_cmd_fs_subvolumegroup_info':
+                return UNMANAGED_VOLUME_ERROR
+            if cmd == '_cmd_fs_subvolumegroup_getpath':
+                return (0, GROUP_PATH, '')
+            self.fail(f'unexpected volumes command: {cmd}')
+
+        mgr.remote = Mock(side_effect=remote_side_effect)
+
+        self._get(
+            f'/api/cephfs/subvolume/group/{VOL_NAME}/info'
+            f'?group_name={GROUP_NAME}'
+        )
+        self.assertStatus(200)
+        self.assertJsonBody({
+            **_mirrored_subvolume_info(),
+            'path': GROUP_PATH,
+        })
+
+    def test_subvolume_snapshot_list_mirrored_fallback(self):
+        def remote_side_effect(module, cmd, *_args, **_kwargs):
+            self.assertEqual(module, 'volumes')
+            if cmd == '_cmd_fs_subvolume_snapshot_ls':
+                return (0, json.dumps([{'name': SNAP_NAME}]), '')
+            if cmd == '_cmd_fs_subvolume_snapshot_info':
+                return UNMANAGED_VOLUME_ERROR
+            self.fail(f'unexpected volumes command: {cmd}')
+
+        mgr.remote = Mock(side_effect=remote_side_effect)
+
+        self._get(f'/api/cephfs/subvolume/snapshot/{VOL_NAME}/{SUBVOL_NAME}')
+        self.assertStatus(200)
+        self.assertJsonBody([{
+            'name': SNAP_NAME,
+            'info': _mirrored_snapshot_info(),
+        }])
+
+    def test_subvolume_snapshot_info_mirrored_fallback(self):
+        mgr.remote = Mock(return_value=UNMANAGED_VOLUME_ERROR)
+
+        self._get(
+            f'/api/cephfs/subvolume/snapshot/{VOL_NAME}/{SUBVOL_NAME}/info'
+            f'?snap_name={SNAP_NAME}'
+        )
+        self.assertStatus(200)
+        self.assertJsonBody(_mirrored_snapshot_info())
+        mgr.remote.assert_called_once_with(
+            'volumes', '_cmd_fs_subvolume_snapshot_info', None, {
+                'vol_name': VOL_NAME,
+                'sub_name': SUBVOL_NAME,
+                'snap_name': SNAP_NAME,
+            })
 
 
 class CephFSMirrorStatusTest(ControllerTestCase):

--- a/src/pybind/mgr/dashboard/tests/test_cephfs.py
+++ b/src/pybind/mgr/dashboard/tests/test_cephfs.py
@@ -10,18 +10,10 @@ except ImportError:
     from unittest.mock import Mock, patch
 
 from .. import mgr
-from ..controllers.cephfs import (
-    CephFS,
-    CephFSMirror,
-    CephFSMirrorStatus,
-    CephFSSubvolume,
-    CephFSSubvolumeGroups,
-    CephFSSubvolumeSnapshots,
-    _mirrored_snapshot_info,
-    _mirrored_subvolume_info,
-)
+from ..controllers.cephfs import CephFS, CephFSMirror, CephFSMirrorStatus, \
+    CephFSSubvolume, CephFSSubvolumeGroups, CephFSSubvolumeSnapshots
+from ..services.cephfs import unmanaged_volume_info
 from ..tests import ControllerTestCase
-
 
 UNMANAGED_VOLUME_ERROR = (-errno.EINVAL, '', 'failed to getxattr on subvolume metadata')
 VOL_NAME = 'test_fs'
@@ -540,21 +532,14 @@ class CephFSMirrorTest(ControllerTestCase):  # pylint: disable=too-many-public-m
     def test_mirror_status_success(self):
         fs_name = 'test_fs'
         peer_uuid = 'peer-uuid-123'
+        last_synced_snap = {
+            'name': 'snap1',
+            'sync_bytes': '1.00 KiB',
+            'sync_time_stamp': '1704189600.000000s'
+        }
+        peer_status = {'state': 'idle', 'last_synced_snap': last_synced_snap}
         expected_status = {
-            'metrics': {
-                '/dir1': {
-                    'peer': {
-                        peer_uuid: {
-                            'state': 'idle',
-                            'last_synced_snap': {
-                                'name': 'snap1',
-                                'sync_bytes': '1.00 KiB',
-                                'sync_time_stamp': '1704189600.000000s'
-                            }
-                        }
-                    }
-                }
-            }
+            'metrics': {'/dir1': {'peer': {peer_uuid: peer_status}}}
         }
         mock_output = json.dumps(expected_status)
         mgr.remote = Mock(return_value=(0, mock_output, ''))
@@ -579,7 +564,7 @@ class CephFSMirrorTest(ControllerTestCase):  # pylint: disable=too-many-public-m
             'mirroring', 'snapshot_mirror_status', fs_name, None, None)
 
 
-class CephFSMirroredVolumeFallbackTest(ControllerTestCase):
+class CephFSUnmanagedVolumeFallbackTest(ControllerTestCase):
 
     @classmethod
     def setup_server(cls):
@@ -589,7 +574,7 @@ class CephFSMirroredVolumeFallbackTest(ControllerTestCase):
             CephFSSubvolumeSnapshots,
         ])
 
-    def test_subvolume_list_mirrored_fallback(self):
+    def test_subvolume_list_unmanaged_fallback(self):
         def remote_side_effect(module, cmd, *_args, **_kwargs):
             self.assertEqual(module, 'volumes')
             if cmd == '_cmd_fs_subvolume_ls':
@@ -598,7 +583,7 @@ class CephFSMirroredVolumeFallbackTest(ControllerTestCase):
                 return UNMANAGED_VOLUME_ERROR
             if cmd == '_cmd_fs_subvolume_getpath':
                 return (0, SUBVOL_PATH, '')
-            self.fail(f'unexpected volumes command: {cmd}')
+            raise AssertionError(f'unexpected volumes command: {cmd}')
 
         mgr.remote = Mock(side_effect=remote_side_effect)
 
@@ -607,19 +592,19 @@ class CephFSMirroredVolumeFallbackTest(ControllerTestCase):
         self.assertJsonBody([{
             'name': SUBVOL_NAME,
             'info': {
-                **_mirrored_subvolume_info(),
+                **unmanaged_volume_info(),
                 'path': SUBVOL_PATH,
             },
         }])
 
-    def test_subvolume_info_mirrored_fallback(self):
+    def test_subvolume_info_unmanaged_fallback(self):
         def remote_side_effect(module, cmd, *_args, **_kwargs):
             self.assertEqual(module, 'volumes')
             if cmd == '_cmd_fs_subvolume_info':
                 return UNMANAGED_VOLUME_ERROR
             if cmd == '_cmd_fs_subvolume_getpath':
                 return (0, SUBVOL_PATH, '')
-            self.fail(f'unexpected volumes command: {cmd}')
+            raise AssertionError(f'unexpected volumes command: {cmd}')
 
         mgr.remote = Mock(side_effect=remote_side_effect)
 
@@ -629,11 +614,11 @@ class CephFSMirroredVolumeFallbackTest(ControllerTestCase):
         )
         self.assertStatus(200)
         self.assertJsonBody({
-            **_mirrored_subvolume_info(),
+            **unmanaged_volume_info(),
             'path': SUBVOL_PATH,
         })
 
-    def test_subvolume_group_list_mirrored_fallback(self):
+    def test_subvolume_group_list_unmanaged_fallback(self):
         def remote_side_effect(module, cmd, *_args, **_kwargs):
             self.assertEqual(module, 'volumes')
             if cmd == '_cmd_fs_subvolumegroup_ls':
@@ -642,7 +627,7 @@ class CephFSMirroredVolumeFallbackTest(ControllerTestCase):
                 return UNMANAGED_VOLUME_ERROR
             if cmd == '_cmd_fs_subvolumegroup_getpath':
                 return (0, GROUP_PATH, '')
-            self.fail(f'unexpected volumes command: {cmd}')
+            raise AssertionError(f'unexpected volumes command: {cmd}')
 
         mgr.remote = Mock(side_effect=remote_side_effect)
 
@@ -651,19 +636,19 @@ class CephFSMirroredVolumeFallbackTest(ControllerTestCase):
         self.assertJsonBody([{
             'name': GROUP_NAME,
             'info': {
-                **_mirrored_subvolume_info(),
+                **unmanaged_volume_info(),
                 'path': GROUP_PATH,
             },
         }])
 
-    def test_subvolume_group_info_mirrored_fallback(self):
+    def test_subvolume_group_info_unmanaged_fallback(self):
         def remote_side_effect(module, cmd, *_args, **_kwargs):
             self.assertEqual(module, 'volumes')
             if cmd == '_cmd_fs_subvolumegroup_info':
                 return UNMANAGED_VOLUME_ERROR
             if cmd == '_cmd_fs_subvolumegroup_getpath':
                 return (0, GROUP_PATH, '')
-            self.fail(f'unexpected volumes command: {cmd}')
+            raise AssertionError(f'unexpected volumes command: {cmd}')
 
         mgr.remote = Mock(side_effect=remote_side_effect)
 
@@ -673,18 +658,18 @@ class CephFSMirroredVolumeFallbackTest(ControllerTestCase):
         )
         self.assertStatus(200)
         self.assertJsonBody({
-            **_mirrored_subvolume_info(),
+            **unmanaged_volume_info(),
             'path': GROUP_PATH,
         })
 
-    def test_subvolume_snapshot_list_mirrored_fallback(self):
+    def test_subvolume_snapshot_list_unmanaged_fallback(self):
         def remote_side_effect(module, cmd, *_args, **_kwargs):
             self.assertEqual(module, 'volumes')
             if cmd == '_cmd_fs_subvolume_snapshot_ls':
                 return (0, json.dumps([{'name': SNAP_NAME}]), '')
             if cmd == '_cmd_fs_subvolume_snapshot_info':
                 return UNMANAGED_VOLUME_ERROR
-            self.fail(f'unexpected volumes command: {cmd}')
+            raise AssertionError(f'unexpected volumes command: {cmd}')
 
         mgr.remote = Mock(side_effect=remote_side_effect)
 
@@ -692,10 +677,10 @@ class CephFSMirroredVolumeFallbackTest(ControllerTestCase):
         self.assertStatus(200)
         self.assertJsonBody([{
             'name': SNAP_NAME,
-            'info': _mirrored_snapshot_info(),
+            'info': unmanaged_volume_info(),
         }])
 
-    def test_subvolume_snapshot_info_mirrored_fallback(self):
+    def test_subvolume_snapshot_info_unmanaged_fallback(self):
         mgr.remote = Mock(return_value=UNMANAGED_VOLUME_ERROR)
 
         self._get(
@@ -703,7 +688,7 @@ class CephFSMirroredVolumeFallbackTest(ControllerTestCase):
             f'?snap_name={SNAP_NAME}'
         )
         self.assertStatus(200)
-        self.assertJsonBody(_mirrored_snapshot_info())
+        self.assertJsonBody(unmanaged_volume_info())
         mgr.remote.assert_called_once_with(
             'volumes', '_cmd_fs_subvolume_snapshot_info', None, {
                 'vol_name': VOL_NAME,


### PR DESCRIPTION
Signed-off-by: Dnyaneshwari Talwekar <dtalweka@redhat.com>
Co-authored-by: Pedro Gonzalez Gomez <pegonzal@ibm.com>

**Before fix** `400 getxattr` error on mirrored remote fs.

[screen-capture (37).webm](https://github.com/user-attachments/assets/990a0502-1f68-48a4-bc10-643e102a31a7)



**After fix**

[screen-capture (38).webm](https://github.com/user-attachments/assets/2bceabd3-4200-4fff-b417-cc5f61eb350a)



Video is missing `unmanaged` label that has been added as well

<img width="1901" height="683" alt="image" src="https://github.com/user-attachments/assets/2cea3599-d360-4a24-a387-1e0b472a185a" />


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
