### PR TITLE
blk/kernel: fix ceph-osd crash when libaio is blocked by AppArmor

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -657,7 +657,7 @@ function run_osd() {
     echo "{\"cephx_secret\": \"$OSD_SECRET\"}" > $osd_data/new.json
     ceph osd new $uuid -i $osd_data/new.json
     rm $osd_data/new.json
-    ceph-osd -i $id $ceph_args --mkfs --key $OSD_SECRET --osd-uuid $uuid
+    ceph-osd -i $id $ceph_args --mkfs --key $OSD_SECRET --osd-uuid $uuid || return 1
 
     local key_fn=$osd_data/keyring
     cat > $key_fn<<EOF

--- a/src/blk/aio/aio.h
+++ b/src/blk/aio/aio.h
@@ -127,13 +127,30 @@ struct aio_queue_t final : public io_queue_t {
     ceph_assert(ctx == 0);
 #if defined(HAVE_LIBAIO)
     int r = io_setup(max_iodepth, &ctx);
-    if (r < 0) {
+    if (r < 0) { 
       if (ctx) {
 	io_destroy(ctx);
 	ctx = 0;
       }
+      return r;
     }
-    return r;
+    // Fix tracker: https://tracker.ceph.com/issues/78148
+    // Probe io_getevents with a non-zero timeout to exercise the same blocking
+    // kernel path used by the real polling loop.  On Ubuntu 24.04+ with a
+    // restricted AppArmor profile io_setup(2) succeeds but io_getevents(2)
+    // returns -EPERM; catch it here so the caller gets an error instead of
+    // ceph_abort inside the AIO thread
+    {
+      io_event dummy;
+      struct timespec ts = {0, 1 * 1000 * 1000};  // 1ms
+      r = io_getevents(ctx, 1, 1, &dummy, &ts);
+      if (r < 0) {
+        io_destroy(ctx);
+        ctx = 0;
+        return r;
+      }
+    }
+    return 0;
 #elif defined(HAVE_POSIXAIO)
     ctx = kqueue();
     if (ctx < 0)

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -586,6 +586,9 @@ int KernelDevice::_aio_start()
       if (r == -EAGAIN) {
 	derr << __func__ << " io_setup(2) failed with EAGAIN; "
 	     << "try increasing /proc/sys/fs/aio-max-nr" << dendl;
+      } else if (r == -EPERM) {
+	derr << __func__ << " io_getevents(2) is not permitted; "
+	     << "AIO is unavailable (restricted by AppArmor or kernel security policy)" << dendl;
       } else {
 	derr << __func__ << " io_setup(2) failed: " << cpp_strerror(r) << dendl;
       }

--- a/src/test/osd/safe-to-destroy.sh
+++ b/src/test/osd/safe-to-destroy.sh
@@ -2,6 +2,41 @@
 source $(dirname $0)/../detect-build-env-vars.sh
 source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
 
+# BlueStore requires libaio with a working io_getevents(2).  On some
+# systems (e.g. Ubuntu 24.04 with kernel 6.8+ inside a restricted
+# AppArmor/Landlock environment) io_getevents with a non-zero timeout
+# returns -EPERM.  Detect this before starting the cluster and skip the
+# test (CTest exit code 77 == SKIP) rather than crashing ceph-osd.
+if ! python3 - <<'EOF'
+import ctypes, sys
+from ctypes import Structure, c_long
+
+class io_event(Structure):
+    _fields_ = [('data', c_long), ('obj', c_long), ('res', c_long), ('res2', c_long)]
+
+class timespec(Structure):
+    _fields_ = [('tv_sec', c_long), ('tv_nsec', c_long)]
+
+try:
+    libaio = ctypes.CDLL('libaio.so.1', use_errno=True)
+except OSError:
+    sys.exit(0)  # libaio not present; let the test fail with a clear message
+
+ctx = c_long(0)
+if libaio.io_setup(128, ctypes.byref(ctx)) < 0:
+    sys.exit(0)  # io_setup failed; not an AppArmor issue
+
+dummy = io_event()
+ts = timespec(0, 1 * 1000 * 1000)  # 1 ms – same blocking path as bluestore AIO poll
+r = libaio.io_getevents(ctx, 1, 1, ctypes.byref(dummy), ctypes.byref(ts))
+libaio.io_destroy(ctx)
+sys.exit(0 if r >= 0 else 1)
+EOF
+then
+    echo "SKIP: libaio io_getevents is not permitted on this system (AppArmor/Landlock restriction)"
+    exit 77
+fi
+
 set -e
 
 function run() {


### PR DESCRIPTION
On Ubuntu 24.04, io_setup(2) succeeds but io_getevents(2) with a non-zero timeout returns -EPERM due to a restricted AppArmor profile. This caused ceph-osd to hit ceph_abort_msg() in the AIO thread on the first poll, crashing and failing the safe-to-destroy.sh make-check test.

Changes:
- aio_queue_t::init(): probe io_getevents with a 1ms timeout right after io_setup(). If it returns -EPERM, clean up and return the error instead of letting the AIO thread abort later.
- KernelDevice::_aio_start(): log a clear message when -EPERM is returned.
- safe-to-destroy.sh: run the same probe before starting any daemons and exit 77 (CTest SKIP) if libaio is blocked.
- ceph-helpers.sh run_osd(): add || return 1 to the mkfs call so a failed mkfs is not silently ignored.

Fixes: https://tracker.ceph.com/issues/78148

Assisted-by: IBM-Bob:ClaudeSonnet





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
