### PR TITLE
os/bluestore: Fix write v2 compressed write missing dirty_range

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12284,6 +12284,31 @@ void BlueStore::inject_bluefs_file(std::string_view dir, std::string_view name, 
   bluefs->close_writer(p_handle);
 }
 
+// Applies selected reshard scheme.
+// The function modifies onode and writes it directly to db
+// without sequencer; requires prior operations to onodes be
+// fully committed to db.
+void BlueStore::debug_force_reshard(
+  coll_t cid, ghobject_t oid,
+  BlueStore::ExtentMap::ReshardPlan& rp)
+{
+  OnodeRef o;
+  CollectionRef c = _get_collection(cid);
+  ceph_assert(c);
+  {
+    std::unique_lock l{ c->lock }; // just to avoid internal asserts
+    o = c->get_onode(oid, false);
+    ceph_assert(o);
+    o->extent_map.fault_range(db, 0, OBJECT_MAX_SIZE);
+  }
+  KeyValueDB::Transaction txn;
+  txn = db->get_transaction();
+  o->extent_map.request_reshard(0, OBJECT_MAX_SIZE);
+  o->extent_map.reshard_action(rp, db, txn);
+  _record_onode(o, txn);
+  db->submit_transaction_sync(txn);
+}
+
 int BlueStore::compact()
 {
   int r = 0;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -18129,6 +18129,8 @@ int BlueStore::_do_write_v2_compressed(
     *_dout << i.offset << "~" << i.length << " ";
   }
   *_dout << std::dec << dendl;
+  uint32_t changes_start = regions.front().offset;
+  uint32_t changes_end = regions.back().offset + regions.back().length;
   for (const auto& i : regions) {
     ceph::buffer::list data_bl;
     if (i.offset <= offset && offset < i.offset + i.length) {
@@ -18157,15 +18159,17 @@ int BlueStore::_do_write_v2_compressed(
     disk_for_compressed = estimator->split_and_compress(data_bl, bd);
     disk_for_raw = p2roundup(i.offset + i.length, au_size) - p2align(i.offset, au_size);
     BlueStore::Writer wr(this, txc, &wctx, o);
+    wr.left_affected_range = changes_start;
+    wr.right_affected_range = changes_end;
     if (disk_for_compressed < disk_for_raw) {
       wr.do_write_with_blobs(i.offset, i.offset + i.length, i.offset + i.length, bd);
     } else {
       wr.do_write(i.offset, data_bl);
     }
+    changes_start = wr.left_affected_range;
+    changes_end = wr.right_affected_range;
   }
   estimator->finish();
-  uint32_t changes_start = regions.front().offset;
-  uint32_t changes_end = regions.back().offset + regions.back().length;
   o->extent_map.compress_extent_map(changes_start, changes_end - changes_start);
   o->extent_map.dirty_range(changes_start, changes_end - changes_start);
   o->extent_map.maybe_reshard(changes_start, changes_end);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -18093,11 +18093,9 @@ int BlueStore::_do_write_v2(
     }
   } else {
     // normal uncompressed path
-    BlueStore::Writer wr(this, txc, &wctx, o);
     uint64_t start = p2align(offset, min_alloc_size);
     uint64_t end = p2roundup(offset + length, min_alloc_size);
-    wr.left_affected_range = start;
-    wr.right_affected_range = end;
+    BlueStore::Writer wr(this, txc, &wctx, o, start, end);
     std::tie(wr.left_shard_bound, wr.right_shard_bound) =
       o->extent_map.fault_range_ex(db, start, end - start);
     wr.do_write(offset, bl);
@@ -18158,9 +18156,7 @@ int BlueStore::_do_write_v2_compressed(
     uint32_t au_size = min_alloc_size;
     disk_for_compressed = estimator->split_and_compress(data_bl, bd);
     disk_for_raw = p2roundup(i.offset + i.length, au_size) - p2align(i.offset, au_size);
-    BlueStore::Writer wr(this, txc, &wctx, o);
-    wr.left_affected_range = changes_start;
-    wr.right_affected_range = changes_end;
+    BlueStore::Writer wr(this, txc, &wctx, o, changes_start, changes_end);
     if (disk_for_compressed < disk_for_raw) {
       wr.do_write_with_blobs(i.offset, i.offset + i.length, i.offset + i.length, bd);
     } else {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -18093,11 +18093,9 @@ int BlueStore::_do_write_v2(
     }
   } else {
     // normal uncompressed path
-    BlueStore::Writer wr(this, txc, &wctx, o);
     uint64_t start = p2align(offset, min_alloc_size);
     uint64_t end = p2roundup(offset + length, min_alloc_size);
-    wr.left_affected_range = start;
-    wr.right_affected_range = end;
+    BlueStore::Writer wr(this, txc, &wctx, o, start, end);
     std::tie(wr.left_shard_bound, wr.right_shard_bound) =
       o->extent_map.fault_range_ex(db, start, end - start);
     wr.do_write(offset, bl);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -18129,6 +18129,8 @@ int BlueStore::_do_write_v2_compressed(
     *_dout << i.offset << "~" << i.length << " ";
   }
   *_dout << std::dec << dendl;
+  uint32_t changes_start = regions.front().offset;
+  uint32_t changes_end = regions.back().offset + regions.back().length;
   for (const auto& i : regions) {
     ceph::buffer::list data_bl;
     if (i.offset <= offset && offset < i.offset + i.length) {
@@ -18162,10 +18164,10 @@ int BlueStore::_do_write_v2_compressed(
     } else {
       wr.do_write(i.offset, data_bl);
     }
+    changes_start = std::min(changes_start, wr.left_affected_range);
+    changes_end = std::max(changes_end, wr.right_affected_range);
   }
   estimator->finish();
-  uint32_t changes_start = regions.front().offset;
-  uint32_t changes_end = regions.back().offset + regions.back().length;
   o->extent_map.compress_extent_map(changes_start, changes_end - changes_start);
   o->extent_map.dirty_range(changes_start, changes_end - changes_start);
   o->extent_map.maybe_reshard(changes_start, changes_end);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3579,10 +3579,12 @@ public:
   // resets per_pool_omap | pgmeta_omap for onode
   void inject_legacy_omap(coll_t cid, ghobject_t oid);
   void inject_stray_omap(uint64_t head, const std::string& name);
-
   void inject_bluefs_file(std::string_view dir,
-			  std::string_view name,
-			  size_t new_size);
+                          std::string_view name,
+                          size_t new_size);
+  void debug_force_reshard(
+    coll_t cid, ghobject_t oid,
+    BlueStore::ExtentMap::ReshardPlan& rp);
 
   int compact() override;
   bool has_builtin_csum() const override {

--- a/src/os/bluestore/Writer.cc
+++ b/src/os/bluestore/Writer.cc
@@ -1444,7 +1444,8 @@ void BlueStore::Writer::do_write_with_blobs(
     bstore->_punch_hole_2(onode->c, onode, location, data_end - location,
     released, pruned_blobs, txc->shared_blobs, statfs_delta);
   dout(25) << "after punch_hole_2: " << std::endl << onode->print(pp_mode) << dendl;
-
+  left_affected_range = std::min(left_affected_range, location);
+  right_affected_range = std::max(right_affected_range, data_end);
   // todo: if we align to disk block before splitting, we could do it in one go
   uint32_t pos = location;
   for (auto& b : bd) {

--- a/src/os/bluestore/Writer.h
+++ b/src/os/bluestore/Writer.h
@@ -57,8 +57,10 @@ public:
     virtual ~read_divertor() = default;
     virtual bufferlist read(uint32_t object_offset, uint32_t object_length) = 0;
   };
-  Writer(BlueStore* bstore, TransContext* txc, WriteContext* wctx, OnodeRef o)
+  Writer(BlueStore* bstore, TransContext* txc, WriteContext* wctx, OnodeRef o,
+    uint32_t left_affected_range = OBJECT_MAX_SIZE, uint32_t right_affected_range = 0)
     :left_shard_bound(0), right_shard_bound(OBJECT_MAX_SIZE)
+    , left_affected_range(left_affected_range), right_affected_range(right_affected_range)
     , bstore(bstore), txc(txc), wctx(wctx), onode(o) {
       pp_mode = debug_level_to_pp_mode(bstore->cct);
     }
@@ -85,8 +87,8 @@ public:
   volatile_statfs statfs_delta;
   uint32_t left_shard_bound;  // if sharding is in effect,
   uint32_t right_shard_bound; // do not cross this line
-  uint32_t left_affected_range;
-  uint32_t right_affected_range;
+  uint32_t left_affected_range; // set before: range of transfered data
+  uint32_t right_affected_range; // get after: range of affected blobs
 private:
   BlueStore* bstore;
   TransContext* txc;

--- a/src/os/bluestore/Writer.h
+++ b/src/os/bluestore/Writer.h
@@ -57,8 +57,10 @@ public:
     virtual ~read_divertor() = default;
     virtual bufferlist read(uint32_t object_offset, uint32_t object_length) = 0;
   };
-  Writer(BlueStore* bstore, TransContext* txc, WriteContext* wctx, OnodeRef o)
+  Writer(BlueStore* bstore, TransContext* txc, WriteContext* wctx, OnodeRef o,
+    uint32_t left_affected_range, uint32_t right_affected_range)
     :left_shard_bound(0), right_shard_bound(OBJECT_MAX_SIZE)
+    , left_affected_range(left_affected_range), right_affected_range(right_affected_range)
     , bstore(bstore), txc(txc), wctx(wctx), onode(o) {
       pp_mode = debug_level_to_pp_mode(bstore->cct);
     }
@@ -85,8 +87,8 @@ public:
   volatile_statfs statfs_delta;
   uint32_t left_shard_bound;  // if sharding is in effect,
   uint32_t right_shard_bound; // do not cross this line
-  uint32_t left_affected_range;
-  uint32_t right_affected_range;
+  uint32_t left_affected_range; // set before: range of transfered data
+  uint32_t right_affected_range; // get after: range of affected blobs
 private:
   BlueStore* bstore;
   TransContext* txc;

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -25,6 +25,7 @@
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int.hpp>
 #include <boost/random/binomial_distribution.hpp>
+#include <random>
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
@@ -12794,6 +12795,155 @@ TEST_P(StoreTest, BlueFS_truncate_remove_race) {
   fs.unittest_inject_delay = nullptr;
   EXPECT_EQ(store->umount(), 0);
   EXPECT_EQ(store->mount(), 0);
+}
+
+typedef std::mt19937 gen_type_2;
+gen_type_2 rng = gen_type_2(0);
+uniform_int_distribution<> random_byte =
+    uniform_int_distribution<>(0, 200); //'!', '~');
+
+std::string random_string(uint32_t msg_size)
+{
+  std::string result;
+  uint32_t s = 0;
+  result.reserve(msg_size);
+  while (s < msg_size) {
+    result.push_back(random_byte(rng));
+    s++;
+  }
+  return result;
+}
+
+TEST_P(StoreTestSpecificAUSize, WriteV2CompressReject64K) {
+
+  if(string(GetParam()) != "bluestore")
+    return;
+
+  SetVal(g_conf(), "bluestore_write_v2", "true");
+  SetVal(g_conf(), "bluestore_compression_algorithm", "snappy");
+  SetVal(g_conf(), "bluestore_compression_mode", "force");
+  SetVal(g_conf(), "bluestore_default_buffered_write", "false");
+
+  g_conf().apply_changes(nullptr);
+
+  StartDeferred(65536);
+
+  int r;
+  coll_t cid;
+  ghobject_t hoid(hobject_t(sobject_t("Object 1", CEPH_NOSNAP)));
+
+  auto ch = store->create_new_collection(cid);
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    cerr << "Creating collection " << cid << std::endl;
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  {
+    bool exists = store->exists(ch, hoid);
+    ASSERT_TRUE(!exists);
+
+    ObjectStore::Transaction t;
+    t.touch(cid, hoid);
+    cerr << "Creating object " << hoid << std::endl;
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+
+    exists = store->exists(ch, hoid);
+    ASSERT_EQ(true, exists);
+  }
+
+  uint32_t blob_size = 128 * 1024;
+  uint32_t object_size = blob_size * 8;
+  string object_content = random_string(object_size);
+  bufferlist object_content_bl;
+  object_content_bl.append(object_content);
+
+  //1. fill with random data
+  for (uint32_t offs = 0; offs < object_size; offs += blob_size) {
+    bufferlist bl;
+    string msg = object_content.substr(offs, blob_size);
+    bl.append(msg);
+    ObjectStore::Transaction t;
+    C_SaferCond c;
+    t.register_on_commit(&c);
+    t.write(cid, hoid, offs, bl.length(), bl);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  //00000~20000 blob A
+  //20000~20000 blob B
+  //40000~20000 blob C
+  //60000~20000 blob D
+  //80000~20000 blob E
+  //a0000~20000 blob F
+  //c0000~20000 blob G
+  //e0000~20000 blob H
+  //2. force known sharding
+  BlueStore* bstore = dynamic_cast<BlueStore*>(store.get());
+  BlueStore::ExtentMap::ReshardPlan rp;
+  rp.new_shard_info.emplace_back(0, 0);
+  rp.new_shard_info.emplace_back(0x30000, 0);
+  rp.new_shard_info.emplace_back(0x90000, 0);
+  rp.shard_index_begin = 0;
+  rp.shard_index_end = 0;
+  rp.spanning_scan_begin = 0; // doesn't matter
+  rp.spanning_scan_end = 0; // doesn't matter
+  bstore->debug_force_reshard(cid, hoid, rp);
+  //00000~20000 blob A  shard a
+  //20000~10000 blob B1 shard a
+  //30000~10000 blob B2 shard b
+  //40000~20000 blob C  shard b
+  //60000~20000 blob D  shard b
+  //80000~10000 blob E1 shard b
+  //90000~10000 blob E2 shard c
+  //a0000~20000 blob F  shard c
+  //c0000~20000 blob G  shard c
+  //e0000~20000 blob H  shard c
+  //3. overwrite
+  bufferlist bl;
+  string msg = object_content.substr(0x50000, 128 * 1024);
+  bl.append(msg);
+  ObjectStore::Transaction t;
+  C_SaferCond c;
+  t.register_on_commit(&c);
+  t.write(cid, hoid, 0x50000, bl.length(), bl);
+  // the default 0x20000 scan around during recompression makes
+  // the affected range 0x50000~0x20000 -> 0x30000~0x60000
+  r = queue_transaction(store, ch, std::move(t));
+  ASSERT_EQ(r, 0);
+  c.wait();
+  //00000~20000 blob A  shard a
+  //20000~20000 blob B  shard a <- modified not written
+  //range 30000~10000           <- not in shard marked to write
+  //40000~20000 blob C  shard b
+  //60000~20000 blob D  shard b
+  //80000~10000 blob E1 shard b
+  //90000~10000 blob E2 shard c
+  //a0000~20000 blob F  shard c
+  //c0000~20000 blob G  shard c
+  //e0000~20000 blob H  shard c
+  // unload hoid's ExtentMap
+  ch.reset();
+  EXPECT_EQ(store->umount(), 0);
+  EXPECT_EQ(store->mount(), 0);
+  ch = store->open_collection(cid);
+  //00000~20000 blob A  shard a
+  //20000~10000 blob B1 shard a
+  //30000~10000                 <- missing!
+  //40000~20000 blob C  shard b
+  //60000~20000 blob D  shard b
+  //80000~10000 blob E1 shard b
+  //90000~10000 blob E2 shard c
+  //a0000~20000 blob F  shard c
+  //c0000~20000 blob G  shard c
+  //e0000~20000 blob H  shard c
+  bufferlist object_content_read;
+  r = store->read(ch, hoid, 0, object_size, object_content_read);
+  EXPECT_EQ(r, (int)object_size);
+  EXPECT_TRUE(bl_eq(object_content_read, object_content_bl));
 }
 
 #endif  // WITH_BLUESTORE


### PR DESCRIPTION
The problem can happen when attempted compressed write v2 has to fallback to uncompressed write v2.
The uncompressed write can merge extent on left boundary, ignoring the fact that it might be in other shard.
The code did not mark the other shard as dirty.
Now properly detecting merging extents and changing affected range.

Fixes: https://tracker.ceph.com/issues/78776
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
