### PR TITLE
umbrella: rgw_gc: don't fail when processing entry with nonexisting pool

### DIFF
--- a/src/rgw/driver/rados/rgw_gc.cc
+++ b/src/rgw/driver/rados/rgw_gc.cc
@@ -675,9 +675,9 @@ int RGWGC::process(int index, int max_secs, bool expired_only,
 	    ctx = new IoCtx;
 	    ret = rgw_init_ioctx(this, store->get_rados_handle(), obj.pool, *ctx);
 	    if (ret < 0) {
-        if (transitioned_objects_cache[index]) {
-          goto done;
-        }
+	      if (ret != -ENOENT && transitioned_objects_cache[index]) {
+		goto done;
+	      }
 	      last_pool = "";
 	      ldpp_dout(this, 0) << "ERROR: failed to create ioctx pool=" <<
 		obj.pool << dendl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78495

---

backport of https://github.com/ceph/ceph/pull/59902
parent tracker: https://tracker.ceph.com/issues/68169

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh