### PR TITLE
mgr/dashboard: fix list_hosts nvmeof cli commanad empty table bug

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -30,7 +30,7 @@ NVME_SCHEMA = {
 
 try:
     from ..services.nvmeof_client import NVMeoFClient, convert_to_model, \
-        empty_response, handle_nvmeof_error, pick
+        empty_response, handle_nvmeof_error, namedtuple_to_dict, pick
 except ImportError as e:
     logger.error("Failed to import NVMeoFClient and related components: %s", e)
 else:
@@ -1833,11 +1833,11 @@ else:
                     hosts=list(ns.hosts)
                 ))
 
-            return model.NamespaceHostsList(
+            return namedtuple_to_dict(model.NamespaceHostsList(
                 status=ns_list.status,
                 error_message=ns_list.error_message,
                 namespaces=host_infos
-            )
+            ))
 
         @ReadPermission
         @Endpoint('GET', 'list_locations')
@@ -1897,11 +1897,11 @@ else:
                     namespace_count=count
                 ))
 
-            return model.NamespaceLocationsList(
+            return namedtuple_to_dict(model.NamespaceLocationsList(
                 status=ns_list.status,
                 error_message=ns_list.error_message,
                 locations=location_infos
-            )
+            ))
 
         @ReadPermission
         @Endpoint('PUT', '{nsid}/set_auto_resize')

--- a/src/pybind/mgr/dashboard/tests/test_nvmeof_cli.py
+++ b/src/pybind/mgr/dashboard/tests/test_nvmeof_cli.py
@@ -1770,3 +1770,197 @@ class TestCliEmptyMessageForAllListCommands:
             assert '"hosts": []' in result.stdout
         finally:
             del NvmeofCLICommand.COMMANDS[test_cmd_hosts]
+
+
+class TestNamespaceListHosts:
+    def test_non_empty_hosts_renders_table(self):
+        from ..model.nvmeof import NamespaceHostsList
+
+        test_cmd = "nvmeof test namespace list_hosts non empty"
+
+        @NvmeofCLICommand(test_cmd, NamespaceHostsList)
+        def func(_):  # pylint: disable=unused-argument, unused-variable
+            return {
+                'status': 0,
+                'error_message': '',
+                'namespaces': [
+                    {
+                        'nqn': 'nqn.2001-07.com.ceph:1783923316687.group1',
+                        'nsid': 1,
+                        'hosts': [
+                            'nqn.2014-08.org.nvmexpress:uuid:8d78a673-8b0f-4228-ae7e-89f5fd5c3a74'
+                        ],
+                    }
+                ],
+            }
+
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(MagicMock(), {})
+
+            assert isinstance(result, HandleCommandResult)
+            assert result.retval == 0
+            host_nqn = 'nqn.2014-08.org.nvmexpress:uuid:8d78a673-8b0f-4228-ae7e-89f5fd5c3a74'
+            assert host_nqn in result.stdout
+            assert '1' in result.stdout  # nsid
+        finally:
+            del NvmeofCLICommand.COMMANDS[test_cmd]
+
+    def test_empty_hosts_renders_empty_table(self):
+        from ..model.nvmeof import NamespaceHostsList
+
+        test_cmd = "nvmeof test namespace list_hosts empty"
+
+        @NvmeofCLICommand(test_cmd, NamespaceHostsList)
+        def func(_):  # pylint: disable=unused-argument, unused-variable
+            return {
+                'status': 0,
+                'error_message': '',
+                'namespaces': [
+                    {
+                        'nqn': 'nqn.2001-07.com.ceph:1783923316687.group1',
+                        'nsid': 2,
+                        'hosts': [],
+                    }
+                ],
+            }
+
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(MagicMock(), {})
+
+            assert isinstance(result, HandleCommandResult)
+            assert result.retval == 0
+            assert 'None' in result.stdout
+            assert '2' in result.stdout  # nsid
+        finally:
+            del NvmeofCLICommand.COMMANDS[test_cmd]
+
+    def test_multiple_hosts_per_namespace(self):
+        from ..model.nvmeof import NamespaceHostsList
+
+        test_cmd = "nvmeof test namespace list_hosts multi"
+
+        @NvmeofCLICommand(test_cmd, NamespaceHostsList)
+        def func(_):  # pylint: disable=unused-argument, unused-variable
+            return {
+                'status': 0,
+                'error_message': '',
+                'namespaces': [
+                    {
+                        'nqn': 'nqn.2001-07.com.ceph:test',
+                        'nsid': 1,
+                        'hosts': [
+                            'nqn.2014-08.org.nvmexpress:uuid:host-aaa',
+                            'nqn.2014-08.org.nvmexpress:uuid:host-bbb',
+                        ],
+                    },
+                    {
+                        'nqn': 'nqn.2001-07.com.ceph:test',
+                        'nsid': 2,
+                        'hosts': [],
+                    },
+                ],
+            }
+
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(MagicMock(), {})
+
+            assert isinstance(result, HandleCommandResult)
+            assert result.retval == 0
+            assert 'nqn.2014-08.org.nvmexpress:uuid:host-aaa' in result.stdout
+            assert 'nqn.2014-08.org.nvmexpress:uuid:host-bbb' in result.stdout
+            assert 'None' in result.stdout  # nsid 2 has no hosts
+        finally:
+            del NvmeofCLICommand.COMMANDS[test_cmd]
+
+
+class TestNamespaceListLocations:
+    def test_non_empty_locations_renders_table(self):
+        from ..model.nvmeof import NamespaceLocationsList
+
+        test_cmd = "nvmeof test namespace list_locations non empty"
+
+        @NvmeofCLICommand(test_cmd, NamespaceLocationsList)
+        def func(_):  # pylint: disable=unused-argument, unused-variable
+            return {
+                'status': 0,
+                'error_message': '',
+                'locations': [
+                    {
+                        'subsystem': 'nqn.2001-07.com.ceph:test',
+                        'load_balancing_group': 1,
+                        'location': 'india',
+                        'namespace_count': 2,
+                    }
+                ],
+            }
+
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(MagicMock(), {})
+
+            assert isinstance(result, HandleCommandResult)
+            assert result.retval == 0
+            assert 'nqn.2001-07.com.ceph:test' in result.stdout
+            assert 'india' in result.stdout
+            assert '2' in result.stdout  # namespace_count
+        finally:
+            del NvmeofCLICommand.COMMANDS[test_cmd]
+
+    def test_empty_locations_renders_empty_table(self):
+        from ..model.nvmeof import NamespaceLocationsList
+
+        test_cmd = "nvmeof test namespace list_locations empty"
+
+        @NvmeofCLICommand(test_cmd, NamespaceLocationsList)
+        def func(_):  # pylint: disable=unused-argument, unused-variable
+            return {
+                'status': 0,
+                'error_message': '',
+                'locations': [],
+            }
+
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(MagicMock(), {})
+
+            assert isinstance(result, HandleCommandResult)
+            assert result.retval == 0
+            assert result.stdout == ''
+        finally:
+            del NvmeofCLICommand.COMMANDS[test_cmd]
+
+    def test_multiple_locations_aggregated(self):
+        from ..model.nvmeof import NamespaceLocationsList
+
+        test_cmd = "nvmeof test namespace list_locations multi"
+
+        @NvmeofCLICommand(test_cmd, NamespaceLocationsList)
+        def func(_):  # pylint: disable=unused-argument, unused-variable
+            return {
+                'status': 0,
+                'error_message': '',
+                'locations': [
+                    {
+                        'subsystem': 'nqn.2001-07.com.ceph:test',
+                        'load_balancing_group': 1,
+                        'location': 'india',
+                        'namespace_count': 3,
+                    },
+                    {
+                        'subsystem': 'nqn.2001-07.com.ceph:test',
+                        'load_balancing_group': 2,
+                        'location': '<default>',
+                        'namespace_count': 1,
+                    },
+                ],
+            }
+
+        try:
+            result = NvmeofCLICommand.COMMANDS[test_cmd].call(MagicMock(), {})
+
+            assert isinstance(result, HandleCommandResult)
+            assert result.retval == 0
+            assert 'india' in result.stdout
+            assert '<default>' in result.stdout
+            assert '3' in result.stdout
+            assert '1' in result.stdout
+        finally:
+            del NvmeofCLICommand.COMMANDS[test_cmd]


### PR DESCRIPTION
Before this change, the `ns list_hosts` command would return empty table even if there were hosts that were added to namespaces, due to a bug - NamedTuple was passed instead of a dict.

Fixes: https://tracker.ceph.com/issues/78241

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
