### PR TITLE
mgr/cephadm: fix HostConnectionError serialization

### DIFF
--- a/src/pybind/mgr/cephadm/ssh.py
+++ b/src/pybind/mgr/cephadm/ssh.py
@@ -36,7 +36,8 @@ class HostConnectionError(OrchestratorError):
         self.addr = addr
 
     def __reduce__(self) -> tuple:
-        return (type(self), (self.args[0], self.hostname, self.addr))
+        return (type(self), (self.args[0], self.hostname, self.addr),
+                self.__dict__)
 
 
 DEFAULT_SSH_CONFIG = """

--- a/src/pybind/mgr/cephadm/ssh.py
+++ b/src/pybind/mgr/cephadm/ssh.py
@@ -35,6 +35,9 @@ class HostConnectionError(OrchestratorError):
         self.hostname = hostname
         self.addr = addr
 
+    def __reduce__(self) -> tuple:
+        return (type(self), (self.args[0], self.hostname, self.addr))
+
 
 DEFAULT_SSH_CONFIG = """
 Host *

--- a/src/pybind/mgr/cephadm/tests/test_ssh.py
+++ b/src/pybind/mgr/cephadm/tests/test_ssh.py
@@ -153,7 +153,6 @@ class TestHostConnectionErrorPickle:
 
     def test_pickle_round_trip_with_orchtresult(self):
         """End-to-end: exception through OrchResult serialization matches production path."""
-        import pickle
         from cephadm.ssh import HostConnectionError
         from orchestrator._interface import OrchResult, completion_to_result
 

--- a/src/pybind/mgr/cephadm/tests/test_ssh.py
+++ b/src/pybind/mgr/cephadm/tests/test_ssh.py
@@ -126,3 +126,41 @@ def test_offline_watcher_uses_cephadm_check_online(run_cephadm, cephadm_module):
         'test', cephadmNoImage, ['_orch', 'check-online'], [],
         no_fsid=True, log_output=cephadm_module.log_refresh_metadata
     )
+
+
+class TestHostConnectionErrorPickle:
+    """Verify HostConnectionError survives pickle round-trip (deserialization).
+
+    The orchestrator uses pickle to serialize exceptions across mgr sub-interpreters
+    via OrchResult. If __reduce__ is missing or wrong, pickle.loads() will fail with
+    TypeError because __init__ requires hostname and addr beyond the base message.
+    """
+
+    def test_pickle_round_trip_preserves_attributes(self):
+        import pickle
+        from cephadm.ssh import HostConnectionError
+
+        original = HostConnectionError('connection refused', 'ceph-node-01', '192.168.100.101')
+
+        data = pickle.dumps(original)
+        restored = pickle.loads(data)
+
+        assert type(restored) is HostConnectionError
+        assert str(restored) == 'connection refused'
+        assert restored.hostname == 'ceph-node-01'
+        assert restored.addr == '192.168.100.101'
+        assert restored.errno == original.errno
+
+    def test_pickle_round_trip_with_orchtresult(self):
+        """End-to-end: exception through OrchResult serialization matches production path."""
+        import pickle
+        from cephadm.ssh import HostConnectionError
+        from orchestrator._interface import OrchResult, completion_to_result
+
+        err = HostConnectionError('host unreachable', 'node-02', '10.0.0.2')
+        result = OrchResult(None, exception=err)
+
+        assert result.serialized_exception is not None
+        cmd_result = completion_to_result(result)
+        assert cmd_result.retval != 0
+        assert 'host unreachable' in cmd_result.stderr

--- a/src/pybind/mgr/cephadm/tests/test_ssh.py
+++ b/src/pybind/mgr/cephadm/tests/test_ssh.py
@@ -151,7 +151,7 @@ class TestHostConnectionErrorPickle:
         assert restored.addr == '192.168.100.101'
         assert restored.errno == original.errno
 
-    def test_pickle_round_trip_with_orchtresult(self):
+    def test_pickle_round_trip_with_orch_result(self):
         """End-to-end: exception through OrchResult serialization matches production path."""
         from cephadm.ssh import HostConnectionError
         from orchestrator._interface import OrchResult, completion_to_result


### PR DESCRIPTION
**Problem**

When cephadm encountered a HostConnectionError while communicating with a
remote host, the exception was serialized and later deserialized before
being returned to the CLI.

HostConnectionError requires three constructor arguments
(message, hostname, addr), but only the message was preserved in
Exception.args. During deserialization, pickle attempted to reconstruct
the exception using only the message, resulting in:

```
TypeError: HostConnectionError.__init__() missing 2 required
positional arguments: 'hostname' and 'addr'
```

This masked the original connection failure with an internal Python
exception.

Fixes: https://tracker.ceph.com/issues/78450
Signed-off-by: Shubha Jain [SHUBHA.JAIN1@ibm.com]
Resolves: https://ibm-ceph.atlassian.net/browse/IBMCEPH-11244

**Solution**

Implement __reduce__() for HostConnectionError so that pickle preserves
all constructor arguments required to reconstruct the exception.

```python
def __reduce__(self):
    return (type(self), (self.args[0], self.hostname, self.addr))

**Validation**

Before fix

Reproduced by running maintenance on an unreachable host:

ceph orch host maintenance enter ceph-node-01 --force

Result:

```
TypeError: HostConnectionError.__init__() missing 2 required positional
arguments: 'hostname' and 'addr'
```

After fix

Running the same command returns the original error instead of an
internal exception:

```
Error EINVAL: Can't communicate with remote host
`192.168.100.101`, possibly because the host is not reachable or
python3 is not installed on the host.
[Errno 113] Connect call failed ('192.168.100.101', 22)
Maintenance workflow validation
```

Verified the original maintenance workflow:

Enter maintenance.
Simulate host reboot by stopping and starting the VM.
Exit maintenance.

Result:

maintenance exit succeeds
no internal TypeError is raised
cluster returns to HEALTH_OK

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
