### PR TITLE
ptl-tool: add audit-and-relabel option to --qe-label ticket prompt

### DIFF
--- a/src/script/ptl-tool.py
+++ b/src/script/ptl-tool.py
@@ -51,6 +51,7 @@ import tempfile
 import textwrap
 import threading
 import webbrowser
+from urllib.parse import quote
 
 MISSING_DEPS = []
 
@@ -436,6 +437,108 @@ def get_pr_tracker_string(session, pr, response=None):
     title = response["title"].strip().replace('|', '&#124;')
     pr_link = f'"PR #{pr}":{response["html_url"]}'
     return f'| {pr_link} | {author} | {labels_str} | {title} |'
+
+def audit_tracker_and_relabel(session, redmine_issue, default_label, dry_run=False):
+    """
+    Interactive helper for the --qe-label ticket-decision prompt's 'a'
+    option: confirm the matched tracker is actually QA Approved, then
+    offer to swap its PR label for a caller-chosen set of "done" labels
+    (TESTED + ready-to-merge by default) on every open PR still carrying
+    it. Mirrors the already-verified relabel_tested()/sync_approved()
+    logic in the ptl-tool-helper skill's check-wip-labels.sh, done here
+    natively so ptl-tool.py doesn't depend on that separate script.
+
+    Returns one of:
+      'not_approved' -- ticket isn't QA Approved yet, caller should
+                        re-prompt without exiting.
+      'cancelled'    -- user backed out (or there was nothing to do)
+                        before applying anything, caller should re-prompt.
+      'completed'    -- labels were actually changed (or would have been,
+                        under --dry-run), caller should exit.
+
+    Calls sys.exit(1) instead of returning if every PR in the batch failed
+    to update -- 'completed' must never be returned for a run that changed
+    nothing, since the caller treats it as unconditional success.
+    """
+    status_name = redmine_issue.status.name
+    if status_name != "QA Approved":
+        print(f"Tracker #{redmine_issue.id} is not QA Approved yet (current status: '{status_name}').")
+        print("Nothing to relabel until QA approves this ticket.")
+        return 'not_approved'
+
+    label_in = input(f"Label to relabel [{default_label}] (Enter to accept, type a different label, or 'q' to cancel): ").strip()
+    if label_in.lower() == 'q':
+        print("Audit cancelled.")
+        return 'cancelled'
+    label = label_in or default_label
+
+    print(f"Fetching open {BASE_PROJECT}/{BASE_REPO} PRs labeled '{label}'...")
+    endpoint = f"https://api.github.com/repos/{BASE_PROJECT}/{BASE_REPO}/issues"
+    prs = []
+    for page in get(session, endpoint, params={'labels': label, 'state': 'open'}):
+        for item in page:
+            if 'pull_request' in item:
+                prs.append((item['number'], item['title']))
+
+    if not prs:
+        print(f"No open PRs found with label '{label}' -- nothing to do.")
+        return 'cancelled'
+
+    print("\nPRs to update:")
+    for num, title in prs:
+        # Titles are arbitrary contributor-authored text; normalize to ASCII
+        # so this never crashes under a non-UTF-8 stdout (e.g. LANG=en_US
+        # over a non-interactive SSH session -- the same bug class already
+        # hit and fixed for this function's own UI strings).
+        safe_title = title.encode('ascii', 'replace').decode('ascii')
+        print(f"  #{num}  {safe_title}")
+
+    targets_in = input("Labels to apply instead [TESTED,ready-to-merge] (comma-separated, or 'q' to cancel): ").strip()
+    if targets_in.lower() == 'q':
+        print("Audit cancelled.")
+        return 'cancelled'
+    target_labels = [t.strip() for t in targets_in.split(',') if t.strip()] if targets_in else ["TESTED", "ready-to-merge"]
+    if not target_labels:
+        print("No target labels given (input was empty after parsing) -- nothing to apply. Audit cancelled.")
+        return 'cancelled'
+
+    print(f"\nPlan: remove '{label}', add {', '.join(target_labels)} on {len(prs)} PR(s) above.")
+    if dry_run:
+        print("[DRY RUN] Would apply the above -- no labels changed.")
+        return 'completed'
+
+    confirm = input("Apply this? [y/N] ").strip().lower()
+    if confirm != 'y':
+        print("Audit cancelled -- no labels changed.")
+        return 'cancelled'
+
+    print("Applying label changes...")
+    updated = 0
+    for num, title in prs:
+        # Add the new labels FIRST, remove the old one second: if the POST
+        # fails, the PR still has its old label (safe, retry-able). Doing it
+        # the other way round risks a PR left with neither label if the POST
+        # fails after a successful DELETE.
+        add_url = f"https://api.github.com/repos/{BASE_PROJECT}/{BASE_REPO}/issues/{num}/labels"
+        resp = session.post(add_url, auth=GithubBearerAuth(), json={"labels": target_labels})
+        if resp.status_code != 200:
+            log.error(f"Failed to add labels to #{num}: {resp.status_code} {resp.text}")
+            continue
+        updated += 1
+        del_url = f"https://api.github.com/repos/{BASE_PROJECT}/{BASE_REPO}/issues/{num}/labels/{quote(label, safe='')}"
+        resp = session.delete(del_url, auth=GithubBearerAuth())
+        if resp.status_code not in (200, 404):
+            log.error(f"Added new labels to #{num} but failed to remove '{label}': {resp.status_code} {resp.text}")
+            print(f"  PARTIAL #{num}: new labels added, old label '{label}' still present -- see error above")
+        else:
+            print(f"  OK #{num} updated")
+
+    if updated == 0:
+        log.error(f"All {len(prs)} PR(s) failed to update -- no labels were changed anywhere.")
+        sys.exit(1)
+
+    print(f"\nDone. Re-run ptl-tool.py if you want to start a new round for tracker #{redmine_issue.id} or a different label.")
+    return 'completed'
 
 def verify_redmine_auth(R):
     """
@@ -2188,7 +2291,7 @@ def build_branch(args):
             log.info(f"\nFound existing open QA ticket: #{t.id} - {t.subject}")
             log.info(f"Link: {t_url}")
             while True:
-                ans = logged_input("Do you want to update this existing QA ticket? [y/n/o/q] (y=update existing, n=create new, o=open in browser, q=quit): ").strip().lower()
+                ans = logged_input("Do you want to update this existing QA ticket? [y/n/o/a/q] (y=update existing, n=create new, o=open in browser, a=audit tracker & relabel tested PRs, q=quit): ").strip().lower()
                 if ans == 'y':
                     args.update_qa = t.id
                     log.info(f"Will update existing QA ticket #{t.id}.")
@@ -2200,13 +2303,19 @@ def build_branch(args):
                 elif ans == 'o':
                     open_in_browser([t_url])
                     log.info(f"Opened {t_url} in browser.")
+                elif ans == 'a':
+                    result = audit_tracker_and_relabel(session, t, args.qe_label, dry_run=args.dry_run)
+                    if result == 'completed':
+                        log.info("Exiting script.")
+                        sys.exit(0)
+                    # 'not_approved' or 'cancelled' -- fall through, re-prompt
                 elif ans == 'q':
                     log.info("Exiting script.")
                     sys.exit(0)
                 elif ans == '':
                     continue
                 else:
-                    log.info("Invalid choice. Please enter y, n, o, or q.")
+                    log.info("Invalid choice. Please enter y, n, o, a, or q.")
         else:
             log.info("No open QA tickets found for this label. Will create a new QA ticket.")
             args.create_qa = True

--- a/src/script/ptl-tool.py
+++ b/src/script/ptl-tool.py
@@ -562,6 +562,14 @@ def audit_tracker_and_relabel(session, redmine_issue, default_label, dry_run=Fal
         if resp.status_code not in (200, 404):
             log.error(f"Added new labels to #{num} but failed to remove '{label}': {resp.status_code} {resp.text}")
             print(f"  PARTIAL #{num}: new labels added, old label '{label}' still present -- see error above")
+        elif resp.status_code == 404:
+            # Old label was already gone before we tried to remove it (most
+            # likely a retry of a previous partial run). Not a failure --
+            # updated already counts this PR -- but worth a distinct log line
+            # so "label removed just now" and "label was already gone" don't
+            # both read as identical "OK" output in a real run.
+            log.info(f"#{num}: old label '{label}' was already gone (404 on delete)")
+            print(f"  OK #{num} updated (old label '{label}' was already gone)")
         else:
             print(f"  OK #{num} updated")
 

--- a/src/script/ptl-tool.py
+++ b/src/script/ptl-tool.py
@@ -442,11 +442,11 @@ def audit_tracker_and_relabel(session, redmine_issue, default_label, dry_run=Fal
     """
     Interactive helper for the --qe-label ticket-decision prompt's 'a'
     option: confirm the matched tracker is actually QA Approved, then
-    offer to swap its PR label for a caller-chosen set of "done" labels
-    (TESTED + ready-to-merge by default) on every open PR still carrying
-    it. Mirrors the already-verified relabel_tested()/sync_approved()
-    logic in the ptl-tool-helper skill's check-wip-labels.sh, done here
-    natively so ptl-tool.py doesn't depend on that separate script.
+    swap its PR label for the hardcoded 'needs-merge' label on every
+    open PR still carrying it. Mirrors the already-verified
+    relabel_tested()/sync_approved() logic in the ptl-tool-helper
+    skill's check-wip-labels.sh, done here natively so ptl-tool.py
+    doesn't depend on that separate script.
 
     Returns one of:
       'not_approved' -- ticket isn't QA Approved yet, caller should
@@ -525,14 +525,7 @@ def audit_tracker_and_relabel(session, redmine_issue, default_label, dry_run=Fal
         safe_title = title.encode('ascii', 'replace').decode('ascii')
         print(f"  #{num}  {safe_title}")
 
-    targets_in = input("Labels to apply instead [TESTED,ready-to-merge] (comma-separated, or 'q' to cancel): ").strip()
-    if targets_in.lower() == 'q':
-        print("Audit cancelled.")
-        return 'cancelled'
-    target_labels = [t.strip() for t in targets_in.split(',') if t.strip()] if targets_in else ["TESTED", "ready-to-merge"]
-    if not target_labels:
-        print("No target labels given (input was empty after parsing) -- nothing to apply. Audit cancelled.")
-        return 'cancelled'
+    target_labels = ["needs-merge"]
 
     print(f"\nPlan: remove '{label}', add {', '.join(target_labels)} on {len(prs)} PR(s) above.")
     if dry_run:

--- a/src/script/ptl-tool.py
+++ b/src/script/ptl-tool.py
@@ -474,14 +474,46 @@ def audit_tracker_and_relabel(session, redmine_issue, default_label, dry_run=Fal
 
     print(f"Fetching open {BASE_PROJECT}/{BASE_REPO} PRs labeled '{label}'...")
     endpoint = f"https://api.github.com/repos/{BASE_PROJECT}/{BASE_REPO}/issues"
-    prs = []
+    labeled_prs = []
     for page in get(session, endpoint, params={'labels': label, 'state': 'open'}):
         for item in page:
             if 'pull_request' in item:
-                prs.append((item['number'], item['title']))
+                labeled_prs.append((item['number'], item['title']))
+
+    if not labeled_prs:
+        print(f"No open PRs found with label '{label}' -- nothing to do.")
+        return 'cancelled'
+
+    # A label can be reused for a later, unrelated round of testing once this
+    # ticket has already been approved -- matching by label text alone would
+    # then relabel PRs that were never part of THIS ticket as tested. Cross-
+    # check against the ticket's own recorded PR list (the same '"PR #N":'
+    # markers its description table is built from -- see old_prs in
+    # manage_qa_tracker()) before trusting that a labeled PR belongs here.
+    owned_prs = set()
+    if hasattr(redmine_issue, 'description') and redmine_issue.description:
+        for match in re.finditer(r'"PR #(\d+)":', redmine_issue.description):
+            owned_prs.add(int(match.group(1)))
+
+    if not owned_prs:
+        print(f"Tracker #{redmine_issue.id}'s description has no \"PR #N\": entries -- "
+              f"can't verify which PRs actually belong to this ticket, so refusing to "
+              f"relabel by label text alone (the label may have been reused for a later, "
+              f"unrelated round of testing).")
+        return 'cancelled'
+
+    prs = [(num, title) for num, title in labeled_prs if num in owned_prs]
+    unowned = [(num, title) for num, title in labeled_prs if num not in owned_prs]
+    if unowned:
+        print(f"\nSkipping {len(unowned)} PR(s) that carry label '{label}' but are NOT in "
+              f"tracker #{redmine_issue.id}'s own PR list (label likely reused for a newer, "
+              f"unrelated round of testing):")
+        for num, title in unowned:
+            safe_title = title.encode('ascii', 'replace').decode('ascii')
+            print(f"  SKIP #{num}  {safe_title}")
 
     if not prs:
-        print(f"No open PRs found with label '{label}' -- nothing to do.")
+        print(f"No open PRs both labeled '{label}' and listed in tracker #{redmine_issue.id} -- nothing to do.")
         return 'cancelled'
 
     print("\nPRs to update:")

--- a/src/script/ptl-tool.py
+++ b/src/script/ptl-tool.py
@@ -438,7 +438,7 @@ def get_pr_tracker_string(session, pr, response=None):
     pr_link = f'"PR #{pr}":{response["html_url"]}'
     return f'| {pr_link} | {author} | {labels_str} | {title} |'
 
-def audit_tracker_and_relabel(session, redmine_issue, default_label, dry_run=False):
+def audit_tracker_and_relabel(session, redmine_issue, default_label, dry_run=False, R=None):
     """
     Interactive helper for the --qe-label ticket-decision prompt's 'a'
     option: confirm the matched tracker is actually QA Approved, then
@@ -447,6 +447,13 @@ def audit_tracker_and_relabel(session, redmine_issue, default_label, dry_run=Fal
     relabel_tested()/sync_approved() logic in the ptl-tool-helper
     skill's check-wip-labels.sh, done here natively so ptl-tool.py
     doesn't depend on that separate script.
+
+    If R (the Redmine client) is given, also clears the tracker's own
+    'Ceph PR Label' custom field once the PR relabel succeeds -- that
+    field is exactly what the --qe-label gate above filters open
+    trackers on, so clearing it (not closing the tracker, not touching
+    its status) is what actually frees the label for a new round while
+    this one stays QA Approved and open, full audit trail intact.
 
     Returns one of:
       'not_approved' -- ticket isn't QA Approved yet, caller should
@@ -569,6 +576,11 @@ def audit_tracker_and_relabel(session, redmine_issue, default_label, dry_run=Fal
     if updated == 0:
         log.error(f"All {len(prs)} PR(s) failed to update -- no labels were changed anywhere.")
         sys.exit(1)
+
+    if R is not None:
+        R.issue.update(redmine_issue.id, custom_fields=[{'id': REDMINE_CUSTOM_FIELD_ID_CEPH_PR_LABEL, 'value': ''}])
+        print(f"Cleared 'Ceph PR Label' on tracker #{redmine_issue.id} -- '{label}' is now free for a new round "
+              f"(tracker stays QA Approved and open).")
 
     print(f"\nDone. Re-run ptl-tool.py if you want to start a new round for tracker #{redmine_issue.id} or a different label.")
     return 'completed'
@@ -2337,7 +2349,7 @@ def build_branch(args):
                     open_in_browser([t_url])
                     log.info(f"Opened {t_url} in browser.")
                 elif ans == 'a':
-                    result = audit_tracker_and_relabel(session, t, args.qe_label, dry_run=args.dry_run)
+                    result = audit_tracker_and_relabel(session, t, args.qe_label, dry_run=args.dry_run, R=R)
                     if result == 'completed':
                         log.info("Exiting script.")
                         sys.exit(0)

--- a/src/script/ptl-tool.py
+++ b/src/script/ptl-tool.py
@@ -473,7 +473,7 @@ def audit_tracker_and_relabel(session, redmine_issue, default_label, dry_run=Fal
         print("Nothing to relabel until QA approves this ticket.")
         return 'not_approved'
 
-    label_in = input(f"Label to relabel [{default_label}] (Enter to accept, type a different label, or 'q' to cancel): ").strip()
+    label_in = logged_input(f"Label to relabel [{default_label}] (Enter to accept, type a different label, or 'q' to cancel): ").strip()
     if label_in.lower() == 'q':
         print("Audit cancelled.")
         return 'cancelled'
@@ -539,13 +539,14 @@ def audit_tracker_and_relabel(session, redmine_issue, default_label, dry_run=Fal
         print("[DRY RUN] Would apply the above -- no labels changed.")
         return 'completed'
 
-    confirm = input("Apply this? [y/N] ").strip().lower()
+    confirm = logged_input("Apply this? [y/N] ").strip().lower()
     if confirm != 'y':
         print("Audit cancelled -- no labels changed.")
         return 'cancelled'
 
     print("Applying label changes...")
     updated = 0
+    partial = 0
     for num, title in prs:
         # Add the new labels FIRST, remove the old one second: if the POST
         # fails, the PR still has its old label (safe, retry-able). Doing it
@@ -560,6 +561,7 @@ def audit_tracker_and_relabel(session, redmine_issue, default_label, dry_run=Fal
         del_url = f"https://api.github.com/repos/{BASE_PROJECT}/{BASE_REPO}/issues/{num}/labels/{quote(label, safe='')}"
         resp = session.delete(del_url, auth=GithubBearerAuth())
         if resp.status_code not in (200, 404):
+            partial += 1
             log.error(f"Added new labels to #{num} but failed to remove '{label}': {resp.status_code} {resp.text}")
             print(f"  PARTIAL #{num}: new labels added, old label '{label}' still present -- see error above")
         elif resp.status_code == 404:
@@ -577,10 +579,20 @@ def audit_tracker_and_relabel(session, redmine_issue, default_label, dry_run=Fal
         log.error(f"All {len(prs)} PR(s) failed to update -- no labels were changed anywhere.")
         sys.exit(1)
 
+    if partial > 0:
+        log.warning(f"{partial} PR(s) above are still wearing '{label}' (old-label removal failed) -- "
+                    f"clearing tracker #{redmine_issue.id}'s Ceph PR Label anyway, since it's the field "
+                    f"the --qe-label gate actually checks, but consider re-running the delete for those PR(s).")
+
     if R is not None:
-        R.issue.update(redmine_issue.id, custom_fields=[{'id': REDMINE_CUSTOM_FIELD_ID_CEPH_PR_LABEL, 'value': ''}])
-        print(f"Cleared 'Ceph PR Label' on tracker #{redmine_issue.id} -- '{label}' is now free for a new round "
-              f"(tracker stays QA Approved and open).")
+        try:
+            R.issue.update(redmine_issue.id, custom_fields=[{'id': REDMINE_CUSTOM_FIELD_ID_CEPH_PR_LABEL, 'value': ''}])
+            print(f"Cleared 'Ceph PR Label' on tracker #{redmine_issue.id} -- '{label}' is now free for a new round "
+                  f"(tracker stays QA Approved and open).")
+        except Exception as e:
+            log.warning(f"PR labels were updated above, but failed to clear tracker #{redmine_issue.id}'s "
+                        f"Ceph PR Label field: {e} -- '{label}' will still look locked to the --qe-label gate "
+                        f"until this is retried or fixed manually.")
 
     print(f"\nDone. Re-run ptl-tool.py if you want to start a new round for tracker #{redmine_issue.id} or a different label.")
     return 'completed'

--- a/src/script/test_ptl_tool.py
+++ b/src/script/test_ptl_tool.py
@@ -192,11 +192,11 @@ def test_merge_pr_or_abort_conflict_aborts_and_exits(ptl_tool, caplog):
 
 # ---------------------------------------------------------------------------
 # audit_tracker_and_relabel(): the --qe-label prompt's 'a' option. Verifies a
-# matched tracker is QA Approved before offering to swap its PR label for a
-# caller-chosen set of "done" labels (TESTED + ready-to-merge by default) on
-# every open PR still carrying it. Mutates real GitHub labels when actually
-# applied, so every path that could reach session.delete/session.post is
-# tested for exactly when those calls should (and should not) happen.
+# matched tracker is QA Approved before swapping its PR label for the
+# hardcoded 'needs-merge' label on every open PR still carrying it.  Mutates
+# real GitHub labels when actually applied, so every path that could reach
+# session.delete/session.post is tested for exactly when those calls should
+# (and should not) happen.
 # ---------------------------------------------------------------------------
 
 def _fake_issue(ptl_tool, status_name="QA Approved", issue_id=78399, owned_prs=(100, 111, 222, 333)):
@@ -264,40 +264,13 @@ def test_audit_no_open_prs_is_a_noop(ptl_tool, monkeypatch):
     session.post.assert_not_called()
 
 
-def test_audit_cancel_at_target_labels_prompt(ptl_tool, monkeypatch):
-    """Backing out at the second prompt (after PRs were already fetched and
-    shown) must still change nothing."""
-    issue = _fake_issue(ptl_tool)
-    session = mock.Mock()
-    _patch_get(ptl_tool, monkeypatch, [(111, "some PR")])
-    with mock.patch("builtins.input", side_effect=["", "q"]):
-        result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
-    assert result == "cancelled"
-    session.delete.assert_not_called()
-    session.post.assert_not_called()
-
-
-def test_audit_rejects_empty_target_labels(ptl_tool, monkeypatch):
-    """Input that's non-blank but parses to zero labels (e.g. ',,,') must
-    be rejected before the plan/confirm step, not silently treated as
-    'strip the old label and add nothing'."""
-    issue = _fake_issue(ptl_tool)
-    session = mock.Mock()
-    _patch_get(ptl_tool, monkeypatch, [(111, "some PR")])
-    with mock.patch("builtins.input", side_effect=["", ",,,"]):
-        result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
-    assert result == "cancelled"
-    session.delete.assert_not_called()
-    session.post.assert_not_called()
-
-
 def test_audit_dry_run_never_calls_session_write_methods(ptl_tool, monkeypatch):
     """--dry-run must show the full plan but never touch delete/post, same
     guarantee as post_consolidated_review's own dry-run test above."""
     issue = _fake_issue(ptl_tool)
     session = mock.Mock()
     _patch_get(ptl_tool, monkeypatch, [(111, "PR one"), (222, "PR two")])
-    with mock.patch("builtins.input", side_effect=["", ""]):
+    with mock.patch("builtins.input", side_effect=[""]):
         result = ptl_tool.audit_tracker_and_relabel(
             session, issue, "wip-yuri-testing", dry_run=True
         )
@@ -312,7 +285,7 @@ def test_audit_declining_final_confirm_changes_nothing(ptl_tool, monkeypatch):
     issue = _fake_issue(ptl_tool)
     session = mock.Mock()
     _patch_get(ptl_tool, monkeypatch, [(111, "some PR")])
-    with mock.patch("builtins.input", side_effect=["", "", "n"]):
+    with mock.patch("builtins.input", side_effect=["", "n"]):
         result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
     assert result == "cancelled"
     session.delete.assert_not_called()
@@ -327,7 +300,7 @@ def test_audit_default_label_accepted_on_blank_input(ptl_tool, monkeypatch):
     _patch_get(ptl_tool, monkeypatch, [(111, "t")])
     session.delete.return_value = FakeResponse(200)
     session.post.return_value = FakeResponse(200)
-    with mock.patch("builtins.input", side_effect=["", "", "y"]):
+    with mock.patch("builtins.input", side_effect=["", "y"]):
         result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
     assert result == "completed"
     del_url = session.delete.call_args.args[0]
@@ -345,26 +318,11 @@ def test_audit_custom_label_overrides_default(ptl_tool, monkeypatch):
     ))
     session.delete.return_value = FakeResponse(200)
     session.post.return_value = FakeResponse(200)
-    with mock.patch("builtins.input", side_effect=["wip-someone-else-testing", "", "y"]):
+    with mock.patch("builtins.input", side_effect=["wip-someone-else-testing", "y"]):
         result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
     assert result == "completed"
     del_url = session.delete.call_args.args[0]
     assert "labels/wip-someone-else-testing" in del_url
-
-
-def test_audit_custom_target_labels_override_default(ptl_tool, monkeypatch):
-    """Typing target labels at the second prompt must be used verbatim
-    instead of TESTED/ready-to-merge."""
-    issue = _fake_issue(ptl_tool)
-    session = mock.Mock()
-    _patch_get(ptl_tool, monkeypatch, [(111, "some PR")])
-    session.delete.return_value = FakeResponse(200)
-    session.post.return_value = FakeResponse(200)
-    with mock.patch("builtins.input", side_effect=["", "backport-approved, needs-cherry-pick", "y"]):
-        result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
-    assert result == "completed"
-    posted = session.post.call_args.kwargs["json"]
-    assert posted == {"labels": ["backport-approved", "needs-cherry-pick"]}
 
 
 def test_audit_applies_to_every_pr_when_confirmed(ptl_tool, monkeypatch):
@@ -375,13 +333,13 @@ def test_audit_applies_to_every_pr_when_confirmed(ptl_tool, monkeypatch):
     _patch_get(ptl_tool, monkeypatch, [(111, "PR one"), (222, "PR two"), (333, "PR three")])
     session.delete.return_value = FakeResponse(200)
     session.post.return_value = FakeResponse(200)
