### PR TITLE
mds: update lock for snap MD ops to support multi-MDS scenario

### DIFF
--- a/qa/suites/fs/functional/tasks/snapshots.yaml
+++ b/qa/suites/fs/functional/tasks/snapshots.yaml
@@ -1,4 +1,10 @@
 overrides:
+  install:
+    extra_system_packages:
+      rpm:
+        - python3-pytest
+      deb:
+        - python3-pytest
   check-counter:
     dry_run: true
   ceph:
@@ -13,4 +19,6 @@ tasks:
 - cephfs_test_runner:
     fail_on_skip: false
     modules:
+      # TODO: for dev phase only, remove before merging the PR
+      - tasks.cephfs.test_snapshots.TestMultiMDS
       - tasks.cephfs.test_snapshots

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -20,6 +20,7 @@ import re
 import socket
 import yaml
 
+from json import dumps
 from paramiko import SSHException
 from tasks.ceph_manager import CephManager, write_conf, get_valgrind_args
 from tarfile import ReadError
@@ -713,7 +714,7 @@ def cluster(ctx, config):
     data_dir = '{tdir}/{cluster}.data'.format(tdir=testdir, cluster=cluster_name)
     log.info('Creating ceph cluster %s...', cluster_name)
     log.info('config %s', config)
-    log.info('ctx.config %s', ctx.config)
+    log.info('ctx.config %s', dumps(ctx.config, indent=4))
     run.wait(
         ctx.cluster.run(
             args=[

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from textwrap import dedent
 
 from teuthology.contextutil import safe_while
-from teuthology.misc import get_file, write_file
+from teuthology.misc import get_file, write_file, get_testdir
 from teuthology.orchestra import run
 from teuthology.orchestra.run import Raw
 from teuthology.exceptions import CommandFailedError, ConnectionLostError
@@ -95,6 +95,10 @@ class CephFSMountBase(object):
         self.test_files = ['a', 'b', 'c']
 
         self.background_procs = []
+
+    def __del__(self):
+        self.rm_pybind_test_files()
+        super().__del__()
 
     # This will cleanup the stale netnses, which are from the
     # last failed test cases.
@@ -928,6 +932,68 @@ class CephFSMountBase(object):
                                 check_status=False)
         self._verify(proc, retval, errmsgs)
         return proc
+
+    def rm_pybind_test_files(self):
+        if not hasattr(self, 'pybind_test_files') or \
+           not self.pybind_test_files:
+            return
+
+        self.client_remote.run(f'rm --verbose --force {self.pybind_test_files}')
+        self.PYBIND_TEST_FILE_PATH = ''
+
+    def fetch_pybind_test_files(self):
+        '''
+        Fetch files for CephFS Pybind unit tests from the Teuthology Worker Node
+        to the given testing node.
+        '''
+        # dont fetch files again if they have been fetched already.
+        if hasattr(self, 'pybind_test_files') and \
+            self.pybind_test_files:
+            return
+
+        TEST_FILE_NAMES = ('assertions.py', 'test_cephfs.py')
+        REMOTE_TEST_DIR_PATH = get_testdir(self.ctx)
+        # TWN = teuthology worker node
+        dirname = os.path.dirname
+        TWN_CEPH_REPO_ROOT = dirname(dirname(dirname(dirname(__file__))))
+        TWN_PYBIND_TEST_DIR_PATH = os.path.join(TWN_CEPH_REPO_ROOT,
+                                                'src/test/pybind')
+
+        for name in TEST_FILE_NAMES:
+            log.info(f'running put_file() for file "{name}"...')
+
+            twn_file_path = os.path.join(TWN_PYBIND_TEST_DIR_PATH, name)
+            remote_file_path = os.path.join(REMOTE_TEST_DIR_PATH, name)
+
+            self.client_remote.put_file(twn_file_path, remote_file_path)
+
+            self.pybind_test_files = ' ' + remote_file_path
+            if 'test_cephfs.py' in remote_file_path:
+                self.PYBIND_TEST_FILE_PATH = remote_file_path
+
+    def run_pybind_test(self, TEST_CLASS_NAME=None, TEST_FUNC_NAME=None):
+        '''
+        Run CephFS Pybind unit tests using pytest command. Test files should be
+        copied (from src/test/pybind) to client's remote machine beforehand.
+        '''
+        self.fetch_pybind_test_files()
+
+        if TEST_CLASS_NAME and TEST_FUNC_NAME:
+            FILTER_STR = f'{TEST_CLASS_NAME} and {TEST_FUNC_NAME}'
+        elif TEST_CLASS_NAME and not TEST_FUNC_NAME:
+            FILTER_STR = TEST_CLASS_NAME
+        elif not TEST_CLASS_NAME and TEST_FUNC_NAME:
+            FILTER_STR = TEST_FUNC_NAME
+        else:
+            FILTER_STR = ''
+
+        if FILTER_STR:
+            pytest_cmd = (f'pytest --verbose -k "{FILTER_STR}" '
+                          f'{self.PYBIND_TEST_FILE_PATH}')
+        else:
+            pytest_cmd = f'pytest --verbose {self.PYBIND_TEST_FILE_PATH}'
+
+        self.run_shell(args=pytest_cmd)
 
     def open_for_reading(self, basename):
         """

--- a/qa/tasks/cephfs/test_snapshots.py
+++ b/qa/tasks/cephfs/test_snapshots.py
@@ -401,6 +401,125 @@ class TestSnapshots(CephFSTestCase):
         # 2024-07-04T02:11:26.990+0000 7f6b14e71640 10 MDSAuthCap is_capable inode(path /dir1/dir2 owner 1141:1141 mode 0100644) by caller 1141:1141 mask 1 new 0:0 cap: MDSAuthCaps[allow rws fsname=cephfs path="/dir1"]
         self.mount_a.run_shell_payload("stat .snap/one/dir2/file")
 
+    class SnapLimitViolationException(Exception):
+        failed_snapshot_number = -1
+
+        def __init__(self, num):
+            self.failed_snapshot_number = num
+
+    def get_snap_name(self, dir_name, sno):
+            sname = "{dir_name}/.snap/s_{sno}".format(dir_name=dir_name, sno=sno)
+            return sname
+
+    def create_snap_dir(self, sname):
+        self.mount_a.run_shell(["mkdir", sname])
+
+    def delete_dir_and_snaps(self, dir_name, snaps):
+        for sno in range(1, snaps+1, 1):
+            sname = self.get_snap_name(dir_name, sno)
+            self.mount_a.run_shell(["rmdir", sname])
+        self.mount_a.run_shell(["rmdir", dir_name])
+
+    def create_dir_and_snaps(self, dir_name, snaps):
+        self.mount_a.run_shell(["mkdir", dir_name])
+
+        for sno in range(1, snaps+1, 1):
+            sname = self.get_snap_name(dir_name, sno)
+            try:
+                self.create_snap_dir(sname)
+            except CommandFailedError as e:
+                # failing at the last mkdir beyond the limit is expected
+                if sno == snaps:
+                    log.info("failed while creating snap #{}: {}".format(sno, repr(e)))
+                    raise TestSnapshots.SnapLimitViolationException(sno)
+
+    def test_mds_max_snaps_per_dir_default_limit(self):
+        """
+        Test the newly introudced option named mds_max_snaps_per_dir
+        Default snaps limit is 100
+        Test if the default number of snapshot directories can be created
+        """
+        self.create_dir_and_snaps("accounts", int(self.mds_max_snaps_per_dir))
+        self.delete_dir_and_snaps("accounts", int(self.mds_max_snaps_per_dir))
+
+    def test_mds_max_snaps_per_dir_with_increased_limit(self):
+        """
+        Test the newly introudced option named mds_max_snaps_per_dir
+        First create 101 directories and ensure that the 101st directory
+        creation fails. Then increase the default by one and see if the
+        additional directory creation succeeds
+        """
+        # first test the default limit
+        new_limit = int(self.mds_max_snaps_per_dir)
+        self.fs.rank_asok(['config', 'set', 'mds_max_snaps_per_dir', repr(new_limit)])
+        try:
+            self.create_dir_and_snaps("accounts", new_limit + 1)
+        except TestSnapshots.SnapLimitViolationException as e:
+            if e.failed_snapshot_number == (new_limit + 1):
+                pass
+        # then increase the limit by one and test
+        new_limit = new_limit + 1
+        self.fs.rank_asok(['config', 'set', 'mds_max_snaps_per_dir', repr(new_limit)])
+        sname = self.get_snap_name("accounts", new_limit)
+        self.create_snap_dir(sname)
+        self.delete_dir_and_snaps("accounts", new_limit)
+
+    def test_mds_max_snaps_per_dir_with_reduced_limit(self):
+        """
+        Test the newly introudced option named mds_max_snaps_per_dir
+        First create 99 directories. Then reduce the limit to 98. Then try
+        creating another directory and ensure that additional directory
+        creation fails.
+        """
+        # first test the new limit
+        new_limit = int(self.mds_max_snaps_per_dir) - 1
+        self.create_dir_and_snaps("accounts", new_limit)
+        sname = self.get_snap_name("accounts", new_limit + 1)
+        # then reduce the limit by one and test
+        new_limit = new_limit - 1
+        self.fs.rank_asok(['config', 'set', 'mds_max_snaps_per_dir', repr(new_limit)])
+        try:
+            self.create_snap_dir(sname)
+        except CommandFailedError:
+            # after reducing limit we expect the new snapshot creation to fail
+            pass
+        self.delete_dir_and_snaps("accounts", new_limit + 1)
+
+
+class TestMultiMDS(CephFSTestCase):
+    MDSS_REQUIRED = 3
+
+    def setUp(self):
+        super(TestMultiMDS, self).setUp()
+        self.fs.set_allow_new_snaps(True);
+        self.fs.set_max_mds(2)
+        status = self.fs.wait_for_daemons()
+
+    def test_do_snap_md_add(self):
+        self.mount_a.run_pybind_test('TestDoSnapMdOp',
+                                     'test_create_allows_adding')
+
+    def test_do_snap_md_update(self):
+        self.mount_a.run_pybind_test('TestDoSnapMdOp',
+                                     'test_create_allows_updating')
+
+    def test_do_snap_md_excl_allows_add(self):
+        self.mount_a.run_pybind_test('TestDoSnapMdOp',
+                                     'test_excl_allows_adding')
+
+    def test_do_snap_md_excl_disallows_update(self):
+        self.mount_a.run_pybind_test('TestDoSnapMdOp',
+                                     'test_excl_disallows_updating')
+
+    def test_do_snap_md_remove(self):
+        self.mount_a.run_pybind_test('TestDoSnapMdOp', 'test_remove')
+
+    def test_do_snap_with_empty_strings(self):
+        self.mount_a.run_pybind_test('TestDoSnapMdOp',
+                                     'test_with_empty_strings')
+
+    def test_do_snap_md_negtesting(self):
+        self.mount_a.run_pybind_test('TestDoSnapMdOp', 'test_neg')
 
     def test_multimds_mksnap(self):
         """
@@ -492,90 +611,6 @@ class TestSnapshots(CephFSTestCase):
 
         self.mount_a.run_shell(["rmdir", "d1/.snap/s1"])
         self.mount_a.run_shell(["rm", "-rf", "d0", "d1"])
-
-    class SnapLimitViolationException(Exception):
-        failed_snapshot_number = -1
-
-        def __init__(self, num):
-            self.failed_snapshot_number = num
-
-    def get_snap_name(self, dir_name, sno):
-            sname = "{dir_name}/.snap/s_{sno}".format(dir_name=dir_name, sno=sno)
-            return sname
-
-    def create_snap_dir(self, sname):
-        self.mount_a.run_shell(["mkdir", sname])
-
-    def delete_dir_and_snaps(self, dir_name, snaps):
-        for sno in range(1, snaps+1, 1):
-            sname = self.get_snap_name(dir_name, sno)
-            self.mount_a.run_shell(["rmdir", sname])
-        self.mount_a.run_shell(["rmdir", dir_name])
-
-    def create_dir_and_snaps(self, dir_name, snaps):
-        self.mount_a.run_shell(["mkdir", dir_name])
-
-        for sno in range(1, snaps+1, 1):
-            sname = self.get_snap_name(dir_name, sno)
-            try:
-                self.create_snap_dir(sname)
-            except CommandFailedError as e:
-                # failing at the last mkdir beyond the limit is expected
-                if sno == snaps:
-                    log.info("failed while creating snap #{}: {}".format(sno, repr(e)))
-                    raise TestSnapshots.SnapLimitViolationException(sno)
-
-    def test_mds_max_snaps_per_dir_default_limit(self):
-        """
-        Test the newly introudced option named mds_max_snaps_per_dir
-        Default snaps limit is 100
-        Test if the default number of snapshot directories can be created
-        """
-        self.create_dir_and_snaps("accounts", int(self.mds_max_snaps_per_dir))
-        self.delete_dir_and_snaps("accounts", int(self.mds_max_snaps_per_dir))
-
-    def test_mds_max_snaps_per_dir_with_increased_limit(self):
-        """
-        Test the newly introudced option named mds_max_snaps_per_dir
-        First create 101 directories and ensure that the 101st directory
-        creation fails. Then increase the default by one and see if the
-        additional directory creation succeeds
-        """
-        # first test the default limit
-        new_limit = int(self.mds_max_snaps_per_dir)
-        self.fs.rank_asok(['config', 'set', 'mds_max_snaps_per_dir', repr(new_limit)])
-        try:
-            self.create_dir_and_snaps("accounts", new_limit + 1)
-        except TestSnapshots.SnapLimitViolationException as e:
-            if e.failed_snapshot_number == (new_limit + 1):
-                pass
-        # then increase the limit by one and test
-        new_limit = new_limit + 1
-        self.fs.rank_asok(['config', 'set', 'mds_max_snaps_per_dir', repr(new_limit)])
-        sname = self.get_snap_name("accounts", new_limit)
-        self.create_snap_dir(sname)
-        self.delete_dir_and_snaps("accounts", new_limit)
-
-    def test_mds_max_snaps_per_dir_with_reduced_limit(self):
-        """
-        Test the newly introudced option named mds_max_snaps_per_dir
-        First create 99 directories. Then reduce the limit to 98. Then try
-        creating another directory and ensure that additional directory
-        creation fails.
-        """
-        # first test the new limit
-        new_limit = int(self.mds_max_snaps_per_dir) - 1
-        self.create_dir_and_snaps("accounts", new_limit)
-        sname = self.get_snap_name("accounts", new_limit + 1)
-        # then reduce the limit by one and test
-        new_limit = new_limit - 1
-        self.fs.rank_asok(['config', 'set', 'mds_max_snaps_per_dir', repr(new_limit)])
-        try:
-            self.create_snap_dir(sname)
-        except CommandFailedError:
-            # after reducing limit we expect the new snapshot creation to fail
-            pass
-        self.delete_dir_and_snaps("accounts", new_limit + 1)
 
 
 class TestMonSnapsAndFsPools(CephFSTestCase):

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -11931,7 +11931,7 @@ void Server::handle_client_snap_md_op(const MDRequestRef& mdr)
 {
   const cref_t<MClientRequest> &req = mdr->client_request;
 
-  CInode* diri = rdlock_path_pin_ref(mdr, false, true);
+  CInode* diri = rdlock_path_pin_ref(mdr, true, false);
   if (!diri)
     return;
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/78427






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>