### PR TITLE
umbrella: monitoring: Rename Ceph Object - Sync Overview - Replication (objects) from Source Zone

### DIFF
--- a/monitoring/ceph-mixin/dashboards/rgw.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/rgw.libsonnet
@@ -84,7 +84,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         7
       ),
       RgwSyncOverviewPanel(
-        'Replication (objects) from Source Zone',
+        'Replication Rate (Objects/s) from Source Zone',
         'short',
         'Objects/s',
         'ceph_data_sync_from_zone_fetch_bytes_count',

--- a/monitoring/ceph-mixin/dashboards_out/radosgw-sync-overview.json
+++ b/monitoring/ceph-mixin/dashboards_out/radosgw-sync-overview.json
@@ -207,7 +207,7 @@
          "thresholds": [ ],
          "timeFrom": null,
          "timeShift": null,
-         "title": "Replication (objects) from Source Zone",
+         "title": "Replication Rate (Objects/s) from Source Zone",
          "tooltip": {
             "shared": true,
             "sort": 0,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78297

---

backport of https://github.com/ceph/ceph/pull/70213
parent tracker: https://tracker.ceph.com/issues/78230

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh