### PR TITLE
tools/cephfs_mirror: prune old COMPLETE mirroring checkpoints

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -216,8 +216,11 @@
   ``ceph fs snapshot mirror checkpoint now`` to checkpoint the latest snapshot,
   ``ceph fs snapshot mirror checkpoint ls`` to list all checkpoints with their status
   (created/complete/failed), and ``ceph fs snapshot mirror checkpoint remove`` to remove
-  a checkpoint. Checkpoint metadata is persistent across daemon restarts. This feature is
-  useful for compliance auditing, application consistency verification, and SLA tracking.
+  a checkpoint. Checkpoint metadata is persistent across daemon restarts. The mirror daemon
+  automatically prunes old COMPLETE checkpoints per directory, retaining the newest ones;
+  retention is controlled by ``cephfs_mirror_checkpoint_keep_count`` (default: 10). CREATED
+  and FAILED checkpoints are not pruned. This feature is useful for compliance auditing,
+  application consistency verification, and SLA tracking.
   For more information, see https://tracker.ceph.com/issues/73454
 * RBD: Mirror snapshot creation and trash purge schedules are now automatically
   staggered when no explicit "start-time" is specified. This reduces scheduling

--- a/doc/cephfs/cephfs-mirroring-checkpoints.rst
+++ b/doc/cephfs/cephfs-mirroring-checkpoints.rst
@@ -351,6 +351,17 @@ When you rename a snapshot that has a checkpoint:
 - Always use ``checkpoint ls`` to verify current snapshot names before removing checkpoints
 - Update any automation scripts if you rename snapshots
 
+Automatic Retention
+-------------------
+
+The ``cephfs-mirror`` daemon automatically prunes old **complete** checkpoints so that
+only the newest ones are retained per mirrored directory.
+
+- Default retention: last **10** complete checkpoints (``cephfs_mirror_checkpoint_keep_count``)
+- Pruning runs lazily when checkpoints are initialized (directory acquire, checkpoint
+  add/now, or daemon restart) — not on a fixed timer
+- Checkpoints in **created** or **failed** status are never pruned automatically
+- Only checkpoint metadata is removed; the underlying snapshots are not deleted
 
 Additional Resources
 ====================

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -950,6 +950,13 @@ class TestMirroring(CephFSTestCase):
         for snap_name in snap_names:
             self.check_checkpoint_status(fs_name, dir_path, snap_name, expected_status)
 
+    @retry_assert(timeout=120, interval=5)
+    def check_checkpoint_list_snap_names(self, fs_name, dir_path, expected_names):
+        res = self.checkpoint_list(fs_name, dir_path)
+        names = [cp['snap_name'] for cp in res['checkpoints']]
+        self.assertEqual(sorted(names), sorted(expected_names),
+                         f'expected checkpoints {expected_names}, got {names}')
+
     def setup_mount_b(self, mds_perm):
         log.debug('reconfigure client auth caps')
         self.get_ceph_cmd_result(
@@ -1397,6 +1404,111 @@ class TestMirroring(CephFSTestCase):
         self.start_mirror_daemon()
         self.check_checkpoint_statuses(
             self.primary_fs_name, dir_path, checkpoint_snaps, 'complete')
+
+        self._teardown_mirroring(dir_path, peer_spec)
+
+    def test_checkpoint_auto_prune_old_complete(self):
+        """Old COMPLETE checkpoints are pruned down to keep_count on initialize.
+
+        Sync more than keep_count COMPLETE checkpoints first (prune does not run
+        on the sync path). Restarting the mirror daemon re-acquires the directory
+        and runs initialize_checkpoints(), which prunes the oldest already-COMPLETE
+        checkpoints. Snapshots themselves must remain.
+
+        Also verifies that updating cephfs_mirror_checkpoint_keep_count is honored
+        by the daemon (override below; restored via addCleanup).
+        """
+        keep_count = 3
+        dir_path = '/cp_prune'
+        dir_name = dir_path.lstrip('/')
+        peer_spec = "client.mirror_remote@ceph"
+        snap_names = [f'snap{i}' for i in range(keep_count + 2)]
+        expected_kept = snap_names[-keep_count:]
+        expected_pruned = snap_names[:-keep_count]
+
+        # Override keep_count so this test also covers config update pickup
+        self.config_set('client.mirror', 'cephfs_mirror_checkpoint_keep_count',
+                        keep_count)
+        self.addCleanup(self.config_rm, 'client.mirror',
+                        'cephfs_mirror_checkpoint_keep_count')
+
+        self._setup_mirrored_directory(dir_path, peer_spec=peer_spec, mount_b=True)
+
+        for snap_name in snap_names:
+            self._add_checkpoint_snapshot(dir_path, snap_name)
+
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, dir_path, snap_names[-1], len(snap_names))
+        self.check_checkpoint_statuses(
+            self.primary_fs_name, dir_path, snap_names, 'complete')
+
+        res = self.checkpoint_list(self.primary_fs_name, dir_path)
+        self.assertEqual(len(res['checkpoints']), len(snap_names))
+
+        # Re-acquire directories so initialize_checkpoints() prunes already-COMPLETE
+        self.restart_mirror_daemon()
+
+        self.check_checkpoint_list_snap_names(
+            self.primary_fs_name, dir_path, expected_kept)
+        self.check_checkpoint_statuses(
+            self.primary_fs_name, dir_path, expected_kept, 'complete')
+        for snap_name in expected_pruned:
+            self.assert_checkpoint_not_listed(
+                self.primary_fs_name, dir_path, snap_name)
+
+        # Prune removes checkpoint metadata only; snapshots remain
+        snap_list = self.mount_a.ls(path=f'{dir_name}/.snap')
+        for snap_name in snap_names:
+            self.assertIn(snap_name, snap_list)
+
+        self._teardown_mirroring(dir_path, peer_spec)
+
+    def test_checkpoint_auto_prune_on_checkpoint_add(self):
+        """checkpoint add triggers initialize_checkpoints() and prunes old COMPLETE.
+
+        After more than the default keep_count COMPLETE checkpoints exist, adding
+        a checkpoint on a newly synced snapshot sends an acquire notify. The new
+        checkpoint is marked COMPLETE in that pass (so it is not pruned), while
+        older already-COMPLETE checkpoints are removed down to the default
+        cephfs_mirror_checkpoint_keep_count (10).
+        """
+        keep_count = 10  # default cephfs_mirror_checkpoint_keep_count
+        dir_path = '/cp_prune_add'
+        dir_name = dir_path.lstrip('/')
+        peer_spec = "client.mirror_remote@ceph"
+        existing = [f'snap{i}' for i in range(keep_count + 2)]
+        new_snap = f'snap{len(existing)}'
+        # already-COMPLETE after prune: newest (keep_count - 1), plus the new one
+        expected_kept = existing[-(keep_count - 1):] + [new_snap]
+        expected_pruned = existing[:-(keep_count - 1)]
+
+        self._setup_mirrored_directory(dir_path, peer_spec=peer_spec, mount_b=True)
+
+        for snap_name in existing:
+            self._add_checkpoint_snapshot(dir_path, snap_name)
+
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, dir_path, existing[-1], len(existing))
+        self.check_checkpoint_statuses(
+            self.primary_fs_name, dir_path, existing, 'complete')
+
+        # Sync one more snapshot, then checkpoint it to trigger initialize/prune
+        self.mount_a.run_shell(["mkdir", f"{dir_name}/.snap/{new_snap}"])
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, dir_path, new_snap, len(existing) + 1)
+        self.checkpoint_add(self.primary_fs_name, dir_path, new_snap)
+
+        self.check_checkpoint_list_snap_names(
+            self.primary_fs_name, dir_path, expected_kept)
+        self.check_checkpoint_statuses(
+            self.primary_fs_name, dir_path, expected_kept, 'complete')
+        for snap_name in expected_pruned:
+            self.assert_checkpoint_not_listed(
+                self.primary_fs_name, dir_path, snap_name)
+
+        snap_list = self.mount_a.ls(path=f'{dir_name}/.snap')
+        for snap_name in existing + [new_snap]:
+            self.assertIn(snap_name, snap_list)
 
         self._teardown_mirroring(dir_path, peer_spec)
 

--- a/src/common/options/cephfs-mirror.yaml.in
+++ b/src/common/options/cephfs-mirror.yaml.in
@@ -115,6 +115,19 @@ options:
   services:
   - cephfs-mirror
   min: 1
+- name: cephfs_mirror_checkpoint_keep_count
+  type: uint
+  level: advanced
+  desc: maximum number of completed mirroring checkpoints retained per directory
+  long_desc: when more than this many COMPLETE checkpoints exist under a mirrored
+    directory, initialize_checkpoints() removes the oldest ones (by snapshot id),
+    keeping only the newest. That path runs lazily from the tick thread when a
+    directory is acquired or a checkpoint is added (not on every tick). CREATED
+    and FAILED checkpoints are never pruned.
+  default: 10
+  services:
+  - cephfs-mirror
+  min: 1
 - name: cephfs_mirror_max_consecutive_failures_per_directory
   type: uint
   level: advanced

--- a/src/tools/cephfs_mirror/Checkpoint.cc
+++ b/src/tools/cephfs_mirror/Checkpoint.cc
@@ -166,5 +166,20 @@ int write_checkpoint_metadata(CephContext *cct, MountRef mnt,
   return 0;
 }
 
+int remove_checkpoint_metadata(MountRef mnt, const std::string &snap_path,
+                               const std::map<std::string, std::string> &snap_metadata) {
+  for (const auto &key : CHECKPOINT_METADATA_KEY_LIST) {
+    if (!snap_metadata.count(key)) {
+      continue;
+    }
+    int r = ceph_do_snap_md_op(mnt, snap_path.c_str(), key.c_str(), "",
+                               CEPH_SNAP_MD_OP_REMOVE);
+    if (r < 0) {
+      return r;
+    }
+  }
+  return 0;
+}
+
 } // namespace mirror
 } // namespace cephfs

--- a/src/tools/cephfs_mirror/Checkpoint.h
+++ b/src/tools/cephfs_mirror/Checkpoint.h
@@ -82,6 +82,10 @@ int write_checkpoint_metadata(CephContext *cct, MountRef mnt,
                               const std::map<std::string, std::string> &snap_metadata,
                               const CheckpointInfo &info);
 
+// Remove all checkpoint metadata keys from a snapshot
+int remove_checkpoint_metadata(MountRef mnt, const std::string &snap_path,
+                               const std::map<std::string, std::string> &snap_metadata);
+
 // Check if checkpoint key exists in snapshot metadata
 inline bool has_checkpoint(const std::map<std::string, std::string> &snap_metadata) {
   return snap_metadata.find(CHECKPOINT_STATUS_KEY) != snap_metadata.end();

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -1470,6 +1470,12 @@ void PeerReplayer::initialize_checkpoints(const std::string &dir_root) {
 
   dout(10) << ": remote_highest_snap_id=" << remote_highest_snap_id << dendl;
 
+  // Already-COMPLETE checkpoints (oldest first). Do not include checkpoints
+  // promoted to COMPLETE in this pass so a newly added checkpoint is not
+  // immediately pruned before the user can observe it.
+  std::vector<std::pair<uint64_t, std::string>> already_complete;
+  size_t newly_complete = 0;
+
   // Iterate through local snapshots and mark checkpoints as COMPLETE
   // if their snap_id is <= remote_highest_snap_id
   for (const auto &[snap_id, snap_name] : local_snap_map) {
@@ -1507,8 +1513,57 @@ void PeerReplayer::initialize_checkpoints(const std::string &dir_root) {
       } else {
         dout(10) << ": successfully marked checkpoint as COMPLETE for snap_id=" << snap_id
                  << " snap_name=" << snap_name << dendl;
+        ++newly_complete;
       }
+    } else if (info.status == CheckpointStatus::COMPLETE) {
+      already_complete.emplace_back(snap_id, snap_name);
     }
+  }
+
+  prune_old_synced_checkpoints(dir_root, already_complete, newly_complete);
+}
+
+void PeerReplayer::prune_old_synced_checkpoints(
+    const std::string &dir_root,
+    const std::vector<std::pair<uint64_t, std::string>> &already_complete,
+    size_t newly_complete) {
+  auto keep_count = g_ceph_context->_conf.get_val<uint64_t>(
+    "cephfs_mirror_checkpoint_keep_count");
+
+  size_t total_complete = already_complete.size() + newly_complete;
+  if (total_complete <= keep_count || already_complete.empty()) {
+    dout(20) << ": nothing to prune, already_complete=" << already_complete.size()
+             << " newly_complete=" << newly_complete
+             << " keep_count=" << keep_count << dendl;
+    return;
+  }
+
+  size_t to_remove = std::min(already_complete.size(),
+                              total_complete - keep_count);
+  dout(5) << ": pruning " << to_remove << " old COMPLETE checkpoint(s) under "
+          << dir_root << " (already_complete=" << already_complete.size()
+          << " newly_complete=" << newly_complete
+          << " keep_count=" << keep_count << ")" << dendl;
+
+  for (size_t i = 0; i < to_remove; ++i) {
+    const auto &[snap_id, snap_name] = already_complete[i];
+    auto snap_path = snapshot_path(m_cct, dir_root, snap_name);
+    std::map<std::string, std::string> snap_metadata;
+    int r = read_snap_metadata(m_local_mount, snap_path, &snap_metadata);
+    if (r < 0) {
+      derr << ": failed to read snap metadata for prune snap_id=" << snap_id
+           << " snap_name=" << snap_name << ": " << cpp_strerror(r) << dendl;
+      continue;
+    }
+    r = remove_checkpoint_metadata(m_local_mount, snap_path, snap_metadata);
+    if (r < 0) {
+      derr << ": failed to prune checkpoint for snap_id=" << snap_id
+           << " snap_name=" << snap_name << " dir_root=" << dir_root
+           << ": " << cpp_strerror(r) << dendl;
+      continue;
+    }
+    dout(10) << ": pruned COMPLETE checkpoint snap_id=" << snap_id
+             << " snap_name=" << snap_name << dendl;
   }
 }
 

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -785,6 +785,10 @@ private:
                      bool is_remote=false);
 
   void initialize_checkpoints(const std::string &dir_root);
+  void prune_old_synced_checkpoints(
+      const std::string &dir_root,
+      const std::vector<std::pair<uint64_t, std::string>> &already_complete,
+      size_t newly_complete);
   void checkpoint_sync_complete(const std::string &dir_root, uint64_t synced_snap_id,
                                 const std::string &snap_name);
   void checkpoint_sync_failed(const std::string &dir_root, uint64_t snap_id,


### PR DESCRIPTION
Keep only the newest N COMPLETE checkpoints per directory (cephfs_mirror_checkpoint_keep_count, default 10). Prune lazily from initialize_checkpoints() so work runs only on directory acquire / checkpoint add, reuses the existing snap scan, and does not drop checkpoints promoted to COMPLETE in the same pass.

Fixes: https://tracker.ceph.com/issues/77437


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
