### PR TITLE
rgw: avoid dangling DoutPrefixProvider in RGWOwnerStatsCache

### DIFF
--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -2089,7 +2089,7 @@ int POSIXDriver::initialize(CephContext *cct, const DoutPrefixProvider *dpp)
   }
 
   ldpp_dout(dpp, 20) << "root_fd: " << root_dir->get_fd() << dendl;
-  quota_handler = RGWQuotaHandler::generate_handler(dpp, this, true);
+  quota_handler = RGWQuotaHandler::generate_handler(this, true);
 
   ldpp_dout(dpp, 20) << "SUCCESS" << dendl;
   return 0;

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -1389,7 +1389,7 @@ int RGWRados::init_complete(const DoutPrefixProvider *dpp, optional_yield y, rgw
     return ret;
   }
 
-  quota_handler = RGWQuotaHandler::generate_handler(dpp, this->driver, quota_threads);
+  quota_handler = RGWQuotaHandler::generate_handler(this->driver, quota_threads);
 
   bucket_index_max_shards = (cct->_conf->rgw_override_bucket_index_max_shards ? cct->_conf->rgw_override_bucket_index_max_shards :
                              zone.bucket_index_max_shards);

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -339,7 +339,6 @@ int RGWBucketStatsCache::init_refresh(const rgw_owner& owner, const rgw_bucket& 
 }
 
 class RGWOwnerStatsCache : public RGWQuotaCache<rgw_owner> {
-  const DoutPrefixProvider *dpp;
   std::atomic<bool> down_flag = { false };
   ceph::shared_mutex mutex = ceph::make_shared_mutex("RGWOwnerStatsCache");
   map<rgw_bucket, rgw_owner> modified_buckets;
@@ -502,8 +501,8 @@ protected:
   }
 
 public:
-  RGWOwnerStatsCache(const DoutPrefixProvider *dpp, rgw::sal::Driver* _driver, bool quota_threads)
-    : RGWQuotaCache<rgw_owner>(_driver, _driver->ctx()->_conf->rgw_bucket_quota_cache_size), dpp(dpp)
+  RGWOwnerStatsCache(rgw::sal::Driver* _driver, bool quota_threads)
+    : RGWQuotaCache<rgw_owner>(_driver, _driver->ctx()->_conf->rgw_bucket_quota_cache_size)
   {
     if (quota_threads) {
       buckets_sync_thread = new BucketsSyncThread(driver->ctx(), this);
@@ -557,11 +556,12 @@ int RGWOwnerStatsCache::init_refresh(const rgw_owner& owner, const rgw_bucket& b
   boost::intrusive_ptr cb = new OwnerAsyncRefreshHandler(
       this, std::move(waiter), owner, bucket);
 
-  ldpp_dout(dpp, 20) << "initiating async quota refresh for owner=" << owner << dendl;
+  const DoutPrefix dp(driver->ctx(), dout_subsys, "rgw owner async refresh handler: ");
+  ldpp_dout(&dp, 20) << "initiating async quota refresh for owner=" << owner << dendl;
 
-  int r = driver->load_stats_async(dpp, owner, std::move(cb));
+  int r = driver->load_stats_async(&dp, owner, std::move(cb));
   if (r < 0) {
-    ldpp_dout(dpp, 0) << "could not read stats for owner=" << owner << dendl;
+    ldpp_dout(&dp, 0) << "could not read stats for owner=" << owner << dendl;
     return r;
   }
 
@@ -925,9 +925,9 @@ class RGWQuotaHandlerImpl : public RGWQuotaHandler {
     return 0;
   }
 public:
-  RGWQuotaHandlerImpl(const DoutPrefixProvider *dpp, rgw::sal::Driver* _driver, bool quota_threads) : driver(_driver),
+  RGWQuotaHandlerImpl(rgw::sal::Driver* _driver, bool quota_threads) : driver(_driver),
                                     bucket_stats_cache(_driver),
-                                    owner_stats_cache(dpp, _driver, quota_threads) {}
+                                    owner_stats_cache(_driver, quota_threads) {}
 
   int check_quota(const DoutPrefixProvider *dpp,
                   const rgw_owner& owner,
@@ -981,9 +981,9 @@ public:
 }; // class RGWQuotaHandlerImpl
 
 
-RGWQuotaHandler *RGWQuotaHandler::generate_handler(const DoutPrefixProvider *dpp, rgw::sal::Driver* driver, bool quota_threads)
+RGWQuotaHandler *RGWQuotaHandler::generate_handler(rgw::sal::Driver* driver, bool quota_threads)
 {
-  return new RGWQuotaHandlerImpl(dpp, driver, quota_threads);
+  return new RGWQuotaHandlerImpl(driver, quota_threads);
 }
 
 void RGWQuotaHandler::free_handler(RGWQuotaHandler *handler)

--- a/src/rgw/rgw_quota.h
+++ b/src/rgw/rgw_quota.h
@@ -37,7 +37,7 @@ public:
 
   virtual void update_stats(const rgw_owner& bucket_owner, rgw_bucket& bucket, int obj_delta, uint64_t added_bytes, uint64_t removed_bytes) = 0;
 
-  static RGWQuotaHandler *generate_handler(const DoutPrefixProvider *dpp, rgw::sal::Driver* driver, bool quota_threads);
+  static RGWQuotaHandler *generate_handler(rgw::sal::Driver* driver, bool quota_threads);
   static void free_handler(RGWQuotaHandler *handler);
 };
 

--- a/src/test/rgw/test_rgw_posix_driver.cc
+++ b/src/test/rgw/test_rgw_posix_driver.cc
@@ -1099,7 +1099,7 @@ public:
         }
       }
     }
-    quota_handler = RGWQuotaHandler::generate_handler(env->dpp, this, false);
+    quota_handler = RGWQuotaHandler::generate_handler(this, false);
     /* ordered listing cache */
     bucket_cache.reset(new BucketCache(
         this, base_path, cache_base, 100, 3, 3, 3));


### PR DESCRIPTION
### Problem

`RGWOwnerStatsCache` stores the `DoutPrefixProvider*` passed to its constructor as a member, then dereferences it later in `init_refresh()` via `ldpp_dout()` / `driver->load_stats_async()`.

When the store is recreated by `RGWRealmReloader::reload()`, that pointer is `&dp` — a stack-local `DoutPrefix` in `reload()`'s frame (`src/rgw/rgw_realm_reloader.cc`). Once `reload()` returns, the member dangles, and the next async owner-quota refresh dereferences it (**use-after-free**).

Normal startup is unaffected because its `dp` lives in a frame that never returns (`rgw_appmain.cc`), so this only manifests after a **realm period reload**.

Call chain that carries the stack pointer into the heap member:

```
RGWRealmReloader::reload()            // const DoutPrefix dp on stack
  -> DriverManager::get_storage(&dp)
  -> RGWRados::init_complete(dpp=&dp)                 // driver/rados/rgw_rados.cc
  -> RGWQuotaHandler::generate_handler(dpp)           // rgw_quota.cc
  -> new RGWQuotaHandlerImpl(dpp)
  -> RGWOwnerStatsCache(dpp)                          // stores dpp = &dp as a member
... reload() returns, dp destroyed, member dangles ...
  -> RGWOwnerStatsCache::init_refresh()               // ldpp_dout(dpp, ...) / load_stats_async(dpp, ...)
```

### Fix

The sibling `RGWBucketStatsCache` already avoids this by **not** storing `dpp` and constructing a local `DoutPrefix` in `init_refresh()`. Mirror that for `RGWOwnerStatsCache`, and drop the now-unused `dpp` parameter from `RGWQuotaHandler::generate_handler()` and its two callers.

Changes:
- `src/rgw/rgw_quota.cc` — `RGWOwnerStatsCache`: remove the `dpp` member; remove `dpp` from the constructor; `init_refresh()` builds a local `const DoutPrefix dp(driver->ctx(), dout_subsys, ...)`; propagate the removal through `RGWQuotaHandlerImpl` and `generate_handler()`.
- `src/rgw/rgw_quota.h` — drop `dpp` from the `generate_handler()` declaration.
- `src/rgw/driver/rados/rgw_rados.cc`, `src/rgw/driver/posix/rgw_sal_posix.cc` — update the two call sites.

No new allocations, threads, or lifetime changes — purely replacing the dangling pointer with an always-valid local object (the cache outlives any single request, and `driver->ctx()` is valid for the cache's whole lifetime).

Reproducer (optional, not included): build radosgw with `-fsanitize=address`, configure a realm, `radosgw-admin period commit` to force a reload, then enable owner/bucket quota and generate stats activity to trigger an async refresh; ASAN reports `heap-use-after-free` in `RGWOwnerStatsCache::init_refresh()`.

Signed-off-by: dengjie <317524211@qq.com>

---

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
