### PR TITLE
mgr/smb: add support for RGW shares with external Ceph clusters

### DIFF
--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -1567,14 +1567,122 @@ fsid
 mon_host
     String. The ``mon_host`` string (as sourced from a ceph.conf file)
 cephfs_user
-    Object. Fields:
+    Optional object. Required if the cluster will host CephFS-backed shares.
+    Fields:
 
     name
-        String. A ceph user name indicating the cephx user that will
+        String. A Ceph user name indicating the CephX user that will
         access the CephFS volume(s) on the external cluster
     key
-        String. The Base64 encoded key value corresponding to the cephx
+        String. The Base64 encoded key value corresponding to the CephX
         user name provided
+rgw_user
+    Optional object. Required if the cluster will host RGW-backed shares.
+    Fields:
+
+    name
+        String. A Ceph user name indicating the CephX user that will
+        access the RGW bucket(s) on the external cluster
+    key
+        String. The Base64 encoded key value corresponding to the CephX
+        user name provided
+
+.. note::
+   At least one of ``cephfs_user`` or ``rgw_user`` must be configured.
+   Configure only the user(s) needed for your share types:
+
+   - CephFS-only clusters: Configure only ``cephfs_user``
+   - RGW-only clusters: Configure only ``rgw_user``
+   - Mixed clusters: Configure both ``cephfs_user`` and ``rgw_user``
+
+Examples
+~~~~~~~~
+
+External cluster with CephFS support only:
+
+.. code-block:: yaml
+
+    resource_type: ceph.smb.ext.cluster
+    external_ceph_cluster_id: external-cephfs
+    cluster:
+      fsid: "12345678-1234-1234-1234-123456789abc"
+      mon_host: "10.0.1.10:6789,10.0.1.11:6789"
+      cephfs_user:
+        name: "client.external-cephfs"
+        key: "AQC1234567890abcdefghijklmnopqrstuvwxyz=="
+
+External cluster with RGW support only:
+
+.. code-block:: yaml
+
+    resource_type: ceph.smb.ext.cluster
+    external_ceph_cluster_id: external-rgw
+    cluster:
+      fsid: "12345678-1234-1234-1234-123456789abc"
+      mon_host: "10.0.1.10:6789,10.0.1.11:6789"
+      rgw_user:
+        name: "client.external-rgw"
+        key: "AQD9876543210zyxwvutsrqponmlkjihgfedcba=="
+
+External cluster with both CephFS and RGW support:
+
+.. code-block:: yaml
+
+    resource_type: ceph.smb.ext.cluster
+    external_ceph_cluster_id: external-mixed
+    cluster:
+      fsid: "12345678-1234-1234-1234-123456789abc"
+      mon_host: "10.0.1.10:6789,10.0.1.11:6789"
+      cephfs_user:
+        name: "client.external-cephfs"
+        key: "AQC1234567890abcdefghijklmnopqrstuvwxyz=="
+      rgw_user:
+        name: "client.external-rgw"
+        key: "AQD9876543210zyxwvutsrqponmlkjihgfedcba=="
+
+
+.. important::
+   **RGW Shares on External Clusters Require Manual Credentials**
+
+   When creating RGW shares on external clusters, you **must** manually define
+   RGW credentials using the ``ceph.smb.rgw.credential`` resource. Unlike local
+   clusters where credentials can be auto-fetched, external clusters cannot
+   automatically retrieve S3 access keys.
+
+   Example configuration with manual RGW credentials:
+
+   .. code-block:: yaml
+
+       resources:
+         # Define the external cluster with rgw_user
+         - resource_type: ceph.smb.ext.cluster
+           external_ceph_cluster_id: external-rgw
+           cluster:
+             fsid: "12345678-1234-1234-1234-123456789abc"
+             mon_host: "10.0.1.10:6789,10.0.1.11:6789"
+             rgw_user:
+               name: "client.external-rgw"
+               key: "AQD9876543210zyxwvutsrqponmlkjihgfedcba=="
+
+         # Define RGW credentials manually (REQUIRED for external clusters)
+         - resource_type: ceph.smb.rgw.credential
+           rgw_credential_id: my-s3-creds
+           user_id: s3-user
+           access_key_id: AKIAIOSFODNN7EXAMPLE
+           secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+
+         # RGW share referencing the manual credentials
+         - resource_type: ceph.smb.share
+           cluster_id: my-cluster
+           share_id: s3-share
+           name: "S3 Share"
+           rgw:
+             bucket: my-bucket
+             credential_ref: my-s3-creds
+
+   The ``rgw_user`` in the external cluster definition provides the CephX
+   credentials for accessing the RGW service, while the ``ceph.smb.rgw.credential``
+   resource provides the S3 access key and secret key for bucket operations.
 
 
 A Declarative Configuration Example

--- a/src/pybind/mgr/cephadm/services/smb.py
+++ b/src/pybind/mgr/cephadm/services/smb.py
@@ -609,20 +609,23 @@ def _to_conf(ext_cluster: SMBExternalCephCluster) -> str:
 
 
 def _to_keyring(ext_cluster: SMBExternalCephCluster) -> str:
-    return '\n'.join(
-        [
-            f'[{ext_cluster.user}]',
-            f'key = {ext_cluster.key}',
-            '',
-        ]
-    )
+    entries = []
+    if ext_cluster.user and ext_cluster.key:
+        entries += [f'[{ext_cluster.user}]', f'key = {ext_cluster.key}', '']
+    if ext_cluster.rgw_user and ext_cluster.rgw_key:
+        entries += [f'[{ext_cluster.rgw_user}]', f'key = {ext_cluster.rgw_key}', '']
+    return '\n'.join(entries)
 
 
 def _hash_ceph_cluster_config(spec: SMBExternalCephCluster) -> str:
-    _fields = ['alias', 'fsid', 'mon_host', 'user', 'key']
+    _fields = ['alias', 'fsid', 'mon_host', 'user', 'key', 'rgw_user', 'rgw_key']
     fdg = hashlib.sha256()
     for field_name in _fields:
-        fdg.update(getattr(spec, field_name, '').encode())
+        value = getattr(spec, field_name, '')
+        # Handle None values explicitly
+        if value is None:
+            value = ''
+        fdg.update(value.encode())
     return f'sha256:{fdg.hexdigest()}'
 
 

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -881,21 +881,35 @@ class _ClusterConf:
             str
         ] = []  # passed to cephadm service spec
         ceph_cluster = ''  # empty string means local cluster
+
+        has_cephfs_shares = any(
+            s.cephfs is not None for s in change_group.shares
+        )
+        has_rgw_shares = any(s.rgw is not None for s in change_group.shares)
+
         if extcc:
             log.debug('external ceph cluster')
             resolver = ExoResolver(change_group.cluster)
             ceph_cluster = 'exo'
-            cephx_entity = checked(extcc.cluster).cephfs_user.name
-            cephfs_entity = cephx_entity
-            cephadm_data_entities = [cephx_entity]
+
+            # Handle CephFS user if available and needed
+            if has_cephfs_shares:
+                if not extcc.cluster or not extcc.cluster.cephfs_user:
+                    raise ValueError(
+                        'External cluster must have cephfs_user configured for CephFS shares'
+                    )
+
+                cephx_entity = extcc.cluster.cephfs_user.name
+                cephfs_entity = cephx_entity
+            # Handle RGW user if available and needed
+            if has_rgw_shares:
+                if not extcc.cluster or not extcc.cluster.rgw_user:
+                    raise ValueError(
+                        'External cluster must have rgw_user configured for RGW shares'
+                    )
+                log.debug('external ceph cluster with RGW shares')
+                rgw_entity = extcc.cluster.rgw_user.name
         elif change_group.shares:
-            # Check if we have any CephFS shares that need CephX auth
-            has_cephfs_shares = any(
-                s.cephfs is not None for s in change_group.shares
-            )
-            has_rgw_shares = any(
-                s.rgw is not None for s in change_group.shares
-            )
             if has_cephfs_shares:
                 log.debug('local ceph cluster with CephFS shares')
                 cephfs_entity = _cephx_data_entity(change_group.cluster)
@@ -1190,10 +1204,28 @@ def _generate_config(conf: _ClusterConf) -> Dict[str, Any]:
             '',
         )
         if rgw_entity:
-            cluster_global_opts[
-                'ceph_rgw:config_file'
-            ] = '/etc/ceph/ceph.conf'
-            cluster_global_opts['ceph_rgw:keyring_file'] = '/etc/ceph/keyring'
+            # Check if this is an external cluster
+            is_external_cluster = any(
+                share.ceph_cluster == 'exo'
+                for share in conf.shares
+                if share.resource.rgw
+            )
+
+            if is_external_cluster:
+                cluster_global_opts[
+                    'ceph_rgw:config_file'
+                ] = '/etc/ceph/exo.ceph.conf'
+                cluster_global_opts[
+                    'ceph_rgw:keyring_file'
+                ] = '/etc/ceph/exo.ceph.keyring'
+            else:
+                cluster_global_opts[
+                    'ceph_rgw:config_file'
+                ] = '/etc/ceph/ceph.conf'
+                cluster_global_opts[
+                    'ceph_rgw:keyring_file'
+                ] = '/etc/ceph/keyring'
+
             cluster_global_opts['ceph_rgw:id'] = cephx_stripped_entity(
                 rgw_entity
             )
@@ -1350,13 +1382,28 @@ def _generate_smb_service_spec(
     ceph_cluster_configs = None
     if ext_ceph_cluster:
         exo = checked(ext_ceph_cluster.cluster)
+
+        rgw_user = None
+        rgw_key = None
+        cephfs_user = None
+        cephfs_key = None
+
+        if exo.rgw_user:
+            rgw_user = exo.rgw_user.name
+            rgw_key = exo.rgw_user.key
+        if exo.cephfs_user:
+            cephfs_user = exo.cephfs_user.name
+            cephfs_key = exo.cephfs_user.key
+
         ceph_cluster_configs = [
             SMBExternalCephCluster(
                 alias='exo',
                 fsid=exo.fsid,
                 mon_host=exo.mon_host,
-                user=exo.cephfs_user.name,
-                key=exo.cephfs_user.key,
+                user=cephfs_user,
+                key=cephfs_key,
+                rgw_user=rgw_user,
+                rgw_key=rgw_key,
             )
         ]
     return SMBSpec(

--- a/src/pybind/mgr/smb/resources.py
+++ b/src/pybind/mgr/smb/resources.py
@@ -1249,7 +1249,18 @@ class ExternalCephClusterValues(_RBase):
 
     fsid: str
     mon_host: str
-    cephfs_user: CephUserKey
+    cephfs_user: Optional[CephUserKey] = None
+    rgw_user: Optional[CephUserKey] = None
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self) -> None:
+        """Validate that at least one user (cephfs_user or rgw_user) is configured."""
+        if not self.cephfs_user and not self.rgw_user:
+            raise ValueError(
+                'At least one of cephfs_user or rgw_user must be configured'
+            )
 
 
 @resourcelib.resource('ceph.smb.ext.cluster')

--- a/src/pybind/mgr/smb/staging.py
+++ b/src/pybind/mgr/smb/staging.py
@@ -376,9 +376,26 @@ def _check_share_resource(
 
     # Handle RGW shares
     if share.rgw is not None:
+        # Check if cluster uses external Ceph cluster
+        cluster = staging.get_cluster(share.cluster_id)
+        is_external_cluster = (
+            cluster.external_ceph_cluster is not None
+            and cluster.external_ceph_cluster.ref
+        )
+
         # If credential_ref is not provided, auto-create credential
         if not share.rgw.credential_ref:
-            # Fetch credentials from RGW
+            # For external clusters, require explicit credential_ref
+            if is_external_cluster:
+                raise ErrorResult(
+                    share,
+                    msg=(
+                        "RGW shares with external clusters require explicit 'credential_ref'. "
+                        "Create an RGWCredential resource and reference it in the share."
+                    ),
+                )
+
+            # Fetch credentials from RGW (LOCAL cluster only)
             try:
                 (
                     fetched_user_id,
@@ -455,14 +472,17 @@ def _check_share_resource(
                         'other_cluster_id': cred.linked_to_cluster,
                     },
                 )
-        # Validate bucket exists
-        if not rgw.validate_rgw_bucket(
-            staging._tool_execer, share.rgw.bucket
-        ):
-            raise ErrorResult(
-                share,
-                msg=f"RGW bucket '{share.rgw.bucket}' does not exist or is not accessible",
-            )
+        # Validate bucket exists (skip for external clusters)
+        if not is_external_cluster:
+            if not rgw.validate_rgw_bucket(
+                staging._tool_execer, share.rgw.bucket
+            ):
+                raise ErrorResult(
+                    share,
+                    msg=f"RGW bucket '{share.rgw.bucket}' does not exist or is not accessible",
+                )
+        # For external clusters, skip bucket validation
+        # User must ensure bucket exists on external cluster
 
         name_used_by = _share_name_in_use(staging, share)
         if name_used_by:

--- a/src/pybind/mgr/smb/tests/test_rgw_shares.py
+++ b/src/pybind/mgr/smb/tests/test_rgw_shares.py
@@ -506,3 +506,360 @@ def test_multi_share_stub_covers_all_rgw_shares(split_handler):
     assert b1opts['ceph_rgw:secret_access_key'] == 'AUTO_FETCHED_SECRET_KEY'
     assert b2opts['ceph_rgw:access_key'] == 'AUTO_FETCHED_ACCESS_KEY'
     assert b2opts['ceph_rgw:secret_access_key'] == 'AUTO_FETCHED_SECRET_KEY'
+
+
+# ---- External Cluster RGW Share Tests ----
+
+
+def test_external_cluster_rgw_only(thandler):
+    """Test external cluster with RGW user only (no CephFS user)."""
+    ext_cluster = smb.resources.ExternalCephCluster(
+        external_ceph_cluster_id='exo-rgw',
+        cluster=smb.resources.ExternalCephClusterValues(
+            fsid='12345678-1234-1234-1234-123456789abc',
+            mon_host='10.0.1.10:6789',
+            rgw_user=smb.resources.CephUserKey(
+                name='client.rgw.exo',
+                key='AQExternalRGWKey==',
+            ),
+        ),
+    )
+    cluster = _cluster(
+        cluster_id='exo-rgw',
+        auth_mode=smb.enums.AuthMode.USER,
+        external_ceph_cluster=smb.resources.ExternalCephClusterSource(
+            ref='exo-rgw',
+        ),
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.EMPTY,
+            ),
+        ],
+    )
+    # Add RGW credential (required for external clusters)
+    credential = smb.resources.RGWCredential(
+        rgw_credential_id='exo-user',
+        user_id='exo-user',
+        access_key_id='EXTERNAL_ACCESS_KEY',
+        secret_access_key='EXTERNAL_SECRET_KEY',
+    )
+    share = smb.resources.Share(
+        cluster_id='exo-rgw',
+        share_id='exo-bucket',
+        name='External Bucket',
+        rgw=smb.resources.RGWStorage(
+            bucket='external-bucket',
+            user_id='exo-user',
+            credential_ref='exo-user',
+        ),
+    )
+
+    rg = thandler.apply([ext_cluster, cluster, credential, share])
+    assert rg.success, rg.to_simplified()
+
+    # Verify external cluster was stored
+    assert ('ext_ceph_clusters', 'exo-rgw') in thandler.internal_store.data
+    ext_data = thandler.internal_store.data[('ext_ceph_clusters', 'exo-rgw')]
+    assert (
+        ext_data['cluster']['fsid'] == '12345678-1234-1234-1234-123456789abc'
+    )
+    assert ext_data['cluster']['rgw_user']['name'] == 'client.rgw.exo'
+    assert 'cephfs_user' not in ext_data['cluster']
+
+    # Verify share was created
+    assert ('shares', 'exo-rgw.exo-bucket') in thandler.internal_store.data
+
+    # Verify RGW credential was auto-created
+    assert ('rgw_creds', 'exo-user') in thandler.internal_store.data
+
+
+def test_external_cluster_mixed_users(thandler):
+    """Test external cluster with both CephFS and RGW users."""
+    ext_cluster = smb.resources.ExternalCephCluster(
+        external_ceph_cluster_id='exo-mixed',
+        cluster=smb.resources.ExternalCephClusterValues(
+            fsid='12345678-1234-1234-1234-123456789abc',
+            mon_host='10.0.1.10:6789',
+            cephfs_user=smb.resources.CephUserKey(
+                name='client.fs.exo',
+                key='AQExternalFSKey==',
+            ),
+            rgw_user=smb.resources.CephUserKey(
+                name='client.rgw.exo',
+                key='AQExternalRGWKey==',
+            ),
+        ),
+    )
+    cluster = _cluster(
+        cluster_id='exo-mixed',
+        auth_mode=smb.enums.AuthMode.USER,
+        external_ceph_cluster=smb.resources.ExternalCephClusterSource(
+            ref='exo-mixed',
+        ),
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.EMPTY,
+            ),
+        ],
+    )
+    cephfs_share = smb.resources.Share(
+        cluster_id='exo-mixed',
+        share_id='fs-share',
+        name='FS Share',
+        cephfs=smb.resources.CephFSStorage(
+            volume='cephfs',
+            path='/data',
+        ),
+    )
+    # Add RGW credential (required for external clusters)
+    credential = smb.resources.RGWCredential(
+        rgw_credential_id='mixed-user',
+        user_id='mixed-user',
+        access_key_id='EXTERNAL_ACCESS_KEY',
+        secret_access_key='EXTERNAL_SECRET_KEY',
+    )
+    rgw_share = smb.resources.Share(
+        cluster_id='exo-mixed',
+        share_id='rgw-share',
+        name='RGW Share',
+        rgw=smb.resources.RGWStorage(
+            bucket='mixed-bucket',
+            user_id='mixed-user',
+            credential_ref='mixed-user',
+        ),
+    )
+
+    rg = thandler.apply(
+        [ext_cluster, cluster, cephfs_share, credential, rgw_share]
+    )
+    assert rg.success, rg.to_simplified()
+
+    # Verify external cluster has both users
+    ext_data = thandler.internal_store.data[
+        ('ext_ceph_clusters', 'exo-mixed')
+    ]
+    assert ext_data['cluster']['cephfs_user']['name'] == 'client.fs.exo'
+    assert ext_data['cluster']['rgw_user']['name'] == 'client.rgw.exo'
+
+    # Verify both shares were created
+    assert ('shares', 'exo-mixed.fs-share') in thandler.internal_store.data
+    assert ('shares', 'exo-mixed.rgw-share') in thandler.internal_store.data
+
+    # Verify RGW credential was auto-created
+    assert ('rgw_creds', 'mixed-user') in thandler.internal_store.data
+
+
+def test_external_cluster_multiple_rgw_shares(thandler):
+    """Test multiple RGW shares on external cluster."""
+    ext_cluster = smb.resources.ExternalCephCluster(
+        external_ceph_cluster_id='exo-multi',
+        cluster=smb.resources.ExternalCephClusterValues(
+            fsid='12345678-1234-1234-1234-123456789abc',
+            mon_host='10.0.1.10:6789',
+            rgw_user=smb.resources.CephUserKey(
+                name='client.rgw.exo',
+                key='AQExternalRGWKey==',
+            ),
+        ),
+    )
+    cluster = _cluster(
+        cluster_id='exo-multi',
+        auth_mode=smb.enums.AuthMode.USER,
+        external_ceph_cluster=smb.resources.ExternalCephClusterSource(
+            ref='exo-multi',
+        ),
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.EMPTY,
+            ),
+        ],
+    )
+    # Add RGW credentials (required for external clusters)
+    credential1 = smb.resources.RGWCredential(
+        rgw_credential_id='exo-user-1',
+        user_id='exo-user-1',
+        access_key_id='EXTERNAL_ACCESS_KEY_1',
+        secret_access_key='EXTERNAL_SECRET_KEY_1',
+    )
+    credential2 = smb.resources.RGWCredential(
+        rgw_credential_id='exo-user-2',
+        user_id='exo-user-2',
+        access_key_id='EXTERNAL_ACCESS_KEY_2',
+        secret_access_key='EXTERNAL_SECRET_KEY_2',
+    )
+    share1 = smb.resources.Share(
+        cluster_id='exo-multi',
+        share_id='bucket1',
+        name='Bucket 1',
+        rgw=smb.resources.RGWStorage(
+            bucket='exo-bucket-1',
+            user_id='exo-user-1',
+            credential_ref='exo-user-1',
+        ),
+    )
+    share2 = smb.resources.Share(
+        cluster_id='exo-multi',
+        share_id='bucket2',
+        name='Bucket 2',
+        rgw=smb.resources.RGWStorage(
+            bucket='exo-bucket-2',
+            user_id='exo-user-2',
+            credential_ref='exo-user-2',
+        ),
+    )
+
+    rg = thandler.apply(
+        [ext_cluster, cluster, credential1, credential2, share1, share2]
+    )
+    assert rg.success, rg.to_simplified()
+
+    # Verify both shares were created
+    shares = thandler.share_ids()
+    assert len(shares) == 2
+    assert ('exo-multi', 'bucket1') in shares
+    assert ('exo-multi', 'bucket2') in shares
+
+    # Verify credentials were auto-created for both users
+    assert ('rgw_creds', 'exo-user-1') in thandler.internal_store.data
+    assert ('rgw_creds', 'exo-user-2') in thandler.internal_store.data
+
+
+def test_external_cluster_rgw_credential_isolation(split_handler):
+    """Test RGW credentials on external cluster are properly isolated."""
+    h, pub, priv = split_handler
+
+    ext_cluster = smb.resources.ExternalCephCluster(
+        external_ceph_cluster_id='exo-iso',
+        cluster=smb.resources.ExternalCephClusterValues(
+            fsid='12345678-1234-1234-1234-123456789abc',
+            mon_host='10.0.1.10:6789',
+            rgw_user=smb.resources.CephUserKey(
+                name='client.rgw.exo',
+                key='AQExternalRGWKey==',
+            ),
+        ),
+    )
+    cluster = _cluster(
+        cluster_id='exo-iso',
+        auth_mode=smb.enums.AuthMode.USER,
+        external_ceph_cluster=smb.resources.ExternalCephClusterSource(
+            ref='exo-iso',
+        ),
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.EMPTY,
+            ),
+        ],
+    )
+    # Add RGW credential (required for external clusters)
+    credential = smb.resources.RGWCredential(
+        rgw_credential_id='iso-user',
+        user_id='iso-user',
+        access_key_id='EXTERNAL_ACCESS_KEY',
+        secret_access_key='EXTERNAL_SECRET_KEY',
+    )
+    share = smb.resources.Share(
+        cluster_id='exo-iso',
+        share_id='iso-bucket',
+        name='Isolated Bucket',
+        rgw=smb.resources.RGWStorage(
+            bucket='iso-bucket',
+            user_id='iso-user',
+            credential_ref='iso-user',
+        ),
+    )
+
+    rg = h.apply([ext_cluster, cluster, credential, share])
+    assert rg.success, rg.to_simplified()
+
+    # Verify credential was auto-created
+    assert ('rgw_creds', 'iso-user') in h.internal_store.data
+
+    # Verify public config has empty credential values
+    pub_cfg = pub['exo-iso', 'config.smb'].get()
+    opts = pub_cfg['shares']['Isolated Bucket']['options']
+    assert opts['ceph_rgw:access_key'] == ''
+    assert opts['ceph_rgw:secret_access_key'] == ''
+
+    # Verify private store has real credential values
+    stub = priv['exo-iso', 'config.smb.rgw'].get()
+    merge_opts = stub['config:merge']['shares']['Isolated Bucket']['options']
+    assert merge_opts['ceph_rgw:access_key'] == 'EXTERNAL_ACCESS_KEY'
+    assert merge_opts['ceph_rgw:secret_access_key'] == 'EXTERNAL_SECRET_KEY'
+
+
+def test_external_cluster_rgw_share_removal(thandler):
+    """Test removing RGW share from external cluster."""
+    ext_cluster = smb.resources.ExternalCephCluster(
+        external_ceph_cluster_id='exo-rm',
+        cluster=smb.resources.ExternalCephClusterValues(
+            fsid='12345678-1234-1234-1234-123456789abc',
+            mon_host='10.0.1.10:6789',
+            rgw_user=smb.resources.CephUserKey(
+                name='client.rgw.exo',
+                key='AQExternalRGWKey==',
+            ),
+        ),
+    )
+    cluster = _cluster(
+        cluster_id='exo-rm',
+        auth_mode=smb.enums.AuthMode.USER,
+        external_ceph_cluster=smb.resources.ExternalCephClusterSource(
+            ref='exo-rm',
+        ),
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.EMPTY,
+            ),
+        ],
+    )
+    # Add RGW credential (required for external clusters)
+    credential = smb.resources.RGWCredential(
+        rgw_credential_id='rm-user',
+        user_id='rm-user',
+        access_key_id='EXTERNAL_ACCESS_KEY',
+        secret_access_key='EXTERNAL_SECRET_KEY',
+    )
+    share = smb.resources.Share(
+        cluster_id='exo-rm',
+        share_id='rm-bucket',
+        name='Remove Bucket',
+        rgw=smb.resources.RGWStorage(
+            bucket='rm-bucket',
+            user_id='rm-user',
+            credential_ref='rm-user',
+        ),
+    )
+
+    # Create the share
+    rg = thandler.apply([ext_cluster, cluster, credential, share])
+    assert rg.success, rg.to_simplified()
+
+    # Verify external cluster and share were created
+    assert ('ext_ceph_clusters', 'exo-rm') in thandler.internal_store.data
+    assert ('shares', 'exo-rm.rm-bucket') in thandler.internal_store.data
+
+    # Remove the share
+    rmshare = smb.resources.RemovedShare(
+        cluster_id='exo-rm',
+        share_id='rm-bucket',
+    )
+    rg = thandler.apply([rmshare])
+    assert rg.success, rg.to_simplified()
+
+    # Verify share was removed
+    shares = thandler.share_ids()
+    assert ('exo-rm', 'rm-bucket') not in shares
+    assert ('shares', 'exo-rm.rm-bucket') not in thandler.internal_store.data
+
+
+def test_external_cluster_no_user_validation(thandler):
+    """Test that external cluster requires at least one user."""
+    # Try to create external cluster values without any users (should fail during validation)
+    with pytest.raises(
+        ValueError, match='At least one of cephfs_user or rgw_user'
+    ):
+        smb.resources.ExternalCephClusterValues(
+            fsid='12345678-1234-1234-1234-123456789abc',
+            mon_host='10.0.1.10:6789',
+        )

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -4041,14 +4041,18 @@ class SMBExternalCephCluster:
         fsid: str,
         mon_host: str,
         # default user and key
-        user: str,
-        key: str,
+        user: Optional[str] = None,
+        key: Optional[str] = None,
+        rgw_user: Optional[str] = None,
+        rgw_key: Optional[str] = None,
     ) -> None:
         self.alias = alias
         self.fsid = fsid
         self.mon_host = mon_host
         self.user = user
         self.key = key
+        self.rgw_user = rgw_user
+        self.rgw_key = rgw_key
         self.validate()
 
     def validate(self) -> None:
@@ -4058,25 +4062,60 @@ class SMBExternalCephCluster:
             raise SpecValidationError('an fsid value is required')
         if not self.mon_host:
             raise SpecValidationError('a mon_host value is required')
-        if not self.user:
-            raise SpecValidationError('a default user name is required')
-        if not self.key:
-            raise SpecValidationError('a default key is required')
+
+        # Validate CephFS credentials (user+key pair)
+        has_user = self.user is not None and self.user != ''
+        has_key = self.key is not None and self.key != ''
+        if has_user != has_key:
+            raise SpecValidationError(
+                'CephFS credentials must be provided as a complete pair: '
+                'both user and key are required if either is specified'
+            )
+
+        # Validate RGW credentials (rgw_user+rgw_key pair)
+        has_rgw_user = self.rgw_user is not None and self.rgw_user != ''
+        has_rgw_key = self.rgw_key is not None and self.rgw_key != ''
+        if has_rgw_user != has_rgw_key:
+            raise SpecValidationError(
+                'RGW credentials must be provided as a complete pair: '
+                'both rgw_user and rgw_key are required if either is specified'
+            )
+
+        # Ensure at least one complete credential pair is provided
+        has_cephfs_creds = has_user and has_key
+        has_rgw_creds = has_rgw_user and has_rgw_key
+        if not has_cephfs_creds and not has_rgw_creds:
+            raise SpecValidationError(
+                'at least one complete credential pair is required: '
+                'either (user+key) for CephFS or (rgw_user+rgw_key) for RGW'
+            )
 
     def __repr__(self) -> str:
-        _names = ['alias', 'fsid', 'mon_host', 'user', 'key']
+        _names = ['alias', 'fsid', 'mon_host', 'user', 'key', 'rgw_user', 'rgw_key']
         fields = ', '.join(f'{n}={getattr(self, n, "")!r}' for n in _names)
         return f'{self.__class__.__name__}({fields})'
 
     def to_simplified(self) -> Dict[str, Any]:
         """Return a serializable representation of SMBExternalCephCluster."""
-        return {
+        result: Dict[str, Any] = {
             'alias': self.alias,
             'fsid': self.fsid,
             'mon_host': self.mon_host,
-            'user': self.user,
-            'key': self.key,
         }
+
+        # Only include CephFS credentials if they are set
+        if self.user:
+            result['user'] = self.user
+        if self.key:
+            result['key'] = self.key
+
+        # Only include RGW credentials if they are set
+        if self.rgw_user:
+            result['rgw_user'] = self.rgw_user
+        if self.rgw_key:
+            result['rgw_key'] = self.rgw_key
+
+        return result
 
     def to_json(self) -> Dict[str, Any]:
         """Return a JSON-compatible dict."""


### PR DESCRIPTION
 Implement support for creating RGW-backed SMB shares on external Ceph
 clusters with user configuration.
    
 Fixes: https://tracker.ceph.com/issues/77784


## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [X] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

