### PR TITLE
qa/cephfs: cephfs-mirror qa runtime and logging improvements

### DIFF
--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -47,7 +47,9 @@ def retry_assert(timeout=60, interval=1):
             last_exc = None
             attempt = 1
 
-            with safe_while(sleep=interval, tries=tries, action=f"retry {func.__name__}") as proceed:
+            with safe_while(sleep=interval, tries=tries,
+                            action=f"retry {func.__name__}",
+                            _raise=False) as proceed:
                 while proceed():
                     try:
                         return func(*args, **kwargs)
@@ -55,18 +57,24 @@ def retry_assert(timeout=60, interval=1):
                         last_exc = e
                         log.debug(
                             f"[retry_assert] {func.__name__}: "
-                            f"attempt {attempt} failed ({type(e).__name__}), retrying..."
+                            f"attempt {attempt} failed ({type(e).__name__}): {e}, "
+                            f"retrying..."
                         )
                         attempt += 1
             # Final failure
+            last_reason = str(last_exc) if last_exc else ''
             if last_exc is not None and hasattr(last_exc, "res"):
                 log.error("\n--- Last peer status (res) ---")
                 log.error(last_exc.res)
+            if last_reason:
+                log.error(
+                    f"[retry_assert] {func.__name__}: last failure: {last_reason}")
 
-            raise AssertionError(
-                f"{func.__name__} did not succeed within {timeout}s "
-                f"after {attempt - 1} attempts"
-            ) from last_exc
+            msg = (f"{func.__name__} did not succeed within {timeout}s "
+                   f"after {attempt - 1} attempts")
+            if last_reason:
+                msg = f"{msg}: {last_reason}"
+            raise AssertionError(msg) from last_exc
 
         return wrapper
     return decorator

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -32,7 +32,8 @@ def parse_sync_time_stamp(ts):
 
 
 # Exceptions to retry in test assertions
-RETRY_EXCEPTIONS = (AssertionError, KeyError, IndexError, CommandFailedError)
+RETRY_EXCEPTIONS = (AssertionError, KeyError, IndexError, CommandFailedError,
+                     json.JSONDecodeError)
 # retry decorator
 def retry_assert(timeout=60, interval=1):
     """
@@ -154,8 +155,19 @@ class TestMirroring(CephFSTestCase):
         asok_stat = self.peer_dir_status(asok_res, dir_path, peer_uuid)
         if expected_state is not None:
             self.assertEqual(asok_stat['state'], expected_state)
+            # omap can lag the asok; require mgr to show the same state before
+            # the multi-call scope walk so we do not compare syncing asok to
+            # default-idle omap metrics.
+            mgr_stat = self.dir_status_from_mgr(fs_name, dir_path, peer_uuid)
+            self.assertEqual(mgr_stat['state'], expected_state,
+                             msg=f'mgr not yet {expected_state}: {mgr_stat}')
         self.assert_mgr_mirror_status_scopes(
             fs_name, dir_path, peer_uuid, expected_dirs, asok_res)
+        if expected_state is not None:
+            # Sync may finish during the scope walk; retry while still active.
+            asok_after = self.dir_status_from_asok(
+                fs_name, fs_id, dir_path, peer_uuid)
+            self.assertEqual(asok_after['state'], expected_state)
 
     def tearDown(self):
         self.disable_mirroring_module()
@@ -198,48 +210,128 @@ class TestMirroring(CephFSTestCase):
                 if dirmap.get('state') == 'mapped':
                     return
 
+    @retry_assert(timeout=60, interval=1)
+    def _wait_mirroring_enabled(self, fs_name, fs_id, vbefore):
+        res = self.mirror_daemon_command(f'mirror status for fs: {fs_name}',
+                                         'fs', 'mirror', 'status', f'{fs_name}@{fs_id}')
+        self.assertEqual(res['peers'], {})
+        self.assertEqual(res['snap_dirs']['dir_count'], 0)
+
+        res = self.mirror_daemon_command(f'counter dump for fs: {fs_name}', 'counter', 'dump')
+        self.assertEqual(
+            res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_FS][0]["labels"]["filesystem"],
+            fs_name)
+        vafter = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR][0]
+        self.assertGreater(vafter["counters"]["mirrored_filesystems"],
+                           vbefore["counters"]["mirrored_filesystems"])
+
+    @retry_assert(timeout=30, interval=1)
+    def _wait_mirroring_disabled(self, fs_name, fs_id, vbefore):
+        try:
+            self.mirror_daemon_command(f'mirror status for fs: {fs_name}',
+                                       'fs', 'mirror', 'status', f'{fs_name}@{fs_id}')
+        except (CommandFailedError, json.JSONDecodeError):
+            pass
+        else:
+            raise AssertionError('expected admin socket to be unavailable')
+
+        res = self.mirror_daemon_command(f'counter dump for fs: {fs_name}', 'counter', 'dump')
+        vafter = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR][0]
+        self.assertLess(vafter["counters"]["mirrored_filesystems"],
+                        vbefore["counters"]["mirrored_filesystems"])
+
+    @retry_assert(timeout=30, interval=1)
+    def _wait_mirror_asok_unavailable(self, fs_name, fs_id):
+        try:
+            self.mirror_daemon_command(f'mirror status for fs: {fs_name}',
+                                       'fs', 'mirror', 'status', f'{fs_name}@{fs_id}')
+        except (CommandFailedError, json.JSONDecodeError):
+            pass
+        else:
+            raise AssertionError('expected admin socket to be unavailable')
+
+    @retry_assert(timeout=30, interval=1)
+    def _wait_peer_added(self, fs_name, fs_id, peer_spec, remote_fs_name,
+                         vbefore, check_perf_counter):
+        self.verify_peer_added(fs_name, fs_id, peer_spec, remote_fs_name)
+        if not check_perf_counter:
+            return
+        res = self.mirror_daemon_command(f'counter dump for fs: {fs_name}', 'counter', 'dump')
+        vafter = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_FS][0]
+        self.assertGreater(vafter["counters"]["mirroring_peers"],
+                           vbefore["counters"]["mirroring_peers"])
+
+    @retry_assert(timeout=30, interval=1)
+    def _wait_peer_removed(self, fs_name, fs_id, vbefore):
+        res = self.mirror_daemon_command(f'mirror status for fs: {fs_name}',
+                                         'fs', 'mirror', 'status', f'{fs_name}@{fs_id}')
+        self.assertEqual(res['peers'], {})
+        self.assertEqual(res['snap_dirs']['dir_count'], 0)
+
+        res = self.mirror_daemon_command(f'counter dump for fs: {fs_name}', 'counter', 'dump')
+        vafter = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_FS][0]
+        self.assertLess(vafter["counters"]["mirroring_peers"],
+                        vbefore["counters"]["mirroring_peers"])
+
+    @retry_assert(timeout=30, interval=1)
+    def _wait_directory_added(self, fs_name, fs_id, dir_count, vbefore,
+                              check_perf_counter):
+        res = self.mirror_daemon_command(f'mirror status for fs: {fs_name}',
+                                         'fs', 'mirror', 'status', f'{fs_name}@{fs_id}')
+        new_dir_count = res['snap_dirs']['dir_count']
+        log.debug(f'new dir_count={new_dir_count}')
+        self.assertGreater(new_dir_count, dir_count)
+
+        if not check_perf_counter:
+            return
+        res = self.mirror_daemon_command(f'counter dump for fs: {fs_name}', 'counter', 'dump')
+        vafter = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_FS][0]
+        self.assertGreater(vafter["counters"]["directory_count"],
+                           vbefore["counters"]["directory_count"])
+
+    @retry_assert(timeout=30, interval=1)
+    def _wait_directory_absent_from_mirror(self, fs_name, dir_name):
+        dirs_list = json.loads(
+            self.get_ceph_cmd_stdout("fs", "snapshot", "mirror", "ls", fs_name))
+        self.assertNotIn(dir_name, dirs_list)
+
+    @retry_assert(timeout=30, interval=1)
+    def _wait_directory_removed(self, fs_name, fs_id, dir_count, vbefore):
+        res = self.mirror_daemon_command(f'mirror status for fs: {fs_name}',
+                                         'fs', 'mirror', 'status', f'{fs_name}@{fs_id}')
+        new_dir_count = res['snap_dirs']['dir_count']
+        log.debug(f'new dir_count={new_dir_count}')
+        self.assertLess(new_dir_count, dir_count)
+
+        res = self.mirror_daemon_command(f'counter dump for fs: {fs_name}', 'counter', 'dump')
+        vafter = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_FS][0]
+        self.assertLess(vafter["counters"]["directory_count"],
+                        vbefore["counters"]["directory_count"])
+
+    @retry_assert(timeout=30, interval=1)
+    def _wait_mirror_directory_ls(self, fs_name, fs_id, *dir_names):
+        dirs_list = json.loads(
+            self.get_ceph_cmd_stdout("fs", "snapshot", "mirror", "ls", fs_name))
+        res = self.mirror_daemon_command(f'mirror status for fs: {fs_name}',
+                                         'fs', 'mirror', 'status', f'{fs_name}@{fs_id}')
+        dir_count = res['snap_dirs']['dir_count']
+        self.assertEqual(len(dirs_list), dir_count)
+        for dir_name in dir_names:
+            self.assertIn(dir_name, dirs_list)
+
     def enable_mirroring(self, fs_name, fs_id):
         res = self.mirror_daemon_command(f'counter dump for fs: {fs_name}', 'counter', 'dump')
         vbefore = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR][0]
 
         self.run_ceph_cmd("fs", "snapshot", "mirror", "enable", fs_name)
-        time.sleep(10)
-        # verify via asok
-        res = self.mirror_daemon_command(f'mirror status for fs: {fs_name}',
-                                         'fs', 'mirror', 'status', f'{fs_name}@{fs_id}')
-        self.assertTrue(res['peers'] == {})
-        self.assertTrue(res['snap_dirs']['dir_count'] == 0)
-
-        # verify labelled perf counter
-        res = self.mirror_daemon_command(f'counter dump for fs: {fs_name}', 'counter', 'dump')
-        self.assertEqual(res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_FS][0]["labels"]["filesystem"],
-                         fs_name)
-        vafter = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR][0]
-
-        self.assertGreater(vafter["counters"]["mirrored_filesystems"],
-                           vbefore["counters"]["mirrored_filesystems"])
+        self._wait_mirroring_enabled(fs_name, fs_id, vbefore)
 
     def disable_mirroring(self, fs_name, fs_id):
         res = self.mirror_daemon_command(f'counter dump for fs: {fs_name}', 'counter', 'dump')
         vbefore = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR][0]
 
         self.run_ceph_cmd("fs", "snapshot", "mirror", "disable", fs_name)
-        time.sleep(10)
-        # verify via asok
-        try:
-            self.mirror_daemon_command(f'mirror status for fs: {fs_name}',
-                                       'fs', 'mirror', 'status', f'{fs_name}@{fs_id}')
-        except CommandFailedError:
-            pass
-        else:
-            raise RuntimeError('expected admin socket to be unavailable')
-
-        # verify labelled perf counter
-        res = self.mirror_daemon_command(f'counter dump for fs: {fs_name}', 'counter', 'dump')
-        vafter = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR][0]
-
-        self.assertLess(vafter["counters"]["mirrored_filesystems"],
-                        vbefore["counters"]["mirrored_filesystems"])
+        self._wait_mirroring_disabled(fs_name, fs_id, vbefore)
 
     def verify_peer_added(self, fs_name, fs_id, peer_spec, remote_fs_name=None):
         # verify via asok
@@ -264,13 +356,9 @@ class TestMirroring(CephFSTestCase):
             self.run_ceph_cmd("fs", "snapshot", "mirror", "peer_add", fs_name, peer_spec, remote_fs_name)
         else:
             self.run_ceph_cmd("fs", "snapshot", "mirror", "peer_add", fs_name, peer_spec)
-        time.sleep(10)
-        self.verify_peer_added(fs_name, fs_id, peer_spec, remote_fs_name)
-
-        if check_perf_counter:
-            res = self.mirror_daemon_command(f'counter dump for fs: {fs_name}', 'counter', 'dump')
-            vafter = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_FS][0]
-            self.assertGreater(vafter["counters"]["mirroring_peers"], vbefore["counters"]["mirroring_peers"])
+        self._wait_peer_added(fs_name, fs_id, peer_spec, remote_fs_name,
+                              vbefore if check_perf_counter else None,
+                              check_perf_counter)
 
     def peer_remove(self, fs_name, fs_id, peer_spec):
         res = self.mirror_daemon_command(f'counter dump for fs: {fs_name}', 'counter', 'dump')
@@ -278,16 +366,7 @@ class TestMirroring(CephFSTestCase):
 
         peer_uuid = self.get_peer_uuid(peer_spec)
         self.run_ceph_cmd("fs", "snapshot", "mirror", "peer_remove", fs_name, peer_uuid)
-        time.sleep(10)
-        # verify via asok
-        res = self.mirror_daemon_command(f'mirror status for fs: {fs_name}',
-                                         'fs', 'mirror', 'status', f'{fs_name}@{fs_id}')
-        self.assertTrue(res['peers'] == {} and res['snap_dirs']['dir_count'] == 0)
-
-        res = self.mirror_daemon_command(f'counter dump for fs: {fs_name}', 'counter', 'dump')
-        vafter = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_FS][0]
-
-        self.assertLess(vafter["counters"]["mirroring_peers"], vbefore["counters"]["mirroring_peers"])
+        self._wait_peer_removed(fs_name, fs_id, vbefore)
 
     def bootstrap_peer(self, fs_name, client_name, site_name):
         outj = json.loads(self.get_ceph_cmd_stdout(
@@ -312,18 +391,9 @@ class TestMirroring(CephFSTestCase):
 
         self.run_ceph_cmd("fs", "snapshot", "mirror", "add", fs_name, dir_name)
 
-        time.sleep(10)
-        # verify via asok
-        res = self.mirror_daemon_command(f'mirror status for fs: {fs_name}',
-                                         'fs', 'mirror', 'status', f'{fs_name}@{fs_id}')
-        new_dir_count = res['snap_dirs']['dir_count']
-        log.debug(f'new dir_count={new_dir_count}')
-        self.assertTrue(new_dir_count > dir_count)
-
-        if check_perf_counter:
-            res = self.mirror_daemon_command(f'counter dump for fs: {fs_name}', 'counter', 'dump')
-            vafter = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_FS][0]
-            self.assertGreater(vafter["counters"]["directory_count"], vbefore["counters"]["directory_count"])
+        self._wait_directory_added(fs_name, fs_id, dir_count,
+                                   vbefore if check_perf_counter else None,
+                                   check_perf_counter)
 
     def remove_directory(self, fs_name, fs_id, dir_name):
         res = self.mirror_daemon_command(f'counter dump for fs: {fs_name}', 'counter', 'dump')
@@ -336,18 +406,13 @@ class TestMirroring(CephFSTestCase):
 
         self.run_ceph_cmd("fs", "snapshot", "mirror", "remove", fs_name, dir_name)
 
-        time.sleep(10)
-        # verify via asok
-        res = self.mirror_daemon_command(f'mirror status for fs: {fs_name}',
-                                         'fs', 'mirror', 'status', f'{fs_name}@{fs_id}')
-        new_dir_count = res['snap_dirs']['dir_count']
-        log.debug(f'new dir_count={new_dir_count}')
-        self.assertTrue(new_dir_count < dir_count)
+        if dir_count == 0:
+            # The daemon may already have dropped the directory (e.g. after
+            # blocklist/restart) even though mon config still lists it.
+            self._wait_directory_absent_from_mirror(fs_name, dir_name)
+            return
 
-        res = self.mirror_daemon_command(f'counter dump for fs: {fs_name}', 'counter', 'dump')
-        vafter = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_FS][0]
-
-        self.assertLess(vafter["counters"]["directory_count"], vbefore["counters"]["directory_count"])
+        self._wait_directory_removed(fs_name, fs_id, dir_count, vbefore)
 
     @retry_assert(timeout=140, interval=2)
     def check_mirror_status_after_failure(self):
@@ -404,6 +469,16 @@ class TestMirroring(CephFSTestCase):
         if actual != expected:
             raise AssertionError(
                 f'expected add_directory={expected}, got {actual}')
+
+    @retry_assert(timeout=60, interval=1)
+    def wait_for_sync_failures(self, min_count=1):
+        """Wait until peer sync_failures reaches min_count.
+
+        remove_directory() returns when dir_count drops; sync_failures is
+        incremented only after the worker finishes sync_snaps() with error.
+        """
+        counters = self.get_peer_perf_counters()
+        self.assertGreaterEqual(counters.get('sync_failures', 0), min_count)
 
     def assert_directory_perf_labels(self, labels, dir_path, peer_uuid):
         self.assertEqual(labels['source_fscid'], str(self.primary_fs_id))
@@ -534,6 +609,68 @@ class TestMirroring(CephFSTestCase):
                 if p.returncode != 0:
                     return
 
+    @retry_assert(timeout=60, interval=2)
+    def _wait_mgr_mirror_policy_ready(self, fs_name):
+        res = self.mgr_mirror_status(fs_name)
+        self.assertIn('metrics', res)
+
+    def prepare_mirror_blocklist_test(self, fs_name, fs_id):
+        """Wait until mgr InstanceWatcher has seen the mirror instance.
+
+        Blocklist tests SIGSTOP the daemon and rely on mgr InstanceWatcher
+        (INSTANCE_TIMEOUT=30s) to blocklist a non-responsive instance.  The
+        watcher only tracks instances that have responded to at least one
+        notify, so wait for mgr policy init and a notify round-trip before
+        freezing the daemon.
+        """
+        self.wait_for_mirror_status_ready(fs_name, fs_id)
+        self._wait_mgr_mirror_policy_ready(fs_name)
+        # NOTIFY_INTERVAL is 1s; allow time for the first notify ack.
+        time.sleep(8)
+        rados_inst = self.get_mirror_rados_addr(fs_name, fs_id)
+        self.assertTrue(rados_inst)
+        return rados_inst
+
+    @retry_assert(timeout=90, interval=2)
+    def wait_for_addr_blocklisted(self, rados_inst):
+        self.assertTrue(self.mds_cluster.is_addr_blocklisted(rados_inst))
+
+    @retry_assert(timeout=60, interval=2)
+    def wait_for_mirror_rados_restart(self, fs_name, fs_id, old_rados_inst):
+        try:
+            rados_inst = self.get_mirror_rados_addr(fs_name, fs_id)
+        except CommandFailedError as e:
+            raise AssertionError(str(e)) from e
+        self.assertTrue(rados_inst)
+        self.assertNotEqual(rados_inst, old_rados_inst)
+
+    @retry_assert(timeout=45, interval=2)
+    def wait_for_dirmap_state(self, fs_name, dir_path, expected_state):
+        res_json = self.get_ceph_cmd_stdout(
+            "fs", "snapshot", "mirror", "dirmap", fs_name, dir_path)
+        res = json.loads(res_json)
+        self.assertEqual(res['state'], expected_state)
+
+    @retry_assert(timeout=45, interval=1)
+    def wait_for_directory_untracked(self, fs_name, dir_path):
+        """Wait until mgr policy finishes DISASSOCIATING (dirmap ENOENT)."""
+        try:
+            self.run_ceph_cmd("fs", "snapshot", "mirror", "dirmap",
+                              fs_name, dir_path)
+        except CommandFailedError as ce:
+            self.assertEqual(ce.exitstatus, errno.ENOENT)
+            return
+        raise AssertionError(
+            f'{dir_path} still tracked after remove; waiting for unmap')
+
+    @retry_assert(timeout=60, interval=2)
+    def wait_for_mirror_status_ready(self, fs_name, fs_id):
+        self.assertTrue(self.get_mirror_rados_addr(fs_name, fs_id))
+        res = self.mirror_daemon_command(
+            f'mirror status for fs: {fs_name}',
+            'fs', 'mirror', 'status', f'{fs_name}@{fs_id}')
+        self.assertIn('snap_dirs', res)
+
     def restart_mirror_daemon(self):
         # daemon.start() always calls restart(), which skips stop() once proc
         # is cleared.  Stop the real cephfs-mirror via its pid file first so
@@ -565,22 +702,14 @@ class TestMirroring(CephFSTestCase):
         log.debug('starting cephfs-mirror')
         daemon.start()
 
-        time.sleep(60)
-        with safe_while(sleep=2, tries=30,
-                        action='wait for mirror daemon restart') as proceed:
-            while proceed():
-                try:
-                    rados_inst = self.get_mirror_rados_addr(
-                        self.primary_fs_name, self.primary_fs_id)
-                    if rados_inst and rados_inst != rados_inst_before:
-                        break
-                except CommandFailedError:
-                    pass
+        self.wait_for_mirror_rados_restart(
+            self.primary_fs_name, self.primary_fs_id, rados_inst_before)
 
-    def wait_for_mirror_daemon_recovery(self, fs_name, fs_id, dir_name, peer_uuid):
+    def wait_for_mirror_daemon_recovery(self, fs_name, fs_id, dir_name, peer_uuid,
+                                        tries=60):
         # A new rados_inst alone does not mean mirroring is ready: wait until the
         # peer is configured, the snap dir is registered, and asok reports it.
-        with safe_while(sleep=2, tries=60,
+        with safe_while(sleep=2, tries=tries,
                         action='wait for mirror daemon recovery') as proceed:
             while proceed():
                 if not self.get_mirror_rados_addr(fs_name, fs_id):
@@ -787,6 +916,10 @@ class TestMirroring(CephFSTestCase):
         log.debug(f'destination snapshot checksum {snap_name} {dest_res}')
         self.assertTrue(source_res == dest_res)
 
+    @retry_assert(timeout=600, interval=10)
+    def wait_for_snapshot_synced(self, dir_name, snap_name):
+        self.verify_snapshot(dir_name, snap_name)
+
     def mirror_dirmap(self, fs_name, dir_name):
         return json.loads(self.get_ceph_cmd_stdout(
             'fs', 'snapshot', 'mirror', 'dirmap', fs_name, dir_name))
@@ -849,6 +982,8 @@ class TestMirroring(CephFSTestCase):
             raise
         res = p.stdout.getvalue().strip()
         log.debug(f'command returned={res}')
+        if not res:
+            raise json.JSONDecodeError("Expecting value", res, 0)
         return json.loads(res)
 
     def get_mirror_daemon_status(self):
@@ -1132,13 +1267,8 @@ class TestMirroring(CephFSTestCase):
         try:
             self.add_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir1}')
             self.add_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir2}')
-            time.sleep(10)
-            dirs_list = json.loads(self.get_ceph_cmd_stdout("fs", "snapshot", "mirror", "ls", self.primary_fs_name))
-            # verify via asok
-            res = self.mirror_daemon_command(f'mirror status for fs: {self.primary_fs_name}',
-                                             'fs', 'mirror', 'status', f'{self.primary_fs_name}@{self.primary_fs_id}')
-            dir_count = res['snap_dirs']['dir_count']
-            self.assertTrue(len(dirs_list) == dir_count and f'/{dir1}' in dirs_list and f'/{dir2}' in dirs_list)
+            self._wait_mirror_directory_ls(
+                self.primary_fs_name, self.primary_fs_id, f'/{dir1}', f'/{dir2}')
         except CommandFailedError:
             raise RuntimeError('Error listing directories')
         except AssertionError:
@@ -1564,9 +1694,8 @@ class TestMirroring(CephFSTestCase):
                                          'fs', 'mirror', 'status', f'{self.primary_fs_name}@{self.primary_fs_id}')
         peers_1 = set(res['peers'])
 
-        # fetch rados address for blacklist check
-        rados_inst = self.get_mirror_rados_addr(self.primary_fs_name, self.primary_fs_id)
-        self.assertTrue(rados_inst)
+        rados_inst = self.prepare_mirror_blocklist_test(
+            self.primary_fs_name, self.primary_fs_id)
 
         # simulate non-responding mirror daemon by sending SIGSTOP
         pid = self.get_mirror_daemon_pid()
@@ -1575,7 +1704,7 @@ class TestMirroring(CephFSTestCase):
 
         # wait for blocklist timeout -- the manager module would blocklist
         # the mirror daemon
-        time.sleep(40)
+        self.wait_for_addr_blocklisted(rados_inst)
 
         # wake up the mirror daemon -- at this point, the daemon should know
         # that it has been blocklisted
@@ -1585,19 +1714,10 @@ class TestMirroring(CephFSTestCase):
         # check if the rados addr is blocklisted
         self.assertTrue(self.mds_cluster.is_addr_blocklisted(rados_inst))
 
-        # wait for restart, which is after 30 seconds timeout (cephfs_mirror_restart_mirror_on_blocklist_interval)
-        time.sleep(60)
-
-        # get the new rados_inst
-        rados_inst_new = ""
-        with safe_while(sleep=2, tries=20, action='wait for mirror status rados_inst') as proceed:
-            while proceed():
-                rados_inst_new = self.get_mirror_rados_addr(self.primary_fs_name, self.primary_fs_id)
-                if rados_inst_new:
-                    break
-
-        # and we should get a new rados instance
-        self.assertTrue(rados_inst != rados_inst_new)
+        # wait for restart, which is after 30 seconds timeout
+        # (cephfs_mirror_restart_mirror_on_blocklist_interval)
+        self.wait_for_mirror_rados_restart(
+            self.primary_fs_name, self.primary_fs_id, rados_inst)
 
         # along with peers that were added
         res = self.mirror_daemon_command(f'mirror status for fs: {self.primary_fs_name}',
@@ -1717,10 +1837,7 @@ class TestMirroring(CephFSTestCase):
         snap_list = self.mount_b.ls(path='d0/.snap')
         self.assertTrue('snap0' not in snap_list)
 
-        # check sync_failures
-        res = self.mirror_daemon_command(f'counter dump for fs: {self.primary_fs_name}', 'counter', 'dump')
-        vmirror_peers = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_PEER][0]
-        self.assertGreater(vmirror_peers["counters"]["sync_failures"], 0)
+        self.wait_for_sync_failures()
 
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
 
@@ -1736,18 +1853,16 @@ class TestMirroring(CephFSTestCase):
         self.add_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
         self.peer_add(self.primary_fs_name, self.primary_fs_id, "client.mirror_remote@ceph", self.secondary_fs_name)
 
-        # fetch rados address for blacklist check
-        rados_inst = self.get_mirror_rados_addr(self.primary_fs_name, self.primary_fs_id)
-
-        # dump perf counters
-        res = self.mirror_daemon_command(f'counter dump for fs: {self.primary_fs_name}', 'counter', 'dump')
-        vbefore = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_PEER][0]
-
         # take a snapshot
         self.mount_a.run_shell(["mkdir", "d0/.snap/snap0"])
 
         self.check_peer_snap_in_progress(self.primary_fs_name, self.primary_fs_id,
                                          "client.mirror_remote@ceph", '/d0', 'snap0')
+
+        # peer/directory are already configured, so the mgr InstanceWatcher has
+        # seen this instance; grab the addr and freeze the daemon mid-sync.
+        rados_inst = self.get_mirror_rados_addr(self.primary_fs_name, self.primary_fs_id)
+        self.assertTrue(rados_inst)
 
         # simulate non-responding mirror daemon by sending SIGSTOP
         pid = self.get_mirror_daemon_pid()
@@ -1756,7 +1871,7 @@ class TestMirroring(CephFSTestCase):
 
         # wait for blocklist timeout -- the manager module would blocklist
         # the mirror daemon
-        time.sleep(40)
+        self.wait_for_addr_blocklisted(rados_inst)
 
         # wake up the mirror daemon -- at this point, the daemon should know
         # that it has been blocklisted
@@ -1766,13 +1881,23 @@ class TestMirroring(CephFSTestCase):
         # check if the rados addr is blocklisted
         self.assertTrue(self.mds_cluster.is_addr_blocklisted(rados_inst))
 
-        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
-                               "client.mirror_remote@ceph", '/d0', 'snap0', expected_snap_count=1)
-        self.verify_snapshot('d0', 'snap0')
-        # check snaps_synced
-        res = self.mirror_daemon_command(f'counter dump for fs: {self.primary_fs_name}', 'counter', 'dump')
-        vafter = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_PEER][0]
-        self.assertGreater(vafter["counters"]["snaps_synced"], vbefore["counters"]["snaps_synced"])
+        # wait for restart, which is after 30 seconds timeout
+        # (cephfs_mirror_restart_mirror_on_blocklist_interval)
+        self.wait_for_mirror_rados_restart(
+            self.primary_fs_name, self.primary_fs_id, rados_inst)
+
+        peer_uuid = self.get_peer_uuid("client.mirror_remote@ceph")
+        self.wait_for_mirror_daemon_recovery(
+            self.primary_fs_name, self.primary_fs_id, '/d0', peer_uuid,
+            tries=90)
+
+        self.wait_for_snapshot_synced('d0', 'snap0')
+        self.check_peer_status_idle(self.primary_fs_name, self.primary_fs_id,
+                                    "client.mirror_remote@ceph", '/d0', 'snap0', 1)
+        # peer-level snaps_synced resets on blocklist restart; directory
+        # counters are restored from persisted sync state.
+        dir_counters = self.get_directory_perf_counters('/d0', peer_uuid)
+        self.assertGreaterEqual(dir_counters['snaps_synced'], 1)
 
         self.remove_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
@@ -1875,15 +2000,8 @@ class TestMirroring(CephFSTestCase):
                     pass
 
         self.run_ceph_cmd("fs", "mirror", "disable", self.primary_fs_name)
-        time.sleep(10)
-        # verify via asok
-        try:
-            self.mirror_daemon_command(f'mirror status for fs: {self.primary_fs_name}',
-                                       'fs', 'mirror', 'status', f'{self.primary_fs_name}@{self.primary_fs_id}')
-        except CommandFailedError:
-            pass
-        else:
-            raise RuntimeError('expected admin socket to be unavailable')
+        self._wait_mirror_asok_unavailable(
+            self.primary_fs_name, self.primary_fs_id)
 
     def test_mirroring_init_failure_with_recovery(self):
         """Test if the mirror daemon can recover from a init failure"""
@@ -1928,15 +2046,8 @@ class TestMirroring(CephFSTestCase):
         self.assertTrue(res['snap_dirs']['dir_count'] == 0)
 
         self.run_ceph_cmd("fs", "mirror", "disable", self.primary_fs_name)
-        time.sleep(10)
-        # verify via asok
-        try:
-            self.mirror_daemon_command(f'mirror status for fs: {self.primary_fs_name}',
-                                       'fs', 'mirror', 'status', f'{self.primary_fs_name}@{self.primary_fs_id}')
-        except CommandFailedError:
-            pass
-        else:
-            raise RuntimeError('expected admin socket to be unavailable')
+        self._wait_mirror_asok_unavailable(
+            self.primary_fs_name, self.primary_fs_id)
 
     def test_cephfs_mirror_peer_bootstrap(self):
         """Test importing peer bootstrap token"""
@@ -2043,8 +2154,8 @@ class TestMirroring(CephFSTestCase):
     def test_cephfs_mirror_remove_on_stall(self):
         self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
 
-        # fetch rados address for blacklist check
-        rados_inst = self.get_mirror_rados_addr(self.primary_fs_name, self.primary_fs_id)
+        rados_inst = self.prepare_mirror_blocklist_test(
+            self.primary_fs_name, self.primary_fs_id)
 
         # simulate non-responding mirror daemon by sending SIGSTOP
         pid = self.get_mirror_daemon_pid()
@@ -2053,7 +2164,7 @@ class TestMirroring(CephFSTestCase):
 
         # wait for blocklist timeout -- the manager module would blocklist
         # the mirror daemon
-        time.sleep(40)
+        self.wait_for_addr_blocklisted(rados_inst)
 
         # make sure the rados addr is blocklisted
         self.assertTrue(self.mds_cluster.is_addr_blocklisted(rados_inst))
@@ -2072,15 +2183,9 @@ class TestMirroring(CephFSTestCase):
         self.assertTrue(res['state'], 'stalled')
 
         self.run_ceph_cmd("fs", "snapshot", "mirror", "remove", self.primary_fs_name, dir_path)
-
-        time.sleep(10)
-        try:
-            self.run_ceph_cmd("fs", "snapshot", "mirror", "dirmap", self.primary_fs_name, dir_path)
-        except CommandFailedError as ce:
-            if ce.exitstatus != errno.ENOENT:
-                raise RuntimeError('invalid errno when checking dirmap status for non-existent directory')
-        else:
-            raise RuntimeError('incorrect errno when checking dirmap state for non-existent directory')
+        # Wait for DISASSOCIATING to finish; parent add fails with EINVAL while
+        # the child is still purging.
+        self.wait_for_directory_untracked(self.primary_fs_name, dir_path)
 
         # adding a parent directory should be allowed
         self.run_ceph_cmd("fs", "snapshot", "mirror", "add", self.primary_fs_name, dir_path_p)
@@ -2098,11 +2203,8 @@ class TestMirroring(CephFSTestCase):
         self.mount_a.run_shell(['kill', '-SIGCONT', pid])
 
         # wait for restart mirror on blocklist
-        time.sleep(60)
-        res_json = self.get_ceph_cmd_stdout("fs", "snapshot", "mirror", "dirmap", self.primary_fs_name, dir_path_p)
-        res = json.loads(res_json)
-        # there are no mirror daemons
-        self.assertTrue(res['state'], 'mapped')
+        self.wait_for_dirmap_state(
+            self.primary_fs_name, dir_path_p, 'mapped')
 
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
 
@@ -3040,7 +3142,6 @@ class TestMirroring(CephFSTestCase):
         try:
             # InstanceWatcher INSTANCE_TIMEOUT is 30s; allow extra time for
             # the mgr notify loop to age out the frozen instance.
-            time.sleep(40)
             self.check_mgr_dir_stat_stale(
                 self.primary_fs_name, '/d0', peer_uuid)
         finally:
@@ -3048,19 +3149,8 @@ class TestMirroring(CephFSTestCase):
             self.mount_a.run_shell(['kill', '-SIGCONT', pid])
 
         # wait for restart mirror on blocklist
-        time.sleep(60)
-        with safe_while(sleep=2, tries=20,
-                        action='wait for mirror daemon recovery after SIGSTOP') as proceed:
-            while proceed():
-                if not self.get_mirror_rados_addr(self.primary_fs_name,
-                                                   self.primary_fs_id):
-                    continue
-                res = self.mirror_daemon_command(
-                    f'mirror status for fs: {self.primary_fs_name}',
-                    'fs', 'mirror', 'status',
-                    f'{self.primary_fs_name}@{self.primary_fs_id}')
-                if 'snap_dirs' in res:
-                    break
+        self.wait_for_mirror_daemon_recovery(
+            self.primary_fs_name, self.primary_fs_id, '/d0', peer_uuid)
 
         self.remove_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
@@ -3241,6 +3331,10 @@ class TestMirroring(CephFSTestCase):
         self.mount_a.run_shell(['mkdir', dir_name])
         self.add_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
         self.remove_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+        # remove_directory() only waits for the daemon to drop the dir.
+        # Mgr policy stays in DISASSOCIATING until MAP_REMOVE; status checks
+        # policy.lookup() and succeeds until then (metrics cache is unrelated).
+        self.wait_for_directory_untracked(self.primary_fs_name, f'/{dir_name}')
 
         try:
             self.mgr_mirror_status(self.primary_fs_name, f'/{dir_name}')
@@ -3280,6 +3374,8 @@ class TestMirroring(CephFSTestCase):
             self.primary_fs_name, self.primary_fs_id, f'/{dir_name}', peer_uuid)
 
         self.mount_b.run_shell(['sudo', 'rmdir', remote_snap_path], omit_sudo=False)
+        self.remove_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+        self.peer_remove(self.primary_fs_name, self.primary_fs_id, peer_spec)
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
 
     def test_mgr_snapshot_mirror_status_cache(self):
@@ -3369,9 +3465,11 @@ class TestMirroring(CephFSTestCase):
 
             sync_dir = 'mgr_nc_sync'
             self.mount_a.run_shell(['mkdir', sync_dir])
-            self.mount_a.create_n_files(f'{sync_dir}/file', 10000, sync=True)
-            for i in range(20):
-                self.mount_a.write_n_mb(os.path.join(sync_dir, f'large_file.{i}'), 100)
+            # Keep sync active across the multi-call mgr/asok scope walk.
+            # Smaller payloads finish between asok syncing and omap update.
+            for i in range(8):
+                self.mount_a.write_n_mb(
+                    os.path.join(sync_dir, f'large_file.{i}'), 1024)
             self.add_directory(self.primary_fs_name, self.primary_fs_id,
                                f'/{sync_dir}')
             snap_name = 'snap0'

--- a/src/tools/cephfs_mirror/FSMirror.cc
+++ b/src/tools/cephfs_mirror/FSMirror.cc
@@ -70,18 +70,13 @@ private:
 
 class MirrorAdminSocketHook : public AdminSocketHook {
 public:
-  MirrorAdminSocketHook(CephContext *cct, const Filesystem &filesystem, FSMirror *fs_mirror)
-    : admin_socket(cct->get_admin_socket()) {
-    int r;
-    std::string cmd;
-
-    // mirror status format is name@fscid
-    cmd = "fs mirror status " + stringify(filesystem.fs_name) + "@" + stringify(filesystem.fscid);
-    r = admin_socket->register_command(
-      cmd, this, "get filesystem mirror status");
-    if (r == 0) {
-      commands[cmd] = new StatusCommand(fs_mirror);
-    }
+  MirrorAdminSocketHook(CephContext *cct, const Filesystem &filesystem,
+                        FSMirror *fs_mirror)
+    : admin_socket(cct->get_admin_socket()),
+      // mirror status format is name@fscid
+      cmd("fs mirror status " + stringify(filesystem.fs_name) + "@" +
+          stringify(filesystem.fscid)),
+      fs_mirror(fs_mirror) {
   }
 
   ~MirrorAdminSocketHook() override {
@@ -89,6 +84,24 @@ public:
     for (auto &[command, cmdptr] : commands) {
       delete cmdptr;
     }
+  }
+
+  // Defer registration until FSMirror::init() finishes so early status
+  // polls cannot block the single-threaded admin socket on m_lock while
+  // connect/mount is still in progress.
+  void register_command() {
+    if (!commands.empty()) {
+      return;
+    }
+
+    int r = admin_socket->register_command(
+      cmd, this, "get filesystem mirror status");
+    if (r < 0) {
+      derr << ": failed to register admin socket command '" << cmd
+           << "': " << cpp_strerror(r) << dendl;
+      return;
+    }
+    commands[cmd] = new StatusCommand(fs_mirror);
   }
 
   int call(std::string_view command, const cmdmap_t& cmdmap,
@@ -102,6 +115,8 @@ private:
   typedef std::map<std::string, MirrorAdminSocketCommand*, std::less<>> Commands;
 
   AdminSocket *admin_socket;
+  std::string cmd;
+  FSMirror *fs_mirror;
   Commands commands;
 };
 
@@ -183,12 +198,20 @@ void FSMirror::reopen_logs() {
 void FSMirror::init(Context *on_finish) {
   dout(20) << dendl;
 
+  // Publish the status command only after init completes (success or
+  // failure). Registering in the constructor lets early polls block the
+  // admin-socket thread on m_lock for the duration of connect/mount.
+  Context *ctx = new LambdaContext([this, on_finish](int r) {
+                                     m_asok_hook->register_command();
+                                     on_finish->complete(r);
+                                   });
+
   std::scoped_lock locker(m_lock);
   int r = connect(g_ceph_context->_conf->name.to_str(),
                   g_ceph_context->_conf->cluster, &m_cluster, "", "", m_args);
   if (r < 0) {
     m_init_failed = true;
-    on_finish->complete(r);
+    ctx->complete(r);
     return;
   }
 
@@ -198,7 +221,7 @@ void FSMirror::init(Context *on_finish) {
     m_cluster.reset();
     derr << ": error accessing local pool (id=" << m_pool_id << "): "
          << cpp_strerror(r) << dendl;
-    on_finish->complete(r);
+    ctx->complete(r);
     return;
   }
 
@@ -207,14 +230,14 @@ void FSMirror::init(Context *on_finish) {
     m_init_failed = true;
     m_ioctx.close();
     m_cluster.reset();
-    on_finish->complete(r);
+    ctx->complete(r);
     return;
   }
 
   m_addrs = m_cluster->get_addrs();
   dout(10) << ": rados addrs=" << m_addrs << dendl;
 
-  init_instance_watcher(on_finish);
+  init_instance_watcher(ctx);
 }
 
 void FSMirror::shutdown(Context *on_finish) {


### PR DESCRIPTION
    qa/mirroring: Improve retry_assert failure logging and improve run time

    Assertion failures during retries were not logged, and the final
    failure was lost when safe_while raised MaxWhileTries instead of
    reaching the timeout handler. Log the assertion on each retry and
    on final timeout, including the last peer status when available.

    Poll mirror enable/disable, peer, and directory helpers with retry_assert
    instead of unconditional 10s sleeps. Add blocklist/restart wait helpers,
    and drop redundant sleeps in directory ls and init-failure tests.

    Fixes: https://tracker.ceph.com/issues/78253


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
