### PR TITLE
tentacle: pybind/rbd: handle non-existent groups properly in list_snaps()

### DIFF
--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -6131,6 +6131,7 @@ cdef class GroupSnapIterator(object):
             if ret >= 0:
                 break
             elif ret != -errno.ERANGE:
+                self.num_group_snaps = 0
                 raise make_ex(ret, 'error listing snapshots for group %s' % group.name, group_errno_to_exception)
 
     def __iter__(self):

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -3080,6 +3080,7 @@ class TestGroups(object):
         create_group()
         snap_name = get_temp_snap_name()
         self.group = Group(ioctx, group_name)
+        self.dne_group = Group(ioctx, "group_does_not_exist")
 
     def teardown_method(self, method):
         remove_group()
@@ -3193,6 +3194,7 @@ class TestGroups(object):
 
     def test_group_snap(self):
         global snap_name
+        assert_raises(ObjectNotFound, self.dne_group.list_snaps)
         eq([], list(self.group.list_snaps()))
         self.group.create_snap(snap_name)
         eq([snap_name], [snap['name'] for snap in self.group.list_snaps()])


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78266

---

backport of https://github.com/ceph/ceph/pull/70039
parent tracker: https://tracker.ceph.com/issues/78034

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh