### PR TITLE
ptl-tool: add --version flag

### DIFF
--- a/src/script/ptl-tool.py
+++ b/src/script/ptl-tool.py
@@ -102,6 +102,7 @@ INDICATIONS = [
     re.compile(r"(Acked-by: .+ <[\w@.-]+>)", re.IGNORECASE),
     re.compile(r"(Tested-by: .+ <[\w@.-]+>)", re.IGNORECASE),
 ]
+SCRIPT_VERSION = "2026.07.21"  # bump on every functional change to this file
 REDMINE_CUSTOM_FIELD_ID_PULL_REQUEST_ID = 21
 REDMINE_CUSTOM_FIELD_ID_RELEASE = 16
 REDMINE_CUSTOM_FIELD_ID_SHAMAN_BUILD = 26
@@ -2312,6 +2313,7 @@ def main():
     argv = sys.argv[1:]
 
     group = parser.add_argument_group('General Options')
+    group.add_argument('--version', action='version', version=f'%(prog)s {SCRIPT_VERSION}')
     group.add_argument('--debug', dest='debug', action='store_true', help='turn debugging on')
     group.add_argument('--dry-run', dest='dry_run', action='store_true', help='print actions without modifying remote state')
     group.add_argument('--examples', dest='examples', action='store_true', help='show extended examples and usage')


### PR DESCRIPTION
## Summary

`ptl-tool.py` has no version tracking at all today, which has repeatedly caused confusion about drift between deployed copies (see e.g. soko04 vs. vossi02 both running stale copies of this script after upstream changes, requiring a manual `gh api .../commits -f path=src/script/ptl-tool.py` diff to even notice).

Adds:
- `SCRIPT_VERSION = "2026.07.21"` — a date-based version constant near the other module-level constants, meant to be bumped in the same diff as any future functional change to this file
- `--version` — wired via argparse's built-in `action='version'`, so it prints and exits cleanly with no custom code needed elsewhere

```
$ python src/script/ptl-tool.py --version
ptl-tool.py 2026.07.21
```

## Test plan

- [x] `python3 -m py_compile src/script/ptl-tool.py`
- [x] Live run of `python src/script/ptl-tool.py --version` in the standard venv on soko04 — confirmed exact output and a clean exit code 0
- No addition to `src/script/test_ptl_tool.py` in this PR — that file only exists on the not-yet-merged #70398, and duplicating/depending on an unmerged PR's test file would be messy. A trivial `--version` test can be added there once #70398 lands.

## Checklist
- Tracker
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [x] No impact that needs to be tracked
- Documentation
  - [x] No doc update is appropriate
- Tests
  - [x] No tests
