### PR TITLE
Wip osdmap epoch checkpoint

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,17 @@
+* RADOS: New ``osd_map_full_checkpoint_interval`` option. When set to a
+  non-zero value N, OSDs persist a full OSDMap only every Nth epoch and keep
+  only the incremental map for intermediate epochs, rebuilding them on demand
+  from the nearest older full map. This substantially reduces per-epoch
+  metadata writes on large clusters with big OSDMaps during periods of fast
+  epoch churn. Full maps received from the monitor are always persisted, and
+  the per-epoch canonical re-encode and CRC verification are unchanged.
+  Enabling the option adds an incompat feature to the OSD superblock; OSD
+  versions without support for it will refuse to start on such a store.
+  Setting the option back to 0 and restarting the OSD backfills the missing
+  full maps and clears the superblock feature, after which downgrading is
+  possible again. The default (0) preserves the previous behavior of storing
+  a full map every epoch.
+
 * CephFS: The ``client_force_lazyio`` configuration option is now correctly marked
   as not supporting runtime updates. Previously, the configuration schema indicated
   this option could be changed at runtime, but changes had no effect on opened file

--- a/qa/standalone/osd/osd-map-checkpoint.sh
+++ b/qa/standalone/osd/osd-map-checkpoint.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+mon_port=$(get_unused_port)
+
+CHECKPOINT_ARGS="--osd-map-full-checkpoint-interval=5"
+
+function run() {
+    local dir=$1
+    shift
+
+    export CEPH_MON="127.0.0.1:$mon_port"
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON "
+    set -e
+
+    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        setup $dir || return 1
+        $func $dir || return 1
+        teardown $dir || return 1
+    done
+}
+
+function churn_osdmap_epochs() {
+    local rounds=$1
+    for i in $(seq 1 $rounds); do
+        ceph osd pool set foo min_size 1
+        ceph osd pool set foo min_size 2
+    done
+}
+
+function TEST_map_checkpoint() {
+    local dir=$1
+
+    run_mon $dir a
+    run_mgr $dir x
+    run_osd $dir 0 $CHECKPOINT_ARGS
+    run_osd $dir 1 $CHECKPOINT_ARGS
+    run_osd $dir 2 $CHECKPOINT_ARGS
+
+    create_pool foo 8
+    wait_for_clean || return 1
+    rados -p foo put obj1 /etc/group || return 1
+
+    churn_osdmap_epochs 10
+    wait_for_clean || return 1
+
+    local newest=$(ceph osd dump -f json | jq .epoch)
+    test "$newest" -gt 15 || return 1
+
+    grep "enabling FULLMAP_CHECKPOINTS" $dir/osd.0.log || return 1
+
+    local stored=$(CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) \
+        perf dump | jq .osd.full_map_stored)
+    local consumed=$(CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) \
+        perf dump | jq .osd.map_message_epochs)
+    test "$stored" -lt "$consumed" || return 1
+
+    # restart: boot has to rebuild the current map when it is not a checkpoint
+    kill_daemons $dir TERM osd.0 || return 1
+    activate_osd $dir 0 $CHECKPOINT_ARGS || return 1
+    TIMEOUT=60 wait_for_osd up 0 || return 1
+    wait_for_clean || return 1
+    rados -p foo put obj2 /etc/group || return 1
+    rados -p foo get obj1 $dir/obj1.out || return 1
+    diff $dir/obj1.out /etc/group || return 1
+
+    # more churn after restart, then read/write again
+    churn_osdmap_epochs 5
+    wait_for_clean || return 1
+    rados -p foo put obj3 /etc/group || return 1
+
+    # offline access must work for every epoch, checkpoint or not
+    kill_daemons $dir TERM osd.0 || return 1
+
+    ceph-objectstore-tool --data-path $dir/0 --no-mon-config \
+        --op dump-super | grep "periodic full osdmap checkpoints" || return 1
+
+    # the cluster keeps advancing epochs after osd.0 stops, so probe the
+    # newest map present in osd.0's own store
+    local maps=$(ceph-objectstore-tool --data-path $dir/0 --no-mon-config \
+        --op dump-super | jq -r .maps)
+    local last_start=$(echo $maps | sed 's/.*[[,]\([0-9]*\)~[0-9]*\]$/\1/')
+    local last_len=$(echo $maps | sed 's/.*~\([0-9]*\)\]$/\1/')
+    newest=$((last_start + last_len - 1))
+    test "$newest" -gt 8 || return 1
+
+    for e in $(seq $((newest - 7)) $newest); do
+        ceph-objectstore-tool --data-path $dir/0 --no-mon-config \
+            --op get-osdmap --epoch $e --file $dir/osdmap.$e || return 1
+        osdmaptool --print $dir/osdmap.$e | grep "epoch $e" || return 1
+    done
+
+    # disabling the option must backfill full maps and clear the feature
+    activate_osd $dir 0 || return 1
+    TIMEOUT=60 wait_for_osd up 0 || return 1
+    wait_for_clean || return 1
+    grep "cleared FULLMAP_CHECKPOINTS feature" $dir/osd.0.log || return 1
+
+    kill_daemons $dir TERM osd.0 || return 1
+    if ceph-objectstore-tool --data-path $dir/0 --no-mon-config \
+        --op dump-super | grep "periodic full osdmap checkpoints" ; then
+        return 1
+    fi
+    activate_osd $dir 0 || return 1
+    TIMEOUT=60 wait_for_osd up 0 || return 1
+    wait_for_clean || return 1
+    rados -p foo put obj4 /etc/group || return 1
+
+    echo success
+
+    delete_pool foo
+    kill_daemons $dir || return 1
+}
+
+function TEST_map_checkpoint_crash_and_reconfigure() {
+    local dir=$1
+
+    run_mon $dir a
+    run_mgr $dir x
+    run_osd $dir 0 $CHECKPOINT_ARGS
+    run_osd $dir 1 $CHECKPOINT_ARGS
+    run_osd $dir 2 $CHECKPOINT_ARGS
+
+    create_pool foo 8
+    wait_for_clean || return 1
+    rados -p foo put obj1 /etc/group || return 1
+    churn_osdmap_epochs 8
+    wait_for_clean || return 1
+
+    # hard crash, then boot must replay from the last checkpoint
+    kill_daemons $dir KILL osd.0 || return 1
+    activate_osd $dir 0 $CHECKPOINT_ARGS || return 1
+    TIMEOUT=60 wait_for_osd up 0 || return 1
+    wait_for_clean || return 1
+    rados -p foo put obj2 /etc/group || return 1
+
+    # restart with a different interval; placement of old checkpoints
+    # must not matter
+    churn_osdmap_epochs 4
+    kill_daemons $dir TERM osd.0 || return 1
+    activate_osd $dir 0 --osd-map-full-checkpoint-interval=3 || return 1
+    TIMEOUT=60 wait_for_osd up 0 || return 1
+    wait_for_clean || return 1
+    churn_osdmap_epochs 4
+    rados -p foo put obj3 /etc/group || return 1
+    rados -p foo get obj1 $dir/obj1.out || return 1
+    diff $dir/obj1.out /etc/group || return 1
+
+    echo success
+
+    delete_pool foo
+    kill_daemons $dir || return 1
+}
+
+function TEST_map_checkpoint_disabled_unaffected() {
+    local dir=$1
+
+    run_mon $dir a
+    run_mgr $dir x
+    run_osd $dir 0
+    run_osd $dir 1
+    run_osd $dir 2
+
+    create_pool foo 8
+    wait_for_clean || return 1
+    rados -p foo put obj1 /etc/group || return 1
+
+    churn_osdmap_epochs 5
+    wait_for_clean || return 1
+
+    if grep "enabling FULLMAP_CHECKPOINTS" $dir/osd.0.log ; then
+        return 1
+    fi
+
+    kill_daemons $dir TERM osd.0 || return 1
+    if ceph-objectstore-tool --data-path $dir/0 --no-mon-config \
+        --op dump-super | grep "periodic full osdmap checkpoints" ; then
+        return 1
+    fi
+    activate_osd $dir 0 || return 1
+    TIMEOUT=60 wait_for_osd up 0 || return 1
+    wait_for_clean || return 1
+
+    echo success
+
+    delete_pool foo
+    kill_daemons $dir || return 1
+}
+
+main osd-map-checkpoint "$@"
+
+# Local Variables:
+# compile-command: "make -j4 && ../qa/run-standalone.sh osd-map-checkpoint.sh"
+# End:

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -890,6 +890,30 @@ options:
   default: 50
   fmt_desc: The number of OSD maps to keep cached.
   with_legacy: true
+- name: osd_map_full_checkpoint_interval
+  type: int
+  level: advanced
+  desc: Store a full OSDMap only every Nth epoch; intermediate epochs keep only
+    the incremental map and are rebuilt on demand from the nearest older full
+    map. 0 means store a full map every epoch.
+  long_desc: Storing full maps only periodically reduces per-epoch metadata
+    writes on every OSD, which matters on large clusters with big OSDMaps
+    (e.g. many pg_upmap entries) during periods of fast epoch churn. Full maps
+    received from the monitor are always stored. Setting a non-zero value adds
+    an incompat superblock feature; OSD versions without support for this
+    feature will refuse to start on such a store. Setting the value back to 0
+    and restarting the OSD backfills the missing full maps and clears the
+    superblock feature again. The value may be changed at any time; placement
+    of already stored full maps is discovered by probing the store, so no
+    invariant depends on the previous setting. Rebuilding an evicted
+    intermediate map costs one incremental replay per epoch since the nearest
+    older full map, so values much larger than osd_map_cache_size are not
+    recommended.
+  default: 0
+  min: 0
+  max: 1000
+  see_also:
+  - osd_map_cache_size
 - name: osd_pg_epoch_max_lag_factor
   type: float
   level: advanced

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -239,6 +239,7 @@ CompatSet OSD::get_osd_compat_set() {
   CompatSet compat =  get_osd_initial_compat_set();
   //Any features here can be set in code, but not in initial superblock
   compat.incompat.insert(CEPH_OSD_FEATURE_INCOMPAT_SHARDS);
+  compat.incompat.insert(CEPH_OSD_FEATURE_INCOMPAT_FULLMAP_CHECKPOINTS);
   return compat;
 }
 
@@ -1443,7 +1444,7 @@ MOSDMap *OSDService::build_incremental_map_msg(epoch_t since, epoch_t to,
              << dendl;
     since = m->cluster_osdmap_trim_lower_bound;
     if (bufferlist bl;
-        get_map_and_adjust_counters(bl, max, max_bytes, [&] { return get_map_bl(since, bl);})) {
+        get_map_and_adjust_counters(bl, max, max_bytes, [&] { return get_or_build_map_bl(since, bl);})) {
       m->maps[since] = std::move(bl);
       ++since;
     } else {
@@ -1459,7 +1460,7 @@ MOSDMap *OSDService::build_incremental_map_msg(epoch_t since, epoch_t to,
     } else {
       dout(10) << __func__ << " missing incremental map " << e << dendl;
       if (bufferlist bl;
-          get_map_and_adjust_counters(bl, max, max_bytes, [&] { return get_map_bl(e, bl);})) {
+          get_map_and_adjust_counters(bl, max, max_bytes, [&] { return get_or_build_map_bl(e, bl);})) {
         m->maps[e] = std::move(bl);
       } else {
         derr << __func__ << " also missing full map " << e << dendl;
@@ -1479,7 +1480,7 @@ MOSDMap *OSDService::build_incremental_map_msg(epoch_t since, epoch_t to,
   bufferlist bl;
   if (get_inc_map_bl(m->newest_map, bl)) {
     m->incremental_maps[m->newest_map] = std::move(bl);
-  } else if (get_map_bl(m->newest_map, bl)) {
+  } else if (get_or_build_map_bl(m->newest_map, bl)) {
     m->maps[m->newest_map] = std::move(bl);
   } else {
     derr << __func__ << " unable to load latest map " << m->newest_map
@@ -1532,6 +1533,11 @@ bool OSDService::_get_map_bl(epoch_t e, bufferlist& bl)
 bool OSDService::get_inc_map_bl(epoch_t e, bufferlist& bl)
 {
   std::lock_guard l(map_cache_lock);
+  return _get_inc_map_bl(e, bl);
+}
+
+bool OSDService::_get_inc_map_bl(epoch_t e, bufferlist& bl)
+{
   bool found = map_bl_inc_cache.lookup(e, &bl);
   if (found) {
     logger->inc(l_osd_map_bl_cache_hit);
@@ -1591,6 +1597,96 @@ OSDMapRef OSDService::_add_map(OSDMap *o)
   return l;
 }
 
+OSDMapRef OSDService::_rebuild_map_from_incrementals(epoch_t epoch)
+{
+  epoch_t floor = 0;
+  {
+    const auto stored_maps = get_superblock().get_maps();
+    for (auto i = stored_maps.begin(); i != stored_maps.end(); ++i) {
+      if (i.get_start() <= epoch && epoch < i.get_start() + i.get_len()) {
+	floor = i.get_start();
+	break;
+      }
+    }
+  }
+  if (floor == 0) {
+    dout(10) << __func__ << " epoch " << epoch
+	     << " is not in the stored map range" << dendl;
+    return OSDMapRef();
+  }
+
+  OSDMapRef base;
+  epoch_t base_epoch = 0;
+  for (epoch_t e = epoch - 1; e >= floor; --e) {
+    if (OSDMapRef m = map_cache.lookup(e)) {
+      base = std::move(m);
+      base_epoch = e;
+      break;
+    }
+    bufferlist fbl;
+    if (_get_map_bl(e, fbl) && fbl.length() > 0) {
+      OSDMap *o = new OSDMap;
+      o->decode(fbl);
+      base = _add_map(o);
+      base_epoch = e;
+      break;
+    }
+  }
+  if (!base) {
+    derr << __func__ << " no full map found at or below epoch " << epoch
+	 << " (floor " << floor << ")" << dendl;
+    return OSDMapRef();
+  }
+
+  OSDMapRef cur = std::move(base);
+  for (epoch_t e = base_epoch + 1; e <= epoch; ++e) {
+    if (OSDMapRef m = map_cache.lookup(e)) {
+      cur = std::move(m);
+      continue;
+    }
+    bufferlist ibl;
+    if (!_get_inc_map_bl(e, ibl) || ibl.length() == 0) {
+      derr << __func__ << " missing incremental map " << e
+	   << " while rebuilding epoch " << epoch << dendl;
+      return OSDMapRef();
+    }
+    OSDMap::Incremental inc;
+    auto p = ibl.cbegin();
+    inc.decode(p);
+    auto o = std::make_unique<OSDMap>();
+    o->deepish_copy_from(*cur);
+    if (o->apply_incremental(inc) < 0) {
+      derr << __func__ << " failed to apply incremental map " << e
+	   << " while rebuilding epoch " << epoch << dendl;
+      return OSDMapRef();
+    }
+    cur = _add_map(o.release());
+  }
+  dout(10) << __func__ << " rebuilt epoch " << epoch
+	   << " from full map " << base_epoch
+	   << " + " << (epoch - base_epoch) << " incrementals" << dendl;
+  logger->inc(l_osd_map_rebuilt);
+  return cur;
+}
+
+bool OSDService::get_or_build_map_bl(epoch_t e, bufferlist& bl)
+{
+  std::lock_guard l(map_cache_lock);
+  if (_get_map_bl(e, bl)) {
+    return true;
+  }
+  OSDMapRef m = map_cache.lookup(e);
+  if (!m) {
+    m = _rebuild_map_from_incrementals(e);
+  }
+  if (!m) {
+    return false;
+  }
+  m->encode(bl, m->get_encoding_features() | CEPH_FEATURE_RESERVED);
+  _add_map_bl(e, bl);
+  return true;
+}
+
 OSDMapRef OSDService::try_get_map(epoch_t epoch)
 {
   std::lock_guard l(map_cache_lock);
@@ -1615,9 +1711,12 @@ OSDMapRef OSDService::try_get_map(epoch_t epoch)
     dout(20) << "get_map " << epoch << " - loading and decoding " << map << dendl;
     bufferlist bl;
     if (!_get_map_bl(epoch, bl) || bl.length() == 0) {
-      derr << "failed to load OSD map for epoch " << epoch << ", got " << bl.length() << " bytes" << dendl;
       delete map;
-      return OSDMapRef();
+      OSDMapRef rebuilt = _rebuild_map_from_incrementals(epoch);
+      if (!rebuilt) {
+	derr << "failed to load OSD map for epoch " << epoch << dendl;
+      }
+      return rebuilt;
     }
     map->decode(bl);
   } else {
@@ -3792,6 +3891,9 @@ int OSD::init()
   }
 
   startup_time = ceph::mono_clock::now();
+
+  maybe_disable_fullmap_checkpoints();
+  service.publish_superblock(superblock);
 
   // load up "current" osdmap
   assert_warn(!get_osdmap());
@@ -8131,9 +8233,101 @@ void OSD::osdmap_subscribe(version_t epoch, bool force_request)
   }
 }
 
+bool OSD::is_full_map_checkpoint_epoch(epoch_t e) const
+{
+  int64_t interval =
+    cct->_conf.get_val<int64_t>("osd_map_full_checkpoint_interval");
+  return interval <= 0 || e % interval == 0;
+}
+
+epoch_t OSD::clamp_trim_to_full_map(epoch_t min)
+{
+  for (epoch_t e = min; e > superblock.get_oldest_map(); --e) {
+    if (store->exists(service.meta_ch, get_osdmap_pobject_name(e))) {
+      return e;
+    }
+  }
+  return superblock.get_oldest_map();
+}
+
+void OSD::maybe_disable_fullmap_checkpoints()
+{
+  if (!superblock.compat_features.incompat.contains(
+	CEPH_OSD_FEATURE_INCOMPAT_FULLMAP_CHECKPOINTS)) {
+    return;
+  }
+  if (cct->_conf.get_val<int64_t>("osd_map_full_checkpoint_interval") > 0) {
+    return;
+  }
+  dout(1) << __func__ << " osd_map_full_checkpoint_interval is 0, backfilling"
+	  << " missing full maps" << dendl;
+  unsigned nwritten = 0;
+  const auto stored_maps = superblock.get_maps();
+  for (auto i = stored_maps.begin(); i != stored_maps.end(); ++i) {
+    OSDMap cur;
+    ObjectStore::Transaction t;
+    for (epoch_t e = i.get_start(); e < i.get_start() + i.get_len(); ++e) {
+      if (store->exists(service.meta_ch, get_osdmap_pobject_name(e))) {
+	continue;
+      }
+      if (cur.get_epoch() != e - 1) {
+	bufferlist bl;
+	if (store->read(service.meta_ch,
+			get_osdmap_pobject_name(e - 1), 0, 0, bl) < 0 ||
+	    bl.length() == 0) {
+	  derr << __func__ << " no full map at epoch " << (e - 1)
+	       << ", leaving FULLMAP_CHECKPOINTS feature set" << dendl;
+	  return;
+	}
+	auto p = bl.cbegin();
+	cur.decode(p);
+      }
+      bufferlist ibl;
+      if (store->read(service.meta_ch,
+		      get_inc_osdmap_pobject_name(e), 0, 0, ibl) < 0 ||
+	  ibl.length() == 0) {
+	derr << __func__ << " missing incremental map " << e
+	     << ", leaving FULLMAP_CHECKPOINTS feature set" << dendl;
+	return;
+      }
+      OSDMap::Incremental inc;
+      auto p = ibl.cbegin();
+      inc.decode(p);
+      if (cur.apply_incremental(inc) < 0) {
+	derr << __func__ << " failed to apply incremental map " << e
+	     << ", leaving FULLMAP_CHECKPOINTS feature set" << dendl;
+	return;
+      }
+      bufferlist fbl;
+      cur.encode(fbl, cur.get_encoding_features() | CEPH_FEATURE_RESERVED);
+      t.write(coll_t::meta(), get_osdmap_pobject_name(e), 0,
+	      fbl.length(), fbl);
+      nwritten++;
+      if (t.get_num_ops() >= cct->_conf->osd_target_transaction_size) {
+	int r = store->queue_transaction(service.meta_ch,
+					 t.claim_and_reset(), nullptr);
+	ceph_assert(r == 0);
+      }
+    }
+    if (t.get_num_ops() > 0) {
+      int r = store->queue_transaction(service.meta_ch, std::move(t), nullptr);
+      ceph_assert(r == 0);
+    }
+  }
+  superblock.compat_features.incompat.remove(
+    CEPH_OSD_FEATURE_INCOMPAT_FULLMAP_CHECKPOINTS);
+  ObjectStore::Transaction t;
+  write_superblock(cct, superblock, t);
+  int r = store->queue_transaction(service.meta_ch, std::move(t), nullptr);
+  ceph_assert(r == 0);
+  dout(1) << __func__ << " backfilled " << nwritten << " full maps, cleared"
+	  << " FULLMAP_CHECKPOINTS feature" << dendl;
+}
+
 void OSD::trim_maps(epoch_t oldest)
 {
   epoch_t min = std::min(oldest, service.map_cache.cached_key_lower_bound());
+  min = clamp_trim_to_full_map(min);
   dout(20) <<  __func__ << ": min=" << min << " oldest_map="
            << superblock.get_oldest_map() << dendl;
   if (min <= superblock.get_oldest_map())
@@ -8209,6 +8403,43 @@ int OSD::trim_stale_maps()
   }
 
   return num_removed;
+}
+
+int OSD::build_full_map_from_store(ObjectStore& store,
+				   epoch_t e,
+				   OSDMap* out)
+{
+  if (e == 0 || !out) {
+    return -EINVAL;
+  }
+  auto ch = store.open_collection(coll_t::meta());
+  if (!ch) {
+    return -ENOENT;
+  }
+  epoch_t base = e;
+  bufferlist fbl;
+  while (store.read(ch, get_osdmap_pobject_name(base), 0, 0, fbl) < 0 ||
+	 fbl.length() == 0) {
+    fbl.clear();
+    if (--base == 0) {
+      return -ENOENT;
+    }
+  }
+  out->decode(fbl);
+  for (epoch_t i = base + 1; i <= e; ++i) {
+    bufferlist ibl;
+    if (store.read(ch, get_inc_osdmap_pobject_name(i), 0, 0, ibl) < 0 ||
+	ibl.length() == 0) {
+      return -ENOENT;
+    }
+    OSDMap::Incremental inc;
+    auto p = ibl.cbegin();
+    inc.decode(p);
+    if (out->apply_incremental(inc) < 0) {
+      return -EINVAL;
+    }
+  }
+  return 0;
 }
 
 void OSD::handle_osd_map(MOSDMap *m)
@@ -8370,6 +8601,7 @@ void OSD::handle_osd_map(MOSDMap *m)
 
       ghobject_t fulloid = get_osdmap_pobject_name(e);
       t.write(coll_t::meta(), fulloid, 0, bl.length(), bl);
+      logger->inc(l_osd_full_map_stored);
       added_maps[e] = add_map(o);
       got_full_map(e);
       continue;
@@ -8440,8 +8672,17 @@ void OSD::handle_osd_map(MOSDMap *m)
       got_full_map(e);
       purged_snaps[e] = o->get_new_purged_snaps();
 
-      ghobject_t fulloid = get_osdmap_pobject_name(e);
-      t.write(coll_t::meta(), fulloid, 0, fbl.length(), fbl);
+      if (is_full_map_checkpoint_epoch(e)) {
+	ghobject_t fulloid = get_osdmap_pobject_name(e);
+	t.write(coll_t::meta(), fulloid, 0, fbl.length(), fbl);
+	logger->inc(l_osd_full_map_stored);
+      } else if (!superblock.compat_features.incompat.contains(
+		   CEPH_OSD_FEATURE_INCOMPAT_FULLMAP_CHECKPOINTS)) {
+	dout(5) << __func__ << " enabling FULLMAP_CHECKPOINTS superblock"
+		<< " feature" << dendl;
+	superblock.compat_features.incompat.insert(
+	  CEPH_OSD_FEATURE_INCOMPAT_FULLMAP_CHECKPOINTS);
+      }
       added_maps[e] = add_map(o);
       continue;
     }

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -707,6 +707,7 @@ public:
     return _add_map(o);
   }
   OSDMapRef _add_map(OSDMap *o);
+  OSDMapRef _rebuild_map_from_incrementals(epoch_t e);
 
   void _add_map_bl(epoch_t e, ceph::buffer::list& bl);
   bool get_map_bl(epoch_t e, ceph::buffer::list& bl) {
@@ -714,9 +715,11 @@ public:
     return _get_map_bl(e, bl);
   }
   bool _get_map_bl(epoch_t e, ceph::buffer::list& bl);
+  bool get_or_build_map_bl(epoch_t e, ceph::buffer::list& bl);
 
   void _add_map_inc_bl(epoch_t e, ceph::buffer::list& bl);
   bool get_inc_map_bl(epoch_t e, ceph::buffer::list& bl);
+  bool _get_inc_map_bl(epoch_t e, ceph::buffer::list& bl);
 
   /// identify split child pgids over a osdmap interval
   void identify_splits_and_merges(
@@ -1338,6 +1341,10 @@ public:
     return ghobject_t(hobject_t(sobject_t(object_t(foo), 0)));
   }
 
+  static int build_full_map_from_store(ObjectStore& store,
+				       epoch_t e,
+				       OSDMap* out);
+
   static ghobject_t make_snapmapper_oid() {
     return ghobject_t(hobject_t(
       sobject_t(
@@ -1904,6 +1911,9 @@ protected:
                                        epoch_t current_added_map_epoch);
   void _committed_osd_maps(epoch_t first, epoch_t last, class MOSDMap *m);
   void trim_maps(epoch_t oldest);
+  bool is_full_map_checkpoint_epoch(epoch_t e) const;
+  epoch_t clamp_trim_to_full_map(epoch_t min);
+  void maybe_disable_fullmap_checkpoints();
   void note_down_osd(int osd);
   void note_up_osd(int osd);
   friend struct C_OnMapCommit;

--- a/src/osd/osd_perf_counters.cc
+++ b/src/osd/osd_perf_counters.cc
@@ -252,6 +252,12 @@ PerfCounters *build_osd_logger(CephContext *cct) {
   osd_plb.add_u64_counter(
     l_osd_inc_map_received, "inc_map_received",
     "number of incremental OSD map received via MOSDMap");
+  osd_plb.add_u64_counter(
+    l_osd_full_map_stored, "full_map_stored",
+    "number of full OSD maps written to the store");
+  osd_plb.add_u64_counter(
+    l_osd_map_rebuilt, "map_rebuilt",
+    "number of OSD maps rebuilt from incremental maps");
   osd_plb.add_u64_counter(l_osd_mape, "map_message_epochs", "OSD map epochs");
   osd_plb.add_u64_counter(
     l_osd_mape_dup, "map_message_epoch_dups", "OSD map duplicates");

--- a/src/osd/osd_perf_counters.h
+++ b/src/osd/osd_perf_counters.h
@@ -93,6 +93,8 @@ enum osd_counter_idx_t {
   l_osd_mape_dup,
   l_osd_full_map_received,
   l_osd_inc_map_received,
+  l_osd_full_map_stored,
+  l_osd_map_rebuilt,
 
   l_osd_waiting_for_map,
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -77,6 +77,7 @@
 #define CEPH_OSD_FEATURE_INCOMPAT_FASTINFO CompatSet::Feature(15, "fastinfo pg attr")
 #define CEPH_OSD_FEATURE_INCOMPAT_RECOVERY_DELETES CompatSet::Feature(16, "deletes in missing set")
 #define CEPH_OSD_FEATURE_INCOMPAT_SNAPMAPPER2 CompatSet::Feature(17, "new snapmapper key structure")
+#define CEPH_OSD_FEATURE_INCOMPAT_FULLMAP_CHECKPOINTS CompatSet::Feature(18, "periodic full osdmap checkpoints")
 
 
 /// pool priority range set by user

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -1130,8 +1130,19 @@ int get_osdmap(ObjectStore *store, epoch_t e, OSDMap &osdmap, bufferlist& bl)
   bool found = store->read(
     ch, OSD::get_osdmap_pobject_name(e), 0, 0, bl) >= 0;
   if (!found) {
-    cerr << "Can't find OSDMap for pg epoch " << e << std::endl;
-    return -ENOENT;
+    bl.clear();
+    int r = OSD::build_full_map_from_store(*store, e, &osdmap);
+    if (r < 0) {
+      cerr << "Can't find OSDMap for pg epoch " << e << std::endl;
+      return -ENOENT;
+    }
+    osdmap.encode(bl, osdmap.get_encoding_features() | CEPH_FEATURE_RESERVED);
+    if (debug) {
+      cerr << "rebuilt osdmap epoch " << e << " from incremental maps"
+	   << std::endl;
+      cerr << osdmap << std::endl;
+    }
+    return 0;
   }
   osdmap.decode(bl);
   if (debug)

--- a/src/tools/rebuild_mondb.cc
+++ b/src/tools/rebuild_mondb.cc
@@ -298,26 +298,41 @@ int update_osdmap(ObjectStore& fs, OSDSuperblock& sb, MonitorDBStore& ms)
       bufferlist bl;
       int nread = fs.read(ch, oid, 0, 0, bl);
       if (nread <= 0) {
-        cerr << "missing " << oid << std::endl;
-        return -EINVAL;
-      }
-      t->put(prefix, ms.combine_strings("full", e), bl);
-
-      auto p = bl.cbegin();
-      osdmap.decode(p);
-      if (osdmap.have_crc()) {
+        bl.clear();
+        if (osdmap.get_epoch() != e &&
+            OSD::build_full_map_from_store(fs, e, &osdmap) < 0) {
+          cerr << "missing " << oid << std::endl;
+          return -EINVAL;
+        }
+        if (!features) {
+          features = osdmap.get_encoding_features() | CEPH_FEATURE_RESERVED;
+        }
+        osdmap.encode(bl, features);
         if (have_crc && osdmap.get_crc() != crc) {
-          cerr << "mismatched full/inc crc: "
+          cerr << "mismatched rebuilt full crc: "
                << osdmap.get_crc() << " != " << crc << std::endl;
           return -EINVAL;
         }
-        uint32_t saved_crc = osdmap.get_crc();
-        bufferlist fbl;
-        osdmap.encode(fbl, features);
-        if (osdmap.get_crc() != saved_crc) {
-          cerr << "mismatched full crc: "
-               << saved_crc << " != " << osdmap.get_crc() << std::endl;
-          return -EINVAL;
+        t->put(prefix, ms.combine_strings("full", e), bl);
+      } else {
+        t->put(prefix, ms.combine_strings("full", e), bl);
+
+        auto p = bl.cbegin();
+        osdmap.decode(p);
+        if (osdmap.have_crc()) {
+          if (have_crc && osdmap.get_crc() != crc) {
+            cerr << "mismatched full/inc crc: "
+                 << osdmap.get_crc() << " != " << crc << std::endl;
+            return -EINVAL;
+          }
+          uint32_t saved_crc = osdmap.get_crc();
+          bufferlist fbl;
+          osdmap.encode(fbl, features);
+          if (osdmap.get_crc() != saved_crc) {
+            cerr << "mismatched full crc: "
+                 << saved_crc << " != " << osdmap.get_crc() << std::endl;
+            return -EINVAL;
+          }
         }
       }
     }


### PR DESCRIPTION



First step of https://tracker.ceph.com/issues/78474 ("Make per-epoch OSDMap handling cost independent of map size").

## What

Adds `osd_map_full_checkpoint_interval` (default 0 = current behavior). When set to N > 0, the OSD persists a locally re-encoded full OSDMap only at epochs where `e % N == 0`; other epochs store only the incremental. Full maps received from the monitor are always persisted. Epochs without an on-disk full map are rebuilt on demand from the nearest older full map plus incremental replay (map cache misses, boot, peer map sharing, offline tools).

## Why

On large clusters the encoded OSDMap reaches multiple MB (e.g. tens of thousands of pg_upmap entries during balancer operation or upmap-based migrations). Persisting a full map on every OSD for every epoch multiplies map size by epoch churn rate into significant cluster-wide metadata write traffic, and sits on the map-ingest path that client ops stamped with a new epoch wait on. See the tracker ticket for the full analysis and the staged plan; this PR is stage 1.

## Design notes

- The per-epoch canonical re-encode and CRC verification against `inc.full_crc` are unchanged; this PR removes write bytes, not the divergence check.
- Checkpoint placement is deterministic (`e % N`), so no persistent bookkeeping is needed: readers and trim discover full-map locations by probing the store. `trim_maps` clamps the trim floor to the newest on-disk full map at or below the target, so the oldest stored epoch is always a valid rebuild base.
- Enabling the option inserts a new `FULLMAP_CHECKPOINTS` superblock incompat feature in the same transaction as the first skipped write; older OSD/tool builds refuse such a store with a clear error. Setting the option back to 0 backfills missing full maps at the next boot and clears the feature, making downgrade possible again.
- `ceph-objectstore-tool --op get-osdmap` and `update-mon-db` (rebuild_mondb) rebuild missing full maps from incrementals; rebuild_mondb still verifies rebuilt maps against `inc.full_crc`.
- New perf counters: `full_map_stored`, `map_rebuilt`.
- Known scope cuts: crimson-osd has its own map store path and is not covered; the per-epoch re-encode CPU cost is retained by design (addressed by a later stage in the ticket); worst-case rebuild cost is bounded by the option's max (1000) and documented to be kept <= osd_map_cache_size.

## Testing

- New standalone test `qa/standalone/osd/osd-map-checkpoint.sh`, 3 scenarios, all passing:
  - full lifecycle: enable, churn, OSD restart onto a non-checkpoint epoch, offline get-osdmap of hole epochs (verified with osdmaptool), superblock feature presence, disable + backfill + feature cleared, IO before/after throughout;
  - SIGKILL crash + boot replay + runtime interval change (5 -> 3);
  - regression: default configuration stores full maps every epoch and never sets the feature.
- `qa/standalone/osd/bad-inc-map.sh` (adjacent CRC-failure path in handle_osd_map): passing.
- Perf counters confirmed the mechanism during the test run: 11 full maps stored vs 191 map epochs consumed at interval 5.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
