### PR TITLE
crimson, erasure-code: fix ISA plugin logging for shared Fast EC code 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -606,7 +606,8 @@ set(ceph_common_objs
   $<TARGET_OBJECTS:common_mountcephfs_objs>
   $<TARGET_OBJECTS:crush_objs>
   $<TARGET_OBJECTS:json_spirit>
-  $<TARGET_OBJECTS:erasure_code>)
+  $<TARGET_OBJECTS:erasure_code>
+  $<TARGET_OBJECTS:erasure_code_log>)
 set(ceph_common_deps
   common_utf8 extblkdev arch crc32
   ${LIB_RESOLV}

--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(crimson-osd
   pg_map.cc
   pg_interval_interrupt_condition.cc
   objclass.cc
+  ErasureCodeLog.cc
   ${PROJECT_SOURCE_DIR}/src/objclass/class_api.cc
   ${PROJECT_SOURCE_DIR}/src/osd/ClassHandler.cc
   ${PROJECT_SOURCE_DIR}/src/osd/ECCommon.cc

--- a/src/crimson/osd/ErasureCodeLog.cc
+++ b/src/crimson/osd/ErasureCodeLog.cc
@@ -1,0 +1,42 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Crimson implementation of the erasure-code logging boundary (ec_log).
+ *
+ * Although the body looks the same as the classical implementation,
+ * it is different because of how the `dout` macro expands under WITH_CRIMSON:
+ * it routes to the per-shard seastar logger via crimson::common::local_conf().
+ */
+
+#include <cstdarg>
+#include <boost/container/small_vector.hpp>
+
+#include "erasure-code/ErasureCodeLog.h"
+
+#include "common/ceph_context.h"
+#include "common/config.h"
+#include "crimson/common/config_proxy.h"
+#include "common/debug.h"
+#include "global/global_context.h"
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_osd
+
+int ec_log(int level, const char *format, ...)
+{
+  size_t size = 256;
+  va_list ap;
+  while (1) {
+    boost::container::small_vector<char, 256> buf(size);
+    va_start(ap, format);
+    int n = vsnprintf(buf.data(), size, format, ap);
+    va_end(ap);
+    constexpr size_t MAX_SIZE = 8196UL;
+    if ((n > -1 && static_cast<size_t>(n) < size) || size > MAX_SIZE) {
+      dout(ceph::dout::need_dynamic(level)) << buf.data() << dendl;
+      return n;
+    }
+    size *= 2;
+  }
+}

--- a/src/erasure-code/CMakeLists.txt
+++ b/src/erasure-code/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(erasure_code $<$<PLATFORM_ID:Windows>:dlfcn_win32>
                       ${CMAKE_DL_LIBS})
 
 add_library(erasure_code_objs OBJECT ErasureCode.cc)
+add_library(erasure_code_log OBJECT ErasureCodeLog.cc)
 
 add_custom_target(erasure_code_plugins DEPENDS
     ${EC_ISA_LIB}

--- a/src/erasure-code/ErasureCodeLog.cc
+++ b/src/erasure-code/ErasureCodeLog.cc
@@ -1,0 +1,45 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Classic implementation of the erasure-code logging boundary (ec_log).
+ *
+ * Linked into ceph-common, and thus into every classic consumer that loads an
+ * erasure-code plugin (ceph-osd, ceph-mon, ceph-erasure-code-tool, tests). 
+ * Differs from crimson in how the `dout` macro expands. 
+ */
+
+#include <cstdarg>
+#include <boost/container/small_vector.hpp>
+
+#include "erasure-code/ErasureCodeLog.h"
+
+#include "common/ceph_context.h"
+#include "common/config.h"
+#include "common/debug.h"
+#include "global/global_context.h"
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_osd
+
+int ec_log(int level, const char *format, ...)
+{
+  if (!g_ceph_context ||
+      !g_ceph_context->_conf->subsys.should_gather(dout_subsys, level)) {
+    return 0;
+  }
+  size_t size = 256;
+  va_list ap;
+  while (1) {
+    boost::container::small_vector<char, 256> buf(size);
+    va_start(ap, format);
+    int n = vsnprintf(buf.data(), size, format, ap);
+    va_end(ap);
+    constexpr size_t MAX_SIZE = 8196UL;
+    if ((n > -1 && static_cast<size_t>(n) < size) || size > MAX_SIZE) {
+      dout(ceph::dout::need_dynamic(level)) << buf.data() << dendl;
+      return n;
+    }
+    size *= 2;
+  }
+}

--- a/src/erasure-code/ErasureCodeLog.h
+++ b/src/erasure-code/ErasureCodeLog.h
@@ -1,0 +1,28 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#ifndef CEPH_ERASURE_CODE_LOG_H
+#define CEPH_ERASURE_CODE_LOG_H
+
+/*
+ * Logging boundary for erasure-code plugins.
+ *
+ * The erasure-code plugins are classic, shared objects between the 
+ * classic and crimson OSDs. To ensure logging is correctly wired 
+ * for both types of OSDs, `ec_log()` is used, similar to `cls_log()`. 
+ *
+ * The implementation differs per OSD flavor: 
+ *  - classic uses g_ceph_context-based `dout` 
+ *  - crimson routes to the per-shard seastar logger
+ *
+ * The plugin only declares and calls `ec_log`; it never defines it and never
+ * references `g_ceph_context`.  The symbol is resolved from the host at dlopen.
+ */
+extern int ec_log(int level, const char *format, ...)
+  __attribute__((__format__(printf, 2, 3)));
+
+#define EC_LOG(level, fmt, ...)                                         \
+  ec_log(level, "<ec> %s:%d: " fmt, __FILE__, __LINE__, ##__VA_ARGS__)
+#define EC_ERR(fmt, ...) EC_LOG(0, fmt, ##__VA_ARGS__)
+
+#endif // CEPH_ERASURE_CODE_LOG_H

--- a/src/erasure-code/isa/ErasureCodeIsa.cc
+++ b/src/erasure-code/isa/ErasureCodeIsa.cc
@@ -15,9 +15,12 @@
 // -----------------------------------------------------------------------------
 #include <algorithm>
 #include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 // -----------------------------------------------------------------------------
-#include "common/debug.h"
 #include "ErasureCodeIsa.h"
+#include "erasure-code/ErasureCodeLog.h"
 #include "include/ceph_assert.h"
 using namespace std;
 using namespace ceph;
@@ -26,20 +29,6 @@ using namespace ceph;
 extern "C" {
 #include "isa-l/include/erasure_code.h"
 #include "isa-l/include/raid.h"
-}
-// -----------------------------------------------------------------------------
-#define dout_context g_ceph_context
-#define dout_subsys ceph_subsys_osd
-#undef dout_prefix
-#define dout_prefix _prefix(_dout)
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-static ostream&
-_prefix(std::ostream* _dout)
-{
-  return *_dout << "ErasureCodeIsa: ";
 }
 // -----------------------------------------------------------------------------
 
@@ -67,12 +56,12 @@ ErasureCodeIsa::get_chunk_size(unsigned int stripe_width) const
 {
   unsigned alignment = get_alignment();
   unsigned chunk_size = (stripe_width + k - 1) / k;
-  dout(20) << "get_chunk_size: chunk_size " << chunk_size
-           << " must be modulo " << alignment << dendl;
+  EC_LOG(20, "get_chunk_size: chunk_size %u must be modulo %u",
+         chunk_size, alignment);
   unsigned modulo = chunk_size % alignment;
   if (modulo) {
-    dout(10) << "get_chunk_size: " << chunk_size
-             << " padded to " << chunk_size + alignment - modulo << dendl;
+    EC_LOG(10, "get_chunk_size: %u padded to %u",
+           chunk_size, chunk_size + alignment - modulo);
     chunk_size += alignment - modulo;
   }
   return chunk_size;
@@ -450,7 +439,7 @@ ErasureCodeIsaDefault::isa_decode(int *erasures,
   if ((m == 1) || 
       ((matrixtype == kVandermonde) && (nerrs == 1) && (erasures[0] < (k + 1)))) {
     // single parity decoding
-    dout(20) << "isa_decode: reconstruct using xor_gen [" << erasures[0] << "]" << dendl;
+    EC_LOG(20, "isa_decode: reconstruct using xor_gen [%d]", erasures[0]);
     isa_xor(recover_buf, recover_buf[k], blocksize, k);
     return 0;
   }
@@ -488,7 +477,7 @@ ErasureCodeIsaDefault::isa_decode(int *erasures,
 
     offset += snprintf(sig_buf + offset, sizeof(sig_buf) - offset, "+%d", r);
     if (offset >= (int)sizeof(sig_buf)) {
-      dout(0) << "isa_decode: signature buffer overflow" << dendl;
+      EC_LOG(0, "isa_decode: signature buffer overflow");
       return -1;
     }
   }
@@ -500,7 +489,7 @@ ErasureCodeIsaDefault::isa_decode(int *erasures,
   for (int p = 0; p < nerrs; p++) {
     offset += snprintf(sig_buf + offset, sizeof(sig_buf) - offset, "-%d", erasures[p]);
     if (offset >= (int)sizeof(sig_buf)) {
-      dout(0) << "isa_decode: signature buffer overflow" << dendl;
+      EC_LOG(0, "isa_decode: signature buffer overflow");
       return -1;
     }
   }
@@ -533,7 +522,7 @@ ErasureCodeIsaDefault::isa_decode(int *erasures,
     // does not help. Therefor we keep the code simpler.
     // --------------------------------------------------------
     if (gf_invert_matrix(b, d, k) < 0) {
-      dout(0) << "isa_decode: bad matrix" << dendl;
+      EC_LOG(0, "isa_decode: bad matrix");
       return -1;
     }
 
@@ -647,8 +636,7 @@ ErasureCodeIsaDefault::prepare()
   ceph_assert(p_enc_coeff);
 
   if (!*p_enc_coeff) {
-    dout(10) << "[ cache tables ] creating coeff for k=" <<
-      k << " m=" << m << dendl;
+    EC_LOG(10, "[ cache tables ] creating coeff for k=%d m=%d", k, m);
     // build encoding coefficients which need to be computed once for each (k,m)
     //
     // the coeff array is freed by ErasureCodeIsaTableCache::setEncodingCoefficient
@@ -670,8 +658,7 @@ ErasureCodeIsaDefault::prepare()
   ceph_assert(encode_coeff);
 
   if (!*p_enc_table) {
-    dout(10) << "[ cache tables ] creating tables for k=" <<
-      k << " m=" << m << dendl;
+    EC_LOG(10, "[ cache tables ] creating tables for k=%d m=%d", k, m);
     // build encoding table which needs to be computed once for each (k,m)
     encode_tbls = new unsigned char[k * (m + k)*32];
     ec_init_tables(k, m, &encode_coeff[k * k], encode_tbls);
@@ -688,9 +675,9 @@ ErasureCodeIsaDefault::prepare()
   unsigned memory_lru_cache =
     k * (m + k) * 32 * tcache.decoding_tables_lru_length;
 
-  dout(10) << "[ cache memory ] = " << memory_lru_cache << " bytes" <<
-    " [ matrix ] = " <<
-    ((matrixtype == kVandermonde) ? "Vandermonde" : "Cauchy") << dendl;
+  EC_LOG(10, "[ cache memory ] = %u bytes [ matrix ] = %s",
+         memory_lru_cache,
+         (matrixtype == kVandermonde) ? "Vandermonde" : "Cauchy");
 
   ceph_assert((matrixtype == kVandermonde) || (matrixtype == kCauchy));
 

--- a/src/erasure-code/isa/ErasureCodeIsaTableCache.cc
+++ b/src/erasure-code/isa/ErasureCodeIsaTableCache.cc
@@ -24,24 +24,10 @@
  */
 
 // -----------------------------------------------------------------------------
+#include <cstring>
+
 #include "ErasureCodeIsaTableCache.h"
-#include "common/debug.h"
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-#define dout_context g_ceph_context
-#define dout_subsys ceph_subsys_osd
-#undef dout_prefix
-#define dout_prefix _tc_prefix(_dout)
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-static std::ostream&
-_tc_prefix(std::ostream* _dout)
-{
-  return *_dout << "ErasureCodeIsaTableCache: ";
-}
+#include "erasure-code/ErasureCodeLog.h"
 
 // -----------------------------------------------------------------------------
 
@@ -247,7 +233,7 @@ ErasureCodeIsaTableCache::getDecodingTableFromCache(std::string &signature,
   // bytes and depends on both k and m.
   // --------------------------------------------------------------------------
 
-  dout(12) << "[ get table    ] = " << signature << dendl;
+  EC_LOG(12, "[ get table    ] = %s", signature.c_str());
 
   // we try to fetch a decoding table from an LRU cache
   std::lock_guard lock{codec_tables_guard};
@@ -263,11 +249,11 @@ ErasureCodeIsaTableCache::getDecodingTableFromCache(std::string &signature,
     return false;
   }
   const auto& [lru_list_it, cached_table] = lru_map_it->second;
-  dout(12) << "[ cached table ] = " << signature << dendl;
+  EC_LOG(12, "[ cached table ] = %s", signature.c_str());
   // copy the table out of the cache
   memcpy(table, cached_table.c_str(), k * (m + k)*32);
   // find item in LRU queue and push back
-  dout(12) << "[ cache size   ] = " << decode_tbls_lru->size() << dendl;
+  EC_LOG(12, "[ cache size   ] = %zu", decode_tbls_lru->size());
   decode_tbls_lru->splice( (decode_tbls_lru->begin()), *decode_tbls_lru, lru_list_it);
   return true;
 }
@@ -288,7 +274,7 @@ ErasureCodeIsaTableCache::putDecodingTableToCache(std::string &signature,
   // cache key uniqueness. See getDecodingTableFromCache() for details.
   // --------------------------------------------------------------------------
 
-  dout(12) << "[ put table    ] = " << signature << dendl;
+  EC_LOG(12, "[ put table    ] = %s", signature.c_str());
 
   // we store a new table to the cache
 
@@ -304,7 +290,7 @@ ErasureCodeIsaTableCache::putDecodingTableToCache(std::string &signature,
 
   // evt. shrink the LRU queue/map
   if ((int) decode_tbls_lru->size() >= ErasureCodeIsaTableCache::decoding_tables_lru_length) {
-    dout(12) << "[ shrink lru   ] = " << signature << dendl;
+    EC_LOG(12, "[ shrink lru   ] = %s", signature.c_str());
     // reuse old buffer
     cachetable = (*decode_tbls_map)[decode_tbls_lru->back()].second;
 
@@ -322,12 +308,12 @@ ErasureCodeIsaTableCache::putDecodingTableToCache(std::string &signature,
     // add the new to the map
     (*decode_tbls_map)[signature] = std::make_pair(decode_tbls_lru->begin(), cachetable);
   } else {
-    dout(12) << "[ store table  ] = " << signature << dendl;
+    EC_LOG(12, "[ store table  ] = %s", signature.c_str());
     // allocate a new buffer
     cachetable = ceph::buffer::create(k * (m + k)*32);
     decode_tbls_lru->push_front(signature);
     (*decode_tbls_map)[signature] = std::make_pair(decode_tbls_lru->begin(), cachetable);
-    dout(12) << "[ cache size   ] = " << decode_tbls_lru->size() << dendl;
+    EC_LOG(12, "[ cache size   ] = %zu", decode_tbls_lru->size());
   }
 
   // copy-in the new table


### PR DESCRIPTION
## Investigation 
On enabling the (previously disabled) unit tests for Fast EC in crimson, we encountered the following error: 

```
ERROR 2026-07-12 03:15:38,268 [shard 1:main] osd - Aborting Got SIGSEGV on shard 1 - Stopping all shards
ERROR 2026-07-12 03:15:39,186 [shard 1:main] osd - Got SIGSEGV on shard 1
Backtrace:
  0# ErasureCodeIsaDefault::prepare() in /usr/lib64/ceph/erasure-code/libec_isa.so
```

It only was happening when using seastore as a backend and not with bluestore. On debugging a core further with gdb  I saw: 

```
#7  ErasureCodeIsaDefault::prepare (this=0x600000336000) at /home/shraddhaag/Documents/ceph/src/erasure-code/isa/ErasureCodeIsa.cc:650
``` 

which points to line number 650 in ErasureCodeIsa.cc, which is: 

```
dout(10) << "[ cache tables ] creating coeff for k=" <<
      k << " m=" << m << dendl;
```

Somehow, a dout was causing the seg fault. Debugging frame 7 further with gdb we see: 

```
#7  ErasureCodeIsaDefault::prepare (this=0x600000336000) at /home/shraddhaag/Documents/ceph/src/erasure-code/isa/ErasureCodeIsa.cc:650
650        dout(10) << "[ cache tables ] creating coeff for k=" <<
$1 = (ceph::common::CephContext *) 0x0
```

This points to g_ceph_context being null (0x0). That would explain why a dout was causing a seg fault. 

## Root Cause 

The problem is with running Fast EC unit tests with seastore. The tests are seg faulting when trying to log. This is due to the null `g_ceph_context`.

The EC plugins are compiled as classic and expect `g_ceph_context` to be set to a classic `CephContext`. While bluestore does this (see: https://github.com/ceph/ceph/blob/main/src/crimson/os/alienstore/alien_store.cc#L89-L97), seastore does not and so we get a seg fault. 

The problem essentially boils down to how do we do logging in shared code across Fast EC, as the shared code is compiled as classic. For this PR we are focusing on the ISA plugin specifically. 

## Exploring Approaches

I looked at various solutions, `#ifdef WITH_CRIMSON` used in global_context.cc, or the approach taken in https://github.com/ceph/ceph/pull/67284/. Both of these approaches did seem the right fit here. 

I finally landed on https://github.com/ceph/ceph/pull/45278 which uses an interface `cls_log()` which has different implementations for classic and crimson. We are going to use a similar approach here but scoped to fast EC. 

## Solution 

We introduce a new interface `ec_log()` with macros `EC_LOG` and `EC_ERR`. Similar to `cls_log()`, `ec_log()` has different implementations for classic and crimson. 

### `ec_log` for classic

Uses `g_ceph_context` based `dout`. Verifies `g_ceph_context` isn't null. Is compiled into `erasure_code_log` and added to `ceph_common_objs`. 

### `ec_log` for crimson

`dout` macro routes to seastar's per shard logger. 

For this PR, this is only used in ISA plugin, but the usage will be expanded across all shared FastEC code where needed. 

## Testing 

Locally tested on a vstart cluster and running the tests is possible and does not seg fault as soon as a dout is encountered. A sample log looks like: 

```
2026-07-21 12:31:17,458 [shard 0:main] osd - <ec> /home/shraddhaag/Documents/ceph/src/erasure-code/isa/ErasureCodeIsa.cc:678: [ cache memory ] = 483072 bytes [ matrix ] = Vandermonde
```

Fixes: https://tracker.ceph.com/issues/78199

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
