### PR TITLE
cephadm: allow nfs ganesha container to start with cephadm shell

### DIFF
--- a/src/cephadm/cephadmlib/daemons/nfs.py
+++ b/src/cephadm/cephadmlib/daemons/nfs.py
@@ -55,7 +55,7 @@ class NFSGanesha(ContainerDaemonForm):
         self.image = image
 
         # config-json options
-        self.pool = dict_get(config_json, 'pool', require=True)
+        self.pool = dict_get(config_json, 'pool')
         self.namespace = dict_get(config_json, 'namespace')
         self.userid = dict_get(config_json, 'userid')
         self.extra_args = dict_get(config_json, 'extra_args', [])
@@ -136,14 +136,18 @@ class NFSGanesha(ContainerDaemonForm):
             raise Error('invalid daemon_id: %s' % self.daemon_id)
         if not self.image:
             raise Error('invalid image: %s' % self.image)
-
-        # check for the required files
-        if self.required_files:
-            for fname in self.required_files:
-                if fname not in self.files:
-                    raise Error(
+        config_json_is_empty = not self.pool and not self.files
+        if not config_json_is_empty:
+            # check for the required pools
+            if not self.pool:
+                raise Error('pool missing from dict')
+            # check for the required files
+            if self.required_files:
+                for fname in self.required_files:
+                    if fname not in self.files:
+                        raise Error(
                         'required file missing from config-json: %s' % fname
-                    )
+                        )
 
         # check for an RGW config
         if self.rgw:


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/78381

**Before fix:**

```
# cephadm -v shell --name nfs.mfs1.0.0.ceph5-node1.sjrusl
Traceback (most recent call last):
  File "/usr/lib64/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/usr/sbin/cephadm/__main__.py", line 6127, in <module>
  File "/usr/sbin/cephadm/__main__.py", line 6115, in main
  File "/usr/sbin/cephadm/__main__.py", line 409, in _infer_config
  File "/usr/sbin/cephadm/__main__.py", line 353, in _infer_fsid
  File "/usr/sbin/cephadm/__main__.py", line 409, in _infer_config
  File "/usr/sbin/cephadm/__main__.py", line 437, in _infer_image
  File "/usr/sbin/cephadm/__main__.py", line 311, in _validate_fsid
  File "/usr/sbin/cephadm/__main__.py", line 3516, in command_shell
  File "/usr/sbin/cephadm/__main__.py", line 840, in get_container_mounts
  File "/usr/sbin/cephadm/cephadmlib/daemon_form.py", line 125, in create
  File "/usr/sbin/cephadm/cephadmlib/daemons/nfs.py", line 77, in create
  File "/usr/sbin/cephadm/cephadmlib/daemons/nfs.py", line 71, in init
  File "/usr/sbin/cephadm/cephadmlib/daemons/nfs.py", line 57, in __init__
  File "/usr/sbin/cephadm/cephadmlib/data_utils.py", line 39, in dict_get
cephadmlib.exceptions.Error: pool missing from dict

```

**After Fix:**

```
[root@ceph5-node1 ~]# ./cephadm_patched_v3 shell --name nfs.mfs1.0.0.ceph5-node1.sjrusl
Inferring fsid 29c7617a-6fd0-11f1-b0f4-02000197f860
Inferring config /var/lib/ceph/29c7617a-6fd0-11f1-b0f4-02000197f860/nfs.mfs1.0.0.ceph5-node1.sjrusl/config
[ceph: root@ceph5-node1 /]# ls /etc/ganesha/
ganesha.conf  idmap.conf  kmip	tls
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
