### PR TITLE
tentacle: cephadm: use release/autobuild .asc instead of .gpg for repo_gpgkey

### DIFF
--- a/src/cephadm/cephadmlib/packagers.py
+++ b/src/cephadm/cephadmlib/packagers.py
@@ -136,9 +136,9 @@ class Packager(object):
         if self.ctx.gpg_url:
             return self.ctx.gpg_url, 'manual'
         if self.stable or self.version:
-            return 'https://download.ceph.com/keys/release.gpg', 'release'
+            return 'https://download.ceph.com/keys/release.asc', 'release'
         else:
-            return 'https://download.ceph.com/keys/autobuild.gpg', 'autobuild'
+            return 'https://download.ceph.com/keys/autobuild.asc', 'autobuild'
 
 
 class Apt(Packager):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78644

---

backport of https://github.com/ceph/ceph/pull/70154
parent tracker: https://tracker.ceph.com/issues/78179

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh