### PR TITLE
rgw/swift: add allowed_digests to /info API tempurl section

### DIFF
--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -23,6 +23,7 @@
 #include "rgw_auth.h"
 #include "rgw_auth_registry.h"
 #include "rgw_swift_auth.h"
+#include "rgw_swift_digest_helpers.h"
 
 #include "rgw_request.h"
 #include "rgw_process.h"
@@ -122,6 +123,11 @@ public:
 };
 
 std::unique_ptr<RGWFormPost::SignatureHelper> RGWFormPost::SignatureHelper::get_sig_helper(std::string_view x) {
+  // Get reference to the shared digest helper map
+  const auto& formpost_digest_helpers =
+    rgw::auth::swift::get_digest_helper_map<RGWFormPost::SignatureHelper,
+                                             RGWFormPost::SignatureHelper_x>();
+
   size_t pos = x.find(':');
   if (pos == x.npos || pos <= 0) {
     switch(x.length()) {
@@ -135,15 +141,21 @@ std::unique_ptr<RGWFormPost::SignatureHelper> RGWFormPost::SignatureHelper::get_
     return std::make_unique<BadSignatureHelper>();
   }
   std::string_view type { x.substr(0,pos) };
-  if (type == "sha1") {
-    return std::make_unique<SignatureHelper_x<ceph::crypto::HMACSHA1,rgw::auth::swift::SignatureFlavor::NAMED_BASE64>>();
-  } else if (type == "sha256") {
-    return std::make_unique<SignatureHelper_x<ceph::crypto::HMACSHA256,rgw::auth::swift::SignatureFlavor::NAMED_BASE64>>();
-  } else if (type == "sha512") {
-    return std::make_unique<SignatureHelper_x<ceph::crypto::HMACSHA512,rgw::auth::swift::SignatureFlavor::NAMED_BASE64>>();
+  // Look up the digest algorithm in the map
+  auto it = formpost_digest_helpers.find(type);
+  if (it != formpost_digest_helpers.end()) {
+    return it->second();
   }
   return std::make_unique<BadSignatureHelper>();
 };
+
+std::vector<std::string_view> RGWFormPost::get_supported_digest_algorithms() {
+  // Access the digest helper map through the friend relationship
+  const auto& formpost_digest_helpers =
+    rgw::auth::swift::get_digest_helper_map<RGWFormPost::SignatureHelper,
+                                             RGWFormPost::SignatureHelper_x>();
+  return rgw::auth::swift::get_digest_algorithm_names(formpost_digest_helpers);
+}
 
 int RGWListBuckets_ObjStore_SWIFT::get_params(optional_yield y)
 {
@@ -2044,6 +2056,12 @@ void RGWInfo_ObjStore_SWIFT::list_tempurl_data(Formatter& formatter,
   formatter.dump_string("methodname", "PUT");
   formatter.dump_string("methodname", "POST");
   formatter.dump_string("methodname", "DELETE");
+  formatter.close_section();
+  formatter.open_array_section("allowed_digests");
+  // Get supported digest algorithms from the FormPost implementation
+  for (const auto& digest_name : RGWFormPost::get_supported_digest_algorithms()) {
+    formatter.dump_string("algorithm", digest_name);
+  }
   formatter.close_section();
   formatter.close_section();
 }

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -279,6 +279,7 @@ public:
   void send_response() override;
 
   static bool is_formpost_req(req_state* const s);
+  static std::vector<std::string_view> get_supported_digest_algorithms();
 };
 
 

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -11,6 +11,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include "rgw_swift_auth.h"
+#include "rgw_swift_digest_helpers.h"
 #include "rgw_rest.h"
 
 #include "common/ceph_crypto.h"
@@ -257,6 +258,11 @@ class TempURLSignature {
 };
 
 std::unique_ptr<TempURLEngine::SignatureHelper> TempURLEngine::SignatureHelper::get_sig_helper(std::string_view x) {
+  // Get reference to the shared digest helper map
+  const auto& tempurl_digest_helpers =
+    rgw::auth::swift::get_digest_helper_map<TempURLEngine::SignatureHelper,
+                                             TempURLSignature::SignatureHelper_x>();
+
   size_t pos = x.find(':');
   if (pos == x.npos || pos <= 0) {
     switch(x.length()) {
@@ -270,12 +276,10 @@ std::unique_ptr<TempURLEngine::SignatureHelper> TempURLEngine::SignatureHelper::
     return std::make_unique<TempURLSignature::BadSignatureHelper>();
   }
   std::string_view type { x.substr(0,pos) };
-  if (type == "sha1") {
-    return std::make_unique<TempURLSignature::SignatureHelper_x<ceph::crypto::HMACSHA1,rgw::auth::swift::SignatureFlavor::NAMED_BASE64>>();
-  } else if (type == "sha256") {
-    return std::make_unique<TempURLSignature::SignatureHelper_x<ceph::crypto::HMACSHA256,rgw::auth::swift::SignatureFlavor::NAMED_BASE64>>();
-  } else if (type == "sha512") {
-    return std::make_unique<TempURLSignature::SignatureHelper_x<ceph::crypto::HMACSHA512,rgw::auth::swift::SignatureFlavor::NAMED_BASE64>>();
+  // Look up the digest algorithm in the map
+  auto it = tempurl_digest_helpers.find(type);
+  if (it != tempurl_digest_helpers.end()) {
+    return it->second();
   }
   return std::make_unique<TempURLSignature::BadSignatureHelper>();
 };

--- a/src/rgw/rgw_swift_digest_helpers.h
+++ b/src/rgw/rgw_swift_digest_helpers.h
@@ -1,0 +1,58 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+#pragma once
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <string_view>
+#include <vector>
+#include "rgw_swift_auth.h"
+#include "common/ceph_crypto.h"
+
+namespace rgw::auth::swift {
+
+// Helper template to create digest factory maps.
+// This map serves as the single source of truth for supported digest algorithms.
+// Usage: make_digest_helper_map<BaseHelperType, HelperImplTemplate>()
+template<typename HelperType, template<typename, SignatureFlavor> class HelperImpl>
+auto make_digest_helper_map() {
+  using Factory = std::function<std::unique_ptr<HelperType>()>;
+  return std::map<std::string_view, Factory>{
+    {"sha1", []() {
+      return std::make_unique<HelperImpl<ceph::crypto::HMACSHA1,
+                                         SignatureFlavor::NAMED_BASE64>>();
+    }},
+    {"sha256", []() {
+      return std::make_unique<HelperImpl<ceph::crypto::HMACSHA256,
+                                         SignatureFlavor::NAMED_BASE64>>();
+    }},
+    {"sha512", []() {
+      return std::make_unique<HelperImpl<ceph::crypto::HMACSHA512,
+                                         SignatureFlavor::NAMED_BASE64>>();
+    }},
+  };
+}
+
+// Get reference to the shared digest helper map for a specific helper type.
+// Returns a static instance for signature verification.
+template<typename HelperType, template<typename, SignatureFlavor> class HelperImpl>
+const auto& get_digest_helper_map() {
+  static const auto map = make_digest_helper_map<HelperType, HelperImpl>();
+  return map;
+}
+
+// Extract just the algorithm names from a digest helper map.
+// Use this for the /info API to avoid exposing private helper classes.
+template<typename MapType>
+std::vector<std::string_view> get_digest_algorithm_names(const MapType& map) {
+  std::vector<std::string_view> names;
+  names.reserve(map.size());
+  for (const auto& [name, factory] : map) {
+    names.push_back(name);
+  }
+  return names;
+}
+
+} // namespace rgw::auth::swift

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -147,6 +147,13 @@ add_executable(unittest_http_manager test_http_manager.cc)
 add_ceph_unittest(unittest_http_manager)
 target_link_libraries(unittest_http_manager ${rgw_libs})
 
+# unittest_rgw_swift_info
+add_executable(unittest_rgw_swift_info test_rgw_swift_info.cc)
+add_ceph_unittest(unittest_rgw_swift_info)
+target_include_directories(unittest_rgw_swift_info
+  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
+target_link_libraries(unittest_rgw_swift_info ${rgw_libs})
+
 if(WITH_RADOSGW_RADOS)
 # unittest_rgw_reshard_wait
 add_executable(unittest_rgw_reshard_wait test_rgw_reshard_wait.cc)

--- a/src/test/rgw/test_rgw_swift_info.cc
+++ b/src/test/rgw/test_rgw_swift_info.cc
@@ -1,0 +1,71 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include <gtest/gtest.h>
+#include "rgw_rest_swift.h"
+#include "common/ceph_json.h"
+#include "common/Formatter.h"
+#include "common/config.h"
+#include <sstream>
+
+using namespace std;
+
+TEST(RGWSwiftInfo, TempurlAllowedDigests)
+{
+  // Create a JSON formatter to capture the output
+  JSONFormatter formatter;
+
+  // Wrap in parent section like production code does
+  formatter.open_object_section("info");
+  RGWInfo_ObjStore_SWIFT::list_tempurl_data(formatter, g_conf(), nullptr);
+  formatter.close_section();
+
+  // Get the formatted output
+  stringstream ss;
+  formatter.flush(ss);
+  string output = ss.str();
+
+  // Parse the JSON output
+  JSONParser parser;
+  ASSERT_TRUE(parser.parse(output.c_str(), output.length()));
+
+  // Verify the tempurl object exists (parser.find_obj searches recursively)
+  JSONObj *tempurl_obj = parser.find_obj("tempurl");
+  ASSERT_TRUE(tempurl_obj != nullptr);
+
+  // Verify methods array exists and contains expected values
+  JSONObj *methods_obj = tempurl_obj->find_obj("methods");
+  ASSERT_TRUE(methods_obj != nullptr);
+
+  vector<string> methods;
+  JSONDecoder::decode_json("methods", methods, tempurl_obj);
+  ASSERT_EQ(5u, methods.size());
+  EXPECT_EQ("GET", methods[0]);
+  EXPECT_EQ("HEAD", methods[1]);
+  EXPECT_EQ("PUT", methods[2]);
+  EXPECT_EQ("POST", methods[3]);
+  EXPECT_EQ("DELETE", methods[4]);
+
+  // Verify allowed_digests array exists and contains sha1, sha256, sha512
+  JSONObj *digests_obj = tempurl_obj->find_obj("allowed_digests");
+  ASSERT_TRUE(digests_obj != nullptr);
+
+  vector<string> allowed_digests;
+  JSONDecoder::decode_json("allowed_digests", allowed_digests, tempurl_obj);
+  ASSERT_EQ(3u, allowed_digests.size());
+
+  // Verify all expected digests are present (order doesn't matter)
+  EXPECT_NE(find(allowed_digests.begin(), allowed_digests.end(), "sha1"), allowed_digests.end());
+  EXPECT_NE(find(allowed_digests.begin(), allowed_digests.end(), "sha256"), allowed_digests.end());
+  EXPECT_NE(find(allowed_digests.begin(), allowed_digests.end(), "sha512"), allowed_digests.end());
+}


### PR DESCRIPTION
rgw/swift: add allowed_digests to /info API tempurl section

The Swift /info API now reports the list of supported digest algorithms for tempurl/formpost signatures in the "allowed_digests" field.

Previously, even though SHA256 and SHA512 support was added in https://github.com/ceph/ceph/pull/47723, clients had no way to discover which digest algorithms were supported by querying the API.

This commit introduces a map-based architecture where digest algorithm names are directly coupled with their hash function implementations:

- formpost_digest_helpers map in rgw_rest_swift.cc
- tempurl_digest_helpers map in rgw_swift_auth.cc

The /info endpoint iterates over the map keys to populate the allowed_digests array, ensuring it always stays in sync with the actual signature verification code. When a digest algorithm is added or removed from the map, both the verification logic and the /info API automatically reflect the change.

Example /info API response:
```
{
  "tempurl": {
    "methods": ["GET", "HEAD", "PUT", "POST", "DELETE"],
    "allowed_digests": ["sha1", "sha256", "sha512"]
  }
}
```

Fixes: https://tracker.ceph.com/issues/78341

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
