### PR TITLE
cephfs-shell: Add command flags to provide ceph.conf and ceph auth id.

### DIFF
--- a/doc/man/8/cephfs-shell.rst
+++ b/doc/man/8/cephfs-shell.rst
@@ -42,6 +42,14 @@ Options
 
    Path to cephfs-shell.conf
 
+.. option:: -C, --ceph-config FILE
+
+   Path to ceph.conf
+
+.. option:: -I, --ceph-id ID
+
+   Ceph auth client id.
+
 .. option:: -f, --fs FS
 
    Name of filesystem to mount.

--- a/src/tools/cephfs/shell/cephfs-shell
+++ b/src/tools/cephfs/shell/cephfs-shell
@@ -1693,7 +1693,7 @@ def setup_cephfs(args):
     """
     global cephfs
     try:
-        cephfs = libcephfs.LibCephFS(conffile='')
+        cephfs = libcephfs.LibCephFS(conffile=args.ceph_config,auth_id=args.ceph_id)
         cephfs.mount(filesystem_name=args.fs)
     except libcephfs.ObjectNotFound as e:
         print('couldn\'t find ceph configuration not found')
@@ -1770,12 +1770,18 @@ def get_shell_conffile_path(arg_conf=''):
 def manage_args():
     main_parser = argparse.ArgumentParser(description='')
     main_parser.add_argument('-b', '--batch', action='store',
-                             help='Path to CephFS shell script/batch file'
+                             help='Path to CephFS shell script/batch file '
                                   'containing CephFS shell commands',
                              type=str)
     main_parser.add_argument('-c', '--config', action='store',
-                             help='Path to Ceph configuration file.',
+                             help='Path to cephfs-shell configuration file.',
                              type=str)
+    main_parser.add_argument('-C','--ceph-config',action='store',
+                             help='Path to ceph.conf configuration file.',
+                             type=str, default='')
+    main_parser.add_argument('-I','--ceph-id', action='store',
+                             help='Ceph auth id used to connect to cluster.',
+                             type=str, default=None)
     main_parser.add_argument('-f', '--fs', action='store',
                              help='Name of filesystem to mount.',
                              type=str)
@@ -1867,7 +1873,6 @@ if __name__ == '__main__':
     args = manage_args()
 
     shell = CephFSShell()
-    # TODO: perhaps, we should add an option to pass ceph.conf?
     read_shell_conf(shell, get_shell_conffile_path(args.config))
     # XXX: setting shell.exit_code to zero so that in case there are no errors
     # and exceptions, it is not set by any method or function of cephfs-shell


### PR DESCRIPTION
This commit's primary contribution is to add a couple of invocation flags to support using cephfs-shell from a remote machine from the target cluster.

The `-C` or `--ceph-config` flag takes a path to a ceph.conf file. The `-I` or `--ceph-id` flag takes a ceph auth id. Both are used in the initialization of the LibCephFS object.

This responds to a todo in the code (and my own needs), but I haven't found a corresponding tracked issue.
We might want to consider if we need to add a keyring option too. (But I'm not sure I would know how to do so.)  

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

