### PR TITLE
mgr/prometheus: skip hardware metrics when node-proxy is disabled

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -2211,6 +2211,9 @@ class Module(MgrModule, OrchestratorClientMixin):
         if not self.orch_is_available():
             return
 
+        if not self.get_module_option_ex('cephadm', 'hw_monitoring', False):
+            return
+
         try:
             report = raise_if_exception(self.node_proxy_fullreport())
         except Exception as e:

--- a/src/pybind/mgr/prometheus/test_module.py
+++ b/src/pybind/mgr/prometheus/test_module.py
@@ -471,3 +471,26 @@ class HardwareMetricsTest(TestCase):
         self.module._process_processors(self.status, self.hostname)
         for labels in self.module.metrics['hardware_cpu_cores'].value:
             self.assertEqual(len(labels), 5)
+
+    # --- get_hardware_metrics orchestration ---
+
+    def test_skips_when_orch_unavailable(self):
+        from prometheus.module import Module
+        self.module.orch_is_available.return_value = False
+        Module.get_hardware_metrics(self.module)
+        self.module.node_proxy_fullreport.assert_not_called()
+
+    def test_skips_when_hw_monitoring_disabled(self):
+        from prometheus.module import Module
+        self.module.orch_is_available.return_value = True
+        self.module.get_module_option_ex.return_value = False
+        Module.get_hardware_metrics(self.module)
+        self.module.node_proxy_fullreport.assert_not_called()
+
+    def test_fetches_when_hw_monitoring_enabled(self):
+        from prometheus.module import Module
+        self.module.orch_is_available.return_value = True
+        self.module.get_module_option_ex.return_value = True
+        self.module.node_proxy_fullreport.return_value = {}
+        Module.get_hardware_metrics(self.module)
+        self.module.node_proxy_fullreport.assert_called_once()


### PR DESCRIPTION
Guard get_hardware_metrics() with a hw_monitoring cephadm config check
If node-proxy is not enabled, skip the node_proxy_fullreport() call entirely
Previously, the function only checked orchestrator availability — it would still attempt to fetch node-proxy data even when hw_monitoring was false