### PR TITLE
mgr/orchestrator: add required oauth2-proxy CLI parameters

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -2185,6 +2185,10 @@ Usage:
     @OrchestratorCLICommand.Write('orch apply oauth2-proxy')
     def _apply_oauth2_proxy(self,
                             https_address: Optional[str] = None,
+                            provider_display_name: Optional[str] = None,
+                            oidc_issuer_url: Optional[str] = None,
+                            client_id: Optional[str] = None,
+                            client_secret: Optional[str] = None,
                             placement: Optional[str] = None,
                             unmanaged: bool = False,
                             dry_run: bool = False,
@@ -2199,6 +2203,10 @@ Usage:
             placement=PlacementSpec.from_string(placement),
             unmanaged=unmanaged,
             https_address=https_address,
+            provider_display_name=provider_display_name,
+            oidc_issuer_url=oidc_issuer_url,
+            client_id=client_id,
+            client_secret=client_secret,
         )
         spec.preview_only = dry_run
 

--- a/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
@@ -401,6 +401,53 @@ class TestApplyOAuth2Proxy:
         ) in res.stderr
         mock_apply_misc.assert_not_called()
 
+    def test_cli_args_propagated_to_spec(self, mock_apply_misc):
+        mock_apply_misc.return_value = HandleCommandResult(retval=0, stdout="Success")
+
+        res = self.m._apply_oauth2_proxy(
+            provider_display_name="My OIDC Provider",
+            oidc_issuer_url="https://idp.example.com",
+            client_id="oauth-client",
+            client_secret="oauth-secret",
+        )
+
+        assert res.retval == 0
+        mock_apply_misc.assert_called_once()
+        spec = mock_apply_misc.call_args[0][0][0]
+        assert spec.provider_display_name == "My OIDC Provider"
+        assert spec.oidc_issuer_url == "https://idp.example.com"
+        assert spec.client_id == "oauth-client"
+        assert spec.client_secret == "oauth-secret"
+
+    def test_cli_args_with_https_address(self, mock_apply_misc):
+        mock_apply_misc.return_value = HandleCommandResult(retval=0, stdout="Success")
+
+        res = self.m._apply_oauth2_proxy(
+            provider_display_name="My OIDC Provider",
+            oidc_issuer_url="https://idp.example.com",
+            client_id="oauth-client",
+            client_secret="oauth-secret",
+            https_address="gateway.example.com:443",
+        )
+
+        assert res.retval == 0
+        spec = mock_apply_misc.call_args[0][0][0]
+        assert spec.https_address == "gateway.example.com:443"
+        assert spec.provider_display_name == "My OIDC Provider"
+        assert spec.oidc_issuer_url == "https://idp.example.com"
+        assert spec.client_id == "oauth-client"
+        assert spec.client_secret == "oauth-secret"
+
+    def test_partial_cli_args_raises_error(self, mock_apply_misc):
+        res = self.m._apply_oauth2_proxy(
+            provider_display_name="My OIDC Provider",
+            client_id="oauth-client",
+        )
+
+        assert res.retval != 0
+        assert 'Missing required fields for oauth2-proxy' in res.stderr
+        mock_apply_misc.assert_not_called()
+
 
 @mock.patch("orchestrator.module.OrchestratorCli._apply_misc")
 class TestApplyOAuth2ProxyYaml:


### PR DESCRIPTION
## Summary
Follow up PR : https://github.com/ceph/ceph/pull/68699

The `ceph orch apply oauth2-proxy` command previously exposed only
placement-related options, requiring users to use a YAML service spec
to provide the mandatory OAuth2 configuration fields.

This change adds CLI support for the required `OAuth2ProxySpec`
parameters:

- `--provider-display-name`
- `--oidc-issuer-url`
- `--client-id`
- `--client-secret`

The provided values are propagated to `OAuth2ProxySpec`, allowing
oauth2-proxy to be configured directly through the CLI while keeping
the existing YAML-based workflow unchanged.

## Testing

- Added unit tests to verify the new CLI arguments are accepted.
- Verified the CLI arguments are correctly propagated to
  `OAuth2ProxySpec`.
- Confirmed existing behavior remains unchanged when using a YAML
  service specification.
  
  Fixes: https://tracker.ceph.com/issues/76372
Signed-off-by: Shubha Jain [SHUBHA.JAIN1@ibm.com]

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.


## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
