### PR TITLE
squid: rgw/multisite: sync put-object-lock-configuration

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -2539,6 +2539,9 @@ void RGWBucketInfo::dump(Formatter *f) const
   if (!empty_sync_policy()) {
     encode_json("sync_policy", *sync_policy, f);
   }
+  if (obj_lock_enabled()) {
+    encode_json("obj_lock", obj_lock, f);
+  }
 }
 
 void RGWBucketInfo::decode_json(JSONObj *obj) {
@@ -2581,6 +2584,9 @@ void RGWBucketInfo::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("sync_policy", sp, obj);
   if (!sp.empty()) {
     set_sync_policy(std::move(sp));
+  }
+  if (obj_lock_enabled()) {
+    JSONDecoder::decode_json("obj_lock", obj_lock, obj);
   }
 }
 

--- a/src/rgw/rgw_object_lock.cc
+++ b/src/rgw/rgw_object_lock.cc
@@ -5,6 +5,12 @@
 
 using namespace std;
 
+void DefaultRetention::decode_json(JSONObj *obj) {
+  JSONDecoder::decode_json("mode", mode, obj);
+  JSONDecoder::decode_json("days", days, obj);
+  JSONDecoder::decode_json("years", years, obj);
+}
+
 void DefaultRetention::decode_xml(XMLObj *obj) {
   RGWXMLDecoder::decode_xml("Mode", mode, obj, true);
   if (mode.compare("GOVERNANCE") != 0 && mode.compare("COMPLIANCE") != 0) {
@@ -18,11 +24,11 @@ void DefaultRetention::decode_xml(XMLObj *obj) {
 }
 
 void DefaultRetention::dump(Formatter *f) const {
-  f->dump_string("mode", mode);
+  encode_json("mode", mode, f);
   if (days > 0) {
-    f->dump_int("days", days);
+    encode_json("days", days, f);
   } else {
-    f->dump_int("years", years);
+    encode_json("years", years, f);
   }
 }
 
@@ -35,6 +41,10 @@ void DefaultRetention::dump_xml(Formatter *f) const {
   }
 }
 
+void ObjectLockRule::decode_json(JSONObj *obj) {
+  JSONDecoder::decode_json("defaultRetention", defaultRetention, obj);
+}
+
 void ObjectLockRule::decode_xml(XMLObj *obj) {
   RGWXMLDecoder::decode_xml("DefaultRetention", defaultRetention, obj, true);
 }
@@ -44,14 +54,20 @@ void ObjectLockRule::dump_xml(Formatter *f) const {
 }
 
 void ObjectLockRule::dump(Formatter *f) const {
-  f->open_object_section("default_retention");
-  defaultRetention.dump(f);
-  f->close_section();
+  encode_json("defaultRetention", defaultRetention, f);
 }
 
 void ObjectLockRule::generate_test_instances(std::list<ObjectLockRule*>& o) {
   ObjectLockRule *obj = new ObjectLockRule;
   o.push_back(obj);
+}
+
+void RGWObjectLock::decode_json(JSONObj *obj) {
+  JSONDecoder::decode_json("enabled", enabled, obj);
+  JSONDecoder::decode_json("rule_exist", rule_exist, obj);
+  if (rule_exist) {
+    JSONDecoder::decode_json("rule", rule, obj);
+  }
 }
 
 void RGWObjectLock::decode_xml(XMLObj *obj) {
@@ -75,12 +91,12 @@ void RGWObjectLock::dump_xml(Formatter *f) const {
 }
 
 void RGWObjectLock::dump(Formatter *f) const {
-  f->dump_bool("enabled", enabled);
-  f->dump_bool("rule_exist", rule_exist);
+  if (enabled) {
+    encode_json("enabled", enabled, f);
+  }
+  encode_json("rule_exist", rule_exist, f);
   if (rule_exist) {
-    f->open_object_section("rule");
-    rule.dump(f);
-    f->close_section();
+    encode_json("rule", rule, f);
   }
 }
 

--- a/src/rgw/rgw_object_lock.h
+++ b/src/rgw/rgw_object_lock.h
@@ -6,6 +6,7 @@
 #include <string>
 #include "common/ceph_time.h"
 #include "common/iso_8601.h"
+#include "common/ceph_json.h"
 #include "rgw_xml.h"
 
 class DefaultRetention
@@ -45,6 +46,8 @@ public:
     decode(years, bl);
     DECODE_FINISH(bl);
   }
+
+  void decode_json(JSONObj *obj);
   void dump(Formatter *f) const;
   void decode_xml(XMLObj *obj);
   void dump_xml(Formatter *f) const;
@@ -80,6 +83,7 @@ public:
     DECODE_FINISH(bl);
   }
 
+  void decode_json(JSONObj *obj);
   void decode_xml(XMLObj *obj);
   void dump_xml(Formatter *f) const;
   void dump(Formatter *f) const;
@@ -140,6 +144,7 @@ public:
     DECODE_FINISH(bl);
   }
 
+  void decode_json(JSONObj *obj);
   void decode_xml(XMLObj *obj);
   void dump_xml(Formatter *f) const;
   ceph::real_time get_lock_until_date(const ceph::real_time& mtime) const;

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -3948,3 +3948,40 @@ def test_bucket_full_sync_when_the_bucket_is_deleted_in_the_meantime():
         except:
             pass
         raise
+
+def test_object_lock_sync():
+
+    zonegroup = realm.master_zonegroup()
+    zonegroup_conns = ZonegroupConns(zonegroup)
+    primary = zonegroup_conns.rw_zones[0]
+    secondary = zonegroup_conns.rw_zones[1]
+
+    bucket = primary.create_bucket(gen_bucket_name())
+    log.debug('created bucket=%s', bucket.name)
+
+    # enable versioning
+    primary.s3_client.put_bucket_versioning(
+        Bucket=bucket.name,
+        VersioningConfiguration={'Status': 'Enabled'})
+    zonegroup_meta_checkpoint(zonegroup)
+
+    lock_config = {
+    'ObjectLockEnabled': 'Enabled',
+    'Rule': {
+        'DefaultRetention': {
+            'Mode': 'COMPLIANCE',
+            'Days': 1
+            }
+        }
+    }
+
+    # enable object lock on bucket
+    primary.s3_client.put_object_lock_configuration(
+        Bucket=bucket.name,
+        ObjectLockConfiguration = lock_config)
+
+    zonegroup_meta_checkpoint(zonegroup)
+    zone_data_checkpoint(secondary.zone, primary.zone)
+
+    response = secondary.s3_client.get_object_lock_configuration(Bucket=bucket.name)
+    assert(response['ObjectLockConfiguration'] == lock_config)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73067

backport of https://github.com/ceph/ceph/pull/63089
parent tracker: https://tracker.ceph.com/issues/71157



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
