### PR TITLE
mgr/dashboard: Hide Authentication section when "Allow All Hosts" is enabled

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-2/nvmeof-subsystem-step-2.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-2/nvmeof-subsystem-step-2.component.spec.ts
@@ -83,6 +83,15 @@ describe('NvmeofSubsystemsStepTwoComponent', () => {
     });
   });
 
+  describe('host type change events', () => {
+    it('should emit host type changes for parent step visibility', () => {
+      const emitSpy = spyOn(component.hostTypeChanged, 'emit');
+      form.get('hostType')?.setValue(component.HOST_TYPE.ALL);
+
+      expect(emitSpy).toHaveBeenCalledWith(component.HOST_TYPE.ALL);
+    });
+  });
+
   describe('custom NQN validator', () => {
     it('should mark invalid NQN format', () => {
       form.get('hostname')?.setValue('invalid-nqn');

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-2/nvmeof-subsystem-step-2.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-2/nvmeof-subsystem-step-2.component.ts
@@ -1,4 +1,13 @@
-import { Component, Input, OnInit, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  TemplateRef,
+  ViewChild,
+  ViewEncapsulation
+} from '@angular/core';
 import { FormControl, UntypedFormControl } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
@@ -21,6 +30,7 @@ export class NvmeofSubsystemsStepTwoComponent implements OnInit, TearsheetStep {
   @Input() group!: string;
   @Input() existingHosts: string[] = [];
   @Input() allowAllHosts = true;
+  @Output() hostTypeChanged = new EventEmitter<string>();
   @ViewChild('rightInfluencer', { static: true })
   rightInfluencer?: TemplateRef<any>;
   formGroup: CdFormGroup;
@@ -50,7 +60,8 @@ export class NvmeofSubsystemsStepTwoComponent implements OnInit, TearsheetStep {
   ngOnInit() {
     this.createForm();
 
-    this.formGroup.get('hostType')?.valueChanges.subscribe(() => {
+    this.formGroup.get('hostType')?.valueChanges.subscribe((hostType: string) => {
+      this.hostTypeChanged.emit(hostType);
       this.formGroup.get('hostname')?.updateValueAndValidity();
     });
 
@@ -58,6 +69,7 @@ export class NvmeofSubsystemsStepTwoComponent implements OnInit, TearsheetStep {
       this.formGroup.get('hostname')?.updateValueAndValidity();
     });
 
+    this.hostTypeChanged.emit(this.formGroup.get('hostType')?.value);
     this.formGroup.get('hostname')?.updateValueAndValidity();
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.html
@@ -16,6 +16,7 @@
     <cd-nvmeof-subsystem-step-two
       #tearsheetStep
       [group]="group"
+      (hostTypeChanged)="onHostTypeChanged($event)"
     ></cd-nvmeof-subsystem-step-two>
   </cd-tearsheet-step>
   @if (showAuthStep) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.spec.ts
@@ -220,5 +220,20 @@ describe('NvmeofSubsystemsFormComponent', () => {
         gw_group: mockGroupName
       });
     });
+
+    it('should hide authentication step when host type is ALL', () => {
+      component.onHostTypeChanged(HOST_TYPE.ALL);
+
+      expect(component.showAuthStep).toBeFalsy();
+      expect(component.steps.some((step) => step.label === 'Authentication')).toBeFalsy();
+    });
+
+    it('should show authentication step when host type is SPECIFIC', () => {
+      component.onHostTypeChanged(HOST_TYPE.ALL);
+      component.onHostTypeChanged(HOST_TYPE.SPECIFIC);
+
+      expect(component.showAuthStep).toBeTruthy();
+      expect(component.steps.some((step) => step.label === 'Authentication')).toBeTruthy();
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.ts
@@ -103,10 +103,18 @@ export class NvmeofSubsystemsFormComponent implements OnInit {
     this.rebuildSteps();
   }
 
+  onHostTypeChanged(hostType: string) {
+    this.setAuthStepVisibility(this.shouldShowAuthStep(hostType));
+  }
+
   private setAuthStepVisibility(nextShowAuth: boolean) {
     if (this.showAuthStep === nextShowAuth) return;
     this.showAuthStep = nextShowAuth;
     this.rebuildSteps();
+  }
+
+  private shouldShowAuthStep(hostType: string | null | undefined): boolean {
+    return (hostType ?? HOST_TYPE.SPECIFIC) === HOST_TYPE.SPECIFIC;
   }
 
   populateReviewData() {
@@ -126,7 +134,7 @@ export class NvmeofSubsystemsFormComponent implements OnInit {
       this.stepTwoValue = step2;
     }
 
-    const nextShowAuth = (step2?.hostType ?? HOST_TYPE.SPECIFIC) === HOST_TYPE.SPECIFIC;
+    const nextShowAuth = this.shouldShowAuthStep(step2?.hostType);
 
     if (nextShowAuth !== this.showAuthStep) {
       this.setAuthStepVisibility(nextShowAuth);


### PR DESCRIPTION


https://github.com/user-attachments/assets/4c825e28-015d-46f9-9d7c-4c1b1555aa9a




Fixes: https://tracker.ceph.com/issues/78280

Signed-off-by: pujaoshahu <pshahu@redhat.com>


Summary :

Update the Create Subsystem UI to hide Authentication when "Allow all hosts" is selected.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
