### PR TITLE
tentacle: mgr/cephadm: set mgr cap for NVMeoF to allow cmd "service dump"

### DIFF
--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -50,6 +50,7 @@ class NvmeofService(CephService):
 
         keyring = self.get_keyring_with_caps(self.get_auth_entity(nvmeof_gw_id),
                                              ['mon', 'profile rbd',
+                                              'mgr', 'allow command "service dump"',
                                               'osd', 'profile rbd'])
 
         # TODO: check if we can force jinja2 to generate dicts with double quotes instead of using json.dumps


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78653

---

backport of https://github.com/ceph/ceph/pull/70281
parent tracker: https://tracker.ceph.com/issues/78339

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh