### PR TITLE
rgw: KV-Based Design for RGW metadata layer

### DIFF
--- a/doc/radosgw/KV-Based-Design-For-RGW.md
+++ b/doc/radosgw/KV-Based-Design-For-RGW.md
@@ -14,8 +14,8 @@ Bucket listing must enumerate it efficiently across potentially billions of obje
 
 In RGW, RADOS head objects serve this purpose. Every S3 object has a corresponding head object that holds its identity, attributes, and a manifest pointing to data chunks.
 
-For small objects, the data itself is inlined into the head object.
-For larger objects, multipart uploads, storage-class placement, versioning (OLH), POSIX, and cloud tiering — the head object acts as a pure metadata pointer, a redirection layer to data stored elsewhere.
+For small objects, the data itself is inlined into the head object.\
+For multipart uploads, storage-class placement, versioning (OLH), and cloud tiering — the head object acts as a pure metadata pointer, a redirection layer to data stored elsewhere.
 
 In effect, RGW is already using head objects as a de facto KV system, but implemented with full RADOS objects carrying all their associated overhead.
 
@@ -45,10 +45,12 @@ Object Lifecycle Head objects add complexity beyond the extra RADOS object itsel
 **3. Server-Side Copy and dedup.**
 Multiple S3 objects cannot share a head object.
 A server-side copy or deduplication must create a full independent head object even when the data is identical.
+- Data inlined in the head-object (up to 4MB) is duplicated and copied by server-side copy.
+- Dedup moves the inline data from the head object into a new tail-object to allow full data deduplication.
 
 **4. Key rename.**
-Renaming an S3 object requires copying the entire object and deleting the original — there is no in-place rename.
-Especially costly when applications like Apache rename entire directory trees.
+Renaming an S3 object requires copying the entire object and deleting the original — there is no in-place rename.\
+Especially costly when applications like Apache Spark/Hadoop rename entire directory trees.
 
 **5. Backend lock-in.**
 The storage tier must implement the full RADOS object model (xattrs, omap).
@@ -59,19 +61,17 @@ Every RADOS head object carries metadata (xattrs, omap) replicated across all K+
 - 6 copies in a 4+2 scheme.
 - 11 copies in 8+3.
 
-This far exceeds what metadata protection requires.
+This far exceeds what metadata protection requires.\
+Furthermore, Delete operations must remove rados objects on **all** K+M EC members.
 
 **7. Bucket listing.**
-Head objects scattered across RADOS cannot be listed efficiently.
+Head objects scattered across RADOS cannot be listed efficiently.\
 This is why the bucket-index exists as a separate structure — duplicating metadata to enable listing, at the cost of dual updates and consistency issues.
 
-**8. Head objects for POSIX.**
-The RGW-POSIX driver needs head objects for metadata — conceptually similar to KV entries, but implemented as expensive RADOS objects with additional cost on EC pools.
-
-**9. Storage-class placement.**
+**8. Storage-class placement.**
 When data is placed in a non-default storage class pool, the head object must still reside in the default pool — acting purely as a KV-style pointer at full RADOS object cost.
 
-**10. Delete overhead.**
+**9. Delete overhead.**
 Deleting an S3 object requires two non-atomic operations on separate systems:
 - Removing the bucket-index entry.
 - Deleting the head object:
@@ -86,6 +86,7 @@ See [Delete](#delete) for detailed analysis.
 
 **R1 — Decouple S3 Object Identity from Storage-Tier Naming.**
 S3 identity (bucket_id, object_name, version_id) lives exclusively in the KV key.
+
 The data store has no concept of S3 names — it stores opaque blobs addressed by `(blob_id, offset, length)`.
 Chunk pointers in the KV value are the sole link between S3 identity and physical storage.
 
@@ -98,13 +99,13 @@ The storage tier becomes a dumb blob store:
 Zero knowledge of S3 and/or RGW. RGW manages its own metadata in the KV store.
 
 **R3 — KV Semantics.**
-Each S3 object (bucket + name + version) maps to exactly one KV entry.
-A key with a live value means the object exists.
-Delete removes or invalidates the entry, making it immediately inaccessible.
+- Each S3 object (bucket + name + version) maps to exactly one KV entry in the S3 KV namespace.
+- A key with a live value means the object exists.
+- Delete removes or invalidates the entry, making it immediately inaccessible.
 
 **R4 — Bucket Listing.**
-KV range scans replace the bucket-index.
-Each entry returns listing attributes directly from the KV value — no data-tier access.
+- KV range scans replace the bucket-index.
+- Each entry returns listing attributes directly from the KV value — no data-tier access.
 
 **R5 — KV Value: Core Requirements.**
 The KV value must always contain:
@@ -126,8 +127,9 @@ The KV value must always contain:
 **R6 — Caching Delegated to KV Store.**
 No local RGW cache for object KV entries.
 The KV store's own distributed cache serves hot entries from memory.
+
 Local RGW caching is limited to:
-- Bucket metadata.
+- Metadata for Bucket/Realms/Zones/etc
 - Mapping tables.
 - Data headers of large objects.
 
@@ -146,16 +148,14 @@ A KV-based design separates them cleanly.
 
 Deleting one S3 object requires:
 - Updating the bucket-index entry.
-- Deleting the head object.
+- Deleting **all** head objects.
 
-Two non-atomic operations on separate systems.
+Two non-atomic operations on separate systems.\
+A crash between the bucket-index update and the head-object delete can leave the system in inconsistent state.
 
-For large or multipart objects, tail data objects must also be deleted.
 On EC pools, each RADOS object deletion fans out across all K+M members (6 OSDs for 4+2, 11 for 8+3).
-Background garbage collection must then process orphaned data objects on the storage tier — equally expensive on EC.
 
-A crash between the bucket-index update and the head-object delete can leave orphaned data or dangling references.
-The `radosgw-admin orphans` tools exist to find and clean these, but they are expensive and unreliable.
+When RADOS objects are stored on HDD, the delete must wait for all members to complete on slow HDD.
 
 ### KV Delete Benefits
 
@@ -164,18 +164,17 @@ The bucket-index is eliminated.
 A single KV mutation (delete or invalidate) makes the object inaccessible.
 No second operation on a separate system.
 
-**Always on fast storage.**
-The KV store resides on SSD/NVMe.
-Delete never touches slow HDD — important when data is stored on HDD.
-
 **No EC fan-out for metadata.**
 A KV delete does not fan out across K+M members.
 The EC cost is deferred entirely to async data cleanup.
 
+**Always on fast storage.**
+The KV store resides on SSD/NVMe.
+Delete never touches slow HDD — important when data is stored on HDD.
+
 **Faster than RADOS object delete.**
 Even on the same hardware, a KV delete is a lightweight metadata operation compared to the full transaction overhead of deleting a RADOS object.
 
-**Comparison with `placement-inline-data=false`.**
 PR #48711 added a new concept (`inline-data=false`) to avoid the delete penalty inline — empty head objects on a fast tier with replica×3.
 But even with this change, GC still needs to delete K+M members on the storage tier, which can degrade system performance under heavy delete load.
 
@@ -193,7 +192,7 @@ Because the delete-log can be written in the same transaction as the KV mutation
 
 ## Bucket Listing
 
-The bucket-index exists in the current model because head objects scattered across RADOS cannot be enumerated efficiently.
+The bucket-index exists in the current model because head objects scattered across RADOS (based on CRUSH hashing) cannot be enumerated efficiently.
 
 It duplicates metadata to enable listing, at the cost of:
 - Dual updates on every PUT/DELETE (bucket-index + head object).
@@ -226,6 +225,43 @@ Its functions — listing, metadata lookup, bucket stats — are absorbed by the
 
 ---
 
+## KV Access API
+
+RGW accesses the KV store through a DB-agnostic API.\
+The API defines the operations RGW requires — Each DB backend maps these operations to its native primitives.\
+Differences in capability are absorbed by the implementation.
+
+This is an early-stage API definition. It will be refined as the design matures and implementation begins.
+
+**Basic operations:**
+
+- `Get(key)` → value, or not-found.
+- `Put(key, value)` — write or overwrite.
+- `Delete(key)` — remove the entry.
+
+**Range operations:**
+
+- `RangeScan(start, end, limit)` → ordered list of KV pairs. Used for bucket listing.
+- `RangeDelete(start, end)` — delete all entries in the range. Used for bucket deletion, prefix cleanup.
+
+**Conditional operations:**
+
+- `PutIfNotExists(key, value)` — write only if the key does not exist. Used in migration, multipart completion.
+- `CompareAndSwap(key, expected_value, new_value)` — write only if the current value matches. Used for stats counters on DBs without blind atomic adds.
+
+**Transactions:**
+
+- `BeginTransaction()` → transaction handle.
+- Within a transaction: any combination of Get, Put, Delete, RangeScan, conditional operations.
+- `Commit()` — atomically apply all mutations, or fail if conflicts are detected.
+- `Abort()` — discard all mutations.
+
+Transactions enable atomic multi-key operations: object write + delete-log entry + stats update in a single commit.
+
+Transaction scope is always within a single cluster — cross-cluster atomicity is handled by RGW-level coordination (see Key Sharding).
+
+---
+
 ## KV Schema
 
 ### Key Format
@@ -241,7 +277,7 @@ Its functions — listing, metadata lookup, bucket stats — are absorbed by the
 
 Key size: average ~256 bytes. Absolute max ~1040 bytes (1024-byte S3 name limit + 16 bytes for bucket_id and version_id, plus prefix).
 
-Bucket metadata (name-to-id mapping, ACLs, policies, quota, versioning, lifecycle) is stored under separate prefixes in the same KV store.
+Bucket/Realm/Zone metadata (name-to-id mapping, ACLs, policies, quota, versioning, lifecycle) is stored under separate prefixes in the same KV store.
 
 ### Value Structure
 
@@ -259,7 +295,6 @@ Target size is ~1KB. Smaller values are accepted as-is. Larger values are split 
 
 - content_disposition, cache_control.
 - User metadata (x-amz-meta-*) — up to 2KB per S3 limits.
-- Tags — up to 10 tags per object.
 - Object ACL overrides, checksum values, object lock.
 
 User attributes are prioritized over read-path metadata for space in the value.
@@ -273,9 +308,15 @@ When user attributes push the value beyond ~2KB, they spill to the extended valu
 
 To keep values compact, attributes are compressed using various techniques (e.g., binary mapping of repeated strings to short IDs, enum encoding of fixed-vocabulary fields).
 
-### Delete Marker
+### AWS S3 Object Tags
 
-On delete, the live value is replaced with a minimal delete marker containing:
+- Object-Tags are stored in a separate child KV (under the same shard) referenced from the S3-Object parent KV
+- All Tags are stored together in a single KV
+- AWS supports a maximum of 10 tags per object each with an aggregated size of 5,120 bytes
+
+### S3 Delete Reference
+
+On delete, we keep the original Key while replacing the live Value with a minimal delete reference containing:
 - A delete flag.
 - A timestamp.
 - The ref_tag of the deleted object.
@@ -283,7 +324,7 @@ On delete, the live value is replaced with a minimal delete marker containing:
 The ref_tag is retained so background cleanup can verify data ownership before freeing storage.
 All other attributes are discarded.
 
-RGW reads the entry, sees the delete marker, and returns 404.
+RGW reads the entry, sees the delete reference, and returns 404.
 
 ### Extended Value
 
@@ -310,24 +351,26 @@ POSIX systems, for example, cannot prepend headers to existing files and would u
 2. Read the KV entry.
 3. Return all S3-visible attributes from the value.
 
-Single KV read. No data-tier access.
+Single KV read. No data-tier access. Should be faster than the current model.\
+The assumption here is that KV-Get is faster than Rados Read with its heavy stack.
 
 ### GET (Full Object)
 
 1. Translate bucket name to bucket_id (local cache).
 2. Read the KV entry.
 3. Read data chunks from the storage tier using the chunk pointers.
-4. The first chunk includes the data header — extract ref_tag (verify against KV value), manifest, compression info.
-5. Decompress/decrypt and stream to client.
+5. Read extended-attributes if needed.
+6. Extract ref_tag (verify against KV value), manifest, compression info.
+7. Decompress/decrypt and stream to client.
 
-The KV read is a new cost compared to the current model, where metadata is piggybacked on the data read.
+The KV read is a new cost compared to the current model, where metadata is piggybacked on the data read.\
 This is mitigated by the KV store's distributed cache serving hot entries from memory.
 
 ### GET (Byte-Range)
 
 1. Read the KV entry.
 2. If read-path metadata is in the KV value (common case): use it directly to locate the target chunk.
-3. If not (large compressed multipart): read the data header from chunk 0, or use a locally cached copy.
+3. If not (large compressed multipart): read the extended attributes, or use a locally cached copy.
 4. Read and decompress/decrypt the target byte range.
 
 ### PUT
@@ -337,46 +380,48 @@ This is mitigated by the KV store's distributed cache serving hot entries from m
    - New object or overwriting a delete marker: write the new value.
    - Overwriting a live object: record old data references in the delete-log, then write the new value.
 
+This is cheaper than the current model since no bucket-index update is needed.
+
 ### DELETE
 
 1. Read the KV entry to get chunk pointers and ref_tag.
 2. Record old data references in the delete-log.
-3. Replace the value with a delete marker, or remove the entry.
+3. Replace the value with a delete reference, or remove the entry.
 4. Return success.
 
 Data cleanup happens asynchronously via the delete-log.
+This is cheaper than the current model since no bucket-index update is needed.
 
 ### LIST (ListObjectsV2)
 
 1. Translate bucket name to bucket_id (local cache).
 2. Range scan on the bucket_id prefix.
-3. Filter out delete markers.
+3. Filter out delete references.
 4. Return up to 1000 keys with listing attributes from the KV values.
 
 Pagination uses the last returned key as the continuation marker.
+
+Should be cheaper than the current model with its excessive sharding and OMAP overhead.
 
 ---
 
 ## Caching
 
 ### What RGW Caches Locally
-
+Locally cached metadata — created and removed, but never modified in place:
 - **Bucket name → bucket_id mapping** — small, stable, fully cached.
 - **Bucket metadata** — ACLs, policies, quota, versioning, lifecycle rules.
+- **Realm/Zone metadata**
 - **Attribute mapping tables** — binary mappings for repeated strings. Small, append-only, fully cached.
-- **Data headers of large objects** — for objects whose read-path metadata overflows the KV value. Cached after first access, validated against ref_tag on every use.
+- **Read-path metadata** — for objects whose read-path metadata overflows the KV value. Cached after first access, validated against ref_tag on every use.
 
 ### What the KV Store Caches
 
-Object KV entries are not cached locally on RGW servers.
+Object KV entries are not cached locally on RGW servers.\
 The KV store's own distributed cache serves frequently accessed entries from memory.
 
 Keeping values small maximizes cache efficiency — more entries fit in the same amount of memory.
 
-### ref_tag Validation
-
-The ref_tag in the KV value is compared against the ref_tag in the data header on every data read.
-A mismatch indicates a consistency problem. This is a safety net, not a cache mechanism.
 
 ---
 
@@ -384,7 +429,7 @@ A mismatch indicates a consistency problem. This is a safety net, not a cache me
 
 ### Why 1KB is the Target
 
-For a typical single-part object with no user metadata and no tags, the KV value contains:
+For a typical single-part object with no user metadata, the KV value contains:
 
 - Listing attributes — etag, last_modified, size, storage_class, owner, content_type, checksum_algorithm.
 - RGW internal fields — state/flags, ref_tag, chunk pointer(s).
@@ -393,7 +438,7 @@ For a typical single-part object with no user metadata and no tags, the KV value
 With compact binary encoding, this fits comfortably under 1KB — including common user attributes.
 The vast majority of objects in a large-scale system are single-part without unusually large user metadata — the 1KB target covers the common case.
 
-Objects with very large user metadata (approaching the 2KB S3 limit) or many tags can push the value beyond 1KB, up to ~2KB.
+Objects with very large user metadata (approaching the 2KB S3 limit) can push the value beyond 1KB, up to ~4KB.
 This is acceptable — user attributes are prioritized for space in the value.
 
 ### Why Read-Path Metadata Can Grow Large
@@ -408,14 +453,15 @@ Server-side encryption adds per-chunk metadata: key references, initialization v
 For multipart objects with many parts, encryption metadata grows proportionally.
 
 **Manifest.**
-The manifest maps logical byte ranges to physical chunk locations.
-For very large multipart objects with hundreds or thousands of parts, the manifest alone can grow to hundreds of KB — potentially up to ~1MB in extreme cases.
+The manifest maps logical byte ranges to physical chunk locations.\
+When chunks have equal size (except the last one) they can be summarized with a simple formula, but compression means that each and every chunk has different size so we need to list them all.\
+For very large multipart objects with hundreds or thousands of parts, the manifest alone can grow to tens of KB — potentially up to multiple MB in extreme cases.
 
 ### The Case for Extended Values
 
 This is why the extended value mechanism exists.
 
-For the common case (single-part, small multipart), everything fits in the KV entry.
+For the common case (single-part, small multipart, multipart with fixed chunk size), everything fits in the KV entry.\
 For large compressed/encrypted multipart objects, the manifest and block table spill to the extended value — keeping the core KV entry small and the KV store's cache efficient.
 
 The 8KB hard upper limit for the KV value is worth testing to determine the practical impact on cache efficiency and listing bandwidth.
@@ -469,9 +515,10 @@ The hash distributes objects uniformly across a fixed number of shards, breaking
 
 This is a locality vs. distribution tradeoff.
 
-Hashing exists to break locality — to take concentrated load on a local range and spread it uniformly across the system. But locality is exactly what makes range operations efficient.
+Hashing exists to break locality — to take concentrated load on a local range and spread it uniformly across the system.\
+But locality is exactly what makes range operations efficient.
 
-Every benefit of hashing is a consequence of breaking locality.
+Every benefit of hashing is a consequence of breaking locality.\
 Every cost is also a consequence of breaking locality.
 
 ### Pros
@@ -480,11 +527,15 @@ Every cost is also a consequence of breaking locality.
 
 This is the primary reason to consider hashing.
 
-When RGW scales beyond a single KV cluster to a fleet of independent KV clusters, there is no KV-store mechanism to balance data across clusters. Without hashing, bucket data is contiguous — buckets land on specific clusters and grow unevenly, creating imbalance over time.
+When RGW scales beyond a single KV cluster to a fleet of independent KV clusters, there is no KV-store mechanism to balance data across clusters.\
+Without hashing, bucket data is contiguous — buckets land on specific clusters and grow unevenly, creating imbalance over time.
 
-The only fix would be RGW acting as a cross-cluster data balancer: detecting skew, migrating data between clusters. That is a massive engineering and operational burden.
+The only fix would be RGW acting as a cross-cluster data balancer: detecting skew, migrating data between clusters.\
+That is a massive engineering and operational burden.
 
-With hashing, shards distribute objects uniformly. Assigning equal numbers of shards to each cluster produces a balanced fleet by construction. Adding a new cluster means reassigning some shards — no data-level rebalancing within existing clusters.
+With hashing, shards distribute objects uniformly.\
+Assigning equal numbers of shards to each cluster produces a balanced fleet by construction.\
+Adding a new cluster means reassigning some shards — no data-level rebalancing within existing clusters.
 
 **Secondary benefits within a single cluster.**
 
@@ -549,15 +600,24 @@ FDB caches per KV entry, so hashing does not cause cache waste there.
 
 Hashing is a fleet-level concern, not a single-cluster optimization.
 
-Within a single cluster, the KV store's own auto-sharding handles distribution. The costs of hashing — degraded listings, lost range operations, cache waste, disabled hibernation, pinned mapping tables — outweigh the secondary benefits.
+Within a single cluster, the KV store's own auto-sharding handles distribution.\
+The costs of hashing — degraded listings, lost range operations, cache waste, disabled hibernation, pinned mapping tables — outweigh the secondary benefits.
 
-For deployments that require a fleet of independent KV clusters, hashing becomes necessary because no KV-store mechanism exists to balance across clusters. The secondary benefits — balanced activity, less rebalancing, predictable performance — partially offset the costs, but do not eliminate them.
+For deployments that require a fleet of independent KV clusters, hashing becomes necessary because no KV-store mechanism exists to balance across clusters.\
+The secondary benefits — balanced activity, less rebalancing, predictable performance — partially offset the costs, but do not eliminate them.
 
 ### Fleet Scaling
 
-Every KV store has a single-cluster capacity ceiling. FDB clusters hold approximately 64 billion KV entries (potentially 128 billion). TiKV clusters can scale to approximately 1 trillion KV entries (potentially more). These are large numbers, but production systems may eventually outgrow them.
+Every KV store has a single-cluster capacity ceiling.\
+FDB clusters hold approximately 64 billion KV entries (potentially 128 billion).\
+TiKV clusters can scale to approximately 1 trillion KV entries (potentially more).
 
-When a single cluster is no longer sufficient, the system must scale out to a fleet of independent KV clusters. There is no cross-cluster balancing built into any KV store — the fleet management is RGW's responsibility.
+These are large numbers, but **some** production systems may eventually outgrow them.
+- The KV store design allocates one extra KV per object to store S3 Object Tags (when present) which can double the KV count
+- Object Annotations allow up to 1000 Annotations per Object, and since we use a standalone KV for each Annotation we can have an effective 1 Trillion KV on a system with a mere 1 Billion S3-Objects.
+
+When a single cluster is no longer sufficient, the system must scale out to a fleet of independent KV clusters.\
+There is no cross-cluster balancing built into any KV store — the fleet management is RGW's responsibility.
 
 Hashing is the simplest method to support a fleet. The shard prefix distributes data uniformly across clusters, and shard migration provides the growth path.
 
@@ -567,15 +627,24 @@ However, hashing is not the only option. Three strategies exist, each with diffe
 
 `shard_id = hash(bucket_id + object_name)`.
 
-Objects within a bucket are scattered across all shards and all clusters. Works for any workload — fleet balance is guaranteed by the hash. Pays the full locality cost: merge-sort listings, degraded range operations, pinned mapping tables, cross-cluster coordination for multi-key operations.
+Objects within a bucket are scattered across all shards and all clusters.\
+Works for any workload — fleet balance is guaranteed by the hash.\
+Pays the full locality cost:
+- merge-sort listings
+- degraded range operations
+- pinned mapping tables
+- cross-cluster coordination for multi-key operations
 
 The simplest strategy. The most expensive in day-to-day operation.
 
 **Strategy 2 — RGW as fleet rebalancer (no hashing).**
 
-Keys remain ordered. No shard prefix. RGW detects imbalance across clusters and migrates data ranges to restore balance.
+- Keys remain ordered
+- No shard prefix
+- RGW detects imbalance across clusters and migrates data ranges to restore balance
 
-This requires RGW to build and operate a cross-cluster data balancer — detecting skew, selecting ranges to move, coordinating live migration, handling failures. A massive engineering and operational burden. Unattractive.
+This requires RGW to build and operate a cross-cluster data balancer — detecting skew, selecting ranges to move, coordinating live migration, handling failures.\
+A massive engineering and operational burden. Unattractive.
 
 **Strategy 3 — Bucket-level hashing with fleet-friendly buckets.**
 
@@ -589,9 +658,13 @@ Viable for controlled environments where customers can design their bucket layou
 
 ### Cross-Cluster Coordination Cost
 
-On a single cluster, any set of KV mutations can be committed in one transaction. On a fleet, mutations landing on different clusters cannot share a transaction — no KV store supports cross-cluster transactions.
+On a single cluster, any set of KV mutations can be committed in one transaction.\
+On a fleet, mutations landing on different clusters cannot share a transaction — no KV store supports cross-cluster transactions.
 
-Operations where the source and destination keys hash to different shards require RGW-level coordination: two separate transactions, crash recovery logic, and potential inconsistency windows.
+Operations where the source and destination keys hash to different shards require RGW-level coordination:
+- two separate transactions
+- crash recovery logic
+- and potential inconsistency windows.
 
 This is another reason to minimize the number of shards to the absolute minimum needed for fleet balance. Fewer shards means fewer cross-cluster operations. Growing from 2 shards to 4 is far less disruptive than jumping to 128.
 
@@ -599,11 +672,20 @@ With bucket-level hashing, most operations stay within a single bucket and there
 
 ### Key Naming and Transaction Locality
 
-Smart key naming minimizes cross-cluster operations by ensuring that logically related KV entries hash to the same shard.
+Hashing-aware key schemes minimize cross-cluster operations by ensuring that logically related KV entries hash to the same shard.\
+This maximizes single-cluster transactions.\
+Only operations involving two distinct object identities require cross-cluster coordination.
 
-Since `shard_id = hash(bucket_id + object_name)` and `version_id` is excluded from the hash, all versions of the same object — same bucket, same name, different versions — get the same `shard_id` and land on the same cluster.
+**Design principle:**\
+A KV entry logically tied to a specific object should derive its shard from the parent KV.\
+The child KV should **logically** be\
+`<prefix> <shard_id> <bucket_id> <object_name>::<child-suffix>`\
+This way it will always follow the same shard as the parent KV
 
-The following entries all share the same shard as the object they belong to:
+We can replace the `<object_name>` (up to 1024 Bytes long) on child KV with an 8-byte `<parent-object-id>` which must be stored in the parent KV and used to construct the child KV.\
+Alternatively, we can use a 32-64 byte cryptographic hash as an `<parent-object-id>` saving the need to query the parent KV before accessing the child KV
+
+### Entries Sharing the Parent Shard:
 
 **All versions of an object.**
 
@@ -627,7 +709,13 @@ When an object is overwritten or deleted, the old chunk pointers must be recorde
 
 **Object tags, ACLs, and lock metadata.**
 
-S3 supports per-object tags (up to 10 key-value pairs), per-object ACL overrides, and object lock settings (retention period, legal hold). These are typically stored inline in the KV value. If they ever spill to separate KV entries — due to size or access pattern optimization — deriving the shard from the same `(bucket_id + object_name)` keeps them co-located. PutObjectTagging or PutObjectLockConfiguration updates are transactional with the object's metadata.
+S3 supports per-object tags (up to 10 key-value pairs) and per-object ACL overrides (up to 100 grants)\
+These are typically stored inline in the KV value.\
+If they ever spill to separate KV entries — due to size or access pattern optimization — deriving the shard from the same `(bucket_id + object_name)` keeps them co-located.\
+PutObjectTagging or PutObjectAcl are transactional with the object's metadata.
+
+- Object-Tags are probably best kept in a standalone child KV since they are individually mutable
+- ACL can be stored inside the parent KV or spillover to extended-metadata since they are overwritten together
 
 **Per-shard stats counters.**
 
@@ -641,7 +729,6 @@ If each shard maintains its own stats keys on the same cluster, the object write
 
 - **Cross-bucket operations** — any operation touching objects in different buckets may land on different clusters.
 
-**Design principle:** every KV entry logically tied to a specific object should derive its shard from `hash(bucket_id + object_name)`. This maximizes single-cluster transactions. Only operations involving two distinct object identities require cross-cluster coordination — and minimizing shard count minimizes the probability that two objects land on different clusters.
 
 ### Logical Hashing Epoch
 

--- a/doc/radosgw/KV-Based-Design-For-RGW.md
+++ b/doc/radosgw/KV-Based-Design-For-RGW.md
@@ -1,0 +1,701 @@
+# KV-Based Design for RGW
+
+## Introduction
+
+An S3-compatible object store must maintain metadata for every object:
+
+- Its identity — bucket, name, version.
+- User-visible attributes — content-type, etag, tags, ACLs, checksums.
+- Internal data attributes — manifest, compression, encryption.
+
+This metadata must be accessible independently of the data itself.
+HEAD requests return it without reading any data.
+Bucket listing must enumerate it efficiently across potentially billions of objects.
+
+In RGW, RADOS head objects serve this purpose. Every S3 object has a corresponding head object that holds its identity, attributes, and a manifest pointing to data chunks.
+
+For small objects, the data itself is inlined into the head object.
+For larger objects, multipart uploads, storage-class placement, versioning (OLH), POSIX, and cloud tiering — the head object acts as a pure metadata pointer, a redirection layer to data stored elsewhere.
+
+In effect, RGW is already using head objects as a de facto KV system, but implemented with full RADOS objects carrying all their associated overhead.
+
+This document proposes replacing head objects with entries in an external KV store.
+
+The design is DB-agnostic — it defines the KV contract RGW requires, using FoundationDB and TiKV as reference examples. Any KV system meeting the contract can serve as the metadata layer, including systems that do not yet exist.
+
+---
+
+## Problems with the Current Model
+
+The one-to-one mapping between S3 objects and RADOS objects creates a set of compounding problems:
+
+**1. Small-object packing.**
+Each S3 object, no matter how small, requires its own RADOS object.
+- Prevents aggregating small objects into larger blobs.
+- Every small object carries full RADOS overhead: OSD tracking, PG membership, recovery bookkeeping.
+- Recovery cost scales with object count rather than data volume.
+- The storage tier cannot optimize for large sequential I/O.
+
+**2. Versioning (OLH).**
+Object Lifecycle Head objects add complexity beyond the extra RADOS object itself:
+- Managing the current-version pointer.
+- Copying data into new objects on version changes.
+- Lack of atomicity across OLH, head object, and bucket-index updates.
+
+**3. Server-Side Copy and dedup.**
+Multiple S3 objects cannot share a head object.
+A server-side copy or deduplication must create a full independent head object even when the data is identical.
+
+**4. Key rename.**
+Renaming an S3 object requires copying the entire object and deleting the original — there is no in-place rename.
+Especially costly when applications like Apache rename entire directory trees.
+
+**5. Backend lock-in.**
+The storage tier must implement the full RADOS object model (xattrs, omap).
+RGW cannot use a simpler blob store without reimplementing that model.
+
+**6. EC metadata amplification.**
+Every RADOS head object carries metadata (xattrs, omap) replicated across all K+M EC members.
+- 6 copies in a 4+2 scheme.
+- 11 copies in 8+3.
+
+This far exceeds what metadata protection requires.
+
+**7. Bucket listing.**
+Head objects scattered across RADOS cannot be listed efficiently.
+This is why the bucket-index exists as a separate structure — duplicating metadata to enable listing, at the cost of dual updates and consistency issues.
+
+**8. Head objects for POSIX.**
+The RGW-POSIX driver needs head objects for metadata — conceptually similar to KV entries, but implemented as expensive RADOS objects with additional cost on EC pools.
+
+**9. Storage-class placement.**
+When data is placed in a non-default storage class pool, the head object must still reside in the default pool — acting purely as a KV-style pointer at full RADOS object cost.
+
+**10. Delete overhead.**
+Deleting an S3 object requires two non-atomic operations on separate systems:
+- Removing the bucket-index entry.
+- Deleting the head object:
+    - Head object might be on a slow storage tier (HDD).
+    - On EC, head-object delete fans out across all K+M members.
+
+See [Delete](#delete) for detailed analysis.
+
+---
+
+## Requirements
+
+**R1 — Decouple S3 Object Identity from Storage-Tier Naming.**
+S3 identity (bucket_id, object_name, version_id) lives exclusively in the KV key.
+The data store has no concept of S3 names — it stores opaque blobs addressed by `(blob_id, offset, length)`.
+Chunk pointers in the KV value are the sole link between S3 identity and physical storage.
+
+**R2 — Decouple RGW from the Storage Tier.**
+The storage tier becomes a dumb blob store:
+- Write bytes.
+- Read byte ranges.
+- Punch holes.
+
+Zero knowledge of S3 and/or RGW. RGW manages its own metadata in the KV store.
+
+**R3 — KV Semantics.**
+Each S3 object (bucket + name + version) maps to exactly one KV entry.
+A key with a live value means the object exists.
+Delete removes or invalidates the entry, making it immediately inaccessible.
+
+**R4 — Bucket Listing.**
+KV range scans replace the bucket-index.
+Each entry returns listing attributes directly from the KV value — no data-tier access.
+
+**R5 — KV Value: Core Requirements.**
+The KV value must always contain:
+- All listing attributes (key, last_modified, etag, size, storage_class, owner, checksum_algorithm).
+- Routing info for the first data chunk.
+- Routing info for spillover metadata (user attributes, manifest, etc.) when present.
+
+> *Stretch goals — desirable but may be overridden by KV system constraints or value size limits:*
+>
+> **R5.1 — KV Value Contains the Full S3 API Surface.**
+> Aim to store all user-visible S3 attributes (user metadata, tags, ACLs, object lock) in the KV value.
+> Objects with very large user attributes may spill to an external location.
+> Whether to always keep all user attributes in a single KV entry or allow spillover is an open design question.
+>
+> **R5.2 — KV Value Contains Full Routing Info.**
+> Aim to store the complete manifest, compression, and encryption metadata in the KV value, so that data access requires no secondary metadata lookup.
+> When these do not fit (e.g., large compressed multipart objects), RGW falls back to reading them from the data header or spillover storage.
+
+**R6 — Caching Delegated to KV Store.**
+No local RGW cache for object KV entries.
+The KV store's own distributed cache serves hot entries from memory.
+Local RGW caching is limited to:
+- Bucket metadata.
+- Mapping tables.
+- Data headers of large objects.
+
+---
+
+## Delete
+
+Deleting an S3 object involves two distinct concerns:
+- **Fencing** — making the object inaccessible.
+- **Data cleanup** — reclaiming storage space.
+
+In the current model, both are entangled with RADOS object operations.
+A KV-based design separates them cleanly.
+
+### Current Model
+
+Deleting one S3 object requires:
+- Updating the bucket-index entry.
+- Deleting the head object.
+
+Two non-atomic operations on separate systems.
+
+For large or multipart objects, tail data objects must also be deleted.
+On EC pools, each RADOS object deletion fans out across all K+M members (6 OSDs for 4+2, 11 for 8+3).
+Background garbage collection must then process orphaned data objects on the storage tier — equally expensive on EC.
+
+A crash between the bucket-index update and the head-object delete can leave orphaned data or dangling references.
+The `radosgw-admin orphans` tools exist to find and clean these, but they are expensive and unreliable.
+
+### KV Delete Benefits
+
+**Single atomic operation.**
+The bucket-index is eliminated.
+A single KV mutation (delete or invalidate) makes the object inaccessible.
+No second operation on a separate system.
+
+**Always on fast storage.**
+The KV store resides on SSD/NVMe.
+Delete never touches slow HDD — important when data is stored on HDD.
+
+**No EC fan-out for metadata.**
+A KV delete does not fan out across K+M members.
+The EC cost is deferred entirely to async data cleanup.
+
+**Faster than RADOS object delete.**
+Even on the same hardware, a KV delete is a lightweight metadata operation compared to the full transaction overhead of deleting a RADOS object.
+
+**Comparison with `placement-inline-data=false`.**
+PR #48711 added a new concept (`inline-data=false`) to avoid the delete penalty inline — empty head objects on a fast tier with replica×3.
+But even with this change, GC still needs to delete K+M members on the storage tier, which can degrade system performance under heavy delete load.
+
+### Background Data Cleanup
+
+Background processing to reclaim storage-tier space is needed regardless of the metadata model.
+
+The KV design uses a persistent delete-log:
+- Every operation that orphans data (DELETE, PUT-overwrite) appends an entry recording the old data references.
+- A background process drains the log and frees storage.
+
+Because the delete-log can be written in the same transaction as the KV mutation, there is no orphan window — every orphaned data reference is tracked.
+
+---
+
+## Bucket Listing
+
+The bucket-index exists in the current model because head objects scattered across RADOS cannot be enumerated efficiently.
+
+It duplicates metadata to enable listing, at the cost of:
+- Dual updates on every PUT/DELETE (bucket-index + head object).
+- Consistency drift between the two.
+- A separate resharding mechanism as buckets grow.
+
+With a KV-based metadata layer, the bucket-index is eliminated.
+Listing is a direct range scan on the KV store — each entry already contains all listing attributes.
+No secondary structure, no dual updates, no resharding.
+
+Listing performance depends on key ordering:
+- **Without sharding** — a bucket's objects form a contiguous key range. Listing is a simple range scan.
+- **With sharding** — listing requires parallel scans across shards followed by a merge-sort. Still efficient, but more complex.
+
+The full analysis of sharding trade-offs is covered in a separate document.
+
+---
+
+## Architecture
+
+Two components: a KV store for metadata and a data store for opaque blobs.
+
+- **KV store** — owns object existence, all S3 attributes, data pointers, and bucket metadata.
+- **Data store** — owns raw bytes. No knowledge of S3, buckets, or object names.
+
+RGW owns all intelligence: access control, manifest interpretation, compression, encryption, packing logic.
+
+The bucket-index is eliminated.
+Its functions — listing, metadata lookup, bucket stats — are absorbed by the KV store.
+
+---
+
+## KV Schema
+
+### Key Format
+
+```
+<prefix> <bucket_id> <object_name> <version_id>
+```
+
+- **prefix** — a short namespace identifier distinguishing object entries from bucket metadata, stats, and other KV schemas sharing the same store.
+- **bucket_id** — binary bucket identifier. All objects in a bucket share the same prefix.
+- **object_name** — the S3 object key, stored as raw bytes. Preserves natural lexicographic ordering.
+- **version_id** — binary value using a descending scheme. The latest version sorts first, so a non-versioned GET reads the first key without scanning.
+
+Key size: average ~256 bytes. Absolute max ~1040 bytes (1024-byte S3 name limit + 16 bytes for bucket_id and version_id, plus prefix).
+
+Bucket metadata (name-to-id mapping, ACLs, policies, quota, versioning, lifecycle) is stored under separate prefixes in the same KV store.
+
+### Value Structure
+
+The KV value is a binary-encoded entry containing all metadata for the object.
+
+Target size is ~1KB. Smaller values are accepted as-is. Larger values are split into a core value and an extended value.
+
+**Core value** (always in the KV entry):
+
+- Listing attributes — etag, last_modified, size, storage_class, owner, checksum_algorithm, content_type, content_encoding, content_language.
+- RGW internal fields — state/flags, ref_tag, size_physical, chunk pointers. Each chunk pointer is a `(blob_id, offset, length)` tuple — no S3 names on the storage tier. Multiple S3 objects may share a blob_id (packing).
+- Routing info for spillover metadata, when present.
+
+**User-visible attributes** (in the KV entry when they fit):
+
+- content_disposition, cache_control.
+- User metadata (x-amz-meta-*) — up to 2KB per S3 limits.
+- Tags — up to 10 tags per object.
+- Object ACL overrides, checksum values, object lock.
+
+User attributes are prioritized over read-path metadata for space in the value.
+When user attributes push the value beyond ~2KB, they spill to the extended value.
+
+**Read-path metadata** (in the KV entry when it fits):
+
+- Manifest, compression info, encryption details.
+- For most objects (single-part, small multipart), these fit comfortably.
+- For large compressed multipart objects, they spill to the data header or extended storage.
+
+To keep values compact, attributes are compressed using various techniques (e.g., binary mapping of repeated strings to short IDs, enum encoding of fixed-vocabulary fields).
+
+### Delete Marker
+
+On delete, the live value is replaced with a minimal delete marker containing:
+- A delete flag.
+- A timestamp.
+- The ref_tag of the deleted object.
+
+The ref_tag is retained so background cleanup can verify data ownership before freeing storage.
+All other attributes are discarded.
+
+RGW reads the entry, sees the delete marker, and returns 404.
+
+### Extended Value
+
+When metadata overflows the core KV entry, it is stored in an extended value.
+The KV entry always contains routing info pointing to the extended value's location.
+
+The extended value is a logical concept — its physical storage is pluggable. Possible implementations include:
+
+- **Data header** — prepended to the first data chunk on the storage tier. Natural fit for RGW-controlled backends. For full-object GETs from offset 0, it is read as part of the first chunk at no extra cost. For byte-range reads, it requires reading chunk 0 separately (can be cached locally after first access).
+- **Object annotations** — sidecar metadata attached to the data object by the storage tier.
+- **Standalone files** — separate metadata files alongside the data.
+- **Additional KV entries** — overflow stored in the same KV store under a related key.
+
+The choice depends on the storage backend's capabilities.
+POSIX systems, for example, cannot prepend headers to existing files and would use an alternative (discussed in the POSIX section).
+
+---
+
+## Operations
+
+### HEAD
+
+1. Translate bucket name to bucket_id (local cache).
+2. Read the KV entry.
+3. Return all S3-visible attributes from the value.
+
+Single KV read. No data-tier access.
+
+### GET (Full Object)
+
+1. Translate bucket name to bucket_id (local cache).
+2. Read the KV entry.
+3. Read data chunks from the storage tier using the chunk pointers.
+4. The first chunk includes the data header — extract ref_tag (verify against KV value), manifest, compression info.
+5. Decompress/decrypt and stream to client.
+
+The KV read is a new cost compared to the current model, where metadata is piggybacked on the data read.
+This is mitigated by the KV store's distributed cache serving hot entries from memory.
+
+### GET (Byte-Range)
+
+1. Read the KV entry.
+2. If read-path metadata is in the KV value (common case): use it directly to locate the target chunk.
+3. If not (large compressed multipart): read the data header from chunk 0, or use a locally cached copy.
+4. Read and decompress/decrypt the target byte range.
+
+### PUT
+
+1. Write data to the storage tier. The first chunk includes the data header.
+2. Write the KV entry:
+   - New object or overwriting a delete marker: write the new value.
+   - Overwriting a live object: record old data references in the delete-log, then write the new value.
+
+### DELETE
+
+1. Read the KV entry to get chunk pointers and ref_tag.
+2. Record old data references in the delete-log.
+3. Replace the value with a delete marker, or remove the entry.
+4. Return success.
+
+Data cleanup happens asynchronously via the delete-log.
+
+### LIST (ListObjectsV2)
+
+1. Translate bucket name to bucket_id (local cache).
+2. Range scan on the bucket_id prefix.
+3. Filter out delete markers.
+4. Return up to 1000 keys with listing attributes from the KV values.
+
+Pagination uses the last returned key as the continuation marker.
+
+---
+
+## Caching
+
+### What RGW Caches Locally
+
+- **Bucket name → bucket_id mapping** — small, stable, fully cached.
+- **Bucket metadata** — ACLs, policies, quota, versioning, lifecycle rules.
+- **Attribute mapping tables** — binary mappings for repeated strings. Small, append-only, fully cached.
+- **Data headers of large objects** — for objects whose read-path metadata overflows the KV value. Cached after first access, validated against ref_tag on every use.
+
+### What the KV Store Caches
+
+Object KV entries are not cached locally on RGW servers.
+The KV store's own distributed cache serves frequently accessed entries from memory.
+
+Keeping values small maximizes cache efficiency — more entries fit in the same amount of memory.
+
+### ref_tag Validation
+
+The ref_tag in the KV value is compared against the ref_tag in the data header on every data read.
+A mismatch indicates a consistency problem. This is a safety net, not a cache mechanism.
+
+---
+
+## Value Sizing
+
+### Why 1KB is the Target
+
+For a typical single-part object with no user metadata and no tags, the KV value contains:
+
+- Listing attributes — etag, last_modified, size, storage_class, owner, content_type, checksum_algorithm.
+- RGW internal fields — state/flags, ref_tag, chunk pointer(s).
+- Read-path metadata — minimal for single-part (compression type, a few encryption fields).
+
+With compact binary encoding, this fits comfortably under 1KB — including common user attributes.
+The vast majority of objects in a large-scale system are single-part without unusually large user metadata — the 1KB target covers the common case.
+
+Objects with very large user metadata (approaching the 2KB S3 limit) or many tags can push the value beyond 1KB, up to ~2KB.
+This is acceptable — user attributes are prioritized for space in the value.
+
+### Why Read-Path Metadata Can Grow Large
+
+**Compression and multipart.**
+Compressed multipart objects require a compression block table — a mapping from logical byte offsets to physical byte offsets.
+Each block adds an entry.
+For a large multipart object with many parts and many compression blocks, this table can grow to tens of KB.
+
+**Encryption.**
+Server-side encryption adds per-chunk metadata: key references, initialization vectors, cipher parameters.
+For multipart objects with many parts, encryption metadata grows proportionally.
+
+**Manifest.**
+The manifest maps logical byte ranges to physical chunk locations.
+For very large multipart objects with hundreds or thousands of parts, the manifest alone can grow to hundreds of KB — potentially up to ~1MB in extreme cases.
+
+### The Case for Extended Values
+
+This is why the extended value mechanism exists.
+
+For the common case (single-part, small multipart), everything fits in the KV entry.
+For large compressed/encrypted multipart objects, the manifest and block table spill to the extended value — keeping the core KV entry small and the KV store's cache efficient.
+
+The 8KB hard upper limit for the KV value is worth testing to determine the practical impact on cache efficiency and listing bandwidth.
+
+---
+
+## Stats and Quota
+
+### Current Model
+
+Bucket statistics (object count, total bytes) are maintained per-shard in the bucket-index.
+Overall bucket stats are the sum across all shards.
+
+This approach suffers from:
+- **Drift.** Bucket-index update and head-object write are separate operations. A crash between them leaves stats inconsistent.
+- **Expensive repair.** `radosgw-admin bucket check` must iterate all objects to recompute — impractical for large buckets.
+- **Approximate quota.** Quotas based on potentially drifted stats may over-allow or wrongly reject requests.
+
+### KV Model
+
+Stats counters can be updated in the same transaction as the object metadata mutation.
+No drift, no repair needed, accurate quota enforcement.
+
+However, this is not a simple win.
+Concurrent writes to a single bucket all update the same stats keys, creating contention:
+
+- **FDB** — provides blind atomic add operations that merge without conflicting. Well suited for counters. But each counter must be a separate key, so every object write touches multiple unrelated keys (object entry + stats keys). Stats keys are hot and sticky in cache, so the extra writes are cheap in practice.
+
+- **TiKV** — has no blind atomic add, only compare-and-swap. Under high concurrency to a single bucket, this leads to retry storms on stats keys.
+
+Per-shard stats keys (one set per shard) reduce contention proportionally to shard count.
+This is a concrete benefit of application-level sharding — discussed further in the sharding document.
+
+---
+
+## Key Sharding
+
+The base key format places all objects in a bucket in a contiguous range:
+
+```
+<prefix> <bucket_id> <object_name> <version_id>
+```
+
+An alternative is to prepend a shard identifier — a cryptographic hash of `(bucket_id + object_name)`:
+
+```
+<prefix> <shard_id> <bucket_id> <object_name> <version_id>
+```
+
+The hash distributes objects uniformly across a fixed number of shards, breaking the contiguous bucket range into N disjoint ranges scattered across the key space.
+
+This is a locality vs. distribution tradeoff.
+
+Hashing exists to break locality — to take concentrated load on a local range and spread it uniformly across the system. But locality is exactly what makes range operations efficient.
+
+Every benefit of hashing is a consequence of breaking locality.
+Every cost is also a consequence of breaking locality.
+
+### Pros
+
+**Fleet-level balancing without a fleet balancer.**
+
+This is the primary reason to consider hashing.
+
+When RGW scales beyond a single KV cluster to a fleet of independent KV clusters, there is no KV-store mechanism to balance data across clusters. Without hashing, bucket data is contiguous — buckets land on specific clusters and grow unevenly, creating imbalance over time.
+
+The only fix would be RGW acting as a cross-cluster data balancer: detecting skew, migrating data between clusters. That is a massive engineering and operational burden.
+
+With hashing, shards distribute objects uniformly. Assigning equal numbers of shards to each cluster produces a balanced fleet by construction. Adding a new cluster means reassigning some shards — no data-level rebalancing within existing clusters.
+
+**Secondary benefits within a single cluster.**
+
+Hashing provides additional benefits that partially offset its costs:
+
+- Evenly balanced write activity — writes to a hot bucket don't concentrate on a few partitions.
+- Less internal rebalancing — data is pre-distributed, so the DB's own range-splitting triggers less frequently.
+- More predictable performance — fewer rebalance sessions competing with foreground I/O.
+
+These are real but not sufficient on their own to justify hashing. The cons outweigh them at the single-cluster level — which is the reason KV stores don't use hashing internally. They use ordered range-partitioning precisely to preserve locality.
+
+### Cons
+
+**Listing becomes fundamentally harder.**
+
+Without hashing, `ListObjectsV2` is a single ordered range scan. The KV store returns keys in the lexicographic order S3 requires. Pagination is a single cursor. Memory usage is minimal.
+
+With hashing, listing requires:
+
+- N concurrent range scans, one per shard.
+- Merge-sort across all N streams to reconstruct lexicographic order.
+
+Strictly harder — more code, more network round-trips, more memory, more failure modes.
+
+**Memory cost of sharded listing.**
+
+Without hashing, listing 1000 objects is a single range-read of ~1.5MB of sequential data, loaded directly into the caller. These entries are unlikely to be accessed again soon, so the read does not pollute the DB cache.
+
+With hashing (e.g., 128 shards), each shard contributes on average ~8 entries — a mere ~12KB read per shard. These are tiny, inefficient requests.
+
+The alternative is to over-fetch from each shard and buffer the excess in RGW memory, consuming N times more memory than the unsharded case.
+
+**Range operations are degraded.**
+
+Any operation that benefits from key contiguity within a bucket is broken by hashing:
+
+- **Range-delete** — deleting all objects in a bucket (or under a prefix) becomes N separate range-deletes across scattered ranges, losing atomicity.
+
+- **Range-rename** — applications like Apache Spark and Hive rename entire directory trees. With hashing, each object maps to a different shard — the rename is N scattered point operations with no locality benefit.
+
+**Mapping table must be fully pinned.**
+
+With locality, accessing a bucket touches a small number of contiguous ranges mapped to a small number of servers. The range-to-server mapping table benefits from caching — hot buckets mean hot ranges.
+
+With hashing, any bucket operation potentially touches every server. The mapping table cannot benefit from caching because access patterns have no locality. The full table must be pinned in memory on every RGW instance, and it scales with fleet size.
+
+**Region hibernation is disabled (TiKV-specific).**
+
+TiKV supports region hibernation — inactive regions stop sending Raft heartbeats, reducing CPU on both TiKV nodes and PD. With locality, cold buckets mean cold regions that go dormant.
+
+With hashing, every region contains fragments of many buckets. Even one active bucket touches all regions. All regions stay awake, broadcasting constant Raft heartbeats. Baseline CPU consumption scales with total region count regardless of actual workload.
+
+**Page-cache waste (RocksDB / TiKV-specific).**
+
+RocksDB caches data in 4KB pages of sequential KV entries. With locality, a page fetch brings in neighbors likely needed next — e.g., adjacent listing entries.
+
+With hashing, adjacent keys on a page belong to unrelated buckets. A typical KV entry is ~1.5KB, so roughly 60% of every cached page is wasted.
+
+FDB caches per KV entry, so hashing does not cause cache waste there.
+
+### Assessment
+
+Hashing is a fleet-level concern, not a single-cluster optimization.
+
+Within a single cluster, the KV store's own auto-sharding handles distribution. The costs of hashing — degraded listings, lost range operations, cache waste, disabled hibernation, pinned mapping tables — outweigh the secondary benefits.
+
+For deployments that require a fleet of independent KV clusters, hashing becomes necessary because no KV-store mechanism exists to balance across clusters. The secondary benefits — balanced activity, less rebalancing, predictable performance — partially offset the costs, but do not eliminate them.
+
+### Fleet Scaling
+
+Every KV store has a single-cluster capacity ceiling. FDB clusters hold approximately 64 billion KV entries (potentially 128 billion). TiKV clusters can scale to approximately 1 trillion KV entries (potentially more). These are large numbers, but production systems may eventually outgrow them.
+
+When a single cluster is no longer sufficient, the system must scale out to a fleet of independent KV clusters. There is no cross-cluster balancing built into any KV store — the fleet management is RGW's responsibility.
+
+Hashing is the simplest method to support a fleet. The shard prefix distributes data uniformly across clusters, and shard migration provides the growth path.
+
+However, hashing is not the only option. Three strategies exist, each with different trade-offs.
+
+**Strategy 1 — Object-level hashing.**
+
+`shard_id = hash(bucket_id + object_name)`.
+
+Objects within a bucket are scattered across all shards and all clusters. Works for any workload — fleet balance is guaranteed by the hash. Pays the full locality cost: merge-sort listings, degraded range operations, pinned mapping tables, cross-cluster coordination for multi-key operations.
+
+The simplest strategy. The most expensive in day-to-day operation.
+
+**Strategy 2 — RGW as fleet rebalancer (no hashing).**
+
+Keys remain ordered. No shard prefix. RGW detects imbalance across clusters and migrates data ranges to restore balance.
+
+This requires RGW to build and operate a cross-cluster data balancer — detecting skew, selecting ranges to move, coordinating live migration, handling failures. A massive engineering and operational burden. Unattractive.
+
+**Strategy 3 — Bucket-level hashing with fleet-friendly buckets.**
+
+`shard_id = hash(bucket_id)`.
+
+All objects in a bucket share the same shard and land on the same cluster. Intra-bucket locality is fully preserved — listing is a simple range scan, range-delete and range-rename work naturally, no merge-sort.
+
+Fleet balance depends on customers creating many smaller, similarly-sized buckets. The hash distributes buckets evenly across clusters. If one bucket grows disproportionately, its cluster becomes hot — there is no automatic fix without falling back to object-level hashing.
+
+Viable for controlled environments where customers can design their bucket layout.
+
+### Cross-Cluster Coordination Cost
+
+On a single cluster, any set of KV mutations can be committed in one transaction. On a fleet, mutations landing on different clusters cannot share a transaction — no KV store supports cross-cluster transactions.
+
+Operations where the source and destination keys hash to different shards require RGW-level coordination: two separate transactions, crash recovery logic, and potential inconsistency windows.
+
+This is another reason to minimize the number of shards to the absolute minimum needed for fleet balance. Fewer shards means fewer cross-cluster operations. Growing from 2 shards to 4 is far less disruptive than jumping to 128.
+
+With bucket-level hashing, most operations stay within a single bucket and therefore a single cluster — cross-cluster coordination is only needed for cross-bucket operations, which are rare in S3.
+
+### Key Naming and Transaction Locality
+
+Smart key naming minimizes cross-cluster operations by ensuring that logically related KV entries hash to the same shard.
+
+Since `shard_id = hash(bucket_id + object_name)` and `version_id` is excluded from the hash, all versions of the same object — same bucket, same name, different versions — get the same `shard_id` and land on the same cluster.
+
+The following entries all share the same shard as the object they belong to:
+
+**All versions of an object.**
+
+Every version — current, prior, and delete markers — shares the same `(bucket_id, object_name)` and therefore the same shard. Creating a new version and invalidating the old one is a single local transaction. This eliminates the need for OLH (Object Lifecycle Head) as a separate coordination object.
+
+**Delete markers.**
+
+In S3 versioned buckets, deleting an object creates a delete marker — a lightweight version entry that makes the object appear deleted without removing its data. A delete marker is just another version of the same object. It hashes to the same shard. Creating the delete marker and updating version state is atomic within one transaction.
+
+**Multipart upload state.**
+
+Upload metadata (upload_id, part list) and the final committed object all relate to the same target `(bucket_id, object_name)`. If multipart state keys derive their shard from the target object's identity, all multipart operations — initiate, upload parts, complete, abort — are local. CompleteMultipartUpload (commit parts + write final object + clean up part entries) is a single transaction.
+
+**Extended value / spillover entries.**
+
+When object metadata overflows the core KV entry, spillover entries must use the same key prefix with a distinguishing suffix. This ensures they hash to the same shard. Writing the core entry and its spillover is a single transaction.
+
+**Delete-log entries.**
+
+When an object is overwritten or deleted, the old chunk pointers must be recorded for async data cleanup. The delete-log entry captures which storage-tier blobs to free later. If the delete-log key derives its shard from the same `(bucket_id + object_name)`, the object mutation and the delete-log write are a single transaction — guaranteeing no orphan window. Every overwrite or delete atomically records what to clean up.
+
+**Object tags, ACLs, and lock metadata.**
+
+S3 supports per-object tags (up to 10 key-value pairs), per-object ACL overrides, and object lock settings (retention period, legal hold). These are typically stored inline in the KV value. If they ever spill to separate KV entries — due to size or access pattern optimization — deriving the shard from the same `(bucket_id + object_name)` keeps them co-located. PutObjectTagging or PutObjectLockConfiguration updates are transactional with the object's metadata.
+
+**Per-shard stats counters.**
+
+If each shard maintains its own stats keys on the same cluster, the object write and the stats update share a transaction. No drift, no separate counter reconciliation.
+
+**Inherently cross-cluster — cannot be solved by naming:**
+
+- **Server-side copy** — source and destination are different object names, different hashes, potentially different clusters. Always requires RGW coordination.
+
+- **Rename** — different name means different hash, potentially different cluster.
+
+- **Cross-bucket operations** — any operation touching objects in different buckets may land on different clusters.
+
+**Design principle:** every KV entry logically tied to a specific object should derive its shard from `hash(bucket_id + object_name)`. This maximizes single-cluster transactions. Only operations involving two distinct object identities require cross-cluster coordination — and minimizing shard count minimizes the probability that two objects land on different clusters.
+
+### Logical Hashing Epoch
+
+A deployment does not need to choose its final shard count upfront.
+
+The system supports a **logical hashing epoch** — a global counter that defines the current shard count. Each epoch transition increases the shard count, and the same migration protocol runs each time.
+
+**Epoch 0** — `SHARD_COUNT = 1`. All keys get `shard_id = 0`. Effectively no hashing. The entire keyspace is one contiguous range on one cluster. Simple listing, simple everything. The key still carries the `shard_id` prefix, but it is always 0.
+
+**Epoch 1** — when the cluster reaches a capacity threshold (e.g., 80% full), the admin triggers a reshard. `SHARD_COUNT` increases — for example, to 2. Existing keys are re-keyed with their new `shard_id`. From this point, the fleet growth path is available — shards can be distributed across clusters.
+
+**Epoch N** — further reshards as the system grows. Each transition increases the shard count: 1 → 2 → 4 → 8 → 16 → ... The customer controls when to reshard and by how much.
+
+This means the listing complexity grows gradually, not all at once. With 2 shards, listing is a 2-way merge — barely noticeable. With 4, still manageable. The customer pays only the complexity their current scale demands.
+
+**Resharding mechanism.**
+
+Resharding uses the same watermark-based background migration protocol as directory rename:
+
+- A **background worker** scans range-by-range, re-keying each entry from the old `shard_id` to the new `shard_id`. The watermark advances through the keyspace as processing progresses.
+
+- **On-access reshard** — when a client writes to a key above the watermark (not yet resharded by the background worker), RGW reshards that entry on the fly, writing it with the new `shard_id`.
+
+- **GETs** check the watermark. Below the watermark — look in the new shard. Above the watermark — look in the old shard. A false negative on a race condition (watermark just advanced but the gateway's cached copy is stale) is fixed with a watermark reload and a retry using the new shard.
+
+- **Per-bucket progression** is natural. In epoch 0, each bucket is a contiguous range. The migration can be ordered by bucket, allowing admins to prioritize — e.g., reshard daytime-active buckets during the night.
+
+**Fleet-wide coordination.**
+
+Resharding is a fleet-wide operation — the shard count is a global constant, so changing it affects every cluster. RGW coordinates the transition:
+
+- **Sequential** — reshard one cluster at a time. Lower system load, safer, but slower. Suitable during heavy production traffic.
+
+- **Parallel** — reshard multiple clusters concurrently. Faster overall, but higher I/O pressure across the fleet. Suitable during maintenance windows or low-traffic periods.
+
+Each cluster's migration is independent, with its own watermark progress. RGW ensures all gateways are aware of the new epoch before any migration begins.
+
+---
+
+## Deployment
+
+The KV store is a separate service from the data store.
+RGW connects to it via a client library or network protocol — the exact mechanism depends on the KV system chosen.
+
+### Ceph-Integrated
+
+For RGW deployments backed by Ceph RADOS:
+- KV store runs on dedicated NVMe partitions on existing OSD nodes, separate from BlueStore.
+- Reuses existing infrastructure — no new hardware required.
+- Failure domains can be aligned with Ceph's (rack/host).
+
+### Standalone
+
+For RGW deployments without Ceph, or where the KV store is managed independently:
+- KV store runs on RGW nodes with local NVMe, or on dedicated metadata nodes.
+- The data store can be any backend that supports write, read-range, and punch-hole — RADOS, a distributed filesystem, cloud storage, or other.
+

--- a/doc/radosgw/KV-Based-Design-For-RGW.md
+++ b/doc/radosgw/KV-Based-Design-For-RGW.md
@@ -47,21 +47,31 @@ Object Lifecycle Head objects add complexity beyond the extra RADOS object itsel
 - All writes to objects in the same PG are serialized — unrelated S3 objects that happen to share a PG block each other.
 - RGW objects have no internal dependency, but RADOS forces them to wait.
 
-**4. Server-Side Copy and dedup.**
+**4. No cross-OSD atomicity.**
+RADOS transactions are scoped to a single PG. Objects mapped to different PGs (via CRUSH) cannot share a transaction. Every S3 mutation touches at least two RADOS objects — the head object and the bucket-index entry — which are on different PGs. There is no way to update them atomically.
+
+- **PUT** — writes the head object and updates the bucket-index entry in two separate operations. A crash between them leaves the bucket-index inconsistent with the actual object state.
+- **DELETE** — removes the bucket-index entry and deletes the head object separately. A crash can leave an orphaned head object (invisible but consuming storage) or a dangling bucket-index entry (pointing to nothing).
+- **Versioning** — the worst case. OLH, head object, and bucket-index are three separate RADOS objects, potentially on three different OSDs. Updating the version pointer, writing the new head, and updating the index are three non-atomic steps.
+- **CompleteMultipartUpload** — writes the final head object, updates the bucket-index, and cleans up multipart part objects. Multiple non-atomic operations across different PGs.
+
+A KV store eliminates this problem. The bucket-index is gone — all related entries (`:O:`, `:V:`, `:M:`, stats, delete-log) share the same shard and can be committed in a single transaction.
+
+**5. Server-Side Copy and dedup.**
 Multiple S3 objects cannot share a head object.
 A server-side copy or deduplication must create a full independent head object even when the data is identical.
 - Data inlined in the head-object (up to 4MB) is duplicated and copied by server-side copy.
 - Dedup moves the inline data from the head object into a new tail-object to allow full data deduplication.
 
-**5. Key rename.**
+**6. Key rename.**
 Renaming an S3 object requires copying the entire object and deleting the original — there is no in-place rename.\
 Especially costly when applications like Apache Spark/Hadoop rename entire directory trees.
 
-**6. Backend lock-in.**
+**7. Backend lock-in.**
 The storage tier must implement the full RADOS object model (xattrs, omap).
 RGW cannot use a simpler blob store without reimplementing that model.
 
-**7. EC metadata amplification.**
+**8. EC metadata amplification.**
 Every RADOS head object carries metadata (xattrs, omap) replicated across all K+M EC members.
 - 6 copies in a 4+2 scheme.
 - 11 copies in 8+3.
@@ -69,14 +79,14 @@ Every RADOS head object carries metadata (xattrs, omap) replicated across all K+
 This far exceeds what metadata protection requires.\
 Furthermore, Delete operations must remove rados objects on **all** K+M EC members.
 
-**8. Bucket listing.**
+**9. Bucket listing.**
 Head objects scattered across RADOS cannot be listed efficiently.\
 This is why the bucket-index exists as a separate structure — duplicating metadata to enable listing, at the cost of dual updates and consistency issues.
 
-**9. Storage-class placement.**
+**10. Storage-class placement.**
 When data is placed in a non-default storage class pool, the head object must still reside in the default pool — acting purely as a KV-style pointer at full RADOS object cost.
 
-**10. Delete overhead.**
+**11. Delete overhead.**
 Deleting an S3 object requires two non-atomic operations on separate systems:
 - Removing the bucket-index entry.
 - Deleting the head object:
@@ -277,16 +287,56 @@ Transaction scope is always within a single cluster — cross-cluster atomicity 
 
 ### Key Format
 
+Four key namespaces separate current objects, old versions, child entries, and multipart uploads:
+
+**Current object (`:O:`):**
+
 ```
-<prefix> <bucket_id> <object_name> <version_id>
+<prefix> <shard_id> <bucket_id> :O: <object_name>
 ```
+
+**Old versions and delete markers (`:V:`):**
+
+```
+<prefix> <shard_id> <bucket_id> :V: <object_name> <version_id>
+```
+
+**Child entries (`:C:`):**
+
+```
+<prefix> <shard_id> <bucket_id> :C: <ref_tag> :: <type> <identifier>
+```
+
+Child type prefixes: `A` (annotation), `T` (tags), `E` (extended value), `L` (ACL).
+
+**Multipart uploads (`:M:`):**
+
+```
+<prefix> <shard_id> <bucket_id> :M: <object_name> <upload_id>
+```
+
+Multipart upload entries are transient — they exist only between `CreateMultipartUpload` and `CompleteMultipartUpload`/`AbortMultipartUpload`. A dedicated namespace keyed by object_name (not ref_tag) is required because `ListMultipartUploads` is a bucket-wide API that lists all active uploads sorted by object key with prefix/delimiter filtering — a range scan on `:M:` satisfies this directly.
+
+**Field definitions:**
 
 - **prefix** — a short namespace identifier distinguishing object entries from bucket metadata, stats, and other KV schemas sharing the same store.
+- **shard_id** — always present. When sharding is not enabled (epoch 0), `shard_id = 1`.
 - **bucket_id** — binary bucket identifier. All objects in a bucket share the same prefix.
 - **object_name** — the S3 object key, stored as raw bytes. Preserves natural lexicographic ordering.
-- **version_id** — binary value using a descending scheme. The latest version sorts first, so a non-versioned GET reads the first key without scanning.
+- **version_id** — binary value using a descending scheme. The latest version sorts first.
+- **ref_tag** — compact unique identifier from the parent `:O:` entry (see [ref_tag](#ref_tag)).
 
-Key size: average ~256 bytes. Absolute max ~1040 bytes (1024-byte S3 name limit + 16 bytes for bucket_id and version_id, plus prefix).
+Key size: average ~256 bytes. Absolute max ~1040 bytes (1024-byte S3 name limit + 16 bytes for bucket_id and version_id, plus prefix and shard_id).
+
+**Listing behavior:**
+
+ListObjectsV2 scans `:O:` only — one entry per object key, no children, no old versions.
+
+ListObjectVersions scans `:O:` and `:V:`, merge-sorts by object name. All versions of the same object appear together, latest first.
+
+ListMultipartUploads scans `:M:` only — one entry per active upload, sorted by object key then upload initiation time. Supports prefix/delimiter filtering directly on the object key.
+
+Child entries under `:C:` are never encountered during bucket listing.
 
 Bucket/Realm/Zone metadata (name-to-id mapping, ACLs, policies, quota, versioning, lifecycle) is stored under separate prefixes in the same KV store.
 
@@ -304,25 +354,20 @@ Target size is ~1KB. Smaller values are accepted as-is. Larger values are split 
 
 <a id="ref_tag">**ref_tag**</a> — an existing RGW concept carried forward with an expanded role.
 
-A unique-per-bucket identifier generated by RGW before writing the KV entry.\
+A globally unique identifier generated by RGW before writing the KV entry.\
 It uniquely identifies a specific write/instance of an S3 object — necessary because S3 allows overwriting the same key with different data.
 
 In the current model, ref_tag is a deterministically generated string combining the gateway instance ID, a high-resolution epoch timestamp, and a randomly generated modifier.\
 It also serves as the RADOS object name for tail objects — the fixed short names for the 4MB child stripes of a parent head object.
 
-In the KV model, this role generalizes to compact identity for all child KV entries (tags, multipart state, extended value entries) — logically equivalent, applied to KV children instead of RADOS children.
+In the KV model, this role generalizes to compact identity for all child KV entries under the `:C:` namespace (annotations, tags, extended value entries) — logically equivalent, applied to KV children instead of RADOS children.
 
-Two generation strategies:
+**Generation — 12-byte binary:** `<rgw_id (4B)><seq_id (8B)>`
 
-- **Counter** — 64-bit value from a per-shard `atomic_inc()` counter, prefixed with the originating shard_id.\
-  Compact.\
-  Shard-split-safe: the originating shard_id is baked into the ref_tag permanently, so migrated objects never collide with new objects on the destination shard.\
-  During resharding, the original shard's counter KV must be migrated first.
+- **rgw_id (32 bits)** — allocated from a single global `atomic_inc()` counter in the KV store at RGW boot. Each restart gets a new ID.
+- **seq_id (64 bits)** — in-memory counter starting at 0 on each boot. Incremented per write.
 
-- **Hash** — 256-bit cryptographic hash of\
-`(S3_name + high_resolution_epoch_timestamp + rgw_id)`.\
-  Stateless — no coordination, no counter to maintain or migrate.\
-  Naturally shard-safe.
+Globally unique by construction — each `(rgw_id, seq_id)` pair appears exactly once. No per-shard state, no coordination between RGW instances, no cryptographic hash, no state to migrate during resharding. Compact enough to keep child `:C:` keys short.
 
 **User-visible attributes** (in the KV entry when they fit):
 
@@ -343,8 +388,8 @@ To keep values compact, attributes are compressed using various techniques (e.g.
 
 ### AWS S3 Object Tags
 
-- Object-Tags are stored in a separate child KV (under the same shard) referenced from the S3-Object parent KV
-- All Tags are stored together in a single KV
+- Object-Tags are stored in a separate child KV under `:C:<ref_tag>::T`, co-located on the same shard as the parent `:O:` entry.
+- All Tags are stored together in a single KV entry.
 - AWS supports a maximum of 10 tags per object each with an aggregated size of 5,120 bytes
 
 ### S3 Delete Reference
@@ -532,16 +577,16 @@ This is a concrete benefit of application-level sharding — discussed further i
 
 ## Key Sharding
 
-The base key format places all objects in a bucket in a contiguous range:
+With a single shard (`shard_id = 1`, epoch 0), all objects in a bucket form a contiguous range:
 
 ```
-<prefix> <bucket_id> <object_name> <version_id>
+<prefix> 1 <bucket_id> :O: <object_name>
 ```
 
-An alternative is to prepend a shard identifier — a cryptographic hash of `(bucket_id + object_name)`:
+With multiple shards, the `shard_id` is a cryptographic hash of `(bucket_id + object_name)`:
 
 ```
-<prefix> <shard_id> <bucket_id> <object_name> <version_id>
+<prefix> <shard_id> <bucket_id> :O: <object_name>
 ```
 
 The hash distributes objects uniformly across a fixed number of shards, breaking the contiguous bucket range into N disjoint ranges scattered across the key space.
@@ -710,21 +755,19 @@ This maximizes single-cluster transactions.\
 Only operations involving two distinct object identities require cross-cluster coordination.
 
 **Design principle:**\
-A KV entry logically tied to a specific object should derive its shard from the parent KV.\
-The child KV should **logically** be\
-`<prefix> <shard_id> <bucket_id> <object_name>::<child-suffix>`\
-This way it will always follow the same shard as the parent KV
+A KV entry logically tied to a specific object should derive its shard from the parent `:O:` entry.\
+Child entries use the `:C:` namespace with the parent's ref_tag:
 
-The <object_name> (up to 1024 bytes long) in child KV keys could be replaced by the parent's ref_tag — a compact unique identifier already stored in the parent KV value 
-  (see [ref_tag](#ref_tag))
+`<prefix> <shard_id> <bucket_id> :C: <ref_tag> :: <type> <identifier>`
 
+The ref_tag replaces the full object_name (up to 1024 bytes) with a compact identifier (see [ref_tag](#ref_tag)). All children of an object share the same ref_tag and therefore the same shard — enabling local transactions.
 
 
 ### Entries Sharing the Parent Shard:
 
 **All versions of an object.**
 
-Every version — current, prior, and delete markers — shares the same `(bucket_id, object_name)` and therefore the same shard. Creating a new version and invalidating the old one is a single local transaction. This eliminates the need for OLH (Object Lifecycle Head) as a separate coordination object.
+The current version lives under `:O:`, old versions and delete markers under `:V:`. All share the same `(bucket_id, object_name)` and therefore the same shard. Creating a new version (writing to `:O:` and moving the old entry to `:V:`) is a single local transaction. This eliminates the need for OLH (Object Lifecycle Head) as a separate coordination object.
 
 **Delete markers.**
 
@@ -732,7 +775,7 @@ In S3 versioned buckets, deleting an object creates a delete marker — a lightw
 
 **Multipart upload state.**
 
-Upload metadata (upload_id, part list) and the final committed object all relate to the same target `(bucket_id, object_name)`. If multipart state keys derive their shard from the target object's identity, all multipart operations — initiate, upload parts, complete, abort — are local. CompleteMultipartUpload (commit parts + write final object + clean up part entries) is a single transaction.
+Multipart uploads use the `:M:` namespace keyed by `(bucket_id, object_name, upload_id)`. The object_name ensures multipart entries hash to the same shard as the target `:O:` entry. All multipart operations — initiate, upload parts, complete, abort — are shard-local. CompleteMultipartUpload (write `:O:` entry + delete all `:M:` entries for the upload) is a single transaction.
 
 **Extended value / spillover entries.**
 
@@ -749,8 +792,8 @@ These are typically stored inline in the KV value.\
 If they ever spill to separate KV entries — due to size or access pattern optimization — deriving the shard from the same `(bucket_id + object_name)` keeps them co-located.\
 PutObjectTagging or PutObjectAcl are transactional with the object's metadata.
 
-- Object-Tags are probably best kept in a standalone child KV since they are individually mutable
-- ACL can be stored inside the parent KV or spillover to extended-metadata since they are overwritten together
+- Object-Tags are stored in a standalone child KV (`:C:<ref_tag>::T`) since they are individually mutable.
+- ACL can be stored inside the parent `:O:` entry or spillover to extended-metadata since they are overwritten together.
 
 **Per-shard stats counters.**
 

--- a/doc/radosgw/KV-Based-Design-For-RGW.md
+++ b/doc/radosgw/KV-Based-Design-For-RGW.md
@@ -42,21 +42,26 @@ Object Lifecycle Head objects add complexity beyond the extra RADOS object itsel
 - Copying data into new objects on version changes.
 - Lack of atomicity across OLH, head object, and bucket-index updates.
 
-**3. Server-Side Copy and dedup.**
+**3. PG-level write serialization.**
+- RADOS allows a single transaction per PG at a time.
+- All writes to objects in the same PG are serialized — unrelated S3 objects that happen to share a PG block each other.
+- RGW objects have no internal dependency, but RADOS forces them to wait.
+
+**4. Server-Side Copy and dedup.**
 Multiple S3 objects cannot share a head object.
 A server-side copy or deduplication must create a full independent head object even when the data is identical.
 - Data inlined in the head-object (up to 4MB) is duplicated and copied by server-side copy.
 - Dedup moves the inline data from the head object into a new tail-object to allow full data deduplication.
 
-**4. Key rename.**
+**5. Key rename.**
 Renaming an S3 object requires copying the entire object and deleting the original — there is no in-place rename.\
 Especially costly when applications like Apache Spark/Hadoop rename entire directory trees.
 
-**5. Backend lock-in.**
+**6. Backend lock-in.**
 The storage tier must implement the full RADOS object model (xattrs, omap).
 RGW cannot use a simpler blob store without reimplementing that model.
 
-**6. EC metadata amplification.**
+**7. EC metadata amplification.**
 Every RADOS head object carries metadata (xattrs, omap) replicated across all K+M EC members.
 - 6 copies in a 4+2 scheme.
 - 11 copies in 8+3.
@@ -64,14 +69,14 @@ Every RADOS head object carries metadata (xattrs, omap) replicated across all K+
 This far exceeds what metadata protection requires.\
 Furthermore, Delete operations must remove rados objects on **all** K+M EC members.
 
-**7. Bucket listing.**
+**8. Bucket listing.**
 Head objects scattered across RADOS cannot be listed efficiently.\
 This is why the bucket-index exists as a separate structure — duplicating metadata to enable listing, at the cost of dual updates and consistency issues.
 
-**8. Storage-class placement.**
+**9. Storage-class placement.**
 When data is placed in a non-default storage class pool, the head object must still reside in the default pool — acting purely as a KV-style pointer at full RADOS object cost.
 
-**9. Delete overhead.**
+**10. Delete overhead.**
 Deleting an S3 object requires two non-atomic operations on separate systems:
 - Removing the bucket-index entry.
 - Deleting the head object:
@@ -103,11 +108,16 @@ Zero knowledge of S3 and/or RGW. RGW manages its own metadata in the KV store.
 - A key with a live value means the object exists.
 - Delete removes or invalidates the entry, making it immediately inaccessible.
 
-**R4 — Bucket Listing.**
+**R4 — Per-Key Write Concurrency.**
+Unrelated writes proceed concurrently, with contention only on actual key conflicts.
+
+No placement-group or shard-level serialization — the KV store must not force unrelated objects to wait on each other.
+
+**R5 — Bucket Listing.**
 - KV range scans replace the bucket-index.
 - Each entry returns listing attributes directly from the KV value — no data-tier access.
 
-**R5 — KV Value: Core Requirements.**
+**R6 — KV Value: Core Requirements.**
 The KV value must always contain:
 - All listing attributes (key, last_modified, etag, size, storage_class, owner, checksum_algorithm).
 - Routing info for the first data chunk.
@@ -115,16 +125,16 @@ The KV value must always contain:
 
 > *Stretch goals — desirable but may be overridden by KV system constraints or value size limits:*
 >
-> **R5.1 — KV Value Contains the Full S3 API Surface.**
+> **R6.1 — KV Value Contains the Full S3 API Surface.**
 > Aim to store all user-visible S3 attributes (user metadata, tags, ACLs, object lock) in the KV value.
 > Objects with very large user attributes may spill to an external location.
 > Whether to always keep all user attributes in a single KV entry or allow spillover is an open design question.
 >
-> **R5.2 — KV Value Contains Full Routing Info.**
+> **R6.2 — KV Value Contains Full Routing Info.**
 > Aim to store the complete manifest, compression, and encryption metadata in the KV value, so that data access requires no secondary metadata lookup.
 > When these do not fit (e.g., large compressed multipart objects), RGW falls back to reading them from the data header or spillover storage.
 
-**R6 — Caching Delegated to KV Store.**
+**R7 — Caching Delegated to KV Store.**
 No local RGW cache for object KV entries.
 The KV store's own distributed cache serves hot entries from memory.
 
@@ -258,7 +268,8 @@ This is an early-stage API definition. It will be refined as the design matures 
 
 Transactions enable atomic multi-key operations: object write + delete-log entry + stats update in a single commit.
 
-Transaction scope is always within a single cluster — cross-cluster atomicity is handled by RGW-level coordination (see Key Sharding).
+Transaction scope is always within a single cluster — cross-cluster atomicity is handled by RGW-level coordination 
+(see [Key Sharding](#key-sharding))
 
 ---
 
@@ -290,6 +301,28 @@ Target size is ~1KB. Smaller values are accepted as-is. Larger values are split 
 - Listing attributes — etag, last_modified, size, storage_class, owner, checksum_algorithm, content_type, content_encoding, content_language.
 - RGW internal fields — state/flags, ref_tag, size_physical, chunk pointers. Each chunk pointer is a `(blob_id, offset, length)` tuple — no S3 names on the storage tier. Multiple S3 objects may share a blob_id (packing).
 - Routing info for spillover metadata, when present.
+
+<a id="ref_tag">**ref_tag**</a> — an existing RGW concept carried forward with an expanded role.
+
+A unique-per-bucket identifier generated by RGW before writing the KV entry.\
+It uniquely identifies a specific write/instance of an S3 object — necessary because S3 allows overwriting the same key with different data.
+
+In the current model, ref_tag is a deterministically generated string combining the gateway instance ID, a high-resolution epoch timestamp, and a randomly generated modifier.\
+It also serves as the RADOS object name for tail objects — the fixed short names for the 4MB child stripes of a parent head object.
+
+In the KV model, this role generalizes to compact identity for all child KV entries (tags, multipart state, extended value entries) — logically equivalent, applied to KV children instead of RADOS children.
+
+Two generation strategies:
+
+- **Counter** — 64-bit value from a per-shard `atomic_inc()` counter, prefixed with the originating shard_id.\
+  Compact.\
+  Shard-split-safe: the originating shard_id is baked into the ref_tag permanently, so migrated objects never collide with new objects on the destination shard.\
+  During resharding, the original shard's counter KV must be migrated first.
+
+- **Hash** — 256-bit cryptographic hash of\
+`(S3_name + high_resolution_epoch_timestamp + rgw_id)`.\
+  Stateless — no coordination, no counter to maintain or migrate.\
+  Naturally shard-safe.
 
 **User-visible attributes** (in the KV entry when they fit):
 
@@ -682,8 +715,10 @@ The child KV should **logically** be\
 `<prefix> <shard_id> <bucket_id> <object_name>::<child-suffix>`\
 This way it will always follow the same shard as the parent KV
 
-We can replace the `<object_name>` (up to 1024 Bytes long) on child KV with an 8-byte `<parent-object-id>` which must be stored in the parent KV and used to construct the child KV.\
-Alternatively, we can use a 32-64 byte cryptographic hash as an `<parent-object-id>` saving the need to query the parent KV before accessing the child KV
+The <object_name> (up to 1024 bytes long) in child KV keys could be replaced by the parent's ref_tag — a compact unique identifier already stored in the parent KV value 
+  (see [ref_tag](#ref_tag))
+
+
 
 ### Entries Sharing the Parent Shard:
 

--- a/doc/radosgw/KV-Based-Design-For-RGW.md
+++ b/doc/radosgw/KV-Based-Design-For-RGW.md
@@ -223,7 +223,9 @@ The `G` namespace supports both per-instance entries (`G:O`, `G:V`, `G:U`, `G:A`
 
 **Storage-tier idempotency.** KV and storage-tier operations cannot be atomic. Every storage-tier chunk embeds its `ref_tag`, enabling GC workers to verify ownership before freeing data. This makes all GC deletions idempotent — safe to retry after a crash at any point. For packed small objects, "freeing data" means a Logical-Punch-Hole rather than a physical delete. See [Storage-Tier-Requirements.md](Storage-Tier-Requirements.md).
 
-**Transaction model.** Every operation that writes storage-tier data (PutObject, UploadPart, PutObjectAnnotation, CompleteMultipartUpload) uses a coordination entry in the `P` (pending operations) namespace to prevent orphaned data on crash. The `P` entry is written before data, deleted in the commit transaction. A background sweeper cleans up stale entries. DELETE operations use an optimistic pattern: read outside the transaction, then verify ref_tag inside a small transaction before committing the move to `G`. See [S3 Operations — Transaction Patterns](S3-Operations-Over-KV.md#transaction-patterns) and [Pending Operations Namespace](S3-Operations-Over-KV.md#pending-operations-namespace).
+**Three-tier data storage.** Object data is stored at one of three tiers based on size: (1) inline in the O: value (< 256B — single KV write, single KV read), (2) D: namespace entry (256B–8KB — single transaction, no storage-tier involvement), (3) storage tier (> 8KB — three-phase protocol with P:O coordination). The chunk descriptor in O: encapsulates the data location: `{type: INLINE, data}`, `{type: CHILD_D, size_tier, mtime}`, or `{type: STORAGE, storage_id, blob_id, offset, length}`. Multipart uploads always use Tier 3. Tier 2 objects can be migrated to Tier 3 via background packing (P:D coordination) when KV capacity is under pressure or objects become cold. The D: key includes a hash_prefix for write scatter and mtime for LRU ordering. Pre-reshard protocol drains all D: entries before resharding to keep shard migration lightweight. See [data-tiering.md](data-tiering.md) for the full protocol.
+
+**Transaction model.** Operations that write storage-tier data use coordination entries to prevent orphaned data on crash. PutObject (Tier 3) and PutObjectAnnotation (large annotations) use entries in the `P` (pending) namespace — written before data, verified and deleted in the commit transaction. CompleteMultipartUpload creates a `P:M` entry at completion Phase 1 as a crash-recovery anchor. UploadPart uses `:M:` part entries directly as coordination records (no per-part `P` entries). Tiers 1 and 2 need no coordination entries — data and metadata commit atomically in a single KV transaction. A background sweeper moves stale `P` entries to `G` for asynchronous data cleanup. See [bucket_delete.md](bucket_delete.md) for the full transaction protocol and race-condition analysis.
 
 **Vendor-unique delete-all-versions.** AWS S3 does not provide a single API to delete an object along with all its versions. The `G:F` directive enables an optional vendor-specific extension: a single call deletes the `:O:` entry and writes one `G:F` directive; background workers asynchronously clean up all versions, parts, and children. This extension may never be implemented. See [S3 Operations — Delete All Versions](S3-Operations-Over-KV.md#delete-all-versions-optional-vendor-extension) for the detailed design.
 
@@ -516,12 +518,13 @@ This is mitigated by the KV store's distributed cache serving hot entries from m
 
 ### PUT
 
-1. Write data to the storage tier.
-2. Write the KV entry:
-   - New object: write the new value.
-   - Overwriting a live object: move old entry to the `G` (GC) namespace with a stripped value, then write the new value. See [S3 Operations — GC Namespace](S3-Operations-Over-KV.md#gc-namespace-and-background-cleanup).
+Three-phase protocol coordinated through the `P` (pending) namespace:
 
-This is cheaper than the current model since no bucket-index update is needed.
+1. **Phase 1 — record intent:** In a single transaction: `get(B)` (verify bucket exists) + `put(P:O)` (coordination entry with ref_tag). If bucket has `delete-pending` flag → `NoSuchBucket`.
+2. **Phase 2 — write data:** Write blob to storage tier addressed by ref_tag. No KV operations.
+3. **Phase 3 — commit metadata:** In a single transaction: `get(P:O)` (verify not cleaned by sweeper) + write `:O:` + `delete(P:O)`. On overwrite: also move old `:O:` to `G` namespace.
+
+Crash recovery: if the process dies between Phase 1 and Phase 3, the `P:O` entry remains. The sweeper moves it to `G:O`, and the GC worker frees orphaned storage-tier data. See [bucket_delete.md](bucket_delete.md) for the full transaction protocol, sweeper interaction, and FDB/TiKV race-condition analysis.
 
 ### DELETE
 
@@ -565,6 +568,47 @@ The KV store's own distributed cache serves frequently accessed entries from mem
 
 Keeping values small maximizes cache efficiency — more entries fit in the same amount of memory.
 
+### Small-Object Data in KV — Cache Bypass
+
+When small objects (≤ 64 KB) are stored as KV entries in the `D` namespace (pending aggregation into packed blobs on the storage tier), their data values are large and transient. Reading them must not pollute the KV store's block/page cache — these are write-once entries that will be deleted after aggregation.
+
+**Rule:** All reads of small-object data from the `D` namespace — whether by the aggregator's bulk scan or by a GET serving a not-yet-aggregated object — must use the KV store's cache-bypass flag.
+
+**FDB — `READ_SERVER_SIDE_CACHE_DISABLE` (transaction option 508).**
+
+Set on the transaction before issuing reads:
+
+```
+fdb_transaction_set_option(tr, 508, NULL, 0);  // READ_SERVER_SIDE_CACHE_DISABLE
+```
+
+> "Storage server should not cache disk blocks needed for subsequent read requests in this transaction. This can be used to avoid cache pollution for reads not expected to be repeated."
+
+This is a transaction-level option — all reads in that transaction bypass the storage server's block cache. Use a dedicated transaction for D-namespace reads, separate from any metadata reads that benefit from caching.
+
+**TiKV — `ReadOptions::fill_cache(false)`.**
+
+RocksDB's native per-request option, exposed through TiKV's engine interface:
+
+```
+let mut opts = ReadOptions::new();
+opts.fill_cache(false);
+```
+
+> "Specify whether the data block / index block / filter block read for this iteration should be cached in memory. Callers may wish to set this field to false for bulk scans."
+
+Per-request granularity — can be set independently for each Get or iterator without affecting other reads in the same transaction.
+
+**Write-path cache behavior.**
+
+There is no "no-cache write" flag in either system. The impact of writes on the read cache depends on the storage engine:
+
+| Engine | Write populates read cache? | Notes |
+|---|---|---|
+| RocksDB (TiKV, FDB ssd-rocksdb-v1) | No — writes go to memtable, a separate memory pool from the block cache | Non-issue. Block cache is only populated by reads. |
+| Redwood (FDB ssd-redwood-1, default) | Yes — B-tree page modifications remain in the page cache | Mitigated by key-range separation: D-namespace keys occupy different B-tree pages from S-namespace metadata. Pages evicted by LRU as D entries are short-lived. |
+
+For deployments where write-path cache pollution is a concern, the RocksDB-based engine provides natural isolation.
 
 ---
 
@@ -920,4 +964,20 @@ For RGW deployments backed by Ceph RADOS:
 For RGW deployments without Ceph, or where the KV store is managed independently:
 - KV store runs on RGW nodes with local NVMe, or on dedicated metadata nodes.
 - The data store can be any backend that supports write, read-range, and punch-hole — RADOS, a distributed filesystem, cloud storage, or other.
+
+---
+
+## Small-Object Packing
+
+Small objects (≤ 64 KB) land their data directly in the KV store in a dedicated `D` namespace, bypassing the storage tier entirely at PUT time. A background aggregator collects ~4 MB of accumulated data per bucket and writes it as a single packed blob to the storage tier. After the blob is committed, the `:O:` values are updated with final `(blob_id, offset, length)` and the D entries are deleted.
+
+This eliminates per-object storage-tier overhead for small objects and turns the storage tier into a bulk-write target — large sequential writes that amortize EC parity computation and member coordination across dozens of objects.
+
+**Key properties:**
+
+- PUT for small objects is a single atomic KV transaction (`:O:` + D entry). No `P:O` coordination, no storage-tier write.
+- DELETE before aggregation is a single transaction deleting both entries. No GC needed.
+- Per-bucket packing. P:Pack coordination entry for crash recovery. SingleDelete for D entry cleanup.
+
+For the full design — including the aggregation protocol, crash recovery, storage-tier integration, cache-bypass mechanisms, and RocksDB/TiKV-specific LSM considerations — see [Small-Object-Packing.md](Small-Object-Packing.md).
 

--- a/doc/radosgw/KV-Based-Design-For-RGW.md
+++ b/doc/radosgw/KV-Based-Design-For-RGW.md
@@ -295,9 +295,16 @@ Transaction scope is always within a single cluster — cross-cluster atomicity 
 
 ## KV Schema
 
-### Key Format
+&lt;namespace&gt; &lt;shard_count&gt; &lt;shard_id&gt; &lt;bucket_id&gt;**&lt;category&gt;**&lt;object_name&gt;
 
-Four categories separate current objects, old versions, child entries, and multipart uploads. Category tags are 1-byte ASCII values (`O`, `V`, `M`, `C`). In prose, these are written as `:O:`, `:V:`, `:M:`, `:C:` for visual clarity.
+Four **categories** separate current objects:
+- Current S3 **O**bjects
+- S3 old **V**ersions
+- RGW internal **C**hild entries
+- **M**ultipart uploads.
+
+Category tags are 1-byte ASCII values (`O`, `V`, `C`, `M`).\
+For visual clarity they are written as `:O:`, `:V:`, `:C:`, `:M:`
 
 **Current object (`:O:`):**
 
@@ -328,16 +335,27 @@ Child type values: `A` (annotation), `T` (tags), `E` (extended value).
 
 **Field definitions:**
 
-- **namespace (1 B, ASCII)** — KV namespace: `S` (S3 object entries), `B` (bucket metadata), `Z` (zone/realm metadata), `G` (GC entries for background data cleanup — uses a different header layout, see below), `P` (pending multi-phase operations — crash recovery coordination).
-- **shard_count (2 B, uint16 big-endian)** — number of shards for this bucket (starts at 1, max 65535). `shard_id = hash(bucket_id + object_name) % shard_count`.
-- **shard_id (2 B, uint16 big-endian)** — zero-based shard index. Invariant: `shard_id < shard_count`. When `shard_count = 1`, always `0`.
+- **namespace (1 B, ASCII)** — KV namespace:
+- `S` - S3 object entries
+- `B` - bucket metadata (keyed by tenant_id + bucket_name)
+- `T` - tenant metadata
+- `Z` - zone/realm metadata
+- `G` - GC entries for background data cleanup
+- `P` - pending multi-phase operations — crash recovery coordination
+
+- **shard_count (2 B, uint16 big-endian)** — number of shards for this bucket.\
+`shard_id = hash(bucket_id + object_name) % shard_count`.
+- **shard_id (2 B, uint16 big-endian)** — zero-based shard index.\
+Invariant: `shard_id < shard_count`. When `shard_count = 1`, always `0`.
 - **bucket_id (8 B)** — binary bucket identifier.
 - **cat (1 B, ASCII)** — category tag: `O`, `V`, `M`, or `C`.
 - **object_name (1–1024 B)** — the S3 object key, stored as raw bytes. Preserves natural lexicographic ordering.
 - **version_id (4 B, uint32 big-endian)** — descending; first value is `max_uint32`, then decreasing. Latest version sorts first.
 - **ref_tag (12 B)** — compact unique identifier from the parent `:O:` entry (see [ref_tag](#ref_tag)).
 - **child_type (1 B, ASCII)** — `A`, `T`, or `E`.
-- **part_number (2 B, uint16 big-endian)** — 0 for upload metadata, 1–10000 for individual parts.
+- **part_number (2 B, uint16 big-endian)** —
+    - 0 for upload metadata
+    - 1–10000 for individual parts
 - **child_id (0–512 B)** — annotation name (type `A`); empty for `T`, `E`.
 
 See [S3 Operations — GC Namespace](S3-Operations-Over-KV.md#gc-namespace-and-background-cleanup).
@@ -346,15 +364,38 @@ For detailed binary layout, construction, deconstruction, and pseudo-code, see [
 
 **Listing behavior:**
 
-ListObjectsV2 scans `:O:` only — one entry per object key, no children, no old versions.
+ListObjectsV2 scans
+- `:O:` only — one entry per object key
+- no children
+- no old versions
 
-ListObjectVersions scans `:O:` and `:V:`, merge-sorts by object name. All versions of the same object appear together, latest first.
+ListObjectVersions scans
+- `:O:` and `:V:`
+- merge-sorts by object name
+- All versions of the same object appear together, latest first.
 
-ListMultipartUploads scans `:M:` only — one entry per active upload, sorted by object key then upload initiation time. Supports prefix/delimiter filtering directly on the object key.
+ListMultipartUploads scans
+- `:M:` only — one entry per active upload
+- sorted by object key, then by upload_id (ref_tag)
+- Supports prefix/delimiter filtering directly on the object key.
 
 Child entries under `:C:` are never encountered during bucket listing.
 
-Bucket/Realm/Zone metadata (name-to-id mapping, ACLs, policies, quota, versioning, lifecycle) is stored under separate namespaces in the same KV store.
+Bucket/Tenant/Realm/Zone metadata (name-to-id mappings, ACLs, policies, quota, versioning, lifecycle) is stored under separate namespaces (`B`, `T`, `Z`) in the same KV store.
+
+### Multi-Tenancy
+
+Every bucket belongs to exactly one tenant. Bucket names are unique per tenant, not globally — two tenants can each have a bucket called "test" with different bucket_ids.
+
+**B namespace key:** `B <tenant_id 4B> <bucket_name 1–63B>`
+
+ListBuckets per tenant is a prefix scan on `B <tenant_id>`.
+
+Cross-tenant access (tenant B reading tenant A's bucket) requires the client to explicitly name the owning tenant. The bucket remains owned by tenant A — sharing is an access-control decision, not a storage-layout decision.
+
+**T namespace** stores tenant-level metadata (quota, rate limits, tenant-wide policies).
+
+tenant_id does not appear in `S`/`G`/`P` namespace keys. Tenant identity is resolved once at request entry and does not affect the object key scheme or shard hash.
 
 ### Value Structure
 
@@ -378,16 +419,20 @@ It also serves as the RADOS object name for tail objects — the fixed short nam
 
 In the KV model, this role generalizes to compact identity for all child KV entries under the `:C:` namespace (annotations, tags, extended value entries) — logically equivalent, applied to KV children instead of RADOS children.
 
-**Generation — 12-byte binary:** `<rgw_id (4B, uint32 BE)><seq_id (8B, uint64 BE)>`
+**ref_tag generation:** `<rgw_id (4B, uint32 BE)><seq_id (8B, uint64 BE)>`
 
-- **rgw_id (32 bits)** — allocated from a single global `atomic_inc()` counter in the KV store at RGW boot. Each restart gets a new ID.
-- **seq_id (64 bits)** — in-memory counter starting at 0 on each boot. Incremented per write.
+- **rgw_id (32 bits)** — 
+    - Allocated from a single global `atomic_inc()` counter in the KV store at RGW boot.
+    - Each restart gets a new ID.
+- **seq_id (64 bits)** —
+    - In-memory counter starting at 0 on each boot.
+    - Incremented per write.
 
 Globally unique by construction — each `(rgw_id, seq_id)` pair appears exactly once. No per-shard state, no coordination between RGW instances, no cryptographic hash, no state to migrate during resharding. Compact enough to keep child `:C:` keys short.
 
 **User-visible attributes** (in the KV entry when they fit):
 
-- content_disposition, cache_control.
+- Content_disposition, cache_control.
 - User metadata (x-amz-meta-*) — up to 2KB per S3 limits.
 - Object ACL overrides, checksum values, object lock.
 
@@ -431,7 +476,7 @@ POSIX systems, for example, cannot prepend headers to existing files and would u
 
 ### HEAD
 
-1. Translate bucket name to bucket_id (local cache).
+1. Resolve bucket: (tenant_id, bucket_name) → bucket_id (local cache).
 2. Read the KV entry.
 3. If not found → return 404. If fenced delete marker → return 404 with `x-amz-delete-marker: true`.
 4. Return all S3-visible attributes from the value.
@@ -441,7 +486,7 @@ The assumption here is that KV-Get is faster than Rados Read with its heavy stac
 
 ### GET (Full Object)
 
-1. Translate bucket name to bucket_id (local cache).
+1. Resolve bucket: (tenant_id, bucket_name) → bucket_id (local cache).
 2. Read the KV entry.
 3. If not found → return 404. If fenced delete marker → return 404.
 4. Read data chunks from the storage tier using the chunk pointers.
@@ -462,7 +507,7 @@ This is mitigated by the KV store's distributed cache serving hot entries from m
 
 ### PUT
 
-1. Write data to the storage tier. The first chunk includes the data header.
+1. Write data to the storage tier.
 2. Write the KV entry:
    - New object: write the new value.
    - Overwriting a live object: move old entry to the `G` (GC) namespace with a stripped value, then write the new value. See [S3 Operations — GC Namespace](S3-Operations-Over-KV.md#gc-namespace-and-background-cleanup).
@@ -473,7 +518,7 @@ This is cheaper than the current model since no bucket-index update is needed.
 
 1. Read the KV entry.
 2. If not found → return success (idempotent).
-3. Move the entry to the `G` (GC) namespace with a stripped value containing only cleanup information. The key is removed from `S`. Update stats counters.
+3. Move the entry to the `G` (GC) namespace with a stripped value containing only cleanup information. The key is removed from `S`
 4. Return success.
 
 Data cleanup happens asynchronously — background workers scan `G` and free storage-tier data. See [S3 Operations — GC Namespace](S3-Operations-Over-KV.md#gc-namespace-and-background-cleanup) for the full protocol.
@@ -482,7 +527,7 @@ This is cheaper than the current model since no bucket-index update is needed.
 
 ### LIST (ListObjectsV2)
 
-1. Translate bucket name to bucket_id (local cache).
+1. Resolve bucket: (tenant_id, bucket_name) → bucket_id (local cache).
 2. Range scan on `:O:` entries for this bucket — `<namespace><shard_count><shard_id><bucket_id>O`.
 3. Filter out fenced entries (delete markers in versioned buckets). Non-versioned deleted objects are simply absent.
 4. Return up to 1000 keys with listing attributes from the KV values.
@@ -497,7 +542,8 @@ Should be cheaper than the current model with its excessive sharding and OMAP ov
 
 ### What RGW Caches Locally
 Locally cached metadata — created and removed, but never modified in place:
-- **Bucket name → bucket_id mapping** — small, stable, fully cached.
+- **tenant_name → tenant_id mapping** — small, stable, fully cached.
+- **(tenant_id, bucket_name) → bucket_id mapping** — small, stable, fully cached.
 - **Bucket metadata** — ACLs, policies, quota, versioning, lifecycle rules.
 - **Realm/Zone metadata**
 - **Attribute mapping tables** — binary mappings for repeated strings. Small, append-only, fully cached.

--- a/doc/radosgw/KV-Based-Design-For-RGW.md
+++ b/doc/radosgw/KV-Based-Design-For-RGW.md
@@ -96,6 +96,15 @@ Deleting an S3 object requires two non-atomic operations on separate systems:
 
 See [Delete](#delete) for detailed analysis.
 
+**12. Delete markers as full RADOS objects.**
+In versioned buckets, deleting an object without a version-id creates a delete marker — a zero-byte metadata-only entry indicating the object appears deleted.
+Despite carrying no user data, each delete marker is a full RADOS head object:
+- PG membership, OSD tracking, recovery bookkeeping — all for zero bytes of content.
+- On EC pools, replicated across all K+M members (6 copies of nothing for 4+2, 11 for 8+3).
+- On HDD-backed pools, creating and eventually deleting the DM incurs disk I/O on every member.
+
+Workloads with frequent versioned deletes (e.g., lifecycle expiration creating delete markers) accumulate large numbers of these zero-byte RADOS objects, consuming cluster resources disproportionate to their purpose.
+
 ---
 
 ## Requirements

--- a/doc/radosgw/KV-Based-Design-For-RGW.md
+++ b/doc/radosgw/KV-Based-Design-For-RGW.md
@@ -219,7 +219,7 @@ The KV design uses a dedicated `G` (GC) namespace:
 
 Because the move to `G` is in the same transaction as the KV mutation, there is no orphan window — every orphaned data reference is tracked. See [S3 Operations — GC Namespace](S3-Operations-Over-KV.md#gc-namespace-and-background-cleanup) for the full protocol.
 
-The `G` namespace supports both per-instance entries (`G:O`, `G:V`, `G:M`, `G:A` — fixed-length, one entry per deleted/overwritten instance) and directive entries (`G:P` — one entry to clean up all parts of an aborted upload; `G:F` — one entry to clean up all versions of an object). Directives reduce the number of `G` entries for bulk operations from thousands to one.
+The `G` namespace supports both per-instance entries (`G:O`, `G:V`, `G:U`, `G:A` — fixed-length, one entry per deleted/overwritten instance or multipart part) and directive entries (`G:M` — one entry to clean up all parts of a completed or aborted upload; `G:F` — one entry to clean up all versions of an object). Directives reduce the number of `G` entries for bulk operations from thousands to one.
 
 **Storage-tier idempotency.** KV and storage-tier operations cannot be atomic. Every storage-tier chunk embeds its `ref_tag`, enabling GC workers to verify ownership before freeing data. This makes all GC deletions idempotent — safe to retry after a crash at any point. For packed small objects, "freeing data" means a Logical-Punch-Hole rather than a physical delete. See [Storage-Tier-Requirements.md](Storage-Tier-Requirements.md).
 

--- a/doc/radosgw/KV-Based-Design-For-RGW.md
+++ b/doc/radosgw/KV-Based-Design-For-RGW.md
@@ -8,14 +8,22 @@ An S3-compatible object store must maintain metadata for every object:
 - User-visible attributes — content-type, etag, tags, ACLs, checksums.
 - Internal data attributes — manifest, compression, encryption.
 
-This metadata must be accessible independently of the data itself.
-HEAD requests return it without reading any data.
+This metadata must be accessible independently of the data itself. \
+HEAD requests return it without reading any data. \
 Bucket listing must enumerate it efficiently across potentially billions of objects.
 
-In RGW, RADOS head objects serve this purpose. Every S3 object has a corresponding head object that holds its identity, attributes, and a manifest pointing to data chunks.
+In RGW, RADOS head objects serve this purpose.\
+Every S3 object has a corresponding head object that holds its:
+- identity
+- attributes
+- and a manifest pointing to data chunks.
 
-For small objects, the data itself is inlined into the head object.\
-For multipart uploads, storage-class placement, versioning (OLH), and cloud tiering — the head object acts as a pure metadata pointer, a redirection layer to data stored elsewhere.
+The head object acts as a metadata pointer, a redirection layer to data stored elsewhere:
+- multipart uploads
+- storage-class placement
+- versioning (OLH) 
+
+There is a special case where the data itself is inlined into the head object - when object size is smaller than 4MB and is non of the above cases.
 
 In effect, RGW is already using head objects as a de facto KV system, but implemented with full RADOS objects carrying all their associated overhead.
 
@@ -34,7 +42,6 @@ Each S3 object, no matter how small, requires its own RADOS object.
 - Prevents aggregating small objects into larger blobs.
 - Every small object carries full RADOS overhead: OSD tracking, PG membership, recovery bookkeeping.
 - Recovery cost scales with object count rather than data volume.
-- The storage tier cannot optimize for large sequential I/O.
 
 **2. Versioning (OLH).**
 Object Lifecycle Head objects add complexity beyond the extra RADOS object itself:
@@ -51,12 +58,13 @@ Object Lifecycle Head objects add complexity beyond the extra RADOS object itsel
 RADOS transactions are scoped to a single PG. Objects mapped to different PGs (via CRUSH) cannot share a transaction.\
 Every S3 mutation touches at least two RADOS objects — the head object and the bucket-index entry — which are on different PGs. There is no way to update them atomically.
 
-- **PUT** — writes the head object and updates the bucket-index entry in two separate operations. A crash between them leaves the bucket-index inconsistent with the actual object state.
-- **DELETE** — removes the bucket-index entry and deletes the head object separately. A crash can leave an orphaned head object (invisible but consuming storage) or a dangling bucket-index entry (pointing to nothing).
+- **PUT** — writes the head object and updates the bucket-index entry in two separate operations.
+- **DELETE** — removes the bucket-index entry and deletes the head object separately.
 - **Versioning** — the worst case. OLH, head object, and bucket-index are three separate RADOS objects, potentially on three different OSDs. Updating the version pointer, writing the new head, and updating the index are three non-atomic steps.
 - **CompleteMultipartUpload** — writes the final head object, updates the bucket-index, and cleans up multipart part objects. Multiple non-atomic operations across different PGs.
 
-A KV store eliminates this problem. The bucket-index is gone — all related entries can be committed in a single transaction.
+A KV store eliminates this problem.\
+The bucket-index is gone — all related entries can be committed in a single transaction.
 
 **5. Server-Side Copy and dedup.**
 Multiple S3 objects cannot share a head object.
@@ -185,8 +193,6 @@ A crash between the bucket-index update and the head-object delete can leave the
 
 On EC pools, each RADOS object deletion fans out across all K+M members (6 OSDs for 4+2, 11 for 8+3).
 
-When RADOS objects are stored on HDD, the delete must wait for all members to complete on slow HDD.
-
 ### KV Delete Benefits
 
 **Single atomic operation.**
@@ -205,30 +211,6 @@ Delete never touches slow HDD — important when data is stored on HDD.
 **Faster than RADOS object delete.**
 Even on the same hardware, a KV delete is a lightweight metadata operation compared to the full transaction overhead of deleting a RADOS object.
 
-PR #48711 added a new concept (`inline-data=false`) to avoid the delete penalty inline — empty head objects on a fast tier with replica×3.
-But even with this change, GC still needs to delete K+M members on the storage tier, which can degrade system performance under heavy delete load.
-
-### Background Data Cleanup
-
-Background processing to reclaim storage-tier space is needed regardless of the metadata model.
-
-The KV design uses a dedicated `G` (GC) namespace:
-- Every operation that orphans data (DELETE, PUT-overwrite) moves the old KV entry to the `G` namespace with a stripped value retaining only cleanup information.
-- Background workers scan `G` entries, free storage-tier data, remove child KV entries, and delete the `G` entry.
-- The `G` key includes a logarithmic `size_tier` byte enabling prioritized cleanup — small objects can be batched for throughput, large objects prioritized for capacity recovery.
-
-Because the move to `G` is in the same transaction as the KV mutation, there is no orphan window — every orphaned data reference is tracked. See [S3 Operations — GC Namespace](S3-Operations-Over-KV.md#gc-namespace-and-background-cleanup) for the full protocol.
-
-The `G` namespace supports both per-instance entries (`G:O`, `G:V`, `G:U`, `G:A` — fixed-length, one entry per deleted/overwritten instance or multipart part) and directive entries (`G:M` — one entry to clean up all parts of a completed or aborted upload; `G:F` — one entry to clean up all versions of an object). Directives reduce the number of `G` entries for bulk operations from thousands to one.
-
-**Storage-tier idempotency.** KV and storage-tier operations cannot be atomic. Every storage-tier chunk embeds its `ref_tag`, enabling GC workers to verify ownership before freeing data. This makes all GC deletions idempotent — safe to retry after a crash at any point. For packed small objects, "freeing data" means a Logical-Punch-Hole rather than a physical delete. See [Storage-Tier-Requirements.md](Storage-Tier-Requirements.md).
-
-**Three-tier data storage.** Object data is stored at one of three tiers based on size: (1) inline in the O: value (< 256B — single KV write, single KV read), (2) D: namespace entry (256B–8KB — single transaction, no storage-tier involvement), (3) storage tier (> 8KB — three-phase protocol with P:O coordination). The chunk descriptor in O: encapsulates the data location: `{type: INLINE, data}`, `{type: CHILD_D, size_tier, mtime}`, or `{type: STORAGE, storage_id, blob_id, offset, length}`. Multipart uploads always use Tier 3. Tier 2 objects can be migrated to Tier 3 via background packing (P:D coordination) when KV capacity is under pressure or objects become cold. The D: key includes a hash_prefix for write scatter and mtime for LRU ordering. Pre-reshard protocol drains all D: entries before resharding to keep shard migration lightweight. See [data-tiering.md](data-tiering.md) for the full protocol.
-
-**Transaction model.** Operations that write storage-tier data use coordination entries to prevent orphaned data on crash. PutObject (Tier 3) and PutObjectAnnotation (large annotations) use entries in the `P` (pending) namespace — written before data, verified and deleted in the commit transaction. CompleteMultipartUpload creates a `P:M` entry at completion Phase 1 as a crash-recovery anchor. UploadPart uses `:M:` part entries directly as coordination records (no per-part `P` entries). Tiers 1 and 2 need no coordination entries — data and metadata commit atomically in a single KV transaction. A background sweeper moves stale `P` entries to `G` for asynchronous data cleanup. See [bucket_delete.md](bucket_delete.md) for the full transaction protocol and race-condition analysis.
-
-**Vendor-unique delete-all-versions.** AWS S3 does not provide a single API to delete an object along with all its versions. The `G:F` directive enables an optional vendor-specific extension: a single call deletes the `:O:` entry and writes one `G:F` directive; background workers asynchronously clean up all versions, parts, and children. This extension may never be implemented. See [S3 Operations — Delete All Versions](S3-Operations-Over-KV.md#delete-all-versions-optional-vendor-extension) for the detailed design.
-
 ---
 
 ## Bucket Listing
@@ -245,7 +227,7 @@ Listing is a direct range scan on the KV store — each entry already contains a
 No secondary structure, no dual updates.
 
 Listing performance depends on key ordering:
-- **Without sharding** — a bucket's objects form a contiguous key range. Listing is a simple range scan.
+- **Without sharding (i.e single cluster)** — a bucket's objects form a contiguous key range. Listing is a simple range scan.
 - **With sharding** — listing requires parallel scans across shards followed by a merge-sort. Still efficient, but more complex.
 
 The full analysis of sharding trade-offs is covered in a separate document.
@@ -263,6 +245,54 @@ RGW owns all intelligence: access control, manifest interpretation, compression,
 
 The bucket-index is eliminated.
 Its functions — listing, metadata lookup, bucket stats — are absorbed by the KV store.
+
+### Three-tier data storage
+
+Object data is stored at one of three tiers based on size:
+- inline in the O: value (< 256B — single KV write, single KV read)
+- D: namespace entry (256B–8KB — single transaction, no storage-tier involvement) 
+- storage tier (> 8KB — three-phase protocol with P:O coordination)
+
+The chunk descriptor in O: encapsulates the data location:
+- `{type: INLINE, data}`
+- `{type: CHILD_D, size_tier, mtime}`
+- `{type: STORAGE, storage_id, blob_id, offset, length}`
+
+Multipart uploads always use Tier 3.\
+Tier 2 objects can be migrated to Tier 3 via background packing (P:D coordination) when KV capacity is under pressure or objects become cold.\
+See [data-tiering.md](data-tiering.md) for the full protocol.
+
+### Transaction model
+
+Operations that write storage-tier data use coordination entries to prevent orphaned data on crash.\
+PutObject (Tier 3) and PutObjectAnnotation (large annotations) use entries in the `P` (pending) namespace:
+- written before data
+- verified and deleted in the commit transaction.
+
+CompleteMultipartUpload creates a `P:M` entry at completion Phase 1 as a crash-recovery anchor.\
+UploadPart uses `:M:` part entries directly as coordination records (no per-part `P` entries).\
+Tiers 1 and 2 need no coordination entries — data and metadata commit atomically in a single KV transaction.\
+A background sweeper moves stale `P` entries to `G` for asynchronous data cleanup.\
+See [bucket_delete.md](bucket_delete.md) for the full transaction protocol and race-condition analysis.
+
+
+### Background Data Cleanup
+
+Background processing to reclaim storage-tier space is needed regardless of the metadata model.
+
+The KV design uses a dedicated `G` (GC) namespace:
+- Every operation that orphans data (DELETE, PUT-overwrite) moves the old KV entry to the `G` namespace with a stripped value retaining only cleanup information.
+- Background workers scan `G` entries, free storage-tier data, remove child KV entries, and delete the `G` entry.
+- The `G` key includes a logarithmic `size_tier` byte enabling prioritized cleanup — small objects can be batched for throughput, large objects prioritized for capacity recovery.
+
+Because the move to `G` is in the same transaction as the KV mutation, there is no orphan window — every orphaned data reference is tracked. See [S3 Operations — GC Namespace](S3-Operations-Over-KV.md#gc-namespace-and-background-cleanup) for the full protocol.
+
+The `G` namespace supports both per-instance entries (`G:O`, `G:V`, `G:U`, `G:A` — fixed-length, one entry per deleted/overwritten instance or multipart part) and directive entries (`G:M` — one entry to clean up all parts of a completed or aborted upload). Directives reduce the number of `G` entries for bulk operations from thousands to one.
+
+**Storage-tier idempotency.** 
+- KV and storage-tier operations cannot be atomic. 
+- Every storage-tier chunk embeds its `ref_tag`, enabling GC workers to verify ownership before freeing data. 
+- This makes all GC deletions idempotent — safe to retry after a crash at any point.
 
 ---
 
@@ -567,48 +597,6 @@ Object KV entries are not cached locally on RGW servers.\
 The KV store's own distributed cache serves frequently accessed entries from memory.
 
 Keeping values small maximizes cache efficiency — more entries fit in the same amount of memory.
-
-### Small-Object Data in KV — Cache Bypass
-
-When small objects (≤ 64 KB) are stored as KV entries in the `D` namespace (pending aggregation into packed blobs on the storage tier), their data values are large and transient. Reading them must not pollute the KV store's block/page cache — these are write-once entries that will be deleted after aggregation.
-
-**Rule:** All reads of small-object data from the `D` namespace — whether by the aggregator's bulk scan or by a GET serving a not-yet-aggregated object — must use the KV store's cache-bypass flag.
-
-**FDB — `READ_SERVER_SIDE_CACHE_DISABLE` (transaction option 508).**
-
-Set on the transaction before issuing reads:
-
-```
-fdb_transaction_set_option(tr, 508, NULL, 0);  // READ_SERVER_SIDE_CACHE_DISABLE
-```
-
-> "Storage server should not cache disk blocks needed for subsequent read requests in this transaction. This can be used to avoid cache pollution for reads not expected to be repeated."
-
-This is a transaction-level option — all reads in that transaction bypass the storage server's block cache. Use a dedicated transaction for D-namespace reads, separate from any metadata reads that benefit from caching.
-
-**TiKV — `ReadOptions::fill_cache(false)`.**
-
-RocksDB's native per-request option, exposed through TiKV's engine interface:
-
-```
-let mut opts = ReadOptions::new();
-opts.fill_cache(false);
-```
-
-> "Specify whether the data block / index block / filter block read for this iteration should be cached in memory. Callers may wish to set this field to false for bulk scans."
-
-Per-request granularity — can be set independently for each Get or iterator without affecting other reads in the same transaction.
-
-**Write-path cache behavior.**
-
-There is no "no-cache write" flag in either system. The impact of writes on the read cache depends on the storage engine:
-
-| Engine | Write populates read cache? | Notes |
-|---|---|---|
-| RocksDB (TiKV, FDB ssd-rocksdb-v1) | No — writes go to memtable, a separate memory pool from the block cache | Non-issue. Block cache is only populated by reads. |
-| Redwood (FDB ssd-redwood-1, default) | Yes — B-tree page modifications remain in the page cache | Mitigated by key-range separation: D-namespace keys occupy different B-tree pages from S-namespace metadata. Pages evicted by LRU as D entries are short-lived. |
-
-For deployments where write-path cache pollution is a concern, the RocksDB-based engine provides natural isolation.
 
 ---
 

--- a/doc/radosgw/KV-Based-Design-For-RGW.md
+++ b/doc/radosgw/KV-Based-Design-For-RGW.md
@@ -48,14 +48,15 @@ Object Lifecycle Head objects add complexity beyond the extra RADOS object itsel
 - RGW objects have no internal dependency, but RADOS forces them to wait.
 
 **4. No cross-OSD atomicity.**
-RADOS transactions are scoped to a single PG. Objects mapped to different PGs (via CRUSH) cannot share a transaction. Every S3 mutation touches at least two RADOS objects — the head object and the bucket-index entry — which are on different PGs. There is no way to update them atomically.
+RADOS transactions are scoped to a single PG. Objects mapped to different PGs (via CRUSH) cannot share a transaction.\
+Every S3 mutation touches at least two RADOS objects — the head object and the bucket-index entry — which are on different PGs. There is no way to update them atomically.
 
 - **PUT** — writes the head object and updates the bucket-index entry in two separate operations. A crash between them leaves the bucket-index inconsistent with the actual object state.
 - **DELETE** — removes the bucket-index entry and deletes the head object separately. A crash can leave an orphaned head object (invisible but consuming storage) or a dangling bucket-index entry (pointing to nothing).
 - **Versioning** — the worst case. OLH, head object, and bucket-index are three separate RADOS objects, potentially on three different OSDs. Updating the version pointer, writing the new head, and updating the index are three non-atomic steps.
 - **CompleteMultipartUpload** — writes the final head object, updates the bucket-index, and cleans up multipart part objects. Multiple non-atomic operations across different PGs.
 
-A KV store eliminates this problem. The bucket-index is gone — all related entries (`:O:`, `:V:`, `:M:`, stats, delete-log) share the same shard and can be committed in a single transaction.
+A KV store eliminates this problem. The bucket-index is gone — all related entries can be committed in a single transaction.
 
 **5. Server-Side Copy and dedup.**
 Multiple S3 objects cannot share a head object.
@@ -202,11 +203,20 @@ But even with this change, GC still needs to delete K+M members on the storage t
 
 Background processing to reclaim storage-tier space is needed regardless of the metadata model.
 
-The KV design uses a persistent delete-log:
-- Every operation that orphans data (DELETE, PUT-overwrite) appends an entry recording the old data references.
-- A background process drains the log and frees storage.
+The KV design uses a dedicated `G` (GC) namespace:
+- Every operation that orphans data (DELETE, PUT-overwrite) moves the old KV entry to the `G` namespace with a stripped value retaining only cleanup information.
+- Background workers scan `G` entries, free storage-tier data, remove child KV entries, and delete the `G` entry.
+- The `G` key includes a logarithmic `size_tier` byte enabling prioritized cleanup — small objects can be batched for throughput, large objects prioritized for capacity recovery.
 
-Because the delete-log can be written in the same transaction as the KV mutation, there is no orphan window — every orphaned data reference is tracked.
+Because the move to `G` is in the same transaction as the KV mutation, there is no orphan window — every orphaned data reference is tracked. See [S3 Operations — GC Namespace](S3-Operations-Over-KV.md#gc-namespace-and-background-cleanup) for the full protocol.
+
+The `G` namespace supports both per-instance entries (`G:O`, `G:V`, `G:M`, `G:A` — fixed-length, one entry per deleted/overwritten instance) and directive entries (`G:P` — one entry to clean up all parts of an aborted upload; `G:F` — one entry to clean up all versions of an object). Directives reduce the number of `G` entries for bulk operations from thousands to one.
+
+**Storage-tier idempotency.** KV and storage-tier operations cannot be atomic. Every storage-tier chunk embeds its `ref_tag`, enabling GC workers to verify ownership before freeing data. This makes all GC deletions idempotent — safe to retry after a crash at any point. For packed small objects, "freeing data" means a Logical-Punch-Hole rather than a physical delete. See [Storage-Tier-Requirements.md](Storage-Tier-Requirements.md).
+
+**Transaction model.** Every operation that writes storage-tier data (PutObject, UploadPart, PutObjectAnnotation, CompleteMultipartUpload) uses a coordination entry in the `P` (pending operations) namespace to prevent orphaned data on crash. The `P` entry is written before data, deleted in the commit transaction. A background sweeper cleans up stale entries. DELETE operations use an optimistic pattern: read outside the transaction, then verify ref_tag inside a small transaction before committing the move to `G`. See [S3 Operations — Transaction Patterns](S3-Operations-Over-KV.md#transaction-patterns) and [Pending Operations Namespace](S3-Operations-Over-KV.md#pending-operations-namespace).
+
+**Vendor-unique delete-all-versions.** AWS S3 does not provide a single API to delete an object along with all its versions. The `G:F` directive enables an optional vendor-specific extension: a single call deletes the `:O:` entry and writes one `G:F` directive; background workers asynchronously clean up all versions, parts, and children. This extension may never be implemented. See [S3 Operations — Delete All Versions](S3-Operations-Over-KV.md#delete-all-versions-optional-vendor-extension) for the detailed design.
 
 ---
 
@@ -221,7 +231,7 @@ It duplicates metadata to enable listing, at the cost of:
 
 With a KV-based metadata layer, the bucket-index is eliminated.
 Listing is a direct range scan on the KV store — each entry already contains all listing attributes.
-No secondary structure, no dual updates, no resharding.
+No secondary structure, no dual updates.
 
 Listing performance depends on key ordering:
 - **Without sharding** — a bucket's objects form a contiguous key range. Listing is a simple range scan.
@@ -276,7 +286,7 @@ This is an early-stage API definition. It will be refined as the design matures 
 - `Commit()` — atomically apply all mutations, or fail if conflicts are detected.
 - `Abort()` — discard all mutations.
 
-Transactions enable atomic multi-key operations: object write + delete-log entry + stats update in a single commit.
+Transactions enable atomic multi-key operations: object write + GC entry + stats update in a single commit.
 
 Transaction scope is always within a single cluster — cross-cluster atomicity is handled by RGW-level coordination 
 (see [Key Sharding](#key-sharding))
@@ -287,46 +297,52 @@ Transaction scope is always within a single cluster — cross-cluster atomicity 
 
 ### Key Format
 
-Four key namespaces separate current objects, old versions, child entries, and multipart uploads:
+Four categories separate current objects, old versions, child entries, and multipart uploads. Category tags are 1-byte ASCII values (`O`, `V`, `M`, `C`). In prose, these are written as `:O:`, `:V:`, `:M:`, `:C:` for visual clarity.
 
 **Current object (`:O:`):**
 
 ```
-<prefix> <shard_id> <bucket_id> :O: <object_name>
+<namespace> <shard_count> <shard_id> <bucket_id> O <object_name>
 ```
 
 **Old versions and delete markers (`:V:`):**
 
 ```
-<prefix> <shard_id> <bucket_id> :V: <object_name> <version_id>
+<namespace> <shard_count> <shard_id> <bucket_id> V <object_name> <version_id>
 ```
 
 **Child entries (`:C:`):**
 
 ```
-<prefix> <shard_id> <bucket_id> :C: <ref_tag> :: <type> <identifier>
+<namespace> <shard_count> <shard_id> <bucket_id> C <ref_tag> <child_type> <child_id>
 ```
 
-Child type prefixes: `A` (annotation), `T` (tags), `E` (extended value), `L` (ACL).
+Child type values: `A` (annotation), `T` (tags), `E` (extended value).
 
 **Multipart uploads (`:M:`):**
 
 ```
-<prefix> <shard_id> <bucket_id> :M: <object_name> <upload_id>
+<namespace> <shard_count> <shard_id> <bucket_id> M <object_name> <ref_tag> <part_number>
 ```
 
-Multipart upload entries are transient — they exist only between `CreateMultipartUpload` and `CompleteMultipartUpload`/`AbortMultipartUpload`. A dedicated namespace keyed by object_name (not ref_tag) is required because `ListMultipartUploads` is a bucket-wide API that lists all active uploads sorted by object key with prefix/delimiter filtering — a range scan on `:M:` satisfies this directly.
 
 **Field definitions:**
 
-- **prefix** — a short namespace identifier distinguishing object entries from bucket metadata, stats, and other KV schemas sharing the same store.
-- **shard_id** — always present. When sharding is not enabled (epoch 0), `shard_id = 1`.
-- **bucket_id** — binary bucket identifier. All objects in a bucket share the same prefix.
-- **object_name** — the S3 object key, stored as raw bytes. Preserves natural lexicographic ordering.
-- **version_id** — binary value using a descending scheme. The latest version sorts first.
-- **ref_tag** — compact unique identifier from the parent `:O:` entry (see [ref_tag](#ref_tag)).
+- **namespace (1 B, ASCII)** — KV namespace: `S` (S3 object entries), `B` (bucket metadata), `Z` (zone/realm metadata), `G` (GC entries for background data cleanup — uses a different header layout, see below), `P` (pending multi-phase operations — crash recovery coordination).
+- **shard_count (2 B, uint16 big-endian)** — number of shards for this bucket (starts at 1, max 65535). `shard_id = hash(bucket_id + object_name) % shard_count`.
+- **shard_id (2 B, uint16 big-endian)** — zero-based shard index. Invariant: `shard_id < shard_count`. When `shard_count = 1`, always `0`.
+- **bucket_id (8 B)** — binary bucket identifier.
+- **cat (1 B, ASCII)** — category tag: `O`, `V`, `M`, or `C`.
+- **object_name (1–1024 B)** — the S3 object key, stored as raw bytes. Preserves natural lexicographic ordering.
+- **version_id (4 B, uint32 big-endian)** — descending; first value is `max_uint32`, then decreasing. Latest version sorts first.
+- **ref_tag (12 B)** — compact unique identifier from the parent `:O:` entry (see [ref_tag](#ref_tag)).
+- **child_type (1 B, ASCII)** — `A`, `T`, or `E`.
+- **part_number (2 B, uint16 big-endian)** — 0 for upload metadata, 1–10000 for individual parts.
+- **child_id (0–512 B)** — annotation name (type `A`); empty for `T`, `E`.
 
-Key size: average ~256 bytes. Absolute max ~1040 bytes (1024-byte S3 name limit + 16 bytes for bucket_id and version_id, plus prefix and shard_id).
+See [S3 Operations — GC Namespace](S3-Operations-Over-KV.md#gc-namespace-and-background-cleanup).
+
+For detailed binary layout, construction, deconstruction, and pseudo-code, see [Listing-and-Key-Scheme.md — Key Schema](Listing-and-Key-Scheme.md#key-schema--binary-layout).
 
 **Listing behavior:**
 
@@ -338,7 +354,7 @@ ListMultipartUploads scans `:M:` only — one entry per active upload, sorted by
 
 Child entries under `:C:` are never encountered during bucket listing.
 
-Bucket/Realm/Zone metadata (name-to-id mapping, ACLs, policies, quota, versioning, lifecycle) is stored under separate prefixes in the same KV store.
+Bucket/Realm/Zone metadata (name-to-id mapping, ACLs, policies, quota, versioning, lifecycle) is stored under separate namespaces in the same KV store.
 
 ### Value Structure
 
@@ -362,7 +378,7 @@ It also serves as the RADOS object name for tail objects — the fixed short nam
 
 In the KV model, this role generalizes to compact identity for all child KV entries under the `:C:` namespace (annotations, tags, extended value entries) — logically equivalent, applied to KV children instead of RADOS children.
 
-**Generation — 12-byte binary:** `<rgw_id (4B)><seq_id (8B)>`
+**Generation — 12-byte binary:** `<rgw_id (4B, uint32 BE)><seq_id (8B, uint64 BE)>`
 
 - **rgw_id (32 bits)** — allocated from a single global `atomic_inc()` counter in the KV store at RGW boot. Each restart gets a new ID.
 - **seq_id (64 bits)** — in-memory counter starting at 0 on each boot. Incremented per write.
@@ -388,21 +404,11 @@ To keep values compact, attributes are compressed using various techniques (e.g.
 
 ### AWS S3 Object Tags
 
-- Object-Tags are stored in a separate child KV under `:C:<ref_tag>::T`, co-located on the same shard as the parent `:O:` entry.
-- All Tags are stored together in a single KV entry.
-- AWS supports a maximum of 10 tags per object each with an aggregated size of 5,120 bytes
-
-### S3 Delete Reference
-
-On delete, we keep the original Key while replacing the live Value with a minimal delete reference containing:
-- A delete flag.
-- A timestamp.
-- The ref_tag of the deleted object.
-
-The ref_tag is retained so background cleanup can verify data ownership before freeing storage.
-All other attributes are discarded.
-
-RGW reads the entry, sees the delete reference, and returns 404.
+- Object-Tags are stored inline in the `:O:` value when they are short and space permits.
+- When tags are too large for the `:O:` value, they spill to a standalone child KV under `:C:<ref_tag>T`, co-located on the same shard as the parent `:O:` entry.
+- The `:O:` value indicates whether tags are inline or external.
+- All tags for an object are stored together (either all inline or all in the child KV entry).
+- AWS supports a maximum of 10 tags per object with an aggregated size of up to 5,120 bytes.
 
 ### Extended Value
 
@@ -427,7 +433,8 @@ POSIX systems, for example, cannot prepend headers to existing files and would u
 
 1. Translate bucket name to bucket_id (local cache).
 2. Read the KV entry.
-3. Return all S3-visible attributes from the value.
+3. If not found → return 404. If fenced delete marker → return 404 with `x-amz-delete-marker: true`.
+4. Return all S3-visible attributes from the value.
 
 Single KV read. No data-tier access. Should be faster than the current model.\
 The assumption here is that KV-Get is faster than Rados Read with its heavy stack.
@@ -436,7 +443,8 @@ The assumption here is that KV-Get is faster than Rados Read with its heavy stac
 
 1. Translate bucket name to bucket_id (local cache).
 2. Read the KV entry.
-3. Read data chunks from the storage tier using the chunk pointers.
+3. If not found → return 404. If fenced delete marker → return 404.
+4. Read data chunks from the storage tier using the chunk pointers.
 5. Read extended-attributes if needed.
 6. Extract ref_tag (verify against KV value), manifest, compression info.
 7. Decompress/decrypt and stream to client.
@@ -447,37 +455,39 @@ This is mitigated by the KV store's distributed cache serving hot entries from m
 ### GET (Byte-Range)
 
 1. Read the KV entry.
-2. If read-path metadata is in the KV value (common case): use it directly to locate the target chunk.
-3. If not (large compressed multipart): read the extended attributes, or use a locally cached copy.
-4. Read and decompress/decrypt the target byte range.
+2. If not found → return 404. If fenced delete marker → return 404.
+3. If read-path metadata is in the KV value (common case): use it directly to locate the target chunk.
+4. If not (large compressed multipart): read the extended attributes, or use a locally cached copy.
+5. Read and decompress/decrypt the target byte range.
 
 ### PUT
 
 1. Write data to the storage tier. The first chunk includes the data header.
 2. Write the KV entry:
-   - New object or overwriting a delete marker: write the new value.
-   - Overwriting a live object: record old data references in the delete-log, then write the new value.
+   - New object: write the new value.
+   - Overwriting a live object: move old entry to the `G` (GC) namespace with a stripped value, then write the new value. See [S3 Operations — GC Namespace](S3-Operations-Over-KV.md#gc-namespace-and-background-cleanup).
 
 This is cheaper than the current model since no bucket-index update is needed.
 
 ### DELETE
 
-1. Read the KV entry to get chunk pointers and ref_tag.
-2. Record old data references in the delete-log.
-3. Replace the value with a delete reference, or remove the entry.
+1. Read the KV entry.
+2. If not found → return success (idempotent).
+3. Move the entry to the `G` (GC) namespace with a stripped value containing only cleanup information. The key is removed from `S`. Update stats counters.
 4. Return success.
 
-Data cleanup happens asynchronously via the delete-log.
+Data cleanup happens asynchronously — background workers scan `G` and free storage-tier data. See [S3 Operations — GC Namespace](S3-Operations-Over-KV.md#gc-namespace-and-background-cleanup) for the full protocol.
+
 This is cheaper than the current model since no bucket-index update is needed.
 
 ### LIST (ListObjectsV2)
 
 1. Translate bucket name to bucket_id (local cache).
-2. Range scan on the bucket_id prefix.
-3. Filter out delete references.
+2. Range scan on `:O:` entries for this bucket — `<namespace><shard_count><shard_id><bucket_id>O`.
+3. Filter out fenced entries (delete markers in versioned buckets). Non-versioned deleted objects are simply absent.
 4. Return up to 1000 keys with listing attributes from the KV values.
 
-Pagination uses the last returned key as the continuation marker.
+Pagination uses the last returned key as the continuation marker. With sharding: fan out to all shards, merge-sort by object_name.
 
 Should be cheaper than the current model with its excessive sharding and OMAP overhead.
 
@@ -577,16 +587,16 @@ This is a concrete benefit of application-level sharding — discussed further i
 
 ## Key Sharding
 
-With a single shard (`shard_id = 1`, epoch 0), all objects in a bucket form a contiguous range:
+With a single shard (`shard_count = 1`, `shard_id = 0`), all objects in a bucket form a contiguous range:
 
 ```
-<prefix> 1 <bucket_id> :O: <object_name>
+<namespace> <shard_count=1> <shard_id=0> <bucket_id> O <object_name>
 ```
 
-With multiple shards, the `shard_id` is a cryptographic hash of `(bucket_id + object_name)`:
+With multiple shards, `shard_id = hash(bucket_id + object_name) % shard_count`:
 
 ```
-<prefix> <shard_id> <bucket_id> :O: <object_name>
+<namespace> <shard_count> <shard_id> <bucket_id> O <object_name>
 ```
 
 The hash distributes objects uniformly across a fixed number of shards, breaking the contiguous bucket range into N disjoint ranges scattered across the key space.
@@ -691,7 +701,7 @@ FDB clusters hold approximately 64 billion KV entries (potentially 128 billion).
 TiKV clusters can scale to approximately 1 trillion KV entries (potentially more).
 
 These are large numbers, but **some** production systems may eventually outgrow them.
-- The KV store design allocates one extra KV per object to store S3 Object Tags (when present) which can double the KV count
+- S3 Object Tags are stored inline in the `:O:` value when short; when they spill to an external child KV (`...C<ref_tag>T`), each tagged object adds one extra KV entry
 - Object Annotations allow up to 1000 Annotations per Object, and since we use a standalone KV for each Annotation we can have an effective 1 Trillion KV on a system with a mere 1 Billion S3-Objects.
 
 When a single cluster is no longer sufficient, the system must scale out to a fleet of independent KV clusters.\
@@ -758,7 +768,7 @@ Only operations involving two distinct object identities require cross-cluster c
 A KV entry logically tied to a specific object should derive its shard from the parent `:O:` entry.\
 Child entries use the `:C:` namespace with the parent's ref_tag:
 
-`<prefix> <shard_id> <bucket_id> :C: <ref_tag> :: <type> <identifier>`
+`<namespace> <shard_count> <shard_id> <bucket_id> C <ref_tag> <child_type> <child_id>`
 
 The ref_tag replaces the full object_name (up to 1024 bytes) with a compact identifier (see [ref_tag](#ref_tag)). All children of an object share the same ref_tag and therefore the same shard — enabling local transactions.
 
@@ -775,15 +785,15 @@ In S3 versioned buckets, deleting an object creates a delete marker — a lightw
 
 **Multipart upload state.**
 
-Multipart uploads use the `:M:` namespace keyed by `(bucket_id, object_name, upload_id)`. The object_name ensures multipart entries hash to the same shard as the target `:O:` entry. All multipart operations — initiate, upload parts, complete, abort — are shard-local. CompleteMultipartUpload (write `:O:` entry + delete all `:M:` entries for the upload) is a single transaction.
+Multipart uploads use the `:M:` namespace keyed by `(bucket_id, object_name, ref_tag, part_number)`. The `ref_tag` serves as the upload_id. The object_name ensures multipart entries hash to the same shard as the target `:O:` entry. All multipart operations — initiate, upload parts, complete, abort — are shard-local. CompleteMultipartUpload (write `:O:` entry + delete all `:M:` entries for the upload) is a single transaction.
 
 **Extended value / spillover entries.**
 
 When object metadata overflows the core KV entry, spillover entries must use the same key prefix with a distinguishing suffix. This ensures they hash to the same shard. Writing the core entry and its spillover is a single transaction.
 
-**Delete-log entries.**
+**GC entries.**
 
-When an object is overwritten or deleted, the old chunk pointers must be recorded for async data cleanup. The delete-log entry captures which storage-tier blobs to free later. If the delete-log key derives its shard from the same `(bucket_id + object_name)`, the object mutation and the delete-log write are a single transaction — guaranteeing no orphan window. Every overwrite or delete atomically records what to clean up.
+When an object is overwritten or deleted, its KV entry is moved to the `G` (GC) namespace for async data cleanup. The `G` entry retains the same `shard_count` and `shard_id` as the original — it is co-located on the same shard, so the metadata mutation and the GC write are a single transaction. No orphan window. See [S3 Operations — GC Namespace](S3-Operations-Over-KV.md#gc-namespace-and-background-cleanup).
 
 **Object tags, ACLs, and lock metadata.**
 
@@ -792,8 +802,8 @@ These are typically stored inline in the KV value.\
 If they ever spill to separate KV entries — due to size or access pattern optimization — deriving the shard from the same `(bucket_id + object_name)` keeps them co-located.\
 PutObjectTagging or PutObjectAcl are transactional with the object's metadata.
 
-- Object-Tags are stored in a standalone child KV (`:C:<ref_tag>::T`) since they are individually mutable.
-- ACL can be stored inside the parent `:O:` entry or spillover to extended-metadata since they are overwritten together.
+- Object-Tags are stored inline in the `:O:` value when short; spill to a standalone child KV (`:C:<ref_tag>T`) when they exceed the inline budget.
+- ACL is always stored inline in the parent `:O:` entry (spills to extended value if needed) since ACLs are overwritten as a whole.
 
 **Per-shard stats counters.**
 
@@ -808,31 +818,21 @@ If each shard maintains its own stats keys on the same cluster, the object write
 - **Cross-bucket operations** — any operation touching objects in different buckets may land on different clusters.
 
 
-### Logical Hashing Epoch
+### Hashing/Sharding
 
 A deployment does not need to choose its final shard count upfront.
 
-The system supports a **logical hashing epoch** — a global counter that defines the current shard count. Each epoch transition increases the shard count, and the same migration protocol runs each time.
+The system supports a global counter that defines the current shard count.
+Each transition increases the shard count, and the same migration protocol runs each time.
 
-**Epoch 0** — `SHARD_COUNT = 1`. All keys get `shard_id = 0`. Effectively no hashing. The entire keyspace is one contiguous range on one cluster. Simple listing, simple everything. The key still carries the `shard_id` prefix, but it is always 0.
+**Base Sharding** — `SHARD_COUNT = 1`. All keys get `shard_id = 0`. Effectively no hashing. The entire keyspace is one contiguous range on one cluster. Simple listing, simple everything. The key still carries the `shard_id` prefix, but it is always 0.
 
-**Epoch 1** — when the cluster reaches a capacity threshold (e.g., 80% full), the admin triggers a reshard. `SHARD_COUNT` increases — for example, to 2. Existing keys are re-keyed with their new `shard_id`. From this point, the fleet growth path is available — shards can be distributed across clusters.
+**First Reshard** — when the cluster reaches a capacity threshold (e.g., 80% full), the admin triggers a reshard. `SHARD_COUNT` increases — for example, to 2. Existing keys are re-keyed with their new `shard_id`. From this point, the fleet growth path is available — shards can be distributed across clusters.
 
-**Epoch N** — further reshards as the system grows. Each transition increases the shard count: 1 → 2 → 4 → 8 → 16 → ... The customer controls when to reshard and by how much.
+**Reshard N** — further reshards as the system grows. Each transition increases the shard count: 1 → 2 → 4 → 8 → 16 → ... The customer controls when to reshard and by how much.
 
 This means the listing complexity grows gradually, not all at once. With 2 shards, listing is a 2-way merge — barely noticeable. With 4, still manageable. The customer pays only the complexity their current scale demands.
 
-**Resharding mechanism.**
-
-Resharding uses the same watermark-based background migration protocol as directory rename:
-
-- A **background worker** scans range-by-range, re-keying each entry from the old `shard_id` to the new `shard_id`. The watermark advances through the keyspace as processing progresses.
-
-- **On-access reshard** — when a client writes to a key above the watermark (not yet resharded by the background worker), RGW reshards that entry on the fly, writing it with the new `shard_id`.
-
-- **GETs** check the watermark. Below the watermark — look in the new shard. Above the watermark — look in the old shard. A false negative on a race condition (watermark just advanced but the gateway's cached copy is stale) is fixed with a watermark reload and a retry using the new shard.
-
-- **Per-bucket progression** is natural. In epoch 0, each bucket is a contiguous range. The migration can be ordered by bucket, allowing admins to prioritize — e.g., reshard daytime-active buckets during the night.
 
 **Fleet-wide coordination.**
 
@@ -843,6 +843,8 @@ Resharding is a fleet-wide operation — the shard count is a global constant, s
 - **Parallel** — reshard multiple clusters concurrently. Faster overall, but higher I/O pressure across the fleet. Suitable during maintenance windows or low-traffic periods.
 
 Each cluster's migration is independent, with its own watermark progress. RGW ensures all gateways are aware of the new epoch before any migration begins.
+
+**Listing during resharding** — while old and new shard_count keys coexist, listing merges all X + Y streams (old shards + new shards). See [Listing During Resharding](Listing-and-Key-Scheme.md#listing-during-resharding) for the full protocol.
 
 ---
 

--- a/doc/radosgw/Versioned-Bucket-Operations.md
+++ b/doc/radosgw/Versioned-Bucket-Operations.md
@@ -7,15 +7,44 @@ This document describes how S3 versioning operations map to the KV schema define
 ---
 ## Version ID Scheme
 
-- First version: `version_id = max_uint32` (0xFFFFFFFF). `next_vid = max_uint32 - 1`.
-- Each subsequent version (PUT or DELETE): `version_id = O:.next_vid`. Then `O:.next_vid = vid - 1`.
-- The `:O:` value stores both fields:
-  - `version_id` — this version's ID. What GET returns, what goes into the V: key when moved to history.
-  - `next_vid` — the next available ID. Monotonically decreasing counter, consumed on each new version. Never resets upward.
-- On promotion (DELETE Case 2): `next_vid` is inherited from the OUTGOING O: entry, not from the promoted V: entry. This prevents version ID reuse after deletion — deleted IDs are permanently consumed.
-- In `:V:`, entries include the version_id in the **Key**\
+Monotonically decreasing counter consumed on each new version.\
+Never resets upward.
 keys sort by `<object_name><version_id>`.\
 Since version_id decreases over time and is stored big-endian, later versions have smaller byte values and sort first — latest version first.
+
+- First version:
+    - `version_id = max_uint32` (0xFFFFFFFF).
+    - `next_vid = max_uint32 - 1`.
+- Each subsequent version (PUT or DELETE):
+    - `version_id = O:.next_vid`.
+    - Then `O:.next_vid = vid - 1`.
+- The `:O:` value stores both fields:
+   - `version_id` — this version's ID.\
+   What GET returns, what goes into the V: key when moved to history.
+   - `next_vid` — the next available ID.
+- On promotion (DELETE Case 2):
+    - `next_vid` is inherited from the OUTGOING O: entry, not from the promoted V: entry.
+    - This prevents version ID reuse after deletion — **deleted IDs are permanently consumed**.
+- In `:V:`, entries include the version_id in the **Key**
+
+### Special Version ID Values
+
+| Value | Name | Meaning |
+|---|---|---|
+| 0 | `NO_VERSION` | Written in unversioned mode. No versioning applies. |
+| 1 | `NULL_ID` | Written in suspended mode. The null-version slot. |
+| 2 – max_uint32 | Real version IDs | Versioned entries (start at max_uint32, decrement via next_vid) |
+
+Real version_ids start at max_uint32 and decrease — they will never reach 1 or 0 in practice (4+ billion operations per object key would be required).
+
+**Invariant:** If `O:.version_id > 0` (NULL_ID or real), the bucket MUST be versioned or suspended. If bucket metadata says unversioned — this is an internal error (corruption). Abort and report.
+
+### Null-version rule
+
+**Null-version entries (version_id == 1, NULL_ID) never move to V: — always overwrite (→ G:O).**
+
+This applies regardless of current bucket state. A null-vid entry represents the "suspended-mode slot." It is always overwritten, never preserved as a version in V:.
+
 
 ## KV Schema
 
@@ -156,7 +185,9 @@ With sharding: fan out to all shards, merge-sort across shards by object_name.
 All operations that write a new value to `:O:` on a versioned bucket — including PUT, DELETE-without-version-id (creates delete marker), and CompleteMultipartUpload (writes assembled manifest):
 
 1. Move the current `:O:` entry to `:V:` (keyed by its version_id).
-2. Write a new entry to `:O:` with `version_id = O:.next_vid`. Set `O:.next_vid = vid - 1`.
+2. Write a new entry to `:O:`
+    - Set `version_id = O:.next_vid`.
+    - Set `O:.next_vid = vid - 1`.
 3. All in a single transaction.
 
 PUT writes a live value. DELETE writes a **fenced delete marker**.
@@ -199,9 +230,13 @@ No `P:O` coordination entry is needed — since no storage-tier data is written.
    - If a KV exists in `:O:`
        - Move the current `:O:` entry to `:V:`\
        (key = `...V<object_name><current_version_id>`).
-       - Write fenced delete marker to `:O:` with `version_id = O:.next_vid`, `next_vid = vid - 1`.
+       - Write fenced delete marker to `:O:`
+           - `version_id = O:.next_vid`
+           - `next_vid = vid - 1`.
    - If no KV exists in `:O:`
-       - Write fenced delete marker to `:O:` with `version_id = max_uint32`, `next_vid = max_uint32 - 1`.
+       - Write fenced delete marker to `:O:`
+           - `version_id = max_uint32`
+           - `next_vid = max_uint32 - 1`.
        - Nothing to move to `:V:`.
 2. Return the delete marker's version_id to the client.
 
@@ -237,7 +272,8 @@ In a single transaction:
         - range scan on `...V<object_name>` with limit=1
     - If a `:V:` entry exists:
         - Move it from `:V:` to `:O:` (promoting it to current).
-        - Set `O:.next_vid = old_next_vid` (inherit counter from outgoing O:, NOT from promoted V:).
+            - Set `O.version_id = version_id from Key` (the promoted V: ID).
+            - Set `O:.next_vid = old_next_vid` (inherit counter from outgoing O:, NOT from promoted V:).
     - If no `:V:` entry exists:
         - Remove `:O:` entirely — the object ceases to exist.
     - If the removed `:O:` entry had data (not a delete marker):
@@ -245,17 +281,38 @@ In a single transaction:
     - If the removed `:O:` entry is a delete marker:
         - Simply delete it.
 
-The `:O:` read is always inside the transaction —
-- For operations that write O: (PUT, DELETE-without-vid, Case 2): the `:O:` write serves as the serialization point. Write-write conflict on `:O:` protects against concurrent modifications.
-- For Case 1 (delete non-current version): `:O:` is only read (to confirm target ≠ current). Serialization is via write-write conflict on the V:<target> key. On FDB, the O: read also creates a conflict range. On TiKV, this is safe because V: entries are immutable — no concurrent operation can invalidate a non-current version deletion. See [transaction-safety.md](transaction-safety.md).
-- See [The Uniform Rule](#the-uniform-rule) for the shared `:O:` write invariant (applies to all operations except Case 1).
-
 This is the only operation that moves a KV from `:V:` to `:O:`.\
 All other versioned operations only move from `:O:` to `:V:`.
 
-**Child operations on old versions (tags, annotations):** S3 allows PutObjectTagging and PutObjectAnnotation with a `versionId` parameter targeting a non-current version. These operations read and write V:<vid> (updating `tag_count` or `annotation_count` in the version entry) instead of O:. The write to V:<vid> provides write-write conflict with DELETE Case 1 targeting the same version. See [child-kv-operations.md](child-kv-operations.md).
+**DeleteBucket and version entries:**
+- DeleteBucket scans both `:O:` and `:V:` for committed data.
+- If any `:V:` entries exist:
+    - DeleteBucket returns `BucketNotEmpty` 
+    - the client must delete all versions before the bucket can be removed.
+- This covers the case where a bucket was versioned, then suspended, and objects deleted non-versioned (leaving orphaned V: entries without corresponding O: entries).
+    - TBD: are client opertions allowed on orphaned objects without corresponding O: entries???
+    - each change in bucket policy (e.g. versioned on/off) increments 32bits bucket epoch
+    - :P: entries include 32 bits bucket-epoch in the key
+- V: entries are treated identically to O: entries: committed client data that cannot be force-aborted.
+- See [bucket_delete.md](bucket_delete.md).
 
-**DeleteBucket and version entries:** DeleteBucket scans both `:O:` and `:V:` for committed data. If any `:V:` entries exist, DeleteBucket returns `BucketNotEmpty` — the client must delete all versions before the bucket can be removed. This covers the case where a bucket was versioned, then suspended, and objects deleted non-versioned (leaving orphaned V: entries without corresponding O: entries). V: entries are treated identically to O: entries: committed client data that cannot be force-aborted. See [bucket_delete.md](bucket_delete.md).
+Transaction safety analysis - 
+- For operations that write O: (PUT, DELETE-without-vid, Case 2):
+    - the `:O:` write serves as the serialization point.
+    - Write-write conflict on `:O:` protects against concurrent modifications.
+- For Case 1 (delete non-current version): `:O:` is only read (to confirm target ≠ current).
+    - No write-write serialization covering both `:O:` and V:<target> keys.
+    - On FDB, the O: read also creates a conflict range.
+    - On TiKV, this is safe because V: entries are immutable — no concurrent operation can invalidate a non-current version deletion. See [transaction-safety.md](transaction-safety.md).
+- See [The Uniform Rule](#the-uniform-rule) for the shared `:O:` write invariant (applies to all operations except Case 1).
+
+**Child operations on old versions (tags, annotations):**
+- S3 allows PutObjectTagging and PutObjectAnnotation with a `versionId` parameter targeting a non-current version.
+- These operations read and write V:<vid> (updating `tag_count` or `annotation_count` in the version entry) instead of O:.
+    - TBD: are client opertions allowed on orphaned objects without corresponding O: entries???
+    - If not we might need adding Get(:O:) on FDB and even include Put(:O:) for TiKV
+- The write to V:<vid> provides write-write conflict with DELETE Case 1 targeting the same version. See [child-kv-operations.md](child-kv-operations.md).
+
 
 **Undelete:**
 - Removing a delete marker (DELETE with version-id targeting a delete marker in `:O:`) triggers Case 2.
@@ -297,9 +354,101 @@ Versioning enable/disable triggers a cluster-wide cache invalidation:
 - Higher complexity (needs coordination channel between RGW instances).
 - Same infrastructure could serve other bucket-level state changes (policies, quotas, lifecycle).
 
+### Option C - Refuse requests while in-flight operations exist
+RangeScan **P** \< ... \> \<**bucket-id**\> for current bucket:
+- If not empty -> refuse operation
+- Might need to invoke GC to find and remove old P: entries which timed out
+
+
 ### Note
 
 The same issue exists in the current RADOS model — `RGWSetBucketVersioning::execute` writes `bucket_info` with no broadcast, no cache invalidation, no wait for in-flight operations. Other RGW processes pick up the change on TTL-based cache refresh. In-flight operations use whatever state they cached at request start. No mitigation exists today. **Need to verify with Casey.**
+
+AWS explicitly allows a 15-minute propagation window for versioning enable (and Suspended→Enabled re-enable). Enabled→Suspended takes effect immediately per AWS. Buckets can never return to unversioned — only toggle between Enabled and Suspended.
+
+---
+
+## Unified PUT — Versioning-Aware Phase 3
+
+PUT is a single operation. Phase 1 reads B to determine bucket state. Phase 3 branches based on that state — with targeted re-reads when transition signals are detected.
+
+### Phase 1 (universal)
+
+```
+txn {
+  get(B) → read bucket_id + state (unversioned / versioned / suspended)
+  put(P:O, {ref_tag, bucket_state, ...})
+  commit
+}
+```
+
+### Phase 3 (versioning-aware)
+
+```
+txn {
+  get(P:O) → if null → abort (self-cleanup if needed)
+
+  // Time-based re-read (catches long uploads spanning transitions)
+  If elapsed > N seconds: get(B) → update bucket_state
+
+  get(O:) → read existing entry
+
+  // Null-vid trigger (versioned mode only — detects recent suspension)
+  If bucket_state == versioned AND O: exists AND O:.version_id == NULL_ID (1):
+    get(B) → update bucket_state to current
+    If B says unversioned → ABORT with internal error (invariant violation)
+
+  // Unversioned contradiction trigger (detects versioning enabled since Phase 1)
+  If bucket_state == unversioned AND O: exists AND O:.version_id > 0:
+    get(B) → update bucket_state to current
+    If B says unversioned → ABORT with internal error (invariant violation: versioned O: in unversioned bucket)
+
+  // Branch on (possibly refreshed) bucket_state:
+  if unversioned:
+    If O: exists: put(G:O, old)
+    put(O:, new_value)
+
+  if suspended:
+    If O: has real vid (>= 2): put(V:<old_vid>, old)  — preserve versioned entry
+    If O: has NULL_ID (1): put(G:O, old)               — overwrite null slot
+    put(O:, new_value with vid=NULL_ID)
+
+  if versioned:
+    If O: has real vid (>= 2): put(V:<old_vid>, old)  — preserve
+    If O: has NULL_ID (1): put(G:O, old)               — null entries NEVER go to V:
+    put(O:, new_value with vid=next_vid, next_vid=vid-1)
+
+  delete(P:O)
+  commit
+}
+```
+
+### Null-version rule
+
+**Null-version entries never move to V: — always overwrite (→ G:O).**
+
+This rule applies regardless of current bucket state. A null-vid O: entry represents the "suspended-mode slot" or "pre-versioning entry." It is always overwritten, never preserved as a version. This prevents accumulation of null entries in the version history and ensures consistent behavior during Versioned → Suspended transitions.
+
+### Cost by scenario
+
+| Condition | Extra reads in Phase 3 | Frequency |
+|---|---|---|
+| O: has real vid (>= 2), fast PUT | 0 | Common case (vast majority) |
+| O: has real vid, slow PUT (> N sec) | 1 (get B) | Large uploads only |
+| O: has NULL_ID (1) in versioned mode | 1 (get B) | Rare (only during/after suspend transition) |
+| O: has version_id > 0 in unversioned mode | 1 (get B) | Rare (only during/after versioning enable) |
+| O: null (first write) | 0 | New objects |
+| O: has NO_VERSION (0) in unversioned mode | 0 | Consistent — no transition |
+
+### Why this is safe
+
+- **Unversioned → Enabled/Suspended (15-min propagation):** Stale PUT overwrites instead of versioning. Legal within AWS's propagation window. Conditional re-read catches long uploads.
+
+- **Versioned → Suspended (immediate per AWS):** Stale fast PUT may create one extra real-versioned entry. Benign — no data loss, self-heals on next correct write. Null-vid trigger catches cases where the transition already affected O:.
+
+- **Suspended → Enabled (15-min propagation):** Stale PUT writes null vid instead of real. Legal within AWS's window. Conditional re-read catches long uploads.
+
+- **Reverse (versioned/suspended → unversioned):** Impossible — AWS forbids returning to unversioned.
 
 ---
 
@@ -450,6 +599,9 @@ Operation on Non-versioned buckets:
 ## Delete All Versions (Optional Vendor Extension)
 
 > **Note:** AWS S3 does not provide a single API call to delete an object along with all its versions. This is an optional vendor-specific extension that may never be implemented.
+
+Delete All Versions introduces a new problem of orphaned :V: entries we might need to block for Annotation / ID-Tag operations\
+The same issue might exist for orphaned :V: objects when bucket-state changes disabling versioning
 
 - A single call deletes the `:O:` entry and writes one `G:F` (**F**ull Object GC) directive to the `G` namespace.
 - The `G:F` key contains the `object_name` and the `ref_tag` from the `:O:` entry.

--- a/doc/radosgw/Versioned-Bucket-Operations.md
+++ b/doc/radosgw/Versioned-Bucket-Operations.md
@@ -1,0 +1,417 @@
+# Versioned Bucket Operations
+
+## Introduction
+
+This document describes how S3 versioning operations map to the KV schema defined in [KV-Based-Design-For-RGW.md](KV-Based-Design-For-RGW.md) and [Listing-and-Key-Scheme.md](Listing-and-Key-Scheme.md).
+
+---
+## Version ID Scheme
+
+- First version: `version_id = max_uint32` (0xFFFFFFFF).
+- Each subsequent version (PUT or DELETE): `version_id = current_version - 1`.
+- The `:O:` entries don't include version_id in the Key, it is stored in the **Value** instead.\
+The next operation reads it and decrements.
+- In `:V:`, entries include the version_id in the **Key**\
+keys sort by `<object_name><version_id>`.\
+Since version_id decreases over time and is stored big-endian, later versions have smaller byte values and sort first — latest version first.
+
+## KV Schema
+
+&lt;namespace&gt; &lt;shard_count&gt; &lt;shard_id&gt; &lt;bucket_id&gt;**&lt;category&gt;**&lt;object_name&gt;
+
+Four **categories** separate current objects:
+- Current S3 **O**bjects
+- S3 old **V**ersions
+- RGW internal **C**hild entries
+- **M**ultipart uploads.
+
+Category tags are 1-byte ASCII values (`O`, `V`, `C`, `M`).\
+For visual clarity they are written as `:O:`, `:V:`, `:C:`, `:M:`
+
+**Current object (`:O:`):**
+
+```
+<namespace> <shard_count> <shard_id> <bucket_id> O <object_name>
+```
+
+**Old versions and delete markers (`:V:`):**
+
+```
+<namespace> <shard_count> <shard_id> <bucket_id> V <object_name> <version_id>
+```
+
+**Child entries (`:C:`):**
+
+```
+<namespace> <shard_count> <shard_id> <bucket_id> C <ref_tag> <child_type> <child_id>
+```
+
+Child type values: `A` (annotation), `T` (tags), `E` (extended value).
+
+**Multipart uploads (`:M:`):**
+
+```
+<namespace> <shard_count> <shard_id> <bucket_id> M <object_name> <ref_tag> <part_number>
+```
+
+---
+
+### `:O:` — Current Version
+
+```
+<namespace> <shard_count> <shard_id> <bucket_id> O <object_name>
+```
+
+
+One entry per object key.\
+The **value** contains the current version's metadata:
+- version_id — the current version's ID (stored in the value, not the key).
+- ref_tag — unique write instance identifier (12 B).
+- All S3 attributes (etag, last_modified, size, etc.).
+- Chunk pointers for data access.
+- Fenced flag — set when the entry is a delete marker; GetObject returns 404.
+
+In a versioned bucket, `:O:` always has exactly one entry per object_name — either a live value or a fenced delete marker.\
+ListObjectsV2 scans `:O:` and skips fenced entries.
+
+---
+
+### `:V:` — Old Versions and Delete Markers
+
+```
+<namespace> <shard_count> <shard_id> <bucket_id> V <object_name> <version_id 4B>
+```
+
+### The **value** contains:
+
+- All S3 attributes for that version.
+- ref_tag, chunk pointers (for live versions).
+- Delete marker flag (for delete markers — no data, no ref_tag).
+
+All versions of the same object share the same shard_id (version_id is excluded from the hash). All operations are shard-local transactions.
+
+## Shard Locality
+
+`shard_id = hash(bucket_id + object_name) % shard_count`.
+
+version_id is excluded from the hash.\
+All entries for the same object_name — `:O:` and `:V:` entries — land on the same shard.\
+Moving a version from `:O:` to `:V:` (or back) is always a local transaction.
+
+---
+
+## Listing
+
+### ListObjectsV2
+
+Scans `:O:` only. Returns current objects in lexicographic order by object_name.
+
+```
+Range scan: <namespace><shard_count><shard_id><bucket_id>O ...
+```
+
+For each entry:
+- If live → include in results (key, last_modified, etag, size, storage_class, owner, checksum_algorithm).
+- If fenced (delete marker) → skip. The object appears deleted.
+
+No interaction with `:V:`. No merge. No version awareness. One range scan per shard (or a single scan without sharding).
+
+Prefix/delimiter filtering applies to object_name as usual.
+
+### ListObjectVersions
+
+Returns all versions of all objects — live values, delete markers, and fenced delete markers — sorted by object_name, then latest version first.
+
+Scans both `:O:` and `:V:`, merges by object_name.
+
+```
+Range scan on :O: → <namespace><shard_count><shard_id><bucket_id>O ...
+Range scan on :V: → <namespace><shard_count><shard_id><bucket_id>V ...
+```
+
+**Merge protocol:**
+
+For each object_name encountered in either scan:
+
+1. The `:O:` entry (if present) is the **current version** — it sorts first for that object_name.
+2. `:V:` entries follow in version_id order (latest first by key construction).
+
+The merge advances through both scans in parallel by object_name. When the same object_name appears in both `:O:` and `:V:`, the `:O:` entry is emitted first, then all `:V:` entries for that object_name, then the merge moves to the next object_name.
+
+Each entry is returned with:
+- key, version_id, is_latest (true only for the `:O:` entry).
+- last_modified, etag, size, storage_class, owner.
+- Type indicator: `Version` or `DeleteMarker`.
+
+Prefix/delimiter filtering applies to object_name.
+
+With sharding: fan out to all shards, merge-sort across shards by object_name.
+
+---
+
+## The Uniform Rule
+
+Both PUT and DELETE on a versioned bucket:
+
+1. Move the current `:O:` entry to `:V:` (keyed by its version_id).
+2. Write a new entry to `:O:` with `version_id = current_version - 1`.
+3. All in a single transaction.
+
+PUT writes a live value. DELETE writes a **fenced delete marker**.
+
+A delete marker in `:O:` is a lightweight value — a fenced flag, the delete marker's version_id, a timestamp, and the owner. GetObject reads `:O:`, sees the fenced flag, returns 404 with `x-amz-delete-marker: true` and the delete marker's version_id.
+
+A delete marker is just a value. When displaced by the next PUT or DELETE, it moves from `:O:` to `:V:` like any other value.
+
+---
+
+## Operations
+
+### PUT (versioned bucket)
+
+PUT follows the standard 3-phase protocol. See [S3 Operations — PUT](S3-Operations-Over-KV.md#put) for the full flow and RADOS comparison.
+
+1. Generate ref_tag.
+2. Write `P:O` coordination entry with object_name, ref_tag, and estimated size.
+3. Write data to storage tier.
+4. In a single transaction:
+   - Read `:O:` to get the current version_id.
+   - If a KV exists in `:O:`
+       - Move the current `:O:` entry to `:V:`\
+       (key = `...V<object_name><current_version_id>`).
+       - Write new live value to `:O:` with version_id = current - 1.
+   - If no KV exists in `:O:`
+       - Write to `:O:` with version_id = max_uint32.
+   - Delete the `P:O` coordination entry.
+
+No GC entry — the old version is preserved in `:V:`, not orphaned.
+
+**Crash recovery:** If the process crashes before the commit transaction, the `P:O` entry remains. The background sweeper finds the stale entry, frees orphaned storage-tier data by ref_tag, then deletes `P:O`. See [Sweeper Protocol](S3-Operations-Over-KV.md#sweeper-protocol).
+
+### DELETE without version-id (create delete marker)
+
+No `P:O` coordination entry is needed — since no storage-tier data is written.
+
+1. In a single transaction:
+   - Read `:O:` to get the current version_id.
+   - If a KV exists in `:O:`
+       - Move the current `:O:` entry to `:V:`\
+       (key = `...V<object_name><current_version_id>`).
+       - Write fenced delete marker to `:O:` with version_id = current - 1.
+   - If no KV exists in `:O:`
+       - Write fenced delete marker to `:O:` with version_id = max_uint32.
+       - Nothing to move to `:V:`.
+2. Return the delete marker's version_id to the client.
+
+No data is removed. No GC entry. All previous versions remain accessible by version-id.
+
+
+### DELETE with version-id (remove specific version)
+
+Permanently removes a specific version.\
+Two cases depending on where the target version lives:
+
+Case 1 — Target is in `:V:`:
+- The `:V:` entry is deleted (or moved to `G` if it has data).
+- No promotion. `:O:` is unaffected.
+
+Case 2 — Target is the current version in `:O:`:
+- Removing the current version requires promotion —
+    - The latest version from `:V:` must become the new current version.
+    - If no `:V:` entry exists, `:O:` is removed entirely.
+  
+In a single transaction:
+- Read `:O:` to get the current version_id.
+- If target version_id does not match (Case 1):
+    - Read the `:V:` entry at `...V<object_name><target_version_id>`.
+        - If not found → 404 (NoSuchKey).
+    - If it had data (not a delete marker):
+        - Move the `:V:` entry to the `G` namespace with a stripped value.
+    - If it is a delete marker:
+        - Simply delete the `:V:` entry.
+- If target version_id matches (Case 2):
+    - Find the latest entry in `:V:` for this object_name
+        - range scan on `...V<object_name>` with limit=1
+    - If a `:V:` entry exists:
+        - Move it from `:V:` to `:O:` (promoting it to current).
+    - If no `:V:` entry exists:
+        - Remove `:O:` entirely — the object ceases to exist.
+    - If the removed `:O:` entry had data (not a delete marker):
+        - Move to the `G` namespace with a stripped value.
+    - If the removed `:O:` entry is a delete marker:
+        - Simply delete it.
+
+The `:O:` read is always inside the transaction —
+- It serves as the serialization point.
+- Every operation that mutates the version chain writes to `:O:`
+- Write-Write conflict on `:O:` protects against concurrent modifications.
+- See [The Uniform Rule](#the-uniform-rule) for the shared `:O:` write invariant.
+
+This is the only operation that moves a KV from `:V:` to `:O:`.\
+All other versioned operations only move from `:O:` to `:V:`.
+
+**Undelete:**
+- Removing a delete marker (DELETE with version-id targeting a delete marker in `:O:`) triggers Case 2.
+- The latest entry from `:V:` is promoted to `:O:`.
+- If the promoted entry is a live version, the object is restored.
+- If it is another delete marker, the object remains deleted.
+
+---
+
+## Worked Examples
+
+### Example 1 — PUT, PUT, DELETE, PUT, DELETE
+
+```
+PUT(Key1, V1)
+PUT(Key1, V2)
+DELETE(Key1)
+PUT(Key1, V3)
+DELETE(Key1)
+```
+
+| Step | Operation | `:O:` | `:V:` |
+|---|---|---|---|
+| 1 | PUT V1 | V1 (ver=FFFF) | — |
+| 2 | PUT V2 | V2 (ver=FFFE) | V1 (ver=FFFF) |
+| 3 | DELETE | dm1 fenced (ver=FFFD) | V2 (ver=FFFE), V1 (ver=FFFF) |
+| 4 | PUT V3 | V3 (ver=FFFC) | dm1 (ver=FFFD), V2 (ver=FFFE), V1 (ver=FFFF) |
+| 5 | DELETE | dm2 fenced (ver=FFFB) | V3 (ver=FFFC), dm1 (ver=FFFD), V2 (ver=FFFE), V1 (ver=FFFF) |
+
+(version_id values shown as last 4 hex digits for brevity; actual values are full uint32)
+
+ListObjectsV2: skips fenced `:O:` → returns nothing.
+
+ListObjectVersions: dm2, V3, dm1, V2, V1 — latest first.
+
+### Example 2 — Double delete
+
+```
+PUT(Key1, V1)
+DELETE(Key1)
+DELETE(Key1)
+```
+
+| Step | Operation | `:O:` | `:V:` |
+|---|---|---|---|
+| 1 | PUT V1 | V1 (ver=FFFF) | — |
+| 2 | DELETE | dm1 fenced (ver=FFFE) | V1 (ver=FFFF) |
+| 3 | DELETE | dm2 fenced (ver=FFFD) | dm1 (ver=FFFE), V1 (ver=FFFF) |
+
+Each DELETE creates a new delete marker.
+
+### Example 3 — Undelete
+
+```
+ver_1=PUT(Key1, V1)
+ver_2=DELETE(Key1)
+DeleteObject(Key1, versionId=ver_2)
+```
+
+| Step | Operation | `:O:` | `:V:` |
+|---|---|---|---|
+| 1 | PUT V1 | V1 (ver=FFFF) | — |
+| 2 | DELETE | dm1 fenced (ver=FFFE) | V1 (ver=FFFF) |
+| 3 | Delete FFFE | V1 (ver=FFFF) | — |
+
+Step 3:
+- dm1's version_id matches `:O:`.
+- Promotion triggers — V1 is moved from `:V:` to `:O:`.
+- The object is restored.
+
+GetObject(Key1) → returns V1. ListObjectsV2 → returns Key1.
+
+### Example 4 — Delete specific old version
+
+```
+ver_1=PUT(Key1, V1)
+ver_2=PUT(Key1, V2)
+ver_3=PUT(Key1, V3)
+DeleteObject(Key1, versionId=ver_1)
+```
+
+| Step | Operation | `:O:` | `:V:` |
+|---|---|---|---|
+| 1 | PUT V1 | V1 (ver=FFFF) | — |
+| 2 | PUT V2 | V2 (ver=FFFE) | V1 (ver=FFFF) |
+| 3 | PUT V3 | V3 (ver=FFFD) | V2 (ver=FFFE), V1 (ver=FFFF) |
+| 4 | Delete FFFF | V3 (ver=FFFD) | V2 (ver=FFFE) |
+
+Step 4:
+- target version_id (FFFF) is not in `:O:` (FFFD).
+- Simple `:V:` delete — no promotion.
+- V1's entry is moved to the `G` namespace for async data cleanup.
+
+---
+
+## Listing Behavior
+
+### ListObjectsV2
+
+- Scans `:O:` only
+- Filters out fenced delete markers — returns nothing for that object_name
+- Non-versioned deleted objects are simply absent (their entries have been moved to the `G` namespace)
+- No interaction with `:V:`.
+
+### ListObjectVersions
+
+- Merges `:O:` and `:V:` for each object_name.
+- The `:O:` entry (live or fenced delete marker) represents the current version.
+- For each object_name, it sorts first (latest version). `:V:` entries follow in version_id order (latest first by construction).
+- Delete markers in both `:O:` (fenced) and `:V:` are returned with a `DeleteMarker` type indicator.
+
+---
+
+## GetObject Behavior
+
+### Without version-id
+
+1. Read `:O:` for the object_name.
+2. If not found → 404 (NoSuchKey).
+3. If fenced (delete marker) → 404 with `x-amz-delete-marker: true` and the delete marker's version_id.
+4. If live → return the object.
+
+Single read. No need to check `:V:`.
+
+### With version-id
+
+1. Read `:O:` for the object_name. Compare version_id in the value.
+2. If it matches → return from `:O:` (or 405 Method Not Allowed error if fenced delete marker).
+3. If it doesn't match → read `...V<object_name><version_id>`.
+4. If found → return the version (or 405 Method Not Allowed error if a delete marker).
+5. If not found → 404.
+
+---
+
+## Non-Versioned Buckets
+
+Non-versioned buckets do not use `:V:` at all.
+- No version_id tracking.
+- No delete markers.
+- No promotion.
+
+Operation on Non-versioned buckets:
+- PUT follows the standard 3-phase protocol:
+    - (`P:O` → data write → commit transaction).
+    - If the object key already exists, the old `:O:` entry is moved to the `G` (GC) namespace with a stripped value within the commit transaction.
+        - See [S3 Operations — PUT](S3-Operations-Over-KV.md#put).
+- DELETE moves the `:O:` entry to the `G` namespace in a single transaction.
+    - The key is removed from `:O:` — subsequent reads find no entry and return 404 naturally.
+        - See [S3 Operations — DELETE](S3-Operations-Over-KV.md#delete-non-versioned).
+
+
+---
+
+## Delete All Versions (Optional Vendor Extension)
+
+> **Note:** AWS S3 does not provide a single API call to delete an object along with all its versions. This is an optional vendor-specific extension that may never be implemented.
+
+- A single call deletes the `:O:` entry and writes one `G:F` (**F**ull Object GC) directive to the `G` namespace.
+- The `G:F` key contains the `object_name` and the `ref_tag` from the `:O:` entry.
+- The object becomes immediately invisible.
+- Background workers asynchronously rangeScan `:V:` for all older versions of the object
+    - free data
+    - clean up children
+    - and remove all entries.
+
+See [S3 Operations — Delete All Versions](S3-Operations-Over-KV.md#delete-all-versions-optional-vendor-extension) for the detailed design.

--- a/doc/radosgw/Versioned-Bucket-Operations.md
+++ b/doc/radosgw/Versioned-Bucket-Operations.md
@@ -7,10 +7,12 @@ This document describes how S3 versioning operations map to the KV schema define
 ---
 ## Version ID Scheme
 
-- First version: `version_id = max_uint32` (0xFFFFFFFF).
-- Each subsequent version (PUT or DELETE): `version_id = current_version - 1`.
-- The `:O:` entries don't include version_id in the Key, it is stored in the **Value** instead.\
-The next operation reads it and decrements.
+- First version: `version_id = max_uint32` (0xFFFFFFFF). `next_vid = max_uint32 - 1`.
+- Each subsequent version (PUT or DELETE): `version_id = O:.next_vid`. Then `O:.next_vid = vid - 1`.
+- The `:O:` value stores both fields:
+  - `version_id` — this version's ID. What GET returns, what goes into the V: key when moved to history.
+  - `next_vid` — the next available ID. Monotonically decreasing counter, consumed on each new version. Never resets upward.
+- On promotion (DELETE Case 2): `next_vid` is inherited from the OUTGOING O: entry, not from the promoted V: entry. This prevents version ID reuse after deletion — deleted IDs are permanently consumed.
 - In `:V:`, entries include the version_id in the **Key**\
 keys sort by `<object_name><version_id>`.\
 Since version_id decreases over time and is stored big-endian, later versions have smaller byte values and sort first — latest version first.
@@ -151,10 +153,10 @@ With sharding: fan out to all shards, merge-sort across shards by object_name.
 
 ## The Uniform Rule
 
-Both PUT and DELETE on a versioned bucket:
+All operations that write a new value to `:O:` on a versioned bucket — including PUT, DELETE-without-version-id (creates delete marker), and CompleteMultipartUpload (writes assembled manifest):
 
 1. Move the current `:O:` entry to `:V:` (keyed by its version_id).
-2. Write a new entry to `:O:` with `version_id = current_version - 1`.
+2. Write a new entry to `:O:` with `version_id = O:.next_vid`. Set `O:.next_vid = vid - 1`.
 3. All in a single transaction.
 
 PUT writes a live value. DELETE writes a **fenced delete marker**.
@@ -179,9 +181,9 @@ PUT follows the standard 3-phase protocol. See [S3 Operations — PUT](S3-Operat
    - If a KV exists in `:O:`
        - Move the current `:O:` entry to `:V:`\
        (key = `...V<object_name><current_version_id>`).
-       - Write new live value to `:O:` with version_id = current - 1.
+       - Write new live value to `:O:` with `version_id = O:.next_vid`, `next_vid = vid - 1`.
    - If no KV exists in `:O:`
-       - Write to `:O:` with version_id = max_uint32.
+       - Write to `:O:` with `version_id = max_uint32`, `next_vid = max_uint32 - 1`.
    - Delete the `P:O` coordination entry.
 
 No GC entry — the old version is preserved in `:V:`, not orphaned.
@@ -197,9 +199,9 @@ No `P:O` coordination entry is needed — since no storage-tier data is written.
    - If a KV exists in `:O:`
        - Move the current `:O:` entry to `:V:`\
        (key = `...V<object_name><current_version_id>`).
-       - Write fenced delete marker to `:O:` with version_id = current - 1.
+       - Write fenced delete marker to `:O:` with `version_id = O:.next_vid`, `next_vid = vid - 1`.
    - If no KV exists in `:O:`
-       - Write fenced delete marker to `:O:` with version_id = max_uint32.
+       - Write fenced delete marker to `:O:` with `version_id = max_uint32`, `next_vid = max_uint32 - 1`.
        - Nothing to move to `:V:`.
 2. Return the delete marker's version_id to the client.
 
@@ -230,10 +232,12 @@ In a single transaction:
     - If it is a delete marker:
         - Simply delete the `:V:` entry.
 - If target version_id matches (Case 2):
+    - Save `old_next_vid = O:.next_vid` (preserve the version counter).
     - Find the latest entry in `:V:` for this object_name
         - range scan on `...V<object_name>` with limit=1
     - If a `:V:` entry exists:
         - Move it from `:V:` to `:O:` (promoting it to current).
+        - Set `O:.next_vid = old_next_vid` (inherit counter from outgoing O:, NOT from promoted V:).
     - If no `:V:` entry exists:
         - Remove `:O:` entirely — the object ceases to exist.
     - If the removed `:O:` entry had data (not a delete marker):
@@ -242,19 +246,60 @@ In a single transaction:
         - Simply delete it.
 
 The `:O:` read is always inside the transaction —
-- It serves as the serialization point.
-- Every operation that mutates the version chain writes to `:O:`
-- Write-Write conflict on `:O:` protects against concurrent modifications.
-- See [The Uniform Rule](#the-uniform-rule) for the shared `:O:` write invariant.
+- For operations that write O: (PUT, DELETE-without-vid, Case 2): the `:O:` write serves as the serialization point. Write-write conflict on `:O:` protects against concurrent modifications.
+- For Case 1 (delete non-current version): `:O:` is only read (to confirm target ≠ current). Serialization is via write-write conflict on the V:<target> key. On FDB, the O: read also creates a conflict range. On TiKV, this is safe because V: entries are immutable — no concurrent operation can invalidate a non-current version deletion. See [transaction-safety.md](transaction-safety.md).
+- See [The Uniform Rule](#the-uniform-rule) for the shared `:O:` write invariant (applies to all operations except Case 1).
 
 This is the only operation that moves a KV from `:V:` to `:O:`.\
 All other versioned operations only move from `:O:` to `:V:`.
+
+**Child operations on old versions (tags, annotations):** S3 allows PutObjectTagging and PutObjectAnnotation with a `versionId` parameter targeting a non-current version. These operations read and write V:<vid> (updating `tag_count` or `annotation_count` in the version entry) instead of O:. The write to V:<vid> provides write-write conflict with DELETE Case 1 targeting the same version. See [child-kv-operations.md](child-kv-operations.md).
+
+**DeleteBucket and version entries:** DeleteBucket scans both `:O:` and `:V:` for committed data. If any `:V:` entries exist, DeleteBucket returns `BucketNotEmpty` — the client must delete all versions before the bucket can be removed. This covers the case where a bucket was versioned, then suspended, and objects deleted non-versioned (leaving orphaned V: entries without corresponding O: entries). V: entries are treated identically to O: entries: committed client data that cannot be force-aborted. See [bucket_delete.md](bucket_delete.md).
 
 **Undelete:**
 - Removing a delete marker (DELETE with version-id targeting a delete marker in `:O:`) triggers Case 2.
 - The latest entry from `:V:` is promoted to `:O:`.
 - If the promoted entry is a live version, the object is restored.
 - If it is another delete marker, the object remains deleted.
+
+---
+
+## Open Issue: Versioning State Change During In-Flight PUT
+
+### The Problem
+
+PUT Phase 3 must decide whether old O: goes to V: (versioned) or G:O (non-versioned). This decision uses the bucket's versioning state. If versioning is enabled or suspended between Phase 1 and Phase 3:
+
+- Phase 3 uses cached bucket metadata from request start (stale).
+- Wrong decision: old O: moved to G:O instead of V: → **previous version lost** (versioned was just enabled).
+- Or: old O: moved to V: instead of G:O → unnecessary version preserved (versioned was just suspended — storage leak, benign).
+
+The window is narrow (only during the exact transition moment while a PUT Phase 2 is in-flight). But the first case is data loss.
+
+### Option A — Conditional B read on long Phase 2
+
+If elapsed time between Phase 1 and Phase 3 exceeds a threshold (e.g., 1 second):
+
+- Phase 3 re-reads B to get fresh versioning state before deciding V: vs G:O.
+- Only impacts large Tier 3 PUTs with slow uploads (> 1 second Phase 2).
+- Tier 1/2 (single-transaction): no issue (no Phase 1/3 split).
+- Fast Tier 3 (< 1 second): no extra read.
+- Very small subset of PUTs impacted.
+
+### Option B — Cluster state transfer (broadcast invalidation)
+
+Versioning enable/disable triggers a cluster-wide cache invalidation:
+
+- All RGW processes refresh their bucket metadata cache for the affected bucket.
+- Next operation on that bucket uses fresh versioning state.
+- More robust — covers all in-flight operations, not just slow ones.
+- Higher complexity (needs coordination channel between RGW instances).
+- Same infrastructure could serve other bucket-level state changes (policies, quotas, lifecycle).
+
+### Note
+
+The same issue exists in the current RADOS model — `RGWSetBucketVersioning::execute` writes `bucket_info` with no broadcast, no cache invalidation, no wait for in-flight operations. Other RGW processes pick up the change on TTL-based cache refresh. In-flight operations use whatever state they cached at request start. No mitigation exists today. **Need to verify with Casey.**
 
 ---
 

--- a/doc/radosgw/child-kv-operations.md
+++ b/doc/radosgw/child-kv-operations.md
@@ -1,0 +1,565 @@
+# Child KV Operations — Annotations, Tags, Extended Value
+
+## Semantics
+
+Child KV entries (`:C:` namespace) store metadata that belongs to a parent object (`:O:`) but doesn't fit inline in the parent's value, or represents independently-addressable sub-resources (like S3 annotations).
+
+Child entries are:
+- **Owned by a specific version** of the parent object, identified by `parent_ref_tag`.
+- **Co-located** on the same shard as the parent (same `bucket_id + object_name` → same `shard_id`).
+- **Deleted when the parent is deleted or overwritten** — GC workers clean children as part of parent cleanup.
+
+Three child types exist (in the `C:` category within the `S` namespace):
+
+| Type byte | Name | Content | Storage-tier data? |
+|---|---|---|---|
+| `A` | Annotation | Application-defined key-value sub-resource | Optional (blob via `anno_ref_tag`) |
+| `T` | Tags | S3 object tags (array of up to 10 key-value pairs) | Never |
+| `E` | Extended Value | Metadata overflow (manifest, compression info) | Never |
+
+
+---
+
+## Key Structure
+
+```
+C:<parent_ref_tag><type><id>
+```
+
+Full key layout (from Listing-and-Key-Scheme.md):
+```
+[header 14B] [ref_tag 12B] [child_type 1B] [child_id 0–512B]
+```
+
+| Child type | child_id | Example |
+|---|---|---|
+| `A` (annotation) | annotation key name (1–512B) | `C:<ref_tag>A<"user-metadata-1">` |
+| `T` (tags) | empty (single entry per object) | `C:<ref_tag>T` |
+| `E` (extended value) | empty (single entry per object) | `C:<ref_tag>E` |
+
+---
+
+## Parent Dependency
+
+A child entry cannot exist without its parent. Every operation that creates or modifies a child entry must verify the parent exists and hasn't been replaced.
+
+**For current version (targeting O:):**
+
+1. **`get(O:)` → verify non-null.**
+    - If null, the object was deleted — abort.
+2. **Verify `O:.ref_tag == expected_parent_ref_tag`.**
+    - If mismatch, the object was overwritten with a new version — the old children belong to the old version (now in `:V:` or `G:`).
+    - Abort.
+
+**For old version (targeting V:<vid> — S3 `versionId` parameter):**
+
+1. **`get(V:<vid>)` → check result:**
+   - If exists → use V:<vid> as parent. Read `ref_tag` from value.
+   - If null → version may have been promoted to current (DELETE Case 2). Fallback:
+2. **Fallback: `get(O:)` → check if `O:.version_id == vid`:**
+   - If match → version was promoted to O:. Use O: as parent.
+   - If no match → version truly deleted. Return `NoSuchVersion`.
+
+This fallback handles the case where DELETE Case 2 promoted V:<vid> to O:. The version still exists — just in a different location. Clients using versionId APIs don't need to know whether their target is current or non-current.
+
+```
+// Version resolution (applies to GET, PUT child ops, DELETE child ops)
+get(V:<vid>)
+if exists:
+  parent = V:<vid>
+else:
+  get(O:) → if O:.version_id == vid:
+    parent = O:
+  else:
+    → abort (NoSuchVersion)
+```
+
+In both cases, the parent entry (O: or V:<vid>) is read AND written (count fields updated) in the same transaction — providing write-write conflict detection on TiKV with concurrent DELETE operations.
+
+**Why `get(O:)` / `get(V:<vid>)` implies bucket exists:**
+
+- DeleteBucket verifies both `:O:` and `:V:` are empty before deleting `B`.
+- If any `:O:` or `:V:` entry exists → DeleteBucket returns `BucketNotEmpty`.
+- Therefore, a successful `get(O:)` or `get(V:<vid>)` guarantees `B` exists.
+- No separate `get(B)` is needed for child operations.
+
+**FDB (strong, transactional guarantee):**
+
+- DeleteBucket's RangeScans create read conflict ranges.
+- If O: or V: exists in your transaction, DeleteBucket cannot commit concurrently.
+- Absolute guarantee.
+
+**TiKV (soft, probabilistic guarantee):**
+
+- DeleteBucket's RangeScans do NOT create conflict ranges.
+- In the extremely unlikely pend-delete residual risk scenario, O:/V: can exist for a bucket that was already deleted.
+- If violated: child operations produce orphaned entries — cleaned by periodic scrubber.
+- See [bucket_delete.md — Residual risk](bucket_delete.md#residual-risk).
+
+
+---
+
+## When P: Coordination is Needed
+
+**Rule:** A `P:` coordination entry is needed only when an operation writes to the storage tier between transaction phases (the two-domain problem).
+
+| Operation | Storage-tier write? | P: needed? |
+|---|---|---|
+| PutObjectAnnotation (with blob data) | Yes (annotation blob) | Yes (`P:A`) |
+| PutObjectAnnotation (inline value only) | No | No — single txn |
+| DeleteObjectAnnotation | No (GC frees data asynchronously) | No — single txn |
+| PutObjectTagging | No (pure KV) | No — single txn |
+| DeleteObjectTagging | No (pure KV) | No — single txn |
+| Extended Value write | No (pure KV overflow) | No — written in PUT Phase 3 txn |
+
+When extended value data lives on the storage tier, it is referenced directly from the `:O:` value (blob pointer in the manifest). No child KV entry is created — it is covered by the parent's `P:O` coordination entry during PUT.
+
+---
+
+## Operations
+
+### PutObjectAnnotation — With Storage-Tier Data (overwrite)
+
+Annotations with blob data require the three-phase protocol:
+
+**Phase 1 — Record intent:**
+```
+txn {
+  1. Generate anno_ref_tag
+  2. get(O:) → if null → abort
+     Read annotation_count → if annotation_count >= max → abort (limit exceeded)
+     Record parent_ref_tag = O:.ref_tag
+  3. put(P:A, {anno_ref_tag, parent_ref_tag, object_name, annotation_key, timestamp})
+  commit
+}
+```
+
+**Phase 2 — Write annotation data (storage tier, no KV):**
+
+Write annotation blob addressed by `anno_ref_tag`.
+
+**Phase 3 — Commit annotation:**
+
+**Normal path (commit):**
+```
+txn {
+  1. get(P:A) → if null → abort (sweeper already took it — nothing to clean)
+  2. get(O:) → if null or ref_tag mismatch → self-cleanup abort (see below)
+  3. get(C:<parent_ref_tag>A<annotation_key>) → check if overwrite
+     If overwrite with storage data → put(G:A, {old_anno_ref_tag, old_chunk_pointers})
+  4. put(C:<parent_ref_tag>A<annotation_key>, {anno_ref_tag, size, content_type, ...})
+  5. delete(P:A)
+  6. put(O:, annotation_count + 1)  // new annotation
+     — or put(O:, same_count)        // overwrite — count unchanged
+  commit
+}
+```
+
+**Self-cleanup abort** (parent deleted or overwritten):
+```
+txn {
+  1. get(P:A) → exists
+  2. get(O:) → null or ref_tag mismatch → invalid state
+  3. put(G:A, {anno_ref_tag})  ← queue annotation blob for GC
+  4. delete(P:A)
+  commit  ← cleanup-abort, return error to client
+}
+```
+
+Live processes self-clean on abort: move P:A → G:A immediately. Sweeper only handles entries from crashed processes.
+
+Step 6 always writes O: regardless of new or overwrite — creates **write-write** conflict with concurrent parent DELETE/PUT on both FDB and TiKV.
+
+**Crash recovery:**
+- Crash before Phase 1 commit: nothing written. Clean.
+- Crash after Phase 1, before Phase 3: `P:A` exists. Sweeper moves to `G:A`, GC frees annotation blob.
+- Crash after Phase 3 commit: annotation is live. `P:A` gone. Clean.
+
+### PutObjectAnnotation — Inline Value (no storage-tier data)
+
+Small annotations without blob data are a single transaction:
+
+```
+txn {
+  1. get(O:) → if null → abort
+     Read annotation_count → if annotation_count >= max → abort (limit exceeded)
+     Record parent_ref_tag = O:.ref_tag
+  2. get(C:<parent_ref_tag>A<annotation_key>) → check if overwrite
+     If overwrite with storage data → put(G:A, {old_anno_ref_tag, old_chunk_pointers})
+  3. put(C:<parent_ref_tag>A<annotation_key>, {inline_value, size, content_type, ...})
+  4. put(O:, annotation_count + 1)  // new annotation
+     — or put(O:, same_count)        // overwrite — count unchanged
+  commit
+}
+```
+
+No P:A needed — no storage-tier write, no two-domain problem. Always writes O: for conflict detection and count maintenance.
+
+### DeleteObjectAnnotation
+
+Always a single transaction (deletion is a KV operation; old annotation data is GC'd asynchronously):
+
+```
+txn {
+  1. get(O:) → if null → abort
+     Record parent_ref_tag = O:.ref_tag
+  2. get(C:<parent_ref_tag>A<annotation_key>) → if null → success (idempotent)
+  3. If old annotation has storage data:
+     put(G:A, {old_anno_ref_tag, old_chunk_pointers})
+  4. delete(C:<parent_ref_tag>A<annotation_key>)
+  5. put(O:, annotation_count - 1)
+  commit
+}
+```
+
+Always writes the parent entry (O: or V:<vid>) — decrements count, creates write-write conflict on both systems.
+
+### PutObjectAnnotation — Versioned (with versionId, storage-tier data)
+
+Full flow for annotating a specific version. Both Phase 1 and Phase 3 use version resolution (fallback to O: if V:<vid> was promoted).
+
+**Phase 1 — Record intent:**
+```
+txn {
+  1. Generate anno_ref_tag
+  2. Resolve parent:
+     get(V:<vid>) → if exists: parent = V:<vid>
+     if null: get(O:) → if O:.version_id == vid: parent = O:
+     else → abort (NoSuchVersion)
+  3. Read annotation_count from parent → if >= max → abort (limit exceeded)
+     Record parent_ref_tag = parent.ref_tag
+  4. put(P:A, {anno_ref_tag, parent_ref_tag, object_name, annotation_key, vid, timestamp})
+  commit
+}
+```
+
+**Phase 2 — Write annotation data (storage tier, no KV):**
+
+Write annotation blob addressed by `anno_ref_tag`.
+
+**Phase 3 — Commit annotation:**
+
+**Normal path (commit):**
+```
+txn {
+  1. get(P:A) → if null → abort (sweeper already took it)
+  2. Resolve parent (same logic as Phase 1):
+     get(V:<vid>) → if exists: parent = V:<vid>
+     if null: get(O:) → if O:.version_id == vid: parent = O:
+     else → self-cleanup abort (version deleted between phases)
+  3. Verify parent.ref_tag == P:A.parent_ref_tag → if mismatch → self-cleanup abort
+  4. get(C:<parent_ref_tag>A<annotation_key>) → if overwrite with storage data:
+     put(G:A, {old_anno_ref_tag, old_chunk_pointers})
+  5. put(C:<parent_ref_tag>A<annotation_key>, {anno_ref_tag, size, content_type, ...})
+  6. put(parent, annotation_count + 1)  // or same count if overwrite
+  7. delete(P:A)
+  commit
+}
+```
+
+**Why both phases need version resolution:**
+- **Phase 1:** If promotion happened before the client's request — find the version in O: rather than failing.
+- **Phase 3:** If promotion happened between Phase 1 and Phase 3 — the version moved from V: to O: during the data upload. ref_tag is preserved during promotion, so the match in step 3 succeeds regardless of location.
+
+**Self-cleanup abort** (version deleted or ref_tag mismatch):
+```
+txn {
+  1. get(P:A) → exists
+  2. Resolve parent → not found or ref_tag mismatch
+  3. put(G:A, {anno_ref_tag})  ← queue annotation blob for GC
+  4. delete(P:A)
+  commit  ← cleanup-abort, return error to client
+}
+```
+
+Live processes self-clean on abort. Sweeper only handles entries from crashed processes.
+
+**Conflict safety:** `put(parent, ...)` writes to the resolved entry (O: or V:<vid>). This provides write-write conflict with:
+- DELETE Case 1 targeting V:<vid> (if parent is V:)
+- DELETE Case 2 promoting V:<vid> (if parent is V: — concurrent promotion conflicts)
+- Any concurrent PUT overwriting O: (if parent is O:)
+
+**Cost:** Happy path (V:<vid> exists): same as before — no extra reads. Promotion path: one extra `get(O:)` per phase (rare).
+
+---
+
+### PutObjectTagging (full replacement — AWS API)
+
+Tags are stored as an array of up to 10 key-value pairs. S3 `PutObjectTagging` replaces the entire tag set. The storage model (inline in O: value vs external C:T entry) is determined by whether the new tag set exceeds the inline size budget.
+
+```
+txn {
+  1. get(O:) → if null → abort; read ref_tag, current tag state (inline/external/none)
+     Compute new_tag_count = len(new_tags)  // uint8, max 10
+
+  Case A — Current: inline or none, New: fits inline
+    2. put(O:, value_with_new_inline_tags + tag_count = new_tag_count)
+
+  Case B — Current: inline or none, New: exceeds threshold
+    2. put(O:, clear_inline_tags + set_external_flag + tag_count = new_tag_count)
+    3. put(C:<ref_tag>T, new_tag_array)
+
+  Case C — Current: external, New: exceeds threshold
+    2. put(C:<ref_tag>T, new_tag_array)
+    3. put(O:, tag_count = new_tag_count)
+
+  Case D — Current: external, New: fits inline
+    2. delete(C:<ref_tag>T)
+    3. put(O:, clear_external_flag + set_inline_tags + tag_count = new_tag_count)
+
+  commit
+}
+```
+
+`tag_count` is a single byte (uint8, max value 10 per S3 limit). All cases write the parent entry (O: for current version, V:<vid> for old versions) with the updated count — provides write-write conflict on both FDB and TiKV.
+
+**Old-version variant:** When targeting a non-current version (S3 `versionId` parameter), use the version resolution logic from [Parent Dependency](#parent-dependency) to locate the parent (V:<vid> or O: if promoted). Replace `get(O:)` with the resolved parent and `put(O:, ...)` with `put(parent, ...)` in all cases above.
+
+### DeleteObjectTagging (remove all — AWS API)
+
+S3 `DeleteObjectTagging` removes all tags regardless of storage model:
+
+```
+txn {
+  1. get(O:) → if null → abort; read ref_tag, current tag state
+  2. If external: delete(C:<ref_tag>T)
+  3. put(O:, clear_all_tag_fields + tag_count = 0)
+  commit
+}
+```
+
+Always writes O: (clears tag fields) → write-write conflict on both FDB and TiKV.
+
+### Extended Value Operations
+
+Extended value holds metadata overflow — internal data that logically belongs to the object but exceeds the O: value size (e.g., large manifests, compression dictionaries, encryption metadata for multipart objects). Extended value is NOT user-addressable — clients never read/write it directly. It is accessed internally as part of GET/PUT operations.
+
+**Three-level storage (similar to annotations, but no standalone KV when on data tier):**
+
+| Metadata size | Storage | Pointer in O: | C:E entry? |
+|---|---|---|---|
+| Fits in O: value | Inline in O: | N/A (data is there) | No |
+| Overflows O: but < KV value limit | C:<ref_tag>E (single entry) | `{ev_location: CHILD_E}` | Yes |
+| Exceeds KV value limit (extreme multipart) | Data tier blob | `{ev_location: STORAGE, storage_id, blob_id, offset, length}` | No |
+
+Unlike annotations, extended value on the storage tier does NOT need a C:E entry — O: holds the storage pointer directly. Extended value is not user-addressable, so there's nothing for a client to look up by name.
+
+**Write (during PUT Phase 3):**
+
+Extended values are written atomically in the same transaction as the parent O: entry:
+
+```
+txn {
+  ... (PUT Phase 3 steps) ...
+  get(P:O) → if null → abort
+  put(O:, value_with_ev_location_flag)
+  put(C:<ref_tag>E, overflow_metadata)  // only if ev_location = CHILD_E
+  delete(P:O)
+  commit
+}
+```
+
+For storage-tier extended value: written in PUT Phase 2 alongside object data (same blob or adjacent blob, same P:O coordination). O: stores the pointer directly — no C:E entry created.
+
+No separate P: coordination needed for C:E — piggybacks on the parent's P:O.
+
+**Read (on first access):**
+
+When GET encounters extended value:
+- `CHILD_E`: follow-up read `get(C:<ref_tag>E)`. Single KV read, typically cached after first access.
+- `STORAGE`: fetch from data tier (same as reading object data — one storage-tier read).
+
+**Lifecycle:** Owned entirely by the parent. When the parent moves to G: (deletion/overwrite):
+- `CHILD_E`: GC deletes C:E via `RangeScan(C:<ref_tag>*)`.
+- `STORAGE`: GC frees the storage blob (same mechanism as freeing object data — may be the same blob).
+
+---
+
+## Data Storage
+
+Object data is stored at one of three tiers (inline in O:, D: namespace entry, or storage tier) based on size.\
+The data tiering model, D: namespace key schema, PUT/GET transactions per tier, GC cleanup, background migration, and capacity considerations are documented in [data-tiering.md](data-tiering.md).
+
+Child KV entries (C:A, C:T, C:E) are independent of the data tier — they coexist with any tier and are cleaned uniformly by GC via `RangeScan(C:<ref_tag>*)`.
+
+---
+
+## TiKV: Conflict Detection via Functional O: Writes
+
+### Why child operations are safe on TiKV
+
+TiKV optimistic transactions detect only write-write conflicts. A child operation that reads O: but doesn't write it cannot detect a concurrent DELETE/PUT of the parent. However, all child operations in this document write O: for **functional** reasons:
+
+- **Annotations:** write `annotation_count` to O: (increment on add, decrement on delete, same value on overwrite)
+- **Tags:** write `tag_count` to O: (updated on every PutObjectTagging/DeleteObjectTagging)
+- **Extended Value:** written in PUT Phase 3 alongside O: (no separate operation)
+
+These functional writes create write-write conflicts with concurrent parent DELETE/PUT on TiKV — no additional conflict-detection field is needed.
+
+### Operations and their O: write reason
+
+| Operation | O: field written | TiKV conflict via |
+|---|---|---|
+| PutObjectAnnotation (new) | `annotation_count + 1` | Write-write on O: |
+| PutObjectAnnotation (overwrite) | `annotation_count` (same) | Write-write on O: |
+| DeleteObjectAnnotation | `annotation_count - 1` | Write-write on O: |
+| PutObjectTagging (all cases) | `tag_count` | Write-write on O: |
+| DeleteObjectTagging | `tag_count = 0` | Write-write on O: |
+| Extended Value write | Part of PUT Phase 3 | Write-write on O: (PUT writes O:) |
+
+All child operations use identical transactions on FDB and TiKV. No backend-specific code paths.
+
+### On FDB
+
+FDB does not need the O: write for conflict detection — the `get(O:)` read creates a conflict range that detects concurrent writes. However, the functional writes (counts) are still performed on FDB because they serve a data purpose (limit enforcement, HeadObject metadata). Same code, both systems.
+
+### Where conflict detection comes from
+
+All child operations write their parent entry (O: for current versions, V:<vid> for old versions) for functional AWS reasons — `tag_count`, `annotation_count`, or inline tag data. These writes provide write-write conflict detection on TiKV as a free side effect. No additional conflict-detection field is needed for any child operation.
+
+For DELETE with version-id Case 1: Case 1 writes (deletes) V:<X>. Any child operation targeting V:<X> also writes V:<X> (count fields). Write-write conflict on V:<X> provides mutual exclusion. See [transaction-safety.md](transaction-safety.md).
+
+---
+
+## Child Cleanup on Parent Deletion
+
+When a parent object is deleted or overwritten, the parent entry moves to `G:` (GC namespace). The G: entry retains the `ref_tag`. Background GC workers are responsible for cleaning all children:
+
+**GC worker processing G:O (or G:V) entry:**
+```
+1. RangeScan(C:<ref_tag>*) → find all child entries
+2. For each C:A with storage-tier data:
+   - put(G:A, {anno_ref_tag, chunk_pointers}) — queue annotation blob for deletion
+   - delete(C:A entry)
+3. For C:T, C:E entries (pure KV):
+   - delete directly (no storage-tier cleanup needed)
+4. Free parent object's storage-tier data (by ref_tag)
+5. delete(G:O entry)
+```
+
+**Properties:**
+- Children are cleaned AFTER the parent is moved to G: — no race with active readers (parent is already invisible to S3 API once O: is gone).
+- Annotation blobs are cleaned via G:A entries (idempotent, safe to retry).
+- Tags and extended values are pure KV deletes — no external cleanup.
+- If GC crashes mid-cleanup: G:O still exists (step 5 not reached), GC retries. Idempotent deletes ensure no double-free.
+- **Pagination:** An object can have up to 1000 annotations. The `RangeScan(C:<ref_tag>*)` may return a large result set. GC must handle paginated scans — processing and deleting entries in batches while keeping G:O alive until all children are cleaned. Design TBD.
+
+---
+
+## Read-Path Operations
+
+Read operations on child KVs are pure snapshot reads — no writes, no conflict detection needed. Snapshot isolation provides a consistent point-in-time view on both FDB and TiKV.
+
+### GetObjectTagging
+
+Single transaction — both reads in the same snapshot:
+
+```
+txn {
+  get(O:) → if null → 404; read ref_tag
+  get(C:<ref_tag>T) → read tag array (null if inline or no tags)
+  Return tags (from C:T if external, or from O: value if inline)
+}
+```
+
+**Analysis:** Safe on both FDB and TiKV. If a concurrent DELETE removes O: after our snapshot, we still return the tags as of our snapshot — valid under S3 read consistency. If DELETE + GC committed before our snapshot, `get(O:)` → null → 404.
+
+### GetObjectAnnotation (inline value — no storage-tier data)
+
+Single transaction:
+
+```
+txn {
+  get(O:) → if null → 404; read parent_ref_tag
+  get(C:<parent_ref_tag>A<annotation_key>) → if null → 404
+  Return annotation value
+}
+```
+
+**Analysis:** Same as GetObjectTagging — single snapshot, safe on both systems.
+
+### GetObjectAnnotation (with storage-tier data)
+
+Multi-phase read — KV metadata and storage-tier data cannot be read atomically:
+
+```
+Phase 1 (KV snapshot):
+txn {
+  get(O:) → if null → 404; read parent_ref_tag
+  get(C:<parent_ref_tag>A<annotation_key>) → if null → 404
+  Record anno_ref_tag and data-tier pointer from C:A value
+}
+
+Phase 2 (storage tier):
+  Read annotation blob using anno_ref_tag
+  → if blob not found (GC freed it) → retry from Phase 1
+
+Phase 3 (verification):
+txn {
+  get(O:) → verify parent_ref_tag matches Phase 1
+  get(C:<parent_ref_tag>A<annotation_key>) → verify anno_ref_tag matches Phase 1
+  → if match → return data to client
+  → if mismatch → retry from Phase 1 (annotation was overwritten)
+}
+```
+
+**Analysis:**
+
+- **Phase 1:** consistent KV snapshot. Safe.
+- **Phase 2:** reads blob outside KV transaction. Can fail if GC freed the blob (annotation was overwritten, G:A processed). On failure → retry from Phase 1.
+- **Phase 3:** re-verifies annotation is still current. If ref_tags match → data is valid, return. If mismatch → annotation was overwritten between phases → retry.
+- **All phases are read-only** — no writes, no conflict detection needed.
+- **Safe on both FDB and TiKV.** Purely snapshot reads + application-level verification.
+- **No TiKV special handling needed for read paths.**
+
+### GetObjectExtendedValue
+
+Single transaction (extended value is always in KV, never on storage tier):
+
+```
+txn {
+  get(O:) → if null → 404; read ref_tag, verify has_extended_value flag
+  get(C:<ref_tag>E) → read overflow metadata
+  Return extended value
+}
+```
+
+**Analysis:** Same pattern as GetObjectTagging — single snapshot, safe on both systems. Typically cached after first access (extended value doesn't change without a full PUT overwrite).
+
+---
+
+## Sweeper and GC Interaction with Child KV — Safety Overview
+
+### What triggers background cleanup?
+
+| Entry | Created by | Cleaned by | Interacts with children? |
+|---|---|---|---|
+| `P:O` | PUT Phase 1 | Sweeper → G:O → GC | No (Phase 3 never committed → no children exist) |
+| `P:A` | PutObjectAnnotation Phase 1 | Sweeper → G:A → GC | No (Phase 3 never committed → no C:A created) |
+| `P:M` | CompleteMultipartUpload Phase 1 | Sweeper (replay completion or rollback) | No (separate domain — :M: parts, not :C: children). See [S3-Operations — Upload protection model](S3-Operations-Over-KV.md#upload-protection-model). |
+| `G:O` | DELETE / PUT overwrite | GC worker | Yes — scans and deletes all C:<ref_tag>* entries |
+| `G:A` | Annotation overwrite/delete | GC worker | Yes — frees annotation blob on storage tier |
+
+### Sweeper interaction — minimal
+
+The sweeper prevents children from being created — it does NOT clean existing ones:
+- Moves P:O → G:O (or P:A → G:A) atomically in a single transaction
+- After commit: Phase 3's `get(P:X)` → null → abort → no C: entry written
+- The write-write conflict on `delete(P:X)` ensures mutual exclusion between sweeper and Phase 3
+
+### GC interaction — safe by design
+
+GC runs only after O: is removed (G:O committed). Child operations cannot race with GC because:
+
+1. **Child writers:** Every child write does `get(O:)` → null → abort. On TiKV, the functional write to O: (`annotation_count`, `tag_count`, or same value on overwrite) creates write-write conflict with the DELETE that removed O: → transaction fails → retry → O: null → abort. No new children can be created after O: is removed.
+
+2. **Child readers:** Use transactional reads (single snapshot). If O: exists in the snapshot, C: entries are intact at that snapshot (GC hasn't committed yet at that point in time). Consistent view guaranteed.
+
+3. **Atomicity of sweeper move:** The sweeper's `{get(P:X), put(G:X), delete(P:X)}` is a single atomic transaction. This prevents the race where GC frees data (via G:X) while Phase 3 is still able to commit (P:X still exists). After commit: P:X is gone AND G:X exists simultaneously — Phase 3 sees null, GC can safely proceed.
+
+### FDB vs TiKV — no difference for background cleanup
+
+Both systems handle sweeper/GC safely:
+- Sweeper's write-write conflict on `delete(P:X)` works on both (both detect concurrent Phase 3 deleting the same key)
+- GC processes G: entries after O: is removed — child operations detect O: removal via `get(O:)` (FDB: read conflict range, TiKV: functional O: write creates write-write conflict)
+- Read-path operations are pure snapshot reads — no difference between FDB and TiKV


### PR DESCRIPTION
## Summary
Propose replacing RADOS head objects with entries in an external KV
store, decoupling S3 object identity from storage-tier naming.
- Define a DB-agnostic KV contract (key format, value structure,
  operations) — FDB and TiKV as reference examples
- Eliminate the bucket-index — listing via KV range scans, no dual
  updates, no resharding
- Single atomic KV delete replaces two non-atomic operations (BI +
  head object), with persistent delete-log for async data cleanup
- Decouple RGW from the storage tier — data store becomes a dumb
  blob store (write, read-range, punch-hole)
- Analyze key sharding for fleet scaling — three strategies,
  transaction locality via key naming, logical hashing epoch for
  incremental growth without upfront commitment to shard count
## Motivation
The 1:1 mapping between S3 objects and RADOS objects creates
compounding problems:
- small-object overhead
- versioning complexity(OLH)
- EC metadata amplification
- costly deletes
- bucket-index as a secondary mechanism with all its pain
- storage-tier lock-in.

RGW already uses head objects as a de facto KV system — this design replaces them with areal one.

## Status
Design document — open for discussion.




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
