### PR TITLE
umbrella: tools/immutable_object_cache: don't leak in-flight replies on teardown

### DIFF
--- a/src/tools/immutable_object_cache/CacheSession.cc
+++ b/src/tools/immutable_object_cache/CacheSession.cc
@@ -122,13 +122,15 @@ void CacheSession::send(ObjectCacheRequest* reply) {
   bufferlist bl;
   reply->encode();
   bl.append(reply->get_payload_bufferlist());
+  // bl owns the encoded payload; free reply here so it can't leak if the
+  // handler is dropped on teardown.
+  delete reply;
 
   boost::asio::async_write(m_dm_socket,
         boost::asio::buffer(bl.c_str(), bl.length()),
         boost::asio::transfer_exactly(bl.length()),
-        [this, bl, reply](const boost::system::error_code& err,
+        [this, bl](const boost::system::error_code& err,
           size_t bytes_transferred) {
-          delete reply;
           if (err || bytes_transferred != bl.length()) {
             fault(err);
             return;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78267

---

backport of https://github.com/ceph/ceph/pull/69623
parent tracker: https://tracker.ceph.com/issues/77552