### PR TITLE
src/crimson: statically link EC plugin, ISA, in crimson-osd

### DIFF
--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -209,3 +209,15 @@ add_subdirectory(admin)
 add_subdirectory(os)
 add_subdirectory(osd)
 add_subdirectory(tools)
+
+if(WITH_EC_ISA_PLUGIN)
+  add_library(ec_isa_crimson STATIC
+    ${PROJECT_SOURCE_DIR}/src/erasure-code/isa/ErasureCodeIsa.cc
+    ${PROJECT_SOURCE_DIR}/src/erasure-code/isa/ErasureCodeIsaTableCache.cc
+    ${PROJECT_SOURCE_DIR}/src/erasure-code/isa/ErasureCodePluginIsa.cc
+    $<TARGET_OBJECTS:erasure_code_objs>)
+  target_link_libraries(ec_isa_crimson PUBLIC ISAL::ISAL crimson::cflags)
+  target_compile_definitions(ec_isa_crimson INTERFACE WITH_EC_ISA_PLUGIN)
+  target_link_libraries(crimson-osd
+    -Wl,--whole-archive ec_isa_crimson -Wl,--no-whole-archive)
+endif()

--- a/src/erasure-code/ErasureCodePlugin.cc
+++ b/src/erasure-code/ErasureCodePlugin.cc
@@ -46,7 +46,7 @@ ErasureCodePluginRegistry::~ErasureCodePluginRegistry()
     assert(plugin);
     void *library = plugin->library;
     delete plugin;
-    if (!disable_dlclose) {
+    if (library && !disable_dlclose) {
       dlclose(library);
     }
   }
@@ -60,7 +60,9 @@ int ErasureCodePluginRegistry::remove(const std::string &name)
   std::map<std::string,ErasureCodePlugin*>::iterator plugin = plugins.find(name);
   void *library = plugin->second->library;
   delete plugin->second;
-  dlclose(library);
+  if (library) {
+    dlclose(library);
+  }
   plugins.erase(plugin);
   return 0;
 }
@@ -82,6 +84,21 @@ ErasureCodePlugin *ErasureCodePluginRegistry::get(const std::string &name)
     return plugins[name];
   else
     return 0;
+}
+
+static std::map<std::string, std::function<ErasureCodePlugin*()>>&
+builtin_plugins()
+{
+  static std::map<std::string, std::function<ErasureCodePlugin*()>> reg;
+  return reg;
+}
+
+int ErasureCodePluginRegistry::register_builtin(
+  const std::string &name,
+  std::function<ErasureCodePlugin*()> create)
+{
+  builtin_plugins()[name] = std::move(create);
+  return 0;
 }
 
 int ErasureCodePluginRegistry::factory(const std::string &plugin_name,
@@ -124,6 +141,16 @@ int ErasureCodePluginRegistry::load(const std::string &plugin_name,
 				    ostream *ss)
 {
   ceph_assert(ceph_mutex_is_locked(lock));
+
+  if (auto it = builtin_plugins().find(plugin_name);
+      it != builtin_plugins().end()) {
+    int r = add(plugin_name, it->second());
+    if (r == 0) {
+      *plugin = get(plugin_name);
+    }
+    return r;
+  }
+
   std::string fname = directory + "/" PLUGIN_PREFIX
     + plugin_name + PLUGIN_SUFFIX;
   void *library = dlopen(fname.c_str(), RTLD_NOW);

--- a/src/erasure-code/ErasureCodePlugin.h
+++ b/src/erasure-code/ErasureCodePlugin.h
@@ -19,6 +19,8 @@
 #ifndef CEPH_ERASURE_CODE_PLUGIN_H
 #define CEPH_ERASURE_CODE_PLUGIN_H
 
+#include <functional>
+
 #include "common/ceph_mutex.h"
 #include "ErasureCodeInterface.h"
 
@@ -68,6 +70,10 @@ namespace ceph {
     int add(const std::string &name, ErasureCodePlugin *plugin);
     int remove(const std::string &name);
     ErasureCodePlugin *get(const std::string &name);
+
+    static int register_builtin(
+      const std::string &name,
+      std::function<ErasureCodePlugin*()> create);
 
     int load(const std::string &plugin_name,
 	     const std::string &directory,

--- a/src/erasure-code/isa/ErasureCodePluginIsa.cc
+++ b/src/erasure-code/isa/ErasureCodePluginIsa.cc
@@ -81,7 +81,13 @@ int __erasure_code_init(char *plugin_name, char *directory)
   auto plugin = std::make_unique<ErasureCodePluginIsa>();
   int r = instance.add(plugin_name, plugin.get());
   if (r == 0) {
-    plugin.release();  
+    plugin.release();
   }
   return r;
 }
+
+#ifdef WITH_CRIMSON
+[[maybe_unused]] static int _isa_builtin =
+  ceph::ErasureCodePluginRegistry::register_builtin(
+    "isa", []{ return new ErasureCodePluginIsa(); });
+#endif


### PR DESCRIPTION
## Problem
Before this change, when the ISA plugin (classic build, dlopen'd), would try to log, it'd segfault due to null `g_ceph_context`. More details here: https://tracker.ceph.com/issues/78199#note-3

Objective: We need a way to make logging work for EC plugins in crimson.

## Solution

By building the ISA plugin `WITH_CRIMSON`, its logging is routed to seastar's logger, solving the issue.

It is not build separately and dlopen'd like in classic because doing so would require the plugin to have its own seastar logger copy, an undesirable outcome.

It is a statically linked library in the crimson-osd binary, and thus it shares the single seastar logger. The library is linked with --whole-archive so the self-registration constructor is not dropped.

## Supporting static plugins in EC plugin registry

Before this change, all plugins in EC were expected to be dlopen'd. To support statically linked plugins in EC, we add the functionality in EC plugin registry to support built in (statically linked) plugins. This is done by 2 main changes:

1. introducing a new map, `builtin_plugins`, where plugins can register a factory for itself at startup.
2. `load()` now first checks if the plugin is builtin and instantiates it, otherwise it falls back to dynamically linking the plugin.

## Testing 

Sample logs from ISA plugin: 
```
out/osd.0.log:DEBUG 2026-07-23 12:58:51,522 [shard 0:main] osd - ErasureCodeIsa: [ cache tables ] creating coeff for k=2 m=1
out/osd.0.log:DEBUG 2026-07-23 12:58:51,522 [shard 0:main] osd - ErasureCodeIsa: [ cache tables ] creating tables for k=2 m=1
out/osd.0.log:DEBUG 2026-07-23 12:58:51,522 [shard 0:main] osd - ErasureCodeIsa: [ cache memory ] = 483072 bytes [ matrix ] = Vandermonde
out/osd.0.log:DEBUG 2026-07-23 12:58:51,528 [shard 0:main] osd - ErasureCodeIsa: [ cache memory ] = 483072 bytes [ matrix ] = Vandermonde
out/osd.0.log:DEBUG 2026-07-23 12:58:51,535 [shard 0:main] osd - ErasureCodeIsa: [ cache memory ] = 483072 bytes [ matrix ] = Vandermonde
out/osd.0.log:DEBUG 2026-07-23 12:58:52,538 [shard 0:main] osd - ErasureCodeIsa: [ cache memory ] = 483072 bytes [ matrix ] = Vandermonde
out/osd.0.log:DEBUG 2026-07-23 12:58:52,543 [shard 0:main] osd - ErasureCodeIsa: [ cache memory ] = 483072 bytes [ matrix ] = Vandermonde
out/osd.0.log:DEBUG 2026-07-23 12:58:52,547 [shard 0:main] osd - ErasureCodeIsa: [ cache memory ] = 483072 bytes [ matrix ] = Vandermonde
```

Fixes: https://tracker.ceph.com/issues/78199 

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
