### PR TITLE
ui: implement native dashboard for RBD overview

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
@@ -111,6 +111,7 @@ import { NvmeofGatewayGroupDeleteGuardModalComponent } from './nvmeof-gateway-gr
 import { NvmeofSetupCardsComponent } from './nvmeof-setup-cards/nvmeof-setup-cards.component';
 import { NvmeofGatewayGroupFilterComponent } from './nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component';
 import { NvmeofEditAuthenticationComponent } from './nvmeof-edit-authentication/nvmeof-edit-authentication.component';
+import { PerformanceCardComponent } from '~/app/shared/components/performance-card/performance-card.component';
 
 @NgModule({
   imports: [
@@ -123,6 +124,7 @@ import { NvmeofEditAuthenticationComponent } from './nvmeof-edit-authentication/
     NgbTooltipModule,
     PipesModule,
     SharedModule,
+    PerformanceCardComponent,
     RouterModule,
     TreeviewModule,
     UIShellModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-performance/rbd-performance.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-performance/rbd-performance.component.html
@@ -1,11 +1,134 @@
 <cd-rbd-tabs></cd-rbd-tabs>
 
-<cd-grafana
-  i18n-title
-  title="RBD overview"
-  [grafanaPath]="'ceph-block-overview?'"
-  [type]="'metrics'"
-  uid="41FrpeUiz"
-  grafanaStyle="two"
+<main
+  cdsGrid
+  [fullWidth]="true"
+  [narrow]="true"
+  class="rbd-overview cds-mt-5"
 >
-</cd-grafana>
+  <!-- TIER 1: Summary Cards -->
+  <div
+    cdsRow
+    class="cds-mb-5"
+  >
+    <div
+      cdsCol
+      [columnNumbers]="{ lg: 16 }"
+    >
+      <cd-productive-card [applyShadow]="false">
+        <ng-template #header>
+          <h2
+            class="cds--type-heading-compact-02"
+            i18n
+          >
+            RBD Overview
+          </h2>
+        </ng-template>
+
+        <ng-container *ngIf="loading">
+          <cds-skeleton-text [lines]="3"></cds-skeleton-text>
+        </ng-container>
+        
+        <ng-container *ngIf="!loading">
+          <div class="rbd-overview-grid">
+            <div class="rbd-overview-grid__item">
+              <span
+                class="cds--type-label-01"
+                i18n
+                >Pools</span
+              >
+              <a
+                class="cds--link cds--type-body-compact-01"
+                routerLink="/block/rbd"
+                >{{ totalPools }}</a
+              >
+            </div>
+            <div class="rbd-overview-grid__item">
+              <span
+                class="cds--type-label-01"
+                i18n
+                >Images</span
+              >
+              <a
+                class="cds--link cds--type-body-compact-01"
+                routerLink="/block/rbd"
+                >{{ totalImages }}</a
+              >
+            </div>
+            <div class="rbd-overview-grid__item">
+              <span
+                class="cds--type-label-01"
+                i18n
+                >Namespaces</span
+              >
+              <a
+                class="cds--link cds--type-body-compact-01"
+                routerLink="/block/rbd/namespaces"
+                >{{ totalNamespaces }}</a
+              >
+            </div>
+            <div class="rbd-overview-grid__item">
+              <span
+                class="cds--type-label-01"
+                i18n
+                >Trash Images</span
+              >
+              <a
+                class="cds--link cds--type-body-compact-01"
+                routerLink="/block/rbd/trash"
+                >{{ totalTrashImages }}</a
+              >
+            </div>
+          </div>
+        </ng-container>
+      </cd-productive-card>
+    </div>
+  </div>
+
+  <!-- TIER 2: Performance Row (Native Charts) -->
+  <div
+    cdsRow
+    class="cds-mb-5"
+  >
+    <div
+      cdsCol
+      [columnNumbers]="{ lg: 16 }"
+    >
+      <cd-performance-card></cd-performance-card>
+    </div>
+  </div>
+
+  <!-- TIER 3: Replication / Mirroring Status -->
+  <div cdsRow>
+    <div
+      cdsCol
+      [columnNumbers]="{ lg: 16 }"
+    >
+      <cd-productive-card [applyShadow]="false">
+        <ng-template #header>
+          <h2
+            class="cds--type-heading-compact-02"
+            i18n
+          >
+            Mirroring Status
+          </h2>
+        </ng-template>
+
+        <div class="mirroring-summary">
+          <p class="cds--type-body-compact-01" i18n>
+            Replication status is managed at the pool and image levels. To check or configure mirroring, please visit the RBD image details or mirroring management page.
+          </p>
+          <div>
+            <a
+              cdsLink
+              routerLink="/block/mirroring"
+              i18n
+            >
+              Go to Mirroring Settings →
+            </a>
+          </div>
+        </div>
+      </cd-productive-card>
+    </div>
+  </div>
+</main>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-performance/rbd-performance.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-performance/rbd-performance.component.scss
@@ -1,0 +1,18 @@
+.rbd-overview-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  row-gap: var(--cds-spacing-06);
+  column-gap: var(--cds-spacing-07);
+
+  &__item {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cds-spacing-02);
+  }
+}
+
+.mirroring-summary {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cds-spacing-03);
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-performance/rbd-performance.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-performance/rbd-performance.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
 
 import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 
@@ -8,23 +9,71 @@ import { SharedModule } from '~/app/shared/shared.module';
 import { configureTestBed } from '~/testing/unit-test-helper';
 import { RbdTabsComponent } from '../rbd-tabs/rbd-tabs.component';
 import { RbdPerformanceComponent } from './rbd-performance.component';
+import { RbdService } from '~/app/shared/api/rbd.service';
+import { PoolService } from '~/app/shared/api/pool.service';
+import { PerformanceCardComponent } from '~/app/shared/components/performance-card/performance-card.component';
 
 describe('RbdPerformanceComponent', () => {
   let component: RbdPerformanceComponent;
   let fixture: ComponentFixture<RbdPerformanceComponent>;
+  let rbdService: RbdService;
+  let poolService: PoolService;
 
   configureTestBed({
-    imports: [HttpClientTestingModule, RouterTestingModule, SharedModule, NgbNavModule],
+    imports: [
+      HttpClientTestingModule,
+      RouterTestingModule,
+      SharedModule,
+      NgbNavModule,
+      PerformanceCardComponent
+    ],
     declarations: [RbdPerformanceComponent, RbdTabsComponent]
   });
 
   beforeEach(() => {
+    rbdService = TestBed.inject(RbdService);
+    poolService = TestBed.inject(PoolService);
+
+    spyOn(rbdService, 'list').and.returnValue(
+      of([
+        { pool_name: 'pool1', value: [{ name: 'img1' }, { name: 'img2' }] },
+        { pool_name: 'pool2', value: [{ name: 'img3' }] }
+      ])
+    );
+    spyOn(rbdService, 'listTrash').and.returnValue(of([{ name: 'trash1' }]));
+    spyOn(poolService, 'list').and.returnValue(
+      Promise.resolve([
+        { pool_name: 'pool1', type: 'replicated', application_metadata: ['rbd'] },
+        { pool_name: 'pool2', type: 'replicated', application_metadata: ['rbd'] }
+      ])
+    );
+    spyOn(rbdService, 'isRBDPool').and.callFake(() => true);
+    spyOn(rbdService, 'listNamespaces').and.callFake((poolName: string) => {
+      if (poolName === 'pool1') {
+        return of([{ namespace: 'ns1' }]);
+      }
+      return of([]);
+    });
+
     fixture = TestBed.createComponent(RbdPerformanceComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
   });
+
+  it('should calculate counts correctly', fakeAsync(() => {
+    fixture.detectChanges();
+    tick(); // resolve the pool list promise
+    fixture.detectChanges();
+    tick(); // resolve listNamespaces forkJoin observables
+
+    expect(component.totalPools).toBe(2);
+    expect(component.totalImages).toBe(3);
+    expect(component.totalTrashImages).toBe(1);
+    expect(component.totalNamespaces).toBe(1);
+    expect(component.loading).toBeFalsy();
+  }));
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-performance/rbd-performance.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-performance/rbd-performance.component.ts
@@ -1,4 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { forkJoin, Subscription } from 'rxjs';
+import { PoolService } from '~/app/shared/api/pool.service';
+import { RbdService } from '~/app/shared/api/rbd.service';
 
 @Component({
   selector: 'cd-rbd-performance',
@@ -6,4 +9,74 @@ import { Component } from '@angular/core';
   styleUrls: ['./rbd-performance.component.scss'],
   standalone: false
 })
-export class RbdPerformanceComponent {}
+export class RbdPerformanceComponent implements OnInit, OnDestroy {
+  loading = true;
+  totalPools = 0;
+  totalImages = 0;
+  totalNamespaces = 0;
+  totalTrashImages = 0;
+
+  private subscription = new Subscription();
+
+  constructor(
+    private rbdService: RbdService,
+    private poolService: PoolService
+  ) {}
+
+  ngOnInit() {
+    this.refresh();
+  }
+
+  refresh() {
+    this.loading = true;
+    
+    const rbdList$ = this.rbdService.list({});
+    const trashList$ = this.rbdService.listTrash();
+    const pools$ = this.poolService.list(['pool_name', 'type', 'application_metadata']);
+
+    this.subscription.add(
+      forkJoin([rbdList$, trashList$, pools$]).subscribe(
+        ([rbdPools, trashImages, allPools]: [any[], any[], any[]]) => {
+          // Calculate pools and images count
+          this.totalPools = rbdPools.length;
+          this.totalImages = rbdPools.reduce((acc, pool) => acc + (pool.value?.length || 0), 0);
+          
+          // Calculate trash images count
+          this.totalTrashImages = trashImages.reduce((acc, pool) => acc + (pool.value?.length || 0), 0);
+
+          // Fetch namespaces for replicated RBD pools
+          const rbdReplicatedPools = allPools.filter(
+            (pool: any) => this.rbdService.isRBDPool(pool) && pool.type === 'replicated'
+          );
+
+          if (rbdReplicatedPools.length > 0) {
+            const nsQueries = rbdReplicatedPools.map((pool) =>
+              this.rbdService.listNamespaces(pool.pool_name)
+            );
+            this.subscription.add(
+              forkJoin(nsQueries).subscribe(
+                (namespacesList: any[][]) => {
+                  this.totalNamespaces = namespacesList.reduce((acc, ns) => acc + (ns?.length || 0), 0);
+                  this.loading = false;
+                },
+                () => {
+                  this.loading = false;
+                }
+              )
+            );
+          } else {
+            this.totalNamespaces = 0;
+            this.loading = false;
+          }
+        },
+        () => {
+          this.loading = false;
+        }
+      )
+    );
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.html
@@ -43,15 +43,65 @@
         >Performance Details</a
       >
       <ng-template ngbNavContent>
-        <cd-grafana
-          i18n-title
-          title="RGW instance details"
-          [grafanaPath]="'ceph-object-instance-details?var-rgw_servers=rgw.' + serviceId"
-          [type]="'metrics'"
-          uid="x5ARzZtmk"
-          grafanaStyle="one"
+        <div class="cds-mb-4">
+          <cd-time-picker
+            [dropdownSize]="'sm'"
+            [label]="'Time Span'"
+            (selectedTime)="getPrometheusData($event)"
+          ></cd-time-picker>
+        </div>
+        <div
+          cdsGrid
+          [narrow]="true"
+          [condensed]="false"
+          [fullWidth]="true"
         >
-        </cd-grafana>
+          <div
+            cdsRow
+            [narrow]="true"
+          >
+            <div
+              cdsCol
+              class="cds-mb-5"
+              [columnNumbers]="{ lg: 8, md: 8, sm: 12 }"
+            >
+              <cd-area-chart
+                chartTitle="Requests/sec"
+                i18n-chartTitle
+                [dataUnit]="''"
+                [rawData]="requestsChartData"
+              >
+              </cd-area-chart>
+            </div>
+            <div
+              cdsCol
+              class="cds-mb-5"
+              [columnNumbers]="{ lg: 8, md: 8, sm: 12 }"
+            >
+              <cd-area-chart
+                chartTitle="Latency"
+                i18n-chartTitle
+                [dataUnit]="'ms'"
+                [decimals]="2"
+                [rawData]="latencyChartData"
+              >
+              </cd-area-chart>
+            </div>
+            <div
+              cdsCol
+              class="cds-mb-5"
+              [columnNumbers]="{ lg: 16, md: 8, sm: 12 }"
+            >
+              <cd-area-chart
+                chartTitle="Bandwidth"
+                i18n-chartTitle
+                [dataUnit]="'B'"
+                [rawData]="bandwidthChartData"
+              >
+              </cd-area-chart>
+            </div>
+          </div>
+        </div>
       </ng-template>
     </ng-container>
   </nav>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.ts
@@ -1,11 +1,15 @@
-import { Component, Input, OnChanges } from '@angular/core';
+import { Component, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
 
 import _ from 'lodash';
+import { Subscription } from 'rxjs';
 
 import { RgwDaemon } from '~/app/ceph/rgw/models/rgw-daemon';
 import { RgwDaemonService } from '~/app/shared/api/rgw-daemon.service';
 import { Permission } from '~/app/shared/models/permissions';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
+import { PrometheusService } from '~/app/shared/api/prometheus.service';
+import { RefreshIntervalService } from '~/app/shared/services/refresh-interval.service';
+import { ChartPoint } from '~/app/shared/models/area-chart-point';
 
 @Component({
   selector: 'cd-rgw-daemon-details',
@@ -13,26 +17,58 @@ import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
   styleUrls: ['./rgw-daemon-details.component.scss'],
   standalone: false
 })
-export class RgwDaemonDetailsComponent implements OnChanges {
+export class RgwDaemonDetailsComponent implements OnChanges, OnInit, OnDestroy {
   metadata: any;
   serviceId = '';
   serviceMapId = '';
   grafanaPermission: Permission;
+
+  requestsChartData: ChartPoint[] = [];
+  latencyChartData: ChartPoint[] = [];
+  bandwidthChartData: ChartPoint[] = [];
+  
+  private interval = new Subscription();
+  private timerGetPrometheusDataSub: Subscription;
+  private lastTimeSpan: { start: number; end: number; step: number };
 
   @Input()
   selection: RgwDaemon;
 
   constructor(
     private rgwDaemonService: RgwDaemonService,
-    private authStorageService: AuthStorageService
+    private authStorageService: AuthStorageService,
+    private prometheusService: PrometheusService,
+    private refreshIntervalService: RefreshIntervalService
   ) {
     this.grafanaPermission = this.authStorageService.getPermissions().grafana;
+  }
+
+  ngOnInit() {
+    this.interval = this.refreshIntervalService.intervalData$.subscribe(() => {
+      this.getMetaData();
+      if (this.lastTimeSpan) {
+        this.getPrometheusData(this.lastTimeSpan);
+      }
+    });
   }
 
   ngOnChanges() {
     if (this.selection) {
       this.serviceId = this.selection.id;
       this.serviceMapId = this.selection.service_map_id;
+      this.getMetaData();
+      if (this.lastTimeSpan) {
+        this.getPrometheusData(this.lastTimeSpan);
+      }
+    }
+  }
+
+  ngOnDestroy() {
+    if (this.interval) {
+      this.interval.unsubscribe();
+    }
+    if (this.timerGetPrometheusDataSub) {
+      this.timerGetPrometheusDataSub.unsubscribe();
     }
   }
 
@@ -43,5 +79,47 @@ export class RgwDaemonDetailsComponent implements OnChanges {
     this.rgwDaemonService.get(this.serviceId).subscribe((resp: any) => {
       this.metadata = resp['rgw_metadata'];
     });
+  }
+
+  getPrometheusData(time: { start: number; end: number; step: number }) {
+    if (_.isEmpty(this.serviceMapId)) return;
+    this.lastTimeSpan = time;
+    
+    // Extract instance_id from serviceId (e.g., 'data123.ceph-node-00.dpqvin' -> 'dpqvin')
+    const instanceId = this.serviceId.split('.').pop();
+    const customQueries = {
+      RGW_REQUEST_PER_SECOND: `sum(rate(ceph_rgw_req{instance_id="${instanceId}"}[1m]))`,
+      AVG_GET_LATENCY: `(sum(rate(ceph_rgw_op_get_obj_lat_sum{instance_id="${instanceId}"}[1m])) / sum(rate(ceph_rgw_op_get_obj_lat_count{instance_id="${instanceId}"}[1m]))) * 1000`,
+      AVG_PUT_LATENCY: `(sum(rate(ceph_rgw_op_put_obj_lat_sum{instance_id="${instanceId}"}[1m])) / sum(rate(ceph_rgw_op_put_obj_lat_count{instance_id="${instanceId}"}[1m]))) * 1000`,
+      GET_BANDWIDTH: `sum(rate(ceph_rgw_op_get_obj_bytes{instance_id="${instanceId}"}[1m]))`,
+      PUT_BANDWIDTH: `sum(rate(ceph_rgw_op_put_obj_bytes{instance_id="${instanceId}"}[1m]))`
+    };
+
+    if (this.timerGetPrometheusDataSub) {
+      this.timerGetPrometheusDataSub.unsubscribe();
+    }
+    
+    this.timerGetPrometheusDataSub = this.prometheusService
+      .getRangeQueriesData(time, customQueries, true)
+      .subscribe((data) => {
+        this.requestsChartData = [
+          ...this.toSeries(data['RGW_REQUEST_PER_SECOND'] || [], 'Total Requests')
+        ];
+        this.latencyChartData = [
+          ...this.toSeries(data['AVG_GET_LATENCY'] || [], 'GET Latency'),
+          ...this.toSeries(data['AVG_PUT_LATENCY'] || [], 'PUT Latency')
+        ];
+        this.bandwidthChartData = [
+          ...this.toSeries(data['GET_BANDWIDTH'] || [], 'GET Bandwidth'),
+          ...this.toSeries(data['PUT_BANDWIDTH'] || [], 'PUT Bandwidth')
+        ];
+      });
+  }
+
+  private toSeries(metric: [number, string][], label: string): ChartPoint[] {
+    return metric.map(([ts, val]) => ({
+      timestamp: new Date(ts * 1000),
+      values: { [label]: Number(val) }
+    }));
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.html
@@ -29,28 +29,6 @@
 
   <ng-container
     ngbNavItem
-    *ngIf="grafanaPermission.read"
-  >
-    <a
-      ngbNavLink
-      i18n
-      >Overall Performance</a
-    >
-    <ng-template ngbNavContent>
-      <cd-grafana
-        i18n-title
-        title="RGW overview"
-        [grafanaPath]="'ceph-object-overview?'"
-        [type]="'metrics'"
-        uid="WAkugZpiz"
-        grafanaStyle="three"
-      >
-      </cd-grafana>
-    </ng-template>
-  </ng-container>
-
-  <ng-container
-    ngbNavItem
     *ngIf="grafanaPermission.read && isMultiSite"
   >
     <a
@@ -59,15 +37,7 @@
       >Sync Performance</a
     >
     <ng-template ngbNavContent>
-      <cd-grafana
-        i18n-title
-        title="Radosgw sync overview"
-        [grafanaPath]="'ceph-object-sync-overview?'"
-        [type]="'metrics'"
-        uid="rgw-sync-overview"
-        grafanaStyle="two"
-      >
-      </cd-grafana>
+      <!-- Native Sync Performance can be implemented here if needed -->
     </ng-template>
   </ng-container>
 </nav>


### PR DESCRIPTION
This commit replaces the legacy Grafana iframe integration in the Block > Overall Performance tab with a modern, native Carbon Design System dashboard. It introduces a structured 3-tier layout using the shared cd-performance-card component, eliminating iframe SSL/CORS issues while maintaining visual consistency across the UI.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
