### PR TITLE
mgr/dashboard: resolve e2e cephfs snapshot test flakyness

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/table-helper.feature.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/table-helper.feature.po.ts
@@ -1,5 +1,7 @@
 import { And, Then, When } from 'cypress-cucumber-preprocessor/steps';
 
+const expandedRow = () => cy.get('[data-testid="datatable-row-detail"]');
+
 // When you are clicking on an action in the table actions dropdown button
 When('I click on {string} button from the table actions', (button: string) => {
   cy.get(`[aria-label="${button}"]`).click({ force: true });
@@ -38,9 +40,20 @@ When('I select a row {string}', (row: string) => {
 });
 
 When('I select a row {string} in the expanded row', (row: string) => {
-  cy.get('[data-testid="datatable-row-detail"]').within(() => {
+  expandedRow().within(() => {
     cy.get('.cds--search-input').first().clear().type(row);
-    cy.contains(`[cdstablerow] [cdstabledata]`, row).click();
+    cy.contains('[cdstablerow] [cdstabledata]', row).should('exist').click();
+  });
+});
+
+/**
+ * Waits for an expanded-row cd-table to finish loading before row search/selection.
+ */
+And('the table in the expanded row is ready', () => {
+  expandedRow().within(() => {
+    cy.get('cd-loading-panel').should('not.exist');
+    cy.get('cd-table').should('exist');
+    cy.get('.cds--search-input').should('be.visible');
   });
 });
 
@@ -62,7 +75,10 @@ Then('I should see a table in the expanded row', () => {
 });
 
 Then('I should not see a row with {string} in the expanded row', (row: string) => {
-  cy.get('[data-testid="datatable-row-detail"]').within(() => {
+  expandedRow().within(() => {
+    cy.get('cd-loading-panel').should('not.exist');
+    cy.get('cds-icon-button.toolbar-action').first().click();
+    cy.get('cd-loading-panel').should('not.exist');
     cy.get('.cds--search-input').first().clear().type(row);
     cy.contains(`[cdstablerow] [cdstabledata]`, row).should('not.exist');
   });

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/snapshots.e2e-spec.feature
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/snapshots.e2e-spec.feature
@@ -37,6 +37,7 @@ Feature: CephFS Snapshot Management
         Given I am on the "cephfs" page
         When I expand the row "test_cephfs"
         And I go to the "Snapshots" tab
+        And the table in the expanded row is ready
         And I click on "Create" button from the expanded row
         And enter "snapshotName" "test_snapshot" in the carbon modal
         And I click on "Create Snapshot" button
@@ -46,7 +47,9 @@ Feature: CephFS Snapshot Management
         Given I am on the "cephfs" page
         When I expand the row "test_cephfs"
         And I go to the "Snapshots" tab
-        And I select a row "test_snapshot" in the expanded row
+        And the table in the expanded row is ready
+        Then I should see a row with "test_snapshot" in the expanded row
+        When I select a row "test_snapshot" in the expanded row
         And I click on "Clone" button from the table actions in the expanded row
         And enter "cloneName" "test_clone" in the carbon modal
         And I click on "Create Clone" button
@@ -58,6 +61,7 @@ Feature: CephFS Snapshot Management
         Given I am on the "cephfs" page
         When I expand the row "test_cephfs"
         And I go to the "Subvolumes" tab
+        And the table in the expanded row is ready
         And I select a row "test_clone" in the expanded row
         And I click on "Remove" button from the table actions in the expanded row
         And I confirm the resource "test_clone"
@@ -69,7 +73,8 @@ Feature: CephFS Snapshot Management
         Given I am on the "cephfs" page
         When I expand the row "test_cephfs"
         And I go to the "Snapshots" tab
-        And I select a row "test_snapshot" in the expanded row
+        And the table in the expanded row is ready
+        When I select a row "test_snapshot" in the expanded row
         And I click on "Remove" button from the table actions in the expanded row
         And I confirm the resource "test_snapshot"
         And I click on "Remove Snapshot" button


### PR DESCRIPTION
Test were originally passing on my local but had to be run a couple times due timing issues. This PR intends to fix these tests flakiness.

<img width="473" height="440" alt="image" src="https://github.com/user-attachments/assets/5bcc2a1f-c58a-4fae-8d0e-38d38f309101" />


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
