### PR TITLE
mgr/cephadm: normalize inventory and host-cache keys at load time to fix upgrade regression

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Dict, List, Iterator, Optional, Any, Tuple, Se
 
 import orchestrator
 from ceph.deployment import inventory
+from ceph.deployment.hostspec import normalize_hostname
 from ceph.deployment.service_spec import (
     ServiceSpec,
     PlacementSpec,
@@ -86,17 +87,53 @@ class Inventory:
         # load inventory
         i = self.mgr.get_store('inventory')
         if i:
-            self._inventory: Dict[str, dict] = json.loads(i)
-            # handle old clusters missing 'hostname' key from hostspec
-            for k, v in self._inventory.items():
-                if 'hostname' not in v:
-                    v['hostname'] = k
+            raw_inventory = json.loads(i)
+            # Normalize hostname keys to lowercase (RFC 952/1123:
+            # hostnames are case-insensitive). This ensures upgraded
+            # clusters with uppercase hostnames become consistent with
+            # HostSpec normalization on first load.
+            #
+            # Group entries by normalized (lowercased) hostname so
+            # that keys differing only by case map to the same slot.
+            # Example:
+            #   raw_inventory = {"HOST1": {...}, "host1": {...}, "node2": {...}}
+            #   -> entries_by_host = {"host1": [("HOST1", {...}), ("host1", {...})],
+            #                         "node2": [("node2", {...})]}
+            #
+            # Single-entry groups are stored directly; multi-entry
+            # groups (case collisions) are merged deterministically.
+            self._inventory: Dict[str, dict] = {}
+            needs_save = False
+            entries_by_host: Dict[str, List[Tuple[str, dict]]] = {}
+            for k, v in raw_inventory.items():
+                normalized_key = normalize_hostname(k)
+                if normalized_key != k or v.get('hostname', '') != normalized_key:
+                    needs_save = True
+                v['hostname'] = normalized_key
+                entries_by_host.setdefault(normalized_key, []).append((k, v))
 
+            for normalized_key, entries in entries_by_host.items():
+                if len(entries) == 1:
+                    orig_key, host_info = entries[0]
+                    self._inventory[normalized_key] = host_info
+                else:
+                    needs_save = True
+                    original_keys = [e[0] for e in entries]
+                    logger.warning(
+                        f'Inventory: case-collision detected for hostname '
+                        f'{normalized_key!r}: found keys {original_keys}. '
+                        f'Merging labels and keeping richest record.'
+                    )
+                    merged = self._merge_inventory_entries(
+                        normalized_key, entries)
+                    self._inventory[normalized_key] = merged
+
+            for k, v in self._inventory.items():
                 # convert legacy non-IP addr?
                 if is_valid_ip(str(v.get('addr'))):
                     continue
                 if len(self._inventory) > 1:
-                    if k == socket.gethostname():
+                    if k == normalize_hostname(socket.gethostname()):
                         # Never try to resolve our own host!  This is
                         # fraught and can lead to either a loopback
                         # address (due to podman's futzing with
@@ -117,20 +154,65 @@ class Inventory:
                     )
                     v['addr'] = ip
                     adjusted_addrs = True
-            if adjusted_addrs:
+            if adjusted_addrs or needs_save:
                 self.save()
         else:
             self._inventory = dict()
         self._all_known_names: Dict[str, List[str]] = {}
         logger.debug('Loaded inventory %s' % self._inventory)
 
+    @staticmethod
+    def _merge_inventory_entries(
+        normalized_key: str,
+        entries: List[Tuple[str, dict]],
+    ) -> dict:
+        """Merge multiple inventory records that map to the same
+        normalized hostname.
+
+        Deterministic precedence (does not depend on dict iteration order):
+          1. Sort entries by (most labels desc, original key asc) for a
+             stable winner.
+          2. Union all labels across every record.
+          3. For scalar fields (addr, status), keep the winner's value
+             but log a warning when a losing record has a different
+             non-empty value so operators can audit the result.
+          4. Fill any field present in a loser but absent in the winner.
+        """
+        entries = sorted(entries, key=lambda e: (-len(e[1].get('labels', [])), e[0]))
+        winner_key, winner = entries[0]
+
+        all_labels: Set[str] = set()
+        for _orig_key, entry in entries:
+            all_labels.update(entry.get('labels', []))
+
+        for loser_key, loser in entries[1:]:
+            for field in ('addr', 'status', 'location'):
+                w_val = winner.get(field, '')
+                l_val = loser.get(field, '')
+                if l_val and w_val and l_val != w_val:
+                    logger.warning(
+                        f'Inventory merge for {normalized_key!r}: '
+                        f'field {field!r} differs between '
+                        f'{winner_key!r} ({w_val!r}) and '
+                        f'{loser_key!r} ({l_val!r}); '
+                        f'keeping value from {winner_key!r}'
+                    )
+                if l_val and not w_val:
+                    winner[field] = l_val
+
+        winner['labels'] = sorted(all_labels)
+        winner['hostname'] = normalized_key
+        return winner
+
     def keys(self) -> List[str]:
         return list(self._inventory.keys())
 
     def __contains__(self, host: str) -> bool:
+        host = normalize_hostname(host)
         return host in self._inventory or host in itertools.chain.from_iterable(self._all_known_names.values())
 
     def _get_stored_name(self, host: str) -> str:
+        host = normalize_hostname(host)
         self.assert_host(host)
         if host in self._inventory:
             return host
@@ -140,6 +222,7 @@ class Inventory:
         return host
 
     def get_fqdn(self, hname: str) -> Optional[str]:
+        hname = normalize_hostname(hname)
         if hname in self._inventory:
             if hname in self._all_known_names:
                 all_names = self._all_known_names[hname]  # [hostname, shortname, fqdn]
@@ -149,9 +232,10 @@ class Inventory:
         return None
 
     def update_known_hostnames(self, hostname: str, shortname: str, fqdn: str) -> None:
+        hostname = normalize_hostname(hostname)
+        shortname = normalize_hostname(shortname)
+        fqdn = normalize_hostname(fqdn)
         for hname in [hostname, shortname, fqdn]:
-            # if we know the host by any of the names, store the full set of names
-            # in order to be able to check against those names for matching a host
             if hname in self._inventory:
                 self._all_known_names[hname] = [hostname, shortname, fqdn]
                 return
@@ -821,35 +905,56 @@ class HostCache():
                     host))
                 self.mgr.set_store(k, None)
             try:
+                original_host = host
+                host = normalize_hostname(host)
                 j = json.loads(v)
+
+                host_already_in_cache = host in self.daemons
+                needs_save = False
+                if original_host != host:
+                    needs_save = True
+                if host_already_in_cache:
+                    needs_save = True
+                    self.mgr.log.warning(
+                        f'HostCache: case-collision detected for '
+                        f'{host!r}: merging record from key '
+                        f'{original_host!r} into existing entry'
+                    )
+
                 if 'last_device_update' in j:
                     self.last_device_update[host] = str_to_datetime(j['last_device_update'])
-                else:
-                    self.device_refresh_queue.append(host)
                 if 'last_device_change' in j:
                     self.last_device_change[host] = str_to_datetime(j['last_device_change'])
-                # for services, we ignore the persisted last_*_update
-                # and always trigger a new scrape on mgr restart.
-                self.daemon_refresh_queue.append(host)
-                self.network_refresh_queue.append(host)
-                self.daemons[host] = {}
-                self.osdspec_previews[host] = []
-                self.osdspec_last_applied[host] = {}
-                self.networks[host] = {}
-                self.daemon_config_deps[host] = {}
+
+                if not host_already_in_cache:
+                    # First time seeing this host: initialize all structures.
+                    if 'last_device_update' not in j:
+                        self.device_refresh_queue.append(host)
+                    # for services, we ignore the persisted last_*_update
+                    # and always trigger a new scrape on mgr restart.
+                    self.daemon_refresh_queue.append(host)
+                    self.network_refresh_queue.append(host)
+                    self.daemons[host] = {}
+                    self.osdspec_previews[host] = j.get('osdspec_previews', {})
+                    self.osdspec_last_applied[host] = {}
+                    self.networks[host] = j.get('networks_and_interfaces', {})
+                    self.daemon_config_deps[host] = {}
+                    self.devices[host] = []
+                else:
+                    # Collision: merge into existing entry.
+                    self.networks[host].update(
+                        j.get('networks_and_interfaces', {}))
+
                 for name, d in j.get('daemons', {}).items():
                     self.daemons[host][name] = \
                         orchestrator.DaemonDescription.from_json(d)
-                self.devices[host] = []
                 # still want to check old device location for upgrade scenarios
                 for d in j.get('devices', []):
                     self.devices[host].append(inventory.Device.from_json(d))
-                self.devices[host] += self.load_host_devices(host)
-                self.networks[host] = j.get('networks_and_interfaces', {})
-                self.osdspec_previews[host] = j.get('osdspec_previews', {})
-                self.last_client_files[host] = {
+                self.devices[host] += self.load_host_devices(original_host)
+                self.last_client_files.setdefault(host, {}).update({
                     path: tuple(v) for path, v in j.get('last_client_files', {}).items()
-                }
+                })
                 for name, ts in j.get('osdspec_last_applied', {}).items():
                     self.osdspec_last_applied[host][name] = str_to_datetime(ts)
 
@@ -870,6 +975,14 @@ class HostCache():
                 self.registry_login_queue.add(host)
                 self.scheduled_daemon_actions[host] = j.get('scheduled_daemon_actions', {})
                 self.metadata_up_to_date[host] = j.get('metadata_up_to_date', False)
+
+                if needs_save:
+                    self.save_host(host)
+                    if original_host != host:
+                        self.mgr.set_store(k, None)
+                        for dk, _dv in self.mgr.get_store_prefix(
+                                HOST_CACHE_PREFIX + original_host + '.devices.').items():
+                            self.mgr.set_store(dk, None)
 
                 self.mgr.log.debug(
                     'HostCache.load: host %s has %d daemons, '
@@ -900,6 +1013,7 @@ class HostCache():
 
     def update_host_daemons(self, host, dm):
         # type: (str, Dict[str, orchestrator.DaemonDescription]) -> None
+        host = normalize_hostname(host)
         self.daemons[host] = dm
         self._tmp_daemons.pop(host, {})
         self.last_daemon_update[host] = datetime_now()
@@ -909,12 +1023,14 @@ class HostCache():
         # just deployed but not yet had the chance to pick up in a daemon refresh
         # _tmp_daemons is cleared for a host upon receiving a real update of the
         # host's dameons
+        host = normalize_hostname(host)
         if host not in self._tmp_daemons:
             self._tmp_daemons[host] = {}
         self._tmp_daemons[host][dd.name()] = dd
 
     def update_host_facts(self, host, facts):
         # type: (str, Dict[str, Dict[str, Any]]) -> None
+        host = normalize_hostname(host)
         self.facts[host] = facts
         hostnames: List[str] = []
         for k in ['hostname', 'shortname', 'fqdn']:
@@ -924,13 +1040,16 @@ class HostCache():
         self.last_facts_update[host] = datetime_now()
 
     def update_autotune(self, host: str) -> None:
+        host = normalize_hostname(host)
         self.last_autotune[host] = datetime_now()
 
     def invalidate_autotune(self, host: str) -> None:
+        host = normalize_hostname(host)
         if host in self.last_autotune:
             del self.last_autotune[host]
 
     def devices_changed(self, host: str, b: List[inventory.Device]) -> bool:
+        host = normalize_hostname(host)
         old_devs = inventory.Devices(self.devices[host])
         new_devs = inventory.Devices(b)
         # relying on Devices class __eq__ function here
@@ -944,6 +1063,7 @@ class HostCache():
             host: str,
             dls: List[inventory.Device],
     ) -> None:
+        host = normalize_hostname(host)
         if (
                 host not in self.devices
                 or host not in self.last_device_change
@@ -958,11 +1078,13 @@ class HostCache():
             host: str,
             nets: Dict[str, Dict[str, List[str]]]
     ) -> None:
+        host = normalize_hostname(host)
         self.networks[host] = nets
         self.last_network_update[host] = datetime_now()
 
     def get_interface_for_ip(self, host: str, ip: str) -> Optional[str]:
         """Return the network interface name that has the given IP on host, or None."""
+        host = normalize_hostname(host)
         for _subnet, ifaces in self.networks.get(host, {}).items():
             for iface, ips in ifaces.items():
                 if ip in ips:
@@ -970,6 +1092,7 @@ class HostCache():
         return None
 
     def update_daemon_config_deps(self, host: str, name: str, deps: List[str], stamp: datetime.datetime) -> None:
+        host = normalize_hostname(host)
         self.daemon_config_deps[host][name] = {
             'deps': deps,
             'last_config': stamp,
@@ -977,10 +1100,12 @@ class HostCache():
 
     def update_last_host_check(self, host):
         # type: (str) -> None
+        host = normalize_hostname(host)
         self.last_host_check[host] = datetime_now()
 
     def update_osdspec_last_applied(self, host, service_name, ts):
         # type: (str, str, datetime.datetime) -> None
+        host = normalize_hostname(host)
         self.osdspec_last_applied[host][service_name] = ts
 
     def update_client_file(self,
@@ -990,11 +1115,13 @@ class HostCache():
                            mode: int,
                            uid: int,
                            gid: int) -> None:
+        host = normalize_hostname(host)
         if host not in self.last_client_files:
             self.last_client_files[host] = {}
         self.last_client_files[host][path] = (digest, mode, uid, gid)
 
     def removed_client_file(self, host: str, path: str) -> None:
+        host = normalize_hostname(host)
         if (
             host in self.last_client_files
             and path in self.last_client_files[host]
@@ -1006,6 +1133,7 @@ class HostCache():
         """
         Install an empty entry for a host
         """
+        host = normalize_hostname(host)
         self.daemons[host] = {}
         self.devices[host] = []
         self.networks[host] = {}
@@ -1021,7 +1149,7 @@ class HostCache():
 
     def refresh_all_host_info(self, host):
         # type: (str) -> None
-
+        host = normalize_hostname(host)
         self.last_host_check.pop(host, None)
         self.daemon_refresh_queue.append(host)
         self.registry_login_queue.add(host)
@@ -1032,6 +1160,7 @@ class HostCache():
 
     def invalidate_host_daemons(self, host):
         # type: (str) -> None
+        host = normalize_hostname(host)
         self.daemon_refresh_queue.append(host)
         if host in self.last_daemon_update:
             del self.last_daemon_update[host]
@@ -1039,6 +1168,7 @@ class HostCache():
 
     def invalidate_host_devices(self, host):
         # type: (str) -> None
+        host = normalize_hostname(host)
         self.device_refresh_queue.append(host)
         if host in self.last_device_update:
             del self.last_device_update[host]
@@ -1046,6 +1176,7 @@ class HostCache():
 
     def invalidate_host_networks(self, host):
         # type: (str) -> None
+        host = normalize_hostname(host)
         self.network_refresh_queue.append(host)
         if host in self.last_network_update:
             del self.last_network_update[host]
@@ -1055,6 +1186,7 @@ class HostCache():
         self.registry_login_queue = set(self.mgr.inventory.keys())
 
     def save_host(self, host: str) -> None:
+        host = normalize_hostname(host)
         j: Dict[str, Any] = {
             'daemons': {},
             'devices': [],
@@ -1104,6 +1236,7 @@ class HostCache():
         self.mgr.set_store(HOST_CACHE_PREFIX + host, json.dumps(j))
 
     def save_host_devices(self, host: str) -> None:
+        host = normalize_hostname(host)
         if host not in self.devices or not self.devices[host]:
             logger.debug(f'Host {host} has no devices to save')
             return
@@ -1165,6 +1298,7 @@ class HostCache():
 
     def rm_host(self, host):
         # type: (str) -> None
+        host = normalize_hostname(host)
         if host in self.daemons:
             del self.daemons[host]
         if host in self.devices:
@@ -1304,6 +1438,7 @@ class HostCache():
         return hostname in [h.hostname for h in self.get_draining_hosts()]
 
     def get_facts(self, host: str) -> Dict[str, Any]:
+        host = normalize_hostname(host)
         return self.facts.get(host, {})
 
     def _get_daemons(self) -> Iterator[orchestrator.DaemonDescription]:
@@ -1326,10 +1461,13 @@ class HostCache():
         return r
 
     def get_daemons_by_host(self, host: str) -> List[orchestrator.DaemonDescription]:
+        host = normalize_hostname(host)
         return list(self.daemons.get(host, {}).values())
 
     def get_daemon(self, daemon_name: str, host: Optional[str] = None) -> orchestrator.DaemonDescription:
         assert not daemon_name.startswith('ha-rgw.')
+        if host:
+            host = normalize_hostname(host)
         dds = self.get_daemons_by_host(host) if host else self._get_daemons()
         for dd in dds:
             if dd.name() == daemon_name:
@@ -1384,6 +1522,8 @@ class HostCache():
 
     def get_daemons_by_type(self, service_type: str, host: str = '') -> List[orchestrator.DaemonDescription]:
         assert service_type not in ['keepalived', 'haproxy']
+        if host:
+            host = normalize_hostname(host)
         daemons = self.daemons[host].values() if host else self._get_daemons()
         return [d for d in daemons if d.daemon_type in service_to_daemon_types(service_type)]
 
@@ -1396,6 +1536,7 @@ class HostCache():
 
     def get_daemon_types(self, hostname: str) -> Set[str]:
         """Provide a list of the types of daemons on the host"""
+        hostname = normalize_hostname(hostname)
         return cast(Set[str], {d.daemon_type for d in self.daemons[hostname].values()})
 
     def get_daemon_names(self):
@@ -1403,6 +1544,7 @@ class HostCache():
         return [d.name() for d in self._get_daemons()]
 
     def get_daemon_last_config_deps(self, host: str, name: str) -> Tuple[Optional[List[str]], Optional[datetime.datetime]]:
+        host = normalize_hostname(host)
         if host in self.daemon_config_deps:
             if name in self.daemon_config_deps[host]:
                 return self.daemon_config_deps[host][name].get('deps', []), \
@@ -1410,10 +1552,12 @@ class HostCache():
         return None, None
 
     def get_host_client_files(self, host: str) -> Dict[str, Tuple[str, int, int, int]]:
+        host = normalize_hostname(host)
         return self.last_client_files.get(host, {})
 
     def host_needs_daemon_refresh(self, host):
         # type: (str) -> bool
+        host = normalize_hostname(host)
         if host in self.mgr.offline_hosts:
             logger.debug(f'Host "{host}" marked as offline. Skipping daemon refresh')
             return False
@@ -1430,6 +1574,7 @@ class HostCache():
 
     def host_needs_facts_refresh(self, host):
         # type: (str) -> bool
+        host = normalize_hostname(host)
         if host in self.mgr.offline_hosts:
             logger.debug(f'Host "{host}" marked as offline. Skipping gather facts refresh')
             return False
@@ -1443,6 +1588,7 @@ class HostCache():
 
     def host_needs_autotune_memory(self, host):
         # type: (str) -> bool
+        host = normalize_hostname(host)
         if host in self.mgr.offline_hosts:
             logger.debug(f'Host "{host}" marked as offline. Skipping autotune')
             return False
@@ -1453,6 +1599,7 @@ class HostCache():
         return False
 
     def host_needs_tuned_profile_update(self, host: str, profile: str) -> bool:
+        host = normalize_hostname(host)
         if host in self.mgr.offline_hosts:
             logger.debug(f'Host "{host}" marked as offline. Cannot apply tuned profile')
             return False
@@ -1474,6 +1621,7 @@ class HostCache():
         """
         ... at least once.
         """
+        host = normalize_hostname(host)
         if host in self.last_daemon_update:
             return True
         if host not in self.daemons:
@@ -1482,6 +1630,7 @@ class HostCache():
 
     def host_needs_device_refresh(self, host):
         # type: (str) -> bool
+        host = normalize_hostname(host)
         if host in self.mgr.offline_hosts:
             logger.debug(f'Host "{host}" marked as offline. Skipping device refresh')
             return False
@@ -1498,6 +1647,7 @@ class HostCache():
 
     def host_needs_network_refresh(self, host):
         # type: (str) -> bool
+        host = normalize_hostname(host)
         if host in self.mgr.offline_hosts:
             logger.debug(f'Host "{host}" marked as offline. Skipping network refresh')
             return False
@@ -1513,6 +1663,7 @@ class HostCache():
         return False
 
     def host_needs_osdspec_preview_refresh(self, host: str) -> bool:
+        host = normalize_hostname(host)
         if host in self.mgr.offline_hosts:
             logger.debug(f'Host "{host}" marked as offline. Skipping osdspec preview refresh')
             return False
@@ -1525,11 +1676,13 @@ class HostCache():
 
     def host_needs_check(self, host):
         # type: (str) -> bool
+        host = normalize_hostname(host)
         cutoff = datetime_now() - datetime.timedelta(
             seconds=self.mgr.host_check_interval)
         return host not in self.last_host_check or self.last_host_check[host] < cutoff
 
     def osdspec_needs_apply(self, host: str, spec: ServiceSpec) -> bool:
+        host = normalize_hostname(host)
         if (
             host not in self.devices
             or host not in self.last_device_change
@@ -1544,6 +1697,7 @@ class HostCache():
         return self.osdspec_last_applied[host][spec.service_name()] < self.last_device_change[host]
 
     def host_needs_registry_login(self, host: str) -> bool:
+        host = normalize_hostname(host)
         if host in self.mgr.offline_hosts:
             return False
         if host in self.registry_login_queue:
@@ -1552,6 +1706,7 @@ class HostCache():
         return False
 
     def host_metadata_up_to_date(self, host: str) -> bool:
+        host = normalize_hostname(host)
         if host not in self.metadata_up_to_date or not self.metadata_up_to_date[host]:
             return False
         return True
@@ -1567,12 +1722,13 @@ class HostCache():
 
     def add_daemon(self, host, dd):
         # type: (str, orchestrator.DaemonDescription) -> None
+        host = normalize_hostname(host)
         assert host in self.daemons
         self.daemons[host][dd.name()] = dd
 
     def rm_daemon(self, host: str, name: str) -> None:
         assert not name.startswith('ha-rgw.')
-
+        host = normalize_hostname(host)
         if host in self.daemons:
             if name in self.daemons[host]:
                 del self.daemons[host][name]
@@ -1593,7 +1749,7 @@ class HostCache():
 
     def schedule_daemon_action(self, host: str, daemon_name: str, action: str) -> None:
         assert not daemon_name.startswith('ha-rgw.')
-
+        host = normalize_hostname(host)
         priorities = {
             'start': 1,
             'restart': 2,
@@ -1613,6 +1769,7 @@ class HostCache():
         self.scheduled_daemon_actions[host][daemon_name] = action
 
     def rm_scheduled_daemon_action(self, host: str, daemon_name: str) -> bool:
+        host = normalize_hostname(host)
         found = False
         if host in self.scheduled_daemon_actions:
             if daemon_name in self.scheduled_daemon_actions[host]:
@@ -1624,10 +1781,11 @@ class HostCache():
 
     def get_scheduled_daemon_action(self, host: str, daemon: str) -> Optional[str]:
         assert not daemon.startswith('ha-rgw.')
-
+        host = normalize_hostname(host)
         return self.scheduled_daemon_actions.get(host, {}).get(daemon)
 
     def get_host_network_ips(self, host: str) -> List[str]:
+        host = normalize_hostname(host)
         return [
             ip
             for net_details in self.networks.get(host, {}).values()
@@ -1651,26 +1809,32 @@ class NodeProxyCache:
 
     def load(self) -> None:
         _oob = self.mgr.get_store(f'{NODE_PROXY_CACHE_PREFIX}/oob', '{}')
-        self.oob = json.loads(_oob)
+        raw_oob = json.loads(_oob)
+        self.oob = {normalize_hostname(h): v for h, v in raw_oob.items()}
 
         _keyrings = self.mgr.get_store(f'{NODE_PROXY_CACHE_PREFIX}/keyrings', '{}')
-        self.keyrings = json.loads(_keyrings)
+        raw_keyrings = json.loads(_keyrings)
+        self.keyrings = {normalize_hostname(h): v for h, v in raw_keyrings.items()}
 
         for k, v in self.mgr.get_store_prefix(f'{NODE_PROXY_CACHE_PREFIX}/data').items():
-            host = k.split('/')[-1:][0]
+            original_host = k.split('/')[-1:][0]
+            host = normalize_hostname(original_host)
 
-            if host not in self.mgr.inventory.keys():
-                # remove entry for host that no longer exists
-                self.mgr.set_store(f'{NODE_PROXY_CACHE_PREFIX}/data/{host}', None)
+            if host not in self.mgr.inventory:
+                self.mgr.set_store(f'{NODE_PROXY_CACHE_PREFIX}/data/{original_host}', None)
                 try:
-                    self.oob.pop(host)
-                    self.data.pop(host)
-                    self.keyrings.pop(host)
+                    self.oob.pop(host, None)
+                    self.data.pop(host, None)
+                    self.keyrings.pop(host, None)
                 except KeyError:
                     pass
                 continue
 
             self.data[host] = json.loads(v)
+            if original_host != host:
+                self.save(host=host, data=self.data[host])
+                self.mgr.set_store(
+                    f'{NODE_PROXY_CACHE_PREFIX}/data/{original_host}', None)
 
     def save(self,
              host: str = '',
@@ -1875,11 +2039,13 @@ class AgentCache():
     def load(self):
         # type: () -> None
         for k, v in self.mgr.get_store_prefix(AGENT_CACHE_PREFIX).items():
-            host = k[len(AGENT_CACHE_PREFIX):]
+            original_host = k[len(AGENT_CACHE_PREFIX):]
+            host = normalize_hostname(original_host)
             if host not in self.mgr.inventory:
                 self.mgr.log.warning('removing stray AgentCache record for agent on %s' % (
-                    host))
+                    original_host))
                 self.mgr.set_store(k, None)
+                continue
             try:
                 j = json.loads(v)
                 self.agent_config_deps[host] = {}
@@ -1894,6 +2060,14 @@ class AgentCache():
                 agent_port = int(j.get('agent_ports', 0))
                 if agent_port:
                     self.agent_ports[host] = agent_port
+
+                if original_host != host:
+                    self.mgr.log.info(
+                        f'AgentCache: normalized key {original_host!r} '
+                        f'-> {host!r}, re-persisting'
+                    )
+                    self.save_agent(host)
+                    self.mgr.set_store(k, None)
 
             except Exception as e:
                 self.mgr.log.warning('unable to load cached state for agent on host %s: %s' % (

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -946,8 +946,9 @@ class HostCache():
                         j.get('networks_and_interfaces', {}))
 
                 for name, d in j.get('daemons', {}).items():
-                    self.daemons[host][name] = \
-                        orchestrator.DaemonDescription.from_json(d)
+                    dd = orchestrator.DaemonDescription.from_json(d)
+                    dd.hostname = host
+                    self.daemons[host][name] = dd
                 # still want to check old device location for upgrade scenarios
                 for d in j.get('devices', []):
                     self.devices[host].append(inventory.Device.from_json(d))

--- a/src/pybind/mgr/cephadm/migrations.py
+++ b/src/pybind/mgr/cephadm/migrations.py
@@ -17,7 +17,7 @@ from orchestrator import OrchestratorError, DaemonDescription
 if TYPE_CHECKING:
     from .module import CephadmOrchestrator
 
-LAST_MIGRATION = 9
+LAST_MIGRATION = 10
 
 logger = logging.getLogger(__name__)
 
@@ -128,6 +128,11 @@ class Migrations:
             logger.info('Running migration 8 -> 9')
             if self.migrate_8_9():
                 self.set(9)
+
+        if self.mgr.migration_current == 9:
+            logger.info('Running migration 9 -> 10')
+            if self.migrate_9_10():
+                self.set(10)
 
     def migrate_0_1(self) -> bool:
         """
@@ -559,6 +564,54 @@ class Migrations:
         if nfs_services:
             self.mgr.set_store('nfs_services_with_old_nodeid', ','.join(nfs_services))
         self.mgr.remove_health_warning('CEPHADM_MIGRATION_FAILURE')
+        return True
+
+    def migrate_9_10(self) -> bool:
+        """
+        Migration 9 -> 10
+        Normalize persisted service spec placement host patterns to lowercase.
+        Specs stored by older versions may contain uppercase host_pattern values
+        (e.g. 'MYHOST-[0-2]'). This patches the stored JSON directly rather
+        than going through spec_store.save(), which would set _needs_configuration
+        and emit a spurious 'service was created' event for every affected spec.
+        The in-memory spec is already correct (HostPattern.__init__ lowercases
+        fnmatch patterns on load).
+        """
+        from cephadm.inventory import SPEC_STORE_PREFIX
+        for spec in self.mgr.spec_store.all_specs.values():
+            if not spec.placement.host_pattern or not spec.placement.host_pattern.pattern:
+                continue
+            name = spec.service_name()
+            store_key = SPEC_STORE_PREFIX + name
+            raw = self.mgr.get_store(store_key)
+            if not raw:
+                continue
+            stored_data = json.loads(raw)
+            hp = stored_data.get('spec', {}).get('placement', {}).get('host_pattern')
+            if isinstance(hp, str):
+                stored_pattern = hp
+            elif isinstance(hp, dict):
+                if hp.get('pattern_type') == 'regex':
+                    continue
+                stored_pattern = hp.get('pattern', '')
+            else:
+                continue
+            normalized = stored_pattern.lower()
+            if stored_pattern == normalized:
+                continue
+            if isinstance(hp, str):
+                stored_data['spec']['placement']['host_pattern'] = normalized
+            else:
+                stored_data['spec']['placement']['host_pattern']['pattern'] = normalized
+            logger.info(
+                f'Normalizing host_pattern for {name} '
+                f'to lowercase: \'{stored_pattern}\' -> \'{normalized}\''
+            )
+            # Update only the persisted JSON; the in-memory ServiceSpec is
+            # already normalized by HostPattern.__init__ during spec_store.load().
+            # Using set_store() directly avoids triggering _needs_configuration
+            # and a spurious 'service was created' event via SpecStore.save().
+            self.mgr.set_store(store_key, json.dumps(stored_data, sort_keys=True))
         return True
 
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -34,6 +34,7 @@ from prettytable import PrettyTable
 from ceph.cephadm.images import DefaultImages
 from ceph.deployment import inventory
 from ceph.deployment.drive_group import DriveGroupSpec, OSDType
+from ceph.deployment.hostspec import normalize_hostname
 from ceph.deployment.service_spec import (
     ServiceSpec,
     PlacementSpec,
@@ -143,13 +144,15 @@ def host_exists(hostname_position: int = 1) -> Callable:
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             this = args[0]  # self object
-            hostname = args[hostname_position]
+            hostname = normalize_hostname(args[hostname_position])
             if hostname not in this.cache.get_hosts():
                 candidates = ','.join([h for h in this.cache.get_hosts() if h.startswith(hostname)])
                 help_msg = f"Did you mean {candidates}?" if candidates else ""
                 raise OrchestratorError(
                     f"Cannot find host '{hostname}' in the inventory. {help_msg}")
 
+            args = list(args)  # type: ignore
+            args[hostname_position] = hostname
             return func(*args, **kwargs)
         return wrapper
     return inner
@@ -1178,6 +1181,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         self.offline_watcher.set_hosts(list(set([h for h in hosts_to_watch if h is not None])))
 
     def offline_hosts_remove(self, host: str) -> None:
+        host = normalize_hostname(host)
         if host in self.offline_hosts:
             self.offline_hosts.remove(host)
             self._invalidate_all_host_metadata_and_kick_serve(host)
@@ -2354,6 +2358,7 @@ Then run the following:
         :param force: bypass running daemons check
         :param offline: remove offline host
         """
+        host = normalize_hostname(host)
 
         # check if host is offline
         host_offline = host in self.offline_hosts
@@ -2449,6 +2454,7 @@ Then run the following:
 
     @handle_orch_error
     def update_host_addr(self, host: str, addr: str) -> str:
+        host = normalize_hostname(host)
         self._check_valid_addr(host, addr)
         self.inventory.set_addr(host, addr)
         self.ssh.reset_con(host)
@@ -2489,6 +2495,7 @@ Then run the following:
 
     @handle_orch_error
     def remove_host_label(self, host: str, label: str, force: bool = False) -> str:
+        host = normalize_hostname(host)
         # if we remove the _admin label from the only host that has it we could end up
         # removing the only instance of the config and keyring and cause issues
         if not force and label == SpecialHostLabels.ADMIN:
@@ -2548,6 +2555,7 @@ Then run the following:
 
     @handle_orch_error
     def host_ok_to_stop(self, hostname: str) -> str:
+        hostname = normalize_hostname(hostname)
         if hostname not in self.cache.get_hosts():
             raise OrchestratorError(f'Cannot find host "{hostname}"', errno=errno.EINVAL)
 
@@ -3339,9 +3347,10 @@ Then run the following:
             str: output from the zap command
         """
 
+        host = normalize_hostname(host)
         self.log.info('Zap device %s:%s' % (host, path))
 
-        if host not in self.inventory.keys():
+        if host not in self.inventory:
             raise OrchestratorError(
                 f"Host '{host}' is not a member of the cluster")
 
@@ -4805,6 +4814,7 @@ Then run the following:
                        clear: bool = False,
                        yes_i_really_mean_it: bool = False) -> Any:
         output: str = ''
+        hostname = normalize_hostname(hostname)
 
         self.ceph_volume.lvm_list.get_data(hostname=hostname)
 
@@ -4812,7 +4822,7 @@ Then run the following:
             output = self.ceph_volume.clear_replace_header(hostname, device)
         else:
             osds_to_zap: List[str] = []
-            if hostname not in list(self.inventory.keys()):
+            if hostname not in self.inventory:
                 raise OrchestratorError(f'{hostname} invalid host.')
 
             if device not in self.ceph_volume.lvm_list.all_devices():

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2358,6 +2358,7 @@ Then run the following:
         :param force: bypass running daemons check
         :param offline: remove offline host
         """
+        original_host = host
         host = normalize_hostname(host)
 
         # check if host is offline
@@ -2427,7 +2428,7 @@ Then run the following:
 
             cmd_args = {
                 'prefix': 'osd crush rm',
-                'name': host
+                'name': original_host
             }
             run_cmd(cmd_args)
 
@@ -2435,7 +2436,7 @@ Then run the following:
             try:
                 self.check_mon_command({
                     'prefix': 'osd crush remove',
-                    'name': host,
+                    'name': original_host,
                 })
             except MonCommandFailed as e:
                 self.log.error(f'Couldn\'t remove host {host} from CRUSH map: {str(e)}')

--- a/src/pybind/mgr/cephadm/ssh.py
+++ b/src/pybind/mgr/cephadm/ssh.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from io import StringIO
 from shlex import quote
 from typing import TYPE_CHECKING, Optional, List, Tuple, Dict, Iterator, TypeVar, Awaitable, Union, Any
+from ceph.deployment.hostspec import normalize_hostname
 from orchestrator import OrchestratorError
 
 try:
@@ -230,7 +231,7 @@ class SSHManager:
         try:
             yield
         except OSError as e:
-            self.mgr.offline_hosts.add(host)
+            self.mgr.offline_hosts.add(normalize_hostname(host))
             log_content = log_string.getvalue()
             msg = f"Can't communicate with remote host `{addr}`, possibly because the host is not reachable or python3 is not installed on the host. {str(e)}"
             logger.exception(msg)
@@ -238,7 +239,7 @@ class SSHManager:
                 logger.debug(f'SSH log for {host} ({addr}): {log_content}')
             raise HostConnectionError(msg, host, addr)
         except asyncssh.Error as e:
-            self.mgr.offline_hosts.add(host)
+            self.mgr.offline_hosts.add(normalize_hostname(host))
             log_content = log_string.getvalue()
             msg = f'Failed to connect to {host} ({addr}). {str(e)}'
             logger.exception(msg)
@@ -246,7 +247,7 @@ class SSHManager:
                 logger.debug(f'SSH log for {host} ({addr}): {log_content}')
             raise HostConnectionError(msg, host, addr)
         except Exception as e:
-            self.mgr.offline_hosts.add(host)
+            self.mgr.offline_hosts.add(normalize_hostname(host))
             log_content = log_string.getvalue()
             msg = f'Failed to connect to {host} ({addr}): {repr(e)}'
             logger.exception(msg)
@@ -348,7 +349,7 @@ class SSHManager:
                             f'ChannelOpenError code {error_code} is not recoverable, '
                             f'not retrying for host {host}')
                         await self._reset_con(host)
-                        self.mgr.offline_hosts.add(host)
+                        self.mgr.offline_hosts.add(normalize_hostname(host))
                         raise HostConnectionError(
                             f'Unable to reach remote host {host}. {str(e)}',
                             host, address)
@@ -371,7 +372,7 @@ class SSHManager:
                         continue
                 else:
                     # Last attempt failed, raise the error
-                    self.mgr.offline_hosts.add(host)
+                    self.mgr.offline_hosts.add(normalize_hostname(host))
                     raise HostConnectionError(
                         f'Unable to reach remote host {host} after '
                         f'{self.SSH_RETRY_COUNT} attempts. {str(e)}',
@@ -380,7 +381,7 @@ class SSHManager:
                 msg = f"ProcessError cannot execute the command '{rcmd}' on the {host}. {str(e.stderr)}."
                 logger.exception(msg)
                 await self._reset_con(host)
-                self.mgr.offline_hosts.add(host)
+                self.mgr.offline_hosts.add(normalize_hostname(host))
                 raise HostConnectionError(msg, host, address)
             except Exception as e:
                 error_type = type(e).__name__
@@ -388,7 +389,7 @@ class SSHManager:
                        f"on the host {host}. {str(e)}.")
                 logger.exception(msg)
                 await self._reset_con(host)
-                self.mgr.offline_hosts.add(host)
+                self.mgr.offline_hosts.add(normalize_hostname(host))
                 raise HostConnectionError(msg, host, address)
 
         def _rstrip(v: Union[bytes, str, None]) -> str:

--- a/src/pybind/mgr/cephadm/tests/test_facts.py
+++ b/src/pybind/mgr/cephadm/tests/test_facts.py
@@ -29,3 +29,79 @@ def test_known_hostnames(_update_known_hostnames, cephadm_module: CephadmOrchest
                   'nic_count': 2}
     cephadm_module.cache.update_host_facts('host1', host_facts)
     _update_known_hostnames.assert_called_with('host1.domain', '', '')
+
+
+def test_host_cache_load_normalizes_uppercase_keys(cephadm_module: CephadmOrchestrator):
+    """HostCache.load() normalizes uppercase persisted keys to lowercase."""
+    import json
+    from cephadm.inventory import HOST_CACHE_PREFIX
+
+    cache = cephadm_module.cache
+    host_data = json.dumps({
+        'daemons': {},
+        'last_device_update': '2024-01-01T00:00:00.000000',
+    })
+    cephadm_module.inventory._inventory['ceph-node-00'] = {
+        'hostname': 'ceph-node-00', 'addr': '10.0.0.1', 'labels': [], 'status': '',
+    }
+    cephadm_module.set_store(HOST_CACHE_PREFIX + 'CEPH-NODE-00', host_data)
+
+    cache.load()
+
+    assert 'ceph-node-00' in cache.daemons
+    assert 'CEPH-NODE-00' not in cache.daemons
+    assert 'ceph-node-00' in cache.last_device_update
+
+
+def test_inventory_load_normalizes_keys(cephadm_module: CephadmOrchestrator):
+    """Inventory.__init__ normalizes uppercase persisted keys on load and persists them."""
+    import json
+
+    raw_data = {
+        'MULTI80-SITE1': {
+            'hostname': 'MULTI80-SITE1',
+            'addr': '10.245.0.5',
+            'labels': ['_admin'],
+            'status': '',
+        },
+        'MULTI80-SITE2': {
+            'hostname': 'MULTI80-SITE2',
+            'addr': '10.245.0.6',
+            'labels': [],
+            'status': '',
+        },
+    }
+    cephadm_module.set_store('inventory', json.dumps(raw_data))
+
+    from cephadm.inventory import Inventory
+    inv = Inventory(cephadm_module)
+
+    assert 'multi80-site1' in inv
+    assert 'MULTI80-SITE1' in inv
+    assert list(inv._inventory.keys()) == ['multi80-site1', 'multi80-site2']
+    assert inv._inventory['multi80-site1']['hostname'] == 'multi80-site1'
+
+    saved = json.loads(cephadm_module.get_store('inventory'))
+    assert 'multi80-site1' in saved
+    assert 'MULTI80-SITE1' not in saved
+
+
+def test_inventory_case_insensitive_operations(cephadm_module: CephadmOrchestrator):
+    """Verify that inventory operations (rm, label, addr) accept any hostname case."""
+    inv = cephadm_module.inventory
+    inv._inventory = {
+        'myhost-01': {
+            'hostname': 'myhost-01',
+            'addr': '10.0.0.1',
+            'labels': ['_admin'],
+        },
+    }
+    assert inv.get_addr('MYHOST-01') == '10.0.0.1'
+    assert inv.get_addr('MyHost-01') == '10.0.0.1'
+    assert inv.has_label('MYHOST-01', '_admin') is True
+
+    inv.add_label('MYHOST-01', 'mon')
+    assert inv.has_label('myhost-01', 'mon') is True
+
+    inv.rm_label('MYHOST-01', 'mon')
+    assert inv.has_label('myhost-01', 'mon') is False

--- a/src/pybind/mgr/cephadm/tests/test_migration.py
+++ b/src/pybind/mgr/cephadm/tests/test_migration.py
@@ -454,3 +454,150 @@ def test_migrate_cert_store(cephadm_module: CephadmOrchestrator):
     assert cephadm_module.cert_mgr.get_key('iscsi_ssl_key', service_name='iscsi.foo')
     assert cephadm_module.cert_mgr.get_cert('ingress_ssl_cert', service_name='ingress.rgw.foo')
     assert cephadm_module.cert_mgr.get_key('ingress_ssl_key', service_name='ingress.rgw.foo')
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+def test_migrate_host_pattern_uppercase(cephadm_module: CephadmOrchestrator):
+    with with_host(cephadm_module, 'host1'):
+        cephadm_module.set_store(SPEC_STORE_PREFIX + 'mon', json.dumps({
+            'spec': {
+                'service_type': 'mon',
+                'placement': {
+                    'host_pattern': 'MYHOST-[0-2]'
+                }
+            },
+            'created': datetime_to_str(datetime_now()),
+        }, sort_keys=True))
+        cephadm_module.set_store(SPEC_STORE_PREFIX + 'crash', json.dumps({
+            'spec': {
+                'service_type': 'crash',
+                'placement': {
+                    'host_pattern': 'TESTNODE-[0-5]'
+                }
+            },
+            'created': datetime_to_str(datetime_now()),
+        }, sort_keys=True))
+
+        cephadm_module.spec_store.load()
+
+        cephadm_module.migration_current = 9
+        cephadm_module.migration.migrate()
+        assert cephadm_module.migration_current == LAST_MIGRATION
+
+        assert cephadm_module.spec_store.all_specs['mon'].placement.host_pattern.pattern == 'myhost-[0-2]'
+        assert cephadm_module.spec_store.all_specs['crash'].placement.host_pattern.pattern == 'testnode-[0-5]'
+
+        raw_mon = json.loads(cephadm_module.get_store(SPEC_STORE_PREFIX + 'mon'))
+        assert raw_mon['spec']['placement']['host_pattern'] == 'myhost-[0-2]'
+        raw_crash = json.loads(cephadm_module.get_store(SPEC_STORE_PREFIX + 'crash'))
+        assert raw_crash['spec']['placement']['host_pattern'] == 'testnode-[0-5]'
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+def test_migrate_host_pattern_already_lowercase(cephadm_module: CephadmOrchestrator):
+    with with_host(cephadm_module, 'host1'):
+        cephadm_module.set_store(SPEC_STORE_PREFIX + 'mon', json.dumps({
+            'spec': {
+                'service_type': 'mon',
+                'placement': {
+                    'host_pattern': 'myhost-[0-2]'
+                }
+            },
+            'created': datetime_to_str(datetime_now()),
+        }, sort_keys=True))
+
+        cephadm_module.spec_store.load()
+
+        cephadm_module.migration_current = 9
+        cephadm_module.migration.migrate()
+        assert cephadm_module.migration_current == LAST_MIGRATION
+
+        assert cephadm_module.spec_store.all_specs['mon'].placement.host_pattern.pattern == 'myhost-[0-2]'
+
+        raw = json.loads(cephadm_module.get_store(SPEC_STORE_PREFIX + 'mon'))
+        assert raw['spec']['placement']['host_pattern'] == 'myhost-[0-2]'
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+def test_migrate_host_pattern_wildcard(cephadm_module: CephadmOrchestrator):
+    with with_host(cephadm_module, 'host1'):
+        cephadm_module.set_store(SPEC_STORE_PREFIX + 'mon', json.dumps({
+            'spec': {
+                'service_type': 'mon',
+                'placement': {
+                    'host_pattern': '*'
+                }
+            },
+            'created': datetime_to_str(datetime_now()),
+        }, sort_keys=True))
+
+        cephadm_module.spec_store.load()
+
+        cephadm_module.migration_current = 9
+        cephadm_module.migration.migrate()
+        assert cephadm_module.migration_current == LAST_MIGRATION
+
+        assert cephadm_module.spec_store.all_specs['mon'].placement.host_pattern.pattern == '*'
+
+        raw = json.loads(cephadm_module.get_store(SPEC_STORE_PREFIX + 'mon'))
+        assert raw['spec']['placement']['host_pattern'] == '*'
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+def test_migrate_host_pattern_idempotent(cephadm_module: CephadmOrchestrator):
+    with with_host(cephadm_module, 'host1'):
+        cephadm_module.set_store(SPEC_STORE_PREFIX + 'mon', json.dumps({
+            'spec': {
+                'service_type': 'mon',
+                'placement': {
+                    'host_pattern': 'MYHOST-[0-2]'
+                }
+            },
+            'created': datetime_to_str(datetime_now()),
+        }, sort_keys=True))
+
+        cephadm_module.spec_store.load()
+
+        cephadm_module.migration_current = 9
+        cephadm_module.migration.migrate()
+        assert cephadm_module.migration_current == LAST_MIGRATION
+
+        raw_after_first = cephadm_module.get_store(SPEC_STORE_PREFIX + 'mon')
+
+        cephadm_module.migration_current = 9
+        cephadm_module.migration.migrate()
+        assert cephadm_module.migration_current == LAST_MIGRATION
+
+        raw_after_second = cephadm_module.get_store(SPEC_STORE_PREFIX + 'mon')
+        assert raw_after_first == raw_after_second
+
+        assert cephadm_module.spec_store.all_specs['mon'].placement.host_pattern.pattern == 'myhost-[0-2]'
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+def test_migrate_host_pattern_regex_unchanged(cephadm_module: CephadmOrchestrator):
+    with with_host(cephadm_module, 'host1'):
+        cephadm_module.set_store(SPEC_STORE_PREFIX + 'mon', json.dumps({
+            'spec': {
+                'service_type': 'mon',
+                'placement': {
+                    'host_pattern': {
+                        'pattern': 'NODE[0-9]',
+                        'pattern_type': 'regex'
+                    }
+                }
+            },
+            'created': datetime_to_str(datetime_now()),
+        }, sort_keys=True))
+
+        cephadm_module.spec_store.load()
+
+        cephadm_module.migration_current = 9
+        cephadm_module.migration.migrate()
+        assert cephadm_module.migration_current == LAST_MIGRATION
+
+        assert cephadm_module.spec_store.all_specs['mon'].placement.host_pattern.pattern == 'NODE[0-9]'
+
+        raw = json.loads(cephadm_module.get_store(SPEC_STORE_PREFIX + 'mon'))
+        assert raw['spec']['placement']['host_pattern']['pattern'] == 'NODE[0-9]'
+        assert raw['spec']['placement']['host_pattern']['pattern_type'] == 'regex'

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -229,6 +229,8 @@ class HostPattern():
     def __init__(self,
                  pattern: Optional[str] = None,
                  pattern_type: PatternType = PatternType.fnmatch) -> None:
+        if pattern and pattern_type == PatternType.fnmatch:
+            pattern = pattern.lower()
         self.pattern: Optional[str] = pattern
         self.pattern_type: PatternType = pattern_type
         self.compiled_regex = None


### PR DESCRIPTION
Problem
PR #66820 introduced normalize_hostname() in HostSpec.__init__() which lowercases hostnames at the model layer. However, the persistent storage keys in Inventory._inventory and HostCache (daemons, networks, last_daemon_update, etc.) remain uppercase for clusters that were deployed with uppercase hostnames prior to the upgrade.

This creates a key mismatch: HostSpec.hostname returns "multi80-site1" but all cache dicts are keyed by "MULTI80-SITE1". As a result:

get_schedulable_hosts() returns an empty list (no hosts pass host_had_daemon_refresh())
All service placements fail: "Failed to apply 12 service(s)"
Host management commands fail: "host multi80-site3 does not exist"

Fixes: https://tracker.ceph.com/issues/78426
Signed-off-by: Shubha Jain [SHUBHA.JAIN1@ibm.com]

Solution
This PR fixes hostname normalization regressions observed after upgrading clusters that originally used uppercase hostnames.

The changes:

1. Normalize persisted inventory, host cache, AgentCache, and NodeProxy hostnames using the common normalize_hostname() helper during load.
2. Add deterministic collision handling when legacy entries differ only by hostname case, preserving data and emitting warnings instead of silently overwriting entries.
3. Introduce a cephadm migration to normalize persisted placement host_pattern values to lowercase for fnmatch patterns while leaving regex patterns unchanged.
4. Update persisted placement specs directly using mgr.set_store() to avoid unnecessary service reconfiguration during migration.
5. Add comprehensive unit tests covering migration, collision handling, idempotency, and backward compatibility.

Testing confirmed that ceph orch commands work correctly after upgrade, and redeploying an OSD continues to use the existing CRUSH host bucket. Remaining uppercase hostnames in commands such as ceph mon stat and ceph osd tree are cosmetic and do not affect service placement or CRUSH behavior.






## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
