### PR TITLE
rados: simple autoscaler with effective ratio

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -7,6 +7,27 @@
 * RADOS: PG autoscaler allows overlapping roots. Each root receives a PG target based
   on its OSDs, with OSDs shared across multiple roots contributing proportionally
   less to each root's allocation.
+
+* RADOS: New "simple" autoscaling provisions pools by an absolute share of
+  the PG-per-OSD budget. The new ``simpleautoscale`` cluster flag is the
+  master switch: while it is set the autoscaler plans each pool's pg_num =
+  ``effective_ratio`` x OSDs x ``mon_target_pg_per_osd`` / size, learning
+  a ratio (fill-only, from current pg_num) for pools that lack one, and a
+  create that declares ``--effective-ratio`` is born at its planned
+  pg_num. ``pg_autoscale_mode`` keeps its classic values and meanings:
+  divergent plans are stamped as ``planned_pg_num`` and reported by the
+  derived ``pg_autoscale_plan`` state (``learn``/``pending``/``current``)
+  and ``POOL_AUTOSCALE_PENDING``; mode ``on`` pools apply their plans via
+  the new atomic ``ceph osd pool autoscale-accept <pool>`` command
+  automatically (except merges beyond
+  ``mon_osd_pool_pg_merge_confirm_bytes``, which are held for
+  ``autoscale-accept --yes-i-really-mean-it``), while mode ``warn`` pools
+  always wait for the operator. Legacy knobs (``target_size_ratio``,
+  ``target_size_bytes``, ``pg_autoscale_bias``, ``bulk``) are rejected
+  while the flag is set; unsetting the flag reverts to legacy autoscaling
+  (ratios remain stored but inert). Additional new health warnings:
+  ``POOL_EFFECTIVE_RATIO_OVERCOMMITTED``, ``POOL_PLAN_CLAMPED_BY_PG_NUM_MAX``
+  and ``POOL_PG_SIZE_DRIFT``.
   
 * CephFS: CephFS snapshots metadata is now mutable. It is now possible to add,
   update and remove existing key-value pairs that are part of a snapshot

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -1450,7 +1450,54 @@ To reset ``target_size_bytes`` to zero, run a command of the following form:
 
    ceph osd pool set <pool-name> target_size_bytes 0
 
-For more information, see :ref:`specifying_pool_target_size`.
+POOL_EFFECTIVE_RATIO_OVERCOMMITTED
+__________________________________
+
+The ``effective_ratio`` values of the pools that share an autoscaler
+budget domain (a CRUSH root or device-class shadow root) sum to more than
+1.0. The pg_autoscaler cannot plan every pool at its full share; lower one
+or more ratios, or raise ``mon_target_pg_per_osd`` if the OSDs have the
+resources to carry more placement groups.
+
+POOL_AUTOSCALE_PENDING
+______________________
+
+One or more pools have an autoscaler plan awaiting acceptance: the plan
+(visible as ``planned_pg_num`` and in the NEW PG_NUM column of ``ceph osd
+pool autoscale-status``) diverged from the pool's current ``pg_num``,
+typically because OSDs were added or removed, ``mon_target_pg_per_osd``
+changed, or the pool's ``effective_ratio`` was edited. A mode ``warn``
+pool always waits for the operator; a mode ``on`` pool appears here only
+when its plan is a large merge held for manual confirmation (see
+``mon_osd_pool_pg_merge_confirm_bytes``). Nothing will move until each
+listed pool's plan is accepted:
+
+.. prompt:: bash #
+
+   ceph osd pool autoscale-accept <pool-name>
+
+For more information, see :ref:`simple_autoscaling`.
+
+POOL_PLAN_CLAMPED_BY_PG_NUM_MAX
+_______________________________
+
+One or more pools have an ``effective_ratio`` whose plan implies a
+``pg_num`` larger than the pool's ``pg_num_max``. ``pg_num_max`` wins, so
+the pool runs with fewer PGs than its ratio promises. Raise or unset
+``pg_num_max``, or lower the ratio.
+
+POOL_PG_SIZE_DRIFT
+__________________
+
+A simple-mode pool stores substantially more data per PG than the cluster
+median (by default more than 4x, tunable via
+``mgr/pg_autoscaler/pg_size_drift_warn_multiple``). Planned pools do not
+gain PGs as they fill, so oversized PGs degrade scrub, backfill, and
+balancer granularity until the ratio is raised. Raise the pool's
+``effective_ratio`` (lowering another pool's ratio first if the budget is
+fully committed).
+
+For more information, see :ref:`simple_autoscaling`.
 
 TOO_FEW_OSDS
 ____________

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -1452,6 +1452,55 @@ To reset ``target_size_bytes`` to zero, run a command of the following form:
 
 For more information, see :ref:`specifying_pool_target_size`.
 
+POOL_EFFECTIVE_RATIO_OVERCOMMITTED
+__________________________________
+
+The ``effective_ratio`` values of the pools that share an autoscaler
+budget domain (a CRUSH root or device-class shadow root) sum to more than
+1.0. The pg_autoscaler cannot plan every pool at its full share; lower one
+or more ratios, or raise ``mon_target_pg_per_osd`` if the OSDs have the
+resources to carry more placement groups.
+
+POOL_AUTOSCALE_PENDING
+______________________
+
+One or more pools have an autoscaler plan awaiting acceptance: the plan
+(visible as ``planned_pg_num`` and in the NEW PG_NUM column of ``ceph osd
+pool autoscale-status``) diverged from the pool's current ``pg_num``,
+typically because OSDs were added or removed, ``mon_target_pg_per_osd``
+changed, or the pool's ``effective_ratio`` was edited. A mode ``warn``
+pool always waits for the operator; a mode ``on`` pool appears here only
+when its plan is a large merge held for manual confirmation (see
+``mon_osd_pool_pg_merge_confirm_bytes``). Nothing will move until each
+listed pool's plan is accepted:
+
+.. prompt:: bash #
+
+   ceph osd pool autoscale-accept <pool-name>
+
+For more information, see :ref:`simple_autoscaling`.
+
+POOL_PLAN_CLAMPED_BY_PG_NUM_MAX
+_______________________________
+
+One or more pools have an ``effective_ratio`` whose plan implies a
+``pg_num`` larger than the pool's ``pg_num_max``. ``pg_num_max`` wins, so
+the pool runs with fewer PGs than its ratio promises. Raise or unset
+``pg_num_max``, or lower the ratio.
+
+POOL_PG_SIZE_DRIFT
+__________________
+
+A simple-mode pool stores substantially more data per PG than the cluster
+median (by default more than 4x, tunable via
+``mgr/pg_autoscaler/pg_size_drift_warn_multiple``). Planned pools do not
+gain PGs as they fill, so oversized PGs degrade scrub, backfill, and
+balancer granularity until the ratio is raised. Raise the pool's
+``effective_ratio`` (lowering another pool's ratio first if the budget is
+fully committed).
+
+For more information, see :ref:`simple_autoscaling`.
+
 TOO_FEW_OSDS
 ____________
 

--- a/doc/rados/operations/placement-groups.rst
+++ b/doc/rados/operations/placement-groups.rst
@@ -142,8 +142,12 @@ The output will resemble the following::
      that collectively they target cluster capacity. For example, four pools
      with target_ratio 1.0 would each have an effective ratio of 0.25.
 
-  The system's calculations use whichever of these two ratios (that is, the 
+  The system's calculations use whichever of these two ratios (that is, the
   target ratio and the effective ratio) is greater.
+
+  Pools with an ``effective_ratio`` (see :ref:`simple_autoscaling`)
+  display their declared ratio here verbatim; neither of the two
+  adjustments above applies to them.
 
 - **BIAS** is used as a multiplier to manually adjust a pool's PG in accordance
   with prior information about how many PGs a specific pool is expected to
@@ -406,6 +410,140 @@ will be raised.
 Note that in most cases it is advised to not set both a bias value other than 1.0
 and a target ratio on the same pool.  Use a higher bias value for metadata /
 omap-rich pools and a target ratio for RADOS data-heavy pools.
+
+.. _simple_autoscaling:
+
+Simple autoscaling: ratio-driven plans
+--------------------------------------
+
+Operators who provision placement groups as a per-OSD budget ("every OSD
+should carry roughly 200 PG replicas") can hand each pool an absolute share
+of that budget with ``effective_ratio``. The ``simpleautoscale`` cluster
+flag is the master switch: while it is set, the autoscaler plans every
+pool's ``pg_num`` from its ratio; while it is unset, ratios are stored but
+inert and autoscaling behaves exactly as described above.
+
+.. prompt:: bash #
+
+   ceph osd pool set simpleautoscale
+   ceph config set global mon_target_pg_per_osd 250
+   ceph osd pool create foo erasure ec22 --effective-ratio 0.5
+   ceph osd pool create bar --effective-ratio 0.4
+   ceph osd pool create baz --effective-ratio 0.1
+
+A pool created this way is *born at its planned size*: the monitor computes
+``pg_num`` = ratio x budget / size (where the budget is OSD count x
+``mon_target_pg_per_osd`` in PG replicas, and size is the replica count or
+``k+m`` for erasure-coded pools), rounds to a power of two, and creates the
+pool with it. One set of ratios works irrespective of replication factor or
+erasure-code profile, and ``ceph osd pool get <pool> effective_ratio``
+always returns exactly the ratio that was declared. Add ``--dry-run`` to
+preview the plan without creating anything.
+
+Mode and plan are orthogonal: the ratio decides what the *plan* is, while
+``pg_autoscale_mode`` keeps its classic values and its classic meaning —
+whether the autoscaler may *act*. Each pool's plan state is derived, never
+stored, and is reported by ``ceph osd pool get <pool> pg_autoscale_plan``
+and the PLAN column of ``autoscale-status``:
+
+* ``learn`` — the pool has no ``effective_ratio`` yet (see
+  :ref:`transitioning <simple_autoscale_transition>` below).
+* ``pending`` — the plan differs from the pool's current ``pg_num``. The
+  planned value is stamped on the pool (visible as ``planned_pg_num`` and
+  in the NEW PG_NUM column) and the ``POOL_AUTOSCALE_PENDING`` health
+  notice lists it.
+* ``current`` — plan and ``pg_num`` agree; there is nothing to do.
+
+When the world changes — OSDs added or removed, ``mon_target_pg_per_osd``
+changed, a pool's ``effective_ratio`` edited — plans diverge and are
+stamped. What happens next is decided by each pool's mode:
+
+* Mode ``warn``: **nothing moves** until the operator reviews ``ceph osd
+  pool autoscale-status`` and accepts:
+
+  .. prompt:: bash #
+
+     ceph osd pool autoscale-accept <pool>
+
+  Acceptance applies exactly the stamped plan the operator reviewed —
+  never a newer one — and clears the stamp. Several pools may be named
+  at once, or ``--all`` to accept every pending plan: the whole set is
+  validated up front and applied in a single osdmap transaction, so a
+  reviewed plan-set commits as one atomic change. Accepting a plan that
+  reduces ``pg_num`` by more than half on a pool storing more than
+  ``mon_osd_pool_pg_merge_confirm_bytes`` (default 1 TiB) requires
+  ``--yes-i-really-mean-it``.
+
+* Mode ``on``: the autoscaler invokes the same acceptance automatically,
+  with one exception: a plan that would require the confirmation above — a
+  large merge, for example after OSDs are lost — is *held* in ``pending``
+  for manual, confirmed acceptance. Growth is hands-off; destructive
+  shrinks get a human sign-off.
+
+* Mode ``off``: the planner ignores the pool entirely.
+
+While the flag is set, the legacy autoscaler knobs —
+``target_size_ratio``, ``target_size_bytes``, ``pg_autoscale_bias`` and
+``bulk`` — are rejected cluster-wide (values already set are simply
+inert), and ``autoscale-status`` switches to a concise table (POOL,
+EFFECTIVE RATIO, PG_NUM, NEW PG_NUM, AUTOSCALE, PLAN; the JSON output
+remains complete).
+
+Actual usage never overrides a plan: a pool that outgrows its share stores
+more data per PG instead, reported by the ``POOL_PG_SIZE_DRIFT`` health
+warning when its bytes-per-PG exceeds a multiple (default 4x, tunable via
+``mgr/pg_autoscaler/pg_size_drift_warn_multiple``) of the cluster median.
+Ratios summing past 1.0 on one budget domain raise
+``POOL_EFFECTIVE_RATIO_OVERCOMMITTED``, and a plan capped by the pool's
+``pg_num_max`` raises ``POOL_PLAN_CLAMPED_BY_PG_NUM_MAX``. Note that
+``mon_target_pg_per_osd`` should be set globally so that the monitor
+(which computes birth sizes, dry runs, and acceptance) and the manager
+(which plans) agree on the budget.
+
+Budget domains
+~~~~~~~~~~~~~~
+
+A ratio is scoped to the pool's autoscaler budget domain: the CRUSH
+subtree that the pool's rule resolves to. For rules that select a device
+class this is the class's shadow root (for example ``default~ssd``), so
+pools on different device classes draw from separate budgets even under
+one nominal root. When an OSD serves more than one budget domain — for
+example, when a class-less rule (used by pools such as ``.mgr``) keeps the
+nominal root in play alongside device-class shadow roots — its per-OSD
+budget is split evenly between those domains and plans are prorated by the
+same split. Unreserved pools receive whatever budget the ratios leave
+behind (pools with ``target_size_ratio`` normalize into that remainder),
+and the autoscaler's per-pool minimum (32 PGs, or ``pg_num_min``) bounds
+any plan from below.
+
+.. _simple_autoscale_transition:
+
+Transitioning an existing cluster
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The recommended runbook makes the transition a reviewed,
+no-op-by-construction process:
+
+.. prompt:: bash #
+
+   ceph osd pool ls | while read p; do ceph osd pool set $p pg_autoscale_mode warn; done
+   ceph osd pool set simpleautoscale
+
+Setting every pool to ``warn`` first guarantees nothing acts during the
+transition; a pool deliberately left in ``on`` keeps its autonomy, because
+that is what ``on`` means. Once the flag is set, a pool without a ratio
+has no plan — so no mode can move it — and shows plan ``learn`` while its
+``effective_ratio`` is *learned* from its current ``pg_num`` (fill-only:
+a declared ratio is never overwritten). Ratios may also be pre-staged with
+``ceph osd pool set <pool> effective_ratio`` before the flag is flipped.
+A learned ratio reproduces the pool's current ``pg_num``, so its plan
+lands ``current``: nothing is pending and nothing moves. From then on,
+divergences surface as ``pending`` plans to accept at leisure — or flip a
+pool to ``on`` once you trust its ratio to run hands-off.
+
+``ceph osd pool unset simpleautoscale`` rolls back completely: the
+machinery never touches ``pg_autoscale_mode``, ratios remain stored but
+inert, and every pool resumes legacy autoscaling.
 
 
 Specifying bounds on a pool's PGs

--- a/doc/rados/operations/placement-groups.rst
+++ b/doc/rados/operations/placement-groups.rst
@@ -142,8 +142,12 @@ The output will resemble the following::
      that collectively they target cluster capacity. For example, four pools
      with target_ratio 1.0 would each have an effective ratio of 0.25.
 
-  The system's calculations use whichever of these two ratios (that is, the 
+  The system's calculations use whichever of these two ratios (that is, the
   target ratio and the effective ratio) is greater.
+
+  Pools with an ``effective_ratio`` (see :ref:`simple_autoscaling`)
+  display their declared ratio here verbatim; neither of the two
+  adjustments above applies to them.
 
 - **BIAS** is used as a multiplier to manually adjust a pool's PG in accordance
   with prior information about how many PGs a specific pool is expected to
@@ -406,6 +410,171 @@ will be raised.
 Note that in most cases it is advised to not set both a bias value other than 1.0
 and a target ratio on the same pool.  Use a higher bias value for metadata /
 omap-rich pools and a target ratio for RADOS data-heavy pools.
+
+.. _simple_autoscaling:
+
+Simple autoscaling: ratio-driven plans
+--------------------------------------
+
+Operators who provision placement groups as a per-OSD budget ("every OSD
+should carry roughly 200 PG replicas") can hand each pool an absolute share
+of that budget with ``effective_ratio``. The ``simpleautoscale`` cluster
+flag is the master switch: while it is set, the autoscaler plans every
+pool's ``pg_num`` from its ratio; while it is unset, ratios are stored but
+inert and autoscaling behaves exactly as described above.
+
+.. prompt:: bash #
+
+   ceph osd pool set simpleautoscale
+   ceph config set global mon_target_pg_per_osd 250
+   ceph osd pool create foo erasure ec22 --effective-ratio 0.5
+   ceph osd pool create bar --effective-ratio 0.4
+   ceph osd pool create baz --effective-ratio 0.1
+
+A pool created this way is *born at its planned size*: the monitor computes
+``pg_num`` = ratio x budget / size (where the budget is OSD count x
+``mon_target_pg_per_osd`` in PG replicas, and size is the replica count or
+``k+m`` for erasure-coded pools), rounds to a power of two, and creates the
+pool with it. One set of ratios works irrespective of replication factor or
+erasure-code profile, and ``ceph osd pool get <pool> effective_ratio``
+always returns exactly the ratio that was declared. Add ``--dry-run`` to
+preview the plan without creating anything.
+
+Mode and plan are orthogonal: the ratio decides what the *plan* is, while
+``pg_autoscale_mode`` keeps its classic values and its classic meaning —
+whether the autoscaler may *act*. Each pool's plan state is derived, never
+stored, and is reported by ``ceph osd pool get <pool> pg_autoscale_plan``
+and the PLAN column of ``autoscale-status``:
+
+* ``learn`` — the pool has no ``effective_ratio`` yet (see
+  :ref:`transitioning <simple_autoscale_transition>` below).
+* ``pending`` — the plan differs from the pool's current ``pg_num``. The
+  planned value is stamped on the pool (visible as ``planned_pg_num`` and
+  in the NEW PG_NUM column) and the ``POOL_AUTOSCALE_PENDING`` health
+  notice lists it.
+* ``current`` — plan and ``pg_num`` agree; there is nothing to do.
+
+When the world changes — OSDs added or removed, ``mon_target_pg_per_osd``
+changed, a pool's ``effective_ratio`` edited — plans diverge and are
+stamped. What happens next is decided by each pool's mode:
+
+* Mode ``warn``: **nothing moves** until the operator reviews ``ceph osd
+  pool autoscale-status`` and accepts:
+
+  .. prompt:: bash #
+
+     ceph osd pool autoscale-accept <pool>
+
+  Acceptance applies exactly the stamped plan the operator reviewed —
+  never a newer one — and clears the stamp. Several pools may be named
+  at once, or ``--all`` to accept every pending plan: the whole set is
+  validated up front and applied in a single osdmap transaction, so a
+  reviewed plan-set commits as one atomic change. Accepting a plan that
+  reduces ``pg_num`` by half or more on a pool storing more than
+  ``mon_osd_pool_pg_merge_confirm_bytes`` (default 1 TiB) requires
+  ``--yes-i-really-mean-it``.
+
+* Mode ``on``: the autoscaler invokes the same acceptance automatically,
+  with one exception: a plan that would require the confirmation above — a
+  large merge, for example after OSDs are lost — is *held* in ``pending``
+  for manual, confirmed acceptance. Growth is hands-off; destructive
+  shrinks get a human sign-off.
+
+* Mode ``off``: the planner ignores the pool entirely.
+
+While the flag is set, the legacy autoscaler knobs —
+``target_size_ratio``, ``target_size_bytes``, ``pg_autoscale_bias`` and
+``bulk`` — are rejected cluster-wide (values already set are simply
+inert), and ``autoscale-status`` switches to a concise table (POOL,
+EFFECTIVE RATIO, PG_NUM, NEW PG_NUM, AUTOSCALE, PLAN; the JSON output
+remains complete).
+
+Actual usage never overrides a plan: a pool that outgrows its share stores
+more data per PG instead, reported by the ``POOL_PG_SIZE_DRIFT`` health
+warning when its bytes-per-PG exceeds a multiple (default 4x, tunable via
+``mgr/pg_autoscaler/pg_size_drift_warn_multiple``) of the cluster median.
+Ratios summing past 1.0 on one budget domain raise
+``POOL_EFFECTIVE_RATIO_OVERCOMMITTED``, and a plan capped by the pool's
+``pg_num_max`` raises ``POOL_PLAN_CLAMPED_BY_PG_NUM_MAX``. Note that
+``mon_target_pg_per_osd`` should be set globally so that the monitor
+(which computes birth sizes, dry runs, and acceptance) and the manager
+(which plans) agree on the budget.
+
+Plans are fitted to the budget together
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A pool's plan is its declared share of the budget, but ``pg_num`` must be a
+power of two. The autoscaler therefore rounds every pool in a budget domain
+together and fits the rounded result to the domain's budget, which means a
+pool's plan depends on the other pools that share the domain and can change
+when they do: when a pool is created or deleted, when another pool's
+``effective_ratio`` is edited, or when the domain gains or loses OSDs.
+Creating a pool can move an existing pool's plan by a power of two, and the
+pool that moves is not necessarily the one that was just changed.
+
+Mode is the operator's control over this. A pool left in mode ``on`` has
+authorized the autoscaler to follow such re-fits; a pool in mode ``warn``
+never moves without review. In either mode a plan that merges away half or
+more of the placement groups of a pool storing more than
+``mon_osd_pool_pg_merge_confirm_bytes`` is held for explicit confirmation,
+so a re-fit cannot silently shrink a pool that holds data.
+
+When provisioning several pools at once, create them in mode ``warn``,
+then review and apply the whole set in one step:
+
+.. prompt:: bash #
+
+   ceph osd pool autoscale-status
+   ceph osd pool autoscale-accept --all
+
+Each pool is then sized once, against the final composition of the domain,
+and the whole set commits as a single osdmap change rather than being
+re-fitted after every create.
+
+Budget domains
+~~~~~~~~~~~~~~
+
+A ratio is scoped to the pool's autoscaler budget domain: the CRUSH
+subtree that the pool's rule resolves to. For rules that select a device
+class this is the class's shadow root (for example ``default~ssd``), so
+pools on different device classes draw from separate budgets even under
+one nominal root. When an OSD serves more than one budget domain — for
+example, when a class-less rule (used by pools such as ``.mgr``) keeps the
+nominal root in play alongside device-class shadow roots — its per-OSD
+budget is split evenly between those domains and plans are prorated by the
+same split. Unreserved pools receive whatever budget the ratios leave
+behind (pools with ``target_size_ratio`` normalize into that remainder),
+and the autoscaler's per-pool minimum (32 PGs, or ``pg_num_min``) bounds
+any plan from below.
+
+.. _simple_autoscale_transition:
+
+Transitioning an existing cluster
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The recommended runbook makes the transition a reviewed,
+no-op-by-construction process:
+
+.. prompt:: bash #
+
+   ceph osd pool ls | while read p; do ceph osd pool set $p pg_autoscale_mode warn; done
+   ceph osd pool set simpleautoscale
+
+Setting every pool to ``warn`` first guarantees nothing acts during the
+transition; a pool deliberately left in ``on`` keeps its autonomy, because
+that is what ``on`` means. Once the flag is set, a pool without a ratio
+has no plan — so no mode can move it — and shows plan ``learn`` while its
+``effective_ratio`` is *learned* from its current ``pg_num`` (fill-only:
+a declared ratio is never overwritten). Ratios may also be pre-staged with
+``ceph osd pool set <pool> effective_ratio`` before the flag is flipped.
+A learned ratio reproduces the pool's current ``pg_num``, so its plan
+lands ``current``: nothing is pending and nothing moves. From then on,
+divergences surface as ``pending`` plans to accept at leisure — or flip a
+pool to ``on`` once you trust its ratio to run hands-off.
+
+``ceph osd pool unset simpleautoscale`` rolls back completely: the
+machinery never touches ``pg_autoscale_mode``, ratios remain stored but
+inert, and every pool resumes legacy autoscaling.
 
 
 Specifying bounds on a pool's PGs

--- a/qa/standalone/mgr/pg-autoscaler-osd-loss.sh
+++ b/qa/standalone/mgr/pg-autoscaler-osd-loss.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 IBM <contact@ibm.com>
+#
+# Author: Kyle Bader <kbader@ibm.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Library Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Library Public License for more details.
+#
+# Losing OSDs shrinks the PG budget, which in legacy autoscaling could
+# trigger an immediate merge storm on top of recovery. Under simple
+# autoscaling nothing may move on its own: warn pools hold their plan
+# pending, and even a mode 'on' pool is held when the plan is a large
+# merge on a pool holding data (mon_osd_pool_pg_merge_confirm_bytes).
+
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+function run() {
+    local dir=$1
+    shift
+
+    export CEPH_MON="127.0.0.1:7103" # git grep '\<7103\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON "
+
+    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        $func $dir || return 1
+    done
+}
+
+NUM_OSDS=8
+# budget = T x OSDs = 768 PG replicas: ratio 0.5 -> pg_num 128 and
+# 0.25 -> 64 at size 3. Keeping 2 of 8 OSDs quarters the budget so the
+# plans stay exact powers of two: 128 -> 32 and 64 -> 16.
+MON_TARGET_PG_PER_OSD=96
+
+function wait_for() {
+    local sec=$1
+    local cmd=$2
+
+    while true ; do
+        if bash -c "$cmd" ; then
+            break
+        fi
+        sec=$(( $sec - 1 ))
+        if [ $sec -le 0 ]; then
+            echo failed
+            return 1
+        fi
+        sleep 1
+    done
+    return 0
+}
+
+function pg_num_target() {
+    ceph osd dump -f json | jq ".pools[] | select(.pool_name == \"$1\") | .pg_num_target"
+}
+
+function TEST_simple_autoscale_osd_loss() {
+    local dir=$1
+
+    setup $dir || return 1
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    local i
+    for i in $(seq 0 $(( NUM_OSDS - 1 ))); do
+        run_osd $dir $i || return 1
+    done
+
+    ceph config set global mon_target_pg_per_osd $MON_TARGET_PG_PER_OSD
+    ceph config set mgr mgr/pg_autoscaler/sleep_interval 5
+    ceph osd pool set simpleautoscale
+
+    # born at their planned pg_num, plan already current
+    ceph osd pool create pin-warn --effective-ratio 0.5 --autoscale-mode warn || return 1
+    ceph osd pool create pin-on --effective-ratio 0.25 --autoscale-mode on || return 1
+    ceph osd pool get pin-warn pg_num | grep -w 128 || return 1
+    ceph osd pool get pin-on pg_num | grep -w 64 || return 1
+    ceph osd pool get pin-warn pg_autoscale_plan | grep -w current || return 1
+    # pg_num_min 16 keeps pin-on's post-loss plan (16) below half of its
+    # pg_num, so the merge-confirm guardrail is exercised
+    ceph osd pool set pin-on pg_num_min 16 || return 1
+    wait_for_clean || return 1
+
+    # pin-on holds data, so its large merge must be held for confirmation
+    ceph config set mon mon_osd_pool_pg_merge_confirm_bytes 4096
+    rados -p pin-on bench 2 write -b 65536 --no-cleanup || return 1
+    wait_for 120 "ceph df | grep -w pin-on | grep -Eq 'KiB|MiB'" || return 1
+
+    # lose three quarters of the cluster: kill and purge 6 of 8 OSDs. The
+    # budget drops to 192 PG replicas: pin-warn plans 32, pin-on plans 16.
+    # (wait_for_osd clobbers a variable named i, so use another)
+    local osd_id
+    for osd_id in 2 3 4 5 6 7; do
+        kill_daemons $dir KILL osd.$osd_id || return 1
+        wait_for_osd down $osd_id || return 1
+        ceph osd purge $osd_id --yes-i-really-mean-it || return 1
+    done
+
+    # both pools go pending with their new plans stamped...
+    wait_for 120 "ceph osd pool get pin-warn pg_autoscale_plan | grep -w pending" || return 1
+    wait_for 120 "ceph osd pool get pin-on pg_autoscale_plan | grep -w pending" || return 1
+    ceph osd pool get pin-warn planned_pg_num | grep -w 32 || return 1
+    ceph osd pool get pin-on planned_pg_num | grep -w 16 || return 1
+    wait_for 120 "ceph health detail | grep POOL_AUTOSCALE_PENDING" || return 1
+    ceph health detail | grep "held for manual acceptance" || return 1
+
+    # ... and nothing moves on its own: not the warn pool (never acts),
+    # not the 'on' pool (its merge is held). Watch several planner passes.
+    for i in $(seq 1 6); do
+        sleep 5
+        test "$(pg_num_target pin-warn)" = "128" || return 1
+        test "$(pg_num_target pin-on)" = "64" || return 1
+    done
+
+    # acceptance executes exactly the stamped plans: the empty warn pool
+    # accepts plainly, the data-bearing 'on' pool requires confirmation
+    ceph osd pool autoscale-accept pin-warn || return 1
+    wait_for 60 "test \$(ceph osd dump -f json | jq '.pools[] | select(.pool_name == \"pin-warn\") | .pg_num_target') = 32" || return 1
+    wait_for 120 "ceph osd pool get pin-warn pg_autoscale_plan | grep -w current" || return 1
+    ! ceph osd pool get pin-warn planned_pg_num || return 1
+
+    ! ceph osd pool autoscale-accept pin-on || return 1
+    ceph osd pool autoscale-accept pin-on --yes-i-really-mean-it || return 1
+    wait_for 60 "test \$(ceph osd dump -f json | jq '.pools[] | select(.pool_name == \"pin-on\") | .pg_num_target') = 16" || return 1
+    wait_for 120 "ceph osd pool get pin-on pg_autoscale_plan | grep -w current" || return 1
+    wait_for_health_gone POOL_AUTOSCALE_PENDING || return 1
+
+    ceph config rm mon mon_osd_pool_pg_merge_confirm_bytes
+    teardown $dir || return 1
+}
+
+main pg-autoscaler-osd-loss "$@"
+
+# Local Variables:
+# compile-command: "cd build ; make -j4 && \
+#    ../qa/run-standalone.sh pg-autoscaler-osd-loss.sh"
+# End:

--- a/qa/workunits/mon/pg_autoscaler.sh
+++ b/qa/workunits/mon/pg_autoscaler.sh
@@ -30,6 +30,11 @@ function wait_for() {
     return 0
 }
 
+function expect_false() {
+    set -x
+    if "$@"; then return 1; else return 0; fi
+}
+
 function power2_floor() { echo "x=l($1)/l(2); scale=0; 2^(x/1)" | bc -l;}
 
 function power2_ceil() { echo "x=l($1)/l(2); scale=0; 2^((x+0.999)/1)" | bc -l; }
@@ -211,6 +216,245 @@ function test_exact_budget() {
     ceph osd pool rm data1 data1 --yes-i-really-really-mean-it
 }
 
+function test_simple_autoscale_greenfield() {
+    # greenfield simple provisioning: with the simpleautoscale flag set, a
+    # pool born with an effective_ratio starts at its planned pg_num with
+    # pg_autoscale_plan 'current' - no acceptance round-trip. pg_num =
+    # ratio * T * NUM_OSDS / size is topology independent for
+    # T = 768 / NUM_OSDS: 0.5 -> 128, 0.25 -> 64 (size 3).
+    MON_TARGET_PG_PER_OSD=$(( 768 / $NUM_OSDS ))
+    ceph config set global mon_target_pg_per_osd $MON_TARGET_PG_PER_OSD
+
+    # a ratio may be pre-staged while the flag is unset, but it is inert
+    # and the pool has no plan state
+    ceph osd pool create inert0
+    ceph osd pool set inert0 effective_ratio 0.5
+    expect_false ceph osd pool get inert0 pg_autoscale_plan
+    expect_false ceph osd pool autoscale-accept inert0
+    ceph osd pool rm inert0 inert0 --yes-i-really-really-mean-it
+
+    # the flag is the master switch for the planner
+    ceph osd pool set simpleautoscale
+    wait_for 30 "ceph osd pool get simpleautoscale 2>&1 | grep -w on"
+
+    # legacy knobs cannot be combined with a ratio at create
+    expect_false ceph osd pool create bad0 --effective-ratio 0.5 --target-size-ratio 0.1
+
+    # --dry-run previews the plan without creating anything
+    OUT=$(ceph osd pool create dry0 --effective-ratio 0.5 --dry-run 2>&1)
+    echo "$OUT" | grep -q "dry run: effective_ratio"
+    expect_false ceph osd pool get dry0 size
+
+    ceph osd pool create pin0 --effective-ratio 0.5 --autoscale-mode warn
+    ceph osd pool create pin1 --effective-ratio 0.25 --autoscale-mode warn
+
+    # born at the planned size, plan already current
+    ceph osd pool get pin0 pg_num | grep -w 128
+    ceph osd pool get pin1 pg_num | grep -w 64
+    RATIO=$(ceph osd pool get pin0 effective_ratio | grep -Eo '[0-9.]+')
+    eval_actual_expected_val $RATIO '0.5'
+    ceph osd pool get pin0 pg_autoscale_plan | grep -w current
+
+    # legacy autoscaler knobs are rejected while the flag is set
+    expect_false ceph osd pool set pin0 target_size_ratio 0.5
+    expect_false ceph osd pool set pin0 target_size_bytes 1000000
+    expect_false ceph osd pool set pin0 pg_autoscale_bias 4
+    expect_false ceph osd pool set pin0 bulk true
+
+    # a world change (here: the budget) never moves a 'warn' pool's
+    # pg_num; the new plans are stamped and the pools go 'pending'
+    ceph config set global mon_target_pg_per_osd $(( $MON_TARGET_PG_PER_OSD * 2 ))
+    wait_for 120 "ceph osd pool get pin0 pg_autoscale_plan | grep -w pending"
+    wait_for 120 "ceph osd pool get pin1 pg_autoscale_plan | grep -w pending"
+    wait_for 120 "ceph health detail | grep POOL_AUTOSCALE_PENDING"
+    ceph osd pool get pin0 pg_num | grep -w 128
+    PLANNED=$(ceph osd pool get pin0 planned_pg_num | grep -Eo '[0-9]+')
+    eval_actual_expected_val $PLANNED 256
+
+    # --all accepts every pending plan in one osdmap transaction: the
+    # command returns after the single commit, so one dump must already
+    # show both stamped plans applied
+    ceph osd pool autoscale-accept --all
+    DUMP=$(ceph osd dump -f json)
+    echo "$DUMP" | jq -e '.pools[] | select(.pool_name == "pin0") | .pg_num_target == 256'
+    echo "$DUMP" | jq -e '.pools[] | select(.pool_name == "pin1") | .pg_num_target == 128'
+    wait_for 120 "ceph osd pool get pin0 pg_autoscale_plan | grep -w current"
+    wait_for 120 "ceph osd pool get pin1 pg_autoscale_plan | grep -w current"
+    expect_false ceph osd pool get pin0 planned_pg_num
+
+    # accepting with nothing pending is an idempotent no-op
+    ceph osd pool autoscale-accept pin0 2>&1 | grep -q 'no plan pending'
+
+    # free budget headroom before raising pin1: the .mgr pool's learned
+    # morsel shares this root, so a full Sigma=1.0 declaration would be
+    # shaved down to fit rather than split. pin0's smaller plan just
+    # stays pending, unaccepted.
+    ceph osd pool set pin0 effective_ratio 0.125
+
+    # a mode 'on' pool applies its own plans (here: a split after its
+    # ratio is raised)
+    ceph osd pool set pin1 pg_autoscale_mode on
+    ceph osd pool set pin1 effective_ratio 0.5
+    wait_for 120 "ceph osd dump | grep -w pin1 | grep -Eq 'pg_num(_target)? 256'"
+    wait_for 120 "ceph osd pool get pin1 pg_autoscale_plan | grep -w current"
+
+    # ... but a plan that merges away half or more of the PGs of a pool
+    # holding data is held 'pending' for manual confirmation, even on 'on'
+    ceph config set mon mon_osd_pool_pg_merge_confirm_bytes 4096
+    rados -p pin1 bench 2 write -b 65536 --no-cleanup
+    wait_for 120 "ceph df | grep -w pin1 | grep -Eq 'KiB|MiB'"
+    ceph osd pool set pin1 effective_ratio 0.0625
+    wait_for 120 "ceph osd pool get pin1 pg_autoscale_plan | grep -w pending"
+    wait_for 120 "ceph health detail | grep POOL_AUTOSCALE_PENDING"
+    ceph osd dump | grep -w pin1 | grep -Eq 'pg_num(_target)? 256'
+    expect_false ceph osd pool autoscale-accept pin1
+    ceph osd pool autoscale-accept pin1 --yes-i-really-mean-it
+    wait_for 120 "ceph osd dump | grep -w pin1 | grep -Eq 'pg_num(_target)? 32'"
+    wait_for 120 "ceph osd pool get pin1 pg_autoscale_plan | grep -w current"
+    ceph config rm mon mon_osd_pool_pg_merge_confirm_bytes
+
+    ceph osd pool rm pin0 pin0 --yes-i-really-really-mean-it
+    ceph osd pool rm pin1 pin1 --yes-i-really-really-mean-it
+    ceph osd pool unset simpleautoscale
+    ceph config set global mon_target_pg_per_osd $MON_TARGET_PG_PER_OSD
+}
+
+function test_simple_autoscale_learn() {
+    # brownfield transition: set legacy pools to 'warn' so nothing acts,
+    # set the simpleautoscale flag; the autoscaler learns each pool's
+    # effective_ratio fill-only from its current pg_num, plans match
+    # pg_num, and the pools sit quietly in plan 'current'
+    MON_TARGET_PG_PER_OSD=$(( 768 / $NUM_OSDS ))
+    ceph config set global mon_target_pg_per_osd $MON_TARGET_PG_PER_OSD
+
+    ceph osd pool create legacy0 --autoscale-mode on
+    ceph osd pool create legacy1 --autoscale-mode on
+    ceph osd pool set legacy0 target_size_ratio 0.5
+    ceph osd pool set legacy1 pg_autoscale_bias 2
+    sleep 60
+
+    LEGACY0_PG=$(ceph osd pool get legacy0 pg_num | grep -Eo '[0-9]+')
+
+    # recommended runbook: warn first, then flag
+    ceph osd pool set legacy0 pg_autoscale_mode warn
+    ceph osd pool set legacy1 pg_autoscale_mode warn
+    ceph osd pool set simpleautoscale
+    wait_for 30 "ceph osd pool get simpleautoscale 2>&1 | grep -w on"
+
+    # the guardrail rejects legacy knobs while the flag is set
+    expect_false ceph osd pool set legacy0 target_size_ratio 0.9
+    expect_false ceph osd pool set legacy1 bulk true
+
+    # while the flag is set the status table is the concise simple view
+    ceph osd pool autoscale-status | grep -q 'EFFECTIVE RATIO'
+    ceph osd pool autoscale-status | grep -qw 'PLAN'
+    expect_false bash -c "ceph osd pool autoscale-status | grep -q 'RAW CAPACITY'"
+
+    # ratios are learned fill-only; a learned plan equals the current
+    # pg_num, so nothing is pending and nothing moves
+    wait_for 180 "ceph osd pool get legacy0 effective_ratio"
+    wait_for 180 "ceph osd pool get legacy1 effective_ratio"
+    wait_for 120 "ceph osd pool get legacy0 pg_autoscale_plan | grep -w current"
+    wait_for 120 "ceph osd pool get legacy1 pg_autoscale_plan | grep -w current"
+    eval_actual_expected_val $(ceph osd pool get legacy0 pg_num | grep -Eo '[0-9]+') $LEGACY0_PG
+    expect_false bash -c "ceph health detail | grep -q POOL_AUTOSCALE_PENDING"
+
+    # accepting a converged pool is an idempotent no-op
+    ceph osd pool autoscale-accept legacy0 2>&1 | grep -q 'no plan pending'
+
+    # stale legacy knobs may remain set (legacy0 still carries its
+    # target_size_ratio); they are simply inert while the flag is set
+
+    # rollback: unset the flag; every pool resumes legacy autoscaling,
+    # ratios stay stored but inert, and legacy knobs work again
+    ceph osd pool unset simpleautoscale
+    ceph osd pool set legacy1 pg_autoscale_bias 4
+    ceph osd pool get legacy0 effective_ratio
+    expect_false ceph osd pool get legacy0 pg_autoscale_plan
+    # the full status table returns once the flag is unset
+    wait_for 30 "ceph osd pool autoscale-status | grep -q 'RAW CAPACITY'"
+
+    ceph osd pool rm legacy0 legacy0 --yes-i-really-really-mean-it
+    ceph osd pool rm legacy1 legacy1 --yes-i-really-really-mean-it
+}
+
+function test_device_class_pins() {
+    # pins are scoped to the budget domain (shadow root) the pool's CRUSH
+    # rule resolves to, not the nominal root
+    MON_TARGET_PG_PER_OSD=200
+    ceph config set global mon_target_pg_per_osd $MON_TARGET_PG_PER_OSD
+
+    # split the OSDs into two artificial device classes
+    HALF=$(( $NUM_OSDS / 2 ))
+    for osd in $(seq 0 $(( $HALF - 1 ))); do
+        ceph osd crush rm-device-class osd.$osd || true
+        ceph osd crush set-device-class fast osd.$osd
+    done
+    for osd in $(seq $HALF $(( $NUM_OSDS - 1 ))); do
+        ceph osd crush rm-device-class osd.$osd || true
+        ceph osd crush set-device-class slow osd.$osd
+    done
+    ceph osd crush rule create-replicated pin-fast default osd fast
+    ceph osd crush rule create-replicated pin-slow default osd slow
+
+    # a classless pool keeps the nominal root in play, so every class OSD
+    # splits its per-OSD budget between the nominal root and its shadow
+    # root; pins are prorated by the same split. Create one explicitly so
+    # the test behaves the same whether or not .mgr exists.
+    ceph osd pool create classless0 --autoscale-mode=on
+
+    # fast0 exercises auto-acceptance (mode on), slow0 the manual
+    # plan/accept walk (mode warn)
+    ceph osd pool create fast0 --autoscale-mode=on
+    ceph osd pool create slow0 --autoscale-mode=warn
+    ceph osd pool set fast0 crush_rule pin-fast
+    ceph osd pool set slow0 crush_rule pin-slow
+    ceph osd pool set fast0 size 3
+    ceph osd pool set slow0 size 3
+    ceph osd pool set simpleautoscale
+    # declare ratios only after the pools are scoped to their shadow
+    # roots. The fractions are derived from HALF so the plan is exactly
+    # 64/32 pgs in both topologies: plan = ratio * (HALF * T / 2) / 3.
+    ceph osd pool set fast0 effective_ratio $(awk "BEGIN{printf \"%.4f\", 384 / $HALF / $MON_TARGET_PG_PER_OSD}")
+    ceph osd pool set slow0 effective_ratio $(awk "BEGIN{printf \"%.4f\", 192 / $HALF / $MON_TARGET_PG_PER_OSD}")
+
+    # mode 'on': the plan (a split up to 64) is applied automatically
+    wait_for 300 "ceph osd dump | grep -w fast0 | grep -Eq 'pg_num(_target)? 64'"
+    wait_for 120 "ceph osd pool get fast0 pg_autoscale_plan | grep -w current"
+
+    # mode 'warn': the plan is stamped and held pending; accept until the
+    # plan converges (crush moves may restamp along the way)
+    accept_plan() {
+        local pool=$1
+        local target=$2
+        local i
+        for i in $(seq 1 60); do
+            if ceph osd dump -f json | jq -e ".pools[] | select(.pool_name == \"$pool\") | .pg_num_target == $target" > /dev/null; then
+                return 0
+            fi
+            if ceph osd pool get $pool pg_autoscale_plan | grep -qw pending; then
+                ceph osd pool autoscale-accept $pool || true
+            fi
+            sleep 5
+        done
+        echo failed
+        return 1
+    }
+    accept_plan slow0 32
+    wait_for 120 "ceph osd pool get slow0 pg_autoscale_plan | grep -w current"
+
+    ceph osd pool rm classless0 classless0 --yes-i-really-really-mean-it
+    ceph osd pool rm fast0 fast0 --yes-i-really-really-mean-it
+    ceph osd pool rm slow0 slow0 --yes-i-really-really-mean-it
+    ceph osd pool unset simpleautoscale
+    ceph osd crush rule rm pin-fast
+    ceph osd crush rule rm pin-slow
+    for osd in $(seq 0 $(( $NUM_OSDS - 1 ))); do
+        ceph osd crush rm-device-class osd.$osd || true
+        ceph osd crush set-device-class hdd osd.$osd
+    done
+}
+
 function test_overlapping_roots() {
     # Create custom CRUSH rules for zone-based placement
     MON_TARGET_PG_PER_OSD=100
@@ -368,6 +612,9 @@ ceph osd pool set threshold 1.0
 test_autoscaler_basic || return 1
 test_pool_starvation || return 1
 test_exact_budget || return 1
+test_simple_autoscale_greenfield || return 1
+test_simple_autoscale_learn || return 1
+test_device_class_pins || return 1
 test_overlapping_roots || return 1
 
 echo OK

--- a/qa/workunits/mon/pg_autoscaler.sh
+++ b/qa/workunits/mon/pg_autoscaler.sh
@@ -30,6 +30,11 @@ function wait_for() {
     return 0
 }
 
+function expect_false() {
+    set -x
+    if "$@"; then return 1; else return 0; fi
+}
+
 function power2_floor() { echo "x=l($1)/l(2); scale=0; 2^(x/1)" | bc -l;}
 
 function power2_ceil() { echo "x=l($1)/l(2); scale=0; 2^((x+0.999)/1)" | bc -l; }
@@ -211,6 +216,245 @@ function test_exact_budget() {
     ceph osd pool rm data1 data1 --yes-i-really-really-mean-it
 }
 
+function test_simple_autoscale_greenfield() {
+    # greenfield simple provisioning: with the simpleautoscale flag set, a
+    # pool born with an effective_ratio starts at its planned pg_num with
+    # pg_autoscale_plan 'current' - no acceptance round-trip. pg_num =
+    # ratio * T * NUM_OSDS / size is topology independent for
+    # T = 768 / NUM_OSDS: 0.5 -> 128, 0.25 -> 64 (size 3).
+    MON_TARGET_PG_PER_OSD=$(( 768 / $NUM_OSDS ))
+    ceph config set global mon_target_pg_per_osd $MON_TARGET_PG_PER_OSD
+
+    # a ratio may be pre-staged while the flag is unset, but it is inert
+    # and the pool has no plan state
+    ceph osd pool create inert0
+    ceph osd pool set inert0 effective_ratio 0.5
+    expect_false ceph osd pool get inert0 pg_autoscale_plan
+    expect_false ceph osd pool autoscale-accept inert0
+    ceph osd pool rm inert0 inert0 --yes-i-really-really-mean-it
+
+    # the flag is the master switch for the planner
+    ceph osd pool set simpleautoscale
+    wait_for 30 "ceph osd pool get simpleautoscale 2>&1 | grep -w on"
+
+    # legacy knobs cannot be combined with a ratio at create
+    expect_false ceph osd pool create bad0 --effective-ratio 0.5 --target-size-ratio 0.1
+
+    # --dry-run previews the plan without creating anything
+    OUT=$(ceph osd pool create dry0 --effective-ratio 0.5 --dry-run 2>&1)
+    echo "$OUT" | grep -q "dry run: effective_ratio"
+    expect_false ceph osd pool get dry0 size
+
+    ceph osd pool create pin0 --effective-ratio 0.5 --autoscale-mode warn
+    ceph osd pool create pin1 --effective-ratio 0.25 --autoscale-mode warn
+
+    # born at the planned size, plan already current
+    ceph osd pool get pin0 pg_num | grep -w 128
+    ceph osd pool get pin1 pg_num | grep -w 64
+    RATIO=$(ceph osd pool get pin0 effective_ratio | grep -Eo '[0-9.]+')
+    eval_actual_expected_val $RATIO '0.5'
+    ceph osd pool get pin0 pg_autoscale_plan | grep -w current
+
+    # legacy autoscaler knobs are rejected while the flag is set
+    expect_false ceph osd pool set pin0 target_size_ratio 0.5
+    expect_false ceph osd pool set pin0 target_size_bytes 1000000
+    expect_false ceph osd pool set pin0 pg_autoscale_bias 4
+    expect_false ceph osd pool set pin0 bulk true
+
+    # a world change (here: the budget) never moves a 'warn' pool's
+    # pg_num; the new plans are stamped and the pools go 'pending'
+    ceph config set global mon_target_pg_per_osd $(( $MON_TARGET_PG_PER_OSD * 2 ))
+    wait_for 120 "ceph osd pool get pin0 pg_autoscale_plan | grep -w pending"
+    wait_for 120 "ceph osd pool get pin1 pg_autoscale_plan | grep -w pending"
+    wait_for 120 "ceph health detail | grep POOL_AUTOSCALE_PENDING"
+    ceph osd pool get pin0 pg_num | grep -w 128
+    PLANNED=$(ceph osd pool get pin0 planned_pg_num | grep -Eo '[0-9]+')
+    eval_actual_expected_val $PLANNED 256
+
+    # --all accepts every pending plan in one osdmap transaction: the
+    # command returns after the single commit, so one dump must already
+    # show both stamped plans applied
+    ceph osd pool autoscale-accept --all
+    DUMP=$(ceph osd dump -f json)
+    echo "$DUMP" | jq -e '.pools[] | select(.pool_name == "pin0") | .pg_num_target == 256'
+    echo "$DUMP" | jq -e '.pools[] | select(.pool_name == "pin1") | .pg_num_target == 128'
+    wait_for 120 "ceph osd pool get pin0 pg_autoscale_plan | grep -w current"
+    wait_for 120 "ceph osd pool get pin1 pg_autoscale_plan | grep -w current"
+    expect_false ceph osd pool get pin0 planned_pg_num
+
+    # accepting with nothing pending is an idempotent no-op
+    ceph osd pool autoscale-accept pin0 2>&1 | grep -q 'no plan pending'
+
+    # free budget headroom before raising pin1: the .mgr pool's learned
+    # morsel shares this root, so a full Sigma=1.0 declaration would be
+    # shaved down to fit rather than split. pin0's smaller plan just
+    # stays pending, unaccepted.
+    ceph osd pool set pin0 effective_ratio 0.125
+
+    # a mode 'on' pool applies its own plans (here: a split after its
+    # ratio is raised)
+    ceph osd pool set pin1 pg_autoscale_mode on
+    ceph osd pool set pin1 effective_ratio 0.5
+    wait_for 120 "ceph osd dump | grep -w pin1 | grep -Eq 'pg_num(_target)? 256'"
+    wait_for 120 "ceph osd pool get pin1 pg_autoscale_plan | grep -w current"
+
+    # ... but a plan that merges away more than half the PGs of a pool
+    # holding data is held 'pending' for manual confirmation, even on 'on'
+    ceph config set mon mon_osd_pool_pg_merge_confirm_bytes 4096
+    rados -p pin1 bench 2 write -b 65536 --no-cleanup
+    wait_for 120 "ceph df | grep -w pin1 | grep -Eq 'KiB|MiB'"
+    ceph osd pool set pin1 effective_ratio 0.0625
+    wait_for 120 "ceph osd pool get pin1 pg_autoscale_plan | grep -w pending"
+    wait_for 120 "ceph health detail | grep POOL_AUTOSCALE_PENDING"
+    ceph osd dump | grep -w pin1 | grep -Eq 'pg_num(_target)? 256'
+    expect_false ceph osd pool autoscale-accept pin1
+    ceph osd pool autoscale-accept pin1 --yes-i-really-mean-it
+    wait_for 120 "ceph osd dump | grep -w pin1 | grep -Eq 'pg_num(_target)? 32'"
+    wait_for 120 "ceph osd pool get pin1 pg_autoscale_plan | grep -w current"
+    ceph config rm mon mon_osd_pool_pg_merge_confirm_bytes
+
+    ceph osd pool rm pin0 pin0 --yes-i-really-really-mean-it
+    ceph osd pool rm pin1 pin1 --yes-i-really-really-mean-it
+    ceph osd pool unset simpleautoscale
+    ceph config set global mon_target_pg_per_osd $MON_TARGET_PG_PER_OSD
+}
+
+function test_simple_autoscale_learn() {
+    # brownfield transition: set legacy pools to 'warn' so nothing acts,
+    # set the simpleautoscale flag; the autoscaler learns each pool's
+    # effective_ratio fill-only from its current pg_num, plans match
+    # pg_num, and the pools sit quietly in plan 'current'
+    MON_TARGET_PG_PER_OSD=$(( 768 / $NUM_OSDS ))
+    ceph config set global mon_target_pg_per_osd $MON_TARGET_PG_PER_OSD
+
+    ceph osd pool create legacy0 --autoscale-mode on
+    ceph osd pool create legacy1 --autoscale-mode on
+    ceph osd pool set legacy0 target_size_ratio 0.5
+    ceph osd pool set legacy1 pg_autoscale_bias 2
+    sleep 60
+
+    LEGACY0_PG=$(ceph osd pool get legacy0 pg_num | grep -Eo '[0-9]+')
+
+    # recommended runbook: warn first, then flag
+    ceph osd pool set legacy0 pg_autoscale_mode warn
+    ceph osd pool set legacy1 pg_autoscale_mode warn
+    ceph osd pool set simpleautoscale
+    wait_for 30 "ceph osd pool get simpleautoscale 2>&1 | grep -w on"
+
+    # the guardrail rejects legacy knobs while the flag is set
+    expect_false ceph osd pool set legacy0 target_size_ratio 0.9
+    expect_false ceph osd pool set legacy1 bulk true
+
+    # while the flag is set the status table is the concise simple view
+    ceph osd pool autoscale-status | grep -q 'EFFECTIVE RATIO'
+    ceph osd pool autoscale-status | grep -qw 'PLAN'
+    expect_false bash -c "ceph osd pool autoscale-status | grep -q 'RAW CAPACITY'"
+
+    # ratios are learned fill-only; a learned plan equals the current
+    # pg_num, so nothing is pending and nothing moves
+    wait_for 180 "ceph osd pool get legacy0 effective_ratio"
+    wait_for 180 "ceph osd pool get legacy1 effective_ratio"
+    wait_for 120 "ceph osd pool get legacy0 pg_autoscale_plan | grep -w current"
+    wait_for 120 "ceph osd pool get legacy1 pg_autoscale_plan | grep -w current"
+    eval_actual_expected_val $(ceph osd pool get legacy0 pg_num | grep -Eo '[0-9]+') $LEGACY0_PG
+    expect_false bash -c "ceph health detail | grep -q POOL_AUTOSCALE_PENDING"
+
+    # accepting a converged pool is an idempotent no-op
+    ceph osd pool autoscale-accept legacy0 2>&1 | grep -q 'no plan pending'
+
+    # stale legacy knobs may remain set (legacy0 still carries its
+    # target_size_ratio); they are simply inert while the flag is set
+
+    # rollback: unset the flag; every pool resumes legacy autoscaling,
+    # ratios stay stored but inert, and legacy knobs work again
+    ceph osd pool unset simpleautoscale
+    ceph osd pool set legacy1 pg_autoscale_bias 4
+    ceph osd pool get legacy0 effective_ratio
+    expect_false ceph osd pool get legacy0 pg_autoscale_plan
+    # the full status table returns once the flag is unset
+    wait_for 30 "ceph osd pool autoscale-status | grep -q 'RAW CAPACITY'"
+
+    ceph osd pool rm legacy0 legacy0 --yes-i-really-really-mean-it
+    ceph osd pool rm legacy1 legacy1 --yes-i-really-really-mean-it
+}
+
+function test_device_class_pins() {
+    # pins are scoped to the budget domain (shadow root) the pool's CRUSH
+    # rule resolves to, not the nominal root
+    MON_TARGET_PG_PER_OSD=200
+    ceph config set global mon_target_pg_per_osd $MON_TARGET_PG_PER_OSD
+
+    # split the OSDs into two artificial device classes
+    HALF=$(( $NUM_OSDS / 2 ))
+    for osd in $(seq 0 $(( $HALF - 1 ))); do
+        ceph osd crush rm-device-class osd.$osd || true
+        ceph osd crush set-device-class fast osd.$osd
+    done
+    for osd in $(seq $HALF $(( $NUM_OSDS - 1 ))); do
+        ceph osd crush rm-device-class osd.$osd || true
+        ceph osd crush set-device-class slow osd.$osd
+    done
+    ceph osd crush rule create-replicated pin-fast default osd fast
+    ceph osd crush rule create-replicated pin-slow default osd slow
+
+    # a classless pool keeps the nominal root in play, so every class OSD
+    # splits its per-OSD budget between the nominal root and its shadow
+    # root; pins are prorated by the same split. Create one explicitly so
+    # the test behaves the same whether or not .mgr exists.
+    ceph osd pool create classless0 --autoscale-mode=on
+
+    # fast0 exercises auto-acceptance (mode on), slow0 the manual
+    # plan/accept walk (mode warn)
+    ceph osd pool create fast0 --autoscale-mode=on
+    ceph osd pool create slow0 --autoscale-mode=warn
+    ceph osd pool set fast0 crush_rule pin-fast
+    ceph osd pool set slow0 crush_rule pin-slow
+    ceph osd pool set fast0 size 3
+    ceph osd pool set slow0 size 3
+    ceph osd pool set simpleautoscale
+    # declare ratios only after the pools are scoped to their shadow
+    # roots. The fractions are derived from HALF so the plan is exactly
+    # 64/32 pgs in both topologies: plan = ratio * (HALF * T / 2) / 3.
+    ceph osd pool set fast0 effective_ratio $(awk "BEGIN{printf \"%.4f\", 384 / $HALF / $MON_TARGET_PG_PER_OSD}")
+    ceph osd pool set slow0 effective_ratio $(awk "BEGIN{printf \"%.4f\", 192 / $HALF / $MON_TARGET_PG_PER_OSD}")
+
+    # mode 'on': the plan (a split up to 64) is applied automatically
+    wait_for 300 "ceph osd dump | grep -w fast0 | grep -Eq 'pg_num(_target)? 64'"
+    wait_for 120 "ceph osd pool get fast0 pg_autoscale_plan | grep -w current"
+
+    # mode 'warn': the plan is stamped and held pending; accept until the
+    # plan converges (crush moves may restamp along the way)
+    accept_plan() {
+        local pool=$1
+        local target=$2
+        local i
+        for i in $(seq 1 60); do
+            if ceph osd dump -f json | jq -e ".pools[] | select(.pool_name == \"$pool\") | .pg_num_target == $target" > /dev/null; then
+                return 0
+            fi
+            if ceph osd pool get $pool pg_autoscale_plan | grep -qw pending; then
+                ceph osd pool autoscale-accept $pool || true
+            fi
+            sleep 5
+        done
+        echo failed
+        return 1
+    }
+    accept_plan slow0 32
+    wait_for 120 "ceph osd pool get slow0 pg_autoscale_plan | grep -w current"
+
+    ceph osd pool rm classless0 classless0 --yes-i-really-really-mean-it
+    ceph osd pool rm fast0 fast0 --yes-i-really-really-mean-it
+    ceph osd pool rm slow0 slow0 --yes-i-really-really-mean-it
+    ceph osd pool unset simpleautoscale
+    ceph osd crush rule rm pin-fast
+    ceph osd crush rule rm pin-slow
+    for osd in $(seq 0 $(( $NUM_OSDS - 1 ))); do
+        ceph osd crush rm-device-class osd.$osd || true
+        ceph osd crush set-device-class hdd osd.$osd
+    done
+}
+
 function test_overlapping_roots() {
     # Create custom CRUSH rules for zone-based placement
     MON_TARGET_PG_PER_OSD=100
@@ -365,6 +609,9 @@ ceph osd pool set threshold 1.0
 test_autoscaler_basic || return 1
 test_pool_starvation || return 1
 test_exact_budget || return 1
+test_simple_autoscale_greenfield || exit 1
+test_simple_autoscale_learn || exit 1
+test_device_class_pins || exit 1
 test_overlapping_roots || exit 1
 
 echo OK

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -46,6 +46,20 @@ options:
   level: advanced
   default: 64_K
   fmt_desc: The maximum number of placement groups per pool.
+- name: mon_osd_pool_pg_merge_confirm_bytes
+  type: size
+  level: advanced
+  desc: pools storing more than this many bytes require --yes-i-really-mean-it
+    on 'osd pool autoscale-accept' when the plan reduces their pg_num by more
+    than half
+  long_desc: Accepting a plan that merges away most of a pool's PGs is an
+    expensive and slow data movement, so the monitor requires explicit
+    confirmation on pools holding significant data. The same threshold keeps
+    the pg_autoscaler from auto-accepting such a merge on a pool whose
+    pg_autoscale_mode is 'on'; the plan is held in pg_autoscale_plan 'pending'
+    for manual acceptance instead.
+  default: 1_T
+  services: [mon]
 - name: mon_mgr_digest_period
   type: int
   level: dev

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -173,6 +173,7 @@ extern const char *ceph_osd_state_name(int s);
 #define CEPH_OSDMAP_NOSNAPTRIM       (1<<21) /* disable snap trimming */
 #define CEPH_OSDMAP_PGLOG_HARDLIMIT  (1<<22) /* put a hard limit on pg log length */
 #define CEPH_OSDMAP_NOAUTOSCALE      (1<<23)  /* block pg autoscale */
+#define CEPH_OSDMAP_SIMPLEAUTOSCALE  (1<<24)  /* simple (ratio-driven) autoscaling: plan from effective_ratio, learn missing ratios, reject legacy autoscaler knobs */
 
 /* these are hidden in 'ceph status' view */
 #define CEPH_OSDMAP_SEMIHIDDEN_FLAGS (CEPH_OSDMAP_REQUIRE_JEWEL|	\

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -887,13 +887,13 @@ COMMAND("osd erasure-code-profile ls",
 COMMAND("osd set "
 	"name=key,type=CephChoices,strings=full|pause|noup|nodown|"
 	"noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|"
-	"notieragent|nosnaptrim|pglog_hardlimit|noautoscale "
+	"notieragent|nosnaptrim|pglog_hardlimit|noautoscale|simpleautoscale "
         "name=yes_i_really_mean_it,type=CephBool,req=false",
 	"set <key>", "osd", "rw")
 COMMAND("osd unset "
 	"name=key,type=CephChoices,strings=full|pause|noup|nodown|"\
 	"noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|"
-	"notieragent|nosnaptrim|noautoscale",
+	"notieragent|nosnaptrim|noautoscale|simpleautoscale",
 	"unset <key>", "osd", "rw")
 COMMAND("osd require-osd-release "\
 	"name=release,type=CephChoices,strings=octopus|pacific|quincy|reef|squid|tentacle|umbrella "
@@ -1145,6 +1145,8 @@ COMMAND("osd pool create "
 	"name=bulk,type=CephBool,req=false "
 	"name=target_size_bytes,type=CephInt,range=0,req=false "
 	"name=target_size_ratio,type=CephFloat,range=0.0,req=false "\
+	"name=effective_ratio,type=CephFloat,range=0.0|1.0,req=false "\
+	"name=dry_run,type=CephBool,req=false "\
 	"name=force_pg_limit,type=CephBool,req=false"
 	"name=yes_i_really_mean_it,type=CephBool,req=false"
 	"name=crimson,type=CephBool,req=false",
@@ -1196,6 +1198,7 @@ COMMAND("osd pool get "
           "|dedup_tier"
           "|ec_coding_shard_count"
           "|ec_data_shard_count"
+          "|effective_ratio"
           "|eio"
           "|erasure_code_profile"
           "|fast_read"
@@ -1218,10 +1221,12 @@ COMMAND("osd pool get "
           "|pct_update_delay"
           "|pg_autoscale_bias"
           "|pg_autoscale_mode"
+          "|pg_autoscale_plan"
           "|pg_num"
           "|pg_num_max"
           "|pg_num_min"
           "|pgp_num"
+          "|planned_pg_num"
           "|read_ratio"
           "|recovery_op_priority"
           "|recovery_priority"
@@ -1261,6 +1266,7 @@ COMMAND("osd pool set "
           "|dedup_cdc_chunk_size"
           "|dedup_chunk_algorithm"
           "|dedup_tier"
+          "|effective_ratio"
           "|eio"
           "|fast_read"
           "|fingerprint_algorithm"
@@ -1287,6 +1293,7 @@ COMMAND("osd pool set "
           "|pg_num_min"
           "|pgp_num"
           "|pgp_num_actual"
+          "|planned_pg_num"
           "|read_ratio"
           "|recovery_op_priority"
           "|recovery_priority"
@@ -1303,11 +1310,18 @@ COMMAND("osd pool set "
           "|use_gmt_hitset"
           "|write_fadvise_dontneed "
 	"name=val,type=CephString "
+	"name=dry_run,type=CephBool,req=false "
 	"name=yes_i_really_mean_it,type=CephBool,req=false",
 	"set pool parameter <var> to <val>", "osd", "rw")
 // 'val' is a CephString because it can include a unit.  Perhaps
 // there should be a Python type for validation/conversion of strings
 // with units.
+COMMAND("osd pool autoscale-accept "
+	"name=pools,type=CephString,n=N,req=false "
+	"name=all,type=CephBool,req=false "
+	"name=yes_i_really_mean_it,type=CephBool,req=false",
+	"accept the pg_autoscaler's planned pg_num for the given pools "
+	"(or --all) in one atomic osdmap change", "osd", "rw")
 COMMAND("osd pool set-quota "
 	"name=pool,type=CephPoolname "
 	"name=field,type=CephChoices,strings=max_objects|max_bytes "

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -887,13 +887,13 @@ COMMAND("osd erasure-code-profile ls",
 COMMAND("osd set "
 	"name=key,type=CephChoices,strings=full|pause|noup|nodown|"
 	"noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|"
-	"notieragent|nosnaptrim|pglog_hardlimit|noautoscale "
+	"notieragent|nosnaptrim|pglog_hardlimit|noautoscale|simpleautoscale "
         "name=yes_i_really_mean_it,type=CephBool,req=false",
 	"set <key>", "osd", "rw")
 COMMAND("osd unset "
 	"name=key,type=CephChoices,strings=full|pause|noup|nodown|"\
 	"noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|"
-	"notieragent|nosnaptrim|noautoscale",
+	"notieragent|nosnaptrim|noautoscale|simpleautoscale",
 	"unset <key>", "osd", "rw")
 COMMAND("osd require-osd-release "\
 	"name=release,type=CephChoices,strings=octopus|pacific|quincy|reef|squid|tentacle|umbrella "
@@ -1145,6 +1145,8 @@ COMMAND("osd pool create "
 	"name=bulk,type=CephBool,req=false "
 	"name=target_size_bytes,type=CephInt,range=0,req=false "
 	"name=target_size_ratio,type=CephFloat,range=0.0,req=false "\
+	"name=effective_ratio,type=CephFloat,range=0.0|1.0,req=false "\
+	"name=dry_run,type=CephBool,req=false "\
 	"name=yes_i_really_mean_it,type=CephBool,req=false"
 	"name=crimson,type=CephBool,req=false",
 	"create pool", "osd", "rw")
@@ -1195,6 +1197,7 @@ COMMAND("osd pool get "
           "|dedup_tier"
           "|ec_coding_shard_count"
           "|ec_data_shard_count"
+          "|effective_ratio"
           "|eio"
           "|erasure_code_profile"
           "|fast_read"
@@ -1217,10 +1220,12 @@ COMMAND("osd pool get "
           "|pct_update_delay"
           "|pg_autoscale_bias"
           "|pg_autoscale_mode"
+          "|pg_autoscale_plan"
           "|pg_num"
           "|pg_num_max"
           "|pg_num_min"
           "|pgp_num"
+          "|planned_pg_num"
           "|read_ratio"
           "|recovery_op_priority"
           "|recovery_priority"
@@ -1260,6 +1265,7 @@ COMMAND("osd pool set "
           "|dedup_cdc_chunk_size"
           "|dedup_chunk_algorithm"
           "|dedup_tier"
+          "|effective_ratio"
           "|eio"
           "|fast_read"
           "|fingerprint_algorithm"
@@ -1286,6 +1292,7 @@ COMMAND("osd pool set "
           "|pg_num_min"
           "|pgp_num"
           "|pgp_num_actual"
+          "|planned_pg_num"
           "|read_ratio"
           "|recovery_op_priority"
           "|recovery_priority"
@@ -1302,11 +1309,18 @@ COMMAND("osd pool set "
           "|use_gmt_hitset"
           "|write_fadvise_dontneed "
 	"name=val,type=CephString "
+	"name=dry_run,type=CephBool,req=false "
 	"name=yes_i_really_mean_it,type=CephBool,req=false",
 	"set pool parameter <var> to <val>", "osd", "rw")
 // 'val' is a CephString because it can include a unit.  Perhaps
 // there should be a Python type for validation/conversion of strings
 // with units.
+COMMAND("osd pool autoscale-accept "
+	"name=pools,type=CephString,n=N,req=false "
+	"name=all,type=CephBool,req=false "
+	"name=yes_i_really_mean_it,type=CephBool,req=false",
+	"accept the pg_autoscaler's planned pg_num for the given pools "
+	"(or --all) in one atomic osdmap change", "osd", "rw")
 COMMAND("osd pool set-quota "
 	"name=pool,type=CephPoolname "
 	"name=field,type=CephChoices,strings=max_objects|max_bytes "

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5583,10 +5583,26 @@ namespace {
     COMPRESSION_MAX_BLOB_SIZE, COMPRESSION_MIN_BLOB_SIZE,
     CSUM_TYPE, CSUM_MAX_BLOCK, CSUM_MIN_BLOCK, FINGERPRINT_ALGORITHM,
     PG_AUTOSCALE_MODE, PG_NUM_MIN, TARGET_SIZE_BYTES, TARGET_SIZE_RATIO,
-    PG_AUTOSCALE_BIAS, DEDUP_TIER, DEDUP_CHUNK_ALGORITHM, 
+    PG_AUTOSCALE_BIAS, DEDUP_TIER, DEDUP_CHUNK_ALGORITHM,
     DEDUP_CDC_CHUNK_SIZE, POOL_EIO, BULK, PG_NUM_MAX, READ_RATIO,
     EC_OPTIMIZATIONS, EC_DATA_SHARD_COUNT, EC_CODING_SHARD_COUNT,
-    SUPPORTS_OMAP };
+    SUPPORTS_OMAP, EFFECTIVE_RATIO, PLANNED_PG_NUM, PG_AUTOSCALE_PLAN };
+
+  // the simple-autoscaling plan state is derived, never stored: 'learn'
+  // until a pool has an effective_ratio, 'pending' while a stamped plan
+  // differs from pg_num, 'current' once they agree
+  std::string pool_pg_autoscale_plan(const pg_pool_t& p)
+  {
+    if (!p.opts.is_set(pool_opts_t::EFFECTIVE_RATIO)) {
+      return "learn";
+    }
+    int64_t planned = 0;
+    p.opts.get(pool_opts_t::PLANNED_PG_NUM, &planned);
+    if (planned > 0 && planned != (int64_t)p.get_pg_num_target()) {
+      return "pending";
+    }
+    return "current";
+  }
 
   std::set<osd_pool_get_choices>
     subtract_second_from_first(const std::set<osd_pool_get_choices>& first,
@@ -6324,6 +6340,115 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
       }
     }
     r = 0;
+  } else if ((prefix == "osd pool create" || prefix == "osd pool set") &&
+	     cmd_getval_or<bool>(cmdmap, "dry_run", false)) {
+    // --dry-run: report what effective_ratio would plan and the
+    // pg_num it implies, without changing anything
+    double frac = 0.0;
+    unsigned size = 0;
+    uint32_t num_osds = 0;
+    bool scoped = false;  // whether num_osds reflects the pool's CRUSH rule
+    auto count_rule_osds = [&](int rule_id) -> uint32_t {
+      set<int> roots;
+      osdmap.crush->find_takes_by_rule(rule_id, &roots);
+      set<int> rule_osds;
+      for (auto root : roots) {
+	set<int> leaves;
+	osdmap.crush->get_leaves(osdmap.crush->get_item_name(root), &leaves);
+	rule_osds.insert(leaves.begin(), leaves.end());
+      }
+      return rule_osds.size();
+    };
+    if (prefix == "osd pool set") {
+      string var, val;
+      cmd_getval(cmdmap, "var", var);
+      cmd_getval(cmdmap, "val", val);
+      if (var != "effective_ratio") {
+	ss << "--dry-run is only supported for effective_ratio";
+	r = -EINVAL;
+	goto reply;
+      }
+      string poolstr;
+      cmd_getval(cmdmap, "pool", poolstr);
+      int64_t pool_id = osdmap.lookup_pg_pool_name(poolstr.c_str());
+      if (pool_id < 0) {
+	ss << "unrecognized pool '" << poolstr << "'";
+	r = -ENOENT;
+	goto reply;
+      }
+      string floaterr;
+      frac = strict_strtod(val.c_str(), &floaterr);
+      if (floaterr.length()) {
+	ss << "error parsing float value '" << val << "': " << floaterr;
+	r = -EINVAL;
+	goto reply;
+      }
+      const pg_pool_t *pp = osdmap.get_pg_pool(pool_id);
+      size = pp->get_size();
+      num_osds = count_rule_osds(pp->get_crush_rule());
+      scoped = true;
+    } else {
+      if (!cmd_getval(cmdmap, "effective_ratio", frac)) {
+	ss << "--dry-run requires --effective-ratio";
+	r = -EINVAL;
+	goto reply;
+      }
+      // read-only estimate: size comes from the erasure profile (k+m) or
+      // the replicated default; the OSD count is scoped to the named CRUSH
+      // rule if it already exists, else it covers the whole map
+      string profile;
+      cmd_getval(cmdmap, "erasure_code_profile", profile);
+      if (profile.length() && osdmap.has_erasure_code_profile(profile)) {
+	auto& ecp = osdmap.get_erasure_code_profile(profile);
+	auto k = ecp.find("k");
+	auto m = ecp.find("m");
+	if (k != ecp.end() && m != ecp.end()) {
+	  size = atoi(k->second.c_str()) + atoi(m->second.c_str());
+	}
+      } else {
+	int64_t repl_size = 0;
+	cmd_getval(cmdmap, "size", repl_size);
+	size = repl_size ? repl_size :
+	  g_conf().get_val<uint64_t>("osd_pool_default_size");
+      }
+      string rule_name;
+      cmd_getval(cmdmap, "rule", rule_name);
+      int rule_id = rule_name.empty() ? -ENOENT :
+	osdmap.crush->get_rule_id(rule_name);
+      if (rule_id >= 0) {
+	num_osds = count_rule_osds(rule_id);
+	scoped = true;
+      } else {
+	num_osds = osdmap.get_num_osds();
+      }
+    }
+    if (frac < 0.0 || frac > 1.0) {
+      ss << "effective_ratio must be between 0.0 and 1.0";
+      r = -ERANGE;
+      goto reply;
+    }
+    {
+      uint64_t target = g_conf().get_val<uint64_t>("mon_target_pg_per_osd");
+      uint64_t reserve = std::lround(frac * target);
+      ss << "dry run: effective_ratio " << frac << " is " << reserve
+	 << " PG replicas per OSD (of mon_target_pg_per_osd " << target << ")";
+      if (size && num_osds) {
+	uint64_t ideal = reserve * num_osds / size;
+	uint64_t lo = 1;
+	while (lo * 2 <= std::max<uint64_t>(ideal, 1)) {
+	  lo *= 2;
+	}
+	uint64_t quant = (ideal - lo <= lo * 2 - ideal) ? lo : lo * 2;
+	ss << "; across " << num_osds
+	   << (scoped ? " OSDs under the pool's CRUSH rule" : " OSDs")
+	   << " at pool size " << size << " the ideal pg_num is " << ideal
+	   << ", quantizing to " << quant
+	   << ". The realized pg_num is chosen by the pg_autoscaler subject"
+	   << " to budget fit, overlap proration, pg_num_min/max and the"
+	   << " per-pool minimum; see 'ceph osd pool autoscale-status'";
+      }
+      r = 0;
+    }
   } else if (prefix == "osd pool get") {
     string poolstr;
     cmd_getval(cmdmap, "pool", poolstr);
@@ -6382,10 +6507,13 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
       {"csum_min_block", CSUM_MIN_BLOCK},
       {"fingerprint_algorithm", FINGERPRINT_ALGORITHM},
       {"pg_autoscale_mode", PG_AUTOSCALE_MODE},
+      {"pg_autoscale_plan", PG_AUTOSCALE_PLAN},
       {"pg_num_min", PG_NUM_MIN},
       {"pg_num_max", PG_NUM_MAX},
       {"target_size_bytes", TARGET_SIZE_BYTES},
       {"target_size_ratio", TARGET_SIZE_RATIO},
+      {"effective_ratio", EFFECTIVE_RATIO},
+      {"planned_pg_num", PLANNED_PG_NUM},
       {"pg_autoscale_bias", PG_AUTOSCALE_BIAS},
       {"dedup_tier", DEDUP_TIER},
       {"dedup_chunk_algorithm", DEDUP_CHUNK_ALGORITHM},
@@ -6437,6 +6565,10 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
         selected_choices = subtract_second_from_first(selected_choices,
 						      ONLY_REPLICA_CHOICES);
       }
+      if (!osdmap.test_flag(CEPH_OSDMAP_SIMPLEAUTOSCALE)) {
+	selected_choices = subtract_second_from_first(selected_choices,
+						      {PG_AUTOSCALE_PLAN});
+      }
     } else /* var != "all" */  {
       choices_map_t::const_iterator found = ALL_CHOICES.find(var);
       if (found == ALL_CHOICES.end()) {
@@ -6447,6 +6579,14 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
       }
 
       osd_pool_get_choices selected = found->second;
+
+      if (selected == PG_AUTOSCALE_PLAN &&
+	  !osdmap.test_flag(CEPH_OSDMAP_SIMPLEAUTOSCALE)) {
+	ss << "simple autoscaling is not enabled (the simpleautoscale flag "
+	   << "is not set)";
+	r = -EINVAL;
+	goto reply;
+      }
 
       if (!p->is_tier() &&
 	  ONLY_TIER_CHOICES.find(selected) != ONLY_TIER_CHOICES.end()) {
@@ -6526,6 +6666,9 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	    f->dump_string("pg_autoscale_mode",
 			   pg_pool_t::get_pg_autoscale_mode_name(
 			     p->pg_autoscale_mode));
+	    break;
+	  case PG_AUTOSCALE_PLAN:
+	    f->dump_string("pg_autoscale_plan", pool_pg_autoscale_plan(*p));
 	    break;
 	  case HASHPSPOOL:
 	  case POOL_EIO:
@@ -6643,6 +6786,8 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	  case DEDUP_CHUNK_ALGORITHM:
 	  case DEDUP_CDC_CHUNK_SIZE:
           case READ_RATIO:
+	  case EFFECTIVE_RATIO:
+	  case PLANNED_PG_NUM:
 	    {
 	      pool_opts_t::key_t key = pool_opts_t::get_opt_desc(i->first).key;
 	      if (p->opts.is_set(key)) {
@@ -6703,6 +6848,9 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	  case PG_AUTOSCALE_MODE:
 	    ss << "pg_autoscale_mode: " << pg_pool_t::get_pg_autoscale_mode_name(
 	      p->pg_autoscale_mode) <<"\n";
+	    break;
+	  case PG_AUTOSCALE_PLAN:
+	    ss << "pg_autoscale_plan: " << pool_pg_autoscale_plan(*p) << "\n";
 	    break;
 	  case HIT_SET_PERIOD:
 	    ss << "hit_set_period: " << p->hit_set_period << "\n";
@@ -6824,6 +6972,8 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	  case DEDUP_CHUNK_ALGORITHM:
 	  case DEDUP_CDC_CHUNK_SIZE:
           case READ_RATIO:
+	  case EFFECTIVE_RATIO:
+	  case PLANNED_PG_NUM:
 	    for (i = ALL_CHOICES.begin(); i != ALL_CHOICES.end(); ++i) {
 	      if (i->second == *it)
 		break;
@@ -7631,7 +7781,7 @@ int OSDMonitor::prepare_new_pool(MonOpRequestRef op)
   bool force_create = false;
   int ret = 0;
   ret = prepare_new_pool(m->name, m->crush_rule, rule_name,
-			 0, 0, 0, 0, 0, 0, 0.0,
+			 0, 0, 0, 0, 0, 0, 0.0, 0.0,
 			 erasure_code_profile,
 			 pg_pool_t::TYPE_REPLICATED, 0, FAST_READ_OFF, {}, bulk,
 			 cct->_conf.get_val<bool>("osd_pool_default_crimson"),
@@ -8272,6 +8422,8 @@ int OSDMonitor::check_pg_num(int64_t pool,
  * @param pg_num_min min pg_num
  * @param pg_num_max max pg_num
  * @param repl_size Replication factor, or 0 for default
+ * @param effective_ratio Share (0,1] of the PG budget for simple-mode
+ *        provisioning, or 0 for none
  * @param erasure_code_profile The profile name in OSDMap to be used for erasure code
  * @param pool_type TYPE_ERASURE, or TYPE_REP
  * @param expected_num_objects expected number of objects on the pool
@@ -8292,6 +8444,7 @@ int OSDMonitor::prepare_new_pool(string& name,
                                  const uint64_t repl_size,
 				 const uint64_t target_size_bytes,
 				 const float target_size_ratio,
+				 const double effective_ratio,
 				 const string &erasure_code_profile,
                                  const unsigned pool_type,
                                  const uint64_t expected_num_objects,
@@ -8308,10 +8461,10 @@ int OSDMonitor::prepare_new_pool(string& name,
     // "off"
     pg_autoscale_mode = "off";
   }
-
   if (name.length() == 0)
     return -EINVAL;
 
+  const bool pg_num_specified = pg_num != 0;
   if (pg_num == 0) {
     pg_num = g_conf().get_val<uint64_t>("osd_pool_default_pg_num");
   }
@@ -8350,6 +8503,18 @@ int OSDMonitor::prepare_new_pool(string& name,
     *ss << "'fast_read' can only apply to erasure coding pool";
     return -EINVAL;
   }
+  if (effective_ratio > 0.0 &&
+      (target_size_ratio > 0.0 || target_size_bytes > 0)) {
+    *ss << "'effective_ratio' cannot be combined with 'target_size_ratio' "
+	<< "or 'target_size_bytes'";
+    return -EINVAL;
+  }
+  if (effective_ratio > 0.0 &&
+      osdmap.require_osd_release < ceph_release_t::umbrella) {
+    *ss << "must set require_osd_release to umbrella or later before "
+	<< "declaring an effective_ratio";
+    return -EINVAL;
+  }
   int r;
   r = prepare_pool_crush_rule(pool_type, erasure_code_profile,
 				 crush_rule_name, &crush_rule, ss);
@@ -8363,6 +8528,30 @@ int OSDMonitor::prepare_new_pool(string& name,
   if (r) {
     dout(10) << "prepare_pool_size returns " << r << dendl;
     return r;
+  }
+  if (effective_ratio > 0.0 && !pg_num_specified &&
+      osdmap.test_flag(CEPH_OSDMAP_SIMPLEAUTOSCALE)) {
+    // under the simpleautoscale flag a pool born with an effective_ratio
+    // starts at its planned pg_num (pg_autoscale_plan 'current'), so a
+    // greenfield create needs no acceptance round-trip; without the flag
+    // the ratio is stored but inert (pre-staged for a later transition)
+    uint64_t pg_target = g_conf().get_val<uint64_t>("mon_target_pg_per_osd");
+    uint64_t replicas = std::lround(
+      effective_ratio * pg_target * get_osd_num_by_crush(crush_rule));
+    uint64_t ideal = size ? replicas / size : 0;
+    uint64_t q = 1;
+    while (q * 2 <= std::max<uint64_t>(ideal, 1)) {
+      q *= 2;
+    }
+    if (ideal > q && ideal - q > q * 2 - ideal) {
+      q *= 2;
+    }
+    if (q > g_conf().get_val<uint64_t>("mon_max_pool_pg_num")) {
+      *ss << "effective_ratio " << effective_ratio << " implies pg_num " << q
+	  << " which exceeds mon_max_pool_pg_num";
+      return -ERANGE;
+    }
+    pg_num = pgp_num = q;
   }
   if (g_conf()->mon_osd_crush_smoke_test) {
     CrushWrapper newcrush = _get_pending_crush();
@@ -8537,6 +8726,9 @@ int OSDMonitor::prepare_new_pool(string& name,
       osdmap.require_osd_release >= ceph_release_t::nautilus) {
     // only store for nautilus+, just to be consistent and tidy.
     pi->opts.set(pool_opts_t::TARGET_SIZE_RATIO, target_size_ratio);
+  }
+  if (effective_ratio > 0.0) {
+    pi->opts.set(pool_opts_t::EFFECTIVE_RATIO, effective_ratio);
   }
 
   pi->cache_target_dirty_ratio_micro =
@@ -9115,6 +9307,11 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
     uint64_t flag = pg_pool_t::get_flag_by_name(var);
     // make sure we only compare against 'n' if we didn't receive a string
     if (val == "true" || (interr.empty() && n == 1)) {
+      if (var == "bulk" && osdmap.test_flag(CEPH_OSDMAP_SIMPLEAUTOSCALE)) {
+	ss << "bulk is a legacy autoscaler knob; not applicable while the "
+	   << "simpleautoscale flag is set";
+	return -EINVAL;
+      }
       p.set_flag(flag);
     } else if (val == "false" || (interr.empty() && n == 0)) {
       p.unset_flag(flag);
@@ -9443,9 +9640,46 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
            << "later before setting target_size_bytes";
         return -EINVAL;
       }
+      if (n > 0 && osdmap.test_flag(CEPH_OSDMAP_SIMPLEAUTOSCALE)) {
+	ss << "target_size_bytes is a legacy autoscaler knob; not applicable "
+	   << "while the simpleautoscale flag is set";
+	return -EINVAL;
+      }
     } else if (var == "target_size_ratio") {
       if (f < 0.0) {
 	ss << "target_size_ratio cannot be negative";
+	return -EINVAL;
+      }
+      if (f > 0.0 && osdmap.test_flag(CEPH_OSDMAP_SIMPLEAUTOSCALE)) {
+	ss << "target_size_ratio is a legacy autoscaler knob; not applicable "
+	   << "while the simpleautoscale flag is set";
+	return -EINVAL;
+      }
+    } else if (var == "effective_ratio") {
+      if (floaterr.length()) {
+	ss << "error parsing float value '" << val << "': " << floaterr;
+	return -EINVAL;
+      }
+      if (f < 0.0 || f > 1.0) {
+	ss << "effective_ratio must be between 0.0 and 1.0";
+	return -ERANGE;
+      }
+      if (f > 0.0 &&
+	  osdmap.require_osd_release < ceph_release_t::umbrella) {
+	ss << "must set require_osd_release to umbrella or later before "
+	   << "declaring an effective_ratio";
+	return -EINVAL;
+      }
+      // stored as the declared fraction of the PG budget; may be
+      // pre-staged at any time but is inert until the simpleautoscale
+      // flag makes the pg_autoscaler plan from it
+    } else if (var == "planned_pg_num") {
+      if (interr.length()) {
+	ss << "error parsing int value '" << val << "': " << interr;
+	return -EINVAL;
+      }
+      if (n < 0) {
+	ss << "planned_pg_num cannot be negative";
 	return -EINVAL;
       }
     } else if (var == "pg_num_min") {
@@ -9483,6 +9717,11 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
     } else if (var == "pg_autoscale_bias") {
       if (f < 0.0 || f > 1000.0) {
 	ss << "pg_autoscale_bias must be between 0 and 1000";
+	return -EINVAL;
+      }
+      if (f != 1.0 && osdmap.test_flag(CEPH_OSDMAP_SIMPLEAUTOSCALE)) {
+	ss << "pg_autoscale_bias is a legacy autoscaler knob; not applicable "
+	   << "while the simpleautoscale flag is set";
 	return -EINVAL;
       }
     } else if (var == "dedup_tier") {
@@ -12415,6 +12654,14 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       }
     } else if (key == "noautoscale") {
       return prepare_set_flag(op, CEPH_OSDMAP_NOAUTOSCALE);
+    } else if (key == "simpleautoscale") {
+      if (osdmap.require_osd_release < ceph_release_t::umbrella) {
+	ss << "must set require_osd_release to umbrella or later before "
+	   << "setting simpleautoscale";
+	err = -EPERM;
+	goto reply_no_propose;
+      }
+      return prepare_set_flag(op, CEPH_OSDMAP_SIMPLEAUTOSCALE);
     } else {
       ss << "unrecognized flag '" << key << "'";
       err = -EINVAL;
@@ -12449,6 +12696,8 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       return prepare_unset_flag(op, CEPH_OSDMAP_NOSNAPTRIM);
     else if (key == "noautoscale")
       return prepare_unset_flag(op, CEPH_OSDMAP_NOAUTOSCALE);
+    else if (key == "simpleautoscale")
+      return prepare_unset_flag(op, CEPH_OSDMAP_SIMPLEAUTOSCALE);
     else {
       ss << "unrecognized flag '" << key << "'";
       err = -EINVAL;
@@ -14121,8 +14370,10 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     cmd_getval(cmdmap, "size", repl_size);
     int64_t target_size_bytes = 0;
     double target_size_ratio = 0.0;
+    double effective_ratio = 0.0;
     cmd_getval(cmdmap, "target_size_bytes", target_size_bytes);
     cmd_getval(cmdmap, "target_size_ratio", target_size_ratio);
+    cmd_getval(cmdmap, "effective_ratio", effective_ratio);
 
     string pg_autoscale_mode;
     cmd_getval(cmdmap, "autoscale_mode", pg_autoscale_mode);
@@ -14138,6 +14389,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 			   rule_name,
 			   pg_num, pgp_num, pg_num_min, pg_num_max,
                            repl_size, target_size_bytes, target_size_ratio,
+			   effective_ratio,
 			   erasure_code_profile, pool_type,
                            (uint64_t)expected_num_objects,
                            fast_read,
@@ -14255,6 +14507,177 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     if (err < 0)
       goto reply_no_propose;
 
+    getline(ss, rs);
+    wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs,
+						   get_last_committed() + 1));
+    return true;
+  } else if (prefix == "osd pool autoscale-accept") {
+    // simple autoscaling's acceptance verb: apply the pg_num plans the
+    // pg_autoscaler stamped as planned_pg_num and clear the stamps - for
+    // one pool, several, or --all - in one osdmap transaction, so a
+    // reviewed plan-set commits in a single epoch. The mgr invokes the
+    // same command to auto-accept plans on mode 'on' pools.
+    if (!osdmap.test_flag(CEPH_OSDMAP_SIMPLEAUTOSCALE)) {
+      ss << "simple autoscaling is not enabled (the simpleautoscale flag "
+	 << "is not set)";
+      err = -EPERM;
+      goto reply_no_propose;
+    }
+    {
+      vector<string> pool_names;
+      cmd_getval(cmdmap, "pools", pool_names);
+      bool accept_all = false;
+      cmd_getval(cmdmap, "all", accept_all);
+      if (pool_names.empty() && !accept_all) {
+	ss << "specify one or more pools, or --all";
+	err = -EINVAL;
+	goto reply_no_propose;
+      }
+      if (!pool_names.empty() && accept_all) {
+	ss << "specify pools or --all, not both";
+	err = -EINVAL;
+	goto reply_no_propose;
+      }
+      bool force = false;
+      cmd_getval(cmdmap, "yes_i_really_mean_it", force);
+
+      // resolve targets: --all covers every pool the planner manages
+      // (mode 'off' pools are ignored, matching the planner)
+      std::vector<std::pair<int64_t,string>> targets;
+      if (accept_all) {
+	for (auto& [id, pool] : osdmap.get_pools()) {
+	  if (pool.pg_autoscale_mode == pg_pool_t::pg_autoscale_mode_t::OFF) {
+	    continue;
+	  }
+	  targets.emplace_back(id, osdmap.get_pool_name(id));
+	}
+      } else {
+	for (auto& name : pool_names) {
+	  int64_t pool_id = osdmap.lookup_pg_pool_name(name.c_str());
+	  if (pool_id < 0) {
+	    ss << "unrecognized pool '" << name << "'";
+	    err = -ENOENT;
+	    goto reply_no_propose;
+	  }
+	  targets.emplace_back(pool_id, name);
+	}
+      }
+
+      // validate everything before staging anything, so acceptance is
+      // all-or-nothing
+      struct accept_t {
+	int64_t pool_id;
+	string name;
+	int64_t planned;
+	uint32_t current;
+      };
+      std::vector<accept_t> accepts;
+      std::list<string> need_confirm;
+      for (auto& [pool_id, name] : targets) {
+	pg_pool_t p = *osdmap.get_pg_pool(pool_id);
+	if (pending_inc.new_pools.count(pool_id))
+	  p = pending_inc.new_pools[pool_id];
+	int64_t planned = 0;
+	p.opts.get(pool_opts_t::PLANNED_PG_NUM, &planned);
+	if (planned <= 0) {
+	  // idempotent: nothing pending is not an error
+	  continue;
+	}
+	// accepting a plan that merges away half or more of the PGs of a
+	// pool holding significant data deserves explicit confirmation
+	if (planned <= (int64_t)p.get_pg_num_target() / 2 && !force) {
+	  uint64_t bytes_threshold = cct->_conf.get_val<Option::size_t>(
+	    "mon_osd_pool_pg_merge_confirm_bytes");
+	  const pool_stat_t *pstat = mon.mgrstatmon()->get_pool_stat(pool_id);
+	  uint64_t stored = pstat ? pstat->stats.sum.num_bytes : 0;
+	  if (stored > bytes_threshold) {
+	    ostringstream os;
+	    os << name << " (pg_num " << p.get_pg_num_target() << " -> "
+	       << planned << ", " << byte_u_t(stored) << " stored)";
+	    need_confirm.push_back(os.str());
+	    continue;
+	  }
+	}
+	accepts.push_back({pool_id, name, planned, p.get_pg_num_target()});
+      }
+      if (!need_confirm.empty()) {
+	ss << "accepting would merge away half or more of the PGs of: ";
+	bool first = true;
+	for (auto& s : need_confirm) {
+	  ss << (first ? "" : "; ") << s;
+	  first = false;
+	}
+	ss << "; pass --yes-i-really-mean-it to proceed";
+	err = -EPERM;
+	goto reply_no_propose;
+      }
+      if (accepts.empty()) {
+	if (accept_all) {
+	  ss << "no plans pending";
+	} else if (targets.size() == 1) {
+	  ss << "pool '" << targets[0].second
+	     << "' has no plan pending; pg_num is current";
+	} else {
+	  ss << "no plans pending on the given pools";
+	}
+	err = 0;
+	goto reply_no_propose;
+      }
+
+      // apply through the regular pg_num path so all of its checks and
+      // machinery apply; every pool stages into this one pending_inc, so
+      // the accepted plans commit in a single osdmap epoch. Snapshot the
+      // staging first: any failure rolls every pool back.
+      std::map<int64_t, std::optional<pg_pool_t>> saved;
+      for (auto& a : accepts) {
+	if (pending_inc.new_pools.count(a.pool_id))
+	  saved.emplace(a.pool_id, pending_inc.new_pools[a.pool_id]);
+	else
+	  saved.emplace(a.pool_id, std::nullopt);
+      }
+      auto rollback = [&] {
+	for (auto& [id, prior] : saved) {
+	  if (prior)
+	    pending_inc.new_pools[id] = *prior;
+	  else
+	    pending_inc.new_pools.erase(id);
+	}
+      };
+      for (auto& a : accepts) {
+	cmdmap_t accept_cmd;
+	accept_cmd["prefix"] = string("osd pool set");
+	accept_cmd["pool"] = a.name;
+	accept_cmd["var"] = string("pg_num");
+	accept_cmd["val"] = stringify(a.planned);
+	accept_cmd["yes_i_really_mean_it"] = force;
+	err = prepare_command_pool_set(accept_cmd, ss);
+	if (err == -EAGAIN) {
+	  rollback();
+	  goto wait;
+	}
+	if (err < 0) {
+	  ss << " (accepting pool '" << a.name << "'; nothing was applied)";
+	  rollback();
+	  goto reply_no_propose;
+	}
+	if (!pending_inc.new_pools.count(a.pool_id)) {
+	  // the plan matched pg_num exactly, so the set staged nothing;
+	  // stage the pool just to clear the stamp
+	  pending_inc.new_pools[a.pool_id] = *osdmap.get_pg_pool(a.pool_id);
+	}
+	pg_pool_t &np = pending_inc.new_pools[a.pool_id];
+	np.opts.unset(pool_opts_t::PLANNED_PG_NUM);
+	np.last_change = pending_inc.epoch;
+      }
+      ss.str("");  // replace the pool-set chatter with the acceptance
+      ss << "accepted " << accepts.size() << " plan(s): ";
+      bool first = true;
+      for (auto& a : accepts) {
+	ss << (first ? "" : ", ") << a.name << " pg_num " << a.current
+	   << " -> " << a.planned;
+	first = false;
+      }
+    }
     getline(ss, rs);
     wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs,
 						   get_last_committed() + 1));

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5583,10 +5583,26 @@ namespace {
     COMPRESSION_MAX_BLOB_SIZE, COMPRESSION_MIN_BLOB_SIZE,
     CSUM_TYPE, CSUM_MAX_BLOCK, CSUM_MIN_BLOCK, FINGERPRINT_ALGORITHM,
     PG_AUTOSCALE_MODE, PG_NUM_MIN, TARGET_SIZE_BYTES, TARGET_SIZE_RATIO,
-    PG_AUTOSCALE_BIAS, DEDUP_TIER, DEDUP_CHUNK_ALGORITHM, 
+    PG_AUTOSCALE_BIAS, DEDUP_TIER, DEDUP_CHUNK_ALGORITHM,
     DEDUP_CDC_CHUNK_SIZE, POOL_EIO, BULK, PG_NUM_MAX, READ_RATIO,
     EC_OPTIMIZATIONS, EC_DATA_SHARD_COUNT, EC_CODING_SHARD_COUNT,
-    SUPPORTS_OMAP };
+    SUPPORTS_OMAP, EFFECTIVE_RATIO, PLANNED_PG_NUM, PG_AUTOSCALE_PLAN };
+
+  // the simple-autoscaling plan state is derived, never stored: 'learn'
+  // until a pool has an effective_ratio, 'pending' while a stamped plan
+  // differs from pg_num, 'current' once they agree
+  std::string pool_pg_autoscale_plan(const pg_pool_t& p)
+  {
+    if (!p.opts.is_set(pool_opts_t::EFFECTIVE_RATIO)) {
+      return "learn";
+    }
+    int64_t planned = 0;
+    p.opts.get(pool_opts_t::PLANNED_PG_NUM, &planned);
+    if (planned > 0 && planned != (int64_t)p.get_pg_num_target()) {
+      return "pending";
+    }
+    return "current";
+  }
 
   std::set<osd_pool_get_choices>
     subtract_second_from_first(const std::set<osd_pool_get_choices>& first,
@@ -6324,6 +6340,115 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
       }
     }
     r = 0;
+  } else if ((prefix == "osd pool create" || prefix == "osd pool set") &&
+	     cmd_getval_or<bool>(cmdmap, "dry_run", false)) {
+    // --dry-run: report what effective_ratio would plan and the
+    // pg_num it implies, without changing anything
+    double frac = 0.0;
+    unsigned size = 0;
+    uint32_t num_osds = 0;
+    bool scoped = false;  // whether num_osds reflects the pool's CRUSH rule
+    auto count_rule_osds = [&](int rule_id) -> uint32_t {
+      set<int> roots;
+      osdmap.crush->find_takes_by_rule(rule_id, &roots);
+      set<int> rule_osds;
+      for (auto root : roots) {
+	set<int> leaves;
+	osdmap.crush->get_leaves(osdmap.crush->get_item_name(root), &leaves);
+	rule_osds.insert(leaves.begin(), leaves.end());
+      }
+      return rule_osds.size();
+    };
+    if (prefix == "osd pool set") {
+      string var, val;
+      cmd_getval(cmdmap, "var", var);
+      cmd_getval(cmdmap, "val", val);
+      if (var != "effective_ratio") {
+	ss << "--dry-run is only supported for effective_ratio";
+	r = -EINVAL;
+	goto reply;
+      }
+      string poolstr;
+      cmd_getval(cmdmap, "pool", poolstr);
+      int64_t pool_id = osdmap.lookup_pg_pool_name(poolstr.c_str());
+      if (pool_id < 0) {
+	ss << "unrecognized pool '" << poolstr << "'";
+	r = -ENOENT;
+	goto reply;
+      }
+      string floaterr;
+      frac = strict_strtod(val.c_str(), &floaterr);
+      if (floaterr.length()) {
+	ss << "error parsing float value '" << val << "': " << floaterr;
+	r = -EINVAL;
+	goto reply;
+      }
+      const pg_pool_t *pp = osdmap.get_pg_pool(pool_id);
+      size = pp->get_size();
+      num_osds = count_rule_osds(pp->get_crush_rule());
+      scoped = true;
+    } else {
+      if (!cmd_getval(cmdmap, "effective_ratio", frac)) {
+	ss << "--dry-run requires --effective-ratio";
+	r = -EINVAL;
+	goto reply;
+      }
+      // read-only estimate: size comes from the erasure profile (k+m) or
+      // the replicated default; the OSD count is scoped to the named CRUSH
+      // rule if it already exists, else it covers the whole map
+      string profile;
+      cmd_getval(cmdmap, "erasure_code_profile", profile);
+      if (profile.length() && osdmap.has_erasure_code_profile(profile)) {
+	auto& ecp = osdmap.get_erasure_code_profile(profile);
+	auto k = ecp.find("k");
+	auto m = ecp.find("m");
+	if (k != ecp.end() && m != ecp.end()) {
+	  size = atoi(k->second.c_str()) + atoi(m->second.c_str());
+	}
+      } else {
+	int64_t repl_size = 0;
+	cmd_getval(cmdmap, "size", repl_size);
+	size = repl_size ? repl_size :
+	  g_conf().get_val<uint64_t>("osd_pool_default_size");
+      }
+      string rule_name;
+      cmd_getval(cmdmap, "rule", rule_name);
+      int rule_id = rule_name.empty() ? -ENOENT :
+	osdmap.crush->get_rule_id(rule_name);
+      if (rule_id >= 0) {
+	num_osds = count_rule_osds(rule_id);
+	scoped = true;
+      } else {
+	num_osds = osdmap.get_num_osds();
+      }
+    }
+    if (frac < 0.0 || frac > 1.0) {
+      ss << "effective_ratio must be between 0.0 and 1.0";
+      r = -ERANGE;
+      goto reply;
+    }
+    {
+      uint64_t target = g_conf().get_val<uint64_t>("mon_target_pg_per_osd");
+      uint64_t reserve = std::lround(frac * target);
+      ss << "dry run: effective_ratio " << frac << " is " << reserve
+	 << " PG replicas per OSD (of mon_target_pg_per_osd " << target << ")";
+      if (size && num_osds) {
+	uint64_t ideal = reserve * num_osds / size;
+	uint64_t lo = 1;
+	while (lo * 2 <= std::max<uint64_t>(ideal, 1)) {
+	  lo *= 2;
+	}
+	uint64_t quant = (ideal - lo <= lo * 2 - ideal) ? lo : lo * 2;
+	ss << "; across " << num_osds
+	   << (scoped ? " OSDs under the pool's CRUSH rule" : " OSDs")
+	   << " at pool size " << size << " the ideal pg_num is " << ideal
+	   << ", quantizing to " << quant
+	   << ". The realized pg_num is chosen by the pg_autoscaler subject"
+	   << " to budget fit, overlap proration, pg_num_min/max and the"
+	   << " per-pool minimum; see 'ceph osd pool autoscale-status'";
+      }
+      r = 0;
+    }
   } else if (prefix == "osd pool get") {
     string poolstr;
     cmd_getval(cmdmap, "pool", poolstr);
@@ -6382,10 +6507,13 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
       {"csum_min_block", CSUM_MIN_BLOCK},
       {"fingerprint_algorithm", FINGERPRINT_ALGORITHM},
       {"pg_autoscale_mode", PG_AUTOSCALE_MODE},
+      {"pg_autoscale_plan", PG_AUTOSCALE_PLAN},
       {"pg_num_min", PG_NUM_MIN},
       {"pg_num_max", PG_NUM_MAX},
       {"target_size_bytes", TARGET_SIZE_BYTES},
       {"target_size_ratio", TARGET_SIZE_RATIO},
+      {"effective_ratio", EFFECTIVE_RATIO},
+      {"planned_pg_num", PLANNED_PG_NUM},
       {"pg_autoscale_bias", PG_AUTOSCALE_BIAS},
       {"dedup_tier", DEDUP_TIER},
       {"dedup_chunk_algorithm", DEDUP_CHUNK_ALGORITHM},
@@ -6437,6 +6565,10 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
         selected_choices = subtract_second_from_first(selected_choices,
 						      ONLY_REPLICA_CHOICES);
       }
+      if (!osdmap.test_flag(CEPH_OSDMAP_SIMPLEAUTOSCALE)) {
+	selected_choices = subtract_second_from_first(selected_choices,
+						      {PG_AUTOSCALE_PLAN});
+      }
     } else /* var != "all" */  {
       choices_map_t::const_iterator found = ALL_CHOICES.find(var);
       if (found == ALL_CHOICES.end()) {
@@ -6447,6 +6579,14 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
       }
 
       osd_pool_get_choices selected = found->second;
+
+      if (selected == PG_AUTOSCALE_PLAN &&
+	  !osdmap.test_flag(CEPH_OSDMAP_SIMPLEAUTOSCALE)) {
+	ss << "simple autoscaling is not enabled (the simpleautoscale flag "
+	   << "is not set)";
+	r = -EINVAL;
+	goto reply;
+      }
 
       if (!p->is_tier() &&
 	  ONLY_TIER_CHOICES.find(selected) != ONLY_TIER_CHOICES.end()) {
@@ -6526,6 +6666,9 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	    f->dump_string("pg_autoscale_mode",
 			   pg_pool_t::get_pg_autoscale_mode_name(
 			     p->pg_autoscale_mode));
+	    break;
+	  case PG_AUTOSCALE_PLAN:
+	    f->dump_string("pg_autoscale_plan", pool_pg_autoscale_plan(*p));
 	    break;
 	  case HASHPSPOOL:
 	  case POOL_EIO:
@@ -6643,6 +6786,8 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	  case DEDUP_CHUNK_ALGORITHM:
 	  case DEDUP_CDC_CHUNK_SIZE:
           case READ_RATIO:
+	  case EFFECTIVE_RATIO:
+	  case PLANNED_PG_NUM:
 	    {
 	      pool_opts_t::key_t key = pool_opts_t::get_opt_desc(i->first).key;
 	      if (p->opts.is_set(key)) {
@@ -6703,6 +6848,9 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	  case PG_AUTOSCALE_MODE:
 	    ss << "pg_autoscale_mode: " << pg_pool_t::get_pg_autoscale_mode_name(
 	      p->pg_autoscale_mode) <<"\n";
+	    break;
+	  case PG_AUTOSCALE_PLAN:
+	    ss << "pg_autoscale_plan: " << pool_pg_autoscale_plan(*p) << "\n";
 	    break;
 	  case HIT_SET_PERIOD:
 	    ss << "hit_set_period: " << p->hit_set_period << "\n";
@@ -6824,6 +6972,8 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	  case DEDUP_CHUNK_ALGORITHM:
 	  case DEDUP_CDC_CHUNK_SIZE:
           case READ_RATIO:
+	  case EFFECTIVE_RATIO:
+	  case PLANNED_PG_NUM:
 	    for (i = ALL_CHOICES.begin(); i != ALL_CHOICES.end(); ++i) {
 	      if (i->second == *it)
 		break;
@@ -7630,7 +7780,7 @@ int OSDMonitor::prepare_new_pool(MonOpRequestRef op)
   bool bulk = false;
   int ret = 0;
   ret = prepare_new_pool(m->name, m->crush_rule, rule_name,
-			 0, 0, 0, 0, 0, 0, 0.0,
+			 0, 0, 0, 0, 0, 0, 0.0, 0.0,
 			 erasure_code_profile,
 			 pg_pool_t::TYPE_REPLICATED, 0, FAST_READ_OFF, {}, bulk,
 			 cct->_conf.get_val<bool>("osd_pool_default_crimson"),
@@ -8261,6 +8411,8 @@ int OSDMonitor::check_pg_num(int64_t pool,
  * @param pg_num_min min pg_num
  * @param pg_num_max max pg_num
  * @param repl_size Replication factor, or 0 for default
+ * @param effective_ratio Share (0,1] of the PG budget for simple-mode
+ *        provisioning, or 0 for none
  * @param erasure_code_profile The profile name in OSDMap to be used for erasure code
  * @param pool_type TYPE_ERASURE, or TYPE_REP
  * @param expected_num_objects expected number of objects on the pool
@@ -8281,6 +8433,7 @@ int OSDMonitor::prepare_new_pool(string& name,
                                  const uint64_t repl_size,
 				 const uint64_t target_size_bytes,
 				 const float target_size_ratio,
+				 const double effective_ratio,
 				 const string &erasure_code_profile,
                                  const unsigned pool_type,
                                  const uint64_t expected_num_objects,
@@ -8296,10 +8449,10 @@ int OSDMonitor::prepare_new_pool(string& name,
     // "off"
     pg_autoscale_mode = "off";
   }
-
   if (name.length() == 0)
     return -EINVAL;
 
+  const bool pg_num_specified = pg_num != 0;
   if (pg_num == 0) {
     auto pg_num_from_mode =
       [pg_num=g_conf().get_val<uint64_t>("osd_pool_default_pg_num")]
@@ -8346,6 +8499,18 @@ int OSDMonitor::prepare_new_pool(string& name,
     *ss << "'fast_read' can only apply to erasure coding pool";
     return -EINVAL;
   }
+  if (effective_ratio > 0.0 &&
+      (target_size_ratio > 0.0 || target_size_bytes > 0)) {
+    *ss << "'effective_ratio' cannot be combined with 'target_size_ratio' "
+	<< "or 'target_size_bytes'";
+    return -EINVAL;
+  }
+  if (effective_ratio > 0.0 &&
+      osdmap.require_osd_release < ceph_release_t::umbrella) {
+    *ss << "must set require_osd_release to umbrella or later before "
+	<< "declaring an effective_ratio";
+    return -EINVAL;
+  }
   int r;
   r = prepare_pool_crush_rule(pool_type, erasure_code_profile,
 				 crush_rule_name, &crush_rule, ss);
@@ -8359,6 +8524,30 @@ int OSDMonitor::prepare_new_pool(string& name,
   if (r) {
     dout(10) << "prepare_pool_size returns " << r << dendl;
     return r;
+  }
+  if (effective_ratio > 0.0 && !pg_num_specified &&
+      osdmap.test_flag(CEPH_OSDMAP_SIMPLEAUTOSCALE)) {
+    // under the simpleautoscale flag a pool born with an effective_ratio
+    // starts at its planned pg_num (pg_autoscale_plan 'current'), so a
+    // greenfield create needs no acceptance round-trip; without the flag
+    // the ratio is stored but inert (pre-staged for a later transition)
+    uint64_t pg_target = g_conf().get_val<uint64_t>("mon_target_pg_per_osd");
+    uint64_t replicas = std::lround(
+      effective_ratio * pg_target * get_osd_num_by_crush(crush_rule));
+    uint64_t ideal = size ? replicas / size : 0;
+    uint64_t q = 1;
+    while (q * 2 <= std::max<uint64_t>(ideal, 1)) {
+      q *= 2;
+    }
+    if (ideal > q && ideal - q > q * 2 - ideal) {
+      q *= 2;
+    }
+    if (q > g_conf().get_val<uint64_t>("mon_max_pool_pg_num")) {
+      *ss << "effective_ratio " << effective_ratio << " implies pg_num " << q
+	  << " which exceeds mon_max_pool_pg_num";
+      return -ERANGE;
+    }
+    pg_num = pgp_num = q;
   }
   if (g_conf()->mon_osd_crush_smoke_test) {
     CrushWrapper newcrush = _get_pending_crush();
@@ -8534,6 +8723,9 @@ int OSDMonitor::prepare_new_pool(string& name,
       osdmap.require_osd_release >= ceph_release_t::nautilus) {
     // only store for nautilus+, just to be consistent and tidy.
     pi->opts.set(pool_opts_t::TARGET_SIZE_RATIO, target_size_ratio);
+  }
+  if (effective_ratio > 0.0) {
+    pi->opts.set(pool_opts_t::EFFECTIVE_RATIO, effective_ratio);
   }
 
   pi->cache_target_dirty_ratio_micro =
@@ -9112,6 +9304,11 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
     uint64_t flag = pg_pool_t::get_flag_by_name(var);
     // make sure we only compare against 'n' if we didn't receive a string
     if (val == "true" || (interr.empty() && n == 1)) {
+      if (var == "bulk" && osdmap.test_flag(CEPH_OSDMAP_SIMPLEAUTOSCALE)) {
+	ss << "bulk is a legacy autoscaler knob; not applicable while the "
+	   << "simpleautoscale flag is set";
+	return -EINVAL;
+      }
       p.set_flag(flag);
     } else if (val == "false" || (interr.empty() && n == 0)) {
       p.unset_flag(flag);
@@ -9440,9 +9637,46 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
            << "later before setting target_size_bytes";
         return -EINVAL;
       }
+      if (n > 0 && osdmap.test_flag(CEPH_OSDMAP_SIMPLEAUTOSCALE)) {
+	ss << "target_size_bytes is a legacy autoscaler knob; not applicable "
+	   << "while the simpleautoscale flag is set";
+	return -EINVAL;
+      }
     } else if (var == "target_size_ratio") {
       if (f < 0.0) {
 	ss << "target_size_ratio cannot be negative";
+	return -EINVAL;
+      }
+      if (f > 0.0 && osdmap.test_flag(CEPH_OSDMAP_SIMPLEAUTOSCALE)) {
+	ss << "target_size_ratio is a legacy autoscaler knob; not applicable "
+	   << "while the simpleautoscale flag is set";
+	return -EINVAL;
+      }
+    } else if (var == "effective_ratio") {
+      if (floaterr.length()) {
+	ss << "error parsing float value '" << val << "': " << floaterr;
+	return -EINVAL;
+      }
+      if (f < 0.0 || f > 1.0) {
+	ss << "effective_ratio must be between 0.0 and 1.0";
+	return -ERANGE;
+      }
+      if (f > 0.0 &&
+	  osdmap.require_osd_release < ceph_release_t::umbrella) {
+	ss << "must set require_osd_release to umbrella or later before "
+	   << "declaring an effective_ratio";
+	return -EINVAL;
+      }
+      // stored as the declared fraction of the PG budget; may be
+      // pre-staged at any time but is inert until the simpleautoscale
+      // flag makes the pg_autoscaler plan from it
+    } else if (var == "planned_pg_num") {
+      if (interr.length()) {
+	ss << "error parsing int value '" << val << "': " << interr;
+	return -EINVAL;
+      }
+      if (n < 0) {
+	ss << "planned_pg_num cannot be negative";
 	return -EINVAL;
       }
     } else if (var == "pg_num_min") {
@@ -9480,6 +9714,11 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
     } else if (var == "pg_autoscale_bias") {
       if (f < 0.0 || f > 1000.0) {
 	ss << "pg_autoscale_bias must be between 0 and 1000";
+	return -EINVAL;
+      }
+      if (f != 1.0 && osdmap.test_flag(CEPH_OSDMAP_SIMPLEAUTOSCALE)) {
+	ss << "pg_autoscale_bias is a legacy autoscaler knob; not applicable "
+	   << "while the simpleautoscale flag is set";
 	return -EINVAL;
       }
     } else if (var == "dedup_tier") {
@@ -12412,6 +12651,14 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       }
     } else if (key == "noautoscale") {
       return prepare_set_flag(op, CEPH_OSDMAP_NOAUTOSCALE);
+    } else if (key == "simpleautoscale") {
+      if (osdmap.require_osd_release < ceph_release_t::umbrella) {
+	ss << "must set require_osd_release to umbrella or later before "
+	   << "setting simpleautoscale";
+	err = -EPERM;
+	goto reply_no_propose;
+      }
+      return prepare_set_flag(op, CEPH_OSDMAP_SIMPLEAUTOSCALE);
     } else {
       ss << "unrecognized flag '" << key << "'";
       err = -EINVAL;
@@ -12446,6 +12693,8 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       return prepare_unset_flag(op, CEPH_OSDMAP_NOSNAPTRIM);
     else if (key == "noautoscale")
       return prepare_unset_flag(op, CEPH_OSDMAP_NOAUTOSCALE);
+    else if (key == "simpleautoscale")
+      return prepare_unset_flag(op, CEPH_OSDMAP_SIMPLEAUTOSCALE);
     else {
       ss << "unrecognized flag '" << key << "'";
       err = -EINVAL;
@@ -14118,8 +14367,10 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     cmd_getval(cmdmap, "size", repl_size);
     int64_t target_size_bytes = 0;
     double target_size_ratio = 0.0;
+    double effective_ratio = 0.0;
     cmd_getval(cmdmap, "target_size_bytes", target_size_bytes);
     cmd_getval(cmdmap, "target_size_ratio", target_size_ratio);
+    cmd_getval(cmdmap, "effective_ratio", effective_ratio);
 
     string pg_autoscale_mode;
     cmd_getval(cmdmap, "autoscale_mode", pg_autoscale_mode);
@@ -14134,6 +14385,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 			   rule_name,
 			   pg_num, pgp_num, pg_num_min, pg_num_max,
                            repl_size, target_size_bytes, target_size_ratio,
+			   effective_ratio,
 			   erasure_code_profile, pool_type,
                            (uint64_t)expected_num_objects,
                            fast_read,
@@ -14250,6 +14502,177 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     if (err < 0)
       goto reply_no_propose;
 
+    getline(ss, rs);
+    wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs,
+						   get_last_committed() + 1));
+    return true;
+  } else if (prefix == "osd pool autoscale-accept") {
+    // simple autoscaling's acceptance verb: apply the pg_num plans the
+    // pg_autoscaler stamped as planned_pg_num and clear the stamps - for
+    // one pool, several, or --all - in one osdmap transaction, so a
+    // reviewed plan-set commits in a single epoch. The mgr invokes the
+    // same command to auto-accept plans on mode 'on' pools.
+    if (!osdmap.test_flag(CEPH_OSDMAP_SIMPLEAUTOSCALE)) {
+      ss << "simple autoscaling is not enabled (the simpleautoscale flag "
+	 << "is not set)";
+      err = -EPERM;
+      goto reply_no_propose;
+    }
+    {
+      vector<string> pool_names;
+      cmd_getval(cmdmap, "pools", pool_names);
+      bool accept_all = false;
+      cmd_getval(cmdmap, "all", accept_all);
+      if (pool_names.empty() && !accept_all) {
+	ss << "specify one or more pools, or --all";
+	err = -EINVAL;
+	goto reply_no_propose;
+      }
+      if (!pool_names.empty() && accept_all) {
+	ss << "specify pools or --all, not both";
+	err = -EINVAL;
+	goto reply_no_propose;
+      }
+      bool force = false;
+      cmd_getval(cmdmap, "yes_i_really_mean_it", force);
+
+      // resolve targets: --all covers every pool the planner manages
+      // (mode 'off' pools are ignored, matching the planner)
+      std::vector<std::pair<int64_t,string>> targets;
+      if (accept_all) {
+	for (auto& [id, pool] : osdmap.get_pools()) {
+	  if (pool.pg_autoscale_mode == pg_pool_t::pg_autoscale_mode_t::OFF) {
+	    continue;
+	  }
+	  targets.emplace_back(id, osdmap.get_pool_name(id));
+	}
+      } else {
+	for (auto& name : pool_names) {
+	  int64_t pool_id = osdmap.lookup_pg_pool_name(name.c_str());
+	  if (pool_id < 0) {
+	    ss << "unrecognized pool '" << name << "'";
+	    err = -ENOENT;
+	    goto reply_no_propose;
+	  }
+	  targets.emplace_back(pool_id, name);
+	}
+      }
+
+      // validate everything before staging anything, so acceptance is
+      // all-or-nothing
+      struct accept_t {
+	int64_t pool_id;
+	string name;
+	int64_t planned;
+	uint32_t current;
+      };
+      std::vector<accept_t> accepts;
+      std::list<string> need_confirm;
+      for (auto& [pool_id, name] : targets) {
+	pg_pool_t p = *osdmap.get_pg_pool(pool_id);
+	if (pending_inc.new_pools.count(pool_id))
+	  p = pending_inc.new_pools[pool_id];
+	int64_t planned = 0;
+	p.opts.get(pool_opts_t::PLANNED_PG_NUM, &planned);
+	if (planned <= 0) {
+	  // idempotent: nothing pending is not an error
+	  continue;
+	}
+	// accepting a plan that merges away more than half the PGs of a
+	// pool holding significant data deserves explicit confirmation
+	if (planned < (int64_t)p.get_pg_num_target() / 2 && !force) {
+	  uint64_t bytes_threshold = cct->_conf.get_val<Option::size_t>(
+	    "mon_osd_pool_pg_merge_confirm_bytes");
+	  const pool_stat_t *pstat = mon.mgrstatmon()->get_pool_stat(pool_id);
+	  uint64_t stored = pstat ? pstat->stats.sum.num_bytes : 0;
+	  if (stored > bytes_threshold) {
+	    ostringstream os;
+	    os << name << " (pg_num " << p.get_pg_num_target() << " -> "
+	       << planned << ", " << byte_u_t(stored) << " stored)";
+	    need_confirm.push_back(os.str());
+	    continue;
+	  }
+	}
+	accepts.push_back({pool_id, name, planned, p.get_pg_num_target()});
+      }
+      if (!need_confirm.empty()) {
+	ss << "accepting would merge away more than half the PGs of: ";
+	bool first = true;
+	for (auto& s : need_confirm) {
+	  ss << (first ? "" : "; ") << s;
+	  first = false;
+	}
+	ss << "; pass --yes-i-really-mean-it to proceed";
+	err = -EPERM;
+	goto reply_no_propose;
+      }
+      if (accepts.empty()) {
+	if (accept_all) {
+	  ss << "no plans pending";
+	} else if (targets.size() == 1) {
+	  ss << "pool '" << targets[0].second
+	     << "' has no plan pending; pg_num is current";
+	} else {
+	  ss << "no plans pending on the given pools";
+	}
+	err = 0;
+	goto reply_no_propose;
+      }
+
+      // apply through the regular pg_num path so all of its checks and
+      // machinery apply; every pool stages into this one pending_inc, so
+      // the accepted plans commit in a single osdmap epoch. Snapshot the
+      // staging first: any failure rolls every pool back.
+      std::map<int64_t, std::optional<pg_pool_t>> saved;
+      for (auto& a : accepts) {
+	if (pending_inc.new_pools.count(a.pool_id))
+	  saved.emplace(a.pool_id, pending_inc.new_pools[a.pool_id]);
+	else
+	  saved.emplace(a.pool_id, std::nullopt);
+      }
+      auto rollback = [&] {
+	for (auto& [id, prior] : saved) {
+	  if (prior)
+	    pending_inc.new_pools[id] = *prior;
+	  else
+	    pending_inc.new_pools.erase(id);
+	}
+      };
+      for (auto& a : accepts) {
+	cmdmap_t accept_cmd;
+	accept_cmd["prefix"] = string("osd pool set");
+	accept_cmd["pool"] = a.name;
+	accept_cmd["var"] = string("pg_num");
+	accept_cmd["val"] = stringify(a.planned);
+	accept_cmd["yes_i_really_mean_it"] = force;
+	err = prepare_command_pool_set(accept_cmd, ss);
+	if (err == -EAGAIN) {
+	  rollback();
+	  goto wait;
+	}
+	if (err < 0) {
+	  ss << " (accepting pool '" << a.name << "'; nothing was applied)";
+	  rollback();
+	  goto reply_no_propose;
+	}
+	if (!pending_inc.new_pools.count(a.pool_id)) {
+	  // the plan matched pg_num exactly, so the set staged nothing;
+	  // stage the pool just to clear the stamp
+	  pending_inc.new_pools[a.pool_id] = *osdmap.get_pg_pool(a.pool_id);
+	}
+	pg_pool_t &np = pending_inc.new_pools[a.pool_id];
+	np.opts.unset(pool_opts_t::PLANNED_PG_NUM);
+	np.last_change = pending_inc.epoch;
+      }
+      ss.str("");  // replace the pool-set chatter with the acceptance
+      ss << "accepted " << accepts.size() << " plan(s): ";
+      bool first = true;
+      for (auto& a : accepts) {
+	ss << (first ? "" : ", ") << a.name << " pg_num " << a.current
+	   << " -> " << a.planned;
+	first = false;
+      }
+    }
     getline(ss, rs);
     wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs,
 						   get_last_committed() + 1));

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -551,6 +551,7 @@ private:
                        uint64_t repl_size,
 		       const uint64_t target_size_bytes,
 		       const float target_size_ratio,
+		       const double effective_ratio,
 		       const std::string &erasure_code_profile,
                        const unsigned pool_type,
                        const uint64_t expected_num_objects,

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -4404,6 +4404,8 @@ string OSDMap::get_flag_string(unsigned f)
     s += ",pglog_hardlimit";
   if (f & CEPH_OSDMAP_NOAUTOSCALE)
     s += ",noautoscale";
+  if (f & CEPH_OSDMAP_SIMPLEAUTOSCALE)
+    s += ",simpleautoscale";
   if (s.length())
     s.erase(0, 1);
   return s;

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1409,7 +1409,11 @@ static opt_mapping_t opt_mapping = boost::assign::map_list_of
 	   ("read_ratio", pool_opts_t::opt_desc_t(
              pool_opts_t::READ_RATIO, pool_opts_t::INT))
 	   ("pct_update_delay", pool_opts_t::opt_desc_t(
-             pool_opts_t::PCT_UPDATE_DELAY, pool_opts_t::INT));
+             pool_opts_t::PCT_UPDATE_DELAY, pool_opts_t::INT))
+	   ("effective_ratio", pool_opts_t::opt_desc_t(
+             pool_opts_t::EFFECTIVE_RATIO, pool_opts_t::DOUBLE))
+	   ("planned_pg_num", pool_opts_t::opt_desc_t(
+             pool_opts_t::PLANNED_PG_NUM, pool_opts_t::INT));
 
 bool pool_opts_t::is_opt_name(const std::string& name)
 {

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1145,6 +1145,33 @@ public:
      * completion if there are no other in progress writes.
      */
     PCT_UPDATE_DELAY,
+    /**
+     * EFFECTIVE_RATIO
+     *
+     * The pool's share (0.0, 1.0] of its budget domain's PG budget
+     * (OSD count x mon_target_pg_per_osd, in PG replicas). May be set
+     * (pre-staged) at any time but is inert unless the osdmap's
+     * SIMPLEAUTOSCALE flag is set; while it is, the pg_autoscaler plans
+     * pg_num = ratio x budget / pool size and stamps divergences as
+     * PLANNED_PG_NUM. Unlike TARGET_SIZE_RATIO it is absolute: never
+     * normalized against other pools and never overridden by actual
+     * usage.
+     */
+    EFFECTIVE_RATIO,
+    /**
+     * PLANNED_PG_NUM
+     *
+     * The pg_num the autoscaler's current plan calls for, stamped by the
+     * pg_autoscaler whenever a pool's plan diverges from its pg_num.
+     * 'osd pool autoscale-accept' applies exactly this stamped value and
+     * clears it in one osdmap transaction, so what the operator saw in
+     * autoscale-status is what they get; on mode 'on' pools the mgr
+     * invokes the same acceptance automatically unless the plan is a
+     * large merge (see mon_osd_pool_pg_merge_confirm_bytes). The derived
+     * plan state (learn/pending/current) is reported by 'osd pool get
+     * pg_autoscale_plan'.
+     */
+    PLANNED_PG_NUM,
   };
 
   enum type_t {

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -72,18 +72,21 @@ def nearest_power_of_two(n: float, direction: str = "nearest") -> int:
 def effective_target_ratio(target_ratio: float,
                            total_target_ratio: float,
                            total_target_bytes: int,
-                           capacity: int) -> float:
+                           capacity: int,
+                           total_pinned_ratio: float = 0.0) -> float:
     """
     Returns the target ratio after normalizing for ratios across pools and
-    adjusting for capacity reserved by pools that have target_size_bytes set.
+    adjusting for capacity reserved by pools that have target_size_bytes or
+    an effective_ratio set.
     """
     target_ratio = float(target_ratio)
     if total_target_ratio:
         target_ratio = target_ratio / total_target_ratio
 
+    fraction_available = 1.0 - min(1.0, total_pinned_ratio)
     if total_target_bytes and capacity:
-        fraction_available = 1.0 - min(1.0, float(total_target_bytes) / capacity)
-        target_ratio *= fraction_available
+        fraction_available -= min(1.0, float(total_target_bytes) / capacity)
+    target_ratio *= max(0.0, fraction_available)
 
     return target_ratio
 
@@ -126,6 +129,7 @@ class CrushRootResourceStatus:
         self.pool_used = 0
         self.total_target_ratio = 0.0
         self.total_target_bytes = 0  # including replication / EC overhead
+        self.total_pinned_ratio = 0.0  # sum of planner pools' effective_ratio
 
 
 class BacktrackNode(NamedTuple):
@@ -207,6 +211,17 @@ class PgAutoscaler(MgrModule):
                        '`PG_NUM` before being accepted. Cannot be less than 1.0'),
             default=3.0,
             min=1.0),
+
+        Option(
+            name='pg_size_drift_warn_multiple',
+            type='float',
+            desc='bytes-per-PG drift multiple for simple-provisioned pools',
+            long_desc=('Warn when a pool with an effective_ratio stores more '
+                       'than this multiple of the cluster median bytes per PG. '
+                       'Planned pools do not gain PGs as they grow, so this is '
+                       'the signal that a ratio has fallen behind the data.'),
+            default=4.0,
+            min=1.0),
     ]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -221,6 +236,7 @@ class PgAutoscaler(MgrModule):
             self.sleep_interval = 60
             self.mon_target_pg_per_osd = 0
             self.threshold = 3.0
+            self.pg_size_drift_warn_multiple = 4.0
 
     def config_notify(self) -> None:
         for opt in self.NATIVE_OPTIONS:
@@ -246,6 +262,39 @@ class PgAutoscaler(MgrModule):
 
         if format in ('json', 'json-pretty'):
             return 0, json.dumps(ps, indent=4, sort_keys=True), ''
+        elif self.has_simpleautoscale_flag():
+            # simple autoscaling: the legacy columns describe the model
+            # being left behind, so show only what the plan/accept
+            # lifecycle needs (JSON output remains complete)
+            table = PrettyTable(['POOL', 'EFFECTIVE RATIO', 'PG_NUM',
+                                 'NEW PG_NUM', 'AUTOSCALE', 'PLAN'],
+                                border=False)
+            table.left_padding_width = 0
+            table.right_padding_width = 2
+            table.align['POOL'] = 'l'
+            table.align['EFFECTIVE RATIO'] = 'r'
+            table.align['PG_NUM'] = 'r'
+            table.align['NEW PG_NUM'] = 'r'
+            table.align['AUTOSCALE'] = 'l'
+            table.align['PLAN'] = 'l'
+            for p in ps:
+                if p.get('planner') and p['pg_num_final'] != p['pg_num_target']:
+                    final = str(p['pg_num_final'])
+                else:
+                    final = ''
+                if p['effective_target_ratio'] > 0.0:
+                    etr = '%.4f' % p['effective_target_ratio']
+                else:
+                    etr = ''
+                table.add_row([
+                    p['pool_name'],
+                    etr,
+                    p['pg_num_target'],
+                    final,
+                    str(p['pg_autoscale_mode']),
+                    str(p.get('pg_autoscale_plan', '')),
+                ])
+            return 0, table.get_string(), ''
         else:
             table = PrettyTable(['POOL', 'SIZE', 'TARGET SIZE',
                                  'RATE', 'RAW CAPACITY',
@@ -385,6 +434,61 @@ class PgAutoscaler(MgrModule):
             })
             return 0, "", "noautoscale is unset, all pools now back to its previous mode"
 
+    def has_simpleautoscale_flag(self) -> bool:
+        flags = self.get_osdmap().dump().get('flags', '')
+        if 'simpleautoscale' in flags:
+            return True
+        else:
+            return False
+
+    @PGAutoscalerCLICommand.Write("osd pool set simpleautoscale")
+    def set_simpleautoscale(self) -> Tuple[int, str, str]:
+        """
+        Switch to simple (ratio-driven) autoscaling: the autoscaler plans
+        each pool's pg_num from its effective_ratio share of the PG budget
+        and learns a ratio for pools that lack one from their current
+        pg_num. Divergent plans are stamped as planned_pg_num: mode 'on'
+        pools apply them automatically (large merges are held), mode
+        'warn' pools wait for 'osd pool autoscale-accept'. Unset the flag
+        to roll back to legacy autoscaling; ratios remain stored but
+        inert.
+        """
+        if self.has_simpleautoscale_flag():
+            return 0, "", "simpleautoscale is already set!"
+        r = self.mon_command({
+            'prefix': 'osd set',
+            'key': 'simpleautoscale'
+        })
+        if r[0] != 0:
+            return r[0], "", r[2]
+        return 0, "", "simpleautoscale is set: planning from effective " \
+            "ratios, learning missing ones"
+
+    @PGAutoscalerCLICommand.Write("osd pool unset simpleautoscale")
+    def unset_simpleautoscale(self) -> Tuple[int, str, str]:
+        """
+        Unset the simpleautoscale flag: all pools resume legacy
+        (usage-driven) autoscaling per their pg_autoscale_mode. Declared
+        and learned effective ratios remain stored but inert.
+        """
+        if not self.has_simpleautoscale_flag():
+            return 0, "", "simpleautoscale is already unset!"
+        self.mon_command({
+            'prefix': 'osd unset',
+            'key': 'simpleautoscale'
+        })
+        return 0, "", "simpleautoscale is unset, legacy autoscaling resumes"
+
+    @PGAutoscalerCLICommand.Read("osd pool get simpleautoscale")
+    def get_simpleautoscale(self) -> Tuple[int, str, str]:
+        """
+        Get the simpleautoscale flag.
+        """
+        if self.has_simpleautoscale_flag():
+            return 0, "", "simpleautoscale is on"
+        else:
+            return 0, "", "simpleautoscale is off"
+
     @PGAutoscalerCLICommand.Write("osd pool set noautoscale")
     def set_noautoscale(self) -> Tuple[int, str, str]:
         """
@@ -435,6 +539,7 @@ class PgAutoscaler(MgrModule):
 
         # We identify subtrees from osdmap
 
+        simple_flag = self.has_simpleautoscale_flag()
         for pool_name, pool in pools.items():
             crush_rule = crush.get_rule_by_id(pool['crush_rule'])
             assert crush_rule is not None
@@ -455,8 +560,13 @@ class PgAutoscaler(MgrModule):
             s.pool_ids.append(pool['pool'])
             s.pool_names.append(pool_name)
             s.pg_current += pool['pg_num_target'] * pool['size']
+            ratio = pool['options'].get('effective_ratio', 0.0)
+            planner = ratio > 0.0 and pool['pg_autoscale_mode'] != 'off' \
+                and simple_flag
             target_ratio = pool['options'].get('target_size_ratio', 0.0)
-            if target_ratio:
+            if planner:
+                s.total_pinned_ratio += ratio
+            elif target_ratio:
                 s.total_target_ratio += target_ratio
             else:
                 target_bytes = pool['options'].get('target_size_bytes', 0)
@@ -732,11 +842,15 @@ class PgAutoscaler(MgrModule):
             bulk: bool,
             p: Dict[str, Any],
             pool_metrics: Dict[str, Dict[str, Any]],
+            simple_flag: bool,
     ) -> None:
         raw_used_rate = osdmap.pool_raw_used_rate(pool_id)
+        ratio = p['options'].get('effective_ratio', 0.0)
+        planner = ratio > 0.0 and p['pg_autoscale_mode'] != 'off' \
+            and simple_flag
         target_bytes = 0
         # ratio takes precedence if both are set
-        if p['options'].get('target_size_ratio', 0.0) == 0.0:
+        if p['options'].get('target_size_ratio', 0.0) == 0.0 and not planner:
             target_bytes = p['options'].get('target_size_bytes', 0)
 
         # What proportion of space are we using?
@@ -751,10 +865,19 @@ class PgAutoscaler(MgrModule):
             root_map[root_id].total_target_bytes,
             capacity))
 
-        target_ratio = effective_target_ratio(p['options'].get('target_size_ratio', 0.0),
-                                            root_map[root_id].total_target_ratio,
-                                            root_map[root_id].total_target_bytes,
-                                            int(capacity))
+        pinned_pgs = 0.0
+        if planner:
+            # simple provisioning: the pool's plan is its declared share of
+            # the domain budget, never normalized against other pools and
+            # never overridden by actual usage
+            pinned_pgs = ratio * root_map[root_id].pg_target
+            target_ratio = ratio
+        else:
+            target_ratio = effective_target_ratio(p['options'].get('target_size_ratio', 0.0),
+                                                root_map[root_id].total_target_ratio,
+                                                root_map[root_id].total_target_bytes,
+                                                int(capacity),
+                                                root_map[root_id].total_pinned_ratio)
         pool_id = p['pool']
         pool_metrics[pool_id] = {
             'target_bytes': target_bytes,
@@ -764,6 +887,8 @@ class PgAutoscaler(MgrModule):
             'pool_raw_used': pool_raw_used,
             'capacity_ratio': capacity_ratio,
             'target_ratio': target_ratio,
+            'pinned_pgs': pinned_pgs,
+            'planner': planner,
             'bulk': bulk,
         }
 
@@ -854,6 +979,7 @@ class PgAutoscaler(MgrModule):
                     'would_adjust': adjust,
                     'bias': p.get('options', {}).get('pg_autoscale_bias', 1.0),
                     'bulk': metrics['bulk'],
+                    'planner': metrics.get('planner', False),
                 })
 
             for copy in ret_copy:
@@ -876,6 +1002,7 @@ class PgAutoscaler(MgrModule):
         Add pools to PoolGroups where all pools with the same GroupKey are
         allocated the same number of PGs
         """
+        simple_flag = self.has_simpleautoscale_flag()
         for pool_name, p in pools.items():
             pool_id = p['pool']
             if pool_id not in pool_stats:
@@ -900,13 +1027,21 @@ class PgAutoscaler(MgrModule):
             flags = p['flags_names'].split(",")
             if "bulk" in flags:
                 bulk = True
-            self._calculate_pool_metrics(osdmap, root_map, root_id, pool_id, pool_stats, capacity, bulk, p, pool_metrics)
+            self._calculate_pool_metrics(osdmap, root_map, root_id, pool_id, pool_stats, capacity, bulk, p, pool_metrics, simple_flag)
             metrics = pool_metrics[pool_id]
             pg_left = root_map[root_id].pg_left
             self.log.debug("{} metrics: {}".format(p['pool_name'], metrics))
 
-            capacity_ratio = max(metrics['capacity_ratio'], metrics['target_ratio'])
-            pg_target_managed = int(capacity_ratio * pg_left)
+            if metrics['pinned_pgs'] > 0:
+                # planner pools get exactly their planned replica count:
+                # usage does not override the plan, bias does not scale it,
+                # and the pool is never subject to bulk/even distribution
+                pg_target_managed = int(metrics['pinned_pgs'])
+                bulk = False
+                bias = 1.0
+            else:
+                capacity_ratio = max(metrics['capacity_ratio'], metrics['target_ratio'])
+                pg_target_managed = int(capacity_ratio * pg_left)
             pg_target_unmanaged = p['pg_num_target'] * p['size']
             autoscale = p['pg_autoscale_mode'] != 'off'
             self.log.debug("pool {} capacity ratio: {} target ratio {} pg_num_target {}".format(pool_name, metrics['capacity_ratio'], metrics['target_ratio'], p['pg_num_target']))
@@ -971,6 +1106,30 @@ class PgAutoscaler(MgrModule):
             for p in ret:
                 p['pg_autoscale_mode'] = 'off'
 
+        # derive the plan state, mirroring 'osd pool get pg_autoscale_plan':
+        # learn until a pool has an effective_ratio, pending while its plan
+        # differs from pg_num, current once they agree
+        simple_flag = self.has_simpleautoscale_flag()
+        for p in ret:
+            if not simple_flag:
+                p['pg_autoscale_plan'] = ''
+                continue
+            if p.get('planner'):
+                p['pg_autoscale_plan'] = (
+                    'pending' if p['pg_num_final'] != p['pg_num_target']
+                    else 'current')
+                continue
+            opts = pools[p['pool_name']]['options']
+            if opts.get('effective_ratio', 0.0) > 0.0:
+                # mode 'off': the planner ignores the pool, so report
+                # against whatever stamp it may still carry
+                planned = opts.get('planned_pg_num', 0)
+                p['pg_autoscale_plan'] = (
+                    'pending' if planned > 0 and planned != p['pg_num_target']
+                    else 'current')
+            else:
+                p['pg_autoscale_plan'] = 'learn'
+
         return (ret, root_map)
 
     def _get_pool_by_id(self,
@@ -1030,6 +1189,25 @@ class PgAutoscaler(MgrModule):
         total_bytes = dict([(r, 0) for r in iter(root_map)])
         total_target_bytes = dict([(r, 0.0) for r in iter(root_map)])
         target_bytes_pools: Dict[int, List[int]] = dict([(r, []) for r in iter(root_map)])
+        simple_flag = self.has_simpleautoscale_flag()
+        total_pinned = dict([(r, 0.0) for r in iter(root_map)])
+        pinned_pools: Dict[int, List[str]] = dict([(r, []) for r in iter(root_map)])
+        plan_clamped: List[str] = []
+        pg_drift: List[str] = []
+        pending_accept: List[str] = []
+        # cluster median bytes-per-PG, used to detect pinned pools whose
+        # data has outgrown their pinned PG count
+        all_bytes_per_pg = sorted(
+            p['logical_used'] / max(p['pg_num_target'], 1)
+            for p in ps if p['logical_used'] > 0)
+        median_bytes_per_pg = 0.0
+        if len(all_bytes_per_pg) >= 2:
+            mid = len(all_bytes_per_pg) // 2
+            if len(all_bytes_per_pg) % 2:
+                median_bytes_per_pg = all_bytes_per_pg[mid]
+            else:
+                median_bytes_per_pg = (
+                    all_bytes_per_pg[mid - 1] + all_bytes_per_pg[mid]) / 2.0
 
         for p in ps:
             pool_id = p['pool_id']
@@ -1043,6 +1221,98 @@ class PgAutoscaler(MgrModule):
             if p['target_bytes'] > 0:
                 total_target_bytes[p['crush_root_id']] += p['target_bytes'] * p['raw_used_rate']
                 target_bytes_pools[p['crush_root_id']].append(p['pool_name'])
+            ratio = pool_opts.get('effective_ratio', 0.0)
+            mode = p['pg_autoscale_mode']
+            planner = ratio > 0.0 and mode != 'off' and simple_flag
+            if planner:
+                total_pinned[p['crush_root_id']] += ratio
+                pinned_pools[p['crush_root_id']].append(p['pool_name'])
+                root = root_map[p['crush_root_id']]
+                size = pools[p['pool_name']]['size']
+                ideal_pg_num = int(ratio * root.pg_target / size)
+                pg_num_max = pool_opts.get('pg_num_max', 0)
+                if pg_num_max and pg_num_max < ideal_pg_num:
+                    plan_clamped.append(
+                        'Pool %s effective_ratio %.4f implies pg_num %d but '
+                        'pg_num_max %d clamps it' % (
+                            p['pool_name'], ratio, ideal_pg_num, pg_num_max))
+                if median_bytes_per_pg > 0 and p['logical_used'] > 0:
+                    bytes_per_pg = p['logical_used'] / max(p['pg_num_target'], 1)
+                    if bytes_per_pg > self.pg_size_drift_warn_multiple * median_bytes_per_pg:
+                        pg_drift.append(
+                            'Pool %s stores %s per PG, more than %.1fx the '
+                            'cluster median of %s; consider raising its '
+                            'effective_ratio' % (
+                                p['pool_name'],
+                                mgr_util.format_bytes(int(bytes_per_pg), 5, colored=False),
+                                self.pg_size_drift_warn_multiple,
+                                mgr_util.format_bytes(int(median_bytes_per_pg), 5, colored=False)))
+                # planner actions: the planner's only write is stamping (or
+                # clearing) planned_pg_num; the pool's mode is operator-owned
+                # and pg_num moves only through 'osd pool autoscale-accept',
+                # invoked automatically here for mode 'on' pools
+                planned = pool_opts.get('planned_pg_num', 0)
+                plan = p['pg_num_final']
+                current = p['pg_num_target']
+                if plan != current and planned != plan:
+                    self.mon_command({
+                        'prefix': 'osd pool set',
+                        'pool': p['pool_name'],
+                        'var': 'planned_pg_num',
+                        'val': str(plan)})
+                elif plan == current and planned:
+                    self.mon_command({
+                        'prefix': 'osd pool set',
+                        'pool': p['pool_name'],
+                        'var': 'planned_pg_num',
+                        'val': '0'})
+                if plan != current:
+                    if mode == 'on':
+                        # hands-off pools accept their own plans; the mon
+                        # holds a large merge for manual confirmation
+                        # (mon_osd_pool_pg_merge_confirm_bytes)
+                        r = self.mon_command({
+                            'prefix': 'osd pool autoscale-accept',
+                            'pools': [p['pool_name']]})
+                        if r[0] == 0:
+                            pool_data = pools[p['pool_name']]
+                            pg_num = pool_data['pg_num']
+                            if pool_id in self._event:
+                                self._event[pool_id].reset(pg_num, plan)
+                            else:
+                                self._event[pool_id] = PgAdjustmentProgress(
+                                    pool_id, pg_num, plan)
+                            self._event[pool_id].update(self, 0.0)
+                        else:
+                            self.log.info(
+                                'plan for %s held for manual acceptance: %s',
+                                p['pool_name'], r[2])
+                            pending_accept.append(
+                                'Pool %s plan pg_num %d held for manual '
+                                'acceptance (current pg_num %d): %s' % (
+                                    p['pool_name'], plan, current, r[2]))
+                    else:
+                        pending_accept.append(
+                            'Pool %s plan pg_num %d awaits acceptance '
+                            '(current pg_num %d)' % (
+                                p['pool_name'], plan, current))
+                continue
+            if simple_flag and mode in ('on', 'warn'):
+                # a pool with no ratio has no plan, so there is nothing any
+                # mode may execute; learn its ratio from its current pg_num
+                # (fill-only, never overwriting)
+                if ratio == 0.0:
+                    root = root_map[p['crush_root_id']]
+                    size = pools[p['pool_name']]['size']
+                    if root.pg_target:
+                        learned = min(
+                            1.0, p['pg_num_target'] * size / root.pg_target)
+                        self.mon_command({
+                            'prefix': 'osd pool set',
+                            'pool': p['pool_name'],
+                            'var': 'effective_ratio',
+                            'val': '%.9f' % learned})
+                continue
             if p['pg_autoscale_mode'] == 'warn':
                 msg = 'Pool %s has %d placement groups, should have %d' % (
                     p['pool_name'],
@@ -1135,6 +1405,46 @@ class PgAutoscaler(MgrModule):
                 'detail': too_much_target_bytes,
             }
 
+        overcommitted_pinned = []
+        for root_id, total in total_pinned.items():
+            # tolerate FP error for ratios meant to sum to exactly 1.0
+            if total > 1.0 + 1e-6:
+                overcommitted_pinned.append(
+                    'Pools %s declare a total effective_ratio of %.4f, '
+                    'exceeding their budget domain' % (
+                        pinned_pools[root_id], total))
+        if overcommitted_pinned:
+            health_checks['POOL_EFFECTIVE_RATIO_OVERCOMMITTED'] = {
+                'severity': 'warning',
+                'summary': "%d subtrees have overcommitted pool effective_ratio" % len(
+                    overcommitted_pinned),
+                'count': len(overcommitted_pinned),
+                'detail': overcommitted_pinned,
+            }
+        if plan_clamped:
+            health_checks['POOL_PLAN_CLAMPED_BY_PG_NUM_MAX'] = {
+                'severity': 'warning',
+                'summary': "%d pools have autoscaler plans clamped by pg_num_max" % len(
+                    plan_clamped),
+                'count': len(plan_clamped),
+                'detail': plan_clamped,
+            }
+        if pg_drift:
+            health_checks['POOL_PG_SIZE_DRIFT'] = {
+                'severity': 'warning',
+                'summary': "%d pools have outgrown their planned PG count" % len(
+                    pg_drift),
+                'count': len(pg_drift),
+                'detail': pg_drift,
+            }
+        if pending_accept:
+            health_checks['POOL_AUTOSCALE_PENDING'] = {
+                'severity': 'warning',
+                'summary': "%d pools have autoscaler plans awaiting acceptance" % len(
+                    pending_accept),
+                'count': len(pending_accept),
+                'detail': pending_accept,
+            }
         if bytes_and_ratio:
             health_checks['POOL_HAS_TARGET_SIZE_BYTES_AND_RATIO'] = {
                 'severity': 'warning',

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -70,18 +70,21 @@ def nearest_power_of_two(n: float, direction: str = "nearest") -> int:
 def effective_target_ratio(target_ratio: float,
                            total_target_ratio: float,
                            total_target_bytes: int,
-                           capacity: int) -> float:
+                           capacity: int,
+                           total_pinned_ratio: float = 0.0) -> float:
     """
     Returns the target ratio after normalizing for ratios across pools and
-    adjusting for capacity reserved by pools that have target_size_bytes set.
+    adjusting for capacity reserved by pools that have target_size_bytes or
+    an effective_ratio set.
     """
     target_ratio = float(target_ratio)
     if total_target_ratio:
         target_ratio = target_ratio / total_target_ratio
 
+    fraction_available = 1.0 - min(1.0, total_pinned_ratio)
     if total_target_bytes and capacity:
-        fraction_available = 1.0 - min(1.0, float(total_target_bytes) / capacity)
-        target_ratio *= fraction_available
+        fraction_available -= min(1.0, float(total_target_bytes) / capacity)
+    target_ratio *= max(0.0, fraction_available)
 
     return target_ratio
 
@@ -124,6 +127,7 @@ class CrushRootResourceStatus:
         self.pool_used = 0
         self.total_target_ratio = 0.0
         self.total_target_bytes = 0  # including replication / EC overhead
+        self.total_pinned_ratio = 0.0  # sum of planner pools' effective_ratio
 
 
 class BacktrackNode(NamedTuple):
@@ -206,6 +210,17 @@ class PgAutoscaler(MgrModule):
                        '`PG_NUM` before being accepted. Cannot be less than 1.0'),
             default=3.0,
             min=1.0),
+
+        Option(
+            name='pg_size_drift_warn_multiple',
+            type='float',
+            desc='bytes-per-PG drift multiple for simple-provisioned pools',
+            long_desc=('Warn when a pool with an effective_ratio stores more '
+                       'than this multiple of the cluster median bytes per PG. '
+                       'Planned pools do not gain PGs as they grow, so this is '
+                       'the signal that a ratio has fallen behind the data.'),
+            default=4.0,
+            min=1.0),
     ]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -221,6 +236,7 @@ class PgAutoscaler(MgrModule):
             self.mon_target_pg_per_osd = 0
             self.threshold = 3.0
             self.osd_pool_default_pg_num = 32
+            self.pg_size_drift_warn_multiple = 4.0
 
     def config_notify(self) -> None:
         for opt in self.NATIVE_OPTIONS:
@@ -246,6 +262,39 @@ class PgAutoscaler(MgrModule):
 
         if format in ('json', 'json-pretty'):
             return 0, json.dumps(ps, indent=4, sort_keys=True), ''
+        elif self.has_simpleautoscale_flag():
+            # simple autoscaling: the legacy columns describe the model
+            # being left behind, so show only what the plan/accept
+            # lifecycle needs (JSON output remains complete)
+            table = PrettyTable(['POOL', 'EFFECTIVE RATIO', 'PG_NUM',
+                                 'NEW PG_NUM', 'AUTOSCALE', 'PLAN'],
+                                border=False)
+            table.left_padding_width = 0
+            table.right_padding_width = 2
+            table.align['POOL'] = 'l'
+            table.align['EFFECTIVE RATIO'] = 'r'
+            table.align['PG_NUM'] = 'r'
+            table.align['NEW PG_NUM'] = 'r'
+            table.align['AUTOSCALE'] = 'l'
+            table.align['PLAN'] = 'l'
+            for p in ps:
+                if p.get('planner') and p['pg_num_final'] != p['pg_num_target']:
+                    final = str(p['pg_num_final'])
+                else:
+                    final = ''
+                if p['effective_target_ratio'] > 0.0:
+                    etr = '%.4f' % p['effective_target_ratio']
+                else:
+                    etr = ''
+                table.add_row([
+                    p['pool_name'],
+                    etr,
+                    p['pg_num_target'],
+                    final,
+                    str(p['pg_autoscale_mode']),
+                    str(p.get('pg_autoscale_plan', '')),
+                ])
+            return 0, table.get_string(), ''
         else:
             table = PrettyTable(['POOL', 'SIZE', 'TARGET SIZE',
                                  'RATE', 'RAW CAPACITY',
@@ -385,6 +434,61 @@ class PgAutoscaler(MgrModule):
             })
             return 0, "", "noautoscale is unset, all pools now back to its previous mode"
 
+    def has_simpleautoscale_flag(self) -> bool:
+        flags = self.get_osdmap().dump().get('flags', '')
+        if 'simpleautoscale' in flags:
+            return True
+        else:
+            return False
+
+    @PGAutoscalerCLICommand.Write("osd pool set simpleautoscale")
+    def set_simpleautoscale(self) -> Tuple[int, str, str]:
+        """
+        Switch to simple (ratio-driven) autoscaling: the autoscaler plans
+        each pool's pg_num from its effective_ratio share of the PG budget
+        and learns a ratio for pools that lack one from their current
+        pg_num. Divergent plans are stamped as planned_pg_num: mode 'on'
+        pools apply them automatically (large merges are held), mode
+        'warn' pools wait for 'osd pool autoscale-accept'. Unset the flag
+        to roll back to legacy autoscaling; ratios remain stored but
+        inert.
+        """
+        if self.has_simpleautoscale_flag():
+            return 0, "", "simpleautoscale is already set!"
+        r = self.mon_command({
+            'prefix': 'osd set',
+            'key': 'simpleautoscale'
+        })
+        if r[0] != 0:
+            return r[0], "", r[2]
+        return 0, "", "simpleautoscale is set: planning from effective " \
+            "ratios, learning missing ones"
+
+    @PGAutoscalerCLICommand.Write("osd pool unset simpleautoscale")
+    def unset_simpleautoscale(self) -> Tuple[int, str, str]:
+        """
+        Unset the simpleautoscale flag: all pools resume legacy
+        (usage-driven) autoscaling per their pg_autoscale_mode. Declared
+        and learned effective ratios remain stored but inert.
+        """
+        if not self.has_simpleautoscale_flag():
+            return 0, "", "simpleautoscale is already unset!"
+        self.mon_command({
+            'prefix': 'osd unset',
+            'key': 'simpleautoscale'
+        })
+        return 0, "", "simpleautoscale is unset, legacy autoscaling resumes"
+
+    @PGAutoscalerCLICommand.Read("osd pool get simpleautoscale")
+    def get_simpleautoscale(self) -> Tuple[int, str, str]:
+        """
+        Get the simpleautoscale flag.
+        """
+        if self.has_simpleautoscale_flag():
+            return 0, "", "simpleautoscale is on"
+        else:
+            return 0, "", "simpleautoscale is off"
+
     @PGAutoscalerCLICommand.Write("osd pool set noautoscale")
     def set_noautoscale(self) -> Tuple[int, str, str]:
         """
@@ -435,6 +539,7 @@ class PgAutoscaler(MgrModule):
 
         # We identify subtrees from osdmap
 
+        simple_flag = self.has_simpleautoscale_flag()
         for pool_name, pool in pools.items():
             crush_rule = crush.get_rule_by_id(pool['crush_rule'])
             assert crush_rule is not None
@@ -455,8 +560,13 @@ class PgAutoscaler(MgrModule):
             s.pool_ids.append(pool['pool'])
             s.pool_names.append(pool_name)
             s.pg_current += pool['pg_num_target'] * pool['size']
+            ratio = pool['options'].get('effective_ratio', 0.0)
+            planner = ratio > 0.0 and pool['pg_autoscale_mode'] != 'off' \
+                and simple_flag
             target_ratio = pool['options'].get('target_size_ratio', 0.0)
-            if target_ratio:
+            if planner:
+                s.total_pinned_ratio += ratio
+            elif target_ratio:
                 s.total_target_ratio += target_ratio
             else:
                 target_bytes = pool['options'].get('target_size_bytes', 0)
@@ -732,11 +842,15 @@ class PgAutoscaler(MgrModule):
             bulk: bool,
             p: Dict[str, Any],
             pool_metrics: Dict[str, Dict[str, Any]],
+            simple_flag: bool,
     ) -> None:
         raw_used_rate = osdmap.pool_raw_used_rate(pool_id)
+        ratio = p['options'].get('effective_ratio', 0.0)
+        planner = ratio > 0.0 and p['pg_autoscale_mode'] != 'off' \
+            and simple_flag
         target_bytes = 0
         # ratio takes precedence if both are set
-        if p['options'].get('target_size_ratio', 0.0) == 0.0:
+        if p['options'].get('target_size_ratio', 0.0) == 0.0 and not planner:
             target_bytes = p['options'].get('target_size_bytes', 0)
 
         # What proportion of space are we using?
@@ -751,10 +865,19 @@ class PgAutoscaler(MgrModule):
             root_map[root_id].total_target_bytes,
             capacity))
 
-        target_ratio = effective_target_ratio(p['options'].get('target_size_ratio', 0.0),
-                                            root_map[root_id].total_target_ratio,
-                                            root_map[root_id].total_target_bytes,
-                                            int(capacity))
+        pinned_pgs = 0.0
+        if planner:
+            # simple provisioning: the pool's plan is its declared share of
+            # the domain budget, never normalized against other pools and
+            # never overridden by actual usage
+            pinned_pgs = ratio * root_map[root_id].pg_target
+            target_ratio = ratio
+        else:
+            target_ratio = effective_target_ratio(p['options'].get('target_size_ratio', 0.0),
+                                                root_map[root_id].total_target_ratio,
+                                                root_map[root_id].total_target_bytes,
+                                                int(capacity),
+                                                root_map[root_id].total_pinned_ratio)
         pool_id = p['pool']
         pool_metrics[pool_id] = {
             'target_bytes': target_bytes,
@@ -764,6 +887,8 @@ class PgAutoscaler(MgrModule):
             'pool_raw_used': pool_raw_used,
             'capacity_ratio': capacity_ratio,
             'target_ratio': target_ratio,
+            'pinned_pgs': pinned_pgs,
+            'planner': planner,
             'bulk': bulk,
         }
 
@@ -854,6 +979,7 @@ class PgAutoscaler(MgrModule):
                     'would_adjust': adjust,
                     'bias': p.get('options', {}).get('pg_autoscale_bias', 1.0),
                     'bulk': metrics['bulk'],
+                    'planner': metrics.get('planner', False),
                 })
 
             for copy in ret_copy:
@@ -876,6 +1002,7 @@ class PgAutoscaler(MgrModule):
         Add pools to PoolGroups where all pools with the same GroupKey are
         allocated the same number of PGs
         """
+        simple_flag = self.has_simpleautoscale_flag()
         for pool_name, p in pools.items():
             pool_id = p['pool']
             if pool_id not in pool_stats:
@@ -900,13 +1027,21 @@ class PgAutoscaler(MgrModule):
             flags = p['flags_names'].split(",")
             if "bulk" in flags:
                 bulk = True
-            self._calculate_pool_metrics(osdmap, root_map, root_id, pool_id, pool_stats, capacity, bulk, p, pool_metrics)
+            self._calculate_pool_metrics(osdmap, root_map, root_id, pool_id, pool_stats, capacity, bulk, p, pool_metrics, simple_flag)
             metrics = pool_metrics[pool_id]
             pg_left = root_map[root_id].pg_left
             self.log.debug("{} metrics: {}".format(p['pool_name'], metrics))
 
-            capacity_ratio = max(metrics['capacity_ratio'], metrics['target_ratio'])
-            pg_target_managed = int(capacity_ratio * pg_left)
+            if metrics['pinned_pgs'] > 0:
+                # planner pools get exactly their planned replica count:
+                # usage does not override the plan, bias does not scale it,
+                # and the pool is never subject to bulk/even distribution
+                pg_target_managed = int(metrics['pinned_pgs'])
+                bulk = False
+                bias = 1.0
+            else:
+                capacity_ratio = max(metrics['capacity_ratio'], metrics['target_ratio'])
+                pg_target_managed = int(capacity_ratio * pg_left)
             pg_target_unmanaged = p['pg_num_target'] * p['size']
             autoscale = p['pg_autoscale_mode'] != 'off'
             self.log.debug("pool {} capacity ratio: {} target ratio {} pg_num_target {}".format(pool_name, metrics['capacity_ratio'], metrics['target_ratio'], p['pg_num_target']))
@@ -971,6 +1106,30 @@ class PgAutoscaler(MgrModule):
             for p in ret:
                 p['pg_autoscale_mode'] = 'off'
 
+        # derive the plan state, mirroring 'osd pool get pg_autoscale_plan':
+        # learn until a pool has an effective_ratio, pending while its plan
+        # differs from pg_num, current once they agree
+        simple_flag = self.has_simpleautoscale_flag()
+        for p in ret:
+            if not simple_flag:
+                p['pg_autoscale_plan'] = ''
+                continue
+            if p.get('planner'):
+                p['pg_autoscale_plan'] = (
+                    'pending' if p['pg_num_final'] != p['pg_num_target']
+                    else 'current')
+                continue
+            opts = pools[p['pool_name']]['options']
+            if opts.get('effective_ratio', 0.0) > 0.0:
+                # mode 'off': the planner ignores the pool, so report
+                # against whatever stamp it may still carry
+                planned = opts.get('planned_pg_num', 0)
+                p['pg_autoscale_plan'] = (
+                    'pending' if planned > 0 and planned != p['pg_num_target']
+                    else 'current')
+            else:
+                p['pg_autoscale_plan'] = 'learn'
+
         return (ret, root_map)
 
     def _get_pool_by_id(self,
@@ -1030,6 +1189,25 @@ class PgAutoscaler(MgrModule):
         total_bytes = dict([(r, 0) for r in iter(root_map)])
         total_target_bytes = dict([(r, 0.0) for r in iter(root_map)])
         target_bytes_pools: Dict[int, List[int]] = dict([(r, []) for r in iter(root_map)])
+        simple_flag = self.has_simpleautoscale_flag()
+        total_pinned = dict([(r, 0.0) for r in iter(root_map)])
+        pinned_pools: Dict[int, List[str]] = dict([(r, []) for r in iter(root_map)])
+        plan_clamped: List[str] = []
+        pg_drift: List[str] = []
+        pending_accept: List[str] = []
+        # cluster median bytes-per-PG, used to detect pinned pools whose
+        # data has outgrown their pinned PG count
+        all_bytes_per_pg = sorted(
+            p['logical_used'] / max(p['pg_num_target'], 1)
+            for p in ps if p['logical_used'] > 0)
+        median_bytes_per_pg = 0.0
+        if len(all_bytes_per_pg) >= 2:
+            mid = len(all_bytes_per_pg) // 2
+            if len(all_bytes_per_pg) % 2:
+                median_bytes_per_pg = all_bytes_per_pg[mid]
+            else:
+                median_bytes_per_pg = (
+                    all_bytes_per_pg[mid - 1] + all_bytes_per_pg[mid]) / 2.0
 
         for p in ps:
             pool_id = p['pool_id']
@@ -1043,6 +1221,98 @@ class PgAutoscaler(MgrModule):
             if p['target_bytes'] > 0:
                 total_target_bytes[p['crush_root_id']] += p['target_bytes'] * p['raw_used_rate']
                 target_bytes_pools[p['crush_root_id']].append(p['pool_name'])
+            ratio = pool_opts.get('effective_ratio', 0.0)
+            mode = p['pg_autoscale_mode']
+            planner = ratio > 0.0 and mode != 'off' and simple_flag
+            if planner:
+                total_pinned[p['crush_root_id']] += ratio
+                pinned_pools[p['crush_root_id']].append(p['pool_name'])
+                root = root_map[p['crush_root_id']]
+                size = pools[p['pool_name']]['size']
+                ideal_pg_num = int(ratio * root.pg_target / size)
+                pg_num_max = pool_opts.get('pg_num_max', 0)
+                if pg_num_max and pg_num_max < ideal_pg_num:
+                    plan_clamped.append(
+                        'Pool %s effective_ratio %.4f implies pg_num %d but '
+                        'pg_num_max %d clamps it' % (
+                            p['pool_name'], ratio, ideal_pg_num, pg_num_max))
+                if median_bytes_per_pg > 0 and p['logical_used'] > 0:
+                    bytes_per_pg = p['logical_used'] / max(p['pg_num_target'], 1)
+                    if bytes_per_pg > self.pg_size_drift_warn_multiple * median_bytes_per_pg:
+                        pg_drift.append(
+                            'Pool %s stores %s per PG, more than %.1fx the '
+                            'cluster median of %s; consider raising its '
+                            'effective_ratio' % (
+                                p['pool_name'],
+                                mgr_util.format_bytes(int(bytes_per_pg), 5, colored=False),
+                                self.pg_size_drift_warn_multiple,
+                                mgr_util.format_bytes(int(median_bytes_per_pg), 5, colored=False)))
+                # planner actions: the planner's only write is stamping (or
+                # clearing) planned_pg_num; the pool's mode is operator-owned
+                # and pg_num moves only through 'osd pool autoscale-accept',
+                # invoked automatically here for mode 'on' pools
+                planned = pool_opts.get('planned_pg_num', 0)
+                plan = p['pg_num_final']
+                current = p['pg_num_target']
+                if plan != current and planned != plan:
+                    self.mon_command({
+                        'prefix': 'osd pool set',
+                        'pool': p['pool_name'],
+                        'var': 'planned_pg_num',
+                        'val': str(plan)})
+                elif plan == current and planned:
+                    self.mon_command({
+                        'prefix': 'osd pool set',
+                        'pool': p['pool_name'],
+                        'var': 'planned_pg_num',
+                        'val': '0'})
+                if plan != current:
+                    if mode == 'on':
+                        # hands-off pools accept their own plans; the mon
+                        # holds a large merge for manual confirmation
+                        # (mon_osd_pool_pg_merge_confirm_bytes)
+                        r = self.mon_command({
+                            'prefix': 'osd pool autoscale-accept',
+                            'pools': [p['pool_name']]})
+                        if r[0] == 0:
+                            pool_data = pools[p['pool_name']]
+                            pg_num = pool_data['pg_num']
+                            if pool_id in self._event:
+                                self._event[pool_id].reset(pg_num, plan)
+                            else:
+                                self._event[pool_id] = PgAdjustmentProgress(
+                                    pool_id, pg_num, plan)
+                            self._event[pool_id].update(self, 0.0)
+                        else:
+                            self.log.info(
+                                'plan for %s held for manual acceptance: %s',
+                                p['pool_name'], r[2])
+                            pending_accept.append(
+                                'Pool %s plan pg_num %d held for manual '
+                                'acceptance (current pg_num %d): %s' % (
+                                    p['pool_name'], plan, current, r[2]))
+                    else:
+                        pending_accept.append(
+                            'Pool %s plan pg_num %d awaits acceptance '
+                            '(current pg_num %d)' % (
+                                p['pool_name'], plan, current))
+                continue
+            if simple_flag and mode in ('on', 'warn'):
+                # a pool with no ratio has no plan, so there is nothing any
+                # mode may execute; learn its ratio from its current pg_num
+                # (fill-only, never overwriting)
+                if ratio == 0.0:
+                    root = root_map[p['crush_root_id']]
+                    size = pools[p['pool_name']]['size']
+                    if root.pg_target:
+                        learned = min(
+                            1.0, p['pg_num_target'] * size / root.pg_target)
+                        self.mon_command({
+                            'prefix': 'osd pool set',
+                            'pool': p['pool_name'],
+                            'var': 'effective_ratio',
+                            'val': '%.9f' % learned})
+                continue
             if p['pg_autoscale_mode'] == 'warn':
                 msg = 'Pool %s has %d placement groups, should have %d' % (
                     p['pool_name'],
@@ -1135,6 +1405,46 @@ class PgAutoscaler(MgrModule):
                 'detail': too_much_target_bytes,
             }
 
+        overcommitted_pinned = []
+        for root_id, total in total_pinned.items():
+            # tolerate FP error for ratios meant to sum to exactly 1.0
+            if total > 1.0 + 1e-6:
+                overcommitted_pinned.append(
+                    'Pools %s declare a total effective_ratio of %.4f, '
+                    'exceeding their budget domain' % (
+                        pinned_pools[root_id], total))
+        if overcommitted_pinned:
+            health_checks['POOL_EFFECTIVE_RATIO_OVERCOMMITTED'] = {
+                'severity': 'warning',
+                'summary': "%d subtrees have overcommitted pool effective_ratio" % len(
+                    overcommitted_pinned),
+                'count': len(overcommitted_pinned),
+                'detail': overcommitted_pinned,
+            }
+        if plan_clamped:
+            health_checks['POOL_PLAN_CLAMPED_BY_PG_NUM_MAX'] = {
+                'severity': 'warning',
+                'summary': "%d pools have autoscaler plans clamped by pg_num_max" % len(
+                    plan_clamped),
+                'count': len(plan_clamped),
+                'detail': plan_clamped,
+            }
+        if pg_drift:
+            health_checks['POOL_PG_SIZE_DRIFT'] = {
+                'severity': 'warning',
+                'summary': "%d pools have outgrown their planned PG count" % len(
+                    pg_drift),
+                'count': len(pg_drift),
+                'detail': pg_drift,
+            }
+        if pending_accept:
+            health_checks['POOL_AUTOSCALE_PENDING'] = {
+                'severity': 'warning',
+                'summary': "%d pools have autoscaler plans awaiting acceptance" % len(
+                    pending_accept),
+                'count': len(pending_accept),
+                'detail': pending_accept,
+            }
         if bytes_and_ratio:
             health_checks['POOL_HAS_TARGET_SIZE_BYTES_AND_RATIO'] = {
                 'severity': 'warning',

--- a/src/pybind/mgr/pg_autoscaler/tests/test_cal_ratio.py
+++ b/src/pybind/mgr/pg_autoscaler/tests/test_cal_ratio.py
@@ -35,3 +35,23 @@ def test_total_bytes():
     assert etr == approx(0.0)
     etr = effective_target_ratio(1, 1, 10, 10)
     assert etr == approx(0.0)
+
+
+def test_pinned_ratio():
+    # pools with a pinned effective_ratio shave the pie available to
+    # pools with a normalized target_size_ratio
+    etr = effective_target_ratio(1, 1, 0, 0, 0.4)
+    assert etr == approx(0.6)
+    # target ratios are still normalized within the remaining fraction
+    etr = effective_target_ratio(0.5, 1.0, 0, 0, 0.5)
+    assert etr == approx(0.25)
+    etr = effective_target_ratio(1, 2, 0, 0, 0.5)
+    assert etr == approx(0.25)
+    # pinned reservations stack with target_size_bytes reservations
+    etr = effective_target_ratio(1, 1, 5, 10, 0.25)
+    assert etr == approx(0.25)
+    # nothing is left once pins (and byte reservations) consume the budget
+    etr = effective_target_ratio(1, 1, 0, 0, 1.0)
+    assert etr == approx(0.0)
+    etr = effective_target_ratio(1, 1, 10, 10, 0.5)
+    assert etr == approx(0.0)

--- a/src/pybind/mgr/pg_autoscaler/tests/test_effective_ratio_planner.py
+++ b/src/pybind/mgr/pg_autoscaler/tests/test_effective_ratio_planner.py
@@ -1,0 +1,102 @@
+# python unit test
+from collections import defaultdict
+
+from pytest import approx
+from tests import mock
+
+from pg_autoscaler import module
+
+
+class FakeRoot:
+
+    def __init__(self,
+                 pg_target=1000,
+                 total_target_ratio=0.0,
+                 total_target_bytes=0,
+                 total_pinned_ratio=0.0):
+        self.pg_target = pg_target
+        self.total_target_ratio = total_target_ratio
+        self.total_target_bytes = total_target_bytes
+        self.total_pinned_ratio = total_pinned_ratio
+
+
+class TestEffectiveRatioPlanner:
+
+    def setup_method(self):
+        self.autoscaler = module.PgAutoscaler('module_name', 0, 0)
+        # the simpleautoscale flag is the master switch for the planner;
+        # individual tests flip it off to assert inertness
+        self.autoscaler.has_simpleautoscale_flag = lambda: True
+
+    def calc_metrics(self, options, root, mode='warn', raw_used_rate=3.0,
+                     bytes_used=0, capacity=1000):
+        osdmap = mock.Mock()
+        osdmap.pool_raw_used_rate.return_value = raw_used_rate
+        pool_metrics = defaultdict(dict)
+        pool_stats = {0: {'bytes_used': bytes_used}}
+        p = {'pool': 0, 'options': options, 'pg_autoscale_mode': mode}
+        self.autoscaler._calculate_pool_metrics(
+            osdmap, {0: root}, 0, 0, pool_stats, capacity, False, p,
+            pool_metrics, self.autoscaler.has_simpleautoscale_flag())
+        return pool_metrics[0]
+
+    def test_plan_is_absolute_share_of_budget(self):
+        # a planner pool's plan is ratio x budget: never normalized against
+        # other pools' ratios, never shaved by target_size_bytes reservations
+        root = FakeRoot(pg_target=1000,
+                        total_target_ratio=2.0,
+                        total_target_bytes=500,
+                        total_pinned_ratio=0.9)
+        metrics = self.calc_metrics({'effective_ratio': 0.5}, root)
+        assert metrics['planner']
+        assert metrics['pinned_pgs'] == approx(500.0)
+        assert metrics['target_ratio'] == approx(0.5)
+
+    def test_ratio_inert_without_flag(self):
+        # the simpleautoscale flag is the master switch: a declared (or
+        # pre-staged) effective_ratio does nothing until it is set
+        self.autoscaler.has_simpleautoscale_flag = lambda: False
+        root = FakeRoot()
+        for mode in ('on', 'warn', 'off'):
+            metrics = self.calc_metrics({'effective_ratio': 0.5}, root,
+                                        mode=mode)
+            assert not metrics['planner']
+            assert metrics['pinned_pgs'] == approx(0.0)
+
+    def test_mode_on_is_planner(self):
+        root = FakeRoot(pg_target=1000)
+        metrics = self.calc_metrics({'effective_ratio': 0.25}, root, mode='on')
+        assert metrics['planner']
+        assert metrics['pinned_pgs'] == approx(250.0)
+
+    def test_mode_off_opts_out(self):
+        # mode 'off' keeps its classic absolute meaning: the planner
+        # ignores the pool even under the flag
+        root = FakeRoot(pg_target=2000)
+        metrics = self.calc_metrics({'effective_ratio': 0.25}, root,
+                                    mode='off')
+        assert not metrics['planner']
+        assert metrics['pinned_pgs'] == approx(0.0)
+
+    def test_planner_ignores_target_size_bytes(self):
+        root = FakeRoot()
+        metrics = self.calc_metrics(
+            {'effective_ratio': 0.5, 'target_size_bytes': 100}, root)
+        assert metrics['target_bytes'] == 0
+        assert metrics['pinned_pgs'] == approx(500.0)
+
+    def test_target_size_ratio_normalized_into_remainder(self):
+        # a legacy target_size_ratio pool only gets a share of what the
+        # planner pools leave behind
+        root = FakeRoot(total_target_ratio=1.0, total_pinned_ratio=0.5)
+        metrics = self.calc_metrics({'target_size_ratio': 0.5}, root,
+                                    mode='on')
+        assert metrics['pinned_pgs'] == approx(0.0)
+        assert metrics['target_ratio'] == approx(0.25)
+
+    def test_no_ratios_unchanged(self):
+        root = FakeRoot(total_target_ratio=1.0)
+        metrics = self.calc_metrics({'target_size_ratio': 0.5}, root,
+                                    mode='on')
+        assert metrics['pinned_pgs'] == approx(0.0)
+        assert metrics['target_ratio'] == approx(0.5)

--- a/src/pybind/mgr/pg_autoscaler/tests/test_overlapping_roots.py
+++ b/src/pybind/mgr/pg_autoscaler/tests/test_overlapping_roots.py
@@ -48,6 +48,8 @@ class TestPgAutoscaler(object):
         # a bunch of attributes for testing.
         self.autoscaler = module.PgAutoscaler('module_name', 0, 0)
         self.autoscaler.mon_target_pg_per_osd = 100
+        # the test harness has no osdmap to read the flag from
+        self.autoscaler.has_simpleautoscale_flag = lambda: False
 
     def helper_test(self, osd_dic, rules, pools, expected_result):
         osdmap = OSDMAP(pools)


### PR DESCRIPTION
This RFC adds **simple autoscaling**: pools are provisioned by an absolute share of the PG-per-OSD budget, plans are always visible before they run, and whether the autoscaler may *act* stays exactly where it has always lived — in `pg_autoscale_mode`.

**History:** reworked 2026-07-25 per review (integer unit, warn-only overcommit, decrement confirmation, shadow-root scoping); revised 2026-07-27 to a budget fraction; redesigned 2026-07-28 into the mode x plan separation below, which deletes the new mode values entirely — `pg_autoscale_mode` keeps its classic `on|warn|off` vocabulary and meanings.

## Motivation

Operators who think in a per-OSD PG budget ("every OSD should carry 200-250 PG replicas") today either turn the autoscaler off and hand-compute `pg_num`, or reverse-engineer `target_size_ratio` weights that later pools silently renormalize and usage overrides. Beyond the arithmetic, the deeper operational complaint is *autonomy*: the autoscaler moves data when the cluster changes, at times of its choosing.

## Design

Two orthogonal axes:

* **`effective_ratio`** decides what the *plan* is: pg_num = ratio x budget / size, absolute (never renormalized, never overridden by usage). The **`simpleautoscale` cluster flag is the master switch** — ratios may be declared or pre-staged at any time but are inert until the flag is set; unsetting it is a complete rollback to legacy autoscaling.
* **`pg_autoscale_mode`** keeps deciding whether the autoscaler may act, with its classic values: `on` acts, `warn` warns, `off` opts out. The machinery never touches a pool's mode.

Each pool's **plan state is derived, never stored** (`osd pool get pg_autoscale_plan`, PLAN column): `learn` (no ratio yet), `pending` (plan differs from pg_num; stamped as `planned_pg_num`, listed by `POOL_AUTOSCALE_PENDING`), `current` (nothing to do).

**Acceptance is a mon command, atomic in one osdmap transaction** — apply exactly the stamped plans the operator reviewed, clear the stamps. This is why it is a command rather than a pool param: one pool, several, or `--all` are validated up front and committed together in a single osdmap epoch, so a reviewed plan-set (say, twenty pools after an expansion) applies as one change or not at all:

```
ceph osd pool autoscale-accept <pool> [<pool> ...] [--all] [--yes-i-really-mean-it]
```

Mode `warn` pools wait for it. Mode `on` pools invoke the same path automatically — with one exception: a plan that merges away more than half the PGs of a pool storing more than `mon_osd_pool_pg_merge_confirm_bytes` (default 1 TiB) is **held pending for manual confirmation**. Growth is hands-off; destructive shrinks get a human sign-off. That closes the merge-storm-on-OSD-loss hole even for fully autonomous pools.

For example — the cluster grows, a `warn` pool's plan diverges and waits:

```
$ ceph health detail
[WRN] POOL_AUTOSCALE_PENDING: 1 pools have autoscaler plans awaiting acceptance
    Pool bar plan pg_num 1024 awaits acceptance (current pg_num 512)
$ ceph osd pool autoscale-status
POOL  EFFECTIVE RATIO  PG_NUM  NEW PG_NUM  AUTOSCALE  PLAN
bar            0.4000     512        1024  warn       pending
$ ceph osd pool autoscale-accept bar
pool 'bar' accepted plan: pg_num 512 -> 1024
```

**Greenfield** — one line per pool, born at the right size, plan `current` from birth:

```
ceph osd pool set simpleautoscale
ceph config set global mon_target_pg_per_osd 250
ceph osd pool create foo erasure ec22 --effective-ratio 0.5
ceph osd pool create bar --effective-ratio 0.4
ceph osd pool create baz --effective-ratio 0.1
```

`--dry-run` previews the computed pg_num without creating; `pool get effective_ratio` returns the declared fraction verbatim. Plans are scoped to real budget domains (device-class shadow roots, overlap proration).

**Brownfield** — the runbook is no-op-by-construction:

```
ceph osd pool ls | while read p; do ceph osd pool set $p pg_autoscale_mode warn; done
ceph osd pool set simpleautoscale
```

Warn-first guarantees nothing acts during the transition (a pool left `on` keeps its autonomy — that is what `on` means). Ratio-less pools have no plan, so no mode can move them; their ratios are learned fill-only from current pg_num and reproduce it, landing plan `current` with nothing pending.

Mid-transition, one status shows the whole story — learned pools have converged to `current`, one pool is still learning, and `rbd`, whose ratio the operator pre-staged deliberately smaller than its legacy size, waits for acceptance:

```
$ ceph osd pool autoscale-status
POOL         EFFECTIVE RATIO  PG_NUM  NEW PG_NUM  AUTOSCALE  PLAN
.mgr                  0.0006       1              warn       current
cephfs.meta                       16              warn       learn
cephfs.data           0.6000    1024              warn       current
rbd                   0.1500     512         256  warn       pending
$ ceph osd pool autoscale-accept rbd
pool 'rbd' accepted plan: pg_num 512 -> 256
``` Legacy knobs (`target_size_ratio`, `target_size_bytes`, `pg_autoscale_bias`, `bulk`) are rejected while the flag is set (already-set values are simply inert), and plain `autoscale-status` becomes a concise POOL/EFFECTIVE RATIO/PG_NUM/NEW PG_NUM/AUTOSCALE/PLAN table. Health backstops: `POOL_PG_SIZE_DRIFT`, `POOL_EFFECTIVE_RATIO_OVERCOMMITTED`, `POOL_PLAN_CLAMPED_BY_PG_NUM_MAX`.

Plan state is a pure function of `(effective_ratio, planned_pg_num, pg_num)`, modes are operator-owned, and the only mutation acceptance performs is the atomic mon-side apply+clear.

## Series

* `mon,osd`: effective_ratio + planned_pg_num opts, derived `pg_autoscale_plan`, born-at-plan creates, `--dry-run`, the `osd pool autoscale-accept` command with its merge-confirm gate, `simpleautoscale` flag + legacy-knob guardrail
* `mgr/pg_autoscaler`: flag-gated planner (stamp/clear only), auto-acceptance for mode `on`, ratio learning, four health checks, unit tests
* `doc/rados`: lifecycle documentation + release note
* `qa`: greenfield/learn/device-class workunit coverage and a standalone OSD-loss test (outage shrinks the budget; nothing moves — warn holds, `on` is held by the merge gate; acceptance executes exactly the stamps)

## Testing

* 30 unit tests pass (7 planner tests: plan-is-absolute, ratio-inert-without-flag, mode-on-planner, mode-off-opt-out, target_size_bytes ignored, remainder normalization).
* Full lifecycle validated on a 6-OSD vstart cluster: inert pre-staging, born-at-plan creates, dry-run, knob guardrails, budget-change pending with pg_num provably unmoved, atomic acceptance, idempotent no-op accept, mode-on auto-split, the held large-merge with confirmed acceptance against real pool stats, learn/quiet-convergence/rollback, and shadow-root scoping with mixed on/warn pools.
* Standalone OSD-loss test (8 OSDs, purge 6): both pools stamp `pending`, pg_num holds across multiple planner passes (no merge storm; the mode-`on` pool is held by the merge gate), then acceptance executes exactly the stamped plans.

## Remaining work

* Dashboard awareness (tracker ticket if this lands).

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

