### PR TITLE
pybind: Fix CLI error message when using force parameter if it doesn't exist

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -1241,7 +1241,7 @@ def validate(args: List[str],
                         or myarg == "--yes-i-really-mean-it" \
                         or myarg == "--yes-i-really-really-mean-it" \
                         or myarg == "--yes-i-really-really-mean-it-not-faking" \
-                        or myarg == "--force" \
+                        or (myarg == "--force" and 'force' in arg_descs_by_name) \
                         or injectargs
 
                 if not is_value:

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -1346,6 +1346,30 @@ class TestValidate(unittest.TestCase):
         for arg_type in (self.ARGS, self.KWARGS, self.KWARGS_EQ, self.MIXED):
             self._arg_kwarg_test(self.prefix, self.args, self.sig, arg_type)
 
+    def test_force_rejected_when_not_in_schema(self):
+        sig = parse_funcsig([
+            {'name': 'nqn', 'type': 'CephString'},
+            {'name': 'nsid', 'type': 'CephString'},
+        ])
+        self.assertRaises(ArgumentValid, validate, ['nqn1', '--force'], sig)
+        self.assertRaises(ArgumentValid, validate, ['--force', 'nqn1'], sig)
+
+    def test_force_accepted_when_in_schema_as_bool(self):
+        sig = parse_funcsig([
+            {'name': 'nqn', 'type': 'CephString'},
+            {'name': 'force', 'type': 'CephBool', 'req': False},
+        ])
+        result = validate(['nqn1', '--force'], sig)
+        self.assertEqual(result.get('force'), True)
+
+    def test_force_accepted_when_in_schema_as_string(self):
+        sig = parse_funcsig([
+            {'name': 'nqn', 'type': 'CephString'},
+            {'name': 'force', 'type': 'CephString', 'req': False},
+        ])
+        result = validate(['nqn1', '--force'], sig)
+        self.assertEqual(result.get('force'), '--force')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Running a command that has no force parameter with --force produces a cryptic error instead of a clean rejection:
```
[xxx@xxx ~]# ceph nvmeof ns del_host --nqn nqn.2016-06.io.spdk:cnode1.mygroup1 --force true
Error EINVAL: invalid literal for int() with base 10: '--force'
```

ceph_argparse.py hardcodes `--force` as an exception in the positional-argument validation loop (line 1244), originally added for backward compatibility with pre-Nautilus daemons that defined force as a `CephString` positional parameter instead of `CephBool`. The exception fired unconditionally — even when force was not part of the command's schema at all — allowing `--force` to be silently absorbed as the value of the next positional parameter (e.g. `nsid`). The module then tried int('--force') and crashed.

This PR fixes it:

```
[xxx@xxx ~]# ceph nvmeof ns del_host --nqn nqn.2016-06.io.spdk:cnode1.mygroup1 --force true
Invalid command: Unexpected argument '--force'
nvmeof ns del_host <nqn> <nsid> [<host_nqn>] [<gw_group>] [<server_address>] [<traddr>] :  Removes a host from the specified NVMeoF namespace
Error EINVAL: invalid command
```

Fixes: https://tracker.ceph.com/issues/78291


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
