### PR TITLE
tentacle: mgr/cephadm: During upgrade if NFS cluster is using old nodeids, keep using old node ids

### DIFF
--- a/src/pybind/mgr/cephadm/migrations.py
+++ b/src/pybind/mgr/cephadm/migrations.py
@@ -1,11 +1,13 @@
 import json
 import re
 import logging
-from typing import TYPE_CHECKING, Iterator, Optional, Dict, Any, List
+from typing import TYPE_CHECKING, Iterator, Optional, Dict, Any, List, cast
 
-from ceph.deployment.service_spec import PlacementSpec, ServiceSpec, HostPlacementSpec, RGWSpec
+from ceph.deployment.service_spec import PlacementSpec, ServiceSpec, HostPlacementSpec, RGWSpec, NFSServiceSpec
 from cephadm.schedule import HostAssignment
 from cephadm.utils import SpecialHostLabels
+from cephadm.services.nfs import NFSService
+from cephadm.services.service_registry import service_registry
 import rados
 
 from mgr_module import NFS_POOL_NAME
@@ -14,7 +16,7 @@ from orchestrator import OrchestratorError, DaemonDescription
 if TYPE_CHECKING:
     from .module import CephadmOrchestrator
 
-LAST_MIGRATION = 7
+LAST_MIGRATION = 8
 
 logger = logging.getLogger(__name__)
 
@@ -108,6 +110,11 @@ class Migrations:
         if self.mgr.migration_current == 6:
             if self.migrate_6_7():
                 self.set(7)
+
+        if self.mgr.migration_current == 7 and not startup:
+            logger.info('Running migration 7 -> 8')
+            if self.migrate_7_8():
+                self.set(8)
 
     def migrate_0_1(self) -> bool:
         """
@@ -440,6 +447,30 @@ class Migrations:
         # NOTE: prometheus, alertmanager, and node-exporter certs were not stored
         # and appeared to just be generated at daemon deploy time if secure_monitoring_stack
         # was set to true. Therefore we have nothing to migrate for those daemons
+        return True
+
+    def migrate_7_8(self) -> bool:
+        # For NFS, check if nfs cluster is using old types of node ids (service_name.0)
+        # if yes, then store those daemons in mon store, to continue using old node ids for those daemons
+        nfs_services = []
+        service_specs = self.mgr.spec_store.get_specs_by_type('nfs')
+        nfs_service = cast(NFSService, service_registry.get_service('nfs'))
+        try:
+            for service_name, spec in service_specs.items():
+                # get grace tool dump
+                out = nfs_service.run_grace_tool(cast(NFSServiceSpec, spec), 'dump')
+                if service_name in out:
+                    nfs_services.append(service_name)
+                    logger.info(f'NFS service {nfs_service} needs to maintain old node ids after upgrade')
+        except Exception as e:
+            logger.exception(f'Got error while executing grace tool: {e}')
+            self.mgr.set_health_warning('CEPHADM_MIGRATION_FAILURE',
+                                        f'Cephadm migration failed: {e}',
+                                        1, [str(e)])
+            return False
+        if nfs_services:
+            self.mgr.set_store('nfs_services_with_old_nodeid', ','.join(nfs_services))
+        self.mgr.remove_health_warning('CEPHADM_MIGRATION_FAILURE')
         return True
 
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2775,6 +2775,15 @@ Then run the following:
                     msg += f'\thost {h}: {" ".join([f"osd.{id}" for id in ls])}'
                 raise OrchestratorError(
                     f'If {service_name} is removed then the following OSDs will remain, --force to proceed anyway\n{msg}')
+        elif service_name.startswith('nfs.'):
+            # check if its using old node id style and remove from mon store
+            nfs_services = self.get_store('nfs_services_with_old_nodeid')
+            if nfs_services:
+                nfs_services = nfs_services.split(',')
+                if service_name in nfs_services:
+                    nfs_services.remove(service_name)
+                    val = ','.join(nfs_services) if nfs_services else None
+                    self.set_store('nfs_services_with_old_nodeid', val)
 
         found = self.spec_store.rm(service_name)
         if found and service_name.startswith('osd.'):

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -47,11 +47,17 @@ class NFSService(CephService):
                 for daemon_id in m.values():
                     if daemon_id is not None:
                         self.fence(daemon_id)
-                del rank_map[rank]
-                nodeid = f'{rank}'
-                self.mgr.log.info(f'Removing {nodeid} from the ganesha grace table')
-                self.run_grace_tool(cast(NFSServiceSpec, spec), 'remove', nodeid)
-                self.mgr.spec_store.save_rank_map(spec.service_name(), rank_map)
+                nodeid = self.get_daemon_nodeid(spec.service_name(), rank)
+                self.mgr.log.info(
+                    "Removing %s from the ganesha grace table for service %s", nodeid, spec.service_name()
+                )
+                try:
+                    self.run_grace_tool(cast(NFSServiceSpec, spec), 'remove', nodeid)
+                    # Only delete from rank_map if grace tool succeeds
+                    del rank_map[rank]
+                    self.mgr.spec_store.save_rank_map(spec.service_name(), rank_map)
+                except RuntimeError:
+                    self.mgr.log.exception('Got exception while removing node id from grace table')
             else:
                 max_gen = max(m.keys())
                 for gen, daemon_id in list(m.items()):
@@ -72,6 +78,12 @@ class NFSService(CephService):
         daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
         return daemon_spec
 
+    def get_daemon_nodeid(self, service_name: str, rank: Optional[int]) -> str:
+        out = self.mgr.get_store('nfs_services_with_old_nodeid')
+        if out and service_name in out.split(','):
+            return f'{service_name}.{rank}'
+        return str(rank)
+
     def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
 
@@ -82,7 +94,7 @@ class NFSService(CephService):
 
         deps: List[str] = []
 
-        nodeid = f'{daemon_spec.rank}'
+        nodeid = self.get_daemon_nodeid(spec.service_name(), daemon_spec.rank)
 
         nfs_idmap_conf = '/etc/ganesha/idmap.conf'
 
@@ -129,7 +141,8 @@ class NFSService(CephService):
                 "nfs_idmap_conf": nfs_idmap_conf,
                 "enable_nlm": str(spec.enable_nlm).lower(),
                 "cluster_id": self.mgr._cluster_fsid,
-                "protocols": "3, 4" if spec.enable_nfsv3 else "4"
+                "protocols": "3, 4" if spec.enable_nfsv3 else "4",
+                "use_old_nodeid": False if nodeid.isdigit() else True
             }
             if spec.enable_haproxy_protocol:
                 context["haproxy_hosts"] = self._haproxy_hosts()
@@ -237,7 +250,7 @@ class NFSService(CephService):
     def run_grace_tool(self,
                        spec: NFSServiceSpec,
                        action: str,
-                       nodeid: str) -> None:
+                       nodeid: str = '') -> str:
         # write a temp keyring and referencing config file.  this is a kludge
         # because the ganesha-grace-tool can only authenticate as a client (and
         # not a mgr).  Also, it doesn't allow you to pass a keyring location via
@@ -274,6 +287,7 @@ class NFSService(CephService):
                 )
                 raise RuntimeError(f'grace tool failed: {result.stderr.decode("utf-8")}')
 
+            return result.stdout.decode("utf-8")
         finally:
             self.mgr.check_mon_command({
                 'prefix': 'auth rm',

--- a/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
@@ -28,7 +28,7 @@ NFSv4 {
 
 RADOS_KV {
         UserId = "{{ user }}";
-        nodeid = {{ nodeid }};
+        nodeid = "{{ nodeid }}";
         pool = "{{ pool }}";
         namespace = "{{ namespace }}";
 }
@@ -43,4 +43,10 @@ RGW {
         name = "client.{{ rgw_user }}";
 }
 
+{% if use_old_nodeid %}
+Ceph {
+	Use_old_uuid = true;
+}
+
+{% endif %}
 %url    {{ url }}

--- a/src/pybind/mgr/cephadm/tests/test_migration.py
+++ b/src/pybind/mgr/cephadm/tests/test_migration.py
@@ -162,6 +162,7 @@ def test_migrate_service_id_mds_one(cephadm_module: CephadmOrchestrator):
         assert len(cephadm_module.spec_store.all_specs) == 0
 
 
+@mock.patch("cephadm.services.nfs.NFSService.run_grace_tool", mock.MagicMock())
 @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
 def test_migrate_nfs_initial(cephadm_module: CephadmOrchestrator):
     with with_host(cephadm_module, 'host1'):
@@ -195,6 +196,7 @@ def test_migrate_nfs_initial(cephadm_module: CephadmOrchestrator):
         assert cephadm_module.migration_current == LAST_MIGRATION
 
 
+@mock.patch("cephadm.services.nfs.NFSService.run_grace_tool", mock.MagicMock())
 @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
 def test_migrate_nfs_initial_octopus(cephadm_module: CephadmOrchestrator):
     with with_host(cephadm_module, 'host1'):

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -3410,7 +3410,7 @@ class TestIngressService:
             '\n'
             'RADOS_KV {\n'
             '        UserId = "nfs.foo.test.0.0";\n'
-            '        nodeid = 0;\n'
+            '        nodeid = "0";\n'
             '        pool = ".nfs";\n'
             '        namespace = "foo";\n'
             '}\n'


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78186

---

backport of https://github.com/ceph/ceph/pull/63617
parent tracker: https://tracker.ceph.com/issues/71509

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh