### PR TITLE
tentacle: RGW SSE-KMS secrets cache

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,6 +1,94 @@
 * ceph-volume: Raw BlueStore OSD preparation now pre-formats NVMe devices and
   skips the slower BlueStore discard phase,reducing mkfs time on
   very large namespaces.
+* RGW: Bucket Logging suppports creating log buckets in EC pools.
+  Implicit logging object commits are now performed asynchronously.
+* RGW: radosgw-admin bucket list now supports pagination for versioned buckets by using
+  both --marker and --object-version options together (e.g., ``--marker=obj1 --object-version=abc123``).
+  This enables proper pagination through versioned bucket listings without duplicates or
+  infinite loops. For non-versioned buckets, use only --marker as before (backward compatible).
+* RGW: OpenSSL engine support is deprecated in favor of provider support.
+  - Removed the `openssl_engine_opts` configuration option. OpenSSL engine configuration in string format is no longer supported.
+  - Added the `openssl_conf` configuration option for loading specified providers as default providers.
+    Configuration file syntax follows the OpenSSL standard (see https://github.com/openssl/openssl/blob/master/doc/man5/config.pod).
+    If the default provider is required when also using custom providers,
+    it must be explicitly loaded in the configuration file or code (see https://github.com/openssl/openssl/blob/master/README-PROVIDERS.md).
+* RGW: Fixed bucket notification events so the 'x_amz_request_id' in NotificationEvent now matches the 'x_amz_request_id' returned by the corresponding S3 operation.
+
+* DASHBOARD: Introduces a new landing page - "Overview". This revamps UX and adds more information in the landing page - overall cluster health, health checks, resilency panel (showing PG status, active/clean percent), total and used raw capacity, alerts, capacity breakdown by object, file and block and performance charts - throughput, latency and IOPS. This renames the landing page from "Dashboard" to "Overview"
+* DASHBOARD: Removed the older landing page which was deprecated in Quincy.
+  Admins can no longer enable the older, deprecated landing page layout by
+  adjusting FEATURE_TOGGLE_DASHBOARD.
+* DASHBOARD: RGW Service form updated to take input regarding QAT compression.
+  - QAT compression is an optional field which can be set to 'Hardware' or 'Software' by selecting options from provided dropdwon. If 'None' is selected, compression is removed altogether.
+* Monitoring: Added new Prometheus alerts for certificate management:
+  - CephCertificateError: Fires when a Ceph certificate has expired (critical severity).
+  - CephCertificateWarning: Fires when a Ceph certificate is about to expire (warning severity).
+* CephFS: The `peer_add` command is deprecated in favor of the `peer_bootstrap` command.
+* RGW: For `radosgw-admin account rm`, the `--purge-data` option previously applied only
+  to buckets and objects, but now deletes account users, roles, groups, and oidc-providers
+  too instead of failing with ENOTEMPTY.
+* RADOS: When objects are read during deep scrubs, the data is read in strides,
+  and the scrubbing process is delayed between each read in order to avoid monopolizing
+  the I/O capacity of the OSD.
+  The default stride size (``osd_deep_scrub_stride``) was 512 KBytes, and is now 4 MBytes.
+* RADOS: When an OSD is overloaded with queued snap-trim operations, no
+  regular (non-urgent) scrubs will be scheduled on that OSD. This is
+  determined by comparing the total snap-trim queue lengths for all PGs
+  for which the OSD is a primary against ``osd_scrub_queued_snaptrims_limit``,
+  which defaults to 500.
+  This restriction does not apply to operator-initiated scrubs, nor to repair scrubs.
+  It can be disabled by setting ``osd_scrub_queued_snaptrims_limit`` to 0.
+* RGW: Add SSE-KMS secrets cache
+
+* RADOS: Stretch mode can now be entered even if the two dividing buckets differ
+  in weight by a small fraction (default 0.1). This is tunable via
+  `mon_stretch_max_bucket_weight_delta`.
+
+* CephFS: The offline CephFS tools (cephfs-data-scan, cephfs-journal-tool,
+  and cephfs-table-tool) now include progress tracking with ETA (Estimated Time of
+  Arrival) for long-running operations. Progress updates are displayed automatically
+  at regular intervals, showing completion percentage, processed items, and time
+  estimates. This feature is enabled by default for relevant commands including
+  scan_extents, scan_inodes, and other state-changing operations.
+  Related Tracker: https://tracker.ceph.com/issues/63191
+* RBD: Fixed incorrect behavior of the "start-time" argument for mirror
+  snapshot and trash purge schedules, where it previously offset the schedule
+  anchor instead of defining it. The argument now requires an ISO 8601
+  date-time. The `schedule ls` output displays the start time in UTC, including
+  the date and time in the format "%Y-%m-%d %H:%M:00". The `schedule status`
+  output now displays the next schedule time in UTC.
+* CephFS Mirroring:  Now utilizes a multi-threaded architecture to improve synchronization
+  performance. The workload is split into two distinct thread pools: a crawler thread pool, which
+  manages snapshot crawl and a data synchronization thread pool, which handles concurrent file
+  transfers. Users can fine-tune these operations using configuration parameters:
+  cephfs_mirror_max_concurrent_directory_syncs (controlling the number of concurrent snapshots being crawled)
+  and cephfs_mirror_max_datasync_threads (controlling the total threads available for data sync).
+  For more information, see https://tracker.ceph.com/issues/73452
+* CephFS Mirroring: Improved incremental synchronization behavior in CephFS mirroring. Previously,
+  block-level delta synchronization was used for all files regardless of size. With this change,
+  blockdiff is applied only to files larger than a configurable threshold, while smaller files are
+  synchronized using full copy, as blockdiff is not efficient for small files. The threshold is
+  controlled by the new configuration option cephfs_mirror_blockdiff_min_file_size (default: 16_M).
+  For more information, see https://tracker.ceph.com/issues/73452
+* CephFS Mirroring: Improved mirror daemon status reporting. The command
+  ``ceph fs snapshot mirror daemon status`` now shows the remote cluster's
+  monitor addresses and cluster ID for each configured peer, making it easier
+  to verify peer connectivity and troubleshoot mirroring issues.
+* RBD: Mirror snapshot creation and trash purge schedules are now automatically
+  staggered when no explicit "start-time" is specified. This reduces scheduling
+  spikes and distributes work more evenly over time.
+* RBD: Introduced a new ``RBD_LOCK_MODE_EXCLUSIVE_TRANSIENT`` policy for
+  ``rbd_lock_acquire()``. This is a low-level interface intended to allow
+  a peer to grab exclusive lock manually for short periods of time with other
+  peers pausing their activity and waiting for the lock to be released rather
+  than instantly aborting I/O and returning an error. It's possible to switch
+  from ``RBD_LOCK_MODE_EXCLUSIVE`` to ``RBD_LOCK_MODE_EXCLUSIVE_TRANSIENT``
+  policy and vice versa even if the lock is already held.
+* OSD: A health warning is reported when BlueFS usage exceeds the
+  configured ratio of the main OSD data device size. This warning is
+  informational and can be muted with:
+  ``ceph health mute BLUESTORE_BLUEFS_OVERSIZED``
 * MGR: The Manager now automatically increases ``mgr_stats_period`` when its
   message queue is congested, reducing daemon reporting frequency to prevent
   overload. The period recovers automatically once the queue clears. This

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -145,6 +145,16 @@
   - CephCertificateError: Fires when a Ceph certificate has expired (critical severity).
   - CephCertificateWarning: Fires when a Ceph certificate is about to expire (warning severity).
 
+
+* DASHBOARD: Introduces a new landing page - "Overview". This revamps UX and adds more information in the landing page - overall cluster health, health checks, resilency panel (showing PG status, active/clean percent), total and used raw capacity, alerts, capacity breakdown by object, file and block and performance charts - throughput, latency and IOPS. This renames the landing page from "Dashboard" to "Overview"
+* DASHBOARD: Removed the older landing page which was deprecated in Quincy.
+  Admins can no longer enable the older, deprecated landing page layout by
+  adjusting FEATURE_TOGGLE_DASHBOARD.
+* DASHBOARD: RGW Service form updated to take input regarding QAT compression.
+  - QAT compression is an optional field which can be set to 'Hardware' or 'Software' by selecting options from provided dropdwon. If 'None' is selected, compression is removed altogether.
+* Monitoring: Added new Prometheus alerts for certificate management:
+  - CephCertificateError: Fires when a Ceph certificate has expired (critical severity).
+  - CephCertificateWarning: Fires when a Ceph certificate is about to expire (warning severity).
 * CephFS: The `peer_add` command is deprecated in favor of the `peer_bootstrap` command.
 * RGW: For `radosgw-admin account rm`, the `--purge-data` option previously applied only
   to buckets and objects, but now deletes account users, roles, groups, and oidc-providers

--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -269,6 +269,16 @@ SSE-S3 Settings
 .. confval:: rgw_crypt_sse_s3_vault_ssl_clientcert
 .. confval:: rgw_crypt_sse_s3_vault_ssl_clientkey
 
+KMS Secrets Cache Settings
+==========================
+
+.. confval:: rgw_crypt_s3_kms_cache_enabled
+.. confval:: rgw_crypt_s3_kms_cache_max_size
+.. confval:: rgw_crypt_s3_kms_cache_positive_ttl
+.. confval:: rgw_crypt_s3_kms_cache_transient_error_ttl
+.. confval:: rgw_crypt_s3_kms_cache_negative_ttl
+
+.. _Encryption: ../encryption
 
 QoS settings
 ------------

--- a/doc/radosgw/encryption.rst
+++ b/doc/radosgw/encryption.rst
@@ -81,7 +81,53 @@ The configuration expects a base64-encoded 256 bit key. For example::
    file is not a secure method for storing encryption keys. Keys that are
    accidentally exposed in this way should be considered compromised.
 
+Caching
+=======
 
+The caching feature for Key Management Service (KMS) secrets greatly
+improves the performance of server-side encryption and lessens the
+load on the KMS.
+
+Secrets are stored using the `Linux Kernel Key Retention Service`_ in
+the RGW processes' process keyring. This is subject to a global quota
+and must be set in accordance with the configured cache size.
+Depending on whether RGW runs as root, these quotas can be managed by adjusting:
+- ``/proc/sys/kernel/keys/root_maxkeys`` and ``/proc/sys/kernel/keys/root_maxbytes``
+- ``/proc/sys/kernel/keys/maxkeys`` and ``/proc/sys/kernel/keys/maxbytes``
+
+Exceeding a quota will disable the cache, fail the request with an
+internal error, and log a failure message.
+
+Three different Cache Time-to-Live (TTL) values can be set:
+- **Positive TTL**: How long a successfully retrieved secret remains
+  in the cache.
+- **Negative TTL**: How long to remember that a key does not exist,
+  preventing unnecessary requests to the KMS.
+- **Transient Error TTL**: How long to cache failures due to temporary
+  issues like KMS timeouts.
+
+Metrics
+---------
+
+The cache exports metrics under the ``kms-cache`` collection.
+- ``hit``: Hit counter
+- ``miss``:  Miss counter
+- ``expired``: Number of TTL expired entries
+- ``size``: Current cache size
+- ``capacity``: Cache maximum size
+- ``clear``: Number of cache clears. Resets ``size``, ``hit``,
+  ``miss``, ``expired``
+
+In addition the ``rgw`` collection has:
+- ``kms_fetch_lat``: Average KMS fetch latency. Also includes a
+  successful request counter. Each event results in a positive cache
+  entry.
+- ``kms_error_transient``: Transient KMS fetch error counter. Each
+  event results in a transient error cache entry.
+- ``kms_error_permanent``: Permanent KMS fetch error counter. Each
+  event results in a negative cache cache entry.
+
+.. _Linux Kernel Key Retention Service:  https://www.kernel.org/doc/html/latest/security/keys/core.html
 .. _Amazon SSE-C: https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html
 .. _Amazon SSE-KMS: http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html
 .. _Amazon SSE-S3: https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -255,4 +255,9 @@ if(HAVE_KEYUTILS)
   set(parse_secret_srcs
     secret.c)
   add_library(parse_secret_objs OBJECT ${parse_secret_srcs})
+
+  set(keyring_srcs
+    keyring.cc)
+  add_library(keyring STATIC ${keyring_srcs})
+  target_link_libraries(keyring keyutils::keyutils)
 endif()

--- a/src/common/async/call_once.h
+++ b/src/common/async/call_once.h
@@ -1,0 +1,113 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <concepts>
+#include <exception>
+#include <mutex>
+#include <variant>
+
+#include "include/function2.hpp"
+
+#include "yield_context.h"
+#include "detail/call_once.h"
+
+namespace ceph::async {
+
+/// Stores the result of call_once(), if any.
+///
+/// The cached Result type must be semiregular (copyable and default-
+/// constructible).
+template <std::semiregular Result>
+class once_result {
+ public:
+  /// Call f() once and cache its return value.
+  ///
+  /// If a call has already completed, return the cached result. If a call
+  /// is already in progress, wait for its completion and return the result.
+  /// If a yield context is provided in y, its coroutine will be suspended
+  /// while waiting. f() may also suspend/resume the same coroutine.
+  ///
+  /// f() must return a Result when called with no arguments. If it throws,
+  /// that exception is rethrown by all calls.
+  ///
+  /// This function is thread-safe.
+  template <typename Callable>
+  friend Result call_once(once_result& self, optional_yield y, Callable&& f)
+      requires std::convertible_to<std::invoke_result_t<Callable>, Result>
+  {
+    auto lock = std::unique_lock{self.mutex};
+    return std::visit(
+        fu2::overload(
+            [&] (const Init&) { return self.do_init(lock, f); },
+            [&] (Wait& w) { return self.do_wait(lock, y, w); },
+            [] (const Complete& c) { return do_complete(c); }),
+        self.state);
+  }
+
+ private:
+  std::mutex mutex;
+
+  // state machine: [Init] -> [Wait] -> [Complete]
+  using Init = std::monostate;
+  using Wait = detail::call_once::WaitState;
+  struct Complete {
+    Result result;
+    std::exception_ptr eptr;
+  };
+  std::variant<Init, Wait, Complete> state;
+
+  Result do_init(std::unique_lock<std::mutex>& lock, auto&& f)
+  {
+    // transition to Wait state
+    auto& wait = state.template emplace<Wait>();
+    lock.unlock();
+
+    Complete complete;
+    try {
+      complete.result = f();
+    } catch (const std::exception&) {
+      complete.eptr = std::current_exception();
+    }
+
+    lock.lock();
+    // wake any waiters
+    wait.wake_all();
+
+    // transition to Complete state and return the result
+    return do_complete(state.template emplace<Complete>(std::move(complete)));
+  }
+
+  Result do_wait(std::unique_lock<std::mutex>& lock,
+                 optional_yield y, Wait& wait)
+  {
+    // wait for the response to an outstanding request
+    wait.wait(lock, y);
+
+    // state must be Complete after wakeup
+    return do_complete(std::get<Complete>(state));
+  }
+
+  static Result do_complete(const Complete& complete)
+  {
+    if (complete.eptr) { // rethrow cached exception
+      std::rethrow_exception(complete.eptr);
+    }
+    return complete.result; // return cached result
+  }
+};
+
+} // namespace ceph::async

--- a/src/common/async/detail/call_once.h
+++ b/src/common/async/detail/call_once.h
@@ -1,0 +1,129 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+
+#include <boost/intrusive/list.hpp>
+
+#include "common/async/service.h"
+#include "common/async/yield_context.h"
+#include "common/async/yield_waiter.h"
+
+namespace ceph::async::detail::call_once {
+
+class AsyncWaiter : public boost::intrusive::list_base_hook<> {
+  yield_waiter<void> impl;
+ public:
+  void wait(std::unique_lock<std::mutex>& lock,
+            boost::asio::yield_context yield)
+  {
+    impl.async_wait(lock, yield);
+  }
+  void wake()
+  {
+    // async_wait() may complete inline via boost::asio::dispatch(), but would
+    // immediately try to reacquire the lock we're already holding. defer the
+    // completion until after we've returned and dropped our lock
+    boost::asio::defer(impl.get_executor(), [this] {
+        impl.complete(boost::system::error_code{});
+      });
+  }
+  void destroy()
+  {
+    impl.shutdown();
+  }
+};
+
+class SyncWaiter : public boost::intrusive::list_base_hook<> {
+  std::condition_variable cond;
+  bool done = false;
+ public:
+  void wait(std::unique_lock<std::mutex>& lock)
+  {
+    cond.wait(lock, [this] { return done; });
+  }
+  void wake()
+  {
+    done = true;
+    cond.notify_one();
+  }
+};
+
+struct WaitState : service_list_base_hook {
+  service<WaitState>* svc = nullptr;
+  boost::intrusive::list<SyncWaiter> sync_waiters;
+  boost::intrusive::list<AsyncWaiter> async_waiters;
+
+  ~WaitState()
+  {
+    if (svc) {
+      svc->remove(*this);
+    }
+  }
+
+  void wait(std::unique_lock<std::mutex>& lock, optional_yield y)
+  {
+    if (y) {
+      auto yield = y.get_yield_context();
+      if (!svc) {
+        // on first async wait, register for service_shutdown() notifications
+        svc = &boost::asio::use_service<service<WaitState>>(
+            boost::asio::query(yield.get_executor(),
+                               boost::asio::execution::context));
+        svc->add(*this);
+      }
+
+      AsyncWaiter waiter;
+      async_waiters.push_back(waiter);
+
+      waiter.wait(lock, yield);
+    } else {
+      SyncWaiter waiter;
+      sync_waiters.push_back(waiter);
+
+      waiter.wait(lock);
+    }
+  }
+
+  void wake_all()
+  {
+    while (!sync_waiters.empty()) {
+      auto& waiter = sync_waiters.front();
+      sync_waiters.pop_front();
+      waiter.wake();
+    }
+    while (!async_waiters.empty()) {
+      auto& waiter = async_waiters.front();
+      async_waiters.pop_front();
+      waiter.wake();
+    }
+  }
+
+  // on shutdown, destroy async waiters that didn't complete. this breaks any
+  // ownership cycles between once_result and the completion handlers
+  void service_shutdown()
+  {
+    while (!async_waiters.empty()) {
+      auto& waiter = async_waiters.front();
+      async_waiters.pop_front();
+      waiter.destroy();
+    }
+  }
+};
+
+} // namespace ceph::async::detail::call_once

--- a/src/common/async/yield_waiter.h
+++ b/src/common/async/yield_waiter.h
@@ -20,6 +20,7 @@
 #include <optional>
 #include <boost/asio/append.hpp>
 #include <boost/asio/associated_cancellation_slot.hpp>
+#include <boost/asio/associated_executor.hpp>
 #include <boost/asio/async_result.hpp>
 #include <boost/asio/dispatch.hpp>
 #include <boost/asio/spawn.hpp>
@@ -64,6 +65,18 @@ class yield_waiter {
 
   /// Returns true if there's a handler awaiting completion.
   operator bool() const { return state.has_value(); }
+
+  /// Returns false if there's a handler awaiting completion.
+  bool empty() const { return !state.has_value(); }
+
+  /// Returns the captured completion handler's executor.
+  /// Precondition: !empty()
+  using executor_type = boost::asio::any_io_executor;
+  executor_type get_executor() const
+  {
+    return boost::asio::get_associated_executor(
+        state->handler, state->work.get_executor());
+  }
 
   /// Suspends the given yield_context until the captured handler is invoked
   /// via complete() or cancel().
@@ -166,6 +179,18 @@ class yield_waiter<void> {
 
   /// Returns true if there's a handler awaiting completion.
   operator bool() const { return state.has_value(); }
+
+  /// Returns false if there's a handler awaiting completion.
+  bool empty() const { return !state.has_value(); }
+
+  /// Returns the captured completion handler's executor.
+  /// Precondition: !empty()
+  using executor_type = boost::asio::any_io_executor;
+  executor_type get_executor() const
+  {
+    return boost::asio::get_associated_executor(
+        state->handler, state->work.get_executor());
+  }
 
   /// Suspends the given yield_context until the captured handler is invoked
   /// via complete() or cancel().

--- a/src/common/keyring.cc
+++ b/src/common/keyring.cc
@@ -1,0 +1,143 @@
+
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2025 Clyso GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "keyring.h"
+
+#ifndef _WIN32
+extern "C" {
+#include <keyutils.h>
+}
+#endif
+
+namespace ceph {
+
+#ifdef _WIN32
+
+LinuxKeyringSecret::LinuxKeyringSecret(key_serial_t serial, size_t len) noexcept
+    : _len(len), _serial(serial) {}
+
+LinuxKeyringSecret::~LinuxKeyringSecret() noexcept {}
+
+tl::expected<LinuxKeyringSecret, std::error_code> LinuxKeyringSecret::add(
+    const std::string& key, const std::string& secret) noexcept {
+  return tl::unexpected(std::error_code(-ENOSYS, std::system_category()));
+}
+
+bool LinuxKeyringSecret::supported() noexcept {
+  return false;
+}
+
+void LinuxKeyringSecret::initialize_process_keyring() noexcept {
+}
+
+[[nodiscard]] std::error_code LinuxKeyringSecret::read(std::string& out) const {
+  return {-ENOSYS, std::system_category()};
+}
+
+[[nodiscard]] std::error_code LinuxKeyringSecret::remove() const {
+  return {-ENOSYS, std::system_category()};
+}
+
+[[nodiscard]] std::error_code LinuxKeyringSecret::reset() {
+  return {-ENOSYS, std::system_category()};
+}
+
+#else
+
+LinuxKeyringSecret::LinuxKeyringSecret(key_serial_t serial, size_t len) noexcept
+    : _len(len), _serial(serial) {}
+
+LinuxKeyringSecret::~LinuxKeyringSecret() noexcept {
+  reset();
+}
+
+tl::expected<LinuxKeyringSecret, std::error_code> LinuxKeyringSecret::add(
+    const std::string& key, const std::string& secret) noexcept {
+  const auto serial = add_key(
+      "user", key.c_str(), secret.c_str(), secret.size(),
+      KEY_SPEC_PROCESS_KEYRING);
+  if (serial == -1) {
+    return tl::unexpected(std::error_code(errno, std::system_category()));
+  }
+  return LinuxKeyringSecret(serial, secret.size());
+}
+
+bool LinuxKeyringSecret::supported(std::error_code* ec) noexcept {
+  auto secret = LinuxKeyringSecret::add("ceph_test_keyring_support", "ceph");
+  if (!secret) {
+    if (ec != nullptr) {
+      *ec = secret.error();
+    }
+    return false;
+  }
+  std::string out;
+  if (auto err = secret.value().read(out); err) {
+    if (ec != nullptr) {
+      *ec = err;
+    }
+    return false;
+  }
+  if (auto err = secret.value().reset(); err) {
+    if (ec != nullptr) {
+      *ec = err;
+    }
+    return false;
+  }
+  return true;
+}
+
+void LinuxKeyringSecret::initialize_process_keyring() noexcept {
+  keyctl_get_keyring_ID(KEY_SPEC_PROCESS_KEYRING, 1);
+}
+
+[[nodiscard]] std::error_code LinuxKeyringSecret::read(std::string& out) const {
+  out.clear();
+  out.resize(_len);
+  const auto ret = keyctl_read(_serial, out.data(), _len);
+  if (ret == -1) {
+    return {errno, std::system_category()};
+  } else if (static_cast<size_t>(ret) != _len) {
+    return {-EINVAL, std::generic_category()};
+  }
+  return {};
+}
+
+[[nodiscard]] std::error_code LinuxKeyringSecret::remove() const {
+  const auto ret = keyctl_invalidate(_serial);
+  if (ret != 0) {
+    return {errno, std::system_category()};
+  }
+  return {};
+}
+
+[[nodiscard]] std::error_code LinuxKeyringSecret::reset() {
+  if (_serial == -1) {
+    return {-EINVAL, std::generic_category()};
+  }
+  if (const auto ret = remove(); !ret) {
+    return ret;
+  }
+  _serial = -1;
+  _len = 0;
+  return {};
+}
+
+[[nodiscard]] bool LinuxKeyringSecret::initialized() const {
+  return _len > 0 && _serial != -1;
+}
+
+#endif
+
+}  // namespace ceph

--- a/src/common/keyring.cc
+++ b/src/common/keyring.cc
@@ -134,7 +134,7 @@ void LinuxKeyringSecret::initialize_process_keyring() noexcept {
   if (_serial == -1) {
     return {-EINVAL, std::generic_category()};
   }
-  if (const auto ret = remove(); !ret) {
+  if (const auto ret = remove(); ret) {
     return ret;
   }
   _serial = -1;

--- a/src/common/keyring.h
+++ b/src/common/keyring.h
@@ -1,0 +1,84 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2025 Clyso GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <ostream>
+#include <system_error>
+#include <utility>
+
+#include "fmt/ostream.h"
+#include "include/expected.hpp"
+
+namespace ceph {
+
+/// RAII style wrapper around a secret stored in the Linux Key
+/// Retention Service.
+/// See: add_key(2), keyctl_read(3), keyctl_invalidate(3)
+class LinuxKeyringSecret {
+  size_t _len;
+  int _serial;
+
+  explicit LinuxKeyringSecret(int serial, size_t len) noexcept;
+ public:
+  LinuxKeyringSecret() = delete;
+  LinuxKeyringSecret(const LinuxKeyringSecret&) = delete;
+  LinuxKeyringSecret& operator=(const LinuxKeyringSecret&) = delete;
+  LinuxKeyringSecret(LinuxKeyringSecret&& other) noexcept
+      : _len(std::exchange(other._len, 0)),
+        _serial(std::exchange(other._serial, -1)) {};
+  LinuxKeyringSecret& operator=(LinuxKeyringSecret&& other) noexcept {
+    if (this != &other) {
+      if (this->initialized()) {
+	this->reset();
+      }
+      _len = std::exchange(other._len, 0);
+      _serial = std::exchange(other._serial, -1);
+    }
+    return *this;
+  };
+
+  ~LinuxKeyringSecret() noexcept;
+
+  // Add a secret to the kernel process keyring. Beware: calling this
+  // with with an existing key _updates_ the value and causes multiple
+  // instances to refer to the same key.
+  static tl::expected<LinuxKeyringSecret, std::error_code> add(
+      const std::string& key, const std::string& secret) noexcept;
+  static bool supported(std::error_code* ec = nullptr) noexcept;
+  // Initialize the process keyring. Do this before starting any
+  // threads that want to share possession of keys in the process
+  // keyring
+  static void initialize_process_keyring() noexcept;
+  [[nodiscard]] std::error_code read(std::string& out) const;
+  [[nodiscard]] std::error_code remove() const;
+  [[nodiscard]] bool initialized() const;
+ private:
+  std::error_code reset();
+
+  friend std::ostream& operator<<(
+      std::ostream& os, const LinuxKeyringSecret& secret) {
+    if (secret._serial == -1) {
+      return os << "LinuxKeyringSecret{}";
+    }
+    return os << "LinuxKeyringSecret{" << secret._serial << "}";
+  }
+  friend class LinuxKeyringTest_LifecycleMoveAssignResetsDestination_Test;
+};
+}  // namespace ceph
+
+#if FMT_VERSION >= 90000
+template <>
+struct fmt::formatter<ceph::LinuxKeyringSecret> : fmt::ostream_formatter {};
+#endif

--- a/src/common/keyring.h
+++ b/src/common/keyring.h
@@ -121,6 +121,7 @@ class LinuxKeyringSecret : public KeyringSecret {
     return os << "LinuxKeyringSecret{" << secret._serial << "}";
   }
   friend class LinuxKeyringTest_LifecycleMoveAssignResetsDestination_Test;
+  friend class LinuxKeyringTest_ResetClearsState_Test;
   friend class LinuxKeyring;
 };
 

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2986,12 +2986,80 @@ options:
   with_legacy: true
 # extra keys that may be used for aws:kms
 # defined as map "key1=YmluCmJvb3N0CmJvb3N0LQ== key2=b3V0CnNyYwpUZXN0aW5nCg=="
+- name: rgw_crypt_s3_kms_cache_enabled
+  type: bool
+  level: advanced
+  desc: Enable caching of encryption keys for SSE-KMS.
+  default: true
+  with_legacy: true
+  services:
+  - rgw
+  see_also:
+  - rgw_crypt_s3_kms_cache_max_size
+  - rgw_crypt_s3_kms_cache_positive_ttl
+  - rgw_crypt_s3_kms_cache_transient_error_ttl
+  - rgw_crypt_s3_kms_cache_negative_ttl
+- name: rgw_crypt_s3_kms_cache_max_size
+  type: uint
+  level: advanced
+  desc: Maximum number of SSE-KMS secrets cached.
+    Each key consumes 32 byte (AES-256) + overhead in memory
+  default: 128
+  with_legacy: true
+  services:
+  - rgw
+  see_also:
+  - rgw_crypt_s3_kms_cache_enabled
+- name: rgw_crypt_s3_kms_cache_positive_ttl
+  type: uint
+  level: advanced
+  desc: Time in seconds after which the KMS cache evicts successful lookups.
+  services:
+  - rgw
+  with_legacy: true
+  default: 60
+  min: 10
+  max: 3600
+  see_also:
+  - rgw_crypt_s3_kms_cache_enabled
 - name: rgw_crypt_s3_kms_encryption_keys
   type: str
   level: dev
   services:
   - rgw
   with_legacy: true
+- name: rgw_crypt_s3_kms_cache_transient_error_ttl
+  type: uint
+  level: advanced
+  desc: Time in seconds after which the KMS cache evicts entries representing transient errors (timeouts, temporary outages, misconfiguration, etc).
+  services:
+  - rgw
+  with_legacy: true
+  default: 10
+  min: 0
+  max: 3600
+  see_also:
+  - rgw_crypt_s3_kms_cache_enabled
+- name: rgw_crypt_s3_kms_cache_negative_ttl
+  type: uint
+  level: advanced
+  desc: Time in seconds after which the KMS cache evicts permanent look-up errors (e.g key does not exist).
+  services:
+  - rgw
+  with_legacy: true
+  default: 120
+  min: 0
+  max: 3600
+  see_also:
+  - rgw_crypt_s3_kms_cache_enabled
+- name: rgw_crypt_s3_kms_testing_delay
+  type: uint
+  level: dev
+  desc: Add delay in milliseconds to the 'testing' KMS key retrieval.
+  services:
+  - rgw
+  with_legacy: true
+  default: 0
 - name: rgw_crypt_vault_auth
   type: str
   level: advanced

--- a/src/common/web_cache.h
+++ b/src/common/web_cache.h
@@ -1,0 +1,559 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2025 Clyso GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
+#include <atomic>
+#include <boost/intrusive/list.hpp>
+#include <chrono>
+#include <iterator>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <ostream>
+#include <shared_mutex>
+#include <unordered_map>
+#include <utility>
+
+#include "common/ceph_context.h"
+#include "common/ceph_time.h"
+#include "include/ceph_assert.h"
+#include "include/common_fwd.h"
+#include "common/perf_counters_collection.h"
+
+// Web Cache
+// A cache for data living on other systems like Key Management Systems
+// Goals/Features
+// (1) Thread safe, bias towards handling highly concurrent lookups
+// (2) Expire entries by ttl
+// (3) Cache replacement tuned to "web" workloads
+//
+// Algorithm
+// The implementation is based on SIEVE [0] with additional TTL
+// expiration support
+//
+// Data Structures
+// - key lookup table: key -> Node{value ptr, metadata) (owns nodes)
+// - SIEVE FIFO + hand intrusive list on lookup's nodes + pointer
+//
+// Cache Stampedes
+//
+// Occurs when numerous threads simultaneously request the same data
+// that is not yet in the cache. This can lead to many redundant,
+// costly requests, that may overwhelm external systems. Although
+// WebCache does not have built-in stampede mitigation, the lookup_or
+// function is designed to be used with additional logic, such as
+// ceph::async::call_once / std::call_once.
+//
+// [0] Zhang, Yazhuo, et al. "{SIEVE} is Simpler than {LRU}: an Efficient
+// {Turn-Key} Eviction Algorithm for Web Caches." 21st USENIX
+// Symposium on Networked Systems Design and Implementation (NSDI 24).
+// 2024.
+
+class WebCacheTest;
+
+namespace webcache {
+
+enum class Metric {
+  metrics_start = 84000,
+  hit,
+  miss,
+  expired,
+  size,
+  capacity,
+  clear,
+  metrics_stop
+};
+
+template <typename Key, typename Value>
+class WebCache {
+ public:
+  // TODO(irq0) let the user choose the value pointer type
+  using ValuePtr = std::shared_ptr<Value>;
+
+ protected:
+  struct Node : public boost::intrusive::list_base_hook<> {
+    std::atomic_bool visited;
+    ceph::real_time expires_at;
+    Key const* key;
+    ValuePtr value;
+
+    explicit Node(ValuePtr value, ceph::timespan ttl)
+        : visited(false),
+          expires_at(ceph::real_clock::now() + ttl),
+          key(nullptr),
+          value(std::move(value)) {};
+    // for testing
+    Node(ValuePtr value, ceph::real_time expires_at)
+        : visited(false),
+          expires_at(expires_at),
+          key(nullptr),
+          value(std::move(value)) {};
+
+    Node(Node&&) = default;
+    Node& operator=(Node&&) = default;
+    Node(const Node&) = delete;
+    Node& operator=(const Node&) = delete;
+    ~Node() = default;
+
+    friend std::ostream& operator<<(
+        std::ostream& os, const WebCache<Key, Value>::Node& node) {
+      fmt::print(
+          os, "$n[{}->{} v:{} expires:{}]", fmt::ptr(node.key),
+          fmt::ptr(node.value.get()), node.visited.load(), node.expires_at);
+      return os;
+    }
+  };
+  using SieveQueue = boost::intrusive::list<Node>;
+
+ private:
+  CephContext* _cct;
+  std::string _name;
+  PerfCounters* _perf;
+  size_t _capacity;
+  ceph::timespan _ttl;
+  std::unordered_map<Key, Node> _lookup;
+  SieveQueue _sieve_queue;
+  Node* _sieve_hand;
+  mutable std::shared_mutex _cache_mutex;
+
+ protected:
+  // sieve_evict removes the next node using the SIEVE algorithm from
+  // _sieve_queue and returns a pointer to the evicted node
+  Node* sieve_evict();
+
+  // sieve_expire_erase_unmutexed removes all expired nodes from the
+  // sieve_queue in place. It writes the expired nodes to out_expired.
+  // Updates the sieve hand
+  static void sieve_expire_erase_unmutexed(
+      SieveQueue& sieve_queue, Node* sieve_hand,
+      ceph::real_time eviction_cutoff, SieveQueue& out_expired);
+
+  using SieveRemoveRet = std::pair<typename SieveQueue::iterator, Node*>;
+  // sieve_remove_unmutexed removes a node from sieve_queue and
+  // returns an iterator to next (or end()) and an updated sieve hand
+  static SieveRemoveRet sieve_remove_unmutexed(
+      SieveQueue& sieve_queue, Node* sieve_hand, const Node& node);
+
+  static PerfCounters* initialize_perf_counters(
+      CephContext* cct, const std::string& name);
+
+  std::optional<ValuePtr> lookup_unmutexed(const Key& key);
+  Node& insert_or_existing_unmutexed(const Key& key, ValuePtr value);
+
+  void perf_tinc(Metric metric, ceph::timespan elapsed) {
+    if (_perf != nullptr) {
+      _perf->tinc(static_cast<int>(metric), elapsed);
+    }
+  }
+  void perf_inc(Metric metric, uint64_t inc = 1) {
+    if (_perf != nullptr) {
+      _perf->inc(static_cast<int>(metric), inc);
+    }
+  }
+  void perf_set(Metric metric, uint64_t set = 1) {
+    if (_perf != nullptr) {
+      _perf->set(static_cast<int>(metric), set);
+    }
+  }
+
+ public:
+  // For testing, custom use
+  explicit WebCache(size_t capacity, ceph::timespan ttl);
+
+  // For system use, activates perf counters
+  WebCache(
+      CephContext* cct, const std::string& name, size_t capacity,
+      ceph::timespan ttl = ceph::timespan::zero());
+
+  // If enabled, remove perf counters (Requires perf counter subsystem
+  // running)
+  ~WebCache();
+
+  // lookup returns the stored value for a given key or not
+  std::optional<ValuePtr> lookup(const Key& key);
+
+  // add caches a key/value pair. If key already exists it does
+  // nothing. Return the stored timestamp of the k/v mapping
+  ceph::real_time add(const Key& key, ValuePtr val);
+
+  // lookup_or returns a value for key. If none is cached yet, insert
+  // new_val and return that. A common use is with
+  // ceph::async::call_once to add cache stampede mitigation
+  ValuePtr lookup_or(const Key& key, ValuePtr new_val);
+
+  // update_ttl_if updates an entry's TTL if its value matches val.
+  // Return true if we updated an entry. False otherwise.
+  bool update_ttl_if(
+      const Key& key, const ValuePtr& val_ptr, ceph::timespan new_ttl);
+
+  // remove_if removes an entry if it finds an entry where its values
+  // matches expected_val. return true if we removed an entry, false
+  // otherwise
+  bool remove_if(const Key& key, const ValuePtr& expected_val);
+
+  size_t size() const;
+  size_t clear();
+
+  // expire_erase erases all expired cache entries
+  size_t expire_erase();
+
+  const std::string& name() { return _name; }
+
+  PerfCounters* perf() { return _perf; }
+
+  friend std::ostream& operator<<(
+      std::ostream& os, const WebCache<Key, Value>& cache) {
+    std::shared_lock<std::shared_mutex> lock(cache._cache_mutex);
+    const auto now = ceph::real_clock::now();
+    os << "$" << cache._name << "[";
+
+    for (const auto& node : cache._sieve_queue) {
+      const auto ttl = node.expires_at - now;
+      fmt::print(
+          os, "\"{}\"({}){}{}", *(node.key),
+          std::chrono::duration_cast<std::chrono::seconds>(ttl),
+          (&node == cache._sieve_hand) ? "👉" : "", node.visited ? "▮" : "▯");
+      if (&node != &cache._sieve_queue.back()) {
+        os << ", ";
+      }
+    }
+    os << "]";
+    return os;
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, const SieveQueue& nodes) {
+    for (const auto& node : nodes) {
+      os << node;
+      if (&node != &nodes.back()) {
+        os << ", ";
+      }
+    }
+    return os;
+  }
+
+  friend class WebCacheTest;
+  friend class WebCacheConcurrencyTest;
+  friend class WebCacheRandomizedTest;
+  friend class WebCacheTest_SieveExample_Test;
+  friend class WebCacheTest_ExpireEraseOne_Test;
+  friend class WebCacheTest_ExpireEraseAll_Test;
+  friend class WebCacheTest_ExpireEraseEmpty_Test;
+  friend class WebCacheTest_ExpireEraseUpdatedTTLs_Test;
+  friend class WebCacheTest_SieveRemoveHand_Test;
+};
+
+template <typename Key, typename Value>
+WebCache<Key, Value>::Node* WebCache<Key, Value>::sieve_evict() {
+  if (_sieve_queue.empty()) {
+    return nullptr;
+  }
+  if (_sieve_hand == nullptr) {
+    _sieve_hand = &_sieve_queue.back();
+  }
+  Node* result = nullptr;
+  const size_t queue_size_before = _sieve_queue.size();
+
+  auto hand = _sieve_queue.iterator_to(*_sieve_hand);
+  const auto rev_it = typename SieveQueue::reverse_iterator(std::next(hand));
+  for (auto it = rev_it; it != _sieve_queue.rend(); ++it) {
+    Node& node = (*it);
+    if (node.visited) {
+      node.visited = false;
+      --hand;
+    } else {
+      hand = std::prev(_sieve_queue.erase(std::next(it).base()));
+      result = &node;
+      break;
+    }
+  }
+  // every node was visited. we need still need to evict the tail
+  if (result == nullptr) {
+    result = &_sieve_queue.back();
+    _sieve_queue.pop_back();
+  }
+
+  ceph_assertf(
+      queue_size_before == 0 || (queue_size_before - _sieve_queue.size()) == 1,
+      "%d -> %d capacity:%d", queue_size_before, _sieve_queue.size(),
+      _capacity);
+  _sieve_hand = (hand == _sieve_queue.begin()) ? &_sieve_queue.back() : &*hand;
+  return result;
+}
+
+template <typename Key, typename Value>
+WebCache<Key, Value>::WebCache(size_t capacity, ceph::timespan ttl)
+    : _cct(nullptr),
+      _perf(nullptr),
+      _capacity(capacity),
+      _ttl(ttl),
+      _lookup(),
+      _sieve_queue(),
+      _sieve_hand(nullptr) {}
+
+template <typename Key, typename Value>
+WebCache<Key, Value>::WebCache(
+    CephContext* cct, const std::string& name, size_t capacity,
+    ceph::timespan ttl)
+    : _cct(cct),
+      _name(name),
+      _perf(initialize_perf_counters(cct, name)),
+      _capacity(capacity),
+      _ttl(ttl),
+      _lookup(),
+      _sieve_queue(),
+      _sieve_hand(nullptr) {
+  ceph_assert(cct != nullptr);
+  perf_set(Metric::capacity, capacity);
+}
+
+template <typename Key, typename Value>
+WebCache<Key, Value>::~WebCache() {
+  if (_cct != nullptr && _perf != nullptr) {
+    _cct->get_perfcounters_collection()->remove(_perf);
+  }
+}
+
+template <typename Key, typename Value>
+PerfCounters* WebCache<Key, Value>::initialize_perf_counters(
+    CephContext* cct, const std::string& name) {
+  PerfCountersBuilder pcb(
+      cct, name, static_cast<int>(Metric::metrics_start),
+      static_cast<int>(Metric::metrics_stop));
+  pcb.set_prio_default(PerfCountersBuilder::PRIO_USEFUL);
+  pcb.add_u64_counter(static_cast<int>(Metric::hit), "hit", "Cache hits");
+  pcb.add_u64_counter(static_cast<int>(Metric::miss), "miss", "Cache misses");
+  pcb.add_u64_counter(
+      static_cast<int>(Metric::expired), "expired", "Expired cache entries");
+  pcb.add_u64(
+      static_cast<int>(Metric::size), "size", "Total number of cache entries");
+  pcb.add_u64(
+      static_cast<int>(Metric::capacity), "capacity", "Maximum cache capacity");
+  pcb.add_u64_counter(
+      static_cast<int>(Metric::clear), "clear", "Total number of cache clears");
+
+  auto* perf = pcb.create_perf_counters();
+  cct->get_perfcounters_collection()->add(perf);
+  return perf;
+}
+
+template <typename Key, typename Value>
+size_t WebCache<Key, Value>::size() const {
+  std::shared_lock<std::shared_mutex> lock(_cache_mutex);
+  ceph_assert(_lookup.size() == _sieve_queue.size());
+  return _lookup.size();
+}
+
+template <typename Key, typename Value>
+size_t WebCache<Key, Value>::clear() {
+  std::lock_guard<std::shared_mutex> lock(_cache_mutex);
+  perf_inc(Metric::clear);
+  const size_t size_before = _sieve_queue.size();
+  _sieve_queue.clear();
+  _sieve_hand = nullptr;
+  _lookup.clear();
+  perf_set(Metric::size, 0);
+  perf_set(Metric::hit, 0);
+  perf_set(Metric::miss, 0);
+  perf_set(Metric::expired, 0);
+  return size_before;
+}
+
+template <typename Key, typename Value>
+ceph::real_time WebCache<Key, Value>::add(const Key& key, ValuePtr value) {
+  // cache hit - fast under read lock
+  {
+    std::shared_lock<std::shared_mutex> lock(_cache_mutex);
+    if (auto search = _lookup.find(key); search != _lookup.end()) {
+      perf_inc(Metric::hit);
+      search->second.visited = true;
+      return search->second.expires_at;
+    }
+  }
+  // miss, take unique lock
+  {
+    std::lock_guard<std::shared_mutex> lock(_cache_mutex);
+    return insert_or_existing_unmutexed(key, value).expires_at;
+  }
+}
+
+template <typename Key, typename Value>
+WebCache<Key, Value>::ValuePtr WebCache<Key, Value>::lookup_or(
+    const Key& key, ValuePtr new_val) {
+  {
+    std::shared_lock<std::shared_mutex> cache_lock(_cache_mutex);
+    auto maybe_value = lookup_unmutexed(key);
+    if (maybe_value.has_value()) {
+      perf_inc(Metric::hit);
+      return maybe_value.value();
+    }
+  }
+
+  // miss, take unique lock
+  {
+    std::lock_guard<std::shared_mutex> lock(_cache_mutex);
+    return insert_or_existing_unmutexed(key, new_val).value;
+  }
+}
+
+template <typename Key, typename Value>
+bool WebCache<Key, Value>::update_ttl_if(
+    const Key& key, const ValuePtr& val, ceph::timespan new_ttl) {
+  std::lock_guard<std::shared_mutex> lock(_cache_mutex);
+  if (auto search = _lookup.find(key);
+      (search != _lookup.end() && search->second.value == val)) {
+    search->second.expires_at = ceph::real_clock::now() + new_ttl;
+    return true;
+  }
+  return false;
+}
+
+template <typename Key, typename Value>
+bool WebCache<Key, Value>::remove_if(
+    const Key& key, const ValuePtr& expected_val) {
+  std::lock_guard<std::shared_mutex> lock(_cache_mutex);
+  if (auto search = _lookup.find(key);
+      (search != _lookup.end() && search->second.value == expected_val)) {
+    auto [_, hand_moved] =
+        sieve_remove_unmutexed(_sieve_queue, _sieve_hand, search->second);
+    _lookup.erase(search);
+    _sieve_hand = hand_moved;
+    return true;
+  }
+  return false;
+}
+
+template <typename Key, typename Value>
+std::optional<typename WebCache<Key, Value>::ValuePtr>
+WebCache<Key, Value>::lookup_unmutexed(const Key& key) {
+  if (auto search = _lookup.find(key); search != _lookup.end()) {  // cache hit
+    search->second.visited = true;
+    return search->second.value;
+  } else {
+    return std::nullopt;
+  }
+}
+
+template <typename Key, typename Value>
+WebCache<Key, Value>::Node& WebCache<Key, Value>::insert_or_existing_unmutexed(
+    const Key& key, ValuePtr value) {
+  const auto& [it, took_place] = _lookup.emplace(
+      std::piecewise_construct, std::forward_as_tuple(key),
+      std::forward_as_tuple(std::move(value), _ttl));
+
+  if (took_place) {  // cache miss
+    perf_inc(Metric::miss);
+
+    ceph_assert(_lookup.size() == _sieve_queue.size() + 1);
+    // cache full? -> evict
+    if (_sieve_queue.size() >= _capacity) {
+      const auto node = sieve_evict();
+      if (node != nullptr) {
+        _lookup.erase(*(node->key));
+      }
+    }
+    auto& [stored_key, node] = *it;
+    node.key = &stored_key;
+    _sieve_queue.push_front(node);
+    perf_set(Metric::size, _lookup.size());
+    return node;
+  } else {  // cache hit
+    perf_inc(Metric::hit);
+    it->second.visited = true;
+    return it->second;
+  }
+}
+
+template <typename Key, typename Value>
+WebCache<Key, Value>::SieveRemoveRet
+WebCache<Key, Value>::sieve_remove_unmutexed(
+    SieveQueue& sieve_queue, Node* sieve_hand, const Node& node) {
+  const bool was_hand = &node == sieve_hand;
+  const auto node_it = sieve_queue.iterator_to(node);
+  auto it = sieve_queue.erase(node_it);
+  if (sieve_queue.empty()) {
+    return {sieve_queue.end(), nullptr};
+  }
+  if (was_hand) {
+    return {
+        it,
+        (it == sieve_queue.begin()) ? &sieve_queue.back() : &(*std::prev(it))};
+  }
+  return {it, sieve_hand};
+}
+
+template <typename Key, typename Value>
+std::optional<typename WebCache<Key, Value>::ValuePtr>
+WebCache<Key, Value>::lookup(const Key& key) {
+  std::shared_lock<std::shared_mutex> lock(_cache_mutex);
+  auto result = lookup_unmutexed(key);
+  if (result.has_value()) {
+    perf_inc(Metric::hit);
+  } else {
+    perf_inc(Metric::miss);
+  }
+  return result;
+}
+
+template <typename Key, typename Value>
+void WebCache<Key, Value>::sieve_expire_erase_unmutexed(
+    SieveQueue& sieve_queue, Node* sieve_hand, ceph::real_time eviction_cutoff,
+    SieveQueue& out_expired) {
+  // The sieve queue is ordered by ascending insertion time which
+  // would allow for efficient epiration by finding the first not
+  // expired element. BUT, since we allow updating TTLs this property
+  // no longer holds and we have do a full sieve queue sweep.
+  for (auto it = sieve_queue.begin(); it != sieve_queue.end();) {
+    Node& node = (*it);
+    const bool expired = node.expires_at <= eviction_cutoff;
+    if (expired) {
+      auto [next_it, next_hand] =
+          sieve_remove_unmutexed(sieve_queue, sieve_hand, node);
+      ceph_assert(!node.is_linked());
+      out_expired.push_back(node);
+      it = next_it;
+      sieve_hand = next_hand;
+    } else {
+      ++it;
+    }
+  }
+}
+
+template <typename Key, typename Value>
+size_t WebCache<Key, Value>::expire_erase() {
+  std::lock_guard<std::shared_mutex> lock(_cache_mutex);
+  const auto expiration_cutoff = ceph::real_clock::now();
+  const auto lookup_size_before = _lookup.size();
+  SieveQueue expired;
+  sieve_expire_erase_unmutexed(
+      _sieve_queue, _sieve_hand, expiration_cutoff, expired);
+  const auto expired_size = expired.size();
+  expired.clear_and_dispose(
+      [&](const Node* node) { _lookup.erase(*node->key); });
+  ceph_assert((lookup_size_before - expired_size) == _lookup.size());
+  perf_inc(Metric::expired, expired_size);
+  perf_set(Metric::size, _lookup.size());
+  return expired_size;
+}
+
+}  // namespace webcache
+
+#if FMT_VERSION >= 90000
+template <typename Key, typename Value>
+struct fmt::formatter<webcache::WebCache<Key, Value>> : fmt::ostream_formatter {
+};
+#endif

--- a/src/common/web_cache.h
+++ b/src/common/web_cache.h
@@ -325,6 +325,7 @@ template <typename Key, typename Value>
 WebCache<Key, Value>::~WebCache() {
   if (_cct != nullptr && _perf != nullptr) {
     _cct->get_perfcounters_collection()->remove(_perf);
+    delete _perf;
   }
 }
 

--- a/src/common/web_cache.h
+++ b/src/common/web_cache.h
@@ -138,8 +138,8 @@ class WebCache {
 
   // sieve_expire_erase_unmutexed removes all expired nodes from the
   // sieve_queue in place. It writes the expired nodes to out_expired.
-  // Updates the sieve hand
-  static void sieve_expire_erase_unmutexed(
+  // Returns the updated sieve hand.
+  static Node* sieve_expire_erase_unmutexed(
       SieveQueue& sieve_queue, Node* sieve_hand,
       ceph::real_time eviction_cutoff, SieveQueue& out_expired);
 
@@ -511,7 +511,7 @@ WebCache<Key, Value>::lookup(const Key& key) {
 }
 
 template <typename Key, typename Value>
-void WebCache<Key, Value>::sieve_expire_erase_unmutexed(
+typename WebCache<Key, Value>::Node* WebCache<Key, Value>::sieve_expire_erase_unmutexed(
     SieveQueue& sieve_queue, Node* sieve_hand, ceph::real_time eviction_cutoff,
     SieveQueue& out_expired) {
   // The sieve queue is ordered by ascending insertion time which
@@ -532,6 +532,7 @@ void WebCache<Key, Value>::sieve_expire_erase_unmutexed(
       ++it;
     }
   }
+  return sieve_hand;
 }
 
 template <typename Key, typename Value>
@@ -540,7 +541,7 @@ size_t WebCache<Key, Value>::expire_erase() {
   const auto expiration_cutoff = ceph::real_clock::now();
   const auto lookup_size_before = _lookup.size();
   SieveQueue expired;
-  sieve_expire_erase_unmutexed(
+  _sieve_hand = sieve_expire_erase_unmutexed(
       _sieve_queue, _sieve_hand, expiration_cutoff, expired);
   const auto expired_size = expired.size();
   expired.clear_and_dispose(

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -305,6 +305,7 @@ target_link_libraries(rgw_common
     cls_version_client
     librados
     libneorados
+    keyring
     rt
     ICU::uc
     OATH::OATH

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -148,6 +148,7 @@ set(librgw_common_srcs
   rgw_rest_iam.cc
   rgw_object_lock.cc
   rgw_kms.cc
+  rgw_kms_cache.cc
   rgw_kmip_client.cc
   rgw_url.cc
   rgw_oidc_provider.cc

--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -636,12 +636,13 @@ void rgw::AppMain::shutdown(std::function<void(void)> finalize_async_signals)
     }
   }
 
-  env.kms_cache.reset();
-
   for (auto& fe : fes) {
     fe->stop();
   }
 
+  if (env.kms_cache) {
+    env.kms_cache->stop_ttl_reaper();
+  }
   ldh.reset(nullptr); // deletes ldap helper if it was created
   rgw_log_usage_finalize();
 

--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -25,6 +25,7 @@
 #include "include/compat.h"
 #include "include/str_list.h"
 #include "include/stringify.h"
+#include "rgw_kms_cache.h"
 #include "rgw_main.h"
 #include "rgw_asio_thread.h"
 #include "rgw_common.h"
@@ -480,6 +481,12 @@ int rgw::AppMain::init_frontends2(RGWLib* rgwlib)
     else if (framework == "beast") {
       need_context_pool();
       fe = new RGWAsioFrontend(env, config, *sched_ctx, *context_pool);
+      if (g_conf()->rgw_crypt_s3_kms_cache_enabled) {
+        env.kms_cache->initialize_ttl_reaper(
+            g_conf()->rgw_beast_enable_async
+            ? std::optional(context_pool->get_executor())
+                : std::nullopt);
+      }
     }
     else if (framework == "rgw-nfs") {
       fe = new RGWLibFrontend(env, config);
@@ -607,6 +614,15 @@ void rgw::AppMain::init_dedup()
   }
 }
 
+void rgw::AppMain::init_kms_cache()
+{
+  if (!g_conf().get_val<bool>("rgw_crypt_s3_kms_cache_enabled")) {
+    return;
+  }
+  env.kms_cache = std::make_unique<rgw::kms::KMSCache>(
+      dpp->get_cct(), Keyring::get_best());
+}
+
 void rgw::AppMain::shutdown(std::function<void(void)> finalize_async_signals)
 {
   if (env.driver->get_name() == "rados") {
@@ -619,6 +635,8 @@ void rgw::AppMain::shutdown(std::function<void(void)> finalize_async_signals)
       dedup_background->unwatch_reload(dpp);
     }
   }
+
+  env.kms_cache.reset();
 
   for (auto& fe : fes) {
     fe->stop();

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -17,6 +17,7 @@
 #include "crypto/crypto_accel.h"
 #include "crypto/crypto_plugin.h"
 #include "rgw/rgw_kms.h"
+#include "rgw/rgw_process_env.h"
 #include "rapidjson/document.h"
 #include "rapidjson/writer.h"
 #include "rapidjson/error/error.h"
@@ -1191,7 +1192,7 @@ int rgw_s3_prepare_encrypt(req_state* s, optional_yield y,
         set_attr(attrs, RGW_ATTR_CRYPT_KEYSEL, key_selector);
         set_attr(attrs, RGW_ATTR_CRYPT_CONTEXT, cooked_context);
         std::string actual_key;
-        res = make_actual_key_from_kms(s, attrs, y, actual_key);
+        res = make_actual_key_from_kms(s, attrs, s->penv.kms_cache.get(), y, actual_key);
         if (res != 0) {
           ldpp_dout(s, 5) << "ERROR: failed to retrieve actual key from key_id: " << key_id << dendl;
           s->err.message = "Failed to retrieve the actual key, kms-keyid: " + std::string(key_id);
@@ -1429,7 +1430,8 @@ int rgw_s3_prepare_decrypt(req_state* s, optional_yield y,
     /* try to retrieve actual key */
     std::string key_id = get_str_attribute(attrs, RGW_ATTR_CRYPT_KEYID);
     std::string actual_key;
-    res = reconstitute_actual_key_from_kms(s, attrs, y, actual_key);
+
+    res = reconstitute_actual_key_from_kms(s, attrs, s->penv.kms_cache.get(), y, actual_key);
     if (res != 0) {
       ldpp_dout(s, 10) << "ERROR: failed to retrieve actual key from key_id: " << key_id << dendl;
       s->err.message = "Failed to retrieve the actual key, kms-keyid: " + key_id;

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -1196,6 +1196,19 @@ int reconstitute_actual_key_from_kms(
                      << dendl;
   ldpp_dout(dpp, 20) << "SSE-KMS backend is " << kms_backend << dendl;
 
+  std::string cache_key_id = key_id;
+  if (RGW_SSE_KMS_BACKEND_VAULT == kms_backend &&
+      kctx.secret_engine() == RGW_SSE_KMS_VAULT_SE_TRANSIT) {
+    const std::string wrapped_key =
+        get_str_attribute(attrs, RGW_ATTR_CRYPT_DATAKEY);
+    // Vault Transit in "old" compat mode behaves like the other K/V
+    // style KMS in that it does not use DATAKEY.
+    if (!wrapped_key.empty()) {
+      cache_key_id = string_cat_reserve(
+          key_id, "T", calc_hash_sha256(wrapped_key).to_str());
+    }
+  }
+
   const auto fetch = [&](std::string& out_secret) -> int {
     PerfGuard perf(perfcounter, l_rgw_kms_fetch_lat);
     if (RGW_SSE_KMS_BACKEND_BARBICAN == kms_backend) {
@@ -1225,7 +1238,7 @@ int reconstitute_actual_key_from_kms(
   };
   const std::string cache_prefix = string_cat_reserve("kms_", kms_backend);
   return maybe_cache_kms_fetch(
-      dpp, cache_prefix, key_id, kms_cache, fetch, actual_key, y);
+      dpp, cache_prefix, cache_key_id, kms_cache, fetch, actual_key, y);
 }
 
 int make_actual_key_from_kms(const DoutPrefixProvider *dpp,

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -1207,6 +1207,15 @@ int reconstitute_actual_key_from_kms(
       cache_key_id = string_cat_reserve(
           key_id, "T", calc_hash_sha256(wrapped_key).to_str());
     }
+  } else if (RGW_SSE_KMS_BACKEND_TESTING == kms_backend) {
+    // The testing backend uses keysel to derive per-object keys with
+    // the same keyid.
+    const std::string key_selector =
+        get_str_attribute(attrs, RGW_ATTR_CRYPT_KEYSEL);
+    if (!key_selector.empty()) {
+      cache_key_id = string_cat_reserve(
+          key_id, "S", calc_hash_sha256(key_selector).to_str());
+    }
   }
 
   const auto fetch = [&](std::string& out_secret) -> int {

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -13,6 +13,9 @@
 #include "rgw/rgw_b64.h"
 #include "rgw/rgw_kms.h"
 #include "rgw/rgw_kmip_client.h"
+#include "rgw/rgw_perf_counters.h"
+#include "rgw_kms_cache.h"
+#include "rgw_string.h"
 #include <rapidjson/allocators.h>
 #include <rapidjson/document.h>
 #include <rapidjson/writer.h>
@@ -1164,41 +1167,70 @@ public:
   };
 };
 
-int reconstitute_actual_key_from_kms(const DoutPrefixProvider *dpp,
-                                     map<string, bufferlist>& attrs,
-                                     optional_yield y,
-                                     std::string& actual_key)
-{
-  std::string key_id = get_str_attribute(attrs, RGW_ATTR_CRYPT_KEYID);
-  KMSContext kctx { dpp->get_cct() };
-  const std::string &kms_backend { kctx.backend() };
+static int maybe_cache_kms_fetch(
+    const DoutPrefixProvider* dpp, const std::string& cache_prefix,
+    const std::string& key_id, rgw::kms::KMSCache* kms_cache,
+    const kms::KMSCache::FetchFn& fetch, std::string& actual_key,
+    optional_yield y) {
+  if (kms_cache == nullptr ||
+      !dpp->get_cct()->_conf->rgw_crypt_s3_kms_cache_enabled) {
+    const auto ret = fetch(actual_key);
+    if (ret == -ENOENT) {
+      perfcounter->inc(l_rgw_kms_error_permanent);
+    } else if (ret < 0) {
+      perfcounter->inc(l_rgw_kms_error_transient);
+    }
+    return ret;
+  }
+  return kms_cache->do_cache(dpp, cache_prefix, key_id, fetch, actual_key, y);
+}
 
-  ldpp_dout(dpp, 20) << "Getting KMS encryption key for key " << key_id << dendl;
+int reconstitute_actual_key_from_kms(
+    const DoutPrefixProvider* dpp, map<string, bufferlist>& attrs,
+    rgw::kms::KMSCache* kms_cache, optional_yield y, std::string& actual_key) {
+  std::string key_id = get_str_attribute(attrs, RGW_ATTR_CRYPT_KEYID);
+  KMSContext kctx{dpp->get_cct()};
+  const std::string& kms_backend{kctx.backend()};
+
+  ldpp_dout(dpp, 20) << "Getting KMS encryption key for key " << key_id
+                     << dendl;
   ldpp_dout(dpp, 20) << "SSE-KMS backend is " << kms_backend << dendl;
 
-  if (RGW_SSE_KMS_BACKEND_BARBICAN == kms_backend) {
-    return get_actual_key_from_barbican(dpp, key_id, y, actual_key);
-  }
+  const auto fetch = [&](std::string& out_secret) -> int {
+    PerfGuard perf(perfcounter, l_rgw_kms_fetch_lat);
+    if (RGW_SSE_KMS_BACKEND_BARBICAN == kms_backend) {
+      return get_actual_key_from_barbican(dpp, key_id, y, out_secret);
+    }
 
-  if (RGW_SSE_KMS_BACKEND_VAULT == kms_backend) {
-    return reconstitute_actual_key_from_vault(dpp, kctx, attrs, y, actual_key);
-  }
+    if (RGW_SSE_KMS_BACKEND_VAULT == kms_backend) {
+      return reconstitute_actual_key_from_vault(
+          dpp, kctx, attrs, y, out_secret);
+    }
 
-  if (RGW_SSE_KMS_BACKEND_KMIP == kms_backend) {
-    return get_actual_key_from_kmip(dpp, key_id, y, actual_key);
-  }
+    if (RGW_SSE_KMS_BACKEND_KMIP == kms_backend) {
+      return get_actual_key_from_kmip(dpp, key_id, y, out_secret);
+    }
 
-  if (RGW_SSE_KMS_BACKEND_TESTING == kms_backend) {
-    std::string key_selector = get_str_attribute(attrs, RGW_ATTR_CRYPT_KEYSEL);
-    return get_actual_key_from_conf(dpp, key_id, key_selector, actual_key);
-  }
-
-  ldpp_dout(dpp, 0) << "ERROR: Invalid rgw_crypt_s3_kms_backend: " << kms_backend << dendl;
-  return -EINVAL;
+    if (RGW_SSE_KMS_BACKEND_TESTING == kms_backend) {
+      std::string key_selector =
+          get_str_attribute(attrs, RGW_ATTR_CRYPT_KEYSEL);
+      std::this_thread::sleep_for(
+          std::chrono::milliseconds(
+              dpp->get_cct()->_conf->rgw_crypt_s3_kms_testing_delay));
+      return get_actual_key_from_conf(dpp, key_id, key_selector, out_secret);
+    }
+    ldpp_dout(dpp, 0) << "ERROR: Invalid rgw_crypt_s3_kms_backend: "
+                      << kms_backend << dendl;
+    return -EINVAL;
+  };
+  const std::string cache_prefix = string_cat_reserve("kms_", kms_backend);
+  return maybe_cache_kms_fetch(
+      dpp, cache_prefix, key_id, kms_cache, fetch, actual_key, y);
 }
 
 int make_actual_key_from_kms(const DoutPrefixProvider *dpp,
                              map<string, bufferlist>& attrs,
+                             rgw::kms::KMSCache* kms_cache,
                              optional_yield y,
                              std::string& actual_key)
 {
@@ -1206,7 +1238,7 @@ int make_actual_key_from_kms(const DoutPrefixProvider *dpp,
   const std::string &kms_backend { kctx.backend() };
   if (RGW_SSE_KMS_BACKEND_VAULT == kms_backend)
     return make_actual_key_from_vault(dpp, kctx, attrs, y, actual_key);
-  return reconstitute_actual_key_from_kms(dpp, attrs, y, actual_key);
+  return reconstitute_actual_key_from_kms(dpp, attrs, kms_cache, y, actual_key);
 }
 
 int reconstitute_actual_key_from_sse_s3(const DoutPrefixProvider *dpp,

--- a/src/rgw/rgw_kms.h
+++ b/src/rgw/rgw_kms.h
@@ -22,6 +22,10 @@ static const std::string RGW_SSE_KMS_VAULT_SE_KV = "kv";
 
 static const std::string RGW_SSE_KMS_KMIP_SE_KV = "kv";
 
+namespace rgw::kms {
+  class KMSCache;
+}
+
 /**
  * Retrieves the actual server-side encryption key from a KMS system given a
  * key ID. Currently supported KMS systems are OpenStack Barbican and HashiCorp
@@ -34,10 +38,12 @@ static const std::string RGW_SSE_KMS_KMIP_SE_KV = "kv";
  */
 int make_actual_key_from_kms(const DoutPrefixProvider *dpp,
                              std::map<std::string, bufferlist>& attrs,
+                             rgw::kms::KMSCache* kms_cache,
                              optional_yield y,
                              std::string& actual_key);
 int reconstitute_actual_key_from_kms(const DoutPrefixProvider *dpp,
                                      std::map<std::string, bufferlist>& attrs,
+                                     rgw::kms::KMSCache* kms_cache,
                                      optional_yield y,
                                      std::string& actual_key);
 int make_actual_key_from_sse_s3(const DoutPrefixProvider *dpp,

--- a/src/rgw/rgw_kms_cache.cc
+++ b/src/rgw/rgw_kms_cache.cc
@@ -1,0 +1,256 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2025 Clyso GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "rgw_kms_cache.h"
+
+#include <boost/asio/associated_executor.hpp>
+#include <boost/asio/bind_cancellation_slot.hpp>
+#include <boost/asio/bind_executor.hpp>
+#include <boost/asio/cancellation_signal.hpp>
+#include <boost/asio/cancellation_type.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/use_future.hpp>
+#include <boost/asio/error.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/spawn.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <boost/asio/strand.hpp>
+#include <utility>
+#include <variant>
+
+#include "common/async/yield_context.h"
+#include "common/dout.h"
+#include "common/dout_fmt.h"
+#include "common/keyring.h"
+#include "include/ceph_assert.h"
+#include "include/function2.hpp"
+#include "rgw_perf_counters.h"
+#include "rgw_string.h"
+
+#define dout_context g_ceph_context
+#define dout_subsys  ceph_subsys_rgw
+
+namespace rgw::kms {
+
+std::jthread KMSCache::make_ttl_reaper_thread(
+    CephContext* cct, KMSSecretCache& cache, std::chrono::seconds ttl) {
+  return std::jthread([cct, &cache, ttl](std::stop_token stop) {
+    const std::string thread_name = fmt::format("{}-ttl-reaper", cache.name());
+    ceph_pthread_setname(thread_name.c_str());
+    std::mutex mutex;
+    std::condition_variable cond;
+    std::stop_callback on_stop(stop, [&cond]() { cond.notify_all(); });
+    ldout(cct, 10) << "KMS Cache: Starting TTL reaper thread " << thread_name
+                   << "/" << std::hex << std::this_thread::get_id() << std::dec
+                   << ", running every " << ttl << dendl;
+    while (!stop.stop_requested()) {
+      std::unique_lock<std::mutex> lock(mutex);
+      if (cond.wait_for(lock, ttl, [&stop] { return stop.stop_requested(); })) {
+        break;
+      }
+      const auto expired_count = cache.expire_erase();
+      ldout(cct, 20) << "KMS Cache: TTL reaper thread expired " << expired_count
+                     << " entries" << dendl;
+    }
+    ldout(cct, 10) << "KMS Cache: Stopping TTL reaper thread " << thread_name
+                   << "/" << std::hex << std::this_thread::get_id() << std::dec
+                   << dendl;
+  });
+}
+
+std::future<void> KMSCache::make_ttl_reaper_async(
+    CephContext* cct, KMSSecretCache& cache, std::chrono::seconds ttl,
+    const boost::asio::strand<boost::asio::io_context::executor_type>& strand,
+    boost::asio::cancellation_signal& cancel_signal) {
+  return boost::asio::spawn(
+      strand,
+      [cct, &cache, ttl](const boost::asio::yield_context& yield) {
+        ldout(cct, 10) << "KMS Cache: Starting async TTL reaper, running every "
+                       << ttl << dendl;
+        boost::asio::steady_timer timer(yield.get_executor());
+        while (true) {
+          timer.expires_after(ttl);
+          boost::system::error_code ec;
+          timer.async_wait(yield[ec]);
+          if (ec == boost::asio::error::operation_aborted) {
+            ldout(cct, 10) << "KMS Cache: Stopping async TTL reaper" << dendl;
+            break;
+          }
+          const auto expired_count = cache.expire_erase();
+          ldout(cct, 20) << "KMS Cache: Async TTL reaper expired "
+                         << expired_count << " entries" << dendl;
+        }
+      },
+      boost::asio::bind_cancellation_slot(
+          cancel_signal.slot(),
+          boost::asio::bind_executor(strand, boost::asio::use_future)));
+}
+
+KMSCache::KMSCache(CephContext* _cct, std::unique_ptr<Keyring> _keyring)
+    : cct(_cct), keyring(std::move(_keyring)) {
+  ldout(cct, 10) << fmt::format(
+                        "KMS Cache: Initializing size:{} TTL pos:{} "
+                        "neg:{} err:{}",
+                        cct->_conf->rgw_crypt_s3_kms_cache_max_size,
+                        cct->_conf->rgw_crypt_s3_kms_cache_positive_ttl,
+                        cct->_conf->rgw_crypt_s3_kms_cache_negative_ttl,
+                        cct->_conf->rgw_crypt_s3_kms_cache_transient_error_ttl)
+                 << dendl;
+  cache = std::make_unique<KMSSecretCache>(
+      cct, "kms-cache", cct->_conf->rgw_crypt_s3_kms_cache_max_size,
+      std::chrono::seconds(cct->_conf->rgw_crypt_s3_kms_cache_positive_ttl));
+
+  std::error_code ec;
+  if (!keyring->supported(&ec)) {
+    ldout(cct, 1) << "KMS Cache: " << keyring->name() << " unsupported (error "
+                  << ec << "). Disabling Cache." << dendl;
+    cct->_conf->rgw_crypt_s3_kms_cache_enabled = false;
+  }
+}
+
+KMSCache::~KMSCache() {
+  stop_ttl_reaper();
+}
+
+void KMSCache::initialize_ttl_reaper(
+    std::optional<boost::asio::io_context::executor_type> executor) {
+  ceph_assert(cache);
+  if (reaper_initialized()) {
+    return;
+  }
+  const auto min_ttl_secs = std::min(
+      {cct->_conf->rgw_crypt_s3_kms_cache_positive_ttl,
+       cct->_conf->rgw_crypt_s3_kms_cache_negative_ttl,
+       cct->_conf->rgw_crypt_s3_kms_cache_transient_error_ttl});
+  if (executor.has_value()) {
+    auto& state = reaper_state.emplace<AsyncState>(executor.value());
+    state.done = make_ttl_reaper_async(
+        cct, *cache, std::chrono::seconds(min_ttl_secs),
+        state.strand, state.cancel_signal);
+  } else {
+    reaper_state.emplace<std::jthread>(make_ttl_reaper_thread(
+        cct, *cache, std::chrono::seconds(min_ttl_secs)));
+  }
+}
+
+void KMSCache::stop_ttl_reaper() {
+  ceph_assert(cache);
+  std::visit(
+      fu2::overload(
+          [](const std::monostate& mono) {},
+          [](AsyncState& async_state) {
+            boost::asio::dispatch(
+                async_state.strand,
+                [&signal = async_state.cancel_signal]() {
+                  signal.emit(boost::asio::cancellation_type::terminal);
+            });
+            try {
+              async_state.done.wait();
+            } catch (const std::future_error& e) {
+              if (e.code() != std::future_errc::no_state) throw;
+            }
+          },
+          [&](const std::jthread&) { reaper_state.emplace<std::monostate>(); }),
+      reaper_state);
+}
+
+void KMSCache::clear_cache() const {
+  cache->clear();
+}
+
+int KMSCache::do_cache(
+    const DoutPrefixProvider* dpp, const std::string& key_prefix_kms,
+    const std::string& key_id, const FetchFn& fetch, std::string& actual_key,
+    optional_yield y) {
+  static std::string_view key_prefix("rgw_sse_");
+  const std::string cache_key =
+      string_cat_reserve(key_prefix, key_prefix_kms, "_", key_id);
+  std::shared_ptr<KMSCache::CacheValue> value =
+      cache->lookup_or(key_id, std::make_shared<KMSCache::CacheValue>());
+  auto result = call_once(
+      *value, y,
+      [&dpp, &fetch, &cache_key, &value, &key_prefix_kms, &key_id,
+       this]() -> KMSCache::CacheResult {
+        std::string secret;
+        const int ret = fetch(secret);
+        ldpp_dout(dpp, 20) << "KMS Cache: " << cache_key
+                           << " call_once fetched with ret " << ret << dendl;
+
+        if (ret == -ENOENT) {  // key does not exists, treat as permanent error
+          ldpp_dout(dpp, 15)
+              << "KMS Cache: " << cache_key
+              << " key does not exists. treating as permanent error " << dendl;
+          cache->update_ttl_if(
+              cache_key, value,
+              std::chrono::seconds(
+                  dpp->get_cct()->_conf->rgw_crypt_s3_kms_cache_negative_ttl));
+          perfcounter->inc(l_rgw_kms_error_permanent);
+          return tl::unexpected(ret);
+        } else if (ret < 0) {  // treat other errors as transient
+          ldpp_dout(dpp, 15)
+              << "KMS Cache: " << cache_key << " fetch error (" << ret << ") "
+              << std::strerror(ret) << " treating as transient error " << dendl;
+          cache->update_ttl_if(
+              cache_key, value,
+              std::chrono::seconds(
+                  dpp->get_cct()
+                      ->_conf->rgw_crypt_s3_kms_cache_transient_error_ttl));
+          perfcounter->inc(l_rgw_kms_error_transient);
+          return tl::unexpected(ret);
+        }
+
+        // This function might be in flight for the same key_id more than
+        // once. The keyring key must, however, be unique to not refer
+        // (and remove) the same key twice.
+        uuid_d uuid;
+        uuid.generate_random();
+        const std::string keyring_key = string_cat_reserve(
+            key_prefix, key_prefix_kms, "_", key_id, "_v", uuid.to_string());
+        auto keyring_secret = keyring->add(keyring_key, secret);
+        ceph::crypto::zeroize_for_security(secret.data(), secret.length());
+        if (!keyring_secret) {
+          ldpp_dout(dpp, 5)
+              << "KMS Cache: " << cache_key << " keyring add error ("
+              << keyring_secret.error()
+              << "). removing from cache. disabling cache." << dendl;
+          cache->remove_if(cache_key, value);
+          disable_cache();
+          perfcounter->inc(l_rgw_kms_error_secret_store);
+          return tl::unexpected(-ERR_INTERNAL_ERROR);
+        }
+        return std::move(keyring_secret.value());
+      });
+
+  ldpp_dout_fmt(
+      dpp, 20, "KMS Cache: {} -> {}/{}", cache_key,
+      result && result.has_value() ? fmt::format("{}", *result.value()) : "-",
+      !result ? result.error() : 0);
+
+  if (result) {
+    if (auto ret = result.value()->read(actual_key); ret.value() != 0) {
+      ldpp_dout(dpp, 5) << "KMS Cache: " << cache_key << " keyring "
+                        << *result.value() << " read error (" << ret
+                        << "). removing from cache. disabling cache." << dendl;
+      cache->remove_if(cache_key, value);
+      disable_cache();
+      perfcounter->inc(l_rgw_kms_error_secret_store);
+      return -ERR_INTERNAL_ERROR;
+    }
+    return 0;
+  } else {
+    return result.error();
+  }
+}
+
+}  // namespace rgw::kms

--- a/src/rgw/rgw_kms_cache.cc
+++ b/src/rgw/rgw_kms_cache.cc
@@ -177,7 +177,7 @@ int KMSCache::do_cache(
   const std::string cache_key =
       string_cat_reserve(key_prefix, key_prefix_kms, "_", key_id);
   std::shared_ptr<KMSCache::CacheValue> value =
-      cache->lookup_or(key_id, std::make_shared<KMSCache::CacheValue>());
+      cache->lookup_or(cache_key, std::make_shared<KMSCache::CacheValue>());
   auto result = call_once(
       *value, y,
       [&dpp, &fetch, &cache_key, &value, &key_prefix_kms, &key_id,

--- a/src/rgw/rgw_kms_cache.cc
+++ b/src/rgw/rgw_kms_cache.cc
@@ -148,7 +148,7 @@ void KMSCache::stop_ttl_reaper() {
   ceph_assert(cache);
   std::visit(
       fu2::overload(
-          [](const std::monostate& mono) {},
+          [](const std::monostate&) {},
           [](AsyncState& async_state) {
             boost::asio::dispatch(
                 async_state.strand,
@@ -161,8 +161,9 @@ void KMSCache::stop_ttl_reaper() {
               if (e.code() != std::future_errc::no_state) throw;
             }
           },
-          [&](const std::jthread&) { reaper_state.emplace<std::monostate>(); }),
+          [](const std::jthread&) {}),
       reaper_state);
+  reaper_state.emplace<std::monostate>();
 }
 
 void KMSCache::clear_cache() const {

--- a/src/rgw/rgw_kms_cache.h
+++ b/src/rgw/rgw_kms_cache.h
@@ -1,0 +1,111 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2025 Clyso GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <sys/stat.h>
+
+#include <boost/asio/executor.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/strand.hpp>
+#include <chrono>
+#include <future>
+#include <thread>
+#include <variant>
+
+#include "common/async/call_once.h"
+#include "common/async/yield_context.h"
+#include "common/dout.h"
+#include "common/keyring.h"
+#include "common/web_cache.h"
+#include "include/expected.hpp"
+
+namespace rgw::kms {
+
+// Cache RGW KMS Secrets
+//
+// Manages a WebCache instance plus TTL reaper. Adds cache stampede
+// mitigation when fetching new values using (async) call once.
+class KMSCache {
+  CephContext* cct;
+
+ public:
+  using SharedSecret = std::shared_ptr<KeyringSecret>;
+  using CacheResult = tl::expected<SharedSecret, int>;
+  using CacheValue = ceph::async::once_result<CacheResult>;
+  using KMSSecretCache = webcache::WebCache<std::string, CacheValue>;
+  using FetchFn = std::function<int(std::string&)>;
+
+ protected:
+  std::unique_ptr<KMSSecretCache> cache;
+  std::unique_ptr<Keyring> keyring;
+
+  // The TTL Reaper is either a service thread we own or async running
+  // on an executor elsewhere (where we keep a strand and cancellation
+  // signal).
+  struct AsyncState {
+    boost::asio::strand<boost::asio::io_context::executor_type> strand;
+    boost::asio::cancellation_signal cancel_signal;
+    std::future<void> done;
+    explicit AsyncState(boost::asio::io_context::executor_type ex)
+        : strand(boost::asio::make_strand(ex)) {}
+  };
+  std::variant<std::monostate, std::jthread, AsyncState> reaper_state;
+
+ public:
+  KMSCache() = delete;
+  KMSCache(const KMSCache&) = delete;
+  KMSCache(KMSCache&&) = delete;
+  KMSCache& operator=(const KMSCache&) = delete;
+  KMSCache& operator=(KMSCache&&) = delete;
+  KMSCache(CephContext* _cct, std::unique_ptr<Keyring> _keyring);
+  virtual ~KMSCache();
+
+  // Initialize a TTL reaper. Either threaded or async depending on
+  // the executor parameter
+  void initialize_ttl_reaper(
+      std::optional<boost::asio::io_context::executor_type> executor);
+
+  // Stop any type of TTL reaper running
+  void stop_ttl_reaper();
+
+  [[nodiscard]] bool reaper_initialized() const noexcept {
+    return !std::holds_alternative<std::monostate>(reaper_state);
+  }
+
+  static std::jthread make_ttl_reaper_thread(
+      CephContext* cct, KMSSecretCache& cache, std::chrono::seconds ttl);
+
+  static std::future<void> make_ttl_reaper_async(CephContext* cct,
+      KMSSecretCache& cache, std::chrono::seconds ttl,
+      const boost::asio::strand<boost::asio::io_context::executor_type>& strand,
+      boost::asio::cancellation_signal& cancel_signal);
+
+  void clear_cache() const;
+
+  // Retrieve a cached KMS secret or fetch, cache, and return a KMS
+  // secret.
+  //
+  // The secret is returned via actual_key and it is up to the caller
+  // to properly clear the secret from memory. The cache may be shared
+  // between SSE-KMS and SSE-S3, where key_kms_prefix is available to
+  // partition the key namespace.
+  int do_cache(
+      const DoutPrefixProvider* dpp, const std::string& key_kms_prefix,
+      const std::string& key_id, const FetchFn& fetch, std::string& actual_key,
+      optional_yield y);
+
+  void disable_cache() { cct->_conf->rgw_crypt_s3_kms_cache_enabled = false; }
+};
+}  // namespace rgw::kms

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -3,6 +3,7 @@
 
 #include <boost/intrusive/list.hpp>
 #include "common/ceph_argparse.h"
+#include "common/keyring.h"
 #include "global/global_init.h"
 #include "global/signal_handler.h"
 #include "common/config.h"
@@ -106,6 +107,8 @@ int main(int argc, char *argv[])
 
   DoutPrefix dp(cct.get(), dout_subsys, "rgw main: ");
   rgw::AppMain main(&dp);
+
+  LinuxKeyringSecret::initialize_process_keyring();
 
   main.init_frontends1(false /* nfs */);
   main.init_numa();

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -165,6 +165,7 @@ int main(int argc, char *argv[])
   main.init_opslog();
   main.init_tracepoints();
   main.init_lua();
+  main.init_kms_cache();
   main.init_dedup();
   r = main.init_frontends2(nullptr /* RGWLib */);
   if (r != 0) {

--- a/src/rgw/rgw_main.h
+++ b/src/rgw/rgw_main.h
@@ -117,6 +117,7 @@ public:
   int init_frontends2(RGWLib* rgwlib = nullptr);
   void init_tracepoints();
   void init_lua();
+  void init_kms_cache();
   void init_dedup();
 
   bool have_http() {

--- a/src/rgw/rgw_perf_counters.cc
+++ b/src/rgw/rgw_perf_counters.cc
@@ -63,6 +63,11 @@ void add_rgw_frontend_counters(PerfCountersBuilder *pcb) {
   pcb->add_u64_counter(l_rgw_d4n_cache_hits, "d4n_cache_hits", "D4N cache hits");
   pcb->add_u64_counter(l_rgw_d4n_cache_misses, "d4n_cache_misses", "D4N cache misses");
   pcb->add_u64_counter(l_rgw_d4n_cache_evictions, "d4n_cache_evictions", "D4N cache evictions");
+
+  pcb->add_time_avg(l_rgw_kms_fetch_lat, "kms_fetch_lat", "Uncached KMS secret fetch latency");
+  pcb->add_u64_counter(l_rgw_kms_error_permanent, "kms_error_permanent", "Permanent (e.g key not found) errors returned from KMS");
+  pcb->add_u64_counter(l_rgw_kms_error_transient, "kms_error_transient", "Trainsient (e.g timeout, overloaded) errors returned from KMS");
+  pcb->add_u64_counter(l_rgw_kms_error_secret_store, "kms_error_secret_store", "Secrt store errors (e.g kernel keyring quota)");
 }
 
 void add_rgw_op_counters(PerfCountersBuilder *lpcb) {

--- a/src/rgw/rgw_perf_counters.cc
+++ b/src/rgw/rgw_perf_counters.cc
@@ -66,8 +66,8 @@ void add_rgw_frontend_counters(PerfCountersBuilder *pcb) {
 
   pcb->add_time_avg(l_rgw_kms_fetch_lat, "kms_fetch_lat", "Uncached KMS secret fetch latency");
   pcb->add_u64_counter(l_rgw_kms_error_permanent, "kms_error_permanent", "Permanent (e.g key not found) errors returned from KMS");
-  pcb->add_u64_counter(l_rgw_kms_error_transient, "kms_error_transient", "Trainsient (e.g timeout, overloaded) errors returned from KMS");
-  pcb->add_u64_counter(l_rgw_kms_error_secret_store, "kms_error_secret_store", "Secrt store errors (e.g kernel keyring quota)");
+  pcb->add_u64_counter(l_rgw_kms_error_transient, "kms_error_transient", "Transient (e.g timeout, overloaded) errors returned from KMS");
+  pcb->add_u64_counter(l_rgw_kms_error_secret_store, "kms_error_secret_store", "Secret store errors (e.g kernel keyring quota)");
 }
 
 void add_rgw_op_counters(PerfCountersBuilder *lpcb) {

--- a/src/rgw/rgw_perf_counters.h
+++ b/src/rgw/rgw_perf_counters.h
@@ -53,6 +53,10 @@ enum {
   l_rgw_d4n_cache_misses,
   l_rgw_d4n_cache_evictions,
 
+  l_rgw_kms_fetch_lat,
+  l_rgw_kms_error_transient,
+  l_rgw_kms_error_permanent,
+  l_rgw_kms_error_secret_store,
   l_rgw_last,
 };
 

--- a/src/rgw/rgw_process_env.h
+++ b/src/rgw/rgw_process_env.h
@@ -6,6 +6,7 @@
 #include <memory>
 
 #include "rgw_auth_registry.h"
+#include "rgw_kms_cache.h"
 
 class ActiveRateLimiter;
 class OpsLogSink;
@@ -50,6 +51,7 @@ struct RGWProcessEnv {
   std::unique_ptr<OpsLogSink> olog;
   std::unique_ptr<rgw::auth::StrategyRegistry> auth_registry;
   ActiveRateLimiter* ratelimiting = nullptr;
+  std::unique_ptr<rgw::kms::KMSCache> kms_cache;
 
 #ifdef WITH_ARROW_FLIGHT
   // managed by rgw:flight::FlightFrontend in rgw_flight_frontend.cc

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1062,7 +1062,17 @@ add_executable(unittest_ceph_assert
   ceph_assert.cc)
 add_ceph_unittest(unittest_ceph_assert)
 target_link_libraries(unittest_ceph_assert ceph-common global)
-endif()
+endif(NOT WIN32)
+
+find_package(benchmark QUIET)
+if (benchmark_FOUND)
+  add_executable(bench_lrus
+  bench_lrus.cc
+  )
+  target_link_libraries(bench_lrus ceph-common global-static benchmark::benchmark Boost::context)
+else()
+  message(STATUS "The google/benchmark library was not found. Skipping micro benchmark tests")
+endif(benchmark_FOUND)
 
 add_executable(test_nvmeof_gw_utils
   test_nvmeof_gw_utils.cc

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1074,7 +1074,7 @@ if (benchmark_FOUND)
   add_executable(bench_secmem
   bench_secmem.cc
   )
-  target_link_libraries(bench_secmem ceph-common global-static benchmark::benchmark keyutils)
+  target_link_libraries(bench_secmem ceph-common global-static benchmark::benchmark keyutils::keyutils)
 else()
   message(STATUS "The google/benchmark library was not found. Skipping micro benchmark tests")
 endif(benchmark_FOUND)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1070,6 +1070,11 @@ if (benchmark_FOUND)
   bench_lrus.cc
   )
   target_link_libraries(bench_lrus ceph-common global-static benchmark::benchmark Boost::context)
+
+  add_executable(bench_secmem
+  bench_secmem.cc
+  )
+  target_link_libraries(bench_secmem ceph-common global-static benchmark::benchmark keyutils)
 else()
   message(STATUS "The google/benchmark library was not found. Skipping micro benchmark tests")
 endif(benchmark_FOUND)

--- a/src/test/bench_lrus.cc
+++ b/src/test/bench_lrus.cc
@@ -1,0 +1,461 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2025 Clyso GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <benchmark/benchmark.h>
+#include <uuid/uuid.h>
+#include <xxhash.h>
+
+#include <atomic>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <initializer_list>
+#include <iterator>
+#include <numeric>
+#include <random>
+#include <thread>
+
+#include "common/ceph_argparse.h"
+#include "common/cohort_lru.h"
+#include "common/shared_cache.hpp"
+#include "common/simple_cache.hpp"
+#include "common/web_cache.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
+#include "include/uuid.h"
+
+
+// Cache implementations in the Ceph codebase:
+// ✅ cohort lru
+// ✅ shared_cache.hpp SharedLRU
+// ✅ simple_cache SimpleLRU
+// ✅ web_cache
+// Not benchmarked here (reason):
+// ❌ LRUSet (not concurrent)
+// ❌ intrusive_lru: lru implementation with embedded map and list hook (not concurrent)
+// ❌ include/lru.h LRU - (not concurrent)
+
+
+// Workload Generator Helper
+//
+// (1) insert unique items > cache size
+//   - exercises cache replacement algorithm
+//   - with > 1 thread - test concurrency
+// (2) Inserts using pareto distributed keys
+//   - approximates real world workload
+
+namespace {
+
+// Config
+
+constexpr size_t SMALL_CACHE = 100;
+constexpr size_t LARGE_CACHE = 1000;
+constexpr size_t CACHE_OP_COUNT = 1000000;
+constexpr size_t THREADS_SINGLE = 1;
+constexpr size_t THREADS_LOTS = 128;
+constexpr size_t RAND_VALUE_LEN = 32;
+constexpr size_t PARETO_KEY_POOL_SIZE = 1000;
+
+std::string random_key() {
+  uuid_d uuid;
+  uuid.generate_random();
+  return uuid.to_string();
+}
+
+std::string random_value() {
+  std::string result(RAND_VALUE_LEN, '0');
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<uint16_t> dist(0, 0xFF);
+  for (size_t i=0; i< RAND_VALUE_LEN; ++i) {
+    result[i] = static_cast<char>(dist(gen));
+  }
+  return result;
+}
+
+std::vector<std::string> key_pool(size_t len) {
+  std::vector<std::string> result;
+  result.reserve(len);
+  for (size_t i = 0; i < len; ++i) {
+    result.push_back(random_key());
+  }
+  return result;
+}
+
+std::vector<std::string_view> workload(
+    const std::vector<std::string>& pool, size_t length) {
+  const double alpha = 1.5;
+  std::vector<double> weights(pool.size());
+  for (size_t i = 0; i < pool.size(); ++i) {
+    weights[i] = std::pow(static_cast<double>(i + 1), -alpha);
+  }
+  const double weights_sum =
+      std::accumulate(weights.begin(), weights.end(), 0.0);
+  for (auto& weight : weights) {
+    weight /= weights_sum;
+  }
+  std::vector<double> partial_sums(weights.size());
+  std::partial_sum(weights.begin(), weights.end(), partial_sums.begin());
+
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<double> dis(0.0, 1.0);
+
+  std::vector<std::string_view> result;
+  result.reserve(length);
+
+  for (size_t i = 0; i < length; ++i) {
+    double u = dis(gen);
+    auto it = std::ranges::lower_bound(partial_sums, u);
+    size_t idx = std::distance(partial_sums.begin(), it);
+    result.push_back(pool[idx]);
+  }
+  return result;
+}
+
+//
+// Cache Adapter (cache impl <-> benchmark)
+//
+
+struct CacheAdapter {
+  CacheAdapter() = default;
+  CacheAdapter(const CacheAdapter&) = default;
+  CacheAdapter(CacheAdapter&&) = delete;
+  CacheAdapter& operator=(const CacheAdapter&) = delete;
+  CacheAdapter& operator=(CacheAdapter&&) = delete;
+  virtual ~CacheAdapter() = default;
+
+  // Simulate common cache operation: lookup value by key, if it isn't
+  // cached add it
+  virtual void cache(const std::string& key, const std::string& value) = 0;
+
+  virtual double hit_miss_ratio() { return -23.42; };
+  virtual bool reset() { return false; };
+};
+
+// Shared LRU {{{
+struct SharedLRUAdapter : public CacheAdapter {
+  SharedLRU<std::string, std::string> _cache;
+
+  std::atomic_int hits;
+  std::atomic_int misses;
+  explicit SharedLRUAdapter(size_t size) : _cache(g_ceph_context, size) {}
+  void cache(const std::string& key, const std::string& value) override {
+    bool existed = false;
+    auto* copy = new std::string(value);
+    const auto ptr = _cache.add(key, copy, &existed);
+    if (existed) {
+      hits++;
+      delete copy;
+    } else {
+      misses++;
+    }
+  }
+
+  double hit_miss_ratio() override {
+    return static_cast<double>(hits) /
+           (static_cast<double>(hits) + static_cast<double>(misses));
+  }
+
+  bool reset() override {
+    _cache.clear();
+    hits = 0;
+    misses = 0;
+    return true;
+  }
+};
+
+// }}}
+
+// Simple LRU {{{
+struct SimpleLRUAdapter : public CacheAdapter {
+  SimpleLRU<std::string, std::string> _cache;
+
+  explicit SimpleLRUAdapter(size_t size) : _cache(size) {}
+  void cache(const std::string& key, const std::string& value) override {
+    std::string out;
+    if (!_cache.lookup(key, &out)) {
+      _cache.add(key, value);
+    }
+  }
+};
+
+// }}}
+
+// Cohort LRU {{{
+namespace cohortlru {
+class Factory;
+
+struct Object : public cohort::lru::Object {
+  std::string m_key;
+  std::string m_value;
+
+  Object(const Object&) = delete;
+  Object(Object&&) = delete;
+  Object& operator=(const Object&) = delete;
+  Object& operator=(Object&&) = delete;
+  ~Object() override = default;
+
+  Object(const std::string& key, const std::string& value) :
+    cohort::lru::Object(), m_key(key), m_value(value)
+  {}
+
+  bool reclaim(const cohort::lru::ObjectFactory* newobj_fac) override;
+
+};
+
+struct Factory : public cohort::lru::ObjectFactory {
+  std::string m_key;
+  std::string m_value;
+
+  Factory(const Factory&) = default;
+  Factory(Factory&&) = delete;
+  Factory& operator=(const Factory&) = default;
+  Factory& operator=(Factory&&) = delete;
+  ~Factory() override = default;
+
+  Factory(const std::string& key, const std::string& value) :
+    cohort::lru::ObjectFactory(), m_key(key), m_value(value)
+  {}
+
+  cohort::lru::Object* alloc() override { return new Object(m_key, m_value); }
+
+  void recycle(cohort::lru::Object* o) override {
+    auto oo = dynamic_cast<Object*>(o);
+    oo->m_key = m_key;
+    oo->m_value = m_value;
+  }
+};
+
+bool Object::reclaim(const cohort::lru::ObjectFactory* newobj_fac) {
+  const auto* factory = dynamic_cast<const Factory*>(newobj_fac);
+  return (factory != nullptr);
+}
+
+}  // namespace cohortlru
+
+struct CohortLRUAdapter : public CacheAdapter {
+  cohort::lru::LRU<std::mutex> _cache;
+
+  explicit CohortLRUAdapter(size_t size)
+      : _cache(
+            static_cast<int>(size / std::thread::hardware_concurrency()),
+            size / std::thread::hardware_concurrency()) {}
+
+  void cache(const std::string& key, const std::string& value) override {
+    cohortlru::Factory prototype(key, value);
+    uint32_t iflags{cohort::lru::FLAG_INITIAL};
+    auto o = dynamic_cast<cohortlru::Object*>(
+        _cache.insert(&prototype, cohort::lru::Edge::MRU, iflags));
+    ceph_assert(o != nullptr);
+    ceph_assert(o->m_key == key);
+    ceph_assert(o->m_value == value);
+  }
+};
+
+// }}}
+
+// Web Cache {{{
+
+struct WebCacheAdapter : public CacheAdapter {
+  using CacheValue = std::string;
+  using Cache = webcache::WebCache<std::string, CacheValue>;
+  Cache _cache;
+
+  WebCacheAdapter(const WebCacheAdapter&) = delete;
+  WebCacheAdapter(WebCacheAdapter&&) = delete;
+  WebCacheAdapter& operator=(const WebCacheAdapter&) = delete;
+  WebCacheAdapter& operator=(WebCacheAdapter&&) = delete;
+
+  explicit WebCacheAdapter(size_t size) :
+    _cache(g_ceph_context, "benchmark", size)
+  {}
+  void cache(const std::string& key, const std::string& value) override {
+    if (!_cache.lookup(key).has_value()) {
+      _cache.add(key, std::make_shared<std::string>(value));
+    }
+  }
+
+  ~WebCacheAdapter() override { _cache.perf()->reset(); }
+
+  double hit_miss_ratio() override {
+    return static_cast<double>(
+               _cache.perf()->get(static_cast<int>(webcache::Metric::hit))) /
+           (static_cast<double>(
+                _cache.perf()->get(static_cast<int>(webcache::Metric::hit))) +
+            static_cast<double>(
+                _cache.perf()->get(static_cast<int>(webcache::Metric::miss))));
+  }
+
+  bool reset() override {
+    _cache.clear();
+    return true;
+  }
+};
+
+struct WebCacheLookupOrAdapter : public CacheAdapter {
+  struct CacheValue {
+    std::once_flag once;
+    std::string value;
+  };
+  using Cache = webcache::WebCache<std::string, CacheValue>;
+  Cache _cache;
+
+  WebCacheLookupOrAdapter(const WebCacheLookupOrAdapter&) = delete;
+  WebCacheLookupOrAdapter(WebCacheLookupOrAdapter&&) = delete;
+  WebCacheLookupOrAdapter& operator=(const WebCacheLookupOrAdapter&) = delete;
+  WebCacheLookupOrAdapter& operator=(WebCacheLookupOrAdapter&&) = delete;
+
+  explicit WebCacheLookupOrAdapter(size_t size) :
+    _cache(g_ceph_context, "benchmark", size)
+  {}
+
+  ~WebCacheLookupOrAdapter() override {
+    _cache.perf()->reset();
+  }
+
+  void cache(const std::string& key, const std::string& value) override {
+    std::shared_ptr<CacheValue> cache_value =
+        _cache.lookup_or(key, std::make_shared<CacheValue>());
+
+    std::call_once(cache_value->once, [&]() { cache_value->value = value; });
+  }
+  double hit_miss_ratio() override {
+    return static_cast<double>(
+               _cache.perf()->get(static_cast<int>(webcache::Metric::hit))) /
+           (static_cast<double>(
+                _cache.perf()->get(static_cast<int>(webcache::Metric::hit))) +
+            static_cast<double>(
+                _cache.perf()->get(static_cast<int>(webcache::Metric::miss))));
+  }
+  bool reset() override {
+    _cache.clear();
+    return true;
+  }
+};
+
+/// }}}
+
+// Benchmarks {{{
+
+template <typename C>
+class CacheFixture : public benchmark::Fixture {
+ public:
+  std::unique_ptr<C> cache;
+  void SetUp(::benchmark::State& state) override {
+    if (state.thread_index() == 0) {
+      cache = std::make_unique<C>(state.range(0));
+    }
+  }
+
+  void TearDown(::benchmark::State& state) override {
+    if (state.thread_index() == 0) {
+      state.counters["hit/miss"] = cache->hit_miss_ratio();
+    }
+  }
+};
+
+template <typename C>
+class ParetoFixture : public CacheFixture<C> {
+ public:
+  std::vector<std::string> pool;
+  std::array<std::vector<std::string_view>, THREADS_LOTS> pareto_keys;
+
+  ParetoFixture() : pool(key_pool(PARETO_KEY_POOL_SIZE)) {}
+
+  void SetUp(::benchmark::State& state) override {
+    if (state.thread_index() == 0) {
+      this->cache = std::make_unique<C>(state.range(0));
+      state.counters["Key Pool"] = pool.size();
+    }
+    pareto_keys[state.thread_index()] =
+        workload(pool, state.range(1) / state.threads());
+    state.counters["Keys/Thread"] = benchmark::Counter(
+        pareto_keys[state.thread_index()].size(),
+        benchmark::Counter::kAvgThreads);
+    ceph_assert(pareto_keys[state.thread_index()].size() > 1000);
+  }
+};
+
+BENCHMARK_TEMPLATE_METHOD_F(CacheFixture, BM_UniqueAdd)(
+    benchmark::State& state) {
+  for (auto _ : state) {
+    const size_t ops = state.range(1) / state.threads();
+    for (size_t i = 0; i < ops; ++i) {
+      this->cache->cache(random_key(), random_value());
+    }
+    state.counters["KeysProcessed"] =
+        benchmark::Counter(ops, benchmark::Counter::kIsRate);
+    state.counters["KeysProcessedInv"] = benchmark::Counter(
+        ops, benchmark::Counter::kIsRate | benchmark::Counter::kInvert);
+  }
+}
+
+BENCHMARK_TEMPLATE_METHOD_F(ParetoFixture, BM_Pareto)(benchmark::State& state) {
+  for (auto _ : state) {
+    const auto keys = this->pareto_keys[state.thread_index()];
+    for (auto key : keys) {
+      this->cache->cache(std::string(key), "some_value");
+    }
+    state.counters["KeysProcessed"] =
+        benchmark::Counter(keys.size(), benchmark::Counter::kIsRate);
+    state.counters["KeysProcessedInv"] = benchmark::Counter(
+        keys.size(), benchmark::Counter::kIsRate | benchmark::Counter::kInvert);
+  }
+}
+
+// }}}
+
+// Benchmark Run Configuration {{{
+
+void DefaultArgs(benchmark::internal::Benchmark* bench) {
+  bench->Args({SMALL_CACHE, CACHE_OP_COUNT})
+      ->Args({LARGE_CACHE, CACHE_OP_COUNT})
+      ->Threads(THREADS_SINGLE)
+      ->Threads(static_cast<int>(std::thread::hardware_concurrency()))
+      ->Threads(THREADS_LOTS);
+}
+
+BENCHMARK_TEMPLATE_INSTANTIATE_F(CacheFixture, BM_UniqueAdd, SharedLRUAdapter)			->Name("UNIQUE shared")->Apply(DefaultArgs);
+BENCHMARK_TEMPLATE_INSTANTIATE_F(CacheFixture, BM_UniqueAdd, SimpleLRUAdapter)			->Name("UNIQUE simple")->Apply(DefaultArgs);
+BENCHMARK_TEMPLATE_INSTANTIATE_F(CacheFixture, BM_UniqueAdd, CohortLRUAdapter)			->Name("UNIQUE cohort")->Apply(DefaultArgs);
+BENCHMARK_TEMPLATE_INSTANTIATE_F(CacheFixture, BM_UniqueAdd, WebCacheAdapter)			->Name("UNIQUE web   ")->Apply(DefaultArgs);
+BENCHMARK_TEMPLATE_INSTANTIATE_F(CacheFixture, BM_UniqueAdd, WebCacheLookupOrAdapter)		->Name("UNIQUE web-O ")->Apply(DefaultArgs);
+BENCHMARK_TEMPLATE_INSTANTIATE_F(ParetoFixture, BM_Pareto, SharedLRUAdapter)			->Name("PARETO shared")->Apply(DefaultArgs);
+BENCHMARK_TEMPLATE_INSTANTIATE_F(ParetoFixture, BM_Pareto, SimpleLRUAdapter)			->Name("PARETO simple")->Apply(DefaultArgs);
+BENCHMARK_TEMPLATE_INSTANTIATE_F(ParetoFixture, BM_Pareto, CohortLRUAdapter)			->Name("PARETO cohort")->Apply(DefaultArgs);
+BENCHMARK_TEMPLATE_INSTANTIATE_F(ParetoFixture, BM_Pareto, WebCacheAdapter)			->Name("PARETO web   ")->Apply(DefaultArgs);
+BENCHMARK_TEMPLATE_INSTANTIATE_F(ParetoFixture, BM_Pareto, WebCacheLookupOrAdapter)		->Name("PARETO web-O ")->Apply(DefaultArgs);
+
+// }}}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  auto args = argv_to_vec(argc, argv);
+  auto cct = global_init(
+      nullptr, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
+      CINIT_FLAG_NO_MON_CONFIG);
+  common_init_finish(g_ceph_context);
+
+  char arg0_default[] = "benchmark";
+  char* args_default = arg0_default;
+  if (argv == nullptr) {
+    argc = 1;
+    argv = &args_default;
+  }
+  ::benchmark::Initialize(&argc, argv);
+  ::benchmark::RunSpecifiedBenchmarks();
+  ::benchmark::Shutdown();
+  return 0;
+}

--- a/src/test/bench_secmem.cc
+++ b/src/test/bench_secmem.cc
@@ -1,0 +1,257 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2025 Clyso GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+// Standalone build:
+// g++ --std=c++20 -O2 -o bench ../src/test/bench_secmem.cc -lbenchmark -lkeyutils
+
+#include <benchmark/benchmark.h>
+extern "C" {
+#include <keyutils.h>
+}
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <format>
+#include <initializer_list>
+#include <mutex>
+#include <random>
+#include <thread>
+
+namespace {
+
+constexpr size_t MEMFD_SECRET_SIZE = 5L * 1024 * 1024;
+constexpr size_t SECRET_SIZE = 128;
+
+void
+BM_MemfdSecret_RandomRead(benchmark::State& state)
+{
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<> dis(0, (MEMFD_SECRET_SIZE / SECRET_SIZE) - 1);
+  static std::once_flag mem_initialized;
+  static void* mem;
+  std::call_once(mem_initialized, [&]() {
+    const int fd = static_cast<int>(syscall(SYS_memfd_secret, 0));
+    if (fd == -1) {
+      state.SkipWithError(
+          std::format(
+              "memfd_secret: {} errno:{} error:{}", fd, errno,
+              std::strerror(errno)));
+      return;
+    }
+    const int ret = ftruncate(fd, MEMFD_SECRET_SIZE);
+    if (ret == -1) {
+      state.SkipWithError(
+          std::format(
+              "ftruncate: {} errno:{} error:{}", ret, errno,
+              std::strerror(errno)));
+      return;
+    }
+    mem = ::mmap(
+        nullptr, MEMFD_SECRET_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (mem == MAP_FAILED) {
+      state.SkipWithError(
+          std::format(
+              "mmap: {} errno:{} error:{}", ret, errno, std::strerror(errno)));
+      return;
+    }
+    std::memset(mem, '$', MEMFD_SECRET_SIZE);
+  });
+
+  if (state.thread_index() == 0) {
+  }
+
+  for (auto _ : state) {
+    const size_t keys_to_read = state.range(0) / state.threads();
+    thread_local size_t bytes_read = 0;
+    for (size_t i = 0; i < keys_to_read; ++i) {
+      std::string buf(SECRET_SIZE, '_');
+      const size_t offset = dis(gen) * SECRET_SIZE;
+      std::memcpy(buf.data(), static_cast<char*>(mem) + offset, SECRET_SIZE);
+      bytes_read += buf.size();
+    }
+    state.counters["BytesRead"] = benchmark::Counter(
+        static_cast<double>(bytes_read), benchmark::Counter::kIsRate);
+    state.counters["KeysRead"] = benchmark::Counter(
+        static_cast<double>(keys_to_read), benchmark::Counter::kIsRate);
+    state.counters["KeysReadInv"] = benchmark::Counter(
+        static_cast<double>(keys_to_read),
+        benchmark::Counter::kIsRate | benchmark::Counter::kInvert);
+  }
+  if (state.thread_index() == 0) {
+  }
+}
+
+void
+BM_PlainMem_RandomRead(benchmark::State& state)
+{
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<> dis(0, (MEMFD_SECRET_SIZE / SECRET_SIZE) - 1);
+  static auto* mem = ::mmap(
+      nullptr, MEMFD_SECRET_SIZE, PROT_READ | PROT_WRITE,
+      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (state.thread_index() == 0) {
+    std::memset(mem, '$', MEMFD_SECRET_SIZE);
+  }
+  for (auto _ : state) {
+    const size_t keys_to_read = state.range(0) / state.threads();
+    thread_local size_t bytes_read = 0;
+    for (size_t i = 0; i < keys_to_read; ++i) {
+      std::string buf(SECRET_SIZE, '_');
+      const size_t offset = dis(gen) * SECRET_SIZE;
+      std::memcpy(buf.data(), static_cast<char*>(mem) + offset, SECRET_SIZE);
+      bytes_read += buf.size();
+    }
+    state.counters["BytesRead"] = benchmark::Counter(
+        static_cast<double>(bytes_read), benchmark::Counter::kIsRate);
+    state.counters["KeysRead"] = benchmark::Counter(
+        static_cast<double>(keys_to_read), benchmark::Counter::kIsRate);
+    state.counters["KeysReadInv"] = benchmark::Counter(
+        static_cast<double>(keys_to_read),
+        benchmark::Counter::kIsRate | benchmark::Counter::kInvert);
+  }
+  if (state.thread_index() == 0) {
+  }
+}
+
+void
+BM_KeyRing_RandomRead(benchmark::State& state)
+{
+  const std::string secret(SECRET_SIZE, '$');
+  static std::vector<key_serial_t> serials;
+  static std::random_device rd;
+  static std::mt19937 gen(rd());
+  static std::uniform_int_distribution<size_t> dis(0, state.range(0) - 1);
+  if (state.thread_index() == 0) {
+    for (size_t i = 0; i < static_cast<size_t>(state.range(0)); ++i) {
+      const key_serial_t serial = ::add_key(
+          "user", std::to_string(i).c_str(), secret.c_str(), secret.size(),
+          KEY_SPEC_PROCESS_KEYRING);
+      if (serial == -1) {
+        state.SkipWithError(
+            std::format(
+                "serial:{} i:{} errno:{} err:{}", serial, i, errno,
+                std::strerror(errno)));
+        return;
+      }
+      serials.push_back(serial);
+    }
+  }
+  for (auto _ : state) {
+    const size_t keys_to_read = state.range(1) / state.threads();
+    thread_local size_t bytes_read = 0;
+    for (size_t i = 0; i < keys_to_read; ++i) {
+      const key_serial_t serial = serials[dis(gen)];
+      std::string out(secret.size(), '$');
+      const auto ret = ::keyctl_read(serial, out.data(), out.size());
+      if (ret < 0) {
+        state.SkipWithError("keyctl_read");
+        return;
+      }
+      bytes_read += ret;
+    }
+    state.counters["BytesRead"] = benchmark::Counter(
+        static_cast<double>(bytes_read), benchmark::Counter::kIsRate);
+    state.counters["KeysRead"] = benchmark::Counter(
+        static_cast<double>(keys_to_read), benchmark::Counter::kIsRate);
+    state.counters["KeysReadInv"] = benchmark::Counter(
+        static_cast<double>(keys_to_read),
+        benchmark::Counter::kIsRate | benchmark::Counter::kInvert);
+  }
+  if (state.thread_index() == 0) {
+  }
+}
+
+void
+BM_KeyRing_WriteReadRemove(benchmark::State& state)
+{
+  const std::string key_prefix = "benchmark_secret_";
+  const std::string secret = "asjdfoilkuj3o8rijsdafo23yo8ifsdjadf";
+  if (state.thread_index() == 0) {
+  }
+  for (auto _ : state) {
+    const size_t keys_to_read = state.range(1) / state.threads();
+    thread_local size_t bytes_read = 0;
+    for (size_t i = 0; i < keys_to_read; ++i) {
+      std::string key(key_prefix);
+      key.append(std::to_string(state.thread_index()));
+      const key_serial_t serial = ::add_key(
+          "user", key.c_str(), secret.c_str(), secret.size(),
+          KEY_SPEC_PROCESS_KEYRING);
+      if (serial == -1) {
+        state.SkipWithError(
+            std::format(
+                "add_key: serial:{} i:{} errno:{} err:{}", serial, i, errno,
+                std::strerror(errno)));
+        return;
+      }
+      std::string out("$", secret.size());
+      const auto read = ::keyctl_read(serial, out.data(), out.size());
+      if (read < 0) {
+        state.SkipWithError(
+            std::format(
+                "keyctl_read(3): {} errno:{} err:{}", read, errno,
+                std::strerror(errno)));
+        return;
+      }
+      bytes_read += read;
+      assert(out == secret);
+
+      const auto inval = ::keyctl_invalidate(serial);
+      if (inval != 0) {
+        state.SkipWithError(std::format("keyctl_invalidate(3): {}", inval));
+        return;
+      }
+    }
+    state.counters["BytesProcessed"] = benchmark::Counter(
+        static_cast<double>(bytes_read), benchmark::Counter::kIsRate);
+    state.counters["KeysProcessed"] = benchmark::Counter(
+        static_cast<double>(keys_to_read), benchmark::Counter::kIsRate);
+    state.counters["KeysProcessedInv"] = benchmark::Counter(
+        static_cast<double>(keys_to_read),
+        benchmark::Counter::kIsRate | benchmark::Counter::kInvert);
+  }
+  if (state.thread_index() == 0) {
+  }
+}
+
+// note: max number of keys is subject to quota. see /proc/key-users
+// increas using /proc/sys/kernel/keys/maxkeys
+BENCHMARK(BM_KeyRing_RandomRead)
+    ->Args({1000, 1000000})
+    ->Threads(1)
+    ->Threads(static_cast<int>(std::thread::hardware_concurrency()))
+    ->Threads(128);
+BENCHMARK(BM_MemfdSecret_RandomRead)
+    ->Args({10000000})
+    ->Threads(1)
+    ->Threads(static_cast<int>(std::thread::hardware_concurrency()))
+    ->Threads(128);
+BENCHMARK(BM_PlainMem_RandomRead)
+    ->Args({10000000})
+    ->Threads(1)
+    ->Threads(static_cast<int>(std::thread::hardware_concurrency()))
+    ->Threads(128);
+BENCHMARK(BM_KeyRing_WriteReadRemove)
+    ->Args({1000, 1000000})
+    ->Threads(1)
+    ->Threads(static_cast<int>(std::thread::hardware_concurrency()))
+    ->Threads(128);
+
+} // namespace
+
+BENCHMARK_MAIN();

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -121,6 +121,15 @@ add_executable(unittest_web_cache
 add_ceph_unittest(unittest_web_cache)
 target_link_libraries(unittest_web_cache ceph-common)
 
+if(HAVE_KEYUTILS)
+  # unittest_web_cache
+  add_executable(unittest_keyring
+    test_keyring.cc
+    )
+  add_ceph_unittest(unittest_keyring)
+  target_link_libraries(unittest_keyring global keyring)
+endif()
+
 # unittest_sloppy_crc_map
 add_executable(unittest_sloppy_crc_map
   test_sloppy_crc_map.cc

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -114,6 +114,13 @@ add_executable(unittest_shared_cache
 add_ceph_unittest(unittest_shared_cache)
 target_link_libraries(unittest_shared_cache global)
 
+# unittest_web_cache
+add_executable(unittest_web_cache
+  test_web_cache.cc
+  )
+add_ceph_unittest(unittest_web_cache)
+target_link_libraries(unittest_web_cache ceph-common)
+
 # unittest_sloppy_crc_map
 add_executable(unittest_sloppy_crc_map
   test_sloppy_crc_map.cc

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -377,6 +377,10 @@ add_executable(unittest_hobject test_hobject.cc
 target_link_libraries(unittest_hobject global ceph-common)
 add_ceph_unittest(unittest_hobject)
 
+add_executable(unittest_async_call_once test_async_call_once.cc)
+add_ceph_unittest(unittest_async_call_once)
+target_link_libraries(unittest_async_call_once ceph-common Boost::context)
+
 add_executable(unittest_async_completion test_async_completion.cc)
 add_ceph_unittest(unittest_async_completion)
 target_link_libraries(unittest_async_completion ceph-common Boost::system)

--- a/src/test/common/test_async_call_once.cc
+++ b/src/test/common/test_async_call_once.cc
@@ -1,0 +1,291 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "common/async/call_once.h"
+
+#include <exception>
+#include <future>
+#include <latch>
+#include <optional>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/spawn.hpp>
+#include <gtest/gtest.h>
+#include "common/async/yield_waiter.h"
+
+void rethrow(std::exception_ptr eptr)
+{
+  if (eptr) std::rethrow_exception(eptr);
+}
+
+auto capture(std::optional<std::exception_ptr>& out) {
+  return [&out] (std::exception_ptr eptr) {
+    out = std::move(eptr);
+  };
+}
+
+template <typename T>
+auto capture(std::optional<T>& out) {
+  return [&out] (std::exception_ptr eptr, T value) {
+    rethrow(eptr);
+    out = std::move(value);
+  };
+}
+
+namespace ceph::async {
+
+TEST(CallOnceAsync, call_wait_shutdown)
+{
+  boost::asio::io_context context;
+  // test that memory doesn't leak when both coroutines hold a shared_ptr to
+  // the once_result they're waiting on
+  auto once = std::make_shared<once_result<int>>();
+  yield_waiter<int> waiter;
+
+  boost::asio::spawn(context, [once, &waiter] (boost::asio::yield_context yield) {
+        call_once(*once, yield, [&] { return waiter.async_wait(yield); });
+      }, rethrow);
+  boost::asio::spawn(context, [once] (boost::asio::yield_context yield) {
+        call_once(*once, yield, [] { return 0; });
+      }, rethrow);
+
+  context.poll();
+  EXPECT_FALSE(context.stopped()); // blocked on waiter, never completes
+}
+
+TEST(CallOnceAsync, call_immediate_result)
+{
+  boost::asio::io_context context;
+  once_result<int> once;
+
+  std::optional<int> result;
+  boost::asio::spawn(context, [&] (boost::asio::yield_context yield) {
+        return call_once(once, yield, [] { return 0; });
+      }, capture(result));
+
+  context.poll();
+  EXPECT_TRUE(context.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_EQ(*result, 0);
+}
+
+TEST(CallOnceAsync, call_immediate_exception)
+{
+  boost::asio::io_context context;
+  once_result<int> once;
+
+  std::optional<std::exception_ptr> eptr;
+  boost::asio::spawn(context, [&] (boost::asio::yield_context yield) {
+        call_once(once, yield, [] { throw std::bad_alloc(); return 0; });
+      }, capture(eptr));
+
+  context.poll();
+  EXPECT_TRUE(context.stopped());
+  ASSERT_TRUE(eptr);
+  EXPECT_THROW(std::rethrow_exception(*eptr), std::bad_alloc);
+}
+
+TEST(CallOnceAsync, call_wait_result)
+{
+  boost::asio::io_context context;
+  once_result<int> once;
+  yield_waiter<int> waiter;
+
+  std::optional<int> call_result;
+  boost::asio::spawn(context, [&] (boost::asio::yield_context yield) {
+        return call_once(once, yield, [&] { return waiter.async_wait(yield); });
+      }, capture(call_result));
+
+  std::optional<int> wait_result;
+  boost::asio::spawn(context, [&] (boost::asio::yield_context yield) {
+        return call_once(once, yield, [] { return 0; });
+      }, capture(wait_result));
+
+  context.poll();
+  EXPECT_FALSE(context.stopped());
+  ASSERT_FALSE(call_result);
+  ASSERT_FALSE(wait_result);
+
+  waiter.complete(boost::system::error_code{}, 42);
+
+  context.poll();
+  EXPECT_TRUE(context.stopped());
+  ASSERT_TRUE(call_result);
+  EXPECT_EQ(*call_result, 42);
+  ASSERT_TRUE(wait_result);
+  EXPECT_EQ(*wait_result, 42);
+
+  std::optional<int> cached_result;
+  boost::asio::spawn(context, [&] (boost::asio::yield_context yield) {
+        return call_once(once, yield, [] { return 0; });
+      }, capture(cached_result));
+
+  context.restart();
+  context.poll();
+  EXPECT_TRUE(context.stopped());
+  ASSERT_TRUE(cached_result);
+  EXPECT_EQ(*cached_result, 42);
+}
+
+TEST(CallOnceAsync, call_wait_exception)
+{
+  boost::asio::io_context context;
+  once_result<int> once;
+  yield_waiter<void> waiter;
+
+  std::optional<std::exception_ptr> call_eptr;
+  boost::asio::spawn(context, [&] (boost::asio::yield_context yield) {
+        call_once(once, yield, [&] {
+            waiter.async_wait(yield);
+            throw std::bad_alloc();
+            return 0;
+          });
+      }, capture(call_eptr));
+
+  std::optional<std::exception_ptr> wait_eptr;
+  boost::asio::spawn(context, [&] (boost::asio::yield_context yield) {
+        call_once(once, yield, [] { return 0; });
+      }, capture(wait_eptr));
+
+  context.poll();
+  EXPECT_FALSE(context.stopped());
+  ASSERT_FALSE(call_eptr);
+  ASSERT_FALSE(wait_eptr);
+
+  waiter.complete(boost::system::error_code{});
+
+  context.poll();
+  EXPECT_TRUE(context.stopped());
+  ASSERT_TRUE(call_eptr);
+  EXPECT_THROW(std::rethrow_exception(*call_eptr), std::bad_alloc);
+  ASSERT_TRUE(wait_eptr);
+  EXPECT_THROW(std::rethrow_exception(*wait_eptr), std::bad_alloc);
+
+  std::optional<std::exception_ptr> cached_eptr;
+  boost::asio::spawn(context, [&] (boost::asio::yield_context yield) {
+        call_once(once, yield, [] { return 0; });
+      }, capture(cached_eptr));
+
+  context.restart();
+  context.poll();
+  EXPECT_TRUE(context.stopped());
+  ASSERT_TRUE(cached_eptr);
+  EXPECT_THROW(std::rethrow_exception(*cached_eptr), std::bad_alloc);
+}
+
+TEST(CallOnceSync, call_immediate_result)
+{
+  once_result<int> once;
+
+  EXPECT_EQ(call_once(once, null_yield, [] { return 42; }), 42);
+}
+
+TEST(CallOnceSync, call_immediate_result_lvalue)
+{
+  once_result<int> once;
+
+  // test that call_once() properly forwards the Callable so
+  // it can be passed by lvalue-ref without copy/move
+  struct noncopyable_fn {
+   public:
+    noncopyable_fn() = default;
+    noncopyable_fn(const noncopyable_fn&) = delete;
+    noncopyable_fn& operator=(const noncopyable_fn&) = delete;
+
+    int operator()() { return 42; }
+  };
+  noncopyable_fn fn;
+
+  EXPECT_EQ(call_once(once, null_yield, fn), 42);
+}
+
+TEST(CallOnceSync, call_immediate_exception)
+{
+  once_result<int> once;
+
+  EXPECT_THROW(call_once(once, null_yield, [] { throw std::bad_alloc(); return 0; }), std::bad_alloc);
+}
+
+TEST(CallOnceSync, call_wait_result)
+{
+  once_result<int> once;
+
+  std::future<int> call_future;
+  std::future<int> wait_future;
+  std::latch call_latch{1};
+  std::latch wait_latch{2};
+
+  call_future = std::async(std::launch::async, [&] {
+      return call_once(once, null_yield, [&] {
+          wait_future = std::async(std::launch::async, [&] {
+              wait_latch.count_down();
+              return call_once(once, null_yield, [] { return 0; });
+            });
+          wait_latch.count_down();
+          call_latch.wait();
+          return 42;
+        });
+    });
+
+  wait_latch.wait();
+
+  using namespace std::chrono_literals;
+  EXPECT_NE(wait_future.wait_for(0s), std::future_status::ready);
+
+  call_latch.count_down(); // let call return
+
+  EXPECT_EQ(call_future.get(), 42);
+  EXPECT_EQ(wait_future.get(), 42);
+
+  // return cached result
+  EXPECT_EQ(call_once(once, null_yield, [] { return 0; }), 42);
+}
+
+TEST(CallOnceSync, call_wait_exception)
+{
+  once_result<int> once;
+
+  std::future<int> call_future;
+  std::future<int> wait_future;
+  std::latch call_latch{1};
+  std::latch wait_latch{2};
+
+  call_future = std::async(std::launch::async, [&] {
+      return call_once(once, null_yield, [&] {
+          wait_future = std::async(std::launch::async, [&] {
+              wait_latch.count_down();
+              return call_once(once, null_yield, [] { return 0; });
+            });
+          wait_latch.count_down();
+          call_latch.wait();
+          throw std::bad_alloc();
+          return 0;
+        });
+    });
+
+  wait_latch.wait();
+
+  using namespace std::chrono_literals;
+  EXPECT_NE(wait_future.wait_for(0s), std::future_status::ready);
+
+  call_latch.count_down(); // let call return
+
+  EXPECT_THROW(call_future.get(), std::bad_alloc);
+  EXPECT_THROW(wait_future.get(), std::bad_alloc);
+
+  // rethrow cached exception
+  EXPECT_THROW(call_once(once, null_yield, [] { return 0; }), std::bad_alloc);
+}
+
+} // namespace ceph::async

--- a/src/test/common/test_keyring.cc
+++ b/src/test/common/test_keyring.cc
@@ -1,0 +1,65 @@
+#include <common/keyring.h>
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+extern "C" {
+#include <keyutils.h>
+}
+
+namespace ceph {
+
+class LinuxKeyringTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    std::error_code ec;
+    if (!LinuxKeyringSecret::supported(&ec)) {
+      GTEST_SKIP() << "Linux Keyring is unsupported. " << ec
+                   << ". Skipping test";
+    }
+  }
+};
+
+TEST_F(LinuxKeyringTest, Basics) {
+  std::string secret("secret");
+  auto maybe_keyring_secret = LinuxKeyringSecret::add("testkey", secret);
+
+  ASSERT_TRUE(maybe_keyring_secret.has_value()) << maybe_keyring_secret.error();
+  auto keyring_secret = std::move(maybe_keyring_secret.value());
+
+  std::string out;
+  ASSERT_FALSE(keyring_secret.read(out));
+  ASSERT_EQ(secret, out);
+
+  ASSERT_FALSE(keyring_secret.remove());
+  ASSERT_TRUE(keyring_secret.read(out));
+}
+
+TEST_F(LinuxKeyringTest, Lifecycle) {
+  std::string secret("secret");
+  auto uut = LinuxKeyringSecret::add("testkey", secret);
+  ASSERT_TRUE(uut.has_value());
+  ASSERT_TRUE(uut->initialized());
+  auto next = std::move(uut);
+  ASSERT_FALSE(uut->initialized());
+  ASSERT_TRUE(next->initialized());
+}
+
+TEST_F(LinuxKeyringTest, LifecycleMoveAssignResetsDestination) {
+  std::string secret("secret");
+  auto dest = LinuxKeyringSecret::add("testkey", secret);
+  auto source = LinuxKeyringSecret::add("testkey2", secret);
+  ASSERT_TRUE(dest.has_value());
+  ASSERT_TRUE(source.has_value());
+
+  auto dest_serial = dest->_serial;
+  ASSERT_NE(-1, dest_serial);
+
+  dest = std::move(source);
+
+  std::array<char, 1024> buf = {0};
+  auto ret = keyctl_describe(dest_serial, buf.data(), buf.size());
+
+  EXPECT_EQ(-1, ret) << buf.data();
+  ASSERT_EQ(ENOKEY, errno);
+}
+
+}  // namespace ceph

--- a/src/test/common/test_keyring.cc
+++ b/src/test/common/test_keyring.cc
@@ -68,4 +68,16 @@ TEST_F(LinuxKeyringTest, LifecycleMoveAssignResetsDestination) {
   ASSERT_EQ(ENOKEY, errno);
 }
 
+TEST_F(LinuxKeyringTest, ResetClearsState) {
+  auto maybe = keyring->add("testkey", "secret");
+  auto* ptr = dynamic_cast<LinuxKeyringSecret*>(maybe.value().get());
+  auto err = ptr->reset();
+  ASSERT_FALSE(err) << err;
+  ASSERT_FALSE(ptr->initialized());
+  ASSERT_EQ(-1, ptr->_serial);
+
+  err = ptr->reset();
+  ASSERT_TRUE(err);
+}
+
 }  // namespace ceph

--- a/src/test/common/test_web_cache.cc
+++ b/src/test/common/test_web_cache.cc
@@ -1,0 +1,642 @@
+#include <gmock/gmock-matchers.h>
+
+#include <atomic>
+#include <chrono>
+#include <include/expected.hpp>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <queue>
+#include <random>
+#include <thread>
+
+#include "common/ceph_context.h"
+#include "common/ceph_time.h"
+#include "common/dout.h"
+#include "common/JSONFormatter.h"
+#include "common/web_cache.h"
+#include "gtest/gtest.h"
+#include "include/ceph_assert.h"
+#include "include/msgr.h"
+#include "include/uuid.h"
+#include "log/Log.h"
+
+using namespace std::chrono_literals;
+
+namespace webcache {
+
+class WebCacheTest : public ::testing::Test {
+ protected:
+  static constexpr size_t SIEVE_EXAMPLE_CACHE_SIZE = 7;
+  const std::string a_key = "testkey";
+  const std::string a_value = "testvalue";
+  const std::shared_ptr<std::string> a_valptr =
+      std::make_shared<std::string>(a_value);
+
+  const std::unique_ptr<CephContext> _cct;
+  size_t _initialized_capacity;
+  std::unique_ptr<WebCache<std::string, std::string>> _uut;
+
+  WebCacheTest()
+      : _cct(new CephContext(CEPH_ENTITY_TYPE_ANY)),
+        _initialized_capacity(SIEVE_EXAMPLE_CACHE_SIZE),
+        _uut(std::make_unique<WebCache<std::string, std::string>>(
+            SIEVE_EXAMPLE_CACHE_SIZE, 42s)) {
+    _cct->_log->start();
+  }
+  void TearDown() override { lderr(_cct.get()) << "AFTER: " << *_uut << dendl; }
+
+  void reset_cache(size_t capacity) {
+    _uut = std::make_unique<WebCache<std::string, std::string>>(capacity, 42s);
+    _initialized_capacity = capacity;
+  }
+  void reset_cache_system_mode(size_t capacity) {
+    _uut = std::make_unique<WebCache<std::string, std::string>>(
+        _cct.get(), "testing", capacity);
+    _initialized_capacity = capacity;
+  }
+
+  std::vector<std::string> sieve_queue_keys() {
+    std::vector<std::string> keys;
+    std::transform(
+        _uut->_sieve_queue.begin(), _uut->_sieve_queue.end(),
+        std::back_inserter(keys), [](const auto& node) { return *node.key; });
+    return keys;
+  }
+  size_t sieve_hand_pos() {
+    if (_uut->_sieve_hand == nullptr) {
+      return _uut->_capacity -1;
+    }
+    return std::distance(
+        _uut->_sieve_queue.begin(),
+        _uut->_sieve_queue.iterator_to(*_uut->_sieve_hand));
+  }
+  std::optional<std::string> sieve_hand_key() {
+    if (_uut->size() == 0) {
+      return std::nullopt;
+    }
+    if (_uut->_sieve_hand == nullptr) {
+      return *_uut->_sieve_queue.back().key;
+    }
+    return *_uut->_sieve_hand->key;
+  }
+};
+
+TEST_F(WebCacheTest, AddReturnsGreaterZeroTs) {
+  auto expires_ts = _uut->add(a_key, a_valptr);
+  ASSERT_GT(expires_ts, ceph::real_clock::zero());
+}
+
+TEST_F(WebCacheTest, MultipleAddsToEmptyReturnFirstTs) {
+  const std::vector<ceph::real_time> inserts = {
+      _uut->add(a_key, a_valptr),
+      _uut->add(a_key, a_valptr),
+      _uut->add(a_key, a_valptr),
+      _uut->add(a_key, a_valptr),
+  };
+  ASSERT_THAT(inserts, ::testing::Each(inserts[0]));
+}
+
+TEST_F(WebCacheTest, TwoSameKeyAddsGivesSize1) {
+  const auto _ = {
+      _uut->add(a_key, a_valptr),
+      _uut->add(a_key, a_valptr),
+      _uut->add(a_key, a_valptr),
+  };
+  ASSERT_THAT(_uut->size(), 1);
+}
+
+TEST_F(WebCacheTest, TwoDistinctKeyAddsGiveSize2) {
+  const auto _ = {
+      _uut->add("a", a_valptr),
+      _uut->add("b", a_valptr),
+  };
+  ASSERT_THAT(_uut->size(), 2);
+}
+
+TEST_F(WebCacheTest, LookupNonExistingReturnsIsNullopt) {
+  ASSERT_FALSE(_uut->lookup("not-existing").has_value());
+}
+
+TEST_F(WebCacheTest, AddDoesNotOverwrite) {
+  _uut->add(a_key, a_valptr);
+  ASSERT_EQ(_uut->lookup(a_key).value(), a_valptr);
+
+  auto another_valptr = std::make_shared<std::string>("another-value");
+  _uut->add(a_key, another_valptr);
+  ASSERT_EQ(_uut->lookup(a_key).value(), a_valptr);
+}
+
+TEST_F(WebCacheTest, LookupReturnsWhatWasAdded) {
+  const std::string key = "testkey";
+  const std::string value = "testvalue";
+  auto addptr = std::make_shared<std::string>(value);
+  _uut->add(key, addptr);
+
+  auto maybe_val = _uut->lookup(key);
+  ASSERT_TRUE(maybe_val);
+  ASSERT_EQ(value, *maybe_val.value());
+}
+
+TEST_F(WebCacheTest, AddsOverCapacityDontGoOver) {
+  for (size_t i = 0; i < (_initialized_capacity + 10); ++i) {
+    _uut->add(std::to_string(i), a_valptr);
+  }
+  ASSERT_EQ(_initialized_capacity, _uut->size());
+}
+
+TEST_F(WebCacheTest, AddALotUnique) {
+  reset_cache(100);
+  for (size_t i = 0; i < 10000; ++i) {
+    uuid_d uuid;
+    uuid.generate_random();
+    _uut->add(uuid.to_string(), a_valptr);
+  }
+}
+
+TEST_F(WebCacheTest, CacheTakesValOwnership) {
+  const std::string a_key = "testkey";
+  const std::string a_value = "testvalue";
+  std::shared_ptr<std::string> a_valptr =
+      std::make_shared<std::string>(a_value);
+  ASSERT_EQ(1, a_valptr.use_count());
+  _uut->add(a_key, a_valptr);
+  ASSERT_EQ(2, a_valptr.use_count());
+  auto retrieved = _uut->lookup(a_key).value();
+  ASSERT_EQ(3, retrieved.use_count());
+  a_valptr.reset();
+  ASSERT_EQ(2, retrieved.use_count());
+}
+
+TEST_F(WebCacheTest, SimpleLookupOr) {
+  auto value = _uut->lookup_or(a_key, std::make_shared<std::string>("test"));
+  ASSERT_EQ("test", *value);
+}
+
+TEST_F(WebCacheTest, LookupOrAddsToCache) {
+  auto future = _uut->lookup_or(a_key, std::make_shared<std::string>("test"));
+  ASSERT_EQ("test", *_uut->lookup(a_key).value());
+}
+
+TEST_F(WebCacheTest, SieveRemoveHand) {
+  std::array<WebCache<std::string, std::string>::Node, 3> store{
+      WebCache<std::string, std::string>::Node{
+          std::make_shared<std::string>("a"), ceph::real_clock::from_time_t(1)},
+      WebCache<std::string, std::string>::Node{
+          std::make_shared<std::string>("b"), ceph::real_clock::from_time_t(2)},
+      WebCache<std::string, std::string>::Node{
+          std::make_shared<std::string>("c"), ceph::real_clock::from_time_t(3)},
+  };
+  WebCache<std::string, std::string>::SieveQueue nodes;
+  for (auto& node : store) {
+    nodes.push_back(node);
+  }
+  // SIEVE QUEUE: a b c
+  WebCache<std::string, std::string>::Node* hand = &store[2];
+  lderr(_cct.get()) << "NODES: " << &store[0] << ", " << &store[1] << ", "
+                    << &store[2] << dendl;
+  lderr(_cct.get()) << "HAND: " << hand << dendl;
+  {
+    auto [it, hand_moved] =
+        WebCache<std::string, std::string>::sieve_remove_unmutexed(
+            nodes, hand, store[2]);
+    ASSERT_EQ(&*nodes.end(), &*it);        // we removed the last element
+    ASSERT_EQ(hand_moved, &nodes.back());  // hand pointed to the last element
+    ASSERT_EQ(hand_moved, &store[1]);
+    hand = hand_moved;
+  }
+
+  {
+    auto [it, hand_moved] =
+        WebCache<std::string, std::string>::sieve_remove_unmutexed(
+            nodes, hand, store[0]);
+    ASSERT_EQ(*it->value, "b");
+    ASSERT_EQ(hand_moved, &store[1]);
+    hand = hand_moved;
+  }
+
+  {
+    auto [it, hand_moved] =
+        WebCache<std::string, std::string>::sieve_remove_unmutexed(
+            nodes, hand, store[1]);
+    ASSERT_EQ(&*nodes.end(), &*it);
+    ASSERT_EQ(hand_moved, nullptr);
+  }
+}
+
+TEST_F(WebCacheTest, ExpireEraseOne) {
+  WebCache<std::string, std::string>::Node alive_node(
+      a_valptr, ceph::real_clock::from_time_t(301));
+  WebCache<std::string, std::string>::Node expired_node(
+      a_valptr, ceph::real_clock::from_time_t(10));
+  WebCache<std::string, std::string>::SieveQueue nodes;
+  nodes.push_back(alive_node);
+  nodes.push_back(expired_node);
+  WebCache<std::string, std::string>::Node* hand = nullptr;
+
+  lderr(_cct.get()) << "NODES:         " << &alive_node << ":" << alive_node
+                    << ", " << &expired_node << ":" << expired_node << dendl;
+  lderr(_cct.get()) << "BEFORE EXPIRE: " << alive_node << ", " << expired_node
+                    << dendl;
+  EXPECT_EQ(2, nodes.size());
+  const auto expiration_cutoff = ceph::real_clock::from_time_t(300);
+  WebCache<std::string, std::string>::SieveQueue expired;
+  WebCache<std::string, std::string>::sieve_expire_erase_unmutexed(
+      nodes, hand, expiration_cutoff, expired);
+  lderr(_cct.get()) << "AFTER EXPIRE:  " << alive_node << ", " << expired_node
+                    << dendl;
+  lderr(_cct.get()) << "EXPIRED:       " << expired << dendl;
+  EXPECT_EQ(1, nodes.size());
+  EXPECT_EQ(nullptr, hand);
+  ASSERT_EQ(1, expired.size());
+  EXPECT_EQ(&*expired.begin(), &expired_node);
+}
+
+TEST_F(WebCacheTest, ExpireEraseAll) {
+  WebCache<std::string, std::string>::Node expired_node_1(
+      a_valptr, ceph::real_clock::from_time_t(23));
+  WebCache<std::string, std::string>::Node expired_node_2(
+      a_valptr, ceph::real_clock::from_time_t(42));
+  WebCache<std::string, std::string>::SieveQueue nodes;
+  nodes.push_back(expired_node_1);
+  nodes.push_back(expired_node_2);
+  WebCache<std::string, std::string>::Node* hand = nullptr;
+  lderr(_cct.get()) << "NODES:         " << &expired_node_1 << ":"
+                    << expired_node_1 << ", " << &expired_node_2 << ":"
+                    << expired_node_2 << dendl;
+  lderr(_cct.get()) << "BEFORE EXPIRE: " << expired_node_1 << ", "
+                    << expired_node_2 << dendl;
+  EXPECT_EQ(2, nodes.size());
+  const auto expiration_cutoff = ceph::real_clock::from_time_t(300);
+  WebCache<std::string, std::string>::SieveQueue expired;
+  WebCache<std::string, std::string>::sieve_expire_erase_unmutexed(
+      nodes, hand, expiration_cutoff, expired);
+  lderr(_cct.get()) << "AFTER EXPIRE:  " << expired_node_1 << ", "
+                    << expired_node_2 << dendl;
+  lderr(_cct.get()) << "EXPIRED:       " << expired << dendl;
+  EXPECT_EQ(0, nodes.size());
+  EXPECT_EQ(nullptr, hand);
+  ASSERT_EQ(2, expired.size());
+  ASSERT_EQ(&*expired.begin(), &expired_node_1);
+  ASSERT_EQ(&expired.back(), &expired_node_2);
+}
+
+TEST_F(WebCacheTest, ExpireEraseUpdatedTTLs) {
+  _uut->add("a", a_valptr);  // oldest
+  _uut->add("b", a_valptr);
+  _uut->add("c", a_valptr);
+  _uut->add("d", a_valptr);
+  _uut->add("e", a_valptr);  // newest
+
+  _uut->update_ttl_if("a", a_valptr, std::chrono::seconds(0));  // expired
+  _uut->update_ttl_if(
+      "b", a_valptr, std::chrono::seconds(100000));  // not expired
+  _uut->update_ttl_if("c", a_valptr, std::chrono::seconds(0));
+  _uut->update_ttl_if("d", a_valptr, std::chrono::seconds(100000));
+  _uut->update_ttl_if("e", a_valptr, std::chrono::seconds(0));
+
+  EXPECT_EQ(5, _uut->size()) << *_uut;
+  EXPECT_EQ(3, _uut->expire_erase());
+  EXPECT_EQ(2, _uut->size()) << *_uut;
+}
+
+TEST_F(WebCacheTest, ExpireEraseEmpty) {
+  WebCache<std::string, std::string>::SieveQueue nodes;
+  const auto expiration_cutoff = ceph::real_clock::from_time_t(42);
+  WebCache<std::string, std::string>::SieveQueue expired;
+  WebCache<std::string, std::string>::Node* hand = nullptr;
+  WebCache<std::string, std::string>::sieve_expire_erase_unmutexed(
+      nodes, hand, expiration_cutoff, expired);
+  ASSERT_EQ(0, nodes.size());
+  ASSERT_EQ(0, expired.size());
+  EXPECT_EQ(nullptr, hand);
+}
+
+TEST_F(WebCacheTest, CacheHasSizeZeroAfterClear) {
+  _uut->add("a", a_valptr);
+  _uut->add("b", a_valptr);
+  _uut->add("c", a_valptr);
+  ASSERT_EQ(3, _uut->size());
+  ASSERT_EQ(3, _uut->clear());
+  ASSERT_EQ(0, _uut->size());
+}
+
+TEST_F(WebCacheTest, SieveExample) {
+  // Example from https://cachemon.github.io/SIEVE-website/
+  _uut->add("a", a_valptr);
+  _uut->add("b", a_valptr);
+  _uut->add("c", a_valptr);
+  _uut->add("d", a_valptr);
+  _uut->add("e", a_valptr);
+  _uut->add("f", a_valptr);
+  _uut->add("g", a_valptr);
+
+  _uut->add("a", a_valptr);
+  _uut->add("b", a_valptr);
+  _uut->add("g", a_valptr);
+  ASSERT_THAT(
+      sieve_queue_keys(),
+      ::testing::ElementsAre("g", "f", "e", "d", "c", "b", "a"));
+  ASSERT_EQ(sieve_hand_pos(), 6);
+
+  _uut->add("h", a_valptr);
+  ASSERT_THAT(
+      sieve_queue_keys(),
+      ::testing::ElementsAre("h", "g", "f", "e", "d", "b", "a"));
+  ASSERT_EQ(sieve_hand_pos(), 4);
+
+  _uut->add("a", a_valptr);
+  ASSERT_THAT(
+      sieve_queue_keys(),
+      ::testing::ElementsAre("h", "g", "f", "e", "d", "b", "a"));
+  ASSERT_EQ(sieve_hand_pos(), 4);
+
+  _uut->add("d", a_valptr);
+  ASSERT_THAT(
+      sieve_queue_keys(),
+      ::testing::ElementsAre("h", "g", "f", "e", "d", "b", "a"));
+  ASSERT_EQ(sieve_hand_pos(), 4);
+
+  _uut->add("i", a_valptr);
+  ASSERT_THAT(
+      sieve_queue_keys(),
+      ::testing::ElementsAre("i", "h", "g", "f", "d", "b", "a"));
+  ASSERT_EQ(sieve_hand_pos(), 3);
+
+  _uut->add("b", a_valptr);
+  ASSERT_THAT(
+      sieve_queue_keys(),
+      ::testing::ElementsAre("i", "h", "g", "f", "d", "b", "a"));
+  ASSERT_EQ(sieve_hand_pos(), 3);
+
+  _uut->add("j", a_valptr);
+  ASSERT_THAT(
+      sieve_queue_keys(),
+      ::testing::ElementsAre("j", "i", "h", "g", "d", "b", "a"));
+  ASSERT_EQ(sieve_hand_pos(), 3);
+}
+
+TEST_F(WebCacheTest, RemoveIfNonExistingReturnsFalse) {
+  ASSERT_FALSE(_uut->remove_if("h", a_valptr));
+}
+
+TEST_F(WebCacheTest, RemoveIfExistingDifferentValueReturnsFalseDoesNothing) {
+  _uut->add("a", a_valptr);
+  ASSERT_FALSE(
+      _uut->remove_if("a", std::make_shared<std::string>("someothervalue")));
+  ASSERT_THAT(sieve_queue_keys(), ::testing::ElementsAre("a"));
+}
+
+TEST_F(WebCacheTest, RemoveIfExampleHandMovement) {
+  // Start with the example from https://cachemon.github.io/SIEVE-website/
+  _uut->add("a", a_valptr);
+  _uut->add("b", a_valptr);
+  _uut->add("c", a_valptr);
+  _uut->add("d", a_valptr);
+  _uut->add("e", a_valptr);
+  _uut->add("f", a_valptr);
+  _uut->add("g", a_valptr);
+  _uut->add("a", a_valptr);
+  _uut->add("b", a_valptr);
+  _uut->add("g", a_valptr);
+  _uut->add("h", a_valptr);
+  ASSERT_THAT(
+      sieve_queue_keys(),
+      ::testing::ElementsAre("h", "g", "f", "e", "d", "b", "a"));
+  ASSERT_EQ(sieve_hand_key(), "d");
+
+  ASSERT_TRUE(_uut->remove_if("h", a_valptr));
+  ASSERT_THAT(
+      sieve_queue_keys(), ::testing::ElementsAre("g", "f", "e", "d", "b", "a"));
+  ASSERT_EQ(sieve_hand_key(), "d");
+
+  ASSERT_TRUE(_uut->remove_if("d", a_valptr));
+  ASSERT_THAT(
+      sieve_queue_keys(), ::testing::ElementsAre("g", "f", "e", "b", "a"));
+  ASSERT_EQ(sieve_hand_key(), "e");
+
+  ASSERT_TRUE(_uut->remove_if("a", a_valptr));
+  ASSERT_THAT(sieve_queue_keys(), ::testing::ElementsAre("g", "f", "e", "b"));
+  ASSERT_EQ(sieve_hand_key(), "e");
+
+  ASSERT_TRUE(_uut->remove_if("f", a_valptr));
+  ASSERT_THAT(sieve_queue_keys(), ::testing::ElementsAre("g", "e", "b"));
+  ASSERT_EQ(sieve_hand_key(), "e");
+
+  ASSERT_TRUE(_uut->remove_if("e", a_valptr));
+  ASSERT_THAT(sieve_queue_keys(), ::testing::ElementsAre("g", "b"));
+  ASSERT_EQ(sieve_hand_key(), "g");
+
+  ASSERT_TRUE(_uut->remove_if("b", a_valptr));
+  ASSERT_THAT(sieve_queue_keys(), ::testing::ElementsAre("g"));
+  ASSERT_EQ(sieve_hand_key(), "g");
+
+  ASSERT_TRUE(_uut->remove_if("g", a_valptr));
+  ASSERT_THAT(0, _uut->size());
+  ASSERT_FALSE(sieve_hand_key().has_value());
+}
+
+TEST_F(WebCacheTest, SieveAllVisited) {
+  reset_cache(2);
+  _uut->add("a", a_valptr);
+  _uut->add("b", a_valptr);
+  _uut->add("a", a_valptr);
+  _uut->add("b", a_valptr);
+  _uut->add("c", a_valptr);
+}
+
+class WebCacheConcurrencyTest : public WebCacheTest {
+  void TearDown() override {
+    if (_uut->perf() != nullptr) {
+      JSONFormatter f(true);
+      _uut->perf()->dump_formatted(&f, false, select_labeled_t::labeled);
+      f.flush(std::cout);
+      _uut->perf()->reset();
+    }
+  }
+};
+
+TEST_F(WebCacheConcurrencyTest, BasicAddSame) {
+  reset_cache_system_mode(100);
+  const auto num_threads =
+      std::max(std::thread::hardware_concurrency() * 100, 100U);
+  std::vector<std::thread> threads;
+  for (size_t i = 0; i < num_threads; ++i) {
+    threads.emplace_back([&]() {
+      for (size_t j = 0; j < 1000; ++j) {
+        _uut->add(a_key, a_valptr);
+      }
+    });
+  }
+  for (auto& th : threads) {
+    th.join();
+  }
+
+  ASSERT_EQ(1, _uut->size());
+  ASSERT_TRUE(_uut->lookup(a_key).has_value());
+}
+
+TEST_F(WebCacheConcurrencyTest, BasicAddUnique) {
+  reset_cache_system_mode(100);
+  const auto num_threads =
+      std::max(std::thread::hardware_concurrency() * 100, 100U);
+  std::vector<std::thread> threads;
+  for (size_t i = 0; i < num_threads; ++i) {
+    threads.emplace_back([&]() {
+      for (size_t j = 0; j < 10; ++j) {
+        uuid_d uuid;
+        uuid.generate_random();
+        _uut->add(uuid.to_string(), a_valptr);
+      }
+    });
+  }
+  for (auto& th : threads) {
+    th.join();
+  }
+}
+
+// Example: Mitigate cache stampedes using std::call_once
+TEST_F(WebCacheConcurrencyTest, StampedeSyncCallOnce) {
+  struct CacheValue {
+    std::once_flag once;
+    std::string value;
+  };
+  webcache::WebCache<std::string, CacheValue> cache(
+      _cct.get(), "test_web_cache", 100);
+  std::atomic_int fetches = 0;
+  const auto num_threads =
+      std::max(std::thread::hardware_concurrency() * 100, 100U);
+  std::vector<std::thread> threads;
+  for (size_t i = 0; i < num_threads; ++i) {
+    threads.emplace_back([&]() {
+      std::shared_ptr<CacheValue> cache_value =
+          cache.lookup_or(a_key, std::make_shared<CacheValue>());
+      std::call_once(cache_value->once, [cache_value, &fetches]() {
+        fetches++;
+        std::this_thread::sleep_for(1000ms);
+        cache_value->value = "test";
+      });
+    });
+  }
+  for (auto& th : threads) {
+    th.join();
+  }
+  ASSERT_EQ(fetches.load(), 1);
+}
+
+// Example: Mitigate cache stampedes using a mutex per value
+TEST_F(WebCacheConcurrencyTest, StampedeMutex) {
+  struct CacheValue {
+    std::mutex mutex;
+    std::string value;
+    std::function<std::string()> fn;
+    CacheValue(std::function<std::string()> fn) : fn(fn) {}
+    std::string get() {
+      std::unique_lock<std::mutex> lock(mutex);
+      if (value.empty()) {
+        value = fn();
+      }
+      return value;
+    }
+  };
+  webcache::WebCache<std::string, CacheValue> cache(
+      _cct.get(), "test_web_cache", 100);
+  std::atomic_int fetches = 0;
+  const auto num_threads =
+      std::max(std::thread::hardware_concurrency() * 100, 100U);
+  std::vector<std::thread> threads;
+  for (size_t i = 0; i < num_threads; ++i) {
+    threads.emplace_back([&]() {
+      std::shared_ptr<CacheValue> cache_value =
+          cache.lookup_or(a_key, std::make_shared<CacheValue>([&fetches]() {
+                            fetches++;
+                            std::this_thread::sleep_for(1000ms);
+                            return "test";
+                          }));
+      cache_value->get();
+    });
+  }
+  for (auto& th : threads) {
+    th.join();
+  }
+  ASSERT_EQ(fetches.load(), 1);
+}
+
+class WebCacheRandomizedTest : public WebCacheTest {
+  void TearDown() override {
+    if (_uut->perf() != nullptr) {
+      JSONFormatter f(true);
+      _uut->perf()->dump_formatted(&f, false, select_labeled_t::labeled);
+      f.flush(std::cout);
+      _uut->perf()->reset();
+    }
+  }
+};
+
+TEST_F(WebCacheRandomizedTest, RandomCallMainOperations) {
+  reset_cache_system_mode(1000);
+  const size_t ops = 100000;
+  const auto num_threads = std::max(std::thread::hardware_concurrency(), 8U);
+
+  std::vector<int> base(100);
+  std::iota(base.begin(), base.end(), 0);
+
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<> dist(0, base.size() - 1);
+  std::queue<std::string> keys;
+  for (size_t i = 0; i < ops; ++i) {
+    keys.emplace(std::to_string(base[dist(gen)]));
+  }
+
+  std::discrete_distribution<> op_dist({90, 1, 9});
+
+  std::mutex mutex;
+  std::vector<std::thread> threads;
+  std::atomic_int lookups;
+  std::atomic_int clears;
+  std::atomic_int expires;
+  for (size_t i = 0; i < num_threads; ++i) {
+    threads.emplace_back([&]() {
+      for (size_t op_i = 0; op_i < ops / num_threads; ++op_i) {
+        std::string key;
+        int op = -1;
+        {
+          std::unique_lock<std::mutex> lock(mutex);
+          key = keys.front();
+          keys.pop();
+          op = op_dist(gen);
+        }
+
+        switch (op) {
+          case 0: {  // lookup_or
+            auto value = _uut->lookup_or(key, a_valptr);
+            lookups++;
+          } break;
+          case 1:  // clear cache
+            _uut->clear();
+            clears++;;
+            break;
+          case 2:  // expire
+            _uut->expire_erase();
+            expires++;
+            break;
+          default:
+            ceph_abort("should not happen");
+        }
+      }
+    });
+  }
+  for (auto& th : threads) {
+    th.join();
+  }
+  EXPECT_GT(lookups, 1);
+  EXPECT_GT(expires, 1);
+  EXPECT_GT(clears, 1);
+  std::cout << "lookups: " << lookups
+            << ", expires: " << expires
+            << ", clears: " << clears
+            << std::endl;
+}
+
+}  // namespace webcache

--- a/src/test/common/test_web_cache.cc
+++ b/src/test/common/test_web_cache.cc
@@ -1,0 +1,642 @@
+#include <gmock/gmock-matchers.h>
+
+#include <atomic>
+#include <chrono>
+#include <include/expected.hpp>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <queue>
+#include <random>
+#include <thread>
+
+#include "common/ceph_context.h"
+#include "common/ceph_time.h"
+#include "common/dout.h"
+#include "common/Formatter.h"
+#include "common/web_cache.h"
+#include "gtest/gtest.h"
+#include "include/ceph_assert.h"
+#include "include/msgr.h"
+#include "include/uuid.h"
+#include "log/Log.h"
+
+using namespace std::chrono_literals;
+
+namespace webcache {
+
+class WebCacheTest : public ::testing::Test {
+ protected:
+  static constexpr size_t SIEVE_EXAMPLE_CACHE_SIZE = 7;
+  const std::string a_key = "testkey";
+  const std::string a_value = "testvalue";
+  const std::shared_ptr<std::string> a_valptr =
+      std::make_shared<std::string>(a_value);
+
+  const std::unique_ptr<CephContext> _cct;
+  size_t _initialized_capacity;
+  std::unique_ptr<WebCache<std::string, std::string>> _uut;
+
+  WebCacheTest()
+      : _cct(new CephContext(CEPH_ENTITY_TYPE_ANY)),
+        _initialized_capacity(SIEVE_EXAMPLE_CACHE_SIZE),
+        _uut(std::make_unique<WebCache<std::string, std::string>>(
+            SIEVE_EXAMPLE_CACHE_SIZE, 42s)) {
+    _cct->_log->start();
+  }
+  void TearDown() override { lderr(_cct.get()) << "AFTER: " << *_uut << dendl; }
+
+  void reset_cache(size_t capacity) {
+    _uut = std::make_unique<WebCache<std::string, std::string>>(capacity, 42s);
+    _initialized_capacity = capacity;
+  }
+  void reset_cache_system_mode(size_t capacity) {
+    _uut = std::make_unique<WebCache<std::string, std::string>>(
+        _cct.get(), "testing", capacity);
+    _initialized_capacity = capacity;
+  }
+
+  std::vector<std::string> sieve_queue_keys() {
+    std::vector<std::string> keys;
+    std::transform(
+        _uut->_sieve_queue.begin(), _uut->_sieve_queue.end(),
+        std::back_inserter(keys), [](const auto& node) { return *node.key; });
+    return keys;
+  }
+  size_t sieve_hand_pos() {
+    if (_uut->_sieve_hand == nullptr) {
+      return _uut->_capacity -1;
+    }
+    return std::distance(
+        _uut->_sieve_queue.begin(),
+        _uut->_sieve_queue.iterator_to(*_uut->_sieve_hand));
+  }
+  std::optional<std::string> sieve_hand_key() {
+    if (_uut->size() == 0) {
+      return std::nullopt;
+    }
+    if (_uut->_sieve_hand == nullptr) {
+      return *_uut->_sieve_queue.back().key;
+    }
+    return *_uut->_sieve_hand->key;
+  }
+};
+
+TEST_F(WebCacheTest, AddReturnsGreaterZeroTs) {
+  auto expires_ts = _uut->add(a_key, a_valptr);
+  ASSERT_GT(expires_ts, ceph::real_clock::zero());
+}
+
+TEST_F(WebCacheTest, MultipleAddsToEmptyReturnFirstTs) {
+  const std::vector<ceph::real_time> inserts = {
+      _uut->add(a_key, a_valptr),
+      _uut->add(a_key, a_valptr),
+      _uut->add(a_key, a_valptr),
+      _uut->add(a_key, a_valptr),
+  };
+  ASSERT_THAT(inserts, ::testing::Each(inserts[0]));
+}
+
+TEST_F(WebCacheTest, TwoSameKeyAddsGivesSize1) {
+  const auto _ = {
+      _uut->add(a_key, a_valptr),
+      _uut->add(a_key, a_valptr),
+      _uut->add(a_key, a_valptr),
+  };
+  ASSERT_THAT(_uut->size(), 1);
+}
+
+TEST_F(WebCacheTest, TwoDistinctKeyAddsGiveSize2) {
+  const auto _ = {
+      _uut->add("a", a_valptr),
+      _uut->add("b", a_valptr),
+  };
+  ASSERT_THAT(_uut->size(), 2);
+}
+
+TEST_F(WebCacheTest, LookupNonExistingReturnsIsNullopt) {
+  ASSERT_FALSE(_uut->lookup("not-existing").has_value());
+}
+
+TEST_F(WebCacheTest, AddDoesNotOverwrite) {
+  _uut->add(a_key, a_valptr);
+  ASSERT_EQ(_uut->lookup(a_key).value(), a_valptr);
+
+  auto another_valptr = std::make_shared<std::string>("another-value");
+  _uut->add(a_key, another_valptr);
+  ASSERT_EQ(_uut->lookup(a_key).value(), a_valptr);
+}
+
+TEST_F(WebCacheTest, LookupReturnsWhatWasAdded) {
+  const std::string key = "testkey";
+  const std::string value = "testvalue";
+  auto addptr = std::make_shared<std::string>(value);
+  _uut->add(key, addptr);
+
+  auto maybe_val = _uut->lookup(key);
+  ASSERT_TRUE(maybe_val);
+  ASSERT_EQ(value, *maybe_val.value());
+}
+
+TEST_F(WebCacheTest, AddsOverCapacityDontGoOver) {
+  for (size_t i = 0; i < (_initialized_capacity + 10); ++i) {
+    _uut->add(std::to_string(i), a_valptr);
+  }
+  ASSERT_EQ(_initialized_capacity, _uut->size());
+}
+
+TEST_F(WebCacheTest, AddALotUnique) {
+  reset_cache(100);
+  for (size_t i = 0; i < 10000; ++i) {
+    uuid_d uuid;
+    uuid.generate_random();
+    _uut->add(uuid.to_string(), a_valptr);
+  }
+}
+
+TEST_F(WebCacheTest, CacheTakesValOwnership) {
+  const std::string a_key = "testkey";
+  const std::string a_value = "testvalue";
+  std::shared_ptr<std::string> a_valptr =
+      std::make_shared<std::string>(a_value);
+  ASSERT_EQ(1, a_valptr.use_count());
+  _uut->add(a_key, a_valptr);
+  ASSERT_EQ(2, a_valptr.use_count());
+  auto retrieved = _uut->lookup(a_key).value();
+  ASSERT_EQ(3, retrieved.use_count());
+  a_valptr.reset();
+  ASSERT_EQ(2, retrieved.use_count());
+}
+
+TEST_F(WebCacheTest, SimpleLookupOr) {
+  auto value = _uut->lookup_or(a_key, std::make_shared<std::string>("test"));
+  ASSERT_EQ("test", *value);
+}
+
+TEST_F(WebCacheTest, LookupOrAddsToCache) {
+  auto future = _uut->lookup_or(a_key, std::make_shared<std::string>("test"));
+  ASSERT_EQ("test", *_uut->lookup(a_key).value());
+}
+
+TEST_F(WebCacheTest, SieveRemoveHand) {
+  std::array<WebCache<std::string, std::string>::Node, 3> store{
+      WebCache<std::string, std::string>::Node{
+          std::make_shared<std::string>("a"), ceph::real_clock::from_time_t(1)},
+      WebCache<std::string, std::string>::Node{
+          std::make_shared<std::string>("b"), ceph::real_clock::from_time_t(2)},
+      WebCache<std::string, std::string>::Node{
+          std::make_shared<std::string>("c"), ceph::real_clock::from_time_t(3)},
+  };
+  WebCache<std::string, std::string>::SieveQueue nodes;
+  for (auto& node : store) {
+    nodes.push_back(node);
+  }
+  // SIEVE QUEUE: a b c
+  WebCache<std::string, std::string>::Node* hand = &store[2];
+  lderr(_cct.get()) << "NODES: " << &store[0] << ", " << &store[1] << ", "
+                    << &store[2] << dendl;
+  lderr(_cct.get()) << "HAND: " << hand << dendl;
+  {
+    auto [it, hand_moved] =
+        WebCache<std::string, std::string>::sieve_remove_unmutexed(
+            nodes, hand, store[2]);
+    ASSERT_EQ(&*nodes.end(), &*it);        // we removed the last element
+    ASSERT_EQ(hand_moved, &nodes.back());  // hand pointed to the last element
+    ASSERT_EQ(hand_moved, &store[1]);
+    hand = hand_moved;
+  }
+
+  {
+    auto [it, hand_moved] =
+        WebCache<std::string, std::string>::sieve_remove_unmutexed(
+            nodes, hand, store[0]);
+    ASSERT_EQ(*it->value, "b");
+    ASSERT_EQ(hand_moved, &store[1]);
+    hand = hand_moved;
+  }
+
+  {
+    auto [it, hand_moved] =
+        WebCache<std::string, std::string>::sieve_remove_unmutexed(
+            nodes, hand, store[1]);
+    ASSERT_EQ(&*nodes.end(), &*it);
+    ASSERT_EQ(hand_moved, nullptr);
+  }
+}
+
+TEST_F(WebCacheTest, ExpireEraseOne) {
+  WebCache<std::string, std::string>::Node alive_node(
+      a_valptr, ceph::real_clock::from_time_t(301));
+  WebCache<std::string, std::string>::Node expired_node(
+      a_valptr, ceph::real_clock::from_time_t(10));
+  WebCache<std::string, std::string>::SieveQueue nodes;
+  nodes.push_back(alive_node);
+  nodes.push_back(expired_node);
+  WebCache<std::string, std::string>::Node* hand = nullptr;
+
+  lderr(_cct.get()) << "NODES:         " << &alive_node << ":" << alive_node
+                    << ", " << &expired_node << ":" << expired_node << dendl;
+  lderr(_cct.get()) << "BEFORE EXPIRE: " << alive_node << ", " << expired_node
+                    << dendl;
+  EXPECT_EQ(2, nodes.size());
+  const auto expiration_cutoff = ceph::real_clock::from_time_t(300);
+  WebCache<std::string, std::string>::SieveQueue expired;
+  WebCache<std::string, std::string>::sieve_expire_erase_unmutexed(
+      nodes, hand, expiration_cutoff, expired);
+  lderr(_cct.get()) << "AFTER EXPIRE:  " << alive_node << ", " << expired_node
+                    << dendl;
+  lderr(_cct.get()) << "EXPIRED:       " << expired << dendl;
+  EXPECT_EQ(1, nodes.size());
+  EXPECT_EQ(nullptr, hand);
+  ASSERT_EQ(1, expired.size());
+  EXPECT_EQ(&*expired.begin(), &expired_node);
+}
+
+TEST_F(WebCacheTest, ExpireEraseAll) {
+  WebCache<std::string, std::string>::Node expired_node_1(
+      a_valptr, ceph::real_clock::from_time_t(23));
+  WebCache<std::string, std::string>::Node expired_node_2(
+      a_valptr, ceph::real_clock::from_time_t(42));
+  WebCache<std::string, std::string>::SieveQueue nodes;
+  nodes.push_back(expired_node_1);
+  nodes.push_back(expired_node_2);
+  WebCache<std::string, std::string>::Node* hand = nullptr;
+  lderr(_cct.get()) << "NODES:         " << &expired_node_1 << ":"
+                    << expired_node_1 << ", " << &expired_node_2 << ":"
+                    << expired_node_2 << dendl;
+  lderr(_cct.get()) << "BEFORE EXPIRE: " << expired_node_1 << ", "
+                    << expired_node_2 << dendl;
+  EXPECT_EQ(2, nodes.size());
+  const auto expiration_cutoff = ceph::real_clock::from_time_t(300);
+  WebCache<std::string, std::string>::SieveQueue expired;
+  WebCache<std::string, std::string>::sieve_expire_erase_unmutexed(
+      nodes, hand, expiration_cutoff, expired);
+  lderr(_cct.get()) << "AFTER EXPIRE:  " << expired_node_1 << ", "
+                    << expired_node_2 << dendl;
+  lderr(_cct.get()) << "EXPIRED:       " << expired << dendl;
+  EXPECT_EQ(0, nodes.size());
+  EXPECT_EQ(nullptr, hand);
+  ASSERT_EQ(2, expired.size());
+  ASSERT_EQ(&*expired.begin(), &expired_node_1);
+  ASSERT_EQ(&expired.back(), &expired_node_2);
+}
+
+TEST_F(WebCacheTest, ExpireEraseUpdatedTTLs) {
+  _uut->add("a", a_valptr);  // oldest
+  _uut->add("b", a_valptr);
+  _uut->add("c", a_valptr);
+  _uut->add("d", a_valptr);
+  _uut->add("e", a_valptr);  // newest
+
+  _uut->update_ttl_if("a", a_valptr, std::chrono::seconds(0));  // expired
+  _uut->update_ttl_if(
+      "b", a_valptr, std::chrono::seconds(100000));  // not expired
+  _uut->update_ttl_if("c", a_valptr, std::chrono::seconds(0));
+  _uut->update_ttl_if("d", a_valptr, std::chrono::seconds(100000));
+  _uut->update_ttl_if("e", a_valptr, std::chrono::seconds(0));
+
+  EXPECT_EQ(5, _uut->size()) << *_uut;
+  EXPECT_EQ(3, _uut->expire_erase());
+  EXPECT_EQ(2, _uut->size()) << *_uut;
+}
+
+TEST_F(WebCacheTest, ExpireEraseEmpty) {
+  WebCache<std::string, std::string>::SieveQueue nodes;
+  const auto expiration_cutoff = ceph::real_clock::from_time_t(42);
+  WebCache<std::string, std::string>::SieveQueue expired;
+  WebCache<std::string, std::string>::Node* hand = nullptr;
+  WebCache<std::string, std::string>::sieve_expire_erase_unmutexed(
+      nodes, hand, expiration_cutoff, expired);
+  ASSERT_EQ(0, nodes.size());
+  ASSERT_EQ(0, expired.size());
+  EXPECT_EQ(nullptr, hand);
+}
+
+TEST_F(WebCacheTest, CacheHasSizeZeroAfterClear) {
+  _uut->add("a", a_valptr);
+  _uut->add("b", a_valptr);
+  _uut->add("c", a_valptr);
+  ASSERT_EQ(3, _uut->size());
+  ASSERT_EQ(3, _uut->clear());
+  ASSERT_EQ(0, _uut->size());
+}
+
+TEST_F(WebCacheTest, SieveExample) {
+  // Example from https://cachemon.github.io/SIEVE-website/
+  _uut->add("a", a_valptr);
+  _uut->add("b", a_valptr);
+  _uut->add("c", a_valptr);
+  _uut->add("d", a_valptr);
+  _uut->add("e", a_valptr);
+  _uut->add("f", a_valptr);
+  _uut->add("g", a_valptr);
+
+  _uut->add("a", a_valptr);
+  _uut->add("b", a_valptr);
+  _uut->add("g", a_valptr);
+  ASSERT_THAT(
+      sieve_queue_keys(),
+      ::testing::ElementsAre("g", "f", "e", "d", "c", "b", "a"));
+  ASSERT_EQ(sieve_hand_pos(), 6);
+
+  _uut->add("h", a_valptr);
+  ASSERT_THAT(
+      sieve_queue_keys(),
+      ::testing::ElementsAre("h", "g", "f", "e", "d", "b", "a"));
+  ASSERT_EQ(sieve_hand_pos(), 4);
+
+  _uut->add("a", a_valptr);
+  ASSERT_THAT(
+      sieve_queue_keys(),
+      ::testing::ElementsAre("h", "g", "f", "e", "d", "b", "a"));
+  ASSERT_EQ(sieve_hand_pos(), 4);
+
+  _uut->add("d", a_valptr);
+  ASSERT_THAT(
+      sieve_queue_keys(),
+      ::testing::ElementsAre("h", "g", "f", "e", "d", "b", "a"));
+  ASSERT_EQ(sieve_hand_pos(), 4);
+
+  _uut->add("i", a_valptr);
+  ASSERT_THAT(
+      sieve_queue_keys(),
+      ::testing::ElementsAre("i", "h", "g", "f", "d", "b", "a"));
+  ASSERT_EQ(sieve_hand_pos(), 3);
+
+  _uut->add("b", a_valptr);
+  ASSERT_THAT(
+      sieve_queue_keys(),
+      ::testing::ElementsAre("i", "h", "g", "f", "d", "b", "a"));
+  ASSERT_EQ(sieve_hand_pos(), 3);
+
+  _uut->add("j", a_valptr);
+  ASSERT_THAT(
+      sieve_queue_keys(),
+      ::testing::ElementsAre("j", "i", "h", "g", "d", "b", "a"));
+  ASSERT_EQ(sieve_hand_pos(), 3);
+}
+
+TEST_F(WebCacheTest, RemoveIfNonExistingReturnsFalse) {
+  ASSERT_FALSE(_uut->remove_if("h", a_valptr));
+}
+
+TEST_F(WebCacheTest, RemoveIfExistingDifferentValueReturnsFalseDoesNothing) {
+  _uut->add("a", a_valptr);
+  ASSERT_FALSE(
+      _uut->remove_if("a", std::make_shared<std::string>("someothervalue")));
+  ASSERT_THAT(sieve_queue_keys(), ::testing::ElementsAre("a"));
+}
+
+TEST_F(WebCacheTest, RemoveIfExampleHandMovement) {
+  // Start with the example from https://cachemon.github.io/SIEVE-website/
+  _uut->add("a", a_valptr);
+  _uut->add("b", a_valptr);
+  _uut->add("c", a_valptr);
+  _uut->add("d", a_valptr);
+  _uut->add("e", a_valptr);
+  _uut->add("f", a_valptr);
+  _uut->add("g", a_valptr);
+  _uut->add("a", a_valptr);
+  _uut->add("b", a_valptr);
+  _uut->add("g", a_valptr);
+  _uut->add("h", a_valptr);
+  ASSERT_THAT(
+      sieve_queue_keys(),
+      ::testing::ElementsAre("h", "g", "f", "e", "d", "b", "a"));
+  ASSERT_EQ(sieve_hand_key(), "d");
+
+  ASSERT_TRUE(_uut->remove_if("h", a_valptr));
+  ASSERT_THAT(
+      sieve_queue_keys(), ::testing::ElementsAre("g", "f", "e", "d", "b", "a"));
+  ASSERT_EQ(sieve_hand_key(), "d");
+
+  ASSERT_TRUE(_uut->remove_if("d", a_valptr));
+  ASSERT_THAT(
+      sieve_queue_keys(), ::testing::ElementsAre("g", "f", "e", "b", "a"));
+  ASSERT_EQ(sieve_hand_key(), "e");
+
+  ASSERT_TRUE(_uut->remove_if("a", a_valptr));
+  ASSERT_THAT(sieve_queue_keys(), ::testing::ElementsAre("g", "f", "e", "b"));
+  ASSERT_EQ(sieve_hand_key(), "e");
+
+  ASSERT_TRUE(_uut->remove_if("f", a_valptr));
+  ASSERT_THAT(sieve_queue_keys(), ::testing::ElementsAre("g", "e", "b"));
+  ASSERT_EQ(sieve_hand_key(), "e");
+
+  ASSERT_TRUE(_uut->remove_if("e", a_valptr));
+  ASSERT_THAT(sieve_queue_keys(), ::testing::ElementsAre("g", "b"));
+  ASSERT_EQ(sieve_hand_key(), "g");
+
+  ASSERT_TRUE(_uut->remove_if("b", a_valptr));
+  ASSERT_THAT(sieve_queue_keys(), ::testing::ElementsAre("g"));
+  ASSERT_EQ(sieve_hand_key(), "g");
+
+  ASSERT_TRUE(_uut->remove_if("g", a_valptr));
+  ASSERT_THAT(0, _uut->size());
+  ASSERT_FALSE(sieve_hand_key().has_value());
+}
+
+TEST_F(WebCacheTest, SieveAllVisited) {
+  reset_cache(2);
+  _uut->add("a", a_valptr);
+  _uut->add("b", a_valptr);
+  _uut->add("a", a_valptr);
+  _uut->add("b", a_valptr);
+  _uut->add("c", a_valptr);
+}
+
+class WebCacheConcurrencyTest : public WebCacheTest {
+  void TearDown() override {
+    if (_uut->perf() != nullptr) {
+      JSONFormatter f(true);
+      _uut->perf()->dump_formatted(&f, false, select_labeled_t::labeled);
+      f.flush(std::cout);
+      _uut->perf()->reset();
+    }
+  }
+};
+
+TEST_F(WebCacheConcurrencyTest, BasicAddSame) {
+  reset_cache_system_mode(100);
+  const auto num_threads =
+      std::max(std::thread::hardware_concurrency() * 100, 100U);
+  std::vector<std::thread> threads;
+  for (size_t i = 0; i < num_threads; ++i) {
+    threads.emplace_back([&]() {
+      for (size_t j = 0; j < 1000; ++j) {
+        _uut->add(a_key, a_valptr);
+      }
+    });
+  }
+  for (auto& th : threads) {
+    th.join();
+  }
+
+  ASSERT_EQ(1, _uut->size());
+  ASSERT_TRUE(_uut->lookup(a_key).has_value());
+}
+
+TEST_F(WebCacheConcurrencyTest, BasicAddUnique) {
+  reset_cache_system_mode(100);
+  const auto num_threads =
+      std::max(std::thread::hardware_concurrency() * 100, 100U);
+  std::vector<std::thread> threads;
+  for (size_t i = 0; i < num_threads; ++i) {
+    threads.emplace_back([&]() {
+      for (size_t j = 0; j < 10; ++j) {
+        uuid_d uuid;
+        uuid.generate_random();
+        _uut->add(uuid.to_string(), a_valptr);
+      }
+    });
+  }
+  for (auto& th : threads) {
+    th.join();
+  }
+}
+
+// Example: Mitigate cache stampedes using std::call_once
+TEST_F(WebCacheConcurrencyTest, StampedeSyncCallOnce) {
+  struct CacheValue {
+    std::once_flag once;
+    std::string value;
+  };
+  webcache::WebCache<std::string, CacheValue> cache(
+      _cct.get(), "test_web_cache", 100);
+  std::atomic_int fetches = 0;
+  const auto num_threads =
+      std::max(std::thread::hardware_concurrency() * 100, 100U);
+  std::vector<std::thread> threads;
+  for (size_t i = 0; i < num_threads; ++i) {
+    threads.emplace_back([&]() {
+      std::shared_ptr<CacheValue> cache_value =
+          cache.lookup_or(a_key, std::make_shared<CacheValue>());
+      std::call_once(cache_value->once, [cache_value, &fetches]() {
+        fetches++;
+        std::this_thread::sleep_for(1000ms);
+        cache_value->value = "test";
+      });
+    });
+  }
+  for (auto& th : threads) {
+    th.join();
+  }
+  ASSERT_EQ(fetches.load(), 1);
+}
+
+// Example: Mitigate cache stampedes using a mutex per value
+TEST_F(WebCacheConcurrencyTest, StampedeMutex) {
+  struct CacheValue {
+    std::mutex mutex;
+    std::string value;
+    std::function<std::string()> fn;
+    CacheValue(std::function<std::string()> fn) : fn(fn) {}
+    std::string get() {
+      std::unique_lock<std::mutex> lock(mutex);
+      if (value.empty()) {
+        value = fn();
+      }
+      return value;
+    }
+  };
+  webcache::WebCache<std::string, CacheValue> cache(
+      _cct.get(), "test_web_cache", 100);
+  std::atomic_int fetches = 0;
+  const auto num_threads =
+      std::max(std::thread::hardware_concurrency() * 100, 100U);
+  std::vector<std::thread> threads;
+  for (size_t i = 0; i < num_threads; ++i) {
+    threads.emplace_back([&]() {
+      std::shared_ptr<CacheValue> cache_value =
+          cache.lookup_or(a_key, std::make_shared<CacheValue>([&fetches]() {
+                            fetches++;
+                            std::this_thread::sleep_for(1000ms);
+                            return "test";
+                          }));
+      cache_value->get();
+    });
+  }
+  for (auto& th : threads) {
+    th.join();
+  }
+  ASSERT_EQ(fetches.load(), 1);
+}
+
+class WebCacheRandomizedTest : public WebCacheTest {
+  void TearDown() override {
+    if (_uut->perf() != nullptr) {
+      JSONFormatter f(true);
+      _uut->perf()->dump_formatted(&f, false, select_labeled_t::labeled);
+      f.flush(std::cout);
+      _uut->perf()->reset();
+    }
+  }
+};
+
+TEST_F(WebCacheRandomizedTest, RandomCallMainOperations) {
+  reset_cache_system_mode(1000);
+  const size_t ops = 100000;
+  const auto num_threads = std::max(std::thread::hardware_concurrency(), 8U);
+
+  std::vector<int> base(100);
+  std::iota(base.begin(), base.end(), 0);
+
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<> dist(0, base.size() - 1);
+  std::queue<std::string> keys;
+  for (size_t i = 0; i < ops; ++i) {
+    keys.emplace(std::to_string(base[dist(gen)]));
+  }
+
+  std::discrete_distribution<> op_dist({90, 1, 9});
+
+  std::mutex mutex;
+  std::vector<std::thread> threads;
+  std::atomic_int lookups;
+  std::atomic_int clears;
+  std::atomic_int expires;
+  for (size_t i = 0; i < num_threads; ++i) {
+    threads.emplace_back([&]() {
+      for (size_t op_i = 0; op_i < ops / num_threads; ++op_i) {
+        std::string key;
+        int op = -1;
+        {
+          std::unique_lock<std::mutex> lock(mutex);
+          key = keys.front();
+          keys.pop();
+          op = op_dist(gen);
+        }
+
+        switch (op) {
+          case 0: {  // lookup_or
+            auto value = _uut->lookup_or(key, a_valptr);
+            lookups++;
+          } break;
+          case 1:  // clear cache
+            _uut->clear();
+            clears++;;
+            break;
+          case 2:  // expire
+            _uut->expire_erase();
+            expires++;
+            break;
+          default:
+            ceph_abort("should not happen");
+        }
+      }
+    });
+  }
+  for (auto& th : threads) {
+    th.join();
+  }
+  EXPECT_GT(lookups, 1);
+  EXPECT_GT(expires, 1);
+  EXPECT_GT(clears, 1);
+  std::cout << "lookups: " << lookups
+            << ", expires: " << expires
+            << ", clears: " << clears
+            << std::endl;
+}
+
+}  // namespace webcache

--- a/src/test/common/test_web_cache.cc
+++ b/src/test/common/test_web_cache.cc
@@ -13,7 +13,7 @@
 #include "common/ceph_context.h"
 #include "common/ceph_time.h"
 #include "common/dout.h"
-#include "common/JSONFormatter.h"
+#include "common/Formatter.h"
 #include "common/web_cache.h"
 #include "gtest/gtest.h"
 #include "include/ceph_assert.h"

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -305,6 +305,13 @@ target_include_directories(unittest_rgw_kms
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
 target_link_libraries(unittest_rgw_kms ${rgw_libs})
 
+# unittest_rgw_kms_cache
+add_executable(unittest_rgw_kms_cache test_rgw_kms_cache.cc)
+add_ceph_unittest(unittest_rgw_kms_cache)
+target_include_directories(unittest_rgw_kms_cache
+  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
+target_link_libraries(unittest_rgw_kms_cache ${rgw_libs})
+
 # unittest_rgw_url
 add_executable(unittest_rgw_url test_rgw_url.cc)
 add_ceph_unittest(unittest_rgw_url)

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -313,6 +313,13 @@ target_include_directories(unittest_rgw_kms
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
 target_link_libraries(unittest_rgw_kms ${rgw_libs})
 
+# unittest_rgw_kms_cache
+add_executable(unittest_rgw_kms_cache test_rgw_kms_cache.cc)
+add_ceph_unittest(unittest_rgw_kms_cache)
+target_include_directories(unittest_rgw_kms_cache
+  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
+target_link_libraries(unittest_rgw_kms_cache ${rgw_libs})
+
 # unittest_rgw_url
 add_executable(unittest_rgw_url test_rgw_url.cc)
 add_ceph_unittest(unittest_rgw_url)

--- a/src/test/rgw/test_rgw_kms.cc
+++ b/src/test/rgw/test_rgw_kms.cc
@@ -1,6 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "gtest/gtest.h"
+#include <common/random_string.h>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include "common/ceph_context.h"
@@ -293,4 +295,15 @@ TEST_F(TestSSEKMS, test_transit_backend_empty_response)
 
   ASSERT_EQ(res, -EINVAL);
   ASSERT_EQ(actual_key, from_base64(""));
+}
+
+TEST_F(TestSSEKMS, TestingBackendDifferentKeyselSameKeyIdDoNotCollide) {
+  map<string, bufferlist> attrs;
+  const NoDoutPrefix no_dpp(cct, 1);
+  cct->_conf->rgw_crypt_s3_kms_encryption_keys =
+      "foo=IyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyM=";
+  std::string out_a, out_b;
+  ASSERT_EQ(0, get_actual_key_from_conf(&no_dpp, "foo", gen_rand_alphanumeric(cct, AES_256_KEYSIZE), out_a));
+  ASSERT_EQ(0, get_actual_key_from_conf(&no_dpp, "foo", gen_rand_alphanumeric(cct, AES_256_KEYSIZE), out_b));
+  ASSERT_NE(out_a, out_b);
 }

--- a/src/test/rgw/test_rgw_kms_cache.cc
+++ b/src/test/rgw/test_rgw_kms_cache.cc
@@ -1,0 +1,368 @@
+#include <common/async/yield_context.h>
+#include <common/ceph_argparse.h>
+#include <common/common_init.h>
+#include <common/keyring.h>
+#include <common/perf_counters.h>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <global/global_context.h>
+#include <global/global_init.h>
+#include <gtest/gtest.h>
+
+#include <boost/asio/cancellation_signal.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/spawn.hpp>
+#include <boost/asio/use_future.hpp>
+#include <cerrno>
+#include <chrono>
+#include <variant>
+#include <thread>
+
+#include "common/web_cache.h"
+#include "rgw_common.h"
+#include "rgw_kms.h"
+#include "rgw_kms_cache.h"
+#include "rgw_perf_counters.h"
+
+class FakeKeyringSecret : public KeyringSecret {
+ public:
+  std::string key;
+  std::string val;
+
+  FakeKeyringSecret(std::string _key, std::string _val)
+      : key(std::move(_key)), val(std::move(_val)) {};
+
+  std::error_code read(std::string& out) const override {
+    out = val;
+    return {};
+  }
+  std::error_code remove() const override { return {}; }
+  bool initialized() const override { return true; }
+};
+
+class FakeKeyring : public Keyring {
+ public:
+  tl::expected<std::unique_ptr<KeyringSecret>, std::error_code> add(
+      const std::string& key, const std::string& val) noexcept override {
+    return std::make_unique<FakeKeyringSecret>(key, val);
+  }
+  bool supported(std::error_code* ec) noexcept override { return true; }
+  std::string_view name() const noexcept override { return "fake"; };
+};
+
+class TestKMSCacheReaperLifecycle : public ::testing::Test,
+                                    public rgw::kms::KMSCache {
+ public:
+  TestKMSCacheReaperLifecycle()
+      : rgw::kms::KMSCache(g_ceph_context, std::make_unique<FakeKeyring>()) {};
+};
+
+static void rethrow(const std::exception_ptr& eptr) {
+  if (eptr) {
+    std::rethrow_exception(eptr);
+  }
+}
+
+TEST_F(TestKMSCacheReaperLifecycle, Threaded) {
+  initialize_ttl_reaper(std::nullopt);
+  EXPECT_TRUE(reaper_initialized());
+  EXPECT_TRUE(std::holds_alternative<std::jthread>(reaper_state));
+
+  stop_ttl_reaper();
+  EXPECT_FALSE(reaper_initialized());
+  EXPECT_FALSE(std::holds_alternative<std::jthread>(reaper_state));
+}
+
+TEST_F(TestKMSCacheReaperLifecycle, NoInit) {
+  EXPECT_FALSE(reaper_initialized());
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(reaper_state));
+  this->stop_ttl_reaper();
+  EXPECT_FALSE(reaper_initialized());
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(reaper_state));
+}
+
+TEST_F(TestKMSCacheReaperLifecycle, Async) {
+  boost::asio::io_context io;
+  auto work = boost::asio::make_work_guard(io);
+  std::jthread io_thread([&]() {
+    io.run();
+  });
+  auto drain = [&] {
+    boost::asio::post(io, boost::asio::use_future).get();
+  };
+  this->initialize_ttl_reaper(io.get_executor());
+  drain();
+  EXPECT_TRUE(reaper_initialized());
+  EXPECT_TRUE(
+      std::holds_alternative<AsyncState>(reaper_state));
+  stop_ttl_reaper();
+  drain();
+  work.reset();
+  io.restart();
+  EXPECT_EQ(io.run(), 0);
+}
+
+class TestKMSCache : public ::testing::Test {
+ protected:
+  CephContext* cct = g_ceph_context;
+  const NoDoutPrefix no_dpp{cct, ceph_subsys_rgw};
+
+ public:
+  std::unique_ptr<rgw::kms::KMSCache> uut =
+      std::make_unique<rgw::kms::KMSCache>(
+          cct, std::make_unique<FakeKeyring>());
+
+  void TearDown() override { perfcounter->reset(); }
+};
+
+TEST_F(TestKMSCache, TransientFetchError) {
+  std::string tmp;
+  ASSERT_EQ(
+      uut->do_cache(
+          &no_dpp, "testing", "foo", [](std::string&) { return -EINVAL; }, tmp,
+          null_yield),
+      -EINVAL);
+  ASSERT_EQ(perfcounter->get(l_rgw_kms_error_transient), 1);
+  ASSERT_EQ(perfcounter->get(l_rgw_kms_error_permanent), 0);
+  ASSERT_EQ(perfcounter->get(l_rgw_kms_error_secret_store), 0);
+  ASSERT_TRUE(cct->_conf->rgw_crypt_s3_kms_cache_enabled);
+}
+
+TEST_F(TestKMSCache, PermanentFetchError) {
+  std::string tmp;
+  ASSERT_EQ(
+      uut->do_cache(
+          &no_dpp, "testing", "foo", [](std::string&) { return -ENOENT; }, tmp,
+          null_yield),
+      -ENOENT);
+  ASSERT_EQ(perfcounter->get(l_rgw_kms_error_transient), 0);
+  ASSERT_EQ(perfcounter->get(l_rgw_kms_error_permanent), 1);
+  ASSERT_EQ(perfcounter->get(l_rgw_kms_error_secret_store), 0);
+  ASSERT_TRUE(cct->_conf->rgw_crypt_s3_kms_cache_enabled);
+}
+
+TEST_F(TestKMSCache, Cache) {
+  const std::string test_key = "37u481923789123u72189ou3jsdf978of";
+  std::string_view test_val = "dlksafj3029jfmsjf8322ty7nghb67435";
+  std::string cache_return;
+  ASSERT_EQ(
+      uut->do_cache(
+          &no_dpp, "testing", test_key,
+          [&](std::string& val) {
+            val = test_val;
+            return 0;
+          },
+          cache_return, null_yield),
+      0);
+  EXPECT_EQ(perfcounter->get(l_rgw_kms_error_transient), 0);
+  EXPECT_EQ(perfcounter->get(l_rgw_kms_error_permanent), 0);
+  EXPECT_EQ(perfcounter->get(l_rgw_kms_error_secret_store), 0);
+  EXPECT_TRUE(cct->_conf->rgw_crypt_s3_kms_cache_enabled);
+  ASSERT_EQ(cache_return, test_val);
+
+  cache_return.clear();
+  ASSERT_EQ(
+      uut->do_cache(
+          &no_dpp, "testing", test_key,
+          [&](std::string&) -> int {
+            EXPECT_TRUE(false) << "fetch must not be called";
+            return -2342;
+          },
+          cache_return, null_yield),
+      0);
+  EXPECT_EQ(perfcounter->get(l_rgw_kms_error_transient), 0);
+  EXPECT_EQ(perfcounter->get(l_rgw_kms_error_permanent), 0);
+  EXPECT_EQ(perfcounter->get(l_rgw_kms_error_secret_store), 0);
+  EXPECT_TRUE(cct->_conf->rgw_crypt_s3_kms_cache_enabled);
+  ASSERT_EQ(cache_return, test_val);
+}
+
+class TestSSEKMSWithTestingKMS : public ::testing::Test {
+ protected:
+  CephContext* cct = g_ceph_context;
+  const NoDoutPrefix no_dpp{cct, ceph_subsys_rgw};
+  std::map<std::string, bufferlist> attrs = {
+      {RGW_ATTR_CRYPT_KEYID,
+       []() {
+         bufferlist bl;
+         bl.append("foo");
+         return bl;
+       }()},
+      {RGW_ATTR_CRYPT_KEYSEL, []() {
+         // AES_ECB(32*"#").decrypt(32*"*")
+         bufferlist bl;
+         bl.append(
+             "\xc6\xb1/\x12\xdc\xf7"
+             "e"
+             "\xe3;\xea\x14\xa4x\x1f"
+             "bX"
+             "\xc6\xb1/\x12\xdc\xf7"
+             "e"
+             "\xe3;\xea\x14\xa4x\x1f"
+             "bX");
+         return bl;
+       }()}};
+  rgw::kms::KMSCache* uut;
+  PerfCounters* cache_perf = nullptr;
+
+  void SetUp() override {
+    // Simulate RGW app KMSCache livecyle. A single instance started
+    // during app init and may be disabled via config.
+    uut = &cct->lookup_or_create_singleton_object<rgw::kms::KMSCache>(
+        "TestSSEKMSWithTestingKMS::kms-cache", false, cct,
+        std::make_unique<FakeKeyring>());
+    cct->get_perfcounters_collection()->with_counters(
+        [&](const PerfCountersCollectionImpl::CounterMap& by_path) {
+          for (const auto& i : by_path) {
+            const auto& perf_counters = i.second.perf_counters;
+            if (perf_counters->get_name() == "kms-cache") {
+              cache_perf = perf_counters;
+              return;
+            }
+          }
+        });
+
+    ASSERT_NE(perfcounter, nullptr);
+    ASSERT_NE(cache_perf, nullptr);
+  }
+
+  void TearDown() override {
+    JSONFormatter f(true);
+    cache_perf->dump_formatted(&f, false, select_labeled_t::labeled);
+    f.flush(std::cout);
+    cct->get_perfcounters_collection()->with_counters(
+        [&](const PerfCountersCollectionImpl::CounterMap& by_path) {
+          for (const auto& i : by_path) {
+            const auto& perf_counters = i.second.perf_counters;
+            if (perf_counters->get_name() == "rgw") {
+              auto [sum, count] =
+                  perf_counters->get_tavg_ns(l_rgw_kms_fetch_lat);
+              fmt::println(
+                  std::cout,
+                  "RGW KMS perf counters: err_trans={} err_perm={} err_sec={} "
+                  "avg_fetch_lat={} fetch_cnt={}",
+                  perf_counters->get(l_rgw_kms_error_transient),
+                  perf_counters->get(l_rgw_kms_error_permanent),
+                  perf_counters->get(l_rgw_kms_error_secret_store),
+                  std::chrono::nanoseconds(sum / count), count);
+              return;
+            }
+          }
+        });
+    uut->clear_cache();
+  }
+
+  void test_do_reconstitue() {
+    std::string actual_key;
+    const int ret = reconstitute_actual_key_from_kms(
+        &no_dpp, attrs, uut, null_yield, actual_key);
+    ASSERT_EQ(ret, 0);
+    ASSERT_EQ(actual_key, "********************************");
+    ASSERT_EQ(perfcounter->get(l_rgw_kms_error_secret_store), 0);
+    ASSERT_EQ(perfcounter->get(l_rgw_kms_error_permanent), 0);
+    ASSERT_EQ(perfcounter->get(l_rgw_kms_error_transient), 0);
+  }
+};
+
+TEST_F(
+    TestSSEKMSWithTestingKMS, TestReconstituteActualKeyFromKMSBasicsDefault) {
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).second, 0);
+  ASSERT_TRUE(cct->_conf->rgw_crypt_s3_kms_cache_enabled);
+  test_do_reconstitue();
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).second, 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::hit)), 0);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::miss)), 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::size)), 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::clear)), 0);
+  EXPECT_EQ(
+      cache_perf->get(static_cast<int>(webcache::Metric::capacity)),
+      cct->_conf->rgw_crypt_s3_kms_cache_max_size);
+}
+
+TEST_F(
+    TestSSEKMSWithTestingKMS,
+    TestReconstituteActualKeyFromKMSBasicsWithoutCache) {
+  cct->_conf.set_val("rgw_crypt_s3_kms_cache_enabled", "false");
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).second, 1);
+  test_do_reconstitue();
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::hit)), 0);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::miss)), 0);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::size)), 0);
+  ASSERT_FALSE(cct->_conf->rgw_crypt_s3_kms_cache_enabled);
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).second, 2);
+}
+
+TEST_F(
+    TestSSEKMSWithTestingKMS, TestReconstituteActualKeyFromKMSBasicsWithCache) {
+  ASSERT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).second, 2);
+
+  cct->_conf.set_val("rgw_crypt_s3_kms_cache_enabled", "true");
+  test_do_reconstitue();
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).second, 3);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::hit)), 0);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::miss)), 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::size)), 1);
+
+  test_do_reconstitue();
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).second, 3);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::hit)), 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::miss)), 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::size)), 1);
+
+  test_do_reconstitue();
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).second, 3);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::hit)), 2);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::miss)), 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::size)), 1);
+}
+
+TEST_F(TestSSEKMSWithTestingKMS, TestRuntimeEnableDisable) {
+  ASSERT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).second, 3);
+
+  cct->_conf.set_val("rgw_crypt_s3_kms_cache_enabled", "true");
+  test_do_reconstitue();
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).second, 4);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::hit)), 0);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::miss)), 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::size)), 1);
+
+  cct->_conf.set_val("rgw_crypt_s3_kms_cache_enabled", "false");
+  test_do_reconstitue();
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).second, 5);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::hit)), 0);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::miss)), 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::size)), 1);
+
+  cct->_conf.set_val("rgw_crypt_s3_kms_cache_enabled", "true");
+  test_do_reconstitue();
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).second, 5);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::hit)), 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::miss)), 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::size)), 1);
+
+  cct->_conf.set_val("rgw_crypt_s3_kms_cache_enabled", "false");
+  uut->clear_cache();
+  test_do_reconstitue();
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).second, 6);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::hit)), 0);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::miss)), 0);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::size)), 0);
+}
+
+int main(int argc, char** argv) {
+  auto args = argv_to_vec(argc, argv);
+  std::map<std::string, std::string> defaults{
+      {"rgw_crypt_s3_kms_backend", RGW_SSE_KMS_BACKEND_TESTING},
+      {"rgw_crypt_s3_kms_encryption_keys",
+       "foo=IyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyM="},
+      {"debug_rgw", "20"}};
+  auto cct = global_init(
+      &defaults, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
+      CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  common_init_finish(g_ceph_context);
+  rgw_perf_start(g_ceph_context);
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/test/rgw/test_rgw_kms_cache.cc
+++ b/src/test/rgw/test_rgw_kms_cache.cc
@@ -8,6 +8,7 @@
 #include <global/global_context.h>
 #include <global/global_init.h>
 #include <gtest/gtest.h>
+#include <rgw_crypt.h>
 
 #include <boost/asio/cancellation_signal.hpp>
 #include <boost/asio/co_spawn.hpp>
@@ -349,6 +350,37 @@ TEST_F(TestSSEKMSWithTestingKMS, TestRuntimeEnableDisable) {
   EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::hit)), 0);
   EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::miss)), 0);
   EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::size)), 0);
+}
+
+TEST_F(TestSSEKMSWithTestingKMS, KeyselCollisionAfterClearCache) {
+  cct->_conf.set_val("rgw_crypt_s3_kms_cache_enabled", "true");
+  auto attrs_A = attrs;
+  auto attrs_B = attrs;
+  set_attr(attrs_B, RGW_ATTR_CRYPT_KEYSEL,
+      "\x3a\xa8\x16\xc2\x48\x0e\xb4\x3e\x9b\xff\xab\x7b\xfc\xc2\xc7\xfd"
+      "\x3a\xa8\x16\xc2\x48\x0e\xb4\x3e\x9b\xff\xab\x7b\xfc\xc2\xc7\xfd");
+
+  std::string out_A1;
+  ASSERT_EQ(reconstitute_actual_key_from_kms(
+                &no_dpp, attrs_A, uut, null_yield, out_A1),
+      0);
+  EXPECT_EQ(out_A1, std::string(32, '*'));
+
+  uut->clear_cache();
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::size)), 0);
+
+  std::string out_B1;
+  ASSERT_EQ(reconstitute_actual_key_from_kms(
+                &no_dpp, attrs_B, uut, null_yield, out_B1),
+      0);
+  EXPECT_EQ(out_B1, std::string(32, '+'));
+
+  std::string out_A2;
+  ASSERT_EQ(reconstitute_actual_key_from_kms(
+                &no_dpp, attrs_A, uut, null_yield, out_A2),
+      0);
+  EXPECT_EQ(out_A2, out_A1);
+  EXPECT_NE(out_A2, out_B1);
 }
 
 int main(int argc, char** argv) {

--- a/src/test/rgw/test_rgw_kms_cache.cc
+++ b/src/test/rgw/test_rgw_kms_cache.cc
@@ -1,0 +1,368 @@
+#include <common/async/yield_context.h>
+#include <common/ceph_argparse.h>
+#include <common/common_init.h>
+#include <common/keyring.h>
+#include <common/perf_counters.h>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <global/global_context.h>
+#include <global/global_init.h>
+#include <gtest/gtest.h>
+
+#include <boost/asio/cancellation_signal.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/spawn.hpp>
+#include <boost/asio/use_future.hpp>
+#include <cerrno>
+#include <chrono>
+#include <variant>
+#include <thread>
+
+#include "common/web_cache.h"
+#include "rgw_common.h"
+#include "rgw_kms.h"
+#include "rgw_kms_cache.h"
+#include "rgw_perf_counters.h"
+
+class FakeKeyringSecret : public KeyringSecret {
+ public:
+  std::string key;
+  std::string val;
+
+  FakeKeyringSecret(std::string _key, std::string _val)
+      : key(std::move(_key)), val(std::move(_val)) {};
+
+  std::error_code read(std::string& out) const override {
+    out = val;
+    return {};
+  }
+  std::error_code remove() const override { return {}; }
+  bool initialized() const override { return true; }
+};
+
+class FakeKeyring : public Keyring {
+ public:
+  tl::expected<std::unique_ptr<KeyringSecret>, std::error_code> add(
+      const std::string& key, const std::string& val) noexcept override {
+    return std::make_unique<FakeKeyringSecret>(key, val);
+  }
+  bool supported(std::error_code* ec) noexcept override { return true; }
+  std::string_view name() const noexcept override { return "fake"; };
+};
+
+class TestKMSCacheReaperLifecycle : public ::testing::Test,
+                                    public rgw::kms::KMSCache {
+ public:
+  TestKMSCacheReaperLifecycle()
+      : rgw::kms::KMSCache(g_ceph_context, std::make_unique<FakeKeyring>()) {};
+};
+
+static void rethrow(const std::exception_ptr& eptr) {
+  if (eptr) {
+    std::rethrow_exception(eptr);
+  }
+}
+
+TEST_F(TestKMSCacheReaperLifecycle, Threaded) {
+  initialize_ttl_reaper(std::nullopt);
+  EXPECT_TRUE(reaper_initialized());
+  EXPECT_TRUE(std::holds_alternative<std::jthread>(reaper_state));
+
+  stop_ttl_reaper();
+  EXPECT_FALSE(reaper_initialized());
+  EXPECT_FALSE(std::holds_alternative<std::jthread>(reaper_state));
+}
+
+TEST_F(TestKMSCacheReaperLifecycle, NoInit) {
+  EXPECT_FALSE(reaper_initialized());
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(reaper_state));
+  this->stop_ttl_reaper();
+  EXPECT_FALSE(reaper_initialized());
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(reaper_state));
+}
+
+TEST_F(TestKMSCacheReaperLifecycle, Async) {
+  boost::asio::io_context io;
+  auto work = boost::asio::make_work_guard(io);
+  std::jthread io_thread([&]() {
+    io.run();
+  });
+  auto drain = [&] {
+    boost::asio::post(io, boost::asio::use_future).get();
+  };
+  this->initialize_ttl_reaper(io.get_executor());
+  drain();
+  EXPECT_TRUE(reaper_initialized());
+  EXPECT_TRUE(
+      std::holds_alternative<AsyncState>(reaper_state));
+  stop_ttl_reaper();
+  drain();
+  work.reset();
+  io.restart();
+  EXPECT_EQ(io.run(), 0);
+}
+
+class TestKMSCache : public ::testing::Test {
+ protected:
+  CephContext* cct = g_ceph_context;
+  const NoDoutPrefix no_dpp{cct, ceph_subsys_rgw};
+
+ public:
+  std::unique_ptr<rgw::kms::KMSCache> uut =
+      std::make_unique<rgw::kms::KMSCache>(
+          cct, std::make_unique<FakeKeyring>());
+
+  void TearDown() override { perfcounter->reset(); }
+};
+
+TEST_F(TestKMSCache, TransientFetchError) {
+  std::string tmp;
+  ASSERT_EQ(
+      uut->do_cache(
+          &no_dpp, "testing", "foo", [](std::string&) { return -EINVAL; }, tmp,
+          null_yield),
+      -EINVAL);
+  ASSERT_EQ(perfcounter->get(l_rgw_kms_error_transient), 1);
+  ASSERT_EQ(perfcounter->get(l_rgw_kms_error_permanent), 0);
+  ASSERT_EQ(perfcounter->get(l_rgw_kms_error_secret_store), 0);
+  ASSERT_TRUE(cct->_conf->rgw_crypt_s3_kms_cache_enabled);
+}
+
+TEST_F(TestKMSCache, PermanentFetchError) {
+  std::string tmp;
+  ASSERT_EQ(
+      uut->do_cache(
+          &no_dpp, "testing", "foo", [](std::string&) { return -ENOENT; }, tmp,
+          null_yield),
+      -ENOENT);
+  ASSERT_EQ(perfcounter->get(l_rgw_kms_error_transient), 0);
+  ASSERT_EQ(perfcounter->get(l_rgw_kms_error_permanent), 1);
+  ASSERT_EQ(perfcounter->get(l_rgw_kms_error_secret_store), 0);
+  ASSERT_TRUE(cct->_conf->rgw_crypt_s3_kms_cache_enabled);
+}
+
+TEST_F(TestKMSCache, Cache) {
+  const std::string test_key = "37u481923789123u72189ou3jsdf978of";
+  std::string_view test_val = "dlksafj3029jfmsjf8322ty7nghb67435";
+  std::string cache_return;
+  ASSERT_EQ(
+      uut->do_cache(
+          &no_dpp, "testing", test_key,
+          [&](std::string& val) {
+            val = test_val;
+            return 0;
+          },
+          cache_return, null_yield),
+      0);
+  EXPECT_EQ(perfcounter->get(l_rgw_kms_error_transient), 0);
+  EXPECT_EQ(perfcounter->get(l_rgw_kms_error_permanent), 0);
+  EXPECT_EQ(perfcounter->get(l_rgw_kms_error_secret_store), 0);
+  EXPECT_TRUE(cct->_conf->rgw_crypt_s3_kms_cache_enabled);
+  ASSERT_EQ(cache_return, test_val);
+
+  cache_return.clear();
+  ASSERT_EQ(
+      uut->do_cache(
+          &no_dpp, "testing", test_key,
+          [&](std::string&) -> int {
+            EXPECT_TRUE(false) << "fetch must not be called";
+            return -2342;
+          },
+          cache_return, null_yield),
+      0);
+  EXPECT_EQ(perfcounter->get(l_rgw_kms_error_transient), 0);
+  EXPECT_EQ(perfcounter->get(l_rgw_kms_error_permanent), 0);
+  EXPECT_EQ(perfcounter->get(l_rgw_kms_error_secret_store), 0);
+  EXPECT_TRUE(cct->_conf->rgw_crypt_s3_kms_cache_enabled);
+  ASSERT_EQ(cache_return, test_val);
+}
+
+class TestSSEKMSWithTestingKMS : public ::testing::Test {
+ protected:
+  CephContext* cct = g_ceph_context;
+  const NoDoutPrefix no_dpp{cct, ceph_subsys_rgw};
+  std::map<std::string, bufferlist> attrs = {
+      {RGW_ATTR_CRYPT_KEYID,
+       []() {
+         bufferlist bl;
+         bl.append("foo");
+         return bl;
+       }()},
+      {RGW_ATTR_CRYPT_KEYSEL, []() {
+         // AES_ECB(32*"#").decrypt(32*"*")
+         bufferlist bl;
+         bl.append(
+             "\xc6\xb1/\x12\xdc\xf7"
+             "e"
+             "\xe3;\xea\x14\xa4x\x1f"
+             "bX"
+             "\xc6\xb1/\x12\xdc\xf7"
+             "e"
+             "\xe3;\xea\x14\xa4x\x1f"
+             "bX");
+         return bl;
+       }()}};
+  rgw::kms::KMSCache* uut;
+  PerfCounters* cache_perf = nullptr;
+
+  void SetUp() override {
+    // Simulate RGW app KMSCache livecyle. A single instance started
+    // during app init and may be disabled via config.
+    uut = &cct->lookup_or_create_singleton_object<rgw::kms::KMSCache>(
+        "TestSSEKMSWithTestingKMS::kms-cache", false, cct,
+        std::make_unique<FakeKeyring>());
+    cct->get_perfcounters_collection()->with_counters(
+        [&](const PerfCountersCollectionImpl::CounterMap& by_path) {
+          for (const auto& i : by_path) {
+            const auto& perf_counters = i.second.perf_counters;
+            if (perf_counters->get_name() == "kms-cache") {
+              cache_perf = perf_counters;
+              return;
+            }
+          }
+        });
+
+    ASSERT_NE(perfcounter, nullptr);
+    ASSERT_NE(cache_perf, nullptr);
+  }
+
+  void TearDown() override {
+    JSONFormatter f(true);
+    cache_perf->dump_formatted(&f, false, select_labeled_t::labeled);
+    f.flush(std::cout);
+    cct->get_perfcounters_collection()->with_counters(
+        [&](const PerfCountersCollectionImpl::CounterMap& by_path) {
+          for (const auto& i : by_path) {
+            const auto& perf_counters = i.second.perf_counters;
+            if (perf_counters->get_name() == "rgw") {
+              auto [sum, count] =
+                  perf_counters->get_tavg_ns(l_rgw_kms_fetch_lat);
+              fmt::println(
+                  std::cout,
+                  "RGW KMS perf counters: err_trans={} err_perm={} err_sec={} "
+                  "avg_fetch_lat={} fetch_cnt={}",
+                  perf_counters->get(l_rgw_kms_error_transient),
+                  perf_counters->get(l_rgw_kms_error_permanent),
+                  perf_counters->get(l_rgw_kms_error_secret_store),
+                  std::chrono::nanoseconds(sum / count), count);
+              return;
+            }
+          }
+        });
+    uut->clear_cache();
+  }
+
+  void test_do_reconstitue() {
+    std::string actual_key;
+    const int ret = reconstitute_actual_key_from_kms(
+        &no_dpp, attrs, uut, null_yield, actual_key);
+    ASSERT_EQ(ret, 0);
+    ASSERT_EQ(actual_key, "********************************");
+    ASSERT_EQ(perfcounter->get(l_rgw_kms_error_secret_store), 0);
+    ASSERT_EQ(perfcounter->get(l_rgw_kms_error_permanent), 0);
+    ASSERT_EQ(perfcounter->get(l_rgw_kms_error_transient), 0);
+  }
+};
+
+TEST_F(
+    TestSSEKMSWithTestingKMS, TestReconstituteActualKeyFromKMSBasicsDefault) {
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).first, 0);
+  ASSERT_TRUE(cct->_conf->rgw_crypt_s3_kms_cache_enabled);
+  test_do_reconstitue();
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).first, 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::hit)), 0);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::miss)), 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::size)), 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::clear)), 0);
+  EXPECT_EQ(
+      cache_perf->get(static_cast<int>(webcache::Metric::capacity)),
+      cct->_conf->rgw_crypt_s3_kms_cache_max_size);
+}
+
+TEST_F(
+    TestSSEKMSWithTestingKMS,
+    TestReconstituteActualKeyFromKMSBasicsWithoutCache) {
+  cct->_conf.set_val("rgw_crypt_s3_kms_cache_enabled", "false");
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).first, 1);
+  test_do_reconstitue();
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::hit)), 0);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::miss)), 0);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::size)), 0);
+  ASSERT_FALSE(cct->_conf->rgw_crypt_s3_kms_cache_enabled);
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).first, 2);
+}
+
+TEST_F(
+    TestSSEKMSWithTestingKMS, TestReconstituteActualKeyFromKMSBasicsWithCache) {
+  ASSERT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).first, 2);
+
+  cct->_conf.set_val("rgw_crypt_s3_kms_cache_enabled", "true");
+  test_do_reconstitue();
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).first, 3);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::hit)), 0);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::miss)), 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::size)), 1);
+
+  test_do_reconstitue();
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).first, 3);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::hit)), 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::miss)), 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::size)), 1);
+
+  test_do_reconstitue();
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).first, 3);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::hit)), 2);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::miss)), 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::size)), 1);
+}
+
+TEST_F(TestSSEKMSWithTestingKMS, TestRuntimeEnableDisable) {
+  ASSERT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).first, 3);
+
+  cct->_conf.set_val("rgw_crypt_s3_kms_cache_enabled", "true");
+  test_do_reconstitue();
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).first, 4);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::hit)), 0);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::miss)), 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::size)), 1);
+
+  cct->_conf.set_val("rgw_crypt_s3_kms_cache_enabled", "false");
+  test_do_reconstitue();
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).first, 5);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::hit)), 0);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::miss)), 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::size)), 1);
+
+  cct->_conf.set_val("rgw_crypt_s3_kms_cache_enabled", "true");
+  test_do_reconstitue();
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).first, 5);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::hit)), 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::miss)), 1);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::size)), 1);
+
+  cct->_conf.set_val("rgw_crypt_s3_kms_cache_enabled", "false");
+  uut->clear_cache();
+  test_do_reconstitue();
+  EXPECT_EQ(perfcounter->get_tavg_ns(l_rgw_kms_fetch_lat).first, 6);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::hit)), 0);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::miss)), 0);
+  EXPECT_EQ(cache_perf->get(static_cast<int>(webcache::Metric::size)), 0);
+}
+
+int main(int argc, char** argv) {
+  auto args = argv_to_vec(argc, argv);
+  std::map<std::string, std::string> defaults{
+      {"rgw_crypt_s3_kms_backend", RGW_SSE_KMS_BACKEND_TESTING},
+      {"rgw_crypt_s3_kms_encryption_keys",
+       "foo=IyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyM="},
+      {"debug_rgw", "20"}};
+  auto cct = global_init(
+      &defaults, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
+      CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  common_init_finish(g_ceph_context);
+  rgw_perf_start(g_ceph_context);
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77282

---

backport of https://github.com/ceph/ceph/pull/61256
parent tracker: https://tracker.ceph.com/issues/68524

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh