### PR TITLE
client: revalidate O_APPEND write position after cap acquisition

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12699,19 +12699,17 @@ int64_t Client::_write(Fh *f, int64_t offset, uint64_t size, bufferlist bl,
   if ((f->mode & CEPH_FILE_MODE_WR) == 0)
     return -EBADF;
 
+  bool is_append = false;
   // use/adjust fd pos?
   if (offset < 0) {
     lock_fh_pos(f);
-    /*
-     * FIXME: this is racy in that we may block _after_ this point waiting for caps, and size may
-     * change out from under us.
-     */
     if (f->flags & O_APPEND) {
       auto r = _lseek(f, 0, SEEK_END);
       if (r < 0) {
         unlock_fh_pos(f);
         return r;
       }
+      is_append = true;
     }
     offset = f->pos;
     fpos = offset+size;
@@ -12747,6 +12745,47 @@ int64_t Client::_write(Fh *f, int64_t offset, uint64_t size, bufferlist bl,
   int r = get_caps(f, CEPH_CAP_FILE_WR|CEPH_CAP_AUTH_SHARED, want, &have, endoff);
   if (r < 0)
     return r;
+
+  /*
+   * For O_APPEND writes we may have waited for Fwx exclusive caps
+   * while the previous Fwx holder (another client) extended the
+   * file.  in->size has been updated via the cap grant message from
+   * the MDS, but offset is still the old EOF.  Re-read in->size
+   * here (no extra MDS round-trip needed) and adjust offset to the
+   * true EOF.  Since we hold Fwx, no other client can change the
+   * file.
+   */
+  if (is_append) {
+    if (in->size != (uint64_t)offset) {
+      ldout(cct, 10) << "O_APPEND: adjusting offset " << offset
+                     << " -> " << in->size << dendl;
+      offset = in->size;
+      fpos = offset + size;
+      endoff = offset + size;
+
+      /*
+       * get_caps() validated the old endoff against
+       * max_size; adjusting offset forward may have
+       * shifted the write range beyond the granted
+       * max_size.  Re-check and truncate if necessary.
+       */
+      if (endoff > in->max_size) {
+        if ((uint64_t)offset >= in->max_size) {
+          put_cap_ref(in, CEPH_CAP_FILE_WR);
+          put_cap_ref(in, CEPH_CAP_AUTH_SHARED);
+          return -EFBIG;
+        }
+        size = in->max_size - offset;
+        fpos = offset + size;
+        endoff = offset + size;
+        bl.splice(size, bl.length() - size);
+        ldout(cct, 10)
+          << "O_APPEND: endoff exceeds max_size ("
+          << in->max_size << "), truncated write to "
+          << size << dendl;
+      }
+    }
+  }
 
   put_cap_ref(in, CEPH_CAP_AUTH_SHARED);
   if (size > 0) {

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4103,7 +4103,15 @@ void Client::send_cap(Inode *in, MetaSession *session, Cap *cap,
 {
   int held = cap->issued | cap->implemented;
   int revoking = cap->implemented & ~cap->issued;
-  retain &= ~revoking;
+  // Caps that the MDS is revoking but that are still in use by an
+  // in-flight write are retained until the references are dropped, so
+  // that the release, and the size flush it carries, reflects the
+  // completed write.  Only FILE_WR/FILE_BUFFER count: Fx and Fc must
+  // be released promptly, or the filelock gather (e.g. the EXCL->MIX
+  // teardown for the next writer's max_size grant) would wait for
+  // them forever.
+  retain &= ~(revoking &
+	      ~(used & (CEPH_CAP_FILE_WR | CEPH_CAP_FILE_BUFFER)));
   int dropping = cap->issued & ~retain;
   int op = CEPH_CAP_OP_UPDATE;
 
@@ -6177,7 +6185,7 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, const M
 
   // max_size
   if (cap == in->auth_cap &&
-      (new_caps & CEPH_CAP_ANY_FILE_WR) &&
+      ((new_caps | issued) & CEPH_CAP_ANY_FILE_WR) &&
       (m->get_max_size() != in->max_size)) {
     ldout(cct, 10) << "max_size " << in->max_size << " -> " << m->get_max_size() << dendl;
     in->max_size = m->get_max_size();

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3956,7 +3956,8 @@ void Client::put_cap_ref(Inode *in, int cap)
 // issued by the mds and @want caps not revoked (or not under revocation).
 // this routine blocks till the cap requirement is satisfied. also account
 // (track) for capability hit when required (when cap requirement succeedes).
-int Client::get_caps(Fh *fh, int need, int want, int *phave, loff_t endoff)
+int Client::get_caps(Fh *fh, int need, int want, int *phave, loff_t endoff,
+                     int allow_implemented)
 {
   Inode *in = fh->inode.get();
 
@@ -3981,6 +3982,13 @@ int Client::get_caps(Fh *fh, int need, int want, int *phave, loff_t endoff)
 
     int implemented;
     int have = in->caps_issued(&implemented);
+    // An O_APPEND writer may proceed with caps that the MDS is
+    // revoking but that are still implemented and in use (e.g. a Fw
+    // revoked by the next writer's gather while our write is about
+    // to start): the release is deferred by our cap ref and will
+    // carry the size flush once the write completes.
+    if (allow_implemented)
+      have |= implemented & allow_implemented;
 
     bool waitfor_caps = false;
     bool waitfor_commit = false;
@@ -6143,6 +6151,17 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, const M
 
   if (new_caps & (CEPH_CAP_ANY_FILE_RD | CEPH_CAP_ANY_FILE_WR)) {
     in->layout = m->get_layout();
+    update_inode_file_size(in, issued, m->effective_size(),
+			   m->get_truncate_seq(), m->get_truncate_size());
+  } else if (cap == in->auth_cap &&
+             (m->get_max_size() != in->max_size)) {
+    /*
+     * A max_size grant that carries no new caps (e.g. a
+     * share_inode_max_size grant after another writer's flush):
+     * apply the fresh size too, so that an O_APPEND revalidation
+     * after such a grant sees the true EOF.
+     * update_inode_file_size() ignores it unless it is newer.
+     */
     update_inode_file_size(in, issued, m->effective_size(),
 			   m->get_truncate_seq(), m->get_truncate_size());
   }
@@ -10993,6 +11012,10 @@ int Client::_release_fh(Fh *f)
       }
     }
 #endif
+    if (f->flags & O_APPEND) {
+      ceph_assert(in->append_open_refs > 0);
+      in->append_open_refs--;
+    }
     if (in->put_open_ref(f->mode)) {
       _flush(in, new C_Client_FlushComplete(this, in));
       check_caps(in, 0);
@@ -11126,6 +11149,8 @@ int Client::_open(const InodeRef& in, int flags, mode_t mode, Fh **fhp,
   if (result >= 0) {
     if (fhp) {
       *fhp = _create_fh(in.get(), flags, cmode, perms);
+      if (flags & O_APPEND)
+        in->append_open_refs++;
       // ceph_flags_sys2wire/ceph_flags_to_mode() calls above transforms O_DIRECTORY flag
       // into CEPH_FILE_MODE_PIN mode. Although this mode is used at server size
       // we [ab]use it here to determine whether we should pin inode to prevent from
@@ -12757,19 +12782,17 @@ int64_t Client::_write(Fh *f, int64_t offset, uint64_t size, bufferlist bl,
   if ((f->mode & CEPH_FILE_MODE_WR) == 0)
     return -EBADF;
 
+  bool is_append = false;
   // use/adjust fd pos?
   if (offset < 0) {
     lock_fh_pos(f);
-    /*
-     * FIXME: this is racy in that we may block _after_ this point waiting for caps, and size may
-     * change out from under us.
-     */
     if (f->flags & O_APPEND) {
       auto r = _lseek(f, 0, SEEK_END);
       if (r < 0) {
         unlock_fh_pos(f);
         return r;
       }
+      is_append = true;
     }
     offset = f->pos;
     fpos = offset+size;
@@ -12802,9 +12825,106 @@ int64_t Client::_write(Fh *f, int64_t offset, uint64_t size, bufferlist bl,
     want = CEPH_CAP_FILE_BUFFER | CEPH_CAP_FILE_LAZYIO;
   else
     want = CEPH_CAP_FILE_BUFFER;
-  int r = get_caps(f, CEPH_CAP_FILE_WR|CEPH_CAP_AUTH_SHARED, want, &have, endoff);
-  if (r < 0)
-    return r;
+  int need = CEPH_CAP_FILE_WR|CEPH_CAP_AUTH_SHARED;
+  int r;
+  if (is_append) {
+    /*
+     * An O_APPEND write must land at the EOF that is current when
+     * the write actually occurs.  Serialize appends through the MDS:
+     * every append asks for a max_size bump, and the MDS gathers the
+     * other writers' caps before granting it - their releases are
+     * deferred until their in-flight writes complete and carry the
+     * size of the completed writes.  The grant is therefore the
+     * serialization ticket: it only arrives after all other writers
+     * have flushed, and it carries the up-to-date size, which the
+     * write revalidates against below.  The +1 guarantees a request
+     * even when max_size already covers endoff, and the wait below
+     * guarantees the write does not proceed on stale caps that we
+     * may already hold.  No cap refs are held while waiting, so the
+     * revokes of the gather are answered promptly.
+     *
+     * get_caps() below accepts implemented (revoking) FILE_WR: the
+     * next writer's gather may revoke our Fw right after the grant,
+     * but as long as it is still implemented we hold its ref and can
+     * proceed to write, deferring the release - and with it the size
+     * flush - until the write completed.  That is what makes the
+     * next writer's grant wait for our write.
+     */
+    in->wanted_max_size = std::max(in->wanted_max_size,
+				   std::max((uint64_t)endoff,
+					    in->max_size + 1));
+    if (in->wanted_max_size > in->max_size &&
+        in->wanted_max_size > in->requested_max_size)
+      check_caps(in, 0);
+    while (in->requested_max_size > 0 &&
+	   in->max_size <= in->requested_max_size) {
+      wait_on_context_list(in->waitfor_caps);
+    }
+    r = get_caps(f, need, want, &have, endoff, CEPH_CAP_FILE_WR);
+    if (r < 0)
+      return r;
+
+    /*
+     * We may have waited for caps while the previous writer
+     * (another client) extended the file.  in->effective_size()
+     * has been updated via the cap grant message from the MDS,
+     * but offset is still the old EOF.  Re-read
+     * in->effective_size() here (no extra MDS round-trip needed)
+     * and adjust offset to the true EOF.
+     *
+     * Note that for fscrypt enabled files in->size and in->max_size
+     * are in encrypted (physical) size, which is the logical size
+     * rounded up to the fscrypt block size, while offset is logical.
+     * So compare against in->effective_size() and convert the write
+     * extent to the physical size before re-checking max_size.
+     */
+    uint64_t eof = in->effective_size();
+    if (eof != (uint64_t)offset) {
+      ldout(cct, 10) << "O_APPEND: adjusting offset " << offset
+                     << " -> " << eof << dendl;
+      offset = eof;
+      fpos = offset + size;
+      endoff = offset + size;
+
+      /*
+       * get_caps() above validated the old endoff against
+       * max_size; adjusting offset forward may have shifted the
+       * write range beyond the granted max_size.  Ask for a
+       * big enough max_size and wait for the grant.
+       */
+      uint64_t extent_end = endoff;
+#if defined(__linux__)
+      if (in->is_fscrypt_enabled())
+        extent_end = fscrypt_next_block_start(endoff);
+#endif
+      if (extent_end > in->max_size) {
+        /*
+         * Drop the FILE_WR ref before waiting: nothing has been
+         * written yet, and while we wait the MDS may revoke our caps
+         * as part of another writer's gather.  Holding the ref would
+         * defer that release, and the grant we are waiting for needs
+         * the gather to complete - a deadlock.
+         */
+        put_cap_ref(in, CEPH_CAP_FILE_WR);
+        in->wanted_max_size = std::max(in->wanted_max_size, extent_end);
+        if (in->wanted_max_size > in->max_size &&
+            in->wanted_max_size > in->requested_max_size)
+          check_caps(in, 0);
+        r = get_caps(f, CEPH_CAP_FILE_WR|CEPH_CAP_AUTH_SHARED, want,
+                     &have, endoff, CEPH_CAP_FILE_WR);
+        if (r < 0) {
+          put_cap_ref(in, CEPH_CAP_AUTH_SHARED);
+          return r;
+        }
+        // drop the extra cap refs taken by the get_caps() call above
+        put_cap_ref(in, CEPH_CAP_AUTH_SHARED);
+      }
+    }
+  } else {
+    r = get_caps(f, need, want, &have, endoff);
+    if (r < 0)
+      return r;
+  }
 
   put_cap_ref(in, CEPH_CAP_AUTH_SHARED);
   if (size > 0) {
@@ -16167,6 +16287,8 @@ int Client::_create(const walk_dentry_result& wdr, int flags, mode_t mode,
 
     (*inp)->get_open_ref(cmode);
     *fhp = _create_fh(inp->get(), flags, cmode, perms);
+    if (flags & O_APPEND)
+      (*inp)->append_open_refs++;
   }
 
  reply_error:

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -853,7 +853,8 @@ public:
   void kick_flushing_caps(Inode *in, MetaSession *session);
   void kick_flushing_caps(MetaSession *session);
   void early_kick_flushing_caps(MetaSession *session);
-  int get_caps(Fh *fh, int need, int want, int *have, loff_t endoff);
+  int get_caps(Fh *fh, int need, int want, int *have, loff_t endoff,
+               int allow_implemented = 0);
   int get_caps_used(Inode *in);
 
   void maybe_update_snaprealm(SnapRealm *realm, snapid_t snap_created, snapid_t snap_highwater,

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -366,6 +366,11 @@ int Inode::caps_file_wanted()
       }
 #endif
     }
+  if (append_open_refs) {
+    // An O_APPEND writer needs Fx so that Client::_write() knows no
+    // other writer can extend the file under it.
+    want |= CEPH_CAP_FILE_EXCL;
+  }
   return want;
 }
 

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -256,6 +256,7 @@ struct Inode : RefCountedObject {
 
   //int open_by_mode[CEPH_FILE_MODE_NUM];
   std::map<int,int> open_by_mode;
+  int append_open_refs = 0; // number of fds opened with O_APPEND
   std::map<int,int> cap_refs;
 
   ObjectCacher::ObjectSet oset; // ORDER DEPENDENCY: ino

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3400,7 +3400,7 @@ client_t CInode::calc_ideal_loner()
     return -1;
   if (!get_mds_caps_wanted().empty())
     return -1;
-  
+
   int n = 0;
   client_t loner = -1;
   for (const auto &p : client_caps) {
@@ -3419,7 +3419,26 @@ client_t CInode::calc_ideal_loner()
 
 bool CInode::choose_ideal_loner()
 {
-  want_loner_cap = calc_ideal_loner();
+  client_t ideal = calc_ideal_loner();
+  // A writer that asked for more max_size was explicitly made the
+  // loner (set_loner_cap() + file_excl_pin): keep it over the ideal
+  // computation, so that the filelock bumps to EXCL and the grant
+  // carries Fx plus the up-to-date size gathered from the other
+  // writers, serializing them - one grant at a time.  The other
+  // writer's wanted caps then tear the filelock back down to MIX,
+  // whose gather defers the grantee's release (and with it the size
+  // flush) until its in-flight write completes, and the next
+  // max_size request re-pins its requester.  The pin is released
+  // only when the pinned client stops wanting Fx (e.g. its O_APPEND
+  // fd closed), so that the ideal computation takes over again.
+  if (file_excl_pin && ideal != loner_cap && loner_cap >= 0) {
+    Capability *cap = get_client_cap(loner_cap);
+    if (cap && (cap->wanted() & CEPH_CAP_FILE_EXCL))
+      ideal = loner_cap;
+    else
+      file_excl_pin = false;
+  }
+  want_loner_cap = ideal;
   int changed = false;
   if (loner_cap >= 0 && loner_cap != want_loner_cap) {
     if (!try_drop_loner())
@@ -3449,6 +3468,7 @@ bool CInode::try_set_loner()
 void CInode::set_loner_cap(client_t l)
 {
   loner_cap = l;
+  want_loner_cap = l;
   authlock.set_excl_client(loner_cap);
   filelock.set_excl_client(loner_cap);
   linklock.set_excl_client(loner_cap);
@@ -4376,13 +4396,20 @@ void CInode::encode_cap_message(const ref_t<MClientCaps> &m, Capability *cap)
  
   const mempool_inode *oi = get_inode().get();
   const mempool_inode *pi = get_projected_inode().get();
-  const mempool_inode *i = (pfile|pauth|plink|pxattr) ? pi : oi;
+  const mempool_inode *i =
+    (pfile|pauth|plink|pxattr) ||
+    ((cap->issued() | cap->pending() | cap->wanted()) &
+     CEPH_CAP_FILE_WR) ? pi : oi;
 
   dout(20) << __func__ << " pfile " << pfile
 	   << " pauth " << pauth << " plink " << plink << " pxattr " << pxattr
 	   << " mtime " << i->mtime << " ctime " << i->ctime << " change_attr " << i->change_attr << dendl;
 
-  i = pfile ? pi:oi;
+  // A client that holds or wants WR caps (e.g. an O_APPEND writer)
+  // should see the projected size, which may include the previous
+  // writer's size flush that has not been committed yet.
+  i = (pfile || ((cap->issued() | cap->pending() | cap->wanted()) &
+		 CEPH_CAP_FILE_WR)) ? pi : oi;
   m->set_layout(i->layout);
   m->size = i->size;
   m->truncate_seq = i->truncate_seq;

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -882,6 +882,13 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
       return -1;
   }
 
+  // Set when a max_size request makes its requester the loner: keep
+  // that client the loner over the ideal computation, so that the
+  // filelock bumps to EXCL and the grant carries Fx, serializing
+  // writers (e.g. O_APPEND), one grant at a time.  Cleared by
+  // choose_ideal_loner() once the pinned client stops wanting Fx.
+  bool file_excl_pin = false;
+
   client_t calc_ideal_loner();
   void set_loner_cap(client_t l);
   bool choose_ideal_loner();

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2945,18 +2945,21 @@ class C_MDL_CheckMaxSize : public LockerContext {
   uint64_t new_max_size;
   uint64_t newsize;
   utime_t mtime;
+  client_t client;
 
 public:
   C_MDL_CheckMaxSize(Locker *l, CInode *i, uint64_t _new_max_size,
-                     uint64_t _newsize, utime_t _mtime) :
+                     uint64_t _newsize, utime_t _mtime, client_t c) :
     LockerContext(l), in(i),
-    new_max_size(_new_max_size), newsize(_newsize), mtime(_mtime)
+    new_max_size(_new_max_size), newsize(_newsize), mtime(_mtime),
+    client(c)
   {
     in->get(CInode::PIN_PTRWAITER);
   }
   void finish(int r) override {
     if (in->is_auth())
-      locker->check_inode_max_size(in, false, new_max_size, newsize, mtime);
+      locker->check_inode_max_size(in, false, new_max_size, newsize, mtime,
+                                   client);
     in->put(CInode::PIN_PTRWAITER);
   }
 };
@@ -3060,7 +3063,7 @@ bool Locker::calc_new_client_ranges(CInode *in, uint64_t size, bool *max_increas
 
 bool Locker::check_inode_max_size(CInode *in, bool force_wrlock,
 				  uint64_t new_max_size, uint64_t new_size,
-				  utime_t new_mtime)
+				  utime_t new_mtime, client_t client)
 {
   ceph_assert(in->is_auth());
   ceph_assert(in->is_file());
@@ -3086,12 +3089,33 @@ bool Locker::check_inode_max_size(CInode *in, bool force_wrlock,
 	   << " update_size " << update_size
 	   << " on " << *in << dendl;
 
+  // For a max_size increase request, if any other client still holds
+  // WR caps it may have unflushed extensions (e.g. concurrent O_APPEND
+  // writers).  Gather their caps first so that the size they flush is
+  // applied before we grant the new max_size, otherwise the grant would
+  // carry a stale size.  Only check issued caps here so that the
+  // condition clears once the gather completes and cannot loop forever.
+  // Exclude the requester: it may still hold its own WR caps (e.g. a
+  // loner's Fx), which must not block its own grant.
+  bool other_writers = false;
+  if (new_max_size > 0) {
+    for (const auto &p : in->client_caps) {
+      if (p.first != client &&
+	  (p.second.issued() & CEPH_CAP_FILE_WR)) {
+        other_writers = true;
+        break;
+      }
+    }
+  }
+
   if (in->is_frozen()) {
     dout(10) << "check_inode_max_size frozen, waiting on " << *in << dendl;
     in->add_waiter(CInode::WAIT_UNFREEZE,
-		   new C_MDL_CheckMaxSize(this, in, new_max_size, new_size, new_mtime));
+		   new C_MDL_CheckMaxSize(this, in, new_max_size, new_size,
+					  new_mtime, client));
     return false;
-  } else if (!force_wrlock && !in->filelock.can_wrlock(in->get_loner())) {
+  } else if (!force_wrlock &&
+             (!in->filelock.can_wrlock(in->get_loner()) || other_writers)) {
     // lock?
     if (in->filelock.is_stable()) {
       auto wanted = in->get_caps_wanted();
@@ -3101,18 +3125,41 @@ bool Locker::check_inode_max_size(CInode *in, bool force_wrlock,
       } else {
         simple_lock(&in->filelock);
       }
+      // re-evaluate after starting the transition above
+      other_writers = false;
+      for (const auto &p : in->client_caps) {
+        if (p.first != client &&
+	    (p.second.issued() & CEPH_CAP_FILE_WR)) {
+          other_writers = true;
+          break;
+        }
+      }
     }
-    if (!in->filelock.can_wrlock(in->get_loner())) {
+    if (!in->filelock.can_wrlock(in->get_loner()) || other_writers) {
       dout(10) << "check_inode_max_size can't wrlock, waiting on " << *in << dendl;
       in->filelock.add_waiter(SimpleLock::WAIT_STABLE,
-			      new C_MDL_CheckMaxSize(this, in, new_max_size, new_size, new_mtime));
+			      new C_MDL_CheckMaxSize(this, in, new_max_size, new_size,
+						     new_mtime, client));
       return false;
+    }
+  }
+
+  if (client >= 0) {
+    Capability *cap = in->get_client_cap(client);
+    if (cap && (cap->wanted() & CEPH_CAP_FILE_EXCL)) {
+      // The requesting client wants Fx (an O_APPEND writer): make it
+      // the loner so that the filelock transitions to EXCL and the
+      // client writes serially, one appender at a time.
+      dout(10) << "check_inode_max_size setting loner to client."
+	       << client << " " << *in << dendl;
+      in->set_loner_cap(client);
+      in->file_excl_pin = true;
     }
   }
 
   MutationRef mut(new MutationImpl());
   mut->ls = mds->mdlog->get_current_segment();
-    
+
   auto pi = in->project_inode(mut);
   pi.inode->version = in->pre_dirty();
 
@@ -3205,6 +3252,10 @@ void Locker::share_inode_max_size(CInode *in, Capability *only_cap)
                                          cap->get_last_issue(),
                                          mds->get_osd_epoch_barrier());
       in->encode_cap_message(m, cap);
+      // carry the projected size so that the grant reflects the
+      // previous writer's size flush even when its journal entry has
+      // not been committed yet; an O_APPEND revalidation relies on it
+      m->set_size(in->get_projected_inode()->size);
       mds->send_message_client_counted(m, cap->get_session());
     }
     if (only_cap)
@@ -4110,17 +4161,41 @@ bool Locker::_do_cap_update(CInode *in, Capability *cap,
       }
     }
 
+    // For an explicit max_size increase request, if other clients hold
+    // or want WR caps they may have unflushed extensions (e.g.
+    // concurrent O_APPEND writers).  Gather their caps first so that
+    // the size they flush is applied before we grant the new max_size,
+    // otherwise the grant would carry a stale size.  Note that during
+    // a gather their issued and pending WR caps may be transiently
+    // revoked, so check wanted() as well.  If the requester already
+    // holds the filelock exclusively there is nothing to gather.
+    bool other_writers = false;
+    if (forced_change_max &&
+        !(in->filelock.get_state() == LOCK_EXCL &&
+          in->get_loner() == client)) {
+      for (const auto &p : in->client_caps) {
+	if (p.first != client &&
+	    (p.second.issued() | p.second.pending() | p.second.wanted()) &
+	    CEPH_CAP_FILE_WR) {
+	  other_writers = true;
+	  break;
+	}
+      }
+    }
+
     if (in->last == CEPH_NOSNAP &&
 	change_max &&
-	!in->filelock.can_wrlock(client) &&
-	!in->filelock.can_force_wrlock(client)) {
+	((!in->filelock.can_wrlock(client) &&
+	  !in->filelock.can_force_wrlock(client)) || other_writers)) {
       dout(10) << " i want to change file_max, but lock won't allow it (yet)" << dendl;
       if (in->filelock.is_stable()) {
 	bool need_issue = false;
 	if (cap)
 	  cap->inc_suppress();
 	if (in->get_mds_caps_wanted().empty() &&
-	    (in->get_loner() >= 0 || (in->get_wanted_loner() >= 0 && in->try_set_loner()))) {
+	    ((in->get_loner() == client) ||
+	     (in->get_loner() < 0 && in->get_wanted_loner() >= 0 &&
+	      in->try_set_loner()))) {
 	  if (in->filelock.get_state() != LOCK_EXCL)
 	    file_excl(&in->filelock, &need_issue);
 	} else
@@ -4130,11 +4205,11 @@ bool Locker::_do_cap_update(CInode *in, Capability *cap,
 	if (cap)
 	  cap->dec_suppress();
       }
-      if (!in->filelock.can_wrlock(client) &&
-	  !in->filelock.can_force_wrlock(client)) {
+      if ((!in->filelock.can_wrlock(client) &&
+	   !in->filelock.can_force_wrlock(client)) || other_writers) {
 	C_MDL_CheckMaxSize *cms = new C_MDL_CheckMaxSize(this, in,
 	                                                 forced_change_max ? new_max : 0,
-	                                                 0, utime_t());
+	                                                 0, utime_t(), client);
 
 	in->filelock.add_waiter(SimpleLock::WAIT_STABLE, cms);
 	change_max = false;
@@ -4190,6 +4265,15 @@ bool Locker::_do_cap_update(CInode *in, Capability *cap,
       cr.range.last = new_max;
       cr.follows = in->first - 1;
       in->mark_clientwriteable();
+      if (cap && (cap->wanted() & CEPH_CAP_FILE_EXCL)) {
+	// An O_APPEND writer asked for more max_size: make it the
+	// loner so that the filelock transitions to EXCL and the
+	// grant carries Fx, serializing appends.
+	dout(10) << "_do_cap_update setting loner to client." << client
+		 << " " << *in << dendl;
+	in->set_loner_cap(client);
+	in->file_excl_pin = true;
+      }
       if (cap)
 	cap->mark_clientwriteable();
     } else {
@@ -5742,7 +5826,12 @@ void Locker::file_eval(ScatterLock *lock, bool *need_issue)
   else if (lock->get_state() != LOCK_EXCL &&
 	   !lock->is_rdlocked() &&
 	   //!lock->is_waiter_for(SimpleLock::WAIT_WR) &&
-	   in->get_target_loner() >= 0 &&
+	   (in->get_target_loner() >= 0 ||
+	    // a max_size request (e.g. from an O_APPEND writer) that
+	    // wrlocked the filelock has made this client the loner;
+	    // bump to EXCL even though calc_ideal_loner() no longer
+	    // prefers it, so that the grant carries Fx
+	    (lock->get_state() == LOCK_LOCK && in->get_loner() >= 0)) &&
 	   (in->is_dir() ?
 	    !in->has_subtree_or_exporting_dirfrag() :
 	    (wanted & (CEPH_CAP_ANY_FILE_WR >> CEPH_CAP_SFILE)))) {

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -203,7 +203,8 @@ public:
 			      bool *max_increased=nullptr);
   bool check_inode_max_size(CInode *in, bool force_wrlock=false,
                             uint64_t newmax=0, uint64_t newsize=0,
-			    utime_t mtime=utime_t());
+			    utime_t mtime=utime_t(),
+			    client_t client=-1);
   void share_inode_max_size(CInode *in, Capability *only_cap=0);
 
   // -- client leases --

--- a/src/test/libcephfs/multiclient.cc
+++ b/src/test/libcephfs/multiclient.cc
@@ -17,9 +17,12 @@
 #include "include/compat.h"
 #include "include/cephfs/libcephfs.h"
 #include "include/ceph_fs.h"
+#include <atomic>
+#include <cstdlib>
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <memory>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -181,6 +184,116 @@ TEST(LibCephFS, MulticlientRevokeCaps) {
   thread2.join();
 }
 
+static void append_worker(struct ceph_mount_info *cmount, const char *path,
+			  char tag, int64_t buf_size, int rounds,
+			  std::atomic<bool> *go, std::atomic<int> *errors)
+{
+  std::unique_ptr<char[]> buf(new char[buf_size]);
+  memset(buf.get(), tag, buf_size);
+
+  int fd = ceph_open(cmount, path, O_CREAT|O_WRONLY|O_APPEND, 0644);
+  if (fd < 0) {
+    errors->fetch_add(1);
+    printf("append_worker: failed to open %s: %s\n", path, strerror(-fd));
+    return;
+  }
+
+  while (!go->load()) {
+    std::this_thread::yield();
+  }
+
+  for (int i = 0; i < rounds; i++) {
+    int r = ceph_write(cmount, fd, buf.get(), buf_size, -1);
+    if (r != buf_size) {
+      errors->fetch_add(1);
+      printf("append_worker: write failed: %d (%s)\n", r,
+             r < 0 ? strerror(-r) : "short write");
+      break;
+    }
+    // give the other writer a chance to acquire caps, so that the
+    // next _lseek(SEEK_END) sees a stale EOF while we wait for Fwx
+    usleep(rand() % 500);
+  }
+
+  ceph_close(cmount, fd);
+}
+
+// Test that O_APPEND writes always land at the EOF that is current
+// once the client actually acquires Fwx caps, even when another
+// client extended the file in the meantime (tracker #7333).
+TEST(LibCephFS, MulticlientAppend) {
+  struct ceph_mount_info *ca, *cb;
+  ASSERT_EQ(ceph_create(&ca, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(ca, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(ca, NULL));
+  ASSERT_EQ(ceph_mount(ca, NULL), 0);
+
+  ASSERT_EQ(ceph_create(&cb, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cb, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cb, NULL));
+  ASSERT_EQ(ceph_mount(cb, NULL), 0);
+
+  char name[32];
+  snprintf(name, sizeof(name), "append.%d", getpid());
+
+  const int64_t buf_size = 1 << 20;
+  const int rounds = 32;
+
+  std::atomic<bool> go{false};
+  std::atomic<int> errors{0};
+
+  std::thread thread_a(append_worker, ca, name, 'A', buf_size, rounds,
+		       &go, &errors);
+  std::thread thread_b(append_worker, cb, name, 'B', buf_size, rounds,
+		       &go, &errors);
+  go = true;
+
+  thread_a.join();
+  thread_b.join();
+
+  ASSERT_EQ(0, errors.load());
+
+  /*
+   * Both writers used O_APPEND, so every write must land at the EOF
+   * that was current when it acquired Fwx.  Any write reusing a
+   * stale EOF would overwrite data and leave the file shorter than
+   * the total written.
+   */
+  int fdr = ceph_open(ca, name, O_RDONLY, 0644);
+  ASSERT_LE(0, fdr);
+
+  struct stat st;
+  ASSERT_EQ(0, ceph_fstat(ca, fdr, &st));
+  ASSERT_EQ(2 * rounds * buf_size, st.st_size);
+
+  std::unique_ptr<char[]> buf(new char[buf_size]);
+  int64_t pos = 0;
+  int a_blocks = 0, b_blocks = 0;
+  while (pos < st.st_size) {
+    int64_t got = ceph_read(ca, fdr, buf.get(), buf_size, pos);
+    ASSERT_EQ(buf_size, got);
+
+    // every block is written entirely by one client
+    char tag = buf[0];
+    ASSERT_TRUE(tag == 'A' || tag == 'B');
+    for (int64_t i = 1; i < buf_size; i++) {
+      ASSERT_EQ(tag, buf[i]);
+    }
+    if (tag == 'A')
+      a_blocks++;
+    else
+      b_blocks++;
+    pos += got;
+  }
+  ASSERT_EQ(rounds, a_blocks);
+  ASSERT_EQ(rounds, b_blocks);
+
+  ceph_close(ca, fdr);
+  ASSERT_EQ(0, ceph_unlink(ca, name));
+
+  ceph_shutdown(ca);
+  ceph_shutdown(cb);
+}
 
 // Test that client #2 can successfully read snap metadata mutation made by
 // client #1.


### PR DESCRIPTION
For O_APPEND writes using the fd position, _lseek() is called with SEEK_END to determine the current EOF, which becomes the write offset. However, get_caps() may need to wait for Fwx exclusive caps if the write extends the file.  While waiting, the previous Fwx holder (another client) may have already extended the file.  When the MDS grants us Fwx, the local in->size is updated via the cap grant message, but offset still points to the old EOF, causing the append write to land at a stale position and overwrite data.

Fix by revalidating offset against in->size after get_caps() returns. Since we now hold Fwx exclusive caps, no other client can modify the file, and in->size reflects the true EOF from the MDS cap grant. No extra MDS round-trip is needed.  Only adjust when the size has actually changed.

We cannot simply check (f->flags & O_APPEND) alone because _write() handles both fd-position writes (offset < 0, where O_APPEND semantics apply) and explicit-offset writes (offset >= 0, equivalent to pwrite() which ignores O_APPEND per POSIX).  By the time we reach get_caps(), offset has been overwritten to f->pos, losing the information about whether the caller originally passed offset=-1.  The is_append boolean preserves this distinction without an extra MDS round-trip that an additional _lseek() would incur.

This matches the equivalent fix in the kclient's ceph_write_iter().

Fixes: https://tracker.ceph.com/issues/7333





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
