### PR TITLE
mgr/smb: remove mirrored copy when a resource is deleted

### DIFF
--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_basic.yaml
@@ -76,3 +76,7 @@ tasks:
 # Wait for the smb service to be removed
 - cephadm.wait_for_service_not_present:
     service: smb.modusr1
+# Removing the cluster should clean that mirror entry too
+- cephadm.shell:
+    host.a:
+      - cmd: '! ceph config-key ls | grep -q "ceph.smb.resources.*modusr1"'

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -1653,13 +1653,18 @@ def _store_transaction(store: ConfigStore) -> Iterator[None]:
 
 
 def _reconcile_store(store: ConfigStore) -> None:
-    """Fix any mismatches between the store and its mirror copy, if the store supports it."""
+    """Fix any mismatches between the store and its mirror copy, if the
+    store supports it.
+    """
     reconcile = getattr(store, 'reconcile', None)
     if not reconcile:
         log.debug("No reconcile support for store")
         return
     log.debug("Reconciling store")
-    reconcile()
+    try:
+        reconcile()
+    except Exception:
+        log.exception("reconcile() failed; continuing")
 
 
 def _has_proxied_vfs(change_group: ClusterChangeGroup) -> bool:

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -403,6 +403,7 @@ class ClusterConfigHandler:
             with _store_transaction(staging.destination_store):
                 results = staging.save()
                 staging.prune_linked_entries()
+            _reconcile_store(staging.destination_store)
             with _store_transaction(staging.destination_store):
                 self._sync_modified(results)
         return results
@@ -1649,6 +1650,16 @@ def _store_transaction(store: ConfigStore) -> Iterator[None]:
     log.debug("Using store transaction")
     with transaction():
         yield None
+
+
+def _reconcile_store(store: ConfigStore) -> None:
+    """Fix any mismatches between the store and its mirror copy, if the store supports it."""
+    reconcile = getattr(store, 'reconcile', None)
+    if not reconcile:
+        log.debug("No reconcile support for store")
+        return
+    log.debug("Reconciling store")
+    reconcile()
 
 
 def _has_proxied_vfs(change_group: ClusterChangeGroup) -> bool:

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -403,6 +403,7 @@ class ClusterConfigHandler:
             with _store_transaction(staging.destination_store):
                 results = staging.save()
                 staging.prune_linked_entries()
+            _reconcile_store(staging.destination_store)
             with _store_transaction(staging.destination_store):
                 self._sync_modified(results)
         return results
@@ -1660,6 +1661,21 @@ def _store_transaction(store: ConfigStore) -> Iterator[None]:
     log.debug("Using store transaction")
     with transaction():
         yield None
+
+
+def _reconcile_store(store: ConfigStore) -> None:
+    """Fix any mismatches between the store and its mirror copy, if the
+    store supports it.
+    """
+    reconcile = getattr(store, 'reconcile', None)
+    if not reconcile:
+        log.debug("No reconcile support for store")
+        return
+    log.debug("Reconciling store")
+    try:
+        reconcile()
+    except Exception:
+        log.exception("reconcile() failed; continuing")
 
 
 def _has_proxied_vfs(change_group: ClusterChangeGroup) -> bool:

--- a/src/pybind/mgr/smb/sqlite_store.py
+++ b/src/pybind/mgr/smb/sqlite_store.py
@@ -454,6 +454,9 @@ class SqliteMirroringStore(SqliteStore):
     ) -> None:
         super().__init__(backend, tables)
         self._mirrors: Dict[str, Mirror] = {m.namespace: m for m in mirrors}
+        self._pending_mirror_removals: Optional[
+            List[Tuple[Mirror, EntryKey]]
+        ] = None
 
     def _mirror(self, key: EntryKey) -> Optional[Mirror]:
         ns, _ = key
@@ -467,10 +470,52 @@ class SqliteMirroringStore(SqliteStore):
             super().set_object(key, obj)
             return
         log.debug("Mirroring set_object: mirror=%r", mirror)
+        if self._pending_mirror_removals is not None:
+            # cancel any earlier queued removal for this key given
+            # we're about to write fresh data for it
+            self._pending_mirror_removals = [
+                item
+                for item in self._pending_mirror_removals
+                if item[1] != key
+            ]
         obj_for_store = mirror.filter_object(obj)
         obj_for_mirror = mirror.filter_mirror_object(obj)
         mirror.store[key].set(obj_for_mirror)
         super().set_object(key, obj_for_store)
+
+    def remove(self, key: EntryKey) -> bool:
+        """Remove an entry from the store, including its mirror copy, if any."""
+        mirror = self._mirror(key)
+        if mirror is None:
+            log.debug("Mirroring remove: no mirror for key %r", key)
+            return super().remove(key)
+        log.debug("Mirroring remove: mirror=%r", mirror)
+        removed = super().remove(key)
+        if removed:
+            if self._pending_mirror_removals is not None:
+                self._pending_mirror_removals.append((mirror, key))
+            else:
+                mirror.store.remove(key)
+        return removed
+
+    @contextlib.contextmanager
+    def transaction(self) -> Iterator[None]:
+        """Flushes any mirror-side removals queued by remove() only
+        after the sqlite transaction commits successfully, and discards
+        them if it doesn't.
+        """
+        self._pending_mirror_removals = []
+        try:
+            with super().transaction():
+                yield None
+        except Exception:
+            self._pending_mirror_removals = None
+            raise
+        else:
+            pending = self._pending_mirror_removals
+            self._pending_mirror_removals = None
+            for mirror, key in pending:
+                mirror.store.remove(key)
 
     def get_object(self, key: EntryKey) -> Simplified:
         """Fetch a simplified object from the store."""

--- a/src/pybind/mgr/smb/sqlite_store.py
+++ b/src/pybind/mgr/smb/sqlite_store.py
@@ -8,6 +8,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Set,
     Tuple,
     Union,
 )
@@ -527,6 +528,46 @@ class SqliteMirroringStore(SqliteStore):
         obj = super().get_object(key)
         mirror_obj = mirror.store[key].get()
         return mirror.merge(obj, mirror_obj)
+
+    def reconcile(self) -> None:
+        """Compare the sqlite store and the mirror store and removes any
+        mirror entries if there's no corresponding sqlite row.
+        Sqlite rows with no mirror entry are only logged.
+        """
+        if not self._mirrors:
+            return
+        with self.transaction():
+            mirror_store = next(iter(self._mirrors.values())).store
+            mirror_ids_by_ns: Dict[str, Set[str]] = {}
+            for ns, name in mirror_store:
+                mirror_ids_by_ns.setdefault(ns, set()).add(name)
+
+            for ns in self._mirrors:
+                if ns not in self._tables:
+                    log.debug(
+                        "reconcile: skipping mirror namespace %r with no"
+                        " matching sqlite table",
+                        ns,
+                    )
+                    continue
+                sqlite_ids = set(self.contents(ns))
+                mirror_ids = mirror_ids_by_ns.get(ns, set())
+
+                for orphan in sorted(mirror_ids - sqlite_ids):
+                    log.warning(
+                        "reconcile: removing orphaned mirror entry"
+                        " (%s, %s) with no matching sqlite row",
+                        ns,
+                        orphan,
+                    )
+                    mirror_store.remove((ns, orphan))
+
+                for missing in sorted(sqlite_ids - mirror_ids):
+                    log.warning(
+                        "reconcile: (%s, %s) has no mirror entry",
+                        ns,
+                        missing,
+                    )
 
 
 class MirrorJoinAuths(Mirror):

--- a/src/pybind/mgr/smb/sqlite_store.py
+++ b/src/pybind/mgr/smb/sqlite_store.py
@@ -455,8 +455,8 @@ class SqliteMirroringStore(SqliteStore):
     ) -> None:
         super().__init__(backend, tables)
         self._mirrors: Dict[str, Mirror] = {m.namespace: m for m in mirrors}
-        self._pending_mirror_removals: Optional[
-            List[Tuple[Mirror, EntryKey]]
+        self._pending_mirror_ops: Optional[
+            Dict[EntryKey, Tuple[Mirror, Optional[Simplified]]]
         ] = None
 
     def _mirror(self, key: EntryKey) -> Optional[Mirror]:
@@ -471,17 +471,12 @@ class SqliteMirroringStore(SqliteStore):
             super().set_object(key, obj)
             return
         log.debug("Mirroring set_object: mirror=%r", mirror)
-        if self._pending_mirror_removals is not None:
-            # cancel any earlier queued removal for this key given
-            # we're about to write fresh data for it
-            self._pending_mirror_removals = [
-                item
-                for item in self._pending_mirror_removals
-                if item[1] != key
-            ]
         obj_for_store = mirror.filter_object(obj)
         obj_for_mirror = mirror.filter_mirror_object(obj)
-        mirror.store[key].set(obj_for_mirror)
+        if self._pending_mirror_ops is not None:
+            self._pending_mirror_ops[key] = (mirror, obj_for_mirror)
+        else:
+            mirror.store[key].set(obj_for_mirror)
         super().set_object(key, obj_for_store)
 
     def remove(self, key: EntryKey) -> bool:
@@ -493,30 +488,33 @@ class SqliteMirroringStore(SqliteStore):
         log.debug("Mirroring remove: mirror=%r", mirror)
         removed = super().remove(key)
         if removed:
-            if self._pending_mirror_removals is not None:
-                self._pending_mirror_removals.append((mirror, key))
+            if self._pending_mirror_ops is not None:
+                self._pending_mirror_ops[key] = (mirror, None)
             else:
                 mirror.store.remove(key)
         return removed
 
     @contextlib.contextmanager
     def transaction(self) -> Iterator[None]:
-        """Flushes any mirror-side removals queued by remove() only
-        after the sqlite transaction commits successfully, and discards
-        them if it doesn't.
+        """Defers mirror-side writes and removals queued by set_object()
+        and remove() until the sqlite transaction commits successfully,
+        and discards them if it doesn't.
         """
         with super().transaction():
-            self._pending_mirror_removals = []
+            self._pending_mirror_ops = {}
             try:
                 yield None
             except Exception:
-                self._pending_mirror_removals = None
+                self._pending_mirror_ops = None
                 raise
             else:
-                pending = self._pending_mirror_removals
-                self._pending_mirror_removals = None
-        for mirror, key in pending:
-            mirror.store.remove(key)
+                pending = self._pending_mirror_ops
+                self._pending_mirror_ops = None
+        for key, (mirror, obj_for_mirror) in pending.items():
+            if obj_for_mirror is None:
+                mirror.store.remove(key)
+            else:
+                mirror.store[key].set(obj_for_mirror)
 
     def get_object(self, key: EntryKey) -> Simplified:
         """Fetch a simplified object from the store."""

--- a/src/pybind/mgr/smb/sqlite_store.py
+++ b/src/pybind/mgr/smb/sqlite_store.py
@@ -524,6 +524,14 @@ class SqliteMirroringStore(SqliteStore):
             return super().get_object(key)
         log.debug("Mirroring get_object: mirror=%r", mirror)
         obj = super().get_object(key)
+        if (
+            self._pending_mirror_ops is not None
+            and key in self._pending_mirror_ops
+        ):
+            _, pending_obj_for_mirror = self._pending_mirror_ops[key]
+            if pending_obj_for_mirror is None:
+                return obj
+            return mirror.merge(obj, pending_obj_for_mirror)
         try:
             mirror_obj = mirror.store[key].get()
         except KeyError:

--- a/src/pybind/mgr/smb/sqlite_store.py
+++ b/src/pybind/mgr/smb/sqlite_store.py
@@ -505,18 +505,18 @@ class SqliteMirroringStore(SqliteStore):
         after the sqlite transaction commits successfully, and discards
         them if it doesn't.
         """
-        self._pending_mirror_removals = []
-        try:
-            with super().transaction():
+        with super().transaction():
+            self._pending_mirror_removals = []
+            try:
                 yield None
-        except Exception:
-            self._pending_mirror_removals = None
-            raise
-        else:
-            pending = self._pending_mirror_removals
-            self._pending_mirror_removals = None
-            for mirror, key in pending:
-                mirror.store.remove(key)
+            except Exception:
+                self._pending_mirror_removals = None
+                raise
+            else:
+                pending = self._pending_mirror_removals
+                self._pending_mirror_removals = None
+        for mirror, key in pending:
+            mirror.store.remove(key)
 
     def get_object(self, key: EntryKey) -> Simplified:
         """Fetch a simplified object from the store."""

--- a/src/pybind/mgr/smb/sqlite_store.py
+++ b/src/pybind/mgr/smb/sqlite_store.py
@@ -526,7 +526,17 @@ class SqliteMirroringStore(SqliteStore):
             return super().get_object(key)
         log.debug("Mirroring get_object: mirror=%r", mirror)
         obj = super().get_object(key)
-        mirror_obj = mirror.store[key].get()
+        try:
+            mirror_obj = mirror.store[key].get()
+        except KeyError:
+            if mirror.filter_object(obj) != obj:
+                log.debug(
+                    "Mirroring get_object: no mirror entry for %r,"
+                    " falling back to sqlite copy",
+                    key,
+                )
+                return obj
+            raise
         return mirror.merge(obj, mirror_obj)
 
     def reconcile(self) -> None:
@@ -602,10 +612,10 @@ class MirrorUsersAndGroups(Mirror):
 
 
 class MirrorTLSCredentials(Mirror):
-    """Mirroring configuration for objects in the tls_credentials namespace."""
+    """Mirroring configuration for objects in the tls_creds namespace."""
 
     def __init__(self, store: ConfigStore) -> None:
-        super().__init__('tls_credentials', store)
+        super().__init__('tls_creds', store)
 
     def filter_object(self, obj: Simplified) -> Simplified:
         """Filter tls_credential for sqlite3 store."""
@@ -631,10 +641,10 @@ class MirrorExternalCephCluster(Mirror):
 
 
 class MirrorRGWCredentials(Mirror):
-    """Mirroring configuration for objects in the rgw_credentials namespace."""
+    """Mirroring configuration for objects in the rgw_creds namespace."""
 
     def __init__(self, store: ConfigStore) -> None:
-        super().__init__('rgw_credentials', store)
+        super().__init__('rgw_creds', store)
 
     def filter_object(self, obj: Simplified) -> Simplified:
         """Filter rgw_credential for sqlite3 store."""

--- a/src/pybind/mgr/smb/sqlite_store.py
+++ b/src/pybind/mgr/smb/sqlite_store.py
@@ -454,6 +454,9 @@ class SqliteMirroringStore(SqliteStore):
     ) -> None:
         super().__init__(backend, tables)
         self._mirrors: Dict[str, Mirror] = {m.namespace: m for m in mirrors}
+        self._pending_mirror_removals: Optional[
+            List[Tuple[Mirror, EntryKey]]
+        ] = None
 
     def _mirror(self, key: EntryKey) -> Optional[Mirror]:
         ns, _ = key
@@ -467,10 +470,52 @@ class SqliteMirroringStore(SqliteStore):
             super().set_object(key, obj)
             return
         log.debug("Mirroring set_object: mirror=%r", mirror)
+        if self._pending_mirror_removals is not None:
+            # cancel any earlier queued removal for this key given
+            # we're about to write fresh data for it
+            self._pending_mirror_removals = [
+                item
+                for item in self._pending_mirror_removals
+                if item[1] != key
+            ]
         obj_for_store = mirror.filter_object(obj)
         obj_for_mirror = mirror.filter_mirror_object(obj)
         mirror.store[key].set(obj_for_mirror)
         super().set_object(key, obj_for_store)
+
+    def remove(self, key: EntryKey) -> bool:
+        """Remove an entry from the store, including its mirror copy, if any."""
+        mirror = self._mirror(key)
+        if mirror is None:
+            log.debug("Mirroring remove: no mirror for key %r", key)
+            return super().remove(key)
+        log.debug("Mirroring remove: mirror=%r", mirror)
+        removed = super().remove(key)
+        if removed:
+            if self._pending_mirror_removals is not None:
+                self._pending_mirror_removals.append((mirror, key))
+            else:
+                mirror.store.remove(key)
+        return removed
+
+    @contextlib.contextmanager
+    def transaction(self) -> Iterator[None]:
+        """Flushes any mirror-side removals queued by remove() only
+        after the sqlite transaction commits successfully, and discards
+        them if it doesn't.
+        """
+        with super().transaction():
+            self._pending_mirror_removals = []
+            try:
+                yield None
+            except Exception:
+                self._pending_mirror_removals = None
+                raise
+            else:
+                pending = self._pending_mirror_removals
+                self._pending_mirror_removals = None
+        for mirror, key in pending:
+            mirror.store.remove(key)
 
     def get_object(self, key: EntryKey) -> Simplified:
         """Fetch a simplified object from the store."""

--- a/src/pybind/mgr/smb/sqlite_store.py
+++ b/src/pybind/mgr/smb/sqlite_store.py
@@ -526,7 +526,17 @@ class SqliteMirroringStore(SqliteStore):
             return super().get_object(key)
         log.debug("Mirroring get_object: mirror=%r", mirror)
         obj = super().get_object(key)
-        mirror_obj = mirror.store[key].get()
+        try:
+            mirror_obj = mirror.store[key].get()
+        except KeyError:
+            if mirror.filter_object(obj) != obj:
+                log.debug(
+                    "Mirroring get_object: no mirror entry for %r,"
+                    " falling back to sqlite copy",
+                    key,
+                )
+                return obj
+            raise
         return mirror.merge(obj, mirror_obj)
 
     def reconcile(self) -> None:
@@ -612,10 +622,10 @@ class MirrorUsersAndGroups(Mirror):
 
 
 class MirrorTLSCredentials(Mirror):
-    """Mirroring configuration for objects in the tls_credentials namespace."""
+    """Mirroring configuration for objects in the tls_creds namespace."""
 
     def __init__(self, store: ConfigStore) -> None:
-        super().__init__('tls_credentials', store)
+        super().__init__('tls_creds', store)
 
     def filter_object(self, obj: Simplified) -> Simplified:
         """Filter tls_credential for sqlite3 store."""
@@ -641,10 +651,10 @@ class MirrorExternalCephCluster(Mirror):
 
 
 class MirrorRGWCredentials(Mirror):
-    """Mirroring configuration for objects in the rgw_credentials namespace."""
+    """Mirroring configuration for objects in the rgw_creds namespace."""
 
     def __init__(self, store: ConfigStore) -> None:
-        super().__init__('rgw_credentials', store)
+        super().__init__('rgw_creds', store)
 
     def filter_object(self, obj: Simplified) -> Simplified:
         """Filter rgw_credential for sqlite3 store."""

--- a/src/pybind/mgr/smb/sqlite_store.py
+++ b/src/pybind/mgr/smb/sqlite_store.py
@@ -8,6 +8,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Set,
     Tuple,
     Union,
 )
@@ -527,6 +528,56 @@ class SqliteMirroringStore(SqliteStore):
         obj = super().get_object(key)
         mirror_obj = mirror.store[key].get()
         return mirror.merge(obj, mirror_obj)
+
+    def reconcile(self) -> None:
+        """Compare the sqlite store and the mirror store and removes any
+        mirror entries if there's no corresponding sqlite row.
+        Sqlite rows with no mirror entry are only logged.
+        """
+        if not self._mirrors:
+            return
+        with self.transaction():
+            mirror_store = next(iter(self._mirrors.values())).store
+            mirror_ids_by_ns: Dict[str, Set[str]] = {}
+            for ns, name in mirror_store:
+                mirror_ids_by_ns.setdefault(ns, set()).add(name)
+
+            for ns in self._mirrors:
+                self._reconcile_namespace(
+                    ns, mirror_store, mirror_ids_by_ns.get(ns, set())
+                )
+
+    def _reconcile_namespace(
+        self,
+        ns: str,
+        mirror_store: ConfigStore,
+        mirror_ids: Set[str],
+    ) -> None:
+        """Repair drift between sqlite and the mirror for one namespace."""
+        if ns not in self._tables:
+            log.debug(
+                "reconcile: skipping mirror namespace %r with no"
+                " matching sqlite table",
+                ns,
+            )
+            return
+        sqlite_ids = set(self.contents(ns))
+
+        for orphan in sorted(mirror_ids - sqlite_ids):
+            log.warning(
+                "reconcile: removing orphaned mirror entry"
+                " (%s, %s) with no matching sqlite row",
+                ns,
+                orphan,
+            )
+            mirror_store.remove((ns, orphan))
+
+        for missing in sorted(sqlite_ids - mirror_ids):
+            log.warning(
+                "reconcile: (%s, %s) has no mirror entry",
+                ns,
+                missing,
+            )
 
 
 class MirrorJoinAuths(Mirror):

--- a/src/pybind/mgr/smb/tests/test_sqlite_store.py
+++ b/src/pybind/mgr/smb/tests/test_sqlite_store.py
@@ -1,0 +1,318 @@
+import logging
+import sqlite3
+
+import pytest
+
+import smb
+
+
+class _FakeDBAccessor:
+    def __init__(self) -> None:
+        self.db = sqlite3.connect(':memory:', isolation_level=None)
+
+
+def _plain_store():
+    return smb.sqlite_store.mgr_sqlite3_db(_FakeDBAccessor())
+
+
+def _mirroring_store(opts=None):
+    mirror_target = smb.config_store.MemConfigStore()
+    store = smb.sqlite_store.mgr_sqlite3_db_with_mirroring(
+        _FakeDBAccessor(), mirror_target, opts
+    )
+    return store, mirror_target
+
+
+def test_basic_crud():
+    store = _plain_store()
+    key = ('clusters', 'smb1')
+
+    store.set_object(key, {'cluster_id': 'smb1', 'auth_mode': 'user'})
+    assert store.get_object(key) == {
+        'cluster_id': 'smb1',
+        'auth_mode': 'user',
+    }
+
+    with pytest.raises(KeyError):
+        store.get_object(('clusters', 'missing'))
+    assert store.remove(('clusters', 'missing')) is False
+
+    assert store.remove(key) is True
+    with pytest.raises(KeyError):
+        store.get_object(key)
+
+
+def test_listing_and_iteration():
+    store = _plain_store()
+    store.set_object(('clusters', 'smb1'), {'cluster_id': 'smb1'})
+    store.set_object(('clusters', 'smb2'), {'cluster_id': 'smb2'})
+    store.set_object(('join_auths', 'auth1'), {'auth': {}})
+
+    assert store.contents('clusters') == {'smb1', 'smb2'}
+    assert 'clusters' in store.namespaces()
+    assert set(store) == {
+        ('clusters', 'smb1'),
+        ('clusters', 'smb2'),
+        ('join_auths', 'auth1'),
+    }
+
+
+def test_share_find():
+    store = _plain_store()
+    store.set_object(
+        ('shares', 'smb1/share1'),
+        {'cluster_id': 'smb1', 'share_id': 'share1', 'name': 'share1'},
+    )
+    store.set_object(
+        ('shares', 'smb1/share2'),
+        {'cluster_id': 'smb1', 'share_id': 'share2', 'name': 'share2'},
+    )
+    found = store.find_entries(
+        'shares', {'cluster_id': 'smb1', 'name': 'share2'}
+    )
+    assert len(found) == 1
+    assert found[0].get()['share_id'] == 'share2'
+
+
+def test_mirror_write_and_get():
+    store, mirror_target = _mirroring_store()
+    key = ('join_auths', 'auth1')
+    store.set_object(key, {'auth': {'username': 'foo', 'password': 'secret'}})
+
+    assert mirror_target[key].get()['auth']['password'] == 'secret'
+    raw = smb.sqlite_store.SqliteStore.get_object(store, key)
+    assert 'password' not in raw['auth']
+    assert store.get_object(key)['auth']['password'] == 'secret'
+
+
+def test_users_and_groups_mirror_write_and_get():
+    store, _ = _mirroring_store()
+    key = ('users_and_groups', 'ug1')
+    obj = {
+        'values': {
+            'users': [{'name': 'u1', 'password': 'secret'}],
+            'groups': [],
+        }
+    }
+    store.set_object(key, obj)
+
+    raw = smb.sqlite_store.SqliteStore.get_object(store, key)
+    assert raw['values']['users'][0]['password'] == ''
+    assert store.get_object(key)['values']['users'][0]['password'] == 'secret'
+
+
+def test_tls_credential_mirror_write_get_remove():
+    store, mirror_target = _mirroring_store()
+    key = ('tls_creds', 'cert1')
+    store.set_object(
+        key, {'credential_type': 'cert', 'value': 'secret-cert-data'}
+    )
+
+    assert mirror_target[key].get()['value'] == 'secret-cert-data'
+    raw = smb.sqlite_store.SqliteStore.get_object(store, key)
+    assert 'value' not in raw
+    assert store.get_object(key)['value'] == 'secret-cert-data'
+
+    assert store.remove(key) is True
+    assert key not in list(mirror_target)
+
+
+def test_rgw_credential_mirror_write_get_remove():
+    store, mirror_target = _mirroring_store()
+    key = ('rgw_creds', 'rgwcred1')
+    store.set_object(
+        key, {'access_key_id': 'AKIA...', 'secret_access_key': 'shh'}
+    )
+
+    assert mirror_target[key].get()['secret_access_key'] == 'shh'
+    raw = smb.sqlite_store.SqliteStore.get_object(store, key)
+    assert 'access_key_id' not in raw
+    assert 'secret_access_key' not in raw
+    assert store.get_object(key)['secret_access_key'] == 'shh'
+
+    assert store.remove(key) is True
+    assert key not in list(mirror_target)
+
+
+def test_mirror_opt_out():
+    store, mirror_target = _mirroring_store(opts={'mirror_join_auths': 'no'})
+    key = ('join_auths', 'auth1')
+    store.set_object(key, {'auth': {'username': 'foo', 'password': 'secret'}})
+
+    assert list(mirror_target) == []
+    assert store.get_object(key)['auth']['password'] == 'secret'
+
+
+def test_remove_mirrors_deletion():
+    store, mirror_target = _mirroring_store()
+    mirrored_key = ('join_auths', 'auth1')
+    unmirrored_key = ('clusters', 'smb1')
+    store.set_object(
+        mirrored_key, {'auth': {'username': 'foo', 'password': 'secret'}}
+    )
+    store.set_object(unmirrored_key, {'cluster_id': 'smb1'})
+    assert mirrored_key in list(mirror_target)
+
+    assert store.remove(mirrored_key) is True
+    assert mirrored_key not in list(mirror_target)
+    assert store.remove(mirrored_key) is False
+
+    assert store.remove(unmirrored_key) is True
+    assert list(mirror_target) == []
+
+
+def test_remove_in_transaction_commits():
+    store, mirror_target = _mirroring_store()
+    key = ('join_auths', 'auth1')
+    store.set_object(key, {'auth': {'username': 'foo', 'password': 'secret'}})
+
+    with store.transaction():
+        assert store.remove(key) is True
+        assert key in list(mirror_target)
+
+    assert key not in list(mirror_target)
+
+
+def test_remove_in_transaction_rollback():
+    store, mirror_target = _mirroring_store()
+    key = ('join_auths', 'auth1')
+    store.set_object(key, {'auth': {'username': 'foo', 'password': 'secret'}})
+
+    with pytest.raises(RuntimeError):
+        with store.transaction():
+            assert store.remove(key) is True
+            raise RuntimeError('later step in the same batch failed')
+
+    assert store.get_object(key)['auth']['password'] == 'secret'
+    assert key in list(mirror_target)
+
+
+def test_remove_then_recreate_keeps_mirror():
+    store, mirror_target = _mirroring_store()
+    key = ('join_auths', 'auth1')
+    store.set_object(key, {'auth': {'username': 'foo', 'password': 'old'}})
+
+    with store.transaction():
+        assert store.remove(key) is True
+        store.set_object(
+            key, {'auth': {'username': 'foo', 'password': 'new'}}
+        )
+
+    assert key in list(mirror_target)
+    assert mirror_target[key].get()['auth']['password'] == 'new'
+    assert store.get_object(key)['auth']['password'] == 'new'
+
+
+def test_set_object_in_transaction_commits():
+    store, mirror_target = _mirroring_store()
+    key = ('join_auths', 'auth1')
+    store.set_object(key, {'auth': {'username': 'foo', 'password': 'old'}})
+
+    with store.transaction():
+        store.set_object(
+            key, {'auth': {'username': 'foo', 'password': 'new'}}
+        )
+        assert mirror_target[key].get()['auth']['password'] == 'old'
+
+    assert mirror_target[key].get()['auth']['password'] == 'new'
+
+
+def test_get_object_sees_pending_write():
+    store, _ = _mirroring_store()
+    key = ('join_auths', 'auth1')
+    store.set_object(
+        key, {'auth': {'username': 'foo', 'password': 'old'}, 'extra': 'old'}
+    )
+
+    with store.transaction():
+        store.set_object(
+            key,
+            {'auth': {'username': 'foo', 'password': 'new'}, 'extra': 'new'},
+        )
+        # not flushed to the mirror yet, but a read in the same
+        # transaction must see the pending write, not the stale mirror
+        seen = store.get_object(key)
+        assert seen['auth']['password'] == 'new'
+        assert seen['extra'] == 'new'
+
+    assert store.get_object(key)['auth']['password'] == 'new'
+
+
+def test_set_object_in_transaction_rollback_keeps_old_mirror():
+    store, mirror_target = _mirroring_store()
+    key = ('join_auths', 'auth1')
+    store.set_object(key, {'auth': {'username': 'foo', 'password': 'old'}})
+
+    with pytest.raises(RuntimeError):
+        with store.transaction():
+            store.set_object(
+                key, {'auth': {'username': 'foo', 'password': 'new'}}
+            )
+            raise RuntimeError('later step in the same batch failed')
+
+    assert mirror_target[key].get()['auth']['password'] == 'old'
+    assert store.get_object(key)['auth']['password'] == 'old'
+
+
+def test_remove_then_recreate_rollback_keeps_old_mirror():
+    store, mirror_target = _mirroring_store()
+    key = ('join_auths', 'auth1')
+    store.set_object(key, {'auth': {'username': 'foo', 'password': 'old'}})
+
+    with pytest.raises(RuntimeError):
+        with store.transaction():
+            assert store.remove(key) is True
+            store.set_object(
+                key, {'auth': {'username': 'foo', 'password': 'new'}}
+            )
+            raise RuntimeError('later step in the same batch failed')
+
+    assert mirror_target[key].get()['auth']['password'] == 'old'
+    assert store.get_object(key)['auth']['password'] == 'old'
+
+
+def test_reconcile_fixes_drift():
+    store, mirror_target = _mirroring_store()
+    good_key = ('join_auths', 'auth1')
+    store.set_object(good_key, {'auth': {'username': 'foo', 'password': 's'}})
+    orphan_auth = ('join_auths', 'orphan-auth')
+    orphan_ug = ('users_and_groups', 'orphan-ug')
+    mirror_target[orphan_auth].set({'auth': {'username': 'y'}})
+    mirror_target[orphan_ug].set({'values': {'users': [], 'groups': []}})
+    unrecoverable_key = ('join_auths', 'auth2')
+    smb.sqlite_store.SqliteStore.set_object(
+        store, unrecoverable_key, {'auth': {'username': 'bar'}}
+    )
+
+    store.reconcile()
+
+    assert set(mirror_target) == {good_key}
+    assert store.get_object(good_key)['auth']['password'] == 's'
+    assert smb.sqlite_store.SqliteStore.get_object(
+        store, unrecoverable_key
+    ) == {'auth': {'username': 'bar'}}
+
+
+def test_reconcile_logs_unrecoverable_entries(caplog):
+    store, _ = _mirroring_store()
+    key = ('join_auths', 'auth1')
+    smb.sqlite_store.SqliteStore.set_object(store, key, {'auth': {}})
+
+    with caplog.at_level(logging.WARNING):
+        store.reconcile()
+
+    assert 'no mirror entry' in caplog.text
+
+
+def test_reconcile_no_mirrors():
+    store, mirror_target = _mirroring_store(
+        opts={
+            'mirror_join_auths': 'no',
+            'mirror_users_and_groups': 'no',
+            'mirror_tls_credentials': 'no',
+            'mirror_external_ceph_clusters': 'no',
+            'mirror_rgw_credentials': 'no',
+        }
+    )
+    store.reconcile()
+    assert list(mirror_target) == []


### PR DESCRIPTION
`set_object()` mirrors secret(join-auth, tls creds, rgw creds,etc..) resources into the mon config-key store, but `remove()` never did the same, so deleting a resource left its secret behind in config-key.

Added a `remove()` override that cleans up the mirror too.

Fixes: https://tracker.ceph.com/issues/78619





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
