### PR TITLE
mgr/dashboard: Add alerts doc url to active alert list

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/active-alert-list/active-alert-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/active-alert-list/active-alert-list.component.html
@@ -64,7 +64,6 @@
 
 <ng-template
   #externalLinkTpl
-  let-row="data.row"
   let-value="data.value"
 >
   <a
@@ -77,4 +76,18 @@
     ></svg>
     Source
   </a>
+</ng-template>
+
+<ng-template
+  #docLinkTpl
+  let-value="data.value"
+>
+  @if (alertDocUrls[value]) {
+    <a
+      [href]="alertDocUrls[value]"
+      target="_blank"
+      i18n
+      ><cd-icon type="launch"></cd-icon> Docs</a
+    >
+  }
 </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/active-alert-list/active-alert-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/active-alert-list/active-alert-list.component.spec.ts
@@ -100,4 +100,33 @@ describe('ActiveAlertListComponent', () => {
       }
     });
   });
+
+  describe('alertDocUrls', () => {
+    beforeEach(() => component.ngOnInit());
+
+    it('should be empty and hasDocUrls false by default (no upstream doc URL)', () => {
+      expect(component.hasDocUrls).toBe(false);
+      expect(component.alertDocUrls).toEqual({});
+    });
+
+    it('should remain empty when alerts arrive and hasDocUrls is false', () => {
+      component['prometheusAlertService'].alerts = [
+        { labels: { alertname: 'CephHealthError' } } as any
+      ];
+      component['prometheusAlertService']['totalSubject'].next(1);
+      expect(component.alertDocUrls).toEqual({});
+    });
+
+    it('should populate map when hasDocUrls is true and alerts arrive', () => {
+      spyOn(component['docService'], 'alertDocUrl').and.returnValue(
+        'https://example.com/docs#managing-alerts__cephhealtherror'
+      );
+      component.hasDocUrls = true;
+      component['prometheusAlertService'].alerts = [
+        { labels: { alertname: 'CephHealthError' } } as any
+      ];
+      component['prometheusAlertService']['totalSubject'].next(1);
+      expect(component.alertDocUrls['CephHealthError']).toContain('cephhealtherror');
+    });
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/active-alert-list/active-alert-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/active-alert-list/active-alert-list.component.ts
@@ -1,5 +1,8 @@
-import { Component, Inject, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { Component, Inject, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+
+import { Subscription } from 'rxjs';
+import { filter, first } from 'rxjs/operators';
 
 import { PrometheusService } from '~/app/shared/api/prometheus.service';
 import { CellTemplate } from '~/app/shared/enum/cell-template.enum';
@@ -14,6 +17,7 @@ import { AlertState } from '~/app/shared/models/prometheus-alerts';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { PrometheusAlertService } from '~/app/shared/services/prometheus-alert.service';
 import { URLBuilderService } from '~/app/shared/services/url-builder.service';
+import { DocService } from '~/app/shared/services/doc.service';
 
 const BASE_URL = 'silences'; // as only silence actions can be used
 
@@ -30,9 +34,11 @@ const SeverityMap = {
   styleUrls: ['./active-alert-list.component.scss'],
   standalone: false
 })
-export class ActiveAlertListComponent extends PrometheusListHelper implements OnInit {
+export class ActiveAlertListComponent extends PrometheusListHelper implements OnInit, OnDestroy {
   @ViewChild('externalLinkTpl', { static: true })
   externalLinkTpl: TemplateRef<any>;
+  @ViewChild('docLinkTpl', { static: true })
+  docLinkTpl: TemplateRef<any>;
   @ViewChild(TableComponent) table: TableComponent;
   columns: CdTableColumn[];
   innerColumns: CdTableColumn[];
@@ -41,7 +47,11 @@ export class ActiveAlertListComponent extends PrometheusListHelper implements On
   selection = new CdTableSelection();
   icons = Icons;
   expandedInnerRow: any;
+  alertDocUrls: Record<string, string | null> = {};
+  hasDocUrls = false;
   multilineTextKeys = ['description', 'impact', 'fix'];
+  private cephRelease = '';
+  private alertsSub: Subscription;
 
   filters: CdTableColumn[] = [
     {
@@ -76,10 +86,21 @@ export class ActiveAlertListComponent extends PrometheusListHelper implements On
     public prometheusAlertService: PrometheusAlertService,
     private urlBuilder: URLBuilderService,
     private route: ActivatedRoute,
+    private docService: DocService,
     @Inject(PrometheusService) prometheusService: PrometheusService
   ) {
     super(prometheusService);
     this.permission = this.authStorageService.getPermissions().prometheus;
+    this.docService.releaseData$
+      .pipe(
+        filter((v) => !!v),
+        first()
+      )
+      .subscribe((release) => {
+        this.cephRelease = release;
+        this.hasDocUrls = !!this.docService.urlGenerator('managing-alerts', release);
+        this.alertDocUrls = {};
+      });
     this.tableActions = [
       {
         permission: 'create',
@@ -153,13 +174,33 @@ export class ActiveAlertListComponent extends PrometheusListHelper implements On
         flexGrow: 1
       },
       {
-        name: $localize`URL`,
+        name: $localize`Query`,
         prop: 'generatorURL',
         flexGrow: 1,
         sortable: false,
         cellTemplate: this.externalLinkTpl
-      }
+      },
+      ...(this.hasDocUrls
+        ? [
+            {
+              name: $localize`Learn more`,
+              prop: 'labels.alertname',
+              flexGrow: 1,
+              sortable: false,
+              cellTemplate: this.docLinkTpl
+            }
+          ]
+        : [])
     ];
+    this.alertsSub = this.prometheusAlertService.totalAlerts$.subscribe(() => {
+      if (!this.hasDocUrls) return;
+      this.alertDocUrls = Object.fromEntries(
+        this.prometheusAlertService.alerts.map((a) => [
+          a.labels.alertname,
+          this.docService.alertDocUrl(a.labels.alertname, this.cephRelease)
+        ])
+      );
+    });
     this.prometheusAlertService.getGroupedAlerts(true);
     this.route.queryParams.subscribe((params) => {
       const severity = params['severity'];
@@ -173,6 +214,10 @@ export class ActiveAlertListComponent extends PrometheusListHelper implements On
         });
       }
     });
+  }
+
+  ngOnDestroy() {
+    this.alertsSub?.unsubscribe();
   }
 
   setExpandedInnerRow(row: any) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/doc.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/doc.service.ts
@@ -52,6 +52,14 @@ export class DocService {
     return sections[section];
   }
 
+  alertDocUrl(alertName: string, releaseVersion = ''): string | null {
+    const baseUrl = this.urlGenerator('managing-alerts', releaseVersion);
+    if (!baseUrl || !alertName) {
+      return null;
+    }
+    return `${baseUrl}#${encodeURIComponent(`managing-alerts__${alertName.toLowerCase()}`)}`;
+  }
+
   subscribeOnce(
     section: string,
     next: (release: string) => void,


### PR DESCRIPTION
1. Add documentation link in Learn more column for every alert in the active alerts list table.
2. Change `URL` column in active alert list to `Query` to make it more understandable. 

Fixes: https://tracker-origin.ceph.com/issues/78747





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
