### PR TITLE
mgr/dashboard: add RBD ,File System , Object overview

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -4,6 +4,7 @@ import { ActivatedRouteSnapshot, PreloadAllModules, RouterModule, Routes } from 
 import _ from 'lodash';
 
 import { CephfsListComponent } from './ceph/cephfs/cephfs-list/cephfs-list.component';
+import { CephfsOverviewComponent } from './ceph/cephfs/cephfs-overview/cephfs-overview.component';
 import { ConfigurationFormComponent } from './ceph/cluster/configuration/configuration-form/configuration-form.component';
 import { ConfigurationComponent } from './ceph/cluster/configuration/configuration.component';
 import { CreateClusterComponent } from './ceph/cluster/create-cluster/create-cluster.component';
@@ -454,6 +455,12 @@ const routes: Routes = [
         path: 'cephfs',
         canActivate: [FeatureTogglesGuardService],
         children: [
+          { path: '', redirectTo: 'overview', pathMatch: 'full' },
+          {
+            path: 'overview',
+            component: CephfsOverviewComponent,
+            data: { breadcrumbs: 'File/Overview' }
+          },
           {
             path: 'fs',
             component: CephfsListComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -4,6 +4,7 @@ import { ActivatedRouteSnapshot, PreloadAllModules, RouterModule, Routes } from 
 import _ from 'lodash';
 
 import { CephfsListComponent } from './ceph/cephfs/cephfs-list/cephfs-list.component';
+import { CephfsOverviewComponent } from './ceph/cephfs/cephfs-overview/cephfs-overview.component';
 import { ConfigurationFormComponent } from './ceph/cluster/configuration/configuration-form/configuration-form.component';
 import { ConfigurationComponent } from './ceph/cluster/configuration/configuration.component';
 import { CreateClusterComponent } from './ceph/cluster/create-cluster/create-cluster.component';
@@ -466,6 +467,12 @@ const routes: Routes = [
         path: 'cephfs',
         canActivate: [FeatureTogglesGuardService],
         children: [
+          { path: '', redirectTo: 'overview', pathMatch: 'full' },
+          {
+            path: 'overview',
+            component: CephfsOverviewComponent,
+            data: { breadcrumbs: 'File/Overview' }
+          },
           {
             path: 'fs',
             component: CephfsListComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
@@ -11,6 +11,9 @@ import { FeatureTogglesGuardService } from '~/app/shared/services/feature-toggle
 import { ModuleStatusGuardService } from '~/app/shared/services/module-status-guard.service';
 import { SharedModule } from '~/app/shared/shared.module';
 import { TextLabelListComponent } from '~/app/shared/components/text-label-list/text-label-list.component';
+import { AreaChartComponent } from '~/app/shared/components/area-chart/area-chart.component';
+import { DonutChartComponent } from '~/app/shared/components/donut-chart/donut-chart.component';
+import { TimePickerComponent } from '~/app/shared/components/time-picker/time-picker.component';
 import { IscsiSettingComponent } from './iscsi-setting/iscsi-setting.component';
 import { IscsiTabsComponent } from './iscsi-tabs/iscsi-tabs.component';
 import { IscsiTargetDetailsComponent } from './iscsi-target-details/iscsi-target-details.component';
@@ -28,6 +31,7 @@ import { RbdConfigurationListComponent } from './rbd-configuration-list/rbd-conf
 import { RbdDetailsComponent } from './rbd-details/rbd-details.component';
 import { RbdFormComponent } from './rbd-form/rbd-form.component';
 import { RbdListComponent } from './rbd-list/rbd-list.component';
+import { RbdOverviewComponent } from './rbd-overview/rbd-overview.component';
 import { RbdNamespaceFormModalComponent } from './rbd-namespace-form/rbd-namespace-form-modal.component';
 import { RbdNamespaceListComponent } from './rbd-namespace-list/rbd-namespace-list.component';
 import { RbdPerformanceComponent } from './rbd-performance/rbd-performance.component';
@@ -111,6 +115,8 @@ import { NvmeofGatewayGroupDeleteGuardModalComponent } from './nvmeof-gateway-gr
 import { NvmeofSetupCardsComponent } from './nvmeof-setup-cards/nvmeof-setup-cards.component';
 import { NvmeofGatewayGroupFilterComponent } from './nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component';
 import { NvmeofEditAuthenticationComponent } from './nvmeof-edit-authentication/nvmeof-edit-authentication.component';
+import { PerformanceCardComponent } from '~/app/shared/components/performance-card/performance-card.component';
+import { OverviewAlertsCardComponent } from '~/app/ceph/overview/alerts-card/overview-alerts-card.component';
 
 @NgModule({
   imports: [
@@ -150,9 +156,15 @@ import { NvmeofEditAuthenticationComponent } from './nvmeof-edit-authentication/
     ThemeModule,
     NvmeofSetupCardsComponent,
     NvmeofGatewayGroupFilterComponent,
-    TextLabelListComponent
+    TextLabelListComponent,
+    PerformanceCardComponent,
+    AreaChartComponent,
+    DonutChartComponent,
+    TimePickerComponent,
+    OverviewAlertsCardComponent
   ],
   declarations: [
+    RbdOverviewComponent,
     RbdListComponent,
     IscsiComponent,
     IscsiSettingComponent,
@@ -231,7 +243,24 @@ export class BlockModule {
     components)
 */
 const routes: Routes = [
-  { path: '', redirectTo: 'rbd', pathMatch: 'full' },
+  { path: '', redirectTo: 'overview', pathMatch: 'full' },
+  {
+    path: 'overview',
+    component: RbdOverviewComponent,
+    canActivate: [FeatureTogglesGuardService, ModuleStatusGuardService],
+    data: {
+      moduleStatusGuardConfig: {
+        uiApiPath: 'block/rbd',
+        redirectTo: 'error',
+        header: $localize`Block Pool is not configured`,
+        button_name: $localize`Configure Default pool`,
+        button_route: '/pool/create',
+        component: 'Default Pool',
+        uiConfig: true
+      },
+      breadcrumbs: 'Overview'
+    }
+  },
   {
     path: 'rbd',
     canActivate: [FeatureTogglesGuardService, ModuleStatusGuardService],

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
@@ -11,6 +11,8 @@ import { FeatureTogglesGuardService } from '~/app/shared/services/feature-toggle
 import { ModuleStatusGuardService } from '~/app/shared/services/module-status-guard.service';
 import { SharedModule } from '~/app/shared/shared.module';
 import { TextLabelListComponent } from '~/app/shared/components/text-label-list/text-label-list.component';
+import { AreaChartComponent } from '~/app/shared/components/area-chart/area-chart.component';
+import { TimePickerComponent } from '~/app/shared/components/time-picker/time-picker.component';
 import { IscsiSettingComponent } from './iscsi-setting/iscsi-setting.component';
 import { IscsiTabsComponent } from './iscsi-tabs/iscsi-tabs.component';
 import { IscsiTargetDetailsComponent } from './iscsi-target-details/iscsi-target-details.component';
@@ -30,6 +32,7 @@ import { RbdImageResourceBreadcrumbResolver } from './rbd-image-resource-page/rb
 import { RbdImageResourcePageComponent } from './rbd-image-resource-page/rbd-image-resource-page.component';
 import { RbdImageResourceSidebarComponent } from './rbd-image-resource-sidebar/rbd-image-resource-sidebar.component';
 import { RbdListComponent } from './rbd-list/rbd-list.component';
+import { RbdOverviewComponent } from './rbd-overview/rbd-overview.component';
 import { RbdNamespaceFormModalComponent } from './rbd-namespace-form/rbd-namespace-form-modal.component';
 import { RbdNamespaceListComponent } from './rbd-namespace-list/rbd-namespace-list.component';
 import { RbdPerformanceComponent } from './rbd-performance/rbd-performance.component';
@@ -83,7 +86,8 @@ import {
   LayoutModule,
   ContainedListModule,
   LayerModule,
-  ThemeModule
+  ThemeModule,
+  PopoverModule
 } from 'carbon-components-angular';
 
 // Icons
@@ -113,6 +117,8 @@ import { NvmeofTabsComponent } from './nvmeof-tabs/nvmeof-tabs.component';
 import { NvmeofSetupCardsComponent } from './nvmeof-setup-cards/nvmeof-setup-cards.component';
 import { NvmeofGatewayGroupFilterComponent } from './nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component';
 import { NvmeofEditAuthenticationComponent } from './nvmeof-edit-authentication/nvmeof-edit-authentication.component';
+import { PerformanceCardComponent } from '~/app/shared/components/performance-card/performance-card.component';
+import { OverviewAlertsCardComponent } from '~/app/ceph/overview/alerts-card/overview-alerts-card.component';
 
 @NgModule({
   imports: [
@@ -152,9 +158,15 @@ import { NvmeofEditAuthenticationComponent } from './nvmeof-edit-authentication/
     ThemeModule,
     NvmeofSetupCardsComponent,
     NvmeofGatewayGroupFilterComponent,
-    TextLabelListComponent
+    TextLabelListComponent,
+    PerformanceCardComponent,
+    AreaChartComponent,
+    TimePickerComponent,
+    OverviewAlertsCardComponent,
+    PopoverModule
   ],
   declarations: [
+    RbdOverviewComponent,
     RbdListComponent,
     IscsiComponent,
     IscsiSettingComponent,
@@ -233,7 +245,24 @@ export class BlockModule {
     components)
 */
 const routes: Routes = [
-  { path: '', redirectTo: 'rbd', pathMatch: 'full' },
+  { path: '', redirectTo: 'overview', pathMatch: 'full' },
+  {
+    path: 'overview',
+    component: RbdOverviewComponent,
+    canActivate: [FeatureTogglesGuardService, ModuleStatusGuardService],
+    data: {
+      moduleStatusGuardConfig: {
+        uiApiPath: 'block/rbd',
+        redirectTo: 'error',
+        header: $localize`Block Pool is not configured`,
+        button_name: $localize`Configure Default pool`,
+        button_route: '/pool/create',
+        component: 'Default Pool',
+        uiConfig: true
+      },
+      breadcrumbs: 'Overview'
+    }
+  },
   {
     path: 'rbd',
     canActivate: [FeatureTogglesGuardService, ModuleStatusGuardService],

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-overview/rbd-overview.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-overview/rbd-overview.component.html
@@ -1,0 +1,264 @@
+<main class="rbd-overview cds-mt-5">
+  <!-- Top Section: Details & Custom Storage Alerts (Carbon Grid Aligned, padding removed) -->
+  <div
+    class="cds--grid cds--grid--full-width cds--grid--narrow cds-mb-5"
+    style="padding-left: 0; padding-right: 0"
+  >
+    <div class="cds--row align-items-stretch">
+      <!-- Details Card (12 Columns) -->
+      <div class="cds--col-lg-12 cds--col-md-8 cds--col-sm-12 cds-d-flex">
+        <cd-resource-overview-card
+          title="Block Storage (RBD) Overview"
+          [columns]="6"
+          [fields]="overviewFields"
+          i18n-title
+        >
+        </cd-resource-overview-card>
+      </div>
+
+      <!-- Storage Alerts Card (4 Columns) -->
+      <div class="cds--col-lg-4 cds--col-md-8 cds--col-sm-12 cds-d-flex">
+        <cd-overview-alerts-card
+          [compact]="true"
+          filterType="block"
+        ></cd-overview-alerts-card>
+      </div>
+    </div>
+  </div>
+
+  <!-- Capacity, Mirroring, Protocols & Efficiency Card -->
+  <div class="cds-mb-5">
+    <cds-tile class="pool-overview-card">
+      <div class="pool-overview-panels">
+        <!-- LEFT COLUMN: Capacity Panel -->
+        <section class="pool-detail-panel">
+          <h4
+            class="cds--type-heading-02"
+            i18n
+          >
+            Capacity
+          </h4>
+          <p
+            class="cds--type-body-compact-01 pool-detail-panel__subtitle"
+            i18n
+          >
+            Storage utilization
+          </p>
+
+          <div class="capacity-flex-container cds-mt-4">
+            <div class="capacity-chart-wrapper">
+              <cd-donut-chart
+                [data]="capacityChartData"
+                title="Storage Capacity"
+                i18n-title
+                height="250px"
+                legendPosition="bottom"
+                [centerTitle]="'Raw Used'"
+                [centerNumber]="usagePercentNumber"
+                [numberFormatter]="percentageFormatter"
+              >
+              </cd-donut-chart>
+            </div>
+
+            <div class="capacity-stats-wrapper cds-ml-5">
+              <div class="pool-detail-stat-box cds-mb-4">
+                <span
+                  class="cds--type-label-01"
+                  i18n
+                  >Total Pool Capacity</span
+                >
+                <span class="cds--type-heading-03">{{ rawTotalBytes | dimlessBinary }}</span>
+              </div>
+              <div class="pool-detail-stat-box cds-mb-4">
+                <span
+                  class="cds--type-label-01"
+                  i18n
+                  >Provisioned</span
+                >
+                <span class="cds--type-heading-03">{{ provisionedBytes | dimlessBinary }}</span>
+              </div>
+              <div class="pool-detail-stat-box">
+                <span
+                  class="cds--type-label-01"
+                  i18n
+                  >Raw Used</span
+                >
+                <span class="cds--type-heading-03">{{ rawUsedBytes | dimlessBinary }}</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- RIGHT COLUMN: Mirroring, Protocols, Efficiency -->
+        <div class="pool-detail-right-column">
+          <!-- Mirroring & Health Panel -->
+          <section class="pool-detail-panel cds-mb-6">
+            <div class="pool-detail-header-row">
+              <div>
+                <h4
+                  class="cds--type-heading-02"
+                  i18n
+                >
+                  Mirroring & Health
+                </h4>
+                <p
+                  class="cds--type-body-compact-01 pool-detail-panel__subtitle"
+                  i18n
+                >
+                  Replication and daemon status
+                </p>
+              </div>
+            </div>
+            <div class="pool-detail-stats cds-mt-4">
+              <div class="pool-detail-stat-box">
+                <span
+                  class="cds--type-label-01"
+                  i18n
+                  >Mirror Daemons</span
+                >
+                <span class="cds--type-heading-03">{{ daemonCount }}</span>
+              </div>
+              <div class="pool-detail-stat-box">
+                <span
+                  class="cds--type-label-01"
+                  i18n
+                  >Mirror Peers</span
+                >
+                <span class="cds--type-heading-03">{{ totalPeers }}</span>
+              </div>
+            </div>
+          </section>
+
+          <!-- Gateways & Protocols Panel -->
+          <section class="pool-detail-panel">
+            <div class="pool-detail-header-row">
+              <div>
+                <h4
+                  class="cds--type-heading-02"
+                  i18n
+                >
+                  Gateways & Protocols
+                </h4>
+                <p
+                  class="cds--type-body-compact-01 pool-detail-panel__subtitle"
+                  i18n
+                >
+                  Block storage access points
+                </p>
+              </div>
+            </div>
+            <div class="pool-detail-stats pool-detail-stats--3-col cds-mt-4">
+              <div class="pool-detail-stat-box">
+                <span
+                  class="cds--type-label-01"
+                  i18n
+                  >NVMe-oF Gateways</span
+                >
+                <span class="cds--type-heading-03">{{ nvmeofGatewayCount }}</span>
+              </div>
+              <div class="pool-detail-stat-box">
+                <span
+                  class="cds--type-label-01"
+                  i18n
+                  >NVMe-oF Subsystems</span
+                >
+                <span class="cds--type-heading-03">{{ nvmeofSubsystemCount }}</span>
+              </div>
+              <div class="pool-detail-stat-box">
+                <span
+                  class="cds--type-label-01"
+                  i18n
+                  >iSCSI Targets</span
+                >
+                <span class="cds--type-heading-03">{{ iscsiTargetCount }}</span>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </cds-tile>
+  </div>
+
+  @if (isMirroringPanelOpen && mirroringIssues.length > 0) {
+    <cd-side-panel
+      [headerText]="'Mirroring Health Issues (' + mirroringIssues.length + ')'"
+      [expanded]="isMirroringPanelOpen"
+      size="md"
+      (closed)="toggleMirroringPanel()"
+    >
+      <div
+        panel-header-description
+        class="cds--type-body-01"
+      >
+        <span i18n>Review the daemons, pools, or images experiencing mirroring issues.</span>
+      </div>
+      <div class="panel-content">
+        @for (issue of mirroringIssues; track issue.name) {
+          <div class="cds-mb-4">
+            <div class="cds--type-body-compact-02 cds-mb-2">
+              <strong>{{ issue.type }}:</strong> {{ issue.name }}
+            </div>
+            <div
+              class="cds--type-body-compact-01"
+              [ngClass]="
+                issue.color === 'error' ? 'cd-status-text--danger' : 'cd-status-text--warning'
+              "
+            >
+              {{ issue.state }}
+            </div>
+          </div>
+        }
+      </div>
+    </cd-side-panel>
+  }
+  <!-- Performance Statistics Card (Single Row Layout matching Object Overview rgw-overview-dashboard.component.html) -->
+  <div class="cds-mb-5">
+    <cd-productive-card [applyShadow]="false">
+      <ng-template #header>
+        <h2
+          class="cds--type-heading-compact-02"
+          i18n
+        >
+          Performance Statistics
+        </h2>
+        <cd-time-picker
+          [dropdownSize]="'sm'"
+          [label]="'Time Span'"
+          (selectedTime)="loadPerformanceData($event)"
+        ></cd-time-picker>
+      </ng-template>
+      <div class="cds--grid cds--grid--narrow cds--grid--full-width">
+        <div class="cds--row cds--row--narrow">
+          <div class="cds--col-lg-5 cds--col-md-8 cds--col-sm-12 cds-mb-5">
+            <cd-area-chart
+              chartTitle="IOPS"
+              i18n-chartTitle
+              [dataUnit]="''"
+              [rawData]="iopsChartData"
+            >
+            </cd-area-chart>
+          </div>
+          <div class="cds--col-lg-5 cds--col-md-8 cds--col-sm-12 cds-mb-5">
+            <cd-area-chart
+              chartTitle="Latency"
+              i18n-chartTitle
+              [dataUnit]="'ms'"
+              [decimals]="2"
+              [rawData]="latencyChartData"
+            >
+            </cd-area-chart>
+          </div>
+          <div class="cds--col-lg-5 cds--col-md-8 cds--col-sm-12 cds-mb-5">
+            <cd-area-chart
+              chartTitle="Throughput"
+              i18n-chartTitle
+              [dataUnit]="'B/s'"
+              [rawData]="throughputChartData"
+            >
+            </cd-area-chart>
+          </div>
+        </div>
+      </div>
+    </cd-productive-card>
+  </div>
+</main>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-overview/rbd-overview.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-overview/rbd-overview.component.html
@@ -1,5 +1,5 @@
-<main class="rgw-overview cds-mt-5">
-  <!-- Top Section: Details & Object Storage Alerts (Full Width Aligned) -->
+<main class="rbd-overview cds-mt-5">
+  <!-- Top Section: Details & Custom Storage Alerts (Full Width Aligned) -->
   <div
     class="cds--grid cds--grid--full-width cds--grid--narrow cds-mb-5"
     style="padding-left: 0; padding-right: 0"
@@ -8,7 +8,7 @@
       <!-- Details Card (12 Columns) -->
       <div class="cds--col-lg-12 cds--col-md-8 cds--col-sm-12 cds-d-flex">
         <cd-resource-overview-card
-          title="Object Storage (RGW) Overview"
+          title="Block Storage (RBD) Overview"
           [columns]="6"
           [fields]="overviewFields"
           i18n-title
@@ -20,17 +20,17 @@
       <div class="cds--col-lg-4 cds--col-md-8 cds--col-sm-12 cds-d-flex">
         <cd-overview-alerts-card
           [compact]="true"
-          filterType="object"
+          filterType="block"
         ></cd-overview-alerts-card>
       </div>
     </div>
   </div>
 
-  <!-- Capacity Card -->
+  <!-- Capacity, Mirroring, Protocols & Efficiency Card -->
   <div class="cds-mb-5">
     <cds-tile class="pool-overview-card">
       <div class="pool-overview-panels">
-        <!-- Capacity Panel -->
+        <!-- LEFT COLUMN: Capacity Panel -->
         <section class="pool-detail-panel">
           <div class="pool-detail-header-row">
             <div>
@@ -170,7 +170,7 @@
           <cd-usage-bar
             *ngIf="logicalTotalBytes > 0; else noCapacityData"
             [total]="logicalTotalBytes"
-            [used]="totalPoolUsedBytes"
+            [used]="logicalUsedBytes"
             title="Storage utilization"
             i18n-title
             width="100%"
@@ -196,7 +196,7 @@
                 i18n
                 >Used</span
               >
-              <span class="cds--type-heading-03">{{ totalPoolUsedBytes | dimlessBinary }}</span>
+              <span class="cds--type-heading-03">{{ logicalUsedBytes | dimlessBinary }}</span>
             </div>
             <div class="pool-detail-stat-box">
               <span
@@ -209,7 +209,7 @@
           </div>
         </section>
 
-        <!-- RIGHT COLUMN: Mirroring, Gateways & Protocols -->
+        <!-- RIGHT COLUMN: Mirroring, Protocols, Efficiency -->
         <div class="pool-detail-right-column">
           <!-- Mirroring & Health Panel -->
           <section class="pool-detail-panel cds-mb-6">
@@ -236,7 +236,7 @@
                   i18n
                   >Mirror Daemons</span
                 >
-                <span class="cds--type-heading-03">0</span>
+                <span class="cds--type-heading-03">{{ daemonCount }}</span>
               </div>
               <div class="pool-detail-stat-box">
                 <span
@@ -244,7 +244,7 @@
                   i18n
                   >Mirror Peers</span
                 >
-                <span class="cds--type-heading-03">0</span>
+                <span class="cds--type-heading-03">{{ totalPeers }}</span>
               </div>
             </div>
           </section>
@@ -263,7 +263,7 @@
                   class="cds--type-body-compact-01 pool-detail-panel__subtitle"
                   i18n
                 >
-                  Object storage access points
+                  Block storage access points
                 </p>
               </div>
             </div>
@@ -272,25 +272,25 @@
                 <span
                   class="cds--type-label-01"
                   i18n
-                  >Gateways</span
+                  >NVMe-oF Gateways</span
                 >
-                <span class="cds--type-heading-03">{{ rgwDaemonCount }}</span>
+                <span class="cds--type-heading-03">{{ nvmeofGatewayCount }}</span>
               </div>
               <div class="pool-detail-stat-box">
                 <span
                   class="cds--type-label-01"
                   i18n
-                  >Realms</span
+                  >NVMe-oF Subsystems</span
                 >
-                <span class="cds--type-heading-03">{{ rgwRealmCount }}</span>
+                <span class="cds--type-heading-03">{{ nvmeofSubsystemCount }}</span>
               </div>
               <div class="pool-detail-stat-box">
                 <span
                   class="cds--type-label-01"
                   i18n
-                  >Zones</span
+                  >iSCSI Targets</span
                 >
-                <span class="cds--type-heading-03">{{ rgwZoneCount }}</span>
+                <span class="cds--type-heading-03">{{ iscsiTargetCount }}</span>
               </div>
             </div>
           </section>
@@ -312,17 +312,18 @@
         <cd-time-picker
           [dropdownSize]="'sm'"
           [label]="'Time Span'"
-          (selectedTime)="getPrometheusData($event)"
+          (selectedTime)="loadConsumptionTrend($event)"
         ></cd-time-picker>
       </ng-template>
       <div class="cds--grid cds--grid--narrow cds--grid--full-width">
         <div class="cds--row cds--row--narrow cds-align-items-center">
           <div class="cds--col-lg-12 cds--col-md-10 cds--col-sm-12">
             <cd-area-chart
+              chartTitle="Consumption trend"
               [chartKey]="'Consumption trend'"
               [dataUnit]="'B'"
               [legendEnabled]="false"
-              [rawData]="bandwidthChartData"
+              [rawData]="consumptionTrendData"
               [subHeading]="'Storage consumption trends based on recent usage'"
               [height]="'200px'"
               [decimals]="2"
@@ -333,7 +334,7 @@
           <div class="cds--col-lg-4 cds--col-md-6 cds--col-sm-12">
             <div class="cds--stack-vertical cds--stack-gap-4">
               <div class="cds--stack-vertical cds--stack-gap-1">
-                <span class="cds--type-heading-03">N/A</span>
+                <span class="cds--type-heading-03">{{ estimatedTimeUntilFull || 'N/A' }}</span>
                 <span
                   class="cds--type-label-01"
                   i18n
@@ -341,7 +342,7 @@
                 >
               </div>
               <div class="cds--stack-vertical cds--stack-gap-1">
-                <span class="cds--type-heading-03">0 B/day</span>
+                <span class="cds--type-heading-03">{{ averageDailyConsumption || '0 B/day' }}</span>
                 <span
                   class="cds--type-label-01"
                   i18n
@@ -355,6 +356,38 @@
     </cd-productive-card>
   </div>
 
+  @if (isMirroringPanelOpen && mirroringIssues.length > 0) {
+    <cd-side-panel
+      [headerText]="'Mirroring Health Issues (' + mirroringIssues.length + ')'"
+      [expanded]="isMirroringPanelOpen"
+      size="md"
+      (closed)="toggleMirroringPanel()"
+    >
+      <div
+        panel-header-description
+        class="cds--type-body-01"
+      >
+        <span i18n>Review the daemons, pools, or images experiencing mirroring issues.</span>
+      </div>
+      <div class="panel-content">
+        @for (issue of mirroringIssues; track issue.name) {
+          <div class="cds-mb-4">
+            <div class="cds--type-body-compact-02 cds-mb-2">
+              <strong>{{ issue.type }}:</strong> {{ issue.name }}
+            </div>
+            <div
+              class="cds--type-body-compact-01"
+              [ngClass]="
+                issue.color === 'error' ? 'cd-status-text--danger' : 'cd-status-text--warning'
+              "
+            >
+              {{ issue.state }}
+            </div>
+          </div>
+        }
+      </div>
+    </cd-side-panel>
+  }
   <!-- Performance Statistics Card -->
   <div class="cds-mb-5">
     <cd-productive-card [applyShadow]="false">
@@ -368,7 +401,7 @@
         <cd-time-picker
           [dropdownSize]="'sm'"
           [label]="'Time Span'"
-          (selectedTime)="getPrometheusData($event)"
+          (selectedTime)="loadPerformanceData($event)"
         ></cd-time-picker>
       </ng-template>
       <div class="cds--grid cds--grid--narrow cds--grid--full-width">
@@ -378,7 +411,7 @@
               chartTitle="IOPS"
               i18n-chartTitle
               [dataUnit]="''"
-              [rawData]="requestsChartData"
+              [rawData]="iopsChartData"
             >
             </cd-area-chart>
           </div>
@@ -397,126 +430,12 @@
               chartTitle="Throughput"
               i18n-chartTitle
               [dataUnit]="'B/s'"
-              [rawData]="bandwidthChartData"
+              [rawData]="throughputChartData"
             >
             </cd-area-chart>
           </div>
         </div>
       </div>
-    </cd-productive-card>
-  </div>
-
-  <!-- Multi-Site Sync Status Card -->
-  <div>
-    <cd-productive-card [applyShadow]="false">
-      <ng-template #header>
-        <h2
-          class="cds--type-heading-compact-02"
-          i18n
-        >
-          Multi-Site Sync Status
-        </h2>
-      </ng-template>
-      <ng-template #notConfigured>
-        <cd-alert-panel
-          type="info"
-          i18n
-        >
-          Multi-site needs to be configured in order to see the multi-site sync status. Please
-          consult the&nbsp;<cd-doc section="multisite"></cd-doc>&nbsp;on how to configure and enable
-          the multi-site functionality.
-        </cd-alert-panel>
-      </ng-template>
-      @if (loading) {
-        <div class="multisite-sync__loading">
-          <cds-loading
-            [isActive]="true"
-            size="sm"
-          ></cds-loading>
-        </div>
-      }
-      @if (multisiteSyncStatus$ | async) {
-        @if (showMultisiteCard) {
-          <div class="multisite-sync__layout">
-            <div class="multisite-sync__primary">
-              <h4
-                class="cds--type-heading-compact-01 multisite-sync__section-title"
-                i18n
-              >
-                Primary Source Zone
-              </h4>
-              <div class="multisite-sync__primary-content">
-                @if (loading) {
-                  <div class="multisite-sync__loading">
-                    <cds-loading
-                      [isActive]="true"
-                      size="sm"
-                    ></cds-loading>
-                  </div>
-                } @else {
-                  <cd-rgw-sync-primary-zone
-                    [realm]="realm"
-                    [zonegroup]="zonegroup"
-                    [zone]="zone"
-                  >
-                  </cd-rgw-sync-primary-zone>
-                }
-              </div>
-            </div>
-            <div class="multisite-sync__source-zones">
-              <h4
-                class="cds--type-heading-compact-01 multisite-sync__section-title multisite-sync__section-title--centered"
-                i18n
-              >
-                Source Zones
-              </h4>
-              @if (loading) {
-                <div class="multisite-sync__loading">
-                  <cds-loading
-                    [isActive]="true"
-                    size="sm"
-                  ></cds-loading>
-                </div>
-              } @else {
-                <div class="multisite-sync__zones-grid">
-                  @for (zone of replicaZonesInfo; track zone) {
-                    <cds-tile class="multisite-sync__zone-tile">
-                      <h5 class="multisite-sync__zone-header">
-                        <svg
-                          [cdsIcon]="icons.deploy"
-                          [size]="icons.size20"
-                        ></svg>
-                        <cds-tag class="tag-info">{{ zone.name }}</cds-tag>
-                      </h5>
-                      <div class="multisite-sync__sync-columns">
-                        @for (title of chartTitles; track title) {
-                          <div
-                            class="multisite-sync__sync-item"
-                            [class.multisite-sync__sync-item--bordered]="title === 'Data Sync'"
-                          >
-                            <span class="cds--type-body-compact-01 multisite-sync__sync-title">{{
-                              title
-                            }}</span>
-                            @if (title === 'Metadata Sync') {
-                              <cd-rgw-sync-metadata-info [metadataSyncInfo]="metadataSyncInfo">
-                              </cd-rgw-sync-metadata-info>
-                            }
-                            @if (title === 'Data Sync') {
-                              <cd-rgw-sync-data-info [zone]="zone"> </cd-rgw-sync-data-info>
-                            }
-                          </div>
-                        }
-                      </div>
-                    </cds-tile>
-                  }
-                </div>
-              }
-            </div>
-          </div>
-        } @else {
-          <ng-container *ngTemplateOutlet="notConfigured"></ng-container>
-        }
-      }
     </cd-productive-card>
   </div>
 </main>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-overview/rbd-overview.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-overview/rbd-overview.component.scss
@@ -1,6 +1,6 @@
 @use '@carbon/layout';
 
-.rgw-overview {
+.rbd-overview {
   display: block;
 
   .cds--grid--full-width {
@@ -64,7 +64,6 @@
 
   .pool-detail-panel__subtitle {
     color: var(--cds-text-secondary, #525252);
-    margin-top: layout.$spacing-01;
   }
 
   .pool-detail-row {
@@ -160,86 +159,4 @@
       }
     }
   }
-}
-
-.multisite-sync {
-  &__loading {
-    display: flex;
-    justify-content: center;
-    padding: var(--cds-spacing-05);
-  }
-
-  &__layout {
-    display: flex;
-    align-items: flex-start;
-  }
-
-  &__primary {
-    flex: 0 0 250px;
-    text-align: center;
-  }
-
-  &__primary-content {
-    border-inline-end: 1px solid var(--cds-border-subtle);
-    padding-inline-end: var(--cds-spacing-05);
-  }
-
-  &__section-title {
-    margin-block-end: var(--cds-spacing-05);
-
-    &--centered {
-      text-align: center;
-    }
-  }
-
-  &__source-zones {
-    flex: 1;
-    padding-inline-start: var(--cds-spacing-05);
-  }
-
-  &__zones-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: var(--cds-spacing-05);
-  }
-
-  &__zone-tile {
-    height: 100%;
-    padding-block-start: 0;
-  }
-
-  &__zone-header {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: var(--cds-spacing-02);
-    margin-block-end: var(--cds-spacing-04);
-  }
-
-  &__sync-columns {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-  }
-
-  &__sync-item {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-
-    &--bordered {
-      border-inline-start: 1px solid var(--cds-border-subtle);
-    }
-  }
-
-  &__sync-title {
-    text-align: center;
-    margin-block-end: var(--cds-spacing-03);
-  }
-}
-
-ul {
-  align-items: center;
-  display: flex;
-  flex-direction: column;
-  list-style-type: none;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-overview/rbd-overview.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-overview/rbd-overview.component.scss
@@ -1,0 +1,124 @@
+@use '@carbon/layout';
+
+.rbd-overview {
+  display: block;
+
+  .pool-overview-card {
+    display: block;
+    padding: layout.$spacing-05;
+  }
+
+  .pool-overview-panels {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: layout.$spacing-06;
+  }
+
+  .pool-detail-panel {
+    padding: layout.$spacing-05;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .pool-detail-header-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: layout.$spacing-03;
+  }
+
+  .pool-detail-panel__subtitle {
+    color: var(--cds-text-secondary, #525252);
+  }
+
+  .pool-detail-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: layout.$spacing-04;
+  }
+
+  .pool-detail-mono-val {
+    max-width: 60%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: right;
+  }
+
+  .pool-detail-panel__usage-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: layout.$spacing-03;
+    margin-bottom: layout.$spacing-03;
+  }
+
+  .pool-detail-stats {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: layout.$spacing-04;
+
+    &--3-col {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  .pool-detail-stat-box {
+    padding: layout.$spacing-04;
+    display: flex;
+    flex-direction: column;
+    gap: layout.$spacing-02;
+    min-height: 5.5rem;
+    background-color: var(--cds-layer-01, #f4f4f4);
+  }
+
+  .pool-detail-divider {
+    border: 0;
+    border-top: 1px solid var(--cds-border-subtle-01, #e0e0e0);
+  }
+
+  cd-usage-bar {
+    display: block;
+  }
+
+  .capacity-flex-container {
+    display: flex;
+    align-items: center;
+    gap: layout.$spacing-06;
+  }
+
+  .capacity-chart-wrapper {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .capacity-stats-wrapper {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .pool-detail-right-column {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  ::ng-deep {
+    cd-resource-overview-card,
+    cd-overview-alerts-card {
+      height: 100%;
+      width: 100%;
+      display: block;
+
+      .cds--tile,
+      .cd-overview-card {
+        height: 100% !important;
+        min-block-size: 0;
+      }
+    }
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-overview/rbd-overview.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-overview/rbd-overview.component.spec.ts
@@ -1,0 +1,115 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+import { GridModule, TilesModule } from 'carbon-components-angular';
+
+import { RbdOverviewComponent } from './rbd-overview.component';
+import { RbdMirroringService } from '~/app/shared/api/rbd-mirroring.service';
+import { RbdService } from '~/app/shared/api/rbd.service';
+import { PoolService } from '~/app/shared/api/pool.service';
+import { SharedModule } from '~/app/shared/shared.module';
+import { configureTestBed } from '~/testing/unit-test-helper';
+
+describe('RbdOverviewComponent', () => {
+  let component: RbdOverviewComponent;
+  let fixture: ComponentFixture<RbdOverviewComponent>;
+  let rbdMirroringService: RbdMirroringService;
+  let rbdService: RbdService;
+  let poolService: PoolService;
+
+  configureTestBed({
+    declarations: [RbdOverviewComponent],
+    imports: [HttpClientTestingModule, RouterTestingModule, SharedModule, GridModule, TilesModule]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RbdOverviewComponent);
+    component = fixture.componentInstance;
+
+    rbdMirroringService = TestBed.inject(RbdMirroringService);
+    rbdService = TestBed.inject(RbdService);
+    poolService = TestBed.inject(PoolService);
+
+    spyOn(rbdMirroringService, 'startPolling').and.returnValue(of({}).subscribe());
+    spyOn(rbdMirroringService, 'subscribeSummary').and.callFake((fn: any) => {
+      fn({
+        site_name: 'site-alpha',
+        content_data: {
+          daemons: [{ id: 'daemon1' }],
+          errors: 0,
+          warnings: 0,
+          pools: [{ name: 'pool1', peer_uuids: ['peer-1'] }]
+        }
+      });
+      return of({}).subscribe();
+    });
+
+    spyOn(poolService, 'getList').and.returnValue(
+      of([
+        {
+          pool_name: 'rbd_pool',
+          application_metadata: ['rbd'],
+          stats: {
+            bytes_used: { latest: 1073741824 },
+            max_avail: { latest: 10737418240 }
+          }
+        }
+      ])
+    );
+
+    spyOn(rbdService, 'list').and.returnValue(
+      of([
+        {
+          pool_name: 'rbd_pool',
+          value: [
+            {
+              name: 'img2',
+              size: 21474836480,
+              num_objs: 512,
+              format: 2,
+              snapshots: [],
+              disk_usage: 1073741824
+            },
+            {
+              name: 'img1',
+              size: 10737418240,
+              num_objs: 256,
+              format: 2,
+              snapshots: [{ id: 1 }],
+              disk_usage: 0
+            }
+          ]
+        }
+      ])
+    );
+
+    spyOn(rbdService, 'listNamespaces').and.returnValue(of([{ namespace: 'namespace1' }]));
+
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load mirroring status and health correctly', () => {
+    expect(component.daemonCount).toBe(1);
+    expect(component.healthStatus).toBe('OK');
+    expect(component.totalPeers).toBe(1);
+  });
+
+  it('should calculate capacity and counts correctly', () => {
+    expect(component.totalPools).toBe(1);
+    expect(component.rawUsedBytes).toBe(1073741824);
+    expect(component.totalImages).toBe(2);
+    expect(component.provisionedBytes).toBe(32212254720);
+    expect(component.totalSnapshots).toBe(1);
+  });
+
+  it('should sort top images by provisioned size descending', () => {
+    expect(component.topImages.length).toBe(2);
+    expect(component.topImages[0].name).toBe('img2');
+    expect(component.topImages[1].name).toBe('img1');
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-overview/rbd-overview.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-overview/rbd-overview.component.spec.ts
@@ -1,0 +1,115 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+import { GridModule, TilesModule } from 'carbon-components-angular';
+
+import { RbdOverviewComponent } from './rbd-overview.component';
+import { RbdMirroringService } from '~/app/shared/api/rbd-mirroring.service';
+import { RbdService } from '~/app/shared/api/rbd.service';
+import { PoolService } from '~/app/shared/api/pool.service';
+import { SharedModule } from '~/app/shared/shared.module';
+import { configureTestBed } from '~/testing/unit-test-helper';
+
+describe('RbdOverviewComponent', () => {
+  let component: RbdOverviewComponent;
+  let fixture: ComponentFixture<RbdOverviewComponent>;
+  let rbdMirroringService: RbdMirroringService;
+  let rbdService: RbdService;
+  let poolService: PoolService;
+
+  configureTestBed({
+    declarations: [RbdOverviewComponent],
+    imports: [HttpClientTestingModule, RouterTestingModule, SharedModule, GridModule, TilesModule]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RbdOverviewComponent);
+    component = fixture.componentInstance;
+
+    rbdMirroringService = TestBed.inject(RbdMirroringService);
+    rbdService = TestBed.inject(RbdService);
+    poolService = TestBed.inject(PoolService);
+
+    spyOn(rbdMirroringService, 'startPolling').and.returnValue(of({}).subscribe());
+    spyOn(rbdMirroringService, 'subscribeSummary').and.callFake((fn: any) => {
+      fn({
+        site_name: 'site-alpha',
+        content_data: {
+          daemons: [{ id: 'daemon1' }],
+          errors: 0,
+          warnings: 0,
+          pools: [{ name: 'pool1', peer_uuids: ['peer-1'] }]
+        }
+      });
+      return of({}).subscribe();
+    });
+
+    spyOn(poolService, 'getList').and.returnValue(
+      of([
+        {
+          pool_name: 'rbd_pool',
+          application_metadata: ['rbd'],
+          stats: {
+            bytes_used: { latest: 1073741824 },
+            max_avail: { latest: 10737418240 }
+          }
+        }
+      ])
+    );
+
+    spyOn(rbdService, 'list').and.returnValue(
+      of([
+        {
+          pool_name: 'rbd_pool',
+          value: [
+            {
+              name: 'img2',
+              size: 21474836480,
+              num_objs: 512,
+              format: 2,
+              snapshots: [],
+              disk_usage: 1073741824
+            },
+            {
+              name: 'img1',
+              size: 10737418240,
+              num_objs: 256,
+              format: 2,
+              snapshots: [{ id: 1 }],
+              disk_usage: 0
+            }
+          ]
+        }
+      ])
+    );
+
+    spyOn(rbdService, 'listNamespaces').and.returnValue(of([{ namespace: 'namespace1' }]));
+
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load mirroring status and health correctly', () => {
+    expect(component.daemonCount).toBe(1);
+    expect(component.healthStatus).toBe('OK');
+    expect(component.totalPeers).toBe(1);
+  });
+
+  it('should calculate capacity and counts correctly', () => {
+    expect(component.rawUsedBytes).toBe(2147483648);
+    expect(component.logicalUsedBytes).toBe(1073741824);
+    expect(component.usableFreeBytes).toBe(10737418240);
+    expect(component.totalImages).toBe(2);
+    expect(component.totalSnapshots).toBe(1);
+  });
+
+  it('should sort top images by provisioned size descending', () => {
+    expect(component.topImages.length).toBe(2);
+    expect(component.topImages[0].name).toBe('img2');
+    expect(component.topImages[1].name).toBe('img1');
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-overview/rbd-overview.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-overview/rbd-overview.component.ts
@@ -1,0 +1,567 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subscription, forkJoin, of } from 'rxjs';
+import { catchError, map, switchMap } from 'rxjs/operators';
+import { RbdMirroringService } from '~/app/shared/api/rbd-mirroring.service';
+import { RbdService } from '~/app/shared/api/rbd.service';
+import { PoolService } from '~/app/shared/api/pool.service';
+import { PerformanceCardService } from '~/app/shared/api/performance-card.service';
+import { PrometheusService } from '~/app/shared/api/prometheus.service';
+import { FormatterService } from '~/app/shared/services/formatter.service';
+import { Icons } from '~/app/shared/enum/icons.enum';
+import { OverviewField } from '~/app/shared/components/resource-overview-card/resource-overview-card.component';
+import { PerformanceData } from '~/app/shared/models/performance-data';
+import { ChartPoint } from '~/app/shared/models/area-chart-point';
+import { IscsiService } from '~/app/shared/api/iscsi.service';
+import { NvmeofService } from '~/app/shared/api/nvmeof.service';
+import { PrometheusAlertService } from '~/app/shared/services/prometheus-alert.service';
+
+@Component({
+  selector: 'cd-rbd-overview',
+  templateUrl: './rbd-overview.component.html',
+  styleUrls: ['./rbd-overview.component.scss'],
+  standalone: false
+})
+export class RbdOverviewComponent implements OnInit, OnDestroy {
+  icons = Icons;
+
+  // Mirroring / Health State
+  healthStatus: string = 'OK';
+  healthColor: 'success' | 'warning' | 'danger' | 'info-circle' = 'success';
+  daemonCount = 0;
+  isMirroringPanelOpen = false;
+  mirroringIssues: { type: string; name: string; state: string; color: string }[] = [];
+  activeBlockAlerts: any[] = [];
+
+  // Capacity metrics
+  rawUsedBytes = 0;
+  logicalUsedBytes = 0;
+  usableFreeBytes = 0;
+  rawTotalBytes = 0;
+  logicalTotalBytes = 0;
+
+  // Consumption Trend Data & KPIs
+  consumptionTrendData: ChartPoint[] = [];
+  averageDailyConsumption = '';
+  estimatedTimeUntilFull = '';
+
+  // KPI Counts
+  totalPools = 0;
+  totalImages = 0;
+  totalSnapshots = 0;
+  totalNamespaces = 0;
+  totalPeers = 0;
+
+  // Performance Statistics Area Charts (Matching Object Overview)
+  iopsChartData: ChartPoint[] = [];
+  latencyChartData: ChartPoint[] = [];
+  throughputChartData: ChartPoint[] = [];
+
+  // Top Images data model
+  topImages: any[] = [];
+  topPools: any[] = [];
+
+  // Interactive Popover Breakdown State
+  isTopConsumersOpen = false;
+  selectedBreakdown = 'image';
+  breakdownOptions = [
+    { label: 'By Image', value: 'image' },
+    { label: 'By Pool', value: 'pool' }
+  ];
+
+  // Gateways & Protocols
+  iscsiTargetCount = 0;
+  nvmeofSubsystemCount = 0;
+  nvmeofGatewayCount = 0;
+
+  // Efficiency & Trash
+  trashImageCount = 0;
+  reclaimableSpace = 0;
+
+  isLoading = true;
+
+  private subs = new Subscription();
+
+  constructor(
+    private rbdMirroringService: RbdMirroringService,
+    private rbdService: RbdService,
+    private poolService: PoolService,
+    private performanceCardService: PerformanceCardService,
+    private iscsiService: IscsiService,
+    private nvmeofService: NvmeofService,
+    private prometheusAlertService: PrometheusAlertService,
+    private prometheusService: PrometheusService,
+    private formatterService: FormatterService
+  ) {}
+
+  ngOnInit(): void {
+    this.loadMirroringSummary();
+    this.loadBlockOverviewData();
+    this.loadConsumptionTrend();
+    this.loadPerformanceData();
+    this.loadProtocolAndEfficiencyData();
+    this.loadActiveBlockAlerts();
+  }
+
+  ngOnDestroy(): void {
+    this.subs.unsubscribe();
+  }
+
+  toggleMirroringPanel(): void {
+    this.isMirroringPanelOpen = !this.isMirroringPanelOpen;
+  }
+
+  toggleTopConsumersPopover(): void {
+    this.isTopConsumersOpen = !this.isTopConsumersOpen;
+  }
+
+  get popoverItems(): { name: string; subtext?: string; value: number }[] {
+    if (this.selectedBreakdown === 'pool') {
+      return this.topPools.map((p) => ({
+        name: p.pool_name,
+        subtext: 'Pool',
+        value: p.stats?.bytes_used?.latest || 0
+      }));
+    }
+    return this.topImages.map((img) => ({
+      name: img.name,
+      subtext: img.pool_name,
+      value: img.disk_usage || img.size || 0
+    }));
+  }
+
+  get popoverRoute(): string {
+    return this.selectedBreakdown === 'pool' ? '/pool' : '/block/rbd';
+  }
+
+  private loadProtocolAndEfficiencyData(): void {
+    // iSCSI Targets
+    this.subs.add(
+      this.iscsiService
+        .listTargets()
+        .pipe(catchError(() => of([])))
+        .subscribe((targets: any[]) => {
+          this.iscsiTargetCount = targets.length;
+        })
+    );
+
+    // NVMe-oF Gateways and Subsystems
+    this.subs.add(
+      this.nvmeofService
+        .listGatewayGroups()
+        .pipe(
+          switchMap((gatewayGroups: any) => {
+            const groups = gatewayGroups?.[0] ?? [];
+            if (groups.length === 0) {
+              return of({ gatewayCount: 0, subsystemCount: 0 });
+            }
+
+            const subsystemRequests = groups.map((group: any) => {
+              const isRunning = (group.status?.running ?? 0) > 0;
+              const groupGatewayCount = group.status?.size ?? 0;
+              if (!isRunning) {
+                return of({ groupGatewayCount, subsystemCount: 0 });
+              }
+              return this.nvmeofService.listSubsystems(group.spec.group).pipe(
+                map((subs: any) => ({
+                  groupGatewayCount,
+                  subsystemCount: Array.isArray(subs) ? subs.length : 0
+                })),
+                catchError(() => of({ groupGatewayCount, subsystemCount: 0 }))
+              );
+            });
+
+            return forkJoin(subsystemRequests).pipe(
+              map((results: any[]) => {
+                let gatewayCount = 0;
+                let subsystemCount = 0;
+                results.forEach((res) => {
+                  gatewayCount += res.groupGatewayCount;
+                  subsystemCount += res.subsystemCount;
+                });
+                return { gatewayCount, subsystemCount };
+              })
+            );
+          }),
+          catchError(() => of({ gatewayCount: 0, subsystemCount: 0 }))
+        )
+        .subscribe(({ gatewayCount, subsystemCount }) => {
+          this.nvmeofGatewayCount = gatewayCount;
+          this.nvmeofSubsystemCount = subsystemCount;
+        })
+    );
+
+    // RBD Trash
+    this.subs.add(
+      this.rbdService
+        .listTrash()
+        .pipe(catchError(() => of([])))
+        .subscribe((trashPools: any[]) => {
+          let trashCount = 0;
+          let reclaimable = 0;
+          trashPools.forEach((pool: any) => {
+            const images = pool.value || [];
+            trashCount += images.length;
+            images.forEach((img: any) => {
+              reclaimable += img.size || 0;
+            });
+          });
+          this.trashImageCount = trashCount;
+          this.reclaimableSpace = reclaimable;
+        })
+    );
+  }
+
+  get usagePercentNumber(): number {
+    const logicalTotal = this.logicalUsedBytes + this.usableFreeBytes;
+    if (logicalTotal > 0) {
+      return (this.logicalUsedBytes / logicalTotal) * 100;
+    }
+    return 0;
+  }
+
+  get overviewFields(): OverviewField[] {
+    return [
+      { label: $localize`RBD Pools`, value: this.totalPools, type: 'text', routerLink: '/pool' },
+      {
+        label: $localize`Total Images`,
+        value: this.totalImages,
+        type: 'text',
+        routerLink: '/block/rbd'
+      },
+      {
+        label: $localize`Namespaces`,
+        value: this.totalNamespaces,
+        type: 'text',
+        routerLink: '/block/rbd/namespaces'
+      },
+      {
+        label: $localize`Snapshots`,
+        value: this.totalSnapshots,
+        type: 'text',
+        routerLink: '/block/rbd'
+      },
+      {
+        label: $localize`Trash Images`,
+        value: this.trashImageCount,
+        type: 'text',
+        routerLink: '/block/rbd/trash'
+      },
+      {
+        label: $localize`Mirroring Health`,
+        value: this.healthStatus,
+        type: 'status',
+        status: this.healthColor,
+        action: () => this.toggleMirroringPanel()
+      }
+    ];
+  }
+
+  loadConsumptionTrend(selectedTime?: { start: number; end: number; step: number }): void {
+    const end = selectedTime?.end || Math.floor(Date.now() / 1000);
+    const start = selectedTime?.start || end - 7 * 86400; // default 7 days
+    const step = selectedTime?.step || 3600;
+
+    const timeRange = { start, end, step };
+
+    // 1. Fetch Consumption Trend Area Chart Points
+    this.subs.add(
+      this.prometheusService
+        .getRangeQueriesData(
+          timeRange,
+          {
+            BLOCK_USED:
+              'sum(ceph_pool_bytes_used * on(pool_id) group_left(application) ceph_pool_metadata{application=~"(.*Block.*)|(.*rbd.*)"})'
+          },
+          true
+        )
+        .pipe(catchError(() => of(null)))
+        .subscribe((results: any) => {
+          const rawTrend = results?.BLOCK_USED || [];
+          this.consumptionTrendData = rawTrend.map(([ts, val]: [number, string]) => ({
+            timestamp: new Date(ts * 1000),
+            values: { Used: Number(val) }
+          }));
+          if (!this.consumptionTrendData.length) {
+            this.consumptionTrendData = [{ timestamp: new Date(), values: { Used: 0 } }];
+          }
+        })
+    );
+
+    const rateWindow = this.getRateWindow(start, end);
+
+    // 2. Fetch Average Daily Consumption
+    const avgQuery = `sum(rate(ceph_pool_bytes_used[${rateWindow}]) * on(pool_id) group_left(application) ceph_pool_metadata{application=~"(.*Block.*)|(.*rbd.*)"}) * 86400`;
+    this.subs.add(
+      this.prometheusService
+        .getPrometheusQueryData({ params: avgQuery })
+        .pipe(catchError(() => of(null)))
+        .subscribe((res: any) => {
+          const val = Number(res?.result?.[0]?.value?.[1] ?? 0);
+          const [formattedVal, unit] = this.formatterService.formatToBinary(val, true);
+          this.averageDailyConsumption = `${formattedVal} ${unit}/day`;
+        })
+    );
+
+    // 3. Fetch Estimated Time Until Full
+    const fullQuery = `(sum(ceph_pool_max_avail * on(pool_id) group_left(application) ceph_pool_metadata{application=~"(.*Block.*)|(.*rbd.*)"})) / (${avgQuery})`;
+    this.subs.add(
+      this.prometheusService
+        .getPrometheusQueryData({ params: fullQuery })
+        .pipe(catchError(() => of(null)))
+        .subscribe((res: any) => {
+          const days = Number(res?.result?.[0]?.value?.[1] ?? Infinity);
+          this.estimatedTimeUntilFull = this.formatTimeUntilFull(days);
+        })
+    );
+  }
+
+  private getRateWindow(start: number, end: number): string {
+    const diffSec = Math.max(60, end - start);
+    if (diffSec <= 600) return '5m';
+    if (diffSec <= 3600) return '1h';
+    if (diffSec <= 86400) return '1d';
+    if (diffSec <= 7 * 86400) return '7d';
+    return '30d';
+  }
+
+  private formatTimeUntilFull(days: number): string {
+    if (!isFinite(days) || days <= 0) return 'N/A';
+    if (days < 1) return `${(days * 24).toFixed(1)} hours`;
+    if (days < 30) return `${days.toFixed(1)} days`;
+    if (days < 365) return `${(days / 30).toFixed(1)} months`;
+    const years = days / 365;
+    if (years > 10) return '> 10 years';
+    return `${years.toFixed(1)} years`;
+  }
+
+  loadPerformanceData(selectedTime?: { start: number; end: number; step: number }): void {
+    const time = selectedTime || {
+      start: Math.floor(Date.now() / 1000) - 3600,
+      end: Math.floor(Date.now() / 1000),
+      step: 14
+    };
+    this.subs.add(
+      this.performanceCardService
+        .getChartData(time)
+        .pipe(catchError(() => of(null)))
+        .subscribe((data: PerformanceData | null) => {
+          if (data) {
+            this.iopsChartData = data.iops || [];
+            this.latencyChartData = data.latency || [];
+            this.throughputChartData = data.throughput || [];
+          }
+        })
+    );
+  }
+
+  private loadMirroringSummary(): void {
+    this.subs.add(this.rbdMirroringService.startPolling());
+    this.subs.add(
+      this.rbdMirroringService.subscribeSummary((summary: any) => {
+        if (!summary) return;
+        let mirroringErrors = 0;
+        let mirroringWarnings = 0;
+
+        this.mirroringIssues = [];
+
+        const daemons = summary.content_data?.daemons || [];
+        this.daemonCount = daemons.length;
+
+        // Helper to extract callout messages from daemon status
+        const getCallouts = (poolName?: string, forDaemon?: any) => {
+          let msgs: string[] = [];
+          const sourceDaemons = forDaemon ? [forDaemon] : daemons;
+          sourceDaemons.forEach((d: any) => {
+            if (d.status) {
+              Object.entries(d.status).forEach(([pName, pData]: [string, any]) => {
+                if ((!poolName || pName === poolName) && pData.callouts) {
+                  Object.values(pData.callouts).forEach((callout: any) => {
+                    if (callout.level === 'error' || callout.level === 'warning') {
+                      msgs.push(callout.text || 'Unknown issue');
+                    }
+                  });
+                }
+              });
+            }
+          });
+          return Array.from(new Set(msgs)).join(', ');
+        };
+
+        daemons.forEach((d: any) => {
+          if (d.health_color === 'error' || d.health_color === 'warning') {
+            if (d.health_color === 'error') mirroringErrors++;
+            else mirroringWarnings++;
+            let stateStr = d.health || 'Unknown State';
+            const callouts = getCallouts(undefined, d);
+            if (callouts) {
+              stateStr += ` - ${callouts}`;
+            }
+            this.mirroringIssues.push({
+              type: 'Daemon',
+              name: d.server_hostname || d.id || 'Unknown',
+              state: stateStr,
+              color: d.health_color
+            });
+          }
+        });
+
+        const pools = summary.content_data?.pools || [];
+        pools.forEach((p: any) => {
+          if (p.health_color === 'error' || p.health_color === 'warning') {
+            if (p.health_color === 'error') mirroringErrors++;
+            else mirroringWarnings++;
+            let stateStr = p.health || 'Unknown State';
+            const callouts = getCallouts(p.name);
+            if (callouts) {
+              stateStr += ` - ${callouts}`;
+            }
+            this.mirroringIssues.push({
+              type: 'Pool',
+              name: p.name || 'Unknown',
+              state: stateStr,
+              color: p.health_color
+            });
+          }
+        });
+
+        const imageErrors = summary.content_data?.image_error || [];
+        imageErrors.forEach((i: any) => {
+          if (i.state_color === 'error' || i.state_color === 'warning') {
+            if (i.state_color === 'error') mirroringErrors++;
+            else mirroringWarnings++;
+            let stateStr = i.state || 'Error';
+            if (i.description) {
+              stateStr += ` - ${i.description}`;
+            }
+            this.mirroringIssues.push({
+              type: 'Image',
+              name: (i.pool_name ? i.pool_name + '/' : '') + (i.name || 'Unknown'),
+              state: stateStr,
+              color: i.state_color
+            });
+          }
+        });
+
+        if (mirroringErrors > 0) {
+          this.healthStatus = `Error (${mirroringErrors})`;
+          this.healthColor = 'danger';
+        } else if (mirroringWarnings > 0) {
+          this.healthStatus = `Warning (${mirroringWarnings})`;
+          this.healthColor = 'warning';
+        } else {
+          this.healthStatus = 'OK';
+          this.healthColor = 'success';
+        }
+
+        this.totalPeers = pools.reduce(
+          (acc: number, p: any) => acc + (p.peer_uuids ? p.peer_uuids.length : 0),
+          0
+        );
+      })
+    );
+  }
+
+  private loadBlockOverviewData(): void {
+    this.isLoading = true;
+    forkJoin({
+      poolsData: this.poolService.getList().pipe(
+        catchError(() => of([])),
+        switchMap((pools: any[]) => {
+          const rbdPools = pools.filter(
+            (p) => p.application_metadata && p.application_metadata.includes('rbd')
+          );
+          if (rbdPools.length === 0) {
+            return of({ pools, namespacesCount: 0 });
+          }
+          const nsRequests = rbdPools.map((p) =>
+            this.rbdService.listNamespaces(p.pool_name).pipe(catchError(() => of([])))
+          );
+          return forkJoin(nsRequests).pipe(
+            map((namespacesArrays: any[]) => {
+              const namespacesCount = namespacesArrays.reduce(
+                (acc, nsArr) => acc + nsArr.length,
+                0
+              );
+              return { pools, namespacesCount };
+            })
+          );
+        })
+      ),
+      images: this.rbdService.list({}).pipe(catchError(() => of([])))
+    }).subscribe(({ poolsData, images }) => {
+      this.isLoading = false;
+      const pools = poolsData.pools;
+      this.totalNamespaces = poolsData.namespacesCount;
+
+      // Filter RBD pools
+      const rbdPools = (pools as any[]).filter(
+        (p) => p.application_metadata && p.application_metadata.includes('rbd')
+      );
+      this.totalPools = rbdPools.length;
+
+      let avail = 0;
+      let rawUsed = 0;
+      rbdPools.forEach((p) => {
+        const poolAvail = p.stats?.max_avail?.latest || 0;
+        if (poolAvail > avail) {
+          avail = poolAvail; // Take the maximum available space across pools to avoid double counting shared OSDs
+        }
+        rawUsed += p.stats?.bytes_used?.latest || 0;
+      });
+
+      // Flatten RBD images across pools
+      const allImages: any[] = [];
+      let totalSnaps = 0;
+      let used = 0;
+
+      (images as any[]).forEach((poolData: any) => {
+        const poolName = poolData.pool_name;
+        const poolImages = poolData.value || [];
+        poolImages.forEach((img: any) => {
+          used += img.disk_usage || 0;
+          totalSnaps += img.snapshots ? img.snapshots.length : 0;
+          allImages.push({
+            ...img,
+            pool_name: poolName
+          });
+        });
+      });
+
+      this.rawUsedBytes = rawUsed;
+      this.logicalUsedBytes = used;
+      this.usableFreeBytes = avail;
+      this.rawTotalBytes = rawUsed + avail;
+      this.logicalTotalBytes = used + avail;
+
+      this.totalImages = allImages.length;
+      this.totalSnapshots = totalSnaps;
+
+      // Sorted list of images for tests
+      this.topImages = allImages.sort((a, b) => (b.size || 0) - (a.size || 0)).slice(0, 5);
+
+      // Sorted list of pools for popover
+      this.topPools = [...rbdPools]
+        .sort((a, b) => (b.stats?.bytes_used?.latest || 0) - (a.stats?.bytes_used?.latest || 0))
+        .slice(0, 5);
+    });
+  }
+
+  private loadActiveBlockAlerts(): void {
+    this.prometheusAlertService.getGroupedAlerts(true);
+    this.subs.add(
+      this.prometheusAlertService.alerts$.subscribe((alerts) => {
+        this.activeBlockAlerts = (alerts || []).filter((alert) => {
+          if (alert.status?.state !== 'active') return false;
+          const name = (alert.labels?.alertname || '').toLowerCase();
+          return (
+            name.includes('rbd') ||
+            name.includes('nvme') ||
+            name.includes('iscsi') ||
+            name.includes('tcmu') ||
+            name.includes('osd')
+          );
+        });
+      })
+    );
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-overview/rbd-overview.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-overview/rbd-overview.component.ts
@@ -1,0 +1,447 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subscription, forkJoin, of } from 'rxjs';
+import { catchError, map, switchMap } from 'rxjs/operators';
+import { RbdMirroringService } from '~/app/shared/api/rbd-mirroring.service';
+import { RbdService } from '~/app/shared/api/rbd.service';
+import { PoolService } from '~/app/shared/api/pool.service';
+import { PerformanceCardService } from '~/app/shared/api/performance-card.service';
+import { Icons } from '~/app/shared/enum/icons.enum';
+import { OverviewField } from '~/app/shared/components/resource-overview-card/resource-overview-card.component';
+import { PerformanceData } from '~/app/shared/models/performance-data';
+import { ChartPoint } from '~/app/shared/models/area-chart-point';
+import { IscsiService } from '~/app/shared/api/iscsi.service';
+import { NvmeofService } from '~/app/shared/api/nvmeof.service';
+import { PrometheusAlertService } from '~/app/shared/services/prometheus-alert.service';
+
+@Component({
+  selector: 'cd-rbd-overview',
+  templateUrl: './rbd-overview.component.html',
+  styleUrls: ['./rbd-overview.component.scss'],
+  standalone: false
+})
+export class RbdOverviewComponent implements OnInit, OnDestroy {
+  icons = Icons;
+
+  // Mirroring / Health State
+  healthStatus: string = 'OK';
+  healthColor: 'success' | 'warning' | 'danger' | 'info-circle' = 'success';
+  daemonCount = 0;
+  isMirroringPanelOpen = false;
+  mirroringIssues: { type: string; name: string; state: string; color: string }[] = [];
+  activeBlockAlerts: any[] = [];
+
+  // Capacity metrics
+  provisionedBytes = 0;
+  rawUsedBytes = 0;
+  rawTotalBytes = 0;
+  capacityChartData: { group: string; value: number }[] = [];
+
+  // KPI Counts
+  totalPools = 0;
+  totalImages = 0;
+  totalSnapshots = 0;
+  totalNamespaces = 0;
+  totalPeers = 0;
+
+  // Performance Statistics Area Charts (Matching Object Overview)
+  iopsChartData: ChartPoint[] = [];
+  latencyChartData: ChartPoint[] = [];
+  throughputChartData: ChartPoint[] = [];
+
+  // Top Images data model
+  topImages: any[] = [];
+
+  // Gateways & Protocols
+  iscsiTargetCount = 0;
+  nvmeofSubsystemCount = 0;
+  nvmeofGatewayCount = 0;
+
+  // Efficiency & Trash
+  trashImageCount = 0;
+  reclaimableSpace = 0;
+
+  isLoading = true;
+
+  private subs = new Subscription();
+
+  constructor(
+    private rbdMirroringService: RbdMirroringService,
+    private rbdService: RbdService,
+    private poolService: PoolService,
+    private performanceCardService: PerformanceCardService,
+    private iscsiService: IscsiService,
+    private nvmeofService: NvmeofService,
+    private prometheusAlertService: PrometheusAlertService
+  ) {}
+
+  ngOnInit(): void {
+    this.loadMirroringSummary();
+    this.loadBlockOverviewData();
+    this.loadPerformanceData();
+    this.loadProtocolAndEfficiencyData();
+    this.loadActiveBlockAlerts();
+  }
+
+  ngOnDestroy(): void {
+    this.subs.unsubscribe();
+  }
+
+  toggleMirroringPanel(): void {
+    this.isMirroringPanelOpen = !this.isMirroringPanelOpen;
+  }
+
+  private loadProtocolAndEfficiencyData(): void {
+    // iSCSI Targets
+    this.subs.add(
+      this.iscsiService
+        .listTargets()
+        .pipe(catchError(() => of([])))
+        .subscribe((targets: any[]) => {
+          this.iscsiTargetCount = targets.length;
+        })
+    );
+
+    // NVMe-oF Gateways and Subsystems
+    this.subs.add(
+      this.nvmeofService
+        .listGatewayGroups()
+        .pipe(
+          switchMap((gatewayGroups: any) => {
+            const groups = gatewayGroups?.[0] ?? [];
+            if (groups.length === 0) {
+              return of({ gatewayCount: 0, subsystemCount: 0 });
+            }
+
+            const subsystemRequests = groups.map((group: any) => {
+              const isRunning = (group.status?.running ?? 0) > 0;
+              const groupGatewayCount = group.status?.size ?? 0;
+              if (!isRunning) {
+                return of({ groupGatewayCount, subsystemCount: 0 });
+              }
+              return this.nvmeofService.listSubsystems(group.spec.group).pipe(
+                map((subs: any) => ({
+                  groupGatewayCount,
+                  subsystemCount: Array.isArray(subs) ? subs.length : 0
+                })),
+                catchError(() => of({ groupGatewayCount, subsystemCount: 0 }))
+              );
+            });
+
+            return forkJoin(subsystemRequests).pipe(
+              map((results: any[]) => {
+                let gatewayCount = 0;
+                let subsystemCount = 0;
+                results.forEach((res) => {
+                  gatewayCount += res.groupGatewayCount;
+                  subsystemCount += res.subsystemCount;
+                });
+                return { gatewayCount, subsystemCount };
+              })
+            );
+          }),
+          catchError(() => of({ gatewayCount: 0, subsystemCount: 0 }))
+        )
+        .subscribe(({ gatewayCount, subsystemCount }) => {
+          this.nvmeofGatewayCount = gatewayCount;
+          this.nvmeofSubsystemCount = subsystemCount;
+        })
+    );
+
+    // RBD Trash
+    this.subs.add(
+      this.rbdService
+        .listTrash()
+        .pipe(catchError(() => of([])))
+        .subscribe((trashPools: any[]) => {
+          let trashCount = 0;
+          let reclaimable = 0;
+          trashPools.forEach((pool: any) => {
+            const images = pool.value || [];
+            trashCount += images.length;
+            images.forEach((img: any) => {
+              reclaimable += img.size || 0;
+            });
+          });
+          this.trashImageCount = trashCount;
+          this.reclaimableSpace = reclaimable;
+        })
+    );
+  }
+
+  get usagePercentNumber(): number {
+    if (this.rawTotalBytes > 0) {
+      return (this.rawUsedBytes / this.rawTotalBytes) * 100;
+    }
+    return 0;
+  }
+
+  percentageFormatter = (value: number) => {
+    if (value > 0 && value < 0.1) {
+      return '< 0.1%';
+    }
+    return `${value.toFixed(1)}%`;
+  };
+
+  get overviewFields(): OverviewField[] {
+    return [
+      { label: $localize`RBD Pools`, value: this.totalPools, type: 'text', routerLink: '/pool' },
+      {
+        label: $localize`Total Images`,
+        value: this.totalImages,
+        type: 'text',
+        routerLink: '/block/rbd'
+      },
+      {
+        label: $localize`Namespaces`,
+        value: this.totalNamespaces,
+        type: 'text',
+        routerLink: '/block/rbd/namespaces'
+      },
+      {
+        label: $localize`Snapshots`,
+        value: this.totalSnapshots,
+        type: 'text',
+        routerLink: '/block/rbd'
+      },
+      {
+        label: $localize`Trash Images`,
+        value: this.trashImageCount,
+        type: 'text',
+        routerLink: '/block/rbd/trash'
+      },
+      {
+        label: $localize`Mirroring Health`,
+        value: this.healthStatus,
+        type: 'status',
+        status: this.healthColor,
+        action: () => this.toggleMirroringPanel()
+      }
+    ];
+  }
+
+  loadPerformanceData(selectedTime?: { start: number; end: number; step: number }): void {
+    const time = selectedTime || {
+      start: Math.floor(Date.now() / 1000) - 3600,
+      end: Math.floor(Date.now() / 1000),
+      step: 14
+    };
+    this.subs.add(
+      this.performanceCardService
+        .getChartData(time)
+        .pipe(catchError(() => of(null)))
+        .subscribe((data: PerformanceData | null) => {
+          if (data) {
+            this.iopsChartData = data.iops || [];
+            this.latencyChartData = data.latency || [];
+            this.throughputChartData = data.throughput || [];
+          }
+        })
+    );
+  }
+
+  private loadMirroringSummary(): void {
+    this.subs.add(this.rbdMirroringService.startPolling());
+    this.subs.add(
+      this.rbdMirroringService.subscribeSummary((summary: any) => {
+        if (!summary) return;
+        let mirroringErrors = 0;
+        let mirroringWarnings = 0;
+
+        this.mirroringIssues = [];
+
+        const daemons = summary.content_data?.daemons || [];
+        this.daemonCount = daemons.length;
+
+        // Helper to extract callout messages from daemon status
+        const getCallouts = (poolName?: string, forDaemon?: any) => {
+          let msgs: string[] = [];
+          const sourceDaemons = forDaemon ? [forDaemon] : daemons;
+          sourceDaemons.forEach((d: any) => {
+            if (d.status) {
+              Object.entries(d.status).forEach(([pName, pData]: [string, any]) => {
+                if ((!poolName || pName === poolName) && pData.callouts) {
+                  Object.values(pData.callouts).forEach((callout: any) => {
+                    if (callout.level === 'error' || callout.level === 'warning') {
+                      msgs.push(callout.text || 'Unknown issue');
+                    }
+                  });
+                }
+              });
+            }
+          });
+          return Array.from(new Set(msgs)).join(', ');
+        };
+
+        daemons.forEach((d: any) => {
+          if (d.health_color === 'error' || d.health_color === 'warning') {
+            if (d.health_color === 'error') mirroringErrors++;
+            else mirroringWarnings++;
+            let stateStr = d.health || 'Unknown State';
+            const callouts = getCallouts(undefined, d);
+            if (callouts) {
+              stateStr += ` - ${callouts}`;
+            }
+            this.mirroringIssues.push({
+              type: 'Daemon',
+              name: d.server_hostname || d.id || 'Unknown',
+              state: stateStr,
+              color: d.health_color
+            });
+          }
+        });
+
+        const pools = summary.content_data?.pools || [];
+        pools.forEach((p: any) => {
+          if (p.health_color === 'error' || p.health_color === 'warning') {
+            if (p.health_color === 'error') mirroringErrors++;
+            else mirroringWarnings++;
+            let stateStr = p.health || 'Unknown State';
+            const callouts = getCallouts(p.name);
+            if (callouts) {
+              stateStr += ` - ${callouts}`;
+            }
+            this.mirroringIssues.push({
+              type: 'Pool',
+              name: p.name || 'Unknown',
+              state: stateStr,
+              color: p.health_color
+            });
+          }
+        });
+
+        const imageErrors = summary.content_data?.image_error || [];
+        imageErrors.forEach((i: any) => {
+          if (i.state_color === 'error' || i.state_color === 'warning') {
+            if (i.state_color === 'error') mirroringErrors++;
+            else mirroringWarnings++;
+            let stateStr = i.state || 'Error';
+            if (i.description) {
+              stateStr += ` - ${i.description}`;
+            }
+            this.mirroringIssues.push({
+              type: 'Image',
+              name: (i.pool_name ? i.pool_name + '/' : '') + (i.name || 'Unknown'),
+              state: stateStr,
+              color: i.state_color
+            });
+          }
+        });
+
+        if (mirroringErrors > 0) {
+          this.healthStatus = `Error (${mirroringErrors})`;
+          this.healthColor = 'danger';
+        } else if (mirroringWarnings > 0) {
+          this.healthStatus = `Warning (${mirroringWarnings})`;
+          this.healthColor = 'warning';
+        } else {
+          this.healthStatus = 'OK';
+          this.healthColor = 'success';
+        }
+
+        this.totalPeers = pools.reduce(
+          (acc: number, p: any) => acc + (p.peer_uuids ? p.peer_uuids.length : 0),
+          0
+        );
+      })
+    );
+  }
+
+  private loadBlockOverviewData(): void {
+    this.isLoading = true;
+    forkJoin({
+      poolsData: this.poolService.getList().pipe(
+        catchError(() => of([])),
+        switchMap((pools: any[]) => {
+          const rbdPools = pools.filter(
+            (p) => p.application_metadata && p.application_metadata.includes('rbd')
+          );
+          if (rbdPools.length === 0) {
+            return of({ pools, namespacesCount: 0 });
+          }
+          const nsRequests = rbdPools.map((p) =>
+            this.rbdService.listNamespaces(p.pool_name).pipe(catchError(() => of([])))
+          );
+          return forkJoin(nsRequests).pipe(
+            map((namespacesArrays: any[]) => {
+              const namespacesCount = namespacesArrays.reduce(
+                (acc, nsArr) => acc + nsArr.length,
+                0
+              );
+              return { pools, namespacesCount };
+            })
+          );
+        })
+      ),
+      images: this.rbdService.list({}).pipe(catchError(() => of([])))
+    }).subscribe(({ poolsData, images }) => {
+      this.isLoading = false;
+      const pools = poolsData.pools;
+      this.totalNamespaces = poolsData.namespacesCount;
+
+      // Filter RBD pools
+      const rbdPools = (pools as any[]).filter(
+        (p) => p.application_metadata && p.application_metadata.includes('rbd')
+      );
+      this.totalPools = rbdPools.length;
+
+      let avail = 0;
+      rbdPools.forEach((p) => {
+        avail += p.stats?.max_avail?.latest || 0;
+      });
+
+      // Flatten RBD images across pools
+      const allImages: any[] = [];
+      let totalProv = 0;
+      let totalSnaps = 0;
+      let used = 0;
+
+      (images as any[]).forEach((poolData: any) => {
+        const poolName = poolData.pool_name;
+        const poolImages = poolData.value || [];
+        poolImages.forEach((img: any) => {
+          used += img.disk_usage || 0;
+          totalProv += img.size || 0;
+          totalSnaps += img.snapshots ? img.snapshots.length : 0;
+          allImages.push({
+            ...img,
+            pool_name: poolName
+          });
+        });
+      });
+
+      this.rawUsedBytes = used;
+      this.rawTotalBytes = used + avail;
+
+      this.capacityChartData = [
+        { group: 'Used', value: this.rawUsedBytes },
+        { group: 'Available', value: this.rawTotalBytes > 0 ? avail : 1 }
+      ];
+
+      this.totalImages = allImages.length;
+      this.provisionedBytes = totalProv;
+      this.totalSnapshots = totalSnaps;
+
+      // Sorted list of images for tests
+      this.topImages = allImages.sort((a, b) => (b.size || 0) - (a.size || 0)).slice(0, 5);
+    });
+  }
+
+  private loadActiveBlockAlerts(): void {
+    this.prometheusAlertService.getGroupedAlerts(true);
+    this.subs.add(
+      this.prometheusAlertService.alerts$.subscribe((alerts) => {
+        this.activeBlockAlerts = (alerts || []).filter((alert) => {
+          if (alert.status?.state !== 'active') return false;
+          const name = (alert.labels?.alertname || '').toLowerCase();
+          return (
+            name.includes('rbd') ||
+            name.includes('nvme') ||
+            name.includes('iscsi') ||
+            name.includes('tcmu') ||
+            name.includes('osd')
+          );
+        });
+      })
+    );
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.html
@@ -1,53 +1,31 @@
-<cds-tabs
-  [type]="'contained'"
-  [followFocus]="true"
-  [isNavigation]="false"
-  [cacheActive]="true"
+<cd-table
+  [data]="filesystems"
+  columnMode="flex"
+  [columns]="columns"
+  (fetchData)="loadFilesystems($event)"
+  identifier="id"
+  forceIdentifier="true"
+  selectionType="single"
+  [hasDetails]="true"
+  (setExpandedRow)="setExpandedRow($event)"
+  (updateSelection)="updateSelection($event)"
 >
-  <cds-tab
-    heading="File systems"
-    i18n-heading
-    [tabContent]="fileSystemListContent"
+  <cd-cephfs-tabs
+    *cdTableDetail
+    [selection]="expandedRow"
   >
-  </cds-tab>
-  <cds-tab
-    heading="Overview"
-    i18n-heading
-    [tabContent]="grafanaContent"
-  >
-  </cds-tab>
-</cds-tabs>
-
-<ng-template #fileSystemListContent>
-  <cd-table
-    [data]="filesystems"
-    columnMode="flex"
-    [columns]="columns"
-    (fetchData)="loadFilesystems($event)"
-    identifier="id"
-    forceIdentifier="true"
-    selectionType="single"
-    [hasDetails]="true"
-    (setExpandedRow)="setExpandedRow($event)"
-    (updateSelection)="updateSelection($event)"
-  >
-    <cd-cephfs-tabs
-      *cdTableDetail
-      [selection]="expandedRow"
+  </cd-cephfs-tabs>
+  <div class="table-actions">
+    <cd-table-actions
+      [permission]="permissions.cephfs"
+      [selection]="selection"
+      class="btn-group"
+      id="cephfs-actions"
+      [tableActions]="tableActions"
     >
-    </cd-cephfs-tabs>
-    <div class="table-actions">
-      <cd-table-actions
-        [permission]="permissions.cephfs"
-        [selection]="selection"
-        class="btn-group"
-        id="cephfs-actions"
-        [tableActions]="tableActions"
-      >
-      </cd-table-actions>
-    </div>
-  </cd-table>
-</ng-template>
+    </cd-table-actions>
+  </div>
+</cd-table>
 
 <ng-template #deleteTpl>
   <cd-alert-panel
@@ -57,17 +35,4 @@
     This will remove its data and metadata pools. It'll also remove the MDS daemon associated with
     the volume.
   </cd-alert-panel>
-</ng-template>
-
-<ng-template #grafanaContent>
-  <cd-grafana
-    i18n-title
-    title="CephFS Overview"
-    [grafanaPath]="'ceph-filesystem-overview?'"
-    [type]="'metrics'"
-    uid="718Bruins"
-    *ngIf="permissions.grafana.read"
-    grafanaStyle="three"
-  >
-  </cd-grafana>
 </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-overview/cephfs-overview.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-overview/cephfs-overview.component.html
@@ -1,0 +1,223 @@
+<main class="cephfs-overview cds-mt-5">
+  <cd-loading-panel
+    *ngIf="isLoading"
+    i18n
+  >
+    Loading File Systems overview...
+  </cd-loading-panel>
+
+  <div *ngIf="!isLoading">
+    <!-- Resource Overview Details Card -->
+    <div class="cds-mb-5">
+      <cd-resource-overview-card
+        title="File Systems Overview"
+        [columns]="6"
+        [fields]="overviewFields"
+        i18n-title
+      >
+      </cd-resource-overview-card>
+    </div>
+
+    <!-- Capacity & Health Card -->
+    <div class="cds-mb-5">
+      <cds-tile class="pool-overview-card">
+        <div class="pool-overview-panels">
+          <!-- LEFT COLUMN: Capacity Panel -->
+          <section class="pool-detail-panel">
+            <h4
+              class="cds--type-heading-02"
+              i18n
+            >
+              Capacity
+            </h4>
+            <p
+              class="cds--type-body-compact-01 pool-detail-panel__subtitle"
+              i18n
+            >
+              Storage utilization across all file systems
+            </p>
+
+            <div class="capacity-flex-container cds-mt-4">
+              <div class="capacity-chart-wrapper">
+                <cd-donut-chart
+                  [data]="capacityChartData"
+                  title="Storage Capacity"
+                  i18n-title
+                  height="250px"
+                  legendPosition="bottom"
+                  [centerTitle]="'Raw Used'"
+                  [centerNumber]="usagePercentNumber"
+                  [numberFormatter]="percentageFormatter"
+                >
+                </cd-donut-chart>
+              </div>
+
+              <div class="capacity-stats-wrapper cds-ml-5">
+                <div class="pool-detail-stat-box cds-mb-4">
+                  <span
+                    class="cds--type-label-01"
+                    i18n
+                    >Total Pool Capacity</span
+                  >
+                  <span class="cds--type-heading-03">{{ totalCapacity | dimlessBinary }}</span>
+                </div>
+                <div class="pool-detail-stat-box cds-mb-4">
+                  <span
+                    class="cds--type-label-01"
+                    i18n
+                    >Data Pools Raw Used</span
+                  >
+                  <span class="cds--type-heading-03">{{ totalDataUsed | dimlessBinary }}</span>
+                </div>
+                <div class="pool-detail-stat-box">
+                  <span
+                    class="cds--type-label-01"
+                    i18n
+                    >Metadata Pools Raw Used</span
+                  >
+                  <span class="cds--type-heading-03">{{ totalMetadataUsed | dimlessBinary }}</span>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <!-- RIGHT COLUMN: Mirroring & Protocols -->
+          <div class="pool-detail-right-column">
+            <!-- Mirroring Panel -->
+            <section class="pool-detail-panel cds-mb-6">
+              <div class="pool-detail-header-row">
+                <div>
+                  <h4
+                    class="cds--type-heading-02"
+                    i18n
+                  >
+                    Mirroring & Health
+                  </h4>
+                  <p
+                    class="cds--type-body-compact-01 pool-detail-panel__subtitle"
+                    i18n
+                  >
+                    Replication and daemon status
+                  </p>
+                </div>
+              </div>
+              <div class="pool-detail-stats cds-mt-4">
+                <div class="pool-detail-stat-box">
+                  <span
+                    class="cds--type-label-01"
+                    i18n
+                    >Mirror Daemons</span
+                  >
+                  <span class="cds--type-heading-03">{{ mirrorDaemonCount }}</span>
+                </div>
+                <div class="pool-detail-stat-box">
+                  <span
+                    class="cds--type-label-01"
+                    i18n
+                    >Mirror Peers</span
+                  >
+                  <span class="cds--type-heading-03">{{ mirrorPeerCount }}</span>
+                </div>
+              </div>
+            </section>
+
+            <!-- Gateways & Protocols Panel -->
+            <section class="pool-detail-panel">
+              <div class="pool-detail-header-row">
+                <div>
+                  <h4
+                    class="cds--type-heading-02"
+                    i18n
+                  >
+                    Gateways & Protocols
+                  </h4>
+                  <p
+                    class="cds--type-body-compact-01 pool-detail-panel__subtitle"
+                    i18n
+                  >
+                    File storage access points
+                  </p>
+                </div>
+              </div>
+              <div class="pool-detail-stats cds-mt-4">
+                <div class="pool-detail-stat-box">
+                  <span
+                    class="cds--type-label-01"
+                    i18n
+                    >NFS Clusters</span
+                  >
+                  <span class="cds--type-heading-03">{{ nfsClusterCount }}</span>
+                </div>
+                <div class="pool-detail-stat-box">
+                  <span
+                    class="cds--type-label-01"
+                    i18n
+                    >NFS Exports</span
+                  >
+                  <span class="cds--type-heading-03">{{ nfsExportCount }}</span>
+                </div>
+                <div class="pool-detail-stat-box">
+                  <span
+                    class="cds--type-label-01"
+                    i18n
+                    >SMB Clusters</span
+                  >
+                  <span class="cds--type-heading-03">{{ smbClusterCount }}</span>
+                </div>
+                <div class="pool-detail-stat-box">
+                  <span
+                    class="cds--type-label-01"
+                    i18n
+                    >SMB Shares</span
+                  >
+                  <span class="cds--type-heading-03">{{ smbShareCount }}</span>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </cds-tile>
+    </div>
+
+    <!-- Performance Statistics Card -->
+    <div class="cds-mb-5">
+      <cd-productive-card [applyShadow]="false">
+        <ng-template #header>
+          <h2
+            class="cds--type-heading-compact-02"
+            i18n
+          >
+            Performance Statistics
+          </h2>
+          <cd-time-picker
+            [dropdownSize]="'sm'"
+            [label]="'Time Span'"
+            (selectedTime)="loadPerformanceData($event)"
+          ></cd-time-picker>
+        </ng-template>
+        <div class="cds--grid cds--grid--narrow cds--grid--full-width">
+          <div class="cds--row cds--row--narrow">
+            <div class="cds--col-lg-8 cds--col-md-8 cds--col-sm-12 cds-mb-5">
+              <cd-area-chart
+                chartTitle="Client Requests"
+                i18n-chartTitle
+                [dataUnit]="'req/s'"
+                [rawData]="clientRequestsChartData"
+              >
+              </cd-area-chart>
+            </div>
+            <div class="cds--col-lg-8 cds--col-md-8 cds--col-sm-12 cds-mb-5">
+              <cd-area-chart
+                chartTitle="Metadata Throughput"
+                i18n-chartTitle
+                [dataUnit]="'B/s'"
+                [rawData]="throughputChartData"
+              >
+              </cd-area-chart>
+            </div>
+          </div>
+        </div>
+      </cd-productive-card>
+    </div>
+  </div>
+</main>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-overview/cephfs-overview.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-overview/cephfs-overview.component.html
@@ -1,0 +1,428 @@
+<main class="cephfs-overview cds-mt-5">
+  <cd-loading-panel
+    *ngIf="isLoading"
+    i18n
+  >
+    Loading File Systems overview...
+  </cd-loading-panel>
+
+  <div *ngIf="!isLoading">
+    <!-- Top Section: Details & Alerts (Grid Layout matching Block Overview) -->
+    <div
+      class="cds--grid cds--grid--full-width cds--grid--narrow cds-mb-5"
+      style="padding-left: 0; padding-right: 0"
+    >
+      <div class="cds--row align-items-stretch">
+        <!-- Details Card (12 Columns) -->
+        <div class="cds--col-lg-12 cds--col-md-8 cds--col-sm-12 cds-d-flex">
+          <cd-resource-overview-card
+            title="File Systems Overview"
+            [columns]="6"
+            [fields]="overviewFields"
+            i18n-title
+          >
+          </cd-resource-overview-card>
+        </div>
+
+        <!-- File Alerts Card (4 Columns) -->
+        <div class="cds--col-lg-4 cds--col-md-8 cds--col-sm-12 cds-d-flex">
+          <cd-overview-alerts-card
+            [compact]="true"
+            filterType="file"
+          ></cd-overview-alerts-card>
+        </div>
+      </div>
+    </div>
+
+    <!-- Capacity & Health Card -->
+    <div class="cds-mb-5">
+      <cds-tile class="pool-overview-card">
+        <div class="pool-overview-panels">
+          <!-- LEFT COLUMN: Capacity Panel -->
+          <section class="pool-detail-panel">
+            <div class="pool-detail-header-row">
+              <div>
+                <h4
+                  class="cds--type-heading-02"
+                  i18n
+                >
+                  Capacity
+                </h4>
+                <p
+                  class="cds--type-body-compact-01 pool-detail-panel__subtitle"
+                  i18n
+                >
+                  Storage utilization across all file systems
+                </p>
+              </div>
+
+              <!-- Carbon Popover per Carbon Design System spec -->
+              <div
+                cdsPopover
+                [isOpen]="isTopConsumersOpen"
+                [autoAlign]="true"
+                [caret]="true"
+              >
+                <button
+                  type="button"
+                  cdsButton="ghost"
+                  size="sm"
+                  class="top-consumers-trigger-btn"
+                  (click)="toggleTopConsumersPopover()"
+                >
+                  <span i18n>Top consumers</span>
+                  <svg
+                    cdsIcon="launch"
+                    size="16"
+                  ></svg>
+                </button>
+
+                <cds-popover-content [cdsLayer]="0">
+                  <div class="top-consumers-popover-content cds-p-4">
+                    <div
+                      class="d-flex align-items-center justify-content-between cds-pb-2 border-bottom"
+                    >
+                      <h5
+                        class="cds--type-heading-compact-01 m-0"
+                        i18n
+                      >
+                        Top consumers
+                      </h5>
+                      <button
+                        type="button"
+                        cdsButton="ghost"
+                        [iconOnly]="true"
+                        size="sm"
+                        aria-label="Close"
+                        (click)="isTopConsumersOpen = false"
+                      >
+                        <svg
+                          cdsIcon="close"
+                          size="16"
+                          class="cds--btn__icon"
+                        ></svg>
+                      </button>
+                    </div>
+
+                    <cds-select
+                      [value]="selectedBreakdown"
+                      (valueChange)="selectedBreakdown = $event"
+                      size="sm"
+                      class="cds-mt-2"
+                    >
+                      <option
+                        *ngFor="let opt of breakdownOptions"
+                        [value]="opt.value"
+                      >
+                        {{ opt.label }}
+                      </option>
+                    </cds-select>
+
+                    <div class="top-consumers-popover-list d-flex flex-column gap-2 cds-mt-3">
+                      <cds-tile
+                        *ngFor="let item of popoverItems; let i = index"
+                        class="d-flex align-items-center gap-3 cds-p-2"
+                      >
+                        <span class="cds--type-label-01 font-weight-bold">{{ i + 1 }}</span>
+                        <div class="flex-grow-1 min-w-0 d-flex flex-column">
+                          <span class="cds--type-body-compact-01 cds--text-truncate--end">{{
+                            item.name
+                          }}</span>
+                          <span
+                            *ngIf="item.subtext"
+                            class="cds--type-helper-text-01 cds--text-truncate--end"
+                            >{{ item.subtext }}</span
+                          >
+                        </div>
+                        <span class="cds--type-body-compact-01 font-weight-bold">{{
+                          item.value | dimlessBinary
+                        }}</span>
+                      </cds-tile>
+
+                      <div
+                        *ngIf="!popoverItems || popoverItems.length === 0"
+                        class="cds--type-body-compact-01 text-center cds-p-3"
+                        i18n
+                      >
+                        No consumer data available
+                      </div>
+                    </div>
+
+                    <div class="d-flex justify-content-end cds-pt-2 cds-mt-3 border-top">
+                      <a
+                        [routerLink]="popoverRoute"
+                        (click)="isTopConsumersOpen = false"
+                        class="cds--link d-inline-flex align-items-center gap-1"
+                      >
+                        <span i18n>View more</span>
+                        <svg
+                          cdsIcon="arrow--right"
+                          size="16"
+                        ></svg>
+                      </a>
+                    </div>
+                  </div>
+                </cds-popover-content>
+              </div>
+            </div>
+
+            <div class="pool-detail-panel__usage-head cds-mt-4">
+              <span
+                class="cds--type-label-01"
+                i18n
+                >Usage</span
+              >
+              <span class="cds--type-heading-04">{{ usagePercentNumber | number: '1.0-1' }}%</span>
+            </div>
+
+            <cd-usage-bar
+              *ngIf="logicalTotalBytes > 0; else noCapacityData"
+              [total]="logicalTotalBytes"
+              [used]="totalDataUsed"
+              title="Storage utilization"
+              i18n-title
+              width="100%"
+              decimals="1"
+            >
+            </cd-usage-bar>
+            <ng-template #noCapacityData>
+              <span class="cds--type-body-compact-01">-</span>
+            </ng-template>
+
+            <div class="pool-detail-stats pool-detail-stats--3-col cds-mt-5">
+              <div class="pool-detail-stat-box">
+                <span
+                  class="cds--type-label-01"
+                  i18n
+                  >Raw used</span
+                >
+                <span class="cds--type-heading-03">{{ totalUsed | dimlessBinary }}</span>
+              </div>
+              <div class="pool-detail-stat-box">
+                <span
+                  class="cds--type-label-01"
+                  i18n
+                  >Used</span
+                >
+                <span class="cds--type-heading-03">{{ totalDataUsed | dimlessBinary }}</span>
+              </div>
+              <div class="pool-detail-stat-box">
+                <span
+                  class="cds--type-label-01"
+                  i18n
+                  >Usable Free</span
+                >
+                <span class="cds--type-heading-03">{{ totalAvailable | dimlessBinary }}</span>
+              </div>
+            </div>
+          </section>
+
+          <!-- RIGHT COLUMN: Mirroring & Protocols -->
+          <div class="pool-detail-right-column">
+            <!-- Mirroring Panel -->
+            <section class="pool-detail-panel cds-mb-6">
+              <div class="pool-detail-header-row">
+                <div>
+                  <h4
+                    class="cds--type-heading-02"
+                    i18n
+                  >
+                    Mirroring & Health
+                  </h4>
+                  <p
+                    class="cds--type-body-compact-01 pool-detail-panel__subtitle"
+                    i18n
+                  >
+                    Replication and daemon status
+                  </p>
+                </div>
+              </div>
+              <div class="pool-detail-stats cds-mt-4">
+                <div class="pool-detail-stat-box">
+                  <span
+                    class="cds--type-label-01"
+                    i18n
+                    >Mirror Daemons</span
+                  >
+                  <span class="cds--type-heading-03">{{ mirrorDaemonCount }}</span>
+                </div>
+                <div class="pool-detail-stat-box">
+                  <span
+                    class="cds--type-label-01"
+                    i18n
+                    >Mirror Peers</span
+                  >
+                  <span class="cds--type-heading-03">{{ mirrorPeerCount }}</span>
+                </div>
+              </div>
+            </section>
+
+            <!-- Gateways & Protocols Panel -->
+            <section class="pool-detail-panel">
+              <div class="pool-detail-header-row">
+                <div>
+                  <h4
+                    class="cds--type-heading-02"
+                    i18n
+                  >
+                    Gateways & Protocols
+                  </h4>
+                  <p
+                    class="cds--type-body-compact-01 pool-detail-panel__subtitle"
+                    i18n
+                  >
+                    File storage access points
+                  </p>
+                </div>
+              </div>
+              <div class="pool-detail-stats pool-detail-stats--4-col cds-mt-4">
+                <div class="pool-detail-stat-box">
+                  <span
+                    class="cds--type-label-01"
+                    i18n
+                    >NFS Clusters</span
+                  >
+                  <span class="cds--type-heading-03">{{ nfsClusterCount }}</span>
+                </div>
+                <div class="pool-detail-stat-box">
+                  <span
+                    class="cds--type-label-01"
+                    i18n
+                    >NFS Exports</span
+                  >
+                  <span class="cds--type-heading-03">{{ nfsExportCount }}</span>
+                </div>
+                <div class="pool-detail-stat-box">
+                  <span
+                    class="cds--type-label-01"
+                    i18n
+                    >SMB Clusters</span
+                  >
+                  <span class="cds--type-heading-03">{{ smbClusterCount }}</span>
+                </div>
+                <div class="pool-detail-stat-box">
+                  <span
+                    class="cds--type-label-01"
+                    i18n
+                    >SMB Shares</span
+                  >
+                  <span class="cds--type-heading-03">{{ smbShareCount }}</span>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </cds-tile>
+    </div>
+
+    <!-- Standalone Full-Span Consumption Trend Card -->
+    <div class="cds-mb-5">
+      <cd-productive-card [applyShadow]="false">
+        <ng-template #header>
+          <h2
+            class="cds--type-heading-compact-02"
+            i18n
+          >
+            Consumption trend
+          </h2>
+          <cd-time-picker
+            [dropdownSize]="'sm'"
+            [label]="'Time Span'"
+            (selectedTime)="loadConsumptionTrend($event)"
+          ></cd-time-picker>
+        </ng-template>
+        <div class="cds--grid cds--grid--narrow cds--grid--full-width">
+          <div class="cds--row cds--row--narrow cds-align-items-center">
+            <div class="cds--col-lg-12 cds--col-md-10 cds--col-sm-12">
+              <cd-area-chart
+                chartTitle="Consumption trend"
+                [chartKey]="'Consumption trend'"
+                [dataUnit]="'B'"
+                [legendEnabled]="false"
+                [rawData]="consumptionTrendData"
+                [subHeading]="'Storage consumption trends based on recent usage'"
+                [height]="'200px'"
+                [decimals]="2"
+                [chartType]="'area'"
+              >
+              </cd-area-chart>
+            </div>
+            <div class="cds--col-lg-4 cds--col-md-6 cds--col-sm-12">
+              <div class="cds--stack-vertical cds--stack-gap-4">
+                <div class="cds--stack-vertical cds--stack-gap-1">
+                  <span class="cds--type-heading-03">{{ estimatedTimeUntilFull || 'N/A' }}</span>
+                  <span
+                    class="cds--type-label-01"
+                    i18n
+                    >Estimated time until full</span
+                  >
+                </div>
+                <div class="cds--stack-vertical cds--stack-gap-1">
+                  <span class="cds--type-heading-03">{{
+                    averageDailyConsumption || '0 B/day'
+                  }}</span>
+                  <span
+                    class="cds--type-label-01"
+                    i18n
+                    >Average consumption</span
+                  >
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </cd-productive-card>
+    </div>
+
+    <!-- Performance Statistics Card -->
+    <div class="cds-mb-5">
+      <cd-productive-card [applyShadow]="false">
+        <ng-template #header>
+          <h2
+            class="cds--type-heading-compact-02"
+            i18n
+          >
+            Performance Statistics
+          </h2>
+          <cd-time-picker
+            [dropdownSize]="'sm'"
+            [label]="'Time Span'"
+            (selectedTime)="loadPerformanceData($event)"
+          ></cd-time-picker>
+        </ng-template>
+        <div class="cds--grid cds--grid--narrow cds--grid--full-width">
+          <div class="cds--row cds--row--narrow">
+            <div class="cds--col-lg-5 cds--col-md-8 cds--col-sm-12 cds-mb-5">
+              <cd-area-chart
+                chartTitle="IOPS"
+                i18n-chartTitle
+                [dataUnit]="''"
+                [rawData]="iopsChartData"
+              >
+              </cd-area-chart>
+            </div>
+            <div class="cds--col-lg-5 cds--col-md-8 cds--col-sm-12 cds-mb-5">
+              <cd-area-chart
+                chartTitle="Latency"
+                i18n-chartTitle
+                [dataUnit]="'ms'"
+                [decimals]="2"
+                [rawData]="latencyChartData"
+              >
+              </cd-area-chart>
+            </div>
+            <div class="cds--col-lg-5 cds--col-md-8 cds--col-sm-12 cds-mb-5">
+              <cd-area-chart
+                chartTitle="Throughput"
+                i18n-chartTitle
+                [dataUnit]="'B/s'"
+                [rawData]="throughputChartData"
+              >
+              </cd-area-chart>
+            </div>
+          </div>
+        </div>
+      </cd-productive-card>
+    </div>
+  </div>
+</main>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-overview/cephfs-overview.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-overview/cephfs-overview.component.scss
@@ -1,0 +1,109 @@
+@use '@carbon/layout';
+
+.cephfs-overview {
+  display: block;
+
+  .pool-overview-card {
+    display: block;
+    padding: layout.$spacing-05;
+  }
+
+  .pool-overview-panels {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: layout.$spacing-06;
+  }
+
+  .pool-detail-panel {
+    padding: layout.$spacing-05;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .pool-detail-header-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: layout.$spacing-03;
+  }
+
+  .pool-detail-panel__subtitle {
+    color: var(--cds-text-secondary, #525252);
+  }
+
+  .pool-detail-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: layout.$spacing-04;
+  }
+
+  .pool-detail-mono-val {
+    max-width: 60%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: right;
+  }
+
+  .pool-detail-panel__usage-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: layout.$spacing-03;
+    margin-bottom: layout.$spacing-03;
+  }
+
+  .pool-detail-stats {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: layout.$spacing-04;
+
+    &--3-col {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  .pool-detail-stat-box {
+    padding: layout.$spacing-04;
+    display: flex;
+    flex-direction: column;
+    gap: layout.$spacing-02;
+    min-height: 5.5rem;
+    background-color: var(--cds-layer-01, #f4f4f4);
+  }
+
+  .pool-detail-divider {
+    border: 0;
+    border-top: 1px solid var(--cds-border-subtle-01, #e0e0e0);
+  }
+
+  cd-usage-bar {
+    display: block;
+  }
+
+  .capacity-flex-container {
+    display: flex;
+    align-items: center;
+    gap: layout.$spacing-06;
+  }
+
+  .capacity-chart-wrapper {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .capacity-stats-wrapper {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .pool-detail-right-column {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-overview/cephfs-overview.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-overview/cephfs-overview.component.scss
@@ -1,6 +1,6 @@
 @use '@carbon/layout';
 
-.rgw-overview {
+.cephfs-overview {
   display: block;
 
   .cds--grid--full-width {
@@ -64,7 +64,6 @@
 
   .pool-detail-panel__subtitle {
     color: var(--cds-text-secondary, #525252);
-    margin-top: layout.$spacing-01;
   }
 
   .pool-detail-row {
@@ -160,86 +159,4 @@
       }
     }
   }
-}
-
-.multisite-sync {
-  &__loading {
-    display: flex;
-    justify-content: center;
-    padding: var(--cds-spacing-05);
-  }
-
-  &__layout {
-    display: flex;
-    align-items: flex-start;
-  }
-
-  &__primary {
-    flex: 0 0 250px;
-    text-align: center;
-  }
-
-  &__primary-content {
-    border-inline-end: 1px solid var(--cds-border-subtle);
-    padding-inline-end: var(--cds-spacing-05);
-  }
-
-  &__section-title {
-    margin-block-end: var(--cds-spacing-05);
-
-    &--centered {
-      text-align: center;
-    }
-  }
-
-  &__source-zones {
-    flex: 1;
-    padding-inline-start: var(--cds-spacing-05);
-  }
-
-  &__zones-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: var(--cds-spacing-05);
-  }
-
-  &__zone-tile {
-    height: 100%;
-    padding-block-start: 0;
-  }
-
-  &__zone-header {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: var(--cds-spacing-02);
-    margin-block-end: var(--cds-spacing-04);
-  }
-
-  &__sync-columns {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-  }
-
-  &__sync-item {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-
-    &--bordered {
-      border-inline-start: 1px solid var(--cds-border-subtle);
-    }
-  }
-
-  &__sync-title {
-    text-align: center;
-    margin-block-end: var(--cds-spacing-03);
-  }
-}
-
-ul {
-  align-items: center;
-  display: flex;
-  flex-direction: column;
-  list-style-type: none;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-overview/cephfs-overview.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-overview/cephfs-overview.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CephfsOverviewComponent } from './cephfs-overview.component';
+
+describe('CephfsOverviewComponent', () => {
+  let component: CephfsOverviewComponent;
+  let fixture: ComponentFixture<CephfsOverviewComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CephfsOverviewComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CephfsOverviewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-overview/cephfs-overview.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-overview/cephfs-overview.component.ts
@@ -1,0 +1,558 @@
+import { CephfsSubvolumeService } from '~/app/shared/api/cephfs-subvolume.service';
+import { CephfsSubvolumeGroupService } from '~/app/shared/api/cephfs-subvolume-group.service';
+import { NfsService } from '~/app/shared/api/nfs.service';
+import { SmbService } from '~/app/shared/api/smb.service';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { CephfsService } from '~/app/shared/api/cephfs.service';
+import { PoolService } from '~/app/shared/api/pool.service';
+import { PrometheusService } from '~/app/shared/api/prometheus.service';
+import { FormatterService } from '~/app/shared/services/formatter.service';
+import { DimlessBinaryPipe } from '~/app/shared/pipes/dimless-binary.pipe';
+import { Observable, Subscription, forkJoin, of } from 'rxjs';
+import { catchError, map, switchMap } from 'rxjs/operators';
+import { PerformanceCardService } from '~/app/shared/api/performance-card.service';
+import { PerformanceData, StorageType } from '~/app/shared/models/performance-data';
+import { ChartPoint } from '~/app/shared/models/area-chart-point';
+
+@Component({
+  selector: 'cd-cephfs-overview',
+  templateUrl: './cephfs-overview.component.html',
+  styleUrls: ['./cephfs-overview.component.scss'],
+  providers: [DimlessBinaryPipe],
+  standalone: false
+})
+export class CephfsOverviewComponent implements OnInit, OnDestroy {
+  isLoading = true;
+  private subs = new Subscription();
+
+  // KPIs
+  fileSystemCount = 0;
+  totalClientConnections = 0;
+  activeMdsCount = 0;
+  standbyMdsCount = 0;
+  totalSubvolumes = 0;
+  totalSubvolumeGroups = 0;
+
+  // Health
+  healthStatus = 'OK';
+  healthColor: 'success' | 'warning' | 'danger' | 'info' = 'success';
+  healthIssues: { type: string; name: string; state: string; color: string }[] = [];
+
+  // Capacity
+  totalCapacity = 0;
+  totalUsed = 0;
+  totalAvailable = 0;
+  totalDataCapacity = 0;
+  totalDataUsed = 0;
+  totalMetadataCapacity = 0;
+  totalMetadataUsed = 0;
+
+  // Consumption Trend Data & KPIs
+  consumptionTrendData: ChartPoint[] = [];
+  averageDailyConsumption = '';
+  estimatedTimeUntilFull = '';
+
+  // Performance Charts Data
+  iopsChartData: any[] = [];
+  latencyChartData: any[] = [];
+  throughputChartData: any[] = [];
+
+  // Gateways & Protocols
+  nfsClusterCount = 0;
+  nfsExportCount = 0;
+  smbClusterCount = 0;
+  smbShareCount = 0;
+  // Top File Systems
+  topFileSystems: { name: string; dataUsed: number; available: number }[] = [];
+  topSubvolumes: { name: string; fsName: string; bytes_used: number }[] = [];
+
+  // Interactive Popover Breakdown State
+  isTopConsumersOpen = false;
+  selectedBreakdown = 'filesystem';
+  breakdownOptions = [
+    { label: 'By File System', value: 'filesystem' },
+    { label: 'By Subvolume', value: 'subvolume' }
+  ];
+
+  // Mirroring
+  mirrorDaemonCount = 0;
+  mirrorPeerCount = 0;
+  mirrorHealthStatus: string = 'OK';
+  mirrorHealthColor: 'success' | 'warning' | 'danger' | 'info' = 'success';
+
+  constructor(
+    private cephfsService: CephfsService,
+    private cephfsSubvolumeService: CephfsSubvolumeService,
+    private cephfsSubvolumeGroupService: CephfsSubvolumeGroupService,
+    private poolService: PoolService,
+    private performanceCardService: PerformanceCardService,
+    private prometheusService: PrometheusService,
+    private formatterService: FormatterService,
+    private nfsService: NfsService,
+    private smbService: SmbService
+  ) {}
+
+  ngOnInit(): void {
+    this.loadCephfsData();
+    this.loadConsumptionTrend();
+  }
+
+  ngOnDestroy(): void {
+    this.subs.unsubscribe();
+  }
+
+  toggleTopConsumersPopover(): void {
+    this.isTopConsumersOpen = !this.isTopConsumersOpen;
+  }
+
+  get popoverItems(): { name: string; subtext?: string; value: number }[] {
+    if (this.selectedBreakdown === 'subvolume') {
+      return this.topSubvolumes.map((sv) => ({
+        name: sv.name,
+        subtext: sv.fsName,
+        value: sv.bytes_used || 0
+      }));
+    }
+    return this.topFileSystems.map((fs) => ({
+      name: fs.name,
+      subtext: 'File System',
+      value: fs.dataUsed
+    }));
+  }
+
+  get popoverRoute(): string {
+    return '/cephfs/fs';
+  }
+
+  loadConsumptionTrend(selectedTime?: { start: number; end: number; step: number }): void {
+    const end = selectedTime?.end || Math.floor(Date.now() / 1000);
+    const start = selectedTime?.start || end - 7 * 86400; // default 7 days
+    const step = selectedTime?.step || 3600;
+
+    const timeRange = { start, end, step };
+
+    // 1. Fetch Consumption Trend Area Chart Points
+    this.subs.add(
+      this.prometheusService
+        .getRangeQueriesData(
+          timeRange,
+          {
+            CEPHFS_USED:
+              'sum(ceph_pool_bytes_used * on(pool_id) group_left(application) ceph_pool_metadata{application=~"(.*Filesystem.*)|(.*cephfs.*)"})'
+          },
+          true
+        )
+        .pipe(catchError(() => of(null)))
+        .subscribe((results: any) => {
+          const rawTrend = results?.CEPHFS_USED || [];
+          this.consumptionTrendData = rawTrend.map(([ts, val]: [number, string]) => ({
+            timestamp: new Date(ts * 1000),
+            values: { Used: Number(val) }
+          }));
+          if (!this.consumptionTrendData.length) {
+            this.consumptionTrendData = [{ timestamp: new Date(), values: { Used: 0 } }];
+          }
+        })
+    );
+
+    const rateWindow = this.getRateWindow(start, end);
+
+    // 2. Fetch Average Daily Consumption
+    const avgQuery = `sum(rate(ceph_pool_bytes_used[${rateWindow}]) * on(pool_id) group_left(application) ceph_pool_metadata{application=~"(.*Filesystem.*)|(.*cephfs.*)"}) * 86400`;
+    this.subs.add(
+      this.prometheusService
+        .getPrometheusQueryData({ params: avgQuery })
+        .pipe(catchError(() => of(null)))
+        .subscribe((res: any) => {
+          const val = Number(res?.result?.[0]?.value?.[1] ?? 0);
+          const [formattedVal, unit] = this.formatterService.formatToBinary(val, true);
+          this.averageDailyConsumption = `${formattedVal} ${unit}/day`;
+        })
+    );
+
+    // 3. Fetch Estimated Time Until Full
+    const fullQuery = `(sum(ceph_pool_max_avail * on(pool_id) group_left(application) ceph_pool_metadata{application=~"(.*Filesystem.*)|(.*cephfs.*)"})) / (${avgQuery})`;
+    this.subs.add(
+      this.prometheusService
+        .getPrometheusQueryData({ params: fullQuery })
+        .pipe(catchError(() => of(null)))
+        .subscribe((res: any) => {
+          const days = Number(res?.result?.[0]?.value?.[1] ?? Infinity);
+          this.estimatedTimeUntilFull = this.formatTimeUntilFull(days);
+        })
+    );
+  }
+
+  private getRateWindow(start: number, end: number): string {
+    const diffSec = Math.max(60, end - start);
+    if (diffSec <= 600) return '5m';
+    if (diffSec <= 3600) return '1h';
+    if (diffSec <= 86400) return '1d';
+    if (diffSec <= 7 * 86400) return '7d';
+    return '30d';
+  }
+
+  private formatTimeUntilFull(days: number): string {
+    if (!isFinite(days) || days <= 0) return 'N/A';
+    if (days < 1) return `${(days * 24).toFixed(1)} hours`;
+    if (days < 30) return `${days.toFixed(1)} days`;
+    if (days < 365) return `${(days / 30).toFixed(1)} months`;
+    const years = days / 365;
+    if (years > 10) return '> 10 years';
+    return `${years.toFixed(1)} years`;
+  }
+
+  loadPerformanceData(selectedTime?: { start: number; end: number; step: number }): void {
+    const time = selectedTime || {
+      start: Math.floor(Date.now() / 1000) - 3600,
+      end: Math.floor(Date.now() / 1000),
+      step: 14
+    };
+    this.subs.add(
+      this.performanceCardService
+        .getChartData(time, StorageType.Filesystem)
+        .pipe(catchError(() => of(null)))
+        .subscribe((data: PerformanceData | null) => {
+          if (data) {
+            this.iopsChartData = data.iops || [];
+            this.latencyChartData = data.latency || [];
+            this.throughputChartData = data.throughput || [];
+          }
+        })
+    );
+  }
+
+  private loadCephfsData() {
+    this.isLoading = true;
+
+    this.subs.add(
+      forkJoin({
+        cephfsList: this.cephfsService.list().pipe(catchError(() => of([]))),
+        pools: this.poolService.getList().pipe(catchError(() => of([]))),
+        nfsClusters: this.nfsService.nfsClusterList().pipe(catchError(() => of([]))),
+        nfsExports: this.nfsService.list().pipe(catchError(() => of([]))),
+        smbClusters: this.smbService.listClusters().pipe(catchError(() => of([]))),
+        mirrorDaemons: this.cephfsService.listDaemonStatus().pipe(catchError(() => of([])))
+      })
+        .pipe(
+          catchError(() =>
+            of({
+              cephfsList: [],
+              pools: [],
+              nfsClusters: [],
+              nfsExports: [],
+              smbClusters: [],
+              mirrorDaemons: []
+            })
+          )
+        )
+        .subscribe((res: any) => {
+          try {
+            const cephfsList = Array.isArray(res?.cephfsList) ? res.cephfsList : [];
+            const pools = Array.isArray(res?.pools) ? res.pools : [];
+            const nfsClusters = Array.isArray(res?.nfsClusters) ? res.nfsClusters : [];
+            const nfsExports = Array.isArray(res?.nfsExports) ? res.nfsExports : [];
+            const smbClusters = Array.isArray(res?.smbClusters) ? res.smbClusters : [];
+            const mirrorDaemons = Array.isArray(res?.mirrorDaemons) ? res.mirrorDaemons : [];
+
+            this.processCephfsData(cephfsList, pools);
+
+            this.nfsClusterCount = nfsClusters.length;
+            this.nfsExportCount = nfsExports.length;
+            this.smbClusterCount = smbClusters.length;
+
+            this.mirrorDaemonCount = mirrorDaemons.length;
+            let totalPeers = 0;
+            let mirrorErrors = 0;
+            mirrorDaemons.forEach((d: any) => {
+              if (d && d.filesystems) {
+                d.filesystems.forEach((fs: any) => {
+                  if (fs.peers) {
+                    totalPeers += fs.peers.length;
+                    fs.peers.forEach((peer: any) => {
+                      if (peer.stats && peer.stats.failure_count > 0) {
+                        mirrorErrors++;
+                      }
+                    });
+                  }
+                });
+              }
+            });
+            this.mirrorPeerCount = totalPeers;
+            if (mirrorErrors > 0) {
+              this.mirrorHealthStatus = `Error (${mirrorErrors})`;
+              this.mirrorHealthColor = 'danger';
+            } else {
+              this.mirrorHealthStatus = 'OK';
+              this.mirrorHealthColor = 'success';
+            }
+
+            const clientReqs: Observable<any>[] = [];
+            const subvolumeReqs: Observable<any>[] = [];
+            const subvolGroupReqs: Observable<any>[] = [];
+            const smbShareReqs: Observable<any>[] = [];
+
+            cephfsList.forEach((fs: any) => {
+              if (!fs || !fs.id) return;
+              clientReqs.push(
+                this.cephfsService
+                  .getClients(fs.id)
+                  .pipe(catchError(() => of({ status: 1, data: [] })))
+              );
+
+              const fsName = fs.mdsmap?.fs_name || fs.name;
+              if (fsName) {
+                const groupsReq = this.cephfsSubvolumeGroupService
+                  .get(fsName, false)
+                  .pipe(catchError(() => of([])));
+                subvolGroupReqs.push(groupsReq);
+
+                const allSubvolsReq = groupsReq.pipe(
+                  switchMap((groups) => {
+                    const svReqs: Observable<any>[] = [];
+                    svReqs.push(
+                      this.cephfsSubvolumeService
+                        .get(fsName, '', false)
+                        .pipe(catchError(() => of([])))
+                    );
+                    if (Array.isArray(groups)) {
+                      groups.forEach((g: any) => {
+                        if (g && g.name && g.name !== '_nogroup') {
+                          svReqs.push(
+                            this.cephfsSubvolumeService
+                              .get(fsName, g.name, false)
+                              .pipe(catchError(() => of([])))
+                          );
+                        }
+                      });
+                    }
+                    return forkJoin(svReqs);
+                  }),
+                  map((results) => {
+                    let total = 0;
+                    if (Array.isArray(results)) {
+                      results.forEach((r: any) => {
+                        if (Array.isArray(r)) total += r.length;
+                      });
+                    }
+                    return total;
+                  }),
+                  catchError(() => of(0))
+                );
+                subvolumeReqs.push(allSubvolsReq);
+              }
+            });
+
+            smbClusters.forEach((cluster: any) => {
+              if (cluster && cluster.cluster_id) {
+                smbShareReqs.push(
+                  this.smbService.listShares(cluster.cluster_id).pipe(catchError(() => of([])))
+                );
+              }
+            });
+
+            if (cephfsList.length > 0 || smbClusters.length > 0) {
+              forkJoin({
+                clients: clientReqs.length ? forkJoin(clientReqs) : of([]),
+                subvolumes: subvolumeReqs.length ? forkJoin(subvolumeReqs) : of([]),
+                subvolGroups: subvolGroupReqs.length ? forkJoin(subvolGroupReqs) : of([]),
+                smbShares: smbShareReqs.length ? forkJoin(smbShareReqs) : of([])
+              })
+                .pipe(
+                  catchError(() =>
+                    of({ clients: [], subvolumes: [], subvolGroups: [], smbShares: [] })
+                  )
+                )
+                .subscribe({
+                  next: ({ clients, subvolumes, subvolGroups, smbShares }) => {
+                    let totalClients = 0;
+                    if (Array.isArray(clients)) {
+                      clients.forEach((res: any) => {
+                        if (res && Array.isArray(res.data)) {
+                          totalClients += res.data.length;
+                        }
+                      });
+                    }
+                    this.totalClientConnections = totalClients;
+
+                    let totalSubvols = 0;
+                    if (Array.isArray(subvolumes)) {
+                      subvolumes.forEach((res: any) => {
+                        if (typeof res === 'number') {
+                          totalSubvols += res;
+                        } else if (Array.isArray(res)) {
+                          totalSubvols += res.length;
+                        }
+                      });
+                    }
+                    this.totalSubvolumes = totalSubvols;
+
+                    let totalGroups = 0;
+                    if (Array.isArray(subvolGroups)) {
+                      subvolGroups.forEach((res: any) => {
+                        if (Array.isArray(res)) {
+                          totalGroups += res.length;
+                        }
+                      });
+                    }
+                    this.totalSubvolumeGroups = totalGroups;
+
+                    let totalSmbShares = 0;
+                    if (Array.isArray(smbShares)) {
+                      smbShares.forEach((res: any) => {
+                        if (Array.isArray(res)) {
+                          totalSmbShares += res.length;
+                        }
+                      });
+                    }
+                    this.smbShareCount = totalSmbShares;
+                    this.isLoading = false;
+                  },
+                  error: () => {
+                    this.isLoading = false;
+                  }
+                });
+            } else {
+              this.isLoading = false;
+            }
+          } catch {
+            this.isLoading = false;
+          }
+        })
+    );
+  }
+
+  private processCephfsData(filesystems: any[], pools: any[]) {
+    this.fileSystemCount = filesystems.length;
+
+    let activeMds = 0;
+    let standbyMds = 0;
+
+    const dataPoolIds = new Set<number>();
+    const metadataPoolIds = new Set<number>();
+
+    let errorCount = 0;
+    let warningCount = 0;
+
+    // Build a map of filesystem name -> data pool IDs for Top 5 computation
+    const fsDataPoolMap = new Map<string, Set<number>>();
+
+    filesystems.forEach((fs) => {
+      if (fs.mdsmap && fs.mdsmap.info) {
+        Object.values(fs.mdsmap.info).forEach((daemon: any) => {
+          if (daemon.state === 'up:active') activeMds++;
+          else standbyMds++;
+        });
+      }
+
+      const fsName = fs.mdsmap?.fs_name || fs.name || `fs-${fs.id}`;
+      const fsPoolIds = new Set<number>();
+
+      if (fs.mdsmap.data_pools) {
+        fs.mdsmap.data_pools.forEach((pid: any) => {
+          dataPoolIds.add(Number(pid));
+          fsPoolIds.add(Number(pid));
+        });
+      }
+      if (fs.mdsmap.metadata_pool) {
+        metadataPoolIds.add(Number(fs.mdsmap.metadata_pool));
+      }
+
+      fsDataPoolMap.set(fsName, fsPoolIds);
+    });
+
+    this.activeMdsCount = activeMds;
+    this.standbyMdsCount = standbyMds;
+
+    let maxDataAvail = 0;
+
+    // Calculate capacity
+    pools.forEach((pool) => {
+      const poolId = Number(pool.pool);
+      const isData = dataPoolIds.has(poolId);
+      const isMeta = metadataPoolIds.has(poolId);
+
+      if (isData || isMeta) {
+        const stats = pool.stats || {};
+        const bytesUsed = stats.bytes_used?.latest || 0;
+        const maxAvail = stats.max_avail?.latest || 0;
+
+        if (isData) {
+          this.totalDataUsed += bytesUsed;
+          this.totalDataCapacity += bytesUsed + maxAvail;
+          if (maxAvail > maxDataAvail) maxDataAvail = maxAvail;
+        }
+        if (isMeta) {
+          this.totalMetadataUsed += bytesUsed;
+          this.totalMetadataCapacity += bytesUsed + maxAvail;
+        }
+
+        this.totalUsed += bytesUsed;
+      }
+    });
+
+    this.totalAvailable = maxDataAvail;
+    this.totalCapacity = this.totalUsed + this.totalAvailable;
+
+    // Compute Top 5 File Systems by data usage
+    const fsUsageList: { name: string; dataUsed: number; available: number }[] = [];
+    fsDataPoolMap.forEach((poolIds, fsName) => {
+      let fsDataUsed = 0;
+      let fsAvailable = 0;
+      pools.forEach((pool) => {
+        if (poolIds.has(Number(pool.pool))) {
+          const stats = pool.stats || {};
+          fsDataUsed += stats.bytes_used?.latest || 0;
+          const avail = stats.max_avail?.latest || 0;
+          if (avail > fsAvailable) fsAvailable = avail;
+        }
+      });
+      fsUsageList.push({ name: fsName, dataUsed: fsDataUsed, available: fsAvailable });
+    });
+    this.topFileSystems = fsUsageList.sort((a, b) => b.dataUsed - a.dataUsed).slice(0, 5);
+
+    if (errorCount > 0) {
+      this.healthStatus = `Error (${errorCount})`;
+      this.healthColor = 'danger';
+    } else if (warningCount > 0) {
+      this.healthStatus = `Warning (${warningCount})`;
+      this.healthColor = 'warning';
+    } else {
+      this.healthStatus = 'OK';
+      this.healthColor = 'success';
+    }
+  }
+
+  get usagePercentNumber(): number {
+    const logicalTotal = this.totalDataUsed + this.totalAvailable;
+    if (logicalTotal > 0) {
+      return (this.totalDataUsed / logicalTotal) * 100;
+    }
+    return 0;
+  }
+
+  get logicalTotalBytes(): number {
+    return this.totalDataUsed + this.totalAvailable;
+  }
+
+  get overviewFields() {
+    return [
+      {
+        label: $localize`File Systems`,
+        value: this.fileSystemCount,
+        type: 'text',
+        routerLink: '/cephfs/fs'
+      },
+      { label: $localize`Subvolumes`, value: this.totalSubvolumes, type: 'text' },
+      { label: $localize`Subvolume Groups`, value: this.totalSubvolumeGroups, type: 'text' },
+      { label: $localize`Client Connections`, value: this.totalClientConnections, type: 'text' },
+      { label: $localize`Active MDS Daemons`, value: this.activeMdsCount, type: 'text' },
+      {
+        label: $localize`Mirroring Health`,
+        value: this.mirrorHealthStatus,
+        type: 'status',
+        status: this.mirrorHealthColor
+      }
+    ];
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-overview/cephfs-overview.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-overview/cephfs-overview.component.ts
@@ -1,0 +1,444 @@
+import { CephfsSubvolumeService } from '~/app/shared/api/cephfs-subvolume.service';
+import { CephfsSubvolumeGroupService } from '~/app/shared/api/cephfs-subvolume-group.service';
+import { NfsService } from '~/app/shared/api/nfs.service';
+import { SmbService } from '~/app/shared/api/smb.service';
+import { Component, OnInit } from '@angular/core';
+import { CephfsService } from '~/app/shared/api/cephfs.service';
+import { PoolService } from '~/app/shared/api/pool.service';
+import { PrometheusService } from '~/app/shared/api/prometheus.service';
+import { DimlessBinaryPipe } from '~/app/shared/pipes/dimless-binary.pipe';
+import { FormatterService } from '~/app/shared/services/formatter.service';
+import { Observable, forkJoin, of } from 'rxjs';
+import { catchError, map, switchMap } from 'rxjs/operators';
+import { PerformanceCardService } from '~/app/shared/api/performance-card.service';
+
+@Component({
+  selector: 'cd-cephfs-overview',
+  templateUrl: './cephfs-overview.component.html',
+  styleUrls: ['./cephfs-overview.component.scss'],
+  providers: [DimlessBinaryPipe],
+  standalone: false
+})
+export class CephfsOverviewComponent implements OnInit {
+  isLoading = true;
+
+  // KPIs
+  fileSystemCount = 0;
+  totalClientConnections = 0;
+  activeMdsCount = 0;
+  standbyMdsCount = 0;
+  totalSubvolumes = 0;
+  totalSubvolumeGroups = 0;
+
+  // Health
+  healthStatus = 'OK';
+  healthColor: 'success' | 'warning' | 'danger' | 'info' = 'success';
+  healthIssues: { type: string; name: string; state: string; color: string }[] = [];
+
+  // Capacity
+  totalCapacity = 0;
+  totalUsed = 0;
+  totalAvailable = 0;
+  totalDataCapacity = 0;
+  totalDataUsed = 0;
+  totalMetadataCapacity = 0;
+  totalMetadataUsed = 0;
+
+  capacityChartData: any;
+  capacityChartOptions: any;
+
+  // Metrics
+  clientRequestsQueries: any;
+  clientRequestsChartData: any;
+
+  throughputQueries: any;
+  throughputChartData: any;
+
+  // Gateways & Protocols
+  nfsClusterCount = 0;
+  nfsExportCount = 0;
+  smbClusterCount = 0;
+  smbShareCount = 0;
+  // Mirroring
+  mirrorDaemonCount = 0;
+  mirrorPeerCount = 0;
+  mirrorHealthStatus: string = 'OK';
+  mirrorHealthColor: 'success' | 'warning' | 'danger' | 'info' = 'success';
+
+  constructor(
+    private cephfsService: CephfsService,
+    private cephfsSubvolumeService: CephfsSubvolumeService,
+    private cephfsSubvolumeGroupService: CephfsSubvolumeGroupService,
+    private poolService: PoolService,
+    private prometheusService: PrometheusService,
+    private formatter: FormatterService,
+    private performanceCardService: PerformanceCardService,
+    private nfsService: NfsService,
+    private smbService: SmbService
+  ) {}
+
+  ngOnInit(): void {
+    this.setupCharts();
+    this.loadCephfsData();
+  }
+
+  private setupCharts() {
+    this.capacityChartOptions = {
+      resizable: true,
+      legend: {
+        position: 'bottom'
+      },
+      donut: {
+        center: {
+          label: $localize`Raw Used`
+        },
+        alignment: 'center'
+      }
+    };
+
+    // Prometheus queries for performance
+    this.clientRequestsQueries = {
+      'Client Reads': 'sum(rate(ceph_mds_request{}[1m]))',
+      'Client Replies': 'sum(rate(ceph_mds_reply{}[1m]))'
+    };
+
+    this.throughputQueries = {
+      'Metadata Read (B/s)': 'sum(rate(ceph_mds_server_handle_client_request{}[1m]))',
+      'Metadata Write (B/s)': 'sum(rate(ceph_mds_server_handle_client_session{}[1m]))'
+    };
+  }
+
+  loadPerformanceData(selectedTime?: { start: number; end: number; step: number }): void {
+    const time = selectedTime || {
+      start: Math.floor(Date.now() / 1000) - 3600,
+      end: Math.floor(Date.now() / 1000),
+      step: 14
+    };
+
+    this.prometheusService
+      .getRangeQueriesData(
+        time,
+        {
+          CLIENT_READS: this.clientRequestsQueries['Client Reads'],
+          CLIENT_REPLIES: this.clientRequestsQueries['Client Replies']
+        },
+        true
+      )
+      .subscribe((results) => {
+        const reads = this.performanceCardService.toSeries(
+          results?.CLIENT_READS || [],
+          'Client Reads'
+        );
+        const replies = this.performanceCardService.toSeries(
+          results?.CLIENT_REPLIES || [],
+          'Client Replies'
+        );
+        this.clientRequestsChartData = this.performanceCardService.mergeSeries(reads, replies);
+
+        if (!this.clientRequestsChartData.length) {
+          this.clientRequestsChartData = [
+            { timestamp: new Date(), values: { 'Client Reads': 0, 'Client Replies': 0 } }
+          ];
+        }
+      });
+
+    this.prometheusService
+      .getRangeQueriesData(
+        time,
+        {
+          META_READS: this.throughputQueries['Metadata Read (B/s)'],
+          META_WRITES: this.throughputQueries['Metadata Write (B/s)']
+        },
+        true
+      )
+      .subscribe((results) => {
+        const reads = this.performanceCardService.toSeries(
+          results?.META_READS || [],
+          'Metadata Read'
+        );
+        const writes = this.performanceCardService.toSeries(
+          results?.META_WRITES || [],
+          'Metadata Write'
+        );
+        this.throughputChartData = this.performanceCardService.mergeSeries(reads, writes);
+
+        if (!this.throughputChartData.length) {
+          this.throughputChartData = [
+            { timestamp: new Date(), values: { 'Metadata Read': 0, 'Metadata Write': 0 } }
+          ];
+        }
+      });
+  }
+
+  private loadCephfsData() {
+    this.isLoading = true;
+
+    forkJoin({
+      cephfsList: this.cephfsService.list().pipe(catchError(() => of([]))),
+      pools: this.poolService.getList().pipe(catchError(() => of([]))),
+      nfsClusters: this.nfsService.nfsClusterList().pipe(catchError(() => of([]))),
+      nfsExports: this.nfsService.list().pipe(catchError(() => of([]))),
+      smbClusters: this.smbService.listClusters().pipe(catchError(() => of([]))),
+      mirrorDaemons: this.cephfsService.listDaemonStatus().pipe(catchError(() => of([])))
+    }).subscribe(({ cephfsList, pools, nfsClusters, nfsExports, smbClusters, mirrorDaemons }) => {
+      this.processCephfsData(cephfsList as any[], pools as any[]);
+
+      this.nfsClusterCount = (nfsClusters as any[]).length;
+      this.nfsExportCount = (nfsExports as any[]).length;
+      this.smbClusterCount = (smbClusters as any[]).length;
+
+      this.mirrorDaemonCount = (mirrorDaemons as any[]).length;
+      let totalPeers = 0;
+      let mirrorErrors = 0;
+      if (mirrorDaemons && (mirrorDaemons as any[]).length) {
+        (mirrorDaemons as any[]).forEach((d) => {
+          if (d.filesystems) {
+            d.filesystems.forEach((fs: any) => {
+              if (fs.peers) {
+                totalPeers += fs.peers.length;
+              }
+              // Check mirroring health via peer stats
+              if (fs.peers) {
+                fs.peers.forEach((peer: any) => {
+                  if (peer.stats && peer.stats.failure_count > 0) {
+                    mirrorErrors++;
+                  }
+                });
+              }
+            });
+          }
+        });
+      }
+      this.mirrorPeerCount = totalPeers;
+      if (mirrorErrors > 0) {
+        this.mirrorHealthStatus = `Error (${mirrorErrors})`;
+        this.mirrorHealthColor = 'danger';
+      } else {
+        this.mirrorHealthStatus = 'OK';
+        this.mirrorHealthColor = 'success';
+      }
+
+      const clientReqs: Observable<any>[] = [];
+      const subvolumeReqs: Observable<any>[] = [];
+      const subvolGroupReqs: Observable<any>[] = [];
+      const smbShareReqs: Observable<any>[] = [];
+
+      (cephfsList as any[]).forEach((fs) => {
+        clientReqs.push(
+          this.cephfsService.getClients(fs.id).pipe(catchError(() => of({ status: 1, data: [] })))
+        );
+
+        const fsName = fs.mdsmap.fs_name;
+        const groupsReq = this.cephfsSubvolumeGroupService
+          .get(fsName, false)
+          .pipe(catchError(() => of([])));
+        subvolGroupReqs.push(groupsReq);
+
+        const allSubvolsReq = groupsReq.pipe(
+          switchMap((groups) => {
+            const svReqs: Observable<any>[] = [];
+            // Always fetch default group
+            svReqs.push(
+              this.cephfsSubvolumeService.get(fsName, '', false).pipe(catchError(() => of([])))
+            );
+            if (groups && groups.length) {
+              groups.forEach((g: any) => {
+                if (g.name !== '_nogroup') {
+                  // Avoid duplicate if backend happens to return it
+                  svReqs.push(
+                    this.cephfsSubvolumeService
+                      .get(fsName, g.name, false)
+                      .pipe(catchError(() => of([])))
+                  );
+                }
+              });
+            }
+            return forkJoin(svReqs);
+          }),
+          map((results) => {
+            let total = 0;
+            results.forEach((res: any) => {
+              if (res && res.length) total += res.length;
+            });
+            return total;
+          })
+        );
+        subvolumeReqs.push(allSubvolsReq);
+      });
+
+      (smbClusters as any[]).forEach((cluster) => {
+        smbShareReqs.push(
+          this.smbService.listShares(cluster.cluster_id).pipe(catchError(() => of([])))
+        );
+      });
+
+      if ((cephfsList as any[]).length > 0 || (smbClusters as any[]).length > 0) {
+        forkJoin({
+          clients: clientReqs.length ? forkJoin(clientReqs) : of([]),
+          subvolumes: subvolumeReqs.length ? forkJoin(subvolumeReqs) : of([]),
+          subvolGroups: subvolGroupReqs.length ? forkJoin(subvolGroupReqs) : of([]),
+          smbShares: smbShareReqs.length ? forkJoin(smbShareReqs) : of([])
+        }).subscribe(({ clients, subvolumes, subvolGroups, smbShares }) => {
+          let totalClients = 0;
+          clients.forEach((res) => {
+            if (res && res.data) {
+              totalClients += res.data.length;
+            }
+          });
+          this.totalClientConnections = totalClients;
+
+          let totalSubvols = 0;
+          subvolumes.forEach((res) => {
+            if (typeof res === 'number') {
+              totalSubvols += res;
+            } else if (res && res.length) {
+              totalSubvols += res.length;
+            }
+          });
+          this.totalSubvolumes = totalSubvols;
+
+          let totalGroups = 0;
+          subvolGroups.forEach((res) => {
+            if (res && res.length) {
+              totalGroups += res.length;
+            }
+          });
+          this.totalSubvolumeGroups = totalGroups;
+
+          let totalSmbShares = 0;
+          smbShares.forEach((res) => {
+            if (res && res.length) {
+              totalSmbShares += res.length;
+            }
+          });
+          this.smbShareCount = totalSmbShares;
+
+          this.isLoading = false;
+        });
+      } else {
+        this.isLoading = false;
+      }
+    });
+  }
+
+  private processCephfsData(filesystems: any[], pools: any[]) {
+    this.fileSystemCount = filesystems.length;
+
+    let activeMds = 0;
+    let standbyMds = 0;
+
+    const dataPoolIds = new Set<number>();
+    const metadataPoolIds = new Set<number>();
+
+    let errorCount = 0;
+    let warningCount = 0;
+
+    filesystems.forEach((fs) => {
+      if (fs.mdsmap && fs.mdsmap.info) {
+        Object.values(fs.mdsmap.info).forEach((daemon: any) => {
+          if (daemon.state === 'up:active') activeMds++;
+          else standbyMds++;
+        });
+      }
+
+      if (fs.mdsmap.data_pools) {
+        fs.mdsmap.data_pools.forEach((pid: any) => dataPoolIds.add(Number(pid)));
+      }
+      if (fs.mdsmap.metadata_pool) {
+        metadataPoolIds.add(Number(fs.mdsmap.metadata_pool));
+      }
+    });
+
+    this.activeMdsCount = activeMds;
+    this.standbyMdsCount = standbyMds;
+
+    // Calculate capacity
+    pools.forEach((pool) => {
+      const poolId = Number(pool.pool);
+      const isData = dataPoolIds.has(poolId);
+      const isMeta = metadataPoolIds.has(poolId);
+
+      if (isData || isMeta) {
+        const stats = pool.stats || {};
+        const bytesUsed = stats.bytes_used?.latest || 0;
+        const maxAvail = stats.max_avail?.latest || 0;
+
+        if (isData) {
+          this.totalDataUsed += bytesUsed;
+          this.totalDataCapacity += bytesUsed + maxAvail;
+        }
+        if (isMeta) {
+          this.totalMetadataUsed += bytesUsed;
+          this.totalMetadataCapacity += bytesUsed + maxAvail;
+        }
+
+        this.totalUsed += bytesUsed;
+        this.totalCapacity += bytesUsed + maxAvail;
+      }
+    });
+
+    this.totalAvailable = this.totalCapacity - this.totalUsed;
+
+    const usedPercentage = this.totalCapacity > 0 ? (this.totalUsed / this.totalCapacity) * 100 : 0;
+    const formattedUsedPercentage = this.formatter.format_number(usedPercentage, 100, ['%'], 1);
+
+    this.capacityChartOptions.donut.center.label = `${formattedUsedPercentage} \n Raw Used`;
+
+    this.capacityChartData = [
+      {
+        group: 'Used',
+        value: this.totalUsed
+      },
+      {
+        group: 'Available',
+        value: this.totalCapacity > 0 ? this.totalAvailable : 1
+      }
+    ];
+
+    if (errorCount > 0) {
+      this.healthStatus = `Error (${errorCount})`;
+      this.healthColor = 'danger';
+    } else if (warningCount > 0) {
+      this.healthStatus = `Warning (${warningCount})`;
+      this.healthColor = 'warning';
+    } else {
+      this.healthStatus = 'OK';
+      this.healthColor = 'success';
+    }
+  }
+
+  get usagePercentNumber(): number {
+    if (this.totalCapacity > 0) {
+      return (this.totalUsed / this.totalCapacity) * 100;
+    }
+    return 0;
+  }
+
+  percentageFormatter = (value: number) => {
+    if (value > 0 && value < 0.1) {
+      return '< 0.1%';
+    }
+    return `${value.toFixed(1)}%`;
+  };
+
+  get overviewFields() {
+    return [
+      {
+        label: $localize`File Systems`,
+        value: this.fileSystemCount,
+        type: 'text',
+        routerLink: '/cephfs/fs'
+      },
+      { label: $localize`Subvolumes`, value: this.totalSubvolumes, type: 'text' },
+      { label: $localize`Subvolume Groups`, value: this.totalSubvolumeGroups, type: 'text' },
+      { label: $localize`Client Connections`, value: this.totalClientConnections, type: 'text' },
+      { label: $localize`Active MDS Daemons`, value: this.activeMdsCount, type: 'text' },
+      {
+        label: $localize`Mirroring Health`,
+        value: this.mirrorHealthStatus,
+        type: 'status',
+        status: this.mirrorHealthColor
+      }
+    ];
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs.module.ts
@@ -14,6 +14,9 @@ import { provideCharts, withDefaultRegisterables, BaseChartDirective } from 'ng2
 import { AppRoutingModule } from '~/app/app-routing.module';
 import { SharedModule } from '~/app/shared/shared.module';
 import { CephfsChartComponent } from './cephfs-chart/cephfs-chart.component';
+import { DonutChartComponent } from '~/app/shared/components/donut-chart/donut-chart.component';
+import { AreaChartComponent } from '~/app/shared/components/area-chart/area-chart.component';
+import { TimePickerComponent } from '~/app/shared/components/time-picker/time-picker.component';
 import { CephfsClientsComponent } from './cephfs-clients/cephfs-clients.component';
 import { CephfsDetailComponent } from './cephfs-detail/cephfs-detail.component';
 import { CephfsDirectoriesComponent } from './cephfs-directories/cephfs-directories.component';
@@ -67,6 +70,7 @@ import Renew16 from '@carbon/icons/es/renew/16';
 import { CephfsMirroringWizardComponent } from './cephfs-mirroring-wizard/cephfs-mirroring-wizard.component';
 import { CephfsFilesystemSelectorComponent } from './cephfs-filesystem-selector/cephfs-filesystem-selector.component';
 import { CephfsMirroringEntityComponent } from './cephfs-mirroring-entity/cephfs-mirroring-entity.component';
+import { CephfsOverviewComponent } from './cephfs-overview/cephfs-overview.component';
 
 @NgModule({
   imports: [
@@ -105,7 +109,10 @@ import { CephfsMirroringEntityComponent } from './cephfs-mirroring-entity/cephfs
     RadioModule,
     TilesModule,
     TagModule,
-    NotificationModule
+    NotificationModule,
+    DonutChartComponent,
+    AreaChartComponent,
+    TimePickerComponent
   ],
   declarations: [
     CephfsDetailComponent,
@@ -130,7 +137,8 @@ import { CephfsMirroringEntityComponent } from './cephfs-mirroring-entity/cephfs
     CephfsMirroringWizardComponent,
     CephfsFilesystemSelectorComponent,
     CephfsMirroringErrorComponent,
-    CephfsMirroringEntityComponent
+    CephfsMirroringEntityComponent,
+    CephfsOverviewComponent
   ],
   providers: [provideCharts(withDefaultRegisterables())]
 })

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs.module.ts
@@ -14,6 +14,8 @@ import { provideCharts, withDefaultRegisterables, BaseChartDirective } from 'ng2
 import { AppRoutingModule } from '~/app/app-routing.module';
 import { SharedModule } from '~/app/shared/shared.module';
 import { CephfsChartComponent } from './cephfs-chart/cephfs-chart.component';
+import { AreaChartComponent } from '~/app/shared/components/area-chart/area-chart.component';
+import { TimePickerComponent } from '~/app/shared/components/time-picker/time-picker.component';
 import { CephfsClientsComponent } from './cephfs-clients/cephfs-clients.component';
 import { CephfsDetailComponent } from './cephfs-detail/cephfs-detail.component';
 import { CephfsDirectoriesComponent } from './cephfs-directories/cephfs-directories.component';
@@ -56,7 +58,9 @@ import {
   TilesModule,
   TreeviewModule,
   TabsModule,
-  NotificationModule
+  NotificationModule,
+  PopoverModule,
+  LayerModule
 } from 'carbon-components-angular';
 
 import AddIcon from '@carbon/icons/es/add/32';
@@ -67,6 +71,8 @@ import Renew16 from '@carbon/icons/es/renew/16';
 import { CephfsMirroringWizardComponent } from './cephfs-mirroring-wizard/cephfs-mirroring-wizard.component';
 import { CephfsFilesystemSelectorComponent } from './cephfs-filesystem-selector/cephfs-filesystem-selector.component';
 import { CephfsMirroringEntityComponent } from './cephfs-mirroring-entity/cephfs-mirroring-entity.component';
+import { CephfsOverviewComponent } from './cephfs-overview/cephfs-overview.component';
+import { OverviewAlertsCardComponent } from '~/app/ceph/overview/alerts-card/overview-alerts-card.component';
 
 @NgModule({
   imports: [
@@ -105,7 +111,12 @@ import { CephfsMirroringEntityComponent } from './cephfs-mirroring-entity/cephfs
     RadioModule,
     TilesModule,
     TagModule,
-    NotificationModule
+    NotificationModule,
+    AreaChartComponent,
+    TimePickerComponent,
+    OverviewAlertsCardComponent,
+    PopoverModule,
+    LayerModule
   ],
   declarations: [
     CephfsDetailComponent,
@@ -130,7 +141,8 @@ import { CephfsMirroringEntityComponent } from './cephfs-mirroring-entity/cephfs
     CephfsMirroringWizardComponent,
     CephfsFilesystemSelectorComponent,
     CephfsMirroringErrorComponent,
-    CephfsMirroringEntityComponent
+    CephfsMirroringEntityComponent,
+    CephfsOverviewComponent
   ],
   providers: [provideCharts(withDefaultRegisterables())]
 })

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/active-alert-list/active-alert-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/active-alert-list/active-alert-list.component.ts
@@ -27,6 +27,13 @@ const SeverityMap = {
   all: $localize`All`
 };
 
+const StorageTypeMap = {
+  block: $localize`Block`,
+  file: $localize`File`,
+  object: $localize`Object`,
+  all: $localize`All`
+};
+
 @Component({
   selector: 'cd-active-alert-list',
   providers: [{ provide: URLBuilderService, useValue: new URLBuilderService(BASE_URL) }],
@@ -75,6 +82,35 @@ export class ActiveAlertListComponent extends PrometheusListHelper implements On
         if (value === SeverityMap['critical']) return row.labels?.severity === 'critical';
         else if (value === SeverityMap['warning']) return row.labels?.severity === 'warning';
         if (value === SeverityMap['all']) return true;
+        return false;
+      }
+    },
+    {
+      name: $localize`Storage Type`,
+      prop: 'labels.alertname',
+      filterOptions: [
+        StorageTypeMap['all'],
+        StorageTypeMap['block'],
+        StorageTypeMap['file'],
+        StorageTypeMap['object']
+      ],
+      filterInitValue: StorageTypeMap['all'],
+      filterPredicate: (row, value) => {
+        const name = (row.labels?.alertname || '').toLowerCase();
+        if (value === StorageTypeMap['block']) {
+          return (
+            name.includes('rbd') ||
+            name.includes('nvme') ||
+            name.includes('iscsi') ||
+            name.includes('tcmu') ||
+            name.includes('osd')
+          );
+        } else if (value === StorageTypeMap['file']) {
+          return name.includes('cephfs') || name.includes('mds') || name.includes('filesystem');
+        } else if (value === StorageTypeMap['object']) {
+          return name.includes('rgw') || name.includes('multisite') || name.includes('bucket');
+        }
+        if (value === StorageTypeMap['all']) return true;
         return false;
       }
     }
@@ -204,7 +240,13 @@ export class ActiveAlertListComponent extends PrometheusListHelper implements On
     this.prometheusAlertService.getGroupedAlerts(true);
     this.route.queryParams.subscribe((params) => {
       const severity = params['severity'];
-      this.filters[1].filterInitValue = SeverityMap[severity];
+      if (severity && SeverityMap[severity]) {
+        this.filters[1].filterInitValue = SeverityMap[severity];
+      }
+      const filterType = params['filterType'];
+      if (filterType && StorageTypeMap[filterType]) {
+        this.filters[2].filterInitValue = StorageTypeMap[filterType];
+      }
       if (params['search']) {
         setTimeout(() => {
           if (this.table) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/active-alert-list/active-alert-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/active-alert-list/active-alert-list.component.ts
@@ -22,6 +22,13 @@ const SeverityMap = {
   all: $localize`All`
 };
 
+const StorageTypeMap = {
+  block: $localize`Block`,
+  file: $localize`File`,
+  object: $localize`Object`,
+  all: $localize`All`
+};
+
 @Component({
   selector: 'cd-active-alert-list',
   providers: [{ provide: URLBuilderService, useValue: new URLBuilderService(BASE_URL) }],
@@ -63,6 +70,35 @@ export class ActiveAlertListComponent extends PrometheusListHelper implements On
         if (value === SeverityMap['critical']) return row.labels?.severity === 'critical';
         else if (value === SeverityMap['warning']) return row.labels?.severity === 'warning';
         if (value === SeverityMap['all']) return true;
+        return false;
+      }
+    },
+    {
+      name: $localize`Storage Type`,
+      prop: 'labels.alertname',
+      filterOptions: [
+        StorageTypeMap['all'],
+        StorageTypeMap['block'],
+        StorageTypeMap['file'],
+        StorageTypeMap['object']
+      ],
+      filterInitValue: StorageTypeMap['all'],
+      filterPredicate: (row, value) => {
+        const name = (row.labels?.alertname || '').toLowerCase();
+        if (value === StorageTypeMap['block']) {
+          return (
+            name.includes('rbd') ||
+            name.includes('nvme') ||
+            name.includes('iscsi') ||
+            name.includes('tcmu') ||
+            name.includes('osd')
+          );
+        } else if (value === StorageTypeMap['file']) {
+          return name.includes('cephfs') || name.includes('mds') || name.includes('filesystem');
+        } else if (value === StorageTypeMap['object']) {
+          return name.includes('rgw') || name.includes('multisite') || name.includes('bucket');
+        }
+        if (value === StorageTypeMap['all']) return true;
         return false;
       }
     }
@@ -161,7 +197,13 @@ export class ActiveAlertListComponent extends PrometheusListHelper implements On
     this.prometheusAlertService.getGroupedAlerts(true);
     this.route.queryParams.subscribe((params) => {
       const severity = params['severity'];
-      this.filters[1].filterInitValue = SeverityMap[severity];
+      if (severity && SeverityMap[severity]) {
+        this.filters[1].filterInitValue = SeverityMap[severity];
+      }
+      const filterType = params['filterType'];
+      if (filterType && StorageTypeMap[filterType]) {
+        this.filters[2].filterInitValue = StorageTypeMap[filterType];
+      }
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/alerts-card/overview-alerts-card.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/alerts-card/overview-alerts-card.component.html
@@ -6,12 +6,21 @@
         class="cds--type-heading-compact-02"
         i18n
       >
-        System alerts
+        @if (filterType === 'block') {
+          Block alerts
+        } @else if (filterType === 'file') {
+          File alerts
+        } @else if (filterType === 'object') {
+          Object alerts
+        } @else {
+          System alerts
+        }
       </h2>
       <button
         cdsButton="ghost"
         size="sm"
         [routerLink]="['/monitoring/active-alerts']"
+        [queryParams]="filterType !== 'all' ? { filterType: filterType } : {}"
         type="button"
         i18n
       >
@@ -46,7 +55,11 @@
                 <a
                   cdsLink
                   [routerLink]="['/monitoring/active-alerts']"
-                  [queryParams]="{ severity: b.key }"
+                  [queryParams]="
+                    filterType !== 'all'
+                      ? { severity: b.key, filterType: filterType }
+                      : { severity: b.key }
+                  "
                 >
                   <cd-icon [type]="b.icon"></cd-icon>
                   <span class="cds-ml-3">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/alerts-card/overview-alerts-card.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/alerts-card/overview-alerts-card.component.spec.ts
@@ -8,20 +8,26 @@ import { provideRouter, RouterModule } from '@angular/router';
 import { take } from 'rxjs/operators';
 
 class MockPrometheusAlertService {
-  private totalSub = new BehaviorSubject<number>(0);
-  private criticalSub = new BehaviorSubject<number>(0);
-  private warningSub = new BehaviorSubject<number>(0);
-
-  totalAlerts$ = this.totalSub.asObservable();
-  criticalAlerts$ = this.criticalSub.asObservable();
-  warningAlerts$ = this.warningSub.asObservable();
+  private alertsSub = new BehaviorSubject<any[]>([]);
+  alerts$ = this.alertsSub.asObservable();
 
   getGroupedAlerts = jest.fn();
 
   emitCounts(total: number, critical: number, warning: number) {
-    this.totalSub.next(total);
-    this.criticalSub.next(critical);
-    this.warningSub.next(warning);
+    const alerts = [];
+    for (let i = 0; i < critical; i++) {
+      alerts.push({
+        status: { state: 'active' },
+        labels: { severity: 'critical', alertname: 'CephOSDDown' }
+      });
+    }
+    for (let i = 0; i < warning; i++) {
+      alerts.push({
+        status: { state: 'active' },
+        labels: { severity: 'warning', alertname: 'CephRbdMirroringSlow' }
+      });
+    }
+    this.alertsSub.next(alerts);
   }
 }
 
@@ -97,7 +103,7 @@ describe('OverviewAlertsCardComponent', () => {
 
     expect(vm.total).toBe(3);
     expect(vm.icon).toBe('warning');
-    expect(vm.statusText).toBe('Need attention');
+    expect(vm.statusText).toBe('Warning');
 
     expect(vm.badges).toEqual([{ key: 'warning', icon: 'warning', count: 3 }]);
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/alerts-card/overview-alerts-card.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/alerts-card/overview-alerts-card.component.spec.ts
@@ -8,20 +8,26 @@ import { provideRouter, RouterModule } from '@angular/router';
 import { take } from 'rxjs/operators';
 
 class MockPrometheusAlertService {
-  private totalSub = new BehaviorSubject<number>(0);
-  private criticalSub = new BehaviorSubject<number>(0);
-  private warningSub = new BehaviorSubject<number>(0);
-
-  totalAlerts$ = this.totalSub.asObservable();
-  criticalAlerts$ = this.criticalSub.asObservable();
-  warningAlerts$ = this.warningSub.asObservable();
+  private alertsSub = new BehaviorSubject<any[]>([]);
+  alerts$ = this.alertsSub.asObservable();
 
   getGroupedAlerts = jest.fn();
 
-  emitCounts(total: number, critical: number, warning: number) {
-    this.totalSub.next(total);
-    this.criticalSub.next(critical);
-    this.warningSub.next(warning);
+  emitCounts(_total: number, critical: number, warning: number) {
+    const alerts = [];
+    for (let i = 0; i < critical; i++) {
+      alerts.push({
+        status: { state: 'active' },
+        labels: { severity: 'critical', alertname: 'CephOSDDown' }
+      });
+    }
+    for (let i = 0; i < warning; i++) {
+      alerts.push({
+        status: { state: 'active' },
+        labels: { severity: 'warning', alertname: 'CephRbdMirroringSlow' }
+      });
+    }
+    this.alertsSub.next(alerts);
   }
 }
 
@@ -97,7 +103,7 @@ describe('OverviewAlertsCardComponent', () => {
 
     expect(vm.total).toBe(3);
     expect(vm.icon).toBe('warning');
-    expect(vm.statusText).toBe('Need attention');
+    expect(vm.statusText).toBe('Warning');
 
     expect(vm.badges).toEqual([{ key: 'warning', icon: 'warning', count: 3 }]);
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/alerts-card/overview-alerts-card.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/alerts-card/overview-alerts-card.component.ts
@@ -6,9 +6,6 @@ import {
   ViewEncapsulation,
   inject
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { combineLatest } from 'rxjs';
-
 import { PrometheusAlertService } from '~/app/shared/services/prometheus-alert.service';
 import {
   ButtonModule,
@@ -20,9 +17,10 @@ import {
 } from 'carbon-components-angular';
 import { RouterModule } from '@angular/router';
 import { ProductiveCardComponent } from '~/app/shared/components/productive-card/productive-card.component';
-import { ComponentsModule } from '~/app/shared/components/components.module';
+import { CommonModule } from '@angular/common';
 import { map, shareReplay, startWith } from 'rxjs/operators';
 import { PipesModule } from '~/app/shared/pipes/pipes.module';
+import { IconComponent } from '~/app/shared/components/icon/icon.component';
 
 const AlertIcon = {
   error: 'error',
@@ -37,7 +35,7 @@ const AlertIcon = {
     CommonModule,
     GridModule,
     TilesModule,
-    ComponentsModule,
+    IconComponent,
     RouterModule,
     ProductiveCardComponent,
     ButtonModule,
@@ -53,29 +51,58 @@ const AlertIcon = {
 })
 export class OverviewAlertsCardComponent implements OnInit {
   @Input() compact = true;
+  @Input() filterType: 'block' | 'file' | 'object' | 'all' = 'all';
   private readonly prometheusAlertService = inject(PrometheusAlertService);
 
   ngOnInit(): void {
     this.prometheusAlertService.getGroupedAlerts(true);
   }
 
-  readonly vm$ = combineLatest([
-    this.prometheusAlertService.criticalAlerts$.pipe(startWith(0)),
-    this.prometheusAlertService.warningAlerts$.pipe(startWith(0))
-  ]).pipe(
-    map(([critical, warning]) => {
-      const total = (critical ?? 0) + (warning ?? 0);
-      const hasAlerts = total > 0;
+  readonly vm$ = this.prometheusAlertService.alerts$.pipe(
+    startWith([]),
+    map((alerts) => {
+      const filtered = (alerts || []).filter((alert) => {
+        if (alert.status?.state !== 'active') return false;
+        if (this.filterType === 'all') return true;
+        const name = (alert.labels?.alertname || '').toLowerCase();
+        if (this.filterType === 'block') {
+          // Block storage includes RBD, NVMe-oF, iSCSI, TCMU, and OSD errors
+          return (
+            name.includes('rbd') ||
+            name.includes('nvme') ||
+            name.includes('iscsi') ||
+            name.includes('tcmu') ||
+            name.includes('osd')
+          );
+        }
+        if (this.filterType === 'file') {
+          // File storage includes CephFS and MDS (Metadata Servers)
+          return name.includes('cephfs') || name.includes('mds') || name.includes('filesystem');
+        }
+        if (this.filterType === 'object') {
+          // Object storage includes RGW (RADOS Gateway) and Multisite sync
+          return name.includes('rgw') || name.includes('multisite') || name.includes('bucket');
+        }
+        return true;
+      });
+
+      const critical = filtered.filter((alert) => alert.labels?.severity === 'critical').length;
+      const warning = filtered.filter((alert) => alert.labels?.severity === 'warning').length;
+      const total = critical + warning;
       const hasCritical = critical > 0;
       const hasWarning = warning > 0;
 
-      const icon = !hasAlerts
-        ? AlertIcon.success
-        : hasCritical
-          ? AlertIcon.error
-          : AlertIcon.warning;
+      const icon = hasCritical
+        ? AlertIcon.error
+        : hasWarning
+          ? AlertIcon.warning
+          : AlertIcon.success;
 
-      const statusText = hasAlerts ? $localize`Need attention` : $localize`No active alerts`;
+      const statusText = hasCritical
+        ? $localize`Need attention`
+        : hasWarning
+          ? $localize`Warning`
+          : $localize`No active alerts`;
 
       const badges = [
         hasCritical && { key: 'critical', icon: AlertIcon.error, count: critical },

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-overview-dashboard/rgw-overview-dashboard.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-overview-dashboard/rgw-overview-dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, Optional } from '@angular/core';
 
 import _ from 'lodash';
 import { Observable, ReplaySubject, Subject, Subscription, combineLatest, of } from 'rxjs';
@@ -12,8 +12,8 @@ import { RgwZoneService } from '~/app/shared/api/rgw-zone.service';
 import { RgwZonegroupService } from '~/app/shared/api/rgw-zonegroup.service';
 import { RgwBucketService } from '~/app/shared/api/rgw-bucket.service';
 import { PrometheusService } from '~/app/shared/api/prometheus.service';
+import { PoolService } from '~/app/shared/api/pool.service';
 
-import { RgwPromqls as queries } from '~/app/shared/enum/dashboard-promqls.enum';
 import { Icons } from '~/app/shared/enum/icons.enum';
 import { RgwMultisiteService } from '~/app/shared/api/rgw-multisite.service';
 import { ChartPoint } from '~/app/shared/models/area-chart-point';
@@ -21,6 +21,8 @@ import { catchError, shareReplay, switchMap, takeUntil, tap } from 'rxjs/operato
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { PerformanceCardService } from '~/app/shared/api/performance-card.service';
+import { PerformanceData, StorageType } from '~/app/shared/models/performance-data';
+import { OverviewField } from '~/app/shared/components/resource-overview-card/resource-overview-card.component';
 
 @Component({
   selector: 'cd-rgw-overview-dashboard',
@@ -41,7 +43,19 @@ export class RgwOverviewDashboardComponent implements OnInit, OnDestroy {
   objectCount = 0;
   UserCount = 0;
   totalPoolUsedBytes = 0;
+  rawUsedBytes = 0;
+  usableFreeBytes = 0;
   averageObjectSize = 0;
+  topBuckets: any[] = [];
+  topUsers: { owner: string; bucketCount: number; totalSize: number }[] = [];
+
+  // Interactive Popover Breakdown State
+  isTopConsumersOpen = false;
+  selectedBreakdown = 'bucket';
+  breakdownOptions = [
+    { label: 'By Bucket', value: 'bucket' },
+    { label: 'By User', value: 'user' }
+  ];
   realmData: any;
   realmSub: Subscription;
   multisiteInfo: object[] = [];
@@ -69,6 +83,7 @@ export class RgwOverviewDashboardComponent implements OnInit, OnDestroy {
   multisiteSyncStatus$: Observable<any>;
   subject = new ReplaySubject<any>();
   fetchDataSub: Subscription;
+  poolSub: Subscription;
   private destroy$ = new Subject<void>();
 
   constructor(
@@ -82,7 +97,8 @@ export class RgwOverviewDashboardComponent implements OnInit, OnDestroy {
     private prometheusService: PrometheusService,
     private rgwMultisiteService: RgwMultisiteService,
     private notificationService: NotificationService,
-    private performanceCardService: PerformanceCardService
+    private performanceCardService: PerformanceCardService,
+    @Optional() private poolService?: PoolService
   ) {
     this.permissions = this.authStorageService.getPermissions();
   }
@@ -106,6 +122,33 @@ export class RgwOverviewDashboardComponent implements OnInit, OnDestroy {
       });
       this.getSyncStatus();
     });
+
+    if (this.poolService) {
+      this.poolSub = this.poolService
+        .getList()
+        .pipe(
+          catchError(() => of([])),
+          takeUntil(this.destroy$)
+        )
+        .subscribe((pools: any[]) => {
+          const rgwPools = pools.filter(
+            (p) => p.application_metadata && p.application_metadata.includes('rgw')
+          );
+          let avail = 0;
+          let rawUsed = 0;
+          const targetPools = rgwPools.length > 0 ? rgwPools : pools;
+          targetPools.forEach((p) => {
+            const poolAvail = p.stats?.max_avail?.latest || 0;
+            if (poolAvail > avail) {
+              avail = poolAvail;
+            }
+            rawUsed += p.stats?.bytes_used?.latest || 0;
+          });
+          this.rawUsedBytes = rawUsed;
+          this.usableFreeBytes = avail;
+        });
+    }
+
     this.realmSub = this.rgwRealmService.list().subscribe((data: any) => {
       this.rgwRealmCount = data['realms'].length || 0;
     });
@@ -116,6 +159,35 @@ export class RgwOverviewDashboardComponent implements OnInit, OnDestroy {
       this.rgwZoneCount = data['zones'].length;
     });
     this.getPrometheusData(this.prometheusService.lastHourDateObject);
+
+    // Subscribe to buckets$ to get Top 5 Buckets and Top 5 Users by size
+    this.rgwBucketService.buckets$?.pipe(takeUntil(this.destroy$)).subscribe((buckets: any[]) => {
+      if (buckets && buckets.length > 0) {
+        this.topBuckets = [...buckets]
+          .sort((a, b) => (b.bucket_size || 0) - (a.bucket_size || 0))
+          .slice(0, 5);
+
+        // Group by owner for Top Users
+        const userMap = new Map<
+          string,
+          { owner: string; bucketCount: number; totalSize: number }
+        >();
+        buckets.forEach((b: any) => {
+          const owner = b.owner || 'Unknown';
+          const size = b.bucket_size || 0;
+          if (!userMap.has(owner)) {
+            userMap.set(owner, { owner, bucketCount: 1, totalSize: size });
+          } else {
+            const existing = userMap.get(owner)!;
+            existing.bucketCount += 1;
+            existing.totalSize += size;
+          }
+        });
+        this.topUsers = Array.from(userMap.values())
+          .sort((a, b) => b.totalSize - a.totalSize)
+          .slice(0, 5);
+      }
+    });
     this.multisiteSyncStatus$ = this.subject.pipe(
       switchMap(() =>
         this.rgwMultisiteService.getSyncStatus().pipe(
@@ -153,30 +225,104 @@ export class RgwOverviewDashboardComponent implements OnInit, OnDestroy {
     this.ZonegroupSub?.unsubscribe();
     this.ZoneSUb?.unsubscribe();
     this.fetchDataSub?.unsubscribe();
+    this.poolSub?.unsubscribe();
     this.destroy$.next();
     this.destroy$.complete();
     this.prometheusService?.unsubscribe();
   }
 
   getPrometheusData(selectedTime: any) {
-    this.prometheusService
-      .getRangeQueriesData(selectedTime, queries, true)
+    this.performanceCardService
+      .getChartData(selectedTime, StorageType.Object)
       .pipe(takeUntil(this.destroy$))
-      .subscribe((results) => {
-        this.queriesResults = results;
-        this.requestsChartData = this.performanceCardService.toSeries(
-          results?.RGW_REQUEST_PER_SECOND || [],
-          $localize`Requests/sec`
-        );
-        this.latencyChartData = this.performanceCardService.mergeSeries(
-          this.performanceCardService.toSeries(results?.AVG_GET_LATENCY || [], 'GET'),
-          this.performanceCardService.toSeries(results?.AVG_PUT_LATENCY || [], 'PUT')
-        );
-        this.bandwidthChartData = this.performanceCardService.mergeSeries(
-          this.performanceCardService.toSeries(results?.GET_BANDWIDTH || [], 'GET'),
-          this.performanceCardService.toSeries(results?.PUT_BANDWIDTH || [], 'PUT')
-        );
+      .subscribe((data: PerformanceData) => {
+        if (data) {
+          this.requestsChartData = data.iops || [];
+          this.latencyChartData = data.latency || [];
+          this.bandwidthChartData = data.throughput || [];
+        }
       });
+  }
+
+  toggleTopConsumersPopover(): void {
+    this.isTopConsumersOpen = !this.isTopConsumersOpen;
+  }
+
+  get usagePercentNumber(): number {
+    const logicalTotal = this.totalPoolUsedBytes + this.usableFreeBytes;
+    if (logicalTotal > 0) {
+      return (this.totalPoolUsedBytes / logicalTotal) * 100;
+    }
+    return 0;
+  }
+
+  get logicalTotalBytes(): number {
+    return this.totalPoolUsedBytes + this.usableFreeBytes;
+  }
+
+  get popoverItems(): { name: string; subtext?: string; value: number }[] {
+    if (this.selectedBreakdown === 'user') {
+      return this.topUsers.map((u) => ({
+        name: u.owner,
+        subtext: `${u.bucketCount} buckets`,
+        value: u.totalSize
+      }));
+    }
+    return this.topBuckets.map((b) => ({
+      name: b.bid,
+      subtext: b.owner,
+      value: b.bucket_size || 0
+    }));
+  }
+
+  get popoverRoute(): string {
+    return this.selectedBreakdown === 'user' ? '/rgw/user' : '/rgw/bucket';
+  }
+
+  get overviewFields(): OverviewField[] {
+    return [
+      {
+        label: $localize`Gateway`,
+        value: this.rgwDaemonCount,
+        type: 'text',
+        routerLink: '/rgw/daemon'
+      },
+      {
+        label: $localize`Realm`,
+        value: this.rgwRealmCount,
+        type: 'text',
+        routerLink: '/rgw/multisite'
+      },
+      {
+        label: $localize`Zonegroup`,
+        value: this.rgwZonegroupCount,
+        type: 'text',
+        routerLink: '/rgw/multisite'
+      },
+      {
+        label: $localize`Zone`,
+        value: this.rgwZoneCount,
+        type: 'text',
+        routerLink: '/rgw/multisite'
+      },
+      {
+        label: $localize`Bucket`,
+        value: this.rgwBucketCount,
+        type: 'text',
+        routerLink: '/rgw/bucket'
+      },
+      {
+        label: $localize`User`,
+        value: this.UserCount,
+        type: 'text',
+        routerLink: '/rgw/user'
+      },
+      {
+        label: $localize`Objects`,
+        value: this.objectCount,
+        type: 'text'
+      }
+    ];
   }
 
   getSyncStatus() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
@@ -93,7 +93,9 @@ import {
   LayoutModule,
   SkeletonModule,
   TilesModule,
-  ContentSwitcherModule
+  ContentSwitcherModule,
+  PopoverModule,
+  LayerModule
 } from 'carbon-components-angular';
 import EditIcon from '@carbon/icons/es/edit/16';
 import ScalesIcon from '@carbon/icons/es/scales/20';
@@ -134,6 +136,7 @@ import { RgwTopicFormComponent } from './rgw-topic-form/rgw-topic-form.component
 import { RgwBucketNotificationListComponent } from './rgw-bucket-notification-list/rgw-bucket-notification-list.component';
 import { RgwNotificationFormComponent } from './rgw-notification-form/rgw-notification-form.component';
 import { ComponentsModule } from '~/app/shared/components/components.module';
+import { OverviewAlertsCardComponent } from '../overview/alerts-card/overview-alerts-card.component';
 import { RgwAccountRolesListComponent } from './rgw-account-roles-list/rgw-account-roles-list.component';
 import { RgwAccountRoleFormComponent } from './rgw-account-role-form/rgw-account-role-form.component';
 import { RgwBucketResourceSidebarComponent } from './rgw-bucket-resource-sidebar/rgw-bucket-resource-sidebar.component';
@@ -185,7 +188,10 @@ import { RgwBucketTagsTableComponent } from './rgw-bucket-tags-table/rgw-bucket-
     TimePickerComponent,
     AreaChartComponent,
     ComponentsModule,
-    ContentSwitcherModule
+    ContentSwitcherModule,
+    PopoverModule,
+    OverviewAlertsCardComponent,
+    LayerModule
   ],
   exports: [
     RgwDaemonResourcePageComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/workbench-layout/workbench-layout.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/workbench-layout/workbench-layout.component.html
@@ -6,8 +6,7 @@
         overview:
           router.url == '/overview' ||
           router.url == '/dashboard_3' ||
-          router.url == '/multi-cluster/overview',
-        'rgw-dashboard': router.url == '/rgw/overview'
+          router.url == '/multi-cluster/overview'
       }"
     >
       <!-- ************************ -->
@@ -19,8 +18,7 @@
           'ms-4 me-4':
             router.url == '/overview' ||
             router.url == '/dashboard_3' ||
-            router.url == '/multi-cluster/overview' ||
-            router.url == '/rgw/overview'
+            router.url == '/multi-cluster/overview'
         }"
       >
         @if (enabledFeature$ | async; as features) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/workbench-layout/workbench-layout.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/workbench-layout/workbench-layout.component.scss
@@ -1,7 +1,6 @@
 @use './src/styles/vendor/variables' as vv;
 
-.overview,
-.rgw-dashboard {
+.overview {
   margin: 0;
   padding: 0;
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -245,6 +245,15 @@
             size="20"
           ></svg>
           <cds-sidenav-item
+            route="/block/overview"
+            [useRouter]="true"
+            title="Overview"
+            i18n-title
+            *ngIf="permissions.rbdImage.read && enabledFeature.rbd"
+            class="tc_submenuitem tc_submenuitem_block_overview"
+            ><span i18n>Overview</span></cds-sidenav-item
+          >
+          <cds-sidenav-item
             route="/block/rbd"
             [useRouter]="true"
             title="Images"
@@ -397,6 +406,15 @@
             icon
             size="20"
           ></svg>
+          <cds-sidenav-item
+            route="/cephfs/overview"
+            [useRouter]="true"
+            title="Overview"
+            i18n-title
+            *ngIf="permissions.cephfs.read && enabledFeature.cephfs"
+            class="tc_submenuitem tc_submenuitem_file_cephfs"
+            ><span i18n>Overview</span></cds-sidenav-item
+          >
           <cds-sidenav-item
             route="/cephfs/fs"
             [useRouter]="true"

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -249,6 +249,15 @@
             size="20"
           ></svg>
           <cds-sidenav-item
+            route="/block/overview"
+            [useRouter]="true"
+            title="Overview"
+            i18n-title
+            *ngIf="permissions.rbdImage.read && enabledFeature.rbd"
+            class="tc_submenuitem tc_submenuitem_block_overview"
+            ><span i18n>Overview</span></cds-sidenav-item
+          >
+          <cds-sidenav-item
             route="/block/rbd"
             [useRouter]="true"
             title="Images"
@@ -401,6 +410,15 @@
             icon
             size="20"
           ></svg>
+          <cds-sidenav-item
+            route="/cephfs/overview"
+            [useRouter]="true"
+            title="Overview"
+            i18n-title
+            *ngIf="permissions.cephfs.read && enabledFeature.cephfs"
+            class="tc_submenuitem tc_submenuitem_file_cephfs"
+            ><span i18n>Overview</span></cds-sidenav-item
+          >
           <cds-sidenav-item
             route="/cephfs/fs"
             [useRouter]="true"

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.spec.ts
@@ -241,6 +241,7 @@ describe('NavigationComponent', () => {
         '.tc_submenuitem_admin_upgrade': 'Upgrade',
         '.tc_submenuitem_observe_log': 'Logs',
         '.tc_submenuitem_observe_monitoring': 'Alerts',
+        '.tc_submenuitem_block_overview': 'Overview',
         '.tc_submenuitem_block_images': 'Images',
         '.tc_submenuitem_block_mirroring': 'Mirroring',
         '.tc_submenuitem_block_iscsi': 'iSCSI',

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-card.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-card.service.ts
@@ -1,7 +1,11 @@
 import { inject, Injectable } from '@angular/core';
 import { PrometheusService } from './prometheus.service';
-import { PerformanceData } from '../models/performance-data';
-import { AllStoragetypesQueries } from '../enum/dashboard-promqls.enum';
+import { PerformanceData, StorageType } from '../models/performance-data';
+import {
+  BlockStorageQueries,
+  FilesystemStorageQueries,
+  ObjectStorageQueries
+} from '../enum/dashboard-promqls.enum';
 import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 import { ChartPoint } from '../models/area-chart-point';
@@ -12,8 +16,18 @@ import { ChartPoint } from '../models/area-chart-point';
 export class PerformanceCardService {
   private prometheusService = inject(PrometheusService);
 
-  getChartData(time: { start: number; end: number; step: number }): Observable<PerformanceData> {
-    return this.prometheusService.getRangeQueriesData(time, AllStoragetypesQueries, true).pipe(
+  getChartData(
+    time: { start: number; end: number; step: number },
+    storageType: StorageType = StorageType.Block
+  ): Observable<PerformanceData> {
+    const queries =
+      storageType === StorageType.Filesystem
+        ? FilesystemStorageQueries
+        : storageType === StorageType.Object
+          ? ObjectStorageQueries
+          : BlockStorageQueries;
+
+    return this.prometheusService.getRangeQueriesData(time, queries, true).pipe(
       map((raw) => {
         const chartData = this.convertPerformanceData(raw);
 
@@ -24,7 +38,12 @@ export class PerformanceCardService {
 
           latency: chartData.latency.length
             ? chartData.latency
-            : [{ timestamp: new Date(), values: { 'Read Latency': 0, 'Write Latency': 0 } }],
+            : [
+                {
+                  timestamp: new Date(),
+                  values: { 'p99 Latency': 0, 'p95 Latency': 0, 'Median Latency': 0 }
+                }
+              ],
 
           throughput: chartData.throughput.length
             ? chartData.throughput
@@ -35,15 +54,24 @@ export class PerformanceCardService {
   }
 
   convertPerformanceData(raw: any): PerformanceData {
+    const hasPercentileLatency = raw?.LATENCYP99 || raw?.LATENCYP95 || raw?.LATENCYMEDIAN;
+    const latencySeries = hasPercentileLatency
+      ? this.mergeSeries(
+          this.toSeries(raw?.LATENCYP99 || [], 'p99 Latency'),
+          this.toSeries(raw?.LATENCYP95 || [], 'p95 Latency'),
+          this.toSeries(raw?.LATENCYMEDIAN || [], 'Median Latency')
+        )
+      : this.mergeSeries(
+          this.toSeries(raw?.READLATENCY || [], 'Read Latency'),
+          this.toSeries(raw?.WRITELATENCY || [], 'Write Latency')
+        );
+
     return {
       iops: this.mergeSeries(
         this.toSeries(raw?.READIOPS || [], 'Read IOPS'),
         this.toSeries(raw?.WRITEIOPS || [], 'Write IOPS')
       ),
-      latency: this.mergeSeries(
-        this.toSeries(raw?.READLATENCY || [], 'Read Latency'),
-        this.toSeries(raw?.WRITELATENCY || [], 'Write Latency')
-      ),
+      latency: latencySeries,
       throughput: this.mergeSeries(
         this.toSeries(raw?.READCLIENTTHROUGHPUT || [], 'Read Throughput'),
         this.toSeries(raw?.WRITECLIENTTHROUGHPUT || [], 'Write Throughput')

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
@@ -188,7 +188,8 @@ import { OverviewComponent } from './resource-overview-card/resource-overview-ca
     LinkModule,
     LayerModule,
     ThemeModule,
-    ProductiveCardComponent
+    ProductiveCardComponent,
+    IconComponent
   ],
   declarations: [
     SparklineComponent,
@@ -229,7 +230,6 @@ import { OverviewComponent } from './resource-overview-card/resource-overview-ca
     FormAdvancedFieldsetComponent,
     ProgressComponent,
     SidePanelComponent,
-    IconComponent,
     InlineMessageComponent,
     DetailsCardComponent,
     ToastComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
@@ -197,7 +197,8 @@ import { OverviewComponent } from './resource-overview-card/resource-overview-ca
     ProductiveCardComponent,
     MenuButtonModule,
     ContextMenuModule,
-    BreadcrumbModule
+    BreadcrumbModule,
+    IconComponent
   ],
   declarations: [
     SparklineComponent,
@@ -239,7 +240,6 @@ import { OverviewComponent } from './resource-overview-card/resource-overview-ca
     FormAdvancedFieldsetComponent,
     ProgressComponent,
     SidePanelComponent,
-    IconComponent,
     InlineMessageComponent,
     DetailsCardComponent,
     ToastComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/donut-chart/donut-chart.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/donut-chart/donut-chart.component.html
@@ -1,0 +1,6 @@
+<ibm-donut-chart
+  *ngIf="chartData && chartOptions"
+  [data]="chartData"
+  [options]="chartOptions"
+>
+</ibm-donut-chart>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/donut-chart/donut-chart.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/donut-chart/donut-chart.component.ts
@@ -1,0 +1,63 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input, OnChanges, SimpleChanges, ChangeDetectionStrategy } from '@angular/core';
+import { DonutChartOptions, ChartTabularData, ChartsModule } from '@carbon/charts-angular';
+
+@Component({
+  selector: 'cd-donut-chart',
+  templateUrl: './donut-chart.component.html',
+  styleUrls: ['./donut-chart.component.scss'],
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ChartsModule, CommonModule]
+})
+export class DonutChartComponent implements OnChanges {
+  @Input() data!: { group: string; value: number }[];
+  @Input() title: string = '';
+  @Input() legendPosition: 'top' | 'bottom' | 'left' | 'right' = 'bottom';
+  @Input() height: string = '280px';
+  @Input() centerTitle: string = '';
+  @Input() centerNumber: number = 0;
+  @Input() numberFormatter?: (value: number) => string;
+
+  chartData: ChartTabularData = [];
+  chartOptions!: DonutChartOptions;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['data'] && this.data) {
+      this.prepareData();
+      this.prepareOptions();
+    }
+  }
+
+  private prepareData(): void {
+    this.chartData = this.data.map((d) => ({
+      group: d.group,
+      value: d.value
+    }));
+  }
+
+  private prepareOptions(): void {
+    this.chartOptions = {
+      title: this.title,
+      height: this.height,
+      legend: {
+        position: this.legendPosition
+      },
+      toolbar: {
+        enabled: true
+      },
+      pie: {
+        labels: {
+          enabled: false
+        }
+      },
+      donut: {
+        center: {
+          label: this.centerTitle,
+          number: this.centerNumber,
+          ...(this.numberFormatter && { numberFormatter: this.numberFormatter })
+        }
+      }
+    };
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.ts
@@ -6,13 +6,16 @@ import {
   SimpleChanges,
   ViewEncapsulation
 } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IconModule } from 'carbon-components-angular';
 import { ICON_TYPE, Icons, IconSize } from '../../enum/icons.enum';
 
 @Component({
   selector: 'cd-icon',
   templateUrl: './icon.component.html',
   styleUrl: './icon.component.scss',
-  standalone: false,
+  standalone: true,
+  imports: [CommonModule, IconModule],
   encapsulation: ViewEncapsulation.None
 })
 export class IconComponent implements OnInit, OnChanges {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/resource-overview-card/resource-overview-card.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/resource-overview-card/resource-overview-card.component.html
@@ -23,12 +23,37 @@
 
           @if (field.type === 'status') {
             @let statusMeta = field.status | overviewStatus;
-            <span class="cd-overview-status">
-              <cd-icon [type]="statusMeta.icon"></cd-icon>
-              <span [class]="'cds--type-body-compact-01 ' + statusMeta.textClass">
-                {{ field.value | empty: field.emptyText }}
+            @if (field.routerLink) {
+              <a
+                [routerLink]="field.routerLink"
+                class="cd-overview-status"
+              >
+                <cd-icon [type]="statusMeta.icon"></cd-icon>
+                <span [class]="'cds--type-body-compact-01 ' + statusMeta.textClass">
+                  {{ field.value | empty: field.emptyText }}
+                </span>
+              </a>
+            } @else if (field.action) {
+              <a
+                (click)="field.action()"
+                (keyup.enter)="field.action()"
+                tabindex="0"
+                class="cd-overview-status"
+                style="cursor: pointer; text-decoration: none"
+              >
+                <cd-icon [type]="statusMeta.icon"></cd-icon>
+                <span [class]="'cds--type-body-compact-01 ' + statusMeta.textClass">
+                  {{ field.value | empty: field.emptyText }}
+                </span>
+              </a>
+            } @else {
+              <span class="cd-overview-status">
+                <cd-icon [type]="statusMeta.icon"></cd-icon>
+                <span [class]="'cds--type-body-compact-01 ' + statusMeta.textClass">
+                  {{ field.value | empty: field.emptyText }}
+                </span>
               </span>
-            </span>
+            }
           } @else if (field.type === 'tags') {
             <div class="cd-overview-tags">
               @for (value of field.values; track $index) {
@@ -39,7 +64,11 @@
             </div>
           } @else {
             <span class="cds--type-body-compact-01 cd-overview-value">
-              {{ field.value | empty: field.emptyText }}
+              @if (field.routerLink) {
+                <a [routerLink]="field.routerLink">{{ field.value | empty: field.emptyText }}</a>
+              } @else {
+                {{ field.value | empty: field.emptyText }}
+              }
             </span>
           }
         </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/resource-overview-card/resource-overview-card.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/resource-overview-card/resource-overview-card.component.scss
@@ -11,6 +11,8 @@
 }
 
 .cd-overview-grid {
+  display: flex !important;
+  flex-wrap: wrap;
   row-gap: layout.$spacing-05;
   column-gap: layout.$spacing-05;
 }
@@ -21,6 +23,8 @@
 
 .cd-overview-item {
   min-width: 0;
+  flex: 1 1 0%;
+  max-width: none !important;
 }
 
 .cd-overview-label {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/resource-overview-card/resource-overview-card.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/resource-overview-card/resource-overview-card.component.scss
@@ -11,12 +11,16 @@
 }
 
 .cd-overview-grid {
+  display: flex !important;
+  flex-wrap: wrap;
   row-gap: layout.$spacing-05;
   column-gap: layout.$spacing-05;
 }
 
 .cd-overview-item {
   min-width: 0;
+  flex: 1 1 0%;
+  max-width: none !important;
 }
 
 .cd-overview-label {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/resource-overview-card/resource-overview-card.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/resource-overview-card/resource-overview-card.component.ts
@@ -15,6 +15,10 @@ export interface OverviewField {
   status?: 'success' | 'warning' | 'danger' | 'info-circle';
   /* Fallback text shown when the value is empty. */
   emptyText?: string;
+  /* Optional router link to make the value clickable. */
+  routerLink?: string;
+  /* Optional click action when clicked. */
+  action?: () => void;
 }
 
 @Component({

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/dashboard-promqls.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/dashboard-promqls.enum.ts
@@ -57,7 +57,7 @@ export enum MultiClusterPromqlsForPoolUtilization {
   POOL_THROUGHPUT_UTILIZATION = 'topk(5, (irate(ceph_pool_rd_bytes[1m]) + irate(ceph_pool_wr_bytes[1m])) * on(pool_id, cluster) group_left(instance, name) ceph_pool_metadata )'
 }
 
-export const AllStoragetypesQueries = {
+export const BlockStorageQueries = {
   READIOPS: `sum(rate(ceph_osd_op_r[1m]))`,
 
   WRITEIOPS: `sum(rate(ceph_osd_op_w[1m]))`,
@@ -66,7 +66,45 @@ export const AllStoragetypesQueries = {
 
   WRITECLIENTTHROUGHPUT: `sum(rate(ceph_osd_op_w_in_bytes[1m]))`,
 
-  READLATENCY: 'avg_over_time(ceph_osd_apply_latency_ms[1m])',
+  LATENCYP99: 'quantile(0.99, ceph_osd_apply_latency_ms)',
 
-  WRITELATENCY: 'avg_over_time(ceph_osd_commit_latency_ms[1m])'
+  LATENCYP95: 'quantile(0.95, ceph_osd_apply_latency_ms)',
+
+  LATENCYMEDIAN: 'quantile(0.50, ceph_osd_apply_latency_ms)'
 };
+
+export const FilesystemStorageQueries = {
+  READIOPS: 'sum(rate(ceph_pool_rd[1m]))',
+
+  WRITEIOPS: 'sum(rate(ceph_pool_wr[1m]))',
+
+  READCLIENTTHROUGHPUT: 'sum(rate(ceph_pool_rd_bytes[1m]))',
+
+  WRITECLIENTTHROUGHPUT: 'sum(rate(ceph_pool_wr_bytes[1m]))',
+
+  LATENCYP99: 'quantile(0.99, ceph_osd_apply_latency_ms)',
+
+  LATENCYP95: 'quantile(0.95, ceph_osd_apply_latency_ms)',
+
+  LATENCYMEDIAN: 'quantile(0.50, ceph_osd_apply_latency_ms)'
+};
+
+export const ObjectStorageQueries = {
+  READIOPS: 'sum(rate(ceph_pool_rd[1m]))',
+
+  WRITEIOPS: 'sum(rate(ceph_pool_wr[1m]))',
+
+  READCLIENTTHROUGHPUT: 'sum(rate(ceph_pool_rd_bytes[1m]))',
+
+  WRITECLIENTTHROUGHPUT: 'sum(rate(ceph_pool_wr_bytes[1m]))',
+
+  LATENCYP99:
+    '(sum(rate(ceph_rgw_op_get_obj_lat_sum[1m])) / sum(rate(ceph_rgw_op_get_obj_lat_count[1m]))) * 1000',
+
+  LATENCYP95:
+    '(sum(rate(ceph_rgw_op_put_obj_lat_sum[1m])) / sum(rate(ceph_rgw_op_put_obj_lat_count[1m]))) * 1000',
+
+  LATENCYMEDIAN: '0'
+};
+
+export const AllStoragetypesQueries = BlockStorageQueries;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.ts
@@ -20,6 +20,8 @@ export class PrometheusAlertService {
   private canAlertsBeNotified = false;
   private rulesSubject = new BehaviorSubject<PrometheusRule[]>([]);
   rules$ = this.rulesSubject.asObservable();
+  private alertsSubject = new BehaviorSubject<AlertmanagerAlert[]>([]);
+  alerts$ = this.alertsSubject.asObservable();
   alerts: AlertmanagerAlert[] = [];
   activeAlerts: number;
   activeCriticalAlerts: number;
@@ -124,6 +126,7 @@ export class PrometheusAlertService {
     this.alerts = alerts
       .reverse()
       .sort((a, b) => a.labels.severity.localeCompare(b.labels.severity));
+    this.alertsSubject.next(this.alerts);
 
     this.canAlertsBeNotified = true;
   }


### PR DESCRIPTION
mgr/dashboard: add RBD overview POC with mirroring side panel

Signed-off-by: Sagar Gopale <sagar.gopale@ibm.com>

Screencast : 
Block Storage Overview
<img width="3824" height="2094" alt="image" src="https://github.com/user-attachments/assets/06a293bf-b958-44f4-93cc-776116615906" />


File  Storage overview :
<img width="3824" height="2094" alt="image" src="https://github.com/user-attachments/assets/e011ae26-a34b-4f1d-902b-b294df46d94a" />


Object Storage Overview: 
<img width="3824" height="2094" alt="image" src="https://github.com/user-attachments/assets/f62bb1c9-ee64-483b-923a-7afa45dd0056" />

Alerts card example : 
<img width="3824" height="2094" alt="image" src="https://github.com/user-attachments/assets/6b2fa419-69f6-443c-85e0-237ff0cb5b54" />





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
