### PR TITLE
mgr/dashboard: Add "nvmeof top connection" cmd

### DIFF
--- a/src/pybind/mgr/dashboard/services/nvmeof_top_cli.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_top_cli.py
@@ -136,6 +136,36 @@ else:
             self.busy_rate = self.busy_secs.rate(delay)
             self.idle_rate = self.idle_secs.rate(delay)
 
+    class ControllerBucketStats:
+        def __init__(self):
+            self.io_count = Counter()
+            self.bdev_sum = Counter()
+            self.net_sum = Counter()
+            self.qos_sum = Counter()
+            self.total_sum = Counter()
+
+            self.ops_rate = 0.0
+            self.bdev_mean = 0.0
+            self.net_mean = 0.0
+            self.qos_mean = 0.0
+            self.total_mean = 0.0
+
+        def update(self, io_count: int, bdev_mean: float, net_mean: float,
+                   qos_mean: float, total_mean: float):
+            self.io_count.update(io_count)
+            self.bdev_sum.update(bdev_mean * io_count)
+            self.net_sum.update(net_mean * io_count)
+            self.qos_sum.update(qos_mean * io_count)
+            self.total_sum.update(total_mean * io_count)
+
+        def calculate(self, delay: float):
+            self.ops_rate = self.io_count.rate(delay)
+            delta_count = self.io_count.current - self.io_count.last
+            self.bdev_mean = self.bdev_sum.rate(delta_count)
+            self.net_mean = self.net_sum.rate(delta_count)
+            self.qos_mean = self.qos_sum.rate(delta_count)
+            self.total_mean = self.total_sum.rate(delta_count)
+
     class NvmeofTopCollector:  # type: ignore[no-redef]  # noqa  # pylint: disable=function-redefined,too-many-instance-attributes
         def __init__(self):
             self.tool: Any = None
@@ -148,6 +178,7 @@ else:
             self.subsystems: Any = None
             self.reactor_stats = {}
             self.iostats = {}
+            self.controller_stats: dict = {}
             self.gw_info: Any = None
             self.client: Any = None
             self.timestamp = time.time()
@@ -254,6 +285,27 @@ else:
                     ))
             reactor_data.sort(key=lambda t: t[sort_pos], reverse=reverse_sort)
             return reactor_data
+
+        def get_host_controller_data(self, sort_pos: int, reverse_sort: bool):
+            ctrl_data = []
+            for (gw_addr, size_kb), io_stats in self.controller_stats.items():
+                total_iops = 0.0
+                metrics = []
+                for io_type in ('read', 'write'):
+                    stats = io_stats.get(io_type)
+                    if stats:
+                        stats.calculate(self.delay)
+                        total_iops += stats.ops_rate
+                        metrics += [stats.ops_rate, stats.bdev_mean, stats.net_mean,
+                                    max(0.0, stats.qos_mean), stats.total_mean]
+                    else:
+                        metrics += [None, None, None, None, None]
+
+                ctrl_data.append((gw_addr, f"{size_kb}KB", total_iops, *metrics))
+
+            ctrl_data.sort(key=lambda t: t[sort_pos] if t[sort_pos] is not None else 0.0,
+                           reverse=reverse_sort)
+            return ctrl_data
 
         def get_subsystem_summary_data(self):
             return [
@@ -509,6 +561,43 @@ else:
                     return
             logger.debug("collect_io_data completed")
 
+        def collect_controller_data(self):
+            nqn = self.tool.subsystem_nqn
+            host_nqn = self.tool.host_nqn
+            for client in self.clients.values():
+                req = NVMeoFClient.pb2.get_connection_io_statistics_req(
+                    subsystem_nqn=nqn,
+                    host_nqn=host_nqn,
+                    reset=False
+                )
+                ret = self._call_grpc('get_connection_io_statistics', req, client)
+                if ret is None:
+                    if not self.ready:
+                        return
+                    continue
+                if ret.status != 0:
+                    logger.debug("No controller stats from %s: %s",
+                                 client.gateway_addr, ret.error_message)
+                    continue
+                gw_addr = client.gateway_addr
+                for bucket in ret.buckets:
+                    key = (gw_addr, bucket.size)
+                    for io_type, lat_group in (('read', bucket.read), ('write', bucket.write)):
+                        if not lat_group.io_count:
+                            continue
+                        if key not in self.controller_stats:
+                            self.controller_stats[key] = {}
+                        if io_type not in self.controller_stats[key]:
+                            self.controller_stats[key][io_type] = ControllerBucketStats()
+                        self.controller_stats[key][io_type].update(
+                            lat_group.io_count,
+                            lat_group.bdev.mean,
+                            lat_group.net.mean,
+                            lat_group.qos.mean,
+                            lat_group.total.mean,
+                        )
+            logger.debug("collect_controller_data completed")
+
     class NVMeoFTopTool:
         def __init__(self, args: dict):
             self.args = args
@@ -664,6 +753,103 @@ else:
                 rows.append("<no namespaces defined>\n")
 
             return ''.join(rows)
+
+    class NVMeoFTopHostController(NVMeoFTopTool):
+        controller_headers = [
+            'Gateway', 'Size', 'Total IOPS',
+            'rIOPS', 'rBDEV µs', 'rNet µs', 'rQoS µs', 'rTotal µs',
+            'wIOPS', 'wBDEV µs', 'wNet µs', 'wQoS µs', 'wTotal µs',
+        ]
+        controller_template = (
+            "{:<20}   {:>6}   {:>10}"
+            "   {:>6}   {:>8}   {:>7}   {:>7}   {:>8}"
+            "   {:>6}   {:>8}   {:>7}   {:>7}   {:>8}\n"
+        )
+
+        def __init__(self, args: dict):
+            super().__init__(args)
+            self.subsystem_nqn = args.get('nqn')
+            self.host_nqn = args.get('host_nqn')
+
+        def _collect(self):
+            self.collector.collect_controller_data()
+
+        def format_output(self):
+            if self.sort_key not in NVMeoFTopHostController.controller_headers:
+                raise ValueError(
+                    f"Invalid sort key '{self.sort_key}'. "
+                    f"Valid options: {NVMeoFTopHostController.controller_headers}"
+                )
+            sort_pos = NVMeoFTopHostController.controller_headers.index(self.sort_key)
+
+            rows = []
+            if self.args.get('with_timestamp'):
+                timestamp = time.strftime('%Y-%m-%d %H:%M:%S',
+                                          time.localtime(self.collector.timestamp))
+                rows.append(f"{timestamp} (delay: {self.collector.delay:.2f}s)\n")
+
+            ctrl_data = self.collector.get_host_controller_data(
+                sort_pos=sort_pos, reverse_sort=self.reverse_sort)
+
+            if not self.args.get('no_header'):
+                rows.append(NVMeoFTopHostController.controller_template.format(
+                    *NVMeoFTopHostController.controller_headers))
+            if ctrl_data:
+                for row in ctrl_data:
+                    formatted = [
+                        '-' if v is None else (f"{v:.0f}" if isinstance(v, float) else v)
+                        for v in row
+                    ]
+                    rows.append(NVMeoFTopHostController.controller_template.format(*formatted))
+            else:
+                rows.append("<no IO statistics available>\n")
+
+            rows.append("\n")
+            return ''.join(rows)
+
+    @DBCLICommand.Read('nvmeof top controller', poll=True)
+    def nvmeof_top_controller(_, nqn: str = '', host_nqn: str = '',
+                              server_address: str = '', server_port: Optional[int] = None,
+                              gw_group: str = '',
+                              descending: bool = False, sort_by: str = 'Size',
+                              with_timestamp: bool = False, no_header: bool = False,
+                              period: float = 1.0, session_id: Optional[str] = None):
+        '''
+        NVMeoF Top Host Controller IO Tool
+        '''
+        if not nqn:
+            return HandleCommandResult(
+                stderr="Required argument '--nqn' missing",
+                retval=-errno.EINVAL
+            )
+        if not host_nqn:
+            return HandleCommandResult(
+                stderr="Required argument '--host-nqn' missing",
+                retval=-errno.EINVAL
+            )
+        if sort_by not in NVMeoFTopHostController.controller_headers:
+            return HandleCommandResult(
+                stderr=f"Invalid sort-by '{sort_by}': must match a header title: "
+                       f"{NVMeoFTopHostController.controller_headers}",
+                retval=-errno.EINVAL
+            )
+        args = {
+            'nqn': nqn,
+            'host_nqn': host_nqn,
+            'with_timestamp': with_timestamp,
+            'no_header': no_header,
+            'sort_descending': descending,
+            'sort_by': sort_by,
+            'server_address': server_address,
+            'server_port': server_port,
+            'gw_group': gw_group,
+            'period': period,
+            'session_id': session_id,
+        }
+        rc, output = NVMeoFTopHostController(args).run()
+        if rc != 0:
+            return HandleCommandResult(stderr=output, retval=rc)
+        return HandleCommandResult(stdout=output, retval=rc)
 
     @DBCLICommand.Read('nvmeof top cpu', poll=True)
     def nvmeof_top_cpu(_, server_address: str = '', server_port: Optional[int] = None,

--- a/src/pybind/mgr/dashboard/services/nvmeof_top_cli.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_top_cli.py
@@ -7,7 +7,7 @@ import ipaddress
 import json
 import logging
 import time
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from mgr_module import HandleCommandResult
 
@@ -136,6 +136,36 @@ else:
             self.busy_rate = self.busy_secs.rate(delay)
             self.idle_rate = self.idle_secs.rate(delay)
 
+    class ConnectionBucketStats:
+        def __init__(self):
+            self.io_count = Counter()
+            self.bdev_sum = Counter()
+            self.net_sum = Counter()
+            self.qos_sum = Counter()
+            self.total_sum = Counter()
+
+            self.ops_rate = 0.0
+            self.bdev_mean = 0.0
+            self.net_mean = 0.0
+            self.qos_mean = 0.0
+            self.total_mean = 0.0
+
+        def update(self, io_count: int, bdev_mean: float, net_mean: float,
+                   qos_mean: float, total_mean: float):
+            self.io_count.update(io_count)
+            self.bdev_sum.update(bdev_mean * io_count)
+            self.net_sum.update(net_mean * io_count)
+            self.qos_sum.update(qos_mean * io_count)
+            self.total_sum.update(total_mean * io_count)
+
+        def calculate(self, delay: float):
+            self.ops_rate = self.io_count.rate(delay)
+            delta_count = self.io_count.current - self.io_count.last
+            self.bdev_mean = self.bdev_sum.rate(delta_count)
+            self.net_mean = self.net_sum.rate(delta_count)
+            self.qos_mean = self.qos_sum.rate(delta_count)
+            self.total_mean = self.total_sum.rate(delta_count)
+
     class NvmeofTopCollector:  # type: ignore[no-redef]  # noqa  # pylint: disable=function-redefined,too-many-instance-attributes
         def __init__(self):
             self.tool: Any = None
@@ -146,8 +176,9 @@ else:
             self.namespaces = {}
             self.lbg_to_gateway: dict = {}
             self.subsystems: Any = None
-            self.reactor_stats = {}
-            self.iostats = {}
+            self.reactor_stats: Dict[str, Dict[str, ReactorStats]] = {}
+            self.iostats: Dict[str, Dict[str, PerformanceStats]] = {}
+            self.connection_stats: Dict[Tuple[str, int], Dict[str, ConnectionBucketStats]] = {}
             self.gw_info: Any = None
             self.client: Any = None
             self.timestamp = time.time()
@@ -254,6 +285,26 @@ else:
                     ))
             reactor_data.sort(key=lambda t: t[sort_pos], reverse=reverse_sort)
             return reactor_data
+
+        def get_connection_data(self, sort_pos: int, reverse_sort: bool):
+            conn_data: List[Tuple[Any, ...]] = []
+            for (gw_addr, size_kb), io_stats in self.connection_stats.items():
+                total_iops = 0.0
+                metrics: List[Optional[float]] = []
+                for io_type in ('read', 'write'):
+                    stats = io_stats.get(io_type)
+                    if stats:
+                        total_iops += stats.ops_rate
+                        metrics += [stats.ops_rate, stats.bdev_mean, stats.net_mean,
+                                    max(0.0, stats.qos_mean), stats.total_mean]
+                    else:
+                        metrics += [None, None, None, None, None]
+
+                conn_data.append((gw_addr, size_kb, total_iops, *metrics))
+
+            conn_data.sort(key=lambda t: t[sort_pos] if t[sort_pos] is not None else 0.0,
+                           reverse=reverse_sort)
+            return conn_data
 
         def get_subsystem_summary_data(self):
             return [
@@ -509,6 +560,47 @@ else:
                     return
             logger.debug("collect_io_data completed")
 
+        def collect_connection_data(self):
+            nqn = self.tool.subsystem_nqn
+            host_nqn = self.tool.host_nqn
+            for client in self.clients.values():
+                req = NVMeoFClient.pb2.get_connection_io_statistics_req(
+                    subsystem_nqn=nqn,
+                    host_nqn=host_nqn,
+                    reset=False
+                )
+                ret = self._call_grpc('get_connection_io_statistics', req, client)
+                if ret is None:
+                    if not self.ready:
+                        return
+                    continue
+                gw_addr = client.gateway_addr
+                if ret.status != 0:
+                    logger.debug("No connection stats from %s: %s",
+                                 gw_addr, ret.error_message)
+                    stale_keys = [key for key in self.connection_stats if key[0] == gw_addr]
+                    for key in stale_keys:
+                        del self.connection_stats[key]
+                    continue
+                for bucket in ret.buckets:
+                    key = (gw_addr, bucket.size)
+                    for io_type, lat_group in (('read', bucket.read), ('write', bucket.write)):
+                        if not lat_group.io_count:
+                            continue
+                        if key not in self.connection_stats:
+                            self.connection_stats[key] = {}
+                        if io_type not in self.connection_stats[key]:
+                            self.connection_stats[key][io_type] = ConnectionBucketStats()
+                        self.connection_stats[key][io_type].update(
+                            lat_group.io_count,
+                            lat_group.bdev.mean,
+                            lat_group.net.mean,
+                            lat_group.qos.mean,
+                            lat_group.total.mean,
+                        )
+                        self.connection_stats[key][io_type].calculate(self.delay)
+            logger.debug("collect_connection_data completed")
+
     class NVMeoFTopTool:
         def __init__(self, args: dict):
             self.args = args
@@ -664,6 +756,103 @@ else:
                 rows.append("<no namespaces defined>\n")
 
             return ''.join(rows)
+
+    class NVMeoFTopConnection(NVMeoFTopTool):
+        connection_headers = [
+            'Gateway', 'SizeKB', 'Total IOPS',
+            'rIOPS', 'rBDEV µs', 'rNet µs', 'rQoS µs', 'rTotal µs',
+            'wIOPS', 'wBDEV µs', 'wNet µs', 'wQoS µs', 'wTotal µs',
+        ]
+        connection_template = (
+            "{:<20}   {:>6}   {:>10}"
+            "   {:>6}   {:>8}   {:>7}   {:>7}   {:>8}"
+            "   {:>6}   {:>8}   {:>7}   {:>7}   {:>8}\n"
+        )
+
+        def __init__(self, args: dict):
+            super().__init__(args)
+            self.subsystem_nqn = args.get('nqn')
+            self.host_nqn = args.get('host_nqn')
+
+        def _collect(self):
+            self.collector.collect_connection_data()
+
+        def format_output(self):
+            if self.sort_key not in NVMeoFTopConnection.connection_headers:
+                raise ValueError(
+                    f"Invalid sort key '{self.sort_key}'. "
+                    f"Valid options: {NVMeoFTopConnection.connection_headers}"
+                )
+            sort_pos = NVMeoFTopConnection.connection_headers.index(self.sort_key)
+
+            rows = []
+            if self.args.get('with_timestamp'):
+                timestamp = time.strftime('%Y-%m-%d %H:%M:%S',
+                                          time.localtime(self.collector.timestamp))
+                rows.append(f"{timestamp} (delay: {self.collector.delay:.2f}s)\n")
+
+            conn_data = self.collector.get_connection_data(
+                sort_pos=sort_pos, reverse_sort=self.reverse_sort)
+
+            if not self.args.get('no_header'):
+                rows.append(NVMeoFTopConnection.connection_template.format(
+                    *NVMeoFTopConnection.connection_headers))
+            if conn_data:
+                for row in conn_data:
+                    formatted = [
+                        '-' if v is None else (f"{v:.0f}" if isinstance(v, float) else v)
+                        for v in row
+                    ]
+                    rows.append(NVMeoFTopConnection.connection_template.format(*formatted))
+            else:
+                rows.append("<no IO statistics available>\n")
+
+            rows.append("\n")
+            return ''.join(rows)
+
+    @DBCLICommand.Read('nvmeof top connection', poll=True)
+    def nvmeof_top_connection(_, nqn: str = '', host_nqn: str = '',
+                              server_address: str = '', server_port: Optional[int] = None,
+                              gw_group: str = '',
+                              descending: bool = False, sort_by: str = 'Gateway',
+                              with_timestamp: bool = False, no_header: bool = False,
+                              period: float = 1.0, session_id: Optional[str] = None):
+        '''
+        NVMeoF Top Connection Tool
+        '''
+        if not nqn:
+            return HandleCommandResult(
+                stderr="Required argument '--nqn' missing",
+                retval=-errno.EINVAL
+            )
+        if not host_nqn:
+            return HandleCommandResult(
+                stderr="Required argument '--host-nqn' missing",
+                retval=-errno.EINVAL
+            )
+        if sort_by not in NVMeoFTopConnection.connection_headers:
+            return HandleCommandResult(
+                stderr=f"Invalid sort-by '{sort_by}': must match a header title: "
+                       f"{NVMeoFTopConnection.connection_headers}",
+                retval=-errno.EINVAL
+            )
+        args = {
+            'nqn': nqn,
+            'host_nqn': host_nqn,
+            'with_timestamp': with_timestamp,
+            'no_header': no_header,
+            'sort_descending': descending,
+            'sort_by': sort_by,
+            'server_address': server_address,
+            'server_port': server_port,
+            'gw_group': gw_group,
+            'period': period,
+            'session_id': session_id,
+        }
+        rc, output = NVMeoFTopConnection(args).run()
+        if rc != 0:
+            return HandleCommandResult(stderr=output, retval=rc)
+        return HandleCommandResult(stdout=output, retval=rc)
 
     @DBCLICommand.Read('nvmeof top cpu', poll=True)
     def nvmeof_top_cpu(_, server_address: str = '', server_port: Optional[int] = None,

--- a/src/pybind/mgr/dashboard/tests/test_nvmeof_top_cli.py
+++ b/src/pybind/mgr/dashboard/tests/test_nvmeof_top_cli.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ..services.nvmeof_top_cli import MAX_SESSION_TTL, Counter, \
-    NvmeofTopCollector, NVMeoFTopCPU, NVMeoFTopIO
+    NvmeofTopCollector, NVMeoFTopCPU, NVMeoFTopHostController, NVMeoFTopIO
 from ..tests import CLICommandTestMixin, CmdException
 
 
@@ -27,6 +27,15 @@ def fixture_io_collector():
     collector.get_overall_summary_data.return_value = []
     collector.get_gateway_summary_data.return_value = []
     collector.delay = 2.0
+    collector.timestamp = time.time()
+    return collector
+
+
+@pytest.fixture(name='hostcontroller_collector')
+def fixture_hostcontroller_collector():
+    collector = MagicMock()
+    collector.get_host_controller_data.return_value = []
+    collector.delay = 1.0
     collector.timestamp = time.time()
     return collector
 
@@ -168,6 +177,76 @@ class TestNVMeoFTopIOFormat:
     def test_invalid_sort_key(self, io_collector):
         tool = NVMeoFTopIO({**self.default_args, 'sort_by': 'BadKey'})
         tool.collector = io_collector
+        with pytest.raises(ValueError, match="Invalid sort key"):
+            tool.format_output()
+
+
+class TestNVMeoFTopHostControllerFormat:
+    default_args = {
+        'sort_by': 'Size',
+        'sort_descending': False,
+        'with_timestamp': False,
+        'no_header': False,
+        'nqn': 'nqn.2024-01.io.spdk:cnode1',
+        'host_nqn': 'nqn.2014-08.org.nvmexpress:uuid:host1',
+        'server_address': '',
+        'server_port': None,
+        'gw_group': '',
+        'period': 1,
+        'session_id': None,
+    }
+
+    def test_no_controller_data(self, hostcontroller_collector):
+        tool = NVMeoFTopHostController(self.default_args)
+        tool.collector = hostcontroller_collector
+        output = tool.format_output()
+        assert '<no IO statistics available>' in output
+
+    def test_headers_present(self, hostcontroller_collector):
+        tool = NVMeoFTopHostController(self.default_args)
+        tool.collector = hostcontroller_collector
+        output = tool.format_output()
+        assert 'Gateway' in output
+        assert 'rBDEV µs' in output
+        assert 'wTotal µs' in output
+
+    def test_no_header(self, hostcontroller_collector):
+        tool = NVMeoFTopHostController({**self.default_args, 'no_header': True})
+        tool.collector = hostcontroller_collector
+        output = tool.format_output()
+        assert 'Gateway' not in output
+
+    def test_controller_data(self, hostcontroller_collector):
+        hostcontroller_collector.get_host_controller_data.return_value = [
+            ('192.168.1.1:5500', '4k', 100, 50, 10.0, 20.0, 5.0, 35.0,
+             50, 10.0, 20.0, 5.0, 35.0),
+        ]
+        tool = NVMeoFTopHostController(self.default_args)
+        tool.collector = hostcontroller_collector
+        output = tool.format_output()
+        assert '192.168.1.1:5500' in output
+        assert '4k' in output
+
+    def test_controller_data_with_none_values(self, hostcontroller_collector):
+        hostcontroller_collector.get_host_controller_data.return_value = [
+            ('192.168.1.1:5500', '4k', 100, 50, None, None, None, None,
+             50, None, None, None, None),
+        ]
+        tool = NVMeoFTopHostController(self.default_args)
+        tool.collector = hostcontroller_collector
+        output = tool.format_output()
+        assert '-' in output
+
+    def test_with_timestamp(self, hostcontroller_collector):
+        tool = NVMeoFTopHostController({**self.default_args, 'with_timestamp': True})
+        tool.collector = hostcontroller_collector
+        output = tool.format_output()
+        assert 'delay:' in output
+        assert '1.00s' in output
+
+    def test_invalid_sort_key(self, hostcontroller_collector):
+        tool = NVMeoFTopHostController({**self.default_args, 'sort_by': 'BadKey'})
+        tool.collector = hostcontroller_collector
         with pytest.raises(ValueError, match="Invalid sort key"):
             tool.format_output()
 

--- a/src/pybind/mgr/dashboard/tests/test_nvmeof_top_cli.py
+++ b/src/pybind/mgr/dashboard/tests/test_nvmeof_top_cli.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ..services.nvmeof_top_cli import MAX_SESSION_TTL, Counter, \
-    NvmeofTopCollector, NVMeoFTopCPU, NVMeoFTopIO
+    NvmeofTopCollector, NVMeoFTopConnection, NVMeoFTopCPU, NVMeoFTopIO
 from ..tests import CLICommandTestMixin, CmdException
 
 
@@ -27,6 +27,15 @@ def fixture_io_collector():
     collector.get_overall_summary_data.return_value = []
     collector.get_gateway_summary_data.return_value = []
     collector.delay = 2.0
+    collector.timestamp = time.time()
+    return collector
+
+
+@pytest.fixture(name='connection_collector')
+def fixture_connection_collector():
+    collector = MagicMock()
+    collector.get_connection_data.return_value = []
+    collector.delay = 1.0
     collector.timestamp = time.time()
     return collector
 
@@ -168,6 +177,76 @@ class TestNVMeoFTopIOFormat:
     def test_invalid_sort_key(self, io_collector):
         tool = NVMeoFTopIO({**self.default_args, 'sort_by': 'BadKey'})
         tool.collector = io_collector
+        with pytest.raises(ValueError, match="Invalid sort key"):
+            tool.format_output()
+
+
+class TestNVMeoFTopConnectionFormat:
+    default_args = {
+        'sort_by': 'Gateway',
+        'sort_descending': False,
+        'with_timestamp': False,
+        'no_header': False,
+        'nqn': 'nqn.2024-01.io.spdk:cnode1',
+        'host_nqn': 'nqn.2014-08.org.nvmexpress:uuid:host1',
+        'server_address': '',
+        'server_port': None,
+        'gw_group': '',
+        'period': 1,
+        'session_id': None,
+    }
+
+    def test_no_connection_data(self, connection_collector):
+        tool = NVMeoFTopConnection(self.default_args)
+        tool.collector = connection_collector
+        output = tool.format_output()
+        assert '<no IO statistics available>' in output
+
+    def test_headers_present(self, connection_collector):
+        tool = NVMeoFTopConnection(self.default_args)
+        tool.collector = connection_collector
+        output = tool.format_output()
+        assert 'Gateway' in output
+        assert 'rBDEV µs' in output
+        assert 'wTotal µs' in output
+
+    def test_no_header(self, connection_collector):
+        tool = NVMeoFTopConnection({**self.default_args, 'no_header': True})
+        tool.collector = connection_collector
+        output = tool.format_output()
+        assert 'Gateway' not in output
+
+    def test_connection_data(self, connection_collector):
+        connection_collector.get_connection_data.return_value = [
+            ('192.168.1.1:5500', 4, 100, 50, 10.0, 20.0, 5.0, 35.0,
+             50, 10.0, 20.0, 5.0, 35.0),
+        ]
+        tool = NVMeoFTopConnection(self.default_args)
+        tool.collector = connection_collector
+        output = tool.format_output()
+        assert '192.168.1.1:5500' in output
+        assert '4' in output
+
+    def test_connection_data_with_none_values(self, connection_collector):
+        connection_collector.get_connection_data.return_value = [
+            ('192.168.1.1:5500', 4, 100, 50, None, None, None, None,
+             50, None, None, None, None),
+        ]
+        tool = NVMeoFTopConnection(self.default_args)
+        tool.collector = connection_collector
+        output = tool.format_output()
+        assert '-' in output
+
+    def test_with_timestamp(self, connection_collector):
+        tool = NVMeoFTopConnection({**self.default_args, 'with_timestamp': True})
+        tool.collector = connection_collector
+        output = tool.format_output()
+        assert 'delay:' in output
+        assert '1.00s' in output
+
+    def test_invalid_sort_key(self, connection_collector):
+        tool = NVMeoFTopConnection({**self.default_args, 'sort_by': 'BadKey'})
+        tool.collector = connection_collector
         with pytest.raises(ValueError, match="Invalid sort key"):
             tool.format_output()
 
@@ -492,3 +571,74 @@ class TestNvmeofTopCommands(CLICommandTestMixin):
                 )
             assert exc_info.value.retcode == -errno.EINVAL
             assert str(exc_info.value) == 'boom'
+
+    def test_top_connection_missing_nqn_returns_einval(self):
+        with pytest.raises(CmdException) as exc_info:
+            self.exec_nvmeof_cmd(
+                'nvmeof top connection',
+                nqn='',
+                host_nqn='nqn.2014-08.org.nvmexpress:uuid:host1',
+                session_id='sess3'
+            )
+        assert exc_info.value.retcode == -errno.EINVAL
+        assert str(exc_info.value) == "Required argument '--nqn' missing"
+
+    def test_top_connection_missing_host_nqn_returns_einval(self):
+        with pytest.raises(CmdException) as exc_info:
+            self.exec_nvmeof_cmd(
+                'nvmeof top connection',
+                nqn='nqn.2024-01.io.spdk:cnode1',
+                host_nqn='',
+                session_id='sess3'
+            )
+        assert exc_info.value.retcode == -errno.EINVAL
+        assert str(exc_info.value) == "Required argument '--host-nqn' missing"
+
+    def test_top_connection_invalid_sort_by_returns_einval(self):
+        with pytest.raises(CmdException) as exc_info:
+            self.exec_nvmeof_cmd(
+                'nvmeof top connection',
+                nqn='nqn.2024-01.io.spdk:cnode1',
+                host_nqn='nqn.2014-08.org.nvmexpress:uuid:host1',
+                sort_by='BadKey',
+                session_id='sess3'
+            )
+        assert exc_info.value.retcode == -errno.EINVAL
+        assert "Invalid sort-by 'BadKey'" in str(exc_info.value)
+
+    def test_top_connection_success(self):
+        with patch.object(NVMeoFTopConnection, 'run',
+                          return_value=(0, 'connection output\n')):
+            result = self.exec_nvmeof_cmd(
+                'nvmeof top connection',
+                nqn='nqn.2024-01.io.spdk:cnode1',
+                host_nqn='nqn.2014-08.org.nvmexpress:uuid:host1',
+                session_id='sess3'
+            )
+        assert 'connection output' in result
+
+    def test_top_connection_run_fail(self):
+        with patch.object(NVMeoFTopConnection, 'run',
+                          return_value=(-errno.ENOENT, 'connection error')):
+            with pytest.raises(CmdException) as exc_info:
+                self.exec_nvmeof_cmd(
+                    'nvmeof top connection',
+                    nqn='nqn.2024-01.io.spdk:cnode1',
+                    host_nqn='nqn.2014-08.org.nvmexpress:uuid:host1',
+                    session_id='sess3'
+                )
+        assert exc_info.value.retcode == -errno.ENOENT
+        assert str(exc_info.value) == 'connection error'
+
+    def test_top_connection_get_collector_fail(self):
+        with patch('dashboard.services.nvmeof_top_cli.get_collector',
+                   side_effect=RuntimeError("boom")):
+            with pytest.raises(CmdException) as exc_info:
+                self.exec_nvmeof_cmd(
+                    'nvmeof top connection',
+                    nqn='nqn.2024-01.io.spdk:cnode1',
+                    host_nqn='nqn.2014-08.org.nvmexpress:uuid:host1',
+                    session_id='sess3'
+                )
+        assert exc_info.value.retcode == -errno.EINVAL
+        assert str(exc_info.value) == "boom"


### PR DESCRIPTION
Add a new command "nvmeof top connection" to
show host connection iostat.

Fixes: https://tracker.ceph.com/issues/78248

## Calculation Logic

Here's what I get from `connection get_io_statistics` cli:
```
[root@dev-vallari-cluster-node1 ~]# docker run -it quay.io/ceph/nvmeof-cli:1.9 --server-address 10.243.64.86 connection get_io_statistics -n 'nqn.2016-06.io.spdk:cnode1.mygroup1' -t 'nqn.2014-08.org.nvmexpress:uuid:6def1fb3-a3a2-447b-9938-59856fc4805f'
IO statistics for host nqn.2014-08.org.nvmexpress:uuid:6def1fb3-a3a2-447b-9938-59856fc4805f on nqn.2016-06.io.spdk:cnode1.mygroup1:

╒══════════╤══════════╤═════════════╤══════════════════╤══════════════════╤══════════════════╤══════════════════╕
│ Bucket   │ Bucket   │   IOs Count │ BDEV µSec        │ Net µSec         │ QOS µSec         │ Total µSec       │
│ Size     │ Type     │             │ (Min,Max,Mean)   │ (Min,Max,Mean)   │ (Min,Max,Mean)   │ (Min,Max,Mean)   │
╞══════════╪══════════╪═════════════╪══════════════════╪══════════════════╪══════════════════╪══════════════════╡
│ 2KB      │ Write    │           4 │ 303, 11599, 4774 │ 0, 0, 0          │ 0, 3, 2          │ 306, 11600, 4776 │
├──────────┼──────────┼─────────────┼──────────────────┼──────────────────┼──────────────────┼──────────────────┤
│ 4KB      │ Read     │         114 │ 2, 1291, 287     │ 136, 578, 209    │ 0, 5, 0          │ 140, 1553, 497   │
├──────────┼──────────┼─────────────┼──────────────────┼──────────────────┼──────────────────┼──────────────────┤
│ 8KB      │ Read     │           6 │ 413, 646, 505    │ 266, 1043, 482   │ 0, 0, 0          │ 713, 1509, 988   │
├──────────┼──────────┼─────────────┼──────────────────┼──────────────────┼──────────────────┼──────────────────┤
│ 16KB     │ Read     │          18 │ 386, 633, 503    │ 228, 41210, 5068 │ 0, 0, 0          │ 711, 41747, 5572 │
├──────────┼──────────┼─────────────┼──────────────────┼──────────────────┼──────────────────┼──────────────────┤
│ 32KB     │ Read     │          17 │ 31, 748, 478     │ 254, 1455, 557   │ 0, 0, 0          │ 286, 1898, 1036  │
├──────────┼──────────┼─────────────┼──────────────────┼──────────────────┼──────────────────┼──────────────────┤
│ 64KB     │ Read     │          12 │ 377, 626, 498    │ 413, 41218, 4151 │ 0, 0, 0          │ 793, 41765, 4650 │
├──────────┼──────────┼─────────────┼──────────────────┼──────────────────┼──────────────────┼──────────────────┤
│ 128KB    │ Read     │           3 │ 363, 499, 450    │ 654, 1199, 877   │ 0, 0, 0          │ 1154, 1563, 1329 │
╘══════════╧══════════╧═════════════╧══════════════════╧══════════════════╧══════════════════╧══════════════════╛

Total IOs count: 174
```
Now to show it on top tool, I want to calculate stats between two iterations/batches.

But I see that in "connection get_io_statistics", last 4 latency stats columns (bdev, net, qos, total) show all time stats. So to calculate between two iterations, I cannot work with max or min (because max would be all time max latency, and there is no way to get max between an iteration). So I did some calculations with mean values to get mean btw two iterations:

Calculation done for each bucket:
1. total_io_time (t) = mean_latency * io_count 
2. use above total_io_time formula to calculate io time between two iterations (t2 - t1). 
3. mean latency btw two iteration = t2-t1 / (io_count at t2 - io_count at t1)

Then used same calculation for all mean latency (bdev, net, qos, total).


## Output 

First iteration always has garbage values (like other top commands). Also scheduled fio in background on 1  namespace of this subsystems from that host. 
```
[ceph: root@newtop-vallari-cluster-node1 /]# ceph nvmeof top controller 'nqn.2016-06.io.spdk:cnode1.mygroup1' 'nqn.2014-08.org.nvmexpress:uuid:6def1fb3-a3a2-447b-9938-59856fc4805f'
Gateway                  Size   Total IOPS    rIOPS   rBDEV µs   rNet µs   rQoS µs   rTotal µs    wIOPS   wBDEV µs   wNet µs   wQoS µs   wTotal µs
10.243.64.68:5500       128KB          731      731        641       781         0       1424        -          -         -         -          -
10.243.64.69:5500       128KB           46       46        500       958         1       1461        -          -         -         -          -
10.243.64.67:5500       128KB           46       46        453       794         0       1248        -          -         -         -          -
10.243.64.68:5500        16KB       128968    85708        618       272         0        891    43260       2711       205         0       2918
10.243.64.69:5500        16KB          139      139        407       447         0        855        -          -         -         -          -
10.243.64.67:5500        16KB          139      139        596       341         1        940        -          -         -         -          -
10.243.64.68:5500         2KB           58        -          -         -         -          -       58      33011         0         1      33012
10.243.64.69:5500         2KB           46        -          -         -         -          -       46      20732         0         1      20733
10.243.64.67:5500         2KB           35        -          -         -         -          -       35       4314         0         1       4315
10.243.64.68:5500        32KB       192791   127877        666       331         0        999    64914       2980       248         0       3229
10.243.64.69:5500        32KB          186      186        258       450         1        710        -          -         -         -          -
10.243.64.67:5500        32KB          186      186        486       425         0        912        -          -         -         -          -
10.243.64.68:5500         4KB        58528    45513        474       191         0        666    13015       2480         0         1       2481
10.243.64.69:5500         4KB         1869     1869        196       189         1        387        -          -         -         -          -
10.243.64.67:5500         4KB         1637     1637        179       171         0        351        -          -         -         -          -
10.243.64.68:5500        64KB        36236    24777        651       407         0       1060    11459       3619       295         0       3915
10.243.64.69:5500        64KB           93       93        395       549         0        945        -          -         -         -          -
10.243.64.67:5500        64KB           93       93        656       486         0       1144        -          -         -         -          -
10.243.64.68:5500         8KB        73505    49634        579       217         0        797    23871       2595        83         1       2680
10.243.64.69:5500         8KB           46       46        386       441         0        829        -          -         -         -          -
10.243.64.67:5500         8KB           46       46        489       517         0       1007        -          -         -         -          -
 ---- 

Gateway                  Size   Total IOPS    rIOPS   rBDEV µs   rNet µs   rQoS µs   rTotal µs    wIOPS   wBDEV µs   wNet µs   wQoS µs   wTotal µs
10.243.64.68:5500       128KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.69:5500       128KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.67:5500       128KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.68:5500        16KB          135       62        618       272         0        891       72       2854       205         0       3013
10.243.64.69:5500        16KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.67:5500        16KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.68:5500         2KB            0        -          -         -         -          -        0          0         0         0          0
10.243.64.69:5500         2KB            0        -          -         -         -          -        0          0         0         0          0
10.243.64.67:5500         2KB            0        -          -         -         -          -        0          0         0         0          0
10.243.64.68:5500        32KB          191       90        666       443         0        999      101       3031       197         0       3280
10.243.64.69:5500        32KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.67:5500        32KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.68:5500         4KB           42       18        474       191         0        863       24       2612         0         1       2613
10.243.64.69:5500         4KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.67:5500         4KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.68:5500        64KB           35       16        531       407         0        821       19       3619       343         0       3963
10.243.64.69:5500        64KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.67:5500        64KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.68:5500         8KB           80       42        485       217         0        703       38       2595        33         1       2680
10.243.64.69:5500         8KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.67:5500         8KB            0        0          0         0         0          0        -          -         -         -          -
 ---- 

Gateway                  Size   Total IOPS    rIOPS   rBDEV µs   rNet µs   rQoS µs   rTotal µs    wIOPS   wBDEV µs   wNet µs   wQoS µs   wTotal µs
10.243.64.68:5500       128KB            2        2        576       781         0       1326        -          -         -         -          -
10.243.64.69:5500       128KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.67:5500       128KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.68:5500        16KB          193      164        702       356         0       1060       29       2714       205         0       3040
10.243.64.69:5500        16KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.67:5500        16KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.68:5500         2KB            0        -          -         -         -          -        0          0         0         0          0
10.243.64.69:5500         2KB            0        -          -         -         -          -        0          0         0         0          0
10.243.64.67:5500         2KB            0        -          -         -         -          -        0          0         0         0          0
10.243.64.68:5500        32KB          283      238        753       419         0       1172       45       2981       247         0       3230
10.243.64.69:5500        32KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.67:5500        32KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.68:5500         4KB          106      100        511       228         0        704        6       2483         0         1       2649
10.243.64.69:5500         4KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.67:5500         4KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.68:5500        64KB           62       50        730       487         0       1219       12       3619       296         0       3995
10.243.64.69:5500        64KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.67:5500        64KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.68:5500         8KB          111       91        666       261         0        927       20       2691        82         1       2776
10.243.64.69:5500         8KB            0        0          0         0         0          0        -          -         -         -          -
10.243.64.67:5500         8KB            0        0          0         0         0          0        -          -         -         -          -
  ---- 

^CInterrupted
```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
