### PR TITLE
tentacle: mgr/dashboard: disable ibm telemetry on CI env

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -137,7 +137,7 @@ build_dashboard_frontend() {
   cd src/pybind/mgr/dashboard/frontend
 
   . $TEMP_DIR/bin/activate
-  NG_CLI_ANALYTICS=false timeout 1h npm ci
+  NG_CLI_ANALYTICS=false IBM_TELEMETRY_DISABLED=true timeout 1h npm ci
   echo "Building ceph-dashboard frontend with build:localize script";
   # we need to use "--" because so that "--configuration production"
   # survives accross all scripts redirections inside package.json

--- a/qa/workunits/cephadm/test_dashboard_e2e.sh
+++ b/qa/workunits/cephadm/test_dashboard_e2e.sh
@@ -76,6 +76,7 @@ CYPRESS_BASE_URL=$(ceph mgr services | jq -r .dashboard)
 export CYPRESS_BASE_URL
 
 cd $DASHBOARD_FRONTEND_DIR
+export IBM_TELEMETRY_DISABLED=true
 
 # This is required for Cypress to understand typescript
 npm ci --unsafe-perm

--- a/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
@@ -49,6 +49,7 @@ with_libvirt "kcli delete plan -y ceph || true"
 # Build dashboard frontend (required to start the module).
 cd ${CEPH_DEV_FOLDER}/src/pybind/mgr/dashboard/frontend
 export NG_CLI_ANALYTICS=false
+export IBM_TELEMETRY_DISABLED=true
 if [[ -n "$JENKINS_HOME" ]]; then
     npm cache clean --force
 fi

--- a/src/pybind/mgr/dashboard/frontend/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/frontend/CMakeLists.txt
@@ -93,7 +93,7 @@ endif(WITH_SYSTEM_NPM)
 
 add_npm_command(
   OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/node_modules"
-  COMMAND CYPRESS_CACHE_FOLDER=${CMAKE_SOURCE_DIR}/build/src/pybind/mgr/dashboard/cypress NG_CLI_ANALYTICS=false npm ci -f ${mgr-dashboard-userconfig}
+  COMMAND CYPRESS_CACHE_FOLDER=${CMAKE_SOURCE_DIR}/build/src/pybind/mgr/dashboard/cypress NG_CLI_ANALYTICS=false IBM_TELEMETRY_DISABLED=true npm ci -f ${mgr-dashboard-userconfig}
   DEPENDS package.json
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMENT "dashboard frontend dependencies are being installed"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78561

---

backport of https://github.com/ceph/ceph/pull/70412
parent tracker: https://tracker.ceph.com/issues/78559

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh