### PR TITLE
umbrella: common: fix undefined symbol g_lockdep on Ubuntu 24.04

### DIFF
--- a/src/common/lockdep.h
+++ b/src/common/lockdep.h
@@ -20,7 +20,7 @@
 
 #ifdef CEPH_DEBUG_MUTEX
 
-extern bool g_lockdep;
+__attribute__((visibility("default"))) extern bool g_lockdep;
 
 extern void lockdep_register_ceph_context(CephContext *cct);
 extern void lockdep_unregister_ceph_context(CephContext *cct);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78383

---

backport of https://github.com/ceph/ceph/pull/70268
parent tracker: https://tracker.ceph.com/issues/78321

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh