### PR TITLE
mgr/volumes: fix stale bytes_used in subvolume/subvolumegroup info

### DIFF
--- a/src/pybind/mgr/volumes/fs/operations/group.py
+++ b/src/pybind/mgr/volumes/fs/operations/group.py
@@ -115,7 +115,17 @@ class Group(GroupTemplate):
                            | cephfs.CEPH_STATX_UID | cephfs.CEPH_STATX_GID | cephfs.CEPH_STATX_MODE
                            | cephfs.CEPH_STATX_ATIME | cephfs.CEPH_STATX_MTIME | cephfs.CEPH_STATX_CTIME,
                            cephfs.AT_SYMLINK_NOFOLLOW)
-        usedbytes = st["size"]
+        # Fetch 'ceph.dir.rbytes' vxattr instead of relying on statx size
+        # (rstat of a dir); the getxattr path forces a getattr with the
+        # rstat mask which is routed to the auth MDS, whereas statx may be
+        # satisfied from stale cache or a replica MDS in multi-active
+        # setups, occasionally reporting 0.
+        try:
+            usedbytes = int(self.fs.getxattr(self.path,
+                                             'ceph.dir.rbytes'
+                                             ).decode('utf-8'))
+        except cephfs.NoData:
+            usedbytes = st["size"]
         try:
             nsize = int(self.fs.getxattr(self.path, 'ceph.quota.max_bytes').decode('utf-8'))
         except cephfs.NoData:

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
@@ -561,7 +561,17 @@ class SubvolumeBase(object):
                            | cephfs.CEPH_STATX_MTIME
                            | cephfs.CEPH_STATX_CTIME,
                            cephfs.AT_SYMLINK_NOFOLLOW)
-        usedbytes = st["size"]
+        # Fetch 'ceph.dir.rbytes' vxattr instead of relying on statx size
+        # (rstat of a dir); the getxattr path forces a getattr with the
+        # rstat mask which is routed to the auth MDS, whereas statx may be
+        # satisfied from stale cache or a replica MDS in multi-active
+        # setups, occasionally reporting 0.
+        try:
+            usedbytes = int(self.fs.getxattr(subvolpath,
+                                             'ceph.dir.rbytes'
+                                             ).decode('utf-8'))
+        except cephfs.NoData:
+            usedbytes = st["size"]
         try:
             nsize = int(self.fs.getxattr(subvolpath,
                                          'ceph.quota.max_bytes'


### PR DESCRIPTION
`ceph fs subvolume info` and `ceph fs subvolumegroup info` intermittently report a stale `bytes_used`, including `0`, while `ceph.dir.rbytes` on the same directory is already non-zero.

## Root cause

`SubvolumeBase.info()` and `Group.info()` derive `bytes_used` from a directory `statx(CEPH_STATX_SIZE)`. `Client::statx_to_mask()` never sets `CEPH_STAT_RSTAT` for that mask, so the resulting getattr is not forced to the auth MDS: it can be answered by a replica MDS, or short-circuited from cached `Fs` caps without contacting the MDS at all. Either path can return a stale directory size (including the initial `0`) before fresh recursive usage is reflected.

Reading `ceph.dir.rbytes`, by contrast, goes through the vxattr getxattr path, which forces `CEPH_STAT_RSTAT` (`VXATTR_RSTAT`) and is routed to the auth MDS. This is why the two APIs, both meant to expose the same recursive byte count, can disagree at the same instant.

## Fix

Read `bytes_used` from the `ceph.dir.rbytes` vxattr instead, falling back to the statx size on `cephfs.NoData`. Besides fixing the staleness, `bytes_used` is a user-visible recursive-usage field, so querying the explicit rbytes interface is more correct than depending on the overloaded directory stat size, whose recursive meaning is conditional on `client_dirsize_rbytes`.

## Why not change `statx_to_mask()`

Changing `Client::statx_to_mask()` to request `CEPH_STAT_RSTAT` for every `CEPH_STATX_SIZE` statx would broaden behavior beyond the mgr/volumes info path and make ordinary directory size statx calls force rstat/auth-MDS handling. This fix keeps the scope local to the user-visible recursive usage field that explicitly needs rbytes semantics.

## Performance note

This changes each subvolume/subvolumegroup info call to issue one additional `ceph.dir.rbytes` vxattr lookup, which requests `CEPH_STAT_RSTAT` and may require an auth-MDS round trip instead of using cached statx data. The extra cost is limited to the info path and buys correctness for a field that is expected to report recursive usage. I can benchmark larger batch-listing scenarios if reviewers are concerned.

## Verification

vstart cluster, Ceph main (`21.3.0-1135-g0dfc8345236`), at `max_mds = 1`. This is the strongest control, since the answering MDS is necessarily the auth MDS. Paired sampling captures `bytes_used` and `ceph.dir.rbytes` on the same directory in the same iteration.

| | pre-fix (buggy) | post-fix |
|---|---|---|
| subvolume: `bytes_used = 0` while `ceph.dir.rbytes > 0` | hit within 50 iterations | **0 / 300** |
| subvolumegroup: same signature | hit at iteration 8 | **0 / 246** |

Across 546 paired samples the bug signature did not occur once. `bytes_used` now tracks `ceph.dir.rbytes` exactly, apart from sub-second sampling lag during active writes (inherent rstat propagation, both values non-zero). The pre-fix baseline reproduced the zero within 50 iterations under the identical setup.

Fixes: https://tracker.ceph.com/issues/78671

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI. When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`. Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand comments with more than one command.
</details>