### PR TITLE
mgr/cephadm: Remove SMB TLS certs/keys when SMB service is removed.

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -490,6 +490,8 @@ class SpecStore():
         # type: (str) -> bool
         found = service_name in self._specs
         if found:
+            spec = self._specs[service_name]
+            self._rm_certs_and_keys(spec)
             del self._specs[service_name]
             if service_name in self._rank_maps:
                 del self._rank_maps[service_name]
@@ -517,6 +519,18 @@ class SpecStore():
             self.mgr.cert_mgr.rm_key('nvmeof_server_key', service_name=spec.service_name())
             self.mgr.cert_mgr.rm_key('nvmeof_client_key', service_name=spec.service_name())
             self.mgr.cert_mgr.rm_key('nvmeof_encryption_key', service_name=spec.service_name())
+        if spec.service_type == 'smb':
+            self.mgr.cert_mgr.rm_cert('smb_ssl_cert', service_name=spec.service_name())
+            self.mgr.cert_mgr.rm_key('smb_ssl_key', service_name=spec.service_name())
+            self.mgr.cert_mgr.rm_cert('smb_ssl_ca_cert', service_name=spec.service_name())
+
+            self.mgr.cert_mgr.rm_cert('smb_remote_control_ssl_cert', service_name=spec.service_name())
+            self.mgr.cert_mgr.rm_key('smb_remote_control_ssl_key', service_name=spec.service_name())
+            self.mgr.cert_mgr.rm_cert('smb_remote_control_ca_cert', service_name=spec.service_name())
+
+            self.mgr.cert_mgr.rm_cert('smb_keybridge_ssl_cert', service_name=spec.service_name())
+            self.mgr.cert_mgr.rm_key('smb_keybridge_ssl_key', service_name=spec.service_name())
+            self.mgr.cert_mgr.rm_cert('smb_keybridge_ca_cert', service_name=spec.service_name())
 
     def get_created(self, spec: ServiceSpec) -> Optional[datetime.datetime]:
         return self.spec_created.get(spec.service_name())

--- a/src/pybind/mgr/cephadm/tests/services/test_smb.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_smb.py
@@ -1,14 +1,18 @@
 import json
+import logging
 from unittest.mock import patch
 
 from ceph.smb.constants import REMOTE_CONTROL
 from cephadm.services.smb import SMBSpec, SMBExternalCephCluster
 from cephadm.module import CephadmOrchestrator
-from cephadm.tests.fixtures import with_host, with_service, async_side_effect
+from cephadm.serve import CephadmServe
+from cephadm.tests.fixtures import with_host, with_service, async_side_effect, wait
 
 from cephadm.services.service_registry import service_registry
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 from ceph.deployment.service_spec import PlacementSpec
+
+logger = logging.getLogger(__name__)
 
 _SAMBA_METRICS_IMAGE = 'quay.io/samba.org/samba-metrics:devbuilds-centos-any'
 
@@ -203,6 +207,67 @@ class TestSMB:
                 assert files.get('remote_control.ssl.crt') == ceph_generated_cert
                 assert files.get('remote_control.ssl.key') == ceph_generated_key
                 assert files.get('remote_control.ca.crt') == cephadm_root_ca
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_smb_tls_feature_cert_remove_config_blobs(
+        self, _run_cephadm, cephadm_module: CephadmOrchestrator
+    ):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test', addr='1.2.3.7'):
+            cephadm_module.cache.update_host_networks(
+                'test',
+                {'1.2.3.0/24': {'if0': ['1.2.3.7']}}
+            )
+
+            smb_spec = SMBSpec(
+                cluster_id='foxtrot',
+                service_id='foo',
+                config_uri='rados://.smb/foxtrot/config2.json',
+                placement=PlacementSpec(hosts=['test']),
+                features=[REMOTE_CONTROL],
+                ssl_certificates={
+                    'remote_control': {
+                        'enabled': True,
+                        'ssl_cert': ceph_generated_cert,
+                        'ssl_key': ceph_generated_key,
+                        'ssl_ca_cert': cephadm_root_ca,
+                        'certificate_source': 'inline',
+                    },
+                },
+            )
+            service_name = smb_spec.service_name()
+
+            c = cephadm_module.apply([smb_spec])
+            assert wait(cephadm_module, c) == [f'Scheduled {service_name} update...']
+            CephadmServe(cephadm_module)._apply_all_services()
+
+            smb_conf, _ = service_registry.get_service('smb').generate_config(
+                CephadmDaemonDeploySpec(
+                    host='test',
+                    daemon_id='foo.test.0',
+                    service_name=service_name,
+                )
+            )
+            assert wait(cephadm_module, cephadm_module.remove_service(service_name)) == (
+                f'Removed service {service_name}'
+            )
+            CephadmServe(cephadm_module)._apply_all_services()
+            try:
+                smb_conf, _ = service_registry.get_service('smb.foo').generate_config(
+                    CephadmDaemonDeploySpec(
+                        host='test',
+                        daemon_id='foo.test.0',
+                        service_name=service_name,
+                    )
+                )
+                # If config is generated, verify certificates are removed
+                fs = smb_conf.get('files', {})
+                assert fs.get('remote_control.ssl.crt') is None
+                assert fs.get('remote_control.ssl.key') is None
+                assert fs.get('remote_control.ca.crt') is None
+            except KeyError:
+                pass
 
 
 def test_smb_get_dependencies(cephadm_module):


### PR DESCRIPTION
Previously, Removing an SMB service (`ceph orch rm <service name`> is deleting service but not cleaning TLS certificates associated with SMB service.

This PR created to fix this isse for cert/key cleanup into `SpecStore.finally_rm()` (via `_rm_certs_and_keys()`) so certificates are properly purged.

A test case (`test_smb_tls_feature_cert_remove_config_blobs`) was added to verify that after removing an SMB service with  `remote_control` TLS enabled, the associated cert files no longer appear.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
