### PR TITLE
tentacle: mgr/cephadm: Add IO statistics enable field to the cephadm NVMEoF spec file

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
@@ -49,6 +49,7 @@ subsystem_cache_expiration = {{ spec.subsystem_cache_expiration }}
 force_tls = {{ spec.force_tls }}
 # This is a development flag, do not change it
 max_message_length_in_mb = {{ spec.max_message_length_in_mb }}
+io_stats_enabled = {{ spec.io_stats_enabled }}
 degrade_namespace_on_kmip_error = {{ spec.degrade_namespace_on_kmip_error }}
 
 [gateway-logs]

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -398,6 +398,7 @@ subsystem_cache_expiration = 5
 force_tls = False
 # This is a development flag, do not change it
 max_message_length_in_mb = 4
+io_stats_enabled = True
 degrade_namespace_on_kmip_error = True
 
 [gateway-logs]

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1452,6 +1452,7 @@ class NvmeofServiceSpec(ServiceSpec):
                  subsystem_cache_expiration: Optional[int] = 5,
                  force_tls: Optional[bool] = False,
                  max_message_length_in_mb: Optional[int] = 4,
+                 io_stats_enabled: Optional[bool] = True,
                  degrade_namespace_on_kmip_error: Optional[bool] = True,
                  server_key: Optional[str] = None,
                  server_cert: Optional[str] = None,
@@ -1598,6 +1599,8 @@ class NvmeofServiceSpec(ServiceSpec):
         self.force_tls = force_tls
         #: ``max_message_length_in_mb`` max protobuf message length, in mb
         self.max_message_length_in_mb = max_message_length_in_mb
+        #: ``io_stats_enabled`` enables controller IO statistics
+        self.io_stats_enabled = io_stats_enabled
         #: ``degrade_namespace_on_kmip_error`` on a KMIP key error in update, create a degraded ns
         self.degrade_namespace_on_kmip_error = degrade_namespace_on_kmip_error
         #: ``allowed_consecutive_spdk_ping_failures`` # of ping failures before aborting gateway
@@ -1817,6 +1820,7 @@ class NvmeofServiceSpec(ServiceSpec):
                                    "Subsystem cache expiration period")
         verify_boolean(self.force_tls, "Force TLS")
         verify_positive_int(self.max_message_length_in_mb, "Max protocol message length")
+        verify_boolean(self.io_stats_enabled, "Enable IO statistics")
         verify_boolean(self.degrade_namespace_on_kmip_error, "Degrade namespace on KMIP error")
         verify_non_negative_number(self.monitor_timeout, "Monitor timeout")
         verify_non_negative_int(self.port, "Port")


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78387

---

backport of https://github.com/ceph/ceph/pull/67206
parent tracker: https://tracker.ceph.com/issues/74750

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh