### PR TITLE
mon,osd: optionally preserve acting sets on pool crush_rule change

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,12 @@
+* RADOS: Changing a pool's CRUSH rule can now optionally preserve data
+  placement: with ``mon_crush_rule_change_preserve_acting`` enabled, the
+  monitor stages ``pg-upmap-items`` entries in the same map epoch as the rule
+  change, keeping each shard on an OSD of its acting set whenever the new
+  failure domain allows it and relocating only the violating shards (either
+  load-aware, the default, or by deterministic hashing; see
+  ``mon_crush_rule_change_preserve_acting_fill_strategy``). This avoids
+  relocating the bulk of a pool when only its failure domain changes.
+
 * CephFS: The ``client_force_lazyio`` configuration option is now correctly marked
   as not supporting runtime updates. Previously, the configuration schema indicated
   this option could be changed at runtime, but changes had no effect on opened file

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -4,6 +4,14 @@
   from ``false`` to ``true``.
 * RGW: The default value of ``rgw_rest_conn_ip_fail_timeout_secs`` changed
   from ``2`` to ``30`` seconds.
+* RADOS: Changing a pool's CRUSH rule can now optionally preserve data
+  placement: with ``mon_crush_rule_change_preserve_acting`` enabled, the
+  monitor stages ``pg-upmap-items`` entries in the same map epoch as the rule
+  change, keeping each shard on an OSD of its acting set whenever the new
+  failure domain allows it and relocating only the violating shards (either
+  load-aware, the default, or by deterministic hashing; see
+  ``mon_crush_rule_change_preserve_acting_fill_strategy``). This avoids
+  relocating the bulk of a pool when only its failure domain changes.
 
 * ``src/script/ceph-backport.sh`` now runs on macOS in addition to Linux: it
   re-execs under GNU bash >= 4 when the system bash is too old, and honors a

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -1544,3 +1544,46 @@ options:
   - mon
   flags:
   - runtime
+- name: mon_crush_rule_change_preserve_acting
+  type: bool
+  level: advanced
+  desc: Minimize data movement when a pool's crush rule is changed
+  long_desc: When a pool is switched to a CRUSH rule with a different failure
+    domain, placement is normally recomputed from scratch and most data moves.
+    With this option enabled, the monitor stages pg-upmap-items entries in the
+    same map epoch as the rule change that keep every shard on an OSD of its
+    current acting set whenever the new failure domain allows it, relocating
+    only the shards that violate the new rule. The upmap balancer, when
+    enabled, will gradually optimize the residual imbalance and retire these
+    entries.
+  default: false
+  services:
+  - mon
+  with_legacy: false
+- name: mon_crush_rule_change_preserve_acting_max_pgs
+  type: uint
+  level: advanced
+  desc: Do not attempt acting-preserving crush rule changes on pools with more
+    placement groups than this (bounds the synchronous work in the mon)
+  default: 65536
+  services:
+  - mon
+  with_legacy: false
+- name: mon_crush_rule_change_preserve_acting_fill_strategy
+  type: str
+  level: advanced
+  desc: How to pick replacement OSDs for shards that violate the new failure
+    domain during an acting-preserving crush rule change
+  long_desc: load-aware picks the OSD with the lowest planned shard count,
+    normalized by crush weight, across the remaining free failure-domain
+    buckets, leaving the pool nearly balanced and the upmap balancer with
+    little residual work. hash prefers the raw CRUSH pick when its failure
+    domain bucket is free and otherwise spreads by deterministic hashing,
+    which generates fewer pg-upmap-items pairs but a less balanced result.
+  enum_values:
+  - load-aware
+  - hash
+  default: load-aware
+  services:
+  - mon
+  with_legacy: false

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -1570,3 +1570,46 @@ options:
   - mon
   flags:
   - runtime
+- name: mon_crush_rule_change_preserve_acting
+  type: bool
+  level: advanced
+  desc: Minimize data movement when a pool's crush rule is changed
+  long_desc: When a pool is switched to a CRUSH rule with a different failure
+    domain, placement is normally recomputed from scratch and most data moves.
+    With this option enabled, the monitor stages pg-upmap-items entries in the
+    same map epoch as the rule change that keep every shard on an OSD of its
+    current acting set whenever the new failure domain allows it, relocating
+    only the shards that violate the new rule. The upmap balancer, when
+    enabled, will gradually optimize the residual imbalance and retire these
+    entries.
+  default: false
+  services:
+  - mon
+  with_legacy: false
+- name: mon_crush_rule_change_preserve_acting_max_pgs
+  type: uint
+  level: advanced
+  desc: Do not attempt acting-preserving crush rule changes on pools with more
+    placement groups than this (bounds the synchronous work in the mon)
+  default: 65536
+  services:
+  - mon
+  with_legacy: false
+- name: mon_crush_rule_change_preserve_acting_fill_strategy
+  type: str
+  level: advanced
+  desc: How to pick replacement OSDs for shards that violate the new failure
+    domain during an acting-preserving crush rule change
+  long_desc: load-aware picks the OSD with the lowest planned shard count,
+    normalized by crush weight, across the remaining free failure-domain
+    buckets, leaving the pool nearly balanced and the upmap balancer with
+    little residual work. hash prefers the raw CRUSH pick when its failure
+    domain bucket is free and otherwise spreads by deterministic hashing,
+    which generates fewer pg-upmap-items pairs but a less balanced result.
+  enum_values:
+  - load-aware
+  - hash
+  default: load-aware
+  services:
+  - mon
+  with_legacy: false

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -9104,6 +9104,61 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
       ss << "crush rule " << id << " type does not match pool";
       return -EINVAL;
     }
+    if (g_conf().get_val<bool>("mon_crush_rule_change_preserve_acting") &&
+        id != (int)p.get_crush_rule()) {
+      if (osdmap.require_min_compat_client != ceph_release_t::unknown &&
+          osdmap.require_min_compat_client < ceph_release_t::luminous) {
+        // same gate as the `osd pg-upmap-items` command: pre-luminous
+        // clients cannot decode pg_upmap_items
+        dout(1) << __func__ << " pool " << pool << ": not staging"
+                << " acting-preserving pg-upmap-items:"
+                << " require_min_compat_client "
+                << osdmap.require_min_compat_client << " < luminous" << dendl;
+      } else if (p.get_pg_num() != p.get_pg_num_pending()) {
+        // a pg merge is in flight: pins for the merge-source pgs would
+        // immediately be cleaned again; change the rule plainly instead
+        dout(1) << __func__ << " pool " << pool << ": not staging"
+                << " acting-preserving pg-upmap-items: pg_num change in"
+                << " progress" << dendl;
+      } else if (p.get_pg_num() >
+          g_conf().get_val<uint64_t>(
+            "mon_crush_rule_change_preserve_acting_max_pgs")) {
+        dout(1) << __func__ << " pool " << pool << " has too many pgs for"
+                << " acting-preserving rule change, falling back to plain"
+                << " rule change" << dendl;
+      } else {
+        // Stage, in the same pending incremental as the rule change,
+        // pg_upmap_items that keep each shard on its acting OSD whenever
+        // the new failure domain allows.  Compute them against a scratch
+        // map carrying everything already staged in this proposal (a
+        // pending crush map, pending pool changes, ...) plus the new rule,
+        // so the pins match what will actually be committed.
+        OSDMap tmp;
+        tmp.deepish_copy_from(osdmap);
+        {
+          OSDMap::Incremental t_inc = pending_inc;
+          pg_pool_t tp = p;
+          tp.crush_rule = id;
+          t_inc.new_pools[pool] = tp;
+          tmp.apply_incremental(t_inc);
+        }
+        bool load_aware =
+          g_conf().get_val<std::string>(
+            "mon_crush_rule_change_preserve_acting_fill_strategy") != "hash";
+        int pr = osdmap.calc_crush_rule_change_pins(cct, tmp, pool,
+                                                    &pending_inc, load_aware);
+        if (pr >= 0) {
+          dout(1) << __func__ << " pool " << pool << " crush_rule " << id
+                  << ": staged acting-preserving pg-upmap-items for " << pr
+                  << " pgs (fill=" << (load_aware ? "load-aware" : "hash")
+                  << ")" << dendl;
+        } else {
+          dout(1) << __func__ << " pool " << pool << " crush_rule " << id
+                  << ": could not stage acting-preserving pg-upmap-items: "
+                  << cpp_strerror(pr) << dendl;
+        }
+      }
+    }
     p.crush_rule = id;
   } else if (var == "nodelete" || var == "nopgchange" ||
 	     var == "nosizechange" || var == "write_fadvise_dontneed" ||

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -9107,6 +9107,61 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
       ss << "crush rule " << id << " type does not match pool";
       return -EINVAL;
     }
+    if (g_conf().get_val<bool>("mon_crush_rule_change_preserve_acting") &&
+        id != (int)p.get_crush_rule()) {
+      if (osdmap.require_min_compat_client != ceph_release_t::unknown &&
+          osdmap.require_min_compat_client < ceph_release_t::luminous) {
+        // same gate as the `osd pg-upmap-items` command: pre-luminous
+        // clients cannot decode pg_upmap_items
+        dout(1) << __func__ << " pool " << pool << ": not staging"
+                << " acting-preserving pg-upmap-items:"
+                << " require_min_compat_client "
+                << osdmap.require_min_compat_client << " < luminous" << dendl;
+      } else if (p.get_pg_num() != p.get_pg_num_pending()) {
+        // a pg merge is in flight: pins for the merge-source pgs would
+        // immediately be cleaned again; change the rule plainly instead
+        dout(1) << __func__ << " pool " << pool << ": not staging"
+                << " acting-preserving pg-upmap-items: pg_num change in"
+                << " progress" << dendl;
+      } else if (p.get_pg_num() >
+          g_conf().get_val<uint64_t>(
+            "mon_crush_rule_change_preserve_acting_max_pgs")) {
+        dout(1) << __func__ << " pool " << pool << " has too many pgs for"
+                << " acting-preserving rule change, falling back to plain"
+                << " rule change" << dendl;
+      } else {
+        // Stage, in the same pending incremental as the rule change,
+        // pg_upmap_items that keep each shard on its acting OSD whenever
+        // the new failure domain allows.  Compute them against a scratch
+        // map carrying everything already staged in this proposal (a
+        // pending crush map, pending pool changes, ...) plus the new rule,
+        // so the pins match what will actually be committed.
+        OSDMap tmp;
+        tmp.deepish_copy_from(osdmap);
+        {
+          OSDMap::Incremental t_inc = pending_inc;
+          pg_pool_t tp = p;
+          tp.crush_rule = id;
+          t_inc.new_pools[pool] = tp;
+          tmp.apply_incremental(t_inc);
+        }
+        bool load_aware =
+          g_conf().get_val<std::string>(
+            "mon_crush_rule_change_preserve_acting_fill_strategy") != "hash";
+        int pr = osdmap.calc_crush_rule_change_pins(cct, tmp, pool,
+                                                    &pending_inc, load_aware);
+        if (pr >= 0) {
+          dout(1) << __func__ << " pool " << pool << " crush_rule " << id
+                  << ": staged acting-preserving pg-upmap-items for " << pr
+                  << " pgs (fill=" << (load_aware ? "load-aware" : "hash")
+                  << ")" << dendl;
+        } else {
+          dout(1) << __func__ << " pool " << pool << " crush_rule " << id
+                  << ": could not stage acting-preserving pg-upmap-items: "
+                  << cpp_strerror(pr) << dendl;
+        }
+      }
+    }
     p.crush_rule = id;
   } else if (var == "nodelete" || var == "nopgchange" ||
 	     var == "nosizechange" || var == "write_fadvise_dontneed" ||

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2356,6 +2356,329 @@ void OSDMap::clean_pg_upmaps(
   }
 }
 
+int OSDMap::calc_crush_rule_change_pins(
+  CephContext *cct,
+  const OSDMap& newmap,
+  int64_t pool_id,
+  Incremental *pending_inc,
+  bool load_aware_fill) const
+{
+  const pg_pool_t *pi = newmap.get_pg_pool(pool_id);
+  if (!pi)
+    return -ENOENT;
+  const int rule = pi->get_crush_rule();
+  const unsigned size = pi->get_size();
+
+  if (!newmap.crush->rule_exists(rule))
+    return -ENOENT;
+
+  // failure-domain type = type of the last choose/chooseleaf step of the rule
+  int ftype = 0;
+  const int rule_len = newmap.crush->get_rule_len(rule);
+  for (int step = 0; step < rule_len; ++step) {
+    int op = newmap.crush->get_rule_op(rule, step);
+    if (op == CRUSH_RULE_CHOOSELEAF_FIRSTN ||
+        op == CRUSH_RULE_CHOOSELEAF_INDEP ||
+        op == CRUSH_RULE_CHOOSE_FIRSTN ||
+        op == CRUSH_RULE_CHOOSE_INDEP) {
+      ftype = newmap.crush->get_rule_arg2(rule, step);
+    }
+  }
+  if (ftype <= 0)
+    return 0;               // osd-level rule: nothing to preserve, raw is fine
+
+  // enumerate in+up OSDs of the rule's subtree and their failure-domain bucket
+  std::map<int, float> weight_map;
+  int r = newmap.crush->get_rule_weight_osd_map(rule, &weight_map);
+  if (r < 0)
+    return r;
+  std::map<int, int> fd_of;                 // osd -> failure-domain bucket
+  std::map<int, std::vector<int>> fd_osds;  // bucket -> in osds
+  for (auto& [osd, w] : weight_map) {
+    if (w <= 0)
+      continue;
+    if (osd < 0 || osd >= newmap.get_max_osd() ||
+        !newmap.exists(osd) || !newmap.is_up(osd) ||
+        newmap.get_weightf(osd) == 0)
+      continue;
+    int parent = newmap.crush->get_parent_of_type(osd, ftype, rule);
+    if (parent >= 0)                        // could not resolve an ancestor
+      continue;
+    fd_of[osd] = parent;
+    fd_osds[parent].push_back(osd);
+  }
+  if (fd_osds.size() < size)
+    return -ENOSPC;                         // pool cannot satisfy the domain
+
+  // shards this plan has already assigned per OSD, for the load-aware fill
+  std::map<int, unsigned> planned;
+  int npins = 0;
+  for (unsigned ps = 0; ps < pi->get_pg_num(); ++ps) {
+    pg_t pg(ps, pool_id);
+    std::vector<int> up, acting;
+    // acting from *this* (pre-change) map: up + pg_temp = where the data is
+    pg_to_up_acting_osds(pg, up, acting);
+    std::vector<int> raw_new;
+    int primary;
+    newmap.pg_to_raw_osds(pg, &raw_new, &primary);
+    if (raw_new.size() != size) {
+      for (auto o : raw_new) {
+        if (o != CRUSH_ITEM_NONE)
+          planned[o]++;
+      }
+      continue;
+    }
+
+    // pass 1: keep acting OSDs the new failure domain allows (per position)
+    std::set<int> used;
+    std::vector<int> target(size, CRUSH_ITEM_NONE);
+    std::vector<bool> pinned(size, false);
+    for (unsigned i = 0; i < size && i < acting.size(); ++i) {
+      int a = acting[i];
+      auto it = fd_of.find(a);
+      if (a != CRUSH_ITEM_NONE && it != fd_of.end() &&
+          !used.count(it->second)) {
+        target[i] = a;
+        used.insert(it->second);
+        pinned[i] = true;
+      }
+    }
+    // pass 2: fill the violators; prefer CRUSH's own pick, else spread
+    // deterministically over the free buckets so forced moves stay balanced
+    bool ok = true;
+    for (unsigned i = 0; i < size; ++i) {
+      if (pinned[i])
+        continue;
+      if (load_aware_fill) {
+        // pick the least-loaded (crush-weight normalized) in-OSD across the
+        // remaining free failure-domain buckets; deterministic tie-break so
+        // the result is reproducible for identical inputs.  This scan is
+        // O(#osds in the rule subtree) per relocated shard; the total work
+        // is bounded by mon_crush_rule_change_preserve_acting_max_pgs.
+        int chosen = -1;
+        int chosen_bkt = 0;
+        std::pair<double, uint32_t> best_key;
+        for (auto& [b, osds] : fd_osds) {
+          if (used.count(b))
+            continue;
+          for (int cand : osds) {
+            auto pit = planned.find(cand);
+            std::pair<double, uint32_t> key(
+              (pit == planned.end() ? 0 : pit->second) /
+                (double)weight_map.at(cand),
+              (uint32_t)cand * 2654435761u + (uint32_t)ps * 40503u);
+            if (chosen < 0 || key < best_key) {
+              best_key = key;
+              chosen = cand;
+              chosen_bkt = b;
+            }
+          }
+        }
+        if (chosen < 0) {
+          ok = false;
+          break;
+        }
+        used.insert(chosen_bkt);
+        target[i] = chosen;
+        continue;
+      }
+      int u = raw_new[i];
+      auto it = fd_of.find(u);
+      if (u != CRUSH_ITEM_NONE && it != fd_of.end() &&
+          !used.count(it->second)) {
+        target[i] = u;
+        used.insert(it->second);
+        continue;
+      }
+      std::vector<int> free_bkts;
+      for (auto& q : fd_osds) {
+        if (!used.count(q.first))
+          free_bkts.push_back(q.first);
+      }
+      if (free_bkts.empty()) {
+        ok = false;
+        break;
+      }
+      uint32_t h = ps * 2654435761u + i * 40503u + 3u;
+      int b = free_bkts[h % free_bkts.size()];
+      used.insert(b);
+      int chosen = -1;
+      for (int cand : raw_new) {            // reuse a CRUSH pick living in b
+        auto ct = fd_of.find(cand);
+        if (ct != fd_of.end() && ct->second == b) {
+          chosen = cand;
+          break;
+        }
+      }
+      if (chosen < 0) {
+        auto& leaves = fd_osds[b];
+        uint32_t h2 = ps * 2654435761u + i * 40503u + 7u;
+        chosen = leaves[h2 % leaves.size()];
+      }
+      target[i] = chosen;
+    }
+    if (!ok)
+      continue;
+
+    // Express `target` relative to raw_new as an ordered list of from->to
+    // pairs.  _apply_upmap() substitutes members sequentially and skips a
+    // pair whose `to` is still present, so an OSD that must change slots
+    // (erasure-coded shards are positional) is only expressible if the
+    // pair vacating its old slot is applied first.  Model this as a
+    // displacement graph (edge i -> j when target[j] == raw_new[i]); each
+    // node has at most one predecessor and one successor, so components
+    // are simple paths -- emitted from their source onwards -- or cycles,
+    // which pg_upmap_items cannot express (see the bidirectional-swap
+    // note in _apply_upmap()).  Cycles are broken by re-targeting one
+    // member to a fresh OSD outside raw_new (so no new edge can appear),
+    // which keeps the remaining members of the cycle in place.
+    std::map<unsigned, unsigned> succ, pred;
+    std::set<unsigned> cyc;
+    auto mismatched = [&](unsigned i) {
+      return raw_new[i] != CRUSH_ITEM_NONE &&
+             target[i] != CRUSH_ITEM_NONE &&
+             raw_new[i] != target[i];
+    };
+    auto rebuild_graph = [&]() {
+      succ.clear();
+      pred.clear();
+      cyc.clear();
+      std::map<int, unsigned> pos_in_raw;
+      for (unsigned i = 0; i < size; ++i) {
+        if (raw_new[i] != CRUSH_ITEM_NONE)
+          pos_in_raw[raw_new[i]] = i;
+      }
+      for (unsigned j = 0; j < size; ++j) {
+        if (!mismatched(j))
+          continue;
+        auto it = pos_in_raw.find(target[j]);
+        if (it != pos_in_raw.end() && mismatched(it->second)) {
+          succ[it->second] = j;
+          pred[j] = it->second;
+        }
+      }
+      std::set<unsigned> visited;
+      for (unsigned i = 0; i < size; ++i) {
+        if (!mismatched(i) || pred.count(i))
+          continue;
+        unsigned c = i;
+        while (!visited.count(c)) {
+          visited.insert(c);
+          auto n = succ.find(c);
+          if (n == succ.end())
+            break;
+          c = n->second;
+        }
+      }
+      for (unsigned i = 0; i < size; ++i) {
+        if (mismatched(i) && !visited.count(i))
+          cyc.insert(i);
+      }
+    };
+    rebuild_graph();
+    std::set<int> rawset(raw_new.begin(), raw_new.end());
+    for (unsigned guard = 0; !cyc.empty() && guard < size; ++guard) {
+      unsigned c = *cyc.begin();
+      // free the bucket of the member we re-target, then pick a fresh
+      // OSD; cycles are rare, so the load-aware pick is used for both
+      // fill strategies for simplicity (still deterministic)
+      used.erase(fd_of.at(target[c]));
+      int chosen = -1;
+      int chosen_bkt = 0;
+      std::pair<double, uint32_t> best_key;
+      for (auto& [b, osds] : fd_osds) {
+        if (used.count(b))
+          continue;
+        for (int cand : osds) {
+          if (rawset.count(cand))
+            continue;
+          auto pit = planned.find(cand);
+          std::pair<double, uint32_t> key(
+            (pit == planned.end() ? 0 : pit->second) /
+              (double)weight_map.at(cand),
+            (uint32_t)cand * 2654435761u + (uint32_t)ps * 40503u);
+          if (chosen < 0 || key < best_key) {
+            best_key = key;
+            chosen = cand;
+            chosen_bkt = b;
+          }
+        }
+      }
+      if (chosen < 0) {
+        // cannot break the cycle: accept the rotation for these slots
+        used.insert(fd_of.at(target[c]));
+        for (auto i : cyc)
+          target[i] = raw_new[i];
+      } else {
+        used.insert(chosen_bkt);
+        target[c] = chosen;
+      }
+      rebuild_graph();
+    }
+    if (!cyc.empty()) {
+      for (auto i : cyc)
+        target[i] = raw_new[i];
+      rebuild_graph();
+    }
+
+    for (auto o : target) {
+      if (o != CRUSH_ITEM_NONE)
+        planned[o]++;
+    }
+
+    // emit each path from its source: the pair re-introducing an OSD at
+    // its new slot always follows the pair that vacated its old slot
+    mempool::osdmap::vector<std::pair<int32_t,int32_t>> pairs;
+    std::set<unsigned> emitted;
+    for (unsigned s = 0; s < size; ++s) {
+      if (!mismatched(s) || pred.count(s) || emitted.count(s))
+        continue;
+      unsigned c = s;
+      while (true) {
+        emitted.insert(c);
+        pairs.emplace_back(raw_new[c], target[c]);
+        auto n = succ.find(c);
+        if (n == succ.end())
+          break;
+        c = n->second;
+      }
+    }
+
+    if (pairs.empty()) {
+      // raw placement already optimal; drop a stale pre-change entry if any
+      if (pg_upmap_items.count(pg))
+        pending_inc->old_pg_upmap_items.insert(pg);
+      continue;
+    }
+    // final safety: the intended up must satisfy the new rule
+    std::vector<int> intended(raw_new);
+    for (auto& [f, t] : pairs) {
+      bool exists = false;
+      ssize_t pos = -1;
+      for (unsigned i = 0; i < intended.size(); ++i) {
+        if (intended[i] == t) {
+          exists = true;
+          break;
+        }
+        if (intended[i] == f && pos < 0)
+          pos = i;
+      }
+      if (!exists && pos >= 0)
+        intended[pos] = t;
+    }
+    if (newmap.crush->verify_upmap(cct, rule, size, intended) < 0) {
+      ldout(cct, 10) << __func__ << " pg " << pg
+                     << " computed pin failed verify_upmap, skipping" << dendl;
+      continue;
+    }
+    pending_inc->new_pg_upmap_items[pg] = pairs;
+    ++npins;
+  }
+  ldout(cct, 10) << __func__ << " pool " << pool_id << " pinned "
+                 << npins << " pgs" << dendl;
+  return npins;
+}
+
 bool OSDMap::clean_pg_upmaps(
   CephContext *cct,
   Incremental *pending_inc) const

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2357,6 +2357,329 @@ void OSDMap::clean_pg_upmaps(
   }
 }
 
+int OSDMap::calc_crush_rule_change_pins(
+  CephContext *cct,
+  const OSDMap& newmap,
+  int64_t pool_id,
+  Incremental *pending_inc,
+  bool load_aware_fill) const
+{
+  const pg_pool_t *pi = newmap.get_pg_pool(pool_id);
+  if (!pi)
+    return -ENOENT;
+  const int rule = pi->get_crush_rule();
+  const unsigned size = pi->get_size();
+
+  if (!newmap.crush->rule_exists(rule))
+    return -ENOENT;
+
+  // failure-domain type = type of the last choose/chooseleaf step of the rule
+  int ftype = 0;
+  const int rule_len = newmap.crush->get_rule_len(rule);
+  for (int step = 0; step < rule_len; ++step) {
+    int op = newmap.crush->get_rule_op(rule, step);
+    if (op == CRUSH_RULE_CHOOSELEAF_FIRSTN ||
+        op == CRUSH_RULE_CHOOSELEAF_INDEP ||
+        op == CRUSH_RULE_CHOOSE_FIRSTN ||
+        op == CRUSH_RULE_CHOOSE_INDEP) {
+      ftype = newmap.crush->get_rule_arg2(rule, step);
+    }
+  }
+  if (ftype <= 0)
+    return 0;               // osd-level rule: nothing to preserve, raw is fine
+
+  // enumerate in+up OSDs of the rule's subtree and their failure-domain bucket
+  std::map<int, float> weight_map;
+  int r = newmap.crush->get_rule_weight_osd_map(rule, &weight_map);
+  if (r < 0)
+    return r;
+  std::map<int, int> fd_of;                 // osd -> failure-domain bucket
+  std::map<int, std::vector<int>> fd_osds;  // bucket -> in osds
+  for (auto& [osd, w] : weight_map) {
+    if (w <= 0)
+      continue;
+    if (osd < 0 || osd >= newmap.get_max_osd() ||
+        !newmap.exists(osd) || !newmap.is_up(osd) ||
+        newmap.get_weightf(osd) == 0)
+      continue;
+    int parent = newmap.crush->get_parent_of_type(osd, ftype, rule);
+    if (parent >= 0)                        // could not resolve an ancestor
+      continue;
+    fd_of[osd] = parent;
+    fd_osds[parent].push_back(osd);
+  }
+  if (fd_osds.size() < size)
+    return -ENOSPC;                         // pool cannot satisfy the domain
+
+  // shards this plan has already assigned per OSD, for the load-aware fill
+  std::map<int, unsigned> planned;
+  int npins = 0;
+  for (unsigned ps = 0; ps < pi->get_pg_num(); ++ps) {
+    pg_t pg(ps, pool_id);
+    std::vector<int> up, acting;
+    // acting from *this* (pre-change) map: up + pg_temp = where the data is
+    pg_to_up_acting_osds(pg, up, acting);
+    std::vector<int> raw_new;
+    int primary;
+    newmap.pg_to_raw_osds(pg, &raw_new, &primary);
+    if (raw_new.size() != size) {
+      for (auto o : raw_new) {
+        if (o != CRUSH_ITEM_NONE)
+          planned[o]++;
+      }
+      continue;
+    }
+
+    // pass 1: keep acting OSDs the new failure domain allows (per position)
+    std::set<int> used;
+    std::vector<int> target(size, CRUSH_ITEM_NONE);
+    std::vector<bool> pinned(size, false);
+    for (unsigned i = 0; i < size && i < acting.size(); ++i) {
+      int a = acting[i];
+      auto it = fd_of.find(a);
+      if (a != CRUSH_ITEM_NONE && it != fd_of.end() &&
+          !used.count(it->second)) {
+        target[i] = a;
+        used.insert(it->second);
+        pinned[i] = true;
+      }
+    }
+    // pass 2: fill the violators; prefer CRUSH's own pick, else spread
+    // deterministically over the free buckets so forced moves stay balanced
+    bool ok = true;
+    for (unsigned i = 0; i < size; ++i) {
+      if (pinned[i])
+        continue;
+      if (load_aware_fill) {
+        // pick the least-loaded (crush-weight normalized) in-OSD across the
+        // remaining free failure-domain buckets; deterministic tie-break so
+        // the result is reproducible for identical inputs.  This scan is
+        // O(#osds in the rule subtree) per relocated shard; the total work
+        // is bounded by mon_crush_rule_change_preserve_acting_max_pgs.
+        int chosen = -1;
+        int chosen_bkt = 0;
+        std::pair<double, uint32_t> best_key;
+        for (auto& [b, osds] : fd_osds) {
+          if (used.count(b))
+            continue;
+          for (int cand : osds) {
+            auto pit = planned.find(cand);
+            std::pair<double, uint32_t> key(
+              (pit == planned.end() ? 0 : pit->second) /
+                (double)weight_map.at(cand),
+              (uint32_t)cand * 2654435761u + (uint32_t)ps * 40503u);
+            if (chosen < 0 || key < best_key) {
+              best_key = key;
+              chosen = cand;
+              chosen_bkt = b;
+            }
+          }
+        }
+        if (chosen < 0) {
+          ok = false;
+          break;
+        }
+        used.insert(chosen_bkt);
+        target[i] = chosen;
+        continue;
+      }
+      int u = raw_new[i];
+      auto it = fd_of.find(u);
+      if (u != CRUSH_ITEM_NONE && it != fd_of.end() &&
+          !used.count(it->second)) {
+        target[i] = u;
+        used.insert(it->second);
+        continue;
+      }
+      std::vector<int> free_bkts;
+      for (auto& q : fd_osds) {
+        if (!used.count(q.first))
+          free_bkts.push_back(q.first);
+      }
+      if (free_bkts.empty()) {
+        ok = false;
+        break;
+      }
+      uint32_t h = ps * 2654435761u + i * 40503u + 3u;
+      int b = free_bkts[h % free_bkts.size()];
+      used.insert(b);
+      int chosen = -1;
+      for (int cand : raw_new) {            // reuse a CRUSH pick living in b
+        auto ct = fd_of.find(cand);
+        if (ct != fd_of.end() && ct->second == b) {
+          chosen = cand;
+          break;
+        }
+      }
+      if (chosen < 0) {
+        auto& leaves = fd_osds[b];
+        uint32_t h2 = ps * 2654435761u + i * 40503u + 7u;
+        chosen = leaves[h2 % leaves.size()];
+      }
+      target[i] = chosen;
+    }
+    if (!ok)
+      continue;
+
+    // Express `target` relative to raw_new as an ordered list of from->to
+    // pairs.  _apply_upmap() substitutes members sequentially and skips a
+    // pair whose `to` is still present, so an OSD that must change slots
+    // (erasure-coded shards are positional) is only expressible if the
+    // pair vacating its old slot is applied first.  Model this as a
+    // displacement graph (edge i -> j when target[j] == raw_new[i]); each
+    // node has at most one predecessor and one successor, so components
+    // are simple paths -- emitted from their source onwards -- or cycles,
+    // which pg_upmap_items cannot express (see the bidirectional-swap
+    // note in _apply_upmap()).  Cycles are broken by re-targeting one
+    // member to a fresh OSD outside raw_new (so no new edge can appear),
+    // which keeps the remaining members of the cycle in place.
+    std::map<unsigned, unsigned> succ, pred;
+    std::set<unsigned> cyc;
+    auto mismatched = [&](unsigned i) {
+      return raw_new[i] != CRUSH_ITEM_NONE &&
+             target[i] != CRUSH_ITEM_NONE &&
+             raw_new[i] != target[i];
+    };
+    auto rebuild_graph = [&]() {
+      succ.clear();
+      pred.clear();
+      cyc.clear();
+      std::map<int, unsigned> pos_in_raw;
+      for (unsigned i = 0; i < size; ++i) {
+        if (raw_new[i] != CRUSH_ITEM_NONE)
+          pos_in_raw[raw_new[i]] = i;
+      }
+      for (unsigned j = 0; j < size; ++j) {
+        if (!mismatched(j))
+          continue;
+        auto it = pos_in_raw.find(target[j]);
+        if (it != pos_in_raw.end() && mismatched(it->second)) {
+          succ[it->second] = j;
+          pred[j] = it->second;
+        }
+      }
+      std::set<unsigned> visited;
+      for (unsigned i = 0; i < size; ++i) {
+        if (!mismatched(i) || pred.count(i))
+          continue;
+        unsigned c = i;
+        while (!visited.count(c)) {
+          visited.insert(c);
+          auto n = succ.find(c);
+          if (n == succ.end())
+            break;
+          c = n->second;
+        }
+      }
+      for (unsigned i = 0; i < size; ++i) {
+        if (mismatched(i) && !visited.count(i))
+          cyc.insert(i);
+      }
+    };
+    rebuild_graph();
+    std::set<int> rawset(raw_new.begin(), raw_new.end());
+    for (unsigned guard = 0; !cyc.empty() && guard < size; ++guard) {
+      unsigned c = *cyc.begin();
+      // free the bucket of the member we re-target, then pick a fresh
+      // OSD; cycles are rare, so the load-aware pick is used for both
+      // fill strategies for simplicity (still deterministic)
+      used.erase(fd_of.at(target[c]));
+      int chosen = -1;
+      int chosen_bkt = 0;
+      std::pair<double, uint32_t> best_key;
+      for (auto& [b, osds] : fd_osds) {
+        if (used.count(b))
+          continue;
+        for (int cand : osds) {
+          if (rawset.count(cand))
+            continue;
+          auto pit = planned.find(cand);
+          std::pair<double, uint32_t> key(
+            (pit == planned.end() ? 0 : pit->second) /
+              (double)weight_map.at(cand),
+            (uint32_t)cand * 2654435761u + (uint32_t)ps * 40503u);
+          if (chosen < 0 || key < best_key) {
+            best_key = key;
+            chosen = cand;
+            chosen_bkt = b;
+          }
+        }
+      }
+      if (chosen < 0) {
+        // cannot break the cycle: accept the rotation for these slots
+        used.insert(fd_of.at(target[c]));
+        for (auto i : cyc)
+          target[i] = raw_new[i];
+      } else {
+        used.insert(chosen_bkt);
+        target[c] = chosen;
+      }
+      rebuild_graph();
+    }
+    if (!cyc.empty()) {
+      for (auto i : cyc)
+        target[i] = raw_new[i];
+      rebuild_graph();
+    }
+
+    for (auto o : target) {
+      if (o != CRUSH_ITEM_NONE)
+        planned[o]++;
+    }
+
+    // emit each path from its source: the pair re-introducing an OSD at
+    // its new slot always follows the pair that vacated its old slot
+    mempool::osdmap::vector<std::pair<int32_t,int32_t>> pairs;
+    std::set<unsigned> emitted;
+    for (unsigned s = 0; s < size; ++s) {
+      if (!mismatched(s) || pred.count(s) || emitted.count(s))
+        continue;
+      unsigned c = s;
+      while (true) {
+        emitted.insert(c);
+        pairs.emplace_back(raw_new[c], target[c]);
+        auto n = succ.find(c);
+        if (n == succ.end())
+          break;
+        c = n->second;
+      }
+    }
+
+    if (pairs.empty()) {
+      // raw placement already optimal; drop a stale pre-change entry if any
+      if (pg_upmap_items.count(pg))
+        pending_inc->old_pg_upmap_items.insert(pg);
+      continue;
+    }
+    // final safety: the intended up must satisfy the new rule
+    std::vector<int> intended(raw_new);
+    for (auto& [f, t] : pairs) {
+      bool exists = false;
+      ssize_t pos = -1;
+      for (unsigned i = 0; i < intended.size(); ++i) {
+        if (intended[i] == t) {
+          exists = true;
+          break;
+        }
+        if (intended[i] == f && pos < 0)
+          pos = i;
+      }
+      if (!exists && pos >= 0)
+        intended[pos] = t;
+    }
+    if (newmap.crush->verify_upmap(cct, rule, size, intended) < 0) {
+      ldout(cct, 10) << __func__ << " pg " << pg
+                     << " computed pin failed verify_upmap, skipping" << dendl;
+      continue;
+    }
+    pending_inc->new_pg_upmap_items[pg] = pairs;
+    ++npins;
+  }
+  ldout(cct, 10) << __func__ << " pool " << pool_id << " pinned "
+                 << npins << " pgs" << dendl;
+  return npins;
+}
+
 bool OSDMap::clean_pg_upmaps(
   CephContext *cct,
   Incremental *pending_inc) const

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1156,6 +1156,24 @@ public:
     const std::map<pg_t, mempool::osdmap::vector<std::pair<int,int>>>& to_remap) const;
   bool clean_pg_upmaps(CephContext *cct, Incremental *pending_inc) const;
 
+  /**
+   * For every PG of @pool_id, stage pg_upmap_items into @pending_inc that
+   * keep each shard of the PG's current acting set (as known from this map,
+   * i.e. up + pg_temp) whenever the pool's crush rule in @newmap allows it,
+   * relocating only the shards that violate the new failure domain.  @newmap
+   * must be a scratch copy of this map with the pool's new crush_rule
+   * applied.  Replacement OSDs for the violating shards are picked either
+   * load-aware (lowest planned shard count per crush weight across the free
+   * failure-domain buckets, the default) or, with load_aware_fill=false, by
+   * preferring the raw CRUSH pick and falling back to deterministic hashing.
+   * Returns the number of PGs pinned, or -errno.
+   */
+  int calc_crush_rule_change_pins(CephContext *cct,
+                                  const OSDMap& newmap,
+                                  int64_t pool_id,
+                                  Incremental *pending_inc,
+                                  bool load_aware_fill = true) const;
+
   int apply_incremental(const Incremental &inc);
 
   /// try to re-use/reference addrs in oldmap from newmap

--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -3490,3 +3490,398 @@ INSTANTIATE_TEST_SUITE_P(
     std::make_pair<int, int>(3, 0)  // chooseleaf firstn 3 osd
   )
 );
+
+TEST_F(OSDMapTest, CalcCrushRuleChangePins) {
+  // 12 osds -> 6 hosts (2 osds each) -> 3 racks (2 hosts each) under default
+  set_up_map(12, true);
+  {
+    CrushWrapper newcrush;
+    get_crush(osdmap, newcrush);
+    for (int i = 0; i < 12; i++) {
+      map<string,string> loc = {
+        {"root", "default"},
+        {"rack", "rack" + std::to_string(i / 4)},
+        {"host", "host" + std::to_string(i / 2)},
+      };
+      int r = newcrush.create_or_move_item(
+        g_ceph_context, i, 1.0, "osd." + std::to_string(i), loc);
+      ASSERT_GE(r, 0);
+    }
+    OSDMap::Incremental pending_inc(osdmap.get_epoch() + 1);
+    pending_inc.fsid = osdmap.get_fsid();
+    pending_inc.crush.clear();
+    newcrush.encode(pending_inc.crush, CEPH_FEATURES_SUPPORTED_DEFAULT);
+    osdmap.apply_incremental(pending_inc);
+  }
+  int host_rule = crush_rule_create_replicated("pins_host", "default", "host");
+  ASSERT_GE(host_rule, 0);
+  int rack_rule = crush_rule_create_replicated("pins_rack", "default", "rack");
+  ASSERT_GE(rack_rule, 0);
+  const int rack_type = osdmap.crush->get_type_id("rack");
+  ASSERT_GT(rack_type, 0);
+
+  // a size-3 replicated pool with failure domain host
+  uint64_t pool_id;
+  {
+    OSDMap::Incremental new_pool_inc(osdmap.get_epoch() + 1);
+    new_pool_inc.fsid = osdmap.get_fsid();
+    new_pool_inc.new_pool_max = osdmap.get_pool_max();
+    pg_pool_t empty;
+    pool_id = ++new_pool_inc.new_pool_max;
+    pg_pool_t *p = new_pool_inc.get_new_pool(pool_id, &empty);
+    p->size = 3;
+    p->set_pg_num(64);
+    p->set_pgp_num(64);
+    p->type = pg_pool_t::TYPE_REPLICATED;
+    p->crush_rule = host_rule;
+    p->set_flag(pg_pool_t::FLAG_HASHPSPOOL);
+    new_pool_inc.new_pool_names[pool_id] = "pinpool";
+    osdmap.apply_incremental(new_pool_inc);
+  }
+
+  // pristine snapshot of the pre-change state (pool on host_rule); later
+  // sections mutate osdmap, so re-computations start from this instead
+  OSDMap base;
+  base.deepish_copy_from(osdmap);
+
+  // record the pre-change up sets (clean cluster: acting == up)
+  map<unsigned, set<int>> old_up;
+  for (unsigned ps = 0; ps < 64; ++ps) {
+    pg_t pg(ps, pool_id);
+    vector<int> up, acting;
+    osdmap.pg_to_up_acting_osds(pg, up, acting);
+    ASSERT_EQ(3u, up.size());
+    old_up[ps] = set<int>(up.begin(), up.end());
+  }
+
+  // stage the host->rack rule change and the pins in ONE incremental,
+  // exactly as OSDMonitor::prepare_command_pool_set does
+  OSDMap::Incremental pending_inc(osdmap.get_epoch() + 1);
+  pending_inc.fsid = osdmap.get_fsid();
+  {
+    pg_pool_t tp = *osdmap.get_pg_pool(pool_id);
+    tp.crush_rule = rack_rule;
+    pending_inc.new_pools[pool_id] = tp;
+  }
+  OSDMap scratch;
+  scratch.deepish_copy_from(osdmap);
+  {
+    OSDMap::Incremental s_inc(scratch.get_epoch() + 1);
+    s_inc.fsid = scratch.get_fsid();
+    pg_pool_t tp = *osdmap.get_pg_pool(pool_id);
+    tp.crush_rule = rack_rule;
+    s_inc.new_pools[pool_id] = tp;
+    scratch.apply_incremental(s_inc);
+  }
+  int pins = osdmap.calc_crush_rule_change_pins(
+    g_ceph_context, scratch, pool_id, &pending_inc);
+  ASSERT_GT(pins, 0);
+
+  OSDMap newmap;
+  newmap.deepish_copy_from(osdmap);
+  newmap.apply_incremental(pending_inc);
+
+  int total_moved = 0;
+  for (unsigned ps = 0; ps < 64; ++ps) {
+    pg_t pg(ps, pool_id);
+    vector<int> up, acting;
+    newmap.pg_to_up_acting_osds(pg, up, acting);
+    ASSERT_EQ(3u, up.size());
+
+    // 1) the new up must satisfy the rack failure domain
+    set<int> racks;
+    for (auto o : up) {
+      int r = newmap.crush->get_parent_of_type(o, rack_type, rack_rule);
+      ASSERT_LT(r, 0);
+      racks.insert(r);
+    }
+    ASSERT_EQ(3u, racks.size());
+
+    // 2) retention is maximal: exactly one old-up member is kept per distinct
+    //    rack the old up covered (the theoretical minimal-movement floor)
+    set<int> old_racks;
+    for (auto o : old_up[ps]) {
+      old_racks.insert(
+        osdmap.crush->get_parent_of_type(o, rack_type, rack_rule));
+    }
+    unsigned kept = 0;
+    for (auto o : up) {
+      if (old_up[ps].count(o))
+        kept++;
+    }
+    ASSERT_EQ(old_racks.size(), kept);
+    total_moved += 3 - kept;
+  }
+  // with 3 racks and a host-level old placement, some PGs must have had
+  // rack collisions, so some data moves -- but far from all of it
+  ASSERT_GT(total_moved, 0);
+  ASSERT_LT(total_moved, 3 * 64);
+
+  // 3) the mon must find nothing to cancel or simplify: the pins are stable
+  {
+    OSDMap::Incremental clean_inc(newmap.get_epoch() + 1);
+    clean_inc.fsid = newmap.get_fsid();
+    ASSERT_FALSE(newmap.clean_pg_upmaps(g_ceph_context, &clean_inc));
+  }
+
+  // 4) an osd-level target rule has no failure domain to preserve
+  {
+    int osd_rule = crush_rule_create_replicated("pins_osd", "default", "osd");
+    ASSERT_GE(osd_rule, 0);
+    OSDMap scratch2;
+    scratch2.deepish_copy_from(osdmap);
+    OSDMap::Incremental s_inc(scratch2.get_epoch() + 1);
+    s_inc.fsid = scratch2.get_fsid();
+    pg_pool_t tp = *osdmap.get_pg_pool(pool_id);
+    tp.crush_rule = osd_rule;
+    s_inc.new_pools[pool_id] = tp;
+    scratch2.apply_incremental(s_inc);
+    OSDMap::Incremental noop_inc(osdmap.get_epoch() + 1);
+    ASSERT_EQ(0, osdmap.calc_crush_rule_change_pins(
+      g_ceph_context, scratch2, pool_id, &noop_inc));
+    ASSERT_TRUE(noop_inc.new_pg_upmap_items.empty());
+  }
+
+  // 5) a pool whose size exceeds the number of failure-domain buckets
+  //    cannot be pinned (3 racks < size 4)
+  {
+    uint64_t big_pool;
+    OSDMap::Incremental new_pool_inc(osdmap.get_epoch() + 1);
+    new_pool_inc.fsid = osdmap.get_fsid();
+    new_pool_inc.new_pool_max = osdmap.get_pool_max();
+    pg_pool_t empty;
+    big_pool = ++new_pool_inc.new_pool_max;
+    pg_pool_t *p = new_pool_inc.get_new_pool(big_pool, &empty);
+    p->size = 4;
+    p->set_pg_num(8);
+    p->set_pgp_num(8);
+    p->type = pg_pool_t::TYPE_REPLICATED;
+    p->crush_rule = host_rule;
+    p->set_flag(pg_pool_t::FLAG_HASHPSPOOL);
+    new_pool_inc.new_pool_names[big_pool] = "bigpool";
+    osdmap.apply_incremental(new_pool_inc);
+
+    OSDMap scratch3;
+    scratch3.deepish_copy_from(osdmap);
+    OSDMap::Incremental s_inc(scratch3.get_epoch() + 1);
+    s_inc.fsid = scratch3.get_fsid();
+    pg_pool_t tp = *osdmap.get_pg_pool(big_pool);
+    tp.crush_rule = rack_rule;
+    s_inc.new_pools[big_pool] = tp;
+    scratch3.apply_incremental(s_inc);
+    OSDMap::Incremental fail_inc(osdmap.get_epoch() + 1);
+    ASSERT_EQ(-ENOSPC, osdmap.calc_crush_rule_change_pins(
+      g_ceph_context, scratch3, big_pool, &fail_inc));
+    ASSERT_TRUE(fail_inc.new_pg_upmap_items.empty());
+  }
+
+  // 6) fill strategies: identical (minimal) data movement, and the default
+  //    load-aware fill must leave the pool at least as balanced as hash.
+  //    Recomputed from the pristine snapshot so earlier sections that mutate
+  //    osdmap cannot perturb the comparison.
+  {
+    OSDMap sc;
+    sc.deepish_copy_from(base);
+    {
+      OSDMap::Incremental si(sc.get_epoch() + 1);
+      si.fsid = sc.get_fsid();
+      pg_pool_t tp = *base.get_pg_pool(pool_id);
+      tp.crush_rule = rack_rule;
+      si.new_pools[pool_id] = tp;
+      sc.apply_incremental(si);
+    }
+    OSDMap::Incremental la_inc(base.get_epoch() + 1);
+    OSDMap::Incremental h_inc(base.get_epoch() + 1);
+    la_inc.fsid = h_inc.fsid = base.get_fsid();
+    {
+      pg_pool_t tp = *base.get_pg_pool(pool_id);
+      tp.crush_rule = rack_rule;
+      la_inc.new_pools[pool_id] = tp;
+      h_inc.new_pools[pool_id] = tp;
+    }
+    int la_pins = base.calc_crush_rule_change_pins(
+      g_ceph_context, sc, pool_id, &la_inc, true);
+    int h_pins = base.calc_crush_rule_change_pins(
+      g_ceph_context, sc, pool_id, &h_inc, false);
+    ASSERT_GT(la_pins, 0);
+    // The hash fill may legitimately produce zero pg-upmap-items: when a
+    // violating shard's natural raw-CRUSH landing is acceptable it lets CRUSH
+    // relocate the shard instead of adding an entry.  The data still moves the
+    // same amount (asserted below), it is just not upmap-expressed -- which is
+    // exactly why load-aware is the default.  ASSERT_GE also catches an error
+    // return (negative) from the hash path.
+    ASSERT_GE(h_pins, 0);
+
+    OSDMap lam, ham;
+    lam.deepish_copy_from(base);
+    lam.apply_incremental(la_inc);
+    ham.deepish_copy_from(base);
+    ham.apply_incremental(h_inc);
+
+    map<int, int> la_cnt, h_cnt;
+    int la_moved = 0, h_moved = 0;
+    for (unsigned ps = 0; ps < 64; ++ps) {
+      pg_t pg(ps, pool_id);
+      vector<int> up, acting;
+      lam.pg_to_up_acting_osds(pg, up, acting);
+      for (auto o : up) {
+        la_cnt[o]++;
+        if (!old_up[ps].count(o))
+          la_moved++;
+      }
+      vector<int> up2, acting2;
+      ham.pg_to_up_acting_osds(pg, up2, acting2);
+      for (auto o : up2) {
+        h_cnt[o]++;
+        if (!old_up[ps].count(o))
+          h_moved++;
+      }
+    }
+    // the fill strategy affects balance, never the amount of data moved
+    ASSERT_EQ(la_moved, h_moved);
+    double mean = 3.0 * 64 / 12;
+    double la_ssq = 0, h_ssq = 0;
+    for (int o = 0; o < 12; ++o) {
+      la_ssq += (la_cnt[o] - mean) * (la_cnt[o] - mean);
+      h_ssq += (h_cnt[o] - mean) * (h_cnt[o] - mean);
+    }
+    ASSERT_LE(la_ssq, h_ssq);
+  }
+
+  // 7) a down (but still in) osd must never be chosen as a pin target:
+  //    _raw_to_up_osds() would strip it from the up set, leaving the pg
+  //    degraded until it returns
+  {
+    OSDMap dmap;
+    dmap.deepish_copy_from(base);
+    {
+      OSDMap::Incremental di(dmap.get_epoch() + 1);
+      di.fsid = dmap.get_fsid();
+      di.new_state[0] = CEPH_OSD_UP;          // mark osd.0 down
+      dmap.apply_incremental(di);
+    }
+    ASSERT_TRUE(dmap.exists(0));
+    ASSERT_FALSE(dmap.is_up(0));
+    OSDMap dsc;
+    dsc.deepish_copy_from(dmap);
+    {
+      OSDMap::Incremental si(dsc.get_epoch() + 1);
+      si.fsid = dsc.get_fsid();
+      pg_pool_t tp = *dmap.get_pg_pool(pool_id);
+      tp.crush_rule = rack_rule;
+      si.new_pools[pool_id] = tp;
+      dsc.apply_incremental(si);
+    }
+    OSDMap::Incremental dpins(dmap.get_epoch() + 1);
+    dpins.fsid = dmap.get_fsid();
+    {
+      pg_pool_t tp = *dmap.get_pg_pool(pool_id);
+      tp.crush_rule = rack_rule;
+      dpins.new_pools[pool_id] = tp;
+    }
+    int dp = dmap.calc_crush_rule_change_pins(
+      g_ceph_context, dsc, pool_id, &dpins, true);
+    ASSERT_GT(dp, 0);
+    for (auto& [pg, items] : dpins.new_pg_upmap_items) {
+      for (auto& fr : items) {
+        ASSERT_NE(0, fr.second);
+      }
+    }
+  }
+
+  // 8) EC (indep) rule change: retention must be positional -- an old up
+  //    member present in the new up sits at its old index, since
+  //    erasure-coded shards are positional and a permuted set still moves
+  {
+    OSDMap emap;
+    emap.deepish_copy_from(base);
+    int host_ec = -1, rack_ec = -1;
+    {
+      CrushWrapper newcrush;
+      get_crush(emap, newcrush);
+      std::ostringstream ss;
+      host_ec = newcrush.add_simple_rule(
+        "pins_host_ec", "default", "host", "", "indep",
+        pg_pool_t::TYPE_ERASURE, &ss);
+      ASSERT_GE(host_ec, 0);
+      rack_ec = newcrush.add_simple_rule(
+        "pins_rack_ec", "default", "rack", "", "indep",
+        pg_pool_t::TYPE_ERASURE, &ss);
+      ASSERT_GE(rack_ec, 0);
+      OSDMap::Incremental ci(emap.get_epoch() + 1);
+      ci.fsid = emap.get_fsid();
+      ci.crush.clear();
+      newcrush.encode(ci.crush, CEPH_FEATURES_SUPPORTED_DEFAULT);
+      emap.apply_incremental(ci);
+    }
+    uint64_t ec_pool_id;
+    {
+      OSDMap::Incremental pi(emap.get_epoch() + 1);
+      pi.fsid = emap.get_fsid();
+      pi.new_pool_max = emap.get_pool_max();
+      pg_pool_t empty;
+      ec_pool_id = ++pi.new_pool_max;
+      pg_pool_t *pp = pi.get_new_pool(ec_pool_id, &empty);
+      pp->size = 3;
+      pp->min_size = 2;
+      pp->set_pg_num(64);
+      pp->set_pgp_num(64);
+      pp->type = pg_pool_t::TYPE_ERASURE;
+      pp->crush_rule = host_ec;
+      pp->set_flag(pg_pool_t::FLAG_HASHPSPOOL);
+      pi.new_pool_names[ec_pool_id] = "pinpool_ec";
+      emap.apply_incremental(pi);
+    }
+    map<unsigned, vector<int>> ec_old;
+    for (unsigned ps = 0; ps < 64; ++ps) {
+      pg_t pg(ps, ec_pool_id);
+      vector<int> up, acting;
+      emap.pg_to_up_acting_osds(pg, up, acting);
+      ASSERT_EQ(3u, up.size());
+      ec_old[ps] = up;
+    }
+    OSDMap esc;
+    esc.deepish_copy_from(emap);
+    {
+      OSDMap::Incremental si(esc.get_epoch() + 1);
+      si.fsid = esc.get_fsid();
+      pg_pool_t tp = *emap.get_pg_pool(ec_pool_id);
+      tp.crush_rule = rack_ec;
+      si.new_pools[ec_pool_id] = tp;
+      esc.apply_incremental(si);
+    }
+    OSDMap::Incremental epins(emap.get_epoch() + 1);
+    epins.fsid = emap.get_fsid();
+    {
+      pg_pool_t tp = *emap.get_pg_pool(ec_pool_id);
+      tp.crush_rule = rack_ec;
+      epins.new_pools[ec_pool_id] = tp;
+    }
+    int ep = emap.calc_crush_rule_change_pins(
+      g_ceph_context, esc, ec_pool_id, &epins, true);
+    ASSERT_GT(ep, 0);
+    OSDMap after;
+    after.deepish_copy_from(emap);
+    after.apply_incremental(epins);
+    for (unsigned ps = 0; ps < 64; ++ps) {
+      pg_t pg(ps, ec_pool_id);
+      vector<int> up, acting;
+      after.pg_to_up_acting_osds(pg, up, acting);
+      ASSERT_EQ(3u, up.size());
+      set<int> racks;
+      for (auto o : up) {
+        ASSERT_NE(CRUSH_ITEM_NONE, o);
+        int r = after.crush->get_parent_of_type(o, rack_type, rack_ec);
+        ASSERT_LT(r, 0);
+        racks.insert(r);
+      }
+      ASSERT_EQ(up.size(), racks.size());
+      set<int> old_set(ec_old[ps].begin(), ec_old[ps].end());
+      for (unsigned i = 0; i < up.size(); ++i) {
+        if (old_set.count(up[i])) {
+          ASSERT_EQ(ec_old[ps][i], up[i]);
+        }
+      }
+    }
+  }
+}

--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -3542,3 +3542,398 @@ INSTANTIATE_TEST_SUITE_P(
     std::make_pair<int, int>(3, 0)  // chooseleaf firstn 3 osd
   )
 );
+
+TEST_F(OSDMapTest, CalcCrushRuleChangePins) {
+  // 12 osds -> 6 hosts (2 osds each) -> 3 racks (2 hosts each) under default
+  set_up_map(12, true);
+  {
+    CrushWrapper newcrush;
+    get_crush(osdmap, newcrush);
+    for (int i = 0; i < 12; i++) {
+      map<string,string> loc = {
+        {"root", "default"},
+        {"rack", "rack" + std::to_string(i / 4)},
+        {"host", "host" + std::to_string(i / 2)},
+      };
+      int r = newcrush.create_or_move_item(
+        g_ceph_context, i, 1.0, "osd." + std::to_string(i), loc);
+      ASSERT_GE(r, 0);
+    }
+    OSDMap::Incremental pending_inc(osdmap.get_epoch() + 1);
+    pending_inc.fsid = osdmap.get_fsid();
+    pending_inc.crush.clear();
+    newcrush.encode(pending_inc.crush, CEPH_FEATURES_SUPPORTED_DEFAULT);
+    osdmap.apply_incremental(pending_inc);
+  }
+  int host_rule = crush_rule_create_replicated("pins_host", "default", "host");
+  ASSERT_GE(host_rule, 0);
+  int rack_rule = crush_rule_create_replicated("pins_rack", "default", "rack");
+  ASSERT_GE(rack_rule, 0);
+  const int rack_type = osdmap.crush->get_type_id("rack");
+  ASSERT_GT(rack_type, 0);
+
+  // a size-3 replicated pool with failure domain host
+  uint64_t pool_id;
+  {
+    OSDMap::Incremental new_pool_inc(osdmap.get_epoch() + 1);
+    new_pool_inc.fsid = osdmap.get_fsid();
+    new_pool_inc.new_pool_max = osdmap.get_pool_max();
+    pg_pool_t empty;
+    pool_id = ++new_pool_inc.new_pool_max;
+    pg_pool_t *p = new_pool_inc.get_new_pool(pool_id, &empty);
+    p->size = 3;
+    p->set_pg_num(64);
+    p->set_pgp_num(64);
+    p->type = pg_pool_t::TYPE_REPLICATED;
+    p->crush_rule = host_rule;
+    p->set_flag(pg_pool_t::FLAG_HASHPSPOOL);
+    new_pool_inc.new_pool_names[pool_id] = "pinpool";
+    osdmap.apply_incremental(new_pool_inc);
+  }
+
+  // pristine snapshot of the pre-change state (pool on host_rule); later
+  // sections mutate osdmap, so re-computations start from this instead
+  OSDMap base;
+  base.deepish_copy_from(osdmap);
+
+  // record the pre-change up sets (clean cluster: acting == up)
+  map<unsigned, set<int>> old_up;
+  for (unsigned ps = 0; ps < 64; ++ps) {
+    pg_t pg(ps, pool_id);
+    vector<int> up, acting;
+    osdmap.pg_to_up_acting_osds(pg, up, acting);
+    ASSERT_EQ(3u, up.size());
+    old_up[ps] = set<int>(up.begin(), up.end());
+  }
+
+  // stage the host->rack rule change and the pins in ONE incremental,
+  // exactly as OSDMonitor::prepare_command_pool_set does
+  OSDMap::Incremental pending_inc(osdmap.get_epoch() + 1);
+  pending_inc.fsid = osdmap.get_fsid();
+  {
+    pg_pool_t tp = *osdmap.get_pg_pool(pool_id);
+    tp.crush_rule = rack_rule;
+    pending_inc.new_pools[pool_id] = tp;
+  }
+  OSDMap scratch;
+  scratch.deepish_copy_from(osdmap);
+  {
+    OSDMap::Incremental s_inc(scratch.get_epoch() + 1);
+    s_inc.fsid = scratch.get_fsid();
+    pg_pool_t tp = *osdmap.get_pg_pool(pool_id);
+    tp.crush_rule = rack_rule;
+    s_inc.new_pools[pool_id] = tp;
+    scratch.apply_incremental(s_inc);
+  }
+  int pins = osdmap.calc_crush_rule_change_pins(
+    g_ceph_context, scratch, pool_id, &pending_inc);
+  ASSERT_GT(pins, 0);
+
+  OSDMap newmap;
+  newmap.deepish_copy_from(osdmap);
+  newmap.apply_incremental(pending_inc);
+
+  int total_moved = 0;
+  for (unsigned ps = 0; ps < 64; ++ps) {
+    pg_t pg(ps, pool_id);
+    vector<int> up, acting;
+    newmap.pg_to_up_acting_osds(pg, up, acting);
+    ASSERT_EQ(3u, up.size());
+
+    // 1) the new up must satisfy the rack failure domain
+    set<int> racks;
+    for (auto o : up) {
+      int r = newmap.crush->get_parent_of_type(o, rack_type, rack_rule);
+      ASSERT_LT(r, 0);
+      racks.insert(r);
+    }
+    ASSERT_EQ(3u, racks.size());
+
+    // 2) retention is maximal: exactly one old-up member is kept per distinct
+    //    rack the old up covered (the theoretical minimal-movement floor)
+    set<int> old_racks;
+    for (auto o : old_up[ps]) {
+      old_racks.insert(
+        osdmap.crush->get_parent_of_type(o, rack_type, rack_rule));
+    }
+    unsigned kept = 0;
+    for (auto o : up) {
+      if (old_up[ps].count(o))
+        kept++;
+    }
+    ASSERT_EQ(old_racks.size(), kept);
+    total_moved += 3 - kept;
+  }
+  // with 3 racks and a host-level old placement, some PGs must have had
+  // rack collisions, so some data moves -- but far from all of it
+  ASSERT_GT(total_moved, 0);
+  ASSERT_LT(total_moved, 3 * 64);
+
+  // 3) the mon must find nothing to cancel or simplify: the pins are stable
+  {
+    OSDMap::Incremental clean_inc(newmap.get_epoch() + 1);
+    clean_inc.fsid = newmap.get_fsid();
+    ASSERT_FALSE(newmap.clean_pg_upmaps(g_ceph_context, &clean_inc));
+  }
+
+  // 4) an osd-level target rule has no failure domain to preserve
+  {
+    int osd_rule = crush_rule_create_replicated("pins_osd", "default", "osd");
+    ASSERT_GE(osd_rule, 0);
+    OSDMap scratch2;
+    scratch2.deepish_copy_from(osdmap);
+    OSDMap::Incremental s_inc(scratch2.get_epoch() + 1);
+    s_inc.fsid = scratch2.get_fsid();
+    pg_pool_t tp = *osdmap.get_pg_pool(pool_id);
+    tp.crush_rule = osd_rule;
+    s_inc.new_pools[pool_id] = tp;
+    scratch2.apply_incremental(s_inc);
+    OSDMap::Incremental noop_inc(osdmap.get_epoch() + 1);
+    ASSERT_EQ(0, osdmap.calc_crush_rule_change_pins(
+      g_ceph_context, scratch2, pool_id, &noop_inc));
+    ASSERT_TRUE(noop_inc.new_pg_upmap_items.empty());
+  }
+
+  // 5) a pool whose size exceeds the number of failure-domain buckets
+  //    cannot be pinned (3 racks < size 4)
+  {
+    uint64_t big_pool;
+    OSDMap::Incremental new_pool_inc(osdmap.get_epoch() + 1);
+    new_pool_inc.fsid = osdmap.get_fsid();
+    new_pool_inc.new_pool_max = osdmap.get_pool_max();
+    pg_pool_t empty;
+    big_pool = ++new_pool_inc.new_pool_max;
+    pg_pool_t *p = new_pool_inc.get_new_pool(big_pool, &empty);
+    p->size = 4;
+    p->set_pg_num(8);
+    p->set_pgp_num(8);
+    p->type = pg_pool_t::TYPE_REPLICATED;
+    p->crush_rule = host_rule;
+    p->set_flag(pg_pool_t::FLAG_HASHPSPOOL);
+    new_pool_inc.new_pool_names[big_pool] = "bigpool";
+    osdmap.apply_incremental(new_pool_inc);
+
+    OSDMap scratch3;
+    scratch3.deepish_copy_from(osdmap);
+    OSDMap::Incremental s_inc(scratch3.get_epoch() + 1);
+    s_inc.fsid = scratch3.get_fsid();
+    pg_pool_t tp = *osdmap.get_pg_pool(big_pool);
+    tp.crush_rule = rack_rule;
+    s_inc.new_pools[big_pool] = tp;
+    scratch3.apply_incremental(s_inc);
+    OSDMap::Incremental fail_inc(osdmap.get_epoch() + 1);
+    ASSERT_EQ(-ENOSPC, osdmap.calc_crush_rule_change_pins(
+      g_ceph_context, scratch3, big_pool, &fail_inc));
+    ASSERT_TRUE(fail_inc.new_pg_upmap_items.empty());
+  }
+
+  // 6) fill strategies: identical (minimal) data movement, and the default
+  //    load-aware fill must leave the pool at least as balanced as hash.
+  //    Recomputed from the pristine snapshot so earlier sections that mutate
+  //    osdmap cannot perturb the comparison.
+  {
+    OSDMap sc;
+    sc.deepish_copy_from(base);
+    {
+      OSDMap::Incremental si(sc.get_epoch() + 1);
+      si.fsid = sc.get_fsid();
+      pg_pool_t tp = *base.get_pg_pool(pool_id);
+      tp.crush_rule = rack_rule;
+      si.new_pools[pool_id] = tp;
+      sc.apply_incremental(si);
+    }
+    OSDMap::Incremental la_inc(base.get_epoch() + 1);
+    OSDMap::Incremental h_inc(base.get_epoch() + 1);
+    la_inc.fsid = h_inc.fsid = base.get_fsid();
+    {
+      pg_pool_t tp = *base.get_pg_pool(pool_id);
+      tp.crush_rule = rack_rule;
+      la_inc.new_pools[pool_id] = tp;
+      h_inc.new_pools[pool_id] = tp;
+    }
+    int la_pins = base.calc_crush_rule_change_pins(
+      g_ceph_context, sc, pool_id, &la_inc, true);
+    int h_pins = base.calc_crush_rule_change_pins(
+      g_ceph_context, sc, pool_id, &h_inc, false);
+    ASSERT_GT(la_pins, 0);
+    // The hash fill may legitimately produce zero pg-upmap-items: when a
+    // violating shard's natural raw-CRUSH landing is acceptable it lets CRUSH
+    // relocate the shard instead of adding an entry.  The data still moves the
+    // same amount (asserted below), it is just not upmap-expressed -- which is
+    // exactly why load-aware is the default.  ASSERT_GE also catches an error
+    // return (negative) from the hash path.
+    ASSERT_GE(h_pins, 0);
+
+    OSDMap lam, ham;
+    lam.deepish_copy_from(base);
+    lam.apply_incremental(la_inc);
+    ham.deepish_copy_from(base);
+    ham.apply_incremental(h_inc);
+
+    map<int, int> la_cnt, h_cnt;
+    int la_moved = 0, h_moved = 0;
+    for (unsigned ps = 0; ps < 64; ++ps) {
+      pg_t pg(ps, pool_id);
+      vector<int> up, acting;
+      lam.pg_to_up_acting_osds(pg, up, acting);
+      for (auto o : up) {
+        la_cnt[o]++;
+        if (!old_up[ps].count(o))
+          la_moved++;
+      }
+      vector<int> up2, acting2;
+      ham.pg_to_up_acting_osds(pg, up2, acting2);
+      for (auto o : up2) {
+        h_cnt[o]++;
+        if (!old_up[ps].count(o))
+          h_moved++;
+      }
+    }
+    // the fill strategy affects balance, never the amount of data moved
+    ASSERT_EQ(la_moved, h_moved);
+    double mean = 3.0 * 64 / 12;
+    double la_ssq = 0, h_ssq = 0;
+    for (int o = 0; o < 12; ++o) {
+      la_ssq += (la_cnt[o] - mean) * (la_cnt[o] - mean);
+      h_ssq += (h_cnt[o] - mean) * (h_cnt[o] - mean);
+    }
+    ASSERT_LE(la_ssq, h_ssq);
+  }
+
+  // 7) a down (but still in) osd must never be chosen as a pin target:
+  //    _raw_to_up_osds() would strip it from the up set, leaving the pg
+  //    degraded until it returns
+  {
+    OSDMap dmap;
+    dmap.deepish_copy_from(base);
+    {
+      OSDMap::Incremental di(dmap.get_epoch() + 1);
+      di.fsid = dmap.get_fsid();
+      di.new_state[0] = CEPH_OSD_UP;          // mark osd.0 down
+      dmap.apply_incremental(di);
+    }
+    ASSERT_TRUE(dmap.exists(0));
+    ASSERT_FALSE(dmap.is_up(0));
+    OSDMap dsc;
+    dsc.deepish_copy_from(dmap);
+    {
+      OSDMap::Incremental si(dsc.get_epoch() + 1);
+      si.fsid = dsc.get_fsid();
+      pg_pool_t tp = *dmap.get_pg_pool(pool_id);
+      tp.crush_rule = rack_rule;
+      si.new_pools[pool_id] = tp;
+      dsc.apply_incremental(si);
+    }
+    OSDMap::Incremental dpins(dmap.get_epoch() + 1);
+    dpins.fsid = dmap.get_fsid();
+    {
+      pg_pool_t tp = *dmap.get_pg_pool(pool_id);
+      tp.crush_rule = rack_rule;
+      dpins.new_pools[pool_id] = tp;
+    }
+    int dp = dmap.calc_crush_rule_change_pins(
+      g_ceph_context, dsc, pool_id, &dpins, true);
+    ASSERT_GT(dp, 0);
+    for (auto& [pg, items] : dpins.new_pg_upmap_items) {
+      for (auto& fr : items) {
+        ASSERT_NE(0, fr.second);
+      }
+    }
+  }
+
+  // 8) EC (indep) rule change: retention must be positional -- an old up
+  //    member present in the new up sits at its old index, since
+  //    erasure-coded shards are positional and a permuted set still moves
+  {
+    OSDMap emap;
+    emap.deepish_copy_from(base);
+    int host_ec = -1, rack_ec = -1;
+    {
+      CrushWrapper newcrush;
+      get_crush(emap, newcrush);
+      std::ostringstream ss;
+      host_ec = newcrush.add_simple_rule(
+        "pins_host_ec", "default", "host", "", "indep",
+        pg_pool_t::TYPE_ERASURE, &ss);
+      ASSERT_GE(host_ec, 0);
+      rack_ec = newcrush.add_simple_rule(
+        "pins_rack_ec", "default", "rack", "", "indep",
+        pg_pool_t::TYPE_ERASURE, &ss);
+      ASSERT_GE(rack_ec, 0);
+      OSDMap::Incremental ci(emap.get_epoch() + 1);
+      ci.fsid = emap.get_fsid();
+      ci.crush.clear();
+      newcrush.encode(ci.crush, CEPH_FEATURES_SUPPORTED_DEFAULT);
+      emap.apply_incremental(ci);
+    }
+    uint64_t ec_pool_id;
+    {
+      OSDMap::Incremental pi(emap.get_epoch() + 1);
+      pi.fsid = emap.get_fsid();
+      pi.new_pool_max = emap.get_pool_max();
+      pg_pool_t empty;
+      ec_pool_id = ++pi.new_pool_max;
+      pg_pool_t *pp = pi.get_new_pool(ec_pool_id, &empty);
+      pp->size = 3;
+      pp->min_size = 2;
+      pp->set_pg_num(64);
+      pp->set_pgp_num(64);
+      pp->type = pg_pool_t::TYPE_ERASURE;
+      pp->crush_rule = host_ec;
+      pp->set_flag(pg_pool_t::FLAG_HASHPSPOOL);
+      pi.new_pool_names[ec_pool_id] = "pinpool_ec";
+      emap.apply_incremental(pi);
+    }
+    map<unsigned, vector<int>> ec_old;
+    for (unsigned ps = 0; ps < 64; ++ps) {
+      pg_t pg(ps, ec_pool_id);
+      vector<int> up, acting;
+      emap.pg_to_up_acting_osds(pg, up, acting);
+      ASSERT_EQ(3u, up.size());
+      ec_old[ps] = up;
+    }
+    OSDMap esc;
+    esc.deepish_copy_from(emap);
+    {
+      OSDMap::Incremental si(esc.get_epoch() + 1);
+      si.fsid = esc.get_fsid();
+      pg_pool_t tp = *emap.get_pg_pool(ec_pool_id);
+      tp.crush_rule = rack_ec;
+      si.new_pools[ec_pool_id] = tp;
+      esc.apply_incremental(si);
+    }
+    OSDMap::Incremental epins(emap.get_epoch() + 1);
+    epins.fsid = emap.get_fsid();
+    {
+      pg_pool_t tp = *emap.get_pg_pool(ec_pool_id);
+      tp.crush_rule = rack_ec;
+      epins.new_pools[ec_pool_id] = tp;
+    }
+    int ep = emap.calc_crush_rule_change_pins(
+      g_ceph_context, esc, ec_pool_id, &epins, true);
+    ASSERT_GT(ep, 0);
+    OSDMap after;
+    after.deepish_copy_from(emap);
+    after.apply_incremental(epins);
+    for (unsigned ps = 0; ps < 64; ++ps) {
+      pg_t pg(ps, ec_pool_id);
+      vector<int> up, acting;
+      after.pg_to_up_acting_osds(pg, up, acting);
+      ASSERT_EQ(3u, up.size());
+      set<int> racks;
+      for (auto o : up) {
+        ASSERT_NE(CRUSH_ITEM_NONE, o);
+        int r = after.crush->get_parent_of_type(o, rack_type, rack_ec);
+        ASSERT_LT(r, 0);
+        racks.insert(r);
+      }
+      ASSERT_EQ(up.size(), racks.size());
+      set<int> old_set(ec_old[ps].begin(), ec_old[ps].end());
+      for (unsigned i = 0; i < up.size(); ++i) {
+        if (old_set.count(up[i])) {
+          ASSERT_EQ(ec_old[ps][i], up[i]);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Changing a pool's CRUSH rule to a different failure domain today relocates far more data than the new rule requires: CRUSH recomputes placement statelessly, the balancer's pg_upmap_items are cancelled (`verify_upmap`) or pruned (source OSD gone from the new raw mapping), and nothing in that path looks at the acting set.

Measured on a production map (1600 OSDs, EC 6+2, 16384 PGs, rack -> row): **84.5% of shards move while the failure-domain floor is 26.5%**; 78.6% of the pre-existing upmap entries are discarded outright. The balancer then re-moves part of the data again to fix the resulting imbalance.

The wipe is also *irreversible*: with `norebalance` set, changing the rule and immediately reverting it to its original value still leaves **12.15% of the shards (~3.45 PiB) misplaced on the same map, with zero bytes actually moved** — the revert restores raw CRUSH but not the cancelled upmap layer. With this feature enabled, that round trip becomes a true no-op (the revert re-pins to the unchanged, fully-compliant acting sets).

This PR adds an **opt-in, off-by-default** monitor behaviour: with `mon_crush_rule_change_preserve_acting` enabled, `ceph osd pool set <pool> crush_rule <rule>` stages, **in the same pending incremental as the rule change**,  pg_upmap_items that keep each shard on an OSD of its acting set whenever the new failure domain allows it, relocating only the genuine violators. OSDs see the rule and the pins atomically in one epoch — no `norebalance` dance, no transient full-pool misplacement window. Note that **no existing tooling covers this scenario**: CERN's `upmap-remapped.py` handles hardware add/remove and PG splits by pinning PGs back to their acting sets, but after a failure-domain change those acting sets violate the new rule, so the mons reject its pins (`verify_upmap`) and it has no mechanism to substitute compliant OSDs.

Results on the map above (movement identical to the theoretical floor, 26.6%, i.e. **3.2x less data moved**), depending on `mon_crush_rule_change_preserve_acting_fill_strategy`:

| fill strategy | data moved | per-OSD spread (CoV) | residual balancer work | pairs |
|---|---|---|---|---|
| `load-aware` (default) | 26.6% | **3.7%** | **1.4%** | ~55k |
| `hash` | 26.6% | 13.9% | 5.5% | ~42k |
| (today, plain rule change) | 84.5% | 15.6% | 6.2% | — |

Design points reviewers may want to weigh in on:

* **Safety guards** — pinning silently falls back to a plain rule change (with a `dout(1)` explanation) when `require_min_compat_client` <  luminous (same gate as the `osd pg-upmap-items` command), when a `pg_num` change is in flight (pins for merge sources would immediately be cleaned again), or when the pool exceeds  `mon_crush_rule_change_preserve_acting_max_pgs` (bounds the synchronous work in the command path; the load-aware scan is O(#osds in the rule  subtree) per relocated shard).

* **Consistency** — the pins are computed against a scratch map that applies everything already staged in the same paxos proposal (pending crush map, pending pools) plus the new rule, mirroring how `prepare_command_pool_set` itself reads `pending_inc.new_pools`.
* **Validation** — every placement is checked with `CrushWrapper::verify_upmap` before staging, so the `check_pg_upmaps` pass in `encode_pending` keeps the entries.
* **Compatibility** — plain pg_upmap_items, no new encoding; nothing beyond the existing SERVER_LUMINOUS requirement. The read balancer is unaffected: pg_upmap_primaries invalidated by the rule change are already cancelled by existing logic, and `balance_primaries()`  re-optimizes on top of the pinned up sets.
* Deliberately **not** calling `check_cluster_features(OSDMAP_PG_UPMAP)` in addition to the min-compat gate: the feature bit is luminous-era and present on all supported releases, and its `-EAGAIN`/wait path would complicate `prepare_command_pool_set`; happy to add it if preferred.

Testing:

* New gtest `OSDMapTest.CalcCrushRuleChangePins` (12 osds / 6 hosts / 3 racks; host -> rack rule change staged in one incremental) asserts:

failure-domain validity of every resulting up set; **maximal retention** (exactly one old-up member kept per distinct target-domain bucket the old up covered — the minimal-movement floor); `clean_pg_upmaps()`
stability (the mon finds nothing to cancel or simplify); osd-level target rule pins nothing; `-ENOSPC` when pool size exceeds the bucket
count; both fill strategies move exactly the same amount of data with  load-aware at least as balanced.
Run: `./bin/unittest_osdmap --gtest_filter=OSDMapTest.CalcCrushRuleChangePins`

* The placement algorithm was additionally validated out-of-tree against a  Python model of the CRUSH mapper checked bit-for-bit against `crushtool` on a 1600-OSD production osdmap (16384-PG full-pass comparisons; all generated placements accepted by `verify_upmap`).
* qa/standalone coverage for the OSDMonitor guards is proposed as a follow-up in the tracker.

Fixes: https://tracker.ceph.com/issues/78569

Assisted-by: Claude Opus 4.8 High and Claude Fable 5 Extra.

Live demos on Umbrella build:

* Demo N°1: how much data moves when mon_crush_rule_change_preserve_acting is true/false: https://youtu.be/kkK2IndTKPA

* Demo N°2: how the cluster reacts to multiple crush rule changes when mon_crush_rule_change_preserve_acting is true/false: https://youtu.be/-r4BffAzOO4


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests