### PR TITLE
test/rgw/notifications: stabilize flaky persistent topic config tests

### DIFF
--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -3636,6 +3636,19 @@ def persistent_topic_configs(persistency_time, config_dict):
     # topic stats
     get_stats_persistent_topic(topic_name, 0)
 
+    # wait for the persistent topic's queue to be discovered and owned by the
+    # notification manager before generating events. the manager refreshes its
+    # list of queues once per fixed queues_update_period (a 30s constant in
+    # src/rgw/driver/rados/rgw_notify.cc, not a tunable), and a queue created
+    # just after a refresh isn't picked up until the next cycle; it then still
+    # has to lock the queue and start processing before entries begin
+    # retrying/expiring. sleep for more than one full period so discovery is
+    # guaranteed to have happened (sleeping exactly one period can still race).
+    # without this wait, create-phase events can remain in the queue (not yet
+    # retried/expired) when the delete phase runs, inflating the entry count.
+    queue_discovery_period = 30
+    time.sleep(queue_discovery_period + 5)
+
     # create objects in the bucket (async)
     number_of_objects = 10
     client_threads = []
@@ -3703,7 +3716,13 @@ def create_persistency_config_string(config_dict):
 @pytest.mark.basic_test
 def test_persistent_topic_configs_ttl():
     """ test persistent topic configurations with time_to_live """
-    config_dict = {"time_to_live": 30, "max_retries": "None", "retry_sleep_duration": "None"}
+    # set retry_sleep_duration explicitly instead of leaving it "None" (which
+    # defaults to rgw_topic_persistency_sleep_duration=0). the push endpoint in
+    # this test is intentionally unreachable, so a 0s sleep makes the manager
+    # retry the same events hundreds of times per second, which is both wasteful
+    # and has been observed to wedge the queue's processing. a 1s sleep paces the
+    # retries without affecting what the test asserts (expiry is driven by ttl).
+    config_dict = {"time_to_live": 30, "max_retries": "None", "retry_sleep_duration": 1}
     persistency_time = config_dict["time_to_live"]
 
     persistent_topic_configs(persistency_time, config_dict)


### PR DESCRIPTION
## Description

`test_persistent_topic_configs_max_retries` and `test_persistent_topic_configs_ttl` have been intermittently failing with an inflated persistent-queue entry count (e.g. `20 != 10` or `15 != 10`): events from the create phase are still sitting in the queue when the delete phase runs, so the two phases' entries add up.

Root cause is timing, in two independent places:

1. **Queue discovery race.** The notification manager only refreshes its list of persistent queues every `rgw_notification_queue_update_period` (30s by default). A queue created just after a refresh isn't picked up for processing until the next cycle, so the create-phase events may not have started retrying/expiring by the time the test checks the queue. This is the failure reported in the tracker. Fix: wait 30s after creating the topic (before generating any events) so the queue is discovered and owned first.

2. **Zero retry sleep in the ttl test.** Leaving `retry_sleep_duration` as `"None"` falls back to `rgw_topic_persistency_sleep_duration=0`. Because the push endpoint here is intentionally unreachable, a 0s sleep makes the manager retry the same events hundreds of times per second — wasteful, and observed to wedge queue processing. Fix: set `retry_sleep_duration=1` to pace the retries; expiry is still driven by `time_to_live`, so the assertions are unchanged.

Both changes are test-only.

### Testing

Looping the affected tests on a vstart cluster:
- `test_persistent_topic_configs_max_retries`: was reproducibly failing (~1 in 16 runs); passes consistently with change (1).
- `test_persistent_topic_configs_ttl`: went from ~8/10 failures to ~9/10 passes with change (2).

Fixes: https://tracker.ceph.com/issues/71979

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
