### PR TITLE
umbrella: mgr/DaemonServer: Make an ok-to-upgrade error message more generic

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -2389,8 +2389,7 @@ bool DaemonServer::_handle_command(
         cmdctx->reply(-EAGAIN, ss);
       }
       if (!pg_offline_report.ok_to_stop()) {
-        ss << "unsafe to upgrade OSD(s) at this time (at least "
-           << pg_offline_report.not_ok.size()
+        ss << "unsafe to upgrade OSD(s) at this time (one or more"
            << " PG(s) will become offline if any OSD out of the "
            << osds_in_crush_bucket.size() << " in CRUSH bucket '"
            << crush_bucket_name << "' is stopped)";


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78486

---

backport of https://github.com/ceph/ceph/pull/70357
parent tracker: https://tracker.ceph.com/issues/78425

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh