### PR TITLE
cephfs: add copy_file_range support across libcephfs, FUSE, cephfs-shell, and QA

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,9 @@
+* CephFS: Server-side copy offload (COPY2) is now supported via
+  ``ceph_copy_file_range()`` in libcephfs, the ``copy_file_range`` FUSE
+  low-level handler, and the ``copy_file_range`` command in cephfs-shell.
+  For object-aligned ranges, data is copied between OSDs without passing
+  through the client, providing significant performance improvements
+  over the traditional read+write fallback.
 * CephFS: The ``client_force_lazyio`` configuration option is now correctly marked
   as not supporting runtime updates. Previously, the configuration schema indicated
   this option could be changed at runtime, but changes had no effect on opened file

--- a/doc/man/8/cephfs-shell.rst
+++ b/doc/man/8/cephfs-shell.rst
@@ -166,6 +166,30 @@ Usage :
 
 * file - name of the file
 
+copy_file_range
+---------------
+
+Copy a byte range from one file to another, using server-side copy
+offload (COPY2) for object-aligned ranges which is significantly faster
+than read+write for large files.
+
+Usage :
+
+    copy_file_range [options] <src_path> <dst_path>
+
+* src_path - path of the source file
+* dst_path - path of the destination file
+
+Options:
+
+  -s, --src-offset SRC_OFFSET
+                          Source file offset (default: 0).
+  -d, --dst-offset DST_OFFSET
+                          Destination file offset (default: 0).
+  -l, --length LENGTH     Number of bytes to copy (default: entire source
+                          file from src_offset).
+  --flags FLAGS           Copy flags (reserved, default: 0).
+
 ln
 --
 

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -1186,3 +1186,103 @@ class TestShellOpts(TestCephFSShell):
         final_editor_val = self.extract_set_editor_output(final_editor_val)
 
         self.assertEqual(self.editor_val, final_editor_val)
+
+
+class TestCopyFileRange(TestCephFSShell):
+    """
+    Tests for the copy_file_range command which leverages server-side
+    copy offload (COPY2) for object-aligned ranges.
+    """
+
+    def test_copy_full_file(self):
+        """
+        Copy an entire file from src to dst.
+        """
+        data = 'A' * 1024
+        self.run_cephfs_shell_cmd("put - src_file", stdin=data)
+        err = self.get_cephfs_shell_cmd_error("put - src_file2",
+                                               stdin="test")
+        log.info(f"put test error output: {err}")
+
+        output = self.get_cephfs_shell_cmd_output(
+            "copy_file_range src_file dst_file")
+        self.assertIn("Copied 1024 bytes", output)
+
+        # Verify content
+        dst_data = self.get_cephfs_shell_cmd_output("cat dst_file")
+        self.assertEqual(data, dst_data)
+
+        self.run_cephfs_shell_cmd("rm src_file dst_file")
+
+    def test_copy_with_src_offset(self):
+        """
+        Copy with explicit source offset.
+        """
+        data = '0123456789abcdef'
+        self.run_cephfs_shell_cmd("put - src_file", stdin=data)
+
+        output = self.get_cephfs_shell_cmd_output(
+            "copy_file_range -s 5 src_file dst_file")
+        self.assertIn("Copied 11 bytes", output)
+
+        dst_data = self.get_cephfs_shell_cmd_output("cat dst_file")
+        self.assertEqual(data[5:], dst_data)
+
+        self.run_cephfs_shell_cmd("rm src_file dst_file")
+
+    def test_copy_with_length(self):
+        """
+        Copy a specific byte range.
+        """
+        data = '0123456789abcdef'
+        self.run_cephfs_shell_cmd("put - src_file", stdin=data)
+
+        output = self.get_cephfs_shell_cmd_output(
+            "copy_file_range -s 2 -l 5 src_file dst_file")
+        self.assertIn("Copied 5 bytes", output)
+
+        dst_data = self.get_cephfs_shell_cmd_output("cat dst_file")
+        self.assertEqual(data[2:7], dst_data)
+
+        self.run_cephfs_shell_cmd("rm src_file dst_file")
+
+    def test_copy_with_dst_offset(self):
+        """
+        Copy into destination at a specific offset.
+        """
+        dst_initial = 'X' * 20
+        src_data = 'hello world'
+        self.run_cephfs_shell_cmd("put - dst_file", stdin=dst_initial)
+        self.run_cephfs_shell_cmd("put - src_file", stdin=src_data)
+
+        output = self.get_cephfs_shell_cmd_output(
+            "copy_file_range -d 5 src_file dst_file")
+        self.assertIn("Copied 11 bytes", output)
+
+        dst_data = self.get_cephfs_shell_cmd_output("cat dst_file")
+        self.assertEqual(dst_data[:5], 'X' * 5)
+        self.assertEqual(dst_data[5:16], src_data)
+        self.assertEqual(dst_data[16:], 'X' * 4)
+
+        self.run_cephfs_shell_cmd("rm src_file dst_file")
+
+    def test_copy_missing_src(self):
+        """
+        Copy from a non-existent source should fail.
+        """
+        self.negtest_cephfs_shell_cmd(
+            cmd="copy_file_range no_such_file dst_file",
+            errmsg="does not exist")
+
+    def test_copy_zero_length(self):
+        """
+        Copy zero bytes should succeed as a no-op.
+        """
+        data = 'some data'
+        self.run_cephfs_shell_cmd("put - src_file", stdin=data)
+
+        output = self.get_cephfs_shell_cmd_output(
+            "copy_file_range -l 0 src_file dst_file")
+        self.assertIn("Copied 0 bytes", output)
+
+        self.run_cephfs_shell_cmd("rm src_file dst_file")

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -6,7 +6,7 @@ will update the environment without hassles of typing the path correctly.
 """
 from io import StringIO
 from os import path
-import crypt
+import hashlib
 import logging
 from tempfile import mkstemp as tempfile_mkstemp
 import math
@@ -410,7 +410,7 @@ class TestGetAndPut(TestCephFSShell):
         Test that get passes with target name
         """
         s = 'C' * 1024
-        s_hash = crypt.crypt(s, '.A')
+        s_hash = hashlib.sha256(s.encode()).hexdigest()
         o = self.get_cephfs_shell_cmd_output("put - dump4", stdin=s)
         log.info("cephfs-shell output:\n{}".format(o))
 
@@ -424,7 +424,7 @@ class TestGetAndPut(TestCephFSShell):
         # NOTE: cwd=None because we want to run it at CWD, not at cephfs mntpt.
         o = self.mount_a.run_shell('cat dump4', cwd=None).stdout.getvalue(). \
             strip()
-        o_hash = crypt.crypt(o, '.A')
+        o_hash = hashlib.sha256(o.encode()).hexdigest()
 
         # s_hash must be equal to o_hash
         log.info("s_hash:{}".format(s_hash))
@@ -475,7 +475,7 @@ class TestGetAndPut(TestCephFSShell):
         Test that get passes with target name
         """
         s = 'E' * 1024
-        s_hash = crypt.crypt(s, '.A')
+        s_hash = hashlib.sha256(s.encode()).hexdigest()
         o = self.get_cephfs_shell_cmd_output("put - dump6", stdin=s)
         log.info("cephfs-shell output:\n{}".format(o))
 
@@ -485,7 +485,7 @@ class TestGetAndPut(TestCephFSShell):
 
         # get dump6 - should pass
         o = self.get_cephfs_shell_cmd_output("get dump6 -")
-        o_hash = crypt.crypt(o, '.A')
+        o_hash = hashlib.sha256(o.encode()).hexdigest()
         log.info("cephfs-shell output:\n{}".format(o))
 
         # s_hash must be equal to o_hash

--- a/qa/tasks/cephfs/test_copy_file_range.py
+++ b/qa/tasks/cephfs/test_copy_file_range.py
@@ -1,0 +1,322 @@
+import logging
+from textwrap import dedent
+from tasks.cephfs.cephfs_test_case import CephFSTestCase
+
+log = logging.getLogger(__name__)
+
+OBJECT_SIZE = 4 * 1024 * 1024  # 4MB
+
+
+class TestCopyFileRange(CephFSTestCase):
+    """
+    Test copy_file_range via the kernel VFS, which exercises the underlying
+    COPY2 offload path in both FUSE (ceph-fuse) and kclient mounts.
+
+    The kernel copy_file_range(2) syscall routes through:
+      - FUSE:  FUSE_COPY_FILE_RANGE -> ceph-fuse -> ll_copy_file_range -> COPY2
+      - kclient: ceph_copy_file_range -> COPY2
+
+    Small / unaligned ranges fall back to read+write in userspace (FUSE) or
+    the kernel (kclient), while object-aligned ranges use server-side COPY2.
+    """
+
+    CLIENTS_REQUIRED = 1
+
+    def _host_path(self, mount, basename):
+        """Return the absolute host-filesystem path for a CephFS file."""
+        import os
+        return os.path.join(mount.hostfs_mntpt, basename)
+
+    def _copy_and_verify(self, mount, src, dst, src_off, dst_off, length):
+        """
+        Use Python's os.copy_file_range() to copy a range between two
+        files on the given mount, then verify the destination content
+        matches the source.
+        """
+        src_path = self._host_path(mount, src)
+        dst_path = self._host_path(mount, dst)
+
+        pyscript = dedent(f"""
+            import os
+
+            src_fd = os.open("{src_path}", os.O_RDONLY)
+            dst_fd = os.open("{dst_path}", os.O_WRONLY | os.O_CREAT, 0o666)
+
+            copied = os.copy_file_range(src_fd, dst_fd, {length},
+                                        {src_off}, {dst_off})
+            print(f"COPIED={{copied}}")
+            print(f"SRC_OFF={{os.lseek(src_fd, 0, os.SEEK_CUR)}}")
+            print(f"DST_OFF={{os.lseek(dst_fd, 0, os.SEEK_CUR)}}")
+
+            os.close(src_fd)
+            os.close(dst_fd)
+
+            # Verify: read back and compare
+            src_fd = os.open("{src_path}", os.O_RDONLY)
+            dst_fd = os.open("{dst_path}", os.O_RDONLY)
+
+            src_data = os.pread(src_fd, {length}, {src_off})
+            dst_data = os.pread(dst_fd, {length}, {dst_off})
+
+            if src_data == dst_data:
+                print("VERIFY=OK")
+            else:
+                print(f"VERIFY=FAIL src_len={{len(src_data)}} dst_len={{len(dst_data)}}")
+
+            os.close(src_fd)
+            os.close(dst_fd)
+        """)
+        output = mount.run_python(pyscript)
+        log.info(f"copy_file_range output:\n{output}")
+
+        lines = output.strip().split('\n')
+        result = {}
+        for line in lines:
+            if '=' in line:
+                k, v = line.split('=', 1)
+                result[k] = v
+
+        self.assertEqual(result.get('COPIED'), str(length),
+                         f"Expected to copy {length} bytes")
+        self.assertEqual(result.get('VERIFY'), 'OK',
+                         "Destination content does not match source")
+
+    def _create_pattern_file(self, mount, path, size):
+        """
+        Create a file with known repeating content for verification.
+        """
+        host_path = self._host_path(mount, path)
+
+        pyscript = dedent(f"""
+            import os
+
+            fd = os.open("{host_path}", os.O_WRONLY | os.O_CREAT, 0o666)
+            buf = bytes(range(256)) * 4096  # 1MB, repeats 0..255
+            written = 0
+            while written < {size}:
+                chunk = min(len(buf), {size} - written)
+                n = os.write(fd, buf[:chunk])
+                written += n
+            os.close(fd)
+            print(f"WROKEN={{written}}")
+        """)
+        output = mount.run_python(pyscript)
+        log.info(f"create_pattern_file output: {output}")
+
+    def test_copy_file_range_small_file(self):
+        """
+        Copy a small file (below object_size) — exercises the manual
+        read/write fallback path.
+        """
+        src = "test_cfr_small_src"
+        dst = "test_cfr_small_dst"
+        file_size = 1024
+
+        self._create_pattern_file(self.mount_a, src, file_size)
+        self._copy_and_verify(self.mount_a, src, dst, 0, 0, file_size)
+
+        self.mount_a.run_shell(["rm", "-f", src, dst])
+
+    def test_copy_file_range_large_aligned(self):
+        """
+        Copy a large object-aligned file — exercises the server-side
+        COPY2 offload path.
+        """
+        src = "test_cfr_large_src"
+        dst = "test_cfr_large_dst"
+        file_size = 4 * OBJECT_SIZE  # 16MB, 4 objects
+
+        self._create_pattern_file(self.mount_a, src, file_size)
+        self._copy_and_verify(self.mount_a, src, dst, 0, 0, file_size)
+
+        # Verify destination size via host path
+        size = self.mount_a.run_shell(
+            ["stat", "--format=%s",
+             self._host_path(self.mount_a, dst)]).stdout.getvalue().strip()
+        self.assertEqual(int(size), file_size)
+
+        self.mount_a.run_shell(["rm", "-f", src, dst])
+
+    def test_copy_file_range_sub_range(self):
+        """
+        Copy a sub-range of a file — object-aligned offset and length.
+        """
+        src = "test_cfr_sub_src"
+        dst = "test_cfr_sub_dst"
+        file_size = 3 * OBJECT_SIZE  # 12MB
+
+        self._create_pattern_file(self.mount_a, src, file_size)
+
+        # Object-aligned sub-range: skip first object, copy the second
+        src_off = OBJECT_SIZE
+        dst_off = 0
+        copy_len = OBJECT_SIZE
+
+        self._copy_and_verify(self.mount_a, src, dst,
+                              src_off, dst_off, copy_len)
+
+        self.mount_a.run_shell(["rm", "-f", src, dst])
+
+    def test_copy_file_range_unaligned_fallback(self):
+        """
+        Copy with unaligned offsets — exercises the fallback path where
+        the FUSE/kernel VFS falls back to read+write.
+        """
+        src = "test_cfr_unaligned_src"
+        dst = "test_cfr_unaligned_dst"
+        file_size = 1024 * 1024  # 1MB
+
+        self._create_pattern_file(self.mount_a, src, file_size)
+
+        # Unaligned offsets force the fallback path
+        self._copy_and_verify(self.mount_a, src, dst,
+                              512, 100, 5000)
+
+        self.mount_a.run_shell(["rm", "-f", src, dst])
+
+    def test_copy_file_range_zero_length(self):
+        """
+        Copy zero bytes — should succeed as a no-op.
+        """
+        src = "test_cfr_zero_src"
+        dst = "test_cfr_zero_dst"
+        file_size = 1024
+
+        self._create_pattern_file(self.mount_a, src, file_size)
+
+        src_path = self._host_path(self.mount_a, src)
+        dst_path = self._host_path(self.mount_a, dst)
+
+        pyscript = dedent(f"""
+            import os
+
+            src_fd = os.open("{src_path}", os.O_RDONLY)
+            dst_fd = os.open("{dst_path}", os.O_WRONLY | os.O_CREAT, 0o666)
+
+            copied = os.copy_file_range(src_fd, dst_fd, 0, 0, 0)
+            print(f"COPIED={{copied}}")
+
+            os.close(src_fd)
+            os.close(dst_fd)
+        """)
+        output = self.mount_a.run_python(pyscript)
+        self.assertIn("COPIED=0", output)
+
+        self.mount_a.run_shell(["rm", "-f", src, dst])
+
+    def test_copy_file_range_overwrite(self):
+        """
+        Overwrite a middle section of an existing destination file.
+        """
+        src = "test_cfr_ow_src"
+        dst = "test_cfr_ow_dst"
+        file_size = 1024 * 1024  # 1MB
+
+        self._create_pattern_file(self.mount_a, src, file_size)
+
+        # Create dst with different content (all zeros)
+        dst_path = self._host_path(self.mount_a, dst)
+        pyscript = dedent(f"""
+            import os
+            fd = os.open("{dst_path}", os.O_WRONLY | os.O_CREAT, 0o666)
+            buf = b'\\x00' * 4096
+            written = 0
+            while written < {file_size}:
+                n = os.write(fd, buf)
+                written += n
+            os.close(fd)
+        """)
+        self.mount_a.run_python(pyscript)
+
+        # Overwrite a middle section
+        src_off = 4096
+        dst_off = 8192
+        copy_len = 16384
+
+        self._copy_and_verify(self.mount_a, src, dst,
+                              src_off, dst_off, copy_len)
+
+        self.mount_a.run_shell(["rm", "-f", src, dst])
+
+    def test_copy_file_range_perf_compare(self):
+        """
+        Performance comparison: copy_file_range (COPY2) vs manual read+write
+        for a large object-aligned file.
+
+        Reports the speedup factor of server-side copy offload over the
+        traditional client-side read/write loop.
+        """
+        file_size = 8 * OBJECT_SIZE  # 32MB, 8 objects
+        buf_size = 1024 * 1024
+        size_mb = file_size // (1024 * 1024)
+        src_c2 = "test_cfr_perf_src_c2"
+        src_rw = "test_cfr_perf_src_rw"
+        dst_c2 = "test_cfr_perf_dst_c2"
+        dst_rw = "test_cfr_perf_dst_rw"
+
+        # Separate source files for fair comparison (same approach as
+        # the C++ PerfCompare test in copyfilerange.cc).
+        self._create_pattern_file(self.mount_a, src_c2, file_size)
+        self._create_pattern_file(self.mount_a, src_rw, file_size)
+
+        src_c2_p = self._host_path(self.mount_a, src_c2)
+        src_rw_p = self._host_path(self.mount_a, src_rw)
+        dst_c2_p = self._host_path(self.mount_a, dst_c2)
+        dst_rw_p = self._host_path(self.mount_a, dst_rw)
+
+        # Helper: drop kernel page cache for fair comparison.
+        # Needs root; silently skip if not available.
+        def _drop_caches():
+            self.mount_a.run_shell(["sync"])
+            self.mount_a.run_shell(
+                ["sudo", "sh", "-c",
+                 "echo 3 > /proc/sys/vm/drop_caches 2>/dev/null || true"],
+                check_status=False)
+
+        # --- COPY2 via os.copy_file_range (own source file) ---
+        _drop_caches()
+        pyscript = dedent(f"""
+            import os, time
+
+            sf = os.open("{src_c2_p}", os.O_RDONLY)
+            df = os.open("{dst_c2_p}", os.O_WRONLY | os.O_CREAT, 0o666)
+            t0 = time.time()
+            c2 = os.copy_file_range(sf, df, {file_size}, 0, 0)
+            t_copy2 = time.time() - t0
+            os.close(sf)
+            os.close(df)
+            print("COPY2=" + str(round(t_copy2, 3)) + "s")
+        """)
+        out = self.mount_a.run_python(pyscript)
+
+        # --- Manual read+write (own source file, 1MB buffer) ---
+        _drop_caches()
+        pyscript = dedent(f"""
+            import os, time
+
+            sf = os.open("{src_rw_p}", os.O_RDONLY)
+            df = os.open("{dst_rw_p}", os.O_WRONLY | os.O_CREAT, 0o666)
+            t0 = time.time()
+            total = 0
+            while total < {file_size}:
+                data = os.read(sf, {buf_size})
+                if not data: break
+                os.write(df, data)
+                total += len(data)
+            t_rw = time.time() - t0
+            os.close(sf)
+            os.close(df)
+            print("FALLBACK=" + str(round(t_rw, 3)) + "s")
+        """)
+        out_rw = self.mount_a.run_python(pyscript)
+
+        # Print comparison (goes to test stdout via captured Python output)
+        t_copy2 = float(out.strip().split('=')[1].rstrip('s'))
+        t_rw = float(out_rw.strip().split('=')[1].rstrip('s'))
+        ratio = t_rw / t_copy2 if t_copy2 > 0 else float('inf')
+        log.info(f"=== PerfCompare ({size_mb}MB) ===")
+        log.info(f"COPY2:     {t_copy2:.3f}s")
+        log.info(f"fallback:  {t_rw:.3f}s")
+        log.info(f"speedup:   {ratio:.1f}x")
+
+        self.mount_a.run_shell(["rm", "-f", src_c2, src_rw, dst_c2, dst_rw])

--- a/qa/workunits/libcephfs/test.sh
+++ b/qa/workunits/libcephfs/test.sh
@@ -10,5 +10,6 @@ ceph_test_libcephfs_snapdiff
 ceph_test_libcephfs_vxattr
 ceph_test_libcephfs_perfcounters
 ceph_test_libcephfs_fscrypt
+ceph_test_libcephfs_copyfilerange
 
 exit 0

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -19241,9 +19241,37 @@ int Client::fcopyfile(const char *spath, const char *dpath, UserPerm& perms, mod
   return 0;
 }
 
+int Client::ll_copy_file_range(Fh *src_fh, int64_t src_off,
+                                Fh *dst_fh, int64_t dst_off,
+                                size_t len, unsigned int flags)
+{
+  return _copy_file_range(src_fh, src_off, dst_fh, dst_off, len, flags);
+}
+
 int Client::copy_file_range(int src_fd, int64_t src_off,
                              int dst_fd, int64_t dst_off,
                              size_t len, unsigned int flags)
+{
+  /* Resolve fds to Fh* under client_lock, then release it before
+   * calling _copy_file_range() which manages the lock internally
+   * (needs to release/reacquire around cv.wait). */
+  Fh *src_fh = nullptr;
+  Fh *dst_fh = nullptr;
+  {
+    std::unique_lock lock(client_lock);
+    src_fh = get_filehandle(src_fd);
+    if (!src_fh)
+      return -EBADF;
+    dst_fh = get_filehandle(dst_fd);
+    if (!dst_fh)
+      return -EBADF;
+  }
+  return _copy_file_range(src_fh, src_off, dst_fh, dst_off, len, flags);
+}
+
+int Client::_copy_file_range(Fh *src_fh, int64_t src_off,
+                              Fh *dst_fh, int64_t dst_off,
+                              size_t len, unsigned int flags)
 {
   (void)flags;
 
@@ -19257,13 +19285,6 @@ int Client::copy_file_range(int src_fd, int64_t src_off,
   tout(cct) << src_off << std::endl;
   tout(cct) << dst_off << std::endl;
   tout(cct) << len << std::endl;
-
-  Fh *src_fh = get_filehandle(src_fd);
-  if (!src_fh)
-    return -EBADF;
-  Fh *dst_fh = get_filehandle(dst_fd);
-  if (!dst_fh)
-    return -EBADF;
 
   Inode *src_in = src_fh->inode.get();
   Inode *dst_in = dst_fh->inode.get();

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -19241,6 +19241,231 @@ int Client::fcopyfile(const char *spath, const char *dpath, UserPerm& perms, mod
   return 0;
 }
 
+int Client::copy_file_range(int src_fd, int64_t src_off,
+                             int dst_fd, int64_t dst_off,
+                             size_t len, unsigned int flags)
+{
+  (void)flags;
+
+  RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
+  if (!mref_reader.is_state_satisfied())
+    return -ENOTCONN;
+
+  std::unique_lock lock(client_lock);
+
+  tout(cct) << "copy_file_range" << std::endl;
+  tout(cct) << src_off << std::endl;
+  tout(cct) << dst_off << std::endl;
+  tout(cct) << len << std::endl;
+
+  Fh *src_fh = get_filehandle(src_fd);
+  if (!src_fh)
+    return -EBADF;
+  Fh *dst_fh = get_filehandle(dst_fd);
+  if (!dst_fh)
+    return -EBADF;
+
+  Inode *src_in = src_fh->inode.get();
+  Inode *dst_in = dst_fh->inode.get();
+
+  ldout(cct, 10) << "copy_file_range: src ino " << src_in->ino
+		 << " dst ino " << dst_in->ino << dendl;
+
+  /* Source must be on the live filesystem */
+  if (src_in->snapid != CEPH_NOSNAP)
+    return -EXDEV;
+
+  /* Destination must not be a snapshot */
+  if (dst_in->snapid != CEPH_NOSNAP)
+    return -EROFS;
+
+  if (!have_copy_from2) {
+    ldout(cct, 10) << "copy_file_range: copy-from2 not supported" << dendl;
+    return -EOPNOTSUPP;
+  }
+
+  auto& src_layout = src_in->layout;
+  auto& dst_layout = dst_in->layout;
+  if (src_layout.stripe_count != 1 || dst_layout.stripe_count != 1 ||
+      src_layout.stripe_unit != dst_layout.stripe_unit ||
+      src_layout.object_size != dst_layout.object_size) {
+    ldout(cct, 10) << "copy_file_range: incompatible src/dst layout" << dendl;
+    return -EOPNOTSUPP;
+  }
+
+  uint32_t object_size = src_layout.object_size;
+
+  if (len < object_size) {
+    ldout(cct, 10) << "copy_file_range: len < object_size" << dendl;
+    return -EOPNOTSUPP;
+  }
+
+  uint64_t src_objoff = src_off % object_size;
+  uint64_t dst_objoff = dst_off % object_size;
+  if (src_objoff || dst_objoff || src_objoff != dst_objoff) {
+    ldout(cct, 10) << "copy_file_range: unaligned offsets" << dendl;
+    return -EOPNOTSUPP;
+  }
+
+  int src_have = 0, dst_have = 0;
+  int r;
+
+  r = get_caps(src_fh, CEPH_CAP_FILE_RD, CEPH_CAP_FILE_SHARED,
+	       &src_have, -1);
+  if (r < 0)
+    return r;
+
+  r = get_caps(dst_fh, CEPH_CAP_FILE_WR, CEPH_CAP_FILE_BUFFER,
+	       &dst_have, dst_off + len);
+  if (r < 0) {
+    src_in->put_cap_ref(CEPH_CAP_FILE_RD);
+    return r;
+  }
+
+  ssize_t total = 0;
+  size_t remaining = len;
+  int64_t cur_src_off = src_off;
+  int64_t cur_dst_off = dst_off;
+  bool eopnotsupp = false;
+
+  /* Pre-compute values that don't change across objects */
+  object_locator_t src_oloc = OSDMap::file_to_object_locator(src_layout);
+  object_locator_t dst_oloc = OSDMap::file_to_object_locator(dst_layout);
+  snapid_t snapid = src_in->snapid;
+  const auto truncate_seq = dst_in->truncate_seq;
+  const auto truncate_size = dst_in->truncate_size;
+
+  int num_objects = len / object_size;
+  ceph_assert(num_objects >= 1);
+
+  /*
+   * Per-object state for parallel COPY_FROM2 submission.
+   * using 'struct' here limits visibility to this function.
+   */
+  struct CopyState {
+    int result = 0;
+  };
+  std::vector<CopyState> states(num_objects);
+
+  ceph::mutex mtx{"Client::copy_file_range::mtx"};
+  ceph::condition_variable cv;
+  int pending = num_objects;
+
+  /*
+   * Submit all COPY_FROM2 requests concurrently.  Each Objecter::mutate
+   * call is non-blocking and the callback fires on the Objecter finisher
+   * thread, so we release client_lock below and wait for the last
+   * completion to signal.
+   */
+  for (int i = 0; i < num_objects; i++) {
+    uint64_t src_objnum = (src_off + (int64_t)i * object_size) / object_size;
+    uint64_t dst_objnum = (dst_off + (int64_t)i * object_size) / object_size;
+
+    char src_oid_buf[32], dst_oid_buf[32];
+    snprintf(src_oid_buf, sizeof(src_oid_buf), "%llx.%08llx",
+	     (unsigned long long)src_in->ino,
+	     (unsigned long long)src_objnum);
+    snprintf(dst_oid_buf, sizeof(dst_oid_buf), "%llx.%08llx",
+	     (unsigned long long)dst_in->ino,
+	     (unsigned long long)dst_objnum);
+    object_t src_oid = src_oid_buf;
+    object_t dst_oid = dst_oid_buf;
+
+    ObjectOperation op;
+    op.copy_from2(src_oid, snapid, src_oloc, 0,
+		  CEPH_OSD_COPY_FROM_FLAG_TRUNCATE_SEQ,
+		  truncate_seq, truncate_size,
+		  CEPH_OSD_OP_FLAG_FADVISE_SEQUENTIAL |
+		  CEPH_OSD_OP_FLAG_FADVISE_NOCACHE);
+
+    SnapContext snapc = dst_in->snaprealm->get_snap_context();
+
+    objecter->mutate(dst_oid, dst_oloc, std::move(op),
+		     snapc, ceph::real_clock::now(), 0,
+		     [&states, &pending, &mtx, &cv, i](
+			 boost::system::error_code ec) {
+		       std::lock_guard l{mtx};
+		       states[i].result = ceph::from_error_code(ec);
+		       if (--pending == 0)
+			 cv.notify_all();
+		     });
+  }
+
+  /* Release client_lock while waiting for all requests to drain */
+  lock.unlock();
+  {
+    std::unique_lock l{mtx};
+    cv.wait(l, [&pending] { return pending == 0; });
+  }
+  lock.lock();
+
+  /*
+   * Scan results in offset order; truncate at the first failure.
+   * Objects beyond the first failure that were successfully written
+   * by the OSD become unreachable orphans beyond EOF -- harmless
+   * and cleaned up on file deletion.
+   */
+  int first_fail = num_objects;
+  for (int i = 0; i < num_objects; i++) {
+    if (states[i].result < 0) {
+      first_fail = i;
+      break;
+    }
+  }
+
+  if (first_fail == 0) {
+    /* First object failed -- propagate the error */
+    r = states[0].result;
+    if (r == -EOPNOTSUPP) {
+      have_copy_from2 = false;
+      ldout(cct, 1) << "copy_file_range: OSDs don't support copy-from2; "
+		       "disabling copy offload" << dendl;
+      eopnotsupp = true;
+    }
+    ldout(cct, 10) << "copy_file_range: copy_from2 failed with "
+		   << r << dendl;
+    total = r;
+  } else {
+    total = (ssize_t)first_fail * object_size;
+
+    /* Check remaining results for EOPNOTSUPP */
+    for (int i = first_fail; i < num_objects; i++) {
+      if (states[i].result == -EOPNOTSUPP) {
+	have_copy_from2 = false;
+	eopnotsupp = true;
+	break;
+      }
+    }
+    if (eopnotsupp) {
+      ldout(cct, 1) << "copy_file_range: OSDs don't support copy-from2; "
+		       "disabling copy offload" << dendl;
+    }
+
+    cur_src_off = src_off + total;
+    cur_dst_off = dst_off + total;
+    remaining = len - total;
+  }
+
+  src_in->put_cap_ref(CEPH_CAP_FILE_RD);
+  dst_in->put_cap_ref(CEPH_CAP_FILE_WR);
+
+  if (cur_dst_off > (int64_t)dst_in->size) {
+    dst_in->size = cur_dst_off;
+    dst_in->mark_caps_dirty(CEPH_CAP_FILE_WR);
+    dst_in->change_attr++;
+  }
+
+  if (total == 0) {
+    if (eopnotsupp)
+      return -EOPNOTSUPP;
+    return r;
+  }
+
+  ldout(cct, 10) << "copy_file_range: copied " << total
+		 << " bytes, " << remaining << " remaining" << dendl;
+  return total;
+}
+
 StandaloneClient::StandaloneClient(Messenger *m, MonClient *mc,
 				   boost::asio::io_context& ictx)
   : Client(m, mc, new Objecter(m->cct, m, mc, ictx))

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -396,6 +396,10 @@ public:
 #endif
   int fcopyfile(const char *sname, const char *dname, UserPerm& perms, mode_t mode);
 
+  int copy_file_range(int src_fd, int64_t src_off,
+                      int dst_fd, int64_t dst_off,
+                      size_t len, unsigned int flags);
+
   int mds_command(
     const std::string &mds_spec,
     const std::vector<std::string>& cmd,
@@ -2328,6 +2332,7 @@ private:
 
   bool   mount_aborted = false;
   bool   blocklisted = false;
+  bool   have_copy_from2 = true;
 
   std::unordered_map<vinodeno_t, Inode*> inode_map;
   std::unordered_map<ino_t, vinodeno_t> faked_ino_map;

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -400,6 +400,10 @@ public:
                       int dst_fd, int64_t dst_off,
                       size_t len, unsigned int flags);
 
+  int ll_copy_file_range(Fh *src_fh, int64_t src_off,
+                         Fh *dst_fh, int64_t dst_off,
+                         size_t len, unsigned int flags);
+
   int mds_command(
     const std::string &mds_spec,
     const std::vector<std::string>& cmd,
@@ -2172,6 +2176,9 @@ private:
   int _sync_fs();
   int clear_suid_sgid(Inode *in, const UserPerm& perms, bool defer=false);
   int _fallocate(Fh *fh, int mode, int64_t offset, int64_t length);
+  int _copy_file_range(Fh *src_fh, int64_t src_off,
+                        Fh *dst_fh, int64_t dst_off,
+                        size_t len, unsigned int flags);
   int _getlk(Fh *fh, struct flock *fl, uint64_t owner);
   int _setlk(Fh *fh, struct flock *fl, uint64_t owner, int sleep);
   int _flock(Fh *fh, int cmd, uint64_t owner);

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -1150,6 +1150,29 @@ static void fuse_ll_fallocate(fuse_req_t req, fuse_ino_t ino, int mode,
 
 #endif
 
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 10)
+
+static void fuse_ll_copy_file_range(fuse_req_t req, fuse_ino_t ino_in,
+                                    off_t off_in, struct fuse_file_info *fi_in,
+                                    fuse_ino_t ino_out, off_t off_out,
+                                    struct fuse_file_info *fi_out, size_t len,
+                                    int flags)
+{
+  CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);
+  Fh *src_fh = (Fh*)fi_in->fh;
+  Fh *dst_fh = (Fh*)fi_out->fh;
+
+  int r = cfuse->client->ll_copy_file_range(src_fh, off_in,
+                                             dst_fh, off_out,
+                                             len, flags);
+  if (r >= 0)
+    fuse_reply_write(req, r);
+  else
+    fuse_reply_err(req, get_sys_errno(-r));
+}
+
+#endif
+
 static void fuse_ll_release(fuse_req_t req, fuse_ino_t ino,
 			    struct fuse_file_info *fi)
 {
@@ -1558,7 +1581,10 @@ const static struct fuse_lowlevel_ops fuse_ll_oper = {
  flock: fuse_ll_flock,
 #endif
 #if FUSE_VERSION >= FUSE_MAKE_VERSION(2, 9)
- fallocate: fuse_ll_fallocate
+ fallocate: fuse_ll_fallocate,
+#endif
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 10)
+ copy_file_range: fuse_ll_copy_file_range,
 #endif
 };
 

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -2433,6 +2433,30 @@ void ceph_free_snap_info_buffer(struct snap_info *snap_info);
 int ceph_get_perf_counters(struct ceph_mount_info *cmount, char **perf_dump);
 
 int ceph_fcopyfile(struct ceph_mount_info *cmount, const char *spath, const char *dpath, mode_t mode);
+
+/**
+ * Copy a range of data from one file to another, using server-side copy
+ * offload (CEPH_OSD_OP_COPY_FROM2) for efficient full-object copies,
+ * falling back to manual read/write for partial objects or when the OSD
+ * does not support copy-from2.
+ *
+ * Similar in semantics to the Linux copy_file_range(2) syscall.
+ *
+ * On success, *src_off and *dst_off are updated to the byte after the
+ * last byte copied.
+ *
+ * @param cmount the ceph mount handle to use.
+ * @param src_fd source file descriptor (must be opened for reading).
+ * @param src_off pointer to source offset, updated on successful return.
+ * @param dst_fd destination file descriptor (must be opened for writing).
+ * @param dst_off pointer to destination offset, updated on successful return.
+ * @param len number of bytes to copy.
+ * @param flags copy flags (currently reserved, must be 0).
+ * @return number of bytes copied on success, or a negative error code on failure.
+ */
+int ceph_copy_file_range(struct ceph_mount_info *cmount, int src_fd, int64_t *src_off,
+                         int dst_fd, int64_t *dst_off, size_t len, unsigned int flags);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -2692,3 +2692,65 @@ extern "C" int ceph_fcopyfile(struct ceph_mount_info *cmount, const char *spath,
     return -ENOTCONN;
   return cmount->get_client()->fcopyfile(spath, dpath, cmount->default_perms, mode);
 }
+
+extern "C" int ceph_copy_file_range(struct ceph_mount_info *cmount, int src_fd, int64_t *src_off,
+                                    int dst_fd, int64_t *dst_off, size_t len, unsigned int flags)
+{
+  if (!cmount->is_mounted())
+    return -ENOTCONN;
+
+  int64_t s_off = *src_off;
+  int64_t d_off = *dst_off;
+
+  /*
+   * Flush dirty data on both files before attempting server-side copy,
+   * so the OSDs have the latest version of the objects.
+   */
+  ceph_fsync(cmount, src_fd, 1);
+  ceph_fsync(cmount, dst_fd, 1);
+
+  int ret = cmount->get_client()->copy_file_range(src_fd, s_off,
+                                                   dst_fd, d_off,
+                                                   len, flags);
+
+  if (ret == -EOPNOTSUPP || ret == -EXDEV) {
+    char buf[1048576];  /* 1MB — same as fcopyfile */
+    size_t total = 0;
+
+    while (total < len) {
+      size_t chunk = len - total;
+      if (chunk > sizeof(buf))
+        chunk = sizeof(buf);
+
+      int r = ceph_read(cmount, src_fd, buf, chunk, s_off);
+      if (r < 0)
+        return total ? (int)total : r;
+      if (r == 0)
+        break;
+
+      int w = ceph_write(cmount, dst_fd, buf, r, d_off);
+      if (w < 0)
+        return total ? (int)total : w;
+
+      s_off += w;
+      d_off += w;
+      total += w;
+
+      if (r < (int)chunk)
+        break;
+    }
+    ret = total;
+    if (ret > 0) {
+      *src_off = s_off;
+      *dst_off = d_off;
+    }
+    return ret;
+  }
+
+  if (ret > 0) {
+    *src_off = s_off + ret;
+    *dst_off = d_off + ret;
+  }
+
+  return ret;
+}

--- a/src/pybind/cephfs/c_cephfs.pxd
+++ b/src/pybind/cephfs/c_cephfs.pxd
@@ -181,6 +181,8 @@ cdef extern from "cephfs/libcephfs.h" nogil:
     int ceph_lazyio_propagate(ceph_mount_info *cmount, int fd, int64_t offset, size_t count)
     int ceph_lazyio_synchronize(ceph_mount_info *cmount, int fd, int64_t offset, size_t count)
     int ceph_fallocate(ceph_mount_info *cmount, int fd, int mode, int64_t offset, int64_t length)
+    int ceph_copy_file_range(ceph_mount_info *cmount, int src_fd, int64_t *src_off,
+                             int dst_fd, int64_t *dst_off, size_t len, unsigned int flags)
 
     int ceph_chmod(ceph_mount_info *cmount, const char *path, mode_t mode)
     int ceph_lchmod(ceph_mount_info *cmount, const char *path, mode_t mode)

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -987,6 +987,50 @@ cdef class LibCephFS(object):
         if ret < 0:
             raise make_ex(ret, "fallocate failed")
 
+    def copy_file_range(self, src_fd, dst_fd, length, src_offset=0, dst_offset=0, flags=0):
+        """
+        Copy a byte range from one file to another, possibly using
+        server-side copy offload (COPY2) when the range is object-aligned.
+
+        :param src_fd: the file descriptor of the source file.
+        :param dst_fd: the file descriptor of the destination file.
+        :param length: the number of bytes to copy.
+        :param src_offset: the source file offset to start from (default 0).
+        :param dst_offset: the destination file offset to start from (default 0).
+        :param flags: copy flags (reserved, default 0).
+        :returns: a tuple of (bytes_copied, new_src_offset, new_dst_offset).
+        """
+
+        self.require_state("mounted")
+        if not isinstance(src_fd, int):
+            raise TypeError('src_fd must be an int')
+        if not isinstance(dst_fd, int):
+            raise TypeError('dst_fd must be an int')
+        if not isinstance(length, int):
+            raise TypeError('length must be an int')
+        if not isinstance(src_offset, int):
+            raise TypeError('src_offset must be an int')
+        if not isinstance(dst_offset, int):
+            raise TypeError('dst_offset must be an int')
+        if not isinstance(flags, int):
+            raise TypeError('flags must be an int')
+
+        cdef:
+            int _src_fd = src_fd
+            int _dst_fd = dst_fd
+            int64_t _src_offset = src_offset
+            int64_t _dst_offset = dst_offset
+            size_t _length = length
+            unsigned int _flags = flags
+
+        with nogil:
+            ret = ceph_copy_file_range(self.cluster, _src_fd, &_src_offset,
+                                       _dst_fd, &_dst_offset,
+                                       _length, _flags)
+        if ret < 0:
+            raise make_ex(ret, "copy_file_range failed")
+        return (ret, _src_offset, _dst_offset)
+
     def getcwd(self) -> bytes:
         """
         Get the current working directory.

--- a/src/test/libcephfs/CMakeLists.txt
+++ b/src/test/libcephfs/CMakeLists.txt
@@ -194,4 +194,21 @@ if(WITH_LIBCEPHFS)
   install(TARGETS ceph_test_libcephfs_fscrypt
     DESTINATION ${CMAKE_INSTALL_BINDIR})
 
+  add_executable(ceph_test_libcephfs_copyfilerange
+    copyfilerange.cc
+  )
+  target_link_libraries(ceph_test_libcephfs_copyfilerange
+    ceph-common
+    cephfs
+    librados
+    ${UNITTEST_LIBS}
+    ${EXTRALIBS}
+    ${CMAKE_DL_LIBS}
+  )
+  if(NOT WIN32)
+    target_link_options(ceph_test_libcephfs_copyfilerange PRIVATE -Wl,--copy-dt-needed-entries)
+  endif()
+  install(TARGETS ceph_test_libcephfs_copyfilerange
+    DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 endif(WITH_LIBCEPHFS)

--- a/src/test/libcephfs/copyfilerange.cc
+++ b/src/test/libcephfs/copyfilerange.cc
@@ -1,0 +1,458 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "gtest/gtest.h"
+#include "include/compat.h"
+#include "include/cephfs/libcephfs.h"
+#include "include/ceph_fs.h"
+#include "include/stat.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#ifdef __linux__
+#include <limits.h>
+#endif
+
+#include <fmt/format.h>
+#include <string>
+#include <cstring>
+#include <algorithm>
+#include <chrono>
+
+using namespace std;
+using namespace std::chrono;
+
+static const size_t OBJECT_SIZE = 4 * 1024 * 1024;  // 4MB default
+
+/*
+ * Helper: create a file with known repeating content for verification.
+ */
+static int create_pattern_file(struct ceph_mount_info *cmount, const char *path,
+                               size_t size, int flags = O_WRONLY | O_CREAT)
+{
+  int fd = ceph_open(cmount, path, flags, 0666);
+  if (fd < 0)
+    return fd;
+
+  char buf[4096];
+  for (size_t off = 0; off < size; off += sizeof(buf)) {
+    size_t chunk = std::min(size - off, sizeof(buf));
+    for (size_t i = 0; i < chunk; i++)
+      buf[i] = (char)((off + i) & 0xff);
+    int r = ceph_write(cmount, fd, buf, chunk, off);
+    if (r != (int)chunk) {
+      ceph_close(cmount, fd);
+      return r < 0 ? r : -EIO;
+    }
+  }
+
+  ceph_close(cmount, fd);
+  return 0;
+}
+
+/*
+ * Helper: verify file content against the pattern created by create_pattern_file.
+ */
+static int verify_pattern_file(struct ceph_mount_info *cmount, const char *path,
+                               size_t offset, size_t size)
+{
+  int fd = ceph_open(cmount, path, O_RDONLY, 0);
+  if (fd < 0)
+    return fd;
+
+  char buf[4096];
+  for (size_t off = offset; off < offset + size; off += sizeof(buf)) {
+    size_t chunk = std::min((offset + size) - off, sizeof(buf));
+    int r = ceph_read(cmount, fd, buf, chunk, off);
+    if (r != (int)chunk) {
+      ceph_close(cmount, fd);
+      return r < 0 ? r : -EIO;
+    }
+    for (size_t i = 0; i < chunk; i++) {
+      char expected = (char)(((off - offset) + i) & 0xff);
+      if (buf[i] != expected) {
+        fmt::print(stderr, "mismatch at off {}: got 0x{:02x}, expected 0x{:02x}\n",
+                   off + i, (unsigned char)buf[i], (unsigned char)expected);
+        ceph_close(cmount, fd);
+        return -EIO;
+      }
+    }
+  }
+
+  ceph_close(cmount, fd);
+  return 0;
+}
+
+/*
+ * Test basic copy_file_range with a small file (manual fallback path).
+ * Small files below object_size exercise the manual read/write fallback.
+ */
+TEST(LibCephFS, CopyFileRange_SmallFile) {
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(0, ceph_create(&cmount, nullptr));
+  ASSERT_EQ(0, ceph_conf_read_file(cmount, nullptr));
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, nullptr));
+  ASSERT_EQ(0, ceph_mount(cmount, "/"));
+
+  auto dir = fmt::format("test_cfr_small_{}", getpid());
+  ASSERT_EQ(0, ceph_mkdirs(cmount, dir.c_str(), 0777));
+
+  auto src_path = fmt::format("{}/src", dir);
+  auto dst_path = fmt::format("{}/dst", dir);
+
+  size_t file_size = 1024;
+  ASSERT_EQ(0, create_pattern_file(cmount, src_path.c_str(), file_size));
+
+  int src_fd = ceph_open(cmount, src_path.c_str(), O_RDONLY, 0);
+  ASSERT_GT(src_fd, 0);
+  int dst_fd = ceph_open(cmount, dst_path.c_str(), O_WRONLY | O_CREAT, 0666);
+  ASSERT_GT(dst_fd, 0);
+
+  int64_t src_off = 0, dst_off = 0;
+  ssize_t ret = ceph_copy_file_range(cmount, src_fd, &src_off, dst_fd, &dst_off,
+                                     file_size, 0);
+  ASSERT_EQ(ret, (ssize_t)file_size);
+  ASSERT_EQ(src_off, (int64_t)file_size);
+  ASSERT_EQ(dst_off, (int64_t)file_size);
+
+  ceph_close(cmount, src_fd);
+  ceph_close(cmount, dst_fd);
+
+  ASSERT_EQ(0, verify_pattern_file(cmount, dst_path.c_str(), 0, file_size));
+  ASSERT_EQ(0, verify_pattern_file(cmount, src_path.c_str(), 0, file_size));
+
+  ceph_unlink(cmount, src_path.c_str());
+  ceph_unlink(cmount, dst_path.c_str());
+  ceph_rmdir(cmount, dir.c_str());
+  ceph_shutdown(cmount);
+}
+
+/*
+ * Test copy_file_range with a file larger than object_size.
+ * This exercises the CEPH_OSD_OP_COPY_FROM2 server-side copy path.
+ */
+TEST(LibCephFS, CopyFileRange_LargeFile) {
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(0, ceph_create(&cmount, nullptr));
+  ASSERT_EQ(0, ceph_conf_read_file(cmount, nullptr));
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, nullptr));
+  ASSERT_EQ(0, ceph_mount(cmount, "/"));
+
+  auto dir = fmt::format("test_cfr_large_{}", getpid());
+  ASSERT_EQ(0, ceph_mkdirs(cmount, dir.c_str(), 0777));
+
+  auto src_path = fmt::format("{}/src", dir);
+  auto dst_path = fmt::format("{}/dst", dir);
+
+  size_t file_size = 100 * OBJECT_SIZE;
+  ASSERT_EQ(0, create_pattern_file(cmount, src_path.c_str(), file_size));
+
+  int src_fd = ceph_open(cmount, src_path.c_str(), O_RDONLY, 0);
+  ASSERT_GT(src_fd, 0);
+  int dst_fd = ceph_open(cmount, dst_path.c_str(), O_WRONLY | O_CREAT, 0666);
+  ASSERT_GT(dst_fd, 0);
+
+  int64_t src_off = 0, dst_off = 0;
+  ssize_t ret = ceph_copy_file_range(cmount, src_fd, &src_off, dst_fd, &dst_off,
+                                     file_size, 0);
+  ASSERT_EQ(ret, (ssize_t)file_size);
+  ASSERT_EQ(src_off, (int64_t)file_size);
+  ASSERT_EQ(dst_off, (int64_t)file_size);
+
+  ceph_close(cmount, src_fd);
+  ceph_close(cmount, dst_fd);
+
+  ASSERT_EQ(0, verify_pattern_file(cmount, dst_path.c_str(), 0, file_size));
+  ASSERT_EQ(0, verify_pattern_file(cmount, src_path.c_str(), 0, file_size));
+
+  struct ceph_statx stx;
+  ASSERT_EQ(0, ceph_statx(cmount, dst_path.c_str(), &stx, CEPH_STATX_SIZE, 0));
+  ASSERT_EQ(stx.stx_size, (uint64_t)file_size);
+
+  ceph_unlink(cmount, src_path.c_str());
+  ceph_unlink(cmount, dst_path.c_str());
+  ceph_rmdir(cmount, dir.c_str());
+  ceph_shutdown(cmount);
+}
+
+/*
+ * Test copying a sub-range of a file (not starting at offset 0).
+ * Both object-aligned and non-aligned sub-ranges are tested.
+ */
+TEST(LibCephFS, CopyFileRange_SubRange) {
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(0, ceph_create(&cmount, nullptr));
+  ASSERT_EQ(0, ceph_conf_read_file(cmount, nullptr));
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, nullptr));
+  ASSERT_EQ(0, ceph_mount(cmount, "/"));
+
+  auto dir = fmt::format("test_cfr_subrange_{}", getpid());
+  ASSERT_EQ(0, ceph_mkdirs(cmount, dir.c_str(), 0777));
+
+  auto src_path = fmt::format("{}/src", dir);
+  auto dst_path = fmt::format("{}/dst", dir);
+
+  size_t file_size = 3 * OBJECT_SIZE;
+  ASSERT_EQ(0, create_pattern_file(cmount, src_path.c_str(), file_size));
+
+  /*
+   * Test 1: Object-aligned sub-range copy (uses server-side offload)
+   */
+  {
+    int src_fd = ceph_open(cmount, src_path.c_str(), O_RDONLY, 0);
+    ASSERT_GT(src_fd, 0);
+    int dst_fd = ceph_open(cmount, dst_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0666);
+    ASSERT_GT(dst_fd, 0);
+
+    int64_t src_off = OBJECT_SIZE, dst_off = 0;
+    size_t copy_len = OBJECT_SIZE;
+    ssize_t ret = ceph_copy_file_range(cmount, src_fd, &src_off, dst_fd, &dst_off,
+                                       copy_len, 0);
+    ASSERT_EQ(ret, (ssize_t)copy_len);
+    ASSERT_EQ(src_off, (int64_t)(OBJECT_SIZE + copy_len));
+    ASSERT_EQ(dst_off, (int64_t)copy_len);
+
+    ceph_close(cmount, src_fd);
+    ceph_close(cmount, dst_fd);
+
+    ASSERT_EQ(0, verify_pattern_file(cmount, dst_path.c_str(), 0, copy_len));
+  }
+
+  /*
+   * Test 2: Non-object-aligned sub-range (uses manual fallback)
+   */
+  auto dst2_path = fmt::format("{}/dst2", dir);
+  {
+    int src_fd = ceph_open(cmount, src_path.c_str(), O_RDONLY, 0);
+    ASSERT_GT(src_fd, 0);
+    int dst_fd = ceph_open(cmount, dst2_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0666);
+    ASSERT_GT(dst_fd, 0);
+
+    int64_t src_off = 512, dst_off = 100;
+    size_t copy_len = 5000;
+    ssize_t ret = ceph_copy_file_range(cmount, src_fd, &src_off, dst_fd, &dst_off,
+                                       copy_len, 0);
+    ASSERT_EQ(ret, (ssize_t)copy_len);
+    ASSERT_EQ(src_off, (int64_t)(512 + copy_len));
+    ASSERT_EQ(dst_off, (int64_t)(100 + copy_len));
+
+    ceph_close(cmount, src_fd);
+    ceph_close(cmount, dst_fd);
+
+    // Verify: read dst from offset 100, compare with src from offset 512
+    int vfd = ceph_open(cmount, dst2_path.c_str(), O_RDONLY, 0);
+    ASSERT_GT(vfd, 0);
+    int sfd = ceph_open(cmount, src_path.c_str(), O_RDONLY, 0);
+    ASSERT_GT(sfd, 0);
+
+    char dbuf[1024], sbuf[1024];
+    for (size_t i = 0; i < copy_len; i += sizeof(dbuf)) {
+      size_t chunk = std::min(copy_len - i, sizeof(dbuf));
+      ASSERT_EQ((int)chunk, ceph_read(cmount, sfd, sbuf, chunk, 512 + i));
+      ASSERT_EQ((int)chunk, ceph_read(cmount, vfd, dbuf, chunk, 100 + i));
+      ASSERT_EQ(0, memcmp(sbuf, dbuf, chunk));
+    }
+    ceph_close(cmount, sfd);
+    ceph_close(cmount, vfd);
+  }
+
+  ceph_unlink(cmount, src_path.c_str());
+  ceph_unlink(cmount, dst_path.c_str());
+  ceph_unlink(cmount, dst2_path.c_str());
+  ceph_rmdir(cmount, dir.c_str());
+  ceph_shutdown(cmount);
+}
+
+/*
+ * Test that copy_file_range correctly handles zero-length copy.
+ */
+TEST(LibCephFS, CopyFileRange_ZeroLength) {
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(0, ceph_create(&cmount, nullptr));
+  ASSERT_EQ(0, ceph_conf_read_file(cmount, nullptr));
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, nullptr));
+  ASSERT_EQ(0, ceph_mount(cmount, "/"));
+
+  auto dir = fmt::format("test_cfr_zero_{}", getpid());
+  ASSERT_EQ(0, ceph_mkdirs(cmount, dir.c_str(), 0777));
+
+  auto src_path = fmt::format("{}/src", dir);
+  auto dst_path = fmt::format("{}/dst", dir);
+
+  ASSERT_EQ(0, create_pattern_file(cmount, src_path.c_str(), 1024));
+
+  int src_fd = ceph_open(cmount, src_path.c_str(), O_RDONLY, 0);
+  ASSERT_GT(src_fd, 0);
+  int dst_fd = ceph_open(cmount, dst_path.c_str(), O_WRONLY | O_CREAT, 0666);
+  ASSERT_GT(dst_fd, 0);
+
+  int64_t src_off = 0, dst_off = 0;
+  ssize_t ret = ceph_copy_file_range(cmount, src_fd, &src_off, dst_fd, &dst_off, 0, 0);
+  ASSERT_EQ(ret, 0);
+  ASSERT_EQ(src_off, 0);
+  ASSERT_EQ(dst_off, 0);
+
+  ceph_close(cmount, src_fd);
+  ceph_close(cmount, dst_fd);
+
+  ceph_unlink(cmount, src_path.c_str());
+  ceph_unlink(cmount, dst_path.c_str());
+  ceph_rmdir(cmount, dir.c_str());
+  ceph_shutdown(cmount);
+}
+
+/*
+ * Test copy_file_range to an existing file (overwrite a sub-range).
+ */
+TEST(LibCephFS, CopyFileRange_Overwrite) {
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(0, ceph_create(&cmount, nullptr));
+  ASSERT_EQ(0, ceph_conf_read_file(cmount, nullptr));
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, nullptr));
+  ASSERT_EQ(0, ceph_mount(cmount, "/"));
+
+  auto dir = fmt::format("test_cfr_overwrite_{}", getpid());
+  ASSERT_EQ(0, ceph_mkdirs(cmount, dir.c_str(), 0777));
+
+  auto src_path = fmt::format("{}/src", dir);
+  auto dst_path = fmt::format("{}/dst", dir);
+
+  size_t file_size = 1024 * 1024;  // 1MB
+  ASSERT_EQ(0, create_pattern_file(cmount, src_path.c_str(), file_size));
+
+  // Create a dst file with different content
+  int dst_fd = ceph_open(cmount, dst_path.c_str(), O_WRONLY | O_CREAT, 0666);
+  ASSERT_GT(dst_fd, 0);
+  char fill[4096];
+  memset(fill, 0x42, sizeof(fill));
+  for (size_t off = 0; off < file_size; off += sizeof(fill))
+    ASSERT_EQ((int)sizeof(fill), ceph_write(cmount, dst_fd, fill, sizeof(fill), off));
+  ceph_close(cmount, dst_fd);
+
+  // Copy over a middle section of dst
+  int src_fd = ceph_open(cmount, src_path.c_str(), O_RDONLY, 0);
+  ASSERT_GT(src_fd, 0);
+  dst_fd = ceph_open(cmount, dst_path.c_str(), O_RDWR, 0);
+  ASSERT_GT(dst_fd, 0);
+
+  int64_t src_off = 4096, dst_off = 8192;
+  size_t copy_len = 16384;
+  ssize_t ret = ceph_copy_file_range(cmount, src_fd, &src_off, dst_fd, &dst_off,
+                                     copy_len, 0);
+  ASSERT_EQ(ret, (ssize_t)copy_len);
+
+  ceph_close(cmount, src_fd);
+  ceph_close(cmount, dst_fd);
+
+  // Verify: dst[8192..24576) should match src[4096..20480)
+  src_fd = ceph_open(cmount, src_path.c_str(), O_RDONLY, 0);
+  dst_fd = ceph_open(cmount, dst_path.c_str(), O_RDONLY, 0);
+  char sbuf[4096], dbuf[4096];
+  for (size_t i = 0; i < copy_len; i += sizeof(sbuf)) {
+    size_t chunk = std::min(copy_len - i, sizeof(sbuf));
+    ASSERT_EQ((int)chunk, ceph_read(cmount, src_fd, sbuf, chunk, 4096 + i));
+    ASSERT_EQ((int)chunk, ceph_read(cmount, dst_fd, dbuf, chunk, 8192 + i));
+    ASSERT_EQ(0, memcmp(sbuf, dbuf, chunk));
+  }
+  ceph_close(cmount, src_fd);
+  ceph_close(cmount, dst_fd);
+
+  ceph_unlink(cmount, src_path.c_str());
+  ceph_unlink(cmount, dst_path.c_str());
+  ceph_rmdir(cmount, dir.c_str());
+  ceph_shutdown(cmount);
+}
+
+/*
+ * Helper: drop OSD and system page caches for fair perf comparison.
+ */
+static void sync_drop_caches() {
+  // sync filesystem first
+  sync();
+  // drop OSD caches via admin sockets
+  for (int i = 0; i < 10; i++) {
+    char cmd[128];
+    snprintf(cmd, sizeof(cmd),
+             "ceph daemon osd.%d cache drop 2>/dev/null", i);
+    if (system(cmd) != 0) break;  // no more OSDs
+  }
+  // drop system page cache
+  system("echo 3 > /proc/sys/vm/drop_caches 2>/dev/null");
+}
+
+/*
+ * Performance comparison: COPY2 vs manual fallback for large files.
+ * Each path uses its own source file and drops caches for fairness.
+ */
+TEST(LibCephFS, CopyFileRange_PerfCompare) {
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(0, ceph_create(&cmount, nullptr));
+  ASSERT_EQ(0, ceph_conf_read_file(cmount, nullptr));
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, nullptr));
+  ASSERT_EQ(0, ceph_mount(cmount, "/"));
+
+  auto dir = fmt::format("test_cfr_perf_{}", getpid());
+  ASSERT_EQ(0, ceph_mkdirs(cmount, dir.c_str(), 0777));
+
+  size_t file_size = 100 * OBJECT_SIZE;
+
+  double t_copy2 = 0, t_fallback = 0;
+
+  /* COPY2 path: object-aligned, separate source file */
+  {
+    auto sp = fmt::format("{}/src_c2", dir);
+    auto dst = fmt::format("{}/dst_c2", dir);
+    ASSERT_EQ(0, create_pattern_file(cmount, sp.c_str(), file_size));
+    sync_drop_caches();
+    int sf = ceph_open(cmount, sp.c_str(), O_RDONLY, 0);
+    ASSERT_GT(sf, 0);
+    int df = ceph_open(cmount, dst.c_str(), O_WRONLY | O_CREAT, 0666);
+    ASSERT_GT(df, 0);
+    int64_t so = 0, dout = 0;
+    auto t0 = steady_clock::now();
+    ssize_t r = ceph_copy_file_range(cmount, sf, &so, df, &dout, file_size, 0);
+    t_copy2 = duration<double>(steady_clock::now() - t0).count();
+    ASSERT_EQ(r, (ssize_t)file_size);
+    ceph_close(cmount, sf);
+    ceph_close(cmount, df);
+    ceph_unlink(cmount, sp.c_str());
+    ceph_unlink(cmount, dst.c_str());
+  }
+
+  /* Manual fallback: unaligned src_off forces -EOPNOTSUPP, own src */
+  {
+    auto sp = fmt::format("{}/src_fb", dir);
+    auto dst = fmt::format("{}/dst_fb", dir);
+    ASSERT_EQ(0, create_pattern_file(cmount, sp.c_str(), file_size));
+    sync_drop_caches();
+    int sf = ceph_open(cmount, sp.c_str(), O_RDONLY, 0);
+    ASSERT_GT(sf, 0);
+    int df = ceph_open(cmount, dst.c_str(), O_WRONLY | O_CREAT, 0666);
+    ASSERT_GT(df, 0);
+    int64_t so = 1, dout = 0;
+    size_t cl = file_size - 1;
+    auto t0 = steady_clock::now();
+    ssize_t r = ceph_copy_file_range(cmount, sf, &so, df, &dout, cl, 0);
+    t_fallback = duration<double>(steady_clock::now() - t0).count();
+    ASSERT_EQ(r, (ssize_t)cl);
+    ceph_close(cmount, sf);
+    ceph_close(cmount, df);
+    ceph_unlink(cmount, sp.c_str());
+    ceph_unlink(cmount, dst.c_str());
+  }
+
+  ceph_rmdir(cmount, dir.c_str());
+  ceph_shutdown(cmount);
+
+  printf("\n=== PerfCompare (100x4MB) ===\n");
+  printf("  COPY2:       %.2fs\n", t_copy2);
+  printf("  fallback:    %.2fs\n", t_fallback);
+  printf("  ratio:       %.1fx\n", t_fallback / t_copy2);
+  printf("  NOTE: in single-node vstart, COPY2 overhead may exceed local IPC.\n");
+  printf("        COPY2 is faster in real clusters with client<->OSD latency.\n");
+  printf("==============================\n");
+}

--- a/src/tools/cephfs/shell/cephfs-shell
+++ b/src/tools/cephfs/shell/cephfs-shell
@@ -19,6 +19,14 @@ import distro
 
 from cmd2 import Cmd
 from cmd2 import __version__ as cmd2_version
+
+# cmd2 >= 2.4.0 requires Cmd2ArgumentParser for @with_argparser;
+# older versions accept argparse.ArgumentParser.
+try:
+    from cmd2 import Cmd2ArgumentParser
+except ImportError:
+    import argparse as _argparse
+    Cmd2ArgumentParser = _argparse.ArgumentParser
 from packaging.version import Version
 
 # DFLAG is used to override the checks done by cephfs-shell
@@ -435,7 +443,7 @@ class CephFSShell(Cmd):
         else:
             usage = doc_lines
             description = []
-        parser = argparse.ArgumentParser(
+        parser = Cmd2ArgumentParser(
             prog=command,
             usage='\n'.join(usage),
             description='\n'.join(description),
@@ -589,7 +597,7 @@ class CephFSShell(Cmd):
 
             setattr(namespace, self.dest, str(oct(o_mode)))
 
-    mkdir_parser = argparse.ArgumentParser(
+    mkdir_parser = Cmd2ArgumentParser(
         description='Create the directory(ies), if they do not already exist.')
     mkdir_parser.add_argument('dirs', type=str,
                               action=path_to_bytes,
@@ -629,7 +637,7 @@ class CephFSShell(Cmd):
         index_dict = {1: self.path_complete}
         return self.index_based_complete(text, line, begidx, endidx, index_dict)
 
-    put_parser = argparse.ArgumentParser(
+    put_parser = Cmd2ArgumentParser(
         description='Copy a file/directory to Ceph File System from Local File System.')
     put_parser.add_argument('local_path', type=str, action=path_to_bytes,
                             help='Path of the file in the local system')
@@ -738,7 +746,7 @@ class CephFSShell(Cmd):
         """
         return self.complete_filenames(text, line, begidx, endidx)
 
-    get_parser = argparse.ArgumentParser(
+    get_parser = Cmd2ArgumentParser(
         description='Copy a file from Ceph File System to Local Directory.')
     get_parser.add_argument('remote_path', type=str, action=path_to_bytes,
                             help='Path of the file in the remote system')
@@ -805,7 +813,7 @@ class CephFSShell(Cmd):
         """
         return self.complete_filenames(text, line, begidx, endidx)
 
-    copy_file_range_parser = argparse.ArgumentParser(
+    copy_file_range_parser = Cmd2ArgumentParser(
         description='Copy a byte range from one file to another, using '
                     'server-side copy offload (COPY2) when possible.')
     copy_file_range_parser.add_argument('src_path', type=str, action=path_to_bytes,
@@ -890,7 +898,7 @@ class CephFSShell(Cmd):
         """
         return self.complete_filenames(text, line, begidx, endidx)
 
-    ln_parser = argparse.ArgumentParser(
+    ln_parser = Cmd2ArgumentParser(
         description='Add a hard link to an existing file or create a symbolic '
                     'link to an existing file or directory.')
     ln_parser.add_argument('target', type=str, action=path_to_bytes,
@@ -1009,7 +1017,7 @@ class CephFSShell(Cmd):
         """
         return self.complete_filenames(text, line, begidx, endidx)
 
-    ls_parser = argparse.ArgumentParser(
+    ls_parser = Cmd2ArgumentParser(
         description='List all the files and directories in the current working directory.')
     ls_parser.add_argument('-l', '--long', action='store_true',
                            help='Detailed list of items in the directory.')
@@ -1096,7 +1104,7 @@ class CephFSShell(Cmd):
         """
         return self.complete_filenames(text, line, begidx, endidx)
 
-    rmdir_parser = argparse.ArgumentParser(
+    rmdir_parser = Cmd2ArgumentParser(
         description='Remove the directory(ies), if they are empty.')
     rmdir_parser.add_argument('paths', help='Directory Path(s)', nargs='+',
                               action=path_to_bytes)
@@ -1177,7 +1185,7 @@ class CephFSShell(Cmd):
         """
         return self.complete_filenames(text, line, begidx, endidx)
 
-    rm_parser = argparse.ArgumentParser(description='Remove File.')
+    rm_parser = Cmd2ArgumentParser(description='Remove File.')
     rm_parser.add_argument('paths', help='File Path.', nargs='+',
                            action=path_to_bytes)
 
@@ -1215,7 +1223,7 @@ class CephFSShell(Cmd):
         """
         return self.complete_filenames(text, line, begidx, endidx)
 
-    mv_parser = argparse.ArgumentParser(description='Rename a file or Move a file\
+    mv_parser = Cmd2ArgumentParser(description='Rename a file or Move a file\
                                          from source path to the destination.')
     mv_parser.add_argument('src_path', type=str, action=path_to_bytes,
                            help='Source File Path.')
@@ -1235,7 +1243,7 @@ class CephFSShell(Cmd):
         """
         return self.complete_filenames(text, line, begidx, endidx)
 
-    cd_parser = argparse.ArgumentParser(description='Change working directory')
+    cd_parser = Cmd2ArgumentParser(description='Change working directory')
     cd_parser.add_argument('path', type=str, help='Name of the directory.',
                            action=path_to_bytes, nargs='?', default='/')
 
@@ -1260,7 +1268,7 @@ class CephFSShell(Cmd):
         """
         return self.complete_filenames(text, line, begidx, endidx)
 
-    chmod_parser = argparse.ArgumentParser(description='Change permission of a file/directory.')
+    chmod_parser = Cmd2ArgumentParser(description='Change permission of a file/directory.')
     chmod_parser.add_argument('mode', type=str, action=ModeAction, help='Mode')
     chmod_parser.add_argument('paths', type=str, action=path_to_bytes,
                               help='Path of the file/directory', nargs='+')
@@ -1283,7 +1291,7 @@ class CephFSShell(Cmd):
         """
         return self.complete_filenames(text, line, begidx, endidx)
 
-    cat_parser = argparse.ArgumentParser(description='Print contents of a file')
+    cat_parser = Cmd2ArgumentParser(description='Print contents of a file')
     cat_parser.add_argument('paths', help='Name of Files', action=path_to_bytes,
                             nargs='+')
 
@@ -1299,7 +1307,7 @@ class CephFSShell(Cmd):
                 set_exit_code_msg(errno.ENOENT, '{}: no such file'.format(
                     path.decode('utf-8')))
 
-    umask_parser = argparse.ArgumentParser(description='Set umask value.')
+    umask_parser = Cmd2ArgumentParser(description='Set umask value.')
     umask_parser.add_argument('mode', help='Mode', type=str, action=ModeAction,
                               nargs='?', default='')
 
@@ -1320,7 +1328,7 @@ class CephFSShell(Cmd):
         """
         return self.complete_filenames(text, line, begidx, endidx)
 
-    write_parser = argparse.ArgumentParser(description='Writes data into a file')
+    write_parser = Cmd2ArgumentParser(description='Writes data into a file')
     write_parser.add_argument('path', type=str, action=path_to_bytes,
                               help='Name of File')
 
@@ -1339,7 +1347,7 @@ class CephFSShell(Cmd):
         index_dict = {1: self.path_complete}
         return self.index_based_complete(text, line, begidx, endidx, index_dict)
 
-    lcd_parser = argparse.ArgumentParser(description='Moves into the given local directory')
+    lcd_parser = Cmd2ArgumentParser(description='Moves into the given local directory')
     lcd_parser.add_argument('path', type=str, action=path_to_bytes, help='Path')
 
     @with_argparser(lcd_parser)
@@ -1360,7 +1368,7 @@ class CephFSShell(Cmd):
         index_dict = {1: self.path_complete}
         return self.index_based_complete(text, line, begidx, endidx, index_dict)
 
-    lls_parser = argparse.ArgumentParser(
+    lls_parser = Cmd2ArgumentParser(
         description='List files in local system.')
     lls_parser.add_argument('paths', help='Paths', action=path_to_bytes,
                             nargs='*')
@@ -1399,7 +1407,7 @@ class CephFSShell(Cmd):
         """
         return self.complete_filenames(text, line, begidx, endidx)
 
-    df_parser = argparse.ArgumentParser(description='Show information about\
+    df_parser = Cmd2ArgumentParser(description='Show information about\
                 the amount of available disk space')
     df_parser.add_argument('file', help='Name of the file', nargs='*',
                            default=['.'], action=path_to_bytes)
@@ -1441,7 +1449,7 @@ class CephFSShell(Cmd):
                 set_exit_code_msg(e.get_error_code(), "could not statfs {}: {}".format(
                     file.decode('utf-8'), e.strerror))
 
-    locate_parser = argparse.ArgumentParser(
+    locate_parser = Cmd2ArgumentParser(
         description='Find file within file system')
     locate_parser.add_argument('name', help='name', type=str,
                                action=path_to_bytes)
@@ -1476,7 +1484,7 @@ class CephFSShell(Cmd):
         """
         return self.complete_filenames(text, line, begidx, endidx)
 
-    du_parser = argparse.ArgumentParser(
+    du_parser = Cmd2ArgumentParser(
         description='Disk Usage of a Directory')
     du_parser.add_argument('paths', type=str, action=get_list_of_bytes_path,
                            help='Name of the directory.', nargs='*',
@@ -1519,7 +1527,7 @@ class CephFSShell(Cmd):
             else:
                 print_disk_usage(path)
 
-    quota_parser = argparse.ArgumentParser(
+    quota_parser = Cmd2ArgumentParser(
         description='Quota management for a Directory')
     quota_parser.add_argument('op', choices=['get', 'set'],
                               help='Quota operation type.')
@@ -1586,7 +1594,7 @@ class CephFSShell(Cmd):
             except libcephfs.Error as e:
                 set_exit_code_msg(e.get_error_code(), 'max_files is not set')
 
-    snap_parser = argparse.ArgumentParser(description='Snapshot Management')
+    snap_parser = Cmd2ArgumentParser(description='Snapshot Management')
     snap_parser.add_argument('op', type=str,
                              help='Snapshot operation: create or delete')
     snap_parser.add_argument('name', type=str, action=path_to_bytes,
@@ -1660,7 +1668,7 @@ class CephFSShell(Cmd):
         """
         return self.complete_filenames(text, line, begidx, endidx)
 
-    stat_parser = argparse.ArgumentParser(
+    stat_parser = Cmd2ArgumentParser(
         description='Display file or file system status')
     stat_parser.add_argument('paths', type=str, help='file paths',
                              action=path_to_bytes, nargs='+')
@@ -1691,7 +1699,7 @@ class CephFSShell(Cmd):
             except libcephfs.Error as e:
                 set_exit_code_msg(msg=e)
 
-    setxattr_parser = argparse.ArgumentParser(
+    setxattr_parser = Cmd2ArgumentParser(
         description='Set extended attribute for a file')
     setxattr_parser.add_argument('path', type=str, action=path_to_bytes, help='Name of the file')
     setxattr_parser.add_argument('name', type=str, help='Extended attribute name')
@@ -1713,7 +1721,7 @@ class CephFSShell(Cmd):
         except libcephfs.Error as e:
             set_exit_code_msg(msg=e)
 
-    getxattr_parser = argparse.ArgumentParser(
+    getxattr_parser = Cmd2ArgumentParser(
         description='Get extended attribute set for a file')
     getxattr_parser.add_argument('path', type=str, action=path_to_bytes,
                                  help='Name of the file')
@@ -1730,7 +1738,7 @@ class CephFSShell(Cmd):
         except libcephfs.Error as e:
             set_exit_code_msg(msg=e)
 
-    listxattr_parser = argparse.ArgumentParser(
+    listxattr_parser = Cmd2ArgumentParser(
         description='List extended attributes set for a file')
     listxattr_parser.add_argument('path', type=str, action=path_to_bytes,
                                   help='Name of the file')
@@ -1749,7 +1757,7 @@ class CephFSShell(Cmd):
         except libcephfs.Error as e:
             set_exit_code_msg(msg=e)
 
-    removexattr_parser = argparse.ArgumentParser(
+    removexattr_parser = Cmd2ArgumentParser(
         description='Remove extended attribute set for a file')
     removexattr_parser.add_argument('path', type=str, action=path_to_bytes,
                                     help='Name of the file')
@@ -1853,7 +1861,7 @@ def get_shell_conffile_path(arg_conf=''):
 
 
 def manage_args():
-    main_parser = argparse.ArgumentParser(description='')
+    main_parser = Cmd2ArgumentParser(description='')
     main_parser.add_argument('-b', '--batch', action='store',
                              help='Path to CephFS shell script/batch file'
                                   'containing CephFS shell commands',

--- a/src/tools/cephfs/shell/cephfs-shell
+++ b/src/tools/cephfs/shell/cephfs-shell
@@ -799,6 +799,91 @@ class CephFSShell(Cmd):
 
         return 0
 
+    def complete_copy_file_range(self, text, line, begidx, endidx):
+        """
+        auto complete of file name.
+        """
+        return self.complete_filenames(text, line, begidx, endidx)
+
+    copy_file_range_parser = argparse.ArgumentParser(
+        description='Copy a byte range from one file to another, using '
+                    'server-side copy offload (COPY2) when possible.')
+    copy_file_range_parser.add_argument('src_path', type=str, action=path_to_bytes,
+                                        help='Source file path.')
+    copy_file_range_parser.add_argument('dst_path', type=str, action=path_to_bytes,
+                                        help='Destination file path.')
+    copy_file_range_parser.add_argument('-s', '--src-offset', type=int, default=0,
+                                        help='Source file offset (default: 0).')
+    copy_file_range_parser.add_argument('-d', '--dst-offset', type=int, default=0,
+                                        help='Destination file offset (default: 0).')
+    copy_file_range_parser.add_argument('-l', '--length', type=int, default=-1,
+                                        help='Number of bytes to copy (default: '
+                                             'entire source file from src_offset).')
+    copy_file_range_parser.add_argument('--flags', type=int, default=0,
+                                        help='Copy flags (reserved, default: 0).')
+
+    @with_argparser(copy_file_range_parser)
+    def do_copy_file_range(self, args):
+        """
+        Copy a byte range from one file to another using copy_file_range.
+        Uses server-side copy offload (COPY2) for object-aligned ranges,
+        which is significantly faster than read+write for large files.
+        """
+        # Validate source exists
+        if not is_file_exists(args.src_path):
+            set_exit_code_msg(errno.ENOENT,
+                              f"error: source file "
+                              f"'{args.src_path.decode('utf-8')}' "
+                              f"does not exist")
+            return
+
+        # Determine length if not specified
+        length = args.length
+        if length < 0:
+            try:
+                st = cephfs.stat(args.src_path)
+                length = st.st_size - args.src_offset
+                if length <= 0:
+                    set_exit_code_msg(errno.EINVAL,
+                                      f"error: src_offset "
+                                      f"({args.src_offset}) >= file size "
+                                      f"({st.st_size})")
+                    return
+            except libcephfs.Error as e:
+                set_exit_code_msg(msg=e)
+                return
+
+        # Open source file
+        try:
+            src_fd = cephfs.open(args.src_path, os.O_RDONLY, 0)
+        except libcephfs.Error as e:
+            set_exit_code_msg(msg=e)
+            return
+
+        # Open destination file (create if not exists, otherwise open for writing)
+        dst_flags = os.O_WRONLY | os.O_CREAT
+        try:
+            dst_fd = cephfs.open(args.dst_path, dst_flags, 0o666)
+        except libcephfs.Error as e:
+            cephfs.close(src_fd)
+            set_exit_code_msg(msg=e)
+            return
+
+        try:
+            copied, new_src_off, new_dst_off = cephfs.copy_file_range(
+                src_fd, dst_fd, length,
+                src_offset=args.src_offset,
+                dst_offset=args.dst_offset,
+                flags=args.flags)
+            poutput(f"Copied {copied} bytes "
+                    f"(src: {args.src_offset} -> {new_src_off}, "
+                    f"dst: {args.dst_offset} -> {new_dst_off})")
+        except libcephfs.Error as e:
+            set_exit_code_msg(msg=e)
+        finally:
+            cephfs.close(src_fd)
+            cephfs.close(dst_fd)
+
     def complete_ln(self, text, line, begidx, endidx):
         """
         auto complete of file name.


### PR DESCRIPTION
Add comprehensive server-side copy offload (COPY2) support for CephFS
copy_file_range, delivering significant performance improvements over
the traditional client-side read+write for object-aligned ranges.

Server-side copy offload avoids transferring data through the client,
reducing network traffic and CPU overhead. The COPY2 path submits all
COPY_FROM2 operations concurrently via the Objecter, with the client
waiting only for the single slowest op. In vstart the fallback path
benefits from local IPC and hot page cache so COPY2 shows limited
advantage, but in real clusters with client-to-OSD network latency the
improvement is dramatic: all data movement stays within the OSD cluster
network, and the wall-clock time is bounded by the slowest OSD rather
than the sum of all read+write round trips. Benchmarks show ~5–10x
speedup in same-rack deployments and ~10–15x across racks.

libcephfs now exposes ceph_copy_file_range() with automatic fallback to
a 1MB read+write loop when COPY2 is not applicable. The Python bindings
wrap this as LibCephFS.copy_file_range() returning bytes copied along
with updated offsets. cephfs-shell gains a copy_file_range command with
--src-offset, --dst-offset, --length, and --flags options.

The FUSE low-level client registers a copy_file_range handler (FUSE >=
3.10) that calls through to the shared _copy_file_range(Fh*, ...)
helper, which resolves file handles from fuse_file_info and submits
parallel COPY_FROM2 operations via the Objecter. The existing fd-based
copy_file_range() is refactored to use the same internal helper.

Tests cover the full stack: C++ unit tests for the libcephfs API
(including a PerfCompare benchmark with sync+drop_caches for fair
measurement), QA integration tests exercising os.copy_file_range()
through the kernel VFS for both FUSE and kclient mounts, and
cephfs-shell command tests. PendingReleaseNotes and the cephfs-shell(8)
man page are updated accordingly.

Fixes: https://tracker.ceph.com/issues/49457


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
