### PR TITLE
umbrella: mgr/cephadm: set mgr cap for NVMeoF to allow cmd "service dump"

### DIFF
--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -126,6 +126,7 @@ class NvmeofService(CephService):
         map_discovery_addr = spec.discovery_addr_map.get(daemon_spec.host) if spec.discovery_addr_map else None
         keyring = self.get_keyring_with_caps(self.get_auth_entity(nvmeof_gw_id),
                                              ['mon', 'profile rbd',
+                                              'mgr', 'allow command "service dump"',
                                               'osd', 'profile rbd'])
 
         super().prepare_certificates(daemon_spec)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78652

---

backport of https://github.com/ceph/ceph/pull/70281
parent tracker: https://tracker.ceph.com/issues/78339

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh