### PR TITLE
RGW Standalone: versioning fixes

### DIFF
--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -1563,6 +1563,30 @@ int VersionedDirectory::set_cur_version_ent(const DoutPrefixProvider* dpp, FSEnt
   return 0;
 }
 
+int VersionedDirectory::get_latest_version_ent(const DoutPrefixProvider* dpp, std::unique_ptr<FSEnt> &latest)
+{
+  std::unique_ptr<Symlink> sl = std::make_unique<Symlink>(get_name(), this, ctx);
+  int ret = sl->stat(dpp);
+  if (ret < 0) {
+    if (ret == -ENOENT)
+      return 0;
+    return ret;
+  }
+
+  if (!sl->exists()) {
+    return 0;
+  }
+
+  auto nent = sl->get_target()->clone_base();
+  ret = nent->open(dpp);
+  if (ret < 0) {
+    return 0;
+  }
+  latest.swap(nent);
+  return 0;
+}
+
+
 int VersionedDirectory::stat(const DoutPrefixProvider* dpp, bool force)
 {
   int ret = Directory::stat(dpp, force);
@@ -1622,8 +1646,9 @@ int VersionedDirectory::stat(const DoutPrefixProvider* dpp, bool force)
       if (flags & rgw_bucket_dir_entry::FLAG_DELETE_MARKER) {
         ldpp_dout(dpp, 0) << "ERROR: a delete marker, returning ENOENT "
                           << get_name() << dendl;
-        cur_version.reset();
-        return -ENOENT;
+        curr_is_dm = true;
+//      cur_version.reset();
+//      return -ENOENT;
       }
     }
   }
@@ -1734,7 +1759,8 @@ int VersionedDirectory::copy(const DoutPrefixProvider *dpp, optional_yield y,
   }
 
   std::string tgtname;
-  ret = for_each(dpp, [this, &dest, &dest_key, &tgtname, &dpp, &y](const char* name) {
+  bool found{false};
+  ret = for_each(dpp, [this, &dest, &dest_key, &tgtname, &found, &dpp, &y](const char* name) {
     std::unique_ptr<FSEnt> sobj;
 
     if (name[0] == '.') {
@@ -1746,6 +1772,7 @@ int VersionedDirectory::copy(const DoutPrefixProvider *dpp, optional_yield y,
       /* Were asked to copy a single version, and this is not it */
       return 0;
     }
+    found = true;
 
     int r = this->get_ent(dpp, y, name, std::string(), sobj);
     if (r < 0)
@@ -1755,11 +1782,16 @@ int VersionedDirectory::copy(const DoutPrefixProvider *dpp, optional_yield y,
     return sobj->copy(dpp, y, dest.get(), tgtname);
   });
 
-  if (!dest_key.instance.empty()) {
+  if (!dest_key.instance.empty() && !found) {
+    return -ENOENT;
+  }
+
+  if (found && !dest_key.instance.empty()) {
     /* We didn't copy the symlink, make a new one */
     std::unique_ptr<Symlink> sl = std::make_unique<Symlink>(basename, dest.get(), tgtname, ctx);
     ret = sl->create(dpp, /*existed=*/nullptr, /*temp_file=*/false);
   }
+
 
   return ret;
 }
@@ -1833,9 +1865,10 @@ int VersionedDirectory::remove(const DoutPrefixProvider* dpp, optional_yield y,
     key.instance = gen_rand_instance_name();
     tgtname = get_key_fname(key, /*use_version=*/true);
 
-    result->delete_marker = true;
-    result->version_id = key.instance;
-
+    if (result) {
+      result->delete_marker = true;
+      result->version_id = key.instance;
+    }
     f = std::make_unique<File>(tgtname, this, ctx);
     ret = add_delete_marker(dpp, y, f, tgtname);
     if (ret < 0) {
@@ -1848,6 +1881,7 @@ int VersionedDirectory::remove(const DoutPrefixProvider* dpp, optional_yield y,
       return ret;
     }
     cur_version = std::move(f);
+    curr_is_dm = true;
     return 0;
   } else {
     /* Delete specific version */
@@ -1868,12 +1902,16 @@ int VersionedDirectory::remove(const DoutPrefixProvider* dpp, optional_yield y,
       }
       bufferlist bl;
       if (get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
-       result->delete_marker = true;
+        if (result) {
+          result->delete_marker = true;
+        }
       }
       ret = f->remove(dpp, y, /*delete_children=*/true, result);
       if (ret < 0)
        return ret;
-      result->version_id = instance_id;
+      if (result) {
+        result->version_id = instance_id;
+      }
     } else {
       return ret;
     }
@@ -1910,13 +1948,28 @@ int VersionedDirectory::remove(const DoutPrefixProvider* dpp, optional_yield y,
     if (ret < 0) {
       return ret;
     }
+    ret = f->stat(dpp);
+    if (ret < 0) {
+      return ret;
+    }
+
     ret = set_cur_version_ent(dpp, f.get());
     if (ret < 0) {
       return ret;
     }
+/*
     cur_version = std::move(f);
+    Attrs attrs;
+    ret = f->read_attrs(dpp, null_yield, attrs);
+    if (ret < 0) {
+      return ret;
+    }
+    bufferlist bl;
+    if (rgw::sal::get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
+      curr_is_dm = true;  
+    }
+*/
   }
-
   return 0;
 }
 
@@ -3962,13 +4015,33 @@ int POSIXObject::delete_object(const DoutPrefixProvider* dpp,
   cls_rgw_obj_key key;
   get_key().get_index_key(&key);
 
-  if (ret == -ENOENT) {
-    if (!versioned() || !key.instance.empty() ) {
+  if (!versioned()) {
+    if (ret == -ENOENT) {
+      return 0;
+    }
+    ret = ent->remove(dpp, y, /*delete_children=*/false, &del_result);
+
+    if (ret < 0) {
+      return ret;
+    }
+    driver->get_bucket_cache()->remove_entry(dpp, b->get_name(), key);
+    driver->get_quota_handler()->update_stats(b->get_owner(), b->get_key(),
+                                              -1, 0, state.accounted_size);
+    return 0;
+  }
+
+  bool created = false;
+  auto* vd_ent = static_cast<posix::VersionedDirectory*>(ent.get());
+  // Versioned bucket
+  if (vd_ent && !vd_ent->get_cur_version_ent()) {
+    if (!key.instance.empty()) {
       // Nothing to do
       return 0;
     }
+  }
+  if (!vd_ent){
     // A delete marker must be created even if the key does not exist
-    // Create the versioned directory and create a delete marker
+    // Create the versioned directory in order to be able to create a delete marker
     ret = make_ent(ObjectType::VERSIONED);
     if (ret < 0) {
       return ret;
@@ -3979,56 +4052,98 @@ int POSIXObject::delete_object(const DoutPrefixProvider* dpp,
       ldpp_dout(dpp, 0) << "ERROR: could not create " << ent->get_name() << dendl;
       return ret;
     }
+    created = true;
+    vd_ent = static_cast<posix::VersionedDirectory*>(ent.get());
   }
+
+  bool update_cur_version = false;
+
+  std::unique_ptr<FSEnt> old_cur_ent;
+  // The cur version exists
+  if (!created && !key.instance.empty()) {
+    ret = vd_ent->get_latest_version_ent(dpp, old_cur_ent);
+    if (ret < 0) {
+      return ret;
+    }
+    if (old_cur_ent){
+      old_cur_ent->stat(dpp, true);
+    }
+  }
+
+  if (old_cur_ent && ent->get_instance().empty()) {
+    update_cur_version = true;
+  }
+
   ret = ent->remove(dpp, y, /*delete_children=*/false, &del_result);
+  if (ret < 0) {
+    return ret;
+  }
 
+  if ((ent->get_type() == ObjectType::VERSIONED) && !ent->get_instance().empty())  {
+    // key.instance will be the same as ent->instance_id
+    driver->get_bucket_cache()->remove_entry(dpp, b->get_name(), key);
+  }
 
-  driver->get_bucket_cache()->remove_entry(dpp, b->get_name(), key);
-
+  // Last version was removed
   if (!key.instance.empty() && !ent->exists()) {
     /* Remove the non-versioned key as well */
     key.instance.clear();
     driver->get_bucket_cache()->remove_entry(dpp, b->get_name(), key);
+    driver->get_quota_handler()->update_stats(b->get_owner(), b->get_key(),
+                                            -1, 0, state.accounted_size);
+    return 0;
   }
 
   /* after removing a versioned entry, the current version may have
    * changed — if the symlink now points to a delete marker, update
    * its cache entry to add FLAG_CURRENT so the LC can expire it */
-  if (!get_key().instance.empty() && ent->get_parent()) {
-    auto* vdir = dynamic_cast<VersionedDirectory*>(ent->get_parent());
-    if (vdir) {
-      std::unique_ptr<Symlink> sl =
-	std::make_unique<Symlink>(vdir->get_name(), vdir, driver->ctx());
-      if (sl->stat(dpp) >= 0 && sl->exists()) {
-	auto* target = sl->get_target();
-	std::string cur_name = target->get_name();
-	if (!cur_name.empty()) {
-	  std::unique_ptr<FSEnt> cur_ent;
-	  ret = vdir->get_ent(dpp, y, cur_name, std::string(), cur_ent);
-	  if (ret == 0) {
-	    cur_ent->stat(dpp);
-	    rgw_bucket_dir_entry bde{};
-	    rgw_obj_key cur_key = decode_obj_key(cur_name);
-	    cur_key.get_index_key(&bde.key);
-	    bde.flags = rgw_bucket_dir_entry::FLAG_VER
-	      | rgw_bucket_dir_entry::FLAG_CURRENT;
-	    bde.ver.pool = 1;
-	    bde.ver.epoch = 1;
-	    bde.exists = true;
-	    bde.meta.mtime = from_statx_timestamp(cur_ent->get_stx().stx_mtime);
-	    bde.meta.size = cur_ent->get_stx().stx_size;
-	    bde.meta.accounted_size = bde.meta.size;
-	    if (bde.meta.size == 0) {
-	      Attrs attrs;
-	      bufferlist bl;
-	      if (cur_ent->read_attrs(dpp, y, attrs) >= 0 &&
-		  ::rgw::sal::get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
-		bde.flags |= rgw_bucket_dir_entry::FLAG_DELETE_MARKER;
-	      }
-	    }
-	    driver->get_bucket_cache()->add_entry(dpp, b->get_name(), bde);
-	  }
-	}
+
+  if (update_cur_version) {
+    if (old_cur_ent) {
+      std::string old_cur_name = old_cur_ent->get_name();
+      if (!old_cur_name.empty()) {
+        old_cur_ent->stat(dpp);
+        uint32_t fill_flags = FSEnt::FLAG_NONE;
+        Attrs attrs;
+        bufferlist bl;
+        if (old_cur_ent->read_attrs(dpp, y, attrs) >= 0 &&
+            ::rgw::sal::get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
+          fill_flags |= FSEnt::FLAG_DELETE_MARKER;
+        }
+        old_cur_ent->fill_cache( dpp, null_yield,
+          [&](const DoutPrefixProvider *dpp, rgw_bucket_dir_entry &bde) -> int {
+	  driver->get_bucket_cache()->add_entry(dpp, b->get_name(), bde);
+	  return 0;
+        }, fill_flags);
+      }
+    }
+  }
+
+  if (vd_ent) {
+    std::unique_ptr<FSEnt> new_cur_ent;
+    ret = vd_ent->get_latest_version_ent(dpp, new_cur_ent);
+    if (ret < 0) {
+      return ret;
+    }
+    FSEnt *cur_ent = new_cur_ent.get();
+    if (cur_ent) {
+      std::string cur_name = cur_ent->get_name();
+      ldpp_dout(dpp, 0) << "NITHYA: Add NEW cur entry in cache: " << cur_name << dendl;
+      if (!cur_name.empty()) {
+        cur_ent->stat(dpp);
+        uint32_t fill_flags = FSEnt::FLAG_CURRENT;
+        Attrs attrs;
+        bufferlist bl;
+        if (cur_ent->read_attrs(dpp, y, attrs) >= 0 &&
+            ::rgw::sal::get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
+          fill_flags |= FSEnt::FLAG_DELETE_MARKER;
+        }
+        cur_ent->fill_cache( dpp, null_yield,
+          [&](const DoutPrefixProvider *dpp, rgw_bucket_dir_entry &bde) -> int {
+	  driver->get_bucket_cache()->add_entry(dpp, b->get_name(), bde);
+	return 0;
+      }, fill_flags);
+
       }
     }
   }
@@ -4077,10 +4192,6 @@ int POSIXObject::copy_object(const ACLOwner& owner,
     ldpp_dout(dpp, 0) << "ERROR: could not get bucket to copy " << get_name()
                       << dendl;
     return -EINVAL;
-  }
-  if (db->get_info().versioning_enabled() &&
-      !dest_object->have_instance()) {
-    dest_object->gen_rand_obj_instance_name();
   }
   bool has_instance = !get_key().instance.empty();
 
@@ -4538,6 +4649,13 @@ int POSIXObject::stat(const DoutPrefixProvider* dpp)
   if (state.obj.key.instance.empty()) {
     state.obj.key.instance = ent->get_cur_version();
   }
+  if (ent->get_type() == ObjectType::VERSIONED) {
+    auto* vd_ent = static_cast<posix::VersionedDirectory*>(ent.get());
+    if (vd_ent && vd_ent->curr_is_delete_marker()) {
+      state.exists = false;
+      return -ENOENT;
+    }
+  }
 
   state.exists = ent->exists();
   if (!state.exists) {
@@ -4661,18 +4779,18 @@ int POSIXObject::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y)
   ret = open(dpp);
   if (ret < 0) {
     ldpp_dout(dpp, 20)
-        << "ERROR: POSIXAtomicWriter failed opening file" << dendl;
+        << "ERROR: link_temp_file: failed to open file : " << get_name() << dendl;
     return ret;
   }
 
   ret = stat(dpp);
   if (ret < 0) {
     ldpp_dout(dpp, 20)
-        << "ERROR: POSIXAtomicWriter failed closing file" << dendl;
+        << "ERROR: link_temp_file: failed to stat file: " << get_name() << dendl;
     return ret;
   }
 
-  fill_cache( nullptr, null_yield,
+  fill_cache( dpp, null_yield,
       [&](const DoutPrefixProvider *dpp, rgw_bucket_dir_entry &bde) -> int {
 	driver->get_bucket_cache()->add_entry(dpp, b->get_name(), bde);
 	return 0;
@@ -5725,6 +5843,7 @@ int POSIXAtomicWriter::complete(size_t accounted_size, const std::string& etag,
       ldpp_dout(dpp, 0) << "ERROR: could not get bucket for " << obj->get_name() << dendl;
       return -EINVAL;
   }
+
   driver->get_quota_handler()->update_stats(b->get_owner(), b->get_key(),
                                             (exists ? 0 : 1), orig_size, accounted_size);
 

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -1827,16 +1827,6 @@ int VersionedDirectory::remove(const DoutPrefixProvider* dpp, optional_yield y,
     return ret;
 
   if (instance_id.empty()) {
-    /* Check if directory is empty */
-    ret = for_each(dpp, [](const char *n) {
-      return -ENOENT;
-    });
-
-    if (ret == 0) {
-      /* We're empty, nuke us */
-      return Directory::remove(dpp, y, /*delete_children=*/true, result);
-    }
-
     /* Add a delete marker */
     std::unique_ptr<File> f;
     rgw_obj_key key = decode_obj_key(get_name());
@@ -3968,17 +3958,30 @@ int POSIXObject::delete_object(const DoutPrefixProvider* dpp,
   }
 
   int ret = stat(dpp);
-  if (ret < 0) {
-      if (ret == -ENOENT) {
-	// Nothing to do
-	return 0;
-      }
-      return ret;
-  }
-  ret = ent->remove(dpp, y, /*delete_children=*/false, &del_result);
 
   cls_rgw_obj_key key;
   get_key().get_index_key(&key);
+
+  if (ret == -ENOENT) {
+    if (!versioned() || !key.instance.empty() ) {
+      // Nothing to do
+      return 0;
+    }
+    // A delete marker must be created even if the key does not exist
+    // Create the versioned directory and create a delete marker
+    ret = make_ent(ObjectType::VERSIONED);
+    if (ret < 0) {
+      return ret;
+    }
+
+    ret = ent->create(dpp, nullptr, false);
+    if (ret < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: could not create " << ent->get_name() << dendl;
+      return ret;
+    }
+  }
+  ret = ent->remove(dpp, y, /*delete_children=*/false, &del_result);
+
 
   driver->get_bucket_cache()->remove_entry(dpp, b->get_name(), key);
 

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -155,6 +155,7 @@ public:
   virtual std::unique_ptr<FSEnt> clone_base() = 0;
   virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags);
   virtual std::string get_cur_version() { return ""; };
+  virtual std::string get_instance() { return ""; };
 };
 
 class File : public FSEnt {
@@ -305,6 +306,7 @@ class VersionedDirectory : public Directory {
 protected:
   std::string instance_id;
   std::unique_ptr<FSEnt> cur_version;
+  bool curr_is_dm{false};
 
 public:
   VersionedDirectory(std::string _name, Directory* _parent, CephContext* _ctx) : Directory(_name, _parent, _ctx)
@@ -344,12 +346,15 @@ public:
   virtual int link_temp_file(const DoutPrefixProvider* dpp, optional_yield y, std::string target_fname) override;
   virtual int remove(const DoutPrefixProvider* dpp, optional_yield y, bool delete_children, DeleteResult* result) override;
   virtual std::string get_cur_version() override;
+  virtual std::string get_instance() override { return instance_id; };
   std::string get_new_instance();
   int remove_symlink(const DoutPrefixProvider *dpp, optional_yield y, std::string match = "");
   int add_file(const DoutPrefixProvider *dpp, std::unique_ptr<FSEnt>&& file, bool* existed = nullptr, bool temp_file = false);
   int add_delete_marker(const DoutPrefixProvider* dpp, optional_yield y, std::unique_ptr<File>& marker, const std::string &name);
+  virtual bool curr_is_delete_marker() { return curr_is_dm; };
   FSEnt* get_cur_version_ent() { return cur_version.get(); };
   int set_cur_version_ent(const DoutPrefixProvider *dpp, FSEnt* file);
+  int get_latest_version_ent(const DoutPrefixProvider* dpp, std::unique_ptr<FSEnt> &f);
   virtual std::unique_ptr<FSEnt> clone_base() override {
     return std::make_unique<VersionedDirectory>(*this);
   }

--- a/src/test/rgw/test_rgw_posix_driver.cc
+++ b/src/test/rgw/test_rgw_posix_driver.cc
@@ -844,7 +844,7 @@ TEST(FSEnt, VerDirBase)
   ret = testdir->copy(env->dpp, null_yield, root.get(), copyname);
   EXPECT_EQ(ret, 0);
   EXPECT_TRUE(sf::exists(cp));
-  EXPECT_TRUE(sf::is_directory(tp));
+  EXPECT_TRUE(sf::is_directory(cp));
 
   std::unique_ptr<VersionedDirectory> copydir = std::make_unique<VersionedDirectory>(copyname, root.get(), env->cct.get());
   ret = copydir->open(env->dpp);
@@ -878,7 +878,20 @@ TEST(FSEnt, VerDirBase)
   EXPECT_EQ(ret, 0);
   EXPECT_EQ(ent->get_type(), ObjectType::VERSIONED);
 
-  ret = testdir->remove(env->dpp, null_yield, false, nullptr);
+  // This will create a delete marker
+  struct rgw::sal::Object::DeleteOp::Result result;
+  ret = testdir->remove(env->dpp, null_yield, false, &result);
+  EXPECT_EQ(ret, 0);
+
+  std::unique_ptr<VersionedDirectory> testdir2 = std::make_unique<VersionedDirectory>(dirname, root.get(),
+                                                 result.version_id, env->cct.get());
+
+  ret = testdir2->open(env->dpp);
+  EXPECT_EQ(ret, 0);
+  EXPECT_GT(testdir2->get_fd(), 0);
+
+  // remove the delete marker
+  ret = testdir2->remove(env->dpp, null_yield, false, nullptr);
   EXPECT_EQ(ret, 0);
   EXPECT_FALSE(sf::exists(tp));
 }


### PR DESCRIPTION
Fixes various issues in the RGW Standalone versioning feature. 


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
