### PR TITLE
tentacle: mgr/nvmeof: change pool application to nvmeof-meta instead of rbd

### DIFF
--- a/src/pybind/mgr/nvmeof/module.py
+++ b/src/pybind/mgr/nvmeof/module.py
@@ -3,7 +3,6 @@ from typing import Any
 
 from .cli import NVMeoFCLICommand
 from mgr_module import MgrModule
-import rbd
 
 logger = logging.getLogger(__name__)
 
@@ -30,31 +29,21 @@ class NVMeoF(MgrModule):
             self.create_pool(pool_name)
             logger.info(f"Pool '{pool_name}' created.")
         except Exception:
-            logger.error(f"Error creating pool '{pool_name}", exc_info=True)
+            logger.error(f"Error creating pool '{pool_name}'", exc_info=True)
             raise
 
-    def _enable_rbd_application(self, pool_name: str) -> None:
+    def _enable_application(self, pool_name: str, application_name: str) -> None:
         try:
-            self.appify_pool(pool_name, 'rbd')
-            logger.info(f"'rbd' application enabled on pool '{pool_name}'.")
+            self.appify_pool(pool_name, application_name)
+            logger.info(f"'{application_name}' application enabled on pool '{pool_name}'.")
         except Exception:
             logger.error(
-                f"Failed to enable 'rbd' application on '{pool_name}'",
+                f"Failed to enable '{application_name}' application on '{pool_name}'",
                 exc_info=True
             )
-            raise
-
-    def _rbd_pool_init(self, pool_name: str) -> None:
-        try:
-            with self.rados.open_ioctx(pool_name) as ioctx:
-                rbd.RBD().pool_init(ioctx, False)
-            logger.info(f"RBD pool_init completed on '{pool_name}'.")
-        except Exception:
-            logger.error(f"Failed to initialize RBD pool '{pool_name}'", exc_info=True)
             raise
 
     def create_pool_if_not_exists(self) -> None:
         if not self._pool_exists(POOL_NAME):
             self._create_pool(POOL_NAME)
-        self._enable_rbd_application(POOL_NAME)
-        self._rbd_pool_init(POOL_NAME)
+            self._enable_application(POOL_NAME, 'nvmeof-meta')

--- a/src/pybind/mgr/nvmeof/tests/test_nvmeof_module.py
+++ b/src/pybind/mgr/nvmeof/tests/test_nvmeof_module.py
@@ -1,5 +1,3 @@
-
-from contextlib import contextmanager
 from unittest.mock import MagicMock
 
 import nvmeof.module as nvmeof_mod
@@ -8,21 +6,9 @@ import nvmeof.module as nvmeof_mod
 class FakeRados:
     def __init__(self, exists: bool):
         self._exists = exists
-        self.opened_pools = []
 
     def pool_exists(self, pool_name: str) -> bool:
         return self._exists
-
-    @contextmanager
-    def open_ioctx(self, pool_name: str):
-        self.opened_pools.append(pool_name)
-        yield object()
-
-
-def patch_rbd_pool_init(monkeypatch):
-    rbd_instance = MagicMock()
-    monkeypatch.setattr(nvmeof_mod.rbd, "RBD", lambda: rbd_instance)
-    return rbd_instance
 
 
 def make_mgr(mon_handler, exists: bool, monkeypatch):
@@ -37,49 +23,61 @@ def make_mgr(mon_handler, exists: bool, monkeypatch):
     def _pool_exists(self, pool_name: str) -> bool:
         return self._fake_rados.pool_exists(pool_name)
 
-    def _rbd_pool_init(self, pool_name: str):
-        with self._fake_rados.open_ioctx(pool_name) as ioctx:
-            nvmeof_mod.rbd.RBD().pool_init(ioctx, False)
-
     monkeypatch.setattr(nvmeof_mod.NVMeoF, "_pool_exists", _pool_exists, raising=True)
-    monkeypatch.setattr(nvmeof_mod.NVMeoF, "_rbd_pool_init", _rbd_pool_init, raising=True)
 
     return mgr
 
 
-def test_pool_exists_skips_create_calls_enable_and_pool_init(monkeypatch):
+def test_pool_exists_skips_pool_creation(monkeypatch):
     calls = []
 
     def mon_command(cmd, inbuf):
         calls.append(cmd)
         return 0, "", ""
 
-    rbd_instance = patch_rbd_pool_init(monkeypatch)
     mgr = make_mgr(mon_command, exists=True, monkeypatch=monkeypatch)
 
     mgr.create_pool_if_not_exists()
 
     assert not any(c.get("prefix") == "osd pool create" for c in calls)
-    assert any(c.get("prefix") == "osd pool application enable" for c in calls)
 
-    assert mgr._fake_rados.opened_pools == [".nvmeof"]
-    rbd_instance.pool_init.assert_called_once()
+    assert not any(c.get("prefix") == "osd pool application enable" for c in calls)
 
 
-def test_pool_missing_creates_then_enables_then_pool_init(monkeypatch):
+def test_pool_missing_creates_then_enables(monkeypatch):
     calls = []
 
     def mon_command(cmd, inbuf):
         calls.append(cmd)
         return 0, "", ""
 
-    rbd_instance = patch_rbd_pool_init(monkeypatch)
     mgr = make_mgr(mon_command, exists=False, monkeypatch=monkeypatch)
 
     mgr.create_pool_if_not_exists()
 
-    assert any(c.get("prefix") == "osd pool create" for c in calls)
-    assert any(c.get("prefix") == "osd pool application enable" for c in calls)
+    create_calls = [c for c in calls if c.get("prefix") == "osd pool create"]
+    assert len(create_calls) == 1, "Expected one pool create call"
 
-    assert mgr._fake_rados.opened_pools == [".nvmeof"]
-    rbd_instance.pool_init.assert_called_once()
+    assert create_calls[0].get("pool") == ".nvmeof", "Expected pool_name to be '.nvmeof'"
+
+    app_enable_calls = [c for c in calls if c.get("prefix") == "osd pool application enable"]
+    assert len(app_enable_calls) == 1, "Expected one application enable call"
+
+    assert app_enable_calls[0].get("app") == "nvmeof-meta", "Expected 'nvmeof-meta' application to be enabled"
+    assert app_enable_calls[0].get("pool") == ".nvmeof", "Expected pool to be '.nvmeof'"
+
+
+def test_enable_application_with_custom_app_name(monkeypatch):
+    calls = []
+
+    def mon_command(cmd, inbuf):
+        calls.append(cmd)
+        return 0, "", ""
+
+    mgr = make_mgr(mon_command, exists=True, monkeypatch=monkeypatch)
+
+    mgr._enable_application("test-pool", "custom-app")
+
+    custom_enable_calls = [c for c in calls if c.get("prefix") == "osd pool application enable" and c.get("app") == "custom-app"]
+    assert len(custom_enable_calls) == 1, "Expected one 'custom-app' application enable call"
+    assert custom_enable_calls[0].get("pool") == "test-pool"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78543

---

backport of https://github.com/ceph/ceph/pull/70035
parent tracker: https://tracker.ceph.com/issues/77694

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh