### PR TITLE
mgr/smb: only resync clusters that reference a changed resource

### DIFF
--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -654,17 +654,28 @@ class ClusterConfigHandler:
             elif isinstance(result.src, resources.ExternalCephCluster):
                 chg_extc_ids.add(result.src.external_ceph_cluster_id)
 
-        # TODO: here's a lazy bit. if any join auths or users/groups changed we
-        # will regen all clusters because these can be shared by >1 cluster.
-        # In future, make this only pick clusters using the named resources.
-        if (
-            chg_join_ids
-            or chg_ug_ids
-            or chg_tls_ids
-            or chg_extc_ids
-            or chg_rgw_cred_ids
-        ):
+        # rgw credentials are referenced by shares, not clusters, so
+        # narrowing this would mean reading every share in the store.
+        # not worth it for an infrequent change. Keeping the broad regen
+        # until we find a better approach for rgw credentials.
+        if chg_rgw_cred_ids:
             chg_cluster_ids.update(ClusterEntry.ids(self.internal_store))
+        elif chg_join_ids or chg_ug_ids or chg_tls_ids or chg_extc_ids:
+            # these resource types can be shared by >1 cluster. only pick
+            # clusters that actually reference a changed one.
+            for cluster_id in ClusterEntry.ids(self.internal_store):
+                try:
+                    cluster = self._cluster_entry(cluster_id).get_cluster()
+                except KeyError:
+                    continue
+                if (
+                    set(auth_refs(cluster)) & chg_join_ids
+                    or set(ug_refs(cluster)) & chg_ug_ids
+                    or set(tls_refs(cluster)) & chg_tls_ids
+                    or set(ext_cluster_refs(cluster)) & chg_extc_ids
+                ):
+                    chg_cluster_ids.add(cluster_id)
+
         return chg_cluster_ids
 
     def _save_cluster_settings(

--- a/src/pybind/mgr/smb/tests/test_handler.py
+++ b/src/pybind/mgr/smb/tests/test_handler.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 import smb
@@ -854,6 +856,164 @@ def test_modify_cluster_only_touches_changed_cluster(thandler):
     assert 'config.smb' in ekeys
     assert 'spec.smb' in ekeys
     assert 'join.0.json' in ekeys
+
+
+def test_modify_joinauth_only_touches_referencing_clusters(thandler):
+    # clustera and clusterb both reference the shared (unlinked) join auth
+    # "shared1". clusterc uses its own, separate join auth. A change to
+    # shared1 must regenerate clustera and clusterb but must not touch
+    # clusterc.
+    to_apply = [
+        smb.resources.JoinAuth(
+            auth_id='shared1',
+            auth=smb.resources.JoinAuthValues(
+                username='testadmin',
+                password='Passw0rd',
+            ),
+        ),
+        smb.resources.JoinAuth(
+            auth_id='join2',
+            auth=smb.resources.JoinAuthValues(
+                username='otheradmin',
+                password='Passw0rd2',
+            ),
+        ),
+    ]
+    for cluster_id, ref in (
+        ('clustera', 'shared1'),
+        ('clusterb', 'shared1'),
+        ('clusterc', 'join2'),
+    ):
+        to_apply.append(
+            _cluster(
+                cluster_id=cluster_id,
+                auth_mode=smb.enums.AuthMode.ACTIVE_DIRECTORY,
+                domain_settings=smb.resources.DomainSettings(
+                    realm='MYDOMAIN.EXAMPLE.ORG',
+                    join_sources=[
+                        smb.resources.JoinSource(
+                            source_type=smb.enums.JoinSourceType.RESOURCE,
+                            ref=ref,
+                        ),
+                    ],
+                ),
+            )
+        )
+
+    results = thandler.apply(to_apply)
+    assert results.success, results.to_simplified()
+
+    for cluster_id in ('clustera', 'clusterb', 'clusterc'):
+        assert 'cluster-info' in list(
+            thandler.public_store.contents(cluster_id)
+        )
+        thandler.public_store.remove((cluster_id, 'cluster-info'))
+
+    # only modify the join auth shared by clustera and clusterb
+    results = thandler.apply(
+        [
+            smb.resources.JoinAuth(
+                auth_id='shared1',
+                auth=smb.resources.JoinAuthValues(
+                    username='testadmin',
+                    password='NewPassw0rd!',
+                ),
+            ),
+        ]
+    )
+    assert results.success, results.to_simplified()
+
+    assert 'cluster-info' in list(thandler.public_store.contents('clustera'))
+    assert 'cluster-info' in list(thandler.public_store.contents('clusterb'))
+    # clusterc doesn't reference shared1, so it must be untouched
+    assert 'cluster-info' not in list(
+        thandler.public_store.contents('clusterc')
+    )
+
+
+def test_modify_joinauth_large_cluster_set_performance(thandler):
+    # Ensure the resync loop over 20 clusters completes quickly when a shared
+    # join auth is modified (each cluster is deserialized to check references).
+    total_clusters = 20
+    shared_auth_id = 'shared1'
+    own_auth_id = 'own1'
+
+    # first 15 clusters share an auth; last 5 use their own
+    shared_ids = [f'cluster{i:02d}' for i in range(15)]
+    own_ids = [f'cluster{i:02d}' for i in range(15, total_clusters)]
+
+    def _ad_cluster(cluster_id, ref):
+        return _cluster(
+            cluster_id=cluster_id,
+            auth_mode=smb.enums.AuthMode.ACTIVE_DIRECTORY,
+            domain_settings=smb.resources.DomainSettings(
+                realm='MYDOMAIN.EXAMPLE.ORG',
+                join_sources=[
+                    smb.resources.JoinSource(
+                        source_type=smb.enums.JoinSourceType.RESOURCE,
+                        ref=ref,
+                    ),
+                ],
+            ),
+        )
+
+    to_apply = [
+        smb.resources.JoinAuth(
+            auth_id=shared_auth_id,
+            auth=smb.resources.JoinAuthValues(
+                username='testadmin',
+                password='Passw0rd',
+            ),
+        ),
+        smb.resources.JoinAuth(
+            auth_id=own_auth_id,
+            auth=smb.resources.JoinAuthValues(
+                username='otheradmin',
+                password='Passw0rd2',
+            ),
+        ),
+    ]
+    to_apply += [_ad_cluster(cid, shared_auth_id) for cid in shared_ids]
+    to_apply += [_ad_cluster(cid, own_auth_id) for cid in own_ids]
+
+    results = thandler.apply(to_apply)
+    assert results.success, results.to_simplified()
+
+    # clear cluster-info to detect which clusters get regenerated
+    for cid in shared_ids + own_ids:
+        thandler.public_store.remove((cid, 'cluster-info'))
+
+    # modify the shared join auth and measure how long the apply takes
+    t0 = time.monotonic()
+    results = thandler.apply(
+        [
+            smb.resources.JoinAuth(
+                auth_id=shared_auth_id,
+                auth=smb.resources.JoinAuthValues(
+                    username='testadmin',
+                    password='NewPassw0rd!',
+                ),
+            ),
+        ]
+    )
+    elapsed = time.monotonic() - t0
+
+    assert results.success, results.to_simplified()
+    # must complete quickly even when all 20 clusters are to be deserialized
+    assert (
+        elapsed < 1.0
+    ), f'apply took {elapsed:.3f}s with {total_clusters} clusters'
+
+    # only clusters referencing shared_auth_id must be regenerated
+    for cid in shared_ids:
+        assert 'cluster-info' in list(
+            thandler.public_store.contents(cid)
+        ), f'{cid} should have been regenerated'
+    # clusters using own_auth_id must not be touched
+    for cid in own_ids:
+        assert 'cluster-info' not in list(
+            thandler.public_store.contents(cid)
+        ), f'{cid} should not have been touched'
 
 
 def test_apply_remove_cluster(thandler):


### PR DESCRIPTION
`_find_modifications()` regenerated every cluster whenever a JoinAuth, UsersAndGroups, TLSCredential, or ExternalCephCluster changed, since these can be shared across clusters. Use the existing lookup helpers to resync only the clusters that actually reference it.

For rgw creds resync everything(just like old way), as narrowing it scope means scanning every share in the store (which may not scale well), so not worth a change until we have a better way for it.

Fixes: https://tracker.ceph.com/issues/78245





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
