### PR TITLE
tentacle: os/bluestore: Fix ExtentMap::reshard produce stray spanning blobs

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2914,6 +2914,7 @@ void BlueStore::Blob::split(Collection *coll, uint32_t blob_offset, Blob *r)
 {
   dout(10) << __func__ << " 0x" << std::hex << blob_offset << std::dec
 	   << " start " << *this << dendl;
+  ceph_assert(r);
   ceph_assert(blob.can_split());
   ceph_assert(used_in_blob.can_split());
   bluestore_blob_t &lb = dirty_blob();
@@ -2924,6 +2925,10 @@ void BlueStore::Blob::split(Collection *coll, uint32_t blob_offset, Blob *r)
     &(r->used_in_blob));
 
   lb.split(blob_offset, rb);
+
+  maybe_prune_tail(); // we might get tail-to-prune after splitting
+  r->maybe_prune_tail(); // likely redundant (as we tend to prune original blob beforehand)
+                         // but let it be
 
   dout(10) << __func__ << " 0x" << std::hex << blob_offset << std::dec
 	   << " finish " << *this << dendl;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3910,6 +3910,11 @@ void BlueStore::ExtentMap::reshard_action(
 			   << std::hex << bstart1 << " blob_offset 0x"
 			   << blob_offset << std::dec << " " << *b << dendl;
 		  b = split_blob(b, blob_offset, sh.shard_info->offset);
+                  if (b->get_blob().get_ondisk_size() == 0) {
+                    // The blob b is empty; there are no extents that can reference it.
+                    // It will be deleted as soon as it gets out of scope.
+                    break;
+                  }
 		  // switch b to the new right-hand side, in case it
 		  // *also* has to get split.
 		  bstart1 = sh.shard_info->offset;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -997,7 +997,7 @@ void BlueStore::GarbageCollector::process_protrusive_extents(
     Blob* b = b_it->first;
     BlobInfo& bi = b_it->second;
     if (bi.referenced_bytes == 0) {
-      uint64_t len_on_disk = b_it->first->get_blob().get_ondisk_length();
+      uint64_t len_on_disk = b_it->first->get_blob().get_ondisk_capacity();
       int64_t blob_expected_for_release =
         round_up_to(len_on_disk, min_alloc_size) / min_alloc_size;
 
@@ -2935,7 +2935,7 @@ void BlueStore::Blob::split(Collection *coll, uint32_t blob_offset, Blob *r)
 void BlueStore::Blob::maybe_prune_tail() {
   if (get_blob().can_prune_tail()) {
     dirty_blob().prune_tail();
-    used_in_blob.prune_tail(get_blob().get_ondisk_length());
+    used_in_blob.prune_tail(get_blob().get_ondisk_capacity());
     dout(20) << __func__ << " pruned tail, now " << get_blob() << dendl;
   }
 }
@@ -12786,7 +12786,7 @@ int BlueStore::_prepare_read_ioc(
       compressed_blob_bls->push_back(bufferlist());
       bufferlist& bl = compressed_blob_bls->back();
       auto r = bptr->get_blob().map(
-        0, bptr->get_blob().get_ondisk_length(),
+        0, bptr->get_blob().get_ondisk_size(),
         [&](uint64_t offset, uint64_t length) {
           int r = bdev->aio_read(offset, length, &bl, ioc);
           if (r < 0)
@@ -16443,7 +16443,7 @@ void BlueStore::_do_write_small(
 
         // direct write into unused blocks of an existing mutable blob?
         if ((b_off % chunk_size == 0 && b_len % chunk_size == 0) &&
-            b->get_blob().get_ondisk_length() >= b_off + b_len &&
+            b->get_blob().get_ondisk_capacity() >= b_off + b_len &&
             b->get_blob().is_unused(b_off, b_len) &&
             b->get_blob().is_allocated(b_off, b_len)) {
           _buffer_cache_write(txc, o, offset, bl,
@@ -16492,7 +16492,7 @@ void BlueStore::_do_write_small(
 	uint64_t head_read = p2phase(b_off, chunk_size);
 	uint64_t tail_read = p2nphase(b_off + b_len, chunk_size);
 	if ((head_read || tail_read) &&
-	    (b->get_blob().get_ondisk_length() >= b_off + b_len + tail_read) &&
+	    (b->get_blob().get_ondisk_capacity() >= b_off + b_len + tail_read) &&
 	    head_read + tail_read < min_alloc_size) {
 	  b_off -= head_read;
 	  b_len += head_read + tail_read;
@@ -16502,7 +16502,7 @@ void BlueStore::_do_write_small(
 	}
 
 	// chunk-aligned deferred overwrite?
-	if (b->get_blob().get_ondisk_length() >= b_off + b_len &&
+	if (b->get_blob().get_ondisk_capacity() >= b_off + b_len &&
 	    b_off % chunk_size == 0 &&
 	    b_len % chunk_size == 0 &&
 	    b->get_blob().is_allocated(b_off, b_len)) {
@@ -16745,7 +16745,7 @@ bool BlueStore::BigDeferredWriteContext::can_defer(
     off = offset;
     b_off = offset - ep->blob_start();
     uint64_t chunk_size = blob.get_chunk_size(block_size);
-    uint64_t ondisk = blob.get_ondisk_length();
+    uint64_t ondisk = blob.get_ondisk_capacity();
     used = std::min(l, ondisk - b_off);
 
     // will read some data to fill out the chunk?
@@ -18077,7 +18077,7 @@ int BlueStore::_do_remove(
 	sb->loaded &&
 	maybe_unshared_blobs.count(sb)) {
       if (b.is_compressed()) {
-	expect[sb].get(0, b.get_ondisk_length());
+	expect[sb].get(0, b.get_ondisk_size());
       } else {
 	// todo: it seems to be an overkill to go through map()
 	b.map(e.blob_offset, e.length, [&](uint64_t off, uint64_t len) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3590,9 +3590,14 @@ BlueStore::ExtentMap::reshard_decision(uint32_t segment_size) {
 	   << needs_reshard_end << ") segment 0x" << segment_size << std::dec
 	   << " of " << onode->onode.extent_map_shards.size()
 	   << " shards on " << onode->oid << dendl;
-  for (auto& p : spanning_blob_map) {
-    dout(20) << __func__ << "   spanning blob " << p.first << " " << *p.second
-	     << dendl;
+  const int span_blob_log_level = 20;
+  if (cct->_conf->subsys.should_gather<ceph_subsys_bluestore, span_blob_log_level>()) {
+    for (auto& p : spanning_blob_map) {
+      dout(span_blob_log_level) << __func__
+                                << "   spanning blob "
+                                << p.first << " " << *p.second
+	                        << dendl;
+    }
   }
   // determine shard index range
   unsigned shard_index_begin = 0, shard_index_end = 0;

--- a/src/os/bluestore/Compression.cc
+++ b/src/os/bluestore/Compression.cc
@@ -533,7 +533,7 @@ void Scan::candidate(const Extent* e)
       bit->second.consumed_size += e->length;
       if (bit->second.consumed_size == bit->second.blob_use_size) {
         // Seen all extents of the blob, can take gain.
-        gain = h_bblob.get_ondisk_length();
+        gain = h_bblob.get_ondisk_size();
       }
       estimator->batch(e, gain);
     } else {

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -1151,7 +1151,9 @@ uint32_t bluestore_blob_t::release_extents(
   uint32_t released_length = 0;
   constexpr auto EMPTY = bluestore_pextent_t::INVALID_OFFSET;
   if (offset == 0 && length == get_logical_length()) {
-    released_length = get_ondisk_length();
+    // There are 2 distinct cases for releasing whole blob:
+    // a) releasing compressed blob b) speedup for releasing whole regular blob
+    released_length = get_ondisk_capacity();
     released_disk->insert(released_disk->end(), extents.begin(), extents.end());
     extents.resize(1);
     extents[0].offset = EMPTY;

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -568,7 +568,7 @@ public:
       denc_varint_lowz(logical_length, p);
       denc_varint_lowz(compressed_length, p);
     } else {
-      logical_length = get_ondisk_length();
+      logical_length = get_ondisk_capacity();
     }
     if (has_csum()) {
       denc(csum_type, p);
@@ -897,10 +897,26 @@ public:
     }
   }
 
-  uint32_t get_ondisk_length() const {
+  /// Count blob's capacity for data
+  /// It returns how much data blob can hold without resizing.
+  /// Compressed blobs cannot be modified, so actual disk usage is returned.
+  uint32_t get_ondisk_capacity() const {
     uint32_t len = 0;
     for (auto &p : extents) {
       len += p.length;
+    }
+    return len;
+  }
+
+  /// Count blob's usage of disk
+  /// For compressed blobs get_ondisk_capacity == get_ondisk_size.
+  /// It is similar to get_ondisk_capacity() except unmapped extents do not count.
+  uint32_t get_ondisk_size() const {
+    uint32_t len = 0;
+    for (auto &p : extents) {
+      if (p.is_valid()) {
+        len += p.length;
+      }
     }
     return len;
   }

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -1332,6 +1332,56 @@ TEST(ExtentMap, reshard_failure) {
   }
 }
 
+
+TEST(ExtentMap, reshard_split_creates_empty_blob) {
+  BlueStore store(g_ceph_context, "", 4096);
+  std::unique_ptr<BlueStore::OnodeCacheShard> oc(
+    BlueStore::OnodeCacheShard::create(g_ceph_context, "lru", NULL));
+  std::unique_ptr<BlueStore::BufferCacheShard> bc(
+    BlueStore::BufferCacheShard::create(&store, "lru", NULL));
+
+  {
+    auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc.get(), bc.get(), coll_t());
+    BlueStore::Onode onode(coll.get(), ghobject_t(), "");
+    // csum block size = 1K, full blob length covered with csum
+    size_t csum_order = 14;
+    int csum_type = Checksummer::CSUM_CRC32C;
+
+    {
+
+      BlueStore::ExtentMap& em = onode.extent_map;
+      BlueStore::BlobRef bb1(coll->new_blob());
+      {
+      auto& dbb = bb1->dirty_blob();
+      dbb.allocated_test(bluestore_pextent_t(0x12345000,0x4000));
+      dbb.allocated_test(bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET,0xc000));
+      dbb.init_csum(csum_type, csum_order, 0x10000);
+      em.set_lextent(coll, 0, 0, 0x4000, bb1, nullptr);
+      }
+      std::cout << "start:" << std::endl;
+      std::cout << onode.print(42) << std::endl;
+
+      BlueStore::ExtentMap::ReshardPlan rp;
+      rp.new_shard_info.emplace_back(0, 0);
+      rp.new_shard_info.emplace_back(0x4000, 0);
+      rp.new_shard_info.emplace_back(0xf000, 0);
+      rp.shard_index_begin = 0;
+      rp.shard_index_end = 2;
+      rp.spanning_scan_begin = 0; // doesn't matter
+      rp.spanning_scan_end =  0; // doesn't matter
+
+      em.request_reshard(0, 0x10000);
+      em.reshard_action(rp, nullptr, nullptr);
+      std::cout << "resharded:" << std::endl;
+      std::cout << onode.print(42) << std::endl;
+      for(auto& bi : em.spanning_blob_map) {
+        EXPECT_NE(bi.second->get_blob().get_ondisk_size(), 0);
+      }
+    }
+  }
+}
+
+
 class BlueStoreFixture :
   virtual public ::testing::Test,
   virtual public ::testing::WithParamInterface<std::vector<int>>

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -1005,6 +1005,70 @@ TEST(Blob, split) {
     ASSERT_EQ(0x1000u, R.get_blob().get_extents().front().length);
     ASSERT_EQ(0x1000u, R.get_referenced_bytes());
   }
+  {
+    // Check if we prune 'invalid' tails for resulting blobs
+
+    size_t l1 = 0x1000;
+    size_t l2 = 0x2000;
+    size_t l3 = 0x1000;
+    size_t l4 = 0x4000;
+    size_t csum_order = 12;
+    int csum_type = Checksummer::CSUM_CRC32C;
+    size_t csum_chunk = (1u << csum_order);
+    size_t csum_val_size = Checksummer::get_csum_value_size(csum_type);
+    auto make_blob = [&](BlueStore::BlobRef b) {
+      b->dirty_blob().allocated_test(bluestore_pextent_t(0x2000, l1));
+      b->dirty_blob().allocated_test(bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, l2));
+      b->dirty_blob().allocated_test(bluestore_pextent_t(0x12000, l3));
+      b->dirty_blob().allocated_test(bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, l4));
+      // csum block size = 1K, full blob length covered with csum
+      b->dirty_blob().init_csum(csum_type, csum_order, l1 + l2 + l3 + l4);
+      b->get_ref(coll.get(), 0, l1);
+      b->get_ref(coll.get(), l1 + l2, l3);
+      return b;
+    };
+    {
+      BlueStore::BlobRef L = coll->new_blob();
+      BlueStore::BlobRef R = coll->new_blob();
+      make_blob(L);
+      L->split(coll.get(), l1, R.get());
+
+      // L blob verification
+      ASSERT_EQ(l1, L->get_blob().get_logical_length());
+      ASSERT_EQ(l1 / csum_chunk * csum_val_size, L->get_blob().csum_data.length());
+      ASSERT_EQ(1u, L->get_blob().get_extents().size());
+      ASSERT_EQ(0x2000u, L->get_blob().get_extents().front().offset);
+      ASSERT_EQ(l1, L->get_blob().get_extents().front().length);
+      ASSERT_EQ(l1, L->get_referenced_bytes());
+      // R blob verification
+      ASSERT_EQ(l2 + l3, R->get_blob().get_logical_length());
+      ASSERT_EQ((l2 + l3) / csum_chunk * csum_val_size, R->get_blob().csum_data.length());
+      ASSERT_EQ(2u, R->get_blob().get_extents().size());
+      ASSERT_EQ(0x12000u, R->get_blob().get_extents().back().offset);
+      ASSERT_EQ(l3, R->get_blob().get_extents().back().length);
+      ASSERT_EQ(l3, R->get_referenced_bytes());
+    }
+    {
+      BlueStore::BlobRef L = coll->new_blob();
+      BlueStore::BlobRef R = coll->new_blob();
+      make_blob(L);
+      L->split(coll.get(), l1 + l2, R.get());
+      // L blob verification
+      ASSERT_EQ(l1, L->get_blob().get_logical_length());
+      ASSERT_EQ(l1 / csum_chunk * csum_val_size, L->get_blob().csum_data.length());
+      ASSERT_EQ(1u, L->get_blob().get_extents().size());
+      ASSERT_EQ(0x2000u, L->get_blob().get_extents().front().offset);
+      ASSERT_EQ(l1, L->get_blob().get_extents().front().length);
+      ASSERT_EQ(l1, L->get_referenced_bytes());
+      // R blob verification
+      ASSERT_EQ(l3, R->get_blob().get_logical_length());
+      ASSERT_EQ(l3 / csum_chunk * csum_val_size, R->get_blob().csum_data.length());
+      ASSERT_EQ(1u, R->get_blob().get_extents().size());
+      ASSERT_EQ(0x12000u, R->get_blob().get_extents().front().offset);
+      ASSERT_EQ(l3, R->get_blob().get_extents().front().length);
+      ASSERT_EQ(l3, R->get_referenced_bytes());
+    }
+  }
 }
 
 TEST(Blob, legacy_decode) {

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -1071,6 +1071,320 @@ TEST(Blob, split) {
   }
 }
 
+TEST(ExtentMap, split_blob) {
+  BlueStore store(g_ceph_context, "", 4096);
+  BlueStore::OnodeCacheShard *oc =
+      BlueStore::OnodeCacheShard::create(g_ceph_context, "lru", NULL);
+  BlueStore::BufferCacheShard *bc =
+      BlueStore::BufferCacheShard::create(&store, "lru", NULL);
+
+  auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
+  BlueStore::Onode onode(coll.get(), ghobject_t(), "");
+  size_t shard_size =
+    g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size;
+  // csum block size = 1K, full blob length covered with csum
+  size_t csum_order = 12;
+  size_t csum_chunk = 1u << csum_order;
+  int csum_type = Checksummer::CSUM_CRC32C;
+  size_t csum_val_size = Checksummer::get_csum_value_size(csum_type);
+
+  auto make_blob = [&](uint64_t o1,
+                       uint64_t l1,
+                       uint64_t o2,
+                       uint64_t l2,
+                       uint64_t o3,
+                       uint64_t l3,
+                       uint64_t o4,
+                       uint64_t l4) {
+    BlueStore::BlobRef b1(coll->new_blob());
+    b1->dirty_blob().allocated_test(bluestore_pextent_t(o1, l1));
+    b1->dirty_blob().allocated_test(bluestore_pextent_t(o2, l2));
+    b1->dirty_blob().allocated_test(bluestore_pextent_t(o3, l3));
+    b1->dirty_blob().allocated_test(bluestore_pextent_t(o4, l4));
+    b1->dirty_blob().init_csum(csum_type, csum_order, l1 + l2 + l3 + l4);
+    return b1;
+  };
+  {
+    // Split at 0x1000:
+    // [0(0x2000)~0x1000, 0x1000(-1)~0x2000, 0x3000(0x7000)~0x3000, 0xa000(-1)~0x4000]
+    //   result is [0(0x2000)~0x1000]], [0(-1)~2000, 0x2000(0x7000)~0x3000]
+    // (note: offsets above are in the following format: blob_offset(lba))
+    uint64_t o1 = 0x2000;
+    uint64_t l1 = 0x1000;
+    uint64_t o2 = bluestore_pextent_t::INVALID_OFFSET;
+    uint64_t l2 = 0x2000;
+    uint64_t o3 = 0x7000;
+    uint64_t l3 = 0x3000;
+    uint64_t o4 = bluestore_pextent_t::INVALID_OFFSET;
+    uint64_t l4 = 0x4000;
+
+    BlueStore::ExtentMap em(&onode, shard_size);
+    BlueStore::BlobRef lb = make_blob(o1, l1, o2, l2, o3, l3, o4, l4);
+    size_t full_len = l1 + l2 + l3 + l4;
+    // We deliberately span this extent over both valid and invalid
+    // pextents of the blob. Which rather shouldn't happen
+    // in real life.
+    em.set_lextent(coll, 0, 0, full_len, lb, nullptr);
+    auto rb = em.split_blob(lb, l1, l1);
+
+    ASSERT_EQ(l1, lb->get_blob().get_logical_length());
+    ASSERT_EQ(l1 / csum_chunk * csum_val_size, lb->get_blob().csum_data.length());
+    ASSERT_EQ(1u, lb->get_blob().get_extents().size());
+    ASSERT_EQ(o1, lb->get_blob().get_extents().back().offset);
+    ASSERT_EQ(l1, lb->get_blob().get_extents().back().length);
+    ASSERT_EQ(l1, lb->get_referenced_bytes());
+
+    ASSERT_TRUE(rb != nullptr);
+    ASSERT_EQ(l2 + l3, rb->get_blob().get_logical_length()); // tail(l4) was pruned
+    ASSERT_EQ((l2 + l3) / csum_chunk * csum_val_size, rb->get_blob().csum_data.length());
+    ASSERT_EQ(2u, rb->get_blob().get_extents().size());
+    ASSERT_EQ(l2 + l3, rb->get_referenced_bytes());
+
+    ASSERT_EQ(bluestore_pextent_t::INVALID_OFFSET  ,
+              rb->get_blob().get_extents().front().offset);
+    ASSERT_EQ(l2, rb->get_blob().get_extents().front().length);
+    ASSERT_EQ(o3, rb->get_blob().get_extents().back().offset);
+    ASSERT_EQ(l3, rb->get_blob().get_extents().back().length);
+
+    ASSERT_EQ(2u, em.extent_map.size());
+    auto ex_it = em.seek_lextent(0);
+    ASSERT_EQ(lb, ex_it->blob);
+    ASSERT_EQ(0u, ex_it->logical_offset);
+    ASSERT_EQ(0u, ex_it->blob_offset);
+    ASSERT_EQ(l1, ex_it->length);
+    ++ex_it;
+    ASSERT_EQ(rb, ex_it->blob);
+    ASSERT_EQ(l1, ex_it->logical_offset);
+    ASSERT_EQ(0, ex_it->blob_offset);
+    ASSERT_EQ(l2 + l3 + l4, ex_it->length);
+
+  }
+  {
+    // Split at 0x3000:
+    // [0(0x2000)~0x1000, -1~0x2000, 0x3000(0x7000)~0x3000, -1~0x4000],
+    //   result is [0(0x2000)~0x1000], [0(0x7000)~0x3000]
+    // (note: offsets above are in the following format: blob_offset(lba))
+    uint64_t o1 = 0x2000;
+    uint64_t l1 = 0x1000;
+    uint64_t o2 = bluestore_pextent_t::INVALID_OFFSET;
+    uint64_t l2 = 0x2000;
+    uint64_t o3 = 0x7000;
+    uint64_t l3 = 0x3000;
+    uint64_t o4 = bluestore_pextent_t::INVALID_OFFSET;
+    uint64_t l4 = 0x4000;
+
+    BlueStore::ExtentMap em(&onode, shard_size);
+    BlueStore::BlobRef lb = make_blob(o1, l1, o2, l2, o3, l3, o4, l4);
+    size_t full_len = l1 + l2 + l3 + l4;
+    // We deliberately span this extent over both valid and invalid
+    // pextents of the blob. Which rather shouldn't happen
+    // in real life.
+    em.set_lextent(coll, 0, 0, full_len, lb, nullptr);
+    auto rb = em.split_blob(lb, l1 + l2, l1 + l2);
+
+    ASSERT_EQ(l1, lb->get_blob().get_logical_length()); // tail(l2) was pruned
+    ASSERT_EQ(l1 / csum_chunk * csum_val_size, lb->get_blob().csum_data.length());
+    ASSERT_EQ(1u, lb->get_blob().get_extents().size());
+    ASSERT_EQ(o1, lb->get_blob().get_extents().back().offset);
+    ASSERT_EQ(l1, lb->get_blob().get_extents().back().length);
+    ASSERT_EQ(l1, lb->get_referenced_bytes());
+
+    ASSERT_TRUE(rb != nullptr);
+    ASSERT_EQ(l3, rb->get_blob().get_logical_length()); // tail(l4) was pruned
+    ASSERT_EQ((l3) / csum_chunk * csum_val_size, rb->get_blob().csum_data.length());
+    ASSERT_EQ(1u, rb->get_blob().get_extents().size());
+
+    ASSERT_EQ(o3, rb->get_blob().get_extents().back().offset);
+    ASSERT_EQ(l3, rb->get_blob().get_extents().back().length);
+    ASSERT_EQ(l3, rb->get_referenced_bytes());
+
+    ASSERT_EQ(2u, em.extent_map.size());
+    auto ex_it = em.seek_lextent(0);
+
+    ASSERT_EQ(lb, ex_it->blob);
+    ASSERT_EQ(0u, ex_it->logical_offset);
+    ASSERT_EQ(0u, ex_it->blob_offset);
+    ASSERT_EQ(l1 + l2, ex_it->length);
+    ++ex_it;
+    ASSERT_EQ(rb, ex_it->blob);
+    ASSERT_EQ(l1 + l2, ex_it->logical_offset);
+    ASSERT_EQ(0, ex_it->blob_offset);
+    ASSERT_EQ(l3 + l4, ex_it->length);
+  }
+  {
+    // Split at 0x6000:
+    // [0(0x2000)~0x1000, -1~0x2000, 0x3000(0x7000)~0x3000], -1~0x4000,
+    //   result is  [0(0x2000)~0x1000, -1~0x2000, 0x3000(0x7000)~0x3000]
+    // (note: offsets above are in the following format: blob_offset(lba))
+    uint64_t o1 = 0x2000;
+    uint64_t l1 = 0x1000;
+    uint64_t o2 = bluestore_pextent_t::INVALID_OFFSET;
+    uint64_t l2 = 0x2000;
+    uint64_t o3 = 0x7000;
+    uint64_t l3 = 0x3000;
+    uint64_t o4 = bluestore_pextent_t::INVALID_OFFSET;
+    uint64_t l4 = 0x4000;
+
+    BlueStore::ExtentMap em(&onode, shard_size);
+    BlueStore::BlobRef lb = make_blob(o1, l1, o2, l2, o3, l3, o4, l4);
+    size_t full_len = l1 + l2 + l3 + l4;
+    // We deliberately span this extent over both valid and the first(!)
+    // invalid  pextents of the blob. Which permits prunning the tail
+    // during the split
+    em.set_lextent(coll, 0, 0, full_len - l4, lb, nullptr);
+    auto rb = em.split_blob(lb, full_len - l4, full_len - l4);
+
+    ASSERT_EQ(full_len - l4, lb->get_blob().get_logical_length()); // tail(l4) was pruned
+    ASSERT_EQ((full_len - l4) / csum_chunk * csum_val_size, lb->get_blob().csum_data.length());
+    ASSERT_EQ(full_len - l4, lb->get_referenced_bytes());
+    ASSERT_EQ(3u, lb->get_blob().get_extents().size());
+    ASSERT_EQ(o1, lb->get_blob().get_extents().front().offset);
+    ASSERT_EQ(l1, lb->get_blob().get_extents().front().length);
+    ASSERT_EQ(o3, lb->get_blob().get_extents().back().offset);
+    ASSERT_EQ(l3, lb->get_blob().get_extents().back().length);
+
+    ASSERT_TRUE(rb->get_blob().get_ondisk_size() == 0);
+
+    ASSERT_EQ(1u, em.extent_map.size());
+    auto ex_it = em.seek_lextent(0);
+
+    ASSERT_EQ(lb, ex_it->blob);
+    ASSERT_EQ(0u, ex_it->logical_offset);
+    ASSERT_EQ(0u, ex_it->blob_offset);
+    ASSERT_EQ(l1 + l2 + l3, ex_it->length);
+  }
+  {
+    // Split at 0x6000:
+    // [0(0x2000)~0x1000], -1~0x2000, [0x3000(0x7000)~0x3000], -1~0x4000,
+    //   result is [0(0x2000)~0x1000], -1~0x2000, [0x3000(0x7000)~0x3000]
+    // (note: offsets above are in the following format: blob_offset(lba))
+    uint64_t o1 = 0x2000;
+    uint64_t l1 = 0x1000;
+    uint64_t o2 = bluestore_pextent_t::INVALID_OFFSET;
+    uint64_t l2 = 0x2000;
+    uint64_t o3 = 0x7000;
+    uint64_t l3 = 0x3000;
+    uint64_t o4 = bluestore_pextent_t::INVALID_OFFSET;
+    uint64_t l4 = 0x4000;
+
+    BlueStore::ExtentMap em(&onode, shard_size);
+    BlueStore::BlobRef lb = make_blob(o1, l1, o2, l2, o3, l3, o4, l4);
+    size_t full_len = l1 + l2 + l3 + l4;
+    em.set_lextent(coll, 0, 0, l1, lb, nullptr);
+    em.set_lextent(coll, l1 + l2, l1 + l2, l3, lb, nullptr);
+    auto rb = em.split_blob(lb, full_len - l4, full_len - 4);
+
+    ASSERT_EQ(full_len - l4, lb->get_blob().get_logical_length()); // tail(l4) was pruned
+    ASSERT_EQ((full_len - l4) / csum_chunk * csum_val_size, lb->get_blob().csum_data.length());
+    ASSERT_EQ(l1 + l3, lb->get_referenced_bytes());
+    ASSERT_EQ(3u, lb->get_blob().get_extents().size());
+    ASSERT_EQ(o1, lb->get_blob().get_extents().front().offset);
+    ASSERT_EQ(l1, lb->get_blob().get_extents().front().length);
+    ASSERT_EQ(o3, lb->get_blob().get_extents().back().offset);
+    ASSERT_EQ(l3, lb->get_blob().get_extents().back().length);
+
+    ASSERT_TRUE(rb->get_blob().get_ondisk_size() == 0);
+
+    ASSERT_EQ(2u, em.extent_map.size());
+    auto ex_it = em.seek_lextent(0);
+
+    ASSERT_EQ(lb, ex_it->blob);
+    ASSERT_EQ(0u, ex_it->logical_offset);
+    ASSERT_EQ(0u, ex_it->blob_offset);
+    ASSERT_EQ(l1, ex_it->length);
+    ++ex_it;
+    ASSERT_EQ(lb, ex_it->blob);
+    ASSERT_EQ(l1 + l2, ex_it->logical_offset);
+    ASSERT_EQ(l1 + l2, ex_it->blob_offset);
+    ASSERT_EQ(l3, ex_it->length);
+  }
+
+  {
+    // Split at 0x6000:
+    // [0(-1)~0x6000, 0x6000(0x2000)~0x3000, 0x9000(-1)~0x6000, 0xF000(0x7000)~0x1000],
+    //   result is [0(0x2000)~0x3000, -1~0x6000, 0x9000(0x7000)~0x1000]]
+    // (note: offsets above are in the following format: blob_offset(lba))
+    uint64_t o1 = bluestore_pextent_t::INVALID_OFFSET;
+    uint64_t l1 = 0x6000;
+    uint64_t o2 = 0x2000;
+    uint64_t l2 = 0x3000;
+    uint64_t o3 = bluestore_pextent_t::INVALID_OFFSET;;
+    uint64_t l3 = 0x6000;
+    uint64_t o4 = 0x7000;
+    uint64_t l4 = 0x1000;
+
+    BlueStore::ExtentMap em(&onode, shard_size);
+    BlueStore::BlobRef lb = make_blob(o1, l1, o2, l2, o3, l3, o4, l4);
+    size_t full_len = l1 + l2 + l3 + l4;
+    em.set_lextent(coll, l1, l1, full_len - l1, lb, nullptr);
+    auto rb = em.split_blob(lb, l1, l1);
+
+    ASSERT_TRUE(!lb->is_referenced());
+    ASSERT_TRUE(rb != nullptr);
+    ASSERT_EQ(l2 + l3 + l4, rb->get_blob().get_logical_length()); // head(l1) was pruned
+    ASSERT_EQ((l2 + l3 + l4) / csum_chunk * csum_val_size, rb->get_blob().csum_data.length());
+    ASSERT_EQ(3u, rb->get_blob().get_extents().size());
+    ASSERT_EQ(o2, rb->get_blob().get_extents().front().offset);
+    ASSERT_EQ(l2, rb->get_blob().get_extents().front().length);
+    ASSERT_EQ(o4, rb->get_blob().get_extents().back().offset);
+    ASSERT_EQ(l4, rb->get_blob().get_extents().back().length);
+    ASSERT_EQ(l2 + l3 + l4, rb->get_referenced_bytes());
+
+    auto ex_it = em.seek_lextent(0);
+
+    ASSERT_EQ(1u, em.extent_map.size());
+    ASSERT_EQ(rb, ex_it->blob);
+    ASSERT_EQ(l1, ex_it->logical_offset);
+    ASSERT_EQ(0u, ex_it->blob_offset);
+    ASSERT_EQ(l2 + l3 + l4, ex_it->length);
+  }
+  {
+    // Split at 0x6000:
+    // [-1~0x6000, 0x6000(0x2000)~0x3000], (-1)~0x6000, [0xF000(0x7000)~0x1000],
+    //   result is [0(0x2000)~0x3000], -1~0x6000, [0x9000(0x7000)~0x1000]]
+    // (note: offsets above are in the following format: blob_offset(lba))
+    uint64_t o1 = bluestore_pextent_t::INVALID_OFFSET;
+    uint64_t l1 = 0x6000;
+    uint64_t o2 = 0x2000;
+    uint64_t l2 = 0x3000;
+    uint64_t o3 = bluestore_pextent_t::INVALID_OFFSET;;
+    uint64_t l3 = 0x6000;
+    uint64_t o4 = 0x7000;
+    uint64_t l4 = 0x1000;
+
+    BlueStore::ExtentMap em(&onode, shard_size);
+    BlueStore::BlobRef lb = make_blob(o1, l1, o2, l2, o3, l3, o4, l4);
+    size_t full_len = l1 + l2 + l3 + l4;
+    em.set_lextent(coll, l1, l1, l2, lb, nullptr);
+    em.set_lextent(coll, full_len - l4, full_len - l4, l4, lb, nullptr);
+    auto rb = em.split_blob(lb, l1, l1);
+
+    ASSERT_TRUE(!lb->is_referenced());
+    ASSERT_TRUE(rb != nullptr);
+    ASSERT_EQ(l2 + l3 + l4, rb->get_blob().get_logical_length()); // head(l1) was pruned
+    ASSERT_EQ((l2 + l3 + l4) / csum_chunk * csum_val_size, rb->get_blob().csum_data.length());
+    ASSERT_EQ(3u, rb->get_blob().get_extents().size());
+    ASSERT_EQ(o2, rb->get_blob().get_extents().front().offset);
+    ASSERT_EQ(l2, rb->get_blob().get_extents().front().length);
+    ASSERT_EQ(o4, rb->get_blob().get_extents().back().offset);
+    ASSERT_EQ(l4, rb->get_blob().get_extents().back().length);
+    ASSERT_EQ(l2 + l4, rb->get_referenced_bytes());
+
+    ASSERT_EQ(2u, em.extent_map.size());
+
+    auto ex_it = em.seek_lextent(0);
+    ASSERT_EQ(rb, ex_it->blob);
+    ASSERT_EQ(l1, ex_it->logical_offset);
+    ASSERT_EQ(0u, ex_it->blob_offset);
+    ASSERT_EQ(l2, ex_it->length);
+    ++ex_it;
+    ASSERT_EQ(rb, ex_it->blob);
+    ASSERT_EQ(l1 + l2 + l3, ex_it->logical_offset);
+    ASSERT_EQ(l2 + l3, ex_it->blob_offset);
+    ASSERT_EQ(l4, ex_it->length);
+  }
+}
+
 TEST(Blob, legacy_decode) {
   BlueStore store(g_ceph_context, "", 4096);
   BlueStore::OnodeCacheShard *oc =


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/68798
Fixes: https://tracker.ceph.com/issues/78613


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
