### PR TITLE
mgr/DaemonServer: include mgr module options in config show output

### DIFF
--- a/qa/workunits/mon/config.sh
+++ b/qa/workunits/mon/config.sh
@@ -135,6 +135,28 @@ do
     sleep 1
 done
 
+# show mgr module options (tracker #24458)
+# Pick the active mgr name and verify that a known module option appears in
+# "config show" and "config show-with-defaults" once it has been set.
+# Use telemetry/contact (str, default empty) so any set value is non-default
+# and is guaranteed to appear in "config show" (not just "show-with-defaults").
+mgr_name=$(ceph mgr dump --format json | jq -r '.active_name')
+
+ceph config set mgr."$mgr_name" mgr/telemetry/contact test@example.com
+
+# config show must include the option with source "mgr_module"
+while ! ceph config show mgr."$mgr_name" | grep 'telemetry/contact'
+do
+    sleep 1
+done
+ceph config show mgr."$mgr_name" | grep 'telemetry/contact' | grep 'mgr_module'
+
+# config show-with-defaults must also include it
+ceph config show-with-defaults mgr."$mgr_name" | grep 'telemetry/contact'
+
+# single-key lookup
+ceph config show mgr."$mgr_name" mgr/telemetry/contact | grep 'test@example.com'
+
 # show-with-defaults
 ceph config show-with-defaults osd.0 | grep debug_asok
 

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -2640,6 +2640,18 @@ bool DaemonServer::_handle_command(
 	auto q = defaults.find(name);
 	if (q != defaults.end()) {
 	  cmdctx->odata.append(q->second + "\n");
+	} else if (key.type == "mgr") {
+	  // check mgr module options (key format: "mgr/<module>/<option>")
+	  // name may already carry the "mgr/" prefix (e.g. "mgr/telemetry/contact")
+	  // or may omit it (e.g. "telemetry/contact"); normalise to the stored form.
+	  std::string lookup_key =
+	    name.starts_with("mgr/") ? name : ("mgr/" + name);
+	  std::string value;
+	  if (py_modules.get_module_option(lookup_key, &value)) {
+	    cmdctx->odata.append(value + "\n");
+	  } else {
+	    r = -ENOENT;
+	  }
 	} else {
 	  r = -ENOENT;
 	}
@@ -2709,6 +2721,22 @@ bool DaemonServer::_handle_command(
 	    tbl << TextTable::endrow;
 	  }
 	}
+	// also show mgr module options that were explicitly set
+	if (key.type == "mgr") {
+	  for (auto& [k, v] : py_modules.get_module_config_snapshot()) {
+	    // keys are "mgr/<module>/<option>"; strip the leading "mgr/"
+	    std::string_view opt = std::string_view(k).substr(4);
+	    if (f) {
+	      f->open_object_section("value");
+	      f->dump_string("name", opt);
+	      f->dump_string("value", v);
+	      f->dump_string("source", "mgr_module");
+	      f->close_section();
+	    } else {
+	      tbl << opt << v << "mgr_module" << "" << "" << TextTable::endrow;
+	    }
+	  }
+	}
       } else {
 	// show-with-defaults
 	auto& defaults = daemon->_get_config_defaults();
@@ -2776,6 +2804,40 @@ bool DaemonServer::_handle_command(
 	      tbl << "";
 	      tbl << "";
 	      tbl << TextTable::endrow;
+	    }
+	  }
+	}
+	// also show mgr module options (set values and defaults) for mgr daemons
+	if (key.type == "mgr") {
+	  auto mod_config_snapshot = py_modules.get_module_config_snapshot();
+	  for (auto& module : py_modules.get_modules()) {
+	    if (!module->is_enabled()) {
+	      continue;
+	    }
+	    const std::string& mod_name = module->get_name();
+	    for (auto& [opt_name, opt] : module->get_options()) {
+	      std::string display_name = mod_name + "/" + opt_name;
+	      std::string config_key = "mgr/" + display_name;
+	      std::string value;
+	      std::string source;
+	      auto it = mod_config_snapshot.find(config_key);
+	      if (it != mod_config_snapshot.end()) {
+		value = it->second;
+		source = "mgr_module";
+	      } else {
+		value = opt.default_value;
+		source = "default";
+	      }
+	      if (f) {
+		f->open_object_section("value");
+		f->dump_string("name", display_name);
+		f->dump_string("value", value);
+		f->dump_string("source", source);
+		f->close_section();
+	      } else {
+		tbl << display_name << value << source << "" << ""
+		    << TextTable::endrow;
+	      }
 	    }
 	  }
 	}

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -80,6 +80,28 @@ public:
   }
 
   /**
+   * Look up a single mgr module config option by its full key ("mgr/<mod>/<opt>").
+   * Returns true and sets *val if found.
+   */
+  bool get_module_option(const std::string& key, std::string *val) const {
+    std::lock_guard l(module_config.lock);
+    auto it = module_config.config.find(key);
+    if (it == module_config.config.end()) {
+      return false;
+    }
+    *val = it->second;
+    return true;
+  }
+
+  /**
+   * Return a snapshot of the entire module config map.
+   */
+  std::map<std::string, std::string> get_module_config_snapshot() const {
+    std::lock_guard l(module_config.lock);
+    return module_config.config;
+  }
+
+  /**
    * Get references to all modules (whether they have loaded and/or
    * errored) or not.
    */


### PR DESCRIPTION

'ceph config show/show-with-defaults mgr.<id>' omitted all mgr module
options because they are stored in PyModuleConfig, not in the daemon's
config map. This adds them to both commands.
Also adds an integration test to qa/workunits/mon/config.sh.

Fixes: https://tracker.ceph.com/issues/24458




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
