### PR TITLE
mon: reject device-class CRUSH rules for stretch mode 

### DIFF
--- a/qa/standalone/mon-stretch/mon-stretch-device-class.sh
+++ b/qa/standalone/mon-stretch/mon-stretch-device-class.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+function run() {
+    local dir=$1
+    shift
+
+    export CEPH_MON_A="127.0.0.1:7157" # git grep '\<7157\>' : there must be only one
+    export CEPH_MON_B="127.0.0.1:7158" # git grep '\<7158\>' : there must be only one
+    export CEPH_MON_C="127.0.0.1:7159" # git grep '\<7159\>' : there must be only one
+    export CEPH_MON_D="127.0.0.1:7160" # git grep '\<7160\>' : there must be only one
+    export CEPH_MON_E="127.0.0.1:7161" # git grep '\<7161\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+
+    export BASE_CEPH_ARGS=$CEPH_ARGS
+    CEPH_ARGS+="--mon-host=$CEPH_MON_A"
+
+    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        setup $dir || return 1
+        $func $dir || return 1
+        teardown $dir || return 1
+    done
+}
+
+# Stretch mode resolves an OSD's zone through the pool's CRUSH rule, so a rule
+# pinned to a device class reports the shadow bucket "iris~ssd" while degraded
+# stretch mode requires the real "iris". Check that we refuse such a rule
+# instead of accepting it and failing much later, when a zone is lost.
+TEST_stretch_mode_rejects_device_class_rule() {
+    local dir=$1
+    local OSDS=4
+    setup $dir || return 1
+
+    run_mon $dir a --public-addr $CEPH_MON_A || return 1
+    wait_for_quorum 300 1 || return 1
+
+    run_mon $dir b --public-addr $CEPH_MON_B || return 1
+    CEPH_ARGS="$BASE_CEPH_ARGS --mon-host=$CEPH_MON_A,$CEPH_MON_B"
+    wait_for_quorum 300 2 || return 1
+
+    run_mon $dir c --public-addr $CEPH_MON_C || return 1
+    CEPH_ARGS="$BASE_CEPH_ARGS --mon-host=$CEPH_MON_A,$CEPH_MON_B,$CEPH_MON_C"
+    wait_for_quorum 300 3 || return 1
+
+    run_mon $dir d --public-addr $CEPH_MON_D || return 1
+    CEPH_ARGS="$BASE_CEPH_ARGS --mon-host=$CEPH_MON_A,$CEPH_MON_B,$CEPH_MON_C,$CEPH_MON_D"
+    wait_for_quorum 300 4 || return 1
+
+    run_mon $dir e --public-addr $CEPH_MON_E || return 1
+    CEPH_ARGS="$BASE_CEPH_ARGS --mon-host=$CEPH_MON_A,$CEPH_MON_B,$CEPH_MON_C,$CEPH_MON_D,$CEPH_MON_E"
+    wait_for_quorum 300 5 || return 1
+
+    ceph mon set election_strategy connectivity
+    ceph mon add disallowed_leader e
+
+    run_mgr $dir x || return 1
+
+    for osd in $(seq 0 $(expr $OSDS - 1))
+    do
+      run_osd $dir $osd || return 1
+    done
+
+    for zone in iris pze
+    do
+      ceph osd crush add-bucket $zone zone
+      ceph osd crush move $zone root=default
+    done
+
+    ceph osd crush add-bucket node-2 host
+    ceph osd crush add-bucket node-3 host
+    ceph osd crush add-bucket node-4 host
+    ceph osd crush add-bucket node-5 host
+
+    ceph osd crush move node-2 zone=iris
+    ceph osd crush move node-3 zone=iris
+    ceph osd crush move node-4 zone=pze
+    ceph osd crush move node-5 zone=pze
+
+    ceph osd crush move osd.0 host=node-2
+    ceph osd crush move osd.1 host=node-3
+    ceph osd crush move osd.2 host=node-4
+    ceph osd crush move osd.3 host=node-5
+
+    ceph mon set_location a zone=iris host=node-2
+    ceph mon set_location b zone=iris host=node-3
+    ceph mon set_location c zone=pze host=node-4
+    ceph mon set_location d zone=pze host=node-5
+
+    # pin every OSD to one class, so that the shadow tree spans both zones and
+    # a device class rule is a plausible thing for someone to write
+    for osd in $(seq 0 $(expr $OSDS - 1))
+    do
+      ceph osd crush rm-device-class osd.$osd || return 1
+      ceph osd crush set-device-class ssd osd.$osd || return 1
+    done
+
+    hostname=$(hostname -s)
+    ceph osd crush remove $hostname || return 1
+    ceph osd getcrushmap > crushmap || return 1
+    crushtool --decompile crushmap > crushmap.txt || return 1
+    sed 's/^# end crush map$//' crushmap.txt > crushmap_modified.txt || return 1
+    cat >> crushmap_modified.txt << EOF
+rule stretch_rule {
+        id 1
+        type replicated
+        step take iris
+        step chooseleaf firstn 2 type host
+        step emit
+        step take pze
+        step chooseleaf firstn 2 type host
+        step emit
+}
+rule stretch_rule_ssd {
+        id 2
+        type replicated
+        step take iris class ssd
+        step chooseleaf firstn 2 type host
+        step emit
+        step take pze class ssd
+        step chooseleaf firstn 2 type host
+        step emit
+}
+# end crush map
+EOF
+
+    crushtool --compile crushmap_modified.txt -o crushmap.bin || return 1
+    ceph osd setcrushmap -i crushmap.bin || return 1
+
+    local stretched_poolname=stretched_rbdpool
+    # leave size/min_size alone: enabling stretch mode sets them, and pools that
+    # start out non-default are refused before the rule is ever looked at
+    ceph osd pool create $stretched_poolname 32 32 stretch_rule || return 1
+
+    ceph mon set_location e zone=arbiter host=node-1 || return 1
+
+    # a device class rule is not a valid rule to enter stretch mode with
+    expect_failure $dir "does not support" \
+        ceph mon enable_stretch_mode e stretch_rule_ssd zone || return 1
+
+    # ... and refusing it must leave stretch mode off, not half-enabled
+    ! ceph osd dump | grep -q "stretch_mode_enabled true" || return 1
+
+    # while the same command with a class-free rule still works
+    ceph mon enable_stretch_mode e stretch_rule zone || return 1
+    ceph osd dump | grep -q "stretch_mode_enabled true" || return 1
+
+    # nor can a device class be smuggled in by editing the rule the pool
+    # already uses and injecting the map
+    sed -e 's/step take iris$/step take iris class ssd/' \
+        -e 's/step take pze$/step take pze class ssd/' \
+        crushmap_modified.txt > crushmap_classed.txt || return 1
+    crushtool --compile crushmap_classed.txt -o crushmap_classed.bin || return 1
+    expect_failure $dir "does not support" \
+        ceph osd setcrushmap -i crushmap_classed.bin || return 1
+
+    # moving a stretch pool onto a device class rule is refused as well, and the
+    # complaint names both the class and the pool's own peering barrier
+    expect_failure $dir "class ssd" \
+        ceph osd pool set $stretched_poolname crush_rule stretch_rule_ssd || return 1
+    expect_failure $dir "peer if a zone were lost" \
+        ceph osd pool set $stretched_poolname crush_rule stretch_rule_ssd || return 1
+    ceph osd pool get $stretched_poolname crush_rule | grep -q stretch_rule$ || return 1
+
+    # but an operator who insists can still do it
+    ceph osd pool set $stretched_poolname crush_rule stretch_rule_ssd \
+        --yes-i-really-mean-it || return 1
+    ceph osd pool get $stretched_poolname crush_rule | grep -q stretch_rule_ssd || return 1
+
+    # with the pool already on a classed rule, further map changes have to keep
+    # being accepted, or there is no editing the cluster back out of this state
+    sed 's/^# end crush map$//' crushmap_modified.txt > crushmap_benign.txt || return 1
+    cat >> crushmap_benign.txt << EOF
+rule unrelated_rule {
+        id 9
+        type replicated
+        step take default
+        step chooseleaf firstn 0 type host
+        step emit
+}
+# end crush map
+EOF
+    crushtool --compile crushmap_benign.txt -o crushmap_benign.bin || return 1
+    ceph osd setcrushmap -i crushmap_benign.bin || return 1
+
+    # "osd pool stretch set" makes a pool a stretch pool as well, and while the
+    # cluster is in stretch mode it gets the same treatment
+    expect_failure $dir "does not support" \
+        ceph osd pool stretch set $stretched_poolname 2 2 zone \
+        stretch_rule_ssd 4 2 || return 1
+
+    # and a pool created now must not land on the classed rule either
+    expect_failure $dir "does not support" \
+        ceph osd pool create newpool 8 8 stretch_rule_ssd || return 1
+
+    teardown $dir || return 1
+}
+main mon-stretch-device-class "$@"

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -345,6 +345,19 @@ void CrushWrapper::find_takes_by_rule(int rule, set<int> *roots) const
   }
 }
 
+std::optional<int> CrushWrapper::get_rule_device_class(int rule) const
+{
+  set<int> takes;
+  find_takes_by_rule(rule, &takes);
+  for (auto take : takes) {
+    int id, cls;
+    if (split_id_class(take, &id, &cls) == 0 && cls >= 0) {
+      return cls;
+    }
+  }
+  return std::nullopt;
+}
+
 void CrushWrapper::find_roots(set<int> *roots) const
 {
   for (int i = 0; i < crush->max_buckets; i++) {

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -620,6 +620,21 @@ public:
   void find_takes_by_rule(int rule, std::set<int> *roots) const;
 
   /**
+   * return a device class a rule selects from
+   *
+   * "step take <root> class <class>" is compiled into a take of <class>'s
+   * shadow bucket, so a class can be read back from a rule's take targets.
+   * A rule may name several, and which of those comes back is unspecified:
+   * the take targets are collected into a set, so the order the steps were
+   * written in is not preserved. Callers wanting more than "is any class
+   * named here" need a different question.
+   *
+   * @param rule the rule id
+   * @returns a class id, or nullopt if no take is pinned to a class
+   */
+  std::optional<int> get_rule_device_class(int rule) const;
+
+  /**
    * find tree roots
    *
    * These are parentless nodes in the map.

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -8391,6 +8391,16 @@ int OSDMonitor::prepare_new_pool(string& name,
     *ss << "crush rule " << crush_rule << " type does not match pool";
     return -EINVAL;
   }
+  if (osdmap.stretch_mode_enabled) {
+    // a pool created here becomes a stretch pool, so it needs a rule stretch
+    // mode can resolve a surviving bucket from, like any other
+    if (int r = check_stretch_device_class(
+	  *osdmap.crush, crush_rule,
+	  crush_rule_name.empty() ? stringify(crush_rule) : crush_rule_name,
+	  osdmap.stretch_mode_bucket, false, *ss); r < 0) {
+      return r;
+    }
+  }
 
   uint32_t stripe_width = 0;
   r = prepare_pool_stripe_width(pool_type, erasure_code_profile, &stripe_width, ss);
@@ -9104,6 +9114,18 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
       ss << "crush rule " << id << " type does not match pool";
       return -EINVAL;
     }
+    // only degraded stretch mode records a mandatory member, so only a
+    // cluster-wide stretch mode makes a device class fatal here. An individual
+    // stretch pool peers on the bucket count alone, which shadow buckets
+    // satisfy as well as real ones.
+    if (osdmap.stretch_mode_enabled && p.is_stretch_pool() &&
+	!cmd_getval_or<bool>(cmdmap, "yes_i_really_mean_it", false)) {
+      if (int r = check_stretch_device_class(*osdmap.crush, id, val,
+					    p.peering_crush_bucket_barrier,
+					    true, ss); r < 0) {
+	return r;
+      }
+    }
     p.crush_rule = id;
   } else if (var == "nodelete" || var == "nopgchange" ||
 	     var == "nosizechange" || var == "write_fadvise_dontneed" ||
@@ -9663,6 +9685,15 @@ int OSDMonitor::prepare_command_pool_stretch_set(const cmdmap_t& cmdmap,
   if (!crush.rule_valid_for_pool_type(crush_rule, p.get_type())) {
     ss << "crush rule " << crush_rule << " type does not match pool";
     return -EINVAL;
+  }
+  // An individual stretch pool peers on the bucket count alone, which shadow
+  // buckets satisfy as well as real ones, so a device class is only a problem
+  // once the cluster is in stretch mode and records a mandatory member too.
+  if (osdmap.stretch_mode_enabled && !sure) {
+    if (int r = check_stretch_device_class(crush, crush_rule, crush_rule_str,
+					   bucket_barrier, true, ss); r < 0) {
+      return r;
+    }
   }
   int64_t pool_size = cmd_getval_or<int64_t>(cmdmap, "size", 0);
   if (pool_size < 0) {
@@ -15932,7 +15963,14 @@ void OSDMonitor::try_enable_stretch_mode(stringstream& ss, bool *okay,
     ceph_assert(!commit || !exceeds_threshold);
     return;
   }
-  // TODO: check CRUSH rules for pools so that we are appropriately divided
+  if (int r = check_stretch_device_class(crush, new_rule, new_crush_rule,
+					dividing_id, false, ss); r < 0) {
+    *errcode = r;
+    ceph_assert(!commit);
+    return;
+  }
+  // TODO: check that the rule actually reaches every dividing bucket, so that
+  // we are appropriately divided
   if (commit) {
     for (auto pool : pools) {
       pool->crush_rule = new_rule;
@@ -15982,6 +16020,32 @@ bool OSDMonitor::check_for_dead_crush_zones(const map<string,set<string>>& dead_
   dout(10) << "We determined CRUSH buckets " << *really_down_buckets
 	   << " and mons " << *really_down_mons << " are really down" << dendl;
   return really_down;
+}
+
+int OSDMonitor::check_stretch_device_class(const CrushWrapper& crush, int rule,
+					   const string& rule_name, int barrier,
+					   bool overridable,
+					   ostream& ss) const
+{
+  // A rule with a device class takes from that class's shadow tree, so an OSD
+  // resolves to a shadow bucket such as "zone1~ssd" while degraded stretch mode
+  // records the surviving zone as the real "zone1". The two never compare equal,
+  // and every PG of a pool on such a rule fails to peer once a zone is lost.
+  // See https://tracker.ceph.com/issues/67414
+  auto rule_class = crush.get_rule_device_class(rule);
+  if (!rule_class) {
+    return 0;
+  }
+  ss << "crush rule " << rule_name << " selects devices of class "
+     << crush.get_class_name(*rule_class)
+     << ", which stretch mode does not support";
+  if (!overridable) {
+    return -EINVAL;
+  }
+  ss << ": this pool's PGs would fail to peer if a "
+     << crush.get_type_name(barrier)
+     << " were lost. Pass --yes-i-really-mean-it to proceed anyway.";
+  return -EPERM;
 }
 
 void OSDMonitor::trigger_degraded_stretch_mode(const set<int>& dead_buckets,

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -887,6 +887,17 @@ public:
 				  std::set<int> *really_down_buckets,
 				  std::set<std::string> *really_down_mons);
   /**
+   * Refuse a rule stretch mode cannot resolve a surviving bucket from.
+   *
+   * @param overridable whether the command offers --yes-i-really-mean-it, in
+   *                    which case the caller may proceed once the operator says
+   *                    so and the message says as much
+   * @returns 0 if the rule is usable, else the error to reply with
+   */
+  int check_stretch_device_class(const CrushWrapper& crush, int rule,
+				 const std::string& rule_name, int barrier,
+				 bool overridable, std::ostream& ss) const;
+  /**
    * Set degraded mode in the OSDMap, adding the given dead buckets to the dead set
    * and using the live_zones (should presently be size 1)
    */

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -4796,6 +4796,20 @@ int OSDMap::validate_crush_rules(CrushWrapper *newcrush,
       *ss << "pool " << i.first << " type does not match rule " << ruleno;
       return -EINVAL;
     }
+    // A device class hands back a shadow bucket that never matches the
+    // surviving zone recorded on the pool, and only a cluster-wide stretch mode
+    // records that bucket, so an individual stretch pool is left alone. Refuse
+    // only maps that introduce the class: a cluster already in that state has
+    // to stay able to edit its way out.
+    if (stretch_mode_enabled && pool.is_stretch_pool()) {
+      auto newclass = newcrush->get_rule_device_class(ruleno);
+      if (newclass && !crush->get_rule_device_class(ruleno)) {
+        *ss << "pool " << i.first << " is a stretch pool and rule " << ruleno
+            << " selects devices of class " << newcrush->get_class_name(*newclass)
+            << ", which stretch mode does not support";
+        return -EINVAL;
+      }
+    }
   }
   return 0;
 }

--- a/src/test/crush/CrushWrapper.cc
+++ b/src/test/crush/CrushWrapper.cc
@@ -1225,6 +1225,71 @@ TEST_F(CrushWrapperTest, split_id_class) {
   ASSERT_EQ(-1, retrieved_class_id);
 }
 
+TEST_F(CrushWrapperTest, get_rule_device_class) {
+  CrushWrapper c;
+  c.create();
+  c.set_type_name(0, "osd");
+  c.set_type_name(1, "root");
+
+  map<string,string> loc;
+  loc["root"] = "default";
+  c.insert_item(cct, 1, 1, "osd.1", loc);
+  c.insert_item(cct, 2, 1, "osd.2", loc);
+  int class_id = c.get_or_create_class_id("ssd");
+  int other_class_id = c.get_or_create_class_id("hdd");
+  c.class_map[1] = class_id;
+  c.class_map[2] = other_class_id;
+
+  map<int32_t, map<int32_t, int32_t>> old_class_bucket;
+  ASSERT_EQ(c.populate_classes(old_class_bucket), 0);
+  ASSERT_TRUE(c.name_exists("default~ssd"));
+  ASSERT_TRUE(c.name_exists("default~hdd"));
+
+  // a rule without a class takes from the real root
+  int plain = c.add_simple_rule("plain", "default", "osd", "",
+                                "firstn", pg_pool_t::TYPE_REPLICATED);
+  ASSERT_GE(plain, 0);
+  ASSERT_FALSE(c.get_rule_device_class(plain).has_value());
+
+  // ... while a rule with one takes from that class's shadow root
+  int classed = c.add_simple_rule("classed", "default", "osd", "ssd",
+                                  "firstn", pg_pool_t::TYPE_REPLICATED);
+  ASSERT_GE(classed, 0);
+  auto found = c.get_rule_device_class(classed);
+  ASSERT_TRUE(found.has_value());
+  ASSERT_EQ(class_id, *found);
+
+  // a rule can take more than once, as the stretch rules do, and any one of
+  // those takes carrying a class is enough
+  int real_root = c.get_item_id("default");
+  int ssd_root = c.get_item_id("default~ssd");
+  int hdd_root = c.get_item_id("default~hdd");
+
+  int second_take = c.add_rule(2, 4, pg_pool_t::TYPE_REPLICATED);
+  ASSERT_EQ(2, second_take);
+  c.set_rule_step_take(second_take, 0, real_root);
+  c.set_rule_step_emit(second_take, 1);
+  c.set_rule_step_take(second_take, 2, ssd_root);
+  c.set_rule_step_emit(second_take, 3);
+  auto late = c.get_rule_device_class(second_take);
+  ASSERT_TRUE(late.has_value());
+  ASSERT_EQ(class_id, *late);
+
+  // taking from two classes reports one of them, and is still not class-free
+  int two_classes = c.add_rule(3, 4, pg_pool_t::TYPE_REPLICATED);
+  ASSERT_EQ(3, two_classes);
+  c.set_rule_step_take(two_classes, 0, ssd_root);
+  c.set_rule_step_emit(two_classes, 1);
+  c.set_rule_step_take(two_classes, 2, hdd_root);
+  c.set_rule_step_emit(two_classes, 3);
+  auto either = c.get_rule_device_class(two_classes);
+  ASSERT_TRUE(either.has_value());
+  ASSERT_TRUE(*either == class_id || *either == other_class_id);
+
+  // and a rule that does not exist has no class
+  ASSERT_FALSE(c.get_rule_device_class(123).has_value());
+}
+
 TEST_F(CrushWrapperTest, populate_classes) {
   CrushWrapper c;
   c.create();


### PR DESCRIPTION
A rule pinned to a device class takes from that class's shadow tree, so an OSD's dividing bucket resolves to "zone1~ssd" while degraded stretch mode records the surviving zone as the real "zone1". The two never match, so every PG of a pool on such a rule goes inactive once a zone is lost, and stays inactive, because the cluster leaves degraded stretch mode only once no PG is degraded, inactive or unknown.

No path into that state checked for it. `try_enable_stretch_mode()` looked at the bucket type, the subtree count and the weight skew, but never at the rule. `osd pool set <pool> crush_rule` only checked that the rule exists and matches the pool type. And a map injected with `osd setcrushmap` could add a class to a rule already in use. The cluster then reports healthy stretch mode right up until a zone is lost.

Refuse the rule in all three, the pool set unless `--yes-i-really-mean-it` is given. An injected map is refused only when it is what introduces the class, so a cluster already in this state can still change its crush map, not least to get itself out of it.

Spotting a class is cheap: `step take <root> class <class>` compiles into a take of that class's shadow bucket, so `get_rule_device_class()` can read the class back from any of a rule's take targets.

Fixes: https://tracker.ceph.com/issues/78741


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
