### PR TITLE
doc/rados: explain what a device class breaks in stretch mode

### DIFF
--- a/doc/rados/operations/stretch-mode.rst
+++ b/doc/rados/operations/stretch-mode.rst
@@ -152,6 +152,8 @@ loss during zone failures because if a PG were allowed to go ``active`` with rep
 writes could be acknowledged despite a lack of redundancy. In the event of a zone failure, all data in the
 affected PG would be lost.
 
+.. _entering_stretch_mode:
+
 Entering Stretch Mode
 ---------------------
 
@@ -353,17 +355,49 @@ SSDs. Hybrid HDD+SSD or HDD-only OSDs are not recommended
 due to the long time it takes for them to recover after connectivity between
 data centers has been restored. This reduces the potential for data loss.
 
-.. warning:: CRUSH rules that specify a device class are not supported in stretch mode.
-   For example, the following rule specifying the ``ssd`` device class will not work::
+.. warning:: Do not specify a device class in the CRUSH rule used for stretch
+   mode. Ceph accepts such a rule and reports healthy stretch mode, but the PGs
+   will fail to peer if a data center is later lost.
+
+   A device class makes CRUSH select OSDs from a shadow tree, in which
+   ``zone1`` is a separate bucket named ``zone1~ssd``::
 
       rule stretch_replicated_rule {
                  id 1
-                 type replicated class ssd
-                 step take default
+                 type replicated
+                 step take default class ssd
                  step choose firstn 0 type datacenter
                  step chooseleaf firstn 2 type host
                  step emit
       }
+
+   The class is honored and the placement is correct: OSDs of that class are
+   chosen from both data centers, as asked. The problem is in the peering
+   check. Stretch mode resolves each OSD to its ``datacenter`` through the
+   pool's CRUSH rule, so with the rule above it sees ``zone1~ssd`` rather than
+   ``zone1``. You will not notice this while both data centers are up, because
+   peering only counts how many distinct buckets the acting set spans, and two
+   shadow buckets count as two.
+
+   The mismatch matters once a data center is lost. When the cluster enters
+   degraded stretch mode, the Monitors record the surviving data center by its
+   real bucket, ``zone1``, and require every PG to include it. That never
+   matches the ``zone1~ssd`` the rule reports, so every PG of every pool using
+   that rule goes inactive and its data is unavailable.
+
+   Restoring the lost data center does not clear this. The cluster returns to
+   healthy stretch mode only once no PG is left degraded, inactive, or unknown,
+   and these PGs stay inactive for as long as that requirement stands, so
+   recovery never finishes on its own. Breaking the loop takes ``ceph osd
+   force_healthy_stretch_mode --yes-i-really-mean-it``, which drops the
+   requirement and lets the PGs peer.
+
+   Use a rule without a device class from the start, such as the one under
+   :ref:`entering_stretch_mode`. If a cluster is already in stretch mode, check
+   the rule that each of its pools uses and correct it while both data centers
+   are up. Switching a pool to another rule moves most of its data, because the
+   shadow tree and the real tree place data differently even when they hold the
+   same OSDs.
 
 In the future, stretch mode could support erasure-coded pools,
 enable deployments across more than two data centers,


### PR DESCRIPTION
The warning said device classes are "not supported" and that such a rule "will not work", without saying what actually happens. Ceph accepts the rule, honors the class, and places the data correctly. Peering is what fails. The rule takes from a shadow tree, so an OSD's datacenter resolves to "zone1~ssd", while the Monitors record the surviving zone as "zone1". The two never match. Nothing looks wrong while both data centers are up, but once one is lost, the PGs left behind cannot peer. Bringing the data center back does not help either, because the cluster leaves degraded stretch mode only once no PG is inactive.

Describe that, and point at the class-free rule under "Entering Stretch Mode". Also fix the example, which wrote "type replicated class ssd". The CRUSH grammar takes a device class on the take step.

Related-to: https://tracker.ceph.com/issues/67414





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
