### PR TITLE
tentacle: os/bluestore: do not add expanded space to allocator after allocmap recovery

### DIFF
--- a/qa/standalone/osd/osd-bluefs-volume-ops.sh
+++ b/qa/standalone/osd/osd-bluefs-volume-ops.sh
@@ -19,18 +19,14 @@ function run() {
 function TEST_bluestore() {
     local dir=$1
 
-    local flimit=$(ulimit -n)
-    if [ $flimit -lt 1536 ]; then
-        echo "Low open file limit ($flimit), test may fail. Increase to 1536 or higher and retry if that happens."
-    fi
     export CEPH_MON="127.0.0.1:7146" # git grep '\<7146\>' : there must be only one
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
-    CEPH_ARGS+="--bluestore_block_size=2147483648 "
+    CEPH_ARGS+="--bluestore_block_size=2G "
     CEPH_ARGS+="--bluestore_block_db_create=true "
-    CEPH_ARGS+="--bluestore_block_db_size=1073741824 "
-    CEPH_ARGS+="--bluestore_block_wal_size=1073741824 "
+    CEPH_ARGS+="--bluestore_block_db_size=1G "
+    CEPH_ARGS+="--bluestore_block_wal_size=1G "
     CEPH_ARGS+="--bluestore_block_wal_create=true "
     CEPH_ARGS+="--bluestore_fsck_on_mount=true "
     #choosing randomly allocation from file
@@ -345,17 +341,13 @@ function TEST_bluestore() {
 function TEST_bluestore2() {
     local dir=$1
 
-    local flimit=$(ulimit -n)
-    if [ $flimit -lt 1536 ]; then
-        echo "Low open file limit ($flimit), test may fail. Increase to 1536 or higher and retry if that happens."
-    fi
     export CEPH_MON="127.0.0.1:7146" # git grep '\<7146\>' : there must be only one
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
-    CEPH_ARGS+="--bluestore_block_size=4294967296 "
+    CEPH_ARGS+="--bluestore_block_size=4G "
     CEPH_ARGS+="--bluestore_block_db_create=true "
-    CEPH_ARGS+="--bluestore_block_db_size=1073741824 "
+    CEPH_ARGS+="--bluestore_block_db_size=1G "
     CEPH_ARGS+="--bluestore_block_wal_create=false "
     CEPH_ARGS+="--bluestore_fsck_on_mount=true "
     CEPH_ARGS+="--osd_pool_default_size=1 "
@@ -411,17 +403,13 @@ function TEST_bluestore2() {
 function TEST_bluestore_expand() {
     local dir=$1
 
-    local flimit=$(ulimit -n)
-    if [ $flimit -lt 1536 ]; then
-        echo "Low open file limit ($flimit), test may fail. Increase to 1536 or higher and retry if that happens."
-    fi
     export CEPH_MON="127.0.0.1:7146" # git grep '\<7146\>' : there must be only one
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
-    CEPH_ARGS+="--bluestore_block_size=4294967296 "
+    CEPH_ARGS+="--bluestore_block_size=4G "
     CEPH_ARGS+="--bluestore_block_db_create=true "
-    CEPH_ARGS+="--bluestore_block_db_size=1073741824 "
+    CEPH_ARGS+="--bluestore_block_db_size=1G "
     CEPH_ARGS+="--bluestore_block_wal_create=false "
     CEPH_ARGS+="--bluestore_fsck_on_mount=true "
     CEPH_ARGS+="--osd_pool_default_size=1 "

--- a/qa/standalone/osd/osd-bluefs-volume-ops.sh
+++ b/qa/standalone/osd/osd-bluefs-volume-ops.sh
@@ -338,6 +338,8 @@ function TEST_bluestore() {
     timeout 60 rados bench -p foo 15 write -b 4096 --no-cleanup #|| return 1
 
     wait_for_clean || return 1
+    echo PASSED
+    return 0
 }
 
 function TEST_bluestore2() {
@@ -401,6 +403,9 @@ function TEST_bluestore2() {
     osd_pid0=$(cat $dir/osd.0.pid)
 
     wait_for_clean || return 1
+
+    echo PASSED
+    return 0
 }
 
 function TEST_bluestore_expand() {
@@ -485,8 +490,92 @@ function TEST_bluestore_expand() {
     ceph osd down 0
 
     ceph-bluestore-tool --log-file $dir/bluestore_tool.log --path $dir/0 qfsck || return 1
+
+    echo PASSED
+    return 0
 }
 
+function TEST_bluestore_expand_with_allocmap_recovery() {
+    local dir=$1
+
+    export CEPH_MON="127.0.0.1:7146" # git grep '\<7146\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON "
+    CEPH_ARGS+="--bluestore_block_size=2G "
+    CEPH_ARGS+="--bluestore_block_db_create=true "
+    CEPH_ARGS+="--bluestore_block_db_size=1G "
+    CEPH_ARGS+="--bluestore_block_wal_size=1G "
+    CEPH_ARGS+="--bluestore_block_wal_create=true "
+    CEPH_ARGS+="--bluestore_fsck_on_mount=true "
+    CEPH_ARGS+="--osd_pool_default_size=1 "
+    CEPH_ARGS+="--osd_pool_default_min_size=1 "
+    CEPH_ARGS+="--bluestore_debug_enforce_settings=ssd "
+    CEPH_ARGS+="--bluestore_allocation_from_file=1 "
+
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    run_osd $dir 0 || return 1
+    osd_pid0=$(cat $dir/osd.0.pid)
+
+    run_osd $dir 1 || return 1
+    osd_pid1=$(cat $dir/osd.1.pid)
+
+    sleep 5
+
+    create_pool foo 16
+
+    # write some objects
+    timeout 60 rados bench -p foo 5 write -b 4096 --no-cleanup #|| return 1
+
+    echo "after bench"
+
+    # kill OSD.0 non-gracefully
+    while kill -9 $osd_pid0; do sleep 1 ; done
+    ceph osd down 0
+
+    # kill OSD.1 [hopefully] gracefully
+    while kill $osd_pid1; do sleep 1 ; done
+    ceph osd down 1
+
+    available0=$( ceph-objectstore-tool --data-path $dir/0 --op statfs --no-mon-config --format json-pretty | jq ".available" )
+    truncate $dir/0/block -s +2G # 4GB total
+
+    ceph-bluestore-tool --path $dir/0 bluefs-bdev-expand || return 1
+
+    available=$( ceph-objectstore-tool --data-path $dir/0 --op statfs --no-mon-config --format json-pretty | jq ".available" )
+    if [ $(($available-$available0)) -le $((1<<30)) ]; then
+        # Failed to get large enough available space increase
+        echo $available0 " -> " $available ", failed to expand?"
+        return 1
+    fi
+
+    available0=$( ceph-objectstore-tool --data-path $dir/1 --op statfs --no-mon-config --format json-pretty | jq ".available" )
+    truncate $dir/1/block -s +2G # 4GB total
+
+    ceph-bluestore-tool --path $dir/1 bluefs-bdev-expand || return 1
+
+    available=$( ceph-objectstore-tool --data-path $dir/1 --op statfs --no-mon-config --format json-pretty | jq ".available" )
+    if [ $(($available-$available0)) -le $((1<<30)) ]; then
+        # Failed to get large enough available space increase
+        echo $available0 " -> " $available ", failed to expand?"
+        return 1
+    fi
+
+    ceph-bluestore-tool --path $dir/0 fsck || return 1
+    ceph-bluestore-tool --path $dir/1 fsck || return 1
+
+    activate_osd $dir 0 || return 1
+    osd_pid0=$(cat $dir/osd.0.pid)
+
+    activate_osd $dir 1 || return 1
+    osd_pid1=$(cat $dir/osd.1.pid)
+
+    wait_for_clean || return 1
+
+    echo PASSED
+    return 0
+}
 main osd-bluefs-volume-ops "$@"
 
 # Local Variables:

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5672,14 +5672,16 @@ options:
 - name: bluestore_debug_enforce_settings
   type: str
   level: dev
-  desc: Enforces specific hw profile settings
-  long_desc: '''hdd'' enforces settings intended for BlueStore above a rotational
-    drive. ''ssd'' enforces settings intended for BlueStore above a solid drive. ''default''
-    - using settings for the actual hardware.'
+  desc: Enforces specific hardware profile settings
+  long_desc: '''hybrid'' enforces osd settings applicable to hybrid
+    (AKA main=hdd, db/wal=ssd) disk setup.
+    ''ssd'' enforces osd settings applicable to all-flash disk setup.
+    ''default'' specifies automatic settings selection based on real
+    detected hardware.'
   default: default
   enum_values:
   - default
-  - hdd
+  - hybrid
   - ssd
   with_legacy: true
 - name: bluestore_allocator_lookup_policy

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -844,6 +844,7 @@ public:
   int unlink(std::string_view dirname, std::string_view filename);
   int mkdir(std::string_view dirname);
   int rmdir(std::string_view dirname);
+
   bool wal_is_rotational();
   bool db_is_rotational();
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7564,12 +7564,13 @@ int BlueStore::_lock_fsid()
   return 0;
 }
 
-bool BlueStore::is_rotational()
+bool BlueStore::_is_main_rotational()
 {
   if (bdev) {
     return bdev->is_rotational();
   }
 
+  // Do open main devicet if not yet opened.
   bool rotational = true;
   int r = _open_path();
   if (r < 0)
@@ -7596,37 +7597,58 @@ bool BlueStore::is_rotational()
   return rotational;
 }
 
+bool BlueStore::is_rotational()
+{
+  return _use_rotational_settings();
+}
+
 bool BlueStore::is_journal_rotational()
 {
   if (!bluefs) {
-    dout(5) << __func__ << " bluefs disabled, default to store media type"
+    dout(5) << __func__ << " bluefs disabled, default to main device type"
             << dendl;
-    return is_rotational();
+    return _use_rotational_settings();
   }
-  dout(10) << __func__ << " " << (int)bluefs->wal_is_rotational() << dendl;
-  return bluefs->wal_is_rotational();
+  if (cct->_conf->bluestore_debug_enforce_settings == "ssd" ||
+             cct->_conf->bluestore_debug_enforce_settings == "hybrid") {
+    dout(10) << __func__ << " overriden to ssd mode." << dendl;
+    return false;
+  }
+  bool r = bluefs->wal_is_rotational();
+  dout(10) << __func__ << " " << (int)r << dendl;
+  return r;
 }
 
 bool BlueStore::is_db_rotational()
 {
   if (!bluefs) {
-    dout(5) << __func__ << " bluefs disabled, default to store media type"
+    dout(5) << __func__ << " bluefs disabled, default to main device type"
             << dendl;
-    return is_rotational();
+    return _use_rotational_settings();
   }
-  dout(10) << __func__ << " " << (int)bluefs->db_is_rotational() << dendl;
-  return bluefs->db_is_rotational();
+  if (cct->_conf->bluestore_debug_enforce_settings == "ssd" ||
+             cct->_conf->bluestore_debug_enforce_settings == "hybrid") {
+    dout(10) << __func__ << " overriden to ssd mode." << dendl;
+    return false;
+  }
+  bool r = bluefs->db_is_rotational();
+  dout(10) << __func__ << " " << (int)r << dendl;
+  return r;
 }
 
 bool BlueStore::_use_rotational_settings()
 {
-  if (cct->_conf->bluestore_debug_enforce_settings == "hdd") {
-    return true;
-  }
   if (cct->_conf->bluestore_debug_enforce_settings == "ssd") {
+    dout(10) << __func__ << " overriden to ssd." << dendl;
     return false;
   }
-  return bdev->is_rotational();
+  if (cct->_conf->bluestore_debug_enforce_settings == "hybrid") {
+    dout(10) << __func__ << " overriden to hdd." << dendl;
+    return true;
+  }
+  bool r = _is_main_rotational();
+  dout(0) << __func__ << " returns " << r << dendl;
+  return r;
 }
 
 bool BlueStore::is_statfs_recoverable() const

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7417,6 +7417,13 @@ int BlueStore::_init_alloc()
     }
     if (restore_allocator(alloc, &num, &bytes) == 0) {
       dout(5) << __func__ << "::NCB::restore_allocator() completed successfully alloc=" << alloc << dendl;
+      if (before_expansion_bdev_size > 0 &&
+          before_expansion_bdev_size < bdev_label.size) {
+        // we grow the allocation range, must reflect it in the allocation file
+        alloc->init_add_free(before_expansion_bdev_size,
+                             bdev_label.size - before_expansion_bdev_size);
+        need_to_destage_allocation_file = true;
+      }
     } else {
       // This must mean that we had an unplanned shutdown and didn't manage to destage the allocator
       dout(0) << __func__ << "::NCB::restore_allocator() failed! Run Full Recovery from ONodes (might take a while) ..." << dendl;
@@ -7427,13 +7434,6 @@ int BlueStore::_init_alloc()
 	derr << __func__ << "::NCB::If no HW fault is found, please report failure and consider redeploying OSD" << dendl;
 	return -ENOTRECOVERABLE;
       }
-    }
-    if (before_expansion_bdev_size > 0 &&
-        before_expansion_bdev_size < bdev_label.size) {
-      // we grow the allocation range, must reflect it in the allocation file
-      alloc->init_add_free(before_expansion_bdev_size,
-                           bdev_label.size - before_expansion_bdev_size);
-      need_to_destage_allocation_file = true;    
     }
   }
   before_expansion_bdev_size = 0;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -4001,6 +4001,7 @@ private:
   std::array<std::tuple<uint64_t, uint64_t, uint64_t>, 5> alloc_stats_history =
   { std::make_tuple(0ul, 0ul, 0ul) };
 
+  bool _is_main_rotational();
   inline bool _use_rotational_settings();
 
 public:

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -1593,7 +1593,7 @@ TEST_P(StoreTestSpecificAUSize, ReproBug41901Test) {
 
   SetVal(g_conf(), "bluestore_write_v2", "false");
   SetVal(g_conf(), "bluestore_max_blob_size", "524288");
-  SetVal(g_conf(), "bluestore_debug_enforce_settings", "hdd");
+  SetVal(g_conf(), "bluestore_debug_enforce_settings", "hybrid");
   g_conf().apply_changes(nullptr);
   StartDeferred(65536);
 
@@ -9688,7 +9688,7 @@ TEST_P(StoreTestSpecificAUSize, ReproBug56488Test) {
   size_t alloc_size = 65536;
   size_t write_size = 4096;
   SetVal(g_conf(), "bluestore_write_v2", "false");
-  SetVal(g_conf(), "bluestore_debug_enforce_settings", "hdd");
+  SetVal(g_conf(), "bluestore_debug_enforce_settings", "hybrid");
   SetVal(g_conf(), "bluestore_block_db_create", "true");
   SetVal(g_conf(), "bluestore_block_db_size", stringify(1 << 30).c_str());
 
@@ -11378,7 +11378,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreEnforceHWSettingsHdd) {
     return;
 
   SetVal(g_conf(), "bluestore_write_v2", "false");
-  SetVal(g_conf(), "bluestore_debug_enforce_settings", "hdd");
+  SetVal(g_conf(), "bluestore_debug_enforce_settings", "hybrid");
   StartDeferred(0x1000);
 
   int r;
@@ -11736,7 +11736,7 @@ TEST_P(StoreTestSpecificAUSize, Ticket45195Repro) {
 
   SetVal(g_conf(), "bluestore_default_buffered_write", "true");
   SetVal(g_conf(), "bluestore_max_blob_size", "65536");
-  SetVal(g_conf(), "bluestore_debug_enforce_settings", "hdd");
+  SetVal(g_conf(), "bluestore_debug_enforce_settings", "hybrid");
   SetVal(g_conf(), "bluestore_fsck_on_mount", "false");
   g_conf().apply_changes(nullptr);
 


### PR DESCRIPTION
Parent tracker: https://tracker.ceph.com/issues/75852
Backport tracker: https://tracker.ceph.com/issues/78216
Backports: https://github.com/ceph/ceph/pull/68503


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
