### PR TITLE
tentacle: nvmeofgw: arm beacon timeouts for GWs in Created state

### DIFF
--- a/src/mon/NVMeofGwMap.cc
+++ b/src/mon/NVMeofGwMap.cc
@@ -649,15 +649,28 @@ void NVMeofGwMap::skip_failovers_for_group(const NvmeGroupKey& group_key,
   }
 }
 
-int NVMeofGwMap::process_gw_map_gw_no_subsys_no_listeners(
+/*
+ This function called in the following cases:
+  - Gw has no subsystems and no listeners
+  - GW performed fast startup
+  - GW sends the beacon with a wrong sequence number
+  - GW starts in ADMIN_DISABLED state
+ In all cases when GW passes to CREATED state it should not have active ANA groups
+ No failover started in all these cases, GW stay alive and beacon timer is armed
+*/
+int NVMeofGwMap::process_gw_map_gw_pass_to_created(
   const NvmeGwId &gw_id, const NvmeGroupKey& group_key, bool &propose_pending)
 {
   int rc = 0;
   auto& gws_states = created_gws[group_key];
   auto  gw_state = gws_states.find(gw_id);
   if (gw_state != gws_states.end()) {
-    dout(10) << "GW- no subsystems configured " << gw_id << dendl;
+    dout(10) << "GW-id no subsystems configured " << gw_id << dendl;
     auto& st = gw_state->second;
+    if (st.availability == gw_availability_t::GW_CREATED) {
+       dout(20) << "GW-id was already in Created state " <<gw_id << dendl;
+       return 0;
+    }
     st.availability = gw_availability_t::GW_CREATED;
     for (auto& state_itr: created_gws[group_key][gw_id].sm_state) {
       fsm_handle_gw_no_subsystems(

--- a/src/mon/NVMeofGwMap.h
+++ b/src/mon/NVMeofGwMap.h
@@ -111,7 +111,7 @@ public:
   int process_gw_map_gw_down(
     const NvmeGwId &gw_id, const NvmeGroupKey& group_key,
     bool &propose_pending);
-  int process_gw_map_gw_no_subsys_no_listeners(
+  int process_gw_map_gw_pass_to_created(
     const NvmeGwId &gw_id, const NvmeGroupKey& group_key,
     bool &propose_pending);
   void update_active_timers(bool &propose_pending);

--- a/src/mon/NVMeofGwMon.cc
+++ b/src/mon/NVMeofGwMon.cc
@@ -691,8 +691,7 @@ bool NVMeofGwMon::prepare_command(MonOpRequestRef op)
       if (rc == 0) {
         bool propose = false;
         // Simulate  immediate Failover of this GW
-        process_gw_down(id, group_key, propose,
-           gw_availability_t::GW_UNAVAILABLE);
+        process_gw_down(id, group_key, propose);
         pending_map.check_all_gws_in_deleting_state(id, group_key);
       } else if (rc == -EINVAL) {
 	dout (4) << "Error: GW not found in the database " << id << " "
@@ -851,20 +850,14 @@ bool NVMeofGwMon::prepare_command(MonOpRequestRef op)
 }
 
 void NVMeofGwMon::process_gw_down(const NvmeGwId &gw_id,
-   const NvmeGroupKey& group_key, bool &propose_pending,
-   gw_availability_t avail)
+   const NvmeGroupKey& group_key, bool &propose_pending)
 {
   LastBeacon lb = {gw_id, group_key};
   auto it = last_beacon.find(lb);
   if (it != last_beacon.end()) {
     last_beacon.erase(it);
-    if (avail == gw_availability_t::GW_UNAVAILABLE) {
-      pending_map.process_gw_map_gw_down(gw_id, group_key, propose_pending);
-    } else {
-      pending_map.process_gw_map_gw_no_subsys_no_listeners(gw_id, group_key, propose_pending);
-    }
-
   }
+  pending_map.process_gw_map_gw_down(gw_id, group_key, propose_pending);
 }
 
 bool NVMeofGwMon::preprocess_beacon(MonOpRequestRef op)
@@ -1124,7 +1117,8 @@ bool NVMeofGwMon::prepare_beacon(MonOpRequestRef op)
 	dout(1) << " Warning :GW marked as Available in the NVmeofGwMon "
 		<< "database, performed full startup - Apply it but don't allow failover!"
 		<< gw_id << dendl;
-	 process_gw_down(gw_id, group_key, gw_propose, avail);
+	 pending_map.process_gw_map_gw_pass_to_created
+                               (gw_id, group_key, gw_propose);
 	 pending_map.skip_failovers_for_group(group_key);
 	 dout(4) << "fast_reboot:set skip-failovers for group " << gw_id << " group "
 	 << group_key << dendl;
@@ -1222,9 +1216,13 @@ check_availability:
     epoch_t last_osd_epoch = m->get_last_osd_epoch();
     pending_map.process_gw_map_ka(gw_id, group_key, last_osd_epoch, gw_propose);
   // state set by GW client application
-  } else if (avail == gw_availability_t::GW_UNAVAILABLE ||
-      avail == gw_availability_t::GW_CREATED) {
-      process_gw_down(gw_id, group_key, gw_propose, avail);
+  } else if (avail == gw_availability_t::GW_UNAVAILABLE) {
+    process_gw_down(gw_id, group_key, gw_propose);
+  } else if (avail == gw_availability_t::GW_CREATED) {
+    LastBeacon lb = {gw_id, group_key};
+    last_beacon[lb] = now;
+    pending_map.process_gw_map_gw_pass_to_created
+      (gw_id, group_key, gw_propose);
   }
   // Periodic: check active FSM timers
   pending_map.update_active_timers(timer_propose);

--- a/src/mon/NVMeofGwMon.h
+++ b/src/mon/NVMeofGwMon.h
@@ -92,8 +92,7 @@ public:
 private:
   void synchronize_last_beacon();
   void process_gw_down(const NvmeGwId &gw_id,
-     const NvmeGroupKey& group_key, bool &propose_pending,
-     gw_availability_t avail);
+     const NvmeGroupKey& group_key, bool &propose_pending);
   bool get_gw_by_addr(const  entity_addr_t &sub_addr,
        NvmeGwId &gw_id, NvmeGroupKey& group_key);
   epoch_t get_ack_map_epoch(bool gw_created, const NvmeGroupKey& group_key);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78388

---

backport of https://github.com/ceph/ceph/pull/69616
parent tracker: https://tracker.ceph.com/issues/78386

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh