### PR TITLE
Improve Concept vocabulary for libfdb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -861,6 +861,15 @@ else()
   endif()
 endif()
 include_directories(BEFORE SYSTEM ${Boost_INCLUDE_DIRS})
+if(WIN32 AND WITH_CATCH2)
+  foreach(catch2_target Catch2 Catch2WithMain)
+    if(TARGET ${catch2_target})
+      target_include_directories(${catch2_target} SYSTEM PRIVATE
+        ${PROJECT_BINARY_DIR}/include
+        ${Boost_INCLUDE_DIRS})
+    endif()
+  endforeach()
+endif()
 add_library(Boost::asio INTERFACE IMPORTED)
 if(WITH_LIBURING AND CMAKE_SYSTEM_VERSION VERSION_GREATER_EQUAL "5.10")
   # enable uring in boost::asio

--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -188,7 +188,10 @@ endif()
 if(${catch2_opt_NO_CATCH2_MAIN})
   LIST(APPEND tl_libs Catch2::Catch2)
 else()
-  LIST(APPEND tl_libs Catch2::Catch2WithMain)
+  # Accept the gtest XML flag used by the Windows test runner.
+  target_sources(unittest_${test_name}
+    PRIVATE ${CMAKE_SOURCE_DIR}/src/test/catch2_compat_main.cc)
+  LIST(APPEND tl_libs Catch2::Catch2)
 endif()
 
 target_link_libraries(unittest_${test_name} 

--- a/src/common/container_concepts.h
+++ b/src/common/container_concepts.h
@@ -1,0 +1,665 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+#ifndef CEPH_COMMON_CONTAINER_CONCEPTS_H
+ #define CEPH_COMMON_CONTAINER_CONCEPTS_H
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2026 International Business Machines Corp. (IBM)
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <ranges>
+#include <cstddef>
+#include <utility>
+#include <concepts>
+#include <iterator>
+#include <algorithm>
+#include <type_traits>
+
+/* A helpful collection of C++ Concepts that aren't available in the C++23
+* standard. The goal here is to provide common and practical concepts and
+* capability queries.
+*
+* Some of the material is derived from:
+*  - https://eel.is/c++draft/range.utility.conv
+*  - https://en.cppreference.com/w/cpp/ranges/to
+*
+* The facilities provided by this mini-library include:
+*   - some Concepts not in C++ (such as associative_container and
+*   unordered_associative_container);
+*   - a local name for some exposition-only C++ concepts used by the standard (such as
+*   container_compatible_range);
+*
+*   - capability query predicates, which make metaprogramming tasks more straightforward
+*   and are very useful in a variety of algorithms;
+*
+*   - end()/begin() style function forms for some container operations (like clear());
+*
+*   - utility functions for capturing common cases like optionally clearing a container
+*   based on whether or not the operation is supported by its concrete type;
+*
+*   - append helpers that construct values through the container's natural
+*   insertion operation, including stateful appenders for forward-only containers;
+*
+*   - range materialization helpers for building containers without requiring
+*   std::ranges::to support from the local standard library;
+*
+*   Note that a number of the things you might wish were in here are already in implemented
+*   in the Standard Library-- as a guide (depending on your mental model!) this may be helpful:
+*   - ceph::concepts::sequence -> std::ranges::input_range
+*   - ceph::concepts::contiguous_sequence -> std::ranges::contiguous_range
+*   - ceph::util::erase_if -> std::erase_if
+*   - ceph::util::size -> std::ranges::size
+*   - ceph::util::empty -> std::ranges::empty
+*
+* Capability predicates such as can_erase_if and has_size are not direct
+* operation wrappers; keep them when they make generic constraints clearer.
+*
+* This header also keeps local names for useful C++23 exposition-only
+* constraints from ranges::to, including reservable_container and
+* container_appendable.
+*/
+
+// General Concepts:
+namespace ceph::concepts {
+
+template <typename T, typename ...Ts>
+concept same_as_any = (std::same_as<T, Ts> || ...);
+
+template <typename ContainerT>
+concept associative_container = requires(ContainerT& c, const ContainerT& cc,
+                                         const typename ContainerT::key_type& key) {
+  requires std::ranges::range<ContainerT>;
+
+  typename ContainerT::key_type;
+  typename ContainerT::value_type;
+  typename ContainerT::key_compare;
+  typename ContainerT::value_compare;
+  typename ContainerT::iterator;
+  typename ContainerT::const_iterator;
+  typename ContainerT::size_type;
+
+  { cc.key_comp() } -> std::same_as<typename ContainerT::key_compare>;
+  { cc.value_comp() } -> std::same_as<typename ContainerT::value_compare>;
+  { c.find(key) } -> std::same_as<typename ContainerT::iterator>;
+  { cc.find(key) } -> std::same_as<typename ContainerT::const_iterator>;
+  { c.count(key) } -> std::convertible_to<typename ContainerT::size_type>;
+  { c.lower_bound(key) } -> std::same_as<typename ContainerT::iterator>;
+  { cc.lower_bound(key) } -> std::same_as<typename ContainerT::const_iterator>;
+  { c.upper_bound(key) } -> std::same_as<typename ContainerT::iterator>;
+  { cc.upper_bound(key) } -> std::same_as<typename ContainerT::const_iterator>;
+  { c.equal_range(key) };
+  { cc.equal_range(key) };
+};
+
+template <typename ContainerT>
+concept unordered_associative_container = requires(ContainerT& c, const ContainerT& cc,
+                                                   const typename ContainerT::key_type& key) {
+  requires std::ranges::range<ContainerT>;
+
+  typename ContainerT::key_type;
+  typename ContainerT::value_type;
+  typename ContainerT::hasher;
+  typename ContainerT::key_equal;
+  typename ContainerT::iterator;
+  typename ContainerT::const_iterator;
+  typename ContainerT::size_type;
+
+  { cc.hash_function() } -> std::same_as<typename ContainerT::hasher>;
+  { cc.key_eq() } -> std::same_as<typename ContainerT::key_equal>;
+  { c.find(key) } -> std::same_as<typename ContainerT::iterator>;
+  { cc.find(key) } -> std::same_as<typename ContainerT::const_iterator>;
+  { c.count(key) } -> std::convertible_to<typename ContainerT::size_type>;
+  { c.equal_range(key) };
+  { cc.equal_range(key) };
+  { c.bucket_count() } -> std::convertible_to<typename ContainerT::size_type>;
+};
+
+template <typename RangeT, typename T>
+concept container_compatible_range =
+  std::ranges::input_range<RangeT> && std::convertible_to<std::ranges::range_reference_t<RangeT>, T>;
+
+template <typename ContainerT>
+concept reservable_container =
+  std::ranges::sized_range<ContainerT> &&
+  requires(ContainerT& c, std::ranges::range_size_t<ContainerT> n) {
+    c.reserve(n);
+    { c.capacity() } -> std::same_as<decltype(n)>;
+    { c.max_size() } -> std::same_as<decltype(n)>;
+  };
+
+template <typename ContainerT, typename RefT>
+concept container_appendable = requires(ContainerT& c, RefT&& ref) {
+  requires
+    requires { c.emplace_back(std::forward<RefT>(ref)); } ||
+    requires { c.push_back(std::forward<RefT>(ref)); } ||
+    requires { { c.emplace(c.end(), std::forward<RefT>(ref)) } -> std::same_as<decltype(c.end())>; } ||
+    requires { c.insert(c.end(), std::forward<RefT>(ref)); };
+};
+
+} // namespace ceph::concepts
+
+// Capability Queries:
+namespace ceph::concepts {
+
+template <typename ContainerT, typename... ArgsT>
+concept has_emplace_back = requires(ContainerT& c, ArgsT&&... args) {
+  c.emplace_back(std::forward<ArgsT>(args)...);
+};
+
+template <typename ContainerT, typename T>
+concept has_push_back = requires(ContainerT& c, T&& v) {
+  c.push_back(std::forward<T>(v));
+};
+
+template <typename ContainerT, typename... ArgsT>
+concept has_emplace_append = requires(ContainerT& c, ArgsT&&... args) {
+  { c.emplace(std::end(c), std::forward<ArgsT>(args)...) } ->
+    std::same_as<typename ContainerT::iterator>;
+};
+
+template <typename ContainerT, typename T>
+concept has_insert_append = requires(ContainerT& c, T&& v) {
+  c.insert(std::end(c), std::forward<T>(v));
+};
+
+template <typename ContainerT, typename IteratorT, typename... ArgsT>
+concept has_emplace_after = requires(ContainerT& c, IteratorT pos, ArgsT&&... args) {
+  c.emplace_after(pos, std::forward<ArgsT>(args)...);
+};
+
+template <typename ContainerT, typename IteratorT, typename T>
+concept has_insert_after = requires(ContainerT& c, IteratorT pos, T&& v) {
+  c.insert_after(pos, std::forward<T>(v));
+};
+
+template <typename ContainerT, typename RangeT>
+concept has_append_range = requires(ContainerT& c, RangeT&& range) {
+  c.append_range(std::forward<RangeT>(range));
+};
+
+template <typename ContainerT, typename RangeT>
+concept has_insert_range_append = requires(ContainerT& c, RangeT&& range) {
+  c.insert_range(std::end(c), std::forward<RangeT>(range));
+};
+
+template <typename ContainerT, typename RangeT>
+concept has_insert_iterator_range_append = requires(ContainerT& c, RangeT&& range) {
+  requires std::ranges::input_range<RangeT>;
+
+  c.insert(std::end(c), std::begin(range), std::end(range));
+};
+
+template <typename ContainerT, typename IteratorT, typename RangeT>
+concept has_insert_range = requires(ContainerT& c, IteratorT pos, RangeT&& range) {
+  c.insert_range(pos, std::forward<RangeT>(range));
+};
+
+template <typename ContainerT, typename IteratorT, typename RangeT>
+concept has_insert_iterator_range = requires(ContainerT& c, IteratorT pos, RangeT&& range) {
+  requires std::ranges::input_range<RangeT>;
+
+  c.insert(pos, std::begin(range), std::end(range));
+};
+
+template <typename ContainerT, typename T>
+concept has_emplace_front = requires(ContainerT& c, T&& v) {
+  c.emplace_front(std::forward<T>(v));
+};
+
+template <typename ContainerT, typename T>
+concept has_push_front = requires(ContainerT& c, T&& v) {
+  c.push_front(std::forward<T>(v));
+};
+
+template <typename ContainerT, typename T>
+concept has_emplace_at_begin = requires(ContainerT& c, T&& v) {
+  { c.emplace(std::begin(c), std::forward<T>(v)) } -> std::same_as<typename ContainerT::iterator>;
+};
+
+template <typename ContainerT, typename T>
+concept has_insert_at_begin = requires(ContainerT& c, T&& v) {
+  c.insert(std::begin(c), std::forward<T>(v));
+};
+
+template <typename ContainerT>
+concept has_pop_front = requires(ContainerT& c) {
+  c.pop_front();
+};
+
+template <typename ContainerT>
+concept has_erase_begin = requires(ContainerT& c) {
+  c.erase(std::begin(c));
+};
+
+template <typename ContainerT, typename ArgT>
+concept has_erase = requires(ContainerT& c, ArgT&& v) {
+  c.erase(std::forward<ArgT>(v));
+};
+
+template <typename ContainerT, typename IteratorT, typename SentinelT>
+concept has_erase_range = requires(ContainerT& c, IteratorT first, SentinelT last) {
+  c.erase(first, last);
+};
+
+template <typename ContainerT, typename PredicateT>
+concept has_remove_if = requires(ContainerT& c, PredicateT pred) {
+  c.remove_if(pred);
+};
+
+template <typename ContainerT>
+concept has_clear = requires(ContainerT& c) {
+  c.clear();
+};
+
+template <typename ContainerT>
+concept has_reserve = requires(ContainerT& c, std::size_t n) {
+  c.reserve(n);
+};
+
+template <typename ContainerT>
+concept has_capacity = requires(const ContainerT& c) {
+  { c.capacity() } -> std::convertible_to<std::size_t>;
+};
+
+template <typename ContainerT>
+concept has_max_size = requires(const ContainerT& c) {
+  { c.max_size() } -> std::convertible_to<std::size_t>;
+};
+
+template <typename ContainerT>
+concept has_size = requires(const ContainerT& c) {
+  { c.size() } -> std::convertible_to<std::size_t>;
+};
+
+template <typename ContainerT>
+concept has_empty = requires(const ContainerT& c) {
+  { c.empty() } -> std::convertible_to<bool>;
+};
+
+template <typename ContainerT>
+concept has_resize = requires(ContainerT& c, std::size_t n) {
+  c.resize(n);
+};
+
+} // namespace ceph::concepts
+
+// Helpers for composing aggregate capability checks:
+namespace ceph::concepts::detail {
+
+template <typename ContainerT, typename RangeT>
+concept can_append_with_insert =
+  ceph::concepts::has_insert_range_append<ContainerT, RangeT> || ceph::concepts::has_insert_iterator_range_append<ContainerT, RangeT>;
+
+} // namespace ceph::concepts::detail
+
+// Aggregate Capability Checks:
+namespace ceph::concepts {
+
+template <typename ContainerT, typename T>
+concept can_append =
+  container_appendable<ContainerT, T>;
+
+template <typename ContainerT, typename... ArgsT>
+concept can_emplace_append =
+  has_emplace_back<ContainerT, ArgsT...> ||
+  has_emplace_append<ContainerT, ArgsT...> ||
+  (std::constructible_from<typename ContainerT::value_type, ArgsT...> &&
+   can_append<ContainerT, typename ContainerT::value_type>);
+
+template <typename ContainerT, typename IteratorT, typename T>
+concept can_insert_after =
+  has_emplace_after<ContainerT, IteratorT, T> ||
+  has_insert_after<ContainerT, IteratorT, T>;
+
+template <typename ContainerT, typename IteratorT, typename... ArgsT>
+concept can_emplace_after =
+  has_emplace_after<ContainerT, IteratorT, ArgsT...> ||
+  (std::constructible_from<typename ContainerT::value_type, ArgsT...> &&
+   can_insert_after<ContainerT, IteratorT, typename ContainerT::value_type>);
+
+template <typename ContainerT, typename RangeT>
+concept can_append_range =
+  std::ranges::input_range<RangeT> &&
+  (has_append_range<ContainerT, RangeT> ||
+   detail::can_append_with_insert<ContainerT, RangeT> ||
+   can_emplace_append<ContainerT, std::ranges::range_reference_t<RangeT>>);
+
+template <typename ContainerT, typename IteratorT, typename RangeT>
+concept can_insert_any_range =
+  has_insert_range<ContainerT, IteratorT, RangeT> || has_insert_iterator_range<ContainerT, IteratorT, RangeT>;
+
+template <typename ContainerT, typename T>
+concept can_prepend =
+  has_emplace_front<ContainerT, T> ||
+  has_push_front<ContainerT, T> ||
+  has_emplace_at_begin<ContainerT, T> ||
+  has_insert_at_begin<ContainerT, T>;
+
+template <typename ContainerT, typename PredicateT>
+concept can_erase_remove_if = requires(ContainerT& c, PredicateT pred) {
+  requires std::ranges::common_range<ContainerT>;
+  requires has_erase_range<ContainerT,
+                           std::ranges::iterator_t<ContainerT>,
+                           std::ranges::sentinel_t<ContainerT>>;
+
+  std::remove_if(std::begin(c), std::end(c), pred);
+};
+
+template <typename ContainerT, typename PredicateT>
+concept can_erase_if =
+  has_remove_if<ContainerT, PredicateT> || can_erase_remove_if<ContainerT, PredicateT>;
+
+template <typename ContainerT>
+concept can_remove_front =
+  has_pop_front<ContainerT> || has_erase_begin<ContainerT>;
+
+} // namespace ceph::concepts
+
+// Helpers:
+//  - most of these try to "do the right thing" with the underlying container
+//  as-appropriate; use some caution in performance-sensitive situations (although
+//  the answer may be far from cut and dried as cache locality and other features
+//  of modern CPUs can produce extremely counterintuitive results vis-a-vis O(n),
+//  n may need to be surprisingly large before inserting at the head of a list is
+//  *actually* faster than shifting an array, for instance):
+namespace ceph::util {
+
+template <typename ContainerT, typename T>
+requires ceph::concepts::can_append<ContainerT, T>
+constexpr void push_back(ContainerT& c, T&& v)
+{
+  if constexpr (ceph::concepts::has_emplace_back<ContainerT, T>) {
+    c.emplace_back(std::forward<T>(v));
+    return;
+  }
+
+  if constexpr (ceph::concepts::has_push_back<ContainerT, T>) {
+    c.push_back(std::forward<T>(v));
+    return;
+  }
+
+  if constexpr (ceph::concepts::has_emplace_append<ContainerT, T>) {
+    c.emplace(std::end(c), std::forward<T>(v));
+    return;
+  }
+
+  if constexpr (ceph::concepts::has_insert_append<ContainerT, T>) {
+    c.insert(std::end(c), std::forward<T>(v));
+    return;
+  }
+}
+
+// Note: emplace_back() can return a reference, hence decltype(auto):
+template <typename ContainerT, typename... ArgsT>
+constexpr decltype(auto) emplace_back(ContainerT& c, ArgsT&&... args)
+{
+  return c.emplace_back(std::forward<ArgsT>(args)...);
+}
+
+template <typename ContainerT, typename... ArgsT>
+requires ceph::concepts::can_emplace_append<ContainerT, ArgsT...>
+constexpr void emplace_append(ContainerT& c, ArgsT&&... args)
+{
+  if constexpr (ceph::concepts::has_emplace_back<ContainerT, ArgsT...>) {
+    c.emplace_back(std::forward<ArgsT>(args)...);
+    return;
+  }
+
+  if constexpr (ceph::concepts::has_emplace_append<ContainerT, ArgsT...>) {
+    c.emplace(std::end(c), std::forward<ArgsT>(args)...);
+    return;
+  }
+
+  if constexpr (std::constructible_from<typename ContainerT::value_type, ArgsT...>) {
+    push_back(c, typename ContainerT::value_type(std::forward<ArgsT>(args)...));
+  }
+}
+
+template <typename ContainerT, typename RangeT>
+requires ceph::concepts::can_append_range<ContainerT, RangeT>
+constexpr void append_range(ContainerT& c, RangeT&& range)
+{
+  if constexpr (ceph::concepts::has_append_range<ContainerT, RangeT>) {
+    c.append_range(std::forward<RangeT>(range));
+    return;
+  }
+
+  if constexpr (ceph::concepts::has_insert_range_append<ContainerT, RangeT>) {
+    c.insert_range(std::end(c), std::forward<RangeT>(range));
+    return;
+  }
+
+  if constexpr (ceph::concepts::has_insert_iterator_range_append<ContainerT, RangeT>) {
+    c.insert(std::end(c), std::begin(range), std::end(range));
+    return;
+  }
+
+  if constexpr (ceph::concepts::can_emplace_append<ContainerT, std::ranges::range_reference_t<RangeT>>) {
+    for (auto&& v : range) {
+      emplace_append(c, std::forward<decltype(v)>(v));
+    }
+    return;
+  }
+}
+
+template <typename ContainerT, typename IteratorT, typename RangeT>
+requires ceph::concepts::can_insert_any_range<ContainerT, IteratorT, RangeT>
+constexpr void insert_range(ContainerT& c, IteratorT pos, RangeT&& range)
+{
+  if constexpr (ceph::concepts::has_insert_range<ContainerT, IteratorT, RangeT>) {
+    c.insert_range(pos, std::forward<RangeT>(range));
+    return;
+  }
+
+  if constexpr (ceph::concepts::has_insert_iterator_range<ContainerT, IteratorT, RangeT>) {
+    c.insert(pos, std::begin(range), std::end(range));
+    return;
+  }
+}
+
+template <typename ContainerT, typename IteratorT, typename T>
+requires ceph::concepts::can_insert_after<ContainerT, IteratorT, T>
+constexpr auto insert_after(ContainerT& c, IteratorT pos, T&& v)
+{
+  if constexpr (ceph::concepts::has_emplace_after<ContainerT, IteratorT, T>) {
+    return c.emplace_after(pos, std::forward<T>(v));
+  }
+
+  if constexpr (ceph::concepts::has_insert_after<ContainerT, IteratorT, T>) {
+    return c.insert_after(pos, std::forward<T>(v));
+  }
+}
+
+template <typename ContainerT, typename IteratorT, typename... ArgsT>
+requires ceph::concepts::can_emplace_after<ContainerT, IteratorT, ArgsT...>
+constexpr auto emplace_after(ContainerT& c, IteratorT pos, ArgsT&&... args)
+{
+  if constexpr (ceph::concepts::has_emplace_after<ContainerT, IteratorT, ArgsT...>) {
+    return c.emplace_after(pos, std::forward<ArgsT>(args)...);
+  }
+
+  if constexpr (std::constructible_from<typename ContainerT::value_type, ArgsT...>) {
+    return insert_after(c, pos, typename ContainerT::value_type(std::forward<ArgsT>(args)...));
+  }
+}
+
+// Fills a role similar to back_inserter(), but calling emplace_append().
+template <typename ContainerT>
+struct container_appender final {
+  ContainerT& container;
+
+ public:
+  explicit constexpr container_appender(ContainerT& container)
+    : container(container) {}
+
+ public:
+  template <typename... ArgsT>
+  requires ceph::concepts::can_emplace_append<ContainerT, ArgsT...>
+  constexpr void emplace(ArgsT&&... args)
+  {
+    emplace_append(container, std::forward<ArgsT>(args)...);
+  }
+};
+
+template <typename ContainerT>
+struct emplace_after_appender final {
+  ContainerT& container;
+  std::ranges::iterator_t<ContainerT> pos;
+
+ public:
+  explicit constexpr emplace_after_appender(ContainerT& container)
+    : container(container),
+      pos(container.before_begin()) {}
+
+ public:
+  template <typename... ArgsT>
+  requires ceph::concepts::can_emplace_after<ContainerT,
+                                             std::ranges::iterator_t<ContainerT>,
+                                             ArgsT...>
+  constexpr void emplace(ArgsT&&... args)
+  {
+    pos = emplace_after(container, pos, std::forward<ArgsT>(args)...);
+  }
+};
+
+template <typename ContainerT>
+constexpr auto make_appender(ContainerT& c)
+{
+  constexpr auto inserts_after =
+    std::ranges::forward_range<ContainerT> &&
+    !std::ranges::bidirectional_range<ContainerT> &&
+    requires (ContainerT& container) {
+      container.before_begin();
+    };
+
+  if constexpr (inserts_after) {
+    return emplace_after_appender<ContainerT> { c };
+  }
+
+  if constexpr (!inserts_after) {
+    return container_appender<ContainerT> { c };
+  }
+}
+
+template <typename ContainerT, typename ArgT>
+constexpr auto erase(ContainerT& c, ArgT&& v)
+{
+  return c.erase(std::forward<ArgT>(v));
+}
+
+template <typename ContainerT, typename IteratorT, typename SentinelT>
+constexpr auto erase(ContainerT& c, IteratorT first, SentinelT last)
+{
+  return c.erase(first, last);
+}
+
+template <typename ContainerT, typename T>
+requires ceph::concepts::can_prepend<ContainerT, T>
+constexpr void push_front(ContainerT& c, T&& v)
+{
+  if constexpr (ceph::concepts::has_emplace_front<ContainerT, T>) {
+    c.emplace_front(std::forward<T>(v));
+    return;
+  }
+
+  if constexpr (ceph::concepts::has_push_front<ContainerT, T>) {
+    c.push_front(std::forward<T>(v));
+    return;
+  }
+
+  if constexpr (ceph::concepts::has_emplace_at_begin<ContainerT, T>) {
+    c.emplace(std::begin(c), std::forward<T>(v));
+    return;
+  }
+
+  if constexpr (ceph::concepts::has_insert_at_begin<ContainerT, T>) {
+    c.insert(std::begin(c), std::forward<T>(v));
+    return;
+  }
+}
+
+template <typename ContainerT>
+requires ceph::concepts::can_remove_front<ContainerT>
+constexpr void pop_front(ContainerT& c)
+{
+  if constexpr (ceph::concepts::has_pop_front<ContainerT>) {
+    c.pop_front();
+    return;
+  }
+
+  if constexpr (ceph::concepts::has_erase_begin<ContainerT>) {
+    c.erase(std::begin(c));
+    return;
+  }
+}
+
+template <typename ContainerT>
+constexpr std::size_t capacity(const ContainerT& c)
+{
+  return c.capacity();
+}
+
+template <typename ContainerT>
+constexpr std::size_t max_size(const ContainerT& c)
+{
+  return c.max_size();
+}
+
+template <typename ContainerT>
+constexpr void resize(ContainerT& c, std::size_t n)
+{
+  c.resize(n);
+}
+
+template <typename ContainerT>
+constexpr void clear(ContainerT& c)
+{
+  c.clear();
+}
+
+// It's often handy to be able to easily resize if possible,
+// but continue along either way-- so, here we are:
+template <typename ContainerT>
+constexpr void maybe_resize(ContainerT& c, std::size_t n)
+{
+  if constexpr (ceph::concepts::has_resize<ContainerT>) {
+    c.resize(n);
+  }
+}
+
+// reserve() also is frequently "nice to have" in some algorithms:
+template <typename ContainerT>
+constexpr void maybe_reserve(ContainerT& c, std::size_t n)
+{
+  if constexpr (ceph::concepts::has_reserve<ContainerT>) {
+    c.reserve(n);
+  }
+}
+
+template <typename ContainerT, std::ranges::input_range RangeT>
+requires ceph::concepts::can_append_range<ContainerT, RangeT>
+constexpr ContainerT collect_as(RangeT&& range)
+{
+  ContainerT out;
+
+  if constexpr (std::ranges::sized_range<RangeT>) {
+    maybe_reserve(out, std::ranges::size(range));
+  }
+
+  append_range(out, std::forward<RangeT>(range));
+
+  return out;
+}
+
+} // namespace ceph::util
+
+#endif

--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -136,9 +136,7 @@ lfdb::set(dbh, std::begin(people), std::end(people));
 /* Read a key range into an STL associative container. */
 std::map<std::string, std::string> people;
 
-lfdb::get(dbh,
-          lfdb::select { "person/" },
-          std::inserter(people, std::end(people)));
+lfdb::get(dbh, lfdb::select { "person/" }, people);
 ```
 
 ## Key Ordering

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -45,6 +45,8 @@
 #include <filesystem>
 #include <type_traits>
 
+#include "common/container_concepts.h"
+
 #ifdef __cpp_lib_flat_map
  #include <flat_map>
  template <typename ...Args>
@@ -70,11 +72,55 @@ extern transaction_handle make_transaction(database_handle dbh);
 
 } // namespace ceph::libfdb
 
-// MOAR forward declarations-- "pay no attention to that man behind the curtain": 
-namespace ceph::libfdb::detail {
+namespace ceph::libfdb::concepts {
 
-template <typename T, typename ...Ts>
-concept is_any_of = (std::is_same_v<T, Ts> || ...);
+// Note that "stringlikes" are not all "stringview-likes", such as when they can be
+// written to:
+template <typename StringViewLikeT>
+concept stringview_convertible = std::convertible_to<StringViewLikeT, std::string_view>;
+
+template <typename IteratorT>
+concept key_value_iterator =
+ std::input_iterator<IteratorT> and
+ requires(const std::iter_value_t<IteratorT>& kv) {
+  kv.first;
+  kv.second;
+ };
+
+template <typename OutIterT>
+concept string_key_value_output_iterator =
+ std::output_iterator<OutIterT, std::pair<std::string, std::string>>;
+
+template <typename OutContainerT>
+concept string_key_value_output_container =
+ ceph::concepts::can_append<OutContainerT, std::pair<std::string, std::string>>;
+
+template <typename FnT>
+concept value_callback =
+ std::invocable<FnT&, std::span<const std::uint8_t>>;
+
+template <typename T>
+concept value_output =
+ !value_callback<std::remove_reference_t<T>> &&
+ std::is_lvalue_reference_v<T>;
+
+template <typename T>
+concept storable_invocation_result =
+ !std::is_void_v<T> && !std::is_reference_v<T>;
+
+template <typename T>
+concept supported_invocation_result =
+ std::is_void_v<T> || storable_invocation_result<T>;
+
+// There's a high likelihood that we're going to get more sophisticated selectors, 
+// so this is doing a more important job than it may appear to be:
+template <typename T>
+concept selector = ceph::concepts::same_as_any<T, ceph::libfdb::select>;
+
+} // namespace ceph::libfdb::concepts
+
+// MOAR forward declarations-- "pay no attention to that man behind the curtain":
+namespace ceph::libfdb::detail {
 
 struct future_value;
 
@@ -97,49 +143,10 @@ inline std::generator<std::span<const FDBKeyValue>> generate_FDB_pairs(ceph::lib
 
 // Stores a successively-generated of kv pair results to an iterator:
 template <typename OutIterT>
-requires std::output_iterator<OutIterT, std::pair<std::string, std::string>>
+requires ceph::libfdb::concepts::string_key_value_output_iterator<OutIterT>
 inline bool get_value_range_from_transaction(ceph::libfdb::transaction& txn, const ceph::libfdb::select& key_range, OutIterT out_iter);
 
 } // namespace ceph::libfdb::detail
-
-namespace ceph::libfdb::concepts {
-
-// Note that "stringlikes" are not all "stringview-likes", such as when they can be
-// written to:
-template <typename StringViewLikeT>
-concept stringview_convertible = std::convertible_to<StringViewLikeT, std::string_view>;
-
-template <typename IteratorT>
-concept key_value_iterator =
- std::input_iterator<IteratorT> and
- requires(const std::iter_value_t<IteratorT>& kv) {
-  kv.first;
-  kv.second;
- };
-
-template <typename FnT>
-concept value_callback =
- std::invocable<FnT&, std::span<const std::uint8_t>>;
-
-template <typename T>
-concept value_output =
- !value_callback<std::remove_reference_t<T>> &&
- std::is_lvalue_reference_v<T>;
-
-template <typename T>
-concept storable_invocation_result =
- !std::is_void_v<T> && !std::is_reference_v<T>;
-
-template <typename T>
-concept supported_invocation_result =
- std::is_void_v<T> || storable_invocation_result<T>;
-
-// There's a high likelihood that we're going to get more sophisticated selectors, 
-// so this is doing a more important job than it may appear to be:
-template <typename T>
-concept selector = ceph::libfdb::detail::is_any_of<T, ceph::libfdb::select>;
-
-} // namespace ceph::libfdb::concepts
 
 // libfdb_exception: How to deal, when Bad Things(TM) happen:
 namespace ceph::libfdb {
@@ -576,7 +583,7 @@ class transaction final
  // JFW: it's not as easy to wedge an output_range into here as it appears, perhaps
  // needs to be revisited; I'm binding it to what's actually used in practice for now:
  template <typename OutIterT>
- requires std::output_iterator<OutIterT, std::pair<std::string, std::string>>
+ requires concepts::string_key_value_output_iterator<OutIterT>
  bool get(const ceph::libfdb::select& key_range, OutIterT out_iter) {
     return ceph::libfdb::detail::get_value_range_from_transaction(*this, key_range, out_iter);
  }
@@ -623,7 +630,10 @@ class transaction final
                         std::string_view,
                         OutputTargetOrFnT&&,
                         const commit_after_op);
- friend inline bool get(ceph::libfdb::transaction_handle, const ceph::libfdb::select&, auto, const commit_after_op);
+ friend inline bool get(ceph::libfdb::transaction_handle,
+                        const ceph::libfdb::select&,
+                        concepts::string_key_value_output_iterator auto,
+                        const commit_after_op);
 
  friend inline void erase(ceph::libfdb::transaction_handle, std::string_view, const commit_after_op);
  friend inline void erase(ceph::libfdb::transaction_handle, const ceph::libfdb::select&, const commit_after_op);
@@ -868,9 +878,7 @@ inline auto decode_pairs(std::span<const FDBKeyValue> pairs)
 template <typename ValueT, typename AssocT>
 inline AssocT collect_pairs(std::span<const FDBKeyValue> pairs)
 {
- AssocT out;
- std::ranges::copy(decode_pairs<ValueT>(pairs), std::inserter(out, std::end(out)));
- return out;
+ return ceph::util::collect_as<AssocT>(decode_pairs<ValueT>(pairs));
 }
 
 template <typename AssocT>
@@ -892,7 +900,7 @@ inline query_window_result<AssocT> materialize_query_window(transaction& txn, se
 }
 
 template <typename OutIterT>
-requires std::output_iterator<OutIterT, std::pair<std::string, std::string>>
+requires concepts::string_key_value_output_iterator<OutIterT>
 inline bool get_value_range_from_transaction(transaction& txn, const select& key_range, OutIterT out_iter)
 {
  auto flattened = detail::generate_FDB_pairs(txn, key_range) | std::views::join;
@@ -930,23 +938,23 @@ inline std::vector<ceph::libfdb::select> as_select_seq(std::span<const FDBKey> x
  }
 
  // Gather the flattened list into *overlapping* libfdb::select pairs:
- return std::views::iota(std::size_t{0}, xs.size() - 1)
-           | std::views::transform([&parent, xs](const auto i) {
-              const auto& fst = xs[i];
-              const auto& snd = xs[i + 1];
-              const auto first_key = std::string_view((const char *)fst.key,
-                                                       static_cast<std::string::size_type>(fst.key_length));
-              const auto second_key = std::string_view((const char *)snd.key,
-                                                        static_cast<std::string::size_type>(snd.key_length));
+ return ceph::util::collect_as<std::vector<ceph::libfdb::select>>(
+          std::views::iota(std::size_t{0}, xs.size() - 1)
+        | std::views::transform([&parent, xs](const auto i) {
+           const auto& fst = xs[i];
+           const auto& snd = xs[i + 1];
+           const auto first_key = std::string_view((const char *)fst.key,
+                                                    static_cast<std::string::size_type>(fst.key_length));
+           const auto second_key = std::string_view((const char *)snd.key,
+                                                     static_cast<std::string::size_type>(snd.key_length));
 
-              ceph::libfdb::select split(first_key, second_key);
+           ceph::libfdb::select split(first_key, second_key);
 
-              split.options = parent.options;
-              split.begin_inclusive = (0 == i) ? parent.begin_inclusive : true;
-              split.end_inclusive = (i + 2 == xs.size()) ? parent.end_inclusive : false;
-              return split;
-             })
-           | std::ranges::to<std::vector<ceph::libfdb::select>>();
+           split.options = parent.options;
+           split.begin_inclusive = (0 == i) ? parent.begin_inclusive : true;
+           split.end_inclusive = (i + 2 == xs.size()) ? parent.end_inclusive : false;
+           return split;
+          }));
 }
 // Finding a clear example both in the samples and in the documentation is not very easy. The
 // statelessness of FDB requests bleeds into here with basically no hand-holding, but note for instance

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -272,7 +272,8 @@ namespace ceph::libfdb {
 // JFW: Satisfying output_iterator is not as straightforward as it appears, I need to look at this mechanism again; meanwhile, the template doesn't
 // /prevent/ future type narrowing, but I'm forcing it to std::string for now:
 inline bool get(ceph::libfdb::transaction_handle txn,
-                const ceph::libfdb::select& key_range, auto out_iter,
+                const ceph::libfdb::select& key_range,
+                concepts::string_key_value_output_iterator auto out_iter,
                 const ceph::libfdb::commit_after_op commit_after)
 {
  return detail::commit_noreplay(txn, commit_after,
@@ -282,13 +283,15 @@ inline bool get(ceph::libfdb::transaction_handle txn,
 }
 
 inline bool get(ceph::libfdb::transaction_handle txn,
-                const ceph::libfdb::select& key_range, auto out_iter)
+                const ceph::libfdb::select& key_range,
+                concepts::string_key_value_output_iterator auto out_iter)
 { 
  return get(txn, key_range, out_iter, commit_after_op::no_commit);
 }
 
 inline bool get(ceph::libfdb::database_handle dbh,
-                const ceph::libfdb::select& key_range, auto out_iter)
+                const ceph::libfdb::select& key_range,
+                concepts::string_key_value_output_iterator auto out_iter)
 {
  return detail::maybe_retry(ceph::libfdb::make_transaction(dbh),
           [&key_range, out_iter](transaction_handle& txn) {
@@ -432,6 +435,41 @@ inline auto pair_generator(ceph::libfdb::transaction_handle txn, ceph::libfdb::s
                     | std::views::transform(ceph::libfdb::detail::to_decoded_kv_pair<ValueT>);
 
  co_yield std::ranges::elements_of(decoded_pairs);
+}
+
+template <concepts::string_key_value_output_container OutContainerT>
+inline bool get(ceph::libfdb::transaction_handle txn,
+                const ceph::libfdb::select& key_range,
+                OutContainerT& out_container,
+                const ceph::libfdb::commit_after_op commit_after)
+{
+ return detail::commit_noreplay(txn, commit_after,
+          [&key_range, &out_container](const transaction_handle& txn) {
+            for (auto&& p : pair_generator(txn, key_range)) {
+              ceph::util::push_back(out_container, std::move(p));
+            }
+
+            return true;
+          });
+}
+
+template <concepts::string_key_value_output_container OutContainerT>
+inline bool get(ceph::libfdb::transaction_handle txn,
+                const ceph::libfdb::select& key_range,
+                OutContainerT& out_container)
+{
+ return get(txn, key_range, out_container, commit_after_op::no_commit);
+}
+
+template <concepts::string_key_value_output_container OutContainerT>
+inline bool get(ceph::libfdb::database_handle dbh,
+                const ceph::libfdb::select& key_range,
+                OutContainerT& out_container)
+{
+ return detail::maybe_retry(ceph::libfdb::make_transaction(dbh),
+          [&key_range, &out_container](transaction_handle& txn) {
+            return get(txn, key_range, out_container, commit_after_op::no_commit);
+          });
 }
 
 // Note: block_generator() uses split planning to tackle large sets; use pair_generator() for

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1060,6 +1060,9 @@ add_ceph_unittest(unittest_weighted_shuffle)
 
 add_executable(unittest_intarith test_intarith.cc)
 add_ceph_unittest(unittest_intarith)
+
+add_catch2_test(concepts)
+
 #make check ends here
 
 # test_nvmeof_mon_encoding
@@ -1109,4 +1112,3 @@ add_executable(test_nvmeof_gw_utils
 target_link_libraries(test_nvmeof_gw_utils
   mon ceph-common global-static
   )
-

--- a/src/test/catch2_compat.h
+++ b/src/test/catch2_compat.h
@@ -1,0 +1,205 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2026 International Business Machines Corp. (IBM)
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_TEST_CATCH2_COMPAT_H
+#define CEPH_TEST_CATCH2_COMPAT_H
+
+#include <catch2/catch_session.hpp>
+
+#include <cstdio>
+#include <fstream>
+#include <istream>
+#include <iterator>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace ceph::test {
+
+namespace detail {
+
+constexpr bool contains(const std::string_view line,
+                        const std::string_view text) noexcept
+{
+  return std::string_view::npos != line.find(text);
+}
+
+constexpr std::string_view skipped_junit_child_end(const std::string_view line) noexcept
+{
+  if (contains(line, "<properties")) {
+    return "</properties>";
+  }
+
+  if (contains(line, "<system-out")) {
+    return "</system-out>";
+  }
+
+  if (contains(line, "<system-err")) {
+    return "</system-err>";
+  }
+
+  return {};
+}
+
+constexpr bool skipped_junit_child_line(const std::string_view line) noexcept
+{
+  return contains(line, "<property ") ||
+         contains(line, "</properties>") ||
+         contains(line, "</system-out>") ||
+         contains(line, "</system-err>");
+}
+
+inline void sanitize_catch2_junit_for_gtest2subunit(std::istream& in,
+                                                   std::ostream& out)
+{
+  std::string_view skipped_child_end;
+  std::string line;
+
+  while (std::getline(in, line)) {
+    const std::string_view view { line };
+
+    if (!skipped_child_end.empty()) {
+      if (contains(view, skipped_child_end)) {
+        skipped_child_end = {};
+      }
+
+      continue;
+    }
+
+    if (skipped_junit_child_line(view)) {
+      continue;
+    }
+
+    const auto child_end = skipped_junit_child_end(view);
+
+    if (!child_end.empty()) {
+      if (!contains(view, "/>") &&
+          !contains(view, child_end)) {
+        skipped_child_end = child_end;
+      }
+
+      continue;
+    }
+
+    out << line << '\n';
+  }
+}
+
+inline bool sanitize_catch2_junit_for_gtest2subunit(const std::string& input_path,
+                                                   const std::string& output_path)
+{
+  std::ifstream in { input_path };
+  std::ofstream out { output_path, std::ios::trunc };
+
+  if (!in || !out) {
+    return false;
+  }
+
+  sanitize_catch2_junit_for_gtest2subunit(in, out);
+
+  return out.good();
+}
+
+} // namespace detail
+
+class catch2_args final
+{
+ public:
+  catch2_args(const int argc, char *argv[])
+  {
+    args.reserve(static_cast<std::size_t>(argc) + 3);
+    args.emplace_back(argv[0]);
+
+    translate_args(argc, argv);
+
+    argv_out.reserve(std::size(args));
+
+    for (auto& arg : args) {
+      argv_out.push_back(arg.data());
+    }
+  }
+
+  int argc() const
+  {
+    return static_cast<int>(std::size(argv_out));
+  }
+
+  char **argv()
+  {
+    return argv_out.data();
+  }
+
+  bool write_gtest2subunit_xml() const
+  {
+    if (!gtest_xml_output_path) {
+      return true;
+    }
+
+    if (!detail::sanitize_catch2_junit_for_gtest2subunit(
+          catch2_xml_output_path, *gtest_xml_output_path)) {
+      std::fprintf(stderr,
+                   "failed to write gtest-compatible Catch2 XML: %s\n",
+                   gtest_xml_output_path->c_str());
+      return false;
+    }
+
+    std::remove(catch2_xml_output_path.c_str());
+
+    return true;
+  }
+
+ private:
+  static constexpr std::string_view gtest_xml_output = "--gtest_output=xml:";
+
+  void translate_args(const int argc, char *argv[])
+  {
+    for (int i = 1; i < argc; ++i) {
+      const std::string_view arg{ argv[i] };
+
+      if (arg.starts_with(gtest_xml_output)) {
+        gtest_xml_output_path = arg.substr(std::size(gtest_xml_output));
+        catch2_xml_output_path = *gtest_xml_output_path + ".catch2.xml";
+
+        args.emplace_back("-r");
+        args.emplace_back("JUnit");
+        args.emplace_back("-o");
+        args.emplace_back(catch2_xml_output_path);
+        continue;
+      }
+
+      args.emplace_back(arg);
+    }
+  }
+
+  std::vector<std::string> args;
+  std::vector<char *> argv_out;
+  std::optional<std::string> gtest_xml_output_path;
+  std::string catch2_xml_output_path;
+};
+
+inline int run_catch2(const int argc, char *argv[])
+{
+  catch2_args args(argc, argv);
+  const auto result = Catch::Session().run(args.argc(), args.argv());
+
+  if (!args.write_gtest2subunit_xml()) {
+    return 1;
+  }
+
+  return result;
+}
+
+} // namespace ceph::test
+
+#endif

--- a/src/test/catch2_compat_main.cc
+++ b/src/test/catch2_compat_main.cc
@@ -1,0 +1,25 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2026 International Business Machines Corp. (IBM)
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "test/catch2_compat.h"
+
+#include <cstdio>
+#include <exception>
+
+int main(int argc, char *argv[])
+try
+{
+  return ceph::test::run_catch2(argc, argv);
+} catch (const std::exception& e) {
+  std::fprintf(stderr, "Catch2 test runner failed: %s\n", e.what());
+  return 1;
+}

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -1123,12 +1123,11 @@ TEST_CASE("block_generator should correctly handle value types") {
 }
 
 
-// Adapted from Catch2 documentation:
-#include <catch2/catch_session.hpp>
+#include "test/catch2_compat.h"
 
 int main(int argc, char **argv) 
 {
-  int result = Catch::Session().run(argc, argv);
+  const auto result = ceph::test::run_catch2(argc, argv);
 
   // Make sure that FoundationDB is shut down once and only once:
   ceph::libfdb::shutdown_libfdb(); 

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -269,6 +269,19 @@ TEMPLATE_PRODUCT_TEST_CASE("multi-key ops", "[rgw][fdb]",
     CHECK(std::end(out_values) != std::ranges::find(out_values, string_pair { make_key(i), make_value(i) }));
   }
  }
+
+ SECTION("check multiple key selection into container", "[fdb]") {
+  TestType out_values;
+
+  auto txn = lfdb::make_transaction(j);
+
+  CHECK(lfdb::get(txn,
+                  lfdb::select { make_key(0), make_key(100) },
+                  out_values,
+                  lfdb::commit_after_op::no_commit));
+
+  CHECK(100 == out_values.size());
+ }
 }
 
 TEST_CASE("check selectors", "[fdb][rgw]") {
@@ -338,6 +351,12 @@ TEST_CASE("check selectors", "[fdb][rgw]") {
   CHECK(std::ranges::is_sorted(out, std::ranges::greater {},
                                &std::pair<std::string, std::string>::first));
  }
+
+ std::map<std::string, std::string> out_map;
+
+ CHECK(lfdb::get(dbh, select_all, out_map));
+ CHECK(nentries == out_map.size());
+ CHECK(make_value(0) == out_map.at(make_key(0)));
 
  lfdb::set(dbh, test_key("keyx"), "outside");
  out.clear();

--- a/src/test/rgw/test_fdb_ceph.cc
+++ b/src/test/rgw/test_fdb_ceph.cc
@@ -755,11 +755,11 @@ BENCHMARK_ADVANCED("write simple records-- parallel, one transaction per block")
 
 }
 
-#include <catch2/catch_session.hpp>
+#include "test/catch2_compat.h"
 
 int main(int argc, char **argv) 
 {
-  int result = Catch::Session().run(argc, argv);
+  const auto result = ceph::test::run_catch2(argc, argv);
 
   // Make sure that FoundationDB is shut down once and only once:
   ceph::libfdb::shutdown_libfdb(); 

--- a/src/test/test_concepts.cc
+++ b/src/test/test_concepts.cc
@@ -1,0 +1,587 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2026 International Business Machines Corp. (IBM)
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include "common/container_concepts.h"
+
+#include <algorithm>
+#include <array>
+#include <deque>
+#include <forward_list>
+#include <initializer_list>
+#include <list>
+#include <map>
+#include <ranges>
+#include <set>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+using ceph::concepts::associative_container;
+using ceph::concepts::can_append;
+using ceph::concepts::can_append_range;
+using ceph::concepts::can_emplace_append;
+using ceph::concepts::can_erase_if;
+using ceph::concepts::can_insert_after;
+using ceph::concepts::can_prepend;
+using ceph::concepts::can_remove_front;
+using ceph::concepts::container_appendable;
+using ceph::concepts::container_compatible_range;
+using ceph::concepts::has_size;
+using ceph::concepts::reservable_container;
+using ceph::concepts::same_as_any;
+using ceph::concepts::unordered_associative_container;
+
+// Helper gadgets for the unit tests:
+namespace {
+
+struct vector_backed_range {
+  using value_type = int;
+  using iterator = std::vector<int>::iterator;
+  using const_iterator = std::vector<int>::const_iterator;
+
+  std::vector<int> values;
+
+  vector_backed_range() = default;
+  vector_backed_range(std::initializer_list<int> init) : values(init) {}
+
+  iterator begin() { return values.begin(); }
+  iterator end() { return values.end(); }
+  const_iterator begin() const { return values.begin(); }
+  const_iterator end() const { return values.end(); }
+};
+
+// Expose iterator interface to prove can_append() and push_back() will
+// fall back to insert() when push_back()/emplace_back() don't exist:
+struct append_only final : vector_backed_range {
+  using vector_backed_range::vector_backed_range;
+
+  void insert(iterator pos, int value) {
+    values.insert(pos, value);
+  }
+};
+
+struct append_range_only final : vector_backed_range {
+  using vector_backed_range::vector_backed_range;
+
+  void append_range(const std::array<int, 3>& range) {
+    values.insert(values.end(), range.begin(), range.end());
+  }
+};
+
+struct insert_range_only final : vector_backed_range {
+  using vector_backed_range::vector_backed_range;
+
+  iterator insert_range(iterator pos, const std::array<int, 3>& range) {
+    return values.insert(pos, range.begin(), range.end());
+  }
+};
+
+// Only exposes erase(I), to help verify can_remove_front() and pop_front()
+// can work without pop_front() directly being available:
+struct front_erasable final : vector_backed_range {
+  using vector_backed_range::vector_backed_range;
+
+  iterator erase(iterator pos) {
+    return values.erase(pos);
+  }
+};
+
+// May be constructed from int, but does not convert TO one:
+struct explicit_from_int final {
+  explicit explicit_from_int(int) {}
+};
+
+template <typename RangeT, typename ValueT>
+struct range_compat_case final {
+  using range_type = RangeT;
+  using value_type = ValueT;
+};
+
+using int_predicate = bool (*)(int);
+using int_deque = std::deque<int>;
+using int_forward_list = std::forward_list<int>;
+using int_list = std::list<int>;
+using int_set = std::set<int>;
+using int_vector = std::vector<int>;
+using small_array = std::array<int, 3>;
+
+bool is_even(int value)
+{
+  return value % 2 == 0;
+}
+
+template <typename ContainerT>
+requires can_append_range<ContainerT, const std::array<int, 4>&> &&
+         can_prepend<ContainerT, int> &&
+         can_erase_if<ContainerT, int_predicate>
+ContainerT collect_odd_values()
+{
+  const std::array input{1, 2, 3, 4};
+  ContainerT values;
+
+  ceph::util::maybe_reserve(values, input.size() + 1);
+  ceph::util::append_range(values, input);
+  std::erase_if(values, is_even);
+  ceph::util::push_front(values, 0);
+
+  return values;
+}
+
+} // namespace
+
+/*** Tests for library general Concepts: */
+
+TEMPLATE_PRODUCT_TEST_CASE("standard sequence containers model input_range",
+                           "[concepts]",
+                           (std::vector, std::list, std::forward_list),
+                           (int))
+{
+  STATIC_REQUIRE(std::ranges::input_range<TestType>);
+}
+
+TEMPLATE_TEST_CASE("contiguous sequence containers model contiguous_range",
+                   "[concepts]", std::vector<int>, (std::array<int, 3>))
+{
+  STATIC_REQUIRE(std::ranges::contiguous_range<TestType>);
+}
+
+TEMPLATE_TEST_CASE("compatible ranges model container_compatible_range",
+                   "[concepts]",
+                   (range_compat_case<std::vector<int>, int>),
+                   (range_compat_case<const std::vector<int>, int>),
+                   (range_compat_case<std::array<short, 3>, int>),
+                   (range_compat_case<std::string, char>),
+                   (range_compat_case<std::vector<int>, const int&>))
+{
+  STATIC_REQUIRE(container_compatible_range<typename TestType::range_type,
+                                            typename TestType::value_type>);
+}
+
+TEMPLATE_TEST_CASE("reservable containers model reservable_container",
+                   "[concepts]", std::vector<int>, std::string)
+{
+  STATIC_REQUIRE(reservable_container<TestType>);
+}
+
+TEMPLATE_TEST_CASE("appendable containers model container_appendable",
+                   "[concepts]", std::vector<int>, std::deque<int>,
+                   std::list<int>, std::set<int>, append_only)
+{
+  STATIC_REQUIRE(container_appendable<TestType, int>);
+}
+
+TEST_CASE("append capability avoids invalid hinted emplace paths",
+          "[concepts]")
+{
+  STATIC_REQUIRE(can_append<std::set<int>, int>);
+  STATIC_REQUIRE(container_appendable<std::set<int>, int>);
+  STATIC_REQUIRE_FALSE(ceph::concepts::has_emplace_append<std::set<int>, int>);
+  STATIC_REQUIRE(ceph::concepts::has_insert_append<std::set<int>, int>);
+}
+
+TEMPLATE_TEST_CASE("ordered associative containers model associative_container",
+                   "[concepts]", std::set<int>, std::multiset<int>,
+                   (std::map<int, std::string>),
+                   (std::multimap<int, std::string>))
+{
+  STATIC_REQUIRE(associative_container<TestType>);
+}
+
+TEMPLATE_TEST_CASE("unordered associative containers model unordered_associative_container",
+                   "[concepts]", std::unordered_set<int>,
+                   std::unordered_multiset<int>,
+                   (std::unordered_map<int, std::string>),
+                   (std::unordered_multimap<int, std::string>))
+{
+  STATIC_REQUIRE(unordered_associative_container<TestType>);
+}
+
+/*** Tests for aggregate capability checks: */
+
+TEMPLATE_TEST_CASE("appendable containers model can_append", "[concepts]",
+                   std::vector<int>, std::deque<int>, std::list<int>,
+                   std::set<int>, append_only)
+{
+  STATIC_REQUIRE(can_append<TestType, int>);
+}
+
+TEMPLATE_TEST_CASE("appendable containers model can_emplace_append",
+                   "[concepts]",
+                   std::vector<std::string>,
+                   std::deque<std::string>,
+                   std::list<std::string>,
+                   std::set<std::string>)
+{
+  STATIC_REQUIRE(can_emplace_append<TestType, std::string_view>);
+}
+
+TEMPLATE_PRODUCT_TEST_CASE("prependable containers model can_prepend",
+                           "[concepts]",
+                           (std::deque, std::list, std::forward_list,
+                            std::vector),
+                           (int))
+{
+  STATIC_REQUIRE(can_prepend<TestType, int>);
+}
+
+TEMPLATE_PRODUCT_TEST_CASE("standard range appendable containers model "
+                           "can_append_range",
+                           "[concepts]", (std::vector, std::set), (int))
+{
+  STATIC_REQUIRE(can_append_range<TestType, std::array<int, 3>>);
+}
+
+TEST_CASE("forward-only containers model can_insert_after",
+          "[concepts]")
+{
+  STATIC_REQUIRE(can_insert_after<int_forward_list,
+                                  int_forward_list::iterator,
+                                  int>);
+  STATIC_REQUIRE_FALSE(can_insert_after<int_vector,
+                                        int_vector::iterator,
+                                        int>);
+}
+
+TEMPLATE_PRODUCT_TEST_CASE("predicate erasable containers model can_erase_if",
+                           "[concepts]",
+                           (std::vector, std::list, std::forward_list),
+                           (int))
+{
+  STATIC_REQUIRE(can_erase_if<TestType, int_predicate>);
+}
+
+TEMPLATE_PRODUCT_TEST_CASE("standard front removable containers model "
+                           "can_remove_front",
+                           "[concepts]",
+                           (std::deque, std::list, std::forward_list,
+                            std::vector),
+                           (int))
+{
+  STATIC_REQUIRE(can_remove_front<TestType>);
+}
+
+TEST_CASE("concept edge cases",
+          "[concepts]")
+{
+  STATIC_REQUIRE(same_as_any<int, double, int, std::string>);
+  STATIC_REQUIRE_FALSE(same_as_any<int, double, long, std::string>);
+  STATIC_REQUIRE_FALSE(std::ranges::contiguous_range<std::deque<int>>);
+  STATIC_REQUIRE_FALSE(container_compatible_range<std::vector<int>,
+                                                  std::string>);
+  STATIC_REQUIRE_FALSE(container_compatible_range<std::vector<int>,
+                                                  explicit_from_int>);
+  STATIC_REQUIRE_FALSE(container_compatible_range<int, int>);
+  STATIC_REQUIRE_FALSE(associative_container<std::vector<int>>);
+  STATIC_REQUIRE_FALSE(unordered_associative_container<std::set<int>>);
+  STATIC_REQUIRE_FALSE(can_append<std::forward_list<int>, int>);
+  STATIC_REQUIRE_FALSE(can_emplace_append<std::forward_list<int>, int>);
+  STATIC_REQUIRE_FALSE(container_appendable<std::forward_list<int>, int>);
+  STATIC_REQUIRE(can_append_range<append_only, std::array<int, 3>>);
+  STATIC_REQUIRE_FALSE(can_append_range<std::forward_list<int>,
+                                        std::array<int, 3>>);
+  STATIC_REQUIRE_FALSE(has_size<std::forward_list<int>>);
+  STATIC_REQUIRE_FALSE(reservable_container<std::list<int>>);
+  STATIC_REQUIRE(can_remove_front<front_erasable>);
+}
+
+/*** Tests for library helpers: */
+
+TEMPLATE_PRODUCT_TEST_CASE("helpers compose into container-generic algorithms",
+                           "[concepts][util]",
+                           (std::deque, std::list, std::vector),
+                           (int))
+{
+  const TestType expected{0, 1, 3};
+
+  CHECK(collect_odd_values<TestType>() == expected);
+}
+
+TEST_CASE("push_back appends through the best available container operation",
+          "[concepts][util]")
+{
+  SECTION("vector uses back insertion") {
+    std::vector<int> values;
+
+    ceph::util::push_back(values, 1);
+    ceph::util::push_back(values, 2);
+
+    CHECK(values == std::vector{1, 2});
+  }
+
+  SECTION("set falls back to hinted insertion at end") {
+    std::set<int> values;
+
+    ceph::util::push_back(values, 2);
+    ceph::util::push_back(values, 1);
+
+    CHECK(values == std::set{1, 2});
+  }
+
+  SECTION("custom append-only type uses insert(end, value)") {
+    append_only values;
+
+    ceph::util::push_back(values, 1);
+    ceph::util::push_back(values, 2);
+
+    CHECK(values.values == std::vector{1, 2});
+  }
+}
+
+TEST_CASE("emplace_append constructs at the natural append position",
+          "[concepts][util]")
+{
+  SECTION("vector constructs from string_view") {
+    std::vector<std::string> values;
+
+    ceph::util::emplace_append(values, std::string_view { "alpha" });
+    ceph::util::emplace_append(values, std::string_view { "beta" });
+
+    CHECK(values == std::vector<std::string> { "alpha", "beta" });
+  }
+
+  SECTION("list constructs from string_view") {
+    std::list<std::string> values;
+
+    ceph::util::emplace_append(values, std::string_view { "alpha" });
+    ceph::util::emplace_append(values, std::string_view { "beta" });
+
+    CHECK(values == std::list<std::string> { "alpha", "beta" });
+  }
+
+  SECTION("set falls back to value insertion") {
+    std::set<std::string> values;
+
+    ceph::util::emplace_append(values, std::string_view { "beta" });
+    ceph::util::emplace_append(values, std::string_view { "alpha" });
+
+    CHECK(values == std::set<std::string> { "alpha", "beta" });
+  }
+}
+
+TEST_CASE("append_range appends ranges with container-specific fallbacks",
+          "[concepts][util]")
+{
+  SECTION("vector appends iterator ranges") {
+    std::vector<int> values{1};
+    const std::array more{2, 3};
+
+    ceph::util::append_range(values, more);
+
+    CHECK(values == std::vector{1, 2, 3});
+  }
+
+  SECTION("set inserts an input range") {
+    std::set<int> values{1};
+    const std::array more{3, 2};
+
+    ceph::util::append_range(values, more);
+
+    CHECK(values == std::set{1, 2, 3});
+  }
+
+  SECTION("custom append-only type falls back to element appends") {
+    append_only values;
+    const std::array more{1, 2, 3};
+
+    ceph::util::append_range(values, more);
+
+    CHECK(values.values == std::vector{1, 2, 3});
+  }
+}
+
+TEST_CASE("collect_as materializes ranges with append fallbacks",
+          "[concepts][util]")
+{
+  SECTION("sequence from view") {
+    auto values = ceph::util::collect_as<std::vector<int>>(
+      std::views::iota(0, 4));
+
+    CHECK(values == std::vector{0, 1, 2, 3});
+  }
+
+  SECTION("set from transformed view") {
+    auto values = ceph::util::collect_as<std::set<int>>(
+      std::views::iota(0, 4) |
+      std::views::transform([](int i) { return 3 - i; }));
+
+    CHECK(values == std::set{0, 1, 2, 3});
+  }
+
+  SECTION("custom append-only type") {
+    auto values = ceph::util::collect_as<append_only>(
+      std::array{1, 2, 3});
+
+    CHECK(values.values == std::vector{1, 2, 3});
+  }
+}
+
+TEST_CASE("insert_range inserts at the requested position", "[concepts][util]")
+{
+  std::vector<int> values{1, 4};
+  const std::array more{2, 3};
+
+  ceph::util::insert_range(values, values.begin() + 1, more);
+
+  CHECK(values == std::vector{1, 2, 3, 4});
+}
+
+TEST_CASE("insert_after inserts after the requested position",
+          "[concepts][util]")
+{
+  std::forward_list<int> values;
+  auto pos = values.before_begin();
+
+  pos = ceph::util::insert_after(values, pos, 1);
+  pos = ceph::util::emplace_after(values, pos, 2);
+  ceph::util::insert_after(values, pos, 3);
+
+  CHECK(values == std::forward_list{1, 2, 3});
+}
+
+TEST_CASE("make_appender appends through container-specific operations",
+          "[concepts][util]")
+{
+  SECTION("vector appender constructs at the back") {
+    std::vector<std::string> values;
+    auto append = ceph::util::make_appender(values);
+
+    append.emplace(std::string_view { "alpha" });
+    append.emplace(std::string_view { "beta" });
+
+    CHECK(values == std::vector<std::string> { "alpha", "beta" });
+  }
+
+  SECTION("forward_list appender tracks the insertion position") {
+    std::forward_list<std::string> values;
+    auto append = ceph::util::make_appender(values);
+
+    append.emplace(std::string_view { "alpha" });
+    append.emplace(std::string_view { "beta" });
+
+    CHECK(values == std::forward_list<std::string> { "alpha", "beta" });
+  }
+}
+
+TEST_CASE("front helpers use front-specific operations or begin erasure",
+          "[concepts][util]")
+{
+  SECTION("push_front prepends values") {
+    std::vector<int> values{2, 3};
+
+    ceph::util::push_front(values, 1);
+
+    CHECK(values == std::vector{1, 2, 3});
+  }
+
+  SECTION("pop_front removes the first value") {
+    front_erasable values{{1, 2, 3}};
+
+    ceph::util::pop_front(values);
+
+    CHECK(values.values == std::vector{2, 3});
+  }
+}
+
+TEST_CASE("optional sizing helpers call supported operations only",
+          "[concepts][util]")
+{
+  std::vector<int> values;
+
+  ceph::util::maybe_reserve(values, 4);
+  ceph::util::maybe_resize(values, 3);
+
+  CHECK(ceph::util::capacity(values) >= 4);
+  CHECK(std::ranges::size(values) == 3);
+  CHECK(!std::ranges::empty(values));
+
+  ceph::util::clear(values);
+
+  CHECK(std::ranges::empty(values));
+}
+
+/* The use of X-macros here is a bit unfortunate, however as we're not yet using C++26 I
+ * don't think there's another way to express this without having... well, a *LOT* of essentially
+ * redundant tests: */
+#define CEPH_HAS_MEMBER_CAPABILITY_CASES(X)                                     \
+  X(emplace_back, (ceph::concepts::has_emplace_back<int_vector, int>),          \
+    (ceph::concepts::has_emplace_back<int_set, int>))                           \
+  X(push_back, (ceph::concepts::has_push_back<int_vector, int>),                \
+    (ceph::concepts::has_push_back<int_set, int>))                              \
+  X(emplace_append, (ceph::concepts::has_emplace_append<int_vector, int>),      \
+    (ceph::concepts::has_emplace_append<int_set, int>))                         \
+  X(insert_append, (ceph::concepts::has_insert_append<int_vector, int>),        \
+    (ceph::concepts::has_insert_append<int_forward_list, int>))                 \
+  X(emplace_after, (ceph::concepts::has_emplace_after<int_forward_list, int_forward_list::iterator, int>), \
+    (ceph::concepts::has_emplace_after<int_vector, int_vector::iterator, int>)) \
+  X(insert_after, (ceph::concepts::has_insert_after<int_forward_list, int_forward_list::iterator, int>), \
+    (ceph::concepts::has_insert_after<int_vector, int_vector::iterator, int>))  \
+  X(append_range, (ceph::concepts::has_append_range<append_range_only, small_array>), \
+    (ceph::concepts::has_append_range<int_vector, small_array>))                \
+  X(insert_range_append, (ceph::concepts::has_insert_range_append<insert_range_only, small_array>), \
+    (ceph::concepts::has_insert_range_append<int_vector, small_array>))         \
+  X(insert_iterator_range_append, (ceph::concepts::has_insert_iterator_range_append<int_vector, small_array>), \
+    (ceph::concepts::has_insert_iterator_range_append<int_forward_list, small_array>)) \
+  X(insert_range, (ceph::concepts::has_insert_range<insert_range_only, insert_range_only::iterator, small_array>), \
+    (ceph::concepts::has_insert_range<int_vector, int_vector::iterator, small_array>)) \
+  X(insert_iterator_range, (ceph::concepts::has_insert_iterator_range<int_vector, int_vector::iterator, small_array>), \
+    (ceph::concepts::has_insert_iterator_range<int_forward_list, int_forward_list::iterator, small_array>)) \
+  X(emplace_front, (ceph::concepts::has_emplace_front<int_deque, int>),         \
+    (ceph::concepts::has_emplace_front<int_vector, int>))                       \
+  X(push_front, (ceph::concepts::has_push_front<int_deque, int>),               \
+    (ceph::concepts::has_push_front<int_vector, int>))                          \
+  X(emplace_at_begin, (ceph::concepts::has_emplace_at_begin<int_vector, int>),  \
+    (ceph::concepts::has_emplace_at_begin<int_forward_list, int>))              \
+  X(insert_at_begin, (ceph::concepts::has_insert_at_begin<int_vector, int>),    \
+    (ceph::concepts::has_insert_at_begin<int_forward_list, int>))               \
+  X(pop_front, (ceph::concepts::has_pop_front<int_deque>),                      \
+    (ceph::concepts::has_pop_front<int_vector>))                                \
+  X(erase_begin, (ceph::concepts::has_erase_begin<int_vector>),                 \
+    (ceph::concepts::has_erase_begin<int_forward_list>))                        \
+  X(erase, (ceph::concepts::has_erase<int_set, int>),                           \
+    (ceph::concepts::has_erase<int_vector, int>))                               \
+  X(erase_range, (ceph::concepts::has_erase_range<int_vector, int_vector::iterator, int_vector::iterator>), \
+    (ceph::concepts::has_erase_range<int_forward_list, int_forward_list::iterator, int_forward_list::iterator>)) \
+  X(remove_if, (ceph::concepts::has_remove_if<int_list, int_predicate>),        \
+    (ceph::concepts::has_remove_if<int_vector, int_predicate>))                 \
+  X(clear, (ceph::concepts::has_clear<int_vector>),                             \
+    (ceph::concepts::has_clear<int>))                                           \
+  X(reserve, (ceph::concepts::has_reserve<int_vector>),                         \
+    (ceph::concepts::has_reserve<int_list>))                                    \
+  X(capacity, (ceph::concepts::has_capacity<int_vector>),                       \
+    (ceph::concepts::has_capacity<int_list>))                                   \
+  X(max_size, (ceph::concepts::has_max_size<int_vector>),                       \
+    (ceph::concepts::has_max_size<int>))                                        \
+  X(size, (ceph::concepts::has_size<int_vector>),                               \
+    (ceph::concepts::has_size<int_forward_list>))                               \
+  X(empty, (ceph::concepts::has_empty<int_vector>),                             \
+    (ceph::concepts::has_empty<int>))                                           \
+  X(resize, (ceph::concepts::has_resize<int_vector>),                           \
+    (ceph::concepts::has_resize<int_set>))
+
+#define CEPH_CHECK_HAS_MEMBER_CAPABILITY(member, positive, negative) \
+  STATIC_REQUIRE positive;                                           \
+  STATIC_REQUIRE_FALSE negative;
+
+TEST_CASE("has_* member capability predicates match member availability",
+          "[concepts]")
+{
+  CEPH_HAS_MEMBER_CAPABILITY_CASES(CEPH_CHECK_HAS_MEMBER_CAPABILITY)
+}
+
+// Put the X-macro machinery back into the original packaging:
+#undef CEPH_CHECK_HAS_MEMBER_CAPABILITY
+#undef CEPH_HAS_MEMBER_CAPABILITY_CASES

--- a/src/test/test_concepts.cc
+++ b/src/test/test_concepts.cc
@@ -14,6 +14,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 
 #include "common/container_concepts.h"
+#include "test/catch2_compat.h"
 
 #include <algorithm>
 #include <array>
@@ -24,6 +25,7 @@
 #include <map>
 #include <ranges>
 #include <set>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -585,3 +587,33 @@ TEST_CASE("has_* member capability predicates match member availability",
 // Put the X-macro machinery back into the original packaging:
 #undef CEPH_CHECK_HAS_MEMBER_CAPABILITY
 #undef CEPH_HAS_MEMBER_CAPABILITY_CASES
+
+TEST_CASE("Catch2 gtest compatibility XML keeps only testcase children",
+          "[concepts]")
+{
+  std::istringstream in {
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+    "<testsuites>\n"
+    "  <testsuite name=\"unittest_concepts.exe\" tests=\"1\">\n"
+    "    <properties>\n"
+    "      <property name=\"random-seed\" value=\"1\"/>\n"
+    "    </properties>\n"
+    "    <testcase classname=\"unittest_concepts.exe.global\" "
+    "name=\"concepts pass\" time=\"0.000\" status=\"run\"/>\n"
+    "    <system-out/>\n"
+    "    <system-err/>\n"
+    "  </testsuite>\n"
+    "</testsuites>\n"
+  };
+  std::ostringstream out;
+
+  ceph::test::detail::sanitize_catch2_junit_for_gtest2subunit(in, out);
+
+  const auto xml = out.str();
+
+  CHECK(std::string::npos == xml.find("properties"));
+  CHECK(std::string::npos == xml.find("<system-out"));
+  CHECK(std::string::npos == xml.find("<system-err"));
+  CHECK(std::string::npos != xml.find("<testcase"));
+  CHECK(std::string::npos != xml.find("concepts pass"));
+}


### PR DESCRIPTION
Extend a stronger vocabulary of C++ Concepts and helpful functions via an internal collection of some Concepts not currently in the C++ Standard along with useful predicates for compile-time capability queries and runtime feature invocation.

The mini-library provides general capabilities meant for writing clean algorithms, doing metaprogramming, or offering better support for general operations involving sequences, and so on:

Concepts for common container categories (like contiguous sequence, ordered associative, etc.);

Capability queries for container operations such as append, prepend, range insertion, etc.;

Aggregate capability checks such as “can_append”, “can_append_range”, “can_erase_if”, etc.;

Utility helpers that select appropriate operations for containers, like “push_back”, "insert_front", etc.;

The tests cover standard STL containers, custom minimal test containers for fallback behavior, negative concept edge cases, and an example container-generic algorithm that composes several helpers.

Assisted-by: Codex:GPT-5

Signed-off-by: Jesse F. Williamson <jfw@ibm.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
