### PR TITLE
test/common: run unittest_throttle serially

### DIFF
--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -166,7 +166,8 @@ add_executable(unittest_throttle
   $<TARGET_OBJECTS:unit-main>
   )
 add_ceph_unittest(unittest_throttle PARALLEL)
-target_link_libraries(unittest_throttle global) 
+set_property(TEST unittest_throttle PROPERTY RUN_SERIAL TRUE)
+target_link_libraries(unittest_throttle global)
 
 # unittest_lru
 add_executable(unittest_lru


### PR DESCRIPTION
`BackoffThrottle` asserts the throttle settles at an occupancy in (35, 45),
but that equilibrium only holds when the getters outrun the putters' drain
rate. Under a saturated ctest run the getters get preempted and occupancy
sags below the band (observed 26.6 < 35), failing the test though the
throttle behaves correctly. Mark it `RUN_SERIAL` so it runs alone.

A CI failure on this: https://github.com/sunyuechi/ceph-ci/actions/runs/29576130264/job/87870870822

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests