### PR TITLE
umbrella: qa/suites/upgrade: ignore fs down variant

### DIFF
--- a/qa/overrides/upgrade_ignorelist_health.yaml
+++ b/qa/overrides/upgrade_ignorelist_health.yaml
@@ -22,5 +22,7 @@ overrides:
       - osds down
       - MDS_INSUFFICIENT_STANDBY
       - insufficient standby
+      - fs has.*but wants
       - have.*want.*more
+      - fs .* is degraded
       - is offline because no MDS is active for it


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78163

---

backport of https://github.com/ceph/ceph/pull/69149
parent tracker: https://tracker.ceph.com/issues/76969

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh