### PR TITLE
common/admin_socket: unlink stale sockets left by a killed daemon on restart

### DIFF
--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -25,6 +25,7 @@
 typedef void* timer_t;
 #endif
 
+#include <filesystem>
 #include <iomanip>
 #include <optional>
 
@@ -1070,6 +1071,85 @@ public:
   }
 };
 
+/*
+ * Unprivileged daemons (radosgw, rbd-mirror, ...) default their admin socket
+ * path to a per-process name embedding $pid (and $cctid) so that several
+ * instances of the same daemon can coexist. The socket file is only unlinked
+ * on a graceful exit (see add_cleanup_file()/atexit()); a process killed with
+ * SIGKILL -- which is what `ceph orch daemon restart --force` and container or
+ * pod restarts do -- leaves its socket behind. Because the next instance picks
+ * a new $pid/$cctid, bind_and_listen()'s same-path stale-socket unlink never
+ * revisits the old one, so dead sockets accumulate one per forced restart.
+ *
+ * Before binding, sweep the run directory for sibling sockets belonging to
+ * this same daemon and unlink the ones that no longer answer a ping. A live
+ * concurrent instance answers the ping and is left untouched. Our identity is
+ * taken from "$cluster-$name." (the stable prefix of the default per-process
+ * name) so sockets belonging to other daemons are never considered.
+ */
+static void unlink_stale_sibling_sockets(CephContext *cct,
+					 const std::string& path)
+{
+  namespace fs = std::filesystem;
+  const fs::path sockpath(path);
+  fs::path dir = sockpath.parent_path();
+  if (dir.empty()) {
+    dir = ".";
+  }
+  const std::string base = sockpath.filename().string();
+
+  // Recover the stable, entity-specific prefix straight from our identity
+  // rather than parsing digits out of the file name: $pid can be a small value
+  // in a container (e.g. 2) that also appears elsewhere in $name. The default
+  // per-process templates start with either "$cluster-$name." (daemons, e.g.
+  // radosgw) or "$name." (e.g. rbd-mirror); pick whichever our own name uses.
+  // Anchoring on the full $name keeps other daemons' sockets out of scope. If
+  // neither layout matches (a fixed admin_socket, or some other template)
+  // there is nothing here to sweep.
+  const std::string name = cct->_conf->name.to_str();
+  const std::string cluster_prefix = cct->_conf->cluster + "-" + name + ".";
+  const std::string name_prefix = name + ".";
+  static constexpr std::string_view suffix = ".asok";
+  std::string prefix;
+  if (base.starts_with(cluster_prefix)) {
+    prefix = cluster_prefix;
+  } else if (base.starts_with(name_prefix)) {
+    prefix = name_prefix;
+  } else {
+    return;
+  }
+  if (!base.ends_with(suffix)) {
+    return;
+  }
+
+  std::error_code ec;
+  for (const auto& de : fs::directory_iterator(dir, ec)) {
+    if (ec) {
+      break;
+    }
+    std::error_code type_ec;
+    if (!de.is_socket(type_ec)) {              // only unlink actual sockets
+      continue;
+    }
+    const std::string fn = de.path().filename().string();
+    if (fn == base ||                          // our own (not yet bound) socket
+	!fn.starts_with(prefix) ||             // different daemon
+	!fn.ends_with(suffix)) {
+      continue;
+    }
+    const std::string full = de.path().string();
+    AdminSocketClient client(full);
+    bool ok = false;
+    client.ping(&ok);
+    if (ok) {                                  // a live instance owns it
+      continue;
+    }
+    lgeneric_subdout(cct, asok, 5) << "unlinking stale admin socket "
+				   << full << dendl;
+    retry_sys_call(::unlink, full.c_str());
+  }
+}
+
 bool AdminSocket::init(const std::string& path)
 {
   ldout(m_cct, 5) << "init " << path << dendl;
@@ -1095,6 +1175,9 @@ bool AdminSocket::init(const std::string& path)
     lderr(m_cct) << "AdminSocketConfigObs::init: error: " << err << dendl;
     return false;
   }
+#ifndef _WIN32
+  unlink_stale_sibling_sockets(m_cct, path);
+#endif
   int sock_fd;
   err = bind_and_listen(path, &sock_fd);
   if (!err.empty()) {

--- a/src/test/admin_socket.cc
+++ b/src/test/admin_socket.cc
@@ -26,8 +26,11 @@
 #include <stdint.h>
 #include <string.h>
 #include <string>
+#include <sys/socket.h>
 #include <sys/un.h>
 #include <signal.h>
+#include <unistd.h>
+#include <filesystem>
 
 #include <iostream> // for std::cout
 
@@ -343,7 +346,78 @@ TEST(AdminSocket, bind_and_listen) {
   }
 }
 
-class AdminSocketRaise: public ::testing::Test 
+#ifndef _WIN32
+// Create a bound-but-unlistened unix socket file, i.e. a socket that a process
+// left behind after being killed (connect() to it is refused == dead).
+static void make_dead_socket(const std::string& path)
+{
+  int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+  ASSERT_GE(fd, 0);
+  struct sockaddr_un addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sun_family = AF_UNIX;
+  ASSERT_LT(path.size(), sizeof(addr.sun_path));
+  strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
+  ::unlink(path.c_str());
+  ASSERT_EQ(0, ::bind(fd, (struct sockaddr*)&addr, sizeof(addr)));
+  // no listen(): the file persists on close, but connect() is refused
+  ASSERT_EQ(0, ::close(fd));
+}
+
+// AdminSocket::init() sweeps and unlinks admin-socket files left behind by
+// previous, SIGKILLed instances of this same daemon (Redmine #76939), while
+// leaving live instances and other daemons' sockets alone.
+TEST(AdminSocket, UnlinkStaleSiblingSockets) {
+  namespace fs = std::filesystem;
+  const char *tdir = getenv("TMPDIR");
+  const std::string dir = std::string(tdir ? tdir : "/tmp") +
+			  "/asok_sweep_test." + std::to_string(getpid());
+  ASSERT_TRUE(fs::create_directories(dir));
+
+  // Mirror the per-process default admin_socket layout "$cluster-$name.*.asok".
+  const std::string stem = g_ceph_context->_conf->cluster + "-" +
+			   g_ceph_context->_conf->name.to_str();
+  auto sib = [&](const std::string& tag) {
+    return dir + "/" + stem + "." + tag + ".asok";
+  };
+
+  // A stale socket left by a previous instance that was killed with SIGKILL.
+  const std::string stale = sib("1001.11111111");
+  make_dead_socket(stale);
+  ASSERT_TRUE(fs::is_socket(stale));
+
+  // A dead socket belonging to a *different* daemon must be left alone.
+  const std::string other = dir + "/" + g_ceph_context->_conf->cluster +
+			    "-client.other.1002.22222222.asok";
+  make_dead_socket(other);
+
+  // A *live* instance of the same daemon must be left alone.
+  const std::string live = sib("1003.33333333");
+  std::unique_ptr<AdminSocket> liveasok =
+    std::make_unique<AdminSocket>(g_ceph_context);
+  AdminSocketTest livet(liveasok.get());
+  ASSERT_TRUE(livet.init(live));
+
+  // Our own init() runs the sweep and then binds our socket.
+  const std::string ours = sib(std::to_string(getpid()) + ".44444444");
+  std::unique_ptr<AdminSocket> asok =
+    std::make_unique<AdminSocket>(g_ceph_context);
+  AdminSocketTest t(asok.get());
+  ASSERT_TRUE(t.init(ours));
+
+  EXPECT_FALSE(fs::exists(stale));   // dead same-daemon socket swept
+  EXPECT_TRUE(fs::exists(other));    // different daemon untouched
+  EXPECT_TRUE(fs::exists(live));     // live instance preserved
+  EXPECT_TRUE(fs::exists(ours));     // our own socket bound
+
+  ASSERT_TRUE(t.shutdown());
+  ASSERT_TRUE(livet.shutdown());
+  std::error_code ec;
+  fs::remove_all(dir, ec);
+}
+#endif // _WIN32
+
+class AdminSocketRaise: public ::testing::Test
 {
 public:
   struct TestSignal {


### PR DESCRIPTION
Unprivileged daemons (radosgw, rbd-mirror, ...) default their admin socket to a per-process path embedding $pid and $cctid ($cluster-$name.$pid.$cctid.asok) so multiple instances of the same daemon can coexist. That file is only unlinked on a graceful exit, through add_cleanup_file()/atexit().

A daemon killed with SIGKILL skips that cleanup and leaves its socket behind in the run dir. Both `ceph orch daemon restart --force` and container/pod restarts kill the process this way. Since the next instance picks a new $pid/$cctid, bind_and_listen()'s same-path stale-socket unlink never revisits the old file, so dead sockets pile up one per forced restart:

```
# ls /run/ceph/<fsid>/
...rgw...gjcmla.2.100116160633216.asok   <- dead, connection refused
...rgw...gjcmla.2.94007843477888.asok    <- current
```

Reported on cephadm and reproduced on Rook, so this is fixed daemon-side in common/ rather than in the orchestrator.

AdminSocket::init() now sweeps the run directory before binding and unlinks the daemon's own sibling sockets that no longer answer a ping. The daemon identity comes from the "$cluster-$name." (or "$name.") prefix, so:
- other daemons' sockets are never considered,
- a live concurrent instance answers the ping and is left untouched,
- only actual sockets are considered (is_socket guard).

Windows is guarded out (no behavior change there).

Validated on a vstart RGW: a forced restart no longer leaks the old socket, graceful shutdown still cleans its own, and both a live same-name instance and other entities' sockets are left alone. Added unit test AdminSocket.UnlinkStaleSiblingSockets covering all four cases.

Tracker: https://tracker.ceph.com/issues/76939

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes unit test(s)
