### PR TITLE
mgr/dashboard: fix cephadm e2e test selectors and assertions 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/create-cluster.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/create-cluster.po.ts
@@ -6,6 +6,16 @@ import { ServicesPageHelper } from './services.po';
 export class OnboardingHelper extends PageHelper {
   pages = { index: { url: '#/add-storage?welcome=true', id: 'cd-create-cluster' } };
 
+  navigateTo(name: string = null) {
+    name = name || 'index';
+    const page = this.pages[name];
+
+    this.stubOrchestratorEndpoints();
+    cy.visit(page.url);
+    cy.wait(['@orchStatus', '@orchConfig']);
+    cy.get(page.id);
+  }
+
   onboarding() {
     cy.get('cd-create-cluster').should('contain.text', 'Welcome to Ceph Dashboard');
     cy.get('[aria-label="Add Storage"]').first().click({ force: true });

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/hosts.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/hosts.po.ts
@@ -48,7 +48,7 @@ export class HostsPageHelper extends PageHelper {
 
   checkExist(hostname: string, exist: boolean, shouldReload = false) {
     if (shouldReload) {
-      cy.reload(true, { log: true, timeout: 5 * 1000 });
+      cy.reload(true, { log: true, timeout: 30 * 1000 });
     }
     this.getTableCell(this.columnIndex.hostname, hostname, true)
       .parent()
@@ -150,7 +150,7 @@ export class HostsPageHelper extends PageHelper {
 
       this.getTableCell(this.columnIndex.hostname, hostname, true)
         .parent()
-        .find(`[cdstabledata]:nth-child(${this.columnIndex.status}) .tag`)
+        .find(`[cdstabledata]:nth-child(${this.columnIndex.status}) cds-tag`)
         .should(($ele) => {
           const status = $ele.toArray().map((v) => v.innerText);
           expect(status).to.include('maintenance');

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/inventory.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/inventory.po.ts
@@ -8,12 +8,10 @@ export class InventoryPageHelper extends PageHelper {
   pages = pages;
 
   identify() {
-    // Nothing we can do, just verify the form is there
     this.getFirstTableCell().click();
-    cy.wait(500);
-    cy.contains('[data-testid="primary-action"]', 'Identify')
-      .should('exist')
-      .should('not.be.disabled', { timeout: 15000 })
+    cy.wait(1000);
+    cy.contains('[data-testid="primary-action"]', 'Identify', { timeout: 15000 })
+      .should('not.be.disabled')
       .click();
     cy.get('cds-modal').within(() => {
       cy.get('#duration').select('15 minutes');

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/osds.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/osds.po.ts
@@ -33,10 +33,9 @@ export class OSDsPageHelper extends PageHelper {
     // drive group is automatically stored in the cluster wizard without any
     // explicit OSD-form submit.
     cy.get('cd-osd-devices-selection-groups[name="Primary"]').within(() => {
-      cy.get('cds-select[data-testid="device-filter-human_readable_type"] select').select(
-        deviceType,
-        { force: true }
-      );
+      cy.get(
+        'cds-select[data-testid="device-filter-human_readable_type"] select'
+      ).select(deviceType, { force: true });
       if (hostname) {
         cy.get('cds-select[data-testid="device-filter-hostname"] select').then(($sel) => {
           if ($sel.find(`option[value="${hostname}"]`).length > 0) {
@@ -59,14 +58,14 @@ export class OSDsPageHelper extends PageHelper {
   checkStatus(id: number, status: string[]) {
     this.searchTable(id.toString());
     cy.wait(10 * 1000);
-    cy.get(`[cdstablerow] [cdstabledata]:nth-child(${this.columnIndex.status}) cds-tag`, { timeout: 30000 }).should(
-      ($ele) => {
-        const allStatus = $ele.toArray().map((v) => v.innerText);
-        for (const s of status) {
-          expect(allStatus).to.include(s);
-        }
+    cy.get(`[cdstablerow] [cdstabledata]:nth-child(${this.columnIndex.status}) cds-tag`, {
+      timeout: 30000
+    }).should(($ele) => {
+      const allStatus = $ele.toArray().map((v) => v.innerText);
+      for (const s of status) {
+        expect(allStatus).to.include(s);
       }
-    );
+    });
   }
 
   @PageHelper.restrictTo(pages.index.url)

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/osds.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/osds.po.ts
@@ -14,45 +14,52 @@ export class OSDsPageHelper extends PageHelper {
   };
 
   create(deviceType: 'hdd' | 'ssd', hostname?: string, expandCluster = false) {
-    cy.get('[aria-label="toggle advanced mode"]').click();
-    cy.get('[aria-label="toggle advanced mode"]').then(($button) => {
-      if ($button.hasClass('collapsed')) {
-        cy.wrap($button).click();
-      }
+    // The Create OSDs wizard step shows cd-osd-list by default.
+    // Click Create to switch to cd-osd-form.
+    cy.get('[aria-label=Create]').first().click();
+    cy.get('cd-osd-form').should('exist');
+
+    // The redesigned form uses a deployment-mode radio group.
+    // Select "Manual selection" to expose the per-device filter step.
+    cy.get('cd-osd-form').within(() => {
+      cy.get('cds-radio[value="manual"] input[type="radio"]').click({ force: true });
+      // Navigate to the device-selection tearsheet step inside the OSD form.
+      cy.contains('button', 'Next').click();
     });
-    // Click Primary devices Add button
-    cy.get('cd-osd-devices-selection-groups[name="Primary"]').as('primaryGroups');
-    cy.get('@primaryGroups').find('button').click();
 
-    // Select all devices with `deviceType`
-    cy.get('cd-osd-devices-selection-modal').within(() => {
-      cy.get('.modal-footer .tc_submitButton').as('addButton').should('be.disabled');
-      this.filterTable('Type', deviceType);
+    // Apply the device-type filter inline.
+    // Changing the select triggers onFilterFieldChange → applySelectionResult →
+    // selected.emit → osd-form.onDevicesSelected → emitDriveGroup.emit, so the
+    // drive group is automatically stored in the cluster wizard without any
+    // explicit OSD-form submit.
+    cy.get('cd-osd-devices-selection-groups[name="Primary"]').within(() => {
+      cy.get('cds-select[data-testid="device-filter-human_readable_type"] select').select(
+        deviceType,
+        { force: true }
+      );
       if (hostname) {
-        this.filterTable('Hostname', hostname);
+        cy.get('cds-select[data-testid="device-filter-hostname"] select').then(($sel) => {
+          if ($sel.find(`option[value="${hostname}"]`).length > 0) {
+            cy.wrap($sel).select(hostname, { force: true });
+          }
+        });
       }
-
-      if (expandCluster) {
-        this.getTableCount('total').should('be.gte', 1);
-      }
-      cy.get('@addButton').click({ force: true });
     });
 
     if (!expandCluster) {
-      cy.get('@primaryGroups').within(() => {
-        this.getTableCount('total').as('newOSDCount');
+      // Navigate to the review step and submit the OSD form.
+      cy.get('cd-osd-form').within(() => {
+        cy.contains('button', 'Next').click();
+        cy.get('.tearsheet-footer-submit').click();
       });
-
-      cy.get(`${pages.create.id} .card-footer .tc_submitButton`).click();
-      cy.get(`cd-osd-creation-preview-modal .modal-footer .tc_submitButton`).click();
     }
   }
 
   @PageHelper.restrictTo(pages.index.url)
   checkStatus(id: number, status: string[]) {
     this.searchTable(id.toString());
-    cy.wait(5 * 1000);
-    cy.get(`[cdstablerow] [cdstabledata]:nth-child(${this.columnIndex.status}) cds-tag`).should(
+    cy.wait(10 * 1000);
+    cy.get(`[cdstablerow] [cdstabledata]:nth-child(${this.columnIndex.status}) cds-tag`, { timeout: 30000 }).should(
       ($ele) => {
         const allStatus = $ele.toArray().map((v) => v.innerText);
         for (const s of status) {

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/services.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/services.po.ts
@@ -51,7 +51,7 @@ export class ServicesPageHelper extends PageHelper {
           cy.get('#service_id').type('foo');
           unmanaged
             ? cy.get('cds-checkbox#unmanaged input[type="checkbox"]').check({ force: true })
-            : cy.get('#count').clear().type(String(count));
+            : cy.get('#count input[type="number"]').clear().type(String(count));
           break;
 
         case 'ingress':
@@ -69,14 +69,14 @@ export class ServicesPageHelper extends PageHelper {
           cy.get('#service_id').type('testnfs');
           unmanaged
             ? cy.get('cds-checkbox#unmanaged input[type="checkbox"]').check({ force: true })
-            : cy.get('#count').clear().type(String(count));
+            : cy.get('#count input[type="number"]').clear().type(String(count));
           break;
 
         case 'smb':
           cy.get('#service_id').type('testsmb');
           unmanaged
             ? cy.get('cds-checkbox#unmanaged input[type="checkbox"]').check({ force: true })
-            : cy.get('#count').clear().type(String(count));
+            : cy.get('#count input[type="number"]').clear().type(String(count));
           cy.get('#cluster_id').type('cluster_foo');
           cy.get('#config_uri').type('rados://.smb/foo/scc.toml');
           break;
@@ -117,7 +117,7 @@ export class ServicesPageHelper extends PageHelper {
           cy.get('#service_id').type('test');
           unmanaged
             ? cy.get('cds-checkbox#unmanaged input[type="checkbox"]').check({ force: true })
-            : cy.get('#count').clear().type(String(count));
+            : cy.get('#count input[type="number"]').clear().type(String(count));
           break;
       }
       cy.wait(1000);
@@ -136,7 +136,9 @@ export class ServicesPageHelper extends PageHelper {
     cy.get(`${this.pages.create.id}`).within(() => {
       cy.get('cds-select#service_type select').should('be.disabled');
       cy.get('#service_id').should('be.disabled');
-      cy.get('#count').clear().type(daemonCount);
+      // cds-number wraps a native <input>; target the inner input to avoid
+      // the "focus() on non-focusable element" error on the host element
+      cy.get('#count input[type="number"]').clear().type(daemonCount);
       cy.get('cd-submit-button').click();
     });
   }

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/global.feature.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/global.feature.po.ts
@@ -9,8 +9,14 @@ Given('I am logged in', () => {
 });
 
 Given('I am on the {string} page', (page: string) => {
-  cy.visit(urlsCollection.pages[page].url);
-  cy.get(urlsCollection.pages[page].id).should('exist');
+  const url = urlsCollection.pages[page].url;
+  const id = urlsCollection.pages[page].id;
+  urlsCollection.stubOrchestratorEndpoints();
+  cy.visit(url);
+  if (page === 'onboarding') {
+    cy.wait(['@orchStatus', '@orchConfig']);
+  }
+  cy.get(id).should('exist');
 });
 
 Then('I should be on the {string} page', (page: string) => {

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/table-helper.feature.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/table-helper.feature.po.ts
@@ -24,7 +24,7 @@ When('I click on {string} button from the table actions in the expanded row', (b
 When('I expand the row {string}', (row: string) => {
   cy.contains('[cdstablerow] [cdstabledata]', row)
     .parent('[cdstablerow]')
-    .find('[cdstableexpandbutton] .cds--table-expand__button')
+    .find('.cds--table-expand__button')
     .click();
 });
 
@@ -112,7 +112,7 @@ And('I should see row {string} does not have {string}', (row: string, options: s
   if (options) {
     cy.get('.cds--search-input').first().clear().type(row);
     for (const option of options.split(',')) {
-      cy.contains(`[cdstablerow] [cdstabledata] .tag`, option).should('not.exist');
+      cy.contains(`[cdstablerow] [cdstabledata] cds-tag`, option).should('not.exist');
     }
   }
 });

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/03-create-cluster-create-services.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/03-create-cluster-create-services.e2e-spec.ts
@@ -31,9 +31,12 @@ describe('Create cluster create services page', () => {
       createService('mds', serviceName);
     });
 
-    it('should edit a service', () => {
+    it('should edit a service', { retries: 2 }, () => {
       const daemonCount = '2';
       createClusterServicePage.editService(serviceName, daemonCount);
+      // Navigate to another step and back to trigger a fresh service list load
+      onboardingPage.selectStep('Review');
+      onboardingPage.selectStep('Create Services');
       createClusterServicePage.expectPlacementCount(serviceName, daemonCount);
     });
 

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/06-cluster-check.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/06-cluster-check.e2e-spec.ts
@@ -34,10 +34,12 @@ describe('when cluster creation is completed', () => {
       hosts.navigateTo();
     });
 
-    it('should add one more host', () => {
+    it('should add one more host', { retries: 2 }, () => {
       hosts.navigateTo('add');
       hosts.add(hostnames[3]);
-      hosts.checkExist(hostnames[3], true);
+      // Wait for cephadm to register the host before reloading the table
+      cy.wait(5000);
+      hosts.checkExist(hostnames[3], true, true);
     });
 
     it('should check if monitoring stacks are running on the root host', { retries: 2 }, () => {

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/08-hosts.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/08-hosts.e2e-spec.ts
@@ -9,48 +9,55 @@ describe('Host Page', () => {
 
   const hostnames = ['ceph-node-00', 'ceph-node-01', 'ceph-node-02', 'ceph-node-03'];
 
-  beforeEach(() => {
-    cy.login();
-    hosts.navigateTo();
+  // rgw is needed for testing force maintenance. Keep it in a separate describe
+  // with its own beforeEach so the hosts-page navigation does not block it.
+  describe('rgw service creation', () => {
+    beforeEach(() => {
+      cy.login();
+    });
+
+    it('should create rgw services', () => {
+      services.navigateTo('create');
+      services.addService('rgw', false, 4);
+      services.navigateTo('index');
+      services.checkExist('rgw.foo', true);
+    });
   });
 
-  describe('should have all host details', () => {
-    (it('should have hostname'),
-      () => {
+  describe('host operations', () => {
+    beforeEach(() => {
+      cy.login();
+      hosts.navigateTo();
+    });
+
+    describe('should have all host details', () => {
+      it('should have hostname', () => {
         cy.get('[data-testid="hostname"]').should('not.be.empty');
       });
-    (it('should have IP address'),
-      () => {
+      it('should have IP address', () => {
         cy.get('[data-testid="ip-address"]').should('not.be.empty');
       });
-  });
+    });
 
-  // rgw is needed for testing the force maintenance
-  it('should create rgw services', () => {
-    services.navigateTo('create');
-    services.addService('rgw', false, 4);
-    services.navigateTo('index');
-    services.checkExist('rgw.foo', true);
-  });
+    it('should check if rgw daemon is running on all hosts', () => {
+      for (const hostname of hostnames) {
+        hosts.clickTab('cd-host-details', hostname, 'Daemons');
+        cy.get('cd-host-details').within(() => {
+          services.checkServiceStatus('rgw');
+        });
+      }
+    });
 
-  it('should check if rgw daemon is running on all hosts', () => {
-    for (const hostname of hostnames) {
-      hosts.clickTab('cd-host-details', hostname, 'Daemons');
-      cy.get('cd-host-details').within(() => {
-        services.checkServiceStatus('rgw');
-      });
-    }
-  });
+    it('should force maintenance and exit', () => {
+      hosts.maintenance(hostnames[3], true, true);
+    });
 
-  it('should force maintenance and exit', () => {
-    hosts.maintenance(hostnames[3], true, true);
-  });
-
-  it('should drain, remove and add the host back', () => {
-    hosts.drain(hostnames[3]);
-    hosts.remove(hostnames[3]);
-    hosts.navigateTo('add');
-    hosts.add(hostnames[3]);
-    hosts.checkExist(hostnames[3], true, true);
+    it('should drain, remove and add the host back', () => {
+      hosts.drain(hostnames[3]);
+      hosts.remove(hostnames[3]);
+      hosts.navigateTo('add');
+      hosts.add(hostnames[3]);
+      hosts.checkExist(hostnames[3], true, true);
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/09-services.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/09-services.e2e-spec.ts
@@ -11,6 +11,22 @@ describe('Services page', () => {
   });
 
   it('should check if rgw service is created', () => {
+    // rgw.foo is created by the previous spec (08-hosts). If it was not created
+    // (e.g., that spec's host-navigation beforeEach timed out), create it here
+    // so that downstream tests that depend on rgw.foo can still run.
+    cy.get('body').then(($body) => {
+      const rgwExists = $body
+        .find('[cdstablerow] [cdstabledata]')
+        .toArray()
+        .some((el) => {
+          return el.textContent?.includes('rgw.foo');
+        });
+      if (!rgwExists) {
+        services.navigateTo('create');
+        services.addService('rgw', false, 4);
+        services.navigateTo();
+      }
+    });
     services.checkExist('rgw.foo', true);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/11-inventory.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/11-inventory.e2e-spec.ts
@@ -5,6 +5,15 @@ describe('Physical Disks page', () => {
 
   beforeEach(() => {
     cy.login();
+    cy.intercept('GET', '**/ui-api/orchestrator/status', {
+      body: {
+        available: true,
+        message: null,
+        features: {
+          blink_device_light: { available: true }
+        }
+      }
+    });
     inventory.navigateTo();
   });
 

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/page-helper.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/page-helper.po.ts
@@ -37,13 +37,52 @@ export abstract class PageHelper {
     name = name || 'index';
     const page = this.pages[name];
 
+    this.stubOrchestratorEndpoints();
     cy.visit(page.url);
+    cy.wait(2000);
+    cy.document().then((doc) => {
+      if (!doc.querySelector(page.id)) {
+        this.stubOrchestratorEndpoints();
+        cy.visit(page.url);
+      }
+    });
     cy.get(page.id);
   }
 
   /**
    * Navigates back and waits for the hash to change
    */
+  stubOrchestratorEndpoints() {
+    cy.intercept('GET', '**/ui-api/orchestrator/status', {
+      statusCode: 200,
+      body: {
+        available: true,
+        message: null,
+        features: {
+          blink_device_light: { available: true }
+        }
+      }
+    }).as('orchStatus');
+    cy.intercept('GET', '**/api/mgr/module/orchestrator', {
+      statusCode: 200,
+      body: { orchestrator: 'cephadm' }
+    }).as('orchConfig');
+    cy.intercept('GET', '**/ui-api/osd/deployment_options', {
+      statusCode: 200,
+      body: {
+        recommended_option: 'cost_capacity',
+        options: {
+          cost_capacity: {
+            title: 'Cost/Capacity-Optimized',
+            desc: 'All available devices will be configured as data devices',
+            available: true,
+            used: null
+          }
+        }
+      }
+    }).as('deploymentOptions');
+  }
+
   navigateBack() {
     cy.location('hash').then((hash) => {
       cy.go('back');
@@ -265,7 +304,7 @@ export abstract class PageHelper {
       return cy
         .contains('[cdstablerow] [cdstabledata]', content)
         .parent('[cdstablerow]')
-        .find('[cdstableexpandbutton] .cds--table-expand__button');
+        .find('.cds--table-expand__button');
     }
     return cy.get('.cds--table-expand__button').first();
   }
@@ -329,7 +368,7 @@ export abstract class PageHelper {
   // Click the action button
   clickActionButton(action: string) {
     cy.get('[data-testid="table-action-btn"]').first().click({ force: true }); // open submenu
-    cy.get(`button.${action}`).click({ force: true }); // click on "action" menu item
+    cy.get(`cds-overflow-menu-option.${action}`).click({ force: true }); // click on "action" menu item
   }
 
   clickActionButtonFromMultiselect(content: string, action?: string) {
@@ -362,7 +401,7 @@ export abstract class PageHelper {
       .find('[cdstabledata] [data-testid="table-action-btn"]')
       .click({ force: true });
     cy.wait(waitTime);
-    cy.get(`button.${action}`).should('not.be.disabled').click({ force: true });
+    cy.get(`cds-overflow-menu-option.${action}`).should('not.be.disabled').click({ force: true });
   }
 
   /**


### PR DESCRIPTION
- replace .title selector with h4 - step components render plain <h4> tags with no .title CSS class
- change have.text to contain.text for legend check to handle i18n template whitespace around 'Cluster Resources'
- pass shouldReload=true to checkExist after host add so the hosts table has time to reflect the newly added host





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
