### PR TITLE
os/bluestore: add latency and hit/miss counters for BlueStore caches

### DIFF
--- a/src/os/bluestore/BlueAdmin.cc
+++ b/src/os/bluestore/BlueAdmin.cc
@@ -28,7 +28,7 @@ static void take_cache_snapshot(BlueStore& store) {
   snap.onode_shard_hits = store.logger->get(l_bluestore_onode_shard_hits);
   snap.onode_shard_misses = store.logger->get(l_bluestore_onode_shard_misses);
   snap.onode_shard_miss_latency_sum = store.logger->get(l_bluestore_onode_shard_miss_lat);
-  snap.buffer_read_reqs = store.logger->get(l_bluestore_buffer_read_reqs);
+  snap.buffer_hits = store.logger->get(l_bluestore_buffer_hits);
   snap.buffer_miss_count = store.logger->get(l_bluestore_buffer_miss_lat + 1);
   snap.buffer_miss_latency_sum = store.logger->get(l_bluestore_buffer_miss_lat);
   
@@ -58,7 +58,7 @@ static bool get_snapshot_windows(BlueStore& store,
   current.onode_shard_hits = store.logger->get(l_bluestore_onode_shard_hits);
   current.onode_shard_misses = store.logger->get(l_bluestore_onode_shard_misses);
   current.onode_shard_miss_latency_sum = store.logger->get(l_bluestore_onode_shard_miss_lat);
-  current.buffer_read_reqs = store.logger->get(l_bluestore_buffer_read_reqs);
+  current.buffer_hits = store.logger->get(l_bluestore_buffer_hits);
   current.buffer_miss_count = store.logger->get(l_bluestore_buffer_miss_lat + 1);
   current.buffer_miss_latency_sum = store.logger->get(l_bluestore_buffer_miss_lat);
   
@@ -423,9 +423,6 @@ int BlueStore::SocketHook::call(
     
     f->open_object_section("object_data_cache");
     
-    uint64_t read_reqs = store.logger->get(l_bluestore_buffer_read_reqs);
-    f->dump_unsigned("read_requests", read_reqs);
-    
     f->open_object_section("buffer_miss_latency");
     auto buffer_miss_tavg = store.logger->get_tavg_ns(l_bluestore_buffer_miss_lat);
     uint64_t buffer_miss_sum_ns = buffer_miss_tavg.first;
@@ -444,12 +441,13 @@ int BlueStore::SocketHook::call(
     }
     f->close_section();
     
-    uint64_t buffer_hits = (read_reqs > buffer_miss_count) ? (read_reqs - buffer_miss_count) : 0;
+    uint64_t buffer_hits = store.logger->get(l_bluestore_buffer_hits);
     f->dump_unsigned("hits", buffer_hits);
     f->dump_unsigned("misses", buffer_miss_count);
-    
-    if (read_reqs > 0) {
-      double buffer_hit_ratio = static_cast<double>(buffer_hits) / static_cast<double>(read_reqs);
+    uint64_t buffer_total = buffer_hits + buffer_miss_count;
+    f->dump_unsigned("total_accesses", buffer_total);
+    if (buffer_total > 0) {
+      double buffer_hit_ratio = static_cast<double>(buffer_hits) / static_cast<double>(buffer_total);
       f->dump_float("hit_ratio", buffer_hit_ratio);
     } else {
       f->dump_float("hit_ratio", 0.0);
@@ -503,15 +501,15 @@ int BlueStore::SocketHook::call(
         f->close_section();
         
         f->open_object_section("object_data_cache");
-        uint64_t delta_buffer_reqs = current.buffer_read_reqs - most_recent.buffer_read_reqs;
+        uint64_t delta_buffer_hits = current.buffer_hits - most_recent.buffer_hits;
         uint64_t delta_buffer_misses = current.buffer_miss_count - most_recent.buffer_miss_count;
         uint64_t delta_buffer_lat = current.buffer_miss_latency_sum - most_recent.buffer_miss_latency_sum;
-        uint64_t delta_buffer_hits = (delta_buffer_reqs > delta_buffer_misses) ? (delta_buffer_reqs - delta_buffer_misses) : 0;
-        f->dump_unsigned("read_requests", delta_buffer_reqs);
+        uint64_t delta_buffer_total = delta_buffer_hits + delta_buffer_misses;
         f->dump_unsigned("hits", delta_buffer_hits);
         f->dump_unsigned("misses", delta_buffer_misses);
-        if (delta_buffer_reqs > 0) {
-          f->dump_float("hit_ratio", (double)delta_buffer_hits / (double)delta_buffer_reqs);
+        f->dump_unsigned("total_accesses", delta_buffer_total);
+        if (delta_buffer_total > 0) {
+          f->dump_float("hit_ratio", (double)delta_buffer_hits / (double)delta_buffer_total);
         } else {
           f->dump_float("hit_ratio", 0.0);
         }
@@ -568,20 +566,20 @@ int BlueStore::SocketHook::call(
         f->close_section();
         
         f->open_object_section("object_data_cache");
-        uint64_t delta_buffer_reqs = current.buffer_read_reqs - oldest.buffer_read_reqs;
+        uint64_t delta_buffer_hits = current.buffer_hits - oldest.buffer_hits;
         uint64_t delta_buffer_misses = current.buffer_miss_count - oldest.buffer_miss_count;
         uint64_t delta_buffer_lat = current.buffer_miss_latency_sum - oldest.buffer_miss_latency_sum;
-        uint64_t delta_buffer_hits = (delta_buffer_reqs > delta_buffer_misses) ? (delta_buffer_reqs - delta_buffer_misses) : 0;
+        uint64_t delta_buffer_total = delta_buffer_hits + delta_buffer_misses;
         
-        f->dump_unsigned("read_requests", delta_buffer_reqs);
         f->dump_unsigned("hits", delta_buffer_hits);
         f->dump_unsigned("misses", delta_buffer_misses);
-        if (delta_buffer_reqs > 0) {
-          f->dump_float("hit_ratio", (double)delta_buffer_hits / (double)delta_buffer_reqs);
-          f->dump_float("requests_per_second", (double)delta_buffer_reqs / oldest_duration);
+        f->dump_unsigned("total_accesses", delta_buffer_total);
+        if (delta_buffer_total > 0) {
+          f->dump_float("hit_ratio", (double)delta_buffer_hits / (double)delta_buffer_total);
+          f->dump_float("accesses_per_second", (double)delta_buffer_total / oldest_duration);
         } else {
           f->dump_float("hit_ratio", 0.0);
-          f->dump_float("requests_per_second", 0.0);
+          f->dump_float("accesses_per_second", 0.0);
         }
         if (delta_buffer_misses > 0) {
           f->dump_float("avg_miss_latency_us", (double)delta_buffer_lat / (double)delta_buffer_misses / 1000.0);

--- a/src/os/bluestore/BlueAdmin.cc
+++ b/src/os/bluestore/BlueAdmin.cc
@@ -29,7 +29,7 @@ static void take_cache_snapshot(BlueStore& store) {
   snap.onode_shard_misses = store.logger->get(l_bluestore_onode_shard_misses);
   snap.onode_shard_miss_latency_sum = store.logger->get(l_bluestore_onode_shard_miss_lat);
   snap.buffer_hits = store.logger->get(l_bluestore_buffer_hits);
-  snap.buffer_miss_count = store.logger->get(l_bluestore_buffer_miss_lat + 1);
+  snap.buffer_misses = store.logger->get(l_bluestore_buffer_miss_lat + 1);
   snap.buffer_miss_latency_sum = store.logger->get(l_bluestore_buffer_miss_lat);
   
   store.cache_stats_snapshots.push_back(snap);
@@ -59,7 +59,7 @@ static bool get_snapshot_windows(BlueStore& store,
   current.onode_shard_misses = store.logger->get(l_bluestore_onode_shard_misses);
   current.onode_shard_miss_latency_sum = store.logger->get(l_bluestore_onode_shard_miss_lat);
   current.buffer_hits = store.logger->get(l_bluestore_buffer_hits);
-  current.buffer_miss_count = store.logger->get(l_bluestore_buffer_miss_lat + 1);
+  current.buffer_misses = store.logger->get(l_bluestore_buffer_miss_lat + 1);
   current.buffer_miss_latency_sum = store.logger->get(l_bluestore_buffer_miss_lat);
   
   if(store.cache_stats_snapshots.size() >= 2) {
@@ -347,9 +347,18 @@ int BlueStore::SocketHook::call(
     f->open_object_section("onode_cache");
     
     uint64_t onode_hits = store.logger->get(l_bluestore_onode_hits);
+    uint64_t onode_misses = store.logger->get(l_bluestore_onode_misses);
     f->dump_unsigned("hits", onode_hits);
+    f->dump_unsigned("misses", onode_misses);
+    uint64_t total_accesses = onode_hits + onode_misses;
+    f->dump_unsigned("total", total_accesses);
+    if (total_accesses > 0) {
+      double hit_ratio = static_cast<double>(onode_hits) / static_cast<double>(total_accesses);
+      f->dump_float("hit_ratio", hit_ratio);
+    } else {
+      f->dump_float("hit_ratio", 0.0);
+    }
     
-   
     f->open_object_section("onode_cache_miss_latency");
     auto onode_miss_tavg = store.logger->get_tavg_ns(l_bluestore_onode_miss_lat);
     uint64_t onode_miss_sum_ns = onode_miss_tavg.first;
@@ -368,6 +377,20 @@ int BlueStore::SocketHook::call(
     }
     f->close_section();
     
+    f->close_section();
+    
+    f->open_object_section("onode_shard");
+    uint64_t shard_hits = store.logger->get(l_bluestore_onode_shard_hits);
+    uint64_t shard_misses = store.logger->get(l_bluestore_onode_shard_misses);
+    f->dump_unsigned("hits", shard_hits);
+    f->dump_unsigned("misses", shard_misses);
+    uint64_t shard_total = shard_hits + shard_misses;
+    f->dump_unsigned("total", shard_total);
+    if (shard_total > 0) {
+      f->dump_float("hit_ratio", (double)shard_hits / (double)shard_total);
+    } else {
+      f->dump_float("hit_ratio", 0.0);
+    }
     
     f->open_object_section("onode_shard_miss_latency");
     auto shard_miss_tavg = store.logger->get_tavg_ns(l_bluestore_onode_shard_miss_lat);
@@ -387,38 +410,6 @@ int BlueStore::SocketHook::call(
     }
     f->close_section();
     
-    uint64_t total_accesses = onode_hits + onode_miss_count;
-    f->dump_unsigned("total_accesses", total_accesses);
-    if (total_accesses > 0) {
-      double hit_ratio = static_cast<double>(onode_hits) / static_cast<double>(total_accesses);
-      f->dump_float("hit_ratio", hit_ratio);
-    } else {
-      f->dump_float("hit_ratio", 0.0);
-    }
-    
-    f->close_section();
-    
-    f->open_object_section("onode_shard");
-    uint64_t shard_hits = store.logger->get(l_bluestore_onode_shard_hits);
-    uint64_t shard_misses = store.logger->get(l_bluestore_onode_shard_misses);
-    f->dump_unsigned("hits", shard_hits);
-    f->dump_unsigned("misses", shard_misses);
-    uint64_t shard_total = shard_hits + shard_misses;
-    if (shard_total > 0) {
-      f->dump_float("hit_ratio", (double)shard_hits / (double)shard_total);
-    } else {
-      f->dump_float("hit_ratio", 0.0);
-    }
-    
-    auto shard_miss_lat_tavg = store.logger->get_tavg_ns(l_bluestore_onode_shard_miss_lat);
-    uint64_t shard_miss_lat_sum_ns = shard_miss_lat_tavg.first;
-    uint64_t shard_miss_lat_count = shard_miss_lat_tavg.second;
-    if (shard_miss_lat_count > 0) {
-      uint64_t avg_ns = shard_miss_lat_sum_ns / shard_miss_lat_count;
-      f->dump_format_unquoted("avg_miss_latency", "%" PRId64 ".%09" PRId64,
-                              avg_ns / 1000000000ull,
-                              avg_ns % 1000000000ull);
-    }
     f->close_section();
     
     f->open_object_section("object_data_cache");
@@ -426,13 +417,13 @@ int BlueStore::SocketHook::call(
     f->open_object_section("buffer_miss_latency");
     auto buffer_miss_tavg = store.logger->get_tavg_ns(l_bluestore_buffer_miss_lat);
     uint64_t buffer_miss_sum_ns = buffer_miss_tavg.first;
-    uint64_t buffer_miss_count = buffer_miss_tavg.second;
-    f->dump_unsigned("avgcount", buffer_miss_count);
+    uint64_t buffer_misses = buffer_miss_tavg.second;
+    f->dump_unsigned("avgcount", buffer_misses);
     f->dump_format_unquoted("sum", "%" PRId64 ".%09" PRId64,
                             buffer_miss_sum_ns / 1000000000ull,
                             buffer_miss_sum_ns % 1000000000ull);
-    if (buffer_miss_count) {
-      uint64_t avg_ns = buffer_miss_sum_ns / buffer_miss_count;
+    if (buffer_misses) {
+      uint64_t avg_ns = buffer_miss_sum_ns / buffer_misses;
       f->dump_format_unquoted("avgtime", "%" PRId64 ".%09" PRId64,
                               avg_ns / 1000000000ull,
                               avg_ns % 1000000000ull);
@@ -443,8 +434,8 @@ int BlueStore::SocketHook::call(
     
     uint64_t buffer_hits = store.logger->get(l_bluestore_buffer_hits);
     f->dump_unsigned("hits", buffer_hits);
-    f->dump_unsigned("misses", buffer_miss_count);
-    uint64_t buffer_total = buffer_hits + buffer_miss_count;
+    f->dump_unsigned("misses", buffer_misses);
+    uint64_t buffer_total = buffer_hits + buffer_misses;
     f->dump_unsigned("total_accesses", buffer_total);
     if (buffer_total > 0) {
       double buffer_hit_ratio = static_cast<double>(buffer_hits) / static_cast<double>(buffer_total);
@@ -464,7 +455,7 @@ int BlueStore::SocketHook::call(
       auto recent_duration = std::chrono::duration<double>(current.timestamp - most_recent.timestamp).count();
       if (recent_duration > 0) {
         f->open_object_section("since_most_recent_snapshot");
-        f->dump_float("window_seconds", recent_duration);
+        f->dump_float("seconds elapsed", recent_duration);
         
         f->open_object_section("onode_cache");
         uint64_t delta_onode_hits = current.onode_hits - most_recent.onode_hits;
@@ -502,12 +493,12 @@ int BlueStore::SocketHook::call(
         
         f->open_object_section("object_data_cache");
         uint64_t delta_buffer_hits = current.buffer_hits - most_recent.buffer_hits;
-        uint64_t delta_buffer_misses = current.buffer_miss_count - most_recent.buffer_miss_count;
+        uint64_t delta_buffer_misses = current.buffer_misses - most_recent.buffer_misses;
         uint64_t delta_buffer_lat = current.buffer_miss_latency_sum - most_recent.buffer_miss_latency_sum;
         uint64_t delta_buffer_total = delta_buffer_hits + delta_buffer_misses;
         f->dump_unsigned("hits", delta_buffer_hits);
         f->dump_unsigned("misses", delta_buffer_misses);
-        f->dump_unsigned("total_accesses", delta_buffer_total);
+        f->dump_unsigned("total", delta_buffer_total);
         if (delta_buffer_total > 0) {
           f->dump_float("hit_ratio", (double)delta_buffer_hits / (double)delta_buffer_total);
         } else {
@@ -525,7 +516,7 @@ int BlueStore::SocketHook::call(
       
       if (oldest_duration > 0) {
         f->open_object_section("since_oldest_snapshot");
-        f->dump_float("window_seconds", oldest_duration);
+        f->dump_float("seconds elapsed", oldest_duration);
         
         f->open_object_section("onode_cache");
         uint64_t delta_onode_hits = current.onode_hits - oldest.onode_hits;
@@ -535,7 +526,7 @@ int BlueStore::SocketHook::call(
         
         f->dump_unsigned("hits", delta_onode_hits);
         f->dump_unsigned("misses", delta_onode_misses);
-        f->dump_unsigned("total_accesses", delta_onode_total);
+        f->dump_unsigned("total", delta_onode_total);
         if (delta_onode_total > 0) {
           f->dump_float("hit_ratio", (double)delta_onode_hits / (double)delta_onode_total);
           f->dump_float("accesses_per_second", (double)delta_onode_total / oldest_duration);
@@ -567,13 +558,13 @@ int BlueStore::SocketHook::call(
         
         f->open_object_section("object_data_cache");
         uint64_t delta_buffer_hits = current.buffer_hits - oldest.buffer_hits;
-        uint64_t delta_buffer_misses = current.buffer_miss_count - oldest.buffer_miss_count;
+        uint64_t delta_buffer_misses = current.buffer_misses - oldest.buffer_misses;
         uint64_t delta_buffer_lat = current.buffer_miss_latency_sum - oldest.buffer_miss_latency_sum;
         uint64_t delta_buffer_total = delta_buffer_hits + delta_buffer_misses;
         
         f->dump_unsigned("hits", delta_buffer_hits);
         f->dump_unsigned("misses", delta_buffer_misses);
-        f->dump_unsigned("total_accesses", delta_buffer_total);
+        f->dump_unsigned("total", delta_buffer_total);
         if (delta_buffer_total > 0) {
           f->dump_float("hit_ratio", (double)delta_buffer_hits / (double)delta_buffer_total);
           f->dump_float("accesses_per_second", (double)delta_buffer_total / oldest_duration);

--- a/src/os/bluestore/BlueAdmin.cc
+++ b/src/os/bluestore/BlueAdmin.cc
@@ -22,9 +22,9 @@ static void take_cache_snapshot(BlueStore& store) {
   
   BlueStore::CacheStatsSnapshot snap;
   snap.timestamp = ceph::mono_clock::now();
-  snap.onode_hits = store.logger->get(l_bluestore_onode_cache_hit_count);
-  snap.onode_misses = store.logger->get(l_bluestore_onode_cache_time_latency_time + 1);
-  snap.onode_miss_latency_sum = store.logger->get(l_bluestore_onode_cache_time_latency_time);
+  snap.onode_hits = store.logger->get(l_bluestore_onode_hits);
+  snap.onode_misses = store.logger->get(l_bluestore_onode_misses);
+  snap.onode_miss_latency_sum = store.logger->get(l_bluestore_onode_miss_lat);
   snap.onode_shard_hits = store.logger->get(l_bluestore_onode_shard_hits);
   snap.onode_shard_misses = store.logger->get(l_bluestore_onode_shard_misses);
   snap.onode_shard_miss_latency_sum = store.logger->get(l_bluestore_onode_shard_miss_lat);
@@ -52,9 +52,9 @@ static bool get_snapshot_windows(BlueStore& store,
   
   // Get current values 
   current.timestamp = ceph::mono_clock::now();
-  current.onode_hits = store.logger->get(l_bluestore_onode_cache_hit_count);
-  current.onode_misses = store.logger->get(l_bluestore_onode_cache_time_latency_time + 1);
-  current.onode_miss_latency_sum = store.logger->get(l_bluestore_onode_cache_time_latency_time);
+  current.onode_hits = store.logger->get(l_bluestore_onode_hits);
+  current.onode_misses = store.logger->get(l_bluestore_onode_misses);
+  current.onode_miss_latency_sum = store.logger->get(l_bluestore_onode_miss_lat);
   current.onode_shard_hits = store.logger->get(l_bluestore_onode_shard_hits);
   current.onode_shard_misses = store.logger->get(l_bluestore_onode_shard_misses);
   current.onode_shard_miss_latency_sum = store.logger->get(l_bluestore_onode_shard_miss_lat);
@@ -346,12 +346,12 @@ int BlueStore::SocketHook::call(
     
     f->open_object_section("onode_cache");
     
-    uint64_t onode_hits = store.logger->get(l_bluestore_onode_cache_hit_count);
+    uint64_t onode_hits = store.logger->get(l_bluestore_onode_hits);
     f->dump_unsigned("hits", onode_hits);
     
    
     f->open_object_section("onode_cache_miss_latency");
-    auto onode_miss_tavg = store.logger->get_tavg_ns(l_bluestore_onode_cache_time_latency_time);
+    auto onode_miss_tavg = store.logger->get_tavg_ns(l_bluestore_onode_miss_lat);
     uint64_t onode_miss_sum_ns = onode_miss_tavg.first;
     uint64_t onode_miss_count = onode_miss_tavg.second;
     f->dump_unsigned("avgcount", onode_miss_count);

--- a/src/os/bluestore/BlueAdmin.cc
+++ b/src/os/bluestore/BlueAdmin.cc
@@ -16,6 +16,63 @@ using ceph::bufferlist;
 using ceph::Formatter;
 using ceph::common::cmd_getval;
 
+//To help in short term tracking for cache stats
+static void take_cache_snapshot(BlueStore& store) {
+  std::lock_guard l(store.cache_stats_lock);
+  
+  BlueStore::CacheStatsSnapshot snap;
+  snap.timestamp = ceph::mono_clock::now();
+  snap.onode_hits = store.logger->get(l_bluestore_onode_cache_hit_count);
+  snap.onode_misses = store.logger->get(l_bluestore_onode_cache_time_latency_time + 1);
+  snap.onode_miss_latency_sum = store.logger->get(l_bluestore_onode_cache_time_latency_time);
+  snap.onode_shard_hits = store.logger->get(l_bluestore_onode_shard_hits);
+  snap.onode_shard_misses = store.logger->get(l_bluestore_onode_shard_misses);
+  snap.onode_shard_miss_latency_sum = store.logger->get(l_bluestore_onode_shard_miss_lat);
+  snap.buffer_read_reqs = store.logger->get(l_bluestore_buffer_read_reqs);
+  snap.buffer_miss_count = store.logger->get(l_bluestore_buffer_miss_lat + 1);
+  snap.buffer_miss_latency_sum = store.logger->get(l_bluestore_buffer_miss_lat);
+  
+  store.cache_stats_snapshots.push_back(snap);
+  
+  //Remove old ones
+  while (store.cache_stats_snapshots.size() > BlueStore::MAX_CACHE_SNAPSHOTS) {
+    store.cache_stats_snapshots.pop_front();
+  }
+}
+
+static bool get_snapshot_windows(BlueStore& store,
+                                 BlueStore::CacheStatsSnapshot& current,
+                                 BlueStore::CacheStatsSnapshot& most_recent,
+                                 BlueStore::CacheStatsSnapshot& oldest) {
+  std::lock_guard l(store.cache_stats_lock);
+  
+  if (store.cache_stats_snapshots.empty()) {
+    return false;
+  }
+  
+  // Get current values 
+  current.timestamp = ceph::mono_clock::now();
+  current.onode_hits = store.logger->get(l_bluestore_onode_cache_hit_count);
+  current.onode_misses = store.logger->get(l_bluestore_onode_cache_time_latency_time + 1);
+  current.onode_miss_latency_sum = store.logger->get(l_bluestore_onode_cache_time_latency_time);
+  current.onode_shard_hits = store.logger->get(l_bluestore_onode_shard_hits);
+  current.onode_shard_misses = store.logger->get(l_bluestore_onode_shard_misses);
+  current.onode_shard_miss_latency_sum = store.logger->get(l_bluestore_onode_shard_miss_lat);
+  current.buffer_read_reqs = store.logger->get(l_bluestore_buffer_read_reqs);
+  current.buffer_miss_count = store.logger->get(l_bluestore_buffer_miss_lat + 1);
+  current.buffer_miss_latency_sum = store.logger->get(l_bluestore_buffer_miss_lat);
+  
+  if(store.cache_stats_snapshots.size() >= 2) {
+    most_recent = store.cache_stats_snapshots[store.cache_stats_snapshots.size() - 2];
+  } else {
+  most_recent = store.cache_stats_snapshots.back();
+  }
+  oldest = store.cache_stats_snapshots.front();
+  
+  return true;
+}
+
+
 BlueStore::SocketHook::SocketHook(BlueStore& store)
   : store(store)
 {
@@ -72,6 +129,11 @@ BlueStore::SocketHook::SocketHook(BlueStore& store)
       "name=collection,type=CephString,req=false",
       this,
       "clear static fragmentation score, per collection");
+    ceph_assert(r == 0);
+    r = admin_socket->register_command(
+      "bluestore cache stats",
+      this,
+      "print cache performance stats");
     ceph_assert(r == 0);
     r = admin_socket->register_command(
       "bluestore show sharding ",
@@ -273,6 +335,278 @@ int BlueStore::SocketHook::call(
       }
     }
     f->close_section();
+    return 0;
+  } else if (command == "bluestore cache stats") {
+    //Store stats at this time for short term tracking
+    take_cache_snapshot(store);
+    
+    f->open_object_section("cache_stats");
+    
+    f->open_object_section("since_startup");
+    
+    f->open_object_section("onode_cache");
+    
+    uint64_t onode_hits = store.logger->get(l_bluestore_onode_cache_hit_count);
+    f->dump_unsigned("hits", onode_hits);
+    
+   
+    f->open_object_section("onode_cache_miss_latency");
+    auto onode_miss_tavg = store.logger->get_tavg_ns(l_bluestore_onode_cache_time_latency_time);
+    uint64_t onode_miss_sum_ns = onode_miss_tavg.first;
+    uint64_t onode_miss_count = onode_miss_tavg.second;
+    f->dump_unsigned("avgcount", onode_miss_count);
+    f->dump_format_unquoted("sum", "%" PRId64 ".%09" PRId64,
+                            onode_miss_sum_ns / 1000000000ull,
+                            onode_miss_sum_ns % 1000000000ull);
+    if (onode_miss_count) {
+      uint64_t avg_ns = onode_miss_sum_ns / onode_miss_count;
+      f->dump_format_unquoted("avgtime", "%" PRId64 ".%09" PRId64,
+                              avg_ns / 1000000000ull,
+                              avg_ns % 1000000000ull);
+    } else {
+      f->dump_format_unquoted("avgtime", "%" PRId64 ".%09" PRId64, 0, 0);
+    }
+    f->close_section();
+    
+    
+    f->open_object_section("onode_shard_miss_latency");
+    auto shard_miss_tavg = store.logger->get_tavg_ns(l_bluestore_onode_shard_miss_lat);
+    uint64_t shard_miss_sum_ns = shard_miss_tavg.first;
+    uint64_t shard_miss_count = shard_miss_tavg.second;
+    f->dump_unsigned("avgcount", shard_miss_count);
+    f->dump_format_unquoted("sum", "%" PRId64 ".%09" PRId64,
+                            shard_miss_sum_ns / 1000000000ull,
+                            shard_miss_sum_ns % 1000000000ull);
+    if (shard_miss_count) {
+      uint64_t avg_ns = shard_miss_sum_ns / shard_miss_count;
+      f->dump_format_unquoted("avgtime", "%" PRId64 ".%09" PRId64,
+                              avg_ns / 1000000000ull,
+                              avg_ns % 1000000000ull);
+    } else {
+      f->dump_format_unquoted("avgtime", "%" PRId64 ".%09" PRId64, 0, 0);
+    }
+    f->close_section();
+    
+    uint64_t total_accesses = onode_hits + onode_miss_count;
+    f->dump_unsigned("total_accesses", total_accesses);
+    if (total_accesses > 0) {
+      double hit_ratio = static_cast<double>(onode_hits) / static_cast<double>(total_accesses);
+      f->dump_float("hit_ratio", hit_ratio);
+    } else {
+      f->dump_float("hit_ratio", 0.0);
+    }
+    
+    f->close_section();
+    
+    f->open_object_section("onode_shard");
+    uint64_t shard_hits = store.logger->get(l_bluestore_onode_shard_hits);
+    uint64_t shard_misses = store.logger->get(l_bluestore_onode_shard_misses);
+    f->dump_unsigned("hits", shard_hits);
+    f->dump_unsigned("misses", shard_misses);
+    uint64_t shard_total = shard_hits + shard_misses;
+    if (shard_total > 0) {
+      f->dump_float("hit_ratio", (double)shard_hits / (double)shard_total);
+    } else {
+      f->dump_float("hit_ratio", 0.0);
+    }
+    
+    auto shard_miss_lat_tavg = store.logger->get_tavg_ns(l_bluestore_onode_shard_miss_lat);
+    uint64_t shard_miss_lat_sum_ns = shard_miss_lat_tavg.first;
+    uint64_t shard_miss_lat_count = shard_miss_lat_tavg.second;
+    if (shard_miss_lat_count > 0) {
+      uint64_t avg_ns = shard_miss_lat_sum_ns / shard_miss_lat_count;
+      f->dump_format_unquoted("avg_miss_latency", "%" PRId64 ".%09" PRId64,
+                              avg_ns / 1000000000ull,
+                              avg_ns % 1000000000ull);
+    }
+    f->close_section();
+    
+    f->open_object_section("object_data_cache");
+    
+    uint64_t read_reqs = store.logger->get(l_bluestore_buffer_read_reqs);
+    f->dump_unsigned("read_requests", read_reqs);
+    
+    f->open_object_section("buffer_miss_latency");
+    auto buffer_miss_tavg = store.logger->get_tavg_ns(l_bluestore_buffer_miss_lat);
+    uint64_t buffer_miss_sum_ns = buffer_miss_tavg.first;
+    uint64_t buffer_miss_count = buffer_miss_tavg.second;
+    f->dump_unsigned("avgcount", buffer_miss_count);
+    f->dump_format_unquoted("sum", "%" PRId64 ".%09" PRId64,
+                            buffer_miss_sum_ns / 1000000000ull,
+                            buffer_miss_sum_ns % 1000000000ull);
+    if (buffer_miss_count) {
+      uint64_t avg_ns = buffer_miss_sum_ns / buffer_miss_count;
+      f->dump_format_unquoted("avgtime", "%" PRId64 ".%09" PRId64,
+                              avg_ns / 1000000000ull,
+                              avg_ns % 1000000000ull);
+    } else {
+      f->dump_format_unquoted("avgtime", "%" PRId64 ".%09" PRId64, 0, 0);
+    }
+    f->close_section();
+    
+    uint64_t buffer_hits = (read_reqs > buffer_miss_count) ? (read_reqs - buffer_miss_count) : 0;
+    f->dump_unsigned("hits", buffer_hits);
+    f->dump_unsigned("misses", buffer_miss_count);
+    
+    if (read_reqs > 0) {
+      double buffer_hit_ratio = static_cast<double>(buffer_hits) / static_cast<double>(read_reqs);
+      f->dump_float("hit_ratio", buffer_hit_ratio);
+    } else {
+      f->dump_float("hit_ratio", 0.0);
+    }
+    
+    f->close_section();
+    
+    f->close_section();// since_startup
+    
+    // Short-term stat
+    BlueStore::CacheStatsSnapshot current, most_recent, oldest;
+    if (get_snapshot_windows(store, current, most_recent, oldest)) {
+      
+      auto recent_duration = std::chrono::duration<double>(current.timestamp - most_recent.timestamp).count();
+      if (recent_duration > 0) {
+        f->open_object_section("since_most_recent_snapshot");
+        f->dump_float("window_seconds", recent_duration);
+        
+        f->open_object_section("onode_cache");
+        uint64_t delta_onode_hits = current.onode_hits - most_recent.onode_hits;
+        uint64_t delta_onode_misses = current.onode_misses - most_recent.onode_misses;
+        uint64_t delta_onode_lat = current.onode_miss_latency_sum - most_recent.onode_miss_latency_sum;
+        f->dump_unsigned("hits", delta_onode_hits);
+        f->dump_unsigned("misses", delta_onode_misses);
+        uint64_t delta_onode_total = delta_onode_hits + delta_onode_misses;
+        if (delta_onode_total > 0) {
+          f->dump_float("hit_ratio", (double)delta_onode_hits / (double)delta_onode_total);
+        } else {
+          f->dump_float("hit_ratio", 0.0);
+        }
+        if (delta_onode_misses > 0) {
+          f->dump_float("avg_miss_latency_us", (double)delta_onode_lat / (double)delta_onode_misses / 1000.0);
+        }
+        f->close_section();
+        
+        f->open_object_section("onode_shard");
+        uint64_t delta_shard_hits = current.onode_shard_hits - most_recent.onode_shard_hits;
+        uint64_t delta_shard_misses = current.onode_shard_misses - most_recent.onode_shard_misses;
+        uint64_t delta_shard_lat = current.onode_shard_miss_latency_sum - most_recent.onode_shard_miss_latency_sum;
+        f->dump_unsigned("hits", delta_shard_hits);
+        f->dump_unsigned("misses", delta_shard_misses);
+        uint64_t delta_shard_total = delta_shard_hits + delta_shard_misses;
+        if (delta_shard_total > 0) {
+          f->dump_float("hit_ratio", (double)delta_shard_hits / (double)delta_shard_total);
+        } else {
+          f->dump_float("hit_ratio", 0.0);
+        }
+        if (delta_shard_misses > 0) {
+          f->dump_float("avg_miss_latency_us", (double)delta_shard_lat / (double)delta_shard_misses / 1000.0);
+        }
+        f->close_section();
+        
+        f->open_object_section("object_data_cache");
+        uint64_t delta_buffer_reqs = current.buffer_read_reqs - most_recent.buffer_read_reqs;
+        uint64_t delta_buffer_misses = current.buffer_miss_count - most_recent.buffer_miss_count;
+        uint64_t delta_buffer_lat = current.buffer_miss_latency_sum - most_recent.buffer_miss_latency_sum;
+        uint64_t delta_buffer_hits = (delta_buffer_reqs > delta_buffer_misses) ? (delta_buffer_reqs - delta_buffer_misses) : 0;
+        f->dump_unsigned("read_requests", delta_buffer_reqs);
+        f->dump_unsigned("hits", delta_buffer_hits);
+        f->dump_unsigned("misses", delta_buffer_misses);
+        if (delta_buffer_reqs > 0) {
+          f->dump_float("hit_ratio", (double)delta_buffer_hits / (double)delta_buffer_reqs);
+        } else {
+          f->dump_float("hit_ratio", 0.0);
+        }
+        if (delta_buffer_misses > 0) {
+          f->dump_float("avg_miss_latency_us", (double)delta_buffer_lat / (double)delta_buffer_misses / 1000.0);
+        }
+        f->close_section();
+        
+        f->close_section();
+      }
+      
+      auto oldest_duration = std::chrono::duration<double>(current.timestamp - oldest.timestamp).count();
+      
+      if (oldest_duration > 0) {
+        f->open_object_section("since_oldest_snapshot");
+        f->dump_float("window_seconds", oldest_duration);
+        
+        f->open_object_section("onode_cache");
+        uint64_t delta_onode_hits = current.onode_hits - oldest.onode_hits;
+        uint64_t delta_onode_misses = current.onode_misses - oldest.onode_misses;
+        uint64_t delta_onode_lat = current.onode_miss_latency_sum - oldest.onode_miss_latency_sum;
+        uint64_t delta_onode_total = delta_onode_hits + delta_onode_misses;
+        
+        f->dump_unsigned("hits", delta_onode_hits);
+        f->dump_unsigned("misses", delta_onode_misses);
+        f->dump_unsigned("total_accesses", delta_onode_total);
+        if (delta_onode_total > 0) {
+          f->dump_float("hit_ratio", (double)delta_onode_hits / (double)delta_onode_total);
+          f->dump_float("accesses_per_second", (double)delta_onode_total / oldest_duration);
+        } else {
+          f->dump_float("hit_ratio", 0.0);
+          f->dump_float("accesses_per_second", 0.0);
+        }
+        if (delta_onode_misses > 0) {
+          f->dump_float("avg_miss_latency_us", (double)delta_onode_lat / (double)delta_onode_misses / 1000.0);
+        }
+        f->close_section();
+        
+        f->open_object_section("onode_shard");
+        uint64_t delta_shard_hits = current.onode_shard_hits - oldest.onode_shard_hits;
+        uint64_t delta_shard_misses = current.onode_shard_misses - oldest.onode_shard_misses;
+        uint64_t delta_shard_lat = current.onode_shard_miss_latency_sum - oldest.onode_shard_miss_latency_sum;
+        f->dump_unsigned("hits", delta_shard_hits);
+        f->dump_unsigned("misses", delta_shard_misses);
+        uint64_t delta_shard_total = delta_shard_hits + delta_shard_misses;
+        if (delta_shard_total > 0) {
+          f->dump_float("hit_ratio", (double)delta_shard_hits / (double)delta_shard_total);
+        } else {
+          f->dump_float("hit_ratio", 0.0);
+        }
+        if (delta_shard_misses > 0) {
+          f->dump_float("avg_miss_latency_us", (double)delta_shard_lat / (double)delta_shard_misses / 1000.0);
+        }
+        f->close_section();
+        
+        f->open_object_section("object_data_cache");
+        uint64_t delta_buffer_reqs = current.buffer_read_reqs - oldest.buffer_read_reqs;
+        uint64_t delta_buffer_misses = current.buffer_miss_count - oldest.buffer_miss_count;
+        uint64_t delta_buffer_lat = current.buffer_miss_latency_sum - oldest.buffer_miss_latency_sum;
+        uint64_t delta_buffer_hits = (delta_buffer_reqs > delta_buffer_misses) ? (delta_buffer_reqs - delta_buffer_misses) : 0;
+        
+        f->dump_unsigned("read_requests", delta_buffer_reqs);
+        f->dump_unsigned("hits", delta_buffer_hits);
+        f->dump_unsigned("misses", delta_buffer_misses);
+        if (delta_buffer_reqs > 0) {
+          f->dump_float("hit_ratio", (double)delta_buffer_hits / (double)delta_buffer_reqs);
+          f->dump_float("requests_per_second", (double)delta_buffer_reqs / oldest_duration);
+        } else {
+          f->dump_float("hit_ratio", 0.0);
+          f->dump_float("requests_per_second", 0.0);
+        }
+        if (delta_buffer_misses > 0) {
+          f->dump_float("avg_miss_latency_us", (double)delta_buffer_lat / (double)delta_buffer_misses / 1000.0);
+        }
+        f->close_section();
+        
+        f->close_section();
+      }
+    }
+    
+    // RocksDB performance statistics (I think the hits and misses is useful, latency is not, commented out for now)
+    //f->open_object_section("rocksdb_perf_stats");
+    
+    //auto collection = store.cct->get_perfcounters_collection();
+    
+    //if (collection) {
+    //  collection->dump_formatted(f, false, static_cast<select_labeled_t>(0), "rocksdb", "");
+    //} else {
+    //  f->dump_string("status", "perf counters collection not available");
+    //}
+    
+    //f->close_section(); // rocksdb_perf_stats
+    
+    f->close_section(); // cache_stats
+    
     return 0;
   } else if (command == "bluestore clear static frag") {
     std::shared_lock l(store.coll_lock);

--- a/src/os/bluestore/BlueAdmin.cc
+++ b/src/os/bluestore/BlueAdmin.cc
@@ -8,6 +8,7 @@
 #include <asm-generic/errno-base.h>
 #include <vector>
 #include <limits>
+#include <optional>
 
 #define dout_subsys ceph_subsys_bluestore
 #define dout_context store.cct
@@ -16,60 +17,93 @@ using ceph::bufferlist;
 using ceph::Formatter;
 using ceph::common::cmd_getval;
 
-//To help in short term tracking for cache stats
-static void take_cache_snapshot(BlueStore& store) {
-  std::lock_guard l(store.cache_stats_lock);
-  
-  BlueStore::CacheStatsSnapshot snap;
-  snap.timestamp = ceph::mono_clock::now();
-  snap.onode_hits = store.logger->get(l_bluestore_onode_hits);
-  snap.onode_misses = store.logger->get(l_bluestore_onode_misses);
-  snap.onode_miss_latency_sum = store.logger->get(l_bluestore_onode_miss_lat);
-  snap.onode_shard_hits = store.logger->get(l_bluestore_onode_shard_hits);
-  snap.onode_shard_misses = store.logger->get(l_bluestore_onode_shard_misses);
-  snap.onode_shard_miss_latency_sum = store.logger->get(l_bluestore_onode_shard_miss_lat);
-  snap.buffer_hits = store.logger->get(l_bluestore_buffer_hit_bytes);
-  snap.buffer_misses = store.logger->get(l_bluestore_buffer_miss_bytes);
-  snap.buffer_miss_latency_sum = store.logger->get(l_bluestore_buffer_miss_lat);
-  
-  store.cache_stats_snapshots.push_back(snap);
-  
-  //Remove old ones
-  while (store.cache_stats_snapshots.size() > BlueStore::MAX_CACHE_SNAPSHOTS) {
-    store.cache_stats_snapshots.pop_front();
+static void dump_avg_latency(Formatter *f, const char *name, uint64_t sum_ns, uint64_t count) {
+  f->open_object_section(name);
+  f->dump_unsigned("avgcount", count);
+  f->dump_float("sum", sum_ns / 1000000000.0);
+  if (count) {
+    f->dump_float("avgtime", (sum_ns / (double)count) / 1000000000.0);
+  } else {
+    f->dump_float("avgtime", 0.0);
   }
+  f->close_section();
 }
 
-static bool get_snapshot_windows(BlueStore& store,
+static void dump_cache_section(Formatter *f, const char *name,
+                               uint64_t hits, uint64_t misses,
+                               uint64_t lat_sum, uint64_t lat_count,
+                               bool is_byte_cache,
+                               std::optional<double> duration = std::nullopt) {
+  f->open_object_section(name);
+  dump_avg_latency(f, is_byte_cache ? "buffer_miss_latency" : "miss_latency", lat_sum, lat_count);
+
+  f->dump_unsigned(is_byte_cache ? "hit_bytes" : "hits", hits);
+  f->dump_unsigned(is_byte_cache ? "miss_bytes" : "misses", misses);
+  uint64_t total = hits + misses;
+  f->dump_unsigned(is_byte_cache ? "total_byte_accesses" : "total", total);
+  if (total > 0) {
+    f->dump_float(is_byte_cache ? "byte_hit_ratio" : "hit_ratio", (double)hits / (double)total);
+  } else {
+    f->dump_float(is_byte_cache ? "byte_hit_ratio" : "hit_ratio", 0.0);
+  }
+
+  if (duration && *duration > 0) {
+    f->dump_float("accesses_per_second", (double)total / *duration);
+  }
+
+  f->close_section();
+}
+
+static void dump_snapshot_section(Formatter *f, const char *name,
+                                  const BlueStore::CacheStatsSnapshot& snap,
+                                  std::optional<double> duration = std::nullopt) {
+  f->open_object_section(name);
+  if (duration) {
+    f->dump_float("seconds elapsed", *duration);
+  }
+  dump_cache_section(f, "onode_cache", snap.onode_hits, snap.onode_misses,
+                     snap.onode_miss_latency_sum, snap.onode_misses,
+                     false, duration);
+  dump_cache_section(f, "onode_shard", snap.onode_shard_hits, snap.onode_shard_misses,
+                     snap.onode_shard_miss_latency_sum, snap.onode_shard_misses,
+                     false, duration);
+  dump_cache_section(f, "object_data_cache", snap.buffer_hit_bytes, snap.buffer_miss_bytes,
+                     snap.buffer_miss_latency_sum, snap.buffer_miss_lat_count,
+                     true, duration);
+  f->close_section();
+}
+
+static void get_snapshot_windows(BlueStore& store,
                                  BlueStore::CacheStatsSnapshot& current,
                                  BlueStore::CacheStatsSnapshot& most_recent,
                                  BlueStore::CacheStatsSnapshot& oldest) {
   std::lock_guard l(store.cache_stats_lock);
-  
-  if (store.cache_stats_snapshots.empty()) {
-    return false;
-  }
-  
-  // Get current values 
+
+  // Get current values
   current.timestamp = ceph::mono_clock::now();
   current.onode_hits = store.logger->get(l_bluestore_onode_hits);
   current.onode_misses = store.logger->get(l_bluestore_onode_misses);
-  current.onode_miss_latency_sum = store.logger->get(l_bluestore_onode_miss_lat);
+  current.onode_miss_latency_sum = store.logger->get_tavg_ns(l_bluestore_onode_miss_lat).first;
   current.onode_shard_hits = store.logger->get(l_bluestore_onode_shard_hits);
   current.onode_shard_misses = store.logger->get(l_bluestore_onode_shard_misses);
-  current.onode_shard_miss_latency_sum = store.logger->get(l_bluestore_onode_shard_miss_lat);
-  current.buffer_hits = store.logger->get(l_bluestore_buffer_hit_bytes);
-  current.buffer_misses = store.logger->get(l_bluestore_buffer_miss_bytes);
-  current.buffer_miss_latency_sum = store.logger->get(l_bluestore_buffer_miss_lat);
-  
-  if(store.cache_stats_snapshots.size() >= 2) {
+  current.onode_shard_miss_latency_sum = store.logger->get_tavg_ns(l_bluestore_onode_shard_miss_lat).first;
+  current.buffer_hit_bytes = store.logger->get(l_bluestore_buffer_hit_bytes);
+  current.buffer_miss_bytes = store.logger->get(l_bluestore_buffer_miss_bytes);
+  auto buffer_miss_tavg = store.logger->get_tavg_ns(l_bluestore_buffer_miss_lat);
+  current.buffer_miss_latency_sum = buffer_miss_tavg.first;
+  current.buffer_miss_lat_count = buffer_miss_tavg.second;
+
+  store.cache_stats_snapshots.push_back(current);
+  while (store.cache_stats_snapshots.size() > BlueStore::MAX_CACHE_SNAPSHOTS) {
+    store.cache_stats_snapshots.pop_front();
+  }
+
+  if (store.cache_stats_snapshots.size() >= 2) {
     most_recent = store.cache_stats_snapshots[store.cache_stats_snapshots.size() - 2];
   } else {
-  most_recent = store.cache_stats_snapshots.back();
+    most_recent = store.cache_stats_snapshots.back();
   }
   oldest = store.cache_stats_snapshots.front();
-  
-  return true;
 }
 
 
@@ -337,252 +371,26 @@ int BlueStore::SocketHook::call(
     f->close_section();
     return 0;
   } else if (command == "bluestore cache stats") {
-    //Store stats at this time for short term tracking
-    take_cache_snapshot(store);
-    
     f->open_object_section("cache_stats");
-    
-    f->open_object_section("since_startup");
-    
-    f->open_object_section("onode_cache");
-    
-    uint64_t onode_hits = store.logger->get(l_bluestore_onode_hits);
-    uint64_t onode_misses = store.logger->get(l_bluestore_onode_misses);
-    f->dump_unsigned("hits", onode_hits);
-    f->dump_unsigned("misses", onode_misses);
-    uint64_t total_accesses = onode_hits + onode_misses;
-    f->dump_unsigned("total", total_accesses);
-    if (total_accesses > 0) {
-      double hit_ratio = static_cast<double>(onode_hits) / static_cast<double>(total_accesses);
-      f->dump_float("hit_ratio", hit_ratio);
-    } else {
-      f->dump_float("hit_ratio", 0.0);
-    }
-    
-    f->open_object_section("onode_cache_miss_latency");
-    auto onode_miss_tavg = store.logger->get_tavg_ns(l_bluestore_onode_miss_lat);
-    uint64_t onode_miss_sum_ns = onode_miss_tavg.first;
-    uint64_t onode_miss_count = onode_miss_tavg.second;
-    f->dump_unsigned("avgcount", onode_miss_count);
-    f->dump_format_unquoted("sum", "%" PRId64 ".%09" PRId64,
-                            onode_miss_sum_ns / 1000000000ull,
-                            onode_miss_sum_ns % 1000000000ull);
-    if (onode_miss_count) {
-      uint64_t avg_ns = onode_miss_sum_ns / onode_miss_count;
-      f->dump_format_unquoted("avgtime", "%" PRId64 ".%09" PRId64,
-                              avg_ns / 1000000000ull,
-                              avg_ns % 1000000000ull);
-    } else {
-      f->dump_format_unquoted("avgtime", "%" PRId64 ".%09" PRId64, 0, 0);
-    }
-    f->close_section();
-    
-    f->close_section();
-    
-    f->open_object_section("onode_shard");
-    uint64_t shard_hits = store.logger->get(l_bluestore_onode_shard_hits);
-    uint64_t shard_misses = store.logger->get(l_bluestore_onode_shard_misses);
-    f->dump_unsigned("hits", shard_hits);
-    f->dump_unsigned("misses", shard_misses);
-    uint64_t shard_total = shard_hits + shard_misses;
-    f->dump_unsigned("total", shard_total);
-    if (shard_total > 0) {
-      f->dump_float("hit_ratio", (double)shard_hits / (double)shard_total);
-    } else {
-      f->dump_float("hit_ratio", 0.0);
-    }
-    
-    f->open_object_section("onode_shard_miss_latency");
-    auto shard_miss_tavg = store.logger->get_tavg_ns(l_bluestore_onode_shard_miss_lat);
-    uint64_t shard_miss_sum_ns = shard_miss_tavg.first;
-    uint64_t shard_miss_count = shard_miss_tavg.second;
-    f->dump_unsigned("avgcount", shard_miss_count);
-    f->dump_format_unquoted("sum", "%" PRId64 ".%09" PRId64,
-                            shard_miss_sum_ns / 1000000000ull,
-                            shard_miss_sum_ns % 1000000000ull);
-    if (shard_miss_count) {
-      uint64_t avg_ns = shard_miss_sum_ns / shard_miss_count;
-      f->dump_format_unquoted("avgtime", "%" PRId64 ".%09" PRId64,
-                              avg_ns / 1000000000ull,
-                              avg_ns % 1000000000ull);
-    } else {
-      f->dump_format_unquoted("avgtime", "%" PRId64 ".%09" PRId64, 0, 0);
-    }
-    f->close_section();
-    
-    f->close_section();
-    
-    f->open_object_section("object_data_cache");
-    
-    f->open_object_section("buffer_miss_latency");
-    auto buffer_miss_tavg = store.logger->get_tavg_ns(l_bluestore_buffer_miss_lat);
-    uint64_t buffer_miss_sum_ns = buffer_miss_tavg.first;
-    uint64_t buffer_misses = buffer_miss_tavg.second;
-    f->dump_unsigned("avgcount", buffer_misses);
-    f->dump_format_unquoted("sum", "%" PRId64 ".%09" PRId64,
-                            buffer_miss_sum_ns / 1000000000ull,
-                            buffer_miss_sum_ns % 1000000000ull);
-    if (buffer_misses) {
-      uint64_t avg_ns = buffer_miss_sum_ns / buffer_misses;
-      f->dump_format_unquoted("avgtime", "%" PRId64 ".%09" PRId64,
-                              avg_ns / 1000000000ull,
-                              avg_ns % 1000000000ull);
-    } else {
-      f->dump_format_unquoted("avgtime", "%" PRId64 ".%09" PRId64, 0, 0);
-    }
-    f->close_section();
-    
-    uint64_t buffer_hits = store.logger->get(l_bluestore_buffer_hit_bytes);
-    buffer_misses = store.logger->get(l_bluestore_buffer_miss_bytes);
 
-    f->dump_unsigned("hit bytes", buffer_hits);
-    f->dump_unsigned("miss bytes", buffer_misses);
-    uint64_t buffer_total = buffer_hits + buffer_misses;
-    f->dump_unsigned("total byte accesses", buffer_total);
-    if (buffer_total > 0) {
-      double buffer_hit_ratio = static_cast<double>(buffer_hits) / static_cast<double>(buffer_total);
-      f->dump_float("byte_hit_ratio", buffer_hit_ratio);
-    } else {
-      f->dump_float("byte_hit_ratio", 0.0);
-    }
-    
-    f->close_section();
-    
-    f->close_section();// since_startup
-    
-    // Short-term stat
     BlueStore::CacheStatsSnapshot current, most_recent, oldest;
-    if (get_snapshot_windows(store, current, most_recent, oldest)) {
-      
-      auto recent_duration = std::chrono::duration<double>(current.timestamp - most_recent.timestamp).count();
-      if (recent_duration > 0) {
-        f->open_object_section("since_most_recent_snapshot");
-        f->dump_float("seconds elapsed", recent_duration);
-        
-        f->open_object_section("onode_cache");
-        uint64_t delta_onode_hits = current.onode_hits - most_recent.onode_hits;
-        uint64_t delta_onode_misses = current.onode_misses - most_recent.onode_misses;
-        uint64_t delta_onode_lat = current.onode_miss_latency_sum - most_recent.onode_miss_latency_sum;
-        f->dump_unsigned("hits", delta_onode_hits);
-        f->dump_unsigned("misses", delta_onode_misses);
-        uint64_t delta_onode_total = delta_onode_hits + delta_onode_misses;
-        if (delta_onode_total > 0) {
-          f->dump_float("hit_ratio", (double)delta_onode_hits / (double)delta_onode_total);
-        } else {
-          f->dump_float("hit_ratio", 0.0);
-        }
-        if (delta_onode_misses > 0) {
-          f->dump_float("avg_miss_latency_us", (double)delta_onode_lat / (double)delta_onode_misses / 1000.0);
-        }
-        f->close_section();
-        
-        f->open_object_section("onode_shard");
-        uint64_t delta_shard_hits = current.onode_shard_hits - most_recent.onode_shard_hits;
-        uint64_t delta_shard_misses = current.onode_shard_misses - most_recent.onode_shard_misses;
-        uint64_t delta_shard_lat = current.onode_shard_miss_latency_sum - most_recent.onode_shard_miss_latency_sum;
-        f->dump_unsigned("hits", delta_shard_hits);
-        f->dump_unsigned("misses", delta_shard_misses);
-        uint64_t delta_shard_total = delta_shard_hits + delta_shard_misses;
-        if (delta_shard_total > 0) {
-          f->dump_float("hit_ratio", (double)delta_shard_hits / (double)delta_shard_total);
-        } else {
-          f->dump_float("hit_ratio", 0.0);
-        }
-        if (delta_shard_misses > 0) {
-          f->dump_float("avg_miss_latency_us", (double)delta_shard_lat / (double)delta_shard_misses / 1000.0);
-        }
-        f->close_section();
-        
-        f->open_object_section("object_data_cache");
-        uint64_t delta_buffer_hits = current.buffer_hits - most_recent.buffer_hits;
-        uint64_t delta_buffer_misses = current.buffer_misses - most_recent.buffer_misses;
-        uint64_t delta_buffer_lat = current.buffer_miss_latency_sum - most_recent.buffer_miss_latency_sum;
-        uint64_t delta_buffer_total = delta_buffer_hits + delta_buffer_misses;
-        f->dump_unsigned("hit bytes", delta_buffer_hits);
-        f->dump_unsigned("miss bytes", delta_buffer_misses);
-        f->dump_unsigned("total bytes", delta_buffer_total);
-        if (delta_buffer_total > 0) {
-          f->dump_float("byte_hit_ratio", (double)delta_buffer_hits / (double)delta_buffer_total);
-        } else {
-          f->dump_float("byte_hit_ratio", 0.0);
-        }
-        if (delta_buffer_misses > 0) {
-          f->dump_float("avg_miss_latency_us", (double)delta_buffer_lat / (double)delta_buffer_misses / 1000.0);
-        }
-        f->close_section();
-        
-        f->close_section();
-      }
-      
-      auto oldest_duration = std::chrono::duration<double>(current.timestamp - oldest.timestamp).count();
-      
-      if (oldest_duration > 0) {
-        f->open_object_section("since_oldest_snapshot");
-        f->dump_float("seconds elapsed", oldest_duration);
-        
-        f->open_object_section("onode_cache");
-        uint64_t delta_onode_hits = current.onode_hits - oldest.onode_hits;
-        uint64_t delta_onode_misses = current.onode_misses - oldest.onode_misses;
-        uint64_t delta_onode_lat = current.onode_miss_latency_sum - oldest.onode_miss_latency_sum;
-        uint64_t delta_onode_total = delta_onode_hits + delta_onode_misses;
-        
-        f->dump_unsigned("hits", delta_onode_hits);
-        f->dump_unsigned("misses", delta_onode_misses);
-        f->dump_unsigned("total", delta_onode_total);
-        if (delta_onode_total > 0) {
-          f->dump_float("hit_ratio", (double)delta_onode_hits / (double)delta_onode_total);
-          f->dump_float("accesses_per_second", (double)delta_onode_total / oldest_duration);
-        } else {
-          f->dump_float("hit_ratio", 0.0);
-          f->dump_float("accesses_per_second", 0.0);
-        }
-        if (delta_onode_misses > 0) {
-          f->dump_float("avg_miss_latency_us", (double)delta_onode_lat / (double)delta_onode_misses / 1000.0);
-        }
-        f->close_section();
-        
-        f->open_object_section("onode_shard");
-        uint64_t delta_shard_hits = current.onode_shard_hits - oldest.onode_shard_hits;
-        uint64_t delta_shard_misses = current.onode_shard_misses - oldest.onode_shard_misses;
-        uint64_t delta_shard_lat = current.onode_shard_miss_latency_sum - oldest.onode_shard_miss_latency_sum;
-        f->dump_unsigned("hits", delta_shard_hits);
-        f->dump_unsigned("misses", delta_shard_misses);
-        uint64_t delta_shard_total = delta_shard_hits + delta_shard_misses;
-        if (delta_shard_total > 0) {
-          f->dump_float("hit_ratio", (double)delta_shard_hits / (double)delta_shard_total);
-        } else {
-          f->dump_float("hit_ratio", 0.0);
-        }
-        if (delta_shard_misses > 0) {
-          f->dump_float("avg_miss_latency_us", (double)delta_shard_lat / (double)delta_shard_misses / 1000.0);
-        }
-        f->close_section();
-        
-        f->open_object_section("object_data_cache");
-        uint64_t delta_buffer_hits = current.buffer_hits - oldest.buffer_hits;
-        uint64_t delta_buffer_misses = current.buffer_misses - oldest.buffer_misses;
-        uint64_t delta_buffer_lat = current.buffer_miss_latency_sum - oldest.buffer_miss_latency_sum;
-        uint64_t delta_buffer_total = delta_buffer_hits + delta_buffer_misses;
-        
-        f->dump_unsigned("hit bytes", delta_buffer_hits);
-        f->dump_unsigned("miss bytes", delta_buffer_misses);
-        f->dump_unsigned("total", delta_buffer_total);
-        if (delta_buffer_total > 0) {
-          f->dump_float("byte_hit_ratio", (double)delta_buffer_hits / (double)delta_buffer_total);
-          f->dump_float("accesses_per_second", (double)delta_buffer_total / oldest_duration);
-        } else {
-          f->dump_float("byte_hit_ratio", 0.0);
-          f->dump_float("accesses_per_second", 0.0);
-        }
-        if (delta_buffer_misses > 0) {
-          f->dump_float("avg_miss_latency_us", (double)delta_buffer_lat / (double)delta_buffer_misses / 1000.0);
-        }
-        f->close_section();
-        
-        f->close_section();
-      }
+    get_snapshot_windows(store, current, most_recent, oldest);
+    dump_snapshot_section(f, "since_startup", current);
+
+    double recent_duration = std::chrono::duration<double>(
+      current.timestamp - most_recent.timestamp).count();
+    if (recent_duration > 0) {
+      dump_snapshot_section(f, "since_most_recent_snapshot",
+                            current.delta(most_recent), recent_duration);
     }
-    
+
+    double oldest_duration = std::chrono::duration<double>(
+      current.timestamp - oldest.timestamp).count();
+    if (oldest_duration > 0) {
+      dump_snapshot_section(f, "since_oldest_snapshot",
+                            current.delta(oldest), oldest_duration);
+    }
+
     // RocksDB performance statistics (I think the hits and misses is useful, latency is not, commented out for now)
     //f->open_object_section("rocksdb_perf_stats");
     

--- a/src/os/bluestore/BlueAdmin.cc
+++ b/src/os/bluestore/BlueAdmin.cc
@@ -28,8 +28,8 @@ static void take_cache_snapshot(BlueStore& store) {
   snap.onode_shard_hits = store.logger->get(l_bluestore_onode_shard_hits);
   snap.onode_shard_misses = store.logger->get(l_bluestore_onode_shard_misses);
   snap.onode_shard_miss_latency_sum = store.logger->get(l_bluestore_onode_shard_miss_lat);
-  snap.buffer_hits = store.logger->get(l_bluestore_buffer_hits);
-  snap.buffer_misses = store.logger->get(l_bluestore_buffer_miss_lat + 1);
+  snap.buffer_hits = store.logger->get(l_bluestore_buffer_hit_bytes);
+  snap.buffer_misses = store.logger->get(l_bluestore_buffer_miss_bytes);
   snap.buffer_miss_latency_sum = store.logger->get(l_bluestore_buffer_miss_lat);
   
   store.cache_stats_snapshots.push_back(snap);
@@ -58,8 +58,8 @@ static bool get_snapshot_windows(BlueStore& store,
   current.onode_shard_hits = store.logger->get(l_bluestore_onode_shard_hits);
   current.onode_shard_misses = store.logger->get(l_bluestore_onode_shard_misses);
   current.onode_shard_miss_latency_sum = store.logger->get(l_bluestore_onode_shard_miss_lat);
-  current.buffer_hits = store.logger->get(l_bluestore_buffer_hits);
-  current.buffer_misses = store.logger->get(l_bluestore_buffer_miss_lat + 1);
+  current.buffer_hits = store.logger->get(l_bluestore_buffer_hit_bytes);
+  current.buffer_misses = store.logger->get(l_bluestore_buffer_miss_bytes);
   current.buffer_miss_latency_sum = store.logger->get(l_bluestore_buffer_miss_lat);
   
   if(store.cache_stats_snapshots.size() >= 2) {
@@ -432,16 +432,18 @@ int BlueStore::SocketHook::call(
     }
     f->close_section();
     
-    uint64_t buffer_hits = store.logger->get(l_bluestore_buffer_hits);
-    f->dump_unsigned("hits", buffer_hits);
-    f->dump_unsigned("misses", buffer_misses);
+    uint64_t buffer_hits = store.logger->get(l_bluestore_buffer_hit_bytes);
+    buffer_misses = store.logger->get(l_bluestore_buffer_miss_bytes);
+
+    f->dump_unsigned("hit bytes", buffer_hits);
+    f->dump_unsigned("miss bytes", buffer_misses);
     uint64_t buffer_total = buffer_hits + buffer_misses;
-    f->dump_unsigned("total_accesses", buffer_total);
+    f->dump_unsigned("total byte accesses", buffer_total);
     if (buffer_total > 0) {
       double buffer_hit_ratio = static_cast<double>(buffer_hits) / static_cast<double>(buffer_total);
-      f->dump_float("hit_ratio", buffer_hit_ratio);
+      f->dump_float("byte_hit_ratio", buffer_hit_ratio);
     } else {
-      f->dump_float("hit_ratio", 0.0);
+      f->dump_float("byte_hit_ratio", 0.0);
     }
     
     f->close_section();
@@ -496,13 +498,13 @@ int BlueStore::SocketHook::call(
         uint64_t delta_buffer_misses = current.buffer_misses - most_recent.buffer_misses;
         uint64_t delta_buffer_lat = current.buffer_miss_latency_sum - most_recent.buffer_miss_latency_sum;
         uint64_t delta_buffer_total = delta_buffer_hits + delta_buffer_misses;
-        f->dump_unsigned("hits", delta_buffer_hits);
-        f->dump_unsigned("misses", delta_buffer_misses);
-        f->dump_unsigned("total", delta_buffer_total);
+        f->dump_unsigned("hit bytes", delta_buffer_hits);
+        f->dump_unsigned("miss bytes", delta_buffer_misses);
+        f->dump_unsigned("total bytes", delta_buffer_total);
         if (delta_buffer_total > 0) {
-          f->dump_float("hit_ratio", (double)delta_buffer_hits / (double)delta_buffer_total);
+          f->dump_float("byte_hit_ratio", (double)delta_buffer_hits / (double)delta_buffer_total);
         } else {
-          f->dump_float("hit_ratio", 0.0);
+          f->dump_float("byte_hit_ratio", 0.0);
         }
         if (delta_buffer_misses > 0) {
           f->dump_float("avg_miss_latency_us", (double)delta_buffer_lat / (double)delta_buffer_misses / 1000.0);
@@ -562,14 +564,14 @@ int BlueStore::SocketHook::call(
         uint64_t delta_buffer_lat = current.buffer_miss_latency_sum - oldest.buffer_miss_latency_sum;
         uint64_t delta_buffer_total = delta_buffer_hits + delta_buffer_misses;
         
-        f->dump_unsigned("hits", delta_buffer_hits);
-        f->dump_unsigned("misses", delta_buffer_misses);
+        f->dump_unsigned("hit bytes", delta_buffer_hits);
+        f->dump_unsigned("miss bytes", delta_buffer_misses);
         f->dump_unsigned("total", delta_buffer_total);
         if (delta_buffer_total > 0) {
-          f->dump_float("hit_ratio", (double)delta_buffer_hits / (double)delta_buffer_total);
+          f->dump_float("byte_hit_ratio", (double)delta_buffer_hits / (double)delta_buffer_total);
           f->dump_float("accesses_per_second", (double)delta_buffer_total / oldest_duration);
         } else {
-          f->dump_float("hit_ratio", 0.0);
+          f->dump_float("byte_hit_ratio", 0.0);
           f->dump_float("accesses_per_second", 0.0);
         }
         if (delta_buffer_misses > 0) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1924,6 +1924,7 @@ void BlueStore::BufferSpace::read(
   uint64_t miss_bytes = want_bytes - hit_bytes;
   cache->logger->inc(l_bluestore_buffer_hit_bytes, hit_bytes);
   cache->logger->inc(l_bluestore_buffer_miss_bytes, miss_bytes);
+  cache->logger->inc(l_bluestore_buffer_read_reqs, 1);
 }
 
 void BlueStore::BufferSpace::_finish_write(BufferCacheShard* cache,
@@ -4356,6 +4357,9 @@ void BlueStore::ExtentMap::maybe_load_shard(
     ceph_assert((size_t)start < shards.size());
     auto p = &shards[start];
     if (!p->loaded) {
+
+      auto shard_load_start = ceph::mono_clock::now();
+
       BLUE_SCOPE(maybe_load_shard);
       dout(30) << __func__ << " opening shard 0x" << std::hex
 	       << p->shard_info->offset << std::dec << dendl;
@@ -4381,6 +4385,11 @@ void BlueStore::ExtentMap::maybe_load_shard(
 	       << " (" << v.length() << " bytes)" << dendl;
       ceph_assert(p->dirty == false);
       ceph_assert(v.length() == p->shard_info->bytes);
+
+      auto shard_load_end = ceph::mono_clock::now();
+      onode->c->store->logger->tinc(l_bluestore_onode_shard_miss_lat, 
+                                     shard_load_end - shard_load_start);
+
       onode->c->store->logger->inc(l_bluestore_onode_shard_misses);
     } else {
       onode->c->store->logger->inc(l_bluestore_onode_shard_hits);
@@ -5392,8 +5401,14 @@ BlueStore::OnodeRef BlueStore::Collection::get_onode(
   }
 
   OnodeRef o = onode_space.lookup(oid);
-  if (o)
+  if (o) {
+    auto cache = get_onode_cache();
+    if (cache) {
+      store->logger->inc(l_bluestore_onode_cache_hit_count);//////cache hit
+    }
     return o;
+  }
+  auto start = mono_clock::now();//miss
   BLUE_SCOPE(get_onode);
   string key;
   get_object_key(store->cct, oid, &key);
@@ -5419,6 +5434,10 @@ BlueStore::OnodeRef BlueStore::Collection::get_onode(
   // new object, load onode if available
   on = Onode::create_decode(this, oid, key, v, true, store->segment_size != 0);
   o.reset(on);
+  store->log_latency("cacheonode_lat",
+        l_bluestore_onode_cache_time_latency_time,
+	mono_clock::now() - start,
+	store->cct->_conf->bluestore_log_op_age);////miss lat for onode
   return onode_space.add_onode(oid, o);
 }
 
@@ -6510,6 +6529,23 @@ void BlueStore::_init_logger()
   b.add_u64_counter(l_bluestore_write_small_skipped_bytes,
       "write_small_skipped_bytes",
       "Small writes into existing or sparse small blobs skipped due to zero detection (bytes)");
+
+  b.add_time_avg(l_bluestore_buffer_miss_lat, "buffer_miss_lat", "Avg data cache miss disk latency"); //bluestore data buffer
+  b.add_u64_counter(l_bluestore_buffer_read_reqs, "buffer_read_reqs", "Total data cache read requests"); //i think subrtacting the number of requests from the number of misses above will give number of complete hits where the entire read was in cache
+  //after read is called it will always increment l_bluestore_buffer_read_reqs, and if there was any part that wasnt in cache it will eventually log it in l_bluestore_buffer_miss_lat, so the difference should be ones that were fully in cache
+
+  
+  b.add_u64_counter(l_bluestore_onode_cache_hit_count,
+      "onode cache",
+      "onode cache total hits"); 
+
+  b.add_time_avg(l_bluestore_onode_cache_time_latency_time, "cacheonode_lat",
+      "Average onode miss latency",
+      "ro_l", PerfCountersBuilder::PRIO_CRITICAL);
+
+  b.add_time_avg(l_bluestore_onode_shard_miss_lat,
+               "onode_shard_miss_lat",
+               "Average onode shard miss latency"); 
   //****************************************
 
   // compressions stats
@@ -13169,6 +13205,9 @@ int BlueStore::_do_read(
   blobs2read_t blobs2read;
   _read_cache(o, offset, length, read_cache_policy, ready_regions, blobs2read);
 
+  bool is_miss = !blobs2read.empty();
+  ceph::mono_clock::time_point miss_start_time;
+
 
   // read raw blob data.
   start = mono_clock::now(); // for the sake of simplicity
@@ -13184,9 +13223,19 @@ int BlueStore::_do_read(
   int64_t num_ios = blobs2read.size();
   if (ioc.has_pending_aios()) {
     num_ios = ioc.get_num_ios();
+    
+    if (is_miss) {
+      miss_start_time = ceph::mono_clock::now();
+    }
+
     bdev->aio_submit(&ioc);
     dout(20) << __func__ << " waiting for aio" << dendl;
     ioc.aio_wait();
+    if (is_miss) {
+      auto miss_end_time = ceph::mono_clock::now();
+      logger->tinc(l_bluestore_buffer_miss_lat, miss_end_time - miss_start_time);
+    }
+
     r = ioc.get_return_value();
     if (r < 0) {
       ceph_assert(r == -EIO); // no other errors allowed
@@ -13597,9 +13646,14 @@ int BlueStore::_do_readv(
   auto num_ios = m.size();
   if (ioc.has_pending_aios()) {
     num_ios = ioc.get_num_ios();
+    ceph::mono_clock::time_point miss_start_time = ceph::mono_clock::now();
+
     bdev->aio_submit(&ioc);
     dout(20) << __func__ << " waiting for aio" << dendl;
     ioc.aio_wait();
+
+    auto miss_end_time = ceph::mono_clock::now();
+    logger->tinc(l_bluestore_buffer_miss_lat, miss_end_time - miss_start_time);
     r = ioc.get_return_value();
     if (r < 0) {
       ceph_assert(r == -EIO); // no other errors allowed

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5402,10 +5402,6 @@ BlueStore::OnodeRef BlueStore::Collection::get_onode(
 
   OnodeRef o = onode_space.lookup(oid);
   if (o) {
-    auto cache = get_onode_cache();
-    if (cache) {
-      store->logger->inc(l_bluestore_onode_cache_hit_count);//////cache hit
-    }
     return o;
   }
   auto start = mono_clock::now();//miss
@@ -5434,10 +5430,7 @@ BlueStore::OnodeRef BlueStore::Collection::get_onode(
   // new object, load onode if available
   on = Onode::create_decode(this, oid, key, v, true, store->segment_size != 0);
   o.reset(on);
-  store->log_latency("cacheonode_lat",
-        l_bluestore_onode_cache_time_latency_time,
-	mono_clock::now() - start,
-	store->cct->_conf->bluestore_log_op_age);////miss lat for onode
+  store->logger->tinc(l_bluestore_onode_miss_lat, mono_clock::now() - start);
   return onode_space.add_onode(oid, o);
 }
 
@@ -6535,11 +6528,8 @@ void BlueStore::_init_logger()
   //after read is called it will always increment l_bluestore_buffer_read_reqs, and if there was any part that wasnt in cache it will eventually log it in l_bluestore_buffer_miss_lat, so the difference should be ones that were fully in cache
 
   
-  b.add_u64_counter(l_bluestore_onode_cache_hit_count,
-      "onode cache",
-      "onode cache total hits"); 
 
-  b.add_time_avg(l_bluestore_onode_cache_time_latency_time, "cacheonode_lat",
+  b.add_time_avg(l_bluestore_onode_miss_lat, "cacheonode_lat",
       "Average onode miss latency",
       "ro_l", PerfCountersBuilder::PRIO_CRITICAL);
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1924,7 +1924,6 @@ void BlueStore::BufferSpace::read(
   uint64_t miss_bytes = want_bytes - hit_bytes;
   cache->logger->inc(l_bluestore_buffer_hit_bytes, hit_bytes);
   cache->logger->inc(l_bluestore_buffer_miss_bytes, miss_bytes);
-  cache->logger->inc(l_bluestore_buffer_read_reqs, 1);
 }
 
 void BlueStore::BufferSpace::_finish_write(BufferCacheShard* cache,
@@ -6524,8 +6523,6 @@ void BlueStore::_init_logger()
       "Small writes into existing or sparse small blobs skipped due to zero detection (bytes)");
 
   b.add_time_avg(l_bluestore_buffer_miss_lat, "buffer_miss_lat", "Avg data cache miss disk latency"); //bluestore data buffer
-  b.add_u64_counter(l_bluestore_buffer_read_reqs, "buffer_read_reqs", "Total data cache read requests"); //i think subrtacting the number of requests from the number of misses above will give number of complete hits where the entire read was in cache
-  //after read is called it will always increment l_bluestore_buffer_read_reqs, and if there was any part that wasnt in cache it will eventually log it in l_bluestore_buffer_miss_lat, so the difference should be ones that were fully in cache
 
   
 
@@ -6601,10 +6598,13 @@ void BlueStore::_init_logger()
 	    PerfCountersBuilder::PRIO_DEBUGONLY,
 	    unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluestore_buffer_miss_bytes, "buffer_miss_bytes",
-	    "Sum for bytes of read missed in the cache",
-	    NULL,
-	    PerfCountersBuilder::PRIO_DEBUGONLY,
-	    unit_t(UNIT_BYTES));
+     "Sum for bytes of read missed in the cache",
+     NULL,
+     PerfCountersBuilder::PRIO_DEBUGONLY,
+     unit_t(UNIT_BYTES));
+  b.add_u64_counter(l_bluestore_buffer_hits, "buffer_hits",
+     "Count of buffer cache lookup hits",
+     "b_ht", PerfCountersBuilder::PRIO_CRITICAL);
   //****************************************
 
   // internal stats
@@ -13224,6 +13224,8 @@ int BlueStore::_do_read(
     if (is_miss) {
       auto miss_end_time = ceph::mono_clock::now();
       logger->tinc(l_bluestore_buffer_miss_lat, miss_end_time - miss_start_time);
+    } else {
+      logger->inc(l_bluestore_buffer_hits);
     }
 
     r = ioc.get_return_value();
@@ -13649,6 +13651,8 @@ int BlueStore::_do_readv(
       ceph_assert(r == -EIO); // no other errors allowed
       return -EIO;
     }
+  } else {
+    logger->inc(l_bluestore_buffer_hits);
   }
   if (op_flags & CEPH_OSD_OP_FLAG_SCRUB) {
     log_latency_fn_scrub(__func__,

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4385,9 +4385,8 @@ void BlueStore::ExtentMap::maybe_load_shard(
       ceph_assert(p->dirty == false);
       ceph_assert(v.length() == p->shard_info->bytes);
 
-      auto shard_load_end = ceph::mono_clock::now();
-      onode->c->store->logger->tinc(l_bluestore_onode_shard_miss_lat, 
-                                     shard_load_end - shard_load_start);
+      onode->c->store->logger->tinc(l_bluestore_onode_shard_miss_lat,
+                                     ceph::mono_clock::now() - shard_load_start);
 
       onode->c->store->logger->inc(l_bluestore_onode_shard_misses);
     } else {
@@ -5403,7 +5402,7 @@ BlueStore::OnodeRef BlueStore::Collection::get_onode(
   if (o) {
     return o;
   }
-  auto start = mono_clock::now();//miss
+  auto start = mono_clock::now(); //miss 
   BLUE_SCOPE(get_onode);
   string key;
   get_object_key(store->cct, oid, &key);
@@ -6528,7 +6527,7 @@ void BlueStore::_init_logger()
 
   b.add_time_avg(l_bluestore_onode_miss_lat, "cacheonode_lat",
       "Average onode miss latency",
-      "ro_l", PerfCountersBuilder::PRIO_CRITICAL);
+      "ro_l");
 
   b.add_time_avg(l_bluestore_onode_shard_miss_lat,
                "onode_shard_miss_lat",
@@ -6604,7 +6603,7 @@ void BlueStore::_init_logger()
      unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluestore_buffer_hits, "buffer_hits",
      "Count of buffer cache lookup hits",
-     "b_ht", PerfCountersBuilder::PRIO_CRITICAL);
+     "b_ht");
   //****************************************
 
   // internal stats
@@ -13222,8 +13221,7 @@ int BlueStore::_do_read(
     dout(20) << __func__ << " waiting for aio" << dendl;
     ioc.aio_wait();
     if (is_miss) {
-      auto miss_end_time = ceph::mono_clock::now();
-      logger->tinc(l_bluestore_buffer_miss_lat, miss_end_time - miss_start_time);
+      logger->tinc(l_bluestore_buffer_miss_lat, ceph::mono_clock::now() - miss_start_time);
     } else {
       logger->inc(l_bluestore_buffer_hits);
     }
@@ -13644,8 +13642,7 @@ int BlueStore::_do_readv(
     dout(20) << __func__ << " waiting for aio" << dendl;
     ioc.aio_wait();
 
-    auto miss_end_time = ceph::mono_clock::now();
-    logger->tinc(l_bluestore_buffer_miss_lat, miss_end_time - miss_start_time);
+    logger->tinc(l_bluestore_buffer_miss_lat, ceph::mono_clock::now() - miss_start_time);
     r = ioc.get_return_value();
     if (r < 0) {
       ceph_assert(r == -EIO); // no other errors allowed

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -13643,7 +13643,7 @@ int BlueStore::_do_readv(
       ceph_assert(r == -EIO); // no other errors allowed
       return -EIO;
     }
-  } 
+  }
   if (op_flags & CEPH_OSD_OP_FLAG_SCRUB) {
     log_latency_fn_scrub(__func__,
       l_bluestore_read_wait_aio_lat,

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6601,9 +6601,6 @@ void BlueStore::_init_logger()
      NULL,
      PerfCountersBuilder::PRIO_DEBUGONLY,
      unit_t(UNIT_BYTES));
-  b.add_u64_counter(l_bluestore_buffer_hits, "buffer_hits",
-     "Count of buffer cache lookup hits",
-     "b_ht");
   //****************************************
 
   // internal stats
@@ -13222,8 +13219,6 @@ int BlueStore::_do_read(
     ioc.aio_wait();
     if (is_miss) {
       logger->tinc(l_bluestore_buffer_miss_lat, ceph::mono_clock::now() - miss_start_time);
-    } else {
-      logger->inc(l_bluestore_buffer_hits);
     }
 
     r = ioc.get_return_value();
@@ -13648,9 +13643,7 @@ int BlueStore::_do_readv(
       ceph_assert(r == -EIO); // no other errors allowed
       return -EIO;
     }
-  } else {
-    logger->inc(l_bluestore_buffer_hits);
-  }
+  } 
   if (op_flags & CEPH_OSD_OP_FLAG_SCRUB) {
     log_latency_fn_scrub(__func__,
       l_bluestore_read_wait_aio_lat,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -186,8 +186,7 @@ enum {
   l_bluestore_extents,
   l_bluestore_blobs,
   l_bluestore_spanning_blobs,
-  l_bluestore_onode_cache_hit_count,   
-  l_bluestore_onode_cache_time_latency_time,  
+  l_bluestore_onode_miss_lat,  
   l_bluestore_onode_shard_miss_lat,           
   //****************************************
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -186,6 +186,9 @@ enum {
   l_bluestore_extents,
   l_bluestore_blobs,
   l_bluestore_spanning_blobs,
+  l_bluestore_onode_cache_hit_count,   
+  l_bluestore_onode_cache_time_latency_time,  
+  l_bluestore_onode_shard_miss_lat,           
   //****************************************
 
   // buffer cache stats
@@ -194,6 +197,8 @@ enum {
   l_bluestore_buffer_bytes,
   l_bluestore_buffer_hit_bytes,
   l_bluestore_buffer_miss_bytes,
+  l_bluestore_buffer_miss_lat, ////cost per miss
+  l_bluestore_buffer_read_reqs, 
   //****************************************
 
   // internal stats
@@ -2391,6 +2396,31 @@ private:
   mempool::bluestore_cache_buffer::vector<BufferCacheShard*> buffer_cache_shards;
   mempool::bluestore_cache_onode::vector<OnodeCacheShard*> onode_cache_shards;
 
+public:
+  struct CacheStatsSnapshot {
+    ceph::mono_time timestamp;
+    uint64_t onode_hits;
+    uint64_t onode_misses;
+    uint64_t onode_miss_latency_sum;
+    uint64_t onode_shard_hits;
+    uint64_t onode_shard_misses;
+    uint64_t onode_shard_miss_latency_sum;
+    uint64_t buffer_read_reqs;
+    uint64_t buffer_miss_count;
+    uint64_t buffer_miss_latency_sum;
+    
+    CacheStatsSnapshot()
+      : timestamp(ceph::mono_clock::zero()),
+        onode_hits(0), onode_misses(0), onode_miss_latency_sum(0),
+        onode_shard_hits(0), onode_shard_misses(0), onode_shard_miss_latency_sum(0),
+        buffer_read_reqs(0), buffer_miss_count(0), buffer_miss_latency_sum(0) {}
+  };
+
+  ceph::mutex cache_stats_lock = ceph::make_mutex("BlueStore::cache_stats_lock");
+  std::deque<CacheStatsSnapshot> cache_stats_snapshots;
+  static constexpr size_t MAX_CACHE_SNAPSHOTS = 5;
+
+private:
   /// protect zombie_osr_set
   ceph::mutex zombie_osr_lock = ceph::make_mutex("BlueStore::zombie_osr_lock");
   uint32_t next_sequencer_id = 0;
@@ -2432,8 +2462,10 @@ private:
   std::deque<DeferredBatch*> deferred_stable_to_finalize; ///< pending finalization
   bool kv_finalize_in_progress = false;
 
+public:
   PerfCounters *logger = nullptr;
 
+private:
   std::list<CollectionRef> removed_collections;
 
   ceph::shared_mutex debug_read_error_lock =

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2405,14 +2405,14 @@ public:
     uint64_t onode_shard_misses;
     uint64_t onode_shard_miss_latency_sum;
     uint64_t buffer_hits;
-    uint64_t buffer_miss_count;
+    uint64_t buffer_misses;
     uint64_t buffer_miss_latency_sum;
     
     CacheStatsSnapshot()
       : timestamp(ceph::mono_clock::zero()),
         onode_hits(0), onode_misses(0), onode_miss_latency_sum(0),
         onode_shard_hits(0), onode_shard_misses(0), onode_shard_miss_latency_sum(0),
-        buffer_hits(0), buffer_miss_count(0), buffer_miss_latency_sum(0) {}
+        buffer_hits(0), buffer_misses(0), buffer_miss_latency_sum(0) {}
   };
 
   ceph::mutex cache_stats_lock = ceph::make_mutex("BlueStore::cache_stats_lock");

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -196,8 +196,8 @@ enum {
   l_bluestore_buffer_bytes,
   l_bluestore_buffer_hit_bytes,
   l_bluestore_buffer_miss_bytes,
+  l_bluestore_buffer_hits,
   l_bluestore_buffer_miss_lat, ////cost per miss
-  l_bluestore_buffer_read_reqs, 
   //****************************************
 
   // internal stats
@@ -2404,7 +2404,7 @@ public:
     uint64_t onode_shard_hits;
     uint64_t onode_shard_misses;
     uint64_t onode_shard_miss_latency_sum;
-    uint64_t buffer_read_reqs;
+    uint64_t buffer_hits;
     uint64_t buffer_miss_count;
     uint64_t buffer_miss_latency_sum;
     
@@ -2412,7 +2412,7 @@ public:
       : timestamp(ceph::mono_clock::zero()),
         onode_hits(0), onode_misses(0), onode_miss_latency_sum(0),
         onode_shard_hits(0), onode_shard_misses(0), onode_shard_miss_latency_sum(0),
-        buffer_read_reqs(0), buffer_miss_count(0), buffer_miss_latency_sum(0) {}
+        buffer_hits(0), buffer_miss_count(0), buffer_miss_latency_sum(0) {}
   };
 
   ceph::mutex cache_stats_lock = ceph::make_mutex("BlueStore::cache_stats_lock");

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2403,15 +2403,33 @@ public:
     uint64_t onode_shard_hits;
     uint64_t onode_shard_misses;
     uint64_t onode_shard_miss_latency_sum;
-    uint64_t buffer_hits;
-    uint64_t buffer_misses;
+    uint64_t buffer_hit_bytes;
+    uint64_t buffer_miss_bytes;
     uint64_t buffer_miss_latency_sum;
-    
+    uint64_t buffer_miss_lat_count;
+
     CacheStatsSnapshot()
       : timestamp(ceph::mono_clock::zero()),
         onode_hits(0), onode_misses(0), onode_miss_latency_sum(0),
         onode_shard_hits(0), onode_shard_misses(0), onode_shard_miss_latency_sum(0),
-        buffer_hits(0), buffer_misses(0), buffer_miss_latency_sum(0) {}
+        buffer_hit_bytes(0), buffer_miss_bytes(0), buffer_miss_latency_sum(0), buffer_miss_lat_count(0) {}
+
+    CacheStatsSnapshot delta(const CacheStatsSnapshot& older) const {
+      auto sub = [](uint64_t a, uint64_t b) { return a >= b ? a - b : 0; };
+      CacheStatsSnapshot d;
+      d.timestamp = timestamp;
+      d.onode_hits = sub(onode_hits, older.onode_hits);
+      d.onode_misses = sub(onode_misses, older.onode_misses);
+      d.onode_miss_latency_sum = sub(onode_miss_latency_sum, older.onode_miss_latency_sum);
+      d.onode_shard_hits = sub(onode_shard_hits, older.onode_shard_hits);
+      d.onode_shard_misses = sub(onode_shard_misses, older.onode_shard_misses);
+      d.onode_shard_miss_latency_sum = sub(onode_shard_miss_latency_sum, older.onode_shard_miss_latency_sum);
+      d.buffer_hit_bytes = sub(buffer_hit_bytes, older.buffer_hit_bytes);
+      d.buffer_miss_bytes = sub(buffer_miss_bytes, older.buffer_miss_bytes);
+      d.buffer_miss_latency_sum = sub(buffer_miss_latency_sum, older.buffer_miss_latency_sum);
+      d.buffer_miss_lat_count = sub(buffer_miss_lat_count, older.buffer_miss_lat_count);
+      return d;
+    }
   };
 
   ceph::mutex cache_stats_lock = ceph::make_mutex("BlueStore::cache_stats_lock");

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -196,7 +196,6 @@ enum {
   l_bluestore_buffer_bytes,
   l_bluestore_buffer_hit_bytes,
   l_bluestore_buffer_miss_bytes,
-  l_bluestore_buffer_hits,
   l_bluestore_buffer_miss_lat, ////cost per miss
   //****************************************
 


### PR DESCRIPTION
This introduces performance counters to observe the cost of a cache miss (M), frequency of accessing the cache (F), and cache hit ratio (R) across BlueStore's data buffer and onode caches. It explicitly accounts for onode sharding overhead in miss latency measurements. 
Also supports short term tracking by recording the stats whenever the bluestore cache stats admin socket is run and comparing them to previously recorded stats.

This serves as a prelude for calculating cache performance boosts to optimize the Priority Cache Manager memory distribution.

Fixes: http://tracker.ceph.com/issues/77219
Signed-off-by: Aaryan Kumar <kumaraaryan511@gmail.com>




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