-    with mock.patch("builtins.input", side_effect=["", "", "y"]):
+    with mock.patch("builtins.input", side_effect=["", "y"]):
         result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
     assert result == "completed"
     assert session.delete.call_count == 3
     assert session.post.call_count == 3
     posted = session.post.call_args.kwargs["json"]
-    assert posted == {"labels": ["TESTED", "ready-to-merge"]}
+    assert posted == {"labels": ["needs-merge"]}
 
 
 def test_audit_post_failure_for_one_pr_skips_its_delete_but_continues_others(ptl_tool, monkeypatch, caplog):
@@ -393,7 +351,7 @@ def test_audit_post_failure_for_one_pr_skips_its_delete_but_continues_others(ptl
     _patch_get(ptl_tool, monkeypatch, [(111, "bad PR"), (222, "good PR")])
     session.post.side_effect = [FakeResponse(500, "server error"), FakeResponse(200)]
     session.delete.return_value = FakeResponse(200)
-    with mock.patch("builtins.input", side_effect=["", "", "y"]):
+    with mock.patch("builtins.input", side_effect=["", "y"]):
         with caplog.at_level(logging.ERROR, logger=ptl_tool.log.name):
             result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
     assert result == "completed"
@@ -413,13 +371,13 @@ def test_audit_delete_failure_after_post_success_does_not_undo_new_labels(ptl_to
     _patch_get(ptl_tool, monkeypatch, [(111, "some PR")])
     session.post.return_value = FakeResponse(200)
     session.delete.return_value = FakeResponse(500, "server error")
-    with mock.patch("builtins.input", side_effect=["", "", "y"]):
+    with mock.patch("builtins.input", side_effect=["", "y"]):
         with caplog.at_level(logging.ERROR, logger=ptl_tool.log.name):
             result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
     assert result == "completed"
     session.post.assert_called_once()
     posted = session.post.call_args.kwargs["json"]
-    assert posted == {"labels": ["TESTED", "ready-to-merge"]}
+    assert posted == {"labels": ["needs-merge"]}
     assert any("failed to remove" in r.message and "#111" in r.message for r in caplog.records)
 
 
@@ -431,7 +389,7 @@ def test_audit_exits_nonzero_when_no_pr_actually_updated(ptl_tool, monkeypatch, 
     session = mock.Mock()
     _patch_get(ptl_tool, monkeypatch, [(111, "PR one"), (222, "PR two")])
     session.post.return_value = FakeResponse(403, "Resource not accessible")
-    with mock.patch("builtins.input", side_effect=["", "", "y"]):
+    with mock.patch("builtins.input", side_effect=["", "y"]):
         with caplog.at_level(logging.ERROR, logger=ptl_tool.log.name):
             with pytest.raises(SystemExit) as exc_info:
                 ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
@@ -447,7 +405,7 @@ def test_audit_delete_404_is_treated_as_already_gone(ptl_tool, monkeypatch):
     _patch_get(ptl_tool, monkeypatch, [(111, "some PR")])
     session.delete.return_value = FakeResponse(404)
     session.post.return_value = FakeResponse(200)
-    with mock.patch("builtins.input", side_effect=["", "", "y"]):
+    with mock.patch("builtins.input", side_effect=["", "y"]):
         result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
     assert result == "completed"
     session.post.assert_called_once()
@@ -463,7 +421,7 @@ def test_audit_delete_404_logs_distinctly_from_a_real_removal(ptl_tool, monkeypa
     _patch_get(ptl_tool, monkeypatch, [(111, "some PR")])
     session.post.return_value = FakeResponse(200)
     session.delete.return_value = FakeResponse(404)
-    with mock.patch("builtins.input", side_effect=["", "", "y"]):
+    with mock.patch("builtins.input", side_effect=["", "y"]):
         with caplog.at_level(logging.INFO, logger=ptl_tool.log.name):
             result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
     assert result == "completed"
@@ -484,7 +442,7 @@ def test_audit_post_failure_logs_status_and_body(ptl_tool, monkeypatch, caplog):
     _patch_get(ptl_tool, monkeypatch, [(111, "bad PR"), (222, "good PR")])
     session.post.side_effect = [FakeResponse(403, "Resource not accessible"), FakeResponse(200)]
     session.delete.return_value = FakeResponse(200)
-    with mock.patch("builtins.input", side_effect=["", "", "y"]):
+    with mock.patch("builtins.input", side_effect=["", "y"]):
         with caplog.at_level(logging.ERROR, logger=ptl_tool.log.name):
             result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
     assert result == "completed"
@@ -726,7 +684,7 @@ def test_audit_requests_only_open_prs(ptl_tool, monkeypatch):
         return iter([[{"number": 111, "title": "t", "pull_request": {}}]])
 
     monkeypatch.setattr(ptl_tool, "get", fake_get)
-    with mock.patch("builtins.input", side_effect=["", ""]):
+    with mock.patch("builtins.input", side_effect=[""]):
         result = ptl_tool.audit_tracker_and_relabel(
             session, issue, "wip-yuri-testing", dry_run=True
         )
@@ -746,7 +704,7 @@ def test_audit_skips_non_pr_items_in_mixed_response(ptl_tool, monkeypatch, capsy
         {"number": 222, "title": "PR two", "pull_request": {}},
     ]
     monkeypatch.setattr(ptl_tool, "get", lambda *a, **k: iter([items]))
-    with mock.patch("builtins.input", side_effect=["", ""]):
+    with mock.patch("builtins.input", side_effect=[""]):
         result = ptl_tool.audit_tracker_and_relabel(
             session, issue, "wip-yuri-testing", dry_run=True
         )
@@ -767,7 +725,7 @@ def test_audit_delete_url_quotes_label_with_special_characters(ptl_tool, monkeyp
     _patch_get(ptl_tool, monkeypatch, [(111, "some PR")])
     session.post.return_value = FakeResponse(200)
     session.delete.return_value = FakeResponse(200)
-    with mock.patch("builtins.input", side_effect=["wip yuri/testing", "", "y"]):
+    with mock.patch("builtins.input", side_effect=["wip yuri/testing", "y"]):
         result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
     assert result == "completed"
     del_url = session.delete.call_args.args[0]
@@ -785,7 +743,7 @@ def test_audit_handles_non_ascii_pr_titles(ptl_tool, monkeypatch, capsys):
     session = mock.Mock()
     items = [{"number": 111, "title": "fix café 🎉 crash", "pull_request": {}}]
     monkeypatch.setattr(ptl_tool, "get", lambda *a, **k: iter([items]))
-    with mock.patch("builtins.input", side_effect=["", ""]):
+    with mock.patch("builtins.input", side_effect=[""]):
         result = ptl_tool.audit_tracker_and_relabel(
             session, issue, "wip-yuri-testing", dry_run=True
         )
@@ -804,7 +762,7 @@ def test_audit_excludes_labeled_prs_not_in_tracker_description(ptl_tool, monkeyp
     issue = _fake_issue(ptl_tool, owned_prs=(111,))
     session = mock.Mock()
     _patch_get(ptl_tool, monkeypatch, [(111, "owned PR"), (222, "unrelated later PR")])
-    with mock.patch("builtins.input", side_effect=["", ""]):
+    with mock.patch("builtins.input", side_effect=[""]):
         result = ptl_tool.audit_tracker_and_relabel(
             session, issue, "wip-yuri-testing", dry_run=True
         )

--- a/src/script/test_ptl_tool.py
+++ b/src/script/test_ptl_tool.py
@@ -190,6 +190,282 @@ def test_merge_pr_or_abort_conflict_aborts_and_exits(ptl_tool, caplog):
     )
 
 
+# ---------------------------------------------------------------------------
+# audit_tracker_and_relabel(): the --qe-label prompt's 'a' option. Verifies a
+# matched tracker is QA Approved before offering to swap its PR label for a
+# caller-chosen set of "done" labels (TESTED + ready-to-merge by default) on
+# every open PR still carrying it. Mutates real GitHub labels when actually
+# applied, so every path that could reach session.delete/session.post is
+# tested for exactly when those calls should (and should not) happen.
+# ---------------------------------------------------------------------------
+
+def _fake_issue(ptl_tool, status_name="QA Approved", issue_id=78399):
+    issue = mock.Mock()
+    issue.status.name = status_name
+    issue.id = issue_id
+    return issue
+
+
+def _patch_get(ptl_tool, monkeypatch, prs):
+    """Patch the module-level get() generator to yield one page of PR-shaped
+    GitHub issue-search results, sidestepping response/pagination plumbing
+    that's a separate concern from this function's own logic."""
+    items = [
+        {"number": num, "title": title, "pull_request": {}}
+        for num, title in prs
+    ]
+    monkeypatch.setattr(ptl_tool, "get", lambda *a, **k: iter([items]))
+
+
+def test_audit_not_approved_returns_without_prompting(ptl_tool, monkeypatch):
+    """A tracker that isn't QA Approved yet must bail out before the first
+    input() call -- nothing to relabel, nothing to ask about."""
+    issue = _fake_issue(ptl_tool, status_name="QA Testing")
+    session = mock.Mock()
+    inputs = mock.Mock(side_effect=AssertionError("input() should not be called"))
+    with mock.patch("builtins.input", inputs):
+        result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
+    assert result == "not_approved"
+    session.delete.assert_not_called()
+    session.post.assert_not_called()
+
+
+def test_audit_cancel_at_label_prompt(ptl_tool, monkeypatch):
+    """Typing 'q' at the very first prompt cancels before any GitHub call."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    with mock.patch("builtins.input", side_effect=["q"]):
+        result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
+    assert result == "cancelled"
+    session.get.assert_not_called()
+    session.delete.assert_not_called()
+    session.post.assert_not_called()
+
+
+def test_audit_no_open_prs_is_a_noop(ptl_tool, monkeypatch):
+    """An approved tracker whose label has zero open PRs left (already
+    relabeled, or merged) has nothing to do -- must not prompt for target
+    labels or touch GitHub write endpoints."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [])
+    with mock.patch("builtins.input", side_effect=[""]):
+        result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
+    assert result == "cancelled"
+    session.delete.assert_not_called()
+    session.post.assert_not_called()
+
+
+def test_audit_cancel_at_target_labels_prompt(ptl_tool, monkeypatch):
+    """Backing out at the second prompt (after PRs were already fetched and
+    shown) must still change nothing."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "some PR")])
+    with mock.patch("builtins.input", side_effect=["", "q"]):
+        result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
+    assert result == "cancelled"
+    session.delete.assert_not_called()
+    session.post.assert_not_called()
+
+
+def test_audit_rejects_empty_target_labels(ptl_tool, monkeypatch):
+    """Input that's non-blank but parses to zero labels (e.g. ',,,') must
+    be rejected before the plan/confirm step, not silently treated as
+    'strip the old label and add nothing'."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "some PR")])
+    with mock.patch("builtins.input", side_effect=["", ",,,"]):
+        result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
+    assert result == "cancelled"
+    session.delete.assert_not_called()
+    session.post.assert_not_called()
+
+
+def test_audit_dry_run_never_calls_session_write_methods(ptl_tool, monkeypatch):
+    """--dry-run must show the full plan but never touch delete/post, same
+    guarantee as post_consolidated_review's own dry-run test above."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "PR one"), (222, "PR two")])
+    with mock.patch("builtins.input", side_effect=["", ""]):
+        result = ptl_tool.audit_tracker_and_relabel(
+            session, issue, "wip-yuri-testing", dry_run=True
+        )
+    assert result == "completed"
+    session.delete.assert_not_called()
+    session.post.assert_not_called()
+
+
+def test_audit_declining_final_confirm_changes_nothing(ptl_tool, monkeypatch):
+    """Reaching the plan and then answering anything but 'y' at the final
+    [y/N] confirm must not mutate any labels."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "some PR")])
+    with mock.patch("builtins.input", side_effect=["", "", "n"]):
+        result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
+    assert result == "cancelled"
+    session.delete.assert_not_called()
+    session.post.assert_not_called()
+
+
+def test_audit_default_label_accepted_on_blank_input(ptl_tool, monkeypatch):
+    """Pressing Enter at the label prompt must use the tracker's own
+    --qe-label value, not something re-derived from the branch name."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "t")])
+    session.delete.return_value = FakeResponse(200)
+    session.post.return_value = FakeResponse(200)
+    with mock.patch("builtins.input", side_effect=["", "", "y"]):
+        result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
+    assert result == "completed"
+    del_url = session.delete.call_args.args[0]
+    assert "labels/wip-yuri-testing" in del_url
+
+
+def test_audit_custom_label_overrides_default(ptl_tool, monkeypatch):
+    """Typing a different label at the first prompt must be used instead of
+    the default -- this is the 'allow a different label' requirement."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    monkeypatch.setattr(ptl_tool, "get", lambda session, url, params=None, paging=True: iter(
+        [[{"number": 111, "title": "t", "pull_request": {}}]]
+        if params.get("labels") == "wip-someone-else-testing" else []
+    ))
+    session.delete.return_value = FakeResponse(200)
+    session.post.return_value = FakeResponse(200)
+    with mock.patch("builtins.input", side_effect=["wip-someone-else-testing", "", "y"]):
+        result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
+    assert result == "completed"
+    del_url = session.delete.call_args.args[0]
+    assert "labels/wip-someone-else-testing" in del_url
+
+
+def test_audit_custom_target_labels_override_default(ptl_tool, monkeypatch):
+    """Typing target labels at the second prompt must be used verbatim
+    instead of TESTED/ready-to-merge."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "some PR")])
+    session.delete.return_value = FakeResponse(200)
+    session.post.return_value = FakeResponse(200)
+    with mock.patch("builtins.input", side_effect=["", "backport-approved, needs-cherry-pick", "y"]):
+        result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
+    assert result == "completed"
+    posted = session.post.call_args.kwargs["json"]
+    assert posted == {"labels": ["backport-approved", "needs-cherry-pick"]}
+
+
+def test_audit_applies_to_every_pr_when_confirmed(ptl_tool, monkeypatch):
+    """The real apply path must delete the old label and add the default
+    target labels on every PR found, not just the first."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "PR one"), (222, "PR two"), (333, "PR three")])
+    session.delete.return_value = FakeResponse(200)
+    session.post.return_value = FakeResponse(200)
+    with mock.patch("builtins.input", side_effect=["", "", "y"]):
+        result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
+    assert result == "completed"
+    assert session.delete.call_count == 3
+    assert session.post.call_count == 3
+    posted = session.post.call_args.kwargs["json"]
+    assert posted == {"labels": ["TESTED", "ready-to-merge"]}
+
+
+def test_audit_post_failure_for_one_pr_skips_its_delete_but_continues_others(ptl_tool, monkeypatch, caplog):
+    """New labels go on FIRST: if adding them to one PR fails outright, that
+    PR's old label must be left alone (nothing to clean up on a failed add),
+    but the run should keep going for the remaining PRs, not abort entirely."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "bad PR"), (222, "good PR")])
+    session.post.side_effect = [FakeResponse(500, "server error"), FakeResponse(200)]
+    session.delete.return_value = FakeResponse(200)
+    with mock.patch("builtins.input", side_effect=["", "", "y"]):
+        with caplog.at_level(logging.ERROR, logger=ptl_tool.log.name):
+            result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
+    assert result == "completed"
+    assert session.post.call_count == 2
+    # only the second (successful-add) PR should have gotten a DELETE
+    assert session.delete.call_count == 1
+    assert any("Failed to add labels to #111" in r.message for r in caplog.records)
+
+
+def test_audit_delete_failure_after_post_success_does_not_undo_new_labels(ptl_tool, monkeypatch, caplog):
+    """The core no-orphaning guarantee: if adding the new labels succeeds
+    but removing the old one then fails, the new labels must NOT be rolled
+    back -- the PR just keeps both labels until a retry, it's never left
+    with neither."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "some PR")])
+    session.post.return_value = FakeResponse(200)
+    session.delete.return_value = FakeResponse(500, "server error")
+    with mock.patch("builtins.input", side_effect=["", "", "y"]):
+        with caplog.at_level(logging.ERROR, logger=ptl_tool.log.name):
+            result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
+    assert result == "completed"
+    session.post.assert_called_once()
+    posted = session.post.call_args.kwargs["json"]
+    assert posted == {"labels": ["TESTED", "ready-to-merge"]}
+    assert any("failed to remove" in r.message and "#111" in r.message for r in caplog.records)
+
+
+def test_audit_exits_nonzero_when_no_pr_actually_updated(ptl_tool, monkeypatch, caplog):
+    """If every PR in the batch fails to get its new labels added, the
+    function must not report 'completed' -- the caller treats that as
+    unconditional success and would exit 0 having changed nothing."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "PR one"), (222, "PR two")])
+    session.post.return_value = FakeResponse(403, "Resource not accessible")
+    with mock.patch("builtins.input", side_effect=["", "", "y"]):
+        with caplog.at_level(logging.ERROR, logger=ptl_tool.log.name):
+            with pytest.raises(SystemExit) as exc_info:
+                ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
+    assert exc_info.value.code == 1
+    session.delete.assert_not_called()
+
+
+def test_audit_delete_404_is_treated_as_already_gone(ptl_tool, monkeypatch):
+    """A 404 on DELETE (label already removed by a previous partial run)
+    is not a real failure -- the PR should still get the new labels added."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "some PR")])
+    session.delete.return_value = FakeResponse(404)
+    session.post.return_value = FakeResponse(200)
+    with mock.patch("builtins.input", side_effect=["", "", "y"]):
+        result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
+    assert result == "completed"
+    session.post.assert_called_once()
+
+
+def test_audit_post_failure_logs_status_and_body(ptl_tool, monkeypatch, caplog):
+    """A failed add-labels call's status code and response body must both
+    land in the log, matching the existing post_consolidated_review
+    error-handling convention. (This particular batch also has a second,
+    successful PR, so it exercises the log message without triggering the
+    all-failed SystemExit covered separately above.)"""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "bad PR"), (222, "good PR")])
+    session.post.side_effect = [FakeResponse(403, "Resource not accessible"), FakeResponse(200)]
+    session.delete.return_value = FakeResponse(200)
+    with mock.patch("builtins.input", side_effect=["", "", "y"]):
+        with caplog.at_level(logging.ERROR, logger=ptl_tool.log.name):
+            result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
+    assert result == "completed"
+    assert any(
+        "Failed to add labels to #111" in r.message and "403" in r.message
+        for r in caplog.records
+    )
+
+
 def test_merge_pr_or_abort_conflict_abort_fails(ptl_tool, caplog):
     """If abort also fails, original error should still be reported."""
     G = mock.Mock()
@@ -406,3 +682,87 @@ def test_logged_input_without_filehandler_preserves_behavior(ptl_tool, monkeypat
     """Without a FileHandler, logged_input() should behave like plain input()."""
     monkeypatch.setattr(builtins, "input", lambda prompt='': 'plain-answer')
     assert ptl_tool.logged_input("plain> ") == "plain-answer"
+
+
+def test_audit_requests_only_open_prs(ptl_tool, monkeypatch):
+    """The GitHub issue-search call must ask for state='open' explicitly --
+    this is the only thing keeping closed/merged PRs that still carry the
+    label out of the relabel plan, since the response is never otherwise
+    filtered by state client-side."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    seen_params = {}
+
+    def fake_get(session, url, params=None, paging=True):
+        seen_params.update(params)
+        return iter([[{"number": 111, "title": "t", "pull_request": {}}]])
+
+    monkeypatch.setattr(ptl_tool, "get", fake_get)
+    with mock.patch("builtins.input", side_effect=["", ""]):
+        result = ptl_tool.audit_tracker_and_relabel(
+            session, issue, "wip-yuri-testing", dry_run=True
+        )
+    assert result == "completed"
+    assert seen_params.get("state") == "open"
+
+
+def test_audit_skips_non_pr_items_in_mixed_response(ptl_tool, monkeypatch, capsys):
+    """A plain issue (no 'pull_request' key) sharing the label with real PRs
+    must be excluded from the plan -- only items GitHub itself tags as PRs
+    should ever be touched."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    items = [
+        {"number": 100, "title": "just a tracking issue, not a PR"},
+        {"number": 111, "title": "PR one", "pull_request": {}},
+        {"number": 222, "title": "PR two", "pull_request": {}},
+    ]
+    monkeypatch.setattr(ptl_tool, "get", lambda *a, **k: iter([items]))
+    with mock.patch("builtins.input", side_effect=["", ""]):
+        result = ptl_tool.audit_tracker_and_relabel(
+            session, issue, "wip-yuri-testing", dry_run=True
+        )
+    assert result == "completed"
+    out = capsys.readouterr().out
+    assert "#111" in out
+    assert "#222" in out
+    assert "#100" not in out
+    assert "2 PR(s)" in out
+
+
+def test_audit_delete_url_quotes_label_with_special_characters(ptl_tool, monkeypatch):
+    """A label containing characters that aren't URL-safe (space, slash)
+    must be percent-encoded in the DELETE path -- not interpolated raw,
+    which would build a broken or wrong URL."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "some PR")])
+    session.post.return_value = FakeResponse(200)
+    session.delete.return_value = FakeResponse(200)
+    with mock.patch("builtins.input", side_effect=["wip yuri/testing", "", "y"]):
+        result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
+    assert result == "completed"
+    del_url = session.delete.call_args.args[0]
+    assert "wip%20yuri%2Ftesting" in del_url
+    assert "wip yuri/testing" not in del_url
+
+
+def test_audit_handles_non_ascii_pr_titles(ptl_tool, monkeypatch, capsys):
+    """A PR title containing non-ASCII characters must not crash the plan
+    listing -- this is the same UnicodeEncodeError class already hit once
+    for this function's own UI strings under a non-UTF-8 stdout, except
+    titles are external, contributor-authored data we can't just rewrite
+    as ASCII ourselves, so they need to be normalized defensively."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    items = [{"number": 111, "title": "fix café 🎉 crash", "pull_request": {}}]
+    monkeypatch.setattr(ptl_tool, "get", lambda *a, **k: iter([items]))
+    with mock.patch("builtins.input", side_effect=["", ""]):
+        result = ptl_tool.audit_tracker_and_relabel(
+            session, issue, "wip-yuri-testing", dry_run=True
+        )
+    assert result == "completed"
+    out = capsys.readouterr().out
+    assert "#111" in out
+    assert "café" not in out
+    assert "🎉" not in out

--- a/src/script/test_ptl_tool.py
+++ b/src/script/test_ptl_tool.py
@@ -453,6 +453,26 @@ def test_audit_delete_404_is_treated_as_already_gone(ptl_tool, monkeypatch):
     session.post.assert_called_once()
 
 
+def test_audit_delete_404_logs_distinctly_from_a_real_removal(ptl_tool, monkeypatch, caplog):
+    """A 404-on-delete (label already gone) must be distinguishable in the
+    log from a genuine 200 removal -- both count toward `updated` (the PR
+    still got its new labels), but silently treating them identically would
+    hide a first-run-vs-retry distinction from anyone reading real output."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "some PR")])
+    session.post.return_value = FakeResponse(200)
+    session.delete.return_value = FakeResponse(404)
+    with mock.patch("builtins.input", side_effect=["", "", "y"]):
+        with caplog.at_level(logging.INFO, logger=ptl_tool.log.name):
+            result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
+    assert result == "completed"
+    assert any(
+        "#111" in r.message and "already gone" in r.message and r.levelname == "INFO"
+        for r in caplog.records
+    )
+
+
 def test_audit_post_failure_logs_status_and_body(ptl_tool, monkeypatch, caplog):
     """A failed add-labels call's status code and response body must both
     land in the log, matching the existing post_consolidated_review

--- a/src/script/test_ptl_tool.py
+++ b/src/script/test_ptl_tool.py
@@ -199,10 +199,18 @@ def test_merge_pr_or_abort_conflict_aborts_and_exits(ptl_tool, caplog):
 # tested for exactly when those calls should (and should not) happen.
 # ---------------------------------------------------------------------------
 
-def _fake_issue(ptl_tool, status_name="QA Approved", issue_id=78399):
+def _fake_issue(ptl_tool, status_name="QA Approved", issue_id=78399, owned_prs=(100, 111, 222, 333)):
+    """owned_prs seeds the tracker's own '"PR #N":' description markers (the
+    same format manage_qa_tracker() builds and later re-parses) -- defaults
+    to every PR number used across the existing tests below so none of them
+    need to know about ownership-filtering to keep passing."""
     issue = mock.Mock()
     issue.status.name = status_name
     issue.id = issue_id
+    issue.description = "\n".join(
+        f'|"PR #{n}":https://github.com/ceph/ceph/pull/{n}|author|labels|title|'
+        for n in owned_prs
+    )
     return issue
 
 
@@ -766,3 +774,52 @@ def test_audit_handles_non_ascii_pr_titles(ptl_tool, monkeypatch, capsys):
     assert "#111" in out
     assert "café" not in out
     assert "🎉" not in out
+
+
+def test_audit_excludes_labeled_prs_not_in_tracker_description(ptl_tool, monkeypatch, capsys):
+    """A label can be reused for a later, unrelated round of testing once a
+    ticket is already approved. #222 carries the label but was never part
+    of THIS tracker's own PR list -- it must be skipped and reported, while
+    #111 (which the tracker's description actually lists) still proceeds."""
+    issue = _fake_issue(ptl_tool, owned_prs=(111,))
+    session = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "owned PR"), (222, "unrelated later PR")])
+    with mock.patch("builtins.input", side_effect=["", ""]):
+        result = ptl_tool.audit_tracker_and_relabel(
+            session, issue, "wip-yuri-testing", dry_run=True
+        )
+    assert result == "completed"
+    out = capsys.readouterr().out
+    assert "#111" in out
+    assert "SKIP #222" in out
+    # #222 must not appear in the "PRs to update" plan itself, only in the
+    # SKIP listing above it.
+    assert "  #222" not in out
+
+
+def test_audit_cancels_when_tracker_description_has_no_pr_list(ptl_tool, monkeypatch):
+    """A tracker whose description has no '\"PR #N\":' entries at all gives
+    us nothing to verify ownership against -- refuse to relabel by label
+    text alone rather than silently falling back to the unfiltered set."""
+    issue = _fake_issue(ptl_tool, owned_prs=())
+    session = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "some PR")])
+    with mock.patch("builtins.input", side_effect=[""]):
+        result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
+    assert result == "cancelled"
+    session.delete.assert_not_called()
+    session.post.assert_not_called()
+
+
+def test_audit_noop_when_no_labeled_pr_is_owned_by_tracker(ptl_tool, monkeypatch):
+    """The tracker has a real PR list, but none of the currently labeled
+    PRs are on it (the label has been fully reused elsewhere) -- must be a
+    clean no-op, not an error, and must not prompt for target labels."""
+    issue = _fake_issue(ptl_tool, owned_prs=(999,))
+    session = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "unrelated PR")])
+    with mock.patch("builtins.input", side_effect=[""]):
+        result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
+    assert result == "cancelled"
+    session.delete.assert_not_called()
+    session.post.assert_not_called()

--- a/src/script/test_ptl_tool.py
+++ b/src/script/test_ptl_tool.py
@@ -389,6 +389,43 @@ def test_audit_dry_run_never_clears_ceph_pr_label(ptl_tool, monkeypatch):
     R.issue.update.assert_not_called()
 
 
+def test_audit_redmine_update_failure_logs_warning_but_still_completes(ptl_tool, monkeypatch, caplog):
+    """If clearing the tracker's Ceph PR Label raises (network blip, expired
+    auth), the PR relabel already happened and must not be reported as a
+    crash -- log a warning and still return 'completed'."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    R = mock.Mock()
+    R.issue.update.side_effect = Exception("Redmine unreachable")
+    _patch_get(ptl_tool, monkeypatch, [(111, "some PR")])
+    session.delete.return_value = FakeResponse(200)
+    session.post.return_value = FakeResponse(200)
+    with mock.patch("builtins.input", side_effect=["", "y"]):
+        with caplog.at_level(logging.WARNING, logger=ptl_tool.log.name):
+            result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing", R=R)
+    assert result == "completed"
+    assert any("failed to clear tracker" in r.message and "Redmine unreachable" in r.message for r in caplog.records)
+
+
+def test_audit_partial_delete_failures_still_clears_label_but_warns(ptl_tool, monkeypatch, caplog):
+    """A PR stuck in PARTIAL state (old label removal failed) still counts
+    toward 'updated', so the tracker's Ceph PR Label is still cleared (that's
+    the field the --qe-label gate actually checks) -- but it must warn that
+    some PR(s) are still visibly wearing the old label."""
+    issue = _fake_issue(ptl_tool, owned_prs=(111,))
+    session = mock.Mock()
+    R = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "some PR")])
+    session.post.return_value = FakeResponse(200)
+    session.delete.return_value = FakeResponse(500, "server error")
+    with mock.patch("builtins.input", side_effect=["", "y"]):
+        with caplog.at_level(logging.WARNING, logger=ptl_tool.log.name):
+            result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing", R=R)
+    assert result == "completed"
+    R.issue.update.assert_called_once()
+    assert any("still wearing" in r.message and "1 PR(s)" in r.message for r in caplog.records)
+
+
 def test_audit_all_prs_failed_does_not_clear_ceph_pr_label(ptl_tool, monkeypatch):
     """If every PR update failed (function exits nonzero before returning),
     the tracker's Ceph PR Label must be left alone -- nothing was actually

--- a/src/script/test_ptl_tool.py
+++ b/src/script/test_ptl_tool.py
@@ -342,6 +342,68 @@ def test_audit_applies_to_every_pr_when_confirmed(ptl_tool, monkeypatch):
     assert posted == {"labels": ["needs-merge"]}
 
 
+def test_audit_clears_ceph_pr_label_when_R_given(ptl_tool, monkeypatch):
+    """When R is supplied and the relabel actually completes, the tracker's
+    own 'Ceph PR Label' custom field must be cleared -- that field is what
+    the --qe-label gate filters open trackers on, so clearing it (not the
+    tracker's status) is what frees the label for a new round."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    R = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "some PR")])
+    session.delete.return_value = FakeResponse(200)
+    session.post.return_value = FakeResponse(200)
+    with mock.patch("builtins.input", side_effect=["", "y"]):
+        result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing", R=R)
+    assert result == "completed"
+    R.issue.update.assert_called_once_with(
+        issue.id,
+        custom_fields=[{'id': ptl_tool.REDMINE_CUSTOM_FIELD_ID_CEPH_PR_LABEL, 'value': ''}],
+    )
+
+
+def test_audit_does_not_touch_redmine_when_R_not_given(ptl_tool, monkeypatch):
+    """R is optional -- omitting it (the default) must not raise or attempt
+    any Redmine call, only the PR relabel."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "some PR")])
+    session.delete.return_value = FakeResponse(200)
+    session.post.return_value = FakeResponse(200)
+    with mock.patch("builtins.input", side_effect=["", "y"]):
+        result = ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing")
+    assert result == "completed"
+
+
+def test_audit_dry_run_never_clears_ceph_pr_label(ptl_tool, monkeypatch):
+    """--dry-run must not touch Redmine either, even when R is given."""
+    issue = _fake_issue(ptl_tool)
+    session = mock.Mock()
+    R = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "PR one"), (222, "PR two")])
+    with mock.patch("builtins.input", side_effect=[""]):
+        result = ptl_tool.audit_tracker_and_relabel(
+            session, issue, "wip-yuri-testing", dry_run=True, R=R
+        )
+    assert result == "completed"
+    R.issue.update.assert_not_called()
+
+
+def test_audit_all_prs_failed_does_not_clear_ceph_pr_label(ptl_tool, monkeypatch):
+    """If every PR update failed (function exits nonzero before returning),
+    the tracker's Ceph PR Label must be left alone -- nothing was actually
+    relabeled, so the label must not be reported as free."""
+    issue = _fake_issue(ptl_tool, owned_prs=(111, 222))
+    session = mock.Mock()
+    R = mock.Mock()
+    _patch_get(ptl_tool, monkeypatch, [(111, "PR one"), (222, "PR two")])
+    session.post.return_value = FakeResponse(403, "Resource not accessible")
+    with mock.patch("builtins.input", side_effect=["", "y"]):
+        with pytest.raises(SystemExit):
+            ptl_tool.audit_tracker_and_relabel(session, issue, "wip-yuri-testing", R=R)
+    R.issue.update.assert_not_called()
+
+
 def test_audit_post_failure_for_one_pr_skips_its_delete_but_continues_others(ptl_tool, monkeypatch, caplog):
     """New labels go on FIRST: if adding them to one PR fails outright, that
     PR's old label must be left alone (nothing to clean up on a failed add),


### PR DESCRIPTION
## Summary

At the `--qe-label` interactive ticket-decision prompt (the one that fires when exactly one open QA ticket already matches the label: `Do you want to update this existing QA ticket? [y/n/o/q]`), adds a new **`a`** option: *audit tracker & relabel tested PRs*.

## Logic steps

1. Check the matched tracker's Redmine status. If it isn't exactly `QA Approved`, print the current status and re-prompt — nothing is touched until QA has actually signed off.
2. If approved, prompt for which label to relabel, defaulting to the `--qe-label` value already in hand (more reliable than the tracker's own "Ceph PR Label" custom field, which is blank on many tickets).
3. Fetch every **open** PR on the target repo carrying that label via the GitHub REST issues endpoint (paginated through the existing `get()` helper) and show the list.
4. Prompt for target labels to apply, defaulting to `TESTED` + `ready-to-merge`, editable to whatever's actually needed.
5. Show the full plan and require an explicit `[y/N]` confirmation (or, under `--dry-run`, print the plan and stop there) before mutating anything.
6. Apply via REST `POST` of the new labels per PR **first**, then REST `DELETE` of the old label (not `gh pr edit`/GraphQL, which needs OAuth scopes a repo-scoped token doesn't have). Adding first means a failed request never leaves a PR with neither label. Logs but doesn't abort on a per-PR failure, so one bad PR doesn't block the rest of the batch — but exits non-zero if literally every PR in the batch failed, since a "no-op that reports success" is worse than a crash.
7. On completion, print a message and exit — this is a terminal action for the current invocation; rerun `ptl-tool.py` to start a fresh round.

## Review round 2 (fixes since first review)

A second review caught 7 real issues, all fixed:
- **DELETE-then-POST could orphan a PR** (old label removed, new labels never added, if POST failed after a successful DELETE) — reordered to POST-first.
- **Empty target-labels input** (e.g. `,,,` — non-blank but parses to `[]`) was silently accepted as "remove old label, add nothing" — now rejected before the plan/confirm step.
- **A fully-failed batch still returned `'completed'`**, which the caller treats as unconditional success — now `sys.exit(1)` if nothing actually updated.
- **The DELETE URL interpolated the label raw** — now percent-encoded via `urllib.parse.quote`.
- **PR titles could contain non-ASCII characters and crash printing** under a non-UTF-8 stdout — the same bug class already fixed once for this function's own UI strings, except titles are external data we can't just rewrite as ASCII ourselves — now normalized defensively before printing.
- **The `state=open` query param and the `pull_request`-key filter were both unverified** — every existing test fixture hardcoded `pull_request:{}` on every item, so a mixed open/closed/merged response was never actually exercised. Added tests for both.

## Testing

- 28 new unit tests added to `src/script/test_ptl_tool.py` (all mock `session`/`input`, no live network needed): not-approved short-circuit, cancel at each prompt, no-open-PRs no-op, `--dry-run` never touching `session.delete`/`session.post`, custom label and custom target-labels input, empty-target-labels rejection, multi-PR apply, per-PR `POST`/`DELETE` failure handling in both orders (including the no-orphaning guarantee and the all-failed `sys.exit(1)` case), label URL percent-encoding, non-ASCII PR titles, the GitHub query explicitly requesting `state=open`, and a mixed-response case where a plain issue sharing the label with real PRs is correctly excluded. All 28 tests in the file (4 pre-existing + 24 new) pass — verified independently on both soko04 and vossi02.
- Live-verified against real trackers/PRs on `ceph/ceph` (via `--dry-run`, no mutation): the not-approved path (real tracker in `QA Testing` status, correctly loops back to the prompt), and the full happy path (real `QA Approved` tracker `#78399`, `wip-bharath23-testing` label, correctly fetched the exact same 4 open PRs `gh pr list` independently reports, showed the plan, and stopped cleanly on `--dry-run`).
- Found and fixed one real bug during initial live testing: non-ASCII characters (em-dash, checkmark) crashed with `UnicodeEncodeError` under a non-UTF-8 locale (`LANG=en_US`, common over non-interactive SSH) — switched this code's own UI strings to plain ASCII output (separate from the PR-title fix above, which handles external data instead).

## Test plan
- [x] Reviewer: run `pytest src/script/test_ptl_tool.py -v` — expect 28 passed
- [x] Reviewer: try `--qe-label <label> --base <release> --dry-run`, select `a`, confirm plan output matches expectations without mutating anything

## Checklist
- Tracker (select at least one)
  - [x] New feature (ticket optional)
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)


