### PR TITLE
"RADOS fsync", an fsync which does not require MDS participation

### DIFF
--- a/doc/dev/mds_internals/change_attr.rst
+++ b/doc/dev/mds_internals/change_attr.rst
@@ -1,0 +1,66 @@
+Ceph change_attr
+================
+
+The change_attr exists to satisfy the NFS "change" attribute, defined in
+https://www.rfc-editor.org/info/rfc8881/#section-5.8.1.4 . It is exposed as
+the "stx_version" member of a statx struct. NFS defines the change attr as::
+
+  A value created by the server that the client can use to determine if file
+  data, directory contents, or attributes of the object have been modified. The
+  server may return the object's time_metadata attribute for this attribute's
+  value, but only if the file system object cannot be updated more frequently
+  than the resolution of time_metadata.
+
+This is really unfortunate: the implication is that any time we report
+change_attr out to a caller, we have to fully synchronize the change_attr across
+all CephFS clients. It is a "REQUIRED" attribute
+
+Current behavior
+----------------
+change_attr is passed between clients and the MDS using caps traffic. Any time
+an entity receives a new change_attr, it checks and takes the larger value of
+what it currently has, versus what it just received.
+Clients and the MDS freely increment their local change_attr whenever they make
+a change of any kind. It *does not* depend on a particular cap state: as long
+as the Client can make a change to metadata locally, it calls it good and
+increments change_attr. change_attr is incremented in Client::_do_setattr() if
+the Client already had sufficient (ie, X) caps on the necessary attribute, but
+also when completing a write (ie, Fw required, but not Fs nor Fx!)
+
+change_attr is a member of frag_info_t and sr_t; of MClientCaps and
+MClientReply; is embedded in the fscrypt block header; and of inode_t.
+
+In Client::_do_setattr(), it does not explicitty send the MDS new change_attr
+values. Is there something in the make_request() call chain that does that?
+_do_setattr sets up work for Client::encode_cap_releases() with inode_drop, but
+neither that nor Client::encode_inode_release() includes a change_attr value. So
+I am not sure this is quite right, if the Client has exclusive caps: it can make
+a lot of changes locally, but if it runs across one it can't do it has to make
+an MDS request that might increment on a stale change_attr.
+This is pretty hard to make happen, though: it would require the Client to have
+something like pXxFrwxwb but not Ax, and then getting a change on the aut
+values that doesn't trigger other changes. (This may not actually be possible,
+so maybe things work out anyway? It's certainly quite a narrow inaccuracy.) We
+likely need to update this so that the Client can include change_attr in an
+MClientRequest.
+
+The really interesting part is how change_attr is actually exposed. It is only
+available via Client::fill_statx(), with the note::
+  /* Change time and change_attr both require all shared caps to view */
+  if ((mask & CEPH_STAT_CAP_INODE_ALL) == CEPH_STAT_CAP_INODE_ALL) {
+    stx->stx_version = in->change_attr;
+CEPH_STAT_CAP_INODE_ALL is a union of CEPH_CAP_{PIN|AUTH_SHARED|LINK_SHARED|
+FILE_SHARED|XATTR_SHARED}, which...is actually not all caps.
+BUT: every time the Client invokes fill_statx(), it is on a newly-created item,
+after invoking path_walk(), or after invoking _getattr() with the relevant
+mask/caps. So we are following the rules: the MDS does not provide SHARED caps
+if there are multiple writers (we enter MIX modes on the filelock; see locks.c).
+But if there are multiple writers, that means anything which gets the
+change_attr requires an MDS request. That goes into
+Server::handle_client_getattr(), which triggers a client gather stage
+(round-trip to all clients, to get the latest state) by invoking
+Locker::acquire_locks().
+
+The terrible news here is, that means if Ganesha is actually invoking these
+functions and getting a new change_attr, it is triggering that gather on every
+operation.

--- a/doc/dev/mds_internals/rados_fsync.rst
+++ b/doc/dev/mds_internals/rados_fsync.rst
@@ -1,0 +1,119 @@
+============================
+Design Document: RADOS fsync
+============================
+
+1. The problem with fsync
+-------------------------
+Fsync requires commiting to the MDS -- sending the MDS a message, waiting for it
+to successfully journal to RADOS, and then getting an ack back. Besides the
+added latency of going through the MDS, it generates a linear order on cluster
+operations because the journal is strictly ordered. And because the MDS wants to
+satisfy an fsync operation quickly, it stops batching operations and forces a
+journal flush, lowering overall throughput.
+
+In ordinary CephFS usage, this doesn't come up often, because most applications
+do not fsync except at specific and direct need. But there are always edge cases,
+and here the edge case is NFS. NFS can generate an outsized number of fsyncs in
+two specific scenarios we've run across.
+First, NFS clients can mount in "sync" mode, where every single write operation
+is sent to the server (in Ceph's case, a Ganesha daemon -- but this is not
+really specific to Ganesha) with a "stable=2" flag set. This flag means the
+server must persist data and metadata reflecting the write to disk before
+responding to the client.
+Second, if you open a file with O_DIRECT, the Linux NFS client sets that
+"stable=2" flag on all operations for the relevant file, in effect promoting
+it to O_SYNC. This is extremely common behavior when running benchmarks, and is
+also a common operations mode for databases.
+
+2. What does fsync persist to the MDS?
+--------------------------------------
+It persists all metadata, of course. But the only metadata fields which can be
+updated as part of a write() call are mtime, ctime, size and change_attr.
+
+These fields are interesting, because mtime/ctime and size have a special
+property in CephFS: we can in large part recover them from the OSDs.
+
+3. MDS Probing
+--------------
+Whenever a CephFS client crashes, any files it held open and had write caps on
+are added to the RecoveryQueue. Because the client may have updated these files
+and changed their mtime or their size without informing the MDS, these files must
+be "probed" before caps on them can be given to another client.
+
+Probing is implemented in Filer::probe(). When you invoke a prob, it goes out
+and invokes stat() on every object which might be part of the file (ie, from the
+first object in the file up to the maximum size the client was allowed to expand
+the file to). The object stat obviously lets us infer the size of the file and
+include object mtime, which we can use to approximate the mtime/ctime of the file
+as written by the client.
+
+4. What's different after probing?
+----------------------------------
+The file size is inferred from the on-disk RADOS objects. As long as the
+application actually writes data out to the logical EOF, we will set it correctly.
+Happily, any truncate or setattr which changes the size of the file is always
+directed synchronously to the MDS, so if we skip synchronizing the size of a file
+it is always recoverable.
+
+The mtime and ctime are also inferred from the RADOS-level mtime of the underlying
+objects. Unfortunately, these times are NOT the same as the in-memory values
+which the client might have returned on a stat(): the Client updates mtime/ctime
+in Client::_write_success() after the write has completed (either into a buffer,
+or directly to RADOS for synchronous writes).
+
+(RADOS write operations accept an mtime, so we could alter the Client to generate
+an mtime up-front, and attach it on the relevant writes.)
+
+The change_attr is, unfortunately, not persisted and not recoverable from RADOS.
+But I also don't know if it matters in the slightest -- stx_version is not yet
+generally available, and a number of situations where Ganesha could rely on our
+internal change_attr it instead substitutes in the ctime. Update rules in the
+current implementation are also quite strange (individual clients with shared
+caps can separately bump the change_attr, and the MDS tries to reconcile by
+further bumping it when it receives those updates, but it's certainly not a
+single consistent view like our other metadata is!).
+
+5. The Proposal
+---------------
+We should have a config option that does not flush MDS capabilities on an fsync,
+as long as the only dirty bits are those updated by a simple write() call:
+mtime, ctime, size, and change_attr. We can rely on probe() to recover an
+accurate size and a reasonable facsimile of the genuine mtime, and Ganesha as an
+informed user can enable the config option. This is very straightforward:
+in Client::_fsync(), we update the block which invokes check_caps() to simply
+skip over if those are the only dirty caps.
+
+There are some available further enhancements:
+1) we can generate the mtime stamp upfront when doing a write(), and send that
+   timestamp to the OSDs when doing the object write. This will ensure an
+   entirely consistent view of the mtime and ctime. This is also pretty
+   straightforward: all the places where the Client directly writes to RADOS via
+   the ObjectCacher or Objecter, it provides an mtime with ceph::clock::now()!
+   The trickiest bit will be updating the ObjectCacher interface to provide the
+   mtime -- it internally stores a BufferHead::last_write value which is
+   locally generated in ObjectCacher::writex(), but it is easy enough to make
+   that an input parameter.
+   This enhancment lets us preserve mtime exactly, but still does not preserve
+   change_attr or let us avoid the MDS when flushing other metadata.
+2) We can extend the Filer::probe() functionality and interfaces to support
+   fsyncing directly to a RADOS object, and let the Client simply flush out
+   the necessary file data and piggyback any metadata changes on top of that as
+   xattr or omap writes to the file data objects which the MDS then recovers on
+   Client crash. This would let us scale fsync capability directly with data
+   IO capability.
+   This enhancement lets us preserve all metadata without needing to do an MDS
+   commit, but is significantly more complicated at all layers of the stack.
+
+6. Why don't we already have these behaviors?
+---------------------------------------------
+To my knowledge, fsync has not itself been a specific bottleneck before. Far
+more common were issues with file creates such as untar and rsync workloads, or
+workloads which needed to sync across multiple clients. These enhancements would
+not generally improve those situations: they specifically focus on the
+performance of fsync, and anything that requires multi-client synchronization
+will still need to propagate updates to the MDS and wait for it to commit them to
+disk. (In fact, the implementations described here may incidentally *decrease*
+performance in some multi-client workloads, because completing an fsync does not
+mean that a different client will be able to see the update results -- instead,
+the other client attempting to access the file will initiate a separate MDS
+commit that it must wait for.)

--- a/doc/dev/mds_internals/rados_fsync.rst
+++ b/doc/dev/mds_internals/rados_fsync.rst
@@ -121,6 +121,7 @@ We need to build a bunch of internal interfaces for this.
 ------------------
 - Stable mtime.
 - client-side config option enabling us to skip fsync
+- client only enables fsync skip when the MDS supports it
 
 9. Development todo
 -------------------
@@ -128,7 +129,5 @@ We need to build a bunch of internal interfaces for this.
   aren't acknowledged by the MDS. (This covers several bits of metadata and
   scenarios that are otherwise difficult to separate from the caps dirtied by
   a write() call.)
-- implement MDS feature bits shared with the client authorizing it to write
-  out the change_attr to RADOS.
 - Actually write out change_attr to RADOS.
 - Include change_attr param in MClientRequest (for Client::_do_setattr).

--- a/doc/dev/mds_internals/rados_fsync.rst
+++ b/doc/dev/mds_internals/rados_fsync.rst
@@ -124,6 +124,7 @@ We need to build a bunch of internal interfaces for this.
 - client only enables fsync skip when the MDS supports it
 - Track when setattr() is invoked and don't fsync-to-rados when those fields
   aren't acknowledged by the MDS.
+- actually look at change_attr when probing files
 
 9. Development todo
 -------------------

--- a/doc/dev/mds_internals/rados_fsync.rst
+++ b/doc/dev/mds_internals/rados_fsync.rst
@@ -130,6 +130,3 @@ We need to build a bunch of internal interfaces for this.
   scenarios that are otherwise difficult to separate from the caps dirtied by
   a write() call.)
 - Include change_attr param in MClientRequest (for Client::_do_setattr).
-- Right now, we write out change_attr unconditionally. This may have a
-  performance impact. Change that based on client_fsync_to_rados (or
-  another param, for more precise testing options).

--- a/doc/dev/mds_internals/rados_fsync.rst
+++ b/doc/dev/mds_internals/rados_fsync.rst
@@ -129,5 +129,7 @@ We need to build a bunch of internal interfaces for this.
   aren't acknowledged by the MDS. (This covers several bits of metadata and
   scenarios that are otherwise difficult to separate from the caps dirtied by
   a write() call.)
-- Actually write out change_attr to RADOS.
 - Include change_attr param in MClientRequest (for Client::_do_setattr).
+- Right now, we write out change_attr unconditionally. This may have a
+  performance impact. Change that based on client_fsync_to_rados (or
+  another param, for more precise testing options).

--- a/doc/dev/mds_internals/rados_fsync.rst
+++ b/doc/dev/mds_internals/rados_fsync.rst
@@ -117,3 +117,13 @@ performance in some multi-client workloads, because completing an fsync does not
 mean that a different client will be able to see the update results -- instead,
 the other client attempting to access the file will initiate a separate MDS
 commit that it must wait for.)
+
+
+Development todo:
+- Track when we do a write that matches or extends in->size, so that we can do
+an mds fsync if we extend file size without writing to it.
+- is it okay that we don't fsync after somebody sets the
+  CEPH_SETATTR_FSCRYPT_FILE field?
+- is it okay that we don't fsync after somebody sets atime? I didn't think we
+  maintained atime at all, wild.
+- probably I should just track more explicitly on what dirtied the cap

--- a/doc/dev/mds_internals/rados_fsync.rst
+++ b/doc/dev/mds_internals/rados_fsync.rst
@@ -62,13 +62,8 @@ or directly to RADOS for synchronous writes).
 an mtime up-front, and attach it on the relevant writes.)
 
 The change_attr is, unfortunately, not persisted and not recoverable from RADOS.
-But I also don't know if it matters in the slightest -- stx_version is not yet
-generally available, and a number of situations where Ganesha could rely on our
-internal change_attr it instead substitutes in the ctime. Update rules in the
-current implementation are also quite strange (individual clients with shared
-caps can separately bump the change_attr, and the MDS tries to reconcile by
-further bumping it when it receives those updates, but it's certainly not a
-single consistent view like our other metadata is!).
+We would need to extend probe in some fashion to recover change_attribute from
+information the client persists to recover that.
 
 5. The Proposal
 ---------------
@@ -84,7 +79,8 @@ updating the MDS if it has sufficient caps, so we will need to detect that case
 and do a real fsync if we hit it.
 
 There are some available further enhancements:
-1) we can generate the mtime stamp upfront when doing a write(), and send that
+1) [COMPLETED]
+   we can generate the mtime stamp upfront when doing a write(), and send that
    timestamp to the OSDs when doing the object write. This will ensure an
    entirely consistent view of the mtime and ctime. This is also pretty
    straightforward: all the places where the Client directly writes to RADOS via
@@ -93,16 +89,14 @@ There are some available further enhancements:
    mtime -- it internally stores a BufferHead::last_write value which is
    locally generated in ObjectCacher::writex(), but it is easy enough to make
    that an input parameter.
-   This enhancment lets us preserve mtime exactly, but still does not preserve
+   This enhancement lets us preserve mtime exactly, but still does not preserve
    change_attr or let us avoid the MDS when flushing other metadata.
-2) We can extend the Filer::probe() functionality and interfaces to support
-   fsyncing directly to a RADOS object, and let the Client simply flush out
-   the necessary file data and piggyback any metadata changes on top of that as
-   xattr or omap writes to the file data objects which the MDS then recovers on
-   Client crash. This would let us scale fsync capability directly with data
-   IO capability.
-   This enhancement lets us preserve all metadata without needing to do an MDS
-   commit, but is significantly more complicated at all layers of the stack.
+2) We can persist the change_attr to a rados xattr and update it using compound
+   operations alongside the write. (This DOES NOT need to be a conditional write
+   like I previously thought it would: if there are multiple writers, the file
+   is in MIX mode and change_attr won't be exposed to clients without cycling
+   through lock states and updating from all the clients.)
+
 
 6. Why don't we already have these behaviors?
 ---------------------------------------------
@@ -118,12 +112,23 @@ mean that a different client will be able to see the update results -- instead,
 the other client attempting to access the file will initiate a separate MDS
 commit that it must wait for.)
 
+7. Implementing fsync-metadata-to-RADOS
+---------------------------------------
+We need to build a bunch of internal interfaces for this.
 
-Development todo:
-- Track when we do a write that matches or extends in->size, so that we can do
-an mds fsync if we extend file size without writing to it.
-- is it okay that we don't fsync after somebody sets the
-  CEPH_SETATTR_FSCRYPT_FILE field?
-- is it okay that we don't fsync after somebody sets atime? I didn't think we
-  maintained atime at all, wild.
-- probably I should just track more explicitly on what dirtied the cap
+
+8. Completed tasks
+------------------
+- Stable mtime.
+- client-side config option enabling us to skip fsync
+
+9. Development todo
+-------------------
+- Track when setattr() is invoked and don't fsync-to-rados when those fields
+  aren't acknowledged by the MDS. (This covers several bits of metadata and
+  scenarios that are otherwise difficult to separate from the caps dirtied by
+  a write() call.)
+- implement MDS feature bits shared with the client authorizing it to write
+  out the change_attr to RADOS.
+- Actually write out change_attr to RADOS.
+- Include change_attr param in MClientRequest (for Client::_do_setattr).

--- a/doc/dev/mds_internals/rados_fsync.rst
+++ b/doc/dev/mds_internals/rados_fsync.rst
@@ -51,9 +51,6 @@ as written by the client.
 ----------------------------------
 The file size is inferred from the on-disk RADOS objects. As long as the
 application actually writes data out to the logical EOF, we will set it correctly.
-Happily, any truncate or setattr which changes the size of the file is always
-directed synchronously to the MDS, so if we skip synchronizing the size of a file
-it is always recoverable.
 
 The mtime and ctime are also inferred from the RADOS-level mtime of the underlying
 objects. Unfortunately, these times are NOT the same as the in-memory values
@@ -82,6 +79,9 @@ accurate size and a reasonable facsimile of the genuine mtime, and Ganesha as an
 informed user can enable the config option. This is very straightforward:
 in Client::_fsync(), we update the block which invokes check_caps() to simply
 skip over if those are the only dirty caps.
+Annoyingly, a client can extend file size via setattr without immediately
+updating the MDS if it has sufficient caps, so we will need to detect that case
+and do a real fsync if we hit it.
 
 There are some available further enhancements:
 1) we can generate the mtime stamp upfront when doing a write(), and send that

--- a/doc/dev/mds_internals/rados_fsync.rst
+++ b/doc/dev/mds_internals/rados_fsync.rst
@@ -122,11 +122,9 @@ We need to build a bunch of internal interfaces for this.
 - Stable mtime.
 - client-side config option enabling us to skip fsync
 - client only enables fsync skip when the MDS supports it
+- Track when setattr() is invoked and don't fsync-to-rados when those fields
+  aren't acknowledged by the MDS.
 
 9. Development todo
 -------------------
-- Track when setattr() is invoked and don't fsync-to-rados when those fields
-  aren't acknowledged by the MDS. (This covers several bits of metadata and
-  scenarios that are otherwise difficult to separate from the caps dirtied by
-  a write() call.)
 - Include change_attr param in MClientRequest (for Client::_do_setattr).

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12235,7 +12235,8 @@ int Client::_preadv_pwritev(int fd, const struct iovec *iov, int iovcnt,
                                   onfinish, blp);
 }
 
-int64_t Client::_write_success(Fh *f, utime_t start, uint64_t fpos,
+int64_t Client::_write_success(Fh *f, utime_t start, utime_t op_mtime,
+                               uint64_t fpos,
                                int64_t request_offset, uint64_t request_size,
                                int64_t offset, uint64_t size, Inode *in,
                                bool encrypted)
@@ -12283,7 +12284,7 @@ int64_t Client::_write_success(Fh *f, utime_t start, uint64_t fpos,
   }
 
   // mtime
-  in->mtime = in->ctime = ceph_clock_now();
+  in->mtime = in->ctime = op_mtime;
   in->change_attr++;
   in->mark_caps_dirty(CEPH_CAP_FILE_WR);
 
@@ -12311,7 +12312,8 @@ void Client::C_Write_Finisher::finish_io(int r)
       }
     }
 
-    r = clnt->_write_success(f, start, fpos, req_ofs, req_size, offset, size, in, encrypted);
+    r = clnt->_write_success(f, start, op_mtime, fpos, req_ofs, req_size,
+                             offset, size, in, encrypted);
   }
 
   iofinished = true;
@@ -12391,15 +12393,17 @@ bool Client::C_Write_Finisher::try_complete()
 
 Client::WriteEncMgr::WriteEncMgr(Client *clnt,
                                  Fh *f, int64_t offset, uint64_t size,
+                                 const utime_t& w_mtime,
                                  bufferlist& bl,
                                  bool async) : clnt(clnt), whoami(clnt->whoami),
-                                                   cct(clnt->cct),
+                                               cct(clnt->cct),
 #if defined(__linux__)
-						   fscrypt(clnt->fscrypt.get()),
+                                               fscrypt(clnt->fscrypt.get()),
 #endif
-     						   f(f), in(f->inode.get()),
-                                                   offset(offset), size(size), bl(bl),
-                                                   async(async)
+                                               f(f), in(f->inode.get()),
+                                               offset(offset), size(size),
+                                               mtime(w_mtime), bl(bl),
+                                               async(async)
 {
 #if defined(__linux__)
   denc = fscrypt->get_fdata_denc(in->fscrypt_ctx, &in->fscrypt_key_validator);
@@ -12656,7 +12660,7 @@ int Client::WriteEncMgr_Buffered::do_write()
   // async, caching, non-blocking.
   r = clnt->objectcacher->file_write(&in->oset, &in->layout,
                                      in->snaprealm->get_snap_context(),
-                                     offset, size, *pbl, ceph::real_clock::now(),
+                                     offset, size, *pbl, mtime.to_real_time(),
                                      0, iofinish,
                                      !async
                                      ? clnt->objectcacher->CFG_block_writes_upfront()
@@ -12671,7 +12675,7 @@ int Client::WriteEncMgr_NotBuffered::do_write()
   clnt->get_cap_ref(in, CEPH_CAP_FILE_BUFFER);
 
   clnt->filer->write_trunc(in->ino, &in->layout, in->snaprealm->get_snap_context(),
-                           offset, size, *pbl, ceph::real_clock::now(), 0,
+                           offset, size, *pbl, mtime.to_real_time(), 0,
                            in->truncate_size, in->truncate_seq,
                            iofinish);
 
@@ -12741,6 +12745,7 @@ int64_t Client::_write(Fh *f, int64_t offset, uint64_t size, bufferlist bl,
 
   // time it.
   utime_t start = mono_clock_now();
+  utime_t op_mtime = ceph_clock_now();
 
   if (in->inline_version == 0) {
     int r = _getattr(in, CEPH_STAT_CAP_INLINE_DATA, f->actor_perms, true);
@@ -12778,11 +12783,11 @@ int64_t Client::_write(Fh *f, int64_t offset, uint64_t size, bufferlist bl,
 
   if (buffered_write) {
     enc_mgr = ceph::make_ref<WriteEncMgr_Buffered>(this, f,
-						   offset, size, bl,
+						   offset, size, op_mtime, bl,
 						   !!onfinish);
   } else {
     enc_mgr = ceph::make_ref<WriteEncMgr_NotBuffered>(this, f,
-						      offset, size, bl,
+						      offset, size, op_mtime, bl,
 						      !!onfinish);
   }
 
@@ -12839,7 +12844,7 @@ int64_t Client::_write(Fh *f, int64_t offset, uint64_t size, bufferlist bl,
                         cct->_conf->client_oc &&
                           (have & (CEPH_CAP_FILE_BUFFER |
                                  CEPH_CAP_FILE_LAZYIO)),
-                        f, in, fpos,
+                        op_mtime, f, in, fpos,
                         request_offset, request_size,
                         offset, size,
                         do_fsync, syncdataonly, enc_mgr->encrypted()));
@@ -12959,7 +12964,8 @@ success:
 
   // do not get here if non-blocking caller (onfinish != nullptr)
   ldout(cct, 10) << " _write_filer_succeess" << dendl;
-  r = _write_success(f, start, fpos, request_offset, request_size, enc_mgr->get_ofs(), enc_mgr->get_size(), in, enc_mgr->encrypted());
+  r = _write_success(f, start, op_mtime, fpos, request_offset, request_size,
+                     enc_mgr->get_ofs(), enc_mgr->get_size(), in, enc_mgr->encrypted());
 
   if (r >= 0 && do_fsync) {
     int64_t r1;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -13299,8 +13299,19 @@ int Client::_fsync(Inode *in, bool syncdataonly)
     _flush(in, object_cacher_completion.get());
     ldout(cct, 15) << "using return-valued form of _fsync" << dendl;
   }
-  
+  bool mds_flush = false;
   if (!syncdataonly && in->dirty_caps) {
+    if (cct->_conf->client_fsync_to_rados &&
+        in->inline_version == CEPH_INLINE_NONE &&
+        !(in->dirty_caps & ~CEPH_CAP_FILE_WR & ~CEPH_CAP_FILE_EXCL)) {
+      // we don't need to sync to the MDS when we we can recover
+      // everything via Filer::probe()
+      mds_flush = false;
+    } else {
+      mds_flush = true;
+    }
+  }
+  if (mds_flush) {
     check_caps(in, CHECK_CAPS_NODELAY|CHECK_CAPS_SYNCHRONOUS);
     if (in->flushing_caps)
       flush_tid = last_flush_tid;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12680,7 +12680,7 @@ int Client::WriteEncMgr_NotBuffered::do_write()
   clnt->filer->write_trunc(in->ino, &in->layout, in->snaprealm->get_snap_context(),
                            offset, size, *pbl, mtime.to_real_time(), 0,
                            in->truncate_size, in->truncate_seq,
-                           iofinish);
+                           iofinish, 0 /*op_flags*/, in->change_attr);
 
   return 0;
 }

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -405,7 +405,8 @@ Client::Client(Messenger *m, MonClient *mc, Objecter *objecter_)
     objecter_finisher(m->cct),
     m_command_hook(this),
     fscid(0),
-    subvolume_tracker{std::make_unique<SubvolumeMetricTracker>(cct, whoami)}
+    subvolume_tracker{std::make_unique<SubvolumeMetricTracker>(cct, whoami)},
+    do_rados_fsync(false)
 {
   /* We only use the locale for normalization/case folding. That is unaffected
    * by the locale but required by the API.
@@ -2654,10 +2655,12 @@ void Client::_closed_mds_session(MetaSession *s, int err, bool rejected)
     mds_sessions.erase(s->mds_num);
 }
 
-static void reinit_mds_features(MetaSession *session,
-				const MConstRef<MClientSession>& m) {
+void Client::reinit_mds_features(MetaSession *session,
+                                        const MConstRef<MClientSession>& m) {
   session->mds_features = std::move(m->supported_features);
   session->mds_metric_flags = std::move(m->metric_spec.metric_flags);
+  do_rados_fsync = session->mds_features.test(CEPHFS_FEATURE_RADOS_FSYNC) &&
+    cct->_conf.get_val<bool>("client_fsync_to_rados");
 }
 
 void Client::handle_client_session(const MConstRef<MClientSession>& m)
@@ -13307,7 +13310,7 @@ int Client::_fsync(Inode *in, bool syncdataonly)
   }
   bool mds_flush = false;
   if (!syncdataonly && in->dirty_caps) {
-    if (cct->_conf->client_fsync_to_rados &&
+    if (do_rados_fsync &&
         in->inline_version == CEPH_INLINE_NONE &&
         !(in->dirty_caps & ~CEPH_CAP_FILE_WR & ~CEPH_CAP_FILE_EXCL)) {
       // we don't need to sync to the MDS when we we can recover
@@ -18948,6 +18951,7 @@ std::vector<std::string> Client::get_tracked_keys() const noexcept
     "client_deleg_break_on_open",
     "client_deleg_timeout",
     "client_fscrypt_as",
+    "client_fsync_to_rados",
     "client_inject_write_delay_secs",
     "client_mount_timeout",
     "client_oc_max_dirty",
@@ -19022,6 +19026,15 @@ void Client::handle_conf_change(const ConfigProxy& conf,
   if (changed.count("client_fscrypt_as")) {
     fscrypt_as = cct->_conf.get_val<bool>(
       "client_fscrypt_as");
+  }
+  if (changed.count("client_fsync_to_rados")) {
+    bool rados_fsync = false;
+    if (!mds_sessions.empty()) {
+      rados_fsync = mds_sessions.at(0)->
+        mds_features.test(CEPHFS_FEATURE_RADOS_FSYNC);
+    }
+    do_rados_fsync = rados_fsync &&
+      cct->_conf.get_val<bool>("client_fsync_to_rados");
   }
 }
 

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -5175,6 +5175,10 @@ int Client::mark_caps_flushing(Inode *in, ceph_tid_t* ptid)
 
   ceph_tid_t flush_tid = ++last_flush_tid;
   in->flushing_cap_tids[flush_tid] = flushing;
+  if (in->dirty_setattr) {
+    in->dirty_setattr = false;
+    in->unflushed_setattr_tid = flush_tid;
+  }
 
   if (!in->flushing_caps) {
     ldout(cct, 10) << __func__ << " " << ccap_string(flushing) << " " << *in << dendl;
@@ -8476,8 +8480,10 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
     in->ctime = ceph_clock_now();
     if (issued & CEPH_CAP_AUTH_EXCL)
       in->mark_caps_dirty(CEPH_CAP_AUTH_EXCL);
-    else if (issued & CEPH_CAP_FILE_EXCL)
+    else if (issued & CEPH_CAP_FILE_EXCL) {
       in->mark_caps_dirty(CEPH_CAP_FILE_EXCL);
+      in->dirty_setattr = true;
+    }
     else if (issued & CEPH_CAP_XATTR_EXCL)
       in->mark_caps_dirty(CEPH_CAP_XATTR_EXCL);
     else
@@ -8722,6 +8728,7 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
         in->cap_dirtier_uid = perms.uid();
         in->cap_dirtier_gid = perms.gid();
         in->mark_caps_dirty(CEPH_CAP_FILE_EXCL);
+        in->dirty_setattr = true;
         mask &= ~(CEPH_SETATTR_SIZE);
         mask |= CEPH_SETATTR_MTIME;
       } else {
@@ -8749,6 +8756,7 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
       in->cap_dirtier_uid = perms.uid();
       in->cap_dirtier_gid = perms.gid();
       in->mark_caps_dirty(CEPH_CAP_FILE_EXCL);
+      in->dirty_setattr = true;
     } else if (!in->caps_issued_mask(CEPH_CAP_FILE_SHARED) ||
                (paux && in->fscrypt_file != *paux)) {
       inode_drop |= CEPH_CAP_FILE_SHARED | CEPH_CAP_FILE_RD | CEPH_CAP_FILE_WR;
@@ -8763,12 +8771,14 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
       in->ctime = ceph_clock_now();
       in->time_warp_seq++;
       in->mark_caps_dirty(CEPH_CAP_FILE_EXCL);
+      in->dirty_setattr = true;
       mask &= ~CEPH_SETATTR_MTIME;
     } else if (!do_sync && in->caps_issued_mask(CEPH_CAP_FILE_WR) &&
                utime_t(stx->stx_mtime) > in->mtime) {
       in->mtime = utime_t(stx->stx_mtime);
       in->ctime = ceph_clock_now();
       in->mark_caps_dirty(CEPH_CAP_FILE_WR);
+      in->dirty_setattr = true;
       mask &= ~CEPH_SETATTR_MTIME;
     } else if (!in->caps_issued_mask(CEPH_CAP_FILE_SHARED) ||
 	       in->mtime != utime_t(stx->stx_mtime)) {
@@ -8786,12 +8796,14 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
       in->ctime = ceph_clock_now();
       in->time_warp_seq++;
       in->mark_caps_dirty(CEPH_CAP_FILE_EXCL);
+      in->dirty_setattr = true;
       mask &= ~CEPH_SETATTR_ATIME;
     } else if (!do_sync && in->caps_issued_mask(CEPH_CAP_FILE_WR) &&
                utime_t(stx->stx_atime) > in->atime) {
       in->atime = utime_t(stx->stx_atime);
       in->ctime = ceph_clock_now();
       in->mark_caps_dirty(CEPH_CAP_FILE_WR);
+      in->dirty_setattr = true;
       mask &= ~CEPH_SETATTR_ATIME;
     } else if (!in->caps_issued_mask(CEPH_CAP_FILE_SHARED) ||
 	       in->atime != utime_t(stx->stx_atime)) {
@@ -13312,9 +13324,13 @@ int Client::_fsync(Inode *in, bool syncdataonly)
   }
   bool mds_flush = false;
   if (!syncdataonly && in->dirty_caps) {
-    if (do_rados_fsync &&
-        in->inline_version == CEPH_INLINE_NONE &&
-        !(in->dirty_caps & ~CEPH_CAP_FILE_WR & ~CEPH_CAP_FILE_EXCL)) {
+    if (do_rados_fsync && // rados fsync enabled
+        in->inline_version == CEPH_INLINE_NONE && // not inline
+        !(in->dirty_caps & ~CEPH_CAP_FILE_WR & ~CEPH_CAP_FILE_EXCL) && // only write caps are dirty
+        !in->dirty_setattr && // we haven't had a setattr
+        // and finally, we don't have a still-flushing setattr
+        (in->flushing_cap_tids.empty() ||
+         in->unflushed_setattr_tid < in->flushing_cap_tids.begin()->first)) {
       // we don't need to sync to the MDS when we we can recover
       // everything via Filer::probe()
       mds_flush = false;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12667,7 +12667,8 @@ int Client::WriteEncMgr_Buffered::do_write()
                                      0, iofinish,
                                      !async
                                      ? clnt->objectcacher->CFG_block_writes_upfront()
-                                     : false, in->change_attr);
+                                     : false,
+                                     clnt->do_rados_fsync ? in->change_attr : 0);
 
   return r;
 }
@@ -12680,7 +12681,8 @@ int Client::WriteEncMgr_NotBuffered::do_write()
   clnt->filer->write_trunc(in->ino, &in->layout, in->snaprealm->get_snap_context(),
                            offset, size, *pbl, mtime.to_real_time(), 0,
                            in->truncate_size, in->truncate_seq,
-                           iofinish, 0 /*op_flags*/, in->change_attr);
+                           iofinish, 0 /*op_flags*/,
+                           clnt->do_rados_fsync ? in->change_attr : 0);
 
   return 0;
 }

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -13325,6 +13325,7 @@ int Client::_fsync(Inode *in, bool syncdataonly)
   bool mds_flush = false;
   if (!syncdataonly && in->dirty_caps) {
     if (do_rados_fsync && // rados fsync enabled
+        in->unsafe_ops.empty() && // we don't have to wait for ops anyway
         in->inline_version == CEPH_INLINE_NONE && // not inline
         !(in->dirty_caps & ~CEPH_CAP_FILE_WR & ~CEPH_CAP_FILE_EXCL) && // only write caps are dirty
         !in->dirty_setattr && // we haven't had a setattr

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -13114,6 +13114,7 @@ void Client::C_nonblocking_fsync_state::advance()
 
   ceph_assert(ceph_mutex_is_locked_by_me(clnt->client_lock));
 
+  bool mds_flush = false;
   switch (progress) {
   case 0:
     ldout(clnt->cct, 15) << "Client::C_nonblocking_fsync_state::advance - case 0" << dendl;
@@ -13128,6 +13129,22 @@ void Client::C_nonblocking_fsync_state::advance()
     }
 
     if (!syncdataonly && in->dirty_caps) {
+      if (clnt->do_rados_fsync && // rados fsync enabled
+          in->unsafe_ops.empty() && // we don't have to wait for ops anyway
+          in->inline_version == CEPH_INLINE_NONE && // not inline
+          !(in->dirty_caps & ~CEPH_CAP_FILE_WR & ~CEPH_CAP_FILE_EXCL) && // only write caps are dirty
+          !in->dirty_setattr && // we haven't had a setattr
+          // and finally, we don't have a still-flushing setattr
+          (in->flushing_cap_tids.empty() ||
+           in->unflushed_setattr_tid < in->flushing_cap_tids.begin()->first)) {
+        // we don't need to sync to the MDS when we we can recover
+      // everything via Filer::probe()
+        mds_flush = false;
+      } else {
+        mds_flush = true;
+      }
+    }
+    if (mds_flush) {
       clnt->check_caps(in, CHECK_CAPS_NODELAY|CHECK_CAPS_SYNCHRONOUS);
       if (in->flushing_caps)
         flush_tid = clnt->last_flush_tid;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12667,7 +12667,7 @@ int Client::WriteEncMgr_Buffered::do_write()
                                      0, iofinish,
                                      !async
                                      ? clnt->objectcacher->CFG_block_writes_upfront()
-                                     : false);
+                                     : false, in->change_attr);
 
   return r;
 }

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1730,6 +1730,7 @@ private:
 
     int64_t offset;
     uint64_t size;
+    utime_t mtime;
 
     bufferlist bl;
     bufferlist encbl;
@@ -1787,7 +1788,7 @@ private:
 
   public:
     WriteEncMgr(Client *clnt,
-                Fh *f, int64_t offset, uint64_t size,
+                Fh *f, int64_t offset, uint64_t size, const utime_t& w_mtime,
                 bufferlist& bl,
                 bool async);
     virtual ~WriteEncMgr();
@@ -1830,8 +1831,10 @@ private:
   public:
     WriteEncMgr_Buffered(Client *clnt,
                          Fh *f, int64_t offset, uint64_t size,
+                         const utime_t& w_mtime,
                          bufferlist& bl,
-                         bool async) : WriteEncMgr(clnt, f, offset, size, bl, async) {}
+                         bool async) : WriteEncMgr(clnt, f, offset, size,
+                                                   w_mtime,bl, async) {}
 
     void update_write_params() override;
     int do_write() override;
@@ -1841,8 +1844,10 @@ private:
   public:
     WriteEncMgr_NotBuffered(Client *clnt,
                          Fh *f, int64_t offset, uint64_t size,
+                            const utime_t& w_mtime,
                          bufferlist& bl,
-                         bool async) : WriteEncMgr(clnt, f, offset, size, bl, async) {}
+                         bool async) : WriteEncMgr(clnt, f, offset, size,
+                                                   w_mtime, bl, async) {}
 
     void update_write_params() override {}
     int do_write() override;
@@ -1855,13 +1860,14 @@ private:
     void finish_fsync(int r);
 
     C_Write_Finisher(Client *clnt, Context *onfinish, bool dont_need_uninline,
-                     bool is_file_write, Fh *f, Inode *in,
+                     bool is_file_write, utime_t op_mtime, Fh *f, Inode *in,
                      uint64_t fpos, int64_t req_ofs, uint64_t req_size,
                      int64_t offset, uint64_t size,
                      bool do_fsync, bool syncdataonly,
                      bool encrypted)
       : clnt(clnt), onfinish(onfinish),
-        is_file_write(is_file_write), start(mono_clock_now()), f(f), in(in), fpos(fpos),
+        is_file_write(is_file_write), start(mono_clock_now()),
+        op_mtime(op_mtime),f(f), in(in), fpos(fpos),
         req_ofs(req_ofs), req_size(req_size),
         offset(offset), size(size), syncdataonly(syncdataonly),
         encrypted(encrypted) {
@@ -1887,6 +1893,7 @@ private:
     Context *onfinish;
     bool is_file_write;
     utime_t start;
+    utime_t op_mtime;
     Fh *f;
     Inode *in;
     uint64_t fpos;
@@ -2145,7 +2152,7 @@ private:
   int64_t _read(Fh *fh, int64_t offset, uint64_t size, bufferlist *bl,
   		Context *onfinish = nullptr, bool read_for_write = false);
   void do_readahead(Fh *f, Inode *in, uint64_t off, uint64_t len);
-  int64_t _write_success(Fh *fh, utime_t start, uint64_t fpos,
+  int64_t _write_success(Fh *fh, utime_t start, utime_t op_mtime, uint64_t fpos,
                          int64_t request_offset, uint64_t request_size,
                          int64_t offset, uint64_t size, Inode *in,
                          bool encrypted);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1092,6 +1092,7 @@ protected:
   void _closed_mds_session(MetaSession *s, int err=0, bool rejected=false);
   bool _any_stale_sessions() const;
   void _kick_stale_sessions();
+  void reinit_mds_features(MetaSession *session, const MConstRef<MClientSession>& m);
   void handle_client_session(const MConstRef<MClientSession>& m);
   void send_reconnect(MetaSession *s);
   void resend_unsafe_requests(MetaSession *s);
@@ -2413,6 +2414,7 @@ private:
   bool client_permissions;
   bool fuse_default_permissions;
   bool respect_subvolume_snapshot_visibility;
+  bool do_rados_fsync;
 
   std::locale m_locale;
 };

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -248,6 +248,8 @@ struct Inode : RefCountedObject {
   int snap_caps = 0;
   int snap_cap_refs = 0;
   xlist<Inode*>::item delay_cap_item, dirty_cap_item, flushing_cap_item;
+  bool dirty_setattr = false;
+  ceph_tid_t unflushed_setattr_tid = 0;
 
   SnapRealm *snaprealm = 0;
   xlist<Inode*>::item snaprealm_item;

--- a/src/client/ObjecterWriteback.h
+++ b/src/client/ObjecterWriteback.h
@@ -38,12 +38,27 @@ class ObjecterWriteback : public WritebackHandler {
 			   ceph::real_time mtime, uint64_t trunc_size,
 			   __u32 trunc_seq, ceph_tid_t journal_tid,
                            const ZTracer::Trace &parent_trace,
-			   Context *oncommit) override {
-    return m_objecter->write_trunc(oid, oloc, off, len, snapc, bl, mtime, 0,
-				   trunc_size, trunc_seq,
-				   new C_OnFinisher(new C_Lock(m_lock,
-							       oncommit),
-						    m_finisher));
+                           Context *oncommit, uint64_t change_attr=0) override {
+    ceph_tid_t tid;
+    if (change_attr) {
+      ObjectOperation change_op;
+      bufferlist cbl;
+      encode(change_attr, cbl);
+      change_op.setxattr(CHANGE_ATTR_NAME, cbl);
+      tid = m_objecter->write_trunc(oid, oloc, off, len, snapc, bl, mtime, 0,
+                              trunc_size, trunc_seq,
+                              new C_OnFinisher(new C_Lock(m_lock,
+                                                          oncommit),
+                                               m_finisher),
+                              /*objver*/ 0, &change_op);
+    } else {
+      tid = m_objecter->write_trunc(oid, oloc, off, len, snapc, bl, mtime, 0,
+                                    trunc_size, trunc_seq,
+                                    new C_OnFinisher(new C_Lock(m_lock,
+                                                                oncommit),
+                                                     m_finisher));
+    }
+    return tid;
   }
 
   bool can_scattered_write() override { return true; }
@@ -52,11 +67,15 @@ class ObjecterWriteback : public WritebackHandler {
                            std::vector<std::pair<uint64_t, bufferlist> >& io_vec,
 			   const SnapContext& snapc, ceph::real_time mtime,
 			   uint64_t trunc_size, __u32 trunc_seq,
-			   Context *oncommit) override {
+                           Context *oncommit, uint64_t change_attr=0) override {
     ObjectOperation op;
     for (auto& [offset, bl] : io_vec)
       op.write(offset, bl, trunc_size, trunc_seq);
-
+    if (change_attr) {
+      bufferlist cbl;
+      encode(change_attr, cbl);
+      op.setxattr(CHANGE_ATTR_NAME, cbl);
+    }
     return m_objecter->mutate(oid, oloc, op, snapc, mtime, 0,
 			      new C_OnFinisher(new C_Lock(m_lock, oncommit),
 					       m_finisher));

--- a/src/common/options/mds-client.yaml.in
+++ b/src/common/options/mds-client.yaml.in
@@ -648,3 +648,17 @@ options:
   - mds_client
   flags:
   - runtime
+- name: client_fsync_to_rados
+  type: bool
+  level: dev
+  desc: Do not necessarily flush caps to the MDS on every fsync
+  long_desc: When performing an fsync, the client will not flush to the mds
+    if the only dirty caps are size, mtime, ctime, change_attr. The first 3 can
+    be reasonably recovered by probing in case the client crashes; we ignore
+    change_attr and hope for the best.
+  default: false
+  services:
+  - mds_client
+  with_legacy: true
+  flags:
+  - runtime

--- a/src/common/options/mds-client.yaml.in
+++ b/src/common/options/mds-client.yaml.in
@@ -659,6 +659,5 @@ options:
   default: false
   services:
   - mds_client
-  with_legacy: true
   flags:
   - runtime

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -91,6 +91,8 @@ struct ceph_dir_layout {
 	__u32  dl_unused3;
 } __attribute__ ((packed));
 
+#define CHANGE_ATTR_NAME "cattr"
+
 /* crypto algorithms */
 #define CEPH_CRYPTO_NONE 0x0
 #define CEPH_CRYPTO_AES  0x1

--- a/src/librbd/cache/ObjectCacherWriteback.cc
+++ b/src/librbd/cache/ObjectCacherWriteback.cc
@@ -188,7 +188,8 @@ ceph_tid_t ObjectCacherWriteback::write(const object_t& oid,
                                         uint64_t trunc_size,
                                         __u32 trunc_seq, ceph_tid_t journal_tid,
                                         const ZTracer::Trace &parent_trace,
-                                        Context *oncommit)
+                                        Context *oncommit,
+                                        uint64_t change_attr)
 {
   ZTracer::Trace trace;
   if (parent_trace.valid()) {

--- a/src/librbd/cache/ObjectCacherWriteback.h
+++ b/src/librbd/cache/ObjectCacherWriteback.h
@@ -45,7 +45,7 @@ public:
                    ceph::real_time mtime, uint64_t trunc_size,
                    __u32 trunc_seq, ceph_tid_t journal_tid,
                    const ZTracer::Trace &parent_trace,
-                   Context *oncommit) override;
+                   Context *oncommit, uint64_t change_attr=0) override;
   using WritebackHandler::write;
 
   void overwrite_extent(const object_t& oid, uint64_t off,

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2945,18 +2945,22 @@ class C_MDL_CheckMaxSize : public LockerContext {
   uint64_t new_max_size;
   uint64_t newsize;
   utime_t mtime;
+  uint64_t new_change_attr;
 
 public:
   C_MDL_CheckMaxSize(Locker *l, CInode *i, uint64_t _new_max_size,
-                     uint64_t _newsize, utime_t _mtime) :
+                     uint64_t _newsize, utime_t _mtime,
+                     uint64_t _new_change_attr) :
     LockerContext(l), in(i),
-    new_max_size(_new_max_size), newsize(_newsize), mtime(_mtime)
+    new_max_size(_new_max_size), newsize(_newsize), mtime(_mtime),
+    new_change_attr(_new_change_attr)
   {
     in->get(CInode::PIN_PTRWAITER);
   }
   void finish(int r) override {
     if (in->is_auth())
-      locker->check_inode_max_size(in, false, new_max_size, newsize, mtime);
+      locker->check_inode_max_size(in, false, new_max_size, newsize, mtime,
+                                   new_change_attr);
     in->put(CInode::PIN_PTRWAITER);
   }
 };
@@ -3060,7 +3064,7 @@ bool Locker::calc_new_client_ranges(CInode *in, uint64_t size, bool *max_increas
 
 bool Locker::check_inode_max_size(CInode *in, bool force_wrlock,
 				  uint64_t new_max_size, uint64_t new_size,
-				  utime_t new_mtime)
+				  utime_t new_mtime, uint64_t new_change_attr)
 {
   ceph_assert(in->is_auth());
   ceph_assert(in->is_file());
@@ -3072,6 +3076,7 @@ bool Locker::check_inode_max_size(CInode *in, bool force_wrlock,
   if (update_size) {
     new_size = size = std::max(size, new_size);
     new_mtime = std::max(new_mtime, latest->mtime);
+    new_change_attr = std::max(new_change_attr, latest->change_attr);
     if (latest->size == new_size && latest->mtime == new_mtime)
       update_size = false;
   }
@@ -3089,7 +3094,7 @@ bool Locker::check_inode_max_size(CInode *in, bool force_wrlock,
   if (in->is_frozen()) {
     dout(10) << "check_inode_max_size frozen, waiting on " << *in << dendl;
     in->add_waiter(CInode::WAIT_UNFREEZE,
-		   new C_MDL_CheckMaxSize(this, in, new_max_size, new_size, new_mtime));
+		   new C_MDL_CheckMaxSize(this, in, new_max_size, new_size, new_mtime, new_change_attr));
     return false;
   } else if (!force_wrlock && !in->filelock.can_wrlock(in->get_loner())) {
     // lock?
@@ -3105,7 +3110,7 @@ bool Locker::check_inode_max_size(CInode *in, bool force_wrlock,
     if (!in->filelock.can_wrlock(in->get_loner())) {
       dout(10) << "check_inode_max_size can't wrlock, waiting on " << *in << dendl;
       in->filelock.add_waiter(SimpleLock::WAIT_STABLE,
-			      new C_MDL_CheckMaxSize(this, in, new_max_size, new_size, new_mtime));
+			      new C_MDL_CheckMaxSize(this, in, new_max_size, new_size, new_mtime, new_change_attr));
       return false;
     }
   }
@@ -3135,6 +3140,9 @@ bool Locker::check_inode_max_size(CInode *in, bool force_wrlock,
       if (new_mtime > pi.inode->rstat.rctime)
 	pi.inode->rstat.rctime = new_mtime;
     }
+    dout(10) << "check_inode_max_size change_attr " << pi.inode->change_attr
+             << " -> " << new_change_attr << dendl;
+    pi.inode->change_attr = new_change_attr;
   }
 
   // use EOpen if the file is still open; otherwise, use EUpdate.
@@ -4134,7 +4142,7 @@ bool Locker::_do_cap_update(CInode *in, Capability *cap,
 	  !in->filelock.can_force_wrlock(client)) {
 	C_MDL_CheckMaxSize *cms = new C_MDL_CheckMaxSize(this, in,
 	                                                 forced_change_max ? new_max : 0,
-	                                                 0, utime_t());
+	                                                 0, utime_t(), 0);
 
 	in->filelock.add_waiter(SimpleLock::WAIT_STABLE, cms);
 	change_max = false;

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -203,7 +203,8 @@ public:
 			      bool *max_increased=nullptr);
   bool check_inode_max_size(CInode *in, bool force_wrlock=false,
                             uint64_t newmax=0, uint64_t newsize=0,
-			    utime_t mtime=utime_t());
+			    utime_t mtime=utime_t(),
+                            uint64_t new_change_attr=0);
   void share_inode_max_size(CInode *in, Capability *only_cap=0);
 
   // -- client leases --

--- a/src/mds/RecoveryQueue.cc
+++ b/src/mds/RecoveryQueue.cc
@@ -40,9 +40,10 @@ public:
 
   uint64_t size = 0;
   utime_t mtime;
+  uint64_t change_attr = 0;
 protected:
   void finish(int r) override {
-    rq->_recovered(in, r, size, mtime);
+    rq->_recovered(in, r, size, mtime, change_attr);
   }
 
   MDSRank *get_mds() override {
@@ -110,7 +111,8 @@ void RecoveryQueue::_start(CInode *in)
       C_MDC_Recover *fin = new C_MDC_Recover(this, in);
       auto layout = pi->layout;
       filer.probe(in->ino(), &layout, in->last,
-		  pi->get_max_size(), &fin->size, &fin->mtime, false,
+		  pi->get_max_size(), &fin->size, &fin->mtime,
+                  &fin->change_attr, false,
 		  0, fin);
     } else {
       p->second = true;
@@ -184,7 +186,7 @@ void RecoveryQueue::enqueue(CInode *in)
 /**
  * Call back on completion of Filer probe on an inode.
  */
-void RecoveryQueue::_recovered(CInode *in, int r, uint64_t size, utime_t mtime)
+void RecoveryQueue::_recovered(CInode *in, int r, uint64_t size, utime_t mtime, uint64_t change_attr)
 {
   dout(10) << "_recovered r=" << r << " size=" << size << " mtime=" << mtime
 	   << " for " << *in << dendl;
@@ -229,7 +231,7 @@ void RecoveryQueue::_recovered(CInode *in, int r, uint64_t size, utime_t mtime)
     _start(in);
   } else if (!_is_in_any_recover_queue(in)) {
     // journal
-    mds->locker->check_inode_max_size(in, true, 0,  size, mtime);
+    mds->locker->check_inode_max_size(in, true, 0,  size, mtime, change_attr);
     mds->locker->eval(in, CEPH_LOCK_IFILE);
     in->auth_unpin(this);
   }

--- a/src/mds/RecoveryQueue.h
+++ b/src/mds/RecoveryQueue.h
@@ -42,7 +42,7 @@ private:
   friend class C_MDC_Recover;
 
   void _start(CInode *in);  ///< start recovering this file
-  void _recovered(CInode *in, int r, uint64_t size, utime_t mtime);
+  void _recovered(CInode *in, int r, uint64_t size, utime_t mtime, uint64_t change_attr);
 
   size_t file_recover_queue_size = 0;
   size_t file_recover_queue_front_size = 0;

--- a/src/mds/cephfs_features.cc
+++ b/src/mds/cephfs_features.cc
@@ -35,7 +35,8 @@ static const std::array feature_names
   "has_owner_uidgid",
   "client_mds_auth_caps",
   "charmap",
-  "blockdiff"
+  "blockdiff",
+  "rados_fsync"
 };
 static_assert(feature_names.size() == CEPHFS_FEATURE_MAX + 1);
 

--- a/src/mds/cephfs_features.h
+++ b/src/mds/cephfs_features.h
@@ -52,7 +52,8 @@ namespace ceph {
 #define CEPHFS_FEATURE_MDS_AUTH_CAPS_CHECK  21
 #define CEPHFS_FEATURE_CHARMAP              22
 #define CEPHFS_FEATURE_BLOCKDIFF            23
-#define CEPHFS_FEATURE_MAX                  23
+#define CEPHFS_FEATURE_RADOS_FSYNC          24
+#define CEPHFS_FEATURE_MAX                  24
 
 #define CEPHFS_FEATURES_ALL {		\
   0, 1, 2, 3, 4,			\
@@ -77,6 +78,7 @@ namespace ceph {
   CEPHFS_FEATURE_MDS_AUTH_CAPS_CHECK,   \
   CEPHFS_FEATURE_CHARMAP,               \
   CEPHFS_FEATURE_BLOCKDIFF,             \
+  CEPHFS_FEATURE_RADOS_FSYNC,           \
 }
 
 #define CEPHFS_METRIC_FEATURES_ALL {		\

--- a/src/osdc/Filer.cc
+++ b/src/osdc/Filer.cc
@@ -106,12 +106,23 @@ void Filer::write_trunc(inodeno_t ino,
 			uint64_t truncate_size,
 			__u32 truncate_seq,
 			Context *oncommit,
-			int op_flags) {
+			int op_flags, uint64_t change_attr) {
   std::vector<ObjectExtent> extents;
   Striper::file_to_extents(cct, ino, layout, offset, len, truncate_size,
 			   extents);
-  objecter->sg_write_trunc(extents, snapc, bl, mtime, flags,
-			   truncate_size, truncate_seq, oncommit, op_flags);
+  if (change_attr) {
+    ObjectOperation change_op;
+    bufferlist cbl;
+    encode(change_attr, cbl);
+    change_op.setxattr(CHANGE_ATTR_NAME, cbl);
+    objecter->sg_write_trunc(extents, snapc, bl, mtime, flags,
+                             truncate_size, truncate_seq, oncommit, op_flags,
+                             &change_op);
+
+  } else {
+    objecter->sg_write_trunc(extents, snapc, bl, mtime, flags,
+                             truncate_size, truncate_seq, oncommit, op_flags);
+  }
 }
 
 void Filer::zero(inodeno_t ino,

--- a/src/osdc/Filer.cc
+++ b/src/osdc/Filer.cc
@@ -168,9 +168,12 @@ public:
   object_t oid;
   uint64_t size;
   ceph::real_time mtime;
+  bufferlist change_attr_bl;
+  int change_attr_retval;
   C_Probe(Filer *f, Probe *p, object_t o) : filer(f), probe(p), oid(o),
 					    size(0) {}
   void finish(int r) override {
+    bool got_obj = r == 0;
     if (r == -ENOENT) {
       r = 0;
       ceph_assert(size == 0);
@@ -181,8 +184,10 @@ public:
       Probe::unique_lock pl(probe->lock);
       if (r != 0) {
 	probe->err = r;
+      } else if (got_obj && !change_attr_retval) {
+        auto p = change_attr_bl.cbegin();
+        decode(probe->change_attrs[oid], p);
       }
-
       probe_complete = filer->_probed(probe, oid, size, mtime, pl);
       ceph_assert(!pl.owns_lock());
     }
@@ -199,6 +204,7 @@ int Filer::probe(inodeno_t ino,
 		 uint64_t start_from,
 		 uint64_t *end, // LB, when !fwd
 		 ceph::real_time *pmtime,
+                 uint64_t *change_attr,
 		 bool fwd,
 		 int flags,
 		 Context *onfinish)
@@ -211,7 +217,7 @@ int Filer::probe(inodeno_t ino,
   ceph_assert(snapid);  // (until there is a non-NOSNAP write)
 
   Probe *probe = new Probe(ino, *layout, snapid, start_from, end, pmtime,
-			   flags, fwd, onfinish);
+			   change_attr, flags, fwd, onfinish);
 
   return probe_impl(probe, layout, start_from, end);
 }
@@ -222,6 +228,7 @@ int Filer::probe(inodeno_t ino,
 		 uint64_t start_from,
 		 uint64_t *end, // LB, when !fwd
 		 utime_t *pmtime,
+                 uint64_t *change_attr,
 		 bool fwd,
 		 int flags,
 		 Context *onfinish)
@@ -234,7 +241,7 @@ int Filer::probe(inodeno_t ino,
   ceph_assert(snapid);  // (until there is a non-NOSNAP write)
 
   Probe *probe = new Probe(ino, *layout, snapid, start_from, end, pmtime,
-			   flags, fwd, onfinish);
+			   change_attr, flags, fwd, onfinish);
   return probe_impl(probe, layout, start_from, end);
 }
 
@@ -293,9 +300,12 @@ void Filer::_probe(Probe *probe, Probe::unique_lock& pl)
   for (std::vector<ObjectExtent>::iterator i = stat_extents.begin();
        i != stat_extents.end(); ++i) {
     C_Probe *c = new C_Probe(this, probe, i->oid);
+    ObjectOperation change_attr_op;
+    change_attr_op.getxattr(CHANGE_ATTR_NAME, &c->change_attr_bl,
+                            &c->change_attr_retval);
     objecter->stat(i->oid, i->oloc, probe->snapid, &c->size, &c->mtime,
 		   probe->flags | CEPH_OSD_FLAG_RWORDERED,
-		   new C_OnFinisher(c, finisher));
+		   new C_OnFinisher(c, finisher), NULL, &change_attr_op);
   }
 }
 
@@ -315,6 +325,10 @@ bool Filer::_probed(Probe *probe, const object_t& oid, uint64_t size,
   probe->known_size[oid] = size;
   if (mtime > probe->max_mtime)
     probe->max_mtime = mtime;
+
+  if (probe->change_attr && probe->change_attrs[oid] > *probe->change_attr) {
+    *probe->change_attr = probe->change_attrs[oid];
+  }
 
   ceph_assert(probe->ops.count(oid));
   probe->ops.erase(oid);

--- a/src/osdc/Filer.h
+++ b/src/osdc/Filer.h
@@ -162,7 +162,8 @@ class Filer {
 		  uint64_t truncate_size,
 		  __u32 truncate_seq,
 		  Context *oncommit,
-		  int op_flags = 0);
+                  int op_flags = 0,
+                  uint64_t change_atr = 0);
 
   void truncate(inodeno_t ino,
 	       const file_layout_t *layout,

--- a/src/osdc/Filer.h
+++ b/src/osdc/Filer.h
@@ -66,6 +66,7 @@ class Filer {
     uint64_t *psize;
     ceph::real_time *pmtime;
     utime_t *pumtime;
+    uint64_t *change_attr;
 
     int flags;
 
@@ -77,6 +78,7 @@ class Filer {
     uint64_t probing_off, probing_len;
 
     std::map<object_t, uint64_t> known_size;
+    std::map<object_t, uint64_t> change_attrs;
     ceph::real_time max_mtime;
 
     std::set<object_t> ops;
@@ -85,19 +87,20 @@ class Filer {
     bool found_size;
 
     Probe(inodeno_t i, const file_layout_t &l, snapid_t sn,
-	  uint64_t f, uint64_t *e, ceph::real_time *m, int fl, bool fw,
-	  Context *c) :
+	  uint64_t f, uint64_t *e, ceph::real_time *m, uint64_t *pca,
+          int fl, bool fw, Context *c) :
       ino(i), layout(l), snapid(sn),
-      psize(e), pmtime(m), pumtime(nullptr), flags(fl), fwd(fw), onfinish(c),
+      psize(e), pmtime(m), pumtime(nullptr), change_attr(pca),
+      flags(fl), fwd(fw), onfinish(c),
       probing_off(f), probing_len(0),
       err(0), found_size(false) {}
 
     Probe(inodeno_t i, const file_layout_t &l, snapid_t sn,
-	  uint64_t f, uint64_t *e, utime_t *m, int fl, bool fw,
+	  uint64_t f, uint64_t *e, utime_t *m, uint64_t *pca, int fl, bool fw,
 	  Context *c) :
       ino(i), layout(l), snapid(sn),
-      psize(e), pmtime(nullptr), pumtime(m), flags(fl), fwd(fw),
-      onfinish(c), probing_off(f), probing_len(0),
+      psize(e), pmtime(nullptr), pumtime(m), change_attr(pca),
+      flags(fl), fwd(fw), onfinish(c), probing_off(f), probing_len(0),
       err(0), found_size(false) {}
   };
 
@@ -220,6 +223,7 @@ class Filer {
 	    uint64_t start_from,
 	    uint64_t *end,
 	    ceph::real_time *mtime,
+            uint64_t *change_attr,
 	    bool fwd,
 	    int flags,
 	    Context *onfinish);
@@ -233,7 +237,7 @@ class Filer {
 	    int flags,
 	    Context *onfinish) {
     return probe(ino, layout, snapid, start_from, end,
-		 (ceph::real_time* )0, fwd, flags, onfinish);
+		 (ceph::real_time* )0, 0, fwd, flags, onfinish);
   }
 
   int probe(inodeno_t ino,
@@ -242,6 +246,7 @@ class Filer {
 	    uint64_t start_from,
 	    uint64_t *end,
 	    utime_t *mtime,
+            uint64_t *change_attr,
 	    bool fwd,
 	    int flags,
 	    Context *onfinish);

--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -1101,6 +1101,7 @@ void ObjectCacher::bh_write_scattered(list<BufferHead*>& blist)
   io_vec.reserve(blist.size());
 
   uint64_t total_len = 0;
+  uint64_t change_attr = 0;
   for (list<BufferHead*>::iterator p = blist.begin(); p != blist.end(); ++p) {
     BufferHead *bh = *p;
     ldout(cct, 7) << "bh_write_scattered " << *bh << dendl;
@@ -1118,6 +1119,7 @@ void ObjectCacher::bh_write_scattered(list<BufferHead*>& blist)
       snapc = bh->snapc;
     if (bh->last_write > last_write)
       last_write = bh->last_write;
+    change_attr = std::max(change_attr, bh->change_attr);
   }
 
   C_WriteCommit *oncommit = new C_WriteCommit(this, ob->oloc.pool, ob->get_soid(), ranges);
@@ -1125,7 +1127,7 @@ void ObjectCacher::bh_write_scattered(list<BufferHead*>& blist)
   ceph_tid_t tid = writeback_handler.write(ob->get_oid(), ob->get_oloc(),
 					   io_vec, snapc, last_write,
 					   ob->truncate_size, ob->truncate_seq,
-					   oncommit);
+					   oncommit, change_attr);
   oncommit->tid = tid;
   ob->last_write_tid = tid;
   for (list<BufferHead*>::iterator p = blist.begin(); p != blist.end(); ++p) {
@@ -1163,7 +1165,8 @@ void ObjectCacher::bh_write(BufferHead *bh, const ZTracer::Trace &parent_trace)
 					   bh->snapc, bh->bl, bh->last_write,
 					   bh->ob->truncate_size,
 					   bh->ob->truncate_seq,
-					   bh->journal_tid, trace, oncommit);
+					   bh->journal_tid, trace, oncommit,
+                                           bh->change_attr);
   ldout(cct, 20) << " tid " << tid << " on " << bh->ob->get_oid() << dendl;
 
   // set bh last_write_tid
@@ -1827,6 +1830,7 @@ int ObjectCacher::writex(OSDWrite *wr, ObjectSet *oset, Context *onfreespace,
       touch_bh(bh);
 
     bh->last_write = now;
+    bh->change_attr = wr->change_attr;
 
     o->try_merge_bh(bh);
   }

--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -88,18 +88,19 @@ class ObjectCacher {
     ceph::real_time mtime;
     int fadvise_flags;
     ceph_tid_t journal_tid;
+    uint64_t change_attr;
     OSDWrite(const SnapContext& sc, const ceph::buffer::list& b, ceph::real_time mt,
-	     int f, ceph_tid_t _journal_tid)
+	     int f, ceph_tid_t _journal_tid, uint64_t c_attr=0)
       : snapc(sc), bl(b), mtime(mt), fadvise_flags(f),
-	journal_tid(_journal_tid) {}
+	journal_tid(_journal_tid), change_attr(c_attr) {}
   };
 
   OSDWrite *prepare_write(const SnapContext& sc,
 			  const ceph::buffer::list &b,
 			  ceph::real_time mt,
 			  int f,
-			  ceph_tid_t journal_tid) const {
-    return new OSDWrite(sc, b, mt, f, journal_tid);
+			  ceph_tid_t journal_tid, uint64_t change_attr=0) const {
+    return new OSDWrite(sc, b, mt, f, journal_tid, change_attr);
   }
 
 
@@ -134,6 +135,7 @@ class ObjectCacher {
     ceph::real_time last_write;
     SnapContext snapc;
     ceph_tid_t journal_tid;
+    uint64_t change_attr;
     int error; // holds return value for failed reads
 
     std::map<loff_t, std::list<Context*> > waitfor_read;
@@ -148,6 +150,7 @@ class ObjectCacher {
       last_write_tid(0),
       last_read_tid(0),
       journal_tid(0),
+      change_attr(0),
       error(0) {
       ex.start = ex.length = 0;
     }
@@ -727,8 +730,9 @@ public:
   int file_write(ObjectSet *oset, file_layout_t *layout,
 		 const SnapContext& snapc, loff_t offset, uint64_t len,
 		 ceph::buffer::list& bl, ceph::real_time mtime, int flags,
-		 Context *onfreespace, bool block_writes_upfront) {
-    OSDWrite *wr = prepare_write(snapc, bl, mtime, flags, 0);
+		 Context *onfreespace, bool block_writes_upfront,
+                 uint64_t change_attr=0) {
+    OSDWrite *wr = prepare_write(snapc, bl, mtime, flags, 0, change_attr);
     Striper::file_to_extents(cct, oset->ino, layout, offset, len,
 			     oset->truncate_size, wr->extents);
     return writex(wr, oset, onfreespace, nullptr, block_writes_upfront);

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -4032,12 +4032,13 @@ public:
   void sg_write_trunc(std::vector<ObjectExtent>& extents, const SnapContext& snapc,
 		      const ceph::buffer::list& bl, ceph::real_time mtime, int flags,
 		      uint64_t trunc_size, __u32 trunc_seq,
-		      Context *oncommit, int op_flags = 0) {
+		      Context *oncommit, int op_flags = 0,
+                      ObjectOperation *extra_ops=NULL) {
     if (extents.size() == 1) {
       write_trunc(extents[0].oid, extents[0].oloc, extents[0].offset,
 		  extents[0].length, snapc, bl, mtime, flags,
 		  extents[0].truncate_size, trunc_seq, oncommit,
-		  0, 0, op_flags);
+		  0, extra_ops, op_flags);
     } else {
       C_GatherBuilder gcom(cct, oncommit);
       auto it = bl.cbegin();
@@ -4055,7 +4056,7 @@ public:
 	write_trunc(p->oid, p->oloc, p->offset, p->length,
 	      snapc, cur, mtime, flags, p->truncate_size, trunc_seq,
 	      oncommit ? gcom.new_sub():0,
-	      0, 0, op_flags);
+              0, extra_ops, op_flags);
       }
       gcom.activate();
     }

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -3362,6 +3362,17 @@ public:
     ObjectOperation *extra_ops = NULL) {
     Op *o = prepare_stat_op(oid, oloc, snap, psize, pmtime, flags,
 			    onfinish, objver, extra_ops);
+    if (extra_ops) { // fill in out_bl/out_rval/out_ec
+      for (size_t i=0; i<extra_ops->out_bl.size(); ++i) {
+        o->out_bl[i] = extra_ops->out_bl[i];
+      }
+      for (size_t i=0; i<extra_ops->out_rval.size(); ++i) {
+        o->out_rval[i] = extra_ops->out_rval[i];
+      }
+      for (size_t i=0; i<extra_ops->out_ec.size(); ++i) {
+        o->out_ec[i] = extra_ops->out_ec[i];
+      }
+    }
     ceph_tid_t tid;
     op_submit(o, &tid);
     return tid;

--- a/src/osdc/WritebackHandler.h
+++ b/src/osdc/WritebackHandler.h
@@ -39,7 +39,7 @@ class WritebackHandler {
 			   uint64_t trunc_size, __u32 trunc_seq,
                            ceph_tid_t journal_tid,
                            const ZTracer::Trace &parent_trace,
-                           Context *oncommit) = 0;
+                           Context *oncommit, uint64_t change_attr=0) = 0;
 
   virtual void overwrite_extent(const object_t& oid, uint64_t off, uint64_t len,
                                 ceph_tid_t original_journal_tid,
@@ -50,7 +50,7 @@ class WritebackHandler {
 			   std::vector<std::pair<uint64_t, ceph::buffer::list> >& io_vec,
 			   const SnapContext& snapc, ceph::real_time mtime,
 			   uint64_t trunc_size, __u32 trunc_seq,
-			   Context *oncommit) {
+			   Context *oncommit, uint64_t change_attr=0) {
     return 0;
   }
 };

--- a/src/test/osdc/FakeWriteback.cc
+++ b/src/test/osdc/FakeWriteback.cc
@@ -78,7 +78,7 @@ ceph_tid_t FakeWriteback::write(const object_t& oid,
 				uint64_t trunc_size, __u32 trunc_seq,
 				ceph_tid_t journal_tid,
                                 const ZTracer::Trace &parent_trace,
-                                Context *oncommit)
+                                Context *oncommit, uint64_t change_attr)
 {
   C_Delay *wrapper = new C_Delay(m_cct, oncommit, m_lock, off, NULL,
 				 m_delay_ns);

--- a/src/test/osdc/FakeWriteback.h
+++ b/src/test/osdc/FakeWriteback.h
@@ -31,7 +31,7 @@ public:
 			   ceph::real_time mtime, uint64_t trunc_size,
 			   __u32 trunc_seq, ceph_tid_t journal_tid,
                            const ZTracer::Trace &parent_trace,
-			   Context *oncommit) override;
+                           Context *oncommit, uint64_t change_attr=0) override;
 
   using WritebackHandler::write;
 

--- a/src/test/osdc/MemWriteback.cc
+++ b/src/test/osdc/MemWriteback.cc
@@ -109,7 +109,7 @@ ceph_tid_t MemWriteback::write(const object_t& oid,
 				uint64_t trunc_size, __u32 trunc_seq,
 				ceph_tid_t journal_tid,
                                 const ZTracer::Trace &parent_trace,
-                                Context *oncommit)
+                                Context *oncommit, uint64_t change_attr)
 {
   ceph_assert(snapc.seq == 0);
   C_DelayWrite *wrapper = new C_DelayWrite(this, m_cct, oncommit, m_lock, oid,

--- a/src/test/osdc/MemWriteback.h
+++ b/src/test/osdc/MemWriteback.h
@@ -31,7 +31,7 @@ public:
 			   ceph::real_time mtime, uint64_t trunc_size,
 			   __u32 trunc_seq, ceph_tid_t journal_tid,
                            const ZTracer::Trace &parent_trace,
-			   Context *oncommit) override;
+                           Context *oncommit, uint64_t change_attr=0) override;
 
   using WritebackHandler::write;
 


### PR DESCRIPTION
We've recently started seeing more intense users run with the NFS integration on top of CephFS.
This proposal targets an unfortunate scenario where IO gets gated on MDS update performance rather
than OSD cluster performance when NFS clients open files with O_DIRECT or mount with the "sync" mount option.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
