### PR TITLE
rgw: all paths of radosgw-admin bucket list adhere to max-entries

### DIFF
--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -1828,19 +1828,9 @@ static int list_owner_bucket_info(const DoutPrefixProvider* dpp,
 
   const std::string empty_end_marker;
   const size_t list_buckets_max = dpp->get_cct()->_conf->rgw_list_buckets_max_chunk;
+  constexpr bool no_need_stats = false; // set need_stats to false
 
   uint32_t max_items = (uint32_t)list_buckets_max;
-
-  if (max_entries_specified) {
-    /* we never want to allow max_items higher than rgw_list_buckets_max_chunk */
-    if (max_entries > list_buckets_max) {
-      max_items = list_buckets_max;
-    } else {
-      max_items = max_entries;
-    }
-  }
-
-  constexpr bool no_need_stats = false; // set need_stats to false
 
   rgw::sal::BucketList listing;
   listing.next_marker = marker;
@@ -1910,11 +1900,14 @@ int RGWBucketAdminOp::info(rgw::sal::Driver* driver,
   const std::string& bucket_name = op_state.get_bucket_name();
   if (!bucket_name.empty()) {
     ret = bucket.init(driver, op_state, y, dpp);
-    if (-ENOENT == ret)
+    if (-ENOENT == ret) {
       return -ERR_NO_SUCH_BUCKET;
-    else if (ret < 0)
+    } else if (ret < 0) {
       return ret;
+    }
   }
+
+  const bool max_entries_specified = (op_state.max_entries > 0);
 
   Formatter *formatter = flusher.get_formatter();
   flusher.start(0);
@@ -1965,24 +1958,39 @@ int RGWBucketAdminOp::info(rgw::sal::Driver* driver,
       return ret;
     }
   } else {
+    constexpr uint64_t max_keys = 1000;
     void *handle = nullptr;
     bool truncated = true;
+    uint64_t count = 0;
+    bool done = false;
 
     formatter->open_array_section("buckets");
     ret = driver->meta_list_keys_init(dpp, "bucket", string(), &handle);
-    while (ret == 0 && truncated) {
+
+    while (ret == 0 && !done && truncated) {
       std::list<std::string> buckets;
-      constexpr int max_keys = 1000;
+
+      // in experiments, meta_list_keys_next often doesn't return as
+      // many keys as requested; so asking for only the minimal amount
+      // needed to reach max_entries often requires extra calls, so
+      // we'll always ask for the maximum number of keys
       ret = driver->meta_list_keys_next(dpp, handle, max_keys, buckets,
-						   &truncated);
-      for (auto& bucket_name : buckets) {
+                                        &truncated);
+      for (const auto& bucket_name : buckets) {
         if (show_stats) {
-          bucket_stats(driver, site, user_id.tenant, bucket_name, op_state.restore_stats, formatter, dpp, y);
+          bucket_stats(driver, site, user_id.tenant, bucket_name,
+                       op_state.restore_stats, formatter, dpp, y);
 	} else {
           formatter->dump_string("bucket", bucket_name);
 	}
-      }
-    }
+
+        ++count;
+        if (max_entries_specified && count >= op_state.max_entries) {
+          done = true;
+          break;
+        }
+      } // for bucket_name
+    } // while continuing to read
     driver->meta_list_keys_complete(handle);
     formatter->close_section();
   }


### PR DESCRIPTION
Currently most but not all code paths through `radosgw-admin bucket list ...` adhere to the `--max-entries` command-line parameter. This incorporates that limit to the remaining path.

Fixes: https://tracker.ceph.com/issues/78738



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
