### PR TITLE
umbrella: mgr/cephadm: Add degraded namespace flag to NVMEoF spec file

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
@@ -53,6 +53,7 @@ force_tls = {{ spec.force_tls }}
 # This is a development flag, do not change it
 max_message_length_in_mb = {{ spec.max_message_length_in_mb }}
 io_stats_enabled = {{ spec.io_stats_enabled }}
+degrade_namespace_on_kmip_error = {{ spec.degrade_namespace_on_kmip_error }}
 
 [gateway-logs]
 log_level = {{ spec.log_level }}

--- a/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
@@ -150,6 +150,7 @@ force_tls = False
 # This is a development flag, do not change it
 max_message_length_in_mb = 4
 io_stats_enabled = True
+degrade_namespace_on_kmip_error = True
 
 [gateway-logs]
 log_level = INFO
@@ -400,6 +401,7 @@ force_tls = False
 # This is a development flag, do not change it
 max_message_length_in_mb = 4
 io_stats_enabled = True
+degrade_namespace_on_kmip_error = True
 
 [gateway-logs]
 log_level = INFO
@@ -592,6 +594,7 @@ force_tls = False
 # This is a development flag, do not change it
 max_message_length_in_mb = 4
 io_stats_enabled = True
+degrade_namespace_on_kmip_error = True
 
 [gateway-logs]
 log_level = INFO

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1896,6 +1896,7 @@ class NvmeofServiceSpec(ServiceSpec):
                  force_tls: Optional[bool] = False,
                  max_message_length_in_mb: Optional[int] = 4,
                  io_stats_enabled: Optional[bool] = True,
+                 degrade_namespace_on_kmip_error: Optional[bool] = True,
                  server_key: Optional[str] = None,
                  server_cert: Optional[str] = None,
                  client_key: Optional[str] = None,
@@ -2055,6 +2056,8 @@ class NvmeofServiceSpec(ServiceSpec):
         self.max_message_length_in_mb = max_message_length_in_mb
         #: ``io_stats_enabled`` enables controller IO statistics
         self.io_stats_enabled = io_stats_enabled
+        #: ``degrade_namespace_on_kmip_error`` on a KMIP key error in update, create a degraded ns
+        self.degrade_namespace_on_kmip_error = degrade_namespace_on_kmip_error
         #: ``allowed_consecutive_spdk_ping_failures`` # of ping failures before aborting gateway
         self.allowed_consecutive_spdk_ping_failures = allowed_consecutive_spdk_ping_failures
         #: ``spdk_ping_interval_in_seconds`` sleep interval in seconds between SPDK pings
@@ -2304,6 +2307,7 @@ class NvmeofServiceSpec(ServiceSpec):
         verify_boolean(self.force_tls, "Force TLS")
         verify_positive_int(self.max_message_length_in_mb, "Max protocol message length")
         verify_boolean(self.io_stats_enabled, "Enable IO statistics")
+        verify_boolean(self.degrade_namespace_on_kmip_error, "Degrade namespace on KMIP error")
         verify_non_negative_number(self.monitor_timeout, "Monitor timeout")
         verify_non_negative_int(self.port, "Port")
         verify_non_negative_int(self.discovery_port, "Discovery port")


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78404

---

backport of https://github.com/ceph/ceph/pull/69632
parent tracker: https://tracker.ceph.com/issues/77556

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh