### PR TITLE
mgr/dashboard: Fix password form validation mismatch errors

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.spec.ts
@@ -52,6 +52,19 @@ describe('UserPasswordFormComponent', () => {
     formHelper.expectValidChange('oldpassword', 'foo');
   });
 
+  it('should validate old and new password must be different', () => {
+    formHelper.setMultipleValues({
+      oldpassword: 'aaa',
+      newpassword: 'aaa'
+    });
+    formHelper.expectError('oldpassword', 'notmatch');
+    formHelper.expectError('newpassword', 'notmatch');
+
+    formHelper.setValue('newpassword', 'bbb');
+    formHelper.expectValid('oldpassword');
+    formHelper.expectValid('newpassword');
+  });
+
   it('should validate password match', () => {
     formHelper.setValue('newpassword', 'aaa');
     formHelper.expectErrorChange('confirmnewpassword', 'bbb', 'match');

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.ts
@@ -103,6 +103,13 @@ export class UserPasswordFormComponent {
         validators: [CdValidators.match('newpassword', 'confirmnewpassword')]
       }
     );
+
+    this.userForm.get('oldpassword').valueChanges.subscribe(() => {
+      this.userForm.get('newpassword').updateValueAndValidity({ emitEvent: false });
+    });
+    this.userForm.get('newpassword').valueChanges.subscribe(() => {
+      this.userForm.get('oldpassword').updateValueAndValidity({ emitEvent: false });
+    });
   }
 
   onSubmit() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.spec.ts
@@ -524,6 +524,12 @@ describe('CdValidators', () => {
       formHelper.expectValid('x');
       formHelper.expectError('y', 'notUnique');
     });
+
+    it('should not error when confirm value is empty', () => {
+      formHelper.setValue('y', '');
+      CdValidators.match('x', 'y')(form);
+      formHelper.expectValid('y');
+    });
   });
 
   describe('unique', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
@@ -352,7 +352,7 @@ export class CdValidators {
       if (!ctrl1 || !ctrl2) {
         return null;
       }
-      if (ctrl1.value !== ctrl2.value) {
+      if (ctrl2.value && ctrl1.value !== ctrl2.value) {
         const errors = _.merge({}, ctrl2.errors, { match: true });
         ctrl2.setErrors(errors);
       } else {


### PR DESCRIPTION
mgr/dashboard: Fix password form validation mismatch errors

Fixes: https://tracker.ceph.com/issues/78781

Signed-off-by: Sagar Gopale <sagar.gopale@ibm.com>

Before : 

<img width="3078" height="1972" alt="image" src="https://github.com/user-attachments/assets/9635380d-789f-47f1-b28f-cac736dec92d" />

After : 
<img width="3834" height="2090" alt="image" src="https://github.com/user-attachments/assets/aa10b8bb-2344-4fc4-835c-e91609d93a4d" />


> [!NOTE]
> **Regression**: This is a regression introduced during the carbonization of the Change Password form in PR #66006.

#### **Problem**
In Angular Reactive Forms, changing `oldpassword` does not automatically re-evaluate `newpassword`'s validators. When both passwords matched (triggering the `notmatch` custom validator), changing `oldpassword` cleared its own error state but left `newpassword` stuck in a stale `notmatch` error state (and vice versa).

#### **Solution**
1. Added cross-field `valueChanges` subscriptions on `oldpassword` and `newpassword` to trigger `updateValueAndValidity({ emitEvent: false })` whenever either value changes, keeping their error states in sync.
2. Refactored `CdValidators.match` to cleanly handle empty inputs and clear the `match` error in the `else` block without duplicate checks.



***

PR Description : 

1. Fixes validation mismatch issues in the Ceph Dashboard's change password form.
2. Ensures the "The old and new passwords must be different" error immediately clears when passwords differ.
3. Automatically synchronizes the validation state between the Old Password and New Password inputs.
4. Prevents redundant mismatch error messages from showing on the Confirm New Password input when left empty.
5. Adds unit tests to guarantee clean UI validation behavior for all password form scenarios.




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
