### PR TITLE
mgr/dashboard : Access denied issue for cephfs-mgr role

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -1176,7 +1176,8 @@ The list of system roles are:
 - **cluster-manager**: allows full permissions for the *hosts*, *osd*,
   *monitor*, *manager*, and *config-opt* scopes.
 - **pool-manager**: allows full permissions for the *pool* scope.
-- **cephfs-manager**: allows full permissions for the *cephfs* scope.
+- **cephfs-manager**: allows full permissions for the *cephfs* scope, and
+  *read* permission for the *hosts* and *pool* scopes.
 
 The list of available roles can be retrieved with the following command:
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.spec.ts
@@ -9,7 +9,9 @@ import { SharedModule } from '~/app/shared/shared.module';
 import { ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { OrchestratorService } from '~/app/shared/api/orchestrator.service';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
+import { PoolService } from '~/app/shared/api/pool.service';
+import { CephfsService } from '~/app/shared/api/cephfs.service';
 import {
   CheckboxModule,
   ComboBoxModule,
@@ -23,6 +25,8 @@ describe('CephfsVolumeFormComponent', () => {
   let fixture: ComponentFixture<CephfsVolumeFormComponent>;
   let formHelper: FormHelper;
   let orchService: OrchestratorService;
+  let poolService: PoolService;
+  let cephfsService: CephfsService;
 
   configureTestBed({
     imports: [
@@ -44,6 +48,8 @@ describe('CephfsVolumeFormComponent', () => {
     component = fixture.componentInstance;
     formHelper = new FormHelper(component.form);
     orchService = TestBed.inject(OrchestratorService);
+    poolService = TestBed.inject(PoolService);
+    cephfsService = TestBed.inject(CephfsService);
     spyOn(orchService, 'status').and.returnValue(of({ available: true }));
     fixture.detectChanges();
   });
@@ -134,5 +140,33 @@ describe('CephfsVolumeFormComponent', () => {
       fixture.detectChanges();
       expect(submitButton.nativeElement.disabled).toBeFalsy();
     });
+  });
+
+  describe('pool list error handling when creating', () => {
+    beforeEach(() => {
+      component.editing = false;
+      spyOn(cephfsService, 'getUsedPools').and.returnValue(of([]));
+    });
+
+    it('should treat a 403 on pool list as an empty list', fakeAsync(() => {
+      spyOn(poolService, 'getList').and.returnValue(throwError({ status: 403 }));
+      component.ngOnInit();
+      tick();
+      expect(component.pools).toEqual([]);
+    }));
+
+    it('should propagate non-403 errors from pool list', fakeAsync(() => {
+      const err = { status: 500 };
+      spyOn(poolService, 'getList').and.returnValue(throwError(err));
+      let errorHandled = false;
+      const origSetErrors = component.form.setErrors.bind(component.form);
+      spyOn(component.form, 'setErrors').and.callFake((errors: any) => {
+        if (errors?.cdSubmitButton) errorHandled = true;
+        origSetErrors(errors);
+      });
+      component.ngOnInit();
+      tick();
+      expect(errorHandled).toBeTruthy();
+    }));
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.ts
@@ -4,8 +4,8 @@ import { ActivatedRoute, Router } from '@angular/router';
 import _ from 'lodash';
 
 import { NgbNav, NgbTooltip, NgbTypeahead } from '@ng-bootstrap/ng-bootstrap';
-import { forkJoin, Observable, Subject } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { forkJoin, Observable, of, Subject, throwError } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 
 import { CephfsService } from '~/app/shared/api/cephfs.service';
 import { HostService } from '~/app/shared/api/host.service';
@@ -154,28 +154,39 @@ export class CephfsVolumeFormComponent extends CdForm implements OnInit {
     } else {
       forkJoin({
         usedPools: this.cephfsService.getUsedPools(),
-        pools: this.poolService.getList()
-      }).subscribe(({ usedPools, pools }) => {
-        // filtering pools if
-        // * pool is labelled with cephfs
-        // * its not already used by cephfs
-        // * its not erasure coded
-        // * and only if its empty
-        const filteredPools = Object.values(pools).filter(
-          (pool: Pool) =>
-            this.cephfsService.isCephFsPool(pool) &&
-            !usedPools.includes(pool.pool) &&
-            pool.type !== 'erasure' &&
-            pool.stats.bytes_used.latest === 0
-        );
-        if (filteredPools.length < 2) this.form.get('customPools').disable();
-        this.pools = filteredPools;
-        this.metadatPools = this.dataPools = this.pools;
+        pools: this.poolService
+          .getList()
+          .pipe(catchError((err) => (err.status === 403 ? of([]) : throwError(() => err))))
+      }).subscribe({
+        next: ({ usedPools, pools }) => {
+          // filtering pools if
+          // * pool is labelled with cephfs
+          // * its not already used by cephfs
+          // * its not erasure coded
+          // * and only if its empty
+          const filteredPools = Object.values(pools).filter(
+            (pool: Pool) =>
+              this.cephfsService.isCephFsPool(pool) &&
+              !usedPools.includes(pool.pool) &&
+              pool.type !== 'erasure' &&
+              pool.stats.bytes_used.latest === 0
+          );
+          if (filteredPools.length < 2) this.form.get('customPools').disable();
+          this.pools = filteredPools;
+          this.metadatPools = this.dataPools = this.pools;
+        },
+        error: () => {
+          this.form.setErrors({ cdSubmitButton: true });
+        }
       });
 
       this.hostsAndLabels$ = forkJoin({
-        hosts: this.hostService.getAllHosts(),
-        labels: this.hostService.getLabels()
+        hosts: this.hostService
+          .getAllHosts()
+          .pipe(catchError((err) => (err.status === 403 ? of([]) : throwError(() => err)))),
+        labels: this.hostService
+          .getLabels()
+          .pipe(catchError((err) => (err.status === 403 ? of([]) : throwError(() => err))))
       }).pipe(
         map(({ hosts, labels }) => ({
           hosts: hosts.map((host: Host) => ({ content: host['hostname'] })),

--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -277,6 +277,8 @@ POOL_MGR_ROLE = Role(
 CEPHFS_MGR_ROLE = Role(
     'cephfs-manager', 'allows full permissions for the cephfs scope', {
         Scope.CEPHFS: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
+        Scope.HOSTS: [_P.READ],
+        Scope.POOL: [_P.READ],
         Scope.GRAFANA: [_P.READ],
         Scope.PROMETHEUS: [_P.READ]
     })

--- a/src/pybind/mgr/dashboard/tests/test_access_control.py
+++ b/src/pybind/mgr/dashboard/tests/test_access_control.py
@@ -12,8 +12,8 @@ from mgr_module import ERROR_MSG_EMPTY_INPUT_FILE
 
 from .. import mgr
 from ..security import Permission, Scope
-from ..services.access_control import SYSTEM_ROLES, AccessControlDB, \
-    PasswordPolicy, load_access_control_db, password_hash
+from ..services.access_control import CEPHFS_MGR_ROLE, SYSTEM_ROLES, \
+    AccessControlDB, PasswordPolicy, load_access_control_db, password_hash
 from ..settings import Settings
 from ..tests import CLICommandTestMixin, CmdException
 
@@ -179,6 +179,15 @@ class AccessControlTest(unittest.TestCase, CLICommandTestMixin):
     def test_block_manager_role_has_hosts_read(self):
         role = self.exec_cmd('ac-role-show', rolename='block-manager')
         self.assertEqual(role['scopes_permissions'][Scope.HOSTS], [Permission.READ])
+
+    def test_cephfs_mgr_role_scopes(self):
+        role = self.exec_cmd('ac-role-show', rolename='cephfs-manager')
+        self.assertEqual(role['name'], CEPHFS_MGR_ROLE.name)
+        scopes_perms = role['scopes_permissions']
+        self.assertIn(Scope.HOSTS, scopes_perms)
+        self.assertEqual(scopes_perms[Scope.HOSTS], [Permission.READ])
+        self.assertIn(Scope.POOL, scopes_perms)
+        self.assertEqual(scopes_perms[Scope.POOL], [Permission.READ])
 
     def test_delete_system_role(self):
         with self.assertRaises(CmdException) as ctx:


### PR DESCRIPTION
fixes : https://tracker.ceph.com/issues/78414
Signed-off-by: Abhishek Desai <abhishek.desai1@ibm.com>




<img width="1920" height="387" alt="image" src="https://github.com/user-attachments/assets/93dd95ba-cd1f-42a6-99f4-b0dcd70f3bb5" />


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
