### PR TITLE
ptl-tool: add New QA Links to update-qa notification

### DIFF
--- a/src/script/ptl-tool.py
+++ b/src/script/ptl-tool.py
@@ -1838,12 +1838,12 @@ def manage_qa_tracker(args, R, session, branch, prs, tag, qa_tracker_description
             **New Branch:** `{branch}`
 
             **Previous QA Links:**
-            * "Shaman Build":https://shaman.ceph.com/builds/ceph/{old_branch}/
-            * "Pulpito / Teuthology Results":https://pulpito.ceph.com/?branch={old_branch}
+            * Shaman Build: "{old_branch}":https://shaman.ceph.com/builds/ceph/{old_branch}/
+            * Pulpito / Teuthology Results: "{old_branch}":https://pulpito.ceph.com/?branch={old_branch}
 
             **New QA Links:**
-            * "Shaman Build":https://shaman.ceph.com/builds/ceph/{branch}/
-            * "Pulpito / Teuthology Results":https://pulpito.ceph.com/?branch={branch}
+            * Shaman Build: "{branch}":https://shaman.ceph.com/builds/ceph/{branch}/
+            * Pulpito / Teuthology Results: "{branch}":https://pulpito.ceph.com/?branch={branch}
 
             """
         notes = textwrap.dedent(notes)

--- a/src/script/ptl-tool.py
+++ b/src/script/ptl-tool.py
@@ -1841,6 +1841,10 @@ def manage_qa_tracker(args, R, session, branch, prs, tag, qa_tracker_description
             * "Shaman Build":https://shaman.ceph.com/builds/ceph/{old_branch}/
             * "Pulpito / Teuthology Results":https://pulpito.ceph.com/?branch={old_branch}
 
+            **New QA Links:**
+            * "Shaman Build":https://shaman.ceph.com/builds/ceph/{branch}/
+            * "Pulpito / Teuthology Results":https://pulpito.ceph.com/?branch={branch}
+
             """
         notes = textwrap.dedent(notes)
         if old_prs:


### PR DESCRIPTION
## Summary

When `ptl-tool.py --update-qa` re-points a QA tracker at a new integration branch, the auto-posted "Update Triggered" comment lists a **Previous QA Links** section for the *old* branch, but had no equivalent section for the *new* branch — so getting to the new run's results meant copying the "New Branch" text and hand-building the Shaman/Pulpito URLs yourself.

This adds a matching **New QA Links** section for the new branch. It also makes the link *text* itself the actual branch name (e.g. `wip-yuri3-testing-20260721.155422-umbrella`), not a generic "Shaman Build" label — so the reader sees which build/run they're clicking into at a glance, rather than having to hover or click through to find out.

Real example from the live journal entry this produced against https://tracker.ceph.com/issues/78493 (rendered HTML, not the raw Textile):
```
New QA Links:
  Shaman Build: wip-yuriw-testing-20260721.165421-umbrella   (linked to shaman.ceph.com/builds/ceph/wip-yuriw-testing-20260721.165421-umbrella/)
  Pulpito / Teuthology Results: wip-yuriw-testing-20260721.165421-umbrella   (linked to pulpito.ceph.com/?branch=wip-yuriw-testing-20260721.165421-umbrella)
```

Note this is separate from the "Shaman Build"/"QA Runs" Redmine custom fields on the ticket itself, which already render as clickable links via the tracker's custom-field URL pattern — this change only affects the free-text update comment.

## Test plan

- [x] `python3 -m py_compile src/script/ptl-tool.py`
- [x] Two full **live, non-dry-run** `--update-qa 78493` executions against the real tracker ticket that prompted this (not a synthetic/dry-run test): first with a generic-label version, then with this branch-name-as-link-text version. Confirmed via the Redmine API's rendered HTML (`curl .../issues/78493 | grep`) that the final journal entry shows the branch name itself as the clickable link text, e.g. `<a href="...pulpito.ceph.com/?branch=wip-yuriw-testing-20260721.165421-umbrella">wip-yuriw-testing-20260721.165421-umbrella</a>`.

## Checklist
- Tracker
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [x] No impact that needs to be tracked
- Documentation
  - [x] No doc update is appropriate
- Tests
  - [x] No tests
