### PR TITLE
squid: test/kafka: support archived kafka versions

### DIFF
--- a/qa/tasks/kafka.py
+++ b/qa/tasks/kafka.py
@@ -50,8 +50,13 @@ def install_kafka(ctx, config):
 
         link1 = '{apache_mirror_url_front}/kafka/'.format(apache_mirror_url_front=apache_mirror_url_front) + \
             current_version + '/' + kafka_file
+        archive_link = 'https://archive.apache.org/dist/kafka/' + current_version + '/' + kafka_file
+        log.info('Trying to download Kafka from mirror: %s', link1)
+        log.info('Archive fallback URL: %s', archive_link)
         ctx.cluster.only(client).run(
-            args=['cd', '{tdir}'.format(tdir=test_dir), run.Raw('&&'), 'wget', link1],
+            args=['cd', '{tdir}'.format(tdir=test_dir), run.Raw('&&'),
+                  'wget', link1, run.Raw('||'),
+                  run.Raw('('), 'rm', '-f', kafka_file, run.Raw('&&'), 'wget', archive_link, run.Raw(')')],
         )
 
         ctx.cluster.only(client).run(

--- a/qa/tasks/kafka_failover.py
+++ b/qa/tasks/kafka_failover.py
@@ -50,8 +50,13 @@ def install_kafka(ctx, config):
 
         link1 = '{apache_mirror_url_front}/kafka/'.format(apache_mirror_url_front=apache_mirror_url_front) + \
             current_version + '/' + kafka_file
+        archive_link = 'https://archive.apache.org/dist/kafka/' + current_version + '/' + kafka_file
+        log.info('Trying to download Kafka from mirror: %s', link1)
+        log.info('Archive fallback URL: %s', archive_link)
         ctx.cluster.only(client).run(
-            args=['cd', '{tdir}'.format(tdir=test_dir), run.Raw('&&'), 'wget', link1],
+            args=['cd', '{tdir}'.format(tdir=test_dir), run.Raw('&&'),
+                  'wget', link1, run.Raw('||'),
+                  run.Raw('('), 'rm', '-f', kafka_file, run.Raw('&&'), 'wget', archive_link, run.Raw(')')],
         )
 
         ctx.cluster.only(client).run(


### PR DESCRIPTION
Original tracker: https://tracker.ceph.com/issues/78214
Original PR: https://github.com/ceph/ceph/pull/70188
Backport tracker: https://tracker.ceph.com/issues/78242