### PR TITLE
mgr/dashboard: Subvolume group and subvolume not listed in NFS Share form on edit.

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
@@ -220,6 +220,29 @@ describe('NfsFormComponent', () => {
     });
   });
 
+  describe('edit mode CephFS subvolume fields', () => {
+    it('should populate subvolume group and subvolume from export path', () => {
+      component.isEdit = true;
+      spyOn(component['subvolgrpService'], 'get').and.returnValue(of([{ name: 'g1' }]));
+      spyOn(component['subvolService'], 'get').and.returnValue(of([{ name: 'sv1' }]));
+
+      component.resolveModel({
+        fsal: { name: 'CEPH', fs_name: 'testfs' },
+        path: '/volumes/g1/sv1',
+        protocols: [3, 4],
+        transports: ['TCP'],
+        clients: [],
+        squash: 'none'
+      });
+
+      expect(component.nfsForm.get('subvolume_group').value).toBe('g1');
+      expect(component.nfsForm.get('subvolume').value).toBe('sv1');
+      expect(component['subvolgrpService'].get).toHaveBeenCalledWith('testfs');
+      expect(component['subvolService'].get).toHaveBeenCalledWith('testfs', 'g1');
+      expect(component.allsubvols).toEqual([{ name: 'sv1' }]);
+    });
+  });
+
   describe('pathExistence', () => {
     beforeEach(() => {
       component['nfsService']['lsDir'] = jest.fn((): Observable<Directory> =>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -138,7 +138,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
         (params: { cluster_id: string; export_id: string; rgw_export_type?: string }) => {
           this.cluster_id = decodeURIComponent(params.cluster_id);
           this.export_id = decodeURIComponent(params.export_id);
-          if (params.rgw_export_type) {
+          if (params.rgw_export_type && this.storageBackend === SUPPORTED_FSAL.RGW) {
             this.nfsForm.get('rgw_export_type').setValue(params.rgw_export_type);
             if (params.rgw_export_type === RgwExportType.BUCKET) {
               this.setBucket();
@@ -186,11 +186,17 @@ export class NfsFormComponent extends CdForm implements OnInit {
     this.isDefaultSubvolumeGroup();
   }
 
-  async getSubVol() {
-    const fs_name = this.nfsForm.getValue('fsal').fs_name;
+  async getSubVol(fsName?: string) {
+    const fs_name = fsName ?? this.nfsForm.getRawValue()?.fsal?.fs_name;
     const subvolgrp = this.nfsForm.getValue('subvolume_group');
 
-    await this.setSubVolGrpPath();
+    if (!fs_name || !subvolgrp) {
+      return;
+    }
+
+    if (!this.isEdit) {
+      await this.setSubVolGrpPath();
+    }
 
     (subvolgrp === this.defaultSubVolGroup
       ? this.subvolService.get(fs_name)
@@ -422,12 +428,14 @@ export class NfsFormComponent extends CdForm implements OnInit {
 
     this.nfsForm.patchValue({
       fsal: {
-        ...this.nfsForm.get('fsal').value,
+        ...this.nfsForm.getRawValue()?.fsal,
         fs_name: fsName
       },
-      subvolumeGroup,
+      subvolume_group: subvolumeGroup,
       subvolume
     });
+    this.setUpVolumeValidation();
+    this.getSubVol(fsName);
   }
 
   resolveClusters(clusters: string[]) {
@@ -725,7 +733,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
       if (control.pristine || !control.value) {
         return of({ required: true });
       }
-      const fsName = this.nfsForm.getValue('fsal').fs_name;
+      const fsName = this.nfsForm.getRawValue()?.fsal?.fs_name;
       return this.nfsService.lsDir(fsName, control.value).pipe(
         map((directory: Directory) =>
           directory.paths.includes(control.value) === requiredExistenceResult

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.spec.ts
@@ -16,8 +16,9 @@ import { TaskListService } from '~/app/shared/services/task-list.service';
 import { SharedModule } from '~/app/shared/shared.module';
 import { configureTestBed, expectItemTasks, PermissionHelper } from '~/testing/unit-test-helper';
 import { NfsDetailsComponent } from '../nfs-details/nfs-details.component';
-import { NfsListComponent } from './nfs-list.component';
-import { SUPPORTED_FSAL } from '../models/nfs.fsal';
+import { NfsListComponent, RgwExportType } from './nfs-list.component';
+import { RGW_USER_EXPORT_PATH, SUPPORTED_FSAL } from '../models/nfs.fsal';
+import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 
 describe('NfsListComponent', () => {
   let component: NfsListComponent;
@@ -53,6 +54,53 @@ describe('NfsListComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('edit action routerLink', () => {
+    let editRouterLink: () => string | [string, { rgw_export_type: RgwExportType }];
+
+    beforeEach(() => {
+      editRouterLink = component.tableActions.find((action) => action.permission === 'update')
+        .routerLink as () => string | [string, { rgw_export_type: RgwExportType }];
+    });
+
+    it('should return a plain string for CephFS edit (no route params)', () => {
+      component.fsal = SUPPORTED_FSAL.CEPH;
+      component.selection = new CdTableSelection([
+        { cluster_id: 'mycluster', export_id: '42', path: '/volumes/g1/sv1' }
+      ]);
+
+      const link = editRouterLink();
+
+      expect(typeof link).toBe('string');
+      expect(link).toBe('/cephfs/nfs/edit/mycluster/42');
+    });
+
+    it('should return array with rgw_export_type for RGW bucket edit', () => {
+      component.fsal = SUPPORTED_FSAL.RGW;
+      component.selection = new CdTableSelection([
+        { cluster_id: 'rgw-cluster', export_id: '7', path: '/my-bucket' }
+      ]);
+
+      const link = editRouterLink();
+
+      expect(Array.isArray(link)).toBe(true);
+      expect(link[0]).toBe('/rgw/nfs/edit/rgw-cluster/7');
+      expect(link[1]).toEqual({ rgw_export_type: RgwExportType.BUCKET });
+    });
+
+    it('should return array with rgw_export_type user for RGW user-level edit', () => {
+      component.fsal = SUPPORTED_FSAL.RGW;
+      component.selection = new CdTableSelection([
+        { cluster_id: 'rgw-cluster', export_id: '8', path: RGW_USER_EXPORT_PATH }
+      ]);
+
+      const link = editRouterLink();
+
+      expect(Array.isArray(link)).toBe(true);
+      expect(link[0]).toBe('/rgw/nfs/edit/rgw-cluster/8');
+      expect(link[1]).toEqual({ rgw_export_type: RgwExportType.USER });
+    });
   });
 
   describe('after ngOnInit', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.ts
@@ -109,17 +109,23 @@ export class NfsListComponent extends ListWithDetails implements OnInit, OnDestr
     const editAction: CdTableAction = {
       permission: 'update',
       icon: Icons.edit,
-      routerLink: () => [
-        `/${prefix}/nfs/edit/${getNfsUri()}`,
-        {
-          rgw_export_type:
-            this.fsal === SUPPORTED_FSAL.RGW &&
-            !_.isEmpty(this.selection?.first()?.path) &&
-            this.selection?.first()?.path !== RGW_USER_EXPORT_PATH
-              ? RgwExportType.BUCKET
-              : RgwExportType.USER
+      routerLink: () => {
+        const currentPrefix = getPathfromFsal(this.fsal);
+        const editUrl = `/${currentPrefix}/nfs/edit/${getNfsUri()}`;
+        if (this.fsal !== SUPPORTED_FSAL.RGW) {
+          return editUrl;
         }
-      ],
+        return [
+          editUrl,
+          {
+            rgw_export_type:
+              !_.isEmpty(this.selection?.first()?.path) &&
+              this.selection?.first()?.path !== RGW_USER_EXPORT_PATH
+                ? RgwExportType.BUCKET
+                : RgwExportType.USER
+          }
+        ];
+      },
       name: this.actionLabels.EDIT
     };
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/9f60ae4a-754c-4d1c-a6cd-86e5b77477f7




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
