### PR TITLE
umbrella: librbd: fix use-after-free in trash purge on image open error

### DIFF
--- a/src/librbd/api/Trash.cc
+++ b/src/librbd/api/Trash.cc
@@ -487,6 +487,7 @@ int Trash<I>::purge(IoCtx& io_ctx, time_t expire_ts,
           } else if (r < 0) {
             lderr(cct) << "failed to open image " << it << ": "
                        << cpp_strerror(r) << dendl;
+            continue;
           }
 
           r = librbd::api::DiffIterate<I>::diff_iterate(


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77842

---

backport of https://github.com/ceph/ceph/pull/69836
parent tracker: https://tracker.ceph.com/issues/77836