### PR TITLE
mgr: Add retry mechanism for failed always-on modules

### DIFF
--- a/src/mgr/ActivePyModule.cc
+++ b/src/mgr/ActivePyModule.cc
@@ -45,11 +45,28 @@ int ActivePyModule::load(ActivePyModules *py_modules)
   Py_DECREF(pModuleName);
   Py_DECREF(pArgs);
   if (pClassInstance == nullptr) {
+    // Capture the exception type name before handle_pyerror() clears the error state.
+    PyObject *ptype = nullptr, *pvalue = nullptr, *ptraceback = nullptr;
+    PyErr_Fetch(&ptype, &pvalue, &ptraceback);
+    if (ptype) {
+      PyObject *name_attr = PyObject_GetAttrString(ptype, "__name__");
+      if (name_attr) {
+        set_load_exception_type(PyUnicode_AsUTF8(name_attr));
+        Py_DECREF(name_attr);
+      }
+      PyErr_Restore(ptype, pvalue, ptraceback); // restore for handle_pyerror()
+    }
+    std::string error_str = handle_pyerror(true, get_name(), "ActivePyModule::load");
     derr << "Failed to construct class in '" << get_name() << "'" << dendl;
-    derr << handle_pyerror(true, get_name(), "ActivePyModule::load") << dendl;
+    derr << error_str << dendl;
+    set_load_error_string(error_str);
+    increment_load_retry_count();
     return -EINVAL;
   } else {
     dout(1) << "Constructed class from module: " << get_name() << dendl;
+    set_load_error_string("");
+    set_load_exception_type("");
+    reset_load_retry_count();
   }
 
   return 0;

--- a/src/mgr/ActivePyModule.h
+++ b/src/mgr/ActivePyModule.h
@@ -49,6 +49,10 @@ private:
 
   std::string m_command_perms;
   const MgrSession* m_session = nullptr;
+
+  std::string load_error_string;
+  std::string load_exception_type;
+  int load_retry_count = 0;
 public:
   Finisher finisher; // per active module finisher to execute commands
 
@@ -111,6 +115,13 @@ public:
 
   bool is_authorized(const std::map<std::string, std::string>& arguments) const;
 
+  const std::string& get_load_error_string() const { return load_error_string; }
+  void set_load_error_string(const std::string& err) { load_error_string = err; }
+  const std::string& get_load_exception_type() const { return load_exception_type; }
+  void set_load_exception_type(const std::string& t) { load_exception_type = t; }
+  int get_load_retry_count() const { return load_retry_count; }
+  void increment_load_retry_count() { ++load_retry_count; }
+  void reset_load_retry_count() { load_retry_count = 0; }
 };
 
 

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -48,6 +48,35 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "mgr " << __func__ << " "
 
+// Retry mechanism constants
+namespace {
+  constexpr int RETRY_MAX_ATTEMPTS = 5;
+  constexpr int RETRY_BASE_INTERVAL_SECS = 10;
+  constexpr int RETRY_CHECK_INTERVAL_SECS = 10;
+
+  // Exception types that represent transient conditions worth retrying.
+  // Anything not in this list is treated as a permanent programming error
+  // and reported immediately without retrying.
+  constexpr std::string_view RETRYABLE_EXCEPTIONS[] = {
+    "ConnectionRefusedError",
+    "ConnectionResetError",
+    "ConnectionError",
+    "OSError",
+    "TimeoutError",
+    "RuntimeError",
+  };
+
+  bool is_retryable_exception(const std::string& exc_type)
+  {
+    for (const auto& name : RETRYABLE_EXCEPTIONS) {
+      if (exc_type == name) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
 using std::pair;
 using std::string;
 using namespace std::literals;
@@ -63,10 +92,10 @@ ActivePyModules::ActivePyModules(
   PyModuleRegistry &pmr, ThreadMonitor *monitor_)
 : module_config(module_config_), daemon_state(ds), cluster_state(cs),
   monc(mc), clog(clog_), audit_clog(audit_clog_), objecter(objecter_),
-  finisher(f),
-  m_thread_monitor(monitor_),
+  finisher(f), m_thread_monitor(monitor_),
   cmd_finisher(g_ceph_context, "cmd_finisher", "cmdfin"),
-  server(server), py_module_registry(pmr)
+  server(server), py_module_registry(pmr),
+  retry_timer(g_ceph_context, lock)
 {
   store_cache = std::move(store_data);
   // we can only trust our ConfigMap if the mon cluster has provided
@@ -74,6 +103,7 @@ ActivePyModules::ActivePyModules(
   have_local_config_map = mon_provides_kv_sub;
   _refresh_config_map();
   cmd_finisher.start();
+  retry_timer.init();
 }
 
 ActivePyModules::~ActivePyModules()
@@ -83,6 +113,11 @@ ActivePyModules::~ActivePyModules()
   // Stop the thread monitor if it was started
   if (m_thread_monitor) {
     m_thread_monitor->stop_monitoring();
+  }
+
+  {
+    std::lock_guard l(lock);
+    retry_timer.shutdown();
   }
 
   // Stop the finisher thread
@@ -553,14 +588,21 @@ PyObject *ActivePyModules::get_python(std::string_view what, const bool get_muta
   return f.get();
 }
 
-void ActivePyModules::start_one(PyModuleRef py_module)
+void ActivePyModules::start_one(PyModuleRef py_module,
+                                 std::shared_ptr<ActivePyModule> active_module)
 {
   std::lock_guard l(lock);
 
   const auto name = py_module->get_name();
-  auto active_module = std::make_shared<ActivePyModule>(py_module, clog, m_thread_monitor);
-
+  
+  // Create new module instance if not provided (normal start)
+  // Reuse existing instance if provided (retry to preserve retry count)
+  if (!active_module) {
+    active_module = std::make_shared<ActivePyModule>(py_module, clog, m_thread_monitor);
+  }
+  
   pending_modules.insert(name);
+  
   // Send all python calls down a Finisher to avoid blocking
   // C++ code, and avoid any potential lock cycles.
   finisher.queue(new LambdaContext([this, active_module, name, py_module](int) {
@@ -578,6 +620,11 @@ void ActivePyModules::start_one(PyModuleRef py_module)
     if (r != 0) {
       derr << "Failed to run module in active mode ('" << name << "')"
            << dendl;
+      
+      if (py_module->is_always_on()) {
+        dout(4) << "Scheduling retry for always-on module '" << name << "'" << dendl;
+        schedule_retry_failed_module(name, py_module, active_module);
+      }
     } else {
       auto em = modules.emplace(name, active_module);
       ceph_assert(em.second); // actually inserted
@@ -591,6 +638,8 @@ void ActivePyModules::start_one(PyModuleRef py_module)
           active_module->thread.get_tid(),
           name, py_module);
       }
+
+      failed_always_on_modules.erase(name);
     }
 
     // Signal when we're finally done starting up modules
@@ -1817,5 +1866,117 @@ void ActivePyModules::check_all_modules_started(Context *modules_start_complete)
     finisher.queue(modules_start_complete);
   } else {
     recheck_modules_start = modules_start_complete; // signal that we need to check again later
+  }
+}
+
+void ActivePyModules::schedule_retry_failed_module(
+    const std::string& module_name,
+    PyModuleRef py_module,
+    std::shared_ptr<ActivePyModule> active_module)
+{
+  const std::string& exc_type = active_module->get_load_exception_type();
+  int retry_count = active_module->get_load_retry_count();
+
+  // Only known transient exceptions are retried. Anything else is assumed to
+  // be a code bug that won't be fixed by waiting — record it permanently.
+  if (!exc_type.empty() && !is_retryable_exception(exc_type)) {
+    dout(1) << "Module '" << module_name << "' failed with non-retryable exception "
+            << exc_type << ", not retrying" << dendl;
+    // Store without a retry time so health reporting can still see the error.
+    FailedModuleInfo info;
+    info.py_module = py_module;
+    info.active_module = active_module;
+    info.next_retry_time = std::chrono::steady_clock::time_point::max();
+    failed_always_on_modules[module_name] = info;
+    return;
+  }
+
+  if (retry_count >= RETRY_MAX_ATTEMPTS) {
+    dout(1) << "Module '" << module_name << "' exceeded max retry attempts ("
+            << RETRY_MAX_ATTEMPTS << "), giving up" << dendl;
+    // Keep in the map so the health check continues to report the error.
+    FailedModuleInfo info;
+    info.py_module = py_module;
+    info.active_module = active_module;
+    info.next_retry_time = std::chrono::steady_clock::time_point::max();
+    failed_always_on_modules[module_name] = info;
+    return;
+  }
+
+  auto retry_interval = std::chrono::seconds(RETRY_BASE_INTERVAL_SECS * retry_count);
+  auto next_retry = std::chrono::steady_clock::now() + retry_interval;
+
+  dout(4) << "Will retry module '" << module_name << "' in "
+          << retry_interval.count() << "s (attempt " << retry_count
+          << "/" << RETRY_MAX_ATTEMPTS << ")" << dendl;
+
+  // Find the current earliest scheduled time before inserting the new entry,
+  // so we can tell if the new module should fire sooner than the existing timer.
+  auto earliest_before = std::chrono::steady_clock::time_point::max();
+  if (retry_event) {
+    for (const auto& [n, info] : failed_always_on_modules) {
+      if (info.next_retry_time < earliest_before) {
+        earliest_before = info.next_retry_time;
+      }
+    }
+  }
+
+  failed_always_on_modules[module_name] = {py_module, active_module, next_retry};
+
+  if (retry_event) {
+    if (next_retry < earliest_before) {
+      // New module fires sooner — cancel the existing timer and reschedule.
+      retry_timer.cancel_event(retry_event);
+      retry_event = nullptr;
+    } else {
+      return; // existing timer is already early enough
+    }
+  }
+
+  retry_event = new LambdaContext([this](int) {
+    retry_failed_modules();
+  });
+  retry_timer.add_event_after(retry_interval.count(), retry_event);
+}
+
+void ActivePyModules::retry_failed_modules()
+{
+  std::vector<std::pair<PyModuleRef, std::shared_ptr<ActivePyModule>>> modules_to_retry;
+
+  {
+    std::lock_guard l(lock);
+    retry_event = nullptr;
+    auto now = std::chrono::steady_clock::now();
+
+    for (auto it = failed_always_on_modules.begin();
+         it != failed_always_on_modules.end(); ) {
+      if (now >= it->second.next_retry_time) {
+        dout(4) << "Retrying failed always-on module '" << it->first << "'" << dendl;
+        modules_to_retry.emplace_back(it->second.py_module, it->second.active_module);
+        it = failed_always_on_modules.erase(it);
+      } else {
+        ++it;
+      }
+    }
+
+    // Only re-arm the poll timer if there are modules still waiting to be
+    // retried (i.e. not permanently failed ones with time_point::max()).
+    bool has_pending_retry = false;
+    for (const auto& [n, info] : failed_always_on_modules) {
+      if (info.next_retry_time != std::chrono::steady_clock::time_point::max()) {
+        has_pending_retry = true;
+        break;
+      }
+    }
+    if (has_pending_retry) {
+      retry_event = new LambdaContext([this](int) {
+        retry_failed_modules();
+      });
+      retry_timer.add_event_after(RETRY_CHECK_INTERVAL_SECS, retry_event);
+    }
+  }
+
+  for (const auto& [py_module, active_module] : modules_to_retry) {
+    start_one(py_module, active_module);
   }
 }

--- a/src/mgr/ActivePyModules.h
+++ b/src/mgr/ActivePyModules.h
@@ -17,6 +17,7 @@
 #include "ActivePyModule.h"
 
 #include "common/Finisher.h"
+#include "common/Timer.h"
 #include "common/ceph_mutex.h"
 
 #include "PyFormatter.h"
@@ -57,6 +58,12 @@ class ActivePyModules
   Context *recheck_modules_start = nullptr;
   // module class instances already created
   std::map<std::string, std::shared_ptr<ActivePyModule>> modules;
+  
+  struct FailedModuleInfo {
+    PyModuleRef py_module;
+    std::shared_ptr<ActivePyModule> active_module;
+    std::chrono::steady_clock::time_point next_retry_time;
+  };
   PyModuleConfig &module_config;
   bool have_local_config_map = false;
   std::map<std::string, std::string> store_cache;
@@ -78,6 +85,10 @@ private:
   std::map<std::string,ProgressEvent> progress_events;
 
   mutable ceph::mutex lock = ceph::make_mutex("ActivePyModules::lock");
+
+  std::map<std::string, FailedModuleInfo> failed_always_on_modules;
+  SafeTimer retry_timer;
+  Context *retry_event = nullptr;
 
 public:
   ActivePyModules(
@@ -241,6 +252,20 @@ public:
     return modules.count(name) > 0;
   }
 
+  std::string get_module_load_error(const std::string &name) const
+  {
+    std::lock_guard l(lock);
+    auto it = failed_always_on_modules.find(name);
+    if (it != failed_always_on_modules.end() && it->second.active_module) {
+      std::string error = it->second.active_module->get_load_error_string();
+      int retry_count = it->second.active_module->get_load_retry_count();
+      if (!error.empty()) {
+        return error + " (retry " + std::to_string(retry_count) + ")";
+      }
+    }
+    return "";
+  }
+
   bool method_exists(
       const std::string &module_name,
       const std::string &method_name) const
@@ -257,7 +282,9 @@ public:
 
   int init();
 
-  void start_one(PyModuleRef py_module);
+  void start_one(PyModuleRef py_module,
+                 std::shared_ptr<ActivePyModule> active_module = nullptr);
+
 
   void dump_server(const std::string &hostname,
                    const DaemonStateCollection &dmc,
@@ -275,5 +302,11 @@ public:
   // only after all modules are ready.
   // See "PyModuleRegistry::check_all_modules_started()".
   void check_all_modules_started(Context *modules_start_complete);
+
+private:
+  void schedule_retry_failed_module(const std::string& module_name,
+                                     PyModuleRef py_module,
+                                     std::shared_ptr<ActivePyModule> active_module);
+  void retry_failed_modules();
 };
 

--- a/src/mgr/PyModuleRegistry.cc
+++ b/src/mgr/PyModuleRegistry.cc
@@ -445,7 +445,11 @@ void PyModuleRegistry::get_health_checks(health_check_map_t *checks)
       if (!active_modules->module_exists(name)) {
         if (failed_modules.find(name) == failed_modules.end() &&
             dependency_modules.find(name) == dependency_modules.end()) {
-          failed_modules[name] = "Not found or unloadable";
+          std::string error_msg = active_modules->get_module_load_error(name);
+          if (error_msg.empty()) {
+            error_msg = "Not found or unloadable";
+          }
+          failed_modules[name] = error_msg;
         }
       }
     }


### PR DESCRIPTION
A retry mechanism for always-on mgr modules that fail during construction, preventing the cluster from being stuck in HEALTH_ERR indefinitely. When an always-on mgr module fails during init, the module is permanently dropped from the active set. The cluster enters HEALTH_ERR with a generic "Not found or unloadable" message, and the only recovery is manual intervention via 'ceph mgr fail' or mgr restart.

The retry mechanism:
- Captures actual Python exception details for better diagnostics
- Shows detailed error messages with retry count in health checks
- Retries module init with configurable backoff strategy

Backoff Strategies:
- Exponential (default): 10s, 30s, 60s, 120s, 300s (max)
- Linear: 10s, 20s, 30s, 40s, 50s, up to 300s
- Constant: always 30s

Changes:

1. ActivePyModule (h/cc):
   - Added failure tracking fields: load_error_string, last_load_attempt, load_retry_count
   - Modified load() to capture Python exceptions and store error details
   - Clears error state on successful load

2. ActivePyModules (h/cc):
   - Added FailedModuleInfo structure to track failed modules
   - Implemented schedule_retry_failed_module() for retry scheduling
   - Implemented retry_failed_modules() for periodic retry checks
   - Implemented get_retry_interval() with configurable backoff strategies
   - Modified start_one() to schedule retries instead of giving up
   - Added start_one_retry() to reuse ActivePyModule instance and preserve retry count across retries
   - Added get_module_load_error() for health reporting

3. PyModuleRegistry (cc):
   - Modified get_health_checks() to show actual Python exceptions
   - Includes retry count in error messages
   - Format: "<exception_message> (retry <count>)"

4. Configuration (mgr.yaml.in):
   - Added mgr_module_max_retry_attempts option (default: 10)
   - Set to 0 to disable retries and preserve old behavior
   - Added mgr_module_retry_backoff_strategy option (default: exponential)
   - Supports 'exponential', 'linear', and 'constant' strategies
   - Both options are runtime configurable

Example Health Messages:
- During retry: "Module 'dashboard' has failed: ConnectionRefusedError: [Errno 111] Connection refused (retry 3)"
- After max retries: "Module 'dashboard' has failed: ConnectionRefusedError: [Errno 111] Connection refused (retry 10)"

Fixes: https://tracker.ceph.com/issues/77152



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
