### PR TITLE
doc: standardize capitalization of NGINX following the vendor

### DIFF
--- a/doc/cephadm/services/mgmt-gateway.rst
+++ b/doc/cephadm/services/mgmt-gateway.rst
@@ -8,10 +8,10 @@ Deploying mgmt-gateway
 ======================
 
 In Ceph releases beginning with Tentacle, the ``mgmt-gateway`` service introduces a new design for Ceph applications
-based on a modular, service-based architecture. This service, managed by cephadm and built on top of nginx
+based on a modular, service-based architecture. This service, managed by cephadm and built on top of NGINX
 (an open-source, high-performance web server), acts as the new front-end and single entry point to the
 Ceph cluster. The ``mgmt-gateway`` provides unified access to all Ceph applications, including the Ceph dashboard
-and monitoring stack. Employing nginx enhances security and simplifies access management due to its robust
+and monitoring stack. Employing NGINX enhances security and simplifies access management due to its robust
 community support and high-security standards. The ``mgmt-gateway`` service acts as a reverse proxy that routes
 requests to the appropriate Ceph application instances.
 
@@ -28,10 +28,10 @@ consolidated behind the new service endpoint: ``https://<node-ip>:<port>``.
 
 Benefits of the mgmt-gateway service
 ====================================
-* ``Unified Access``: Consolidated access through nginx improves security and provides a single entry point to services.
+* ``Unified Access``: Consolidated access through NGINX improves security and provides a single entry point to services.
 * ``Improved user experience``: Users no longer need to know where each application is running (IP/host).
-* ``High Availability for dashboard``: nginx HA mechanisms are used to provide high availability for the Ceph dashboard.
-* ``High Availability for monitoring``: nginx HA mechanisms are used to provide high availability for monitoring.
+* ``High Availability for dashboard``: NGINX HA mechanisms are used to provide high availability for the Ceph dashboard.
+* ``High Availability for monitoring``: NGINX HA mechanisms are used to provide high availability for monitoring.
 
 Security enhancements
 =====================
@@ -42,7 +42,7 @@ Ceph dashboard.
 
 High availability enhancements
 ==============================
-nginx HA mechanisms are used to provide high availability for all the Ceph management applications including the Ceph dashboard
+NGINX HA mechanisms are used to provide high availability for all the Ceph management applications including the Ceph dashboard
 and monitoring stack. In case of the Ceph dashboard, users no longer need to know where the active manager is running.
 ``mgmt-gateway`` handles manager failover transparently and redirects the user to the active manager. In case of the
 monitoring ``mgmt-gateway`` takes care of handling HA when several instances of Prometheus, Alertmanager or Grafana are
@@ -58,7 +58,7 @@ even if certain core components for the service fail, including the ``mgmt-gatew
 
 Multiple ``mgmt-gateway`` instances can be deployed in an active/standby configuration using keepalived
 for seamless failover. The ``oauth2-proxy`` service can be deployed as multiple stateless instances,
-with nginx acting as a load balancer across them using a round-robin strategy. This setup removes
+with NGINX acting as a load balancer across them using a round-robin strategy. This setup removes
 single points of failure and enhances the resilience of the entire system.
 
 In this setup, the underlying internal services follow the same high availability mechanism. Instead of
@@ -188,7 +188,7 @@ Limitations
 Default images
 ~~~~~~~~~~~~~~
 
-The ``mgmt-gateway`` service internally makes use of nginx reverse proxy. The following container image is used by default:
+The ``mgmt-gateway`` service internally makes use of NGINX reverse proxy. The following container image is used by default:
 
 ::
 

--- a/doc/cephadm/services/oauth2-proxy.rst
+++ b/doc/cephadm/services/oauth2-proxy.rst
@@ -43,7 +43,7 @@ a secure and flexible authentication mechanism.
 High availability
 =================
 In general, `oauth2-proxy` is used in conjunction with the `mgmt-gateway`. The `oauth2-proxy` service can be deployed as multiple
-stateless instances, with the `mgmt-gateway` (nginx reverse-proxy) handling load balancing across these instances using a round-robin strategy.
+stateless instances, with the `mgmt-gateway` (NGINX reverse-proxy) handling load balancing across these instances using a round-robin strategy.
 Since oauth2-proxy integrates with an external identity provider (IDP), ensuring high availability for login is managed externally
 and not the responsibility of this service.
 

--- a/doc/radosgw/rgw-cache.rst
+++ b/doc/radosgw/rgw-cache.rst
@@ -8,10 +8,10 @@ RGW Data Caching and CDN
 
 .. contents::
 
-This feature adds to RGW the ability to securely cache objects and offload the workload from the cluster, using Nginx.
-After an object is accessed the first time it will be stored in the Nginx cache directory.
+This feature adds to RGW the ability to securely cache objects and offload the workload from the cluster, using NGINX.
+After an object is accessed the first time it will be stored in the NGINX cache directory.
 When data is already cached, it need not be fetched from RGW. A permission check will be made against RGW to ensure the requesting user has access.
-This feature is based on the Nginx modules ``ngx_http_auth_request_module`` and `nginx-aws-auth-module <https://github.com/kaltura/nginx-aws-auth-module>`_, and OpenResty for Lua capabilities.
+This feature is based on the NGINX modules ``ngx_http_auth_request_module`` and `nginx-aws-auth-module <https://github.com/kaltura/nginx-aws-auth-module>`_, and OpenResty for Lua capabilities.
 
 Currently this feature will cache only AWSv4 requests (only S3 requests), caching-in the output of the first GET request
 and caching-out on subsequent GET requests, passing through transparently PUT, POST, HEAD, DELETE and COPY requests.
@@ -27,9 +27,9 @@ New APIs
 There are 2 new APIs for this feature:
 
 - **Auth API:** The cache uses this to validate that a user can access the cached data.
-- **Cache API:** Adds the ability to override the ``Range`` header securely so that Nginx can use its own `smart cache <https://www.nginx.com/blog/smart-efficient-byte-range-caching-nginx/>`_ on top of S3.
+- **Cache API:** Adds the ability to override the ``Range`` header securely so that NGINX can use its own `smart cache <https://www.nginx.com/blog/smart-efficient-byte-range-caching-nginx/>`_ on top of S3.
   Using this API gives the ability to read ahead objects when client is asking a specific range from the object.
-  On subsequent accesses to the cached object, Nginx will satisfy requests for already-cached ranges from the cache. Uncached ranges will be read from RGW (and cached).
+  On subsequent accesses to the cached object, NGINX will satisfy requests for already-cached ranges from the cache. Uncached ranges will be read from RGW (and cached).
 
 Auth API
 ~~~~~~~~
@@ -58,7 +58,7 @@ If both checks succeed it will use the ``X-Amz-Cache`` to revalidate that the us
 During this flow the RGW will override the ``Range`` header.
 
 
-Using Nginx with RGW
+Using NGINX with RGW
 --------------------
 
 Download the source of OpenResty:
@@ -67,7 +67,7 @@ Download the source of OpenResty:
 
    wget https://openresty.org/download/openresty-1.15.8.3.tar.gz
 
-Use git to clone the Nginx AWS authentication module:
+Use git to clone the NGINX AWS authentication module:
 
 .. prompt:: bash $
 
@@ -90,9 +90,9 @@ Compile OpenResty, make sure that you have ``pcre`` library and ``openssl`` libr
    sudo gmake install
    sudo ln -sf /usr/local/openresty/bin/openresty /usr/bin/nginx
 
-Put in-place your Nginx configuration files and edit them according to your environment:
+Put in-place your NGINX configuration files and edit them according to your environment:
 
-Example Nginx configuration files are available at
+Example NGINX configuration files are available at
 https://github.com/ceph/ceph/tree/main/examples/rgw/rgw-cache
 
 - ``nginx.conf`` should go to ``/etc/nginx/nginx.conf``.
@@ -123,16 +123,16 @@ And modify the example ``server`` values to point to the RGWs URIs:
 
    radosgw-admin user create --uid=cacheuser --display-name="cache user" --caps="amz-cache=read" --access-key <access> --secret <secret>
 
-It is possible to use `Nginx slicing <https://docs.nginx.com/nginx/admin-guide/content-cache/content-caching/#byte-range-caching>`_ which is suitable for streaming purposes.
+It is possible to use `NGINX slicing <https://docs.nginx.com/nginx/admin-guide/content-cache/content-caching/#byte-range-caching>`_ which is suitable for streaming purposes.
 
 To enable slicing you should use ``nginx-slicing.conf`` instead of ``nginx-default.conf``.
 
 
 If you do not want to use prefetch caching, it is possible to replace ``nginx-default.conf`` with ``nginx-noprefetch.conf``.
-If prefetch caching is disabled Nginx will cache each range request separately and possible overlap in the range requests will be fetched more than once. For example, if a client is sending a range request of 0-4095 and then 0-4096 both requests are fetched completely from RGW.
+If prefetch caching is disabled NGINX will cache each range request separately and possible overlap in the range requests will be fetched more than once. For example, if a client is sending a range request of 0-4095 and then 0-4096 both requests are fetched completely from RGW.
 
 
-Run Nginx (OpenResty):
+Run NGINX (OpenResty):
 
 .. prompt:: bash #
 

--- a/doc/radosgw/troubleshooting.rst
+++ b/doc/radosgw/troubleshooting.rst
@@ -39,7 +39,7 @@ Crashed ``radosgw`` process
 ===========================
 
 If the ``radosgw`` process dies, you will normally see a 500 error
-from the web server (apache, nginx, etc.).  In that situation, simply
+from the web server (Apache, NGINX, etc.).  In that situation, simply
 restarting radosgw will restore service.
 
 To diagnose the cause of the crash, check the log in ``/var/log/ceph``

--- a/doc/releases/tentacle.rst
+++ b/doc/releases/tentacle.rst
@@ -692,14 +692,14 @@ Cephadm
 
 * A new cephadm-managed ``mgmt-gateway`` service provides a single, TLS-terminated
   entry point for Ceph management endpoints such as the Dashboard and the monitoring
-  stack. The gateway is implemented as an nginx-based reverse proxy that fronts Prometheus,
+  stack. The gateway is implemented as an NGINX-based reverse proxy that fronts Prometheus,
   Grafana, and Alertmanager, so users no longer need to connect to those daemons directly or
   know which hosts they run on. When combined with the new ``oauth2-proxy`` service, which
   integrates with external identity providers using the OpenID Connect (OIDC) / OAuth 2.0
   protocols, the gateway can enforce centralized authentication and single sign-on (SSO) for
   both the Ceph Dashboard and the rest of the monitoring stack.
 * High availability for the Ceph Dashboard and the Prometheus-based monitoring stack is now
-  provided via the cephadm-managed ``mgmt-gateway``. nginx high-availability mechanisms allow
+  provided via the cephadm-managed ``mgmt-gateway``. NGINX high-availability mechanisms allow
   the mgmt-gateway to detect healthy instances of the Dashboard, Prometheus, Grafana, and Alertmanager,
   route traffic accordingly, and handle manager failover transparently. When deployed with a virtual
   IP and multiple ``mgmt-gateway`` instances, this architecture keeps management access available


### PR DESCRIPTION
The vendor stylizes it as NGINX.  
Previously docs capitalized it as either NGINX, Nginx or nginx. nginx was the preferred capitalization before commercialization of the software.

Some controversy surrounds the capitalization of the term but I feel it's safe to follow the vendor, the IP owner.

- Original: https://docs.ceph.com/en/latest/cephadm/services/mgmt-gateway/
- Rendered PR: https://ceph--70467.org.readthedocs.build/en/70467/cephadm/services/mgmt-gateway/
- Original: https://docs.ceph.com/en/latest/cephadm/services/oauth2-proxy/#high-availability
- Rendered PR: https://ceph--70467.org.readthedocs.build/en/70467/cephadm/services/oauth2-proxy/#high-availability
- Original: https://docs.ceph.com/en/latest/radosgw/rgw-cache/
- Rendered PR: https://ceph--70467.org.readthedocs.build/en/70467/radosgw/rgw-cache/
- Original: https://docs.ceph.com/en/latest/radosgw/troubleshooting/#crashed-radosgw-process
- Rendered PR: https://ceph--70467.org.readthedocs.build/en/70467/radosgw/troubleshooting/#crashed-radosgw-process
- Original: https://docs.ceph.com/en/latest/releases/tentacle/#cephadm
- Rendered PR: https://ceph--70467.org.readthedocs.build/en/70467/releases/tentacle/#cephadm






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
