### PR TITLE
cephadm: optionally pre-pull upgrade image on in-scope hosts

### DIFF
--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -2,6 +2,8 @@
 Upgrading Ceph
 ==============
 
+.. _cephadm-upgrade:
+
 Cephadm can safely upgrade Ceph from one point release to the next.  For
 example, you can upgrade from v15.2.0 (the first Octopus release) to the next
 point release, v15.2.1.
@@ -59,6 +61,100 @@ The automated upgrade process follows Ceph best practices.  For example:
    If autoscaling was already off before the upgrade, cephadm does not change
    it unless you have set ``pg_autoscale_during_upgrade`` to ``true`` (opt-in
    to turn autoscaling on for the duration of the upgrade).
+
+
+Upgrade image pre-distribution
+==============================
+
+On clusters with many hosts and large container images, pulling the target
+image from a registry on each host during the upgrade can add significant
+time. This is especially noticeable during MDS upgrades when CephFS may
+already be offline while a host still downloads the image.
+
+When enabled, cephadm pre-distributes the target image to in-scope hosts
+**before any daemon is upgraded**. Configure this with a single option,
+``mgr/cephadm/upgrade_image_mirror_method``:
+
+``''`` / ``none`` (default)
+  Disabled. Upgrade behaves as before (per-host pull on demand during
+  daemon upgrade).
+
+``registry``
+  Pull in parallel on each in-scope host from the cluster registry (Harbor,
+  Quay, etc.). Use this when every node already has registry connectivity.
+  No tar, HTTP server, or seed-host disk space is required. Target image
+  digests and Ceph version are learned from those parallel pulls, so there
+  is no extra serial "first pull" on a single host before the batch.
+
+``local_http``
+  Pull once on a seed host, save to a gzip-compressed tar archive, serve it
+  briefly over HTTP on the cluster network, and load it in parallel on
+  worker hosts. Use this when only one or a few nodes can reach the registry
+  (telco, air-gapped, or bandwidth-constrained setups).
+
+Enable pre-distribution by selecting a method:
+
+.. prompt:: bash #
+
+   ceph config set mgr mgr/cephadm/upgrade_image_mirror_method registry
+   # or
+   ceph config set mgr mgr/cephadm/upgrade_image_mirror_method local_http
+
+Disable again (either form):
+
+.. prompt:: bash #
+
+   ceph config set mgr mgr/cephadm/upgrade_image_mirror_method none
+   # or clear to empty
+   ceph config set mgr mgr/cephadm/upgrade_image_mirror_method ''
+
+Optional tuning (both ``registry`` and ``local_http``):
+
+.. prompt:: bash #
+
+   ceph config set mgr mgr/cephadm/upgrade_image_mirror_max_parallel 8
+
+``local_http`` port and firewall
+--------------------------------
+
+When ``upgrade_image_mirror_method`` is ``local_http``, the seed host briefly
+runs a short-lived HTTP server that serves the image tar to other in-scope
+hosts over the cluster / public host network.
+
+Default TCP port: ``8766``
+
+Override if needed:
+
+.. prompt:: bash #
+
+   ceph config set mgr mgr/cephadm/upgrade_image_mirror_port 8766
+
+This port is used **only** for the ``local_http`` method (ignored for
+``registry``). The listener exists only for the duration of the image
+pre-distribution phase and is torn down afterward.
+
+Operators who manage host firewalls manually (``nftables``, ``iptables``,
+or similar) must allow inbound TCP ``8766`` (or the configured
+``upgrade_image_mirror_port``) on the seed host from the other Ceph hosts
+before starting an upgrade that uses ``local_http``. Example ``iptables``
+rule (adjust interface, source CIDR, and port as needed):
+
+.. prompt:: bash #
+
+   sudo iptables -A INPUT -i {iface} -p tcp -s {cluster-cidr} --dport 8766 -j ACCEPT
+
+.. note::
+
+   Cephadm does **not** currently open port ``8766`` automatically via its
+   ``firewalld`` integration. If ``firewalld`` is enabled on the seed host,
+   either open the port yourself for the upgrade window, or use the
+   ``registry`` method (no extra host port). Automatic open/close during
+   the mirror phase may be added in a follow-up.
+
+For ``local_http``, the seed host is the first online ``_admin`` host in
+upgrade scope, or the active mgr host if no ``_admin`` host is in scope.
+Hosts that already have the target image are skipped. If pre-distribution
+fails on any host, the upgrade is paused before any daemon is upgraded.
 
 
 Starting the Upgrade

--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -72,7 +72,7 @@ time. This is especially noticeable during MDS upgrades when CephFS may
 already be offline while a host still downloads the image.
 
 When enabled, cephadm pre-distributes the target image to in-scope hosts
-**before any daemon is upgraded**. Configure this with a single option,
+**before any daemon is upgraded**. Configure this with
 ``mgr/cephadm/upgrade_image_mirror_method``:
 
 ``''`` / ``none`` (default)
@@ -82,23 +82,18 @@ When enabled, cephadm pre-distributes the target image to in-scope hosts
 ``registry``
   Pull in parallel on each in-scope host from the cluster registry (Harbor,
   Quay, etc.). Use this when every node already has registry connectivity.
-  No tar, HTTP server, or seed-host disk space is required. Target image
-  digests and Ceph version are learned from those parallel pulls, so there
-  is no extra serial "first pull" on a single host before the batch.
+  Target image digests and Ceph version are learned from those parallel
+  pulls, so there is no extra serial "first pull" on a single host before
+  the batch. Hosts that already have the target image are skipped. If
+  pre-distribution fails on any host, the upgrade is paused before any
+  daemon is upgraded. Staggered upgrades pre-pull only on hosts in the
+  current upgrade scope.
 
-``local_http``
-  Pull once on a seed host, save to a gzip-compressed tar archive, serve it
-  briefly over HTTP on the cluster network, and load it in parallel on
-  worker hosts. Use this when only one or a few nodes can reach the registry
-  (telco, air-gapped, or bandwidth-constrained setups).
-
-Enable pre-distribution by selecting a method:
+Enable pre-distribution:
 
 .. prompt:: bash #
 
    ceph config set mgr mgr/cephadm/upgrade_image_mirror_method registry
-   # or
-   ceph config set mgr mgr/cephadm/upgrade_image_mirror_method local_http
 
 Disable again (either form):
 
@@ -108,53 +103,11 @@ Disable again (either form):
    # or clear to empty
    ceph config set mgr mgr/cephadm/upgrade_image_mirror_method ''
 
-Optional tuning (both ``registry`` and ``local_http``):
+Optional tuning:
 
 .. prompt:: bash #
 
    ceph config set mgr mgr/cephadm/upgrade_image_mirror_max_parallel 8
-
-``local_http`` port and firewall
---------------------------------
-
-When ``upgrade_image_mirror_method`` is ``local_http``, the seed host briefly
-runs a short-lived HTTP server that serves the image tar to other in-scope
-hosts over the cluster / public host network.
-
-Default TCP port: ``8766``
-
-Override if needed:
-
-.. prompt:: bash #
-
-   ceph config set mgr mgr/cephadm/upgrade_image_mirror_port 8766
-
-This port is used **only** for the ``local_http`` method (ignored for
-``registry``). The listener exists only for the duration of the image
-pre-distribution phase and is torn down afterward.
-
-Operators who manage host firewalls manually (``nftables``, ``iptables``,
-or similar) must allow inbound TCP ``8766`` (or the configured
-``upgrade_image_mirror_port``) on the seed host from the other Ceph hosts
-before starting an upgrade that uses ``local_http``. Example ``iptables``
-rule (adjust interface, source CIDR, and port as needed):
-
-.. prompt:: bash #
-
-   sudo iptables -A INPUT -i {iface} -p tcp -s {cluster-cidr} --dport 8766 -j ACCEPT
-
-.. note::
-
-   Cephadm does **not** currently open port ``8766`` automatically via its
-   ``firewalld`` integration. If ``firewalld`` is enabled on the seed host,
-   either open the port yourself for the upgrade window, or use the
-   ``registry`` method (no extra host port). Automatic open/close during
-   the mirror phase may be added in a follow-up.
-
-For ``local_http``, the seed host is the first online ``_admin`` host in
-upgrade scope, or the active mgr host if no ``_admin`` host is in scope.
-Hosts that already have the target image are skipped. If pre-distribution
-fails on any host, the upgrade is paused before any daemon is upgraded.
 
 
 Starting the Upgrade

--- a/doc/rados/configuration/network-config-ref.rst
+++ b/doc/rados/configuration/network-config-ref.rst
@@ -173,25 +173,6 @@ public or cluster network. For example:
    Ceph OSD Daemons, you can consolidate the public network configuration step. 
 
 
-Cephadm upgrade image mirror (optional)
----------------------------------------
-
-When cephadm upgrade image pre-distribution is enabled with method
-``local_http`` (see :ref:`cephadm-upgrade`), the seed host briefly
-listens on TCP port ``8766`` by default to serve the target container
-image tar to other cluster hosts. The port is configurable via
-``mgr/cephadm/upgrade_image_mirror_port`` and is closed after the
-pre-distribution phase. Allow this port between Ceph hosts if you manage
-host firewalls manually. The ``registry`` pre-distribution method does not
-use this port.
-
-Example:
-
-.. prompt:: bash $
-
-   sudo iptables -A INPUT -i {iface} -p tcp -s {ip-address}/{netmask} --dport 8766 -j ACCEPT
-
-
 Cephadm service discovery (optional)
 ------------------------------------
 

--- a/doc/rados/configuration/network-config-ref.rst
+++ b/doc/rados/configuration/network-config-ref.rst
@@ -173,6 +173,41 @@ public or cluster network. For example:
    Ceph OSD Daemons, you can consolidate the public network configuration step. 
 
 
+Cephadm upgrade image mirror (optional)
+---------------------------------------
+
+When cephadm upgrade image pre-distribution is enabled with method
+``local_http`` (see :ref:`cephadm-upgrade`), the seed host briefly
+listens on TCP port ``8766`` by default to serve the target container
+image tar to other cluster hosts. The port is configurable via
+``mgr/cephadm/upgrade_image_mirror_port`` and is closed after the
+pre-distribution phase. Allow this port between Ceph hosts if you manage
+host firewalls manually. The ``registry`` pre-distribution method does not
+use this port.
+
+Example:
+
+.. prompt:: bash $
+
+   sudo iptables -A INPUT -i {iface} -p tcp -s {ip-address}/{netmask} --dport 8766 -j ACCEPT
+
+
+Cephadm service discovery (optional)
+------------------------------------
+
+When the cephadm monitoring stack uses Prometheus HTTP service discovery,
+mgr daemons listen on TCP port ``8765`` by default (configurable via
+``mgr/cephadm/service_discovery_port``). Allow this port to the mgr hosts
+if you manage host firewalls manually. See the cephadm monitoring docs
+for endpoint details (``https://<mgr-ip>:8765/sd/``).
+
+Example:
+
+.. prompt:: bash $
+
+   sudo iptables -A INPUT -i {iface} -p tcp -s {ip-address}/{netmask} --dport 8765 -j ACCEPT
+
+
 Ceph Networks
 =============
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -436,6 +436,33 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             desc='Maximum number of OSD daemons upgraded in parallel.'
         ),
         Option(
+            'upgrade_image_mirror_method',
+            type='str',
+            default='',
+            enum_allowed=['', 'none', 'registry', 'local_http'],
+            desc='Pre-distribute the upgrade target image to in-scope hosts before '
+                 'any daemon is upgraded. Empty or "none" (default): disabled. '
+                 '"registry": pull in parallel on each in-scope host from the '
+                 'cluster registry (requires registry reachability from hosts; '
+                 'digests/version learned from those pulls). '
+                 '"local_http": pull once on a seed host, save to a gzip-compressed '
+                 'tar, and fan out over HTTP on the cluster network.',
+        ),
+        Option(
+            'upgrade_image_mirror_max_parallel',
+            type='int',
+            default=8,
+            desc='Maximum number of hosts loading (local_http) or pulling (registry) '
+                 'the upgrade image in parallel.',
+        ),
+        Option(
+            'upgrade_image_mirror_port',
+            type='int',
+            default=8766,
+            desc='TCP port for the short-lived HTTP server on the image mirror seed '
+                 'host (local_http method only; ignored for registry).',
+        ),
+        Option(
             'pg_autoscale_during_upgrade',
             type='bool',
             default=False,
@@ -652,6 +679,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.apply_spec_fails: List[Tuple[str, str]] = []
             self.max_osd_draining_count = 10
             self.max_parallel_osd_upgrades = 16
+            self.upgrade_image_mirror_method = ''
+            self.upgrade_image_mirror_max_parallel = 8
+            self.upgrade_image_mirror_port = 8766
             self.device_enhanced_scan = False
             self.inventory_list_all = False
             self.cgroups_split = True

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -445,28 +445,19 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             'upgrade_image_mirror_method',
             type='str',
             default='',
-            enum_allowed=['', 'none', 'registry', 'local_http'],
+            enum_allowed=['', 'none', 'registry'],
             desc='Pre-distribute the upgrade target image to in-scope hosts before '
                  'any daemon is upgraded. Empty or "none" (default): disabled. '
                  '"registry": pull in parallel on each in-scope host from the '
                  'cluster registry (requires registry reachability from hosts; '
-                 'digests/version learned from those pulls). '
-                 '"local_http": pull once on a seed host, save to a gzip-compressed '
-                 'tar, and fan out over HTTP on the cluster network.',
+                 'digests/version learned from those pulls).',
         ),
         Option(
             'upgrade_image_mirror_max_parallel',
             type='int',
             default=8,
-            desc='Maximum number of hosts loading (local_http) or pulling (registry) '
-                 'the upgrade image in parallel.',
-        ),
-        Option(
-            'upgrade_image_mirror_port',
-            type='int',
-            default=8766,
-            desc='TCP port for the short-lived HTTP server on the image mirror seed '
-                 'host (local_http method only; ignored for registry).',
+            desc='Maximum number of hosts pulling the upgrade image in parallel '
+                 'when upgrade_image_mirror_method is registry.',
         ),
         Option(
             'pg_autoscale_during_upgrade',
@@ -698,7 +689,6 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.max_parallel_osd_upgrades = 16
             self.upgrade_image_mirror_method = ''
             self.upgrade_image_mirror_max_parallel = 8
-            self.upgrade_image_mirror_port = 8766
             self.device_enhanced_scan = False
             self.inventory_list_all = False
             self.cgroups_split = True

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -442,6 +442,33 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             desc='Maximum number of OSD daemons upgraded in parallel.'
         ),
         Option(
+            'upgrade_image_mirror_method',
+            type='str',
+            default='',
+            enum_allowed=['', 'none', 'registry', 'local_http'],
+            desc='Pre-distribute the upgrade target image to in-scope hosts before '
+                 'any daemon is upgraded. Empty or "none" (default): disabled. '
+                 '"registry": pull in parallel on each in-scope host from the '
+                 'cluster registry (requires registry reachability from hosts; '
+                 'digests/version learned from those pulls). '
+                 '"local_http": pull once on a seed host, save to a gzip-compressed '
+                 'tar, and fan out over HTTP on the cluster network.',
+        ),
+        Option(
+            'upgrade_image_mirror_max_parallel',
+            type='int',
+            default=8,
+            desc='Maximum number of hosts loading (local_http) or pulling (registry) '
+                 'the upgrade image in parallel.',
+        ),
+        Option(
+            'upgrade_image_mirror_port',
+            type='int',
+            default=8766,
+            desc='TCP port for the short-lived HTTP server on the image mirror seed '
+                 'host (local_http method only; ignored for registry).',
+        ),
+        Option(
             'pg_autoscale_during_upgrade',
             type='bool',
             default=False,
@@ -669,6 +696,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.apply_spec_fails: List[Tuple[str, str]] = []
             self.max_osd_draining_count = 10
             self.max_parallel_osd_upgrades = 16
+            self.upgrade_image_mirror_method = ''
+            self.upgrade_image_mirror_max_parallel = 8
+            self.upgrade_image_mirror_port = 8766
             self.device_enhanced_scan = False
             self.inventory_list_all = False
             self.cgroups_split = True

--- a/src/pybind/mgr/cephadm/tests/test_remote_executables.py
+++ b/src/pybind/mgr/cephadm/tests/test_remote_executables.py
@@ -54,6 +54,7 @@ EXPECTED = [
     ('sysctl', True, ssh_py),
     ('touch', True, ssh_py),
     ('true', True, ssh_py),
+    ('bash', True, 'upgrade.py'),
     # variable executables
     ('self.mgr.cephadm_binary_path', False, serve_py),
     ('/usr/libexec/cephadm_invoker.py', True, ssh_py),

--- a/src/pybind/mgr/cephadm/tests/test_remote_executables.py
+++ b/src/pybind/mgr/cephadm/tests/test_remote_executables.py
@@ -54,7 +54,6 @@ EXPECTED = [
     ('sysctl', True, ssh_py),
     ('touch', True, ssh_py),
     ('true', True, ssh_py),
-    ('bash', True, 'upgrade.py'),
     # variable executables
     ('self.mgr.cephadm_binary_path', False, serve_py),
     ('/usr/libexec/cephadm_invoker.py', True, ssh_py),

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -10,6 +10,8 @@ from cephadm.upgrade import (
     CephadmUpgrade,
     OkToUpgradeMonReport,
     UpgradeState,
+    UPGRADE_IMAGE_MIRROR_METHOD_LOCAL_HTTP,
+    UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY,
     parse_ok_to_upgrade_mon_json,
     request_osd_ok_to_upgrade_report,
 )
@@ -20,6 +22,14 @@ from .fixtures import _run_cephadm, wait, with_host, with_service, \
     receive_agent_metadata, async_side_effect
 
 from typing import List, Tuple, Optional
+
+
+def _upgrade_test_daemon(hostname: str = 'host1') -> DaemonDescription:
+    return DaemonDescription(
+        hostname=hostname,
+        daemon_type='mgr',
+        daemon_id='0',
+    )
 
 
 @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
@@ -1170,3 +1180,507 @@ def test_do_upgrade_limit_exhausted_marks_complete_without_scope_check(
 
     mark_complete.assert_called_once()
     filtered_scope.assert_not_called()
+
+
+def test_upgrade_state_image_mirror_roundtrip():
+    u = UpgradeState('target', 'pid', image_mirror_done=True)
+    restored = UpgradeState.from_json(u.to_json())
+    assert restored
+    assert restored.image_mirror_done is True
+
+
+def test_mirror_tar_basename_uses_gzip_suffix(cephadm_module: CephadmOrchestrator):
+    name = cephadm_module.upgrade._mirror_tar_basename(
+        ['192.168.100.254:5000/ceph/ceph@sha256:abc'])
+    assert name.endswith('.tar.gz')
+
+
+@mock.patch("cephadm.ssh.SSHManager._check_execute_command", new_callable=mock.AsyncMock)
+def test_save_image_on_host_compresses_with_gzip(
+    check_execute: mock.AsyncMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    cephadm_module.wait_async(
+        cephadm_module.upgrade._save_image_on_host(
+            'host1', 'podman', 'ceph/ceph:main', '/var/lib/ceph/fsid/img.tar.gz'))
+    check_execute.assert_called_once()
+    cmd = check_execute.call_args[0][1]
+    assert str(cmd.exe) == 'bash'
+    script = cmd.args[1]
+    assert 'podman save' in script
+    assert 'python3 -m gzip --fast' in script
+    assert '/var/lib/ceph/fsid/img.tar.gz' in script
+
+
+def test_mirror_image_tag_name_prefers_user_tag(cephadm_module: CephadmOrchestrator):
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        '192.168.100.254:5000/ceph/ceph:main3.0.kobi',
+        'pid',
+        target_id='sha256:abc',
+        target_digests=['192.168.100.254:5000/ceph/ceph@sha256:abc'],
+    )
+    assert cephadm_module.upgrade._mirror_image_tag_name() == (
+        '192.168.100.254:5000/ceph/ceph:main3.0.kobi')
+
+
+def test_mirror_image_tag_name_none_for_digest_only(cephadm_module: CephadmOrchestrator):
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        '192.168.100.254:5000/ceph/ceph@sha256:abc',
+        'pid',
+    )
+    assert cephadm_module.upgrade._mirror_image_tag_name() is None
+
+
+@mock.patch("cephadm.ssh.SSHManager._check_execute_command", new_callable=mock.AsyncMock)
+def test_load_image_from_url_retags_after_load(
+    check_execute: mock.AsyncMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    cephadm_module.wait_async(
+        cephadm_module.upgrade._load_image_from_url_on_host(
+            'host1',
+            'podman',
+            'http://seed:8766/img.tar.gz',
+            '/tmp/img.tar.gz',
+            tag_name='192.168.100.254:5000/ceph/ceph:main3.0.kobi',
+            image_id='sha256:4bfa4fc1176d',
+        ))
+    script = check_execute.call_args[0][1].args[1]
+    assert 'podman load -i' in script
+    assert 'podman tag sha256:4bfa4fc1176d 192.168.100.254:5000/ceph/ceph:main3.0.kobi' in script
+
+
+def test_host_has_target_image_matches_image_id():
+    upgrade = CephadmUpgrade.__new__(CephadmUpgrade)
+    upgrade.upgrade_state = UpgradeState(
+        '192.168.100.254:5000/ceph/ceph:main2.0',
+        'pid',
+        target_id='acf49863d4a5ce75d68464d3924f3d3f8a7af21544e7bd9430805f04d70eed8c',
+        target_digests=['192.168.100.254:5000/ceph/ceph@sha256:abc'],
+    )
+    assert upgrade._host_has_target_image(
+        {'image_id': 'acf49863d4a5ce75d68464d3924f3d3f8a7af21544e7bd9430805f04d70eed8c',
+         'repo_digests': []},
+        ['192.168.100.254:5000/ceph/ceph@sha256:abc'],
+    )
+
+
+def test_http_url_host_ipv6():
+    from cephadm.upgrade import _http_url_host
+    assert _http_url_host('2620:52:0:1304::64') == '[2620:52:0:1304::64]'
+    assert _http_url_host('192.168.100.100') == '192.168.100.100'
+
+
+def test_get_image_mirror_host_addr_prefers_public_ipv4(cephadm_module: CephadmOrchestrator):
+    cephadm_module.inventory._inventory['host1'] = {
+        'hostname': 'host1',
+        'addr': '2620:52:0:1304::64',
+        'labels': [],
+    }
+    cephadm_module.cache.networks['host1'] = {
+        '192.168.100.0/24': {'eth0': ['192.168.100.100']},
+        '2620:52:0:1304::/64': {'eth0': ['2620:52:0:1304::64']},
+    }
+    addr = cephadm_module.upgrade._get_image_mirror_host_addr('host1')
+    assert addr == '192.168.100.100'
+
+
+def test_select_image_mirror_seed_host_prefers_admin(cephadm_module: CephadmOrchestrator):
+    cephadm_module.inventory._inventory['host1'] = {
+        'hostname': 'host1',
+        'addr': '192.168.100.1',
+        'labels': [],
+    }
+    cephadm_module.inventory._inventory['host2'] = {
+        'hostname': 'host2',
+        'addr': '192.168.100.2',
+        'labels': ['_admin'],
+    }
+    seed = cephadm_module.upgrade._select_image_mirror_seed_host(['host1', 'host2'])
+    assert seed == 'host2'
+
+
+@mock.patch.object(CephadmUpgrade, '_update_upgrade_progress')
+@mock.patch.object(CephadmUpgrade, '_get_upgrade_scope_hosts', return_value=['host1'])
+@mock.patch.object(CephadmUpgrade, '_pre_distribute_upgrade_images', return_value=True)
+def test_do_upgrade_calls_image_mirror_before_daemons(
+    mirror_mock: mock.MagicMock,
+    _get_upgrade_scope_hosts: mock.MagicMock,
+    _update_upgrade_progress: mock.MagicMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    cephadm_module.upgrade_image_mirror_method = UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target_image',
+        'pid',
+        target_id='image_id',
+        target_digests=['target_image@digest'],
+        target_version='19.3.0-0',
+        image_mirror_done=False,
+    )
+    upgrade_daemon = _upgrade_test_daemon()
+    with mock.patch.object(CephadmUpgrade, '_detect_need_upgrade', return_value=(False, [], [], 0)), \
+            mock.patch.object(CephadmUpgrade, '_to_upgrade', return_value=(True, [])), \
+            mock.patch.object(CephadmUpgrade, '_get_filtered_daemons', return_value=[upgrade_daemon]), \
+            mock.patch.object(CephadmUpgrade, 'get_distinct_container_image_settings', return_value={}), \
+            mock.patch("cephadm.module.CephadmOrchestrator.lookup_release_name", return_value='tentacle'), \
+            mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command", return_value=(0, '{}', '')), \
+            mock.patch("cephadm.module.CephadmOrchestrator.get", return_value={
+                'min_mon_release': 19,
+                'require_osd_release': 'tentacle',
+                'have_local_config_map': True,
+            }), \
+            mock.patch(
+                "cephadm.module.CephadmOrchestrator.version",
+                new_callable=mock.PropertyMock,
+                return_value='ceph version 19.3.0-0 (hash)'), \
+            mock.patch("cephadm.module.HostCache.get_daemons", return_value=[upgrade_daemon]):
+        cephadm_module.upgrade._do_upgrade()
+    mirror_mock.assert_called_once()
+
+
+@mock.patch.object(CephadmUpgrade, '_update_upgrade_progress')
+@mock.patch.object(CephadmUpgrade, '_pre_distribute_upgrade_images')
+def test_do_upgrade_skips_image_mirror_when_done(
+    mirror_mock: mock.MagicMock,
+    _update_upgrade_progress: mock.MagicMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    cephadm_module.upgrade_image_mirror_method = UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target_image',
+        'pid',
+        target_id='image_id',
+        target_digests=['target_image@digest'],
+        target_version='19.3.0-0',
+        image_mirror_done=True,
+    )
+    upgrade_daemon = _upgrade_test_daemon()
+    with mock.patch.object(CephadmUpgrade, '_detect_need_upgrade', return_value=(False, [], [], 0)), \
+            mock.patch.object(CephadmUpgrade, '_to_upgrade', return_value=(True, [])), \
+            mock.patch.object(CephadmUpgrade, 'get_distinct_container_image_settings', return_value={}), \
+            mock.patch("cephadm.module.CephadmOrchestrator.lookup_release_name", return_value='tentacle'), \
+            mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command", return_value=(0, '{}', '')), \
+            mock.patch("cephadm.module.CephadmOrchestrator.get", return_value={
+                'min_mon_release': 19,
+                'require_osd_release': 'tentacle',
+                'have_local_config_map': True,
+            }), \
+            mock.patch(
+                "cephadm.module.CephadmOrchestrator.version",
+                new_callable=mock.PropertyMock,
+                return_value='ceph version 19.3.0-0 (hash)'), \
+            mock.patch("cephadm.module.HostCache.get_daemons", return_value=[upgrade_daemon]):
+        cephadm_module.upgrade._do_upgrade()
+    mirror_mock.assert_not_called()
+
+
+@mock.patch.object(CephadmUpgrade, '_update_upgrade_progress')
+@mock.patch.object(CephadmUpgrade, '_pre_distribute_upgrade_images')
+def test_do_upgrade_skips_image_mirror_when_method_disabled(
+    mirror_mock: mock.MagicMock,
+    _update_upgrade_progress: mock.MagicMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    for disabled in ('', 'none', 'NONE', ' None '):
+        cephadm_module.upgrade_image_mirror_method = disabled
+        cephadm_module.upgrade.upgrade_state = UpgradeState(
+            'target_image',
+            'pid',
+            target_id='image_id',
+            target_digests=['target_image@digest'],
+            target_version='19.3.0-0',
+            image_mirror_done=False,
+        )
+        upgrade_daemon = _upgrade_test_daemon()
+        with mock.patch.object(CephadmUpgrade, '_detect_need_upgrade', return_value=(False, [], [], 0)), \
+                mock.patch.object(CephadmUpgrade, '_to_upgrade', return_value=(True, [])), \
+                mock.patch.object(CephadmUpgrade, 'get_distinct_container_image_settings', return_value={}), \
+                mock.patch("cephadm.module.CephadmOrchestrator.lookup_release_name", return_value='tentacle'), \
+                mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command", return_value=(0, '{}', '')), \
+                mock.patch("cephadm.module.CephadmOrchestrator.get", return_value={
+                    'min_mon_release': 19,
+                    'require_osd_release': 'tentacle',
+                    'have_local_config_map': True,
+                }), \
+                mock.patch(
+                    "cephadm.module.CephadmOrchestrator.version",
+                    new_callable=mock.PropertyMock,
+                    return_value='ceph version 19.3.0-0 (hash)'), \
+                mock.patch("cephadm.module.HostCache.get_daemons", return_value=[upgrade_daemon]):
+            cephadm_module.upgrade._do_upgrade()
+        assert mirror_mock.call_count == 0
+    mirror_mock.assert_not_called()
+
+
+@mock.patch.object(CephadmUpgrade, '_mirror_cleanup', new_callable=mock.AsyncMock)
+@mock.patch.object(CephadmUpgrade, '_inspect_image_on_host', new_callable=mock.AsyncMock)
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm_json", new_callable=mock.AsyncMock)
+@mock.patch("cephadm.ssh.SSHManager._check_execute_command", new_callable=mock.AsyncMock)
+def test_mirror_upgrade_image_marks_done_when_hosts_ready(
+    _check_execute_command: mock.AsyncMock,
+    _run_cephadm_json: mock.AsyncMock,
+    inspect_image: mock.AsyncMock,
+    _mirror_cleanup: mock.AsyncMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    inspect_image.return_value = {'repo_digests': ['target_image@digest']}
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target_image',
+        'pid',
+        target_digests=['target_image@digest'],
+    )
+    result = cephadm_module.wait_async(
+        cephadm_module.upgrade._mirror_upgrade_image_via_http_async(
+            'target_image',
+            ['target_image@digest'],
+            ['host1', 'host2'],
+        ))
+    assert result is True
+    assert cephadm_module.upgrade.upgrade_state.image_mirror_done is True
+    _run_cephadm_json.assert_not_called()
+
+
+@mock.patch.object(CephadmUpgrade, '_mirror_upgrade_image_via_http', return_value=True)
+def test_pre_distribute_upgrade_images_uses_local_http(
+    http_mock: mock.MagicMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    cephadm_module.upgrade_image_mirror_method = UPGRADE_IMAGE_MIRROR_METHOD_LOCAL_HTTP
+    assert cephadm_module.upgrade._pre_distribute_upgrade_images(
+        'target_image', ['target_image@digest'], ['host1']) is True
+    http_mock.assert_called_once_with(
+        'target_image', ['target_image@digest'], ['host1'])
+
+
+@mock.patch.object(CephadmUpgrade, '_pre_pull_image_on_hosts', return_value=True)
+def test_pre_distribute_upgrade_images_uses_registry(
+    registry_mock: mock.MagicMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    cephadm_module.upgrade_image_mirror_method = UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY
+    assert cephadm_module.upgrade._pre_distribute_upgrade_images(
+        'target_image', ['target_image@digest'], ['host1']) is True
+    registry_mock.assert_called_once_with(
+        'target_image', ['target_image@digest'], ['host1'])
+
+
+@mock.patch.object(CephadmUpgrade, '_pre_pull_image_on_hosts')
+@mock.patch.object(CephadmUpgrade, '_mirror_upgrade_image_via_http')
+def test_pre_distribute_upgrade_images_noop_when_disabled(
+    http_mock: mock.MagicMock,
+    registry_mock: mock.MagicMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    for disabled in ('', 'none'):
+        cephadm_module.upgrade_image_mirror_method = disabled
+        assert cephadm_module.upgrade._pre_distribute_upgrade_images(
+            'target_image', ['target_image@digest'], ['host1']) is True
+    http_mock.assert_not_called()
+    registry_mock.assert_not_called()
+
+
+def _registry_prepull_upgrade_state(cephadm_module: CephadmOrchestrator):
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'quay.io/ceph/ceph:vtest',
+        'pid',
+        target_digests=['quay.io/ceph/ceph@sha256:targetdigest'],
+        target_id='targetdigest',
+        target_version='19.2.0',
+    )
+
+
+def _inspect_or_pull(present_hosts, fail_pull_hosts):
+    pulled: set = set()
+
+    async def fake_run(self, host, entity, command, args, image=None,
+                       no_fsid=None, error_ok=None, **kwargs):
+        if command == 'inspect-image':
+            if host in present_hosts or host in pulled:
+                return (
+                    ['{"repo_digests": ["quay.io/ceph/ceph@sha256:targetdigest"]}'],
+                    [], 0)
+            return (['{"repo_digests": ["sha256:other"]}'], [], 0)
+        if host in fail_pull_hosts:
+            return ([], ['no space left on device'], 1)
+        pulled.add(host)
+        return (
+            ['{"repo_digests": ["quay.io/ceph/ceph@sha256:targetdigest"]}'],
+            [], 0)
+    return fake_run
+
+
+@mock.patch.object(CephadmUpgrade, '_registry_login_if_needed', new_callable=mock.AsyncMock)
+def test_registry_pre_pull_success_on_all_hosts(
+    _registry_login: mock.AsyncMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    _registry_prepull_upgrade_state(cephadm_module)
+    cephadm_module.upgrade_image_mirror_max_parallel = 8
+    with mock.patch("cephadm.serve.CephadmServe._run_cephadm",
+                    new=_inspect_or_pull(set(), set())):
+        ok = cephadm_module.wait_async(
+            cephadm_module.upgrade._pre_pull_image_on_hosts_async(
+                'quay.io/ceph/ceph:vtest',
+                ['quay.io/ceph/ceph@sha256:targetdigest'],
+                ['h1', 'h2', 'h3'],
+            ))
+    assert ok is True
+    assert cephadm_module.upgrade.upgrade_state.image_mirror_done is True
+    assert 'UPGRADE_FAILED_PULL' not in cephadm_module.health_checks
+
+
+@mock.patch.object(CephadmUpgrade, '_registry_login_if_needed', new_callable=mock.AsyncMock)
+def test_registry_pre_pull_skips_hosts_that_already_have_image(
+    _registry_login: mock.AsyncMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    _registry_prepull_upgrade_state(cephadm_module)
+    cephadm_module.upgrade_image_mirror_max_parallel = 8
+    pulled = []
+
+    async def fake_run(self, host, entity, command, args, image=None,
+                       no_fsid=None, error_ok=None, **kwargs):
+        if command == 'inspect-image':
+            digest = (
+                'quay.io/ceph/ceph@sha256:targetdigest'
+                if host == 'h2' or host in pulled else 'sha256:other')
+            return ([f'{{"repo_digests": ["{digest}"]}}'], [], 0)
+        pulled.append(host)
+        return (
+            ['{"repo_digests": ["quay.io/ceph/ceph@sha256:targetdigest"]}'],
+            [], 0)
+
+    with mock.patch("cephadm.serve.CephadmServe._run_cephadm", new=fake_run):
+        ok = cephadm_module.wait_async(
+            cephadm_module.upgrade._pre_pull_image_on_hosts_async(
+                'quay.io/ceph/ceph:vtest',
+                ['quay.io/ceph/ceph@sha256:targetdigest'],
+                ['h1', 'h2', 'h3'],
+            ))
+    assert ok is True
+    assert 'h2' not in pulled
+    assert sorted(pulled) == ['h1', 'h3']
+
+
+@mock.patch.object(CephadmUpgrade, '_registry_login_if_needed', new_callable=mock.AsyncMock)
+def test_registry_pre_pull_failure_pauses_and_reports_host(
+    _registry_login: mock.AsyncMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    _registry_prepull_upgrade_state(cephadm_module)
+    cephadm_module.upgrade_image_mirror_max_parallel = 8
+    with mock.patch("cephadm.serve.CephadmServe._run_cephadm",
+                    new=_inspect_or_pull(set(), {'h2'})):
+        ok = cephadm_module.wait_async(
+            cephadm_module.upgrade._pre_pull_image_on_hosts_async(
+                'quay.io/ceph/ceph:vtest',
+                ['quay.io/ceph/ceph@sha256:targetdigest'],
+                ['h1', 'h2', 'h3'],
+            ))
+    assert ok is False
+    assert cephadm_module.upgrade.upgrade_state.paused
+    assert 'UPGRADE_FAILED_PULL' in cephadm_module.health_checks
+    detail = ' '.join(cephadm_module.health_checks['UPGRADE_FAILED_PULL']['detail'])
+    assert 'h2' in detail
+    assert 'no space left on device' in detail
+
+
+_PULL_INFO_JSON = json.dumps({
+    'image_id': 'sha256:targetdigest',
+    'repo_digests': ['quay.io/ceph/ceph@sha256:targetdigest'],
+    'ceph_version': 'ceph version 19.2.0 (abc) squid (stable)',
+})
+
+
+@mock.patch.object(CephadmUpgrade, '_registry_login_if_needed', new_callable=mock.AsyncMock)
+def test_registry_pre_pull_discovers_metadata_from_parallel_pulls(
+    _registry_login: mock.AsyncMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    """When digests/version are unknown, learn them from parallel pulls."""
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'quay.io/ceph/ceph:vtest',
+        'pid',
+    )
+    cephadm_module.upgrade_image_mirror_max_parallel = 8
+    pulled: List[str] = []
+
+    async def fake_run(self, host, entity, command, args, image=None,
+                       no_fsid=None, error_ok=None, **kwargs):
+        assert command == 'pull'
+        pulled.append(host)
+        return ([_PULL_INFO_JSON], [], 0)
+
+    with mock.patch("cephadm.serve.CephadmServe._run_cephadm", new=fake_run):
+        ok = cephadm_module.wait_async(
+            cephadm_module.upgrade._pre_pull_image_on_hosts_async(
+                'quay.io/ceph/ceph:vtest',
+                [],
+                ['h1', 'h2', 'h3'],
+            ))
+    assert ok is True
+    assert sorted(pulled) == ['h1', 'h2', 'h3']
+    st = cephadm_module.upgrade.upgrade_state
+    assert st.image_mirror_done is True
+    assert st.target_id == 'sha256:targetdigest'
+    assert st.target_digests == ['quay.io/ceph/ceph@sha256:targetdigest']
+    assert st.target_version == '19.2.0'
+    assert 'UPGRADE_FAILED_PULL' not in cephadm_module.health_checks
+
+
+@mock.patch.object(CephadmUpgrade, '_update_upgrade_progress')
+@mock.patch.object(CephadmUpgrade, '_get_upgrade_scope_hosts', return_value=['h1', 'h2'])
+@mock.patch.object(CephadmUpgrade, '_pre_pull_image_on_hosts')
+def test_do_upgrade_registry_discovers_without_serial_first_pull(
+    pre_pull_mock: mock.MagicMock,
+    _get_upgrade_scope_hosts: mock.MagicMock,
+    _update_upgrade_progress: mock.MagicMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    """Registry mirror with no target metadata must not call serial First pull."""
+    cephadm_module.upgrade_image_mirror_method = UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'quay.io/ceph/ceph:vtest',
+        'pid',
+        image_mirror_done=False,
+    )
+
+    def _fake_pre_pull(target_image, target_digests, hosts):
+        st = cephadm_module.upgrade.upgrade_state
+        assert st is not None
+        st.target_id = 'sha256:targetdigest'
+        st.target_digests = ['quay.io/ceph/ceph@sha256:targetdigest']
+        st.target_version = '19.2.0'
+        st.image_mirror_done = True
+        return True
+
+    pre_pull_mock.side_effect = _fake_pre_pull
+    upgrade_daemon = _upgrade_test_daemon()
+    first_pull = mock.AsyncMock(
+        side_effect=AssertionError('serial first pull must not run'))
+
+    with mock.patch.object(CephadmUpgrade, '_detect_need_upgrade', return_value=(False, [], [], 0)), \
+            mock.patch.object(CephadmUpgrade, '_to_upgrade', return_value=(True, [])), \
+            mock.patch.object(CephadmUpgrade, '_get_filtered_daemons', return_value=[upgrade_daemon]), \
+            mock.patch.object(CephadmUpgrade, '_pre_distribute_upgrade_images') as mirror_mock, \
+            mock.patch.object(CephadmUpgrade, 'get_distinct_container_image_settings', return_value={}), \
+            mock.patch("cephadm.serve.CephadmServe._get_container_image_info", new=first_pull), \
+            mock.patch("cephadm.module.CephadmOrchestrator.lookup_release_name", return_value='tentacle'), \
+            mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command", return_value=(0, '{}', '')), \
+            mock.patch("cephadm.module.CephadmOrchestrator.get", return_value={
+                'min_mon_release': 19,
+                'require_osd_release': 'tentacle',
+                'have_local_config_map': True,
+            }), \
+            mock.patch(
+                "cephadm.module.CephadmOrchestrator.version",
+                new_callable=mock.PropertyMock,
+                return_value='ceph version 19.2.0-0 (hash)'), \
+            mock.patch("cephadm.module.HostCache.get_daemons", return_value=[upgrade_daemon]):
+        cephadm_module.upgrade._do_upgrade()
+
+    pre_pull_mock.assert_called_once()
+    mirror_mock.assert_not_called()
+    first_pull.assert_not_called()
+    assert cephadm_module.upgrade.upgrade_state.target_version == '19.2.0'

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -10,6 +10,8 @@ from cephadm.upgrade import (
     CephadmUpgrade,
     OkToUpgradeMonReport,
     UpgradeState,
+    UPGRADE_IMAGE_MIRROR_METHOD_LOCAL_HTTP,
+    UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY,
     parse_ok_to_upgrade_mon_json,
     request_osd_ok_to_upgrade_report,
 )
@@ -20,6 +22,14 @@ from .fixtures import _run_cephadm, wait, with_host, with_service, \
     receive_agent_metadata, async_side_effect
 
 from typing import List, Tuple, Optional
+
+
+def _upgrade_test_daemon(hostname: str = 'host1') -> DaemonDescription:
+    return DaemonDescription(
+        hostname=hostname,
+        daemon_type='mgr',
+        daemon_id='0',
+    )
 
 
 @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
@@ -1209,3 +1219,507 @@ def test_do_upgrade_limit_exhausted_marks_complete_without_scope_check(
 
     mark_complete.assert_called_once()
     filtered_scope.assert_not_called()
+
+
+def test_upgrade_state_image_mirror_roundtrip():
+    u = UpgradeState('target', 'pid', image_mirror_done=True)
+    restored = UpgradeState.from_json(u.to_json())
+    assert restored
+    assert restored.image_mirror_done is True
+
+
+def test_mirror_tar_basename_uses_gzip_suffix(cephadm_module: CephadmOrchestrator):
+    name = cephadm_module.upgrade._mirror_tar_basename(
+        ['192.168.100.254:5000/ceph/ceph@sha256:abc'])
+    assert name.endswith('.tar.gz')
+
+
+@mock.patch("cephadm.ssh.SSHManager._check_execute_command", new_callable=mock.AsyncMock)
+def test_save_image_on_host_compresses_with_gzip(
+    check_execute: mock.AsyncMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    cephadm_module.wait_async(
+        cephadm_module.upgrade._save_image_on_host(
+            'host1', 'podman', 'ceph/ceph:main', '/var/lib/ceph/fsid/img.tar.gz'))
+    check_execute.assert_called_once()
+    cmd = check_execute.call_args[0][1]
+    assert str(cmd.exe) == 'bash'
+    script = cmd.args[1]
+    assert 'podman save' in script
+    assert 'python3 -m gzip --fast' in script
+    assert '/var/lib/ceph/fsid/img.tar.gz' in script
+
+
+def test_mirror_image_tag_name_prefers_user_tag(cephadm_module: CephadmOrchestrator):
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        '192.168.100.254:5000/ceph/ceph:main3.0.kobi',
+        'pid',
+        target_id='sha256:abc',
+        target_digests=['192.168.100.254:5000/ceph/ceph@sha256:abc'],
+    )
+    assert cephadm_module.upgrade._mirror_image_tag_name() == (
+        '192.168.100.254:5000/ceph/ceph:main3.0.kobi')
+
+
+def test_mirror_image_tag_name_none_for_digest_only(cephadm_module: CephadmOrchestrator):
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        '192.168.100.254:5000/ceph/ceph@sha256:abc',
+        'pid',
+    )
+    assert cephadm_module.upgrade._mirror_image_tag_name() is None
+
+
+@mock.patch("cephadm.ssh.SSHManager._check_execute_command", new_callable=mock.AsyncMock)
+def test_load_image_from_url_retags_after_load(
+    check_execute: mock.AsyncMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    cephadm_module.wait_async(
+        cephadm_module.upgrade._load_image_from_url_on_host(
+            'host1',
+            'podman',
+            'http://seed:8766/img.tar.gz',
+            '/tmp/img.tar.gz',
+            tag_name='192.168.100.254:5000/ceph/ceph:main3.0.kobi',
+            image_id='sha256:4bfa4fc1176d',
+        ))
+    script = check_execute.call_args[0][1].args[1]
+    assert 'podman load -i' in script
+    assert 'podman tag sha256:4bfa4fc1176d 192.168.100.254:5000/ceph/ceph:main3.0.kobi' in script
+
+
+def test_host_has_target_image_matches_image_id():
+    upgrade = CephadmUpgrade.__new__(CephadmUpgrade)
+    upgrade.upgrade_state = UpgradeState(
+        '192.168.100.254:5000/ceph/ceph:main2.0',
+        'pid',
+        target_id='acf49863d4a5ce75d68464d3924f3d3f8a7af21544e7bd9430805f04d70eed8c',
+        target_digests=['192.168.100.254:5000/ceph/ceph@sha256:abc'],
+    )
+    assert upgrade._host_has_target_image(
+        {'image_id': 'acf49863d4a5ce75d68464d3924f3d3f8a7af21544e7bd9430805f04d70eed8c',
+         'repo_digests': []},
+        ['192.168.100.254:5000/ceph/ceph@sha256:abc'],
+    )
+
+
+def test_http_url_host_ipv6():
+    from cephadm.upgrade import _http_url_host
+    assert _http_url_host('2620:52:0:1304::64') == '[2620:52:0:1304::64]'
+    assert _http_url_host('192.168.100.100') == '192.168.100.100'
+
+
+def test_get_image_mirror_host_addr_prefers_public_ipv4(cephadm_module: CephadmOrchestrator):
+    cephadm_module.inventory._inventory['host1'] = {
+        'hostname': 'host1',
+        'addr': '2620:52:0:1304::64',
+        'labels': [],
+    }
+    cephadm_module.cache.networks['host1'] = {
+        '192.168.100.0/24': {'eth0': ['192.168.100.100']},
+        '2620:52:0:1304::/64': {'eth0': ['2620:52:0:1304::64']},
+    }
+    addr = cephadm_module.upgrade._get_image_mirror_host_addr('host1')
+    assert addr == '192.168.100.100'
+
+
+def test_select_image_mirror_seed_host_prefers_admin(cephadm_module: CephadmOrchestrator):
+    cephadm_module.inventory._inventory['host1'] = {
+        'hostname': 'host1',
+        'addr': '192.168.100.1',
+        'labels': [],
+    }
+    cephadm_module.inventory._inventory['host2'] = {
+        'hostname': 'host2',
+        'addr': '192.168.100.2',
+        'labels': ['_admin'],
+    }
+    seed = cephadm_module.upgrade._select_image_mirror_seed_host(['host1', 'host2'])
+    assert seed == 'host2'
+
+
+@mock.patch.object(CephadmUpgrade, '_update_upgrade_progress')
+@mock.patch.object(CephadmUpgrade, '_get_upgrade_scope_hosts', return_value=['host1'])
+@mock.patch.object(CephadmUpgrade, '_pre_distribute_upgrade_images', return_value=True)
+def test_do_upgrade_calls_image_mirror_before_daemons(
+    mirror_mock: mock.MagicMock,
+    _get_upgrade_scope_hosts: mock.MagicMock,
+    _update_upgrade_progress: mock.MagicMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    cephadm_module.upgrade_image_mirror_method = UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target_image',
+        'pid',
+        target_id='image_id',
+        target_digests=['target_image@digest'],
+        target_version='19.3.0-0',
+        image_mirror_done=False,
+    )
+    upgrade_daemon = _upgrade_test_daemon()
+    with mock.patch.object(CephadmUpgrade, '_detect_need_upgrade', return_value=(False, [], [], 0)), \
+            mock.patch.object(CephadmUpgrade, '_to_upgrade', return_value=(True, [])), \
+            mock.patch.object(CephadmUpgrade, '_get_filtered_daemons', return_value=[upgrade_daemon]), \
+            mock.patch.object(CephadmUpgrade, 'get_distinct_container_image_settings', return_value={}), \
+            mock.patch("cephadm.module.CephadmOrchestrator.lookup_release_name", return_value='tentacle'), \
+            mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command", return_value=(0, '{}', '')), \
+            mock.patch("cephadm.module.CephadmOrchestrator.get", return_value={
+                'min_mon_release': 19,
+                'require_osd_release': 'tentacle',
+                'have_local_config_map': True,
+            }), \
+            mock.patch(
+                "cephadm.module.CephadmOrchestrator.version",
+                new_callable=mock.PropertyMock,
+                return_value='ceph version 19.3.0-0 (hash)'), \
+            mock.patch("cephadm.module.HostCache.get_daemons", return_value=[upgrade_daemon]):
+        cephadm_module.upgrade._do_upgrade()
+    mirror_mock.assert_called_once()
+
+
+@mock.patch.object(CephadmUpgrade, '_update_upgrade_progress')
+@mock.patch.object(CephadmUpgrade, '_pre_distribute_upgrade_images')
+def test_do_upgrade_skips_image_mirror_when_done(
+    mirror_mock: mock.MagicMock,
+    _update_upgrade_progress: mock.MagicMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    cephadm_module.upgrade_image_mirror_method = UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target_image',
+        'pid',
+        target_id='image_id',
+        target_digests=['target_image@digest'],
+        target_version='19.3.0-0',
+        image_mirror_done=True,
+    )
+    upgrade_daemon = _upgrade_test_daemon()
+    with mock.patch.object(CephadmUpgrade, '_detect_need_upgrade', return_value=(False, [], [], 0)), \
+            mock.patch.object(CephadmUpgrade, '_to_upgrade', return_value=(True, [])), \
+            mock.patch.object(CephadmUpgrade, 'get_distinct_container_image_settings', return_value={}), \
+            mock.patch("cephadm.module.CephadmOrchestrator.lookup_release_name", return_value='tentacle'), \
+            mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command", return_value=(0, '{}', '')), \
+            mock.patch("cephadm.module.CephadmOrchestrator.get", return_value={
+                'min_mon_release': 19,
+                'require_osd_release': 'tentacle',
+                'have_local_config_map': True,
+            }), \
+            mock.patch(
+                "cephadm.module.CephadmOrchestrator.version",
+                new_callable=mock.PropertyMock,
+                return_value='ceph version 19.3.0-0 (hash)'), \
+            mock.patch("cephadm.module.HostCache.get_daemons", return_value=[upgrade_daemon]):
+        cephadm_module.upgrade._do_upgrade()
+    mirror_mock.assert_not_called()
+
+
+@mock.patch.object(CephadmUpgrade, '_update_upgrade_progress')
+@mock.patch.object(CephadmUpgrade, '_pre_distribute_upgrade_images')
+def test_do_upgrade_skips_image_mirror_when_method_disabled(
+    mirror_mock: mock.MagicMock,
+    _update_upgrade_progress: mock.MagicMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    for disabled in ('', 'none', 'NONE', ' None '):
+        cephadm_module.upgrade_image_mirror_method = disabled
+        cephadm_module.upgrade.upgrade_state = UpgradeState(
+            'target_image',
+            'pid',
+            target_id='image_id',
+            target_digests=['target_image@digest'],
+            target_version='19.3.0-0',
+            image_mirror_done=False,
+        )
+        upgrade_daemon = _upgrade_test_daemon()
+        with mock.patch.object(CephadmUpgrade, '_detect_need_upgrade', return_value=(False, [], [], 0)), \
+                mock.patch.object(CephadmUpgrade, '_to_upgrade', return_value=(True, [])), \
+                mock.patch.object(CephadmUpgrade, 'get_distinct_container_image_settings', return_value={}), \
+                mock.patch("cephadm.module.CephadmOrchestrator.lookup_release_name", return_value='tentacle'), \
+                mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command", return_value=(0, '{}', '')), \
+                mock.patch("cephadm.module.CephadmOrchestrator.get", return_value={
+                    'min_mon_release': 19,
+                    'require_osd_release': 'tentacle',
+                    'have_local_config_map': True,
+                }), \
+                mock.patch(
+                    "cephadm.module.CephadmOrchestrator.version",
+                    new_callable=mock.PropertyMock,
+                    return_value='ceph version 19.3.0-0 (hash)'), \
+                mock.patch("cephadm.module.HostCache.get_daemons", return_value=[upgrade_daemon]):
+            cephadm_module.upgrade._do_upgrade()
+        assert mirror_mock.call_count == 0
+    mirror_mock.assert_not_called()
+
+
+@mock.patch.object(CephadmUpgrade, '_mirror_cleanup', new_callable=mock.AsyncMock)
+@mock.patch.object(CephadmUpgrade, '_inspect_image_on_host', new_callable=mock.AsyncMock)
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm_json", new_callable=mock.AsyncMock)
+@mock.patch("cephadm.ssh.SSHManager._check_execute_command", new_callable=mock.AsyncMock)
+def test_mirror_upgrade_image_marks_done_when_hosts_ready(
+    _check_execute_command: mock.AsyncMock,
+    _run_cephadm_json: mock.AsyncMock,
+    inspect_image: mock.AsyncMock,
+    _mirror_cleanup: mock.AsyncMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    inspect_image.return_value = {'repo_digests': ['target_image@digest']}
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target_image',
+        'pid',
+        target_digests=['target_image@digest'],
+    )
+    result = cephadm_module.wait_async(
+        cephadm_module.upgrade._mirror_upgrade_image_via_http_async(
+            'target_image',
+            ['target_image@digest'],
+            ['host1', 'host2'],
+        ))
+    assert result is True
+    assert cephadm_module.upgrade.upgrade_state.image_mirror_done is True
+    _run_cephadm_json.assert_not_called()
+
+
+@mock.patch.object(CephadmUpgrade, '_mirror_upgrade_image_via_http', return_value=True)
+def test_pre_distribute_upgrade_images_uses_local_http(
+    http_mock: mock.MagicMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    cephadm_module.upgrade_image_mirror_method = UPGRADE_IMAGE_MIRROR_METHOD_LOCAL_HTTP
+    assert cephadm_module.upgrade._pre_distribute_upgrade_images(
+        'target_image', ['target_image@digest'], ['host1']) is True
+    http_mock.assert_called_once_with(
+        'target_image', ['target_image@digest'], ['host1'])
+
+
+@mock.patch.object(CephadmUpgrade, '_pre_pull_image_on_hosts', return_value=True)
+def test_pre_distribute_upgrade_images_uses_registry(
+    registry_mock: mock.MagicMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    cephadm_module.upgrade_image_mirror_method = UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY
+    assert cephadm_module.upgrade._pre_distribute_upgrade_images(
+        'target_image', ['target_image@digest'], ['host1']) is True
+    registry_mock.assert_called_once_with(
+        'target_image', ['target_image@digest'], ['host1'])
+
+
+@mock.patch.object(CephadmUpgrade, '_pre_pull_image_on_hosts')
+@mock.patch.object(CephadmUpgrade, '_mirror_upgrade_image_via_http')
+def test_pre_distribute_upgrade_images_noop_when_disabled(
+    http_mock: mock.MagicMock,
+    registry_mock: mock.MagicMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    for disabled in ('', 'none'):
+        cephadm_module.upgrade_image_mirror_method = disabled
+        assert cephadm_module.upgrade._pre_distribute_upgrade_images(
+            'target_image', ['target_image@digest'], ['host1']) is True
+    http_mock.assert_not_called()
+    registry_mock.assert_not_called()
+
+
+def _registry_prepull_upgrade_state(cephadm_module: CephadmOrchestrator):
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'quay.io/ceph/ceph:vtest',
+        'pid',
+        target_digests=['quay.io/ceph/ceph@sha256:targetdigest'],
+        target_id='targetdigest',
+        target_version='19.2.0',
+    )
+
+
+def _inspect_or_pull(present_hosts, fail_pull_hosts):
+    pulled: set = set()
+
+    async def fake_run(self, host, entity, command, args, image=None,
+                       no_fsid=None, error_ok=None, **kwargs):
+        if command == 'inspect-image':
+            if host in present_hosts or host in pulled:
+                return (
+                    ['{"repo_digests": ["quay.io/ceph/ceph@sha256:targetdigest"]}'],
+                    [], 0)
+            return (['{"repo_digests": ["sha256:other"]}'], [], 0)
+        if host in fail_pull_hosts:
+            return ([], ['no space left on device'], 1)
+        pulled.add(host)
+        return (
+            ['{"repo_digests": ["quay.io/ceph/ceph@sha256:targetdigest"]}'],
+            [], 0)
+    return fake_run
+
+
+@mock.patch.object(CephadmUpgrade, '_registry_login_if_needed', new_callable=mock.AsyncMock)
+def test_registry_pre_pull_success_on_all_hosts(
+    _registry_login: mock.AsyncMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    _registry_prepull_upgrade_state(cephadm_module)
+    cephadm_module.upgrade_image_mirror_max_parallel = 8
+    with mock.patch("cephadm.serve.CephadmServe._run_cephadm",
+                    new=_inspect_or_pull(set(), set())):
+        ok = cephadm_module.wait_async(
+            cephadm_module.upgrade._pre_pull_image_on_hosts_async(
+                'quay.io/ceph/ceph:vtest',
+                ['quay.io/ceph/ceph@sha256:targetdigest'],
+                ['h1', 'h2', 'h3'],
+            ))
+    assert ok is True
+    assert cephadm_module.upgrade.upgrade_state.image_mirror_done is True
+    assert 'UPGRADE_FAILED_PULL' not in cephadm_module.health_checks
+
+
+@mock.patch.object(CephadmUpgrade, '_registry_login_if_needed', new_callable=mock.AsyncMock)
+def test_registry_pre_pull_skips_hosts_that_already_have_image(
+    _registry_login: mock.AsyncMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    _registry_prepull_upgrade_state(cephadm_module)
+    cephadm_module.upgrade_image_mirror_max_parallel = 8
+    pulled = []
+
+    async def fake_run(self, host, entity, command, args, image=None,
+                       no_fsid=None, error_ok=None, **kwargs):
+        if command == 'inspect-image':
+            digest = (
+                'quay.io/ceph/ceph@sha256:targetdigest'
+                if host == 'h2' or host in pulled else 'sha256:other')
+            return ([f'{{"repo_digests": ["{digest}"]}}'], [], 0)
+        pulled.append(host)
+        return (
+            ['{"repo_digests": ["quay.io/ceph/ceph@sha256:targetdigest"]}'],
+            [], 0)
+
+    with mock.patch("cephadm.serve.CephadmServe._run_cephadm", new=fake_run):
+        ok = cephadm_module.wait_async(
+            cephadm_module.upgrade._pre_pull_image_on_hosts_async(
+                'quay.io/ceph/ceph:vtest',
+                ['quay.io/ceph/ceph@sha256:targetdigest'],
+                ['h1', 'h2', 'h3'],
+            ))
+    assert ok is True
+    assert 'h2' not in pulled
+    assert sorted(pulled) == ['h1', 'h3']
+
+
+@mock.patch.object(CephadmUpgrade, '_registry_login_if_needed', new_callable=mock.AsyncMock)
+def test_registry_pre_pull_failure_pauses_and_reports_host(
+    _registry_login: mock.AsyncMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    _registry_prepull_upgrade_state(cephadm_module)
+    cephadm_module.upgrade_image_mirror_max_parallel = 8
+    with mock.patch("cephadm.serve.CephadmServe._run_cephadm",
+                    new=_inspect_or_pull(set(), {'h2'})):
+        ok = cephadm_module.wait_async(
+            cephadm_module.upgrade._pre_pull_image_on_hosts_async(
+                'quay.io/ceph/ceph:vtest',
+                ['quay.io/ceph/ceph@sha256:targetdigest'],
+                ['h1', 'h2', 'h3'],
+            ))
+    assert ok is False
+    assert cephadm_module.upgrade.upgrade_state.paused
+    assert 'UPGRADE_FAILED_PULL' in cephadm_module.health_checks
+    detail = ' '.join(cephadm_module.health_checks['UPGRADE_FAILED_PULL']['detail'])
+    assert 'h2' in detail
+    assert 'no space left on device' in detail
+
+
+_PULL_INFO_JSON = json.dumps({
+    'image_id': 'sha256:targetdigest',
+    'repo_digests': ['quay.io/ceph/ceph@sha256:targetdigest'],
+    'ceph_version': 'ceph version 19.2.0 (abc) squid (stable)',
+})
+
+
+@mock.patch.object(CephadmUpgrade, '_registry_login_if_needed', new_callable=mock.AsyncMock)
+def test_registry_pre_pull_discovers_metadata_from_parallel_pulls(
+    _registry_login: mock.AsyncMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    """When digests/version are unknown, learn them from parallel pulls."""
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'quay.io/ceph/ceph:vtest',
+        'pid',
+    )
+    cephadm_module.upgrade_image_mirror_max_parallel = 8
+    pulled: List[str] = []
+
+    async def fake_run(self, host, entity, command, args, image=None,
+                       no_fsid=None, error_ok=None, **kwargs):
+        assert command == 'pull'
+        pulled.append(host)
+        return ([_PULL_INFO_JSON], [], 0)
+
+    with mock.patch("cephadm.serve.CephadmServe._run_cephadm", new=fake_run):
+        ok = cephadm_module.wait_async(
+            cephadm_module.upgrade._pre_pull_image_on_hosts_async(
+                'quay.io/ceph/ceph:vtest',
+                [],
+                ['h1', 'h2', 'h3'],
+            ))
+    assert ok is True
+    assert sorted(pulled) == ['h1', 'h2', 'h3']
+    st = cephadm_module.upgrade.upgrade_state
+    assert st.image_mirror_done is True
+    assert st.target_id == 'sha256:targetdigest'
+    assert st.target_digests == ['quay.io/ceph/ceph@sha256:targetdigest']
+    assert st.target_version == '19.2.0'
+    assert 'UPGRADE_FAILED_PULL' not in cephadm_module.health_checks
+
+
+@mock.patch.object(CephadmUpgrade, '_update_upgrade_progress')
+@mock.patch.object(CephadmUpgrade, '_get_upgrade_scope_hosts', return_value=['h1', 'h2'])
+@mock.patch.object(CephadmUpgrade, '_pre_pull_image_on_hosts')
+def test_do_upgrade_registry_discovers_without_serial_first_pull(
+    pre_pull_mock: mock.MagicMock,
+    _get_upgrade_scope_hosts: mock.MagicMock,
+    _update_upgrade_progress: mock.MagicMock,
+    cephadm_module: CephadmOrchestrator,
+):
+    """Registry mirror with no target metadata must not call serial First pull."""
+    cephadm_module.upgrade_image_mirror_method = UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'quay.io/ceph/ceph:vtest',
+        'pid',
+        image_mirror_done=False,
+    )
+
+    def _fake_pre_pull(target_image, target_digests, hosts):
+        st = cephadm_module.upgrade.upgrade_state
+        assert st is not None
+        st.target_id = 'sha256:targetdigest'
+        st.target_digests = ['quay.io/ceph/ceph@sha256:targetdigest']
+        st.target_version = '19.2.0'
+        st.image_mirror_done = True
+        return True
+
+    pre_pull_mock.side_effect = _fake_pre_pull
+    upgrade_daemon = _upgrade_test_daemon()
+    first_pull = mock.AsyncMock(
+        side_effect=AssertionError('serial first pull must not run'))
+
+    with mock.patch.object(CephadmUpgrade, '_detect_need_upgrade', return_value=(False, [], [], 0)), \
+            mock.patch.object(CephadmUpgrade, '_to_upgrade', return_value=(True, [])), \
+            mock.patch.object(CephadmUpgrade, '_get_filtered_daemons', return_value=[upgrade_daemon]), \
+            mock.patch.object(CephadmUpgrade, '_pre_distribute_upgrade_images') as mirror_mock, \
+            mock.patch.object(CephadmUpgrade, 'get_distinct_container_image_settings', return_value={}), \
+            mock.patch("cephadm.serve.CephadmServe._get_container_image_info", new=first_pull), \
+            mock.patch("cephadm.module.CephadmOrchestrator.lookup_release_name", return_value='tentacle'), \
+            mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command", return_value=(0, '{}', '')), \
+            mock.patch("cephadm.module.CephadmOrchestrator.get", return_value={
+                'min_mon_release': 19,
+                'require_osd_release': 'tentacle',
+                'have_local_config_map': True,
+            }), \
+            mock.patch(
+                "cephadm.module.CephadmOrchestrator.version",
+                new_callable=mock.PropertyMock,
+                return_value='ceph version 19.2.0-0 (hash)'), \
+            mock.patch("cephadm.module.HostCache.get_daemons", return_value=[upgrade_daemon]):
+        cephadm_module.upgrade._do_upgrade()
+
+    pre_pull_mock.assert_called_once()
+    mirror_mock.assert_not_called()
+    first_pull.assert_not_called()
+    assert cephadm_module.upgrade.upgrade_state.target_version == '19.2.0'

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -10,7 +10,6 @@ from cephadm.upgrade import (
     CephadmUpgrade,
     OkToUpgradeMonReport,
     UpgradeState,
-    UPGRADE_IMAGE_MIRROR_METHOD_LOCAL_HTTP,
     UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY,
     parse_ok_to_upgrade_mon_json,
     request_osd_ok_to_upgrade_report,
@@ -1228,67 +1227,6 @@ def test_upgrade_state_image_mirror_roundtrip():
     assert restored.image_mirror_done is True
 
 
-def test_mirror_tar_basename_uses_gzip_suffix(cephadm_module: CephadmOrchestrator):
-    name = cephadm_module.upgrade._mirror_tar_basename(
-        ['192.168.100.254:5000/ceph/ceph@sha256:abc'])
-    assert name.endswith('.tar.gz')
-
-
-@mock.patch("cephadm.ssh.SSHManager._check_execute_command", new_callable=mock.AsyncMock)
-def test_save_image_on_host_compresses_with_gzip(
-    check_execute: mock.AsyncMock,
-    cephadm_module: CephadmOrchestrator,
-):
-    cephadm_module.wait_async(
-        cephadm_module.upgrade._save_image_on_host(
-            'host1', 'podman', 'ceph/ceph:main', '/var/lib/ceph/fsid/img.tar.gz'))
-    check_execute.assert_called_once()
-    cmd = check_execute.call_args[0][1]
-    assert str(cmd.exe) == 'bash'
-    script = cmd.args[1]
-    assert 'podman save' in script
-    assert 'python3 -m gzip --fast' in script
-    assert '/var/lib/ceph/fsid/img.tar.gz' in script
-
-
-def test_mirror_image_tag_name_prefers_user_tag(cephadm_module: CephadmOrchestrator):
-    cephadm_module.upgrade.upgrade_state = UpgradeState(
-        '192.168.100.254:5000/ceph/ceph:main3.0.kobi',
-        'pid',
-        target_id='sha256:abc',
-        target_digests=['192.168.100.254:5000/ceph/ceph@sha256:abc'],
-    )
-    assert cephadm_module.upgrade._mirror_image_tag_name() == (
-        '192.168.100.254:5000/ceph/ceph:main3.0.kobi')
-
-
-def test_mirror_image_tag_name_none_for_digest_only(cephadm_module: CephadmOrchestrator):
-    cephadm_module.upgrade.upgrade_state = UpgradeState(
-        '192.168.100.254:5000/ceph/ceph@sha256:abc',
-        'pid',
-    )
-    assert cephadm_module.upgrade._mirror_image_tag_name() is None
-
-
-@mock.patch("cephadm.ssh.SSHManager._check_execute_command", new_callable=mock.AsyncMock)
-def test_load_image_from_url_retags_after_load(
-    check_execute: mock.AsyncMock,
-    cephadm_module: CephadmOrchestrator,
-):
-    cephadm_module.wait_async(
-        cephadm_module.upgrade._load_image_from_url_on_host(
-            'host1',
-            'podman',
-            'http://seed:8766/img.tar.gz',
-            '/tmp/img.tar.gz',
-            tag_name='192.168.100.254:5000/ceph/ceph:main3.0.kobi',
-            image_id='sha256:4bfa4fc1176d',
-        ))
-    script = check_execute.call_args[0][1].args[1]
-    assert 'podman load -i' in script
-    assert 'podman tag sha256:4bfa4fc1176d 192.168.100.254:5000/ceph/ceph:main3.0.kobi' in script
-
-
 def test_host_has_target_image_matches_image_id():
     upgrade = CephadmUpgrade.__new__(CephadmUpgrade)
     upgrade.upgrade_state = UpgradeState(
@@ -1302,41 +1240,6 @@ def test_host_has_target_image_matches_image_id():
          'repo_digests': []},
         ['192.168.100.254:5000/ceph/ceph@sha256:abc'],
     )
-
-
-def test_http_url_host_ipv6():
-    from cephadm.upgrade import _http_url_host
-    assert _http_url_host('2620:52:0:1304::64') == '[2620:52:0:1304::64]'
-    assert _http_url_host('192.168.100.100') == '192.168.100.100'
-
-
-def test_get_image_mirror_host_addr_prefers_public_ipv4(cephadm_module: CephadmOrchestrator):
-    cephadm_module.inventory._inventory['host1'] = {
-        'hostname': 'host1',
-        'addr': '2620:52:0:1304::64',
-        'labels': [],
-    }
-    cephadm_module.cache.networks['host1'] = {
-        '192.168.100.0/24': {'eth0': ['192.168.100.100']},
-        '2620:52:0:1304::/64': {'eth0': ['2620:52:0:1304::64']},
-    }
-    addr = cephadm_module.upgrade._get_image_mirror_host_addr('host1')
-    assert addr == '192.168.100.100'
-
-
-def test_select_image_mirror_seed_host_prefers_admin(cephadm_module: CephadmOrchestrator):
-    cephadm_module.inventory._inventory['host1'] = {
-        'hostname': 'host1',
-        'addr': '192.168.100.1',
-        'labels': [],
-    }
-    cephadm_module.inventory._inventory['host2'] = {
-        'hostname': 'host2',
-        'addr': '192.168.100.2',
-        'labels': ['_admin'],
-    }
-    seed = cephadm_module.upgrade._select_image_mirror_seed_host(['host1', 'host2'])
-    assert seed == 'host2'
 
 
 @mock.patch.object(CephadmUpgrade, '_update_upgrade_progress')
@@ -1452,46 +1355,6 @@ def test_do_upgrade_skips_image_mirror_when_method_disabled(
     mirror_mock.assert_not_called()
 
 
-@mock.patch.object(CephadmUpgrade, '_mirror_cleanup', new_callable=mock.AsyncMock)
-@mock.patch.object(CephadmUpgrade, '_inspect_image_on_host', new_callable=mock.AsyncMock)
-@mock.patch("cephadm.serve.CephadmServe._run_cephadm_json", new_callable=mock.AsyncMock)
-@mock.patch("cephadm.ssh.SSHManager._check_execute_command", new_callable=mock.AsyncMock)
-def test_mirror_upgrade_image_marks_done_when_hosts_ready(
-    _check_execute_command: mock.AsyncMock,
-    _run_cephadm_json: mock.AsyncMock,
-    inspect_image: mock.AsyncMock,
-    _mirror_cleanup: mock.AsyncMock,
-    cephadm_module: CephadmOrchestrator,
-):
-    inspect_image.return_value = {'repo_digests': ['target_image@digest']}
-    cephadm_module.upgrade.upgrade_state = UpgradeState(
-        'target_image',
-        'pid',
-        target_digests=['target_image@digest'],
-    )
-    result = cephadm_module.wait_async(
-        cephadm_module.upgrade._mirror_upgrade_image_via_http_async(
-            'target_image',
-            ['target_image@digest'],
-            ['host1', 'host2'],
-        ))
-    assert result is True
-    assert cephadm_module.upgrade.upgrade_state.image_mirror_done is True
-    _run_cephadm_json.assert_not_called()
-
-
-@mock.patch.object(CephadmUpgrade, '_mirror_upgrade_image_via_http', return_value=True)
-def test_pre_distribute_upgrade_images_uses_local_http(
-    http_mock: mock.MagicMock,
-    cephadm_module: CephadmOrchestrator,
-):
-    cephadm_module.upgrade_image_mirror_method = UPGRADE_IMAGE_MIRROR_METHOD_LOCAL_HTTP
-    assert cephadm_module.upgrade._pre_distribute_upgrade_images(
-        'target_image', ['target_image@digest'], ['host1']) is True
-    http_mock.assert_called_once_with(
-        'target_image', ['target_image@digest'], ['host1'])
-
-
 @mock.patch.object(CephadmUpgrade, '_pre_pull_image_on_hosts', return_value=True)
 def test_pre_distribute_upgrade_images_uses_registry(
     registry_mock: mock.MagicMock,
@@ -1505,9 +1368,7 @@ def test_pre_distribute_upgrade_images_uses_registry(
 
 
 @mock.patch.object(CephadmUpgrade, '_pre_pull_image_on_hosts')
-@mock.patch.object(CephadmUpgrade, '_mirror_upgrade_image_via_http')
 def test_pre_distribute_upgrade_images_noop_when_disabled(
-    http_mock: mock.MagicMock,
     registry_mock: mock.MagicMock,
     cephadm_module: CephadmOrchestrator,
 ):
@@ -1515,8 +1376,19 @@ def test_pre_distribute_upgrade_images_noop_when_disabled(
         cephadm_module.upgrade_image_mirror_method = disabled
         assert cephadm_module.upgrade._pre_distribute_upgrade_images(
             'target_image', ['target_image@digest'], ['host1']) is True
-    http_mock.assert_not_called()
     registry_mock.assert_not_called()
+
+
+def test_pre_distribute_upgrade_images_rejects_unknown_method(
+    cephadm_module: CephadmOrchestrator,
+):
+    cephadm_module.upgrade.upgrade_state = UpgradeState('target_image', 'pid')
+    cephadm_module.upgrade_image_mirror_method = 'local_http'
+    assert cephadm_module.upgrade._pre_distribute_upgrade_images(
+        'target_image', ['target_image@digest'], ['host1']) is False
+    assert 'UPGRADE_FAILED_PULL' in cephadm_module.health_checks
+    detail = ' '.join(cephadm_module.health_checks['UPGRADE_FAILED_PULL']['detail'])
+    assert 'local_http' in detail
 
 
 def _registry_prepull_upgrade_state(cephadm_module: CephadmOrchestrator):

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -1,6 +1,11 @@
+import asyncio
 import errno
+import hashlib
+import ipaddress
 import json
 import logging
+import os
+import shlex
 import time
 import uuid
 from dataclasses import dataclass, field, asdict
@@ -8,12 +13,14 @@ from typing import TYPE_CHECKING, Optional, Dict, List, Tuple, Any, cast, Set
 from cephadm.services.service_registry import service_registry
 
 import orchestrator
+from ceph.deployment.service_spec import PlacementSpec
 from cephadm.registry import Registry
 from cephadm.serve import CephadmServe
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 from cephadm.utils import ceph_release_to_major, name_to_config_section, CEPH_UPGRADE_ORDER, \
-    CEPH_TYPES, CEPH_IMAGE_TYPES, NON_CEPH_IMAGE_TYPES, MONITORING_STACK_TYPES, GATEWAY_TYPES
-from cephadm.ssh import HostConnectionError
+    CEPH_TYPES, CEPH_IMAGE_TYPES, NON_CEPH_IMAGE_TYPES, MONITORING_STACK_TYPES, GATEWAY_TYPES, \
+    SpecialHostLabels
+from cephadm.ssh import HostConnectionError, RemoteCommand, RemoteExecutable, Executables
 from orchestrator import OrchestratorError, DaemonDescription, DaemonDescriptionStatus, daemon_type_to_service
 
 from mgr_module import MonCommandFailed
@@ -31,6 +38,38 @@ CEPH_ORCH_VALID_OSD_UPGRADE_CRUSH_BUCKETS = frozenset({'rack', 'chassis', 'host'
 # from ceph_fs.h
 CEPH_MDSMAP_ALLOW_STANDBY_REPLAY = (1 << 5)
 CEPH_MDSMAP_NOT_JOINABLE = (1 << 0)
+
+# Whole mirror phase (save + HTTP fan-out + load on all hosts). Single-command
+# default_cephadm_command_timeout (15m) is too short for multi-GB images.
+UPGRADE_IMAGE_MIRROR_MIN_TIMEOUT = 7200
+
+UPGRADE_IMAGE_MIRROR_METHOD_NONE = 'none'
+UPGRADE_IMAGE_MIRROR_METHOD_LOCAL_HTTP = 'local_http'
+UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY = 'registry'
+# Empty string or "none" disables pre-distribution (default).
+UPGRADE_IMAGE_MIRROR_METHODS_DISABLED = frozenset({
+    '',
+    UPGRADE_IMAGE_MIRROR_METHOD_NONE,
+})
+UPGRADE_IMAGE_MIRROR_METHODS_ENABLED = frozenset({
+    UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY,
+    UPGRADE_IMAGE_MIRROR_METHOD_LOCAL_HTTP,
+})
+
+
+def _remote_shell(script: str) -> RemoteCommand:
+    return RemoteCommand(RemoteExecutable('bash'), ['-c', script])
+
+
+def _http_url_host(addr: str) -> str:
+    bare = addr.split('/')[0]
+    try:
+        ip = ipaddress.ip_address(bare)
+        if isinstance(ip, ipaddress.IPv6Address):
+            return f'[{bare}]'
+    except ValueError:
+        pass
+    return bare
 
 
 def normalize_image_digest(digest: str, default_registry: str) -> str:
@@ -204,6 +243,7 @@ class UpgradeState:
                  crush_bucket_name: Optional[str] = None,
                  noautoscale_set: Optional[bool] = False,
                  prior_autoscale: Optional[bool] = True,
+                 image_mirror_done: bool = False,
                  ):
 
         self._target_name: str = target_name  # Use CephadmUpgrade.target_image instead.
@@ -226,6 +266,7 @@ class UpgradeState:
         self.crush_bucket_name = crush_bucket_name
         self.noautoscale_set = noautoscale_set
         self.prior_autoscale = prior_autoscale
+        self.image_mirror_done = image_mirror_done
 
     def to_json(self) -> dict:
         return {
@@ -248,6 +289,7 @@ class UpgradeState:
             'crush_bucket_name': self.crush_bucket_name,
             'noautoscale_set': self.noautoscale_set,
             'prior_autoscale': self.prior_autoscale,
+            'image_mirror_done': self.image_mirror_done,
         }
 
     @classmethod
@@ -1105,9 +1147,13 @@ class CephadmUpgrade:
             # were doing something
             return
 
-        logger.error('Upgrade: Paused due to %s: %s' % (alert_id,
-                                                        alert['summary']))
-        self.upgrade_state.error = alert_id + ': ' + alert['summary']
+        detail = alert.get('detail', [])
+        summary = alert['summary']
+        if detail:
+            summary = f"{summary}: {'; '.join(str(d) for d in detail[:5])}"
+
+        logger.error('Upgrade: Paused due to %s: %s' % (alert_id, summary))
+        self.upgrade_state.error = alert_id + ': ' + summary
         self.upgrade_state.paused = True
         # Do not restore PG autoscaling here: upgrade is only paused. Restore
         # only on upgrade_stop or _mark_upgrade_complete so that resume
@@ -1747,6 +1793,800 @@ class CephadmUpgrade:
         self._ok_to_upgrade_osds_in_crush_bucket = None
         self._save_upgrade_state()
 
+    def _get_upgrade_scope_hosts(self, daemons: List[DaemonDescription]) -> List[str]:
+        hosts = sorted({d.hostname for d in daemons if d.hostname})
+        return [h for h in hosts if h not in self.mgr.offline_hosts]
+
+    def _mirror_tar_basename(self, target_digests: List[str]) -> str:
+        digest = target_digests[0] if target_digests else 'unknown'
+        safe = digest.replace('@', '-').replace(':', '-').replace('/', '_')
+        if len(safe) > 80:
+            safe = hashlib.sha256(digest.encode()).hexdigest()[:16]
+        return f'upgrade-image-{safe}.tar.gz'
+
+    def _mirror_paths(self, target_digests: List[str]) -> Tuple[str, str, str]:
+        mirror_dir = f'/var/lib/ceph/{self.mgr._cluster_fsid}'
+        tar_name = self._mirror_tar_basename(target_digests)
+        tar_path = f'{mirror_dir}/{tar_name}'
+        pid_path = f'{mirror_dir}/upgrade-image-http.pid'
+        return mirror_dir, tar_path, pid_path
+
+    def _select_image_mirror_seed_host(self, hosts: List[str]) -> str:
+        admin_hosts = PlacementSpec(
+            label=SpecialHostLabels.ADMIN
+        ).filter_matching_hostspecs(self.mgr.inventory.all_specs())
+        for host in admin_hosts:
+            if host in hosts and host not in self.mgr.offline_hosts:
+                return host
+
+        active_mgr = self.mgr.get_active_mgr()
+        if active_mgr.hostname and active_mgr.hostname in hosts:
+            return active_mgr.hostname
+
+        if not hosts:
+            raise OrchestratorError('no hosts in upgrade scope for image mirror')
+        return hosts[0]
+
+    def _ceph_networks(self) -> List[str]:
+        networks: List[str] = []
+        for entity, key in (('mon', 'public_network'), ('osd', 'cluster_network')):
+            try:
+                value = str(self.mgr.get_foreign_ceph_option(entity, key))
+            except Exception:
+                continue
+            if '/' not in value:
+                continue
+            for net in value.split(','):
+                net = net.strip()
+                if net and net not in networks:
+                    networks.append(net)
+        return networks
+
+    def _ips_on_host_networks(
+        self,
+        host: str,
+        ipv4_only: bool = False,
+        ceph_networks_only: bool = False,
+    ) -> List[str]:
+        ceph_networks = self._ceph_networks() if ceph_networks_only else []
+        ips: List[str] = []
+        for subnet, ifaces in self.mgr.cache.networks.get(host, {}).items():
+            on_ceph_net = False
+            if ceph_networks:
+                try:
+                    host_subnet = ipaddress.ip_network(subnet, strict=False)
+                except ValueError:
+                    continue
+                for ceph_net in ceph_networks:
+                    try:
+                        if host_subnet.overlaps(ipaddress.ip_network(ceph_net, strict=False)):
+                            on_ceph_net = True
+                            break
+                    except ValueError:
+                        continue
+                if not on_ceph_net:
+                    continue
+            for _iface, addr_list in ifaces.items():
+                for addr in addr_list:
+                    bare = addr.split('/')[0]
+                    try:
+                        ip = ipaddress.ip_address(bare)
+                    except ValueError:
+                        continue
+                    if ipv4_only and not isinstance(ip, ipaddress.IPv4Address):
+                        continue
+                    ips.append(str(ip))
+        return ips
+
+    def _get_image_mirror_host_addr(self, host: str) -> str:
+        """Pick a cluster-reachable address for the HTTP mirror (prefer IPv4)."""
+        for ceph_ipv4 in self._ips_on_host_networks(
+                host, ipv4_only=True, ceph_networks_only=True):
+            return ceph_ipv4
+        for host_ipv4 in self._ips_on_host_networks(host, ipv4_only=True):
+            return host_ipv4
+        inventory_addr = self.mgr.inventory.get_addr(host).split('/')[0]
+        try:
+            ip = ipaddress.ip_address(inventory_addr)
+            if isinstance(ip, ipaddress.IPv4Address):
+                return str(ip)
+        except ValueError:
+            pass
+        ceph_ips = self._ips_on_host_networks(
+            host, ceph_networks_only=True)
+        if ceph_ips:
+            return ceph_ips[0]
+        host_ips = self._ips_on_host_networks(host)
+        if host_ips:
+            return host_ips[0]
+        return inventory_addr
+
+    async def _inspect_image_on_host(
+        self,
+        host: str,
+        target_image: str,
+    ) -> Optional[Dict[str, Any]]:
+        out, _, code = await CephadmServe(self.mgr)._run_cephadm(
+            host, '', 'inspect-image', [],
+            image=target_image, no_fsid=True, error_ok=True)
+        if code:
+            return None
+        try:
+            return json.loads(''.join(out))
+        except json.JSONDecodeError:
+            return None
+
+    def _target_image_inspect_refs(self, target_image: str) -> List[str]:
+        refs: List[str] = []
+        assert self.upgrade_state is not None
+        for candidate in (
+            target_image,
+            self.upgrade_state._target_name,
+        ):
+            if candidate and candidate not in refs:
+                refs.append(candidate)
+        target_id = self.upgrade_state.target_id
+        if target_id:
+            bare_id = target_id.replace('sha256:', '')
+            for id_ref in (bare_id, f'sha256:{bare_id}'):
+                if id_ref not in refs:
+                    refs.append(id_ref)
+        return refs
+
+    async def _host_has_target_image_on_host(
+        self,
+        host: str,
+        target_image: str,
+        target_digests: List[str],
+    ) -> bool:
+        for ref in self._target_image_inspect_refs(target_image):
+            inspect_info = await self._inspect_image_on_host(host, ref)
+            if self._host_has_target_image(inspect_info, target_digests):
+                return True
+        return False
+
+    def _host_has_target_image(
+        self,
+        inspect_info: Optional[Dict[str, Any]],
+        target_digests: List[str],
+    ) -> bool:
+        if not inspect_info:
+            return False
+        repo_digests = inspect_info.get('repo_digests', []) or []
+        target_id = self.upgrade_state.target_id if self.upgrade_state else None
+        image_id = inspect_info.get('image_id')
+        if target_id and image_id:
+            if image_id.replace('sha256:', '') == target_id.replace('sha256:', ''):
+                return True
+        if any(d in target_digests for d in repo_digests):
+            return True
+        target_shas = {
+            d.split('@sha256:', 1)[1]
+            for d in target_digests
+            if '@sha256:' in d
+        }
+        for digest in repo_digests:
+            if '@sha256:' in digest and digest.split('@sha256:', 1)[1] in target_shas:
+                return True
+        return False
+
+    async def _get_host_container_engine(self, host: str) -> str:
+        cmd = _remote_shell(
+            'command -v podman 2>/dev/null || command -v docker 2>/dev/null')
+        out, _, code = await self.mgr.ssh._execute_command(host, cmd)
+        engine = (out or '').strip().splitlines()[-1].strip() if not code else ''
+        if not engine:
+            raise OrchestratorError(f'no container engine found on host {host}')
+        return engine
+
+    def _mirror_image_tag_name(self) -> Optional[str]:
+        """
+        Human image:tag used to start the upgrade, if any.
+
+        When use_repo_digest is enabled, ``target_image`` becomes a digest ref
+        (``repo@sha256:…``). Saving/loading by digest restores the layers but
+        leaves TAG as ``<none>`` on worker hosts. Prefer the original tag name
+        for save + an explicit retag after load.
+        """
+        assert self.upgrade_state is not None
+        name = self.upgrade_state._target_name
+        if not name or '@' in name:
+            return None
+        return name
+
+    async def _tag_image_on_host(
+        self,
+        host: str,
+        engine: str,
+        image_ref: str,
+        tag_name: str,
+    ) -> None:
+        script = (
+            f'{shlex.quote(engine)} tag '
+            f'{shlex.quote(image_ref)} {shlex.quote(tag_name)}'
+        )
+        await self.mgr.ssh._check_execute_command(host, _remote_shell(script))
+
+    async def _save_image_on_host(
+        self,
+        host: str,
+        engine: str,
+        image: str,
+        tar_path: str,
+    ) -> None:
+        # gzip --fast: podman/docker load accepts gzip-compressed archives.
+        script = (
+            f'{shlex.quote(engine)} save {shlex.quote(image)} | '
+            f'python3 -m gzip --fast > {shlex.quote(tar_path)}'
+        )
+        await self.mgr.ssh._check_execute_command(host, _remote_shell(script))
+
+    async def _load_image_from_url_on_host(
+        self,
+        host: str,
+        engine: str,
+        url: str,
+        tar_path: str,
+        tag_name: Optional[str] = None,
+        image_id: Optional[str] = None,
+    ) -> None:
+        script = (
+            f'curl -sf {shlex.quote(url)} -o {shlex.quote(tar_path)} && '
+            f'{shlex.quote(engine)} load -i {shlex.quote(tar_path)} && '
+            f'rm -f {shlex.quote(tar_path)}'
+        )
+        # podman/docker load of a digest-saved archive often leaves TAG <none>.
+        # Always retag to the upgrade's original image:tag when we know both.
+        if tag_name and image_id:
+            script += (
+                f' && {shlex.quote(engine)} tag '
+                f'{shlex.quote(image_id)} {shlex.quote(tag_name)}'
+            )
+        await self.mgr.ssh._check_execute_command(host, _remote_shell(script))
+
+    async def _wait_for_http_server(self, host: str, url: str) -> None:
+        last_error = ''
+        curl_check = (
+            f'code=$(curl -sf -o /dev/null -w "%{{http_code}}" {shlex.quote(url)}); '
+            f'test "$code" = "200"'
+        )
+        for _ in range(30):
+            try:
+                await self.mgr.ssh._check_execute_command(
+                    host, _remote_shell(curl_check))
+                return
+            except Exception as e:
+                last_error = str(e)
+                await asyncio.sleep(1)
+        raise OrchestratorError(
+            f'HTTP mirror on {host} did not serve {url} (expected HTTP 200): {last_error}')
+
+    async def _registry_login_if_needed(self, host: str) -> None:
+        if self.mgr.cache.host_needs_registry_login(host) and self.mgr.registry_url:
+            creds = self.mgr.get_store('registry_credentials')
+            if creds:
+                await CephadmServe(self.mgr)._registry_login(host, json.loads(str(creds)))
+
+    async def _mirror_cleanup(
+        self,
+        seed_host: str,
+        pid_path: str,
+        tar_path: str,
+    ) -> None:
+        cleanup_cmd = (
+            f'if [ -f {shlex.quote(pid_path)} ]; then '
+            f'kill "$(cat {shlex.quote(pid_path)})" 2>/dev/null || true; '
+            f'rm -f {shlex.quote(pid_path)}; fi; '
+            f'rm -f {shlex.quote(tar_path)}'
+        )
+        try:
+            await self.mgr.ssh._check_execute_command(
+                seed_host, _remote_shell(cleanup_cmd))
+        except Exception as e:
+            logger.warning('Upgrade: image mirror cleanup on %s failed: %s', seed_host, e)
+
+    async def _mirror_upgrade_image_via_http_async(
+        self,
+        target_image: str,
+        target_digests: List[str],
+        hosts: List[str],
+    ) -> bool:
+        assert self.upgrade_state is not None
+        hosts_needing_image: List[str] = []
+        for host in hosts:
+            if not await self._host_has_target_image_on_host(
+                    host, target_image, target_digests):
+                hosts_needing_image.append(host)
+
+        if not hosts_needing_image:
+            logger.info('Upgrade: all in-scope hosts already have target image')
+            self.upgrade_state.image_mirror_done = True
+            self._save_upgrade_state()
+            return True
+
+        seed_host: Optional[str] = None
+        mirror_dir, tar_path, pid_path = self._mirror_paths(target_digests)
+        tar_name = os.path.basename(tar_path)
+
+        try:
+            seed_host = self._select_image_mirror_seed_host(hosts)
+            seed_addr = self._get_image_mirror_host_addr(seed_host)
+            mirror_port = self.mgr.upgrade_image_mirror_port
+            image_url = (
+                f'http://{_http_url_host(seed_addr)}:'
+                f'{mirror_port}/{tar_name}')
+
+            logger.info(
+                'Upgrade: mirroring target image from seed host %s to %d host(s)',
+                seed_host, len(hosts_needing_image))
+            self.upgrade_info_str = (
+                f'Mirroring upgrade image from {seed_host} to {len(hosts_needing_image)} host(s)')
+
+            await self.mgr.ssh._check_execute_command(
+                seed_host, RemoteCommand(Executables.MKDIR, ['-p', mirror_dir]))
+
+            seed_inspect = await self._inspect_image_on_host(seed_host, target_image)
+            if not self._host_has_target_image(seed_inspect, target_digests):
+                await self._registry_login_if_needed(seed_host)
+                self.upgrade_info_str = f'Pulling upgrade image on seed host {seed_host}'
+                pullargs: List[str] = []
+                if self.mgr.registry_insecure:
+                    pullargs.append('--insecure')
+                await CephadmServe(self.mgr)._run_cephadm_json(
+                    seed_host, '', 'pull', pullargs,
+                    image=target_image, no_fsid=True)
+
+            seed_engine = await self._get_host_container_engine(seed_host)
+            tag_name = self._mirror_image_tag_name()
+            save_ref = tag_name or target_image
+            if tag_name and self.upgrade_state.target_id:
+                # Ensure seed has image:tag even if only the digest ref exists
+                # locally (common when use_repo_digest is enabled).
+                await self._tag_image_on_host(
+                    seed_host, seed_engine,
+                    self.upgrade_state.target_id, tag_name)
+            self.upgrade_info_str = f'Saving upgrade image on seed host {seed_host}'
+            await self._save_image_on_host(
+                seed_host, seed_engine, save_ref, tar_path)
+
+            http_log = f'{mirror_dir}/upgrade-image-http.log'
+            start_server_cmd = (
+                f'if [ -f {shlex.quote(pid_path)} ]; then '
+                f'kill "$(cat {shlex.quote(pid_path)})" 2>/dev/null || true; '
+                f'rm -f {shlex.quote(pid_path)}; fi; '
+                f'if command -v fuser >/dev/null 2>&1; then '
+                f'fuser -k {mirror_port}/tcp 2>/dev/null || true; fi; '
+                f'nohup python3 -m http.server {mirror_port} '
+                f'--directory {shlex.quote(mirror_dir)} '
+                f'--bind {shlex.quote(seed_addr)} '
+                f'> {shlex.quote(http_log)} 2>&1 & echo $! > {shlex.quote(pid_path)}'
+            )
+            await self.mgr.ssh._check_execute_command(
+                seed_host, _remote_shell(start_server_cmd))
+
+            await self._wait_for_http_server(seed_host, image_url)
+
+            hosts_to_load = [h for h in hosts_needing_image if h != seed_host]
+
+            max_parallel = max(1, self.mgr.upgrade_image_mirror_max_parallel)
+            sem = asyncio.Semaphore(max_parallel)
+            failed_hosts: List[Tuple[str, str]] = []
+
+            async def _load_on_host(host: str, index: int) -> None:
+                async with sem:
+                    self.upgrade_info_str = (
+                        f'Mirroring upgrade image to {host} '
+                        f'({index + 1}/{len(hosts_to_load)})')
+                    host_tar = f'{mirror_dir}/{tar_name}.load'
+                    try:
+                        engine = await self._get_host_container_engine(host)
+                        await self._load_image_from_url_on_host(
+                            host, engine, image_url, host_tar,
+                            tag_name=tag_name,
+                            image_id=self.upgrade_state.target_id if self.upgrade_state else None)
+                    except Exception as e:
+                        failed_hosts.append((host, str(e)))
+
+            if hosts_to_load:
+                await asyncio.gather(*[
+                    _load_on_host(host, i) for i, host in enumerate(hosts_to_load)
+                ])
+
+            if failed_hosts:
+                detail = [
+                    f'failed to mirror image to {host}: {reason}'
+                    for host, reason in failed_hosts
+                ]
+                self._fail_upgrade('UPGRADE_FAILED_PULL', {
+                    'severity': 'warning',
+                    'summary': 'Upgrade: failed to mirror target image',
+                    'count': len(failed_hosts),
+                    'detail': detail,
+                })
+                return False
+
+            for host in hosts_needing_image:
+                if not await self._host_has_target_image_on_host(
+                        host, target_image, target_digests):
+                    tried = self._target_image_inspect_refs(target_image)
+                    self._fail_upgrade('UPGRADE_FAILED_PULL', {
+                        'severity': 'warning',
+                        'summary': 'Upgrade: failed to mirror target image',
+                        'count': 1,
+                        'detail': [
+                            f'host {host} does not have target image after mirror '
+                            f'(inspect refs: {tried})'],
+                    })
+                    return False
+
+            self.upgrade_state.image_mirror_done = True
+            self._save_upgrade_state()
+            logger.info('Upgrade: image mirror complete')
+            return True
+        except Exception as e:
+            logger.exception('Upgrade: image mirror failed')
+            self._fail_upgrade('UPGRADE_FAILED_PULL', {
+                'severity': 'warning',
+                'summary': 'Upgrade: failed to mirror target image',
+                'count': 1,
+                'detail': [str(e)],
+            })
+            return False
+        finally:
+            if seed_host:
+                await self._mirror_cleanup(seed_host, pid_path, tar_path)
+
+    def _parse_pull_image_info(self, out: List[str]) -> Optional[Dict[str, Any]]:
+        try:
+            info = json.loads(''.join(out))
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return None
+        if not isinstance(info, dict):
+            return None
+        return info
+
+    def _ceph_version_token_from_pull(self, ceph_version: str) -> Optional[str]:
+        """Normalize ``ceph --version`` output to the short token stored in upgrade state."""
+        if not ceph_version:
+            return None
+        if ceph_version.startswith('ceph version '):
+            parts = ceph_version.split(' ')
+            if len(parts) >= 3:
+                return parts[2]
+            return None
+        return ceph_version
+
+    def _set_target_from_pull_info(self, info: Dict[str, Any]) -> Optional[str]:
+        """
+        Persist target_id / digests / version from cephadm pull/inspect JSON.
+
+        Returns an error string on failure, or None on success.
+        """
+        assert self.upgrade_state is not None
+        image_id = info.get('image_id')
+        digests = info.get('repo_digests') or []
+        ceph_version = info.get('ceph_version') or ''
+        if not image_id or not digests:
+            return 'pull did not return image_id and repo_digests'
+        version_token = self._ceph_version_token_from_pull(str(ceph_version))
+        if not version_token:
+            return 'unable to extract ceph version from container'
+        self.upgrade_state.target_id = str(image_id)
+        self.upgrade_state.target_digests = list(digests)
+        self.upgrade_state.target_version = version_token
+        self._save_upgrade_state()
+        return None
+
+    async def _pre_pull_image_discover_async(
+        self,
+        target_image: str,
+        hosts: List[str],
+    ) -> bool:
+        """
+        Parallel registry pull that also learns target digests/version.
+
+        Used when upgrade_image_mirror_method=registry and upgrade state does not
+        yet have target metadata, so we avoid a serial "First pull" on one host
+        before pulling everywhere else.
+        """
+        assert self.upgrade_state is not None
+        max_parallel = max(1, self.mgr.upgrade_image_mirror_max_parallel)
+        logger.info(
+            'Upgrade: discovering and pre-pulling image %s on %d host(s), '
+            'up to %d in parallel',
+            target_image, len(hosts), max_parallel)
+        self.upgrade_info_str = (
+            f'Discovering and pre-pulling upgrade image on {len(hosts)} host(s)')
+
+        pullargs: List[str] = []
+        if self.mgr.registry_insecure:
+            pullargs.append('--insecure')
+
+        sem = asyncio.Semaphore(max_parallel)
+        # host -> (code, pull_info_or_None, error_reason)
+        results: Dict[str, Tuple[int, Optional[Dict[str, Any]], str]] = {}
+
+        async def _pull_on_host(host: str) -> None:
+            async with sem:
+                if not self.upgrade_state or self.upgrade_state.paused:
+                    return
+                try:
+                    await self._registry_login_if_needed(host)
+                    logger.info('Upgrade: pulling image %s on host %s', target_image, host)
+                    out, errs, code = await CephadmServe(self.mgr)._run_cephadm(
+                        host, '', 'pull', pullargs,
+                        image=target_image, no_fsid=True, error_ok=True)
+                    if code:
+                        reason = ''.join(errs) if errs else 'unknown error'
+                        logger.error('Upgrade: failed to pull image on host %s', host)
+                        results[host] = (code, None, reason)
+                    else:
+                        info = self._parse_pull_image_info(out)
+                        if not info:
+                            results[host] = (1, None, 'invalid or empty pull JSON')
+                            logger.error(
+                                'Upgrade: invalid pull JSON on host %s', host)
+                        else:
+                            results[host] = (0, info, '')
+                            logger.info('Upgrade: pulled image on host %s', host)
+                except Exception as e:
+                    results[host] = (1, None, str(e))
+
+        await asyncio.gather(*[_pull_on_host(host) for host in hosts])
+
+        failed_hosts: List[Tuple[str, str]] = []
+        for host in hosts:
+            if host not in results:
+                failed_hosts.append((host, 'pre-pull interrupted or skipped'))
+                continue
+            code, _info, reason = results[host]
+            if code:
+                failed_hosts.append((host, reason))
+
+        if failed_hosts:
+            detail = [
+                f'failed to pull image on {host}: {reason}'
+                for host, reason in failed_hosts
+            ]
+            self._fail_upgrade('UPGRADE_FAILED_PULL', {
+                'severity': 'warning',
+                'summary': 'Upgrade: failed to pre-pull target image',
+                'count': len(failed_hosts),
+                'detail': detail,
+            })
+            return False
+
+        reference: Optional[Dict[str, Any]] = None
+        for host in hosts:
+            _code, info, _reason = results[host]
+            if not info:
+                continue
+            image_id = info.get('image_id')
+            digests = info.get('repo_digests') or []
+            version_token = self._ceph_version_token_from_pull(
+                str(info.get('ceph_version') or ''))
+            if image_id and digests and version_token:
+                reference = info
+                break
+
+        if not reference:
+            self._fail_upgrade('UPGRADE_FAILED_PULL', {
+                'severity': 'warning',
+                'summary': 'Upgrade: failed to pull target image',
+                'count': 1,
+                'detail': [
+                    'unable to extract image digests/version from parallel pull'],
+            })
+            return False
+
+        apply_err = self._set_target_from_pull_info(reference)
+        if apply_err:
+            self._fail_upgrade('UPGRADE_FAILED_PULL', {
+                'severity': 'warning',
+                'summary': 'Upgrade: failed to pull target image',
+                'count': 1,
+                'detail': [apply_err],
+            })
+            return False
+
+        assert self.upgrade_state.target_digests is not None
+        target_digests = self.upgrade_state.target_digests
+        logger.info(
+            'Upgrade: discovered target digests %s version %s from parallel pull',
+            target_digests, self.upgrade_state.target_version)
+
+        for host in hosts:
+            _code, info, _reason = results[host]
+            if not self._host_has_target_image(info, target_digests):
+                got_digests = info.get('repo_digests') if info else None
+                self._fail_upgrade('UPGRADE_FAILED_PULL', {
+                    'severity': 'warning',
+                    'summary': 'Upgrade: failed to pre-pull target image',
+                    'count': 1,
+                    'detail': [
+                        f'host {host} pull returned mismatched digests '
+                        f'(got {got_digests}, expected {target_digests})',
+                    ],
+                })
+                return False
+
+        self.upgrade_state.image_mirror_done = True
+        self._save_upgrade_state()
+        logger.info('Upgrade: registry pre-pull complete')
+        return True
+
+    async def _pre_pull_image_on_hosts_async(
+        self,
+        target_image: str,
+        target_digests: List[str],
+        hosts: List[str],
+    ) -> bool:
+        assert self.upgrade_state is not None
+        # Discover digests/version from parallel pulls only when digests are
+        # unknown. If digests are already known (typical resume / local_http
+        # first-pull path), use the normal skip-or-pull flow.
+        discovering = not target_digests
+        if discovering:
+            return await self._pre_pull_image_discover_async(target_image, hosts)
+
+        hosts_needing_image: List[str] = []
+        for host in hosts:
+            if not await self._host_has_target_image_on_host(
+                    host, target_image, target_digests):
+                hosts_needing_image.append(host)
+
+        if not hosts_needing_image:
+            logger.info('Upgrade: all in-scope hosts already have target image')
+            self.upgrade_state.image_mirror_done = True
+            self._save_upgrade_state()
+            return True
+
+        max_parallel = max(1, self.mgr.upgrade_image_mirror_max_parallel)
+        logger.info(
+            'Upgrade: pre-pulling image %s on %d host(s), up to %d in parallel',
+            target_image, len(hosts_needing_image), max_parallel)
+        self.upgrade_info_str = (
+            f'Pre-pulling upgrade image on {len(hosts_needing_image)} host(s)')
+
+        pullargs: List[str] = []
+        if self.mgr.registry_insecure:
+            pullargs.append('--insecure')
+
+        sem = asyncio.Semaphore(max_parallel)
+        failed_hosts: List[Tuple[str, str]] = []
+        done = 0
+        total = len(hosts_needing_image)
+
+        async def _pull_on_host(host: str) -> None:
+            nonlocal done
+            async with sem:
+                if not self.upgrade_state or self.upgrade_state.paused:
+                    return
+                try:
+                    await self._registry_login_if_needed(host)
+                    logger.info('Upgrade: pulling image %s on host %s', target_image, host)
+                    _out, errs, code = await CephadmServe(self.mgr)._run_cephadm(
+                        host, '', 'pull', pullargs,
+                        image=target_image, no_fsid=True, error_ok=True)
+                    done += 1
+                    if code:
+                        reason = ''.join(errs) if errs else 'unknown error'
+                        logger.error(
+                            'Upgrade: failed to pull image on host %s (%d/%d done)',
+                            host, done, total)
+                        failed_hosts.append((host, reason))
+                    else:
+                        logger.info(
+                            'Upgrade: pulled image on host %s (%d/%d done)',
+                            host, done, total)
+                except Exception as e:
+                    done += 1
+                    failed_hosts.append((host, str(e)))
+
+        await asyncio.gather(*[_pull_on_host(host) for host in hosts_needing_image])
+
+        if failed_hosts:
+            detail = [
+                f'failed to pull image on {host}: {reason}'
+                for host, reason in failed_hosts
+            ]
+            self._fail_upgrade('UPGRADE_FAILED_PULL', {
+                'severity': 'warning',
+                'summary': 'Upgrade: failed to pre-pull target image',
+                'count': len(failed_hosts),
+                'detail': detail,
+            })
+            return False
+
+        for host in hosts_needing_image:
+            if not await self._host_has_target_image_on_host(
+                    host, target_image, target_digests):
+                tried = self._target_image_inspect_refs(target_image)
+                self._fail_upgrade('UPGRADE_FAILED_PULL', {
+                    'severity': 'warning',
+                    'summary': 'Upgrade: failed to pre-pull target image',
+                    'count': 1,
+                    'detail': [
+                        f'host {host} does not have target image after pull '
+                        f'(tried {tried})',
+                    ],
+                })
+                return False
+
+        self.upgrade_state.image_mirror_done = True
+        self._save_upgrade_state()
+        logger.info('Upgrade: registry pre-pull complete')
+        return True
+
+    def _pre_pull_image_on_hosts(
+        self,
+        target_image: str,
+        target_digests: List[str],
+        hosts: List[str],
+    ) -> bool:
+        timeout = self._mirror_operation_timeout(len(hosts))
+        logger.info(
+            'Upgrade: registry pre-pull timeout set to %d seconds for %d host(s)',
+            timeout, len(hosts))
+        return self.mgr.wait_async(
+            self._pre_pull_image_on_hosts_async(
+                target_image, target_digests, hosts),
+            timeout=timeout)
+
+    def _mirror_operation_timeout(self, host_count: int) -> int:
+        per_host = max(self.mgr.default_cephadm_command_timeout, 1800)
+        return max(UPGRADE_IMAGE_MIRROR_MIN_TIMEOUT, per_host * max(host_count, 1))
+
+    def _mirror_upgrade_image_via_http(
+        self,
+        target_image: str,
+        target_digests: List[str],
+        hosts: List[str],
+    ) -> bool:
+        timeout = self._mirror_operation_timeout(len(hosts))
+        logger.info(
+            'Upgrade: image mirror timeout set to %d seconds for %d host(s)',
+            timeout, len(hosts))
+        return self.mgr.wait_async(
+            self._mirror_upgrade_image_via_http_async(
+                target_image, target_digests, hosts),
+            timeout=timeout)
+
+    def _get_upgrade_image_mirror_method(self) -> str:
+        raw = getattr(self.mgr, 'upgrade_image_mirror_method', '') or ''
+        return str(raw).strip().lower()
+
+    def _upgrade_image_mirror_enabled(self) -> bool:
+        return self._get_upgrade_image_mirror_method() in UPGRADE_IMAGE_MIRROR_METHODS_ENABLED
+
+    def _pre_distribute_upgrade_images(
+        self,
+        target_image: str,
+        target_digests: List[str],
+        hosts: List[str],
+    ) -> bool:
+        method = self._get_upgrade_image_mirror_method()
+        if method in UPGRADE_IMAGE_MIRROR_METHODS_DISABLED:
+            return True
+        if method == UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY:
+            return self._pre_pull_image_on_hosts(
+                target_image, target_digests, hosts)
+        if method == UPGRADE_IMAGE_MIRROR_METHOD_LOCAL_HTTP:
+            return self._mirror_upgrade_image_via_http(
+                target_image, target_digests, hosts)
+        self._fail_upgrade('UPGRADE_FAILED_PULL', {
+            'severity': 'error',
+            'summary': 'Upgrade: invalid upgrade_image_mirror_method',
+            'count': 1,
+            'detail': [
+                f'unknown upgrade_image_mirror_method {method!r}; '
+                f'expected empty/{UPGRADE_IMAGE_MIRROR_METHOD_NONE!r} '
+                f'(disabled), {UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY!r}, or '
+                f'{UPGRADE_IMAGE_MIRROR_METHOD_LOCAL_HTTP!r}',
+            ],
+        })
+        return False
+
     def _do_upgrade(self):
         # type: () -> None
         if not self.upgrade_state:
@@ -1770,9 +2610,24 @@ class CephadmUpgrade:
         target_digests = self.upgrade_state.target_digests
         target_version = self.upgrade_state.target_version
 
+        need_metadata = not target_id or not target_version or not target_digests
+        registry_discover_hosts: List[str] = []
+        use_registry_discover = False
+        if (
+            need_metadata
+            and self._upgrade_image_mirror_enabled()
+            and not self.upgrade_state.image_mirror_done
+            and self._get_upgrade_image_mirror_method() == UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY
+        ):
+            registry_discover_hosts = self._get_upgrade_scope_hosts(
+                self._get_filtered_daemons())
+            use_registry_discover = bool(registry_discover_hosts)
+
         first = False
-        if not target_id or not target_version or not target_digests:
-            # need to learn the container hash
+        if need_metadata and not use_registry_discover:
+            # need to learn the container hash (serial pull on one host).
+            # Skipped for registry pre-pull: digests/version are learned from the
+            # parallel pulls so we do not pay ~2x wall-clock for large images.
             logger.info('Upgrade: First pull of %s' % target_image)
             self.upgrade_info_str = 'Doing first pull of %s image' % (target_image)
             try:
@@ -1803,10 +2658,25 @@ class CephadmUpgrade:
             self.upgrade_state.target_digests = target_digests
             self._save_upgrade_state()
             target_image = self.target_image
+            target_version = self.upgrade_state.target_version
+            first = True
+
+        if use_registry_discover:
+            logger.info(
+                'Upgrade: discovering target image via parallel registry '
+                'pre-pull of %s', target_image)
+            if not self._pre_pull_image_on_hosts(
+                    target_image, target_digests or [], registry_discover_hosts):
+                return
+            target_id = self.upgrade_state.target_id
+            target_digests = self.upgrade_state.target_digests
+            target_version = self.upgrade_state.target_version
+            target_image = self.target_image
             first = True
 
         if target_digests is None:
             target_digests = []
+        assert target_version is not None
         if target_version.startswith('ceph version '):
             # tolerate/fix upgrade state from older version
             self.upgrade_state.target_version = target_version.split(' ')[2]
@@ -1829,6 +2699,19 @@ class CephadmUpgrade:
                 'detail': [version_error],
             })
             return
+
+        if (
+            self._upgrade_image_mirror_enabled()
+            and not self.upgrade_state.image_mirror_done
+        ):
+            # local_http, or registry when metadata was already known (resume).
+            # Registry discover path above already marked image_mirror_done.
+            daemons = self._get_filtered_daemons()
+            hosts = self._get_upgrade_scope_hosts(daemons)
+            if hosts and not self._pre_distribute_upgrade_images(
+                target_image, target_digests, hosts
+            ):
+                return
 
         image_settings = self.get_distinct_container_image_settings()
 

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -1,11 +1,7 @@
 import asyncio
 import errno
-import hashlib
-import ipaddress
 import json
 import logging
-import os
-import shlex
 import time
 import datetime
 import uuid
@@ -14,7 +10,6 @@ from typing import TYPE_CHECKING, Optional, Dict, List, Tuple, Any, cast, Set
 from cephadm.services.service_registry import service_registry
 
 import orchestrator
-from ceph.deployment.service_spec import PlacementSpec
 from cephadm.registry import Registry
 from cephadm.serve import CephadmServe
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
@@ -29,9 +24,8 @@ from cephadm.utils import (
     GATEWAY_TYPES,
     ALLOWED_CIPHERS,
     SERVICE_CIPHER,
-    SpecialHostLabels,
 )
-from cephadm.ssh import HostConnectionError, RemoteCommand, RemoteExecutable, Executables
+from cephadm.ssh import HostConnectionError
 from orchestrator import OrchestratorError, DaemonDescription, DaemonDescriptionStatus, daemon_type_to_service
 from ceph.cephadm.version_entry import UpgradeStatus
 
@@ -67,12 +61,11 @@ MID_UPGRADE_MUTED_WARNINGS = [
     'AUTH_INSECURE_ROTATING_SERVICE_KEY_TYPE'
 ]
 
-# Whole mirror phase (save + HTTP fan-out + load on all hosts). Single-command
+# Parallel registry pre-pull across many hosts. Single-command
 # default_cephadm_command_timeout (15m) is too short for multi-GB images.
 UPGRADE_IMAGE_MIRROR_MIN_TIMEOUT = 7200
 
 UPGRADE_IMAGE_MIRROR_METHOD_NONE = 'none'
-UPGRADE_IMAGE_MIRROR_METHOD_LOCAL_HTTP = 'local_http'
 UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY = 'registry'
 # Empty string or "none" disables pre-distribution (default).
 UPGRADE_IMAGE_MIRROR_METHODS_DISABLED = frozenset({
@@ -81,23 +74,7 @@ UPGRADE_IMAGE_MIRROR_METHODS_DISABLED = frozenset({
 })
 UPGRADE_IMAGE_MIRROR_METHODS_ENABLED = frozenset({
     UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY,
-    UPGRADE_IMAGE_MIRROR_METHOD_LOCAL_HTTP,
 })
-
-
-def _remote_shell(script: str) -> RemoteCommand:
-    return RemoteCommand(RemoteExecutable('bash'), ['-c', script])
-
-
-def _http_url_host(addr: str) -> str:
-    bare = addr.split('/')[0]
-    try:
-        ip = ipaddress.ip_address(bare)
-        if isinstance(ip, ipaddress.IPv6Address):
-            return f'[{bare}]'
-    except ValueError:
-        pass
-    return bare
 
 
 def normalize_image_digest(digest: str, default_registry: str) -> str:
@@ -2186,110 +2163,6 @@ class CephadmUpgrade:
         hosts = sorted({d.hostname for d in daemons if d.hostname})
         return [h for h in hosts if h not in self.mgr.offline_hosts]
 
-    def _mirror_tar_basename(self, target_digests: List[str]) -> str:
-        digest = target_digests[0] if target_digests else 'unknown'
-        safe = digest.replace('@', '-').replace(':', '-').replace('/', '_')
-        if len(safe) > 80:
-            safe = hashlib.sha256(digest.encode()).hexdigest()[:16]
-        return f'upgrade-image-{safe}.tar.gz'
-
-    def _mirror_paths(self, target_digests: List[str]) -> Tuple[str, str, str]:
-        mirror_dir = f'/var/lib/ceph/{self.mgr._cluster_fsid}'
-        tar_name = self._mirror_tar_basename(target_digests)
-        tar_path = f'{mirror_dir}/{tar_name}'
-        pid_path = f'{mirror_dir}/upgrade-image-http.pid'
-        return mirror_dir, tar_path, pid_path
-
-    def _select_image_mirror_seed_host(self, hosts: List[str]) -> str:
-        admin_hosts = PlacementSpec(
-            label=SpecialHostLabels.ADMIN
-        ).filter_matching_hostspecs(self.mgr.inventory.all_specs())
-        for host in admin_hosts:
-            if host in hosts and host not in self.mgr.offline_hosts:
-                return host
-
-        active_mgr = self.mgr.get_active_mgr()
-        if active_mgr.hostname and active_mgr.hostname in hosts:
-            return active_mgr.hostname
-
-        if not hosts:
-            raise OrchestratorError('no hosts in upgrade scope for image mirror')
-        return hosts[0]
-
-    def _ceph_networks(self) -> List[str]:
-        networks: List[str] = []
-        for entity, key in (('mon', 'public_network'), ('osd', 'cluster_network')):
-            try:
-                value = str(self.mgr.get_foreign_ceph_option(entity, key))
-            except Exception:
-                continue
-            if '/' not in value:
-                continue
-            for net in value.split(','):
-                net = net.strip()
-                if net and net not in networks:
-                    networks.append(net)
-        return networks
-
-    def _ips_on_host_networks(
-        self,
-        host: str,
-        ipv4_only: bool = False,
-        ceph_networks_only: bool = False,
-    ) -> List[str]:
-        ceph_networks = self._ceph_networks() if ceph_networks_only else []
-        ips: List[str] = []
-        for subnet, ifaces in self.mgr.cache.networks.get(host, {}).items():
-            on_ceph_net = False
-            if ceph_networks:
-                try:
-                    host_subnet = ipaddress.ip_network(subnet, strict=False)
-                except ValueError:
-                    continue
-                for ceph_net in ceph_networks:
-                    try:
-                        if host_subnet.overlaps(ipaddress.ip_network(ceph_net, strict=False)):
-                            on_ceph_net = True
-                            break
-                    except ValueError:
-                        continue
-                if not on_ceph_net:
-                    continue
-            for _iface, addr_list in ifaces.items():
-                for addr in addr_list:
-                    bare = addr.split('/')[0]
-                    try:
-                        ip = ipaddress.ip_address(bare)
-                    except ValueError:
-                        continue
-                    if ipv4_only and not isinstance(ip, ipaddress.IPv4Address):
-                        continue
-                    ips.append(str(ip))
-        return ips
-
-    def _get_image_mirror_host_addr(self, host: str) -> str:
-        """Pick a cluster-reachable address for the HTTP mirror (prefer IPv4)."""
-        for ceph_ipv4 in self._ips_on_host_networks(
-                host, ipv4_only=True, ceph_networks_only=True):
-            return ceph_ipv4
-        for host_ipv4 in self._ips_on_host_networks(host, ipv4_only=True):
-            return host_ipv4
-        inventory_addr = self.mgr.inventory.get_addr(host).split('/')[0]
-        try:
-            ip = ipaddress.ip_address(inventory_addr)
-            if isinstance(ip, ipaddress.IPv4Address):
-                return str(ip)
-        except ValueError:
-            pass
-        ceph_ips = self._ips_on_host_networks(
-            host, ceph_networks_only=True)
-        if ceph_ips:
-            return ceph_ips[0]
-        host_ips = self._ips_on_host_networks(host)
-        if host_ips:
-            return host_ips[0]
-        return inventory_addr
-
     async def _inspect_image_on_host(
         self,
         host: str,
@@ -2359,271 +2232,11 @@ class CephadmUpgrade:
                 return True
         return False
 
-    async def _get_host_container_engine(self, host: str) -> str:
-        cmd = _remote_shell(
-            'command -v podman 2>/dev/null || command -v docker 2>/dev/null')
-        out, _, code = await self.mgr.ssh._execute_command(host, cmd)
-        engine = (out or '').strip().splitlines()[-1].strip() if not code else ''
-        if not engine:
-            raise OrchestratorError(f'no container engine found on host {host}')
-        return engine
-
-    def _mirror_image_tag_name(self) -> Optional[str]:
-        """
-        Human image:tag used to start the upgrade, if any.
-
-        When use_repo_digest is enabled, ``target_image`` becomes a digest ref
-        (``repo@sha256:…``). Saving/loading by digest restores the layers but
-        leaves TAG as ``<none>`` on worker hosts. Prefer the original tag name
-        for save + an explicit retag after load.
-        """
-        assert self.upgrade_state is not None
-        name = self.upgrade_state._target_name
-        if not name or '@' in name:
-            return None
-        return name
-
-    async def _tag_image_on_host(
-        self,
-        host: str,
-        engine: str,
-        image_ref: str,
-        tag_name: str,
-    ) -> None:
-        script = (
-            f'{shlex.quote(engine)} tag '
-            f'{shlex.quote(image_ref)} {shlex.quote(tag_name)}'
-        )
-        await self.mgr.ssh._check_execute_command(host, _remote_shell(script))
-
-    async def _save_image_on_host(
-        self,
-        host: str,
-        engine: str,
-        image: str,
-        tar_path: str,
-    ) -> None:
-        # gzip --fast: podman/docker load accepts gzip-compressed archives.
-        script = (
-            f'{shlex.quote(engine)} save {shlex.quote(image)} | '
-            f'python3 -m gzip --fast > {shlex.quote(tar_path)}'
-        )
-        await self.mgr.ssh._check_execute_command(host, _remote_shell(script))
-
-    async def _load_image_from_url_on_host(
-        self,
-        host: str,
-        engine: str,
-        url: str,
-        tar_path: str,
-        tag_name: Optional[str] = None,
-        image_id: Optional[str] = None,
-    ) -> None:
-        script = (
-            f'curl -sf {shlex.quote(url)} -o {shlex.quote(tar_path)} && '
-            f'{shlex.quote(engine)} load -i {shlex.quote(tar_path)} && '
-            f'rm -f {shlex.quote(tar_path)}'
-        )
-        # podman/docker load of a digest-saved archive often leaves TAG <none>.
-        # Always retag to the upgrade's original image:tag when we know both.
-        if tag_name and image_id:
-            script += (
-                f' && {shlex.quote(engine)} tag '
-                f'{shlex.quote(image_id)} {shlex.quote(tag_name)}'
-            )
-        await self.mgr.ssh._check_execute_command(host, _remote_shell(script))
-
-    async def _wait_for_http_server(self, host: str, url: str) -> None:
-        last_error = ''
-        curl_check = (
-            f'code=$(curl -sf -o /dev/null -w "%{{http_code}}" {shlex.quote(url)}); '
-            f'test "$code" = "200"'
-        )
-        for _ in range(30):
-            try:
-                await self.mgr.ssh._check_execute_command(
-                    host, _remote_shell(curl_check))
-                return
-            except Exception as e:
-                last_error = str(e)
-                await asyncio.sleep(1)
-        raise OrchestratorError(
-            f'HTTP mirror on {host} did not serve {url} (expected HTTP 200): {last_error}')
-
     async def _registry_login_if_needed(self, host: str) -> None:
         if self.mgr.cache.host_needs_registry_login(host) and self.mgr.registry_url:
             creds = self.mgr.get_store('registry_credentials')
             if creds:
                 await CephadmServe(self.mgr)._registry_login(host, json.loads(str(creds)))
-
-    async def _mirror_cleanup(
-        self,
-        seed_host: str,
-        pid_path: str,
-        tar_path: str,
-    ) -> None:
-        cleanup_cmd = (
-            f'if [ -f {shlex.quote(pid_path)} ]; then '
-            f'kill "$(cat {shlex.quote(pid_path)})" 2>/dev/null || true; '
-            f'rm -f {shlex.quote(pid_path)}; fi; '
-            f'rm -f {shlex.quote(tar_path)}'
-        )
-        try:
-            await self.mgr.ssh._check_execute_command(
-                seed_host, _remote_shell(cleanup_cmd))
-        except Exception as e:
-            logger.warning('Upgrade: image mirror cleanup on %s failed: %s', seed_host, e)
-
-    async def _mirror_upgrade_image_via_http_async(
-        self,
-        target_image: str,
-        target_digests: List[str],
-        hosts: List[str],
-    ) -> bool:
-        assert self.upgrade_state is not None
-        hosts_needing_image: List[str] = []
-        for host in hosts:
-            if not await self._host_has_target_image_on_host(
-                    host, target_image, target_digests):
-                hosts_needing_image.append(host)
-
-        if not hosts_needing_image:
-            logger.info('Upgrade: all in-scope hosts already have target image')
-            self.upgrade_state.image_mirror_done = True
-            self._save_upgrade_state()
-            return True
-
-        seed_host: Optional[str] = None
-        mirror_dir, tar_path, pid_path = self._mirror_paths(target_digests)
-        tar_name = os.path.basename(tar_path)
-
-        try:
-            seed_host = self._select_image_mirror_seed_host(hosts)
-            seed_addr = self._get_image_mirror_host_addr(seed_host)
-            mirror_port = self.mgr.upgrade_image_mirror_port
-            image_url = (
-                f'http://{_http_url_host(seed_addr)}:'
-                f'{mirror_port}/{tar_name}')
-
-            logger.info(
-                'Upgrade: mirroring target image from seed host %s to %d host(s)',
-                seed_host, len(hosts_needing_image))
-            self.upgrade_info_str = (
-                f'Mirroring upgrade image from {seed_host} to {len(hosts_needing_image)} host(s)')
-
-            await self.mgr.ssh._check_execute_command(
-                seed_host, RemoteCommand(Executables.MKDIR, ['-p', mirror_dir]))
-
-            seed_inspect = await self._inspect_image_on_host(seed_host, target_image)
-            if not self._host_has_target_image(seed_inspect, target_digests):
-                await self._registry_login_if_needed(seed_host)
-                self.upgrade_info_str = f'Pulling upgrade image on seed host {seed_host}'
-                pullargs: List[str] = []
-                if self.mgr.registry_insecure:
-                    pullargs.append('--insecure')
-                await CephadmServe(self.mgr)._run_cephadm_json(
-                    seed_host, '', 'pull', pullargs,
-                    image=target_image, no_fsid=True)
-
-            seed_engine = await self._get_host_container_engine(seed_host)
-            tag_name = self._mirror_image_tag_name()
-            save_ref = tag_name or target_image
-            if tag_name and self.upgrade_state.target_id:
-                # Ensure seed has image:tag even if only the digest ref exists
-                # locally (common when use_repo_digest is enabled).
-                await self._tag_image_on_host(
-                    seed_host, seed_engine,
-                    self.upgrade_state.target_id, tag_name)
-            self.upgrade_info_str = f'Saving upgrade image on seed host {seed_host}'
-            await self._save_image_on_host(
-                seed_host, seed_engine, save_ref, tar_path)
-
-            http_log = f'{mirror_dir}/upgrade-image-http.log'
-            start_server_cmd = (
-                f'if [ -f {shlex.quote(pid_path)} ]; then '
-                f'kill "$(cat {shlex.quote(pid_path)})" 2>/dev/null || true; '
-                f'rm -f {shlex.quote(pid_path)}; fi; '
-                f'if command -v fuser >/dev/null 2>&1; then '
-                f'fuser -k {mirror_port}/tcp 2>/dev/null || true; fi; '
-                f'nohup python3 -m http.server {mirror_port} '
-                f'--directory {shlex.quote(mirror_dir)} '
-                f'--bind {shlex.quote(seed_addr)} '
-                f'> {shlex.quote(http_log)} 2>&1 & echo $! > {shlex.quote(pid_path)}'
-            )
-            await self.mgr.ssh._check_execute_command(
-                seed_host, _remote_shell(start_server_cmd))
-
-            await self._wait_for_http_server(seed_host, image_url)
-
-            hosts_to_load = [h for h in hosts_needing_image if h != seed_host]
-
-            max_parallel = max(1, self.mgr.upgrade_image_mirror_max_parallel)
-            sem = asyncio.Semaphore(max_parallel)
-            failed_hosts: List[Tuple[str, str]] = []
-
-            async def _load_on_host(host: str, index: int) -> None:
-                async with sem:
-                    self.upgrade_info_str = (
-                        f'Mirroring upgrade image to {host} '
-                        f'({index + 1}/{len(hosts_to_load)})')
-                    host_tar = f'{mirror_dir}/{tar_name}.load'
-                    try:
-                        engine = await self._get_host_container_engine(host)
-                        await self._load_image_from_url_on_host(
-                            host, engine, image_url, host_tar,
-                            tag_name=tag_name,
-                            image_id=self.upgrade_state.target_id if self.upgrade_state else None)
-                    except Exception as e:
-                        failed_hosts.append((host, str(e)))
-
-            if hosts_to_load:
-                await asyncio.gather(*[
-                    _load_on_host(host, i) for i, host in enumerate(hosts_to_load)
-                ])
-
-            if failed_hosts:
-                detail = [
-                    f'failed to mirror image to {host}: {reason}'
-                    for host, reason in failed_hosts
-                ]
-                self._fail_upgrade('UPGRADE_FAILED_PULL', {
-                    'severity': 'warning',
-                    'summary': 'Upgrade: failed to mirror target image',
-                    'count': len(failed_hosts),
-                    'detail': detail,
-                })
-                return False
-
-            for host in hosts_needing_image:
-                if not await self._host_has_target_image_on_host(
-                        host, target_image, target_digests):
-                    tried = self._target_image_inspect_refs(target_image)
-                    self._fail_upgrade('UPGRADE_FAILED_PULL', {
-                        'severity': 'warning',
-                        'summary': 'Upgrade: failed to mirror target image',
-                        'count': 1,
-                        'detail': [
-                            f'host {host} does not have target image after mirror '
-                            f'(inspect refs: {tried})'],
-                    })
-                    return False
-
-            self.upgrade_state.image_mirror_done = True
-            self._save_upgrade_state()
-            logger.info('Upgrade: image mirror complete')
-            return True
-        except Exception as e:
-            logger.exception('Upgrade: image mirror failed')
-            self._fail_upgrade('UPGRADE_FAILED_PULL', {
-                'severity': 'warning',
-                'summary': 'Upgrade: failed to mirror target image',
-                'count': 1,
-                'detail': [str(e)],
-            })
-            return False
-        finally:
-            if seed_host:
-                await self._mirror_cleanup(seed_host, pid_path, tar_path)
 
     def _parse_pull_image_info(self, out: List[str]) -> Optional[Dict[str, Any]]:
         try:
@@ -2812,8 +2425,8 @@ class CephadmUpgrade:
     ) -> bool:
         assert self.upgrade_state is not None
         # Discover digests/version from parallel pulls only when digests are
-        # unknown. If digests are already known (typical resume / local_http
-        # first-pull path), use the normal skip-or-pull flow.
+        # unknown. If digests are already known (typical resume path), use the
+        # normal skip-or-pull flow.
         discovering = not target_digests
         if discovering:
             return await self._pre_pull_image_discover_async(target_image, hosts)
@@ -2926,21 +2539,6 @@ class CephadmUpgrade:
         per_host = max(self.mgr.default_cephadm_command_timeout, 1800)
         return max(UPGRADE_IMAGE_MIRROR_MIN_TIMEOUT, per_host * max(host_count, 1))
 
-    def _mirror_upgrade_image_via_http(
-        self,
-        target_image: str,
-        target_digests: List[str],
-        hosts: List[str],
-    ) -> bool:
-        timeout = self._mirror_operation_timeout(len(hosts))
-        logger.info(
-            'Upgrade: image mirror timeout set to %d seconds for %d host(s)',
-            timeout, len(hosts))
-        return self.mgr.wait_async(
-            self._mirror_upgrade_image_via_http_async(
-                target_image, target_digests, hosts),
-            timeout=timeout)
-
     def _get_upgrade_image_mirror_method(self) -> str:
         raw = getattr(self.mgr, 'upgrade_image_mirror_method', '') or ''
         return str(raw).strip().lower()
@@ -2960,9 +2558,6 @@ class CephadmUpgrade:
         if method == UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY:
             return self._pre_pull_image_on_hosts(
                 target_image, target_digests, hosts)
-        if method == UPGRADE_IMAGE_MIRROR_METHOD_LOCAL_HTTP:
-            return self._mirror_upgrade_image_via_http(
-                target_image, target_digests, hosts)
         self._fail_upgrade('UPGRADE_FAILED_PULL', {
             'severity': 'error',
             'summary': 'Upgrade: invalid upgrade_image_mirror_method',
@@ -2970,8 +2565,7 @@ class CephadmUpgrade:
             'detail': [
                 f'unknown upgrade_image_mirror_method {method!r}; '
                 f'expected empty/{UPGRADE_IMAGE_MIRROR_METHOD_NONE!r} '
-                f'(disabled), {UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY!r}, or '
-                f'{UPGRADE_IMAGE_MIRROR_METHOD_LOCAL_HTTP!r}',
+                f'(disabled) or {UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY!r}',
             ],
         })
         return False
@@ -3093,8 +2687,8 @@ class CephadmUpgrade:
             self._upgrade_image_mirror_enabled()
             and not self.upgrade_state.image_mirror_done
         ):
-            # local_http, or registry when metadata was already known (resume).
-            # Registry discover path above already marked image_mirror_done.
+            # Registry when metadata was already known (resume). Discover path
+            # above already marked image_mirror_done.
             daemons = self._get_filtered_daemons()
             hosts = self._get_upgrade_scope_hosts(daemons)
             if hosts and not self._pre_distribute_upgrade_images(

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -1,6 +1,11 @@
+import asyncio
 import errno
+import hashlib
+import ipaddress
 import json
 import logging
+import os
+import shlex
 import time
 import datetime
 import uuid
@@ -9,6 +14,7 @@ from typing import TYPE_CHECKING, Optional, Dict, List, Tuple, Any, cast, Set
 from cephadm.services.service_registry import service_registry
 
 import orchestrator
+from ceph.deployment.service_spec import PlacementSpec
 from cephadm.registry import Registry
 from cephadm.serve import CephadmServe
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
@@ -23,8 +29,9 @@ from cephadm.utils import (
     GATEWAY_TYPES,
     ALLOWED_CIPHERS,
     SERVICE_CIPHER,
+    SpecialHostLabels,
 )
-from cephadm.ssh import HostConnectionError
+from cephadm.ssh import HostConnectionError, RemoteCommand, RemoteExecutable, Executables
 from orchestrator import OrchestratorError, DaemonDescription, DaemonDescriptionStatus, daemon_type_to_service
 from ceph.cephadm.version_entry import UpgradeStatus
 
@@ -59,6 +66,38 @@ MID_UPGRADE_MUTED_WARNINGS = [
     'AUTH_INSECURE_SERVICE_KEY_TYPE',
     'AUTH_INSECURE_ROTATING_SERVICE_KEY_TYPE'
 ]
+
+# Whole mirror phase (save + HTTP fan-out + load on all hosts). Single-command
+# default_cephadm_command_timeout (15m) is too short for multi-GB images.
+UPGRADE_IMAGE_MIRROR_MIN_TIMEOUT = 7200
+
+UPGRADE_IMAGE_MIRROR_METHOD_NONE = 'none'
+UPGRADE_IMAGE_MIRROR_METHOD_LOCAL_HTTP = 'local_http'
+UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY = 'registry'
+# Empty string or "none" disables pre-distribution (default).
+UPGRADE_IMAGE_MIRROR_METHODS_DISABLED = frozenset({
+    '',
+    UPGRADE_IMAGE_MIRROR_METHOD_NONE,
+})
+UPGRADE_IMAGE_MIRROR_METHODS_ENABLED = frozenset({
+    UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY,
+    UPGRADE_IMAGE_MIRROR_METHOD_LOCAL_HTTP,
+})
+
+
+def _remote_shell(script: str) -> RemoteCommand:
+    return RemoteCommand(RemoteExecutable('bash'), ['-c', script])
+
+
+def _http_url_host(addr: str) -> str:
+    bare = addr.split('/')[0]
+    try:
+        ip = ipaddress.ip_address(bare)
+        if isinstance(ip, ipaddress.IPv6Address):
+            return f'[{bare}]'
+    except ValueError:
+        pass
+    return bare
 
 
 def normalize_image_digest(digest: str, default_registry: str) -> str:
@@ -235,7 +274,8 @@ class UpgradeState:
                  rotated_mgr_mon_auth_key_daemons: Optional[List[str]] = None,
                  has_set_cephx_allowed_ciphers: Optional[bool] = False,
                  health_warnings_muted: Optional[bool] = False,
-                 rotated_osd_mds_keyrings: Optional[bool] = False
+                 rotated_osd_mds_keyrings: Optional[bool] = False,
+                 image_mirror_done: bool = False,
                  ):
 
         self._target_name: str = target_name  # Use CephadmUpgrade.target_image instead.
@@ -262,6 +302,7 @@ class UpgradeState:
         self.has_set_cephx_allowed_ciphers = has_set_cephx_allowed_ciphers
         self.rotated_osd_mds_keyrings = rotated_osd_mds_keyrings
         self.health_warnings_muted = health_warnings_muted
+        self.image_mirror_done = image_mirror_done
 
     def to_json(self) -> dict:
         return {
@@ -287,7 +328,8 @@ class UpgradeState:
             'rotated_mgr_mon_auth_key_daemons': self.rotated_mgr_mon_auth_key_daemons,
             'has_set_cephx_allowed_ciphers': self.has_set_cephx_allowed_ciphers,
             'health_warnings_muted': self.health_warnings_muted,
-            'rotated_osd_mds_keyrings': self.rotated_osd_mds_keyrings
+            'rotated_osd_mds_keyrings': self.rotated_osd_mds_keyrings,
+            'image_mirror_done': self.image_mirror_done,
         }
 
     @classmethod
@@ -1189,9 +1231,13 @@ class CephadmUpgrade:
             # were doing something
             return
 
-        logger.error('Upgrade: Paused due to %s: %s' % (alert_id,
-                                                        alert['summary']))
-        self.upgrade_state.error = alert_id + ': ' + alert['summary']
+        detail = alert.get('detail', [])
+        summary = alert['summary']
+        if detail:
+            summary = f"{summary}: {'; '.join(str(d) for d in detail[:5])}"
+
+        logger.error('Upgrade: Paused due to %s: %s' % (alert_id, summary))
+        self.upgrade_state.error = alert_id + ': ' + summary
         self.upgrade_state.paused = True
         # Do not restore PG autoscaling here: upgrade is only paused. Restore
         # only on upgrade_stop or _mark_upgrade_complete so that resume
@@ -2136,6 +2182,800 @@ class CephadmUpgrade:
         self._ok_to_upgrade_osds_in_crush_bucket = None
         self._save_upgrade_state()
 
+    def _get_upgrade_scope_hosts(self, daemons: List[DaemonDescription]) -> List[str]:
+        hosts = sorted({d.hostname for d in daemons if d.hostname})
+        return [h for h in hosts if h not in self.mgr.offline_hosts]
+
+    def _mirror_tar_basename(self, target_digests: List[str]) -> str:
+        digest = target_digests[0] if target_digests else 'unknown'
+        safe = digest.replace('@', '-').replace(':', '-').replace('/', '_')
+        if len(safe) > 80:
+            safe = hashlib.sha256(digest.encode()).hexdigest()[:16]
+        return f'upgrade-image-{safe}.tar.gz'
+
+    def _mirror_paths(self, target_digests: List[str]) -> Tuple[str, str, str]:
+        mirror_dir = f'/var/lib/ceph/{self.mgr._cluster_fsid}'
+        tar_name = self._mirror_tar_basename(target_digests)
+        tar_path = f'{mirror_dir}/{tar_name}'
+        pid_path = f'{mirror_dir}/upgrade-image-http.pid'
+        return mirror_dir, tar_path, pid_path
+
+    def _select_image_mirror_seed_host(self, hosts: List[str]) -> str:
+        admin_hosts = PlacementSpec(
+            label=SpecialHostLabels.ADMIN
+        ).filter_matching_hostspecs(self.mgr.inventory.all_specs())
+        for host in admin_hosts:
+            if host in hosts and host not in self.mgr.offline_hosts:
+                return host
+
+        active_mgr = self.mgr.get_active_mgr()
+        if active_mgr.hostname and active_mgr.hostname in hosts:
+            return active_mgr.hostname
+
+        if not hosts:
+            raise OrchestratorError('no hosts in upgrade scope for image mirror')
+        return hosts[0]
+
+    def _ceph_networks(self) -> List[str]:
+        networks: List[str] = []
+        for entity, key in (('mon', 'public_network'), ('osd', 'cluster_network')):
+            try:
+                value = str(self.mgr.get_foreign_ceph_option(entity, key))
+            except Exception:
+                continue
+            if '/' not in value:
+                continue
+            for net in value.split(','):
+                net = net.strip()
+                if net and net not in networks:
+                    networks.append(net)
+        return networks
+
+    def _ips_on_host_networks(
+        self,
+        host: str,
+        ipv4_only: bool = False,
+        ceph_networks_only: bool = False,
+    ) -> List[str]:
+        ceph_networks = self._ceph_networks() if ceph_networks_only else []
+        ips: List[str] = []
+        for subnet, ifaces in self.mgr.cache.networks.get(host, {}).items():
+            on_ceph_net = False
+            if ceph_networks:
+                try:
+                    host_subnet = ipaddress.ip_network(subnet, strict=False)
+                except ValueError:
+                    continue
+                for ceph_net in ceph_networks:
+                    try:
+                        if host_subnet.overlaps(ipaddress.ip_network(ceph_net, strict=False)):
+                            on_ceph_net = True
+                            break
+                    except ValueError:
+                        continue
+                if not on_ceph_net:
+                    continue
+            for _iface, addr_list in ifaces.items():
+                for addr in addr_list:
+                    bare = addr.split('/')[0]
+                    try:
+                        ip = ipaddress.ip_address(bare)
+                    except ValueError:
+                        continue
+                    if ipv4_only and not isinstance(ip, ipaddress.IPv4Address):
+                        continue
+                    ips.append(str(ip))
+        return ips
+
+    def _get_image_mirror_host_addr(self, host: str) -> str:
+        """Pick a cluster-reachable address for the HTTP mirror (prefer IPv4)."""
+        for ceph_ipv4 in self._ips_on_host_networks(
+                host, ipv4_only=True, ceph_networks_only=True):
+            return ceph_ipv4
+        for host_ipv4 in self._ips_on_host_networks(host, ipv4_only=True):
+            return host_ipv4
+        inventory_addr = self.mgr.inventory.get_addr(host).split('/')[0]
+        try:
+            ip = ipaddress.ip_address(inventory_addr)
+            if isinstance(ip, ipaddress.IPv4Address):
+                return str(ip)
+        except ValueError:
+            pass
+        ceph_ips = self._ips_on_host_networks(
+            host, ceph_networks_only=True)
+        if ceph_ips:
+            return ceph_ips[0]
+        host_ips = self._ips_on_host_networks(host)
+        if host_ips:
+            return host_ips[0]
+        return inventory_addr
+
+    async def _inspect_image_on_host(
+        self,
+        host: str,
+        target_image: str,
+    ) -> Optional[Dict[str, Any]]:
+        out, _, code = await CephadmServe(self.mgr)._run_cephadm(
+            host, '', 'inspect-image', [],
+            image=target_image, no_fsid=True, error_ok=True)
+        if code:
+            return None
+        try:
+            return json.loads(''.join(out))
+        except json.JSONDecodeError:
+            return None
+
+    def _target_image_inspect_refs(self, target_image: str) -> List[str]:
+        refs: List[str] = []
+        assert self.upgrade_state is not None
+        for candidate in (
+            target_image,
+            self.upgrade_state._target_name,
+        ):
+            if candidate and candidate not in refs:
+                refs.append(candidate)
+        target_id = self.upgrade_state.target_id
+        if target_id:
+            bare_id = target_id.replace('sha256:', '')
+            for id_ref in (bare_id, f'sha256:{bare_id}'):
+                if id_ref not in refs:
+                    refs.append(id_ref)
+        return refs
+
+    async def _host_has_target_image_on_host(
+        self,
+        host: str,
+        target_image: str,
+        target_digests: List[str],
+    ) -> bool:
+        for ref in self._target_image_inspect_refs(target_image):
+            inspect_info = await self._inspect_image_on_host(host, ref)
+            if self._host_has_target_image(inspect_info, target_digests):
+                return True
+        return False
+
+    def _host_has_target_image(
+        self,
+        inspect_info: Optional[Dict[str, Any]],
+        target_digests: List[str],
+    ) -> bool:
+        if not inspect_info:
+            return False
+        repo_digests = inspect_info.get('repo_digests', []) or []
+        target_id = self.upgrade_state.target_id if self.upgrade_state else None
+        image_id = inspect_info.get('image_id')
+        if target_id and image_id:
+            if image_id.replace('sha256:', '') == target_id.replace('sha256:', ''):
+                return True
+        if any(d in target_digests for d in repo_digests):
+            return True
+        target_shas = {
+            d.split('@sha256:', 1)[1]
+            for d in target_digests
+            if '@sha256:' in d
+        }
+        for digest in repo_digests:
+            if '@sha256:' in digest and digest.split('@sha256:', 1)[1] in target_shas:
+                return True
+        return False
+
+    async def _get_host_container_engine(self, host: str) -> str:
+        cmd = _remote_shell(
+            'command -v podman 2>/dev/null || command -v docker 2>/dev/null')
+        out, _, code = await self.mgr.ssh._execute_command(host, cmd)
+        engine = (out or '').strip().splitlines()[-1].strip() if not code else ''
+        if not engine:
+            raise OrchestratorError(f'no container engine found on host {host}')
+        return engine
+
+    def _mirror_image_tag_name(self) -> Optional[str]:
+        """
+        Human image:tag used to start the upgrade, if any.
+
+        When use_repo_digest is enabled, ``target_image`` becomes a digest ref
+        (``repo@sha256:…``). Saving/loading by digest restores the layers but
+        leaves TAG as ``<none>`` on worker hosts. Prefer the original tag name
+        for save + an explicit retag after load.
+        """
+        assert self.upgrade_state is not None
+        name = self.upgrade_state._target_name
+        if not name or '@' in name:
+            return None
+        return name
+
+    async def _tag_image_on_host(
+        self,
+        host: str,
+        engine: str,
+        image_ref: str,
+        tag_name: str,
+    ) -> None:
+        script = (
+            f'{shlex.quote(engine)} tag '
+            f'{shlex.quote(image_ref)} {shlex.quote(tag_name)}'
+        )
+        await self.mgr.ssh._check_execute_command(host, _remote_shell(script))
+
+    async def _save_image_on_host(
+        self,
+        host: str,
+        engine: str,
+        image: str,
+        tar_path: str,
+    ) -> None:
+        # gzip --fast: podman/docker load accepts gzip-compressed archives.
+        script = (
+            f'{shlex.quote(engine)} save {shlex.quote(image)} | '
+            f'python3 -m gzip --fast > {shlex.quote(tar_path)}'
+        )
+        await self.mgr.ssh._check_execute_command(host, _remote_shell(script))
+
+    async def _load_image_from_url_on_host(
+        self,
+        host: str,
+        engine: str,
+        url: str,
+        tar_path: str,
+        tag_name: Optional[str] = None,
+        image_id: Optional[str] = None,
+    ) -> None:
+        script = (
+            f'curl -sf {shlex.quote(url)} -o {shlex.quote(tar_path)} && '
+            f'{shlex.quote(engine)} load -i {shlex.quote(tar_path)} && '
+            f'rm -f {shlex.quote(tar_path)}'
+        )
+        # podman/docker load of a digest-saved archive often leaves TAG <none>.
+        # Always retag to the upgrade's original image:tag when we know both.
+        if tag_name and image_id:
+            script += (
+                f' && {shlex.quote(engine)} tag '
+                f'{shlex.quote(image_id)} {shlex.quote(tag_name)}'
+            )
+        await self.mgr.ssh._check_execute_command(host, _remote_shell(script))
+
+    async def _wait_for_http_server(self, host: str, url: str) -> None:
+        last_error = ''
+        curl_check = (
+            f'code=$(curl -sf -o /dev/null -w "%{{http_code}}" {shlex.quote(url)}); '
+            f'test "$code" = "200"'
+        )
+        for _ in range(30):
+            try:
+                await self.mgr.ssh._check_execute_command(
+                    host, _remote_shell(curl_check))
+                return
+            except Exception as e:
+                last_error = str(e)
+                await asyncio.sleep(1)
+        raise OrchestratorError(
+            f'HTTP mirror on {host} did not serve {url} (expected HTTP 200): {last_error}')
+
+    async def _registry_login_if_needed(self, host: str) -> None:
+        if self.mgr.cache.host_needs_registry_login(host) and self.mgr.registry_url:
+            creds = self.mgr.get_store('registry_credentials')
+            if creds:
+                await CephadmServe(self.mgr)._registry_login(host, json.loads(str(creds)))
+
+    async def _mirror_cleanup(
+        self,
+        seed_host: str,
+        pid_path: str,
+        tar_path: str,
+    ) -> None:
+        cleanup_cmd = (
+            f'if [ -f {shlex.quote(pid_path)} ]; then '
+            f'kill "$(cat {shlex.quote(pid_path)})" 2>/dev/null || true; '
+            f'rm -f {shlex.quote(pid_path)}; fi; '
+            f'rm -f {shlex.quote(tar_path)}'
+        )
+        try:
+            await self.mgr.ssh._check_execute_command(
+                seed_host, _remote_shell(cleanup_cmd))
+        except Exception as e:
+            logger.warning('Upgrade: image mirror cleanup on %s failed: %s', seed_host, e)
+
+    async def _mirror_upgrade_image_via_http_async(
+        self,
+        target_image: str,
+        target_digests: List[str],
+        hosts: List[str],
+    ) -> bool:
+        assert self.upgrade_state is not None
+        hosts_needing_image: List[str] = []
+        for host in hosts:
+            if not await self._host_has_target_image_on_host(
+                    host, target_image, target_digests):
+                hosts_needing_image.append(host)
+
+        if not hosts_needing_image:
+            logger.info('Upgrade: all in-scope hosts already have target image')
+            self.upgrade_state.image_mirror_done = True
+            self._save_upgrade_state()
+            return True
+
+        seed_host: Optional[str] = None
+        mirror_dir, tar_path, pid_path = self._mirror_paths(target_digests)
+        tar_name = os.path.basename(tar_path)
+
+        try:
+            seed_host = self._select_image_mirror_seed_host(hosts)
+            seed_addr = self._get_image_mirror_host_addr(seed_host)
+            mirror_port = self.mgr.upgrade_image_mirror_port
+            image_url = (
+                f'http://{_http_url_host(seed_addr)}:'
+                f'{mirror_port}/{tar_name}')
+
+            logger.info(
+                'Upgrade: mirroring target image from seed host %s to %d host(s)',
+                seed_host, len(hosts_needing_image))
+            self.upgrade_info_str = (
+                f'Mirroring upgrade image from {seed_host} to {len(hosts_needing_image)} host(s)')
+
+            await self.mgr.ssh._check_execute_command(
+                seed_host, RemoteCommand(Executables.MKDIR, ['-p', mirror_dir]))
+
+            seed_inspect = await self._inspect_image_on_host(seed_host, target_image)
+            if not self._host_has_target_image(seed_inspect, target_digests):
+                await self._registry_login_if_needed(seed_host)
+                self.upgrade_info_str = f'Pulling upgrade image on seed host {seed_host}'
+                pullargs: List[str] = []
+                if self.mgr.registry_insecure:
+                    pullargs.append('--insecure')
+                await CephadmServe(self.mgr)._run_cephadm_json(
+                    seed_host, '', 'pull', pullargs,
+                    image=target_image, no_fsid=True)
+
+            seed_engine = await self._get_host_container_engine(seed_host)
+            tag_name = self._mirror_image_tag_name()
+            save_ref = tag_name or target_image
+            if tag_name and self.upgrade_state.target_id:
+                # Ensure seed has image:tag even if only the digest ref exists
+                # locally (common when use_repo_digest is enabled).
+                await self._tag_image_on_host(
+                    seed_host, seed_engine,
+                    self.upgrade_state.target_id, tag_name)
+            self.upgrade_info_str = f'Saving upgrade image on seed host {seed_host}'
+            await self._save_image_on_host(
+                seed_host, seed_engine, save_ref, tar_path)
+
+            http_log = f'{mirror_dir}/upgrade-image-http.log'
+            start_server_cmd = (
+                f'if [ -f {shlex.quote(pid_path)} ]; then '
+                f'kill "$(cat {shlex.quote(pid_path)})" 2>/dev/null || true; '
+                f'rm -f {shlex.quote(pid_path)}; fi; '
+                f'if command -v fuser >/dev/null 2>&1; then '
+                f'fuser -k {mirror_port}/tcp 2>/dev/null || true; fi; '
+                f'nohup python3 -m http.server {mirror_port} '
+                f'--directory {shlex.quote(mirror_dir)} '
+                f'--bind {shlex.quote(seed_addr)} '
+                f'> {shlex.quote(http_log)} 2>&1 & echo $! > {shlex.quote(pid_path)}'
+            )
+            await self.mgr.ssh._check_execute_command(
+                seed_host, _remote_shell(start_server_cmd))
+
+            await self._wait_for_http_server(seed_host, image_url)
+
+            hosts_to_load = [h for h in hosts_needing_image if h != seed_host]
+
+            max_parallel = max(1, self.mgr.upgrade_image_mirror_max_parallel)
+            sem = asyncio.Semaphore(max_parallel)
+            failed_hosts: List[Tuple[str, str]] = []
+
+            async def _load_on_host(host: str, index: int) -> None:
+                async with sem:
+                    self.upgrade_info_str = (
+                        f'Mirroring upgrade image to {host} '
+                        f'({index + 1}/{len(hosts_to_load)})')
+                    host_tar = f'{mirror_dir}/{tar_name}.load'
+                    try:
+                        engine = await self._get_host_container_engine(host)
+                        await self._load_image_from_url_on_host(
+                            host, engine, image_url, host_tar,
+                            tag_name=tag_name,
+                            image_id=self.upgrade_state.target_id if self.upgrade_state else None)
+                    except Exception as e:
+                        failed_hosts.append((host, str(e)))
+
+            if hosts_to_load:
+                await asyncio.gather(*[
+                    _load_on_host(host, i) for i, host in enumerate(hosts_to_load)
+                ])
+
+            if failed_hosts:
+                detail = [
+                    f'failed to mirror image to {host}: {reason}'
+                    for host, reason in failed_hosts
+                ]
+                self._fail_upgrade('UPGRADE_FAILED_PULL', {
+                    'severity': 'warning',
+                    'summary': 'Upgrade: failed to mirror target image',
+                    'count': len(failed_hosts),
+                    'detail': detail,
+                })
+                return False
+
+            for host in hosts_needing_image:
+                if not await self._host_has_target_image_on_host(
+                        host, target_image, target_digests):
+                    tried = self._target_image_inspect_refs(target_image)
+                    self._fail_upgrade('UPGRADE_FAILED_PULL', {
+                        'severity': 'warning',
+                        'summary': 'Upgrade: failed to mirror target image',
+                        'count': 1,
+                        'detail': [
+                            f'host {host} does not have target image after mirror '
+                            f'(inspect refs: {tried})'],
+                    })
+                    return False
+
+            self.upgrade_state.image_mirror_done = True
+            self._save_upgrade_state()
+            logger.info('Upgrade: image mirror complete')
+            return True
+        except Exception as e:
+            logger.exception('Upgrade: image mirror failed')
+            self._fail_upgrade('UPGRADE_FAILED_PULL', {
+                'severity': 'warning',
+                'summary': 'Upgrade: failed to mirror target image',
+                'count': 1,
+                'detail': [str(e)],
+            })
+            return False
+        finally:
+            if seed_host:
+                await self._mirror_cleanup(seed_host, pid_path, tar_path)
+
+    def _parse_pull_image_info(self, out: List[str]) -> Optional[Dict[str, Any]]:
+        try:
+            info = json.loads(''.join(out))
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return None
+        if not isinstance(info, dict):
+            return None
+        return info
+
+    def _ceph_version_token_from_pull(self, ceph_version: str) -> Optional[str]:
+        """Normalize ``ceph --version`` output to the short token stored in upgrade state."""
+        if not ceph_version:
+            return None
+        if ceph_version.startswith('ceph version '):
+            parts = ceph_version.split(' ')
+            if len(parts) >= 3:
+                return parts[2]
+            return None
+        return ceph_version
+
+    def _set_target_from_pull_info(self, info: Dict[str, Any]) -> Optional[str]:
+        """
+        Persist target_id / digests / version from cephadm pull/inspect JSON.
+
+        Returns an error string on failure, or None on success.
+        """
+        assert self.upgrade_state is not None
+        image_id = info.get('image_id')
+        digests = info.get('repo_digests') or []
+        ceph_version = info.get('ceph_version') or ''
+        if not image_id or not digests:
+            return 'pull did not return image_id and repo_digests'
+        version_token = self._ceph_version_token_from_pull(str(ceph_version))
+        if not version_token:
+            return 'unable to extract ceph version from container'
+        self.upgrade_state.target_id = str(image_id)
+        self.upgrade_state.target_digests = list(digests)
+        self.upgrade_state.target_version = version_token
+        self._save_upgrade_state()
+        return None
+
+    async def _pre_pull_image_discover_async(
+        self,
+        target_image: str,
+        hosts: List[str],
+    ) -> bool:
+        """
+        Parallel registry pull that also learns target digests/version.
+
+        Used when upgrade_image_mirror_method=registry and upgrade state does not
+        yet have target metadata, so we avoid a serial "First pull" on one host
+        before pulling everywhere else.
+        """
+        assert self.upgrade_state is not None
+        max_parallel = max(1, self.mgr.upgrade_image_mirror_max_parallel)
+        logger.info(
+            'Upgrade: discovering and pre-pulling image %s on %d host(s), '
+            'up to %d in parallel',
+            target_image, len(hosts), max_parallel)
+        self.upgrade_info_str = (
+            f'Discovering and pre-pulling upgrade image on {len(hosts)} host(s)')
+
+        pullargs: List[str] = []
+        if self.mgr.registry_insecure:
+            pullargs.append('--insecure')
+
+        sem = asyncio.Semaphore(max_parallel)
+        # host -> (code, pull_info_or_None, error_reason)
+        results: Dict[str, Tuple[int, Optional[Dict[str, Any]], str]] = {}
+
+        async def _pull_on_host(host: str) -> None:
+            async with sem:
+                if not self.upgrade_state or self.upgrade_state.paused:
+                    return
+                try:
+                    await self._registry_login_if_needed(host)
+                    logger.info('Upgrade: pulling image %s on host %s', target_image, host)
+                    out, errs, code = await CephadmServe(self.mgr)._run_cephadm(
+                        host, '', 'pull', pullargs,
+                        image=target_image, no_fsid=True, error_ok=True)
+                    if code:
+                        reason = ''.join(errs) if errs else 'unknown error'
+                        logger.error('Upgrade: failed to pull image on host %s', host)
+                        results[host] = (code, None, reason)
+                    else:
+                        info = self._parse_pull_image_info(out)
+                        if not info:
+                            results[host] = (1, None, 'invalid or empty pull JSON')
+                            logger.error(
+                                'Upgrade: invalid pull JSON on host %s', host)
+                        else:
+                            results[host] = (0, info, '')
+                            logger.info('Upgrade: pulled image on host %s', host)
+                except Exception as e:
+                    results[host] = (1, None, str(e))
+
+        await asyncio.gather(*[_pull_on_host(host) for host in hosts])
+
+        failed_hosts: List[Tuple[str, str]] = []
+        for host in hosts:
+            if host not in results:
+                failed_hosts.append((host, 'pre-pull interrupted or skipped'))
+                continue
+            code, _info, reason = results[host]
+            if code:
+                failed_hosts.append((host, reason))
+
+        if failed_hosts:
+            detail = [
+                f'failed to pull image on {host}: {reason}'
+                for host, reason in failed_hosts
+            ]
+            self._fail_upgrade('UPGRADE_FAILED_PULL', {
+                'severity': 'warning',
+                'summary': 'Upgrade: failed to pre-pull target image',
+                'count': len(failed_hosts),
+                'detail': detail,
+            })
+            return False
+
+        reference: Optional[Dict[str, Any]] = None
+        for host in hosts:
+            _code, info, _reason = results[host]
+            if not info:
+                continue
+            image_id = info.get('image_id')
+            digests = info.get('repo_digests') or []
+            version_token = self._ceph_version_token_from_pull(
+                str(info.get('ceph_version') or ''))
+            if image_id and digests and version_token:
+                reference = info
+                break
+
+        if not reference:
+            self._fail_upgrade('UPGRADE_FAILED_PULL', {
+                'severity': 'warning',
+                'summary': 'Upgrade: failed to pull target image',
+                'count': 1,
+                'detail': [
+                    'unable to extract image digests/version from parallel pull'],
+            })
+            return False
+
+        apply_err = self._set_target_from_pull_info(reference)
+        if apply_err:
+            self._fail_upgrade('UPGRADE_FAILED_PULL', {
+                'severity': 'warning',
+                'summary': 'Upgrade: failed to pull target image',
+                'count': 1,
+                'detail': [apply_err],
+            })
+            return False
+
+        assert self.upgrade_state.target_digests is not None
+        target_digests = self.upgrade_state.target_digests
+        logger.info(
+            'Upgrade: discovered target digests %s version %s from parallel pull',
+            target_digests, self.upgrade_state.target_version)
+
+        for host in hosts:
+            _code, info, _reason = results[host]
+            if not self._host_has_target_image(info, target_digests):
+                got_digests = info.get('repo_digests') if info else None
+                self._fail_upgrade('UPGRADE_FAILED_PULL', {
+                    'severity': 'warning',
+                    'summary': 'Upgrade: failed to pre-pull target image',
+                    'count': 1,
+                    'detail': [
+                        f'host {host} pull returned mismatched digests '
+                        f'(got {got_digests}, expected {target_digests})',
+                    ],
+                })
+                return False
+
+        self.upgrade_state.image_mirror_done = True
+        self._save_upgrade_state()
+        logger.info('Upgrade: registry pre-pull complete')
+        return True
+
+    async def _pre_pull_image_on_hosts_async(
+        self,
+        target_image: str,
+        target_digests: List[str],
+        hosts: List[str],
+    ) -> bool:
+        assert self.upgrade_state is not None
+        # Discover digests/version from parallel pulls only when digests are
+        # unknown. If digests are already known (typical resume / local_http
+        # first-pull path), use the normal skip-or-pull flow.
+        discovering = not target_digests
+        if discovering:
+            return await self._pre_pull_image_discover_async(target_image, hosts)
+
+        hosts_needing_image: List[str] = []
+        for host in hosts:
+            if not await self._host_has_target_image_on_host(
+                    host, target_image, target_digests):
+                hosts_needing_image.append(host)
+
+        if not hosts_needing_image:
+            logger.info('Upgrade: all in-scope hosts already have target image')
+            self.upgrade_state.image_mirror_done = True
+            self._save_upgrade_state()
+            return True
+
+        max_parallel = max(1, self.mgr.upgrade_image_mirror_max_parallel)
+        logger.info(
+            'Upgrade: pre-pulling image %s on %d host(s), up to %d in parallel',
+            target_image, len(hosts_needing_image), max_parallel)
+        self.upgrade_info_str = (
+            f'Pre-pulling upgrade image on {len(hosts_needing_image)} host(s)')
+
+        pullargs: List[str] = []
+        if self.mgr.registry_insecure:
+            pullargs.append('--insecure')
+
+        sem = asyncio.Semaphore(max_parallel)
+        failed_hosts: List[Tuple[str, str]] = []
+        done = 0
+        total = len(hosts_needing_image)
+
+        async def _pull_on_host(host: str) -> None:
+            nonlocal done
+            async with sem:
+                if not self.upgrade_state or self.upgrade_state.paused:
+                    return
+                try:
+                    await self._registry_login_if_needed(host)
+                    logger.info('Upgrade: pulling image %s on host %s', target_image, host)
+                    _out, errs, code = await CephadmServe(self.mgr)._run_cephadm(
+                        host, '', 'pull', pullargs,
+                        image=target_image, no_fsid=True, error_ok=True)
+                    done += 1
+                    if code:
+                        reason = ''.join(errs) if errs else 'unknown error'
+                        logger.error(
+                            'Upgrade: failed to pull image on host %s (%d/%d done)',
+                            host, done, total)
+                        failed_hosts.append((host, reason))
+                    else:
+                        logger.info(
+                            'Upgrade: pulled image on host %s (%d/%d done)',
+                            host, done, total)
+                except Exception as e:
+                    done += 1
+                    failed_hosts.append((host, str(e)))
+
+        await asyncio.gather(*[_pull_on_host(host) for host in hosts_needing_image])
+
+        if failed_hosts:
+            detail = [
+                f'failed to pull image on {host}: {reason}'
+                for host, reason in failed_hosts
+            ]
+            self._fail_upgrade('UPGRADE_FAILED_PULL', {
+                'severity': 'warning',
+                'summary': 'Upgrade: failed to pre-pull target image',
+                'count': len(failed_hosts),
+                'detail': detail,
+            })
+            return False
+
+        for host in hosts_needing_image:
+            if not await self._host_has_target_image_on_host(
+                    host, target_image, target_digests):
+                tried = self._target_image_inspect_refs(target_image)
+                self._fail_upgrade('UPGRADE_FAILED_PULL', {
+                    'severity': 'warning',
+                    'summary': 'Upgrade: failed to pre-pull target image',
+                    'count': 1,
+                    'detail': [
+                        f'host {host} does not have target image after pull '
+                        f'(tried {tried})',
+                    ],
+                })
+                return False
+
+        self.upgrade_state.image_mirror_done = True
+        self._save_upgrade_state()
+        logger.info('Upgrade: registry pre-pull complete')
+        return True
+
+    def _pre_pull_image_on_hosts(
+        self,
+        target_image: str,
+        target_digests: List[str],
+        hosts: List[str],
+    ) -> bool:
+        timeout = self._mirror_operation_timeout(len(hosts))
+        logger.info(
+            'Upgrade: registry pre-pull timeout set to %d seconds for %d host(s)',
+            timeout, len(hosts))
+        return self.mgr.wait_async(
+            self._pre_pull_image_on_hosts_async(
+                target_image, target_digests, hosts),
+            timeout=timeout)
+
+    def _mirror_operation_timeout(self, host_count: int) -> int:
+        per_host = max(self.mgr.default_cephadm_command_timeout, 1800)
+        return max(UPGRADE_IMAGE_MIRROR_MIN_TIMEOUT, per_host * max(host_count, 1))
+
+    def _mirror_upgrade_image_via_http(
+        self,
+        target_image: str,
+        target_digests: List[str],
+        hosts: List[str],
+    ) -> bool:
+        timeout = self._mirror_operation_timeout(len(hosts))
+        logger.info(
+            'Upgrade: image mirror timeout set to %d seconds for %d host(s)',
+            timeout, len(hosts))
+        return self.mgr.wait_async(
+            self._mirror_upgrade_image_via_http_async(
+                target_image, target_digests, hosts),
+            timeout=timeout)
+
+    def _get_upgrade_image_mirror_method(self) -> str:
+        raw = getattr(self.mgr, 'upgrade_image_mirror_method', '') or ''
+        return str(raw).strip().lower()
+
+    def _upgrade_image_mirror_enabled(self) -> bool:
+        return self._get_upgrade_image_mirror_method() in UPGRADE_IMAGE_MIRROR_METHODS_ENABLED
+
+    def _pre_distribute_upgrade_images(
+        self,
+        target_image: str,
+        target_digests: List[str],
+        hosts: List[str],
+    ) -> bool:
+        method = self._get_upgrade_image_mirror_method()
+        if method in UPGRADE_IMAGE_MIRROR_METHODS_DISABLED:
+            return True
+        if method == UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY:
+            return self._pre_pull_image_on_hosts(
+                target_image, target_digests, hosts)
+        if method == UPGRADE_IMAGE_MIRROR_METHOD_LOCAL_HTTP:
+            return self._mirror_upgrade_image_via_http(
+                target_image, target_digests, hosts)
+        self._fail_upgrade('UPGRADE_FAILED_PULL', {
+            'severity': 'error',
+            'summary': 'Upgrade: invalid upgrade_image_mirror_method',
+            'count': 1,
+            'detail': [
+                f'unknown upgrade_image_mirror_method {method!r}; '
+                f'expected empty/{UPGRADE_IMAGE_MIRROR_METHOD_NONE!r} '
+                f'(disabled), {UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY!r}, or '
+                f'{UPGRADE_IMAGE_MIRROR_METHOD_LOCAL_HTTP!r}',
+            ],
+        })
+        return False
+
     def _do_upgrade(self):
         # type: () -> None
         if not self.upgrade_state:
@@ -2159,9 +2999,24 @@ class CephadmUpgrade:
         target_digests = self.upgrade_state.target_digests
         target_version = self.upgrade_state.target_version
 
+        need_metadata = not target_id or not target_version or not target_digests
+        registry_discover_hosts: List[str] = []
+        use_registry_discover = False
+        if (
+            need_metadata
+            and self._upgrade_image_mirror_enabled()
+            and not self.upgrade_state.image_mirror_done
+            and self._get_upgrade_image_mirror_method() == UPGRADE_IMAGE_MIRROR_METHOD_REGISTRY
+        ):
+            registry_discover_hosts = self._get_upgrade_scope_hosts(
+                self._get_filtered_daemons())
+            use_registry_discover = bool(registry_discover_hosts)
+
         first = False
-        if not target_id or not target_version or not target_digests:
-            # need to learn the container hash
+        if need_metadata and not use_registry_discover:
+            # need to learn the container hash (serial pull on one host).
+            # Skipped for registry pre-pull: digests/version are learned from the
+            # parallel pulls so we do not pay ~2x wall-clock for large images.
             logger.info('Upgrade: First pull of %s' % target_image)
             self.upgrade_info_str = 'Doing first pull of %s image' % (target_image)
             try:
@@ -2192,10 +3047,25 @@ class CephadmUpgrade:
             self.upgrade_state.target_digests = target_digests
             self._save_upgrade_state()
             target_image = self.target_image
+            target_version = self.upgrade_state.target_version
+            first = True
+
+        if use_registry_discover:
+            logger.info(
+                'Upgrade: discovering target image via parallel registry '
+                'pre-pull of %s', target_image)
+            if not self._pre_pull_image_on_hosts(
+                    target_image, target_digests or [], registry_discover_hosts):
+                return
+            target_id = self.upgrade_state.target_id
+            target_digests = self.upgrade_state.target_digests
+            target_version = self.upgrade_state.target_version
+            target_image = self.target_image
             first = True
 
         if target_digests is None:
             target_digests = []
+        assert target_version is not None
         if target_version.startswith('ceph version '):
             # tolerate/fix upgrade state from older version
             self.upgrade_state.target_version = target_version.split(' ')[2]
@@ -2218,6 +3088,19 @@ class CephadmUpgrade:
                 'detail': [version_error],
             })
             return
+
+        if (
+            self._upgrade_image_mirror_enabled()
+            and not self.upgrade_state.image_mirror_done
+        ):
+            # local_http, or registry when metadata was already known (resume).
+            # Registry discover path above already marked image_mirror_done.
+            daemons = self._get_filtered_daemons()
+            hosts = self._get_upgrade_scope_hosts(daemons)
+            if hosts and not self._pre_distribute_upgrade_images(
+                target_image, target_digests, hosts
+            ):
+                return
 
         image_settings = self.get_distinct_container_image_settings()
 


### PR DESCRIPTION
---

```markdown
## Summary

Opt-in upgrade image **pre-distribution** before any daemon is upgraded.

Fixes: https://tracker.ceph.com/issues/77270

Based-on-patch-by: Frédéric Nass <frederic.nass@clyso.com>  
Signed-off-by: Kobi Ginon <kginon@redhat.com>

Today, cephadm pulls the target **Ceph** container image on each host on demand during upgrade. On large clusters / large images this adds significant time (and for MDS can extend CephFS unavailability after `fs fail` / scale-down).

this feature only pre-distributes the Ceph upgrade target image (the one from ceph orch upgrade start --image …).
It does not cover Grafana / monitoring or SMB images.

This PR adds a single config option to pre-distribute that image to in-scope hosts **before** daemon upgrades:

| `mgr/cephadm/upgrade_image_mirror_method` | Behavior |
|---|---|
| `''` / `none` (**default**) | Disabled (current behavior) |
| `registry` | Parallel `podman`/`docker` pull on all in-scope hosts from a reachable registry (Harbor/Quay/local registry). Digests/version learned from those pulls (no serial first pull). |

#Not in this PR  , just keeping it here for reference
| `local_http` | Pull once on a seed host, `save` → gzip tar, short-lived HTTP server (default TCP **8766**), parallel load on workers over the cluster LAN. For telco / air-gap where only admin/mgr hosts reach the registry. |

Also:
- Persist `image_mirror_done` in upgrade state (survives mgr failover)
- Pause with `UPGRADE_FAILED_PULL` if pre-distribution fails (no daemons upgraded yet)
- Retag workers after `local_http` load so `image:tag` is preserved (not only IMAGE ID with `<none>` tag)
- Docs: `doc/cephadm/upgrade.rst` + port note in `doc/rados/configuration/network-config-ref.rst`


**Scope:** applies to the **Ceph upgrade target image** only (`ceph orch upgrade start --image …`). Monitoring stack images (Grafana/Prometheus/…) and SMB/NVMeoF images are separate (`NON_CEPH_IMAGE_TYPES`) and are **not** pre-distributed by this feature.

## Config

```bash
# enable parallel registry pre-pull
ceph config set mgr mgr/cephadm/upgrade_image_mirror_method registry

#Not in this PR  , just keeping it here for reference
# OR enable HTTP mirror from seed
ceph config set mgr mgr/cephadm/upgrade_image_mirror_method local_http

# optional tuning
ceph config set mgr mgr/cephadm/upgrade_image_mirror_max_parallel 8

#Not in this PR  , just keeping it here for reference
# local_http only (default 8766)
ceph config set mgr mgr/cephadm/upgrade_image_mirror_port 8766

# disable
ceph config set mgr mgr/cephadm/upgrade_image_mirror_method none
```

## Manual verification (kcli 3-node)

**Environment:** ceph-node-0/1/2, local registry `192.168.100.254:5000`, images `main1.0.kobi` → `main2.0.kobi` / `main3.0.kobi` (mgr code under test baked into the image).

**Monitoring during upgrade:**
- `watch -n 2 'ceph orch upgrade status'`
- `journalctl -u ceph-<fsid>@mgr.<host>.* -f`
- On each host: `podman images`
- For `local_http` on seed: `ss -lntp | grep 8766` (or custom port)

Only scenario A relevant here for testings - as i m removing the second option to be reviewed in a seperate PR
### Scenario A — `registry` (Harbor-like; all hosts can pull)

```bash
ceph config set mgr mgr/cephadm/upgrade_image_mirror_method registry
ceph config set mgr mgr/cephadm/upgrade_image_mirror_max_parallel 8
ceph orch upgrade start --image 192.168.100.254:5000/ceph/ceph:main2.0.kobi
```

Observed progression:
1. `"message": "Discovering and pre-pulling upgrade image on 3 host(s)"` — target image appears on all hosts **before** daemon upgrades
2. Then normal upgrade: mgr → … → osd (`2/11` … `9/11` …)
3. Finish: `There are no upgrades in progress currently.`

Hosts show the new tag/IMAGE ID present during/after the pre-pull phase (watch `podman images` on all three nodes).


#Not in this PR  , just keeping it here for reference

### Scenario B — `local_http` (only seed/admin reaches registry)
```bash
ceph config set mgr mgr/cephadm/upgrade_image_mirror_method local_http
ceph config set mgr mgr/cephadm/upgrade_image_mirror_max_parallel 8
ceph orch upgrade start --image 192.168.100.254:5000/ceph/ceph:<target>
```

Observed progression:
1. `"Doing first pull of … image"` (learn digests/version)
2. `"Saving upgrade image on seed host ceph-node-0"`
3. Seed briefly listens: `ss -lntp | grep 8766` → `192.168.100.100:8766` (`python3`)
4. `"Mirroring upgrade image to ceph-node-N (k/2)"`
5. Then daemon upgrades (`Currently upgrading mgr daemons`, …)
6. Finish successfully

**Port / parallelism override also verified:**
```bash
ceph config set mgr mgr/cephadm/upgrade_image_mirror_method local_http
ceph config set mgr mgr/cephadm/upgrade_image_mirror_port 8788
ceph config set mgr mgr/cephadm/upgrade_image_mirror_max_parallel 1
```
With `max_parallel=1`, mirror messages advance one host at a time (`1/2` then `2/2`).

### Same-image start (no regression)

```bash
ceph orch upgrade start --image 192.168.100.254:5000/ceph/ceph:main2.0.kobi
```
When already on that image: upgrade identifies same image and aborts — no unwanted work.

## Unit / static checks (local)

- `tox -e py3 -- cephadm/tests/` → **1503 passed**, 1 skipped
- `tox -e flake8 -- cephadm` → OK
- `tox -e mypy -- -m cephadm` → OK
- `tox -e jinjalint` → OK
- `src/cephadm` `tox -e py3` / `flake8` → OK

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [x] Affects Orchestrator, opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [ ] No tests
```

---

