### PR TITLE
tentacle: rgw/admin: guard bilog autotrim on non-exporting (archive) zones

### DIFF
--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -11009,6 +11009,19 @@ next:
   }
 
   if (opt_cmd == OPT::BILOG_AUTOTRIM) {
+    // The background sync-log-trim thread only runs bucket trim on zones whose
+    // sync module exports data. Non-exporting zones (e.g. archive) deliberately
+    // forbid bucket-instance removal. Likewise, here, we add the same guard for
+    // user triggered auto-trim.
+    if (!static_cast<rgw::sal::RadosStore*>(driver)->svc()->zone->sync_module_exports_data() &&
+        !yes_i_really_mean_it) {
+      cerr << "This zone's sync module does not export data (e.g. an archive zone). "
+              "bilog autotrim can remove bucket instance metadata that this zone type "
+              "is meant to retain.\n"
+              "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
+      return EPERM;
+    }
+
     RGWCoroutinesManager crs(driver->ctx(), driver->get_cr_registry());
     RGWHTTPManager http(driver->ctx(), crs.get_completion_mgr());
     int ret = http.start();

--- a/src/test/rgw/rgw_multi/tests_az.py
+++ b/src/test/rgw/rgw_multi/tests_az.py
@@ -595,3 +595,14 @@ def test_az_versioning_support_in_zones():
     key_az = bucket_az.get_key("foo", version_id=obj_az_version_id)
     p19 = key_az.get_contents_as_string(encoding='ascii') == "zero"
     assert_equal(p19, True)
+
+
+def test_az_bilog_autotrim_refused_on_archive_zone():
+    """ bilog autotrim must refuse on an archive zone without --yes-i-really-mean-it """
+    _, az_zones = init_env()
+    az_zone = az_zones[0]
+    # a non-exporting (archive) zone forbids bucket-instance removal
+    _, retcode = az_zone.zone.cluster.admin(['bilog', 'autotrim'], check_retcode=False)
+    assert_not_equal(retcode, 0)
+    # the escape hatch still lets a user force it
+    az_zone.zone.cluster.admin(['bilog', 'autotrim', '--yes-i-really-mean-it'])


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78580

---

backport of https://github.com/ceph/ceph/pull/70299
parent tracker: https://tracker.ceph.com/issues/78364

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh