### PR TITLE
tentacle: qa/tasks: Ignore expected `backfill_toofull` warning

### DIFF
--- a/qa/tasks/thrashosds-health.yaml
+++ b/qa/tasks/thrashosds-health.yaml
@@ -38,7 +38,7 @@ overrides:
       - pg degraded
       - PG_BACKFILL_FULL
       - Low space hindering backfill .*? backfill_toofull
-      - OSD_HOST_DOWN
       - OSD_ROOT_DOWN
       - pgs degraded
       - pgs undersized
+      - is active.*backfill_toofull.*


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74920

---

backport of https://github.com/ceph/ceph/pull/64377
parent tracker: https://tracker.ceph.com/issues/70716

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh