### PR TITLE
umbrella: mgr/cephadm: Add CNC fields to NVMEoF spec file

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
@@ -134,6 +134,10 @@ iobuf_options = {{ iobuf_options }}
 {% endif %}
 qos_timeslice_in_usecs = {{ spec.qos_timeslice_in_usecs }}
 notifications_interval = {{ spec.notifications_interval }}
+cnc_enable = {{ spec.cnc_enable }}
+cnc_rate_limiter_bytes = {{ spec.cnc_rate_limiter_bytes }}
+cnc_chunk_blocks = {{ spec.cnc_chunk_blocks }}
+cnc_parallel_chunks = {{ spec.cnc_parallel_chunks }}
 
 [monitor]
 timeout = {{ spec.monitor_timeout }}

--- a/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
@@ -199,6 +199,10 @@ rbd_with_crc32c = True
 tgt_cmd_extra_args = {tgt_cmd_extra_args}
 qos_timeslice_in_usecs = 0
 notifications_interval = 60
+cnc_enable = True
+cnc_rate_limiter_bytes = 100000000
+cnc_chunk_blocks = 512
+cnc_parallel_chunks = 8
 
 [monitor]
 timeout = 1.0\n"""
@@ -449,6 +453,10 @@ rbd_with_crc32c = True
 tgt_cmd_extra_args = {tgt_cmd_extra_args}
 qos_timeslice_in_usecs = 0
 notifications_interval = 60
+cnc_enable = True
+cnc_rate_limiter_bytes = 100000000
+cnc_chunk_blocks = 512
+cnc_parallel_chunks = 8
 
 [monitor]
 timeout = 1.0
@@ -641,6 +649,10 @@ rbd_with_crc32c = True
 tgt_cmd_extra_args = {tgt_cmd_extra_args}
 qos_timeslice_in_usecs = 0
 notifications_interval = 60
+cnc_enable = True
+cnc_rate_limiter_bytes = 100000000
+cnc_chunk_blocks = 512
+cnc_parallel_chunks = 8
 
 [monitor]
 timeout = 1.0

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1922,6 +1922,10 @@ class NvmeofServiceSpec(ServiceSpec):
                  iobuf_options: Optional[Dict[str, int]] = None,
                  qos_timeslice_in_usecs: Optional[int] = 0,
                  notifications_interval: Optional[int] = 60,
+                 cnc_enable: bool = True,
+                 cnc_rate_limiter_bytes: Optional[int] = 100000000,
+                 cnc_chunk_blocks: Optional[int] = 512,
+                 cnc_parallel_chunks: Optional[int] = 8,
                  discovery_addr: Optional[str] = None,
                  discovery_addr_map: Optional[Dict[str, str]] = None,
                  discovery_port: Optional[int] = None,
@@ -2129,6 +2133,14 @@ class NvmeofServiceSpec(ServiceSpec):
         self.qos_timeslice_in_usecs = qos_timeslice_in_usecs
         #: ``notifications_interval`` read SPDK notifications interval, in seconds
         self.notifications_interval = notifications_interval
+        #: ``cnc_enable`` enable CNC feature in SPDK
+        self.cnc_enable = cnc_enable
+        #: ``cnc_rate_limiter_bytes`` CNC rate limiter in bytes
+        self.cnc_rate_limiter_bytes = cnc_rate_limiter_bytes
+        #: ``cnc_chunk_blocks`` CNC chunk blocks
+        self.cnc_chunk_blocks = cnc_chunk_blocks
+        #: ``cnc_parallel_chunks`` CNC parallel chunk
+        self.cnc_parallel_chunks = cnc_parallel_chunks
         #: ``discovery_addr`` address of the discovery service
         self.discovery_addr = discovery_addr
         #: ``discovery_addr_map`` per node address map of the discovery service
@@ -2252,6 +2264,10 @@ class NvmeofServiceSpec(ServiceSpec):
         self.verify_spdk_ceph_connection_allocation()
         verify_non_negative_int(self.qos_timeslice_in_usecs, "QOS timeslice")
         verify_non_negative_int(self.notifications_interval, "SPDK notifications interval")
+        verify_boolean(self.cnc_enable, "Enable CNC")
+        verify_non_negative_int(self.cnc_rate_limiter_bytes, "CNC rate limiter")
+        verify_non_negative_int(self.cnc_chunk_blocks, "CNC chunk blocks")
+        verify_non_negative_int(self.cnc_parallel_chunks, "CNC parallel chunks")
 
         verify_non_negative_number(self.spdk_ping_interval_in_seconds, "SPDK ping interval")
         if (


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78750

---

backport of https://github.com/ceph/ceph/pull/70578
parent tracker: https://tracker.ceph.com/issues/78675

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh