### PR TITLE
script/ptl-tool: check PR review approvals before merging a --pr-label batch

### DIFF
--- a/src/script/ptl-tool.py
+++ b/src/script/ptl-tool.py
@@ -1885,7 +1885,7 @@ class ApprovalCheck(BaseAuditCheck):
 
         log.error(f"PR #{pr} is not approved (reviewDecision=REVIEW_REQUIRED).")
         md_text = "### Automated PR Review - Approval Required\n\n"
-        md_text += "This PR has not been approved yet. Please request a review before it can be finally merged."
+        md_text += "This PR has not been approved yet. Please request a review from the component lead before it can be finally tested and merged."
         if args.ci_mode:
             report.add("Review Approval", md_text)
         else:

--- a/src/script/ptl-tool.py
+++ b/src/script/ptl-tool.py
@@ -1845,6 +1845,64 @@ class MergeConflictCheck(BaseAuditCheck):
                     else:
                         log.info("Invalid choice. Please enter p, r, m, q, or o.")
 
+class ApprovalCheck(BaseAuditCheck):
+    """
+    Verifies GitHub's own reviewDecision (not REVIEW_REQUIRED) before a PR is
+    finally merged. reviewDecision is a computed field GitHub only exposes
+    over GraphQL (the same one `gh pr list --json reviewDecision` reads),
+    not over REST -- get_pr_info()'s REST /pulls/{pr} response has no
+    equivalent field (only requested_reviewers / review_comments*, neither
+    of which reflect an approve/changes-requested decision).
+
+    Only wired into verify_pr_readiness(), which itself only runs under
+    --final-merge/--audit -- ordinary --pr-label/--integration/--qe-label
+    batch merges never reach this check.
+    """
+    @property
+    def name(self) -> str:
+        return "Review Approval"
+
+    def run(self, ctx: AuditContext) -> None:
+        session, pr, report, args = ctx.session, ctx.pr, ctx.report, ctx.args
+        log.info("Checking review approval status for PR #%d...", pr)
+
+        query = 'query {{ repository(owner: "{owner}", name: "{repo}") {{ pullRequest(number: {pr}) {{ reviewDecision }} }} }}'.format(
+            owner=BASE_PROJECT, repo=BASE_REPO, pr=pr
+        )
+        resp = session.post("https://api.github.com/graphql", auth=GithubBearerAuth(), json={'query': query})
+        if resp.status_code != 200:
+            raise SystemExit(f"Failed to fetch review decision for PR #{pr}: {resp.status_code} {resp.text}")
+        data = resp.json()
+        if data.get('errors'):
+            raise SystemExit(f"GraphQL errors fetching review decision for PR #{pr}: {data['errors']}")
+
+        node = data['data']['repository'].get('pullRequest')
+        if node is None:
+            raise SystemExit(f"Could not fetch review status for PR #{pr} (GraphQL returned no data for it)")
+
+        if node.get('reviewDecision') != 'REVIEW_REQUIRED':
+            return
+
+        log.error(f"PR #{pr} is not approved (reviewDecision=REVIEW_REQUIRED).")
+        md_text = "### Automated PR Review - Approval Required\n\n"
+        md_text += "This PR has not been approved yet. Please request a review before it can be finally merged."
+        if args.ci_mode:
+            report.add("Review Approval", md_text)
+        else:
+            while True:
+                ans = input(f"PR #{pr} is not approved! [p/r/m] (p=proceed/skip check, r=add to review, m=skip to merge): ").strip().lower()
+                if ans == 'p':
+                    log.warning(f"Skipping approval check for PR #{pr}.")
+                    break
+                elif ans == 'r':
+                    report.add("Review Approval", md_text)
+                    report.record_failure()
+                    break
+                elif ans == 'm':
+                    raise SkipToMerge()
+                else:
+                    print("Invalid choice. Please enter p, r, or m.")
+
 def write_ci_summary(pr: int, passed: bool, exit_code: int = 1):
     if not passed:
         print(f"::error title=Backport Audit Failed::PTL tool detected parity or conflict issues (exit code {exit_code}). See PR review comments or check this step's logs for details.", file=sys.stderr)
@@ -1873,8 +1931,9 @@ def verify_pr_readiness(G, session, R, pr, pr_commits, tip, base, args):
     
     checks: List[BaseAuditCheck] = [
         MergeConflictCheck(),
+        ApprovalCheck(),
     ]
-    
+
     if base != 'main':
         checks.append(CommitParityCheck())
         if not args.skip_conflict_check:
@@ -2245,7 +2304,7 @@ def build_branch(args):
                 prs.append(n)
     log.info("Will merge PRs: {}".format(prs))
 
-    if args.pr_label is not None and prs:
+    if args.check_approvals and args.pr_label is not None and prs:
         prs = check_pr_approvals(session, prs, args.pr_label, dry_run=args.dry_run, ci_mode=args.ci_mode)
 
     # PRE-FLIGHT: Validate base consistency and auto-detect base from PRs if necessary
@@ -2667,6 +2726,7 @@ def main():
     group.add_argument('--audit', dest='audit', action='store_true', help='run parity and conflict simulations')
     group.add_argument('--skip-conflict-check', dest='skip_conflict_check', action='store_true', help='skip conflict resolution simulation')
     group.add_argument('--ci-mode', dest='ci_mode', action='store_true', help='run non-interactively and post multiple separate reviews for failures')
+    group.add_argument('--check-approvals', dest='check_approvals', action='store_true', help='interactively triage unapproved PRs in a --pr-label batch (accept/remove-label/ignore) before merging; unrelated to the automatic approval gate --final-merge/--audit already run')
 
     def parse_pr(value):
         m = re.search(r'/pull/(\d+)', value)

--- a/src/script/ptl-tool.py
+++ b/src/script/ptl-tool.py
@@ -51,6 +51,7 @@ import tempfile
 import textwrap
 import threading
 import webbrowser
+from urllib.parse import quote
 
 MISSING_DEPS = []
 
@@ -482,6 +483,127 @@ def get(session, url, params=None, paging=True):
             yield response.json()
             link = response.headers.get('link', None)
             page += 1
+
+def check_pr_approvals(session, prs, label, dry_run=False, ci_mode=False):
+    """
+    Pre-flight check: verifies every PR about to be merged via --pr-label has
+    GitHub's own reviewDecision (not REVIEW_REQUIRED) before the PRE-FLIGHT
+    base-branch check runs. Native equivalent of ptl-check-approvals.sh.
+    reviewDecision is a computed field GitHub only exposes over GraphQL (the
+    same one `gh pr list --json reviewDecision` reads), not over REST, so
+    this uses one batched GraphQL query instead of N REST calls.
+
+    Returns the (possibly filtered) list of PR numbers to actually merge.
+    """
+    if not prs:
+        return prs
+
+    query_parts = [
+        f'pr{i}: pullRequest(number: {pr}) {{ number title reviewDecision author {{ login }} }}'
+        for i, pr in enumerate(prs)
+    ]
+    query = 'query {{ repository(owner: "{owner}", name: "{repo}") {{ {fields} }} }}'.format(
+        owner=BASE_PROJECT, repo=BASE_REPO, fields=" ".join(query_parts)
+    )
+
+    log.info("Checking review approval status for %d PR(s)...", len(prs))
+    resp = session.post("https://api.github.com/graphql", auth=GithubBearerAuth(), json={'query': query})
+    if resp.status_code != 200:
+        log.error(f"Failed to fetch review decisions: {resp.status_code} {resp.text}")
+        sys.exit(1)
+    data = resp.json()
+    if data.get('errors'):
+        log.error(f"GraphQL errors fetching review decisions: {data['errors']}")
+        sys.exit(1)
+
+    repo_data = data['data']['repository']
+    unapproved = []
+    for i, pr in enumerate(prs):
+        node = repo_data.get(f'pr{i}')
+        if node is None:
+            raise SystemExit(
+                f"Could not fetch review status for PR #{pr} (GraphQL returned no data for "
+                f"it -- check it actually exists in {BASE_PROJECT}/{BASE_REPO})"
+            )
+        if node.get('reviewDecision') == 'REVIEW_REQUIRED':
+            title = (node.get('title') or '').encode('ascii', 'replace').decode('ascii')
+            author = (node.get('author') or {}).get('login') or 'unknown'
+            unapproved.append({'number': pr, 'title': title, 'author': author})
+
+    if not unapproved:
+        log.info("All %d PR(s) are approved.", len(prs))
+        return prs
+
+    if ci_mode:
+        log.warning(
+            "%d of %d PR(s) are NOT approved (running under --ci-mode, proceeding anyway): %s",
+            len(unapproved), len(prs), ", ".join(f"#{u['number']}" for u in unapproved)
+        )
+        return prs
+
+    print(f"\nWARNING: {len(unapproved)} of {len(prs)} PRs are NOT approved:\n")
+    for u in unapproved:
+        print(f"  #{u['number']} - {u['title']} (author: @{u['author']})")
+    print()
+
+    while True:
+        ans = input(
+            "How do you want to handle unapproved PRs? [a/r/i] (a=accept and proceed, "
+            "posting a reminder comment on each; r=remove the label from unapproved PRs "
+            "and exclude them from this run; i=ignore and proceed with no changes): "
+        ).strip().lower()
+
+        if ans == 'a':
+            for u in unapproved:
+                pr = u['number']
+                mention = f"@{u['author']} " if u['author'] != 'unknown' else ""
+                body = (
+                    f"{mention}this PR is part of the `{label}` integration batch and "
+                    "still needs review approval before it can be merged. Could you request "
+                    "a review or ping a reviewer? Thanks!"
+                )
+                if dry_run:
+                    log.info(f"[DRY RUN] Would comment on PR #{pr} requesting review approval")
+                else:
+                    endpoint = f"https://api.github.com/repos/{BASE_PROJECT}/{BASE_REPO}/issues/{pr}/comments"
+                    r = session.post(endpoint, auth=GithubBearerAuth(), json={'body': body})
+                    if r.status_code != 201:
+                        log.error(f"Failed to comment on PR #{pr}: {r.status_code} {r.text}")
+                    else:
+                        log.info(f"Posted review reminder comment on PR #{pr}")
+            return prs
+
+        elif ans == 'r':
+            unapproved_numbers = {u['number'] for u in unapproved}
+            for u in unapproved:
+                pr = u['number']
+                endpoint = (
+                    f"https://api.github.com/repos/{BASE_PROJECT}/{BASE_REPO}/issues/"
+                    f"{pr}/labels/{quote(label, safe='')}"
+                )
+                if dry_run:
+                    log.info(f"[DRY RUN] Would remove label '{label}' from PR #{pr}")
+                else:
+                    r = session.delete(endpoint, auth=GithubBearerAuth())
+                    if r.status_code == 404:
+                        log.info(f"Label '{label}' already absent from PR #{pr} (404); treating as removed")
+                    elif r.status_code != 200:
+                        log.error(f"Failed to remove label '{label}' from PR #{pr}: {r.status_code} {r.text}")
+                    else:
+                        log.info(f"Removed label '{label}' from PR #{pr}")
+            remaining = [p for p in prs if p not in unapproved_numbers]
+            if not remaining:
+                log.error("All PRs in this batch were unapproved and have been excluded; nothing left to merge.")
+                sys.exit(1)
+            log.info("Proceeding with approved PRs only: %s", remaining)
+            return remaining
+
+        elif ans == 'i':
+            log.info("Ignoring approval check; proceeding with all %d PR(s) as-is.", len(prs))
+            return prs
+
+        else:
+            print("Invalid choice. Please enter a, r, or i.")
 
 def resolve_ref(G, ref, remote_url, always_fetch=False):
     """
@@ -2123,6 +2245,8 @@ def build_branch(args):
                 prs.append(n)
     log.info("Will merge PRs: {}".format(prs))
 
+    if args.pr_label is not None and prs:
+        prs = check_pr_approvals(session, prs, args.pr_label, dry_run=args.dry_run, ci_mode=args.ci_mode)
 
     # PRE-FLIGHT: Validate base consistency and auto-detect base from PRs if necessary
     if prs and (base is None or args.qe_label or args.integration):

--- a/src/script/test_ptl_tool.py
+++ b/src/script/test_ptl_tool.py
@@ -406,3 +406,259 @@ def test_logged_input_without_filehandler_preserves_behavior(ptl_tool, monkeypat
     """Without a FileHandler, logged_input() should behave like plain input()."""
     monkeypatch.setattr(builtins, "input", lambda prompt='': 'plain-answer')
     assert ptl_tool.logged_input("plain> ") == "plain-answer"
+
+
+# ---------------------------------------------------------------------------
+# check_pr_approvals(): pre-flight approval gate for --pr-label merges,
+# native equivalent of ptl-check-approvals.sh. Uses one batched GraphQL call
+# (reviewDecision is only exposed there, same field `gh pr list
+# --json reviewDecision` reads) instead of N REST calls.
+# ---------------------------------------------------------------------------
+
+class FakeJSONResponse(FakeResponse):
+    def __init__(self, status_code, json_data=None, text=""):
+        super().__init__(status_code, text)
+        self._json_data = json_data or {}
+
+    def json(self):
+        return self._json_data
+
+
+def _graphql_response(decisions):
+    """decisions: dict of pr_number -> (reviewDecision, title, author_login)."""
+    repo = {}
+    for i, pr in enumerate(decisions):
+        review_decision, title, author = decisions[pr]
+        repo[f"pr{i}"] = {
+            "number": pr,
+            "title": title,
+            "reviewDecision": review_decision,
+            "author": {"login": author},
+        }
+    return FakeJSONResponse(200, {"data": {"repository": repo}})
+
+
+def test_check_pr_approvals_noop_when_no_prs(ptl_tool):
+    session = mock.Mock()
+    result = ptl_tool.check_pr_approvals(session, [], "wip-yuri-testing")
+    assert result == []
+    session.post.assert_not_called()
+
+
+def test_check_pr_approvals_all_approved_returns_unchanged_no_prompt(ptl_tool):
+    session = mock.Mock()
+    session.post.return_value = _graphql_response({
+        100: ("APPROVED", "fix a", "alice"),
+        200: ("APPROVED", "fix b", "bob"),
+    })
+    with mock.patch("builtins.input") as fake_input:
+        result = ptl_tool.check_pr_approvals(session, [100, 200], "wip-yuri-testing")
+    fake_input.assert_not_called()
+    assert result == [100, 200]
+    session.post.assert_called_once()
+
+
+def test_check_pr_approvals_graphql_query_includes_all_pr_numbers(ptl_tool):
+    session = mock.Mock()
+    session.post.return_value = _graphql_response({
+        100: ("APPROVED", "a", "alice"),
+        200: ("APPROVED", "b", "bob"),
+        300: ("APPROVED", "c", "carol"),
+    })
+    ptl_tool.check_pr_approvals(session, [100, 200, 300], "wip-yuri-testing")
+    query = session.post.call_args.kwargs["json"]["query"]
+    assert "pr0: pullRequest(number: 100)" in query
+    assert "pr1: pullRequest(number: 200)" in query
+    assert "pr2: pullRequest(number: 300)" in query
+
+
+def test_check_pr_approvals_graphql_error_response_exits(ptl_tool):
+    session = mock.Mock()
+    session.post.return_value = FakeResponse(401, "Bad credentials")
+    with pytest.raises(SystemExit):
+        ptl_tool.check_pr_approvals(session, [100], "wip-yuri-testing")
+
+
+def test_check_pr_approvals_ci_mode_skips_prompt_and_proceeds(ptl_tool, caplog):
+    session = mock.Mock()
+    session.post.return_value = _graphql_response({
+        100: ("REVIEW_REQUIRED", "needs review", "alice"),
+    })
+    with mock.patch("builtins.input") as fake_input:
+        with caplog.at_level(logging.WARNING, logger=ptl_tool.log.name):
+            result = ptl_tool.check_pr_approvals(session, [100], "wip-yuri-testing", ci_mode=True)
+    fake_input.assert_not_called()
+    assert result == [100]
+    assert any("NOT approved" in r.message and "--ci-mode" in r.message for r in caplog.records)
+
+
+def test_check_pr_approvals_accept_posts_reminder_comment_and_keeps_all_prs(ptl_tool):
+    session = mock.Mock()
+    session.post.side_effect = [
+        _graphql_response({
+            100: ("REVIEW_REQUIRED", "needs review", "alice"),
+            200: ("APPROVED", "already good", "bob"),
+        }),
+        FakeResponse(201),
+    ]
+    with mock.patch("builtins.input", return_value="a"):
+        result = ptl_tool.check_pr_approvals(session, [100, 200], "wip-yuri-testing")
+    assert result == [100, 200]
+    assert session.post.call_count == 2
+    comment_call = session.post.call_args_list[1]
+    assert comment_call.args[0] == "https://api.github.com/repos/ceph/ceph/issues/100/comments"
+    assert "@alice" in comment_call.kwargs["json"]["body"]
+    assert "wip-yuri-testing" in comment_call.kwargs["json"]["body"]
+    session.delete.assert_not_called()
+
+
+def test_check_pr_approvals_accept_with_two_unapproved_prs_comments_on_both(ptl_tool):
+    """The single-unapproved-PR accept test above only proves one comment POST
+    fires; this confirms the `for u in unapproved` loop actually iterates
+    rather than stopping after the first PR."""
+    session = mock.Mock()
+    session.post.side_effect = [
+        _graphql_response({
+            100: ("REVIEW_REQUIRED", "needs review", "alice"),
+            300: ("REVIEW_REQUIRED", "also needs review", "carol"),
+        }),
+        FakeResponse(201),
+        FakeResponse(201),
+    ]
+    with mock.patch("builtins.input", return_value="a"):
+        result = ptl_tool.check_pr_approvals(session, [100, 300], "wip-yuri-testing")
+    assert result == [100, 300]
+    assert session.post.call_count == 3  # 1 GraphQL fetch + 2 comments
+    commented_urls = {c.args[0] for c in session.post.call_args_list[1:]}
+    assert commented_urls == {
+        "https://api.github.com/repos/ceph/ceph/issues/100/comments",
+        "https://api.github.com/repos/ceph/ceph/issues/300/comments",
+    }
+
+
+def test_check_pr_approvals_accept_unknown_author_has_no_broken_mention(ptl_tool):
+    """A PR whose author resolved to None must not produce a comment addressed
+    to the literal string '@unknown' -- that pings no one and looks broken."""
+    session = mock.Mock()
+    session.post.side_effect = [
+        _graphql_response({100: ("REVIEW_REQUIRED", "needs review", None)}),
+        FakeResponse(201),
+    ]
+    with mock.patch("builtins.input", return_value="a"):
+        ptl_tool.check_pr_approvals(session, [100], "wip-yuri-testing")
+    comment_call = session.post.call_args_list[1]
+    assert "@unknown" not in comment_call.kwargs["json"]["body"]
+
+
+def test_check_pr_approvals_missing_pr_node_raises_systemexit(ptl_tool):
+    """If GraphQL returns no node for one of the aliased PRs (e.g. it doesn't
+    exist in this repo), the PR's approval status is unverifiable -- this must
+    fail closed (exit) rather than silently treating it as approved."""
+    session = mock.Mock()
+    session.post.return_value = FakeJSONResponse(200, {"data": {"repository": {}}})
+    with pytest.raises(SystemExit):
+        ptl_tool.check_pr_approvals(session, [100], "wip-yuri-testing")
+
+
+def test_check_pr_approvals_remove_deletes_label_and_excludes_pr(ptl_tool):
+    session = mock.Mock()
+    session.post.return_value = _graphql_response({
+        100: ("REVIEW_REQUIRED", "needs review", "alice"),
+        200: ("APPROVED", "already good", "bob"),
+    })
+    session.delete.return_value = FakeResponse(200)
+    with mock.patch("builtins.input", return_value="r"):
+        result = ptl_tool.check_pr_approvals(session, [100, 200], "wip-yuri-testing")
+    assert result == [200]
+    session.delete.assert_called_once_with(
+        "https://api.github.com/repos/ceph/ceph/issues/100/labels/wip-yuri-testing",
+        auth=mock.ANY,
+    )
+
+
+def test_check_pr_approvals_remove_delete_404_treated_as_already_removed(ptl_tool, caplog):
+    """A second, approved PR keeps `remaining` non-empty so this test can assert
+    the 404 log message on its own, independent of the all-unapproved exit path
+    covered separately below."""
+    session = mock.Mock()
+    session.post.return_value = _graphql_response({
+        100: ("REVIEW_REQUIRED", "needs review", "alice"),
+        200: ("APPROVED", "already good", "bob"),
+    })
+    session.delete.return_value = FakeResponse(404)
+    with mock.patch("builtins.input", return_value="r"):
+        with caplog.at_level(logging.INFO, logger=ptl_tool.log.name):
+            result = ptl_tool.check_pr_approvals(session, [100, 200], "wip-yuri-testing")
+    assert result == [200]
+    assert any("already absent" in r.message for r in caplog.records)
+
+
+def test_check_pr_approvals_remove_all_unapproved_exits_nonzero(ptl_tool):
+    session = mock.Mock()
+    session.post.return_value = _graphql_response({
+        100: ("REVIEW_REQUIRED", "needs review", "alice"),
+    })
+    session.delete.return_value = FakeResponse(200)
+    with mock.patch("builtins.input", return_value="r"):
+        with pytest.raises(SystemExit):
+            ptl_tool.check_pr_approvals(session, [100], "wip-yuri-testing")
+
+
+def test_check_pr_approvals_ignore_returns_unchanged_no_mutation(ptl_tool):
+    session = mock.Mock()
+    session.post.return_value = _graphql_response({
+        100: ("REVIEW_REQUIRED", "needs review", "alice"),
+        200: ("APPROVED", "already good", "bob"),
+    })
+    with mock.patch("builtins.input", return_value="i"):
+        result = ptl_tool.check_pr_approvals(session, [100, 200], "wip-yuri-testing")
+    assert result == [100, 200]
+    assert session.post.call_count == 1  # only the GraphQL fetch, no comment
+    session.delete.assert_not_called()
+
+
+def test_check_pr_approvals_invalid_choice_reprompts(ptl_tool, capsys):
+    session = mock.Mock()
+    session.post.return_value = _graphql_response({
+        100: ("REVIEW_REQUIRED", "needs review", "alice"),
+    })
+    with mock.patch("builtins.input", side_effect=["bogus", "i"]):
+        result = ptl_tool.check_pr_approvals(session, [100], "wip-yuri-testing")
+    assert result == [100]
+    assert "Invalid choice" in capsys.readouterr().out
+
+
+def test_check_pr_approvals_dry_run_accept_never_posts_comment(ptl_tool):
+    session = mock.Mock()
+    session.post.return_value = _graphql_response({
+        100: ("REVIEW_REQUIRED", "needs review", "alice"),
+    })
+    with mock.patch("builtins.input", return_value="a"):
+        result = ptl_tool.check_pr_approvals(session, [100], "wip-yuri-testing", dry_run=True)
+    assert result == [100]
+    assert session.post.call_count == 1  # GraphQL only, no comment POST
+
+
+def test_check_pr_approvals_dry_run_remove_never_calls_delete_but_still_excludes(ptl_tool):
+    session = mock.Mock()
+    session.post.return_value = _graphql_response({
+        100: ("REVIEW_REQUIRED", "needs review", "alice"),
+        200: ("APPROVED", "already good", "bob"),
+    })
+    with mock.patch("builtins.input", return_value="r"):
+        result = ptl_tool.check_pr_approvals(session, [100, 200], "wip-yuri-testing", dry_run=True)
+    assert result == [200]
+    session.delete.assert_not_called()
+
+
+def test_check_pr_approvals_normalizes_non_ascii_title_without_crashing(ptl_tool, capsys):
+    session = mock.Mock()
+    session.post.return_value = _graphql_response({
+        100: ("REVIEW_REQUIRED", "fix café crash", "alice"),
+    })
+    with mock.patch("builtins.input", return_value="i"):
+        result = ptl_tool.check_pr_approvals(session, [100], "wip-yuri-testing")
+    assert result == [100]
+    out = capsys.readouterr().out
+    assert "caf?" in out
+    assert "é" not in out

--- a/src/script/test_ptl_tool.py
+++ b/src/script/test_ptl_tool.py
@@ -662,3 +662,118 @@ def test_check_pr_approvals_normalizes_non_ascii_title_without_crashing(ptl_tool
     out = capsys.readouterr().out
     assert "caf?" in out
     assert "é" not in out
+
+
+# ---------------------------------------------------------------------------
+# ApprovalCheck: gates --final-merge/--audit specifically (via
+# verify_pr_readiness()'s BaseAuditCheck framework), unlike check_pr_approvals()
+# above which used to run -- unconditionally, and only interactively -- on
+# every --pr-label/--integration/--qe-label batch merge. Per review feedback
+# on PR #70549 (https://github.com/ceph/ceph/pull/70549#pullrequestreview-4813309786),
+# that was too disruptive for ordinary QA batch runs; only a final upstream
+# merge of an unapproved PR should actually be gated.
+# ---------------------------------------------------------------------------
+
+def _single_pr_graphql_response(review_decision):
+    return FakeJSONResponse(200, {"data": {"repository": {"pullRequest": {"reviewDecision": review_decision}}}})
+
+
+def _audit_ctx(ptl_tool, session, pr=100, ci_mode=False):
+    report = ptl_tool.AuditReport()
+    args = mock.Mock(ci_mode=ci_mode)
+    ctx = ptl_tool.AuditContext(
+        G=mock.Mock(), session=session, R=mock.Mock(), pr=pr, pr_commits=[],
+        tip=mock.Mock(), base="squid", args=args, report=report,
+    )
+    return ctx, report
+
+
+def test_approval_check_approved_pr_is_noop(ptl_tool):
+    session = mock.Mock()
+    session.post.return_value = _single_pr_graphql_response("APPROVED")
+    ctx, report = _audit_ctx(ptl_tool, session)
+    with mock.patch("builtins.input") as fake_input:
+        ptl_tool.ApprovalCheck().run(ctx)
+    fake_input.assert_not_called()
+    assert not report.has_errors()
+
+
+def test_approval_check_ci_mode_adds_error_without_prompting(ptl_tool):
+    session = mock.Mock()
+    session.post.return_value = _single_pr_graphql_response("REVIEW_REQUIRED")
+    ctx, report = _audit_ctx(ptl_tool, session, ci_mode=True)
+    with mock.patch("builtins.input") as fake_input:
+        ptl_tool.ApprovalCheck().run(ctx)
+    fake_input.assert_not_called()
+    assert report.has_errors()
+
+
+def test_approval_check_interactive_record_failure_adds_to_report(ptl_tool):
+    session = mock.Mock()
+    session.post.return_value = _single_pr_graphql_response("REVIEW_REQUIRED")
+    ctx, report = _audit_ctx(ptl_tool, session)
+    with mock.patch("builtins.input", return_value="r"):
+        ptl_tool.ApprovalCheck().run(ctx)
+    assert report.has_errors()
+
+
+def test_approval_check_interactive_proceed_does_not_fail_report(ptl_tool):
+    session = mock.Mock()
+    session.post.return_value = _single_pr_graphql_response("REVIEW_REQUIRED")
+    ctx, report = _audit_ctx(ptl_tool, session)
+    with mock.patch("builtins.input", return_value="p"):
+        ptl_tool.ApprovalCheck().run(ctx)
+    assert not report.has_errors()
+
+
+def test_approval_check_interactive_skip_to_merge_raises(ptl_tool):
+    session = mock.Mock()
+    session.post.return_value = _single_pr_graphql_response("REVIEW_REQUIRED")
+    ctx, report = _audit_ctx(ptl_tool, session)
+    with mock.patch("builtins.input", return_value="m"):
+        with pytest.raises(ptl_tool.SkipToMerge):
+            ptl_tool.ApprovalCheck().run(ctx)
+
+
+def test_approval_check_invalid_choice_reprompts(ptl_tool, capsys):
+    session = mock.Mock()
+    session.post.return_value = _single_pr_graphql_response("REVIEW_REQUIRED")
+    ctx, report = _audit_ctx(ptl_tool, session)
+    with mock.patch("builtins.input", side_effect=["bogus", "p"]):
+        ptl_tool.ApprovalCheck().run(ctx)
+    assert "Invalid choice" in capsys.readouterr().out
+
+
+def test_approval_check_graphql_error_response_exits(ptl_tool):
+    session = mock.Mock()
+    session.post.return_value = FakeResponse(401, "Bad credentials")
+    ctx, report = _audit_ctx(ptl_tool, session)
+    with pytest.raises(SystemExit):
+        ptl_tool.ApprovalCheck().run(ctx)
+
+
+def test_approval_check_missing_pr_node_raises_systemexit(ptl_tool):
+    session = mock.Mock()
+    session.post.return_value = FakeJSONResponse(200, {"data": {"repository": {"pullRequest": None}}})
+    ctx, report = _audit_ctx(ptl_tool, session)
+    with pytest.raises(SystemExit):
+        ptl_tool.ApprovalCheck().run(ctx)
+
+
+def test_verify_pr_readiness_includes_approval_check_regardless_of_base(ptl_tool):
+    """ApprovalCheck must run for a final merge into main too, not just backports
+    (unlike CommitParityCheck/ConflictSimulationCheck/RedmineLinkageCheck, which
+    are backport-specific and skipped when base == 'main')."""
+    session = mock.Mock()
+    session.post.return_value = _single_pr_graphql_response("REVIEW_REQUIRED")
+    # ci_mode's post-audit-failure path also calls _hide_previous_bot_reviews(),
+    # which paginates PR reviews via GET before posting the consolidated
+    # review -- give it an empty, well-formed page so it's a no-op.
+    session.get.return_value = FakeJSONResponse(200, [], "")
+    session.get.return_value.headers = {}
+    G = mock.Mock()
+    args = mock.Mock(ci_mode=True, audit=True, dry_run=True)
+    with mock.patch.object(ptl_tool, "MergeConflictCheck") as FakeMergeCheck:
+        FakeMergeCheck.return_value.run.return_value = None
+        passed = ptl_tool.verify_pr_readiness(G, session, mock.Mock(), 100, [], mock.Mock(), "main", args)
+    assert passed is False  # ApprovalCheck's ci-mode failure should have been picked up


### PR DESCRIPTION
## What

Adds `check_pr_approvals()`, a pre-flight approval gate for `--pr-label`/`--integration`/`--qe-label` merges. It's the native `ptl-tool.py` equivalent of the standalone `ptl-check-approvals.sh` script, folded directly into the tool's own flow instead of requiring a separate manual pre-check.

## Where it runs

Right after the label search builds the `prs` list (`Will merge PRs: [...]`), and *before* the existing PRE-FLIGHT base-branch consistency check. This way, if a PR gets excluded here, it never even reaches the base-branch check.

## Behavior

Fetches every PR's `reviewDecision` via one batched GraphQL query (aliased `pr0`, `pr1`, ... — same computed field `gh pr list --json reviewDecision` reads; GitHub only exposes it over GraphQL, not REST). If none are `REVIEW_REQUIRED`, it's a silent no-op. If some are, it prints them and prompts:

```
How do you want to handle unapproved PRs? [a/r/i]
  a = accept and proceed, posting a reminder comment on each unapproved PR
  r = remove the label from unapproved PRs and exclude them from this run
  i = ignore and proceed with no changes
```

- `a`: PRs stay in the merge batch; each gets an `@author` reminder comment (same message the bash script's `--comment` posts).
- `r`: label removed from each unapproved PR via `DELETE .../labels/{label}` (404 treated as already-gone, not an error), and those PRs are dropped from this run's merge list. If every PR in the batch is unapproved, exits non-zero rather than merging nothing.
- `i`: proceeds exactly as before this feature existed — no comment, no label change.

`--ci-mode` skips the prompt entirely (logs a warning, proceeds with all PRs), matching the tool's existing non-interactive contract for `--ci-mode` elsewhere. `--dry-run` skips the comment/DELETE calls but the returned PR list still reflects what a real run would do, so a dry run's PRE-FLIGHT/merge preview matches reality.

## Testing

17 new unit tests (`src/script/test_ptl_tool.py`, mocked session/input, no live network) — no-op on all-approved, GraphQL query batching, GraphQL-error exit, ci-mode skip, accept/remove/ignore paths (including multi-PR accept), remove-all-unapproved exit, 404-on-delete handling, dry-run guards, invalid-input reprompt, non-ASCII title normalization, unresolvable-PR-node fail-closed, and unknown-author mention handling. 25/25 pass (8 pre-existing + 17 new).

Also live-validated end-to-end against real PRs (read-only GraphQL query directly, plus the full interactive flow via a real `--pr-label` batch under `--dry-run`) — correctly identified real unapproved PRs, handled the `a/r/i` prompt, and independently confirmed zero mutation occurred (label still present on GitHub after a dry-run `r` choice).

Signed-off-by: Yuri Weinstein <yweinste@redhat.com>

## Checklist
- Tracker (select at least one)
  - [x] New feature (ticket optional)
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
