### PR TITLE
mgr/cephadm: fix extra_container_args parsing in daemon add osd

### DIFF
--- a/doc/cephadm/services/osd.rst
+++ b/doc/cephadm/services/osd.rst
@@ -192,6 +192,29 @@ There are multiple ways to create new OSDs:
 
     ceph orch daemon add osd host1:data_devices=/dev/sda,/dev/sdb,db_devices=/dev/sdc,osds_per_device=2
 
+* Advanced OSD creation with custom container arguments:
+
+  Pass extra arguments to the OSD container using ``extra_container_args``.
+  Arguments with spaces must be quoted using double quotes. The parser respects
+  shell-style quoting, so you can include values with spaces:
+
+  .. prompt:: bash #
+
+    ceph orch daemon add osd "host1:data_devices=/dev/sdb,extra_container_args=--label \"app=OSD storage daemon\" --memory 32g"
+
+  Example with multiple labels and environment variables:
+
+  .. prompt:: bash #
+
+    ceph orch daemon add osd "host1:data_devices=/dev/sdb,extra_container_args=--memory 32g --cpus 4"
+
+  .. note::
+
+     Use ``extra_container_args`` to pass additional ``podman run`` options to customize
+     OSD container behavior. Common use cases include setting memory limits, CPU
+     restrictions, labels, environment variables, and volume mounts. Ensure that
+     arguments containing spaces are properly quoted.
+
 * Create an OSD on a specific LVM logical volume on a specific host:
 
   .. prompt:: bash #

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3533,7 +3533,9 @@ Then run the following:
             unmanaged=False,
             method=drive_group.method,
             objectstore=drive_group.objectstore,
-            osd_type=OSDType(drive_group.osd_type)
+            osd_type=OSDType(drive_group.osd_type),
+            extra_container_args=drive_group.extra_container_args,
+            extra_entrypoint_args=drive_group.extra_entrypoint_args,
         )
 
         self.log.info(f"Creating OSDs with service ID: {drive_group.service_id} on {host}:{device_list}")

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -50,7 +50,8 @@ from ceph.deployment.service_spec import (
     TunedProfileSpec,
     MgmtGatewaySpec,
     NvmeofServiceSpec,
-    CertificateSource
+    CertificateSource,
+    GeneralArgList
 )
 from ceph.deployment.drive_group import DeviceSelection
 from ceph.utils import str_to_datetime, datetime_to_str, datetime_now
@@ -3700,7 +3701,9 @@ Then run the following:
             unmanaged=False,
             method=drive_group.method,
             objectstore=drive_group.objectstore,
-            osd_type=OSDType(drive_group.osd_type)
+            osd_type=OSDType(drive_group.osd_type),
+            extra_container_args=cast(GeneralArgList, drive_group.extra_container_args),
+            extra_entrypoint_args=cast(GeneralArgList, drive_group.extra_entrypoint_args),
         )
 
         self.log.info(f"Creating OSDs with service ID: {drive_group.service_id} on {host}:{device_list}")

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1373,6 +1373,30 @@ class TestCephadm(object):
                     assert saved.data_devices.paths[0].crush_device_class == 'ssd'
                     mock_apply.assert_called_once()
 
+    def test_create_osd_default_spec_preserves_extra_container_args(self, cephadm_module):
+        with mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}')):
+            with mock.patch("cephadm.module.CephadmOrchestrator.apply") as mock_apply:
+                with with_host(cephadm_module, 'test'):
+                    dg = DriveGroupSpec(
+                        placement=PlacementSpec(host_pattern='test'),
+                        data_devices=DeviceSelection(paths=['/dev/sdb']),
+                        service_id='default',
+                        extra_container_args=['--memory', '32g', '--quiet'],
+                        extra_entrypoint_args=['--verbose'],
+                    )
+                    cephadm_module.create_osd_default_spec(dg)
+                    saved = cephadm_module.spec_store.all_specs['osd.default']
+                    # extra_container_args and extra_entrypoint_args are converted to ArgumentSpec objects
+                    container_args = []
+                    for arg in saved.extra_container_args:
+                        container_args.extend(arg.to_args())
+                    assert container_args == ['--memory', '32g', '--quiet']
+                    entrypoint_args = []
+                    for arg in saved.extra_entrypoint_args:
+                        entrypoint_args.extend(arg.to_args())
+                    assert entrypoint_args == ['--verbose']
+                    mock_apply.assert_called_once()
+
     def test_create_osds_skips_default_spec_when_osd_default_exists(self, cephadm_module):
         with mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}')):
             with mock.patch.object(CephadmOrchestrator, 'validate_device', return_value=''):

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1436,6 +1436,30 @@ class TestCephadm(object):
                     assert saved.data_devices.paths[0].crush_device_class == 'ssd'
                     mock_apply.assert_called_once()
 
+    def test_create_osd_default_spec_preserves_extra_container_args(self, cephadm_module):
+        with mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}')):
+            with mock.patch("cephadm.module.CephadmOrchestrator.apply") as mock_apply:
+                with with_host(cephadm_module, 'test'):
+                    dg = DriveGroupSpec(
+                        placement=PlacementSpec(host_pattern='test'),
+                        data_devices=DeviceSelection(paths=['/dev/sdb']),
+                        service_id='default',
+                        extra_container_args=['--memory', '32g', '--quiet'],
+                        extra_entrypoint_args=['--verbose'],
+                    )
+                    cephadm_module.create_osd_default_spec(dg)
+                    saved = cephadm_module.spec_store.all_specs['osd.default']
+                    # extra_container_args and extra_entrypoint_args are converted to ArgumentSpec objects
+                    container_args = []
+                    for arg in saved.extra_container_args:
+                        container_args.extend(arg.to_args())
+                    assert container_args == ['--memory', '32g', '--quiet']
+                    entrypoint_args = []
+                    for arg in saved.extra_entrypoint_args:
+                        entrypoint_args.extend(arg.to_args())
+                    assert entrypoint_args == ['--verbose']
+                    mock_apply.assert_called_once()
+
     def test_create_osds_skips_default_spec_when_osd_default_exists(self, cephadm_module):
         with mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}')):
             with mock.patch.object(CephadmOrchestrator, 'validate_device', return_value=''):

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1596,6 +1596,9 @@ Usage:
                                             'journal_devices']:
                         drive_group_spec[drv_grp_spec_arg] = []
                         drive_group_spec[drv_grp_spec_arg].append(value)
+                    elif drv_grp_spec_arg in ['extra_container_args',
+                                              'extra_entrypoint_args']:
+                        drive_group_spec[drv_grp_spec_arg] = value.split()
                     else:
                         if value.lower() in ['true', 'false']:
                             list_drive_group_spec_bool_arg.append(drv_grp_spec_arg)

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1592,11 +1592,15 @@ Usage:
             while values:
                 v = values[0].split(',', 1)[0]
                 if '=' in v:
-                    drv_grp_spec_arg, value = v.split('=')
+                    drv_grp_spec_arg, value = v.split('=', 1)
                     if drv_grp_spec_arg in ['data_devices',
                                             'db_devices',
                                             'wal_devices',
                                             'journal_devices']:
+                        drive_group_spec[drv_grp_spec_arg] = []
+                        drive_group_spec[drv_grp_spec_arg].append(value)
+                    elif drv_grp_spec_arg in ['extra_container_args',
+                                              'extra_entrypoint_args']:
                         drive_group_spec[drv_grp_spec_arg] = []
                         drive_group_spec[drv_grp_spec_arg].append(value)
                     else:

--- a/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
@@ -543,3 +543,133 @@ class TestCertStoreCertKeySet:
             None,
             False,
         )
+
+
+@mock.patch("orchestrator.module.OrchestratorCli.create_osds")
+class TestDaemonAddOsd:
+    """Test suite for OSD daemon creation via CLI"""
+
+    def setup_method(self):
+        self.m = OrchestratorCli('orchestrator', 0, 0)
+
+    @pytest.mark.parametrize("svc_arg", [
+        "host1:data_devices=/dev/sda",
+        "host1:data_devices=/dev/sdb,/dev/sdc,/dev/sdd",
+        "host1:data_devices=/dev/sdb,db_devices=/dev/nvme0n1",
+        "host1:data_devices=/dev/sdb,db_devices=/dev/nvme0n1,wal_devices=/dev/nvme0n2",
+        "host1:data_devices=/dev/sdb,encrypted=true",
+        "host1:data_devices=/dev/sdb,extra_container_args=--memory 32g  --memory-reservation 16g",
+    ])
+    def test_daemon_add_osd_simple_device(self, mock_create_osds, svc_arg):
+        """Test basic OSD daemon creation with various device configurations"""
+        mock_create_osds.return_value = mock.MagicMock(
+            serialized_exception=None,
+            result_str=lambda: "OSD created"
+        )
+
+        res = self.m._daemon_add_osd(svc_arg=svc_arg)
+
+        assert res.retval == 0
+        mock_create_osds.assert_called_once()
+
+    def test_daemon_add_osd_with_multiple_device_types(self, mock_create_osds):
+        """Test OSD daemon creation with data, db, and wal devices"""
+        mock_create_osds.return_value = mock.MagicMock(
+            serialized_exception=None,
+            result_str=lambda: "OSD created"
+        )
+
+        res = self.m._daemon_add_osd(
+            svc_arg="host1:data_devices=/dev/sdb,db_devices=/dev/nvme0n1,wal_devices=/dev/nvme0n1p1"
+        )
+
+        assert res.retval == 0
+        mock_create_osds.assert_called_once()
+
+        call_args = mock_create_osds.call_args
+        drive_group_spec = call_args[0][0]
+
+        # Verify all device types were properly set
+        assert drive_group_spec.data_devices is not None
+        assert drive_group_spec.db_devices is not None
+        assert drive_group_spec.wal_devices is not None
+
+    def test_daemon_add_osd_with_encrypted_flag(self, mock_create_osds):
+        """Test OSD daemon creation with encryption enabled"""
+        mock_create_osds.return_value = mock.MagicMock(
+            serialized_exception=None,
+            result_str=lambda: "OSD created"
+        )
+
+        res = self.m._daemon_add_osd(
+            svc_arg="host1:data_devices=/dev/sdb,encrypted=true"
+        )
+
+        assert res.retval == 0
+        mock_create_osds.assert_called_once()
+
+        call_args = mock_create_osds.call_args
+        drive_group_spec = call_args[0][0]
+
+        # Verify encrypted flag was properly set
+        assert drive_group_spec.encrypted is True
+
+    def test_daemon_add_osd_missing_svc_arg(self, mock_create_osds):
+        """Test that missing svc_arg returns error"""
+        res = self.m._daemon_add_osd(svc_arg=None)
+
+        assert res.retval != 0
+        assert "Usage:" in res.stderr
+        mock_create_osds.assert_not_called()
+
+    def test_daemon_add_osd_invalid_format(self, mock_create_osds):
+        """Test that invalid svc_arg format returns error"""
+        res = self.m._daemon_add_osd(svc_arg="invalid_format")
+
+        assert res.retval != 0
+        mock_create_osds.assert_not_called()
+
+    def test_daemon_add_osd_with_extra_container_args(self, mock_create_osds):
+        """Integration test: verify extra_container_args are properly parsed and can be split"""
+        mock_create_osds.return_value = mock.MagicMock(
+            serialized_exception=None,
+            result_str=lambda: "OSD created"
+        )
+
+        # Call the CLI with extra_container_args containing space-separated values
+        # This simulates:
+        # ceph orch daemon add osd host:data_devices=/dev/vdb,extra_container_args=--memory 32g --memory-reservation 16g --label "app=my storage service"
+        res = self.m._daemon_add_osd(
+            svc_arg=(
+                'ceph-node-0:data_devices=/dev/vdb,'
+                'extra_container_args=--memory 32g  --memory-reservation 16g  --label "app=my storage service"'
+            )
+        )
+
+        assert res.retval == 0
+        mock_create_osds.assert_called_once()
+
+        # Extract the DriveGroupSpec from the mock call
+        drive_group_spec = mock_create_osds.call_args[0][0]
+
+        # Verify data_devices
+        assert drive_group_spec.data_devices is not None
+        assert drive_group_spec.data_devices.paths[0].path == '/dev/vdb'
+
+        # Verify extra_container_args were parsed correctly
+        # Note: The value is stored as a single ArgumentSpec object with split=True
+        # The splitting happens when to_args() is called
+        assert drive_group_spec.extra_container_args is not None
+
+        # Verify the argument can be properly split via shlex
+        arg_spec = drive_group_spec.extra_container_args[0]
+        assert arg_spec.split is True
+
+        # When to_args() is called, it should split the space-separated values
+        split_args = arg_spec.to_args()
+        assert '--memory' in split_args
+        assert '32g' in split_args
+        assert '--memory-reservation' in split_args
+        assert '16g' in split_args
+        assert '--label' in split_args
+        assert 'app=my storage service' in split_args

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1,6 +1,7 @@
 import fnmatch
 import os
 import re
+import shlex
 import enum
 from enum import Enum
 from collections import OrderedDict
@@ -758,7 +759,7 @@ class ArgumentSpec:
         """
         if not self.split:
             return [self.argument]
-        return [part for part in self.argument.split(" ") if part]
+        return shlex.split(self.argument)
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ArgumentSpec):


### PR DESCRIPTION
The _daemon_add_osd() command handler was not splitting space-separated container arguments on whitespace, storing them as single strings instead of lists. This caused the code to iterate character-by-character instead of argument-by-argument, producing malformed podman arguments.

For example, `extra_container_args=--memory 32g` would be stored as a single string "–memory 32g" and later iterated to produce individual characters: "- - m e m o r y 3 2 g", rather than the intended separate arguments: ["--memory", "32g"].

Fix by splitting `extra_container_args` and `extra_entrypoint_args` values on whitespace when parsing CLI arguments. Also preserve these fields through the OSD default spec creation so they survive the full OSD deployment pipeline.

Fixes: https://tracker.ceph.com/issues/78308
Signed-off-by: Yonatan Zaken <yzaken@redhat.com>

Steps to reproduce can be found in the tracker.

**Notes**
1) Using the shlex.split() in `ceph/src/python-common/ceph/deployment/service_spec.py ` respects shell-style quoting and escaping rules, which is critical for handling arguments with spaces inside quoted values.

2) Use split('=', 1) (limiting to 1 split) instead of just split('=') to preserve = signs within the argument value itself.
Example:
Input: extra_container_args=--cpus=4
Without the limit (split('=')):
Result: ['extra_container_args', '--cpus', '4'] — 3 parts
Unpacking fails: Can't unpack 3 values into 2 variables
With the limit (split('=', 1)):
Result: ['extra_container_args', '--cpus=4'] — 2 parts

 **Testing** 
After applying this PR on a live setup, when running the following command:
```
[ceph: root@ceph-node-0 /]# ceph orch daemon add osd \
"ceph-node-0:data_devices=/dev/vdb,extra_container_args=--cpus=4 --memory-reservation 16g"
Created osd(s) 0 on host 'ceph-node-0'
```

The unit.run file of the OSD was created properly with the extra_container_args flags as can be seen:
```shell
[root@ceph-node-0 ~]# cat /var/lib/ceph/c0c8d12a-974a-11f1-9343-5254007a4a56/osd.0/unit.run
...
/usr/bin/podman run --rm --ipc=host --stop-signal=SIGTERM --net=host --entrypoint /usr/bin/ceph-osd --privileged \
--group-add=disk --init --name ceph-c0c8d12a-974a-11f1-9343-5254007a4a56-osd-0 --pids-limit=-1 -d \
--log-driver journald --conmon-pidfile /run/ceph-c0c8d12a-974a-11f1-9343-5254007a4a56@osd.0.service-pid \
--cidfile /run/ceph-c0c8d12a-974a-11f1-9343-5254007a4a56@osd.0.service-cid --cgroups=split \
--cpus=4 --memory-reservation 16g
...
``` 

Or the following:
```shell
[ceph: root@ceph-node-0 /]# #[ceph: root@ceph-node-0 /]# ceph orch daemon add osd \
"ceph-node-0:data_devices=/dev/vdb,extra_container_args=--memory 32g  --memory-reservation 16g \
--label \"app=my storage service\""
Created osd(s) 0 on host 'ceph-node-0'
``` 

Producing the following unit.run:
```shell
[root@ceph-node-0 ~]# cat /var/lib/ceph/6ab13d46-9730-11f1-9d2f-525400b361b4/osd.0/unit.run
...
/usr/bin/podman run --rm --ipc=host --stop-signal=SIGTERM --net=host --entrypoint /usr/bin/ceph-osd \
--privileged --group-add=disk --init --name ceph-6ab13d46-9730-11f1-9d2f-525400b361b4-osd-0 --pids-limit=-1 \
-d --log-driver journald --conmon-pidfile /run/ceph-6ab13d46-9730-11f1-9d2f-525400b361b4@osd.0.service-pid \
--cidfile /run/ceph-6ab13d46-9730-11f1-9d2f-525400b361b4@osd.0.service-cid --cgroups=split \
--memory 32g --memory-reservation 16g --label 'app=my storage service'
...
``` 


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
