### PR TITLE
Fast ec failure handling

### DIFF
--- a/doc/dev/osd_internals/erasure_coding/fast_ec_failure_handling.rst
+++ b/doc/dev/osd_internals/erasure_coding/fast_ec_failure_handling.rst
@@ -10,11 +10,11 @@ Overview
 
 Fast EC (``allow_ec_optimizations``) uses variable-size shards whose on-disk
 size is derived from the object's logical size and stripe parameters.  A bug
-in the transaction planning code (`tracker #77276`_) can leave shards on disk
+in the EC write path (e.g. `tracker #77276`_) can leave shards on disk
 that are smaller than this expected size — an *underrun*.  When such a shard
 is later read during a reconstruct operation on a degraded PG, the EC decode
 pipeline receives less data than it requested, returns a non-zero error code,
-and the OSD asserts and crashes (`tracker #78400`_).  Because peering a
+and the OSD asserts and crashes (e.g. `tracker #78400`_).  Because peering a
 degraded PG itself triggers a reconstruct read, the OSD crash-loops and
 cannot rejoin, with the crash migrating across the cluster as PGs remap.
 
@@ -24,15 +24,25 @@ changes needed to make the system *tolerant* of mis-sized shards — whether
 they originate from #77276, from legacy-format objects, or from any other
 cause — rather than asserting on them.
 
-The approach has three parts.  At **read time**, an underrun shard is
-detected and treated as an I/O error, so the decode path never receives
-inconsistent buffers.  In the **recovery write path**, a ``ceph_assert`` that
-fires when shard size accounting is stale is converted to a logged error
-return that reschedules recovery.  During **scrub with repair**, deep scrub's
-existing detection of size-mismatched shards is extended so that those shards
-are automatically corrected through the normal recovery mechanism, providing
-a proactive way to repair shards that have never been read since the bug
-occurred.
+The approach differs between client-driven reads and the recovery path.  For
+**client operations** (reads and read-modify-writes), an underrun shard is
+detected when the reply arrives and treated as an I/O error.  The shard is
+excluded and the read retried on the remaining shards; if not enough healthy
+shards remain, -EIO is returned to the client.  
+
+For the **recovery path**,
+reads do not reject short shards immediately — recovery is unique in that it
+can loop over multiple read rounds.  Instead, after all reads for a recovery
+pass are complete, any shard whose returned data is shorter than the expected
+shard size is identified and added to the missing set; recovery then restarts,
+this time treating the short shard as one that itself needs to be recovered.
+If the result is that insufficient data remains to perform the reconstruction,
+the object is marked unfound. 
+ 
+During **scrub with repair**, scrub's existing detection of size-mismatched
+shards is extended so that those shards are automatically corrected through the
+existing replica-recovery mechanism, providing a proactive way to repair shards that have
+never been involved in a degraded-PG recovery.
 
 
 Background
@@ -41,214 +51,117 @@ Background
 Fast EC and shard sizes
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Fast EC computes the expected on-disk size for each shard from the object's
-logical size and stripe parameters, distributing any remainder across the
-first few shards and aligning to the chunk boundary.  This produces shards
-that are generally *smaller* than under legacy EC, which padded every shard
-to the next full chunk boundary regardless of the object size.
+Fast EC optimises space by using variably-sized shards.  The size of each
+shard is deterministically calculated from the object's logical size and the
+pool's stripe parameters.  Any shard whose on-disk size differs from this
+calculated value is considered mis-sized.
 
-Tracker #77276: transaction planning bug writes under-sized shards
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-`Tracker #77276`_ (fixed in main via PR #69663) describes a transaction
-planning bug in the Fast EC write path.  Under certain rare combinations of
-operations within a single transaction, the Fast EC transaction planner
-produced on-disk shard files smaller than the size that
-``object_size_to_shard_size`` would predict for the object's logical size.
-
-The fix for #77276 corrects the planning logic so that new writes do not
-produce under-sized shards.  However, objects that were already written
-under the buggy code remain on disk with incorrect shard sizes.
-
-Tracker #78400: under-sized shards cause OSD crash cascades
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-`Tracker #78400`_ documents a production outage on v20.2.1 and v20.2.2
-triggered by exactly the shards that #77276 can produce (as well as by
-legacy-format objects on pools that had ``allow_ec_optimizations`` enabled
-retrospectively).
-
-The crash signature is ``ceph_assert(r == 0)`` immediately after ``decode()``
-in the reconstruct-read path, both in the recovery completion handler
-(``ECCommon.cc:handle_recovery_read_complete``) and in the client-read
-completion handler (``ClientReadCompleter::finish_single_request``).  A
-related assertion fires via ``interval_map.h`` through
-``complete_read_op`` → ``handle_sub_read_reply``, because the mismatched
-buffer sizes violate the extent-map invariant on insertion.
-
-**Why does decode return non-zero?**
-
-When the Fast EC read pipeline issues a reconstruct read, it requests
-*optimised-size* extents from each shard — the size that
-``object_size_to_shard_size`` predicts.  If an on-disk shard is smaller
-than this (due to #77276 or the legacy-format scenario), the remote OSD
-returns exactly the bytes requested with no error, but those bytes are
-shorter than expected.  The ``slice_iterator`` / ``decode_chunks`` call
-inside ``shard_extent_map_t::_decode`` (``src/osd/ECUtil.cc:734``) then
-returns a non-zero code because the available buffers do not consistently
-cover the requested extents.  The callers assert on this code.
-
-**Why does this cause an outage?**
-
-Peering a degraded PG immediately issues a reconstruct read.  So an OSD
-that holds a shard for a degraded PG crashes on startup, cannot rejoin,
-and the PG remaps to a new primary — which may itself hold an affected
-shard and crash in turn.  The cascade takes the pool inactive.  Standard
-operational controls (``norecover``, ``pauserd/pausewr``, etc.) do not
-prevent peering reads and therefore do not prevent the crash.
-
-The reporter confirmed via ``ceph-objectstore-tool`` that all shards are
-physically intact and version-consistent — the data is not lost and the
-failure is entirely in the decode logic.
-
-**What #77276's fix does not address**
-
-The fix for #77276 prevents *new* under-sized shards from being written.
-Shards already on disk with the wrong size are unchanged.  On a pool that
-has never been degraded since the bad write occurred, those shards sit
-silently waiting for the first time a PG loses a different shard and
-triggers a reconstruct read — at which point the crash occurs.
-
-The changes described in this document address that residual risk.
-
-
-Improvement 1: Detect and Handle Shard Underruns Before Decode
---------------------------------------------------------------
+Improvement 1: Detect Underruns on Client-Op Reads
+---------------------------------------------------
 
 Problem
 ~~~~~~~
 
-In ``ECBackend::handle_sub_read_reply`` (``src/osd/ECBackend.cc:780``),
-buffers received from a remote OSD are inserted into the read-complete map
-without any validation that each shard returned the number of bytes that were
-requested::
+Client reads and read-modify-writes hit ``ceph_assert(r == 0)`` when the
+decode of a reconstruct-read fails due to a mis-sized source shard.  The
+fix is to detect the short buffer in ``handle_sub_read_reply`` before it
+reaches the decoder, and treat it as an I/O error.
 
-    // current code — no size validation
-    for (auto &&[offset, buffer_list]: offset_buffer_map) {
-        buffers_read.insert_in_shard(from.shard, offset, buffer_list);
-    }
-
-The requested extents for each shard are available in
-``rop.to_read[hoid].shard_reads``.  The actual bytes received are in
-``offset_buffer_map``.  These are never compared.
-
-The mismatch reaches ``shard_extent_map_t::decode()`` →
-``shard_extent_map_t::_decode()`` → ``ec_impl->decode_chunks()``, which
-returns a non-zero error code.  The caller asserts on that code, crashing the
-OSD.
+Additionally, if an object is genuinely the correct size on disk, the
+object store read API guarantees that data will be returned for any
+sub-read request.  A short return in that case indicates a store-level
+failure and the shard should also be treated as -EIO.
 
 Design
 ~~~~~~
 
-When the reply arrives for a shard, compare the total bytes received against
-the total bytes that were requested for that shard.  If they differ,
-synthesise an -EIO error for that shard — exactly as the existing
-error-injection path does when ``bluestore_debug_inject_read_err`` fires —
-and discard the partial buffer::
+A flag ``check_for_underruns`` is added to ``ReadOp``.  It is set for
+client reads (and read-modify-writes) but not for recovery reads (which
+handle short returns differently — see Improvement 2).
+
+When the reply arrives for a shard and ``check_for_underruns`` is set,
+the total bytes received are compared against the total bytes requested
+for that shard.  If they differ, an -EIO error is synthesised for that
+shard — exactly as the existing error-injection path does when
+``bluestore_debug_inject_read_err`` fires — and the partial buffer is
+discarded::
 
     // pseudocode — details to be determined during implementation
-    uint64_t expected = total_requested_bytes(rop, hoid, from.shard);
-    uint64_t received = total_received_bytes(offset_buffer_map);
-    if (received != expected) {
-        dout(0) << __func__ << " shard underrun from " << from
-                << " expected " << expected << " got " << received << dendl;
-        complete.errors[from] = -EIO;
-        complete.buffers_read.remove_shard(from.shard);
-        rop.debug_log.emplace_back(ECUtil::SHARD_UNDERRUN, op.from);
-        continue;  // skip normal buffer insertion
+    if (rop.check_for_underruns) {
+        uint64_t expected = total_requested_bytes(rop, hoid, from.shard);
+        uint64_t received = total_received_bytes(offset_buffer_map);
+        if (received != expected) {
+            dout(0) << __func__ << " shard underrun from " << from
+                    << " expected " << expected << " got " << received << dendl;
+            complete.errors[from] = -EIO;
+            complete.buffers_read.remove_shard(from.shard);
+            rop.debug_log.emplace_back(ECUtil::SHARD_UNDERRUN, op.from);
+            continue;  // skip normal buffer insertion
+        }
     }
-
-**Special case: recovery reads with unknown object size**
-
-On the first pass of a recovery operation, the object info (``obc``) may not
-yet be available and the object size is therefore unknown.
-``continue_recovery_op`` requests up to ``get_recovery_chunk_size()``
-(rounded-up ``osd_recovery_max_chunk``, typically 4 MiB) in this case, and
-shards for small objects will legitimately return fewer bytes than requested.
-This is expected, correct behaviour handled via ``zeros_for_decode`` in
-``update_object_size_after_read``.
-
-The underrun check must therefore be suppressed when the read was issued with
-an unknown object size.  The ``read_request_t::object_size`` field already
-distinguishes these two cases: it is set to the true logical size when
-``op.obc`` is available, and to ``get_recovery_chunk_size()`` otherwise.
-The check should only fire when ``read_request_t::object_size`` reflects the
-actual object size (i.e. not the fallback chunk size), or equivalently when
-``rop.for_recovery`` is false (client reads always know the object size).
-
-On the second and subsequent recovery passes, ``obc`` is populated and the
-read is sized correctly, so the underrun check applies normally.  Any
-shard that returns short data on a correctly-sized recovery read is
-genuinely mis-sized and should be treated as -EIO.
 
 The subsequent ``check_and_maybe_mark_unfound`` / minimum-to-decode check
 determines whether the remaining shards are still sufficient to reconstruct
-the object.  If not, the read pipeline returns -EIO to the caller.
+the object.  If not, -EIO is returned to the client.
 
-For recovery operations, -EIO propagates to
-``RecoveryReadCompleter::finish_single_request`` →
-``_failed_push`` → ``on_failed_pull`` → ``force_object_missing`` on the
-offending shard.  This is important: it is not sufficient merely to exclude
-the short shard from the current decode.  The shard must also be added to the
-missing set so that it is scheduled for recovery itself — i.e. reconstructed
-from the remaining healthy shards and written back at the correct Fast EC
-size.  Without this step, the mis-sized shard remains on disk and will cause
-the same failure the next time that PG becomes degraded.
-
-For non-recovery (client) reads with a degraded PG, the existing -EIO client
-error path is unchanged.
-
-This change prevents the ``ceph_assert(r == 0)`` in both
-``handle_recovery_read_complete`` and ``ClientReadCompleter::finish_single_request``
-from ever being reached for an underrun condition.
-
-Affected files
-~~~~~~~~~~~~~~
-
-* ``src/osd/ECBackend.cc`` — ``handle_sub_read_reply()``: add size validation
-  before buffer insertion
-* ``src/osd/ECUtil.h`` — optionally add ``SHARD_UNDERRUN`` to the debug-log
-  event enum
+This change prevents the ``ceph_assert(r == 0)`` in
+``ClientReadCompleter::finish_single_request`` and in ``interval_map.h``
+from being reached for an underrun condition on client reads.
 
 
-Improvement 2: Replace Recovery Assert with Error Handling
-----------------------------------------------------------
+Improvement 2: Detect and Correct Underruns on the Recovery Path
+-----------------------------------------------------------------
 
 Problem
 ~~~~~~~
 
-In ``ECCommon::RecoveryBackend::handle_recovery_push``
-(``src/osd/ECCommon.cc``), when recovery has finished writing a shard, the
-code computes the expected on-disk size and truncates if needed::
+The recovery path also calls ``decode()`` in ``handle_recovery_read_complete``
+and asserts on failure.  Recovery cannot use the same simple per-shard -EIO
+approach as Improvement 1 because on the first recovery pass the object size
+may not yet be known — the read is sized to ``get_recovery_chunk_size()``
+(rounded-up ``osd_recovery_max_chunk``, typically 4 MiB) — so shards for
+small objects will legitimately return fewer bytes than requested.  This
+expected short return is handled correctly via ``zeros_for_decode`` in
+``update_object_size_after_read`` once the object info arrives with the
+response.
 
-    // src/osd/ECCommon.cc ~line 1240
-    uint64_t shard_size = sinfo.object_size_to_shard_size(
-        op.recovery_info.size, get_parent()->whoami_shard().shard);
-    ceph_assert(shard_size >= tobj_size);  // <-- asserts if stale object_info
-    if (shard_size != tobj_size) {
-        m->t.truncate(coll, tobj, shard_size);
-    }
-
-If the ``object_info.size`` field is stale or inconsistent with the actual
-shard content — which can occur for objects written under the #77276 bug, or
-when objects written under legacy EC have their metadata partially updated —
-the assertion fires, crashing the OSD.
-
-This is a second crash site in the same overall failure mode: the first
-(Improvement 1) is hit when *reading* from a source shard; this one is hit
-when *writing* the recovered destination shard.
+Additionally, the ``ceph_assert`` in ``handle_recovery_push`` that fires
+when a recovered shard's expected size is smaller than the current on-disk
+size must be addressed as a second crash site in the same failure mode.
 
 Design
 ~~~~~~
 
-Replace the ``ceph_assert`` with a logged error return that cancels the
-recovery operation and schedules a retry after re-fetching object metadata
-from the auth peer::
+**Shard size validation before the final push**
+
+Recovery reads do not set ``check_for_underruns`` (see Improvement 1).
+Instead, shard sizes are validated at a higher level: after
+``handle_recovery_read_complete`` has populated ``op.returned_data`` and
+called ``decode()``, and on the final recovery pass when all data has been
+gathered, the size of every source shard that contributed to the read is
+checked against the expected shard size calculated from the now-known object
+size.
+
+If any source shard is found to have returned fewer bytes than its expected
+shard size, the entire recovery operation is restarted with that shard added
+to the missing set.  On the restarted pass, recovery reconstructs the
+short shard from the remaining healthy shards and writes it back at the
+correct size, permanently fixing the on-disk representation.
+
+If adding the short shard to the missing set leaves fewer than k healthy
+source shards available, the object is marked unfound.  No attempt is made
+to wait for that shard to come back online; the operator must intervene.
+
+**Removing the assert in ``handle_recovery_push``**
+
+The ``ceph_assert(shard_size >= tobj_size)`` in ``handle_recovery_push``
+is replaced with a logged error return that cancels and reschedules the
+recovery operation::
 
     if (shard_size < tobj_size) {
         derr << __func__ << ": shard_size " << shard_size
              << " < tobj_size " << tobj_size << " for " << op.soid
-             << "; object_info size may be stale, cancelling recovery" << dendl;
+             << dendl;
         _failed_push(op.hoid, /* synthesise read_result_t with r=-EIO */);
         return;
     }
@@ -256,16 +169,8 @@ from the auth peer::
         m->t.truncate(coll, tobj, shard_size);
     }
 
-This converts a hard OSD crash into a recoverable situation.  If the
-object_info is genuinely inconsistent, the object will eventually be marked
-unfound and the operator can decide how to proceed.  If it was a transient
-inconsistency, recovery succeeds on the next attempt.
-
-Affected files
-~~~~~~~~~~~~~~
-
-* ``src/osd/ECCommon.cc`` — ``handle_recovery_push()``: replace
-  ``ceph_assert(shard_size >= tobj_size)`` with a logged error return
+This eliminates the second assert crash site and converts the failure into
+a recoverable situation.
 
 
 Improvement 3: Scrub Repairs Mis-Sized EC Shards
@@ -274,133 +179,174 @@ Improvement 3: Scrub Repairs Mis-Sized EC Shards
 Problem
 ~~~~~~~
 
-Deep scrub already detects ``SHARD_EC_SIZE_MISMATCH`` in
-``ScrubBackend::scan_object_for_errors``
-(``src/osd/scrubber/scrub_backend.cc:640``).  When
-``smap_obj.ec_size_mismatch`` is set, the shard is correctly excluded from
-auth selection via ``dup_error_cond`` / ``set_ec_size_mismatch``.
+The legacy EC backend (``ECBackendL``) has an existing size-mismatch
+detection and repair pipeline, but it is gated on ``!allows_ecoverwrites()``.
+In ``ECBackendL::be_deep_scrub``, when the pool does not have ``ec_overwrites``
+enabled, the on-disk shard size (``pos.data_pos``) is compared against the
+size stored in ``hinfo``; if they differ, ``ScrubMap::object::ec_size_mismatch``
+is set.  ``scrub_backend.cc`` reads this flag via ``dup_error_cond`` →
+``set_ec_size_mismatch()``, which causes ``errors != 0`` on the shard,
+which causes ``cur_inconsistent.insert(srd)`` at line 1336, which causes
+``repair_object()`` → ``force_object_missing()`` → recovery.  The full
+pipeline works for legacy EC without overwrites.
 
-However, the scrub repair path (``ScrubBackend::apply_repair``) iterates
-``m_inconsistent`` and calls ``repair_object()`` only for objects that were
-explicitly added to that set.  Objects whose only detected error is
-``SHARD_EC_SIZE_MISMATCH`` may not be added to ``m_inconsistent``, so
-``repair_object()`` is never called and the mis-sized on-disk shard persists.
+Fast EC always has ``ec_overwrites`` enabled.  The legacy path's size check
+is therefore never reached.  Additionally, the Fast EC backend
+(``ECBackend::be_deep_scrub``) has no size check of its own — it reads the
+shard, accumulates a hash, and returns.  ``ScrubMap::object::ec_size_mismatch``
+is therefore never set for Fast EC objects, the repair pipeline is never
+triggered, and mis-sized shards sit undetected indefinitely.
 
-Improvements 1 and 2 handle the crash when a mis-sized shard is *read*.  But
-a shard can sit mis-sized indefinitely on a PG that has never become degraded
-since the bad write.  Scrub repair is the only mechanism that can proactively
-find and fix those shards before they cause an outage.
+The fix is straightforward: extend the mechanism that already works for
+legacy EC without overwrites so that it also works for Fast EC with
+overwrites, using the variable-size shard size formula instead of
+``hinfo``-based sizes.
+
+Improvements 1 and 2 handle the crash when a mis-sized shard is encountered
+during a degraded-PG operation.  But a shard can sit mis-sized indefinitely
+on a PG that has never become degraded since the bad write.  Scrub repair is
+the only mechanism that can proactively find and fix those shards before they
+cause an outage.
 
 Design
 ~~~~~~
 
-**Step 1 — Populate ``m_inconsistent`` for ``SHARD_EC_SIZE_MISMATCH``**
+Add a size check to ``ECBackend::be_deep_scrub``: after all strides have
+been read and ``pos.data_pos`` reflects the total bytes on disk, compare
+it against the expected shard size calculated from the object's logical
+size using ``sinfo.object_size_to_shard_size(oi.size, whoami_shard)``.  If
+they differ, set ``o.ec_size_mismatch = true``.
 
-Where ``SHARD_EC_SIZE_MISMATCH`` is detected and the scrub is running in
-repair mode (``m_repair == true``), add the affected shard to the
-``m_inconsistent`` entry for that object alongside the auth peer's
-``pg_shard_t``.  This mirrors the existing handling for ``SHARD_READ_ERR``
-and ``SHARD_MISSING``.
+This is the only change required.  Once ``ec_size_mismatch`` is set in the
+local scan map, the entire downstream pipeline already works correctly for
+all pool types:
 
-**Step 2 — No change to ``repair_object()``**
+* ``scrub_backend.cc:641`` reads the flag → ``set_ec_size_mismatch()`` →
+  ``errors != 0`` on the shard
+* ``scrub_backend.cc:1334`` adds the shard to ``cur_inconsistent``
+* ``inconsistents()`` populates ``m_inconsistent``
+* ``scrub_process_inconsistent()`` calls ``repair_object()`` when
+  ``m_repair == true``
+* ``repair_object()`` calls ``force_object_missing()`` → recovery
+  reconstructs the shard at the correct Fast EC size
 
-``repair_object()`` already calls ``force_object_missing()`` on the bad
-peers, which marks the shard as missing and triggers recovery::
-
-    // src/osd/scrubber/scrub_backend.cc:425 — no changes required
-    m_pg.force_object_missing(ScrubberPasskey{}, bad_peers, soid, oi.version);
-
-For EC pools, recovery reconstructs the shard from the k healthy data shards
-and writes it back with the correct Fast EC size, permanently fixing the
-on-disk representation.
-
-**Step 3 — Gate on ``m_repair``**
-
-A regular deep scrub (without repair) should only detect and log the error,
-consistent with the existing behaviour for all other shard errors.  Repair
-is only performed when ``m_repair == true`` (i.e. ``ceph pg repair`` was
-requested or the auto-repair threshold was crossed).
-
-Affected files
-~~~~~~~~~~~~~~
-
-* ``src/osd/scrubber/scrub_backend.cc`` — logic that populates
-  ``m_inconsistent`` (around the ``set_ec_size_mismatch`` call site,
-  lines ~640–646)
-* ``src/test/osd/test_scrubber_be.cc`` — new unit test for the EC shard
-  size mismatch repair path
+A regular deep scrub (without repair) detects and logs the error without
+attempting to fix it, consistent with all other shard error types.
 
 
-How the Three Improvements Work Together
------------------------------------------
+Testing Requirements
+--------------------
 
-The three improvements form a complete lifecycle for mis-sized Fast EC shards:
+The overriding requirements across all scenarios are:
 
-**Scenario A: Shard mis-sized by #77276, PG later becomes degraded**
+* **A mis-sized shard must never cause an OSD assert.**
+* **A mis-sized shard must be corrected by recovery** when the PG becomes
+  degraded and the shard is involved in a reconstruct operation.
+* **A mis-sized shard must be detected and repaired by scrub** when
+  ``ceph pg repair`` is run, without requiring the PG to become degraded
+  first.
 
-This is the primary scenario from tracker #78400.  With the fixes:
+The following scenarios should be covered by
+automated tests.  Unless otherwise stated, tests should use a Fast EC pool
+with ``ec_overwrites`` enabled.  The error injection mechanism
+(``bluestore_debug_inject_read_err`` or direct object store manipulation to
+truncate a shard) should be used to create mis-sized shards.
 
-1. Recovery reads source shards.  A mis-sized shard returns fewer bytes than
-   the optimised request; Improvement 1 detects the underrun and synthesises
-   -EIO before the data reaches the decoder.
-2. The underrun shard is excluded.  If enough healthy shards remain, decode
-   succeeds and the missing shard is reconstructed at the correct Fast EC
-   size, permanently correcting the on-disk representation for that shard.
-3. If the mis-sized shard must itself serve as a source and fewer than k
-   healthy shards remain, the object is marked unfound.  The operator must
-   correct the shard sizes (e.g. by reading and rewriting the object) before
-   recovery can proceed — but the OSD no longer crashes.
-4. Improvement 2 ensures that even if ``object_info`` is stale during the
-   recovery write, the OSD emits an error and retries rather than asserting.
+**Improvement 1 — Client reads**
 
-**Scenario B: Shard mis-sized by #77276, PG never degraded**
+T1.1 Client read on a degraded PG (k+m pool, one shard offline, one shard
+mis-sized among the remaining k+m−1 shards) where the mis-sized shard is
+needed for the reconstruct.  Expected: the underrun is detected,
+the mis-sized shard is excluded, decode succeeds using the remaining k−1
+healthy shards plus the zeros padding, and the read returns correct data.
 
-Improvement 1 is not exercised (no reconstruct read is ever issued).
-Running ``ceph pg repair`` triggers a deep scrub; Improvement 3 detects the
-size mismatch, marks the shard missing, and recovery corrects it.  This is
-the proactive path that clears #77276-induced corruption before it can
-trigger an outage.
+T1.2 Client read on a degraded PG where the mis-sized shard is the *only*
+redundant copy available (i.e. the pool has exactly m=1 redundancy and
+both the offline shard and the mis-sized shard are required for decoding).
+Expected: -EIO returned to client; no OSD assert.
 
-**Scenario C: Legacy-format shard on a pool upgraded to Fast EC**
+T1.3 Read-modify-write (RMW) on a degraded PG with a mis-sized source shard.
+Expected: the underrun is detected, RMW fails with -EIO; no OSD assert.
 
-Identical to Scenario A: the legacy shard is larger than the optimised size
-expected, but the fast EC read pipeline requests fewer bytes, resulting in an
-apparent underrun.  Improvements 1 and 3 handle this the same way.
+T1.4 Client read on a healthy (non-degraded) PG with a mis-sized shard.
+Expected: read succeeds without touching the mis-sized shard (no
+reconstruct needed); mis-sized shard is not detected here.
 
-The result is defence-in-depth:
+**Improvement 2 — Recovery path**
 
-* **Immediate**: underruns at read time become -EIO, preventing decode asserts
-* **Recovery**: recovery writes are guarded against inconsistent metadata
-* **Proactive**: periodic scrub with repair finds and corrects wrong-sized
-  shards before they can cause an outage
+T2.1 A shard is missing (taken offline).  Among the remaining shards used
+as sources for recovery, one is mis-sized.  Expected: after the first
+recovery pass completes, the mis-sized source shard is detected, added to
+the missing set, and recovery restarts.  On the second pass, the mis-sized
+shard is itself reconstructed from the remaining k−1 healthy shards.  Both
+the originally missing shard and the mis-sized shard are correctly written
+back.  The PG returns to ``active+clean``.
 
+T2.2 A shard is missing and the only mis-sized shard is the one being
+recovered (the destination).  Expected: ``handle_recovery_push`` detects the
+size mismatch, does not assert, and recovery writes the shard at the correct
+size.  PG returns to ``active+clean``.
 
-Error Visibility
-----------------
+T2.3 A shard is missing.  Exactly m source shards are mis-sized (leaving
+fewer than k healthy sources after the mis-sized shards are added to the
+missing set).  Expected: object is marked unfound; no OSD assert; cluster
+health shows unfound objects.
 
-+-------------------------------+---------------------------------------------+
-| Condition                     | Proposed action                             |
-+===============================+=============================================+
-| Shard underrun at read time   | ``dout(0)`` warning + synthesise -EIO;      |
-|                               | for recovery ops: ``_failed_push`` →        |
-|                               | ``on_failed_pull`` →                        |
-|                               | ``force_object_missing``                    |
-+-------------------------------+---------------------------------------------+
-| ``shard_size < tobj_size``    | ``derr`` + cancel recovery op, reschedule   |
-| during recovery push          | (instead of assert/crash)                   |
-+-------------------------------+---------------------------------------------+
-| ``SHARD_EC_SIZE_MISMATCH``    | Existing scrub log entry + (if              |
-| at scrub time                 | ``m_repair``) ``clog.error`` +              |
-|                               | ``repair_object()``                         |
-+-------------------------------+---------------------------------------------+
+T2.4 Recovery of a small object (smaller than ``osd_recovery_max_chunk``).
+The first recovery pass requests more bytes than the object size; all shards
+return short reads legitimately.  Expected: no spurious underrun detection;
+``update_object_size_after_read`` correctly resets the zero masks; recovery
+completes normally.
+
+T2.5 OSD crash-loop regression: reproduce the exact scenario from
+tracker #78400 — a Fast EC pool with legacy-format objects (written before
+``allow_ec_optimizations`` was enabled) on a degraded PG.  Expected: OSDs
+do not crash-loop; recovery eventually completes; no ``ceph_assert`` in logs.
+
+**Improvement 3 — Scrub repair**
+
+T3.1 Deep scrub (without repair) on a healthy PG where one shard is
+mis-sized.  Expected: scrub reports ``SHARD_EC_SIZE_MISMATCH`` in the health
+detail / log; no repair is attempted; PG remains ``active+clean``.
+
+T3.2 ``ceph pg repair`` on a healthy PG where one shard is mis-sized.
+Expected: scrub detects the mismatch, ``repair_object`` is called,
+``force_object_missing`` marks the shard missing, recovery rewrites the shard
+at the correct size, and the PG returns to ``active+clean`` with no
+outstanding size-mismatch errors on the next scrub.
+
+T3.3 ``ceph pg repair`` where multiple shards of the same object are
+mis-sized but fewer than m (i.e. recovery can still reconstruct).  Expected:
+all mis-sized shards are detected and repaired across successive repair
+passes; PG returns to clean.
+
+T3.4 ``ceph pg repair`` where the number of mis-sized shards equals m
+(insufficient sources for recovery).  Expected: object is reported as
+unfound; no OSD assert; remaining healthy shards are not disturbed.
+
+T3.5 Deep scrub on a pool where ``allow_ec_optimizations`` was enabled
+retrospectively on a pool with legacy-format objects.  Expected: legacy
+objects whose shard sizes do not match the Fast EC formula are detected and
+reported; repair corrects them via recovery.
+
+**Cross-cutting**
+
+T4.1 A mis-sized shard combined with a simultaneously offline shard such
+that the total available healthy shards equals exactly k (minimum to
+decode).  Expected: client reads and recovery succeed using exactly those k
+shards; the mis-sized shard is excluded; no assert.
+
+T4.2 Verify that ``bluestore_debug_inject_read_err`` (the existing short-read
+injection mechanism) correctly triggers the new underrun detection path and
+produces the expected ``SHARD_UNDERRUN`` log entry and -EIO behaviour.
+
+T4.3 A mis-sized shard on a PG that is not degraded and is never read in a
+reconstruct context.  The shard persists silently until scrub with repair
+corrects it.  Verify via T3.2 that this path is complete.
 
 
 Out of Scope
 ------------
-
-* **The #77276 write-side fix**: the transaction planning bug is fixed by
-  PR #69663 and is not re-described here.  This document covers only the
-  tolerance and repair work for shards that are already mis-sized.
 
 * **Legacy EC** (``ECBackendL``): the legacy code path pads all shards to
   the chunk boundary and its shard sizes are consistent with what the read
@@ -409,48 +355,10 @@ Out of Scope
 
 * **Hash mismatches** (``SHARD_EC_HASH_MISMATCH``): data that is the correct
   size but has wrong content is handled by the existing deep-scrub
-  decode-verification path and is not changed here.
+  decode-verification path and is not changed here.  Note that today only
+  the first parity shard can be checked, so it is not always possible to
+  identify which specific shard has a hash mismatch.
 
-* **Pool-level EIO flag** (``FLAG_EIO``): the -EIO treatment of underruns
-  (Improvement 1) is at the per-shard level within a single PG operation
-  and does not modify the pool-level flag behaviour.
-
-
-Key Code Locations
-------------------
-
-+-------------------------------+-------------------------------------+---------------------+
-| Function                      | File                                | Change              |
-+===============================+=====================================+=====================+
-| ``handle_sub_read_reply``     | ``src/osd/ECBackend.cc:780``        | Add shard size      |
-|                               |                                     | validation before   |
-|                               |                                     | buffer insertion    |
-+-------------------------------+-------------------------------------+---------------------+
-| ``shard_extent_map_t::        | ``src/osd/ECUtil.cc:639``           | No change; decode   |
-| decode``                      |                                     | error is prevented  |
-|                               |                                     | upstream            |
-+-------------------------------+-------------------------------------+---------------------+
-| ``handle_recovery_read_       | ``src/osd/ECCommon.cc:1350``        | No change; assert   |
-| complete``                    |                                     | at line 1409 is     |
-|                               |                                     | prevented upstream  |
-+-------------------------------+-------------------------------------+---------------------+
-| ``handle_recovery_push``      | ``src/osd/ECCommon.cc:1159``        | Replace assert with |
-|                               |                                     | error return        |
-+-------------------------------+-------------------------------------+---------------------+
-| ``_failed_push``              | ``src/osd/ECCommon.cc:1142``        | No change           |
-+-------------------------------+-------------------------------------+---------------------+
-| ``repair_object``             | ``src/osd/scrubber/                 | No change           |
-|                               | scrub_backend.cc:391``              |                     |
-+-------------------------------+-------------------------------------+---------------------+
-| ``scan_object_for_errors``    | ``src/osd/scrubber/                 | Populate            |
-|                               | scrub_backend.cc:~620``             | ``m_inconsistent``  |
-|                               |                                     | for size mismatch   |
-|                               |                                     | when ``m_repair``   |
-+-------------------------------+-------------------------------------+---------------------+
-| ``object_size_to_shard_size`` | ``src/osd/ECUtil.h:614``            | No change;          |
-|                               |                                     | reference for size  |
-|                               |                                     | computation         |
-+-------------------------------+-------------------------------------+---------------------+
 
 .. _tracker #77276: https://tracker.ceph.com/issues/77276
 .. _Tracker #77276: https://tracker.ceph.com/issues/77276

--- a/doc/dev/osd_internals/erasure_coding/fast_ec_failure_handling.rst
+++ b/doc/dev/osd_internals/erasure_coding/fast_ec_failure_handling.rst
@@ -1,0 +1,458 @@
+==============================
+Fast EC: Failure Handling Design
+==============================
+
+:Author: Alex Ainscow
+:Status: Draft
+
+Overview
+--------
+
+Fast EC (``allow_ec_optimizations``) uses variable-size shards whose on-disk
+size is derived from the object's logical size and stripe parameters.  A bug
+in the transaction planning code (`tracker #77276`_) can leave shards on disk
+that are smaller than this expected size — an *underrun*.  When such a shard
+is later read during a reconstruct operation on a degraded PG, the EC decode
+pipeline receives less data than it requested, returns a non-zero error code,
+and the OSD asserts and crashes (`tracker #78400`_).  Because peering a
+degraded PG itself triggers a reconstruct read, the OSD crash-loops and
+cannot rejoin, with the crash migrating across the cluster as PGs remap.
+
+The fix for #77276 prevents new underruns from being written, but shards
+already on disk remain mis-sized.  This document describes the complementary
+changes needed to make the system *tolerant* of mis-sized shards — whether
+they originate from #77276, from legacy-format objects, or from any other
+cause — rather than asserting on them.
+
+The approach has three parts.  At **read time**, an underrun shard is
+detected and treated as an I/O error, so the decode path never receives
+inconsistent buffers.  In the **recovery write path**, a ``ceph_assert`` that
+fires when shard size accounting is stale is converted to a logged error
+return that reschedules recovery.  During **scrub with repair**, deep scrub's
+existing detection of size-mismatched shards is extended so that those shards
+are automatically corrected through the normal recovery mechanism, providing
+a proactive way to repair shards that have never been read since the bug
+occurred.
+
+
+Background
+----------
+
+Fast EC and shard sizes
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Fast EC computes the expected on-disk size for each shard from the object's
+logical size and stripe parameters, distributing any remainder across the
+first few shards and aligning to the chunk boundary.  This produces shards
+that are generally *smaller* than under legacy EC, which padded every shard
+to the next full chunk boundary regardless of the object size.
+
+Tracker #77276: transaction planning bug writes under-sized shards
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+`Tracker #77276`_ (fixed in main via PR #69663) describes a transaction
+planning bug in the Fast EC write path.  Under certain rare combinations of
+operations within a single transaction, the Fast EC transaction planner
+produced on-disk shard files smaller than the size that
+``object_size_to_shard_size`` would predict for the object's logical size.
+
+The fix for #77276 corrects the planning logic so that new writes do not
+produce under-sized shards.  However, objects that were already written
+under the buggy code remain on disk with incorrect shard sizes.
+
+Tracker #78400: under-sized shards cause OSD crash cascades
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+`Tracker #78400`_ documents a production outage on v20.2.1 and v20.2.2
+triggered by exactly the shards that #77276 can produce (as well as by
+legacy-format objects on pools that had ``allow_ec_optimizations`` enabled
+retrospectively).
+
+The crash signature is ``ceph_assert(r == 0)`` immediately after ``decode()``
+in the reconstruct-read path, both in the recovery completion handler
+(``ECCommon.cc:handle_recovery_read_complete``) and in the client-read
+completion handler (``ClientReadCompleter::finish_single_request``).  A
+related assertion fires via ``interval_map.h`` through
+``complete_read_op`` → ``handle_sub_read_reply``, because the mismatched
+buffer sizes violate the extent-map invariant on insertion.
+
+**Why does decode return non-zero?**
+
+When the Fast EC read pipeline issues a reconstruct read, it requests
+*optimised-size* extents from each shard — the size that
+``object_size_to_shard_size`` predicts.  If an on-disk shard is smaller
+than this (due to #77276 or the legacy-format scenario), the remote OSD
+returns exactly the bytes requested with no error, but those bytes are
+shorter than expected.  The ``slice_iterator`` / ``decode_chunks`` call
+inside ``shard_extent_map_t::_decode`` (``src/osd/ECUtil.cc:734``) then
+returns a non-zero code because the available buffers do not consistently
+cover the requested extents.  The callers assert on this code.
+
+**Why does this cause an outage?**
+
+Peering a degraded PG immediately issues a reconstruct read.  So an OSD
+that holds a shard for a degraded PG crashes on startup, cannot rejoin,
+and the PG remaps to a new primary — which may itself hold an affected
+shard and crash in turn.  The cascade takes the pool inactive.  Standard
+operational controls (``norecover``, ``pauserd/pausewr``, etc.) do not
+prevent peering reads and therefore do not prevent the crash.
+
+The reporter confirmed via ``ceph-objectstore-tool`` that all shards are
+physically intact and version-consistent — the data is not lost and the
+failure is entirely in the decode logic.
+
+**What #77276's fix does not address**
+
+The fix for #77276 prevents *new* under-sized shards from being written.
+Shards already on disk with the wrong size are unchanged.  On a pool that
+has never been degraded since the bad write occurred, those shards sit
+silently waiting for the first time a PG loses a different shard and
+triggers a reconstruct read — at which point the crash occurs.
+
+The changes described in this document address that residual risk.
+
+
+Improvement 1: Detect and Handle Shard Underruns Before Decode
+--------------------------------------------------------------
+
+Problem
+~~~~~~~
+
+In ``ECBackend::handle_sub_read_reply`` (``src/osd/ECBackend.cc:780``),
+buffers received from a remote OSD are inserted into the read-complete map
+without any validation that each shard returned the number of bytes that were
+requested::
+
+    // current code — no size validation
+    for (auto &&[offset, buffer_list]: offset_buffer_map) {
+        buffers_read.insert_in_shard(from.shard, offset, buffer_list);
+    }
+
+The requested extents for each shard are available in
+``rop.to_read[hoid].shard_reads``.  The actual bytes received are in
+``offset_buffer_map``.  These are never compared.
+
+The mismatch reaches ``shard_extent_map_t::decode()`` →
+``shard_extent_map_t::_decode()`` → ``ec_impl->decode_chunks()``, which
+returns a non-zero error code.  The caller asserts on that code, crashing the
+OSD.
+
+Design
+~~~~~~
+
+When the reply arrives for a shard, compare the total bytes received against
+the total bytes that were requested for that shard.  If they differ,
+synthesise an -EIO error for that shard — exactly as the existing
+error-injection path does when ``bluestore_debug_inject_read_err`` fires —
+and discard the partial buffer::
+
+    // pseudocode — details to be determined during implementation
+    uint64_t expected = total_requested_bytes(rop, hoid, from.shard);
+    uint64_t received = total_received_bytes(offset_buffer_map);
+    if (received != expected) {
+        dout(0) << __func__ << " shard underrun from " << from
+                << " expected " << expected << " got " << received << dendl;
+        complete.errors[from] = -EIO;
+        complete.buffers_read.remove_shard(from.shard);
+        rop.debug_log.emplace_back(ECUtil::SHARD_UNDERRUN, op.from);
+        continue;  // skip normal buffer insertion
+    }
+
+**Special case: recovery reads with unknown object size**
+
+On the first pass of a recovery operation, the object info (``obc``) may not
+yet be available and the object size is therefore unknown.
+``continue_recovery_op`` requests up to ``get_recovery_chunk_size()``
+(rounded-up ``osd_recovery_max_chunk``, typically 4 MiB) in this case, and
+shards for small objects will legitimately return fewer bytes than requested.
+This is expected, correct behaviour handled via ``zeros_for_decode`` in
+``update_object_size_after_read``.
+
+The underrun check must therefore be suppressed when the read was issued with
+an unknown object size.  The ``read_request_t::object_size`` field already
+distinguishes these two cases: it is set to the true logical size when
+``op.obc`` is available, and to ``get_recovery_chunk_size()`` otherwise.
+The check should only fire when ``read_request_t::object_size`` reflects the
+actual object size (i.e. not the fallback chunk size), or equivalently when
+``rop.for_recovery`` is false (client reads always know the object size).
+
+On the second and subsequent recovery passes, ``obc`` is populated and the
+read is sized correctly, so the underrun check applies normally.  Any
+shard that returns short data on a correctly-sized recovery read is
+genuinely mis-sized and should be treated as -EIO.
+
+The subsequent ``check_and_maybe_mark_unfound`` / minimum-to-decode check
+determines whether the remaining shards are still sufficient to reconstruct
+the object.  If not, the read pipeline returns -EIO to the caller.
+
+For recovery operations, -EIO propagates to
+``RecoveryReadCompleter::finish_single_request`` →
+``_failed_push`` → ``on_failed_pull`` → ``force_object_missing`` on the
+offending shard.  This is important: it is not sufficient merely to exclude
+the short shard from the current decode.  The shard must also be added to the
+missing set so that it is scheduled for recovery itself — i.e. reconstructed
+from the remaining healthy shards and written back at the correct Fast EC
+size.  Without this step, the mis-sized shard remains on disk and will cause
+the same failure the next time that PG becomes degraded.
+
+For non-recovery (client) reads with a degraded PG, the existing -EIO client
+error path is unchanged.
+
+This change prevents the ``ceph_assert(r == 0)`` in both
+``handle_recovery_read_complete`` and ``ClientReadCompleter::finish_single_request``
+from ever being reached for an underrun condition.
+
+Affected files
+~~~~~~~~~~~~~~
+
+* ``src/osd/ECBackend.cc`` — ``handle_sub_read_reply()``: add size validation
+  before buffer insertion
+* ``src/osd/ECUtil.h`` — optionally add ``SHARD_UNDERRUN`` to the debug-log
+  event enum
+
+
+Improvement 2: Replace Recovery Assert with Error Handling
+----------------------------------------------------------
+
+Problem
+~~~~~~~
+
+In ``ECCommon::RecoveryBackend::handle_recovery_push``
+(``src/osd/ECCommon.cc``), when recovery has finished writing a shard, the
+code computes the expected on-disk size and truncates if needed::
+
+    // src/osd/ECCommon.cc ~line 1240
+    uint64_t shard_size = sinfo.object_size_to_shard_size(
+        op.recovery_info.size, get_parent()->whoami_shard().shard);
+    ceph_assert(shard_size >= tobj_size);  // <-- asserts if stale object_info
+    if (shard_size != tobj_size) {
+        m->t.truncate(coll, tobj, shard_size);
+    }
+
+If the ``object_info.size`` field is stale or inconsistent with the actual
+shard content — which can occur for objects written under the #77276 bug, or
+when objects written under legacy EC have their metadata partially updated —
+the assertion fires, crashing the OSD.
+
+This is a second crash site in the same overall failure mode: the first
+(Improvement 1) is hit when *reading* from a source shard; this one is hit
+when *writing* the recovered destination shard.
+
+Design
+~~~~~~
+
+Replace the ``ceph_assert`` with a logged error return that cancels the
+recovery operation and schedules a retry after re-fetching object metadata
+from the auth peer::
+
+    if (shard_size < tobj_size) {
+        derr << __func__ << ": shard_size " << shard_size
+             << " < tobj_size " << tobj_size << " for " << op.soid
+             << "; object_info size may be stale, cancelling recovery" << dendl;
+        _failed_push(op.hoid, /* synthesise read_result_t with r=-EIO */);
+        return;
+    }
+    if (shard_size != tobj_size) {
+        m->t.truncate(coll, tobj, shard_size);
+    }
+
+This converts a hard OSD crash into a recoverable situation.  If the
+object_info is genuinely inconsistent, the object will eventually be marked
+unfound and the operator can decide how to proceed.  If it was a transient
+inconsistency, recovery succeeds on the next attempt.
+
+Affected files
+~~~~~~~~~~~~~~
+
+* ``src/osd/ECCommon.cc`` — ``handle_recovery_push()``: replace
+  ``ceph_assert(shard_size >= tobj_size)`` with a logged error return
+
+
+Improvement 3: Scrub Repairs Mis-Sized EC Shards
+-------------------------------------------------
+
+Problem
+~~~~~~~
+
+Deep scrub already detects ``SHARD_EC_SIZE_MISMATCH`` in
+``ScrubBackend::scan_object_for_errors``
+(``src/osd/scrubber/scrub_backend.cc:640``).  When
+``smap_obj.ec_size_mismatch`` is set, the shard is correctly excluded from
+auth selection via ``dup_error_cond`` / ``set_ec_size_mismatch``.
+
+However, the scrub repair path (``ScrubBackend::apply_repair``) iterates
+``m_inconsistent`` and calls ``repair_object()`` only for objects that were
+explicitly added to that set.  Objects whose only detected error is
+``SHARD_EC_SIZE_MISMATCH`` may not be added to ``m_inconsistent``, so
+``repair_object()`` is never called and the mis-sized on-disk shard persists.
+
+Improvements 1 and 2 handle the crash when a mis-sized shard is *read*.  But
+a shard can sit mis-sized indefinitely on a PG that has never become degraded
+since the bad write.  Scrub repair is the only mechanism that can proactively
+find and fix those shards before they cause an outage.
+
+Design
+~~~~~~
+
+**Step 1 — Populate ``m_inconsistent`` for ``SHARD_EC_SIZE_MISMATCH``**
+
+Where ``SHARD_EC_SIZE_MISMATCH`` is detected and the scrub is running in
+repair mode (``m_repair == true``), add the affected shard to the
+``m_inconsistent`` entry for that object alongside the auth peer's
+``pg_shard_t``.  This mirrors the existing handling for ``SHARD_READ_ERR``
+and ``SHARD_MISSING``.
+
+**Step 2 — No change to ``repair_object()``**
+
+``repair_object()`` already calls ``force_object_missing()`` on the bad
+peers, which marks the shard as missing and triggers recovery::
+
+    // src/osd/scrubber/scrub_backend.cc:425 — no changes required
+    m_pg.force_object_missing(ScrubberPasskey{}, bad_peers, soid, oi.version);
+
+For EC pools, recovery reconstructs the shard from the k healthy data shards
+and writes it back with the correct Fast EC size, permanently fixing the
+on-disk representation.
+
+**Step 3 — Gate on ``m_repair``**
+
+A regular deep scrub (without repair) should only detect and log the error,
+consistent with the existing behaviour for all other shard errors.  Repair
+is only performed when ``m_repair == true`` (i.e. ``ceph pg repair`` was
+requested or the auto-repair threshold was crossed).
+
+Affected files
+~~~~~~~~~~~~~~
+
+* ``src/osd/scrubber/scrub_backend.cc`` — logic that populates
+  ``m_inconsistent`` (around the ``set_ec_size_mismatch`` call site,
+  lines ~640–646)
+* ``src/test/osd/test_scrubber_be.cc`` — new unit test for the EC shard
+  size mismatch repair path
+
+
+How the Three Improvements Work Together
+-----------------------------------------
+
+The three improvements form a complete lifecycle for mis-sized Fast EC shards:
+
+**Scenario A: Shard mis-sized by #77276, PG later becomes degraded**
+
+This is the primary scenario from tracker #78400.  With the fixes:
+
+1. Recovery reads source shards.  A mis-sized shard returns fewer bytes than
+   the optimised request; Improvement 1 detects the underrun and synthesises
+   -EIO before the data reaches the decoder.
+2. The underrun shard is excluded.  If enough healthy shards remain, decode
+   succeeds and the missing shard is reconstructed at the correct Fast EC
+   size, permanently correcting the on-disk representation for that shard.
+3. If the mis-sized shard must itself serve as a source and fewer than k
+   healthy shards remain, the object is marked unfound.  The operator must
+   correct the shard sizes (e.g. by reading and rewriting the object) before
+   recovery can proceed — but the OSD no longer crashes.
+4. Improvement 2 ensures that even if ``object_info`` is stale during the
+   recovery write, the OSD emits an error and retries rather than asserting.
+
+**Scenario B: Shard mis-sized by #77276, PG never degraded**
+
+Improvement 1 is not exercised (no reconstruct read is ever issued).
+Running ``ceph pg repair`` triggers a deep scrub; Improvement 3 detects the
+size mismatch, marks the shard missing, and recovery corrects it.  This is
+the proactive path that clears #77276-induced corruption before it can
+trigger an outage.
+
+**Scenario C: Legacy-format shard on a pool upgraded to Fast EC**
+
+Identical to Scenario A: the legacy shard is larger than the optimised size
+expected, but the fast EC read pipeline requests fewer bytes, resulting in an
+apparent underrun.  Improvements 1 and 3 handle this the same way.
+
+The result is defence-in-depth:
+
+* **Immediate**: underruns at read time become -EIO, preventing decode asserts
+* **Recovery**: recovery writes are guarded against inconsistent metadata
+* **Proactive**: periodic scrub with repair finds and corrects wrong-sized
+  shards before they can cause an outage
+
+
+Error Visibility
+----------------
+
++-------------------------------+---------------------------------------------+
+| Condition                     | Proposed action                             |
++===============================+=============================================+
+| Shard underrun at read time   | ``dout(0)`` warning + synthesise -EIO;      |
+|                               | for recovery ops: ``_failed_push`` →        |
+|                               | ``on_failed_pull`` →                        |
+|                               | ``force_object_missing``                    |
++-------------------------------+---------------------------------------------+
+| ``shard_size < tobj_size``    | ``derr`` + cancel recovery op, reschedule   |
+| during recovery push          | (instead of assert/crash)                   |
++-------------------------------+---------------------------------------------+
+| ``SHARD_EC_SIZE_MISMATCH``    | Existing scrub log entry + (if              |
+| at scrub time                 | ``m_repair``) ``clog.error`` +              |
+|                               | ``repair_object()``                         |
++-------------------------------+---------------------------------------------+
+
+
+Out of Scope
+------------
+
+* **The #77276 write-side fix**: the transaction planning bug is fixed by
+  PR #69663 and is not re-described here.  This document covers only the
+  tolerance and repair work for shards that are already mis-sized.
+
+* **Legacy EC** (``ECBackendL``): the legacy code path pads all shards to
+  the chunk boundary and its shard sizes are consistent with what the read
+  pipeline requests.  These changes are specific to the Fast EC (optimised)
+  code path.
+
+* **Hash mismatches** (``SHARD_EC_HASH_MISMATCH``): data that is the correct
+  size but has wrong content is handled by the existing deep-scrub
+  decode-verification path and is not changed here.
+
+* **Pool-level EIO flag** (``FLAG_EIO``): the -EIO treatment of underruns
+  (Improvement 1) is at the per-shard level within a single PG operation
+  and does not modify the pool-level flag behaviour.
+
+
+Key Code Locations
+------------------
+
++-------------------------------+-------------------------------------+---------------------+
+| Function                      | File                                | Change              |
++===============================+=====================================+=====================+
+| ``handle_sub_read_reply``     | ``src/osd/ECBackend.cc:780``        | Add shard size      |
+|                               |                                     | validation before   |
+|                               |                                     | buffer insertion    |
++-------------------------------+-------------------------------------+---------------------+
+| ``shard_extent_map_t::        | ``src/osd/ECUtil.cc:639``           | No change; decode   |
+| decode``                      |                                     | error is prevented  |
+|                               |                                     | upstream            |
++-------------------------------+-------------------------------------+---------------------+
+| ``handle_recovery_read_       | ``src/osd/ECCommon.cc:1350``        | No change; assert   |
+| complete``                    |                                     | at line 1409 is     |
+|                               |                                     | prevented upstream  |
++-------------------------------+-------------------------------------+---------------------+
+| ``handle_recovery_push``      | ``src/osd/ECCommon.cc:1159``        | Replace assert with |
+|                               |                                     | error return        |
++-------------------------------+-------------------------------------+---------------------+
+| ``_failed_push``              | ``src/osd/ECCommon.cc:1142``        | No change           |
++-------------------------------+-------------------------------------+---------------------+
+| ``repair_object``             | ``src/osd/scrubber/                 | No change           |
+|                               | scrub_backend.cc:391``              |                     |
++-------------------------------+-------------------------------------+---------------------+
+| ``scan_object_for_errors``    | ``src/osd/scrubber/                 | Populate            |
+|                               | scrub_backend.cc:~620``             | ``m_inconsistent``  |
+|                               |                                     | for size mismatch   |
+|                               |                                     | when ``m_repair``   |
++-------------------------------+-------------------------------------+---------------------+
+| ``object_size_to_shard_size`` | ``src/osd/ECUtil.h:614``            | No change;          |
+|                               |                                     | reference for size  |
+|                               |                                     | computation         |
++-------------------------------+-------------------------------------+---------------------+
+
+.. _tracker #77276: https://tracker.ceph.com/issues/77276
+.. _Tracker #77276: https://tracker.ceph.com/issues/77276
+.. _tracker #78400: https://tracker.ceph.com/issues/78400
+.. _Tracker #78400: https://tracker.ceph.com/issues/78400

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -828,6 +828,7 @@ void ECBackend::handle_sub_read_reply(
         received += bl.length();
       }
       if (received != expected) {
+        BOB: This needs to be an ERROR, and in the cluster log.
         dout(0) << __func__ << " shard underrun from " << from
                 << " on " << hoid
                 << " expected " << expected << " got " << received << dendl;
@@ -1644,6 +1645,8 @@ int ECBackend::be_deep_scrub(
     return -EINPROGRESS;
   }
 
+  BOB: I am confused - I think there is already some code to test shard sizes?
+     can't we use that? (I think its in scrub_backend)'
   // Check shard size against expected size from the object's logical size.
   {
     auto oi_iter = o.attrs.find(OI_ATTR);

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -817,6 +817,32 @@ void ECBackend::handle_sub_read_reply(
       continue;
     }
 
+    if (rop.check_for_underruns &&
+        rop.to_read.at(hoid).shard_reads.contains(from.shard)) {
+      uint64_t expected = 0;
+      for (auto &[off, len] : rop.to_read.at(hoid).shard_reads.at(from.shard).extents) {
+        expected += len;
+      }
+      uint64_t received = 0;
+      for (auto &[off, bl] : offset_buffer_map) {
+        received += bl.length();
+      }
+      if (received != expected) {
+        dout(0) << __func__ << " shard underrun from " << from
+                << " on " << hoid
+                << " expected " << expected << " got " << received << dendl;
+        if (!rop.complete.contains(hoid)) {
+          rop.complete.emplace(hoid, &sinfo);
+        }
+        rop.complete.at(hoid).errors.emplace(from, -EIO);
+        rop.complete.at(hoid).buffers_read.erase_shard(from.shard);
+        rop.complete.at(hoid).processed_read_requests.erase(from.shard);
+        rop.to_read.at(hoid).zeros_for_decode.erase(from.shard);
+        rop.debug_log.emplace_back(ECUtil::SHARD_UNDERRUN, op.from);
+        continue;
+      }
+    }
+
     if (!rop.complete.contains(hoid)) {
       rop.complete.emplace(hoid, &sinfo);
     }
@@ -1616,6 +1642,30 @@ int ECBackend::be_deep_scrub(
   pos.data_pos += r;
   if (r == (int)stride) {
     return -EINPROGRESS;
+  }
+
+  // Check shard size against expected size from the object's logical size.
+  {
+    auto oi_iter = o.attrs.find(OI_ATTR);
+    if (oi_iter != o.attrs.end()) {
+      try {
+        object_info_t oi;
+        auto p = oi_iter->second.cbegin();
+        decode(oi, p);
+        uint64_t expected = sinfo.object_size_to_shard_size(
+          oi.size, get_parent()->whoami_shard().shard);
+        if ((uint64_t)pos.data_pos != expected) {
+          dout(0) << __func__ << " " << poid
+                  << " shard size mismatch: on-disk " << pos.data_pos
+                  << " expected " << expected
+                  << " (object size " << oi.size << ")" << dendl;
+          o.ec_size_mismatch = true;
+        }
+      } catch (ceph::buffer::error &e) {
+        dout(0) << __func__ << " " << poid
+                << " failed to decode OI attr: " << e.what() << dendl;
+      }
+    }
   }
 
   if (sinfo.supports_encode_decode_crcs()) {

--- a/src/osd/ECCommon.cc
+++ b/src/osd/ECCommon.cc
@@ -500,6 +500,7 @@ void ECCommon::ReadPipeline::start_read_op(
     map<hobject_t, read_request_t> &to_read,
     const bool do_redundant_reads,
     const bool for_recovery,
+    const bool check_for_underruns,
     std::unique_ptr<ReadCompleter> on_complete) {
   ceph_tid_t tid = get_parent()->get_tid();
   ceph_assert(!tid_to_read_map.contains(tid));
@@ -510,6 +511,7 @@ void ECCommon::ReadPipeline::start_read_op(
       tid,
       do_redundant_reads,
       for_recovery,
+      check_for_underruns,
       std::move(on_complete),
       std::move(to_read))).first->second;
   dout(10) << __func__ << ": starting " << op << dendl;
@@ -817,6 +819,7 @@ void ECCommon::ReadPipeline::objects_read_and_reconstruct(
     for_read_op,
     fast_read,
     false,
+    true,
     std::make_unique<ClientReadCompleter>(
       *this, &(in_progress_client_reads.back())));
 }
@@ -848,7 +851,7 @@ void ECCommon::ReadPipeline::objects_read_and_reconstruct_for_rmw(
 
   start_read_op(
     CEPH_MSG_PRIO_DEFAULT,
-    for_read_op, false, false,
+    for_read_op, false, false, true,
     std::make_unique<ClientReadCompleter>(
       *this, &(in_progress_client_reads.back())));
 }
@@ -1317,7 +1320,16 @@ void ECCommon::RecoveryBackend::handle_recovery_push(
   if (op.after_progress.data_complete && op.after_progress.omap_complete) {
     uint64_t shard_size = sinfo.object_size_to_shard_size(op.recovery_info.size,
       get_parent()->whoami_shard().shard);
-    ceph_assert(shard_size >= tobj_size);
+    if (shard_size < tobj_size) {
+      derr << __func__ << ": shard_size " << shard_size
+           << " < tobj_size " << tobj_size << " for " << op.soid
+           << ", cancelling push" << dendl;
+      read_result_t res(&sinfo);
+      res.r = -EIO;
+      res.errors[get_parent()->primary_shard()] = -EIO;
+      _failed_push(op.soid, res);
+      return;
+    }
     if (shard_size != tobj_size) {
       m->t.truncate( coll, tobj, shard_size);
     }
@@ -1475,6 +1487,51 @@ void ECCommon::RecoveryBackend::handle_recovery_read_complete(
     op.recovery_progress.omap_complete = true;
   }
 
+  // Validate source shard sizes before decode. If any source shard
+  // returned fewer bytes than expected for its requested extents
+  // (accounting for legitimate end-of-object zeros), treat it as
+  // an underrun and fail the push so recovery restarts without it.
+  {
+    uint64_t obj_size = op.obc->obs.oi.size;
+    for (auto &[shard_id, shard_read] : req.shard_reads) {
+      if (op.missing_on_shards.contains(shard_id)) {
+        continue;
+      }
+      uint64_t expected_shard_size = sinfo.object_size_to_shard_size(
+        obj_size, shard_id);
+      uint64_t requested = 0;
+      for (auto &[off, len] : shard_read.extents) {
+        requested += len;
+      }
+      uint64_t zeros = 0;
+      if (req.zeros_for_decode.contains(shard_id)) {
+        for (auto &[off, len] : req.zeros_for_decode.at(shard_id)) {
+          zeros += len;
+        }
+      }
+      uint64_t received = 0;
+      if (res.buffers_read.contains(shard_id)) {
+        for (auto &[off, len] : res.buffers_read.get_extent_set(shard_id)) {
+          received += len;
+        }
+      }
+      if (received + zeros < requested &&
+          received < expected_shard_size) {
+        derr << __func__ << ": source shard " << shard_read.pg_shard
+             << " underrun on " << hoid
+             << " expected_shard_size=" << expected_shard_size
+             << " requested=" << requested
+             << " received=" << received
+             << " zeros=" << zeros << dendl;
+        read_result_t fail_res(&sinfo);
+        fail_res.r = -EIO;
+        fail_res.errors[shard_read.pg_shard] = -EIO;
+        _failed_push(hoid, fail_res);
+        return;
+      }
+    }
+  }
+
   op.returned_data.emplace(std::move(res.buffers_read));
   uint64_t aligned_size = ECUtil::align_next(op.obc->obs.oi.size);
 
@@ -1484,7 +1541,14 @@ void ECCommon::RecoveryBackend::handle_recovery_read_complete(
 
   op.returned_data->add_zero_padding_for_decode(req.zeros_for_decode);
   int r = op.returned_data->decode(ec_impl, req.shard_want_to_read, aligned_size, get_parent()->get_dpp(), true);
-  ceph_assert(r == 0);
+  if (r != 0) {
+    derr << __func__ << ": decode failed with r=" << r
+         << " for " << hoid << dendl;
+    read_result_t fail_res(&sinfo);
+    fail_res.r = r;
+    _failed_push(hoid, fail_res);
+    return;
+  }
 
   // Finally, we don't want to write any padding, so truncate the buffer
   // to remove it.
@@ -1578,6 +1642,7 @@ void ECCommon::RecoveryBackend::dispatch_recovery_messages(
     m.recovery_reads,
     false,
     true,
+    false,
     std::make_unique<RecoveryReadCompleter>(*this));
 }
 

--- a/src/osd/ECCommon.cc
+++ b/src/osd/ECCommon.cc
@@ -1320,6 +1320,8 @@ void ECCommon::RecoveryBackend::handle_recovery_push(
   if (op.after_progress.data_complete && op.after_progress.omap_complete) {
     uint64_t shard_size = sinfo.object_size_to_shard_size(op.recovery_info.size,
       get_parent()->whoami_shard().shard);
+    BOB: This appears to be in handle_recovery_push - which is too late and on the wrong OSD> 
+       This needs to be handled on the primary, in the sending location. 
     if (shard_size < tobj_size) {
       derr << __func__ << ": shard_size " << shard_size
            << " < tobj_size " << tobj_size << " for " << op.soid
@@ -1491,32 +1493,40 @@ void ECCommon::RecoveryBackend::handle_recovery_read_complete(
   // returned fewer bytes than expected for its requested extents
   // (accounting for legitimate end-of-object zeros), treat it as
   // an underrun and fail the push so recovery restarts without it.
+  BOB: Skip this if not the LAST read.  You should be able to tell this from the raad 
+  progress. 
   {
     uint64_t obj_size = op.obc->obs.oi.size;
     for (auto &[shard_id, shard_read] : req.shard_reads) {
+      BOB: Check this.  Is missing_on_shards the OSDs that are STILL offline, or those that need to be recovered?
       if (op.missing_on_shards.contains(shard_id)) {
         continue;
       }
       uint64_t expected_shard_size = sinfo.object_size_to_shard_size(
         obj_size, shard_id);
+
       uint64_t requested = 0;
       for (auto &[off, len] : shard_read.extents) {
         requested += len;
       }
+      BOB: Zeros are only read AFTER the object logical end (for decode)
       uint64_t zeros = 0;
       if (req.zeros_for_decode.contains(shard_id)) {
         for (auto &[off, len] : req.zeros_for_decode.at(shard_id)) {
           zeros += len;
         }
       }
+      BOB: When this is the last read, the size to check is simply offset + length for the shard. 
       uint64_t received = 0;
       if (res.buffers_read.contains(shard_id)) {
         for (auto &[off, len] : res.buffers_read.get_extent_set(shard_id)) {
           received += len;
         }
       }
+      BOB: This is WRONG check received == expected_shard_size is correct. 
       if (received + zeros < requested &&
           received < expected_shard_size) {
+        BOB: Does this go to the cluster log? Do we need "ERR"?
         derr << __func__ << ": source shard " << shard_read.pg_shard
              << " underrun on " << hoid
              << " expected_shard_size=" << expected_shard_size
@@ -1524,8 +1534,11 @@ void ECCommon::RecoveryBackend::handle_recovery_read_complete(
              << " received=" << received
              << " zeros=" << zeros << dendl;
         read_result_t fail_res(&sinfo);
+        // Hmmm... 
         fail_res.r = -EIO;
         fail_res.errors[shard_read.pg_shard] = -EIO;
+        BOB: Is failed_push really correct here?  This is a read, not a push. 
+        BOB: I don't see any code which would re-drive the recovery from the beginning, with an extra shard *to recover*
         _failed_push(hoid, fail_res);
         return;
       }
@@ -1541,6 +1554,7 @@ void ECCommon::RecoveryBackend::handle_recovery_read_complete(
 
   op.returned_data->add_zero_padding_for_decode(req.zeros_for_decode);
   int r = op.returned_data->decode(ec_impl, req.shard_want_to_read, aligned_size, get_parent()->get_dpp(), true);
+  BOB: Leave this as an assert.  I can't think of another reason besides a missized shard or a BUG that would cause decode to fail. '
   if (r != 0) {
     derr << __func__ << ": decode failed with r=" << r
          << " for " << hoid << dendl;

--- a/src/osd/ECCommon.h
+++ b/src/osd/ECCommon.h
@@ -299,6 +299,10 @@ struct ECCommon {
     // True if reading for recovery which could possibly reading only a subset
     // of the available shards.
     bool for_recovery;
+    // True for client reads/RMW. When set, each shard reply is checked for
+    // underruns (received bytes < requested bytes) and treated as -EIO.
+    // Recovery reads handle short returns differently (see Improvement 2).
+    bool check_for_underruns;
     std::unique_ptr<ReadCompleter> on_complete;
 
     ZTracer::Trace trace;
@@ -320,12 +324,14 @@ struct ECCommon {
         ceph_tid_t tid,
         bool do_redundant_reads,
         bool for_recovery,
+        bool check_for_underruns,
         std::unique_ptr<ReadCompleter> _on_complete,
         std::map<hobject_t, read_request_t> &&_to_read)
       : priority(priority),
         tid(tid),
         do_redundant_reads(do_redundant_reads),
         for_recovery(for_recovery),
+        check_for_underruns(check_for_underruns),
         on_complete(std::move(_on_complete)),
         to_read(std::move(_to_read)) {}
 
@@ -380,6 +386,7 @@ struct ECCommon {
         std::map<hobject_t, read_request_t> &to_read,
         bool do_redundant_reads,
         bool for_recovery,
+        bool check_for_underruns,
         std::unique_ptr<ReadCompleter> on_complete);
 
     void do_read_op(ReadOp &rop);

--- a/src/osd/ECUtil.cc
+++ b/src/osd/ECUtil.cc
@@ -1140,6 +1140,8 @@ std::ostream &operator<<(std::ostream &out, const log_entry_t &rhs) {
     break;
   case COMPLETE: out << "COMPLETE";
     break;
+  case SHARD_UNDERRUN: out << "SHARD_UNDERRUN";
+    break;
   default:
     ceph_assert(false);
   }

--- a/src/osd/ECUtil.h
+++ b/src/osd/ECUtil.h
@@ -1135,7 +1135,8 @@ typedef enum {
   REQUEST_MISSING,
   COMPLETE_ERROR,
   ERROR_CLEAR,
-  COMPLETE
+  COMPLETE,
+  SHARD_UNDERRUN
 } log_event_t;
 
 struct log_entry_t {


### PR DESCRIPTION
A design for improvement EC recovery in response to corruption. 


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
