### PR TITLE
squid: rgw: Fix crashes on realm reload

### DIFF
--- a/src/common/async/context_pool.h
+++ b/src/common/async/context_pool.h
@@ -17,7 +17,6 @@
 #define CEPH_COMMON_ASYNC_CONTEXT_POOL_H
 
 #include <concepts>
-#include <cstddef>
 #include <cstdint>
 #include <mutex>
 #include <optional>
@@ -53,7 +52,7 @@ public:
   }
   template<std::invocable<> Init>
   io_context_pool(std::int64_t threadcnt, Init&& init) noexcept {
-    start(threadcnt, std::move(init));
+    start(threadcnt, std::forward<Init>(init));
   }
   ~io_context_pool() {
     stop();
@@ -79,8 +78,8 @@ public:
       ioctx.restart();
       for (std::int16_t i = 0; i < threadcnt; ++i) {
 	threadvec.emplace_back(make_named_thread("io_context_pool",
-						 [this, init=std::move(init)] {
-						   std::move(init)();
+						 [this, init] {
+						   init();
 						   ioctx.run();
 						 }));
       }

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -1239,6 +1239,41 @@ int RGWRados::init_complete(const DoutPrefixProvider *dpp, optional_yield y)
   auto& zone_params = svc.zone->get_zone_params();
   auto& zone = svc.zone->get_zone();
 
+  binfo_cache = new RGWChainedCacheImpl<bucket_info_entry>;
+  binfo_cache->init(svc.cache);
+
+  topic_cache = new RGWChainedCacheImpl<pubsub_bucket_topics_entry>;
+  topic_cache->init(svc.cache);
+
+  lc = new RGWLC();
+  lc->initialize(cct, this->driver);
+
+  quota_handler = RGWQuotaHandler::generate_handler(dpp, this->driver, quota_threads);
+
+  bucket_index_max_shards = (cct->_conf->rgw_override_bucket_index_max_shards ? cct->_conf->rgw_override_bucket_index_max_shards :
+                             zone.bucket_index_max_shards);
+  if (bucket_index_max_shards > get_max_bucket_shards()) {
+    bucket_index_max_shards = get_max_bucket_shards();
+    ldpp_dout(dpp, 1) << __func__ << " bucket index max shards is too large, reset to value: "
+      << get_max_bucket_shards() << dendl;
+  }
+  ldpp_dout(dpp, 20) << __func__ << " bucket index max shards: " << bucket_index_max_shards << dendl;
+
+  bool need_tombstone_cache = !svc.zone->get_zone_data_notify_to_map().empty(); /* have zones syncing from us */
+
+  if (need_tombstone_cache) {
+    obj_tombstone_cache = new tombstone_cache_t(cct->_conf->rgw_obj_tombstone_cache_size);
+  }
+
+  reshard_wait = std::make_shared<RGWReshardWait>();
+
+  reshard = new RGWReshard(this->driver);
+
+  // disable reshard thread based on zone/zonegroup support
+  run_reshard_thread = run_reshard_thread && svc.zone->can_reshard();
+
+  index_completion_manager = new RGWIndexCompletionManager(this);
+
   /* no point of running sync thread if we don't have a master zone configured
     or there is no rest_master_conn */
   if (!svc.zone->need_to_sync()) {
@@ -1317,47 +1352,12 @@ int RGWRados::init_complete(const DoutPrefixProvider *dpp, optional_yield y)
     data_notifier->start();
   }
 
-  binfo_cache = new RGWChainedCacheImpl<bucket_info_entry>;
-  binfo_cache->init(svc.cache);
-
-  topic_cache = new RGWChainedCacheImpl<pubsub_bucket_topics_entry>;
-  topic_cache->init(svc.cache);
-
-  lc = new RGWLC();
-  lc->initialize(cct, this->driver);
-
   if (use_lc_thread)
     lc->start_processor();
-
-  quota_handler = RGWQuotaHandler::generate_handler(dpp, this->driver, quota_threads);
-
-  bucket_index_max_shards = (cct->_conf->rgw_override_bucket_index_max_shards ? cct->_conf->rgw_override_bucket_index_max_shards :
-                             zone.bucket_index_max_shards);
-  if (bucket_index_max_shards > get_max_bucket_shards()) {
-    bucket_index_max_shards = get_max_bucket_shards();
-    ldpp_dout(dpp, 1) << __func__ << " bucket index max shards is too large, reset to value: "
-      << get_max_bucket_shards() << dendl;
-  }
-  ldpp_dout(dpp, 20) << __func__ << " bucket index max shards: " << bucket_index_max_shards << dendl;
-
-  bool need_tombstone_cache = !svc.zone->get_zone_data_notify_to_map().empty(); /* have zones syncing from us */
-
-  if (need_tombstone_cache) {
-    obj_tombstone_cache = new tombstone_cache_t(cct->_conf->rgw_obj_tombstone_cache_size);
-  }
-
-  reshard_wait = std::make_shared<RGWReshardWait>();
-
-  reshard = new RGWReshard(this->driver);
-
-  // disable reshard thread based on zone/zonegroup support
-  run_reshard_thread = run_reshard_thread && svc.zone->can_reshard();
 
   if (run_reshard_thread)  {
     reshard->start_processor();
   }
-
-  index_completion_manager = new RGWIndexCompletionManager(this);
 
   if (run_notification_thread) {
     if (!rgw::notify::init(dpp, driver, *svc.site)) {

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -42,6 +42,7 @@
 
 #include "rgw_zone.h"
 
+#include "rgw_asio_frontend_connection.h"
 #include "rgw_asio_frontend_timer.h"
 #include "rgw_dmclock_async_scheduler.h"
 
@@ -55,13 +56,11 @@ namespace http = boost::beast::http;
 namespace ssl = boost::asio::ssl;
 #endif
 
-struct Connection;
-
 using timeout_timer = rgw::basic_timeout_timer<ceph::coarse_mono_clock,
-      boost::asio::any_io_executor, Connection>;
+      boost::asio::any_io_executor, rgw::asio::Connection>;
 
-static constexpr size_t parse_buffer_size = 65536;
-using parse_buffer = boost::beast::flat_static_buffer<parse_buffer_size>;
+static constexpr size_t parse_buffer_size = rgw::asio::parse_buffer_size;
+using parse_buffer = rgw::asio::parse_buffer;
 
 // use mmap/mprotect to allocate 512k coroutine stacks
 auto make_stack_allocator() {
@@ -390,56 +389,8 @@ void handle_connection(boost::asio::io_context& context,
   }
 }
 
-// timeout support requires that connections are reference-counted, because the
-// timeout_handler can outlive the coroutine
-struct Connection : boost::intrusive::list_base_hook<>,
-                    boost::intrusive_ref_counter<Connection>
-{
-  tcp::socket socket;
-  parse_buffer buffer;
-
-  explicit Connection(tcp::socket&& socket) noexcept
-      : socket(std::move(socket)) {}
-
-  void close(boost::system::error_code& ec) {
-    socket.close(ec);
-  }
-
-  tcp::socket& get_socket() { return socket; }
-};
-
-class ConnectionList {
-  using List = boost::intrusive::list<Connection>;
-  List connections;
-  std::mutex mutex;
-
-  void remove(Connection& c) {
-    std::lock_guard lock{mutex};
-    if (c.is_linked()) {
-      connections.erase(List::s_iterator_to(c));
-    }
-  }
- public:
-  class Guard {
-    ConnectionList *list;
-    Connection *conn;
-   public:
-    Guard(ConnectionList *list, Connection *conn) : list(list), conn(conn) {}
-    ~Guard() { list->remove(*conn); }
-  };
-  [[nodiscard]] Guard add(Connection& conn) {
-    std::lock_guard lock{mutex};
-    connections.push_back(conn);
-    return Guard{this, &conn};
-  }
-  void close(boost::system::error_code& ec) {
-    std::lock_guard lock{mutex};
-    for (auto& conn : connections) {
-      conn.socket.close(ec);
-    }
-    connections.clear();
-  }
-};
+using rgw::asio::Connection;
+using rgw::asio::ConnectionList;
 
 namespace dmc = rgw::dmclock;
 class AsioFrontend {

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -1125,7 +1125,7 @@ void AsioFrontend::on_accept(Listener& l, tcp::socket stream)
 #endif
     boost::asio::spawn(make_strand(context), std::allocator_arg, make_stack_allocator(),
       [this, s=std::move(stream), ssl_ctx] (boost::asio::yield_context yield) mutable {
-        auto conn = boost::intrusive_ptr{new Connection(std::move(s))};
+        auto conn = boost::intrusive_ptr{new Connection(std::move(s), yield.get_executor())};
         auto c = connections.add(*conn);
         // wrap the tcp stream in an ssl stream
         boost::asio::ssl::stream<tcp::socket&> stream{conn->socket, *ssl_ctx};
@@ -1160,7 +1160,7 @@ void AsioFrontend::on_accept(Listener& l, tcp::socket stream)
 #endif // WITH_RADOSGW_BEAST_OPENSSL
     boost::asio::spawn(make_strand(context), std::allocator_arg, make_stack_allocator(),
       [this, s=std::move(stream)] (boost::asio::yield_context yield) mutable {
-        auto conn = boost::intrusive_ptr{new Connection(std::move(s))};
+        auto conn = boost::intrusive_ptr{new Connection(std::move(s), yield.get_executor())};
         auto c = connections.add(*conn);
         auto timeout = timeout_timer{yield.get_executor(), request_timeout, conn};
         boost::system::error_code ec;
@@ -1191,7 +1191,7 @@ void AsioFrontend::stop()
   }
   ssl_reload_timer.cancel();
   // close all connections
-  connections.close(ec);
+  connections.close();
   pause_mutex.cancel();
 }
 

--- a/src/rgw/rgw_asio_frontend_connection.h
+++ b/src/rgw/rgw_asio_frontend_connection.h
@@ -59,9 +59,12 @@ class ConnectionList {
   void close(boost::system::error_code& ec) {
     std::lock_guard lock{mutex};
     for (auto& conn : connections) {
-      conn.socket.close(ec);
+      // cancel pending reactor operations which delivers operation_aborted
+      // to completion handlers and then shutdown the transport so any
+      // subsequent I/O attempts fail immediately.
+      conn.socket.cancel(ec);
+      conn.socket.shutdown(tcp::socket::shutdown_both, ec);
     }
-    connections.clear();
   }
 };
 

--- a/src/rgw/rgw_asio_frontend_connection.h
+++ b/src/rgw/rgw_asio_frontend_connection.h
@@ -35,7 +35,7 @@ struct Connection : boost::intrusive::list_base_hook<>,
 class ConnectionList {
   using List = boost::intrusive::list<Connection>;
   List connections;
-  std::mutex mutex;
+  mutable std::mutex mutex;
 
   void remove(Connection& c) {
     std::lock_guard lock{mutex};
@@ -55,6 +55,10 @@ class ConnectionList {
     std::lock_guard lock{mutex};
     connections.push_back(conn);
     return Guard{this, &conn};
+  }
+  size_t size() const {
+    std::lock_guard lock{mutex};
+    return connections.size();
   }
   void close(boost::system::error_code& ec) {
     std::lock_guard lock{mutex};

--- a/src/rgw/rgw_asio_frontend_connection.h
+++ b/src/rgw/rgw_asio_frontend_connection.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <mutex>
+
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/beast/core/flat_static_buffer.hpp>
+#include <boost/intrusive/list.hpp>
+#include <boost/smart_ptr/intrusive_ref_counter.hpp>
+
+namespace rgw::asio {
+
+using tcp = boost::asio::ip::tcp;
+
+static constexpr size_t parse_buffer_size = 65536;
+using parse_buffer = boost::beast::flat_static_buffer<parse_buffer_size>;
+
+// timeout support requires that connections are reference-counted, because the
+// timeout_handler can outlive the coroutine
+struct Connection : boost::intrusive::list_base_hook<>,
+                    boost::intrusive_ref_counter<Connection>
+{
+  tcp::socket socket;
+  parse_buffer buffer;
+
+  explicit Connection(tcp::socket&& socket) noexcept
+      : socket(std::move(socket)) {}
+
+  void close(boost::system::error_code& ec) {
+    socket.close(ec);
+  }
+
+  tcp::socket& get_socket() { return socket; }
+};
+
+class ConnectionList {
+  using List = boost::intrusive::list<Connection>;
+  List connections;
+  std::mutex mutex;
+
+  void remove(Connection& c) {
+    std::lock_guard lock{mutex};
+    if (c.is_linked()) {
+      connections.erase(List::s_iterator_to(c));
+    }
+  }
+ public:
+  class Guard {
+    ConnectionList *list;
+    Connection *conn;
+   public:
+    Guard(ConnectionList *list, Connection *conn) : list(list), conn(conn) {}
+    ~Guard() { list->remove(*conn); }
+  };
+  [[nodiscard]] Guard add(Connection& conn) {
+    std::lock_guard lock{mutex};
+    connections.push_back(conn);
+    return Guard{this, &conn};
+  }
+  void close(boost::system::error_code& ec) {
+    std::lock_guard lock{mutex};
+    for (auto& conn : connections) {
+      conn.socket.close(ec);
+    }
+    connections.clear();
+  }
+};
+
+} // namespace rgw::asio

--- a/src/rgw/rgw_asio_frontend_connection.h
+++ b/src/rgw/rgw_asio_frontend_connection.h
@@ -2,9 +2,12 @@
 
 #include <mutex>
 
+#include <boost/asio/any_io_executor.hpp>
+#include <boost/asio/dispatch.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/beast/core/flat_static_buffer.hpp>
 #include <boost/intrusive/list.hpp>
+#include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
 
 namespace rgw::asio {
@@ -21,12 +24,19 @@ struct Connection : boost::intrusive::list_base_hook<>,
 {
   tcp::socket socket;
   parse_buffer buffer;
+  // executor of the handle_connection coroutine's strand. used so that close()
+  // from outside the strand (e.g. frontend pause) serializes with coroutine
+  // operations on the socket instead of racing the reactor
+  boost::asio::any_io_executor strand;
+  Connection(tcp::socket&& socket,
+             boost::asio::any_io_executor strand) noexcept
+      : socket(std::move(socket)), strand(std::move(strand)) {}
 
-  explicit Connection(tcp::socket&& socket) noexcept
-      : socket(std::move(socket)) {}
-
-  void close(boost::system::error_code& ec) {
-    socket.close(ec);
+  void close() {
+    boost::asio::dispatch(strand, [c = boost::intrusive_ptr<Connection>{this}] {
+      boost::system::error_code ec;
+      c->socket.close(ec);
+    });
   }
 
   tcp::socket& get_socket() { return socket; }
@@ -60,16 +70,21 @@ class ConnectionList {
     std::lock_guard lock{mutex};
     return connections.size();
   }
-  void close(boost::system::error_code& ec) {
+  void close() {
     std::lock_guard lock{mutex};
     for (auto& conn : connections) {
-      // cancel pending reactor operations which delivers operation_aborted
-      // to completion handlers and then shutdown the transport so any
-      // subsequent I/O attempts fail immediately.
-      conn.socket.cancel(ec);
-      conn.socket.shutdown(tcp::socket::shutdown_both, ec);
+      // dispatch operations to the connection's strand so it serializes with
+      // the handle_connection coroutine.
+      boost::asio::dispatch(
+	  conn.strand, [c = boost::intrusive_ptr<Connection>{&conn}] {
+	    boost::system::error_code ec;
+	    // cancel pending reactor operations which delivers operation_aborted
+	    // to completion handlers and then shutdown the transport so any
+	    // subsequent I/O attempts fail immediately.
+	    c->socket.cancel(ec);
+	    c->socket.shutdown(tcp::socket::shutdown_both, ec);
+	  });
     }
   }
 };
-
 } // namespace rgw::asio

--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -725,7 +725,15 @@ int RGWCoroutinesManager::run(const DoutPrefixProvider *dpp, list<RGWCoroutinesS
       if (ret < 0) {
        ldout(cct, 5) << "completion_mgr.get_next() returned ret=" << ret << dendl;
       }
-      handle_unblocked_stack(context_stacks, scheduled_stacks, io, &blocked_count, &interval_wait_count);
+      // Without this check, `get_next` will error with -ECANCELED and this loop will never exit.
+      if (going_down) {
+        ldout(cct, 5) << __func__ << "(): was stopped, exiting" << dendl;
+        ret = -ECANCELED;
+        canceled = true;
+        break;
+      }
+      handle_unblocked_stack(context_stacks, scheduled_stacks, io,
+                             &blocked_count, &interval_wait_count);
     }
 
 next:

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -324,6 +324,10 @@ if(WITH_RADOSGW_POSIX)
     ${rgw_libs} ${LMDB_LIBRARIES})
 endif(WITH_RADOSGW_POSIX)
 
+add_executable(unittest_rgw_asio_frontend_connection test_rgw_asio_frontend_connection.cc)
+add_ceph_unittest(unittest_rgw_asio_frontend_connection)
+target_link_libraries(unittest_rgw_asio_frontend_connection ${rgw_libs} ${UNITTEST_LIBS})
+
 add_executable(unittest_rgw_tag test_rgw_tag.cc)
 add_ceph_unittest(unittest_rgw_tag)
 target_link_libraries(unittest_rgw_tag ${rgw_libs} ${UNITTEST_LIBS})

--- a/src/test/rgw/test_rgw_asio_frontend_connection.cc
+++ b/src/test/rgw/test_rgw_asio_frontend_connection.cc
@@ -17,6 +17,8 @@
 
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/strand.hpp>
+#include <boost/asio/spawn.hpp>
 #include <boost/asio/write.hpp>
 #include <boost/intrusive_ptr.hpp>
 
@@ -40,52 +42,64 @@ using rgw::asio::ConnectionList;
 TEST(BeastFrontendShutdown, CloseShutdownsButDoesNotCloseSocket)
 {
   asio::io_context ioctx;
-  ConnectionList connections;
+  asio::spawn(
+      ioctx.get_executor(),
+      [&](asio::yield_context yield) -> void {
+        ConnectionList connections;
 
-  tcp::acceptor acceptor(ioctx, tcp::endpoint(tcp::v4(), 0));
-  acceptor.listen(3);
+        tcp::acceptor acceptor(ioctx, tcp::endpoint(tcp::v4(), 0));
+        acceptor.listen(3);
 
-  tcp::socket c0(ioctx), c1(ioctx), c2(ioctx);
-  c0.connect(acceptor.local_endpoint());
-  auto s0 = acceptor.accept();
-  c1.connect(acceptor.local_endpoint());
-  auto s1 = acceptor.accept();
-  c2.connect(acceptor.local_endpoint());
-  auto s2 = acceptor.accept();
+        tcp::socket c0(ioctx), c1(ioctx), c2(ioctx);
+        c0.async_connect(acceptor.local_endpoint(), yield);
+        auto s0 = acceptor.async_accept(yield);
+        c1.async_connect(acceptor.local_endpoint(), yield);
+        auto s1 = acceptor.async_accept(yield);
+        c2.async_connect(acceptor.local_endpoint(), yield);
+        auto s2 = acceptor.async_accept(yield);
 
-  boost::intrusive_ptr<Connection> conns[] = {
-    new Connection(std::move(s0)),
-    new Connection(std::move(s1)),
-    new Connection(std::move(s2)),
-  };
+        boost::intrusive_ptr<Connection> conns[] = {
+            new Connection(
+                std::move(s0), asio::make_strand(yield.get_executor())),
+            new Connection(
+                std::move(s1), asio::make_strand(yield.get_executor())),
+            new Connection(
+                std::move(s2), asio::make_strand(yield.get_executor())),
+        };
 
-  {
-    auto g0 = connections.add(*conns[0]);
-    auto g1 = connections.add(*conns[1]);
-    auto g2 = connections.add(*conns[2]);
+        {
+          auto g0 = connections.add(*conns[0]);
+          auto g1 = connections.add(*conns[1]);
+          auto g2 = connections.add(*conns[2]);
 
-    ASSERT_EQ(3u, connections.size());
+          ASSERT_EQ(3u, connections.size());
 
-    boost::system::error_code ec;
-    connections.close(ec);
+          connections.close();
 
-    // After close(): sockets must still be "open" from boost::asio's
-    // perspective (fd not released, descriptor_data not zeroed).
-    // socket.close() would have set is_open()=false and fd=-1, which is the
-    // thread-safety violation that causes SIGSEGV.
-    for (auto& conn : conns) {
-      EXPECT_TRUE(conn->socket.is_open());
-      EXPECT_GE(conn->socket.native_handle(), 0);
-    }
+          // After close(): sockets must still be "open" from boost::asio's
+          // perspective (fd not released, descriptor_data not zeroed).
+          // socket.close() would have set is_open()=false and fd=-1, which is the
+          // thread-safety violation that causes SIGSEGV.
+          for (auto& conn : conns) {
+            EXPECT_TRUE(conn->socket.is_open());
+            EXPECT_GE(conn->socket.native_handle(), 0);
+          }
 
-    // But the transport is shut down — writes must fail
-    for (auto& conn : conns) {
-      char buf[] = "test";
-      asio::write(conn->socket, asio::buffer(buf), ec);
-      EXPECT_TRUE(ec.failed())
-          << "Write should fail after shutdown";
-    }
-  } // guards destroyed here — connections removed from list
+          // But the transport is shut down — writes must fail
+          for (auto& conn : conns) {
+            boost::system::error_code ec;
+            char buf[] = "test";
+            asio::async_write(conn->socket, asio::buffer(buf), yield[ec]);
+            EXPECT_TRUE(ec.failed()) << "Write should fail after shutdown";
+          }
+        } // guards destroyed here — connections removed from list
 
-  EXPECT_EQ(0u, connections.size());
+        EXPECT_EQ(0u, connections.size());
+      },
+      [](std::exception_ptr eptr) {
+        if (eptr) {
+          std::rethrow_exception(eptr);
+        }
+      });
+  ioctx.run();
 }

--- a/src/test/rgw/test_rgw_asio_frontend_connection.cc
+++ b/src/test/rgw/test_rgw_asio_frontend_connection.cc
@@ -1,0 +1,91 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "rgw/rgw_asio_frontend_connection.h"
+
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/write.hpp>
+#include <boost/intrusive_ptr.hpp>
+
+#include <gtest/gtest.h>
+
+namespace asio = boost::asio;
+using tcp = asio::ip::tcp;
+using rgw::asio::Connection;
+using rgw::asio::ConnectionList;
+
+// Testcases for ConnectionList::close() shutdown behavior.
+//
+// Verifies that close() uses socket.cancel() + ::shutdown() rather than
+// socket.close(). Calling socket.close() from outside the socket's strand
+// is a boost::asio thread-safety violation that can SIGSEGV or orphaned
+// pending operations.
+
+// Verify that ConnectionList::close() does NOT close the sockets (fd stays
+// valid, is_open() remains true) but does shut down the transport (writes
+// fail). This ensures we never call socket.close() from outside the strand.
+TEST(BeastFrontendShutdown, CloseShutdownsButDoesNotCloseSocket)
+{
+  asio::io_context ioctx;
+  ConnectionList connections;
+
+  tcp::acceptor acceptor(ioctx, tcp::endpoint(tcp::v4(), 0));
+  acceptor.listen(3);
+
+  tcp::socket c0(ioctx), c1(ioctx), c2(ioctx);
+  c0.connect(acceptor.local_endpoint());
+  auto s0 = acceptor.accept();
+  c1.connect(acceptor.local_endpoint());
+  auto s1 = acceptor.accept();
+  c2.connect(acceptor.local_endpoint());
+  auto s2 = acceptor.accept();
+
+  boost::intrusive_ptr<Connection> conns[] = {
+    new Connection(std::move(s0)),
+    new Connection(std::move(s1)),
+    new Connection(std::move(s2)),
+  };
+
+  {
+    auto g0 = connections.add(*conns[0]);
+    auto g1 = connections.add(*conns[1]);
+    auto g2 = connections.add(*conns[2]);
+
+    ASSERT_EQ(3u, connections.size());
+
+    boost::system::error_code ec;
+    connections.close(ec);
+
+    // After close(): sockets must still be "open" from boost::asio's
+    // perspective (fd not released, descriptor_data not zeroed).
+    // socket.close() would have set is_open()=false and fd=-1, which is the
+    // thread-safety violation that causes SIGSEGV.
+    for (auto& conn : conns) {
+      EXPECT_TRUE(conn->socket.is_open());
+      EXPECT_GE(conn->socket.native_handle(), 0);
+    }
+
+    // But the transport is shut down — writes must fail
+    for (auto& conn : conns) {
+      char buf[] = "test";
+      asio::write(conn->socket, asio::buffer(buf), ec);
+      EXPECT_TRUE(ec.failed())
+          << "Write should fail after shutdown";
+    }
+  } // guards destroyed here — connections removed from list
+
+  EXPECT_EQ(0u, connections.size());
+}


### PR DESCRIPTION
Original trackers: https://tracker.ceph.com/issues/76094 https://tracker.ceph.com/issues/77658
Backport trackers: https://tracker.ceph.com/issues/78120 https://tracker.ceph.com/issues/78306
Original PRs: https://github.com/ceph/ceph/pull/68920 https://github.com/ceph/ceph/pull/69713

3a099061cff4223a9291d394719cc57fafa6654b is intentionally not included. It was a change to a cleanup (https://github.com/ceph/ceph/pull/66721) that does not need to be backported.