### PR TITLE
rgw/sts: added logic to disallow role

### DIFF
--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -838,6 +838,15 @@ WebTokenEngine::authenticate( const DoutPrefixProvider* dpp,
 
 int RGWREST_STS::verify_permission(optional_yield y)
 {
+  //blocking role chaining as it is not officially supported in RGW
+  //this logic applies only to AssumeRole* calls.
+  //this needs to be revisited in case any other STS op uses this method
+  //to verify its permission.
+  //disallow temporary credentials from invoking assumerole* calls
+  if (s->auth.identity && s->auth.identity->get_identity_type() == TYPE_ROLE) {
+    s->err.message = "Role chaining is not supported";
+    return -EPERM;
+  }
   STS::STSService _sts(s->cct, driver, s->user->get_id(), s->auth.identity.get());
   sts = std::move(_sts);
 

--- a/src/test/rgw/s3-tests/s3tests/functional/test_sts.py
+++ b/src/test/rgw/s3-tests/s3tests/functional/test_sts.py
@@ -28,6 +28,8 @@ from collections import namedtuple
 
 from email.header import decode_header
 
+from .utils import assert_raises, _get_status_and_error_code
+
 from . import(
     configfile,
     setup_teardown,
@@ -392,6 +394,60 @@ def test_assume_role_allow_head_nonexistent():
         status = e.response['ResponseMetadata']['HTTPStatusCode']
     assert status == 404
 
+@pytest.mark.test_of_sts
+@pytest.mark.fails_on_dbstore
+def test_assume_role_chaining_disallowed():
+    """Verify that role chaining is disallowed (tracker #78697)."""
+    assume_role_error = None
+    iam_client = get_iam_client()
+    sts_client = get_sts_client()
+    sts_user_id = get_alt_user_id()
+    default_endpoint = get_config_endpoint()
+    role_session_name = get_parameter_name()
+
+    # Trust policy: allow the IAM alt-user to call sts:AssumeRole
+    policy_document = (
+        '{"Version":"2012-10-17","Statement":[{"Effect":"Allow",'
+        '"Principal":{"AWS":["arn:aws:iam:::user/' + sts_user_id + '"]},'
+        '"Action":["sts:AssumeRole"]}]}'
+    )
+    (role_error, role_response, general_role_name) = create_role(
+        iam_client, '/', None, policy_document, None, None, None
+    )
+    if role_response:
+        assert role_response['Role']['Arn'] == 'arn:aws:iam:::role/' + general_role_name
+    else:
+        assert False, role_error
+
+    # Permission policy:
+    role_policy = (
+        '{"Version":"2012-10-17","Statement":{"Effect":"Allow",'
+        '"Action":"s3:*","Resource":"arn:aws:s3:::*"}}'
+    )
+    (role_err, response) = put_role_policy(iam_client, general_role_name, None, role_policy)
+    if response:
+        assert response['ResponseMetadata']['HTTPStatusCode'] == 200
+    else:
+        assert False, role_err
+
+    # First assume-role: IAM user → temporary credentials (must succeed)
+    resp = sts_client.assume_role(
+        RoleArn=role_response['Role']['Arn'],
+        RoleSessionName=role_session_name,
+    )
+    assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
+
+    # Second assume-role (role chaining): temporary credentials → same role
+    # Must be denied because role chaining is not supported
+    chained_sts_client = get_sts_client(
+        aws_access_key_id=resp['Credentials']['AccessKeyId'],
+        aws_secret_access_key=resp['Credentials']['SecretAccessKey'],
+        aws_session_token=resp['Credentials']['SessionToken'],
+    )
+    e = assert_raises(ClientError, chained_sts_client.assume_role,
+            RoleArn=role_response['Role']['Arn'],
+            RoleSessionName=get_parameter_name())
+    assert (403, 'AccessDenied') == _get_status_and_error_code(e.response)
 
 @pytest.mark.webidentity_test
 @pytest.mark.token_claims_trust_policy_test


### PR DESCRIPTION
chaining.

fixes: https://tracker-origin.ceph.com/issues/78697

The explanation for the fix is given in the tracker issue above.

Role chaining as a separate STS feature is not officially supported in RGW. It requires the trust policy to have the ARN of the role assuming the role using temporary credentials. There are other rules related to role chaining which are not supported in RGW:
```
Role chaining limits your AWS Management Console, AWS CLI or AWS API role session to a maximum of one hour. It applies regardless of the maximum session duration configured for individual roles. When you use the [AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) API operation to assume a role, you can specify the duration of your role session with the DurationSeconds parameter. You can specify a parameter value of up to 43200 seconds (12 hours), depending on the [maximum session duration setting](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_update-role-settings.html#id_roles_update-session-duration) for your role. However, if you assume a role using role chaining and provide a DurationSeconds parameter value greater than one hour, the operation fails.
```
https://aws.amazon.com/blogs/security/how-to-use-trust-policies-with-iam-roles/
https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
