### PR TITLE
umbrella: rbd-mirror: fix strict weak ordering in PeerSpec::operator<

### DIFF
--- a/src/tools/rbd_mirror/Types.h
+++ b/src/tools/rbd_mirror/Types.h
@@ -156,7 +156,7 @@ struct PeerSpec {
       return cluster_name < rhs.cluster_name;
     } else if (client_name != rhs.client_name) {
       return client_name < rhs.client_name;
-    } else if (mon_host < rhs.mon_host) {
+    } else if (mon_host != rhs.mon_host) {
       return mon_host < rhs.mon_host;
     } else {
       return key < rhs.key;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78271

---

backport of https://github.com/ceph/ceph/pull/70027
parent tracker: https://tracker.ceph.com/issues/78049