### PR TITLE
librbd: implement group image remove modes for snapshot dependencies

### DIFF
--- a/qa/workunits/rbd/rbd_groups.sh
+++ b/qa/workunits/rbd/rbd_groups.sh
@@ -73,11 +73,57 @@ add_image_to_group()
     rbd group image add $group_name $image_name
 }
 
+get_image_id()
+{
+    local image_name=$1
+    rbd info "$image_name" --format=json | jq -r '.id'
+}
+
 remove_image_from_group()
 {
     local image_name=$1
     local group_name=$2
     rbd group image remove $group_name $image_name
+}
+
+force_remove_image_from_group()
+{
+    local image_name=$1
+    local group_name=$2
+
+    rbd group image remove --force "$group_name" "$image_name"
+}
+
+purge_image_from_group()
+{
+    local image_name=$1
+    local group_name=$2
+
+    rbd group image remove --purge-user-snaps "$group_name" "$image_name"
+}
+
+purge_image_from_group_by_id()
+{
+    local image_id=$1
+    local group_name=$2
+
+    rbd group image remove --purge-user-snaps \
+                           --image-id "$image_id" "$group_name"
+}
+
+force_purge_image_from_group()
+{
+    local image_name=$1
+    local group_name=$2
+
+    rbd group image remove --force --purge-user-snaps \
+                           "$group_name" "$image_name"
+}
+
+list_image_snaps()
+{
+    local image_name=$1
+    rbd snap ls "$image_name" --all
 }
 
 check_image_in_group()
@@ -104,6 +150,22 @@ check_image_not_in_group()
         fi
     done
     return 0
+}
+
+check_image_snapshot_exists()
+{
+    local image_name=$1
+    local snap_name=$2
+
+    list_image_snaps "$image_name" | grep -w "$snap_name"
+}
+
+check_image_snapshot_not_exists()
+{
+    local image_name=$1
+    local snap_name=$2
+
+    ! check_image_snapshot_exists "$image_name" "$snap_name"
 }
 
 create_snapshot()
@@ -303,6 +365,105 @@ check_snapshots_count_in_group $group $snap 100
 remove_snapshots $group $snap 100
 remove_group $group
 remove_image $image
+echo "PASSED"
+
+echo "TEST: remove image with --force"
+group="force_group"
+image="force_image"
+snap="snap1"
+create_image "$image"
+create_group "$group"
+add_image_to_group "$image" "$group"
+create_snapshot "$group" "$snap"
+force_remove_image_from_group "$image" "$group"
+check_snapshot_in_group "$group" "$snap"
+check_image_snapshot_exists "$image" "$snap"
+check_image_not_in_group "$image" "$group"
+remove_snapshot "$group" "$snap"
+remove_group "$group"
+remove_image "$image"
+echo "PASSED"
+
+echo "TEST: purge dependent user group snapshots"
+group="purge_group"
+image="purge_image"
+snap="snap1"
+create_image "$image"
+create_group "$group"
+add_image_to_group "$image" "$group"
+create_snapshot "$group" "$snap"
+check_snapshot_in_group "$group" "$snap"
+check_image_snapshot_exists "$image" "$snap"
+purge_image_from_group "$image" "$group"
+check_snapshot_not_in_group "$group" "$snap"
+check_image_not_in_group "$image" "$group"
+check_image_snapshot_not_exists "$image" "$snap"
+remove_group "$group"
+remove_image "$image"
+echo "PASSED"
+
+echo "TEST: purge preserves unrelated snapshots"
+group="purge_group"
+img1="image1"
+img2="image2"
+create_image "$img1"
+create_image "$img2"
+create_group "$group"
+add_image_to_group "$img1" "$group"
+create_snapshot "$group" "snap1"
+add_image_to_group "$img2" "$group"
+force_remove_image_from_group "$img1" "$group"
+create_snapshot "$group" "snap2"
+purge_image_from_group "$img2" "$group"
+check_snapshot_in_group "$group" "snap1"
+check_snapshot_not_in_group "$group" "snap2"
+check_image_snapshot_exists "$img1" "snap1"
+check_image_snapshot_not_exists "$img1" "snap2"
+check_image_snapshot_not_exists "$img2" "snap2"
+check_image_not_in_group "$img2" "$group"
+check_image_not_in_group "$img1" "$group"
+remove_snapshot "$group" "snap1"
+remove_group "$group"
+remove_image "$img1"
+remove_image "$img2"
+echo "PASSED"
+
+echo "TEST: purge with image-id"
+group="purge_group"
+image="purge_image"
+snap="snap1"
+create_image "$image"
+create_group "$group"
+add_image_to_group "$image" "$group"
+create_snapshot "$group" "$snap"
+check_snapshot_in_group "$group" "$snap"
+check_image_snapshot_exists "$image" "$snap"
+image_id=$(get_image_id "$image")
+purge_image_from_group_by_id "$image_id" "$group"
+check_snapshot_not_in_group "$group" "$snap"
+check_image_not_in_group "$image" "$group"
+check_image_snapshot_not_exists "$image" "$snap"
+remove_group "$group"
+remove_image "$image"
+echo "PASSED"
+
+echo "TEST: force and purge are mutually exclusive"
+group="purge_group"
+image="purge_image"
+snap="snap1"
+create_image "$image"
+create_group "$group"
+add_image_to_group "$image" "$group"
+create_snapshot "$group" "$snap"
+! force_purge_image_from_group "$image" "$group"
+check_image_in_group "$image" "$group"
+check_snapshot_in_group "$group" "$snap"
+check_image_snapshot_exists "$image" "$snap"
+remove_snapshot "$group" "$snap"
+remove_image_from_group "$image" "$group"
+check_image_not_in_group "$image" "$group"
+remove_group "$group"
+remove_image "$image"
 echo "PASSED"
 
 echo "OK"

--- a/qa/workunits/rbd/rbd_groups.sh
+++ b/qa/workunits/rbd/rbd_groups.sh
@@ -73,11 +73,57 @@ add_image_to_group()
     rbd group image add $group_name $image_name
 }
 
+get_image_id()
+{
+    local image_name=$1
+    rbd info "$image_name" --format=json | jq -r '.id'
+}
+
 remove_image_from_group()
 {
     local image_name=$1
     local group_name=$2
     rbd group image remove $group_name $image_name
+}
+
+force_remove_image_from_group()
+{
+    local image_name=$1
+    local group_name=$2
+
+    rbd group image remove --force "$group_name" "$image_name"
+}
+
+purge_image_from_group()
+{
+    local image_name=$1
+    local group_name=$2
+
+    rbd group image remove --purge-user-snaps "$group_name" "$image_name"
+}
+
+purge_image_from_group_by_id()
+{
+    local image_id=$1
+    local group_name=$2
+
+    rbd group image remove --purge-user-snaps \
+                           --image-id "$image_id" "$group_name"
+}
+
+force_purge_image_from_group()
+{
+    local image_name=$1
+    local group_name=$2
+
+    rbd group image remove --force --purge-user-snaps \
+                           "$group_name" "$image_name"
+}
+
+list_image_snaps()
+{
+    local image_name=$1
+    rbd snap ls "$image_name" --all
 }
 
 check_image_in_group()
@@ -104,6 +150,22 @@ check_image_not_in_group()
         fi
     done
     return 0
+}
+
+check_image_snapshot_exists()
+{
+    local image_name=$1
+    local snap_name=$2
+
+    list_image_snaps "$image_name" | grep -w "$snap_name"
+}
+
+check_image_snapshot_not_exists()
+{
+    local image_name=$1
+    local snap_name=$2
+
+    ! check_image_snapshot_exists "$image_name" "$snap_name"
 }
 
 create_snapshot()
@@ -303,6 +365,150 @@ check_snapshots_count_in_group $group $snap 100
 remove_snapshots $group $snap 100
 remove_group $group
 remove_image $image
+echo "PASSED"
+
+echo "TEST: remove image with --force"
+group="force_group"
+image="force_image"
+snap="snap1"
+create_image "$image"
+create_group "$group"
+add_image_to_group "$image" "$group"
+create_snapshot "$group" "$snap"
+force_remove_image_from_group "$image" "$group"
+check_snapshot_in_group "$group" "$snap"
+check_image_snapshot_exists "$image" "$snap"
+check_image_not_in_group "$image" "$group"
+remove_snapshot "$group" "$snap"
+remove_group "$group"
+remove_image "$image"
+echo "PASSED"
+
+echo "TEST: purge dependent user group snapshots"
+group="purge_group"
+image="purge_image"
+snap="snap1"
+create_image "$image"
+create_group "$group"
+add_image_to_group "$image" "$group"
+create_snapshot "$group" "$snap"
+check_snapshot_in_group "$group" "$snap"
+check_image_snapshot_exists "$image" "$snap"
+purge_image_from_group "$image" "$group"
+check_snapshot_not_in_group "$group" "$snap"
+check_image_not_in_group "$image" "$group"
+check_image_snapshot_not_exists "$image" "$snap"
+remove_group "$group"
+remove_image "$image"
+echo "PASSED"
+
+echo "TEST: purge preserves unrelated snapshots"
+group="purge_group"
+img1="image1"
+img2="image2"
+create_image "$img1"
+create_image "$img2"
+create_group "$group"
+add_image_to_group "$img1" "$group"
+create_snapshot "$group" "snap1"
+add_image_to_group "$img2" "$group"
+force_remove_image_from_group "$img1" "$group"
+create_snapshot "$group" "snap2"
+purge_image_from_group "$img2" "$group"
+check_snapshot_in_group "$group" "snap1"
+check_snapshot_not_in_group "$group" "snap2"
+check_image_snapshot_exists "$img1" "snap1"
+check_image_snapshot_not_exists "$img1" "snap2"
+check_image_snapshot_not_exists "$img2" "snap2"
+check_image_not_in_group "$img2" "$group"
+check_image_not_in_group "$img1" "$group"
+remove_snapshot "$group" "snap1"
+remove_group "$group"
+remove_image "$img1"
+remove_image "$img2"
+echo "PASSED"
+
+echo "TEST: purge distinguishes same-named images in different pools"
+group="purge_cross_pool_group"
+image_pool="purge_cross_pool_image_pool"
+image="same_name"
+ceph osd pool create "$image_pool" 8
+rbd pool init "$image_pool"
+create_image "$image"
+create_image "$image_pool/$image"
+create_group "$group"
+add_image_to_group "$image" "$group"
+create_snapshot "$group" "snap1"
+add_image_to_group "$image_pool/$image" "$group"
+create_snapshot "$group" "snap2"
+purge_image_from_group "$image_pool/$image" "$group"
+check_snapshot_in_group "$group" "snap1"
+check_snapshot_not_in_group "$group" "snap2"
+check_image_snapshot_exists "$image" "snap1"
+check_image_snapshot_not_exists "$image" "snap2"
+check_image_snapshot_not_exists "$image_pool/$image" "snap2"
+remove_snapshot "$group" "snap1"
+remove_image_from_group "$image" "$group"
+remove_group "$group"
+remove_image "$image"
+remove_image "$image_pool/$image"
+ceph osd pool rm "$image_pool" "$image_pool" --yes-i-really-really-mean-it
+echo "PASSED"
+
+echo "TEST: purge with image-id"
+group="purge_group"
+image="purge_image"
+snap="snap1"
+create_image "$image"
+create_group "$group"
+add_image_to_group "$image" "$group"
+create_snapshot "$group" "$snap"
+check_snapshot_in_group "$group" "$snap"
+check_image_snapshot_exists "$image" "$snap"
+image_id=$(get_image_id "$image")
+purge_image_from_group_by_id "$image_id" "$group"
+check_snapshot_not_in_group "$group" "$snap"
+check_image_not_in_group "$image" "$group"
+check_image_snapshot_not_exists "$image" "$snap"
+remove_group "$group"
+remove_image "$image"
+echo "PASSED"
+
+echo "TEST: purge does not remove snapshots for a non-member image"
+group="purge_non_member_group"
+image="purge_non_member_image"
+snap="snap1"
+create_image "$image"
+create_group "$group"
+add_image_to_group "$image" "$group"
+create_snapshot "$group" "$snap"
+force_remove_image_from_group "$image" "$group"
+! purge_image_from_group "$image" "$group"
+check_snapshot_in_group "$group" "$snap"
+check_image_snapshot_exists "$image" "$snap"
+check_image_not_in_group "$image" "$group"
+remove_snapshot "$group" "$snap"
+remove_group "$group"
+remove_image "$image"
+echo "PASSED"
+
+echo "TEST: force and purge are mutually exclusive"
+group="purge_group"
+image="purge_image"
+snap="snap1"
+create_image "$image"
+create_group "$group"
+add_image_to_group "$image" "$group"
+create_snapshot "$group" "$snap"
+! force_purge_image_from_group "$image" "$group"
+check_image_in_group "$image" "$group"
+check_snapshot_in_group "$group" "$snap"
+check_image_snapshot_exists "$image" "$snap"
+remove_snapshot "$group" "$snap"
+remove_image_from_group "$image" "$group"
+check_image_not_in_group "$image" "$group"
+remove_group "$group"
+remove_image "$image"
 echo "PASSED"
 
 echo "OK"

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -515,6 +515,12 @@ typedef struct {
     size_t passphrase_size;
 } rbd_encryption_luks_format_options_t;
 
+typedef enum {
+  RBD_GROUP_IMAGE_REMOVE_DEFAULT = 0,
+  RBD_GROUP_IMAGE_REMOVE_FORCE,
+  RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS
+} rbd_group_image_remove_mode_t;
+
 CEPH_RBD_API void rbd_image_options_create(rbd_image_options_t* opts);
 CEPH_RBD_API void rbd_image_options_destroy(rbd_image_options_t opts);
 CEPH_RBD_API int rbd_image_options_set_string(rbd_image_options_t opts,
@@ -1611,10 +1617,21 @@ CEPH_RBD_API int rbd_group_image_remove(rados_ioctx_t group_p,
                                         const char *group_name,
                                         rados_ioctx_t image_p,
                                         const char *image_name);
+
 CEPH_RBD_API int rbd_group_image_remove_by_id(rados_ioctx_t group_p,
                                               const char *group_name,
                                               rados_ioctx_t image_p,
                                               const char *image_id);
+CEPH_RBD_API int rbd_group_image_remove2(rados_ioctx_t group_p,
+                                         const char *group_name,
+                                         rados_ioctx_t image_p,
+                                         const char *image_name,
+                                         rbd_group_image_remove_mode_t mode);
+CEPH_RBD_API int rbd_group_image_remove_by_id2(rados_ioctx_t group_p,
+                                               const char *group_name,
+                                               rados_ioctx_t image_p,
+                                               const char *image_id,
+                                               rbd_group_image_remove_mode_t mode);
 CEPH_RBD_API int rbd_group_image_list(rados_ioctx_t group_p,
                                       const char *group_name,
                                       rbd_group_image_info_t *images,

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -518,7 +518,6 @@ typedef struct {
 typedef enum {
   RBD_GROUP_IMAGE_REMOVE_DEFAULT = 0,
   RBD_GROUP_IMAGE_REMOVE_FORCE,
-  RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS
 } rbd_group_image_remove_mode_t;
 
 CEPH_RBD_API void rbd_image_options_create(rbd_image_options_t* opts);

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -290,6 +290,8 @@ namespace librbd {
     std::string passphrase;
   } encryption_luks_format_options_t;
 
+  typedef rbd_group_image_remove_mode_t group_image_remove_mode_t;
+
 class CEPH_RBD_API RBD
 {
 public:
@@ -500,9 +502,13 @@ public:
   int group_image_add(IoCtx& io_ctx, const char *group_name,
                       IoCtx& image_io_ctx, const char *image_name);
   int group_image_remove(IoCtx& io_ctx, const char *group_name,
-                         IoCtx& image_io_ctx, const char *image_name);
+                         IoCtx& image_io_ctx, const char *image_name,
+                         group_image_remove_mode_t mode =
+                           RBD_GROUP_IMAGE_REMOVE_DEFAULT);
   int group_image_remove_by_id(IoCtx& io_ctx, const char *group_name,
-                               IoCtx& image_io_ctx, const char *image_id);
+                               IoCtx& image_io_ctx, const char *image_id,
+                               group_image_remove_mode_t mode =
+                                 RBD_GROUP_IMAGE_REMOVE_DEFAULT);
   int group_image_list(IoCtx& io_ctx, const char *group_name,
                        std::vector<group_image_info_t> *images,
                        size_t group_image_info_size);

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -290,6 +290,8 @@ namespace librbd {
     std::string passphrase;
   } encryption_luks_format_options_t;
 
+  typedef rbd_group_image_remove_mode_t group_image_remove_mode_t;
+
 class CEPH_RBD_API RBD
 {
 public:
@@ -501,8 +503,14 @@ public:
                       IoCtx& image_io_ctx, const char *image_name);
   int group_image_remove(IoCtx& io_ctx, const char *group_name,
                          IoCtx& image_io_ctx, const char *image_name);
+  int group_image_remove(IoCtx& io_ctx, const char *group_name,
+                         IoCtx& image_io_ctx, const char *image_name,
+                         group_image_remove_mode_t mode);
   int group_image_remove_by_id(IoCtx& io_ctx, const char *group_name,
                                IoCtx& image_io_ctx, const char *image_id);
+  int group_image_remove_by_id(IoCtx& io_ctx, const char *group_name,
+                               IoCtx& image_io_ctx, const char *image_id,
+                               group_image_remove_mode_t mode);
   int group_image_list(IoCtx& io_ctx, const char *group_name,
                        std::vector<group_image_info_t> *images,
                        size_t group_image_info_size);

--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -327,58 +327,6 @@ int has_user_group_snapshot_dependency(librados::IoCtx& group_ioctx,
   return 0;
 }
 
-template <typename I>
-int purge_dependent_user_group_snapshots(librados::IoCtx& group_ioctx,
-                                         const std::string& group_id,
-                                         const std::string& image_id) {
-  CephContext* cct = reinterpret_cast<CephContext*>(group_ioctx.cct());
-
-  ldout(cct, 20) << "group_id=" << group_id
-                 << ", image_id=" << image_id << dendl;
-
-  std::vector<cls::rbd::GroupSnapshot> group_snaps;
-  int r = group_snap_list<I>(group_ioctx, group_id,
-                             false, false, &group_snaps);
-  if (r < 0) {
-    if (r == -ENOENT) {
-      return 0;
-    }
-
-    lderr(cct) << "failed to list group snapshots: "
-               << cpp_strerror(r) << dendl;
-    return r;
-  }
-
-  for (const auto& group_snap : group_snaps) {
-    // filter user group snapshots
-    if (!is_user_snapshot(group_snap)) {
-      continue;
-    }
-
-    // check whether this snapshot references the image
-    const auto it = std::find_if(group_snap.snaps.begin(),
-        group_snap.snaps.end(), [&](const auto& snap) {
-          return snap.image_id == image_id;
-        });
-    if (it == group_snap.snaps.end()) {
-      continue;
-    }
-
-    ldout(cct, 10) << "purging dependent user group snapshot "
-                   << group_snap.name << " (" << group_snap.id << ")"
-                   << dendl;
-
-    r = util::group_snap_remove(group_ioctx, group_id, group_snap);
-    if (r < 0) {
-      lderr(cct) << "failed to remove dependent user group snapshot "
-                 << group_snap.name << ": " << cpp_strerror(r) << dendl;
-      return r;
-    }
-  }
-
-  return 0;
-}
-
 } // anonymous namespace
 
 template <typename I>
@@ -1605,13 +1553,6 @@ int Group<I>::group_image_remove(librados::IoCtx& group_ioctx,
 
   int r;
   switch (mode) {
-    case RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS:
-      r = purge_dependent_user_group_snapshots<I>(group_ioctx, group_id,
-                                                  image_id);
-      if (r < 0) {
-        return r;
-      }
-      break;
     case RBD_GROUP_IMAGE_REMOVE_DEFAULT: {
       bool has_dependency = false;
       r = has_user_group_snapshot_dependency<I>(group_ioctx, group_id, image_id,

--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -298,18 +298,101 @@ bool is_user_snapshot(const cls::rbd::GroupSnapshot &group_snap) {
   return ns != nullptr;
 }
 
+template <typename I>
+int has_user_group_snapshot_dependency(librados::IoCtx& group_ioctx,
+                                       const std::string& group_id,
+                                       const std::string& image_id,
+                                       bool* has_dependency) {
+  *has_dependency = false;
+  std::vector<cls::rbd::GroupSnapshot> snaps;
+  int r = group_snap_list<I>(group_ioctx, group_id,
+                             false, false, &snaps);
+  if (r < 0 && r != -ENOENT) {
+    return r;
+  }
+
+  for (const auto& snap : snaps) {
+    if (!is_user_snapshot(snap)) {
+      continue;
+    }
+
+    for (const auto& image_snap : snap.snaps) {
+      if (image_snap.image_id == image_id) {
+        *has_dependency = true;
+        return 0;
+      }
+    }
+  }
+
+  return 0;
+}
+
+template <typename I>
+int purge_dependent_user_group_snapshots(librados::IoCtx& group_ioctx,
+                                         const std::string& group_id,
+                                         const std::string& image_id) {
+  CephContext* cct = reinterpret_cast<CephContext*>(group_ioctx.cct());
+
+  ldout(cct, 20) << "group_id=" << group_id
+                 << ", image_id=" << image_id << dendl;
+
+  std::vector<cls::rbd::GroupSnapshot> group_snaps;
+  int r = group_snap_list<I>(group_ioctx, group_id,
+                             false, false, &group_snaps);
+  if (r < 0) {
+    if (r == -ENOENT) {
+      return 0;
+    }
+
+    lderr(cct) << "failed to list group snapshots: "
+               << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  for (const auto& group_snap : group_snaps) {
+    // filter user group snapshots
+    if (!is_user_snapshot(group_snap)) {
+      continue;
+    }
+
+    // check whether this snapshot references the image
+    const auto it = std::find_if(group_snap.snaps.begin(),
+        group_snap.snaps.end(), [&](const auto& snap) {
+          return snap.image_id == image_id;
+        });
+    if (it == group_snap.snaps.end()) {
+      continue;
+    }
+
+    ldout(cct, 10) << "purging dependent user group snapshot "
+                   << group_snap.name << " (" << group_snap.id << ")"
+                   << dendl;
+
+    r = util::group_snap_remove(group_ioctx, group_id, group_snap);
+    if (r < 0) {
+      lderr(cct) << "failed to remove dependent user group snapshot "
+                 << group_snap.name << ": " << cpp_strerror(r) << dendl;
+      return r;
+    }
+  }
+
+  return 0;
+}
+
 } // anonymous namespace
 
 template <typename I>
 int Group<I>::image_remove_by_id(librados::IoCtx& group_ioctx,
                                  const char *group_name,
                                  librados::IoCtx& image_ioctx,
-                                 const char *image_id)
+                                 const char *image_id,
+                                 group_image_remove_mode_t mode)
 {
   CephContext *cct = (CephContext *)group_ioctx.cct();
   ldout(cct, 20) << "io_ctx=" << &group_ioctx
                  << ", group_name=" << group_name << ", image="
-                 << &image_ioctx << ", id=" << image_id << dendl;
+                 << &image_ioctx << ", id=" << image_id
+                 << ", mode=" << static_cast<int>(mode) << dendl;
 
   string group_id;
 
@@ -346,7 +429,7 @@ int Group<I>::image_remove_by_id(librados::IoCtx& group_ioctx,
                  << " group id " << group_id << dendl;
 
   r = Group<I>::group_image_remove(group_ioctx, group_id, image_ioctx,
-                                   image_id);
+                                   image_id, mode);
 
   return r;
 }
@@ -456,7 +539,8 @@ int Group<I>::remove(librados::IoCtx& io_ctx, const char *group_name)
     }
 
     r = Group<I>::group_image_remove(io_ctx, group_id, image_ioctx,
-                                     image.spec.image_id);
+                                     image.spec.image_id,
+                                     RBD_GROUP_IMAGE_REMOVE_FORCE);
     if (r < 0 && r != -ENOENT) {
       lderr(cct) << "error removing image from a group" << dendl;
       return r;
@@ -711,11 +795,13 @@ template <typename I>
 int Group<I>::image_remove(librados::IoCtx& group_ioctx,
                            const char *group_name,
                            librados::IoCtx& image_ioctx,
-                           const char *image_name) {
+                           const char *image_name,
+                           group_image_remove_mode_t mode) {
   CephContext *cct = (CephContext *)group_ioctx.cct();
   ldout(cct, 20) << "io_ctx=" << &group_ioctx
                  << ", group_name=" << group_name << ", image= "
-                 << &image_ioctx << ", name=" << image_name << dendl;
+                 << &image_ioctx << ", name=" << image_name
+                 << ", mode=" << static_cast<int>(mode) << dendl;
 
   if (group_ioctx.get_namespace() != image_ioctx.get_namespace()) {
     lderr(cct) << "group and image cannot be in different namespaces" << dendl;
@@ -765,7 +851,8 @@ int Group<I>::image_remove(librados::IoCtx& group_ioctx,
     return r;
   }
 
-  r = Group<I>::group_image_remove(group_ioctx, group_id, image_ioctx, image_id);
+  r = Group<I>::group_image_remove(group_ioctx, group_id, image_ioctx,
+                                   image_id, mode);
 
   return r;
 }
@@ -1501,9 +1588,11 @@ int Group<I>::snap_get_mirror_namespace(
 }
 
 template <typename I>
-int Group<I>::group_image_remove(librados::IoCtx& group_ioctx, string group_id,
-		                 librados::IoCtx& image_ioctx,
-                                 string image_id) {
+int Group<I>::group_image_remove(librados::IoCtx& group_ioctx,
+                                 const std::string& group_id,
+                                 librados::IoCtx& image_ioctx,
+                                 const std::string& image_id,
+                                 group_image_remove_mode_t mode) {
   CephContext *cct = (CephContext *)group_ioctx.cct();
 
   string group_header_oid = librbd::util::group_header_name(group_id);
@@ -1511,7 +1600,40 @@ int Group<I>::group_image_remove(librados::IoCtx& group_ioctx, string group_id,
   string image_header_oid = librbd::util::header_name(image_id);
 
   ldout(cct, 20) << "removing image " << image_id
-		 << " image id " << image_header_oid << dendl;
+                 << " image id " << image_header_oid
+                 << " mode " << static_cast<int>(mode) << dendl;
+
+  int r;
+  switch (mode) {
+    case RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS:
+      r = purge_dependent_user_group_snapshots<I>(group_ioctx, group_id,
+                                                  image_id);
+      if (r < 0) {
+        return r;
+      }
+      break;
+    case RBD_GROUP_IMAGE_REMOVE_DEFAULT: {
+      bool has_dependency = false;
+      r = has_user_group_snapshot_dependency<I>(group_ioctx, group_id, image_id,
+                                                &has_dependency);
+      if (r < 0) {
+        return r;
+      }
+
+      if (has_dependency) {
+        lderr(cct) << "image is referenced by one or more user group snapshots"
+                   << dendl;
+        return -EBUSY;
+      }
+      break;
+    }
+    case RBD_GROUP_IMAGE_REMOVE_FORCE:
+      // skip dependency validation
+      break;
+    default:
+      lderr(cct) << "invalid group image remove mode" << dendl;
+      return -EINVAL;
+  }
 
   cls::rbd::GroupSpec group_spec(group_id, group_ioctx.get_id());
 
@@ -1520,8 +1642,8 @@ int Group<I>::group_image_remove(librados::IoCtx& group_ioctx, string group_id,
 
   cls::rbd::GroupImageSpec spec(image_id, image_ioctx.get_id());
 
-  int r = cls_client::group_image_set(&group_ioctx, group_header_oid,
-				      incomplete_st);
+  r = cls_client::group_image_set(&group_ioctx, group_header_oid,
+                                  incomplete_st);
 
   if (r < 0) {
     lderr(cct) << "couldn't put image into removing state: "

--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -298,18 +298,101 @@ bool is_user_snapshot(const cls::rbd::GroupSnapshot &group_snap) {
   return ns != nullptr;
 }
 
+template <typename I>
+int has_user_group_snapshot_dependency(librados::IoCtx& group_ioctx,
+                                       const std::string& group_id,
+                                       const std::string& image_id,
+                                       bool* has_dependency) {
+  *has_dependency = false;
+  std::vector<cls::rbd::GroupSnapshot> snaps;
+  int r = group_snap_list<I>(group_ioctx, group_id,
+                             false, false, &snaps);
+  if (r < 0 && r != -ENOENT) {
+    return r;
+  }
+
+  for (const auto& snap : snaps) {
+    if (!is_user_snapshot(snap)) {
+      continue;
+    }
+
+    for (const auto& image_snap : snap.snaps) {
+      if (image_snap.image_id == image_id) {
+        *has_dependency = true;
+        return 0;
+      }
+    }
+  }
+
+  return 0;
+}
+
+template <typename I>
+int purge_dependent_user_group_snapshots(librados::IoCtx& group_ioctx,
+                                         const std::string& group_id,
+                                         const std::string& image_id) {
+  CephContext* cct = reinterpret_cast<CephContext*>(group_ioctx.cct());
+
+  ldout(cct, 20) << "group_id=" << group_id
+                 << ", image_id=" << image_id << dendl;
+
+  std::vector<cls::rbd::GroupSnapshot> group_snaps;
+  int r = group_snap_list<I>(group_ioctx, group_id,
+                             false, false, &group_snaps);
+  if (r < 0) {
+    if (r == -ENOENT) {
+      return 0;
+    }
+
+    lderr(cct) << "failed to list group snapshots: "
+               << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  for (const auto& group_snap : group_snaps) {
+    // filter user group snapshots
+    if (!is_user_snapshot(group_snap)) {
+      continue;
+    }
+
+    // check whether this snapshot references the image
+    const auto it = std::find_if(group_snap.snaps.begin(),
+        group_snap.snaps.end(), [&](const auto& snap) {
+          return snap.image_id == image_id;
+        });
+    if (it == group_snap.snaps.end()) {
+      continue;
+    }
+
+    ldout(cct, 10) << "purging dependent user group snapshot "
+                   << group_snap.name << " (" << group_snap.id << ")"
+                   << dendl;
+
+    r = util::group_snap_remove(group_ioctx, group_id, group_snap);
+    if (r < 0) {
+      lderr(cct) << "failed to remove dependent user group snapshot "
+                 << group_snap.name << ": " << cpp_strerror(r) << dendl;
+      return r;
+    }
+  }
+
+  return 0;
+}
+
 } // anonymous namespace
 
 template <typename I>
 int Group<I>::image_remove_by_id(librados::IoCtx& group_ioctx,
                                  const char *group_name,
                                  librados::IoCtx& image_ioctx,
-                                 const char *image_id)
+                                 const char *image_id,
+                                 group_image_remove_mode_t mode)
 {
   CephContext *cct = (CephContext *)group_ioctx.cct();
   ldout(cct, 20) << "io_ctx=" << &group_ioctx
                  << ", group_name=" << group_name << ", image="
-                 << &image_ioctx << ", id=" << image_id << dendl;
+                 << &image_ioctx << ", id=" << image_id
+                 << ", mode=" << static_cast<int>(mode) << dendl;
 
   string group_id;
 
@@ -346,7 +429,7 @@ int Group<I>::image_remove_by_id(librados::IoCtx& group_ioctx,
                  << " group id " << group_id << dendl;
 
   r = Group<I>::group_image_remove(group_ioctx, group_id, image_ioctx,
-                                   image_id);
+                                   image_id, mode);
 
   return r;
 }
@@ -456,7 +539,8 @@ int Group<I>::remove(librados::IoCtx& io_ctx, const char *group_name)
     }
 
     r = Group<I>::group_image_remove(io_ctx, group_id, image_ioctx,
-                                     image.spec.image_id);
+                                     image.spec.image_id,
+                                     RBD_GROUP_IMAGE_REMOVE_FORCE);
     if (r < 0 && r != -ENOENT) {
       lderr(cct) << "error removing image from a group" << dendl;
       return r;
@@ -711,11 +795,13 @@ template <typename I>
 int Group<I>::image_remove(librados::IoCtx& group_ioctx,
                            const char *group_name,
                            librados::IoCtx& image_ioctx,
-                           const char *image_name) {
+                           const char *image_name,
+                           group_image_remove_mode_t mode) {
   CephContext *cct = (CephContext *)group_ioctx.cct();
   ldout(cct, 20) << "io_ctx=" << &group_ioctx
                  << ", group_name=" << group_name << ", image= "
-                 << &image_ioctx << ", name=" << image_name << dendl;
+                 << &image_ioctx << ", name=" << image_name
+                 << ", mode=" << static_cast<int>(mode) << dendl;
 
   if (group_ioctx.get_namespace() != image_ioctx.get_namespace()) {
     lderr(cct) << "group and image cannot be in different namespaces" << dendl;
@@ -765,7 +851,8 @@ int Group<I>::image_remove(librados::IoCtx& group_ioctx,
     return r;
   }
 
-  r = Group<I>::group_image_remove(group_ioctx, group_id, image_ioctx, image_id);
+  r = Group<I>::group_image_remove(group_ioctx, group_id, image_ioctx,
+                                   image_id, mode);
 
   return r;
 }
@@ -1504,9 +1591,11 @@ int Group<I>::snap_get_mirror_namespace(
 }
 
 template <typename I>
-int Group<I>::group_image_remove(librados::IoCtx& group_ioctx, string group_id,
-		                 librados::IoCtx& image_ioctx,
-                                 string image_id) {
+int Group<I>::group_image_remove(librados::IoCtx& group_ioctx,
+                                 const std::string& group_id,
+                                 librados::IoCtx& image_ioctx,
+                                 const std::string& image_id,
+                                 group_image_remove_mode_t mode) {
   CephContext *cct = (CephContext *)group_ioctx.cct();
 
   string group_header_oid = librbd::util::group_header_name(group_id);
@@ -1514,7 +1603,40 @@ int Group<I>::group_image_remove(librados::IoCtx& group_ioctx, string group_id,
   string image_header_oid = librbd::util::header_name(image_id);
 
   ldout(cct, 20) << "removing image " << image_id
-		 << " image id " << image_header_oid << dendl;
+                 << " image id " << image_header_oid
+                 << " mode " << static_cast<int>(mode) << dendl;
+
+  int r;
+  switch (mode) {
+    case RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS:
+      r = purge_dependent_user_group_snapshots<I>(group_ioctx, group_id,
+                                                  image_id);
+      if (r < 0) {
+        return r;
+      }
+      break;
+    case RBD_GROUP_IMAGE_REMOVE_DEFAULT: {
+      bool has_dependency = false;
+      r = has_user_group_snapshot_dependency<I>(group_ioctx, group_id, image_id,
+                                                &has_dependency);
+      if (r < 0) {
+        return r;
+      }
+
+      if (has_dependency) {
+        lderr(cct) << "image is referenced by one or more user group snapshots"
+                   << dendl;
+        return -EBUSY;
+      }
+      break;
+    }
+    case RBD_GROUP_IMAGE_REMOVE_FORCE:
+      // skip dependency validation
+      break;
+    default:
+      lderr(cct) << "invalid group image remove mode" << dendl;
+      return -EINVAL;
+  }
 
   cls::rbd::GroupSpec group_spec(group_id, group_ioctx.get_id());
 
@@ -1523,8 +1645,8 @@ int Group<I>::group_image_remove(librados::IoCtx& group_ioctx, string group_id,
 
   cls::rbd::GroupImageSpec spec(image_id, image_ioctx.get_id());
 
-  int r = cls_client::group_image_set(&group_ioctx, group_header_oid,
-				      incomplete_st);
+  r = cls_client::group_image_set(&group_ioctx, group_header_oid,
+                                  incomplete_st);
 
   if (r < 0) {
     lderr(cct) << "couldn't put image into removing state: "

--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -327,58 +327,6 @@ int has_user_group_snapshot_dependency(librados::IoCtx& group_ioctx,
   return 0;
 }
 
-template <typename I>
-int purge_dependent_user_group_snapshots(librados::IoCtx& group_ioctx,
-                                         const std::string& group_id,
-                                         const std::string& image_id) {
-  CephContext* cct = reinterpret_cast<CephContext*>(group_ioctx.cct());
-
-  ldout(cct, 20) << "group_id=" << group_id
-                 << ", image_id=" << image_id << dendl;
-
-  std::vector<cls::rbd::GroupSnapshot> group_snaps;
-  int r = group_snap_list<I>(group_ioctx, group_id,
-                             false, false, &group_snaps);
-  if (r < 0) {
-    if (r == -ENOENT) {
-      return 0;
-    }
-
-    lderr(cct) << "failed to list group snapshots: "
-               << cpp_strerror(r) << dendl;
-    return r;
-  }
-
-  for (const auto& group_snap : group_snaps) {
-    // filter user group snapshots
-    if (!is_user_snapshot(group_snap)) {
-      continue;
-    }
-
-    // check whether this snapshot references the image
-    const auto it = std::find_if(group_snap.snaps.begin(),
-        group_snap.snaps.end(), [&](const auto& snap) {
-          return snap.image_id == image_id;
-        });
-    if (it == group_snap.snaps.end()) {
-      continue;
-    }
-
-    ldout(cct, 10) << "purging dependent user group snapshot "
-                   << group_snap.name << " (" << group_snap.id << ")"
-                   << dendl;
-
-    r = util::group_snap_remove(group_ioctx, group_id, group_snap);
-    if (r < 0) {
-      lderr(cct) << "failed to remove dependent user group snapshot "
-                 << group_snap.name << ": " << cpp_strerror(r) << dendl;
-      return r;
-    }
-  }
-
-  return 0;
-}
-
 } // anonymous namespace
 
 template <typename I>
@@ -1608,13 +1556,6 @@ int Group<I>::group_image_remove(librados::IoCtx& group_ioctx,
 
   int r;
   switch (mode) {
-    case RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS:
-      r = purge_dependent_user_group_snapshots<I>(group_ioctx, group_id,
-                                                  image_id);
-      if (r < 0) {
-        return r;
-      }
-      break;
     case RBD_GROUP_IMAGE_REMOVE_DEFAULT: {
       bool has_dependency = false;
       r = has_user_group_snapshot_dependency<I>(group_ioctx, group_id, image_id,

--- a/src/librbd/api/Group.h
+++ b/src/librbd/api/Group.h
@@ -34,11 +34,15 @@ struct Group {
   static int image_add(librados::IoCtx& group_ioctx, const char *group_name,
                        librados::IoCtx& image_ioctx, const char *image_name);
   static int image_remove(librados::IoCtx& group_ioctx, const char *group_name,
-                          librados::IoCtx& image_ioctx, const char *image_name);
+                          librados::IoCtx& image_ioctx, const char *image_name,
+                          group_image_remove_mode_t mode =
+                            RBD_GROUP_IMAGE_REMOVE_DEFAULT);
   static int image_remove_by_id(librados::IoCtx& group_ioctx,
                                 const char *group_name,
                                 librados::IoCtx& image_ioctx,
-                                const char *image_id);
+                                const char *image_id,
+                                group_image_remove_mode_t mode =
+                                  RBD_GROUP_IMAGE_REMOVE_DEFAULT);
   static int image_list(librados::IoCtx& group_ioctx, const char *group_name,
 		        std::vector<group_image_info_t> *images);
 
@@ -65,9 +69,10 @@ struct Group {
                                     const std::string &group_id,
                                     std::vector<cls::rbd::GroupImageStatus> *images);
   static int group_image_remove(librados::IoCtx& group_ioctx,
-                                std::string group_id,
+                                const std::string& group_id,
                                 librados::IoCtx& image_ioctx,
-                                std::string image_id);
+                                const std::string& image_id,
+                                group_image_remove_mode_t mode);
 
   static int snap_get_mirror_namespace(librados::IoCtx& group_ioctx,
                                        const char *group_name, const char *snap_id,

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -1533,31 +1533,37 @@ namespace librbd {
   }
 
   int RBD::group_image_remove(IoCtx& group_ioctx, const char *group_name,
-                              IoCtx& image_ioctx, const char *image_name)
+                              IoCtx& image_ioctx, const char *image_name,
+                              group_image_remove_mode_t mode)
   {
     TracepointProvider::initialize<tracepoint_traits>(get_cct(group_ioctx));
     tracepoint(librbd, group_image_remove_enter,
                group_ioctx.get_pool_name().c_str(),
                group_ioctx.get_id(), group_name,
                image_ioctx.get_pool_name().c_str(),
-               image_ioctx.get_id(), image_name);
+               image_ioctx.get_id(), image_name,
+               mode);
     int r = librbd::api::Group<>::image_remove(group_ioctx, group_name,
-                                               image_ioctx, image_name);
+                                               image_ioctx, image_name,
+                                               mode);
     tracepoint(librbd, group_image_remove_exit, r);
     return r;
   }
 
   int RBD::group_image_remove_by_id(IoCtx& group_ioctx, const char *group_name,
-                                    IoCtx& image_ioctx, const char *image_id)
+                                    IoCtx& image_ioctx, const char *image_id,
+                                    group_image_remove_mode_t mode)
   {
     TracepointProvider::initialize<tracepoint_traits>(get_cct(group_ioctx));
     tracepoint(librbd, group_image_remove_by_id_enter,
                group_ioctx.get_pool_name().c_str(),
                group_ioctx.get_id(), group_name,
                image_ioctx.get_pool_name().c_str(),
-               image_ioctx.get_id(), image_id);
+               image_ioctx.get_id(), image_id,
+               mode);
     int r = librbd::api::Group<>::image_remove_by_id(group_ioctx, group_name,
-                                                     image_ioctx, image_id);
+                                                     image_ioctx, image_id,
+                                                     mode);
     tracepoint(librbd, group_image_remove_by_id_exit, r);
     return r;
   }
@@ -7647,10 +7653,11 @@ extern "C" int rbd_group_image_add(rados_ioctx_t group_p,
   return r;
 }
 
-extern "C" int rbd_group_image_remove(rados_ioctx_t group_p,
-                                      const char *group_name,
-                                      rados_ioctx_t image_p,
-                                      const char *image_name)
+extern "C" int rbd_group_image_remove2(rados_ioctx_t group_p,
+                                       const char *group_name,
+                                       rados_ioctx_t image_p,
+                                       const char *image_name,
+                                       rbd_group_image_remove_mode_t mode)
 {
   librados::IoCtx group_ioctx;
   librados::IoCtx image_ioctx;
@@ -7661,19 +7668,30 @@ extern "C" int rbd_group_image_remove(rados_ioctx_t group_p,
   TracepointProvider::initialize<tracepoint_traits>(get_cct(group_ioctx));
   tracepoint(librbd, group_image_remove_enter, group_ioctx.get_pool_name().c_str(),
 	     group_ioctx.get_id(), group_name, image_ioctx.get_pool_name().c_str(),
-	     image_ioctx.get_id(), image_name);
+	     image_ioctx.get_id(), image_name, mode);
 
   int r = librbd::api::Group<>::image_remove(group_ioctx, group_name,
-                                             image_ioctx, image_name);
+                                             image_ioctx, image_name,
+                                             mode);
 
   tracepoint(librbd, group_image_remove_exit, r);
   return r;
 }
 
-extern "C" int rbd_group_image_remove_by_id(rados_ioctx_t group_p,
-                                            const char *group_name,
-                                            rados_ioctx_t image_p,
-                                            const char *image_id)
+extern "C" int rbd_group_image_remove(rados_ioctx_t group_p,
+                                      const char *group_name,
+                                      rados_ioctx_t image_p,
+                                      const char *image_name)
+{
+  return rbd_group_image_remove2(group_p, group_name, image_p, image_name,
+                                 RBD_GROUP_IMAGE_REMOVE_FORCE);
+}
+
+extern "C" int rbd_group_image_remove_by_id2(rados_ioctx_t group_p,
+                                             const char *group_name,
+                                             rados_ioctx_t image_p,
+                                             const char *image_id,
+                                             rbd_group_image_remove_mode_t mode)
 {
   librados::IoCtx group_ioctx;
   librados::IoCtx image_ioctx;
@@ -7686,13 +7704,23 @@ extern "C" int rbd_group_image_remove_by_id(rados_ioctx_t group_p,
              group_ioctx.get_pool_name().c_str(),
              group_ioctx.get_id(), group_name,
              image_ioctx.get_pool_name().c_str(),
-             image_ioctx.get_id(), image_id);
+             image_ioctx.get_id(), image_id, mode);
 
   int r = librbd::api::Group<>::image_remove_by_id(group_ioctx, group_name,
-                                                   image_ioctx, image_id);
+                                                   image_ioctx, image_id,
+                                                   mode);
 
   tracepoint(librbd, group_image_remove_by_id_exit, r);
   return r;
+}
+
+extern "C" int rbd_group_image_remove_by_id(rados_ioctx_t group_p,
+                                            const char *group_name,
+                                            rados_ioctx_t image_p,
+                                            const char *image_id)
+{
+  return rbd_group_image_remove_by_id2(group_p, group_name, image_p, image_id,
+                                       RBD_GROUP_IMAGE_REMOVE_FORCE);
 }
 
 extern "C" int rbd_group_image_list(rados_ioctx_t group_p,

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -1535,14 +1535,24 @@ namespace librbd {
   int RBD::group_image_remove(IoCtx& group_ioctx, const char *group_name,
                               IoCtx& image_ioctx, const char *image_name)
   {
+    return group_image_remove(group_ioctx, group_name, image_ioctx, image_name,
+                              RBD_GROUP_IMAGE_REMOVE_FORCE);
+  }
+
+  int RBD::group_image_remove(IoCtx& group_ioctx, const char *group_name,
+                              IoCtx& image_ioctx, const char *image_name,
+                              group_image_remove_mode_t mode)
+  {
     TracepointProvider::initialize<tracepoint_traits>(get_cct(group_ioctx));
     tracepoint(librbd, group_image_remove_enter,
                group_ioctx.get_pool_name().c_str(),
                group_ioctx.get_id(), group_name,
                image_ioctx.get_pool_name().c_str(),
-               image_ioctx.get_id(), image_name);
+               image_ioctx.get_id(), image_name,
+               mode);
     int r = librbd::api::Group<>::image_remove(group_ioctx, group_name,
-                                               image_ioctx, image_name);
+                                               image_ioctx, image_name,
+                                               mode);
     tracepoint(librbd, group_image_remove_exit, r);
     return r;
   }
@@ -1550,14 +1560,24 @@ namespace librbd {
   int RBD::group_image_remove_by_id(IoCtx& group_ioctx, const char *group_name,
                                     IoCtx& image_ioctx, const char *image_id)
   {
+    return group_image_remove_by_id(group_ioctx, group_name, image_ioctx,
+                                    image_id, RBD_GROUP_IMAGE_REMOVE_FORCE);
+  }
+
+  int RBD::group_image_remove_by_id(IoCtx& group_ioctx, const char *group_name,
+                                    IoCtx& image_ioctx, const char *image_id,
+                                    group_image_remove_mode_t mode)
+  {
     TracepointProvider::initialize<tracepoint_traits>(get_cct(group_ioctx));
     tracepoint(librbd, group_image_remove_by_id_enter,
                group_ioctx.get_pool_name().c_str(),
                group_ioctx.get_id(), group_name,
                image_ioctx.get_pool_name().c_str(),
-               image_ioctx.get_id(), image_id);
+               image_ioctx.get_id(), image_id,
+               mode);
     int r = librbd::api::Group<>::image_remove_by_id(group_ioctx, group_name,
-                                                     image_ioctx, image_id);
+                                                     image_ioctx, image_id,
+                                                     mode);
     tracepoint(librbd, group_image_remove_by_id_exit, r);
     return r;
   }
@@ -7643,10 +7663,11 @@ extern "C" int rbd_group_image_add(rados_ioctx_t group_p,
   return r;
 }
 
-extern "C" int rbd_group_image_remove(rados_ioctx_t group_p,
-                                      const char *group_name,
-                                      rados_ioctx_t image_p,
-                                      const char *image_name)
+extern "C" int rbd_group_image_remove2(rados_ioctx_t group_p,
+                                       const char *group_name,
+                                       rados_ioctx_t image_p,
+                                       const char *image_name,
+                                       rbd_group_image_remove_mode_t mode)
 {
   librados::IoCtx group_ioctx;
   librados::IoCtx image_ioctx;
@@ -7657,19 +7678,30 @@ extern "C" int rbd_group_image_remove(rados_ioctx_t group_p,
   TracepointProvider::initialize<tracepoint_traits>(get_cct(group_ioctx));
   tracepoint(librbd, group_image_remove_enter, group_ioctx.get_pool_name().c_str(),
 	     group_ioctx.get_id(), group_name, image_ioctx.get_pool_name().c_str(),
-	     image_ioctx.get_id(), image_name);
+	     image_ioctx.get_id(), image_name, mode);
 
   int r = librbd::api::Group<>::image_remove(group_ioctx, group_name,
-                                             image_ioctx, image_name);
+                                             image_ioctx, image_name,
+                                             mode);
 
   tracepoint(librbd, group_image_remove_exit, r);
   return r;
 }
 
-extern "C" int rbd_group_image_remove_by_id(rados_ioctx_t group_p,
-                                            const char *group_name,
-                                            rados_ioctx_t image_p,
-                                            const char *image_id)
+extern "C" int rbd_group_image_remove(rados_ioctx_t group_p,
+                                      const char *group_name,
+                                      rados_ioctx_t image_p,
+                                      const char *image_name)
+{
+  return rbd_group_image_remove2(group_p, group_name, image_p, image_name,
+                                 RBD_GROUP_IMAGE_REMOVE_FORCE);
+}
+
+extern "C" int rbd_group_image_remove_by_id2(rados_ioctx_t group_p,
+                                             const char *group_name,
+                                             rados_ioctx_t image_p,
+                                             const char *image_id,
+                                             rbd_group_image_remove_mode_t mode)
 {
   librados::IoCtx group_ioctx;
   librados::IoCtx image_ioctx;
@@ -7682,13 +7714,23 @@ extern "C" int rbd_group_image_remove_by_id(rados_ioctx_t group_p,
              group_ioctx.get_pool_name().c_str(),
              group_ioctx.get_id(), group_name,
              image_ioctx.get_pool_name().c_str(),
-             image_ioctx.get_id(), image_id);
+             image_ioctx.get_id(), image_id, mode);
 
   int r = librbd::api::Group<>::image_remove_by_id(group_ioctx, group_name,
-                                                   image_ioctx, image_id);
+                                                   image_ioctx, image_id,
+                                                   mode);
 
   tracepoint(librbd, group_image_remove_by_id_exit, r);
   return r;
+}
+
+extern "C" int rbd_group_image_remove_by_id(rados_ioctx_t group_p,
+                                            const char *group_name,
+                                            rados_ioctx_t image_p,
+                                            const char *image_id)
+{
+  return rbd_group_image_remove_by_id2(group_p, group_name, image_p, image_id,
+                                       RBD_GROUP_IMAGE_REMOVE_FORCE);
 }
 
 extern "C" int rbd_group_image_list(rados_ioctx_t group_p,

--- a/src/pybind/rbd/c_rbd.pxd
+++ b/src/pybind/rbd/c_rbd.pxd
@@ -348,6 +348,11 @@ cdef extern from "rbd/librbd.h" nogil:
         _RBD_ENCRYPTION_ALGORITHM_AES128 "RBD_ENCRYPTION_ALGORITHM_AES128"
         _RBD_ENCRYPTION_ALGORITHM_AES256 "RBD_ENCRYPTION_ALGORITHM_AES256"
 
+    ctypedef enum rbd_group_image_remove_mode_t:
+        RBD_GROUP_IMAGE_REMOVE_DEFAULT
+        RBD_GROUP_IMAGE_REMOVE_FORCE
+        RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS
+
     ctypedef struct rbd_encryption_luks1_format_options_t:
         rbd_encryption_algorithm_t alg
         const char* passphrase
@@ -810,7 +815,9 @@ cdef extern from "rbd/librbd.h" nogil:
                             rados_ioctx_t image_p, const char *image_name)
     int rbd_group_image_remove(rados_ioctx_t group_p, const char *group_name,
                                rados_ioctx_t image_p, const char *image_name)
-
+    int rbd_group_image_remove2(rados_ioctx_t group_p, const char *group_name,
+                                rados_ioctx_t image_p, const char *image_name,
+                                rbd_group_image_remove_mode_t mode)
     int rbd_group_image_list(rados_ioctx_t group_p,
                              const char *group_name,
                              rbd_group_image_info_t *images,

--- a/src/pybind/rbd/c_rbd.pxd
+++ b/src/pybind/rbd/c_rbd.pxd
@@ -351,7 +351,6 @@ cdef extern from "rbd/librbd.h" nogil:
     ctypedef enum rbd_group_image_remove_mode_t:
         RBD_GROUP_IMAGE_REMOVE_DEFAULT
         RBD_GROUP_IMAGE_REMOVE_FORCE
-        RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS
 
     ctypedef struct rbd_encryption_luks1_format_options_t:
         rbd_encryption_algorithm_t alg

--- a/src/pybind/rbd/mock_rbd.pxi
+++ b/src/pybind/rbd/mock_rbd.pxi
@@ -1017,6 +1017,10 @@ cdef nogil:
     int rbd_group_image_remove(rados_ioctx_t group_p, const char *group_name,
                                rados_ioctx_t image_p, const char *image_name):
         pass
+    int rbd_group_image_remove2(rados_ioctx_t group_p, const char *group_name,
+                                rados_ioctx_t image_p, const char *image_name,
+                                rbd_group_image_remove_mode_t mode):
+        pass
     int rbd_group_image_list(rados_ioctx_t group_p,
                              const char *group_name,
                              rbd_group_image_info_t *images,

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -2861,26 +2861,41 @@ cdef class Group(object):
         if ret != 0:
             raise make_ex(ret, 'error adding image to group', group_errno_to_exception)
 
-    def remove_image(self, image_ioctx, image_name):
+    def remove_image(self, image_ioctx, image_name,
+                     force=False, purge_user_snaps=False):
         """
         Remove an image from a group.
 
         :param image_ioctx: determines which RADOS pool the image belongs to.
-        :type ioctx: :class:`rados.Ioctx`
-        :param name: the name of the image to remove
-        :type name: str
+        :type image_ioctx: :class:`rados.Ioctx`
+        :param image_name: the name of the image to remove
+        :type image_name: str
+        :param force: Remove the image even if referenced by user group snapshots.
+        :type force: bool
+        :param purge_user_snaps: Remove dependent user group snapshots before
+                                 removing the image.
+        :type purge_user_snaps: bool
 
         :raises: :class:`ObjectNotFound`
         :raises: :class:`InvalidArgument`
         :raises: :class:`FunctionNotSupported`
         """
+        if force and purge_user_snaps:
+            raise InvalidArgument(
+                    "force and purge_user_snaps are mutually exclusive")
         image_name = cstr(image_name, 'image_name')
         cdef:
             rados_ioctx_t _image_ioctx = convert_ioctx(image_ioctx)
             char *_image_name = image_name
+            rbd_group_image_remove_mode_t mode = RBD_GROUP_IMAGE_REMOVE_DEFAULT
+        if purge_user_snaps:
+            mode = RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS
+        elif force:
+            mode = RBD_GROUP_IMAGE_REMOVE_FORCE
         with nogil:
-            ret = rbd_group_image_remove(self._ioctx, self._name,
-                                         _image_ioctx, _image_name)
+            ret = rbd_group_image_remove2(self._ioctx, self._name,
+                                          _image_ioctx, _image_name,
+                                          mode)
         if ret != 0:
             raise make_ex(ret, 'error removing image from group', group_errno_to_exception)
 

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -2861,8 +2861,7 @@ cdef class Group(object):
         if ret != 0:
             raise make_ex(ret, 'error adding image to group', group_errno_to_exception)
 
-    def remove_image(self, image_ioctx, image_name,
-                     force=False, purge_user_snaps=False):
+    def remove_image(self, image_ioctx, image_name, force=False):
         """
         Remove an image from a group.
 
@@ -2872,25 +2871,17 @@ cdef class Group(object):
         :type image_name: str
         :param force: Remove the image even if referenced by user group snapshots.
         :type force: bool
-        :param purge_user_snaps: Remove dependent user group snapshots before
-                                 removing the image.
-        :type purge_user_snaps: bool
 
         :raises: :class:`ObjectNotFound`
         :raises: :class:`InvalidArgument`
         :raises: :class:`FunctionNotSupported`
         """
-        if force and purge_user_snaps:
-            raise InvalidArgument(
-                    "force and purge_user_snaps are mutually exclusive")
         image_name = cstr(image_name, 'image_name')
         cdef:
             rados_ioctx_t _image_ioctx = convert_ioctx(image_ioctx)
             char *_image_name = image_name
             rbd_group_image_remove_mode_t mode = RBD_GROUP_IMAGE_REMOVE_DEFAULT
-        if purge_user_snaps:
-            mode = RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS
-        elif force:
+        if force:
             mode = RBD_GROUP_IMAGE_REMOVE_FORCE
         with nogil:
             ret = rbd_group_image_remove2(self._ioctx, self._name,

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -979,6 +979,7 @@
                                 [--group <group>] [--image-pool <image-pool>] 
                                 [--image-namespace <image-namespace>] 
                                 [--image <image>] [--image-id <image-id>] 
+                                [--force] [--purge-user-snaps] 
                                 <group-spec> <image-spec> 
   
   Remove an image from a group.
@@ -997,6 +998,8 @@
     --image-namespace arg image namespace name
     --image arg           image name
     --image-id arg        image id
+    --force               keep dependent user group snapshots
+    --purge-user-snaps    delete dependent user group snapshots
   
   rbd help group info
   usage: rbd group info [--pool <pool>] [--namespace <namespace>] 

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -979,6 +979,7 @@
                                 [--group <group>] [--image-pool <image-pool>] 
                                 [--image-namespace <image-namespace>] 
                                 [--image <image>] [--image-id <image-id>] 
+                                [--force] [--purge-user-snaps]
                                 <group-spec> <image-spec> 
   
   Remove an image from a group.
@@ -997,6 +998,8 @@
     --image-namespace arg image namespace name
     --image arg           image name
     --image-id arg        image id
+    --force               keep dependent user group snapshots
+    --purge-user-snaps    delete dependent user group snapshots
   
   rbd help group info
   usage: rbd group info [--pool <pool>] [--namespace <namespace>] 

--- a/src/test/librbd/test_Groups.cc
+++ b/src/test/librbd/test_Groups.cc
@@ -174,8 +174,9 @@ TEST_F(TestGroup, add_image)
   ASSERT_EQ(0, rbd_group_image_list_cleanup(images,
                                             sizeof(rbd_group_image_info_t),
                                             num_images));
-  ASSERT_EQ(0, rbd_group_image_remove(ioctx, group_name, ioctx,
-                                      m_image_name.c_str()));
+  ASSERT_EQ(0, rbd_group_image_remove2(ioctx, group_name, ioctx,
+                                       m_image_name.c_str(),
+                                       RBD_GROUP_IMAGE_REMOVE_DEFAULT));
 
   ASSERT_EQ(0, rbd_get_features(image, &features));
   ASSERT_TRUE((features & RBD_FEATURE_OPERATIONS) == 0ULL);
@@ -253,6 +254,218 @@ TEST_F(TestGroup, add_imagePP)
   ASSERT_EQ(0U, images.size());
 
   ASSERT_EQ(0, rbd.group_remove(ioctx, group_name));
+}
+
+TEST_F(TestGroup, group_image_remove_default)
+{
+  REQUIRE_FORMAT_V2();
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), ioctx));
+
+  const char *group = "busy_group";
+
+  ASSERT_EQ(0, m_rbd.group_create(ioctx, group));
+  ASSERT_EQ(0, m_rbd.group_image_add(ioctx, group,
+                                     ioctx, m_image_name.c_str()));
+
+  ASSERT_EQ(0, m_rbd.group_snap_create(ioctx, group, "snap1"));
+
+  ASSERT_EQ(-EBUSY, m_rbd.group_image_remove(ioctx, group, ioctx,
+                                             m_image_name.c_str(),
+                                             RBD_GROUP_IMAGE_REMOVE_DEFAULT));
+
+  std::vector<librbd::group_image_info_t> images;
+  ASSERT_EQ(0, m_rbd.group_image_list(ioctx, group, &images,
+                                      sizeof(images[0])));
+  ASSERT_EQ(1U, images.size());
+  ASSERT_EQ(m_image_name, images[0].name);
+
+  std::vector<librbd::group_snap_info_t> snaps;
+  ASSERT_EQ(0, m_rbd.group_snap_list(ioctx, group, &snaps, sizeof(snaps[0])));
+  ASSERT_EQ(1U, snaps.size());
+  ASSERT_EQ("snap1", snaps[0].name);
+
+  ASSERT_EQ(0, m_rbd.group_snap_remove(ioctx, group, "snap1"));
+  ASSERT_EQ(0, m_rbd.group_image_remove(ioctx, group, ioctx,
+                                        m_image_name.c_str(),
+                                        RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS));
+  ASSERT_EQ(0, m_rbd.group_remove(ioctx, group));
+}
+
+TEST_F(TestGroup, group_image_remove_force)
+{
+  REQUIRE_FORMAT_V2();
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), ioctx));
+
+  const char *group = "force_group";
+
+  ASSERT_EQ(0, m_rbd.group_create(ioctx, group));
+  ASSERT_EQ(0, m_rbd.group_image_add(ioctx, group,
+                                     ioctx, m_image_name.c_str()));
+
+  ASSERT_EQ(0, m_rbd.group_snap_create(ioctx, group, "snap1"));
+
+  ASSERT_EQ(0, m_rbd.group_image_remove(ioctx, group, ioctx,
+                                        m_image_name.c_str(),
+                                        RBD_GROUP_IMAGE_REMOVE_FORCE));
+
+  std::vector<librbd::group_image_info_t> images;
+  ASSERT_EQ(0, m_rbd.group_image_list(ioctx, group, &images,
+                                      sizeof(images[0])));
+  ASSERT_TRUE(images.empty());
+
+  std::vector<librbd::group_snap_info_t> snaps;
+  ASSERT_EQ(0, m_rbd.group_snap_list(ioctx, group, &snaps, sizeof(snaps[0])));
+  ASSERT_EQ(1U, snaps.size());
+  ASSERT_EQ("snap1", snaps[0].name);
+
+  ASSERT_EQ(0, m_rbd.group_snap_remove(ioctx, group, "snap1"));
+  ASSERT_EQ(0, m_rbd.group_remove(ioctx, group));
+}
+
+TEST_F(TestGroup, group_image_remove_purge_dependent_snapshots)
+{
+  REQUIRE_FORMAT_V2();
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), ioctx));
+
+  const char *group = "purge_dep";
+
+  ASSERT_EQ(0, m_rbd.group_create(ioctx, group));
+  ASSERT_EQ(0, m_rbd.group_image_add(ioctx, group, ioctx,
+                                     m_image_name.c_str()));
+
+  ASSERT_EQ(0, m_rbd.group_snap_create(ioctx, group, "snap1"));
+
+  std::vector<librbd::group_snap_info_t> snaps;
+  ASSERT_EQ(0, m_rbd.group_snap_list(ioctx, group, &snaps, sizeof(snaps[0])));
+  ASSERT_EQ(1U, snaps.size());
+
+  ASSERT_EQ(0, m_rbd.group_image_remove(ioctx, group, ioctx,
+                                        m_image_name.c_str(),
+                                        RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS));
+
+  snaps.clear();
+
+  ASSERT_EQ(0, m_rbd.group_snap_list(ioctx, group, &snaps, sizeof(snaps[0])));
+  ASSERT_TRUE(snaps.empty());
+
+  std::vector<librbd::group_image_info_t> images;
+  ASSERT_EQ(0, m_rbd.group_image_list(ioctx, group, &images,
+                                      sizeof(images[0])));
+  ASSERT_TRUE(images.empty());
+
+  ASSERT_EQ(0, m_rbd.group_remove(ioctx, group));
+}
+
+TEST_F(TestGroup, group_image_remove_purge_preserves_unrelated_group_snapshots)
+{
+  REQUIRE_FORMAT_V2();
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), ioctx));
+
+  std::string image2_name = get_temp_image_name();
+  ASSERT_EQ(0, create_image_pp(m_rbd, ioctx, image2_name, 0));
+
+  const char *group = "preserve_unrelated";
+
+  ASSERT_EQ(0, m_rbd.group_create(ioctx, group));
+
+  ASSERT_EQ(0, m_rbd.group_image_add(ioctx, group, ioctx,
+                                     m_image_name.c_str()));
+
+  ASSERT_EQ(0, m_rbd.group_snap_create(ioctx, group, "snap1"));
+
+  ASSERT_EQ(0, m_rbd.group_image_add(ioctx, group, ioctx,
+                                     image2_name.c_str()));
+
+  ASSERT_EQ(0, m_rbd.group_image_remove(
+      ioctx, group, ioctx, m_image_name.c_str(),
+      RBD_GROUP_IMAGE_REMOVE_FORCE));
+
+  ASSERT_EQ(0, m_rbd.group_snap_create(ioctx, group, "snap2"));
+
+  ASSERT_EQ(0, m_rbd.group_image_remove(
+      ioctx, group, ioctx, image2_name.c_str(),
+      RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS));
+
+  std::vector<librbd::group_snap_info_t> group_snaps;
+  ASSERT_EQ(0, m_rbd.group_snap_list(ioctx, group, &group_snaps,
+                                     sizeof(group_snaps[0])));
+
+  ASSERT_EQ(1U, group_snaps.size());
+  ASSERT_EQ("snap1", group_snaps[0].name);
+
+  {
+    librbd::Image image1;
+    ASSERT_EQ(0, m_rbd.open(ioctx, image1, m_image_name.c_str()));
+
+    std::vector<librbd::snap_info_t> image1_snaps;
+    ASSERT_EQ(0, image1.snap_list(image1_snaps));
+
+    // snap1 should still exist on image1
+    ASSERT_EQ(1U, image1_snaps.size());
+
+    ASSERT_EQ(0, image1.close());
+  }
+
+  {
+    librbd::Image image2;
+    ASSERT_EQ(0, m_rbd.open(ioctx, image2, image2_name.c_str()));
+
+    std::vector<librbd::snap_info_t> image2_snaps;
+    ASSERT_EQ(0, image2.snap_list(image2_snaps));
+
+    // snap2 should have been purged
+    ASSERT_TRUE(image2_snaps.empty());
+
+    ASSERT_EQ(0, image2.close());
+  }
+
+  ASSERT_EQ(0, m_rbd.group_snap_remove(ioctx, group, "snap1"));
+  ASSERT_EQ(0, m_rbd.group_remove(ioctx, group));
+
+  ASSERT_EQ(0, m_rbd.remove(ioctx, image2_name.c_str()));
+}
+
+TEST_F(TestGroup, group_image_remove_invalid_mode)
+{
+  REQUIRE_FORMAT_V2();
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), ioctx));
+
+  const char *group = "invalid_mode";
+
+  ASSERT_EQ(0, m_rbd.group_create(ioctx, group));
+  ASSERT_EQ(0, m_rbd.group_image_add(ioctx, group, ioctx,
+                                     m_image_name.c_str()));
+
+  // Construct an invalid enum value. group_image_remove_mode_t is a
+  // mutually-exclusive mode, not a bitmask. FORCE | PURGE_USER_SNAPS
+  // evaluates to 3, which is not a valid mode.
+  ASSERT_EQ(-EINVAL, m_rbd.group_image_remove(ioctx, group, ioctx,
+                                              m_image_name.c_str(),
+                                              static_cast<librbd::group_image_remove_mode_t>(
+                                                RBD_GROUP_IMAGE_REMOVE_FORCE |
+                                                RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS)));
+
+  // Verify the invalid mode did not modify the group.
+  std::vector<librbd::group_image_info_t> images;
+  ASSERT_EQ(0, m_rbd.group_image_list(ioctx, group, &images,
+                                      sizeof(images[0])));
+  ASSERT_EQ(1U, images.size());
+  ASSERT_EQ(m_image_name, images[0].name);
+
+  ASSERT_EQ(0, m_rbd.group_image_remove(ioctx, group, ioctx,
+                                        m_image_name.c_str(),
+                                        RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS));
+  ASSERT_EQ(0, m_rbd.group_remove(ioctx, group));
 }
 
 TEST_F(TestGroup, add_snapshot)
@@ -641,8 +854,12 @@ TEST_F(TestGroup, snap_list2)
                                    image_name2.c_str()));
   ASSERT_EQ(0, rbd_group_snap_create(ioctx, gp_name, gp_snap_names[2]));
 
-  ASSERT_EQ(0, rbd_group_image_remove(ioctx, gp_name, ioctx,
-                                      m_image_name.c_str()));
+  ASSERT_EQ(-EBUSY, rbd_group_image_remove2(ioctx, gp_name, ioctx,
+                                            m_image_name.c_str(),
+                                            RBD_GROUP_IMAGE_REMOVE_DEFAULT));
+  ASSERT_EQ(0, rbd_group_image_remove2(ioctx, gp_name, ioctx,
+                                       m_image_name.c_str(),
+                                       RBD_GROUP_IMAGE_REMOVE_FORCE)); // old default
   ASSERT_EQ(0, rbd_group_snap_create(ioctx, gp_name, gp_snap_names[3]));
 
   num_snaps = 3U;
@@ -733,8 +950,12 @@ TEST_F(TestGroup, snap_list2PP)
                                      image_name2.c_str()));
   ASSERT_EQ(0, m_rbd.group_snap_create(m_ioctx, gp_name, gp_snap_names[2]));
 
+  ASSERT_EQ(-EBUSY, m_rbd.group_image_remove(m_ioctx, gp_name, m_ioctx,
+                                             m_image_name.c_str(),
+                                             RBD_GROUP_IMAGE_REMOVE_DEFAULT));
   ASSERT_EQ(0, m_rbd.group_image_remove(m_ioctx, gp_name, m_ioctx,
-                                        m_image_name.c_str()));
+                                        m_image_name.c_str(),
+                                        RBD_GROUP_IMAGE_REMOVE_FORCE)); // old default
   ASSERT_EQ(0, m_rbd.group_snap_create(m_ioctx, gp_name, gp_snap_names[3]));
 
   ASSERT_EQ(0, m_rbd.group_snap_list2(m_ioctx, gp_name, &gp_snaps));

--- a/src/test/librbd/test_Groups.cc
+++ b/src/test/librbd/test_Groups.cc
@@ -289,7 +289,7 @@ TEST_F(TestGroup, group_image_remove_default)
   ASSERT_EQ(0, m_rbd.group_snap_remove(ioctx, group, "snap1"));
   ASSERT_EQ(0, m_rbd.group_image_remove(ioctx, group, ioctx,
                                         m_image_name.c_str(),
-                                        RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS));
+                                        RBD_GROUP_IMAGE_REMOVE_FORCE));
   ASSERT_EQ(0, m_rbd.group_remove(ioctx, group));
 }
 
@@ -326,113 +326,6 @@ TEST_F(TestGroup, group_image_remove_force)
   ASSERT_EQ(0, m_rbd.group_remove(ioctx, group));
 }
 
-TEST_F(TestGroup, group_image_remove_purge_dependent_snapshots)
-{
-  REQUIRE_FORMAT_V2();
-
-  librados::IoCtx ioctx;
-  ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), ioctx));
-
-  const char *group = "purge_dep";
-
-  ASSERT_EQ(0, m_rbd.group_create(ioctx, group));
-  ASSERT_EQ(0, m_rbd.group_image_add(ioctx, group, ioctx,
-                                     m_image_name.c_str()));
-
-  ASSERT_EQ(0, m_rbd.group_snap_create(ioctx, group, "snap1"));
-
-  std::vector<librbd::group_snap_info_t> snaps;
-  ASSERT_EQ(0, m_rbd.group_snap_list(ioctx, group, &snaps, sizeof(snaps[0])));
-  ASSERT_EQ(1U, snaps.size());
-
-  ASSERT_EQ(0, m_rbd.group_image_remove(ioctx, group, ioctx,
-                                        m_image_name.c_str(),
-                                        RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS));
-
-  snaps.clear();
-
-  ASSERT_EQ(0, m_rbd.group_snap_list(ioctx, group, &snaps, sizeof(snaps[0])));
-  ASSERT_TRUE(snaps.empty());
-
-  std::vector<librbd::group_image_info_t> images;
-  ASSERT_EQ(0, m_rbd.group_image_list(ioctx, group, &images,
-                                      sizeof(images[0])));
-  ASSERT_TRUE(images.empty());
-
-  ASSERT_EQ(0, m_rbd.group_remove(ioctx, group));
-}
-
-TEST_F(TestGroup, group_image_remove_purge_preserves_unrelated_group_snapshots)
-{
-  REQUIRE_FORMAT_V2();
-
-  librados::IoCtx ioctx;
-  ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), ioctx));
-
-  std::string image2_name = get_temp_image_name();
-  ASSERT_EQ(0, create_image_pp(m_rbd, ioctx, image2_name, 0));
-
-  const char *group = "preserve_unrelated";
-
-  ASSERT_EQ(0, m_rbd.group_create(ioctx, group));
-
-  ASSERT_EQ(0, m_rbd.group_image_add(ioctx, group, ioctx,
-                                     m_image_name.c_str()));
-
-  ASSERT_EQ(0, m_rbd.group_snap_create(ioctx, group, "snap1"));
-
-  ASSERT_EQ(0, m_rbd.group_image_add(ioctx, group, ioctx,
-                                     image2_name.c_str()));
-
-  ASSERT_EQ(0, m_rbd.group_image_remove(
-      ioctx, group, ioctx, m_image_name.c_str(),
-      RBD_GROUP_IMAGE_REMOVE_FORCE));
-
-  ASSERT_EQ(0, m_rbd.group_snap_create(ioctx, group, "snap2"));
-
-  ASSERT_EQ(0, m_rbd.group_image_remove(
-      ioctx, group, ioctx, image2_name.c_str(),
-      RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS));
-
-  std::vector<librbd::group_snap_info_t> group_snaps;
-  ASSERT_EQ(0, m_rbd.group_snap_list(ioctx, group, &group_snaps,
-                                     sizeof(group_snaps[0])));
-
-  ASSERT_EQ(1U, group_snaps.size());
-  ASSERT_EQ("snap1", group_snaps[0].name);
-
-  {
-    librbd::Image image1;
-    ASSERT_EQ(0, m_rbd.open(ioctx, image1, m_image_name.c_str()));
-
-    std::vector<librbd::snap_info_t> image1_snaps;
-    ASSERT_EQ(0, image1.snap_list(image1_snaps));
-
-    // snap1 should still exist on image1
-    ASSERT_EQ(1U, image1_snaps.size());
-
-    ASSERT_EQ(0, image1.close());
-  }
-
-  {
-    librbd::Image image2;
-    ASSERT_EQ(0, m_rbd.open(ioctx, image2, image2_name.c_str()));
-
-    std::vector<librbd::snap_info_t> image2_snaps;
-    ASSERT_EQ(0, image2.snap_list(image2_snaps));
-
-    // snap2 should have been purged
-    ASSERT_TRUE(image2_snaps.empty());
-
-    ASSERT_EQ(0, image2.close());
-  }
-
-  ASSERT_EQ(0, m_rbd.group_snap_remove(ioctx, group, "snap1"));
-  ASSERT_EQ(0, m_rbd.group_remove(ioctx, group));
-
-  ASSERT_EQ(0, m_rbd.remove(ioctx, image2_name.c_str()));
-}
-
 TEST_F(TestGroup, group_image_remove_invalid_mode)
 {
   REQUIRE_FORMAT_V2();
@@ -446,14 +339,10 @@ TEST_F(TestGroup, group_image_remove_invalid_mode)
   ASSERT_EQ(0, m_rbd.group_image_add(ioctx, group, ioctx,
                                      m_image_name.c_str()));
 
-  // Construct an invalid enum value. group_image_remove_mode_t is a
-  // mutually-exclusive mode, not a bitmask. FORCE | PURGE_USER_SNAPS
-  // evaluates to 3, which is not a valid mode.
+  // Construct an invalid enum value.
   ASSERT_EQ(-EINVAL, m_rbd.group_image_remove(ioctx, group, ioctx,
                                               m_image_name.c_str(),
-                                              static_cast<librbd::group_image_remove_mode_t>(
-                                                RBD_GROUP_IMAGE_REMOVE_FORCE |
-                                                RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS)));
+                                              static_cast<librbd::group_image_remove_mode_t>(2)));
 
   // Verify the invalid mode did not modify the group.
   std::vector<librbd::group_image_info_t> images;
@@ -464,7 +353,7 @@ TEST_F(TestGroup, group_image_remove_invalid_mode)
 
   ASSERT_EQ(0, m_rbd.group_image_remove(ioctx, group, ioctx,
                                         m_image_name.c_str(),
-                                        RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS));
+                                        RBD_GROUP_IMAGE_REMOVE_FORCE));
   ASSERT_EQ(0, m_rbd.group_remove(ioctx, group));
 }
 

--- a/src/test/librbd/test_Groups.cc
+++ b/src/test/librbd/test_Groups.cc
@@ -296,7 +296,7 @@ TEST_F(TestGroup, group_image_remove_default)
   ASSERT_EQ(0, m_rbd.group_snap_remove(ioctx, group, "snap1"));
   ASSERT_EQ(0, m_rbd.group_image_remove(ioctx, group, ioctx,
                                         m_image_name.c_str(),
-                                        RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS));
+                                        RBD_GROUP_IMAGE_REMOVE_FORCE));
   ASSERT_EQ(0, m_rbd.group_remove(ioctx, group));
 }
 
@@ -333,113 +333,6 @@ TEST_F(TestGroup, group_image_remove_force)
   ASSERT_EQ(0, m_rbd.group_remove(ioctx, group));
 }
 
-TEST_F(TestGroup, group_image_remove_purge_dependent_snapshots)
-{
-  REQUIRE_FORMAT_V2();
-
-  librados::IoCtx ioctx;
-  ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), ioctx));
-
-  const char *group = "purge_dep";
-
-  ASSERT_EQ(0, m_rbd.group_create(ioctx, group));
-  ASSERT_EQ(0, m_rbd.group_image_add(ioctx, group, ioctx,
-                                     m_image_name.c_str()));
-
-  ASSERT_EQ(0, m_rbd.group_snap_create(ioctx, group, "snap1"));
-
-  std::vector<librbd::group_snap_info_t> snaps;
-  ASSERT_EQ(0, m_rbd.group_snap_list(ioctx, group, &snaps, sizeof(snaps[0])));
-  ASSERT_EQ(1U, snaps.size());
-
-  ASSERT_EQ(0, m_rbd.group_image_remove(ioctx, group, ioctx,
-                                        m_image_name.c_str(),
-                                        RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS));
-
-  snaps.clear();
-
-  ASSERT_EQ(0, m_rbd.group_snap_list(ioctx, group, &snaps, sizeof(snaps[0])));
-  ASSERT_TRUE(snaps.empty());
-
-  std::vector<librbd::group_image_info_t> images;
-  ASSERT_EQ(0, m_rbd.group_image_list(ioctx, group, &images,
-                                      sizeof(images[0])));
-  ASSERT_TRUE(images.empty());
-
-  ASSERT_EQ(0, m_rbd.group_remove(ioctx, group));
-}
-
-TEST_F(TestGroup, group_image_remove_purge_preserves_unrelated_group_snapshots)
-{
-  REQUIRE_FORMAT_V2();
-
-  librados::IoCtx ioctx;
-  ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), ioctx));
-
-  std::string image2_name = get_temp_image_name();
-  ASSERT_EQ(0, create_image_pp(m_rbd, ioctx, image2_name, 0));
-
-  const char *group = "preserve_unrelated";
-
-  ASSERT_EQ(0, m_rbd.group_create(ioctx, group));
-
-  ASSERT_EQ(0, m_rbd.group_image_add(ioctx, group, ioctx,
-                                     m_image_name.c_str()));
-
-  ASSERT_EQ(0, m_rbd.group_snap_create(ioctx, group, "snap1"));
-
-  ASSERT_EQ(0, m_rbd.group_image_add(ioctx, group, ioctx,
-                                     image2_name.c_str()));
-
-  ASSERT_EQ(0, m_rbd.group_image_remove(
-      ioctx, group, ioctx, m_image_name.c_str(),
-      RBD_GROUP_IMAGE_REMOVE_FORCE));
-
-  ASSERT_EQ(0, m_rbd.group_snap_create(ioctx, group, "snap2"));
-
-  ASSERT_EQ(0, m_rbd.group_image_remove(
-      ioctx, group, ioctx, image2_name.c_str(),
-      RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS));
-
-  std::vector<librbd::group_snap_info_t> group_snaps;
-  ASSERT_EQ(0, m_rbd.group_snap_list(ioctx, group, &group_snaps,
-                                     sizeof(group_snaps[0])));
-
-  ASSERT_EQ(1U, group_snaps.size());
-  ASSERT_EQ("snap1", group_snaps[0].name);
-
-  {
-    librbd::Image image1;
-    ASSERT_EQ(0, m_rbd.open(ioctx, image1, m_image_name.c_str()));
-
-    std::vector<librbd::snap_info_t> image1_snaps;
-    ASSERT_EQ(0, image1.snap_list(image1_snaps));
-
-    // snap1 should still exist on image1
-    ASSERT_EQ(1U, image1_snaps.size());
-
-    ASSERT_EQ(0, image1.close());
-  }
-
-  {
-    librbd::Image image2;
-    ASSERT_EQ(0, m_rbd.open(ioctx, image2, image2_name.c_str()));
-
-    std::vector<librbd::snap_info_t> image2_snaps;
-    ASSERT_EQ(0, image2.snap_list(image2_snaps));
-
-    // snap2 should have been purged
-    ASSERT_TRUE(image2_snaps.empty());
-
-    ASSERT_EQ(0, image2.close());
-  }
-
-  ASSERT_EQ(0, m_rbd.group_snap_remove(ioctx, group, "snap1"));
-  ASSERT_EQ(0, m_rbd.group_remove(ioctx, group));
-
-  ASSERT_EQ(0, m_rbd.remove(ioctx, image2_name.c_str()));
-}
-
 TEST_F(TestGroup, group_image_remove_invalid_mode)
 {
   REQUIRE_FORMAT_V2();
@@ -453,14 +346,10 @@ TEST_F(TestGroup, group_image_remove_invalid_mode)
   ASSERT_EQ(0, m_rbd.group_image_add(ioctx, group, ioctx,
                                      m_image_name.c_str()));
 
-  // Construct an invalid enum value. group_image_remove_mode_t is a
-  // mutually-exclusive mode, not a bitmask. FORCE | PURGE_USER_SNAPS
-  // evaluates to 3, which is not a valid mode.
+  // Construct an invalid enum value.
   ASSERT_EQ(-EINVAL, m_rbd.group_image_remove(ioctx, group, ioctx,
                                               m_image_name.c_str(),
-                                              static_cast<librbd::group_image_remove_mode_t>(
-                                                RBD_GROUP_IMAGE_REMOVE_FORCE |
-                                                RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS)));
+                                              static_cast<librbd::group_image_remove_mode_t>(2)));
 
   // Verify the invalid mode did not modify the group.
   std::vector<librbd::group_image_info_t> images;
@@ -471,7 +360,7 @@ TEST_F(TestGroup, group_image_remove_invalid_mode)
 
   ASSERT_EQ(0, m_rbd.group_image_remove(ioctx, group, ioctx,
                                         m_image_name.c_str(),
-                                        RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS));
+                                        RBD_GROUP_IMAGE_REMOVE_FORCE));
   ASSERT_EQ(0, m_rbd.group_remove(ioctx, group));
 }
 

--- a/src/test/librbd/test_Groups.cc
+++ b/src/test/librbd/test_Groups.cc
@@ -178,8 +178,9 @@ TEST_F(TestGroup, add_image)
   ASSERT_EQ(0, rbd_group_image_list_cleanup(images,
                                             sizeof(rbd_group_image_info_t),
                                             num_images));
-  ASSERT_EQ(0, rbd_group_image_remove(ioctx, group_name, ioctx,
-                                      m_image_name.c_str()));
+  ASSERT_EQ(0, rbd_group_image_remove2(ioctx, group_name, ioctx,
+                                       m_image_name.c_str(),
+                                       RBD_GROUP_IMAGE_REMOVE_DEFAULT));
 
   ASSERT_EQ(0, rbd_get_features(image, &features));
   ASSERT_TRUE((features & RBD_FEATURE_OPERATIONS) == 0ULL);
@@ -260,6 +261,218 @@ TEST_F(TestGroup, add_imagePP)
   ASSERT_EQ(0U, images.size());
 
   ASSERT_EQ(0, rbd.group_remove(ioctx, group_name));
+}
+
+TEST_F(TestGroup, group_image_remove_default)
+{
+  REQUIRE_FORMAT_V2();
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), ioctx));
+
+  const char *group = "busy_group";
+
+  ASSERT_EQ(0, m_rbd.group_create(ioctx, group));
+  ASSERT_EQ(0, m_rbd.group_image_add(ioctx, group,
+                                     ioctx, m_image_name.c_str()));
+
+  ASSERT_EQ(0, m_rbd.group_snap_create(ioctx, group, "snap1"));
+
+  ASSERT_EQ(-EBUSY, m_rbd.group_image_remove(ioctx, group, ioctx,
+                                             m_image_name.c_str(),
+                                             RBD_GROUP_IMAGE_REMOVE_DEFAULT));
+
+  std::vector<librbd::group_image_info_t> images;
+  ASSERT_EQ(0, m_rbd.group_image_list(ioctx, group, &images,
+                                      sizeof(images[0])));
+  ASSERT_EQ(1U, images.size());
+  ASSERT_EQ(m_image_name, images[0].name);
+
+  std::vector<librbd::group_snap_info_t> snaps;
+  ASSERT_EQ(0, m_rbd.group_snap_list(ioctx, group, &snaps, sizeof(snaps[0])));
+  ASSERT_EQ(1U, snaps.size());
+  ASSERT_EQ("snap1", snaps[0].name);
+
+  ASSERT_EQ(0, m_rbd.group_snap_remove(ioctx, group, "snap1"));
+  ASSERT_EQ(0, m_rbd.group_image_remove(ioctx, group, ioctx,
+                                        m_image_name.c_str(),
+                                        RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS));
+  ASSERT_EQ(0, m_rbd.group_remove(ioctx, group));
+}
+
+TEST_F(TestGroup, group_image_remove_force)
+{
+  REQUIRE_FORMAT_V2();
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), ioctx));
+
+  const char *group = "force_group";
+
+  ASSERT_EQ(0, m_rbd.group_create(ioctx, group));
+  ASSERT_EQ(0, m_rbd.group_image_add(ioctx, group,
+                                     ioctx, m_image_name.c_str()));
+
+  ASSERT_EQ(0, m_rbd.group_snap_create(ioctx, group, "snap1"));
+
+  ASSERT_EQ(0, m_rbd.group_image_remove(ioctx, group, ioctx,
+                                        m_image_name.c_str(),
+                                        RBD_GROUP_IMAGE_REMOVE_FORCE));
+
+  std::vector<librbd::group_image_info_t> images;
+  ASSERT_EQ(0, m_rbd.group_image_list(ioctx, group, &images,
+                                      sizeof(images[0])));
+  ASSERT_TRUE(images.empty());
+
+  std::vector<librbd::group_snap_info_t> snaps;
+  ASSERT_EQ(0, m_rbd.group_snap_list(ioctx, group, &snaps, sizeof(snaps[0])));
+  ASSERT_EQ(1U, snaps.size());
+  ASSERT_EQ("snap1", snaps[0].name);
+
+  ASSERT_EQ(0, m_rbd.group_snap_remove(ioctx, group, "snap1"));
+  ASSERT_EQ(0, m_rbd.group_remove(ioctx, group));
+}
+
+TEST_F(TestGroup, group_image_remove_purge_dependent_snapshots)
+{
+  REQUIRE_FORMAT_V2();
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), ioctx));
+
+  const char *group = "purge_dep";
+
+  ASSERT_EQ(0, m_rbd.group_create(ioctx, group));
+  ASSERT_EQ(0, m_rbd.group_image_add(ioctx, group, ioctx,
+                                     m_image_name.c_str()));
+
+  ASSERT_EQ(0, m_rbd.group_snap_create(ioctx, group, "snap1"));
+
+  std::vector<librbd::group_snap_info_t> snaps;
+  ASSERT_EQ(0, m_rbd.group_snap_list(ioctx, group, &snaps, sizeof(snaps[0])));
+  ASSERT_EQ(1U, snaps.size());
+
+  ASSERT_EQ(0, m_rbd.group_image_remove(ioctx, group, ioctx,
+                                        m_image_name.c_str(),
+                                        RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS));
+
+  snaps.clear();
+
+  ASSERT_EQ(0, m_rbd.group_snap_list(ioctx, group, &snaps, sizeof(snaps[0])));
+  ASSERT_TRUE(snaps.empty());
+
+  std::vector<librbd::group_image_info_t> images;
+  ASSERT_EQ(0, m_rbd.group_image_list(ioctx, group, &images,
+                                      sizeof(images[0])));
+  ASSERT_TRUE(images.empty());
+
+  ASSERT_EQ(0, m_rbd.group_remove(ioctx, group));
+}
+
+TEST_F(TestGroup, group_image_remove_purge_preserves_unrelated_group_snapshots)
+{
+  REQUIRE_FORMAT_V2();
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), ioctx));
+
+  std::string image2_name = get_temp_image_name();
+  ASSERT_EQ(0, create_image_pp(m_rbd, ioctx, image2_name, 0));
+
+  const char *group = "preserve_unrelated";
+
+  ASSERT_EQ(0, m_rbd.group_create(ioctx, group));
+
+  ASSERT_EQ(0, m_rbd.group_image_add(ioctx, group, ioctx,
+                                     m_image_name.c_str()));
+
+  ASSERT_EQ(0, m_rbd.group_snap_create(ioctx, group, "snap1"));
+
+  ASSERT_EQ(0, m_rbd.group_image_add(ioctx, group, ioctx,
+                                     image2_name.c_str()));
+
+  ASSERT_EQ(0, m_rbd.group_image_remove(
+      ioctx, group, ioctx, m_image_name.c_str(),
+      RBD_GROUP_IMAGE_REMOVE_FORCE));
+
+  ASSERT_EQ(0, m_rbd.group_snap_create(ioctx, group, "snap2"));
+
+  ASSERT_EQ(0, m_rbd.group_image_remove(
+      ioctx, group, ioctx, image2_name.c_str(),
+      RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS));
+
+  std::vector<librbd::group_snap_info_t> group_snaps;
+  ASSERT_EQ(0, m_rbd.group_snap_list(ioctx, group, &group_snaps,
+                                     sizeof(group_snaps[0])));
+
+  ASSERT_EQ(1U, group_snaps.size());
+  ASSERT_EQ("snap1", group_snaps[0].name);
+
+  {
+    librbd::Image image1;
+    ASSERT_EQ(0, m_rbd.open(ioctx, image1, m_image_name.c_str()));
+
+    std::vector<librbd::snap_info_t> image1_snaps;
+    ASSERT_EQ(0, image1.snap_list(image1_snaps));
+
+    // snap1 should still exist on image1
+    ASSERT_EQ(1U, image1_snaps.size());
+
+    ASSERT_EQ(0, image1.close());
+  }
+
+  {
+    librbd::Image image2;
+    ASSERT_EQ(0, m_rbd.open(ioctx, image2, image2_name.c_str()));
+
+    std::vector<librbd::snap_info_t> image2_snaps;
+    ASSERT_EQ(0, image2.snap_list(image2_snaps));
+
+    // snap2 should have been purged
+    ASSERT_TRUE(image2_snaps.empty());
+
+    ASSERT_EQ(0, image2.close());
+  }
+
+  ASSERT_EQ(0, m_rbd.group_snap_remove(ioctx, group, "snap1"));
+  ASSERT_EQ(0, m_rbd.group_remove(ioctx, group));
+
+  ASSERT_EQ(0, m_rbd.remove(ioctx, image2_name.c_str()));
+}
+
+TEST_F(TestGroup, group_image_remove_invalid_mode)
+{
+  REQUIRE_FORMAT_V2();
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), ioctx));
+
+  const char *group = "invalid_mode";
+
+  ASSERT_EQ(0, m_rbd.group_create(ioctx, group));
+  ASSERT_EQ(0, m_rbd.group_image_add(ioctx, group, ioctx,
+                                     m_image_name.c_str()));
+
+  // Construct an invalid enum value. group_image_remove_mode_t is a
+  // mutually-exclusive mode, not a bitmask. FORCE | PURGE_USER_SNAPS
+  // evaluates to 3, which is not a valid mode.
+  ASSERT_EQ(-EINVAL, m_rbd.group_image_remove(ioctx, group, ioctx,
+                                              m_image_name.c_str(),
+                                              static_cast<librbd::group_image_remove_mode_t>(
+                                                RBD_GROUP_IMAGE_REMOVE_FORCE |
+                                                RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS)));
+
+  // Verify the invalid mode did not modify the group.
+  std::vector<librbd::group_image_info_t> images;
+  ASSERT_EQ(0, m_rbd.group_image_list(ioctx, group, &images,
+                                      sizeof(images[0])));
+  ASSERT_EQ(1U, images.size());
+  ASSERT_EQ(m_image_name, images[0].name);
+
+  ASSERT_EQ(0, m_rbd.group_image_remove(ioctx, group, ioctx,
+                                        m_image_name.c_str(),
+                                        RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS));
+  ASSERT_EQ(0, m_rbd.group_remove(ioctx, group));
 }
 
 TEST_F(TestGroup, add_snapshot)
@@ -653,8 +866,12 @@ TEST_F(TestGroup, snap_list2)
                                    image_name2.c_str()));
   ASSERT_EQ(0, rbd_group_snap_create(ioctx, gp_name, gp_snap_names[2]));
 
-  ASSERT_EQ(0, rbd_group_image_remove(ioctx, gp_name, ioctx,
-                                      m_image_name.c_str()));
+  ASSERT_EQ(-EBUSY, rbd_group_image_remove2(ioctx, gp_name, ioctx,
+                                            m_image_name.c_str(),
+                                            RBD_GROUP_IMAGE_REMOVE_DEFAULT));
+  ASSERT_EQ(0, rbd_group_image_remove2(ioctx, gp_name, ioctx,
+                                       m_image_name.c_str(),
+                                       RBD_GROUP_IMAGE_REMOVE_FORCE)); // old default
   ASSERT_EQ(0, rbd_group_snap_create(ioctx, gp_name, gp_snap_names[3]));
 
   num_snaps = 3U;
@@ -745,6 +962,10 @@ TEST_F(TestGroup, snap_list2PP)
                                      image_name2.c_str()));
   ASSERT_EQ(0, m_rbd.group_snap_create(m_ioctx, gp_name, gp_snap_names[2]));
 
+  ASSERT_EQ(-EBUSY, m_rbd.group_image_remove(m_ioctx, gp_name, m_ioctx,
+                                             m_image_name.c_str(),
+                                             RBD_GROUP_IMAGE_REMOVE_DEFAULT));
+  // Verify the legacy overload retains its force behavior.
   ASSERT_EQ(0, m_rbd.group_image_remove(m_ioctx, gp_name, m_ioctx,
                                         m_image_name.c_str()));
   ASSERT_EQ(0, m_rbd.group_snap_create(m_ioctx, gp_name, gp_snap_names[3]));

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -3168,49 +3168,6 @@ class TestGroups(object):
         eq(1, len(list(self.group.list_snaps())))
         self.group.remove_snap("snap1")
 
-    def test_group_image_remove_purge(self):
-        self.group.add_image(ioctx, image_name)
-        self.group.create_snap("snap1")
-        with Image(ioctx, image_name) as image:
-            eq(1, len(list(image.list_snaps())))
-        self.group.remove_image(ioctx, image_name, purge_user_snaps=True)
-        eq([], list(self.group.list_snaps()))
-        with Image(ioctx, image_name) as image:
-            eq([], list(image.list_snaps()))
-        eq([], list(self.group.list_images()))
-
-    def test_group_image_remove_purge_preserves_unrelated_group_snapshot(self):
-        image2_name = get_temp_image_name()
-        RBD().create(ioctx, image2_name, IMG_SIZE)
-        try:
-            self.group.add_image(ioctx, image_name)
-            self.group.create_snap("snap1")
-            self.group.add_image(ioctx, image2_name)
-            # Future snapshots should no longer include image1.
-            self.group.remove_image(ioctx, image_name, force=True)
-            self.group.create_snap("snap2")
-            # Purge only snapshots that reference image2.
-            self.group.remove_image(ioctx, image2_name,
-                                    purge_user_snaps=True)
-            eq(["snap1"], [s["name"] for s in self.group.list_snaps()])
-            with Image(ioctx, image_name) as image:
-                snaps = list(image.list_snaps())
-                eq(1, len(snaps))
-                eq(RBD_SNAP_NAMESPACE_TYPE_GROUP, snaps[0]["namespace"])
-            with Image(ioctx, image2_name) as image:
-                eq([], list(image.list_snaps()))
-            self.group.remove_snap("snap1")
-        finally:
-            RBD().remove(ioctx, image2_name)
-
-    def test_group_image_remove_force_and_purge_invalid(self):
-        self.group.add_image(ioctx, image_name)
-        self.group.create_snap("snap1")
-        assert_raises(InvalidArgument, self.group.remove_image, ioctx,
-                      image_name, force=True, purge_user_snaps=True)
-        eq([image_name], [img["name"] for img in self.group.list_images()])
-        eq(["snap1"], [snap["name"] for snap in self.group.list_snaps()])
-
     def test_group_snap_get_info(self):
         self.image_names.append(create_image())
         self.image_names.sort()

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -3147,6 +3147,70 @@ class TestGroups(object):
         with Image(ioctx, image_name) as image:
             eq(0, image.op_features() & RBD_OPERATION_FEATURE_GROUP)
 
+    def test_group_image_remove_default(self):
+        self.group.add_image(ioctx, image_name)
+        self.group.create_snap("snap1")
+        assert_raises(ImageBusy, self.group.remove_image,
+                      ioctx, image_name)
+        self.group.remove_snap("snap1")
+        self.group.remove_image(ioctx, image_name)
+        eq([], list(self.group.list_images()))
+
+    def test_group_image_remove_force(self):
+        self.group.add_image(ioctx, image_name)
+        self.group.create_snap("snap1")
+        self.group.remove_image(ioctx, image_name, force=True)
+        eq([], list(self.group.list_images()))
+        with Image(ioctx, image_name) as image:
+            snaps = list(image.list_snaps())
+            eq(1, len(snaps))
+            eq(RBD_SNAP_NAMESPACE_TYPE_GROUP, snaps[0]["namespace"])
+        eq(1, len(list(self.group.list_snaps())))
+        self.group.remove_snap("snap1")
+
+    def test_group_image_remove_purge(self):
+        self.group.add_image(ioctx, image_name)
+        self.group.create_snap("snap1")
+        with Image(ioctx, image_name) as image:
+            eq(1, len(list(image.list_snaps())))
+        self.group.remove_image(ioctx, image_name, purge_user_snaps=True)
+        eq([], list(self.group.list_snaps()))
+        with Image(ioctx, image_name) as image:
+            eq([], list(image.list_snaps()))
+        eq([], list(self.group.list_images()))
+
+    def test_group_image_remove_purge_preserves_unrelated_group_snapshot(self):
+        image2_name = get_temp_image_name()
+        RBD().create(ioctx, image2_name, IMG_SIZE)
+        try:
+            self.group.add_image(ioctx, image_name)
+            self.group.create_snap("snap1")
+            self.group.add_image(ioctx, image2_name)
+            # Future snapshots should no longer include image1.
+            self.group.remove_image(ioctx, image_name, force=True)
+            self.group.create_snap("snap2")
+            # Purge only snapshots that reference image2.
+            self.group.remove_image(ioctx, image2_name,
+                                    purge_user_snaps=True)
+            eq(["snap1"], [s["name"] for s in self.group.list_snaps()])
+            with Image(ioctx, image_name) as image:
+                snaps = list(image.list_snaps())
+                eq(1, len(snaps))
+                eq(RBD_SNAP_NAMESPACE_TYPE_GROUP, snaps[0]["namespace"])
+            with Image(ioctx, image2_name) as image:
+                eq([], list(image.list_snaps()))
+            self.group.remove_snap("snap1")
+        finally:
+            RBD().remove(ioctx, image2_name)
+
+    def test_group_image_remove_force_and_purge_invalid(self):
+        self.group.add_image(ioctx, image_name)
+        self.group.create_snap("snap1")
+        assert_raises(InvalidArgument, self.group.remove_image, ioctx,
+                      image_name, force=True, purge_user_snaps=True)
+        eq([image_name], [img["name"] for img in self.group.list_images()])
+        eq(["snap1"], [snap["name"] for snap in self.group.list_snaps()])
+
     def test_group_snap_get_info(self):
         self.image_names.append(create_image())
         self.image_names.sort()
@@ -3259,7 +3323,7 @@ class TestGroups(object):
         self.group.add_image(ioctx, image_name)
         self.group.create_snap(snap_name)
         eq(1, len([snap['name'] for snap in self.image.list_snaps()]))
-        self.group.remove_image(ioctx, image_name)
+        self.group.remove_image(ioctx, image_name, force=True) # old default
         self.group.remove_snap(snap_name)
         eq([], list(self.group.list_snaps()))
 
@@ -3451,7 +3515,7 @@ class TestGroups(object):
             image.write(b'c' * 256, 0)
 
         for i in range(0, 3):
-            self.group.remove_image(ioctx, self.image_names[i])
+            self.group.remove_image(ioctx, self.image_names[i], force=True) # old default
         with Image(ioctx, self.image_names[0]) as image:
             image_snaps = list(image.list_snaps())
             assert [s['namespace'] for s in image_snaps] == [RBD_SNAP_NAMESPACE_TYPE_GROUP,
@@ -3497,21 +3561,21 @@ class TestGroups(object):
             assert read == b'c' * 256
 
         # group = [img1]
-        self.group.remove_image(ioctx, self.image_names[0])
+        self.group.remove_image(ioctx, self.image_names[0], force=True) # old default
         self.group.add_image(ioctx, self.image_names[1])
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name1)
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name2)
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name3)
 
         # group = [img2]
-        self.group.remove_image(ioctx, self.image_names[1])
+        self.group.remove_image(ioctx, self.image_names[1], force=True) # old default
         self.group.add_image(ioctx, self.image_names[2])
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name1)
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name2)
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name3)
 
         # group = [img0 img1]
-        self.group.remove_image(ioctx, self.image_names[2])
+        self.group.remove_image(ioctx, self.image_names[2], force=True) # old default
         # re-add in reverse order to test that order doesn't matter
         self.group.add_image(ioctx, self.image_names[1])
         self.group.add_image(ioctx, self.image_names[0])
@@ -3530,14 +3594,14 @@ class TestGroups(object):
             assert read == b'c' * 256
 
         # group = [img0 img2]
-        self.group.remove_image(ioctx, self.image_names[1])
+        self.group.remove_image(ioctx, self.image_names[1], force=True) # old default
         self.group.add_image(ioctx, self.image_names[2])
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name1)
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name2)
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name3)
 
         # group = [img1 img2]
-        self.group.remove_image(ioctx, self.image_names[0])
+        self.group.remove_image(ioctx, self.image_names[0], force=True) # old default
         self.group.add_image(ioctx, self.image_names[1])
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name1)
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name2)
@@ -3560,7 +3624,7 @@ class TestGroups(object):
             assert read == b'9' * 256
 
         # group = [img0 img1]
-        self.group.remove_image(ioctx, self.image_names[2])
+        self.group.remove_image(ioctx, self.image_names[2], force=True) # old default
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name1)
         self.group.rollback_to_snap(snap_name2)
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name3)
@@ -3576,7 +3640,7 @@ class TestGroups(object):
             assert read == b'9' * 256
 
         # group = [img0]
-        self.group.remove_image(ioctx, self.image_names[1])
+        self.group.remove_image(ioctx, self.image_names[1], force=True) # old default
         self.group.rollback_to_snap(snap_name1)
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name2)
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name3)

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -3148,6 +3148,70 @@ class TestGroups(object):
         with Image(ioctx, image_name) as image:
             eq(0, image.op_features() & RBD_OPERATION_FEATURE_GROUP)
 
+    def test_group_image_remove_default(self):
+        self.group.add_image(ioctx, image_name)
+        self.group.create_snap("snap1")
+        assert_raises(ImageBusy, self.group.remove_image,
+                      ioctx, image_name)
+        self.group.remove_snap("snap1")
+        self.group.remove_image(ioctx, image_name)
+        eq([], list(self.group.list_images()))
+
+    def test_group_image_remove_force(self):
+        self.group.add_image(ioctx, image_name)
+        self.group.create_snap("snap1")
+        self.group.remove_image(ioctx, image_name, force=True)
+        eq([], list(self.group.list_images()))
+        with Image(ioctx, image_name) as image:
+            snaps = list(image.list_snaps())
+            eq(1, len(snaps))
+            eq(RBD_SNAP_NAMESPACE_TYPE_GROUP, snaps[0]["namespace"])
+        eq(1, len(list(self.group.list_snaps())))
+        self.group.remove_snap("snap1")
+
+    def test_group_image_remove_purge(self):
+        self.group.add_image(ioctx, image_name)
+        self.group.create_snap("snap1")
+        with Image(ioctx, image_name) as image:
+            eq(1, len(list(image.list_snaps())))
+        self.group.remove_image(ioctx, image_name, purge_user_snaps=True)
+        eq([], list(self.group.list_snaps()))
+        with Image(ioctx, image_name) as image:
+            eq([], list(image.list_snaps()))
+        eq([], list(self.group.list_images()))
+
+    def test_group_image_remove_purge_preserves_unrelated_group_snapshot(self):
+        image2_name = get_temp_image_name()
+        RBD().create(ioctx, image2_name, IMG_SIZE)
+        try:
+            self.group.add_image(ioctx, image_name)
+            self.group.create_snap("snap1")
+            self.group.add_image(ioctx, image2_name)
+            # Future snapshots should no longer include image1.
+            self.group.remove_image(ioctx, image_name, force=True)
+            self.group.create_snap("snap2")
+            # Purge only snapshots that reference image2.
+            self.group.remove_image(ioctx, image2_name,
+                                    purge_user_snaps=True)
+            eq(["snap1"], [s["name"] for s in self.group.list_snaps()])
+            with Image(ioctx, image_name) as image:
+                snaps = list(image.list_snaps())
+                eq(1, len(snaps))
+                eq(RBD_SNAP_NAMESPACE_TYPE_GROUP, snaps[0]["namespace"])
+            with Image(ioctx, image2_name) as image:
+                eq([], list(image.list_snaps()))
+            self.group.remove_snap("snap1")
+        finally:
+            RBD().remove(ioctx, image2_name)
+
+    def test_group_image_remove_force_and_purge_invalid(self):
+        self.group.add_image(ioctx, image_name)
+        self.group.create_snap("snap1")
+        assert_raises(InvalidArgument, self.group.remove_image, ioctx,
+                      image_name, force=True, purge_user_snaps=True)
+        eq([image_name], [img["name"] for img in self.group.list_images()])
+        eq(["snap1"], [snap["name"] for snap in self.group.list_snaps()])
+
     def test_group_snap_get_info(self):
         self.image_names.append(create_image())
         self.image_names.sort()
@@ -3263,7 +3327,7 @@ class TestGroups(object):
         self.group.add_image(ioctx, image_name)
         self.group.create_snap(snap_name)
         eq(1, len([snap['name'] for snap in self.image.list_snaps()]))
-        self.group.remove_image(ioctx, image_name)
+        self.group.remove_image(ioctx, image_name, force=True) # old default
         self.group.remove_snap(snap_name)
         eq([], list(self.group.list_snaps()))
 
@@ -3456,7 +3520,7 @@ class TestGroups(object):
             image.write(b'c' * 256, 0)
 
         for i in range(0, 3):
-            self.group.remove_image(ioctx, self.image_names[i])
+            self.group.remove_image(ioctx, self.image_names[i], force=True) # old default
         with Image(ioctx, self.image_names[0]) as image:
             image_snaps = list(image.list_snaps())
             assert [s['namespace'] for s in image_snaps] == [RBD_SNAP_NAMESPACE_TYPE_GROUP,
@@ -3505,21 +3569,21 @@ class TestGroups(object):
             assert read == b'c' * 256
 
         # group = [img1]
-        self.group.remove_image(ioctx, self.image_names[0])
+        self.group.remove_image(ioctx, self.image_names[0], force=True) # old default
         self.group.add_image(ioctx, self.image_names[1])
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name1)
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name2)
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name3)
 
         # group = [img2]
-        self.group.remove_image(ioctx, self.image_names[1])
+        self.group.remove_image(ioctx, self.image_names[1], force=True) # old default
         self.group.add_image(ioctx, self.image_names[2])
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name1)
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name2)
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name3)
 
         # group = [img0 img1]
-        self.group.remove_image(ioctx, self.image_names[2])
+        self.group.remove_image(ioctx, self.image_names[2], force=True) # old default
         # re-add in reverse order to test that order doesn't matter
         self.group.add_image(ioctx, self.image_names[1])
         self.group.add_image(ioctx, self.image_names[0])
@@ -3538,14 +3602,14 @@ class TestGroups(object):
             assert read == b'c' * 256
 
         # group = [img0 img2]
-        self.group.remove_image(ioctx, self.image_names[1])
+        self.group.remove_image(ioctx, self.image_names[1], force=True) # old default
         self.group.add_image(ioctx, self.image_names[2])
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name1)
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name2)
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name3)
 
         # group = [img1 img2]
-        self.group.remove_image(ioctx, self.image_names[0])
+        self.group.remove_image(ioctx, self.image_names[0], force=True) # old default
         self.group.add_image(ioctx, self.image_names[1])
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name1)
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name2)
@@ -3568,7 +3632,7 @@ class TestGroups(object):
             assert read == b'9' * 256
 
         # group = [img0 img1]
-        self.group.remove_image(ioctx, self.image_names[2])
+        self.group.remove_image(ioctx, self.image_names[2], force=True) # old default
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name1)
         self.group.rollback_to_snap(snap_name2)
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name3)
@@ -3584,7 +3648,7 @@ class TestGroups(object):
             assert read == b'9' * 256
 
         # group = [img0]
-        self.group.remove_image(ioctx, self.image_names[1])
+        self.group.remove_image(ioctx, self.image_names[1], force=True) # old default
         self.group.rollback_to_snap(snap_name1)
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name2)
         assert_raises(InvalidArgument, self.group.rollback_to_snap, snap_name3)

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -3169,49 +3169,6 @@ class TestGroups(object):
         eq(1, len(list(self.group.list_snaps())))
         self.group.remove_snap("snap1")
 
-    def test_group_image_remove_purge(self):
-        self.group.add_image(ioctx, image_name)
-        self.group.create_snap("snap1")
-        with Image(ioctx, image_name) as image:
-            eq(1, len(list(image.list_snaps())))
-        self.group.remove_image(ioctx, image_name, purge_user_snaps=True)
-        eq([], list(self.group.list_snaps()))
-        with Image(ioctx, image_name) as image:
-            eq([], list(image.list_snaps()))
-        eq([], list(self.group.list_images()))
-
-    def test_group_image_remove_purge_preserves_unrelated_group_snapshot(self):
-        image2_name = get_temp_image_name()
-        RBD().create(ioctx, image2_name, IMG_SIZE)
-        try:
-            self.group.add_image(ioctx, image_name)
-            self.group.create_snap("snap1")
-            self.group.add_image(ioctx, image2_name)
-            # Future snapshots should no longer include image1.
-            self.group.remove_image(ioctx, image_name, force=True)
-            self.group.create_snap("snap2")
-            # Purge only snapshots that reference image2.
-            self.group.remove_image(ioctx, image2_name,
-                                    purge_user_snaps=True)
-            eq(["snap1"], [s["name"] for s in self.group.list_snaps()])
-            with Image(ioctx, image_name) as image:
-                snaps = list(image.list_snaps())
-                eq(1, len(snaps))
-                eq(RBD_SNAP_NAMESPACE_TYPE_GROUP, snaps[0]["namespace"])
-            with Image(ioctx, image2_name) as image:
-                eq([], list(image.list_snaps()))
-            self.group.remove_snap("snap1")
-        finally:
-            RBD().remove(ioctx, image2_name)
-
-    def test_group_image_remove_force_and_purge_invalid(self):
-        self.group.add_image(ioctx, image_name)
-        self.group.create_snap("snap1")
-        assert_raises(InvalidArgument, self.group.remove_image, ioctx,
-                      image_name, force=True, purge_user_snaps=True)
-        eq([image_name], [img["name"] for img in self.group.list_images()])
-        eq(["snap1"], [snap["name"] for snap in self.group.list_snaps()])
-
     def test_group_snap_get_info(self):
         self.image_names.append(create_image())
         self.image_names.sort()

--- a/src/tools/rbd/action/Group.cc
+++ b/src/tools/rbd/action/Group.cc
@@ -445,6 +445,20 @@ int execute_remove_image(const po::variables_map &vm,
     return r;
   }
 
+  const bool purge = vm["purge-user-snaps"].as<bool>();
+  const bool force = vm["force"].as<bool>();
+  if (purge && force) {
+    std::cerr << "rbd: --force and --purge-user-snaps are mutually exclusive."
+              << std::endl;
+    return -EINVAL;
+  }
+  auto mode = RBD_GROUP_IMAGE_REMOVE_DEFAULT;
+  if (purge) {
+    mode = RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS;
+  } else if (force) {
+    mode = RBD_GROUP_IMAGE_REMOVE_FORCE;
+  }
+
   if (group_namespace_name != image_namespace_name) {
     std::cerr << "rbd: group and image namespace must match." << std::endl;
     return -EINVAL;
@@ -470,12 +484,18 @@ int execute_remove_image(const po::variables_map &vm,
   librbd::RBD rbd;
   if (image_id.empty()) {
     r = rbd.group_image_remove(cg_io_ctx, group_name.c_str(),
-                               image_io_ctx, image_name.c_str());
+                               image_io_ctx, image_name.c_str(), mode);
   } else {
     r = rbd.group_image_remove_by_id(cg_io_ctx, group_name.c_str(),
-                                     image_io_ctx, image_id.c_str());
+                                     image_io_ctx, image_id.c_str(), mode);
   }
-  if (r < 0) {
+  if (r == -EBUSY) {
+    std::cerr << "rbd: image is referenced by one or more user group snapshots.\n"
+              << "Use --force to keep dependent snapshots.\n"
+              << "Use --purge-user-snaps to delete dependent snapshots."
+              << std::endl;
+    return r;
+  } else if (r < 0) {
     std::cerr << "rbd: remove image error: " << cpp_strerror(r) << std::endl;
     return r;
   }
@@ -1070,6 +1090,15 @@ void get_remove_image_arguments(po::options_description *positional,
   at::add_image_option(options, at::ARGUMENT_MODIFIER_NONE);
 
   at::add_image_id_option(options);
+
+  options->add_options()
+    ("force",
+     po::bool_switch()->default_value(false),
+     "keep dependent user group snapshots");
+
+  options->add_options()
+    ("purge-user-snaps", po::bool_switch()->default_value(false),
+     "delete dependent user group snapshots");
 }
 
 void get_list_images_arguments(po::options_description *positional,

--- a/src/tools/rbd/action/Group.cc
+++ b/src/tools/rbd/action/Group.cc
@@ -31,6 +31,50 @@ static const std::string IMAGE_POOL_NAME("image-" + at::POOL_NAME);
 static const std::string GROUP_NAMESPACE_NAME("group-" + at::NAMESPACE_NAME);
 static const std::string IMAGE_NAMESPACE_NAME("image-" + at::NAMESPACE_NAME);
 
+namespace {
+
+int purge_dependent_user_group_snapshots(librados::IoCtx& ioctx,
+                                         const std::string& group_name,
+                                         const std::string& image_name)
+{
+  librbd::RBD rbd;
+  std::vector<librbd::group_snap_info2_t> snaps;
+  int r = rbd.group_snap_list2(ioctx, group_name.c_str(), &snaps);
+  if (r < 0) {
+    return r;
+  }
+
+  for (const auto& snap : snaps) {
+    // only purge user-created snapshots
+    if (snap.namespace_type != RBD_GROUP_SNAP_NAMESPACE_TYPE_USER) {
+      continue;
+    }
+
+    auto match = std::find_if(snap.image_snaps.begin(),
+                              snap.image_snaps.end(),
+                              [&](const auto& image_snap) {
+                                return image_snap.image_name == image_name;
+                              });
+    if (match == snap.image_snaps.end()) {
+      continue;
+    }
+
+    std::cout << "purging dependent user group snapshot '" << snap.name
+              << "' from group '" << group_name
+              << "' for image '" << image_name << "'"
+              << std::endl;
+
+    r = rbd.group_snap_remove(ioctx, group_name.c_str(), snap.name.c_str());
+    if (r < 0) {
+      return r;
+    }
+  }
+
+  return 0;
+}
+
+} // anonymous namespace
+
 void add_prefixed_pool_option(po::options_description *opt,
                               const std::string &prefix) {
   std::string name = prefix + "-" + at::POOL_NAME;
@@ -452,12 +496,6 @@ int execute_remove_image(const po::variables_map &vm,
               << std::endl;
     return -EINVAL;
   }
-  auto mode = RBD_GROUP_IMAGE_REMOVE_DEFAULT;
-  if (purge) {
-    mode = RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS;
-  } else if (force) {
-    mode = RBD_GROUP_IMAGE_REMOVE_FORCE;
-  }
 
   if (group_namespace_name != image_namespace_name) {
     std::cerr << "rbd: group and image namespace must match." << std::endl;
@@ -481,7 +519,39 @@ int execute_remove_image(const po::variables_map &vm,
     return r;
   }
 
+  std::string purge_image_name = image_name;
   librbd::RBD rbd;
+  if (purge && !image_id.empty()) {
+    // Group snapshot metadata stores image names, not image IDs.
+    // Resolve the image name from the supplied image ID.
+    librbd::Image image;
+    r = rbd.open_by_id(image_io_ctx, image, image_id.c_str());
+    if (r < 0) {
+      std::cerr << "rbd: failed to open image id "
+                << image_id << ": " << cpp_strerror(r) << std::endl;
+      return r;
+    }
+
+    r = image.get_name(&purge_image_name);
+    image.close();
+    if (r < 0) {
+      std::cerr << "rbd: failed to get image name for image id "
+                << image_id << ": " << cpp_strerror(r) << std::endl;
+      return r;
+    }
+  }
+
+  auto mode = RBD_GROUP_IMAGE_REMOVE_DEFAULT;
+  if (purge) {
+    r = purge_dependent_user_group_snapshots(cg_io_ctx, group_name,
+                                             purge_image_name);
+    if (r < 0) {
+      return r;
+    }
+  } else if (force) {
+    mode = RBD_GROUP_IMAGE_REMOVE_FORCE;
+  }
+
   if (image_id.empty()) {
     r = rbd.group_image_remove(cg_io_ctx, group_name.c_str(),
                                image_io_ctx, image_name.c_str(), mode);

--- a/src/tools/rbd/action/Group.cc
+++ b/src/tools/rbd/action/Group.cc
@@ -31,6 +31,52 @@ static const std::string IMAGE_POOL_NAME("image-" + at::POOL_NAME);
 static const std::string GROUP_NAMESPACE_NAME("group-" + at::NAMESPACE_NAME);
 static const std::string IMAGE_NAMESPACE_NAME("image-" + at::NAMESPACE_NAME);
 
+namespace {
+
+int purge_dependent_user_group_snapshots(librados::IoCtx& ioctx,
+                                         const std::string& group_name,
+                                         int64_t image_pool_id,
+                                         const std::string& image_name)
+{
+  librbd::RBD rbd;
+  std::vector<librbd::group_snap_info2_t> snaps;
+  int r = rbd.group_snap_list2(ioctx, group_name.c_str(), &snaps);
+  if (r < 0) {
+    return r;
+  }
+
+  for (const auto& snap : snaps) {
+    // only purge user-created snapshots
+    if (snap.namespace_type != RBD_GROUP_SNAP_NAMESPACE_TYPE_USER) {
+      continue;
+    }
+
+    auto match = std::find_if(snap.image_snaps.begin(),
+                              snap.image_snaps.end(),
+                              [&](const auto& image_snap) {
+                                return image_snap.pool_id == image_pool_id &&
+                                       image_snap.image_name == image_name;
+                              });
+    if (match == snap.image_snaps.end()) {
+      continue;
+    }
+
+    std::cout << "purging dependent user group snapshot '" << snap.name
+              << "' from group '" << group_name
+              << "' for image '" << image_name << "'"
+              << std::endl;
+
+    r = rbd.group_snap_remove(ioctx, group_name.c_str(), snap.name.c_str());
+    if (r < 0) {
+      return r;
+    }
+  }
+
+  return 0;
+}
+
+} // anonymous namespace
+
 void add_prefixed_pool_option(po::options_description *opt,
                               const std::string &prefix) {
   std::string name = prefix + "-" + at::POOL_NAME;
@@ -452,12 +498,6 @@ int execute_remove_image(const po::variables_map &vm,
               << std::endl;
     return -EINVAL;
   }
-  auto mode = RBD_GROUP_IMAGE_REMOVE_DEFAULT;
-  if (purge) {
-    mode = RBD_GROUP_IMAGE_REMOVE_PURGE_USER_SNAPS;
-  } else if (force) {
-    mode = RBD_GROUP_IMAGE_REMOVE_FORCE;
-  }
 
   if (group_namespace_name != image_namespace_name) {
     std::cerr << "rbd: group and image namespace must match." << std::endl;
@@ -481,13 +521,69 @@ int execute_remove_image(const po::variables_map &vm,
     return r;
   }
 
+  std::string purge_image_name = image_name;
   librbd::RBD rbd;
-  if (image_id.empty()) {
-    r = rbd.group_image_remove(cg_io_ctx, group_name.c_str(),
-                               image_io_ctx, image_name.c_str(), mode);
-  } else {
-    r = rbd.group_image_remove_by_id(cg_io_ctx, group_name.c_str(),
-                                     image_io_ctx, image_id.c_str(), mode);
+  if (purge && !image_id.empty()) {
+    // Group snapshot metadata stores image names, not image IDs.
+    // Resolve the image name from the supplied image ID.
+    librbd::Image image;
+    r = rbd.open_by_id(image_io_ctx, image, image_id.c_str());
+    if (r < 0) {
+      std::cerr << "rbd: failed to open image id "
+                << image_id << ": " << cpp_strerror(r) << std::endl;
+      return r;
+    }
+
+    r = image.get_name(&purge_image_name);
+    image.close();
+    if (r < 0) {
+      std::cerr << "rbd: failed to get image name for image id "
+                << image_id << ": " << cpp_strerror(r) << std::endl;
+      return r;
+    }
+  }
+
+  auto remove_image = [&](rbd_group_image_remove_mode_t mode) {
+    if (image_id.empty()) {
+      return rbd.group_image_remove(cg_io_ctx, group_name.c_str(),
+                                    image_io_ctx, image_name.c_str(), mode);
+    }
+
+    return rbd.group_image_remove_by_id(cg_io_ctx, group_name.c_str(),
+                                        image_io_ctx, image_id.c_str(), mode);
+  };
+
+  if (purge) {
+    std::vector<librbd::group_image_info_t> images;
+    r = rbd.group_image_list(cg_io_ctx, group_name.c_str(), &images,
+                             sizeof(librbd::group_image_info_t));
+    if (r < 0) {
+      return r;
+    }
+
+    auto image_it = std::find_if(
+      images.begin(), images.end(), [&](const auto& image) {
+        return image.pool == image_io_ctx.get_id() &&
+               image.name == purge_image_name;
+      });
+    if (image_it == images.end()) {
+      std::cerr << "rbd: image is not a member of the group." << std::endl;
+      return -ENOENT;
+    }
+  }
+
+  auto mode = force ? RBD_GROUP_IMAGE_REMOVE_FORCE :
+                      RBD_GROUP_IMAGE_REMOVE_DEFAULT;
+  r = remove_image(mode);
+  if (purge && r == -EBUSY) {
+    r = purge_dependent_user_group_snapshots(cg_io_ctx, group_name,
+                                             image_io_ctx.get_id(),
+                                             purge_image_name);
+    if (r < 0) {
+      return r;
+    }
+
+    r = remove_image(RBD_GROUP_IMAGE_REMOVE_DEFAULT);
   }
   if (r == -EBUSY) {
     std::cerr << "rbd: image is referenced by one or more user group snapshots.\n"

--- a/src/tracing/librbd.tp
+++ b/src/tracing/librbd.tp
@@ -2734,7 +2734,8 @@ TRACEPOINT_EVENT(librbd, group_image_remove_enter,
         const char*, group_name,
         const char*, image_pool_name,
         int64_t, image_id,
-        const char*, image_name),
+        const char*, image_name,
+        int, mode),
     TP_FIELDS(
         ctf_string(pool_name, pool_name)
         ctf_integer(int64_t, id, id)
@@ -2742,6 +2743,7 @@ TRACEPOINT_EVENT(librbd, group_image_remove_enter,
         ctf_string(image_pool_name, image_pool_name)
         ctf_integer(int64_t, image_id, image_id)
         ctf_string(image_name, image_name)
+        ctf_integer(int, mode, mode)
     )
 )
 
@@ -2760,7 +2762,8 @@ TRACEPOINT_EVENT(librbd, group_image_remove_by_id_enter,
         const char*, group_name,
         const char*, image_pool_name,
         int64_t, image_ioctx_id,
-        const char*, image_id),
+        const char*, image_id,
+        int, mode),
     TP_FIELDS(
         ctf_string(pool_name, pool_name)
         ctf_integer(int64_t, id, id)
@@ -2768,6 +2771,7 @@ TRACEPOINT_EVENT(librbd, group_image_remove_by_id_enter,
         ctf_string(image_pool_name, image_pool_name)
         ctf_integer(int64_t, image_ioctx_id, image_ioctx_id)
         ctf_string(image_id, image_id)
+        ctf_integer(int, mode, mode)
     )
 )
 


### PR DESCRIPTION
Removing an image from a group currently ignores user group snapshot dependencies. As a result, user group snapshots can continue to reference an image that is no longer a member of the group. The associated .group image snapshots are also retained.

Add three group image remove modes:

* DEFAULT Return -EBUSY if the image is referenced by one or more user group snapshots.

* FORCE Remove the image without checking for user group snapshot dependencies. Existing user group snapshots and their .group image snapshots are preserved. This matches the previous behavior.

* PURGE_USER_SNAPS Remove all user group snapshots that reference the image before removing it from the group. The associated .group image snapshots are also removed.

Implement the removal modes in librbd rather than only in the CLI. Although `--purge-user-snaps` was initially proposed as a CLI convenience option, the behavior represents a distinct removal semantic. Exposing the modes through the API provides consistent behavior across the C, C++, Python, and CLI interfaces, avoids duplicating dependency handling in callers, and keeps the CLI as a thin wrapper over the librbd implementation.

The CLI adds:

--force              keep dependent user group snapshots
--purge-user-snaps   delete dependent user group snapshots
image

The default mode is safer because it prevents removing an image that is still referenced by user group snapshots. Existing internal callers that rely on the previous behavior are updated to use FORCE.

Also add unit and Python tests covering:

* default (-EBUSY) behavior
* force mode
* purge mode
* preserving unrelated group snapshots
* invalid mode





## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
