### PR TITLE
umbrella: qa/suites/nvmeof/upgrade: use refresh True for wait_for_service

### DIFF
--- a/qa/suites/nvmeof/upgrade/1-start-distro/1-start-centos_9.stream-squid.yaml
+++ b/qa/suites/nvmeof/upgrade/1-start-distro/1-start-centos_9.stream-squid.yaml
@@ -27,3 +27,4 @@ tasks:
 
 - cephadm.wait_for_service:
     service: nvmeof.mypool.mygroup0
+    refresh: True

--- a/qa/suites/nvmeof/upgrade/1-start-distro/1-start-centos_9.stream-tentacle.yaml
+++ b/qa/suites/nvmeof/upgrade/1-start-distro/1-start-centos_9.stream-tentacle.yaml
@@ -27,3 +27,4 @@ tasks:
 
 - cephadm.wait_for_service:
     service: nvmeof.mypool.mygroup0
+    refresh: True

--- a/qa/suites/nvmeof/upgrade/1-start-distro/1-start-centos_9.stream-v20.2.0.yaml
+++ b/qa/suites/nvmeof/upgrade/1-start-distro/1-start-centos_9.stream-v20.2.0.yaml
@@ -27,3 +27,4 @@ tasks:
 
 - cephadm.wait_for_service:
     service: nvmeof.mypool.mygroup0
+    refresh: True


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78774

---

backport of https://github.com/ceph/ceph/pull/70614
parent tracker: https://tracker.ceph.com/issues/78770

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh