### PR TITLE
umbrella: debian/rules: exclude ceph-osd-crimson from dwz compression

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -54,6 +54,10 @@ endif
 
 ifeq ($(DWZ), false)
 override_dh_dwz:
+else
+override_dh_dwz:
+	# Exclude ceph-osd-crimson due to excessive debug info (too many DIEs)
+	dh_dwz -Xceph-osd-crimson
 endif
 
 # for python3-${pkg} packages


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78310

---

backport of https://github.com/ceph/ceph/pull/67057
parent tracker: https://tracker.ceph.com/issues/78303

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh