### PR TITLE
test/mds: run unittest_mds_quiesce_db serially

### DIFF
--- a/src/test/mds/CMakeLists.txt
+++ b/src/test/mds/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(unittest_mds_quiesce_db
   $<TARGET_OBJECTS:unit-main>
 )
 add_ceph_unittest(unittest_mds_quiesce_db)
+set_property(TEST unittest_mds_quiesce_db PROPERTY RUN_SERIAL TRUE)
 target_link_libraries(unittest_mds_quiesce_db ceph-common global Boost::url)
 
 # unittest_mds_quiesce_agent


### PR DESCRIPTION
Several `QuiesceDbTest` cases expect state transitions within tight
wall-clock budgets, which only holds when the quiesce db thread and
waiters are scheduled promptly. Under a loaded parallel ctest run they
can be preempted past the budget, failing the assertion although the
state machine is correct.

A CI failure on this: https://github.com/sunyuechi/ceph-ci/actions/runs/29908321831/job/88884997258

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
