### PR TITLE
mgr/dashboard : If user is selected auto-fetch option while creating …

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-1/nvmeof-subsystem-step-1.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-1/nvmeof-subsystem-step-1.component.html
@@ -120,7 +120,7 @@
           <cds-text-label
             i18n
             [invalid]="subnetMaskRef.isInvalid"
-            [invalidText]="subnetMaskInvalidText"
+            [invalidText]="requiredFieldInvalidText"
             helperText="Listeners from this subnet-masks will be use."
             i18n-helperText
           >
@@ -138,7 +138,7 @@
               [invalid]="subnetMaskRef.isInvalid"
             />
           </cds-text-label>
-          <ng-template #subnetMaskInvalidText>
+          <ng-template #requiredFieldInvalidText>
             <span i18n>This field is required.</span>
           </ng-template>
         </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-1/nvmeof-subsystem-step-1.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-1/nvmeof-subsystem-step-1.component.spec.ts
@@ -71,5 +71,13 @@ describe('NvmeofSubsystemsStepOneComponent', () => {
       formHelper.setValue('nqn', 'nqn:2001-07.com.ceph:');
       formHelper.expectError('nqn', 'nqnPattern');
     });
+
+    it('should require subnet mask when auto-fetch is selected and validated', () => {
+      formHelper.setValue('listenerMode', component.LISTENER_MODE.AUTO_FETCH);
+      formHelper.setValue('subnetMask', '');
+      form.get('subnetMask')?.updateValueAndValidity();
+
+      expect(form.get('subnetMask')?.hasError('required')).toBeTruthy();
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component, ViewChild } from '@angular/core';
 import { By } from '@angular/platform-browser';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { SharedModule } from '../../shared.module';
 import { TearsheetStepComponent } from '../tearsheet-step/tearsheet-step.component';
 import { TearsheetComponent, TearsheetOverflowScroll } from './tearsheet.component';
@@ -47,6 +48,51 @@ class MockHostComponent {
   tearsheet!: TearsheetComponent;
 }
 
+@Component({
+  selector: 'cd-mock-form-step',
+  template: '',
+  standalone: false
+})
+class MockFormStepComponent {
+  formGroup = new FormGroup({
+    parent: new FormGroup({
+      child: new FormControl('', Validators.required)
+    })
+  });
+}
+
+@Component({
+  template: `
+    <cd-tearsheet
+      [steps]="steps"
+      [title]="title"
+      [description]="description"
+    >
+      <cd-tearsheet-step>
+        <cd-mock-form-step #tearsheetStep></cd-mock-form-step>
+      </cd-tearsheet-step>
+      <cd-tearsheet-step>
+        <div>Step 2</div>
+      </cd-tearsheet-step>
+    </cd-tearsheet>
+  `,
+  standalone: false
+})
+class MockFormHostComponent {
+  steps = [
+    { label: 'Step 1', complete: false },
+    { label: 'Step 2', complete: false }
+  ];
+  title = 'Form Host';
+  description = 'Form Host Description';
+
+  @ViewChild(TearsheetComponent)
+  tearsheet!: TearsheetComponent;
+
+  @ViewChild(MockFormStepComponent)
+  formStep!: MockFormStepComponent;
+}
+
 describe('TearsheetComponent', () => {
   let hostFixture: ComponentFixture<MockHostComponent>;
   let hostComponent: MockHostComponent;
@@ -54,7 +100,13 @@ describe('TearsheetComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [TearsheetComponent, TearsheetStepComponent, MockHostComponent],
+      declarations: [
+        TearsheetComponent,
+        TearsheetStepComponent,
+        MockHostComponent,
+        MockFormStepComponent,
+        MockFormHostComponent
+      ],
       imports: [SharedModule],
       providers: [
         {
@@ -177,6 +229,25 @@ describe('TearsheetComponent', () => {
       const nextBtn = buttons.find((btn) => btn.nativeElement.textContent.trim() === 'Next');
       expect(nextBtn).toBeTruthy();
       expect(nextBtn?.nativeElement.disabled).toBe(true);
+    });
+  });
+
+  describe('nested form validation on next', () => {
+    it('should mark nested controls dirty and touched on next', () => {
+      const formHostFixture = TestBed.createComponent(MockFormHostComponent);
+      formHostFixture.detectChanges();
+      const formHost = formHostFixture.componentInstance;
+
+      const childControl = formHost.formStep.formGroup.get('parent.child');
+      expect(childControl).toBeTruthy();
+      expect(childControl?.dirty).toBe(false);
+      expect(childControl?.touched).toBe(false);
+
+      formHost.tearsheet.onNext();
+
+      expect(childControl?.dirty).toBe(true);
+      expect(childControl?.touched).toBe(true);
+      expect(childControl?.hasError('required')).toBe(true);
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.ts
@@ -16,7 +16,7 @@ import {
   TemplateRef,
   ViewEncapsulation
 } from '@angular/core';
-import { FormBuilder } from '@angular/forms';
+import { AbstractControl, FormArray, FormBuilder, FormGroup } from '@angular/forms';
 import { Step } from 'carbon-components-angular';
 import { TearsheetStepComponent } from '../tearsheet-step/tearsheet-step.component';
 import { ModalCdsService } from '../../services/modal-cds.service';
@@ -211,13 +211,12 @@ export class TearsheetComponent implements OnInit, AfterViewInit, OnDestroy, OnC
 
   onNext() {
     this.validateStep.emit({ step: this.currentStep });
-
     const wrapper = this.stepContents?.toArray()?.[this.currentStep];
-    const legacyForm = wrapper?.resolvedFormGroup;
-    if (legacyForm) {
-      legacyForm.markAllAsTouched();
-      legacyForm.updateValueAndValidity({ emitEvent: true });
-      this._updateStepInvalid(this.currentStep, legacyForm.invalid);
+    const currentForm = wrapper?.resolvedFormGroup;
+    currentForm?.markAllAsTouched();
+    this.markControlsDirtyAndValidate(currentForm);
+    if (currentForm) {
+      this._updateStepInvalid(this.currentStep, currentForm.invalid);
     }
 
     const canAdvance = wrapper ? wrapper.canProceed : true;
@@ -243,7 +242,7 @@ export class TearsheetComponent implements OnInit, AfterViewInit, OnDestroy, OnC
       const form = wrapper.resolvedFormGroup;
       if (!form) return;
       form.markAllAsTouched();
-      form.updateValueAndValidity({ emitEvent: true });
+      this.markControlsDirtyAndValidate(form);
       this._updateStepInvalid(index, form.invalid);
     });
 
@@ -255,6 +254,17 @@ export class TearsheetComponent implements OnInit, AfterViewInit, OnDestroy, OnC
 
     const mergedPayloads = this.getMergedPayload();
     this.submitRequested.emit(mergedPayloads);
+  }
+
+  private markControlsDirtyAndValidate(control: AbstractControl | null) {
+    if (!control) {
+      return;
+    }
+    if (control instanceof FormGroup || control instanceof FormArray) {
+      Object.values(control.controls).forEach((child) => this.markControlsDirtyAndValidate(child));
+    }
+    control.markAsDirty({ onlySelf: true });
+    control.updateValueAndValidity({ onlySelf: true, emitEvent: true });
   }
 
   closeFullTearsheet() {


### PR DESCRIPTION


https://github.com/user-attachments/assets/2ce6c326-18d3-4f84-819a-4aa2dc3d2d6d




Fixes: https://tracker.ceph.com/issues/78641


Signed-off-by: pujaoshahu <pshahu@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
