### PR TITLE
tentacle: rgw: fix log_remove() -EIO on non-existent FIFO shards

### DIFF
--- a/src/rgw/driver/rados/rgw_log_backing.cc
+++ b/src/rgw/driver/rados/rgw_log_backing.cc
@@ -180,7 +180,10 @@ asio::awaitable<void> log_remove(
       = co_await fifo::FIFO::get_meta(rados, oid, loc, std::nullopt,
 				      asio::redirect_error(asio::use_awaitable,
 							   ec));
-    if (ec == sys::errc::no_such_file_or_directory) continue;
+    if (ec == sys::errc::no_such_file_or_directory) {
+      ec.clear();
+      continue;
+    }
     if (!ec && info.head_part_num > -1) {
       for (auto j = info.tail_part_num; j <= info.head_part_num; ++j) {
 	sys::error_code subec;
@@ -219,8 +222,8 @@ asio::awaitable<void> log_remove(
 			 << ": " << ec.message() << dendl;
     }
   }
-  if (ec)
-    throw sys::error_code(ec);
+  if (ec && ec != sys::errc::no_such_file_or_directory)
+    throw sys::system_error(ec);
   co_return;
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78371

---

backport of https://github.com/ceph/ceph/pull/69293
parent tracker: https://tracker.ceph.com/issues/77669

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh