### PR TITLE
umbrella: osd: cast uint8_t we output as string so they get displayed as numbers

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -2453,8 +2453,10 @@ ostream& operator<<(ostream& out, const pg_pool_t& p)
   out << p.get_type_name();
   if (p.get_type_name() == "erasure") {
     out << " profile " << p.erasure_code_profile;
-    out << " ec_data_shard_count " << p.ec_data_shard_count.value_or(0);
-    out << " ec_coding_shard_count " << p.ec_coding_shard_count.value_or(0);
+    out << " ec_data_shard_count "
+        << static_cast<unsigned int>(p.ec_data_shard_count.value_or(0));
+    out << " ec_coding_shard_count "
+        << static_cast<unsigned int>(p.ec_coding_shard_count.value_or(0));
   }
   out << " size " << p.get_size()
       << " min_size " << p.get_min_size()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78485

---

backport of https://github.com/ceph/ceph/pull/70114
parent tracker: https://tracker.ceph.com/issues/78484

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh