### PR TITLE
rbd/tools/action: include non-user snapshots in the diff calculation

### DIFF
--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -708,6 +708,33 @@ WRITE_CLASS_ENCODER(SnapshotNamespace);
 
 std::ostream& operator<<(std::ostream& os, const SnapshotNamespace& ns);
 
+using SnapshotNameSpaces = std::tuple<UserSnapshotNamespace,
+                                      GroupSnapshotNamespace,
+                                      TrashSnapshotNamespace,
+                                      MirrorSnapshotNamespace>;
+const SnapshotNameSpaces snapshot_namespaces;
+
+using SnapshoNameSpacesIterator =
+  std::function<bool (SnapshotNamespace)>;
+
+template <size_t N>
+constexpr bool iterate_snapshot_namespaces(SnapshoNameSpacesIterator &func) {
+  bool r = iterate_snapshot_namespaces<N-1>(func);
+  if (!r) {
+    return r;
+  }
+  return std::invoke(func, std::get<N>(snapshot_namespaces));
+}
+
+template <>
+constexpr bool iterate_snapshot_namespaces<0>(SnapshoNameSpacesIterator &func) {
+  return std::invoke(func, std::get<0>(snapshot_namespaces));
+}
+
+constexpr void for_each_snapshot_namespace(SnapshoNameSpacesIterator &&func) {
+  iterate_snapshot_namespaces<std::tuple_size_v<SnapshotNameSpaces>-1>(func);
+}
+
 SnapshotNamespaceType get_snap_namespace_type(
     const SnapshotNamespace& snapshot_namespace);
 

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -702,10 +702,12 @@ public:
   int snap_protect(const char *snap_name);
   int snap_unprotect(const char *snap_name);
   int snap_is_protected(const char *snap_name, bool *is_protected);
-  int snap_set(const char *snap_name);
+  int snap_set(const char *snap_name, bool all_snaps = false);
   int snap_set_by_id(uint64_t snap_id);
   int snap_get_name(uint64_t snap_id, std::string *snap_name);
-  int snap_get_id(const std::string snap_name, uint64_t *snap_id);
+  int snap_get_id(const std::string snap_name,
+                  uint64_t *snap_id,
+                  bool all_snaps = false);
   int snap_rename(const char *srcname, const char *dstname);
   int snap_get_limit(uint64_t *limit);
   int snap_set_limit(uint64_t limit);

--- a/src/librbd/api/Snapshot.cc
+++ b/src/librbd/api/Snapshot.cc
@@ -261,8 +261,12 @@ int Snapshot<I>::get_name(I *ictx, uint64_t snap_id, std::string *snap_name)
     return r;
   }
 
-template <typename I>
-int Snapshot<I>::get_id(I *ictx, const std::string& snap_name, uint64_t *snap_id)
+  template <typename I>
+  int Snapshot<I>::get_id(
+    I *ictx,
+    const std::string& snap_name,
+    uint64_t *snap_id,
+    bool all_snaps)
   {
     ldout(ictx->cct, 20) << "snap_get_id " << ictx << " " << snap_name << dendl;
 
@@ -271,19 +275,27 @@ int Snapshot<I>::get_id(I *ictx, const std::string& snap_name, uint64_t *snap_id
       return r;
 
     std::shared_lock image_locker{ictx->image_lock};
-    cls::rbd::for_each_snapshot_namespace(
-      [ictx, &snap_name, &snap_id, &r]
-      (const cls::rbd::SnapshotNamespace &snap_namespace) {
-        *snap_id = ictx->get_snap_id(snap_namespace, snap_name);
-        if (*snap_id == CEPH_NOSNAP) {
-          r = -ENOENT;
-          return true;
+    if (all_snaps) {
+      cls::rbd::for_each_snapshot_namespace(
+        [ictx, &snap_name, &snap_id, &r]
+        (const cls::rbd::SnapshotNamespace &snap_namespace) {
+          *snap_id = ictx->get_snap_id(snap_namespace, snap_name);
+          if (*snap_id == CEPH_NOSNAP) {
+            r = -ENOENT;
+            return true;
+          }
+          r = 0;
+          return false;
         }
-        r = 0;
-        return false;
-      }
-    );
-    return r;
+      );
+      return r;
+    }
+    *snap_id = ictx->get_snap_id(
+      cls::rbd::UserSnapshotNamespace(), snap_name);
+    if (*snap_id == CEPH_NOSNAP) {
+      return -ENOENT;
+    }
+    return 0;
   }
 
 template <typename I>

--- a/src/librbd/api/Snapshot.cc
+++ b/src/librbd/api/Snapshot.cc
@@ -271,11 +271,19 @@ int Snapshot<I>::get_id(I *ictx, const std::string& snap_name, uint64_t *snap_id
       return r;
 
     std::shared_lock image_locker{ictx->image_lock};
-    *snap_id = ictx->get_snap_id(cls::rbd::UserSnapshotNamespace(), snap_name);
-    if (*snap_id == CEPH_NOSNAP)
-      return -ENOENT;
-
-    return 0;
+    cls::rbd::for_each_snapshot_namespace(
+      [ictx, &snap_name, &snap_id, &r]
+      (const cls::rbd::SnapshotNamespace &snap_namespace) {
+        *snap_id = ictx->get_snap_id(snap_namespace, snap_name);
+        if (*snap_id == CEPH_NOSNAP) {
+          r = -ENOENT;
+          return true;
+        }
+        r = 0;
+        return false;
+      }
+    );
+    return r;
   }
 
 template <typename I>

--- a/src/librbd/api/Snapshot.h
+++ b/src/librbd/api/Snapshot.h
@@ -34,7 +34,8 @@ struct Snapshot {
 
   static int get_name(ImageCtxT *ictx, uint64_t snap_id, std::string *snap_name);
 
-  static int get_id(ImageCtxT *ictx, const std::string& snap_name, uint64_t *snap_id);
+  static int get_id(ImageCtxT *ictx, const std::string& snap_name,
+                    uint64_t *snap_id, bool all_snaps = false);
 
   static int list(ImageCtxT *ictx, std::vector<snap_info_t>& snaps);
 

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -2607,21 +2607,26 @@ namespace librbd {
     return r;
   }
 
-  int Image::snap_set(const char *snap_name)
+  int Image::snap_set(const char *snap_name, bool all_snaps)
   {
     ImageCtx *ictx = (ImageCtx *)ctx;
     tracepoint(librbd, snap_set_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, snap_name);
 
     int r = 0;
-    cls::rbd::for_each_snapshot_namespace(
-      [&r, ictx, snap_name](const cls::rbd::SnapshotNamespace &snap_namespace) {
-        r = librbd::api::Image<>::snap_set(ictx, snap_namespace, snap_name);
-        if (r == -ENOENT) {
-          return true;
+    if (all_snaps) {
+      cls::rbd::for_each_snapshot_namespace(
+        [&r, ictx, snap_name](const cls::rbd::SnapshotNamespace &snap_namespace) {
+          r = librbd::api::Image<>::snap_set(ictx, snap_namespace, snap_name);
+          if (r == -ENOENT) {
+            return true;
+          }
+          return false;
         }
-        return false;
-      }
-    );
+      );
+    } else {
+      r = librbd::api::Image<>::snap_set(
+        ictx, cls::rbd::UserSnapshotNamespace(), snap_name);
+    }
     tracepoint(librbd, snap_set_exit, r);
     return r;
   }
@@ -2638,10 +2643,13 @@ namespace librbd {
     return librbd::api::Snapshot<>::get_name(ictx, snap_id, snap_name);
   }
 
-  int Image::snap_get_id(const std::string snap_name, uint64_t *snap_id)
+  int Image::snap_get_id(
+    const std::string snap_name,
+    uint64_t *snap_id,
+    bool all_snaps)
   {
     ImageCtx *ictx = (ImageCtx *)ctx;
-    return librbd::api::Snapshot<>::get_id(ictx, snap_name, snap_id);
+    return librbd::api::Snapshot<>::get_id(ictx, snap_name, snap_id, all_snaps);
   }
 
   ssize_t Image::read(uint64_t ofs, size_t len, bufferlist& bl)

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -2611,8 +2611,17 @@ namespace librbd {
   {
     ImageCtx *ictx = (ImageCtx *)ctx;
     tracepoint(librbd, snap_set_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, snap_name);
-    int r = librbd::api::Image<>::snap_set(
-      ictx, cls::rbd::UserSnapshotNamespace(), snap_name);
+
+    int r = 0;
+    cls::rbd::for_each_snapshot_namespace(
+      [&r, ictx, snap_name](const cls::rbd::SnapshotNamespace &snap_namespace) {
+        r = librbd::api::Image<>::snap_set(ictx, snap_namespace, snap_name);
+        if (r == -ENOENT) {
+          return true;
+        }
+        return false;
+      }
+    );
     tracepoint(librbd, snap_set_exit, r);
     return r;
   }

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -714,7 +714,7 @@
   rbd help diff
   usage: rbd diff [--pool <pool>] [--namespace <namespace>] [--image <image>] 
                   [--snap <snap>] [--from-snap <from-snap>] [--whole-object] 
-                  [--format <format>] [--pretty-format] 
+                  [--all-snapshots] [--format <format>] [--pretty-format] 
                   <image-or-snap-spec> 
   
   Print extents that differ since a previous snap, or image creation.
@@ -731,6 +731,8 @@
     --snap arg            snapshot name
     --from-snap arg       snapshot starting point
     --whole-object        compare whole object
+    --all-snapshots       allow calculating diffs between all kinds of snapshots,
+                          including group/trash/mirror snapshots
     --format arg          output format (plain, json, or xml) [default: plain]
     --pretty-format       pretty formatting (json and xml)
   
@@ -782,8 +784,8 @@
   
   rbd help export
   usage: rbd export [--pool <pool>] [--namespace <namespace>] [--image <image>] 
-                    [--snap <snap>] [--path <path>] [--no-progress] 
-                    [--export-format <export-format>] 
+                    [--snap <snap>] [--path <path>] [--all-snapshots] 
+                    [--no-progress] [--export-format <export-format>] 
                     <source-image-or-snap-spec> <path-name> 
   
   Export image to file.
@@ -801,6 +803,8 @@
     --image arg                  source image name
     --snap arg                   source snapshot name
     --path arg                   export file (or '-' for stdout)
+    --all-snapshots              allow calculating diffs between all kinds of
+                                 snapshots, including group/trash/mirror snapshots
     --no-progress                disable progress output
     --export-format arg          format of image file
   
@@ -808,7 +812,7 @@
   usage: rbd export-diff [--pool <pool>] [--namespace <namespace>] 
                          [--image <image>] [--snap <snap>] [--path <path>] 
                          [--from-snap <from-snap>] [--whole-object] 
-                         [--no-progress] 
+                         [--all-snapshots] [--no-progress] 
                          <source-image-or-snap-spec> <path-name> 
   
   Export incremental diff to file.
@@ -828,6 +832,8 @@
     --path arg                   export file (or '-' for stdout)
     --from-snap arg              snapshot starting point
     --whole-object               compare whole object
+    --all-snapshots              allow calculating diffs between all kinds of
+                                 snapshots, including group/trash/mirror snapshots
     --no-progress                disable progress output
   
   rbd help feature disable

--- a/src/tools/rbd/ArgumentTypes.h
+++ b/src/tools/rbd/ArgumentTypes.h
@@ -55,6 +55,7 @@ static const std::string DEST_SNAPSHOT_NAME("dest-snap");
 static const std::string PATH("path");
 static const std::string FROM_SNAPSHOT_NAME("from-snap");
 static const std::string WHOLE_OBJECT("whole-object");
+static const std::string ALL_SNAPSHOTS("all-snapshots");
 
 // encryption arguments
 static const std::string ENCRYPTION_FORMAT("encryption-format");
@@ -94,7 +95,7 @@ static const std::string IGNORE_QUIESCE_ERROR("ignore-quiesce-error");
 static const std::set<std::string> SWITCH_ARGUMENTS = {
   WHOLE_OBJECT, IMAGE_SHARED, IMAGE_THICK_PROVISION, IMAGE_FLATTEN,
   NO_PROGRESS, PRETTY_FORMAT, VERBOSE, NO_ERR, SKIP_QUIESCE,
-  IGNORE_QUIESCE_ERROR
+  IGNORE_QUIESCE_ERROR, ALL_SNAPSHOTS
 };
 
 struct ImageSize {};

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -925,7 +925,8 @@ int init_and_open_image(const std::string &pool_name,
                         const std::string &image_id,
                         const std::string &snap_name, bool read_only,
                         librados::Rados *rados, librados::IoCtx *io_ctx,
-                        librbd::Image *image) {
+                        librbd::Image *image,
+                        bool all_snaps) {
   int r = init(pool_name, namespace_name, rados, io_ctx);
   if (r < 0) {
     return r;
@@ -941,7 +942,7 @@ int init_and_open_image(const std::string &pool_name,
   }
 
   if (!snap_name.empty()) {
-    r = snap_set(*image, snap_name);
+    r = snap_set(*image, snap_name, all_snaps);
     if (r < 0) {
       return r;
     }
@@ -950,8 +951,12 @@ int init_and_open_image(const std::string &pool_name,
   return 0;
 }
 
-int snap_set(librbd::Image &image, const std::string &snap_name) {
-  int r = image.snap_set(snap_name.c_str());
+int snap_set(
+  librbd::Image &image,
+  const std::string &snap_name,
+  bool all_snaps)
+{
+  int r = image.snap_set(snap_name.c_str(), all_snaps);
   if (r < 0) {
     std::cerr << "error setting snapshot context: " << cpp_strerror(r)
               << std::endl;

--- a/src/tools/rbd/Utils.h
+++ b/src/tools/rbd/Utils.h
@@ -228,9 +228,12 @@ int init_and_open_image(const std::string &pool_name,
                         const std::string &image_id,
                         const std::string &snap_name, bool read_only,
                         librados::Rados *rados, librados::IoCtx *io_ctx,
-                        librbd::Image *image);
+                        librbd::Image *image,
+                        bool all_snaps = false);
 
-int snap_set(librbd::Image &image, const std::string &snap_name);
+int snap_set(librbd::Image &image,
+             const std::string &snap_name,
+             bool all_snaps = false);
 
 void calc_sparse_extent(const bufferptr &bp,
                         size_t sparse_size,

--- a/src/tools/rbd/action/Diff.cc
+++ b/src/tools/rbd/action/Diff.cc
@@ -42,7 +42,7 @@ static int diff_cb(uint64_t ofs, size_t len, int exists, void *arg)
 }
 
 static int do_diff(librbd::Image& image, const char *fromsnapname,
-                   bool whole_object, Formatter *f)
+                   bool whole_object, Formatter *f, bool all_snaps)
 {
   int r;
   librbd::image_info_t info;
@@ -67,7 +67,7 @@ static int do_diff(librbd::Image& image, const char *fromsnapname,
   }
   uint64_t from_snap_id = 0;
   if (fromsnapname != nullptr) {
-    r = image.snap_get_id(fromsnapname, &from_snap_id);
+    r = image.snap_get_id(fromsnapname, &from_snap_id, all_snaps);
     if (r < 0) {
       return r;
     }
@@ -92,7 +92,10 @@ void get_arguments(po::options_description *positional,
   options->add_options()
     (at::FROM_SNAPSHOT_NAME.c_str(), po::value<std::string>(),
      "snapshot starting point")
-    (at::WHOLE_OBJECT.c_str(), po::bool_switch(), "compare whole object");
+    (at::WHOLE_OBJECT.c_str(), po::bool_switch(), "compare whole object")
+    (at::ALL_SNAPSHOTS.c_str(), po::bool_switch(),
+     "allow calculating diffs between all kinds of snapshots, "
+     "including group/trash/mirror snapshots");
   at::add_format_options(options);
 }
 
@@ -128,13 +131,14 @@ int execute(const po::variables_map &vm,
   librados::IoCtx io_ctx;
   librbd::Image image;
   r = utils::init_and_open_image(pool_name, namespace_name, image_name, "",
-                                 snap_name, true, &rados, &io_ctx, &image);
+                                 snap_name, true, &rados, &io_ctx, &image,
+                                 vm[at::ALL_SNAPSHOTS].as<bool>());
   if (r < 0) {
     return r;
   }
 
   r = do_diff(image, from_snap_name.empty() ? nullptr : from_snap_name.c_str(),
-              diff_whole_object, formatter.get());
+              diff_whole_object, formatter.get(), vm[at::ALL_SNAPSHOTS].as<bool>());
   if (r < 0) {
     std::cerr << "rbd: diff error: " << cpp_strerror(r) << std::endl;
     return -r;

--- a/src/tools/rbd/action/Diff.cc
+++ b/src/tools/rbd/action/Diff.cc
@@ -61,9 +61,19 @@ static int do_diff(librbd::Image& image, const char *fromsnapname,
     om.t->define_column("Length", TextTable::LEFT, TextTable::LEFT);
     om.t->define_column("Type", TextTable::LEFT, TextTable::LEFT);
   }
+  uint32_t flags = RBD_DIFF_ITERATE_FLAG_INCLUDE_PARENT;
+  if (whole_object) {
+    flags |= RBD_DIFF_ITERATE_FLAG_WHOLE_OBJECT;
+  }
+  uint64_t from_snap_id = 0;
+  if (fromsnapname != nullptr) {
+    r = image.snap_get_id(fromsnapname, &from_snap_id);
+    if (r < 0) {
+      return r;
+    }
+  }
 
-  r = image.diff_iterate2(fromsnapname, 0, info.size, true, whole_object,
-                          diff_cb, &om);
+  r = image.diff_iterate3(from_snap_id, 0, info.size, flags, diff_cb, &om);
   if (f) {
     f->close_section();
     f->flush(std::cout);

--- a/src/tools/rbd/action/Export.cc
+++ b/src/tools/rbd/action/Export.cc
@@ -195,7 +195,20 @@ int do_export_diff_fd(librbd::Image& image, const char *fromsnapname,
   ExportDiffContext edc(&image, fd, info.size,
                         g_conf().get_val<uint64_t>("rbd_concurrent_management_ops"),
                         no_progress, export_format);
-  r = image.diff_iterate2(fromsnapname, 0, info.size, true, whole_object,
+
+  uint32_t flags = RBD_DIFF_ITERATE_FLAG_INCLUDE_PARENT;
+  if (whole_object) {
+    flags |= RBD_DIFF_ITERATE_FLAG_WHOLE_OBJECT;
+  }
+  uint64_t from_snap_id = 0;
+  if (fromsnapname != nullptr) {
+    r = image.snap_get_id(fromsnapname, &from_snap_id);
+    if (r < 0) {
+      goto out;
+    }
+  }
+
+  r = image.diff_iterate3(from_snap_id, 0, info.size, flags,
                           &C_ExportDiff::export_diff_cb, (void *)&edc);
   if (r < 0) {
     goto out;

--- a/src/tools/rbd/action/Export.cc
+++ b/src/tools/rbd/action/Export.cc
@@ -124,7 +124,8 @@ private:
 
 int do_export_diff_fd(librbd::Image& image, const char *fromsnapname,
 		   const char *endsnapname, bool whole_object,
-		   int fd, bool no_progress, int export_format)
+		   int fd, bool no_progress, int export_format,
+                   bool all_snaps)
 {
   int r;
   librbd::image_info_t info;
@@ -202,7 +203,7 @@ int do_export_diff_fd(librbd::Image& image, const char *fromsnapname,
   }
   uint64_t from_snap_id = 0;
   if (fromsnapname != nullptr) {
-    r = image.snap_get_id(fromsnapname, &from_snap_id);
+    r = image.snap_get_id(fromsnapname, &from_snap_id, all_snaps);
     if (r < 0) {
       goto out;
     }
@@ -237,7 +238,7 @@ out:
 
 int do_export_diff(librbd::Image& image, const char *fromsnapname,
                 const char *endsnapname, bool whole_object,
-                const char *path, bool no_progress)
+                const char *path, bool no_progress, bool all_snaps)
 {
   int r;
   int fd;
@@ -249,7 +250,9 @@ int do_export_diff(librbd::Image& image, const char *fromsnapname,
   if (fd < 0)
     return -errno;
 
-  r = do_export_diff_fd(image, fromsnapname, endsnapname, whole_object, fd, no_progress, 1);
+  r = do_export_diff_fd(
+    image, fromsnapname, endsnapname,
+    whole_object, fd, no_progress, 1, all_snaps);
 
   if (fd != 1)
     close(fd);
@@ -273,7 +276,10 @@ void get_arguments_diff(po::options_description *positional,
   options->add_options()
     (at::FROM_SNAPSHOT_NAME.c_str(), po::value<std::string>(),
      "snapshot starting point")
-    (at::WHOLE_OBJECT.c_str(), po::bool_switch(), "compare whole object");
+    (at::WHOLE_OBJECT.c_str(), po::bool_switch(), "compare whole object")
+    (at::ALL_SNAPSHOTS.c_str(), po::bool_switch(),
+     "allow calculating diffs between all kinds of snapshots, "
+     "including group/trash/mirror snapshots");
   at::add_no_progress_option(options);
 }
 
@@ -307,7 +313,8 @@ int execute_diff(const po::variables_map &vm,
   librados::IoCtx io_ctx;
   librbd::Image image;
   r = utils::init_and_open_image(pool_name, namespace_name, image_name, "",
-                                 snap_name, true, &rados, &io_ctx, &image);
+                                 snap_name, true, &rados, &io_ctx, &image,
+                                 vm[at::ALL_SNAPSHOTS].as<bool>());
   if (r < 0) {
     return r;
   }
@@ -316,7 +323,8 @@ int execute_diff(const po::variables_map &vm,
                      from_snap_name.empty() ? nullptr : from_snap_name.c_str(),
                      snap_name.empty() ? nullptr : snap_name.c_str(),
                      vm[at::WHOLE_OBJECT].as<bool>(), path.c_str(),
-                     vm[at::NO_PROGRESS].as<bool>());
+                     vm[at::NO_PROGRESS].as<bool>(),
+                     vm[at::ALL_SNAPSHOTS].as<bool>());
   if (r < 0) {
     std::cerr << "rbd: export-diff error: " << cpp_strerror(r) << std::endl;
     return r;
@@ -402,7 +410,8 @@ private:
 const uint32_t MAX_KEYS = 64;
 
 static int do_export_v2(librbd::Image& image, librbd::image_info_t &info, int fd,
-		        uint64_t period, int max_concurrent_ops, utils::ProgressContext &pc)
+		        uint64_t period, int max_concurrent_ops,
+                        utils::ProgressContext &pc, bool all_snaps)
 {
   int r = 0;
   // header
@@ -514,7 +523,8 @@ static int do_export_v2(librbd::Image& image, librbd::image_info_t &info, int fd
   const char *last_snap = NULL;
   for (size_t i = 0; i < snaps.size(); ++i) {
     utils::snap_set(image, snaps[i].name.c_str());
-    r = do_export_diff_fd(image, last_snap, snaps[i].name.c_str(), false, fd, true, 2);
+    r = do_export_diff_fd(image, last_snap, snaps[i].name.c_str(),
+                          false, fd, true, 2, all_snaps);
     if (r < 0) {
       return r;
     }
@@ -522,7 +532,8 @@ static int do_export_v2(librbd::Image& image, librbd::image_info_t &info, int fd
     last_snap = snaps[i].name.c_str();
   }
   utils::snap_set(image, std::string(""));
-  r = do_export_diff_fd(image, last_snap, nullptr, false, fd, true, 2);
+  r = do_export_diff_fd(image, last_snap, nullptr, false,
+                        fd, true, 2, all_snaps);
   if (r < 0) {
     return r;
   }
@@ -567,7 +578,7 @@ static int do_export_v1(librbd::Image& image, librbd::image_info_t &info,
 }
 
 static int do_export(librbd::Image& image, const char *path, bool no_progress,
-                     int export_format)
+                     int export_format, bool all_snaps)
 {
   librbd::image_info_t info;
   int64_t r = image.stat(info, sizeof(info));
@@ -595,7 +606,7 @@ static int do_export(librbd::Image& image, const char *path, bool no_progress,
   if (export_format == 1)
     r = do_export_v1(image, info, fd, period, max_concurrent_ops, pc);
   else
-    r = do_export_v2(image, info, fd, period, max_concurrent_ops, pc);
+    r = do_export_v2(image, info, fd, period, max_concurrent_ops, pc, all_snaps);
 
   if (r < 0)
     pc.fail();
@@ -612,6 +623,10 @@ void get_arguments(po::options_description *positional,
                                      at::ARGUMENT_MODIFIER_SOURCE);
   at::add_path_options(positional, options,
                        "export file (or '-' for stdout)");
+  options->add_options()
+    (at::ALL_SNAPSHOTS.c_str(), po::bool_switch(),
+     "allow calculating diffs between all kinds of snapshots, "
+     "including group/trash/mirror snapshots");
   at::add_no_progress_option(options);
   at::add_export_format_option(options);
 }
@@ -641,7 +656,8 @@ int execute(const po::variables_map &vm,
   librados::IoCtx io_ctx;
   librbd::Image image;
   r = utils::init_and_open_image(pool_name, namespace_name, image_name, "",
-                                 snap_name, true, &rados, &io_ctx, &image);
+                                 snap_name, true, &rados, &io_ctx, &image,
+                                 vm[at::ALL_SNAPSHOTS].as<bool>());
   if (r < 0) {
     return r;
   }
@@ -650,7 +666,8 @@ int execute(const po::variables_map &vm,
   if (vm.count("export-format"))
     format = vm["export-format"].as<uint64_t>();
 
-  r = do_export(image, path.c_str(), vm[at::NO_PROGRESS].as<bool>(), format);
+  r = do_export(image, path.c_str(), vm[at::NO_PROGRESS].as<bool>(),
+                format, vm[at::ALL_SNAPSHOTS].as<bool>());
   if (r < 0) {
     std::cerr << "rbd: export error: " << cpp_strerror(r) << std::endl;
     return r;


### PR DESCRIPTION
In our production environment, we found calculating diffs from/to trashed snapshots necessary, especially when exporting/importing snapshot diffs in the context of ceph-csi.

This PR is aim to meet the requirement.

Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
