### PR TITLE
umbrella: os/bluestore: use _release_pending_allocations() during file migration

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4407,6 +4407,7 @@ options:
     sleep state for this duration. Once the idle period expires, it wakes up, scans
     for spillover files, and resumes migration if needed.
   default: 1200
+  min: 0
   see_also:
   - bluefs_spillover_cleaner
   flags:
@@ -4424,6 +4425,8 @@ options:
   default: 0.1
   flags:
   - runtime
+  min: 0.01
+  max: 1.0
   with_legacy: true
 - name: bluefs_debug_force_slow
   type: bool

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -5550,7 +5550,9 @@ void *BlueFS::SpilloverCleanerThread::entry() {
 BlueFS::SpillOverCleanerAction BlueFS::RebalanceToDB::advance(BlueFS *fs)
 {
   if (idx >= pending.size()) {
+    last_scan_time = ceph_clock_now();
     pending.clear();
+    skipped.clear();
     idx = 0;
     std::unique_lock nl(fs->nodes.lock);
     for (auto& [dir, dir_ref] : fs->nodes.dir_map) {
@@ -5567,7 +5569,7 @@ BlueFS::SpillOverCleanerAction BlueFS::RebalanceToDB::advance(BlueFS *fs)
           });
 
         if (has_slow)
-          pending.push_back({dir + "/" + fname,file_ref});
+          pending.push_back({dir + "/" + fname, file_ref});
       }
     }
     if (pending.empty()) {
@@ -5575,6 +5577,13 @@ BlueFS::SpillOverCleanerAction BlueFS::RebalanceToDB::advance(BlueFS *fs)
     }
   }
   auto& [path, file] = pending[idx++];
+  int writers = file->num_writers.load(std::memory_order_relaxed);
+  // MANIFEST is excluded from this check because
+  // RocksDB keeps a writer open to it permanently.
+  if (writers > 0 && !path.ends_with("/MANIFEST")) {
+    skipped.push_back({path, writers});
+    return SpillOverCleanerAction::CONTINUE;
+  }
   int r = fs->migrate_file(
     fs->cct,
     file,
@@ -5639,6 +5648,15 @@ void BlueFS::RebalanceToDB::dump_plan(Formatter* f)
     f->dump_string("file", path);
   }
   f->close_section();
+  f->open_array_section("active_files");
+  for (const auto& [path, writers] : skipped) {
+    f->dump_string(
+      "file",
+      path + " num_writers=" + std::to_string(writers));
+  }
+  f->close_section();
+  f->dump_stream("last_scan_time")
+    << last_scan_time;
 }
 
 // ===============================================

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2092,19 +2092,16 @@ int BlueFS::migrate_file(
 
   sync_metadata(false);
 
-  std::map<int, PExtentVector> releases;
+  std::vector<interval_set<uint64_t>> to_release(MAX_BDEV);
+
   for (const auto& old_ext : old_fnode_extents) {
     vselector->sub_usage(file_ref->vselector_hint, old_ext);
-    releases[old_ext.bdev].emplace_back(
+    to_release[old_ext.bdev].insert(
       old_ext.offset,
       old_ext.length);
-    if (is_shared_alloc(old_ext.bdev)) {
-      shared_alloc->bluefs_used -= old_ext.length;
-    }
   }
-  for (auto& [bdev, vec] : releases) {
-    alloc[bdev]->release(vec);
-  }
+
+  _release_pending_allocations(to_release);
 
   dout(10) << __func__
           << " done ino " << file_ref->fnode.ino

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -1074,6 +1074,8 @@ private:
 
   struct RebalanceToDB : public SpilloverCleanerLogic {
     std::vector<std::pair<std::string, FileRef>> pending;
+    std::vector<std::pair<std::string, int>> skipped;
+    utime_t last_scan_time;
     std::deque<std::string> history;
     static constexpr size_t max_history = 100;
     size_t idx = 0;


### PR DESCRIPTION
`BlueFS::migrate_file()` releases old extents directly via `alloc[bdev]->release()` after a successful migration. This bypasses the common `_release_pending_allocations()` helper, which first attempts to queue discards before releasing extents back to the allocator.

Avoid migrating files that have active writers.

Add validation limits for BlueFS spillover configuration parameters to prevent invalid values.
Set a min value of 0 for `bluefs_spillover_idle_duration` and restrict `bluefs_spillover_cleaner_work_ratio` to the range `0.01 - 1.0` to ensure proper runtime configuration.

Consists
Backport PR : #70217
Backport PR : #70391

Backport Tracker : https://tracker.ceph.com/issues/78468
Backport Tracker : https://tracker.ceph.com/issues/78542


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
