### PR TITLE
osd/scrub: exclude non-primary shards from auth_list

### DIFF
--- a/src/osd/scrubber/scrub_backend.cc
+++ b/src/osd/scrubber/scrub_backend.cc
@@ -1355,7 +1355,7 @@ ScrubBackend::auth_and_obj_errs_t ScrubBackend::match_in_shards(
         object_errors.insert(srd);
         errstream << m_pg_id << " soid " << ho << " : " << ss.str() << "\n";
 
-      } else {
+      } else if (!m_pg.get_is_nonprimary_shard(srd)) {
 
         // XXX: The auth shard might get here that we don't know
         // that it has the "correct" data.

--- a/src/test/osd/scrubber_generators.cc
+++ b/src/test/osd/scrubber_generators.cc
@@ -9,18 +9,31 @@
 
 using namespace ScrubGenerator;
 
+bufferlist ScrubGenerator::encode_object_info(
+    const hobject_t& soid,
+    eversion_t version,
+    uint64_t size,
+    eversion_t prior_version,
+    std::map<shard_id_t, eversion_t> shard_versions)
+{
+  object_info_t oi{};
+  oi.soid = soid;
+  oi.version = version;
+  oi.prior_version = prior_version;
+  oi.size = size;
+  oi.shard_versions = shard_versions;
+  bufferlist bl;
+  oi.encode(bl, -1ull);
+  return bl;
+}
+
 // ref: PGLogTestRebuildMissing()
 bufferlist create_object_info(const ScrubGenerator::RealObj& objver)
 {
-  object_info_t oi{};
-  oi.soid = objver.ghobj.hobj;
-  oi.version = eversion_t(objver.ghobj.generation, 0);
-  oi.size = objver.data.size;
-
-  bufferlist bl;
-  oi.encode(bl,
-	    0 /*get_osdmap()->get_features(CEPH_ENTITY_TYPE_OSD, nullptr)*/);
-  return bl;
+  return ScrubGenerator::encode_object_info(
+      objver.ghobj.hobj,
+      eversion_t(objver.ghobj.generation, 0),
+      objver.data.size);
 }
 
 std::pair<bufferlist, std::vector<snapid_t>> create_object_snapset(

--- a/src/test/osd/scrubber_generators.h
+++ b/src/test/osd/scrubber_generators.h
@@ -117,6 +117,7 @@ struct pool_conf_t {
   std::string name{"rep_pool"};
   uint8_t type{pg_pool_t::TYPE_REPLICATED};
   std::optional<erasure_code_profile_conf_t> erasure_code_profile;
+  std::set<shard_id_t> nonprimary_shards;
 };
 
 using attr_t = std::map<std::string, std::string>;
@@ -261,6 +262,13 @@ RealObjsConfList make_real_objs_conf(int64_t pool_id,
  * to be used as the 'snap_mapper')
  */
 all_clones_snaps_t all_clones(const RealObj& head_obj);
+bufferlist encode_object_info(
+    const hobject_t& soid,
+    eversion_t version,
+    uint64_t size,
+    eversion_t prior_version = eversion_t{},
+    std::map<shard_id_t, eversion_t> shard_versions = {});
+
 }  // namespace ScrubGenerator
 
 template <>

--- a/src/test/osd/test_scrubber_be.cc
+++ b/src/test/osd/test_scrubber_be.cc
@@ -95,9 +95,9 @@ class TestPg : public PgScrubBeListener {
 
   const pg_info_t& get_pg_info(ScrubberPasskey) const final { return m_info; }
 
-  uint64_t logical_to_ondisk_size(uint64_t logical_size,
-                                  shard_id_t shard_id,
-                                  bool unused) const final
+  virtual uint64_t logical_to_ondisk_size(uint64_t logical_size,
+                                          shard_id_t shard_id,
+                                          bool unused) const
   {
     return logical_size;
   }
@@ -544,6 +544,9 @@ OSDMapRef TestTScrubberBe::setup_map(int num_osds,
     p->set_flag(pg_pool_t::FLAG_EC_OVERWRITES);
     p->set_flag(pg_pool_t::FLAG_EC_OPTIMIZATIONS);
   }
+  for (auto s : pconf.nonprimary_shards) {
+    p->nonprimary_shards.insert(s);
+  }
   osdmap->apply_incremental(new_pool_inc);
   return osdmap;
 }
@@ -939,6 +942,290 @@ TEST_F(TestTScrubberBeECCorruptParityShard, ec_parity_inconsistency) {
   auto [incons, fix_list] = sbe->scrub_compare_maps(true, *test_scrubber);
 
   EXPECT_EQ(incons.size(), 1);
+}
+
+// ///////////////////////////////////////////////////////////////////////////
+// Guards against phantom scrub errors from non-primary shards.
+//
+// When any shard has an inconsistency (e.g. wrong OI version from a
+// rollback bug), update_authoritative() replaces the m_cleaned_meta_map
+// entry with data from peers.back().  If peers.back() is a non-primary
+// shard, scrub_snapshot_metadata() can produce phantom errors because it
+// evaluates the replacement using the primary's shard_id:
+//
+//   - Phantom "on disk size ... does not match": the non-primary shard's
+//     on-disk size differs from the primary shard's expected size (only
+//     for non-stripe-aligned objects where shards have different sizes).
+//   - Phantom "no 'snapset' attr": non-primary shards don't carry SS_ATTR.
+//
+// The fix (excluding non-primary shards from auth_list in match_in_shards)
+// ensures peers.back() is always a primary-capable shard.  These tests
+// verify that only the genuine error is reported — no phantom size
+// mismatch and no phantom snapset error.
+//
+// Test fixture: k=4, m=2 optimised EC pool (via TestTScrubberBe).
+//   Non-primary shards: 1, 2, 3.  Primary-capable: 0, 4, 5.
+//   Acting set arranged so that without the fix, peers.back() would be a
+//   non-primary shard with a different expected size from shard 0.
+// ///////////////////////////////////////////////////////////////////////////
+
+// TestPg subclass that models per-shard on-disk sizes for k=4, m=2 EC.
+// The base TestPg::logical_to_ondisk_size() returns logical_size unchanged,
+// which cannot model different shard sizes needed to trigger the size phantom.
+class ECOptimisedPg : public TestPg {
+ public:
+  using TestPg::TestPg;
+
+  static constexpr uint64_t K            = 4;
+  static constexpr uint64_t CHUNK_SIZE   = 16384;
+  static constexpr uint64_t STRIPE_WIDTH = K * CHUNK_SIZE;
+  static constexpr uint64_t ALIGN        = 4096;
+
+  static uint64_t align_next(uint64_t val) {
+    return (val + ALIGN - 1) / ALIGN * ALIGN;
+  }
+
+  static uint64_t shard_size(uint64_t oi_size, uint64_t raw_shard) {
+    if (raw_shard >= K) raw_shard = 0;
+    uint64_t remainder  = oi_size % STRIPE_WIDTH;
+    uint64_t full_part  = (oi_size - remainder) / K;
+    uint64_t partial    = 0;
+    if (remainder > raw_shard * CHUNK_SIZE) {
+      partial = remainder - raw_shard * CHUNK_SIZE;
+      if (partial > CHUNK_SIZE) partial = CHUNK_SIZE;
+    }
+    return align_next(full_part + partial);
+  }
+
+  static uint64_t raw(shard_id_t s) { return static_cast<uint64_t>(int8_t(s)); }
+
+  uint64_t logical_to_ondisk_size(uint64_t logical_size,
+                                  shard_id_t shard_id,
+                                  bool object_is_legacy_ec) const final {
+    if (object_is_legacy_ec) {
+      uint64_t chunks = (logical_size + STRIPE_WIDTH - 1) / STRIPE_WIDTH;
+      return chunks * CHUNK_SIZE;
+    }
+    return shard_size(logical_size, raw(shard_id));
+  }
+};
+
+class TestPhantomScrubErrors : public TestTScrubberBe {
+ public:
+  static pg_shard_t PS(int osd, int shard) {
+    return pg_shard_t{osd, shard_id_t{static_cast<int8_t>(shard)}};
+  }
+
+  hobject_t head_hobj;
+  std::unique_ptr<ECOptimisedPg> ec_test_pg;
+
+  pool_conf_t pl{
+    32, 32, 6, 5, "test_ec_pool", pg_pool_t::TYPE_ERASURE,
+    erasure_code_profile_conf_t{
+      "test_ec_profile",
+      {{"k", "4"}, {"m", "2"}, {"plugin", "isa"},
+       {"technique", "reed_sol_van"}, {"stripe_unit", "16384"}}},
+    {shard_id_t{1}, shard_id_t{2}, shard_id_t{3}}
+  };
+
+  // Not used — build_scenario() drives setup directly.
+  TestTScrubberBeParams inject_params() override { return {}; }
+
+  // Override SetUp to skip the ScrubGenerator pipeline.
+  // Each test calls build_scenario() explicitly.
+  void SetUp() override { logger.err_count = 0; }
+
+  // Build the test scenario.  |bug_shard| is the non-primary shard that
+  // gets the wrong OI version.  |oi_size| controls whether shards have
+  // different expected sizes.
+  void build_scenario(int bug_shard, uint64_t oi_size);
+};
+
+void TestPhantomScrubErrors::build_scenario(int bug_shard, uint64_t oi_size)
+{
+  logger.err_count = 0;
+
+  // Use TestTScrubberBe::setup_map() for OSDMap + pool creation
+  osdmap = setup_map(6, pl);
+  pool_id = osdmap->lookup_pg_pool_name("test_ec_pool");
+  const pg_pool_t* pinfo = osdmap->get_pg_pool(pool_id);
+  pool = std::make_shared<PGPool>(osdmap, pool_id, *pinfo, "test_ec_pool");
+
+  // Acting set: arranged so that the highest pg_shard_t (by osd, shard)
+  // among the non-primary shards is shard 3 on osd.5.  This makes shard 3
+  // the peers.back() candidate when another non-primary shard has errors.
+  i_am = PS(1, 0);
+  acting_shards = {
+    PS(1, 0),  // shard 0: primary-capable
+    PS(5, 1),  // shard 1: non-primary
+    PS(4, 2),  // shard 2: non-primary
+    PS(5, 3),  // shard 3: non-primary (highest pg_shard_t among non-primary)
+    PS(3, 4),  // shard 4: parity, primary-capable
+    PS(2, 5),  // shard 5: parity, primary-capable
+  };
+
+  spg = spg_t{pg_t{0xe, static_cast<uint64_t>(pool_id)}, shard_id_t{0}};
+  info.pgid = spg;
+  info.last_user_version = 1;
+  info.last_backfill = hobject_t::get_max();
+
+  test_scrubber = std::make_unique<TestScrubber>(spg, osdmap, logger);
+  ec_test_pg = std::make_unique<ECOptimisedPg>(pool, info, i_am);
+  ec_test_pg->set_stripe_info(4, 2, 65536, &pool->info);
+
+  sbe = std::make_unique<TestScrubBackend>(
+      *test_scrubber, *ec_test_pg, i_am,
+      /*repair=*/false, scrub_level_t::deep, acting_shards);
+  sbe->new_chunk();
+
+  head_hobj = hobject_t{
+    object_t{"test_object"}, "", CEPH_NOSNAP,
+    0x12345678u, static_cast<int64_t>(pool_id), ""};
+
+  const eversion_t head_ver  {10, 100};
+  const eversion_t prior_ver {10,  99};
+  const eversion_t sv1       { 8,  80};
+  const eversion_t sv2       { 7,  70};
+  const eversion_t sv3       { 6,  60};
+
+  std::map<shard_id_t, eversion_t> auth_shard_versions{
+    {shard_id_t{1}, sv1}, {shard_id_t{2}, sv2}, {shard_id_t{3}, sv3},
+  };
+  std::map<int, eversion_t> correct_sv{{1, sv1}, {2, sv2}, {3, sv3}};
+
+  bufferlist oi_auth = ScrubGenerator::encode_object_info(
+      head_hobj, head_ver, oi_size, prior_ver, auth_shard_versions);
+
+  SnapSet ss;
+  ss.seq = 0;
+  bufferlist ss_bl;
+  encode(ss, ss_bl);
+
+  auto insert_smap = [&](pg_shard_t ps, uint64_t size, bufferlist oi_bl,
+                         bool has_ss) {
+    ScrubMap smap;
+    smap.valid_through = eversion_t{1, 1};
+    smap.incr_since    = eversion_t{1, 1};
+    ScrubMap::object& obj = smap.objects[head_hobj];
+    obj.size = size;
+    obj.attrs[OI_ATTR] = oi_bl;
+    if (has_ss) obj.attrs[SS_ATTR] = ss_bl;
+    sbe->insert_faked_smap(ps, smap);
+  };
+
+  // Primary-capable shards: correct auth OI, correct size, have SS_ATTR
+  insert_smap(PS(1, 0), ECOptimisedPg::shard_size(oi_size, 0), oi_auth, true);
+  insert_smap(PS(3, 4), ECOptimisedPg::shard_size(oi_size, 4), oi_auth, true);
+  insert_smap(PS(2, 5), ECOptimisedPg::shard_size(oi_size, 5), oi_auth, true);
+
+  // Non-primary shards: correct on-disk sizes, no SS_ATTR.
+  // One shard gets the wrong OI version (head_ver instead of its stale
+  // version) to simulate the rollback bug.
+  const pg_shard_t np_shards[] = {PS(5, 1), PS(4, 2), PS(5, 3)};
+  for (int s : {1, 2, 3}) {
+    eversion_t ver = (s == bug_shard) ? head_ver : correct_sv[s];
+    bufferlist oi_bl = ScrubGenerator::encode_object_info(
+        head_hobj, ver, oi_size, prior_ver,
+        (s == bug_shard) ? auth_shard_versions
+                         : std::map<shard_id_t, eversion_t>{});
+    insert_smap(np_shards[s - 1], ECOptimisedPg::shard_size(oi_size, s),
+                oi_bl, false);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Non-stripe-aligned object: guards against both phantom size mismatch
+// and phantom snapset error.
+//
+// oi_size=4050944: shard 3 on-disk size (1003520) differs from shard 0
+// (1015808).  A version error on shard 1 would (without the fix) cause
+// peers.back() = shard 3, leading to:
+//   - phantom "on disk size ... does not match" (1003520 vs 1015808)
+//   - phantom "no 'snapset' attr" (shard 3 has no SS_ATTR)
+//
+// With the fix, only the genuine version-mismatch error should be reported.
+// ---------------------------------------------------------------------------
+TEST_F(TestPhantomScrubErrors, nonprimary_version_error_causes_phantom_size_and_snapset)
+{
+  build_scenario(/*bug_shard=*/1, /*oi_size=*/4050944);
+  ASSERT_TRUE(sbe);
+
+  logger.set_expected_err_count(1);
+
+  auto [incons, fix_list] = sbe->scrub_compare_maps(true, *test_scrubber);
+
+  EXPECT_EQ(fix_list.size(), 0u);
+  EXPECT_EQ(incons.size(), 1u);
+
+  bool found_obj_inconsistency = false;
+  bool found_snapset_phantom   = false;
+  bool found_size_phantom      = false;
+  for (const auto& w : incons) {
+    if (std::holds_alternative<inconsistent_obj_wrapper>(w))
+      found_obj_inconsistency = true;
+    if (auto* s = std::get_if<inconsistent_snapset_wrapper>(&w)) {
+      if (s->snapset_missing())
+        found_snapset_phantom = true;
+      if (s->size_mismatch())
+        found_size_phantom = true;
+    }
+  }
+
+  EXPECT_TRUE(found_obj_inconsistency)
+    << "Expected version-mismatch error on the bug shard";
+  EXPECT_FALSE(found_snapset_phantom)
+    << "Phantom 'no snapset attr': non-primary shard used as "
+       "m_cleaned_meta_map source lacks SS_ATTR";
+  EXPECT_FALSE(found_size_phantom)
+    << "Phantom size mismatch: non-primary shard's on-disk size evaluated "
+       "against primary shard's expected size in scrub_snapshot_metadata";
+}
+
+// ---------------------------------------------------------------------------
+// Stripe-aligned object: guards against the phantom snapset error.
+//
+// oi_size=65536 (one full stripe): all shards have the same on-disk size,
+// so even without the fix, no phantom size mismatch would occur.  But
+// without the fix, the phantom "no 'snapset' attr" would still fire
+// because the non-primary replacement shard lacks SS_ATTR regardless of
+// its on-disk size.
+//
+// With the fix, only the genuine version-mismatch error should be reported.
+// ---------------------------------------------------------------------------
+TEST_F(TestPhantomScrubErrors, stripe_aligned_no_phantom_size_but_phantom_snapset)
+{
+  build_scenario(/*bug_shard=*/1, /*oi_size=*/65536);
+  ASSERT_TRUE(sbe);
+
+  logger.set_expected_err_count(1);
+
+  auto [incons, fix_list] = sbe->scrub_compare_maps(true, *test_scrubber);
+
+  EXPECT_EQ(fix_list.size(), 0u);
+  EXPECT_EQ(incons.size(), 1u);
+
+  bool found_obj_inconsistency = false;
+  bool found_snapset_phantom   = false;
+  bool found_size_phantom      = false;
+  for (const auto& w : incons) {
+    if (std::holds_alternative<inconsistent_obj_wrapper>(w))
+      found_obj_inconsistency = true;
+    if (auto* s = std::get_if<inconsistent_snapset_wrapper>(&w)) {
+      if (s->snapset_missing())
+        found_snapset_phantom = true;
+      if (s->size_mismatch())
+        found_size_phantom = true;
+    }
+  }
+
+  EXPECT_TRUE(found_obj_inconsistency)
+    << "Expected version-mismatch error on the bug shard";
+  EXPECT_FALSE(found_snapset_phantom)
+    << "Phantom 'no snapset attr': still fires for stripe-aligned objects "
+       "because the non-primary source lacks SS_ATTR regardless of size";
+  EXPECT_FALSE(found_size_phantom)
+    << "No size phantom expected: all shards have the same on-disk size "
+       "for a stripe-aligned object";
 }
 
 // Local Variables:


### PR DESCRIPTION
In match_in_shards(), non-primary EC shards could be added to auth_list.  When an object has inconsistencies, update_authoritative() uses peers.back() from auth_list to replace the m_cleaned_meta_map entry.  If that shard is non-primary, scrub_snapshot_metadata() evaluates it using the primary's shard_id, producing phantom errors:

  - "on disk size ... does not match" (non-stripe-aligned objects where the non-primary shard has a different expected size)
  - "no 'snapset' attr" (non-primary shards don't carry SS_ATTR)

The only genuine error is whatever inconsistency triggered update_authoritative() in the first place (e.g. a version mismatch from a rollback bug).

Fix by filtering non-primary shards out of auth_list in match_in_shards().  Unit tests added in test_scrubber_be. cc.

Fixes: https://tracker.ceph.com/issues/78612


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
