### PR TITLE
umbrella: rgw: add support for --shard-id in gc process and gc list commands

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -639,7 +639,7 @@ Options
 
 .. option:: --shard-id=<shard-id>
 
-   Optional for mdlog list, bi list, data sync status. Required for ``mdlog trim``.
+   Optional for mdlog list, bi list, data sync status, gc list, gc process. Required for ``mdlog trim``.
 
 .. option:: --max-entries=<entries>
 

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -651,7 +651,7 @@ void cls_rgw_gc_list(ObjectReadOperation& op, const string& marker,
 
 int cls_rgw_gc_list_decode(const bufferlist& out,
                            std::list<cls_rgw_gc_obj_info>& entries,
-                           bool *truncated, std::string& next_marker)
+                           bool& truncated, std::string& next_marker)
 {
   cls_rgw_gc_list_ret ret;
   try {
@@ -663,8 +663,7 @@ int cls_rgw_gc_list_decode(const bufferlist& out,
 
   entries.swap(ret.entries);
 
-  if (truncated)
-    *truncated = ret.truncated;
+  truncated = ret.truncated;
   next_marker = std::move(ret.next_marker);
   return 0;
 }

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -253,7 +253,7 @@ void cls_rgw_gc_list(librados::ObjectReadOperation& op, const std::string& marke
                      uint32_t max, bool expired_only, bufferlist& bl);
 int cls_rgw_gc_list_decode(const bufferlist& bl,
                            std::list<cls_rgw_gc_obj_info>& entries,
-                           bool *truncated, std::string& next_marker);
+                           bool& truncated, std::string& next_marker);
 
 /* lifecycle */
 void cls_rgw_lc_get_head(librados::ObjectReadOperation& op, bufferlist& bl);

--- a/src/cls/rgw_gc/cls_rgw_gc_client.cc
+++ b/src/cls/rgw_gc/cls_rgw_gc_client.cc
@@ -60,7 +60,7 @@ void cls_rgw_gc_queue_enqueue(ObjectWriteOperation& op, uint32_t expiration_secs
 }
 
 int cls_rgw_gc_queue_list_entries(IoCtx& io_ctx, const string& oid, const string& marker, uint32_t max, bool expired_only,
-                                  list<cls_rgw_gc_obj_info>& entries, bool *truncated, string& next_marker)
+                                  list<cls_rgw_gc_obj_info>& entries, bool& truncated, string& next_marker)
 {
   bufferlist in, out;
   cls_rgw_gc_list_op op;
@@ -83,7 +83,7 @@ int cls_rgw_gc_queue_list_entries(IoCtx& io_ctx, const string& oid, const string
 
   entries.swap(ret.entries);
 
-  *truncated = ret.truncated;
+  truncated = ret.truncated;
 
   next_marker = std::move(ret.next_marker);
 

--- a/src/cls/rgw_gc/cls_rgw_gc_client.h
+++ b/src/cls/rgw_gc/cls_rgw_gc_client.h
@@ -15,6 +15,6 @@ void cls_rgw_gc_queue_init(librados::ObjectWriteOperation& op, uint64_t size, ui
 int cls_rgw_gc_queue_get_capacity(librados::IoCtx& io_ctx, const std::string& oid, uint64_t& size);
 void cls_rgw_gc_queue_enqueue(librados::ObjectWriteOperation& op, uint32_t expiration_secs, const cls_rgw_gc_obj_info& info);
 int cls_rgw_gc_queue_list_entries(librados::IoCtx& io_ctx, const std::string& oid, const std::string& marker, uint32_t max, bool expired_only,
-				  std::list<cls_rgw_gc_obj_info>& entries, bool *truncated, std::string& next_marker);
+				  std::list<cls_rgw_gc_obj_info>& entries, bool& truncated, std::string& next_marker);
 void cls_rgw_gc_queue_remove_entries(librados::ObjectWriteOperation& op, uint32_t num_entries);
 void cls_rgw_gc_queue_defer_entry(librados::ObjectWriteOperation& op, uint32_t expiration_secs, const cls_rgw_gc_obj_info& info);

--- a/src/rgw/driver/rados/rgw_gc.cc
+++ b/src/rgw/driver/rados/rgw_gc.cc
@@ -259,13 +259,18 @@ static int gc_list(const DoutPrefixProvider* dpp, optional_yield y, librados::Io
   return cls_rgw_gc_list_decode(bl, entries, truncated, next_marker);
 }
 
-int RGWGC::list(int *index, string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool *truncated, bool& processing_queue)
+int RGWGC::list(int *index, string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool *truncated, bool& processing_queue, std::optional<int> shard_id)
 {
   result.clear();
   string next_marker;
   bool check_queue = false;
 
-  for (; *index < max_objs && result.size() < max; (*index)++, marker.clear(), check_queue = false) {
+  int max_index = shard_id.has_value() ? (shard_id.value() + 1) : max_objs;
+  if (shard_id.has_value()) {
+    *index = shard_id.value();
+  }
+
+  for (; *index < max_index && result.size() < max; (*index)++, marker.clear(), check_queue = false) {
     std::list<cls_rgw_gc_obj_info> entries, queue_entries;
     int ret = 0;
 
@@ -320,7 +325,7 @@ int RGWGC::list(int *index, string& marker, uint32_t max, bool expired_only, std
 
     marker = next_marker;
 
-    if (*index == max_objs - 1) {
+    if (*index == max_index - 1) {
       if (queue_entries.size() > 0 && *truncated) {
         processing_queue = true;
       } else {
@@ -739,19 +744,26 @@ done:
   return 0;
 }
 
-int RGWGC::process(bool expired_only, optional_yield y)
+int RGWGC::process(bool expired_only, optional_yield y, std::optional<int> shard_id)
 {
   int max_secs = cct->_conf->rgw_gc_processor_max_time;
 
-  const int start = ceph::util::generate_random_number(0, max_objs - 1);
-
   RGWGCIOManager io_manager(this, store->ctx(), this);
 
-  for (int i = 0; i < max_objs; i++) {
-    int index = (i + start) % max_objs;
-    int ret = process(index, max_secs, expired_only, io_manager, y);
+  if (shard_id.has_value()) {
+    // Process only the specified shard
+    int ret = process(shard_id.value(), max_secs, expired_only, io_manager, y);
     if (ret < 0)
       return ret;
+  } else {
+    // Process all shards with random start
+    const int start = ceph::util::generate_random_number(0, max_objs - 1);
+    for (int i = 0; i < max_objs; i++) {
+      int index = (i + start) % max_objs;
+      int ret = process(index, max_secs, expired_only, io_manager, y);
+      if (ret < 0)
+        return ret;
+    }
   }
   if (!going_down()) {
     io_manager.drain();

--- a/src/rgw/driver/rados/rgw_gc.cc
+++ b/src/rgw/driver/rados/rgw_gc.cc
@@ -247,7 +247,7 @@ int RGWGC::remove(int index, int num_entries, optional_yield y)
 
 static int gc_list(const DoutPrefixProvider* dpp, optional_yield y, librados::IoCtx& io_ctx,
                    std::string& oid, std::string& marker, uint32_t max, bool expired_only,
-                   std::list<cls_rgw_gc_obj_info>& entries, bool *truncated, std::string& next_marker)
+                   std::list<cls_rgw_gc_obj_info>& entries, bool& truncated, std::string& next_marker)
 {
   librados::ObjectReadOperation op;
   bufferlist bl;
@@ -259,7 +259,7 @@ static int gc_list(const DoutPrefixProvider* dpp, optional_yield y, librados::Io
   return cls_rgw_gc_list_decode(bl, entries, truncated, next_marker);
 }
 
-int RGWGC::list(int *index, string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool *truncated, bool& processing_queue, std::optional<int> shard_id)
+int RGWGC::list(int& index, string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool& truncated, bool& processing_queue, std::optional<int> shard_id)
 {
   result.clear();
   string next_marker;
@@ -267,33 +267,33 @@ int RGWGC::list(int *index, string& marker, uint32_t max, bool expired_only, std
 
   int max_index = shard_id.has_value() ? (shard_id.value() + 1) : max_objs;
   if (shard_id.has_value()) {
-    *index = shard_id.value();
+    index = shard_id.value();
   }
 
-  for (; *index < max_index && result.size() < max; (*index)++, marker.clear(), check_queue = false) {
+  for (; index < max_index && result.size() < max; index++, marker.clear(), check_queue = false) {
     std::list<cls_rgw_gc_obj_info> entries, queue_entries;
     int ret = 0;
 
     //processing_queue is set to true from previous iteration if the queue was under process and probably has more elements in it.
-    if (! transitioned_objects_cache[*index] && ! check_queue && ! processing_queue) {
-      ret = gc_list(this, null_yield, store->gc_pool_ctx, obj_names[*index], marker, max - result.size(), expired_only, entries, truncated, next_marker);
+    if (! transitioned_objects_cache[index] && ! check_queue && ! processing_queue) {
+      ret = gc_list(this, null_yield, store->gc_pool_ctx, obj_names[index], marker, max - result.size(), expired_only, entries, truncated, next_marker);
       if (ret != -ENOENT && ret < 0) {
         return ret;
       }
       obj_version objv;
-      cls_version_read(store->gc_pool_ctx, obj_names[*index], &objv);
+      cls_version_read(store->gc_pool_ctx, obj_names[index], &objv);
       if (ret == -ENOENT || entries.size() == 0) {
         if (objv.ver == 0) {
           continue;
         } else {
           if (! expired_only) {
-            transitioned_objects_cache[*index] = true;
+            transitioned_objects_cache[index] = true;
             marker.clear();
           } else {
             std::list<cls_rgw_gc_obj_info> non_expired_entries;
-            ret = gc_list(this, null_yield, store->gc_pool_ctx, obj_names[*index], marker, 1, false, non_expired_entries, truncated, next_marker);
+            ret = gc_list(this, null_yield, store->gc_pool_ctx, obj_names[index], marker, 1, false, non_expired_entries, truncated, next_marker);
             if (non_expired_entries.size() == 0) {
-              transitioned_objects_cache[*index] = true;
+              transitioned_objects_cache[index] = true;
               marker.clear();
             }
           }
@@ -304,9 +304,9 @@ int RGWGC::list(int *index, string& marker, uint32_t max, bool expired_only, std
         marker.clear();
       }
     }
-    if (transitioned_objects_cache[*index] || check_queue || processing_queue) {
+    if (transitioned_objects_cache[index] || check_queue || processing_queue) {
       processing_queue = false;
-      ret = cls_rgw_gc_queue_list_entries(store->gc_pool_ctx, obj_names[*index], marker, (max - result.size()) - entries.size(), expired_only, queue_entries, truncated, next_marker);
+      ret = cls_rgw_gc_queue_list_entries(store->gc_pool_ctx, obj_names[index], marker, (max - result.size()) - entries.size(), expired_only, queue_entries, truncated, next_marker);
       if (ret < 0) {
         return ret;
       }
@@ -325,8 +325,8 @@ int RGWGC::list(int *index, string& marker, uint32_t max, bool expired_only, std
 
     marker = next_marker;
 
-    if (*index == max_index - 1) {
-      if (queue_entries.size() > 0 && *truncated) {
+    if (index == max_index - 1) {
+      if (queue_entries.size() > 0 && truncated) {
         processing_queue = true;
       } else {
         processing_queue = false;
@@ -336,22 +336,22 @@ int RGWGC::list(int *index, string& marker, uint32_t max, bool expired_only, std
     }
 
     if (result.size() == max) {
-      if (queue_entries.size() > 0 && *truncated) {
+      if (queue_entries.size() > 0 && truncated) {
         processing_queue = true;
       } else {
         processing_queue = false;
-        *index += 1; //move to next gc object
+        index += 1; //move to next gc object
       }
 
       /* close approximation, it might be that the next of the objects don't hold
        * anything, in this case truncated should have been false, but we can find
        * that out on the next iteration
        */
-      *truncated = true;
+      truncated = true;
       return 0;
     }
   }
-  *truncated = false;
+  truncated = false;
   processing_queue = false;
 
   return 0;
@@ -609,7 +609,7 @@ int RGWGC::process(int index, int max_secs, bool expired_only,
     int ret = 0;
 
     if (! transitioned_objects_cache[index]) {
-      ret = gc_list(this, y, store->gc_pool_ctx, obj_names[index], marker, max, expired_only, entries, &truncated, next_marker);
+      ret = gc_list(this, y, store->gc_pool_ctx, obj_names[index], marker, max, expired_only, entries, truncated, next_marker);
       ldpp_dout(this, 20) <<
       "RGWGC::process cls_rgw_gc_list returned with returned:" << ret <<
       ", entries.size=" << entries.size() << ", truncated=" << truncated <<
@@ -618,7 +618,7 @@ int RGWGC::process(int index, int max_secs, bool expired_only,
       cls_version_read(store->gc_pool_ctx, obj_names[index], &objv);
       if ((objv.ver == 1) && entries.size() == 0) {
         std::list<cls_rgw_gc_obj_info> non_expired_entries;
-        ret = gc_list(this, y, store->gc_pool_ctx, obj_names[index], marker, 1, false, non_expired_entries, &truncated, next_marker);
+        ret = gc_list(this, y, store->gc_pool_ctx, obj_names[index], marker, 1, false, non_expired_entries, truncated, next_marker);
         if (non_expired_entries.size() == 0) {
           transitioned_objects_cache[index] = true;
           marker.clear();
@@ -635,7 +635,7 @@ int RGWGC::process(int index, int max_secs, bool expired_only,
     }
 
     if (transitioned_objects_cache[index]) {
-      ret = cls_rgw_gc_queue_list_entries(store->gc_pool_ctx, obj_names[index], marker, max, expired_only, entries, &truncated, next_marker);
+      ret = cls_rgw_gc_queue_list_entries(store->gc_pool_ctx, obj_names[index], marker, max, expired_only, entries, truncated, next_marker);
       ldpp_dout(this, 20) <<
       "RGWGC::process cls_rgw_gc_queue_list_entries returned with return value:" << ret <<
       ", entries.size=" << entries.size() << ", truncated=" << truncated <<

--- a/src/rgw/driver/rados/rgw_gc.h
+++ b/src/rgw/driver/rados/rgw_gc.h
@@ -65,11 +65,10 @@ public:
   void initialize(CephContext *_cct, RGWRados *_store, optional_yield y);
   void finalize();
 
-  int list(int *index, std::string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool *truncated, bool& processing_queue);
-  void list_init(int *index) { *index = 0; }
+  int list(int *index, std::string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool *truncated, bool& processing_queue, std::optional<int> shard_id = std::nullopt);
   int process(int index, int process_max_secs, bool expired_only,
               RGWGCIOManager& io_manager, optional_yield y);
-  int process(bool expired_only, optional_yield y);
+  int process(bool expired_only, optional_yield y, std::optional<int> shard_id = std::nullopt);
 
   bool going_down();
   void start_processor();

--- a/src/rgw/driver/rados/rgw_gc.h
+++ b/src/rgw/driver/rados/rgw_gc.h
@@ -65,7 +65,7 @@ public:
   void initialize(CephContext *_cct, RGWRados *_store, optional_yield y);
   void finalize();
 
-  int list(int *index, std::string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool *truncated, bool& processing_queue, std::optional<int> shard_id = std::nullopt);
+  int list(int& index, std::string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool& truncated, bool& processing_queue, std::optional<int> shard_id = std::nullopt);
   int process(int index, int process_max_secs, bool expired_only,
               RGWGCIOManager& io_manager, optional_yield y);
   int process(bool expired_only, optional_yield y, std::optional<int> shard_id = std::nullopt);

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -10670,14 +10670,14 @@ int RGWRados::gc_operate(const DoutPrefixProvider *dpp, string& oid, librados::O
   return rgw_rados_operate(dpp, gc_pool_ctx, oid, std::move(op), pbl, y);
 }
 
-int RGWRados::list_gc_objs(int *index, string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool *truncated, bool& processing_queue)
+int RGWRados::list_gc_objs(int *index, string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool *truncated, bool& processing_queue, std::optional<int> shard_id)
 {
-  return gc->list(index, marker, max, expired_only, result, truncated, processing_queue);
+  return gc->list(index, marker, max, expired_only, result, truncated, processing_queue, shard_id);
 }
 
-int RGWRados::process_gc(bool expired_only, optional_yield y)
+int RGWRados::process_gc(bool expired_only, optional_yield y, std::optional<int> shard_id)
 {
-  return gc->process(expired_only, y);
+  return gc->process(expired_only, y, shard_id);
 }
 
 int RGWRados::process_lc(const std::unique_ptr<rgw::sal::Bucket>& optional_bucket)

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -10670,7 +10670,7 @@ int RGWRados::gc_operate(const DoutPrefixProvider *dpp, string& oid, librados::O
   return rgw_rados_operate(dpp, gc_pool_ctx, oid, std::move(op), pbl, y);
 }
 
-int RGWRados::list_gc_objs(int *index, string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool *truncated, bool& processing_queue, std::optional<int> shard_id)
+int RGWRados::list_gc_objs(int& index, string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool& truncated, bool& processing_queue, std::optional<int> shard_id)
 {
   return gc->list(index, marker, max, expired_only, result, truncated, processing_queue, shard_id);
 }

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1629,8 +1629,8 @@ public:
                      librados::ObjectWriteOperation *op);
   int gc_operate(const DoutPrefixProvider *dpp, std::string& oid, librados::ObjectReadOperation&& op, bufferlist *pbl, optional_yield y);
 
-  int list_gc_objs(int *index, std::string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool *truncated, bool& processing_queue);
-  int process_gc(bool expired_only, optional_yield y);
+  int list_gc_objs(int *index, std::string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool *truncated, bool& processing_queue, std::optional<int> shard_id = std::nullopt);
+  int process_gc(bool expired_only, optional_yield y, std::optional<int> shard_id = std::nullopt);
   bool process_expired_objects(const DoutPrefixProvider *dpp, optional_yield y);
   int defer_gc(const DoutPrefixProvider *dpp, RGWObjectCtx* ctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, optional_yield y);
 

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1629,7 +1629,7 @@ public:
                      librados::ObjectWriteOperation *op);
   int gc_operate(const DoutPrefixProvider *dpp, std::string& oid, librados::ObjectReadOperation&& op, bufferlist *pbl, optional_yield y);
 
-  int list_gc_objs(int *index, std::string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool *truncated, bool& processing_queue, std::optional<int> shard_id = std::nullopt);
+  int list_gc_objs(int& index, std::string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool& truncated, bool& processing_queue, std::optional<int> shard_id = std::nullopt);
   int process_gc(bool expired_only, optional_yield y, std::optional<int> shard_id = std::nullopt);
   bool process_expired_objects(const DoutPrefixProvider *dpp, optional_yield y);
   int defer_gc(const DoutPrefixProvider *dpp, RGWObjectCtx* ctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, optional_yield y);

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -9728,7 +9728,7 @@ next:
 
     do {
       list<cls_rgw_gc_obj_info> result;
-      int ret = static_cast<rgw::sal::RadosStore*>(driver)->getRados()->list_gc_objs(&index, marker, 1000, !include_all, result, &truncated, processing_queue, gc_shard_id);
+      int ret = static_cast<rgw::sal::RadosStore*>(driver)->getRados()->list_gc_objs(index, marker, 1000, !include_all, result, truncated, processing_queue, gc_shard_id);
       if (ret < 0) {
 	cerr << "ERROR: failed to list objs: " << cpp_strerror(-ret) << std::endl;
 	return 1;

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -420,6 +420,8 @@ void usage()
   cout << "                                       mdlog list\n";
   cout << "                                       data sync status\n";
   cout << "                                       sync error trim\n";
+  cout << "                                       gc list\n";
+  cout << "                                       gc process\n";
   cout << "                                     required for:\n";
   cout << "                                       mdlog trim\n";
   cout << "   --gen=<gen-id>                    optional for:\n";
@@ -9709,14 +9711,24 @@ next:
   }
 
   if (opt_cmd == OPT::GC_LIST) {
+    if (specified_shard_id) {
+      int max_gc_shards = min(static_cast<int>(g_ceph_context->_conf->rgw_gc_max_objs), rgw_shards_max());
+      if (shard_id < 0 || shard_id >= max_gc_shards) {
+        cerr << "ERROR: shard-id must be in the range [0, " << max_gc_shards - 1 << "]" << std::endl;
+        return EINVAL;
+      }
+    }
+
     int index = 0;
     bool truncated;
     bool processing_queue = false;
     formatter->open_array_section("entries");
 
+    std::optional<int> gc_shard_id = specified_shard_id ? std::optional<int>(shard_id) : std::nullopt;
+
     do {
       list<cls_rgw_gc_obj_info> result;
-      int ret = static_cast<rgw::sal::RadosStore*>(driver)->getRados()->list_gc_objs(&index, marker, 1000, !include_all, result, &truncated, processing_queue);
+      int ret = static_cast<rgw::sal::RadosStore*>(driver)->getRados()->list_gc_objs(&index, marker, 1000, !include_all, result, &truncated, processing_queue, gc_shard_id);
       if (ret < 0) {
 	cerr << "ERROR: failed to list objs: " << cpp_strerror(-ret) << std::endl;
 	return 1;
@@ -9743,6 +9755,14 @@ next:
   }
 
   if (opt_cmd == OPT::GC_PROCESS) {
+    if (specified_shard_id) {
+      int max_gc_shards = min(static_cast<int>(g_ceph_context->_conf->rgw_gc_max_objs), rgw_shards_max());
+      if (shard_id < 0 || shard_id >= max_gc_shards) {
+        cerr << "ERROR: shard-id must be in the range [0, " << max_gc_shards - 1 << "]" << std::endl;
+        return EINVAL;
+      }
+    }
+
     rgw::sal::RadosStore* rados_store = dynamic_cast<rgw::sal::RadosStore*>(driver);
     if (!rados_store) {
       cerr <<
@@ -9752,7 +9772,8 @@ next:
     }
     RGWRados* store = rados_store->getRados();
 
-    int ret = store->process_gc(!include_all, null_yield);
+    std::optional<int> gc_shard_id = specified_shard_id ? std::optional<int>(shard_id) : std::nullopt;
+    int ret = store->process_gc(!include_all, null_yield, gc_shard_id);
     if (ret < 0) {
       cerr << "ERROR: gc processing returned error: " << cpp_strerror(-ret) << std::endl;
       return 1;

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -269,6 +269,8 @@
                                          mdlog list
                                          data sync status
                                          sync error trim
+                                         gc list
+                                         gc process
                                        required for:
                                          mdlog trim
      --gen=<gen-id>                    optional for:

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -754,7 +754,7 @@ static bool cmp_objs(cls_rgw_obj& obj1, cls_rgw_obj& obj2)
 }
 
 static int gc_list(librados::IoCtx& io_ctx, std::string& oid, std::string& marker, uint32_t max, bool expired_only,
-                   std::list<cls_rgw_gc_obj_info>& entries, bool *truncated, std::string& next_marker)
+                   std::list<cls_rgw_gc_obj_info>& entries, bool& truncated, std::string& next_marker)
 {
   librados::ObjectReadOperation op;
   bufferlist bl;
@@ -797,7 +797,7 @@ TEST_F(cls_rgw, gc_set)
   string next_marker;
 
   /* list chains, verify truncated */
-  ASSERT_EQ(0, gc_list(ioctx, oid, marker, 8, true, entries, &truncated, next_marker));
+  ASSERT_EQ(0, gc_list(ioctx, oid, marker, 8, true, entries, truncated, next_marker));
   ASSERT_EQ(8, (int)entries.size());
   ASSERT_EQ(1, truncated);
 
@@ -805,7 +805,7 @@ TEST_F(cls_rgw, gc_set)
   next_marker.clear();
 
   /* list all chains, verify not truncated */
-  ASSERT_EQ(0, gc_list(ioctx, oid, marker, 10, true, entries, &truncated, next_marker));
+  ASSERT_EQ(0, gc_list(ioctx, oid, marker, 10, true, entries, truncated, next_marker));
   ASSERT_EQ(10, (int)entries.size());
   ASSERT_EQ(0, truncated);
  
@@ -874,14 +874,14 @@ TEST_F(cls_rgw, gc_list)
   string next_marker;
 
   /* list chains, verify truncated */
-  ASSERT_EQ(0, gc_list(ioctx, oid, marker, 8, true, entries, &truncated, next_marker));
+  ASSERT_EQ(0, gc_list(ioctx, oid, marker, 8, true, entries, truncated, next_marker));
   ASSERT_EQ(8, (int)entries.size());
   ASSERT_EQ(1, truncated);
 
   marker = next_marker;
   next_marker.clear();
 
-  ASSERT_EQ(0, gc_list(ioctx, oid, marker, 8, true, entries2, &truncated, next_marker));
+  ASSERT_EQ(0, gc_list(ioctx, oid, marker, 8, true, entries2, truncated, next_marker));
   ASSERT_EQ(2, (int)entries2.size());
   ASSERT_EQ(0, truncated);
 
@@ -951,7 +951,7 @@ TEST_F(cls_rgw, gc_defer)
   string next_marker;
 
   /* list chains, verify num entries as expected */
-  ASSERT_EQ(0, gc_list(ioctx, oid, marker, 1, true, entries, &truncated, next_marker));
+  ASSERT_EQ(0, gc_list(ioctx, oid, marker, 1, true, entries, truncated, next_marker));
   ASSERT_EQ(1, (int)entries.size());
   ASSERT_EQ(0, truncated);
 
@@ -965,7 +965,7 @@ TEST_F(cls_rgw, gc_defer)
   next_marker.clear();
 
   /* verify list doesn't show deferred entry (this may fail if cluster is thrashing) */
-  ASSERT_EQ(0, gc_list(ioctx, oid, marker, 1, true, entries, &truncated, next_marker));
+  ASSERT_EQ(0, gc_list(ioctx, oid, marker, 1, true, entries, truncated, next_marker));
   ASSERT_EQ(0, (int)entries.size());
   ASSERT_EQ(0, truncated);
 
@@ -974,7 +974,7 @@ TEST_F(cls_rgw, gc_defer)
   next_marker.clear();
 
   /* verify list shows deferred entry */
-  ASSERT_EQ(0, gc_list(ioctx, oid, marker, 1, true, entries, &truncated, next_marker));
+  ASSERT_EQ(0, gc_list(ioctx, oid, marker, 1, true, entries, truncated, next_marker));
   ASSERT_EQ(1, (int)entries.size());
   ASSERT_EQ(0, truncated);
 
@@ -990,7 +990,7 @@ TEST_F(cls_rgw, gc_defer)
   next_marker.clear();
 
   /* verify entry was removed */
-  ASSERT_EQ(0, gc_list(ioctx, oid, marker, 1, true, entries, &truncated, next_marker));
+  ASSERT_EQ(0, gc_list(ioctx, oid, marker, 1, true, entries, truncated, next_marker));
   ASSERT_EQ(0, (int)entries.size());
   ASSERT_EQ(0, truncated);
 

--- a/src/test/cls_rgw_gc/test_cls_rgw_gc.cc
+++ b/src/test/cls_rgw_gc/test_cls_rgw_gc.cc
@@ -122,7 +122,7 @@ TEST(cls_rgw_gc, gc_queue_ops1)
   string marker, next_marker;
   uint64_t max = 1;
   bool expired_only = false, truncated;
-  cls_rgw_gc_queue_list_entries(ioctx, queue_name, marker, max, expired_only, list_info1, &truncated, next_marker);
+  cls_rgw_gc_queue_list_entries(ioctx, queue_name, marker, max, expired_only, list_info1, truncated, next_marker);
   ASSERT_EQ(1, list_info1.size());
 
   for (auto it : list_info1) {
@@ -151,7 +151,7 @@ TEST(cls_rgw_gc, gc_queue_ops2)
   string marker1, next_marker1;
   uint64_t max1 = 2;
   bool expired_only1 = false, truncated1;
-  cls_rgw_gc_queue_list_entries(ioctx, queue_name, marker1, max1, expired_only1, list_info, &truncated1, next_marker1);
+  cls_rgw_gc_queue_list_entries(ioctx, queue_name, marker1, max1, expired_only1, list_info, truncated1, next_marker1);
   ASSERT_EQ(0, list_info.size());
 
   //Test enqueue
@@ -180,7 +180,7 @@ TEST(cls_rgw_gc, gc_queue_ops2)
   string marker, next_marker;
   uint64_t max = 2;
   bool expired_only = false, truncated;
-  cls_rgw_gc_queue_list_entries(ioctx, queue_name, marker, max, expired_only, list_info1, &truncated, next_marker);
+  cls_rgw_gc_queue_list_entries(ioctx, queue_name, marker, max, expired_only, list_info1, truncated, next_marker);
   ASSERT_EQ(2, list_info1.size());
 
   int i = 0;
@@ -192,7 +192,7 @@ TEST(cls_rgw_gc, gc_queue_ops2)
 
   max = 1;
   truncated = false;
-  cls_rgw_gc_queue_list_entries(ioctx, queue_name, marker, max, expired_only, list_info2, &truncated, next_marker);
+  cls_rgw_gc_queue_list_entries(ioctx, queue_name, marker, max, expired_only, list_info2, truncated, next_marker);
   auto it = list_info2.front();
   ASSERT_EQ(1, list_info2.size());
   ASSERT_EQ(true, truncated);
@@ -200,7 +200,7 @@ TEST(cls_rgw_gc, gc_queue_ops2)
   std::cerr << "[          ] next_marker is: = " << next_marker << std::endl;
 
   marker = next_marker;
-  cls_rgw_gc_queue_list_entries(ioctx, queue_name, marker, max, expired_only, list_info3, &truncated, next_marker);
+  cls_rgw_gc_queue_list_entries(ioctx, queue_name, marker, max, expired_only, list_info3, truncated, next_marker);
   it = list_info3.front();
   ASSERT_EQ(1, list_info3.size());
   ASSERT_EQ(false, truncated);
@@ -402,7 +402,7 @@ TEST(cls_rgw_gc, gc_queue_ops5)
   string marker, next_marker, marker1;
   uint64_t max = 10;
   bool expired_only = true, truncated;
-  cls_rgw_gc_queue_list_entries(ioctx, queue_name, marker, max, expired_only, list_info1, &truncated, next_marker);
+  cls_rgw_gc_queue_list_entries(ioctx, queue_name, marker, max, expired_only, list_info1, truncated, next_marker);
   ASSERT_EQ(2, list_info1.size());
 
   int i = 0;
@@ -420,7 +420,7 @@ TEST(cls_rgw_gc, gc_queue_ops5)
 
   //Test list queue again for all entries
   expired_only = false;
-  cls_rgw_gc_queue_list_entries(ioctx, queue_name, marker, max, expired_only, list_info2, &truncated, next_marker);
+  cls_rgw_gc_queue_list_entries(ioctx, queue_name, marker, max, expired_only, list_info2, truncated, next_marker);
   ASSERT_EQ(1, list_info2.size());
 
 }
@@ -486,7 +486,7 @@ TEST(cls_rgw_gc, gc_queue_ops6)
   string marker, next_marker;
   uint64_t max = 2;
   bool expired_only = false, truncated;
-  cls_rgw_gc_queue_list_entries(ioctx, queue_name, marker, max, expired_only, list_info1, &truncated, next_marker);
+  cls_rgw_gc_queue_list_entries(ioctx, queue_name, marker, max, expired_only, list_info1, truncated, next_marker);
   ASSERT_EQ(2, list_info1.size());
 
   int i = 1;
@@ -558,7 +558,7 @@ TEST(cls_rgw_gc, gc_queue_ops7)
   string marker, next_marker;
   uint64_t max = 2;
   bool expired_only = false, truncated;
-  cls_rgw_gc_queue_list_entries(ioctx, queue_name, marker, max, expired_only, list_info1, &truncated, next_marker);
+  cls_rgw_gc_queue_list_entries(ioctx, queue_name, marker, max, expired_only, list_info1, truncated, next_marker);
   ASSERT_EQ(2, list_info1.size());
 
   int i = 1;
@@ -630,7 +630,7 @@ TEST(cls_rgw_gc, gc_queue_ops8)
   string marker, next_marker;
   uint64_t max = 2;
   bool expired_only = false, truncated;
-  cls_rgw_gc_queue_list_entries(ioctx, queue_name, marker, max, expired_only, list_info1, &truncated, next_marker);
+  cls_rgw_gc_queue_list_entries(ioctx, queue_name, marker, max, expired_only, list_info1, truncated, next_marker);
   ASSERT_EQ(2, list_info1.size());
 
   int i = 1;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78575

---

backport of https://github.com/ceph/ceph/pull/68574
parent tracker: https://tracker.ceph.com/issues/76128

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh