### PR TITLE
squid: dashboard: use metadata = event.get('refs', {}) instead of dict(event…

### DIFF
--- a/src/pybind/mgr/dashboard/services/progress.py
+++ b/src/pybind/mgr/dashboard/services/progress.py
@@ -45,13 +45,29 @@ def _progress_event_to_dashboard_task_common(event, task):
             })
             return
 
+    refs = event.get('refs', {})
+
+    if isinstance(refs, dict):
+        metadata = refs
+    elif isinstance(refs, (list, tuple)):
+        if all(isinstance(i, (list, tuple)) and len(i) == 2 for i in refs):
+            metadata = dict(refs)
+        else:
+            metadata = {"raw_refs": refs}
+    elif isinstance(refs, str):
+        metadata = {"raw_refs": refs}
+    elif refs is None:
+        metadata = {}
+    else:
+        metadata = {"raw_refs": refs}
+
     task.update({
         # we're prepending the "progress/" prefix to tag tasks that come
         # from the progress module
         'name': "progress/{}".format(event['message']),
-        'metadata': dict(event.get('refs', {})),
-        'begin_time': "{}Z".format(datetime.fromtimestamp(event["started_at"])
-                                   .isoformat()),
+        'metadata': metadata,
+        'begin_time': datetime.fromtimestamp(
+            event["started_at"], tz=timezone.utc).isoformat(),
     })
 
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78031

---

backport of https://github.com/ceph/ceph/pull/67901
parent tracker: https://tracker.ceph.com/issues/75619

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh