### PR TITLE
umbrella: src/pybind: fixing the test_invalid_client_id failure

### DIFF
--- a/src/pybind/mgr/stats/fs/perf_stats.py
+++ b/src/pybind/mgr/stats/fs/perf_stats.py
@@ -639,10 +639,7 @@ class FSPerfStats(object):
         return FilterSpec(mds_ranks, client_id, client_ip)
 
     def get_perf_data(self, cmd):
-        try:
-            filter_spec = self.extract_query_filters(cmd)
-        except ValueError as e:
-            return -errno.EINVAL, "", str(e)
+        filter_spec = self.extract_query_filters(cmd)
 
         counters = {}
         with self.lock:

--- a/src/pybind/mgr/stats/module.py
+++ b/src/pybind/mgr/stats/module.py
@@ -3,6 +3,7 @@ performance stats for ceph filesystem (for now...)
 """
 
 import json
+import errno
 from typing import List, Dict
 from xml.dom.minidom import parseString
 
@@ -46,7 +47,11 @@ class Module(MgrModule):
         prefix = cmd['prefix']
         # only supported command is `fs perf stats` right now
         if prefix.startswith('fs perf stats'):
-            result = self.fs_perf_stats.get_perf_data(cmd)
+            try:
+                result = self.fs_perf_stats.get_perf_data(cmd)
+            except ValueError as e:
+                return -errno.EINVAL, "", str(e)
+            
             if 'format' in cmd:
                 if cmd['format'] == 'json-pretty':
                     return 0, json.dumps(result, indent=2), ""
@@ -54,11 +59,11 @@ class Module(MgrModule):
                     if dicttoxml is None:
                         raise ImportError("dicttoxml package required for xml")
                     result = json.loads(json.dumps(result, default=str))
-                    return dicttoxml(result)
+                    return 0, dicttoxml(result).decode('utf-8'), ""
                 elif cmd['format'] == 'xml-pretty':
                     if dicttoxml is None:
                         raise ImportError("dicttoxml package required for xml")
                     res_xml = parseString(dicttoxml(result))
-                    return res_xml.toprettyxml()
+                    return 0, res_xml.toprettyxml(), ""
             return 0, json.dumps(result), ""
         raise NotImplementedError(cmd['prefix'])


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78744

---

backport of https://github.com/ceph/ceph/pull/70375
parent tracker: https://tracker.ceph.com/issues/76162

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh