### PR TITLE
umbrella: node-proxy: fix NodeProxySpec deserialization from JSON

### DIFF
--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -4263,11 +4263,28 @@ class NodeProxySpec(ServiceSpec):
     def __init__(self,
                  service_type: str,
                  placement: Optional[PlacementSpec] = None,
+                 ssl: Optional[bool] = True,
+                 certificate_source: Optional[str] = None,
+                 unmanaged: bool = False,
+                 preview_only: bool = False,
+                 extra_container_args: Optional[GeneralArgList] = None,
+                 extra_entrypoint_args: Optional[GeneralArgList] = None,
+                 custom_configs: Optional[List[CustomConfig]] = None,
                  ) -> None:
         assert service_type == 'node-proxy'
-        super(NodeProxySpec, self).__init__('node-proxy', placement=placement)
-        self.ssl: bool = True
+        super(NodeProxySpec, self).__init__(
+            'node-proxy',
+            placement=placement,
+            ssl=ssl,
+            certificate_source=certificate_source,
+            unmanaged=unmanaged,
+            preview_only=preview_only,
+            extra_container_args=extra_container_args,
+            extra_entrypoint_args=extra_entrypoint_args,
+            custom_configs=custom_configs,
+        )
         self.validate()
 
 
+yaml.add_representer(NodeProxySpec, ServiceSpec.yaml_representer)
 yaml.add_representer(SMBSpec, ServiceSpec.yaml_representer)

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -15,6 +15,7 @@ from ceph.deployment.service_spec import (
     IngressSpec,
     IscsiServiceSpec,
     NFSServiceSpec,
+    NodeProxySpec,
     OAuth2ProxySpec,
     PlacementSpec,
     PrometheusSpec,
@@ -334,6 +335,18 @@ def test_osd_unmanaged():
 
     dg_spec = ServiceSpec.from_json(osd_spec)
     assert dg_spec.unmanaged == True
+
+
+def test_node_proxy_unmanaged():
+    node_proxy_spec = {"placement": {"host_pattern": "*"},
+                       "service_name": "node-proxy",
+                       "service_type": "node-proxy",
+                       "unmanaged": True}
+
+    spec = ServiceSpec.from_json(node_proxy_spec)
+    assert isinstance(spec, NodeProxySpec)
+    assert spec.unmanaged is True
+    ServiceSpec.from_json(spec.to_json())
 
 
 @pytest.mark.parametrize("y",


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78104

---

backport of https://github.com/ceph/ceph/pull/69882
parent tracker: https://tracker.ceph.com/issues/77874

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests