### PR TITLE
common/fmt_common.h: include fmt/core.h

### DIFF
--- a/src/common/fmt_common.h
+++ b/src/common/fmt_common.h
@@ -24,7 +24,7 @@
 // TODO: drop me once fmt v11 is required
 namespace fmt {
   template <typename T, typename Char = char>
-  concept formattable = is_formattable<std::remove_reference_t<T>, Char>::value>;
+  concept formattable = is_formattable<std::remove_reference_t<T>, Char>::value;
 }
 #endif
 

--- a/src/common/fmt_common.h
+++ b/src/common/fmt_common.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <fmt/base.h>
 #include <optional>
 #include <type_traits>
 
@@ -11,6 +10,7 @@
  * \file default fmtlib formatters for specifically-tagged types
  */
 #include <fmt/compile.h>
+#include <fmt/core.h>
 #include <fmt/format.h>
 
 /**


### PR DESCRIPTION
since fmt v11.1.0, formattable concept was moved into base.h, which is in turn included by core.h. but in fmt v10.1.1, base.h didn't exist at all. that's why the tree didn't compile with using libfmt v10.1.1:

```
/usr/bin/c++ -DBOOST_ASIO_DISABLE_THREAD_KEYWORD_EXTENSION -DBOOST_ASIO_NO_TS_EXECUTORS -DCEPH_INSTALL_DATADIR=\"/usr/local/share/ceph\" -DCEPH_INSTALL_FULL_PKGLIBDIR=\"/usr/local/lib/ceph\" -DCMAKE_INSTALL_LIBDIR=\"lib\" -DFMT_SHARED -DHAVE_CONFIG_H -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_REENTRANT -D_THREAD_SAFE -D__CEPH__ -D__STDC_FORMAT_MACROS -D__linux__ -I/home/kefu/dev/ceph/build/src/include -I/home/kefu/dev/ceph/src -I/home/kefu/dev/ceph/src/dmclock/support/src -isystem /home/kefu/dev/ceph/build/boost/include -isystem /home/kefu/dev/ceph/build/include -isystem /home/kefu/dev/ceph/src/jaegertracing/opentelemetry-cpp/api/include -isystem /home/kefu/dev/ceph/src/jaegertracing/opentelemetry-cpp/exporters/jaeger/include -isystem /home/kefu/dev/ceph/src/jaegertracing/opentelemetry-cpp/ext/include -isystem /home/kefu/dev/ceph/src/jaegertracing/opentelemetry-cpp/sdk/include -isystem /home/kefu/dev/ceph/src/xxHash -Og -g -std=c++23 -fPIC -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -Wall -fno-strict-aliasing -fsigned-char -Wtype-limits -Wignored-qualifiers -Wpointer-arith -Werror=format-security -Winit-self -Wno-unknown-pragmas -Wnon-virtual-dtor -Wno-ignored-qualifiers -ftemplate-depth-1024 -DBOOST_ALLOW_DEPRECATED_HEADERS -Wpessimizing-move -Wredundant-move -Wstrict-null-sentinel -Woverloaded-virtual -DCEPH_DEBUG_MUTEX -fstack-protector-strong -D_GLIBCXX_ASSERTIONS -fdiagnostics-color=auto -MD -MT src/common/CMakeFiles/common-common-objs.dir/Formatter.cc.o -MF src/common/CMakeFiles/common-common-objs.dir/Formatter.cc.o.d -o src/common/CMakeFiles/common-common-objs.dir/Formatter.cc.o -c /home/kefu/dev/ceph/src/common/Formatter.cc
In file included from /home/kefu/dev/ceph/src/common/Formatter.h:16,
                 from /home/kefu/dev/ceph/src/common/Formatter.cc:18:
/home/kefu/dev/ceph/src/common/fmt_common.h:6:10: fatal error: fmt/base.h: No such file or directory
    6 | #include <fmt/base.h>
      |          ^~~~~~~~~~~~
```

since our minimal supported version of fmt library is 8.1.1, we need to support libfmt 10.1.1. in this change, we replace fmt/base.h with fmt/core.h, and move this `#include` closer to other `#include <fmt/*>`.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
