### PR TITLE
qa/suites/orch/cephadm/smb: retry CTDB deleted-node check

### DIFF
--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_ctdb_node_gone_state.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_ctdb_node_gone_state.yaml
@@ -54,19 +54,12 @@ tasks:
     service: smb.modusr1
 
 # verify CTDB is healthy, cluster well formed
-- template.exec:
-    host.a:
-      - sleep 30
-      - "{{ctx.cephadm}} ls --no-detail  | {{ctx.cephadm}} shell jq -r 'map(select(.name | startswith(\"smb.modusr1\")))[-1].name' > /tmp/svcname"
-      - "{{ctx.cephadm}} enter -n $(cat /tmp/svcname) ctdb listnodes > /tmp/ctdb_listnodes"
-      - "{{ctx.cephadm}} enter -n $(cat /tmp/svcname) ctdb status > /tmp/ctdb_status"
-      - cat /tmp/ctdb_status
-      - cat /tmp/ctdb_listnodes
-      - grep 'pnn:0 .*OK' /tmp/ctdb_status
-      - grep 'pnn:1 .*OK' /tmp/ctdb_status
-      - grep 'pnn:2 .*OK' /tmp/ctdb_status
-      - grep 'Number of nodes:3' /tmp/ctdb_status
-      - rm -rf /tmp/svcname /tmp/ctdb_status
+- smb.workunit:
+    admin_node: host.a
+    timeout: 15m
+    clients:
+      client.0:
+        - [ctdb_healthy]
 
 # Modify the placement to remove a node
 - cephadm.shell:
@@ -81,18 +74,13 @@ tasks:
 - cephadm.wait_for_service:
     service: smb.modusr1
 
-# verify CTDB status doesn't include the node that was removed
-- template.exec:
-    host.a:
-      - "{{ctx.cephadm}} ls --no-detail  | {{ctx.cephadm}} shell jq -r 'map(select(.name | startswith(\"smb.modusr1\")))[-1].name' > /tmp/svcname"
-      - "{{ctx.cephadm}} enter -n $(cat /tmp/svcname) ctdb listnodes > /tmp/ctdb_listnodes"
-      - "{{ctx.cephadm}} enter -n $(cat /tmp/svcname) ctdb status > /tmp/ctdb_status"
-      - cat /tmp/ctdb_status
-      - cat /tmp/ctdb_listnodes
-      - grep 'pnn:0 .*OK' /tmp/ctdb_status
-      - grep 'pnn:1 .*OK' /tmp/ctdb_status
-      - grep 'Number of nodes:3 (including 1 deleted nodes)' /tmp/ctdb_status
-      - rm -rf /tmp/svcname /tmp/ctdb_status
+# verify CTDB status shows the removed node as deleted (may lag after orch 2/2)
+- smb.workunit:
+    admin_node: host.a
+    timeout: 15m
+    clients:
+      client.0:
+        - [ctdb_node_gone]
 
 - cephadm.shell:
     host.a:

--- a/qa/workunits/smb/tests/pytest.ini
+++ b/qa/workunits/smb/tests/pytest.ini
@@ -1,10 +1,11 @@
-
 [pytest]
 addopts = -m 'default'
 markers =
     default: Default tests
     ceph_smb_ctl_local: Local/container test of ceph-smb-ctl tool
     ceph_smb_ctl_remote: Remote access test of ceph-smb-ctl tool
+    ctdb_healthy: CTDB clustered smb all nodes healthy
+    ctdb_node_gone: CTDB shows deleted node after placement shrink
     domain: Domain integration tests
     hosts_access: Host access tests
     kb_fscrypt: Keybridge and FSCrypt tests

--- a/qa/workunits/smb/tests/smbutil.py
+++ b/qa/workunits/smb/tests/smbutil.py
@@ -177,14 +177,25 @@ class PathWrapper:
 
 
 def get_shares(smb_cfg):
-    """Get all SMB shares."""
+    """Get all SMB shares.
+
+    ``ceph smb show`` defaults to --results=collapsed: with exactly one
+    matching share it returns the share object itself; otherwise it returns
+    {"resources": [...]}. Normalize both shapes to a list.
+    """
     jres = cephutil.cephadm_shell_cmd(
         smb_cfg,
         ["ceph", "smb", "show", "ceph.smb.share"],
         load_json=True,
     )
     assert jres.obj
-    resources = jres.obj['resources']
+    obj = jres.obj
+    if 'resources' in obj:
+        resources = obj['resources']
+    elif obj.get('resource_type') == 'ceph.smb.share':
+        resources = [obj]
+    else:
+        raise AssertionError(f'unexpected smb show output: {obj!r}')
     assert len(resources) > 0
     assert all(r['resource_type'] == 'ceph.smb.share' for r in resources)
     return resources

--- a/qa/workunits/smb/tests/test_ctdb_clustering.py
+++ b/qa/workunits/smb/tests/test_ctdb_clustering.py
@@ -1,0 +1,87 @@
+import re
+import time
+
+import pytest
+
+import cephutil
+import smbutil
+
+
+def _cluster_id(smb_cfg):
+    return smbutil.get_shares(smb_cfg)[0]['cluster_id']
+
+
+def _ctdb_cmd(smb_cfg, cluster_id, args):
+    result = cephutil.cephadm_enter_cmd(
+        smb_cfg,
+        cluster_id,
+        list(args),
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout.decode()
+
+
+def _wait_for_ctdb_status(
+    smb_cfg,
+    cluster_id,
+    matchers,
+    *,
+    attempts=18,
+    sleep_s=10,
+):
+    """Poll ctdb status until all matchers succeed or attempts are exhausted."""
+    last_status = ''
+    last_nodes = ''
+    for i in range(1, attempts + 1):
+        last_status = _ctdb_cmd(smb_cfg, cluster_id, ['ctdb', 'status'])
+        last_nodes = _ctdb_cmd(smb_cfg, cluster_id, ['ctdb', 'listnodes'])
+        if all(m.search(last_status) for m in matchers):
+            return last_status
+        if i < attempts:
+            time.sleep(sleep_s)
+    raise AssertionError(
+        'CTDB status did not converge in time.\n'
+        f'Last status:\n{last_status}\n'
+        f'Last listnodes:\n{last_nodes}'
+    )
+
+
+@pytest.mark.ctdb_healthy
+def test_ctdb_cluster_healthy(smb_cfg):
+    """After deploy with placement count:3, CTDB reports three OK nodes."""
+    cluster_id = _cluster_id(smb_cfg)
+    _wait_for_ctdb_status(
+        smb_cfg,
+        cluster_id,
+        [
+            re.compile(r'pnn:0 .*OK'),
+            re.compile(r'pnn:1 .*OK'),
+            re.compile(r'pnn:2 .*OK'),
+            re.compile(r'Number of nodes:3'),
+        ],
+        # allow CTDB a bit of time after orch reports the service running
+        attempts=12,
+        sleep_s=10,
+    )
+
+
+@pytest.mark.ctdb_node_gone
+def test_ctdb_deleted_node_after_shrink(smb_cfg):
+    """After shrinking placement 3→2, CTDB reports one deleted node.
+
+    orch wait_for_service only waits until running==size; CTDB can lag and
+    briefly omit the deleted-node line, so retry for up to ~3 minutes.
+    """
+    cluster_id = _cluster_id(smb_cfg)
+    _wait_for_ctdb_status(
+        smb_cfg,
+        cluster_id,
+        [
+            re.compile(r'pnn:0 .*OK'),
+            re.compile(r'pnn:1 .*OK'),
+            re.compile(r'Number of nodes:3 \(including 1 deleted nodes\)'),
+        ],
+        attempts=18,
+        sleep_s=10,
+    )


### PR DESCRIPTION
After shrinking the smb placement from 3 to 2, wait_for_service only waits until orch running equals size. CTDB can still lag and briefly omit the deleted-node line, which makes a one-shot grep flake. Retry ctdb status for up to about three minutes until two nodes are OK and the status reports one deleted node.

### Reproduce

1. Deploy SMB with placement count 3.

2. Verify that `cephadm enter -n <smb pod> -- ctdb status` shows OK for all 3 deployed nodes, for example:
```
Number of nodes:3
pnn:0 192.168.100.101  OK
pnn:1 192.168.100.100  OK (THIS NODE)
pnn:2 192.168.100.102  OK
```

3. Decrease the SMB placement count to 2.

4. Sample `cephadm enter -n <smb pod> -- ctdb status` using the same retry logic as in the PR (every 10 seconds for up to ~3 minutes).

5. On the first 1–2 samples, CTDB is often not yet synchronized and still shows a stale/wrong status (as seen in pulpito), for example:
```
Number of nodes:3
pnn:0 192.168.100.101  OK
pnn:1 192.168.100.100  OK (THIS NODE)
pnn:2 192.168.100.102  DISCONNECTED|UNHEALTHY|INACTIVE
```

Then it converges to the expected status:
```
Number of nodes:3 (including 1 deleted nodes)
pnn:0 192.168.100.101  OK
pnn:1 192.168.100.100  OK (THIS NODE)
```

After waiting for that status, the check passes successfully.


Fixes: https://tracker.ceph.com/issues/75369


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

