### PR TITLE
ptl-tool: log the ceph-ci push (and the equivalent git command)

### DIFF
--- a/src/script/ptl-tool.py
+++ b/src/script/ptl-tool.py
@@ -2256,8 +2256,10 @@ def build_branch(args):
     if args.push_ci or (not args.no_push_ci and do_qa):
         if not args.dry_run:
             G.git.push(CI_REMOTE_URL, branch) # for shaman
+            log.info("Pushed branch %s to %s (git push %s %s)" % (branch, CI_REMOTE_URL, CI_REMOTE_URL, branch))
             if created_branch and not args.no_tag:
                 G.git.push(CI_REMOTE_URL, tag.name) # for archival
+                log.info("Pushed tag %s to %s (git push %s %s)" % (tag.name, CI_REMOTE_URL, CI_REMOTE_URL, tag.name))
         else:
             log.info("[DRY RUN] Would push branch %s to %s" % (branch, CI_REMOTE_URL))
             if created_branch and not args.no_tag:


### PR DESCRIPTION
## Summary

- Currently, a real (non-dry-run) `ptl-tool.py` run pushes the integration branch and tag to `ceph-ci` silently -- only the `--dry-run` path logs a "[DRY RUN] Would push ..." message.
- Adds matching `log.info()` calls on the real-push path so the push is visible in the run output, and includes the literal `git push <remote> <ref>` command in the message so it can be copy-pasted and re-run manually (e.g. to re-push after a network blip without re-running the whole merge).

## Test plan

- [x] Confirm `--dry-run` output is unchanged
- [x] Run a real `--integration`/`--qe-label` merge and confirm the new `Pushed branch ...` / `Pushed tag ...` lines appear and the embedded `git push` command is copy-pasteable and correct

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
