### PR TITLE
qa: change rados suite workload files to use the correct object_size definition

### DIFF
--- a/qa/suites/rados/thrash-erasure-code-overwrites/workloads/ec-small-objects-fast-read-overwrites.yaml
+++ b/qa/suites/rados/thrash-erasure-code-overwrites/workloads/ec-small-objects-fast-read-overwrites.yaml
@@ -12,7 +12,7 @@ tasks:
     max_seconds: 600
     max_in_flight: 64
     objects: 1024
-    size: 16384
+    object_size: 16384
     ec_pool: true
     erasure_code_use_overwrites: true
     fast_read: true

--- a/qa/suites/rados/thrash-erasure-code-overwrites/workloads/ec-small-objects-overwrites.yaml
+++ b/qa/suites/rados/thrash-erasure-code-overwrites/workloads/ec-small-objects-overwrites.yaml
@@ -12,7 +12,7 @@ tasks:
     max_seconds: 600
     max_in_flight: 64
     objects: 1024
-    size: 16384
+    object_size: 16384
     ec_pool: true
     erasure_code_use_overwrites: true
     op_weights:

--- a/qa/suites/rados/thrash-erasure-code/workloads/ec-small-objects-fast-read.yaml
+++ b/qa/suites/rados/thrash-erasure-code/workloads/ec-small-objects-fast-read.yaml
@@ -5,7 +5,7 @@ tasks:
     max_seconds: 600
     max_in_flight: 64
     objects: 1024
-    size: 16384
+    object_size: 16384
     ec_pool: true
     fast_read: true
     op_weights:

--- a/qa/suites/rados/thrash-erasure-code/workloads/ec-small-objects-many-deletes.yaml
+++ b/qa/suites/rados/thrash-erasure-code/workloads/ec-small-objects-many-deletes.yaml
@@ -5,7 +5,7 @@ tasks:
     max_seconds: 600
     max_in_flight: 8
     objects: 20
-    size: 16384
+    object_size: 16384
     ec_pool: true
     op_weights:
       write: 0

--- a/qa/suites/rados/thrash-erasure-code/workloads/ec-small-objects.yaml
+++ b/qa/suites/rados/thrash-erasure-code/workloads/ec-small-objects.yaml
@@ -5,7 +5,7 @@ tasks:
     max_seconds: 600
     max_in_flight: 64
     objects: 1024
-    size: 16384
+    object_size: 16384
     ec_pool: true
     op_weights:
       read: 100

--- a/qa/suites/rados/thrash/workloads/small-objects-balanced.yaml
+++ b/qa/suites/rados/thrash/workloads/small-objects-balanced.yaml
@@ -10,7 +10,7 @@ tasks:
     max_seconds: 600
     max_in_flight: 64
     objects: 1024
-    size: 16384
+    object_size: 16384
     balance_reads: true
     op_weights:
       read: 100

--- a/qa/suites/rados/thrash/workloads/small-objects-localized.yaml
+++ b/qa/suites/rados/thrash/workloads/small-objects-localized.yaml
@@ -10,7 +10,7 @@ tasks:
     max_seconds: 600
     max_in_flight: 64
     objects: 1024
-    size: 16384
+    object_size: 16384
     localize_reads: true
     op_weights:
       read: 100

--- a/qa/suites/rados/thrash/workloads/small-objects.yaml
+++ b/qa/suites/rados/thrash/workloads/small-objects.yaml
@@ -10,7 +10,7 @@ tasks:
     max_seconds: 600
     max_in_flight: 64
     objects: 1024
-    size: 16384
+    object_size: 16384
     op_weights:
       read: 100
       write: 100


### PR DESCRIPTION
A number of workload YAML files in the rados suite are incorrectly using `size:` to define the object size, this does nothing. The correct way to define object size is `object_size:`

Fixes: https://tracker.ceph.com/issues/78481

Signed-off-by: Callum James <callum.james@ibm.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
