### PR TITLE
os/bluestore: add health alert when RocksDB column family sharding is not used

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1094,3 +1094,8 @@ Relevant tracker: https://tracker.ceph.com/issues/71677
   until they complete or abort.
 
   Relevant tracker: https://tracker.ceph.com/issues/77509
+* RADOS: A new ``BLUESTORE_NO_DB_SHARDING`` health warning reports OSDs whose
+  RocksDB database does not use column family sharding, i.e. OSDs created
+  prior to Pacific that have not been resharded yet with
+  ``ceph-bluestore-tool reshard``. This warning can be disabled with the new
+  ``bluestore_warn_on_no_db_sharding`` option.

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1152,3 +1152,8 @@ Relevant tracker: https://tracker.ceph.com/issues/71677
   seconds, which matches the previously hardcoded behaviour.
 
   Relevant tracker: https://tracker.ceph.com/issues/78727
+* RADOS: A new ``BLUESTORE_NO_DB_SHARDING`` health warning reports OSDs whose
+  RocksDB database does not use column family sharding, i.e. OSDs created
+  prior to Pacific that have not been resharded yet with
+  ``ceph-bluestore-tool reshard``. This warning can be disabled with the new
+  ``bluestore_warn_on_no_db_sharding`` option.

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -1200,6 +1200,36 @@ To disable this alert, run the following command:
 
    ceph config set global bluestore_warn_on_no_per_pg_omap false
 
+BLUESTORE_NO_DB_SHARDING
+________________________
+
+One or more OSDs have a RocksDB database that does not use column family
+sharding. OSDs created prior to the Pacific release store all of their
+key-value data in a single RocksDB column family, whereas OSDs created in
+Pacific or later releases shard the data across several column families,
+which improves caching and compaction efficiency and reduces the disk space
+that is temporarily required during compaction. See
+:ref:`bluestore-rocksdb-sharding` for more information.
+
+The OSDs can be updated to use sharding by stopping each OSD and resharding
+its RocksDB database. For example, to reshard ``osd.123``, run the following
+commands:
+
+.. prompt:: bash #
+
+   systemctl stop ceph-osd@123
+   ceph-bluestore-tool \
+    --path /var/lib/ceph/osd/ceph-123 \
+    --sharding="m(3) p(3,0-12) O(3,0-13)=block_cache={type=binned_lru} L P" \
+    reshard
+   systemctl start ceph-osd@123
+
+To disable this alert, run the following command:
+
+.. prompt:: bash #
+
+   ceph config set global bluestore_warn_on_no_db_sharding false
+
 
 BLUESTORE_DISK_SIZE_MISMATCH
 ____________________________

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -879,6 +879,36 @@ To disable this alert, run the following command:
 
    ceph config set global bluestore_warn_on_no_per_pg_omap false
 
+BLUESTORE_NO_DB_SHARDING
+________________________
+
+One or more OSDs have a RocksDB database that does not use column family
+sharding. OSDs created prior to the Pacific release store all of their
+key-value data in a single RocksDB column family, whereas OSDs created in
+Pacific or later releases shard the data across several column families,
+which improves caching and compaction efficiency and reduces the disk space
+that is temporarily required during compaction. See
+:ref:`bluestore-rocksdb-sharding` for more information.
+
+The OSDs can be updated to use sharding by stopping each OSD and resharding
+its RocksDB database. For example, to reshard ``osd.123``, run the following
+commands:
+
+.. prompt:: bash #
+
+   systemctl stop ceph-osd@123
+   ceph-bluestore-tool \
+    --path /var/lib/ceph/osd/ceph-123 \
+    --sharding="m(3) p(3,0-12) O(3,0-13)=block_cache={type=binned_lru} L P" \
+    reshard
+   systemctl start ceph-osd@123
+
+To disable this alert, run the following command:
+
+.. prompt:: bash #
+
+   ceph config set global bluestore_warn_on_no_db_sharding false
+
 
 BLUESTORE_DISK_SIZE_MISMATCH
 ____________________________

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5888,6 +5888,17 @@ options:
   desc: Raise a health warning on lack of per-pg omap
   default: false
   with_legacy: true
+- name: bluestore_warn_on_no_db_sharding
+  type: bool
+  level: advanced
+  desc: Raise a health warning if a BlueStore OSD does not use RocksDB column
+    family sharding
+  long_desc: OSDs created prior to the Pacific release do not shard their RocksDB
+    database into multiple column families, which impacts caching and compaction
+    efficiency. Such OSDs can be migrated to a sharded layout offline using
+    'ceph-bluestore-tool reshard'.
+  default: true
+  with_legacy: true
 - name: bluestore_log_op_age
   type: float
   level: advanced

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5849,6 +5849,17 @@ options:
   desc: Raise a health warning on lack of per-pg omap
   default: false
   with_legacy: true
+- name: bluestore_warn_on_no_db_sharding
+  type: bool
+  level: advanced
+  desc: Raise a health warning if a BlueStore OSD does not use RocksDB column
+    family sharding
+  long_desc: OSDs created prior to the Pacific release do not shard their RocksDB
+    database into multiple column families, which impacts caching and compaction
+    efficiency. Such OSDs can be migrated to a sharded layout offline using
+    'ceph-bluestore-tool reshard'.
+  default: true
+  with_legacy: true
 - name: bluestore_log_op_age
   type: float
   level: advanced

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -3329,6 +3329,8 @@ void PGMap::get_health_checks(
 	summary += " reporting legacy (not per-pg) BlueStore omap";
       } else if (asum.first == "BLUESTORE_NO_PER_POOL_OMAP") {
 	summary += " reporting legacy (not per-pool) BlueStore omap usage stats";
+      } else if (asum.first == "BLUESTORE_NO_DB_SHARDING") {
+	summary += " not using RocksDB column family sharding";
       } else if (asum.first == "BLUESTORE_SPURIOUS_READ_ERRORS") {
         summary += " have spurious read errors";
       } else if (asum.first == "BLUESTORE_SLOW_OP_ALERT") {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5906,6 +5906,7 @@ std::vector<std::string> BlueStore::get_tracked_keys() const noexcept
     "bluestore_warn_on_legacy_statfs"s,
     "bluestore_warn_on_no_per_pool_omap"s,
     "bluestore_warn_on_no_per_pg_omap"s,
+    "bluestore_warn_on_no_db_sharding"s,
     "bluestore_max_defer_interval"s,
     "bluestore_onode_segment_size"s,
     "bluestore_allocator_lookup_policy"s,
@@ -5924,6 +5925,9 @@ void BlueStore::handle_conf_change(const ConfigProxy& conf,
   if (changed.count("bluestore_warn_on_no_per_pool_omap") ||
       changed.count("bluestore_warn_on_no_per_pg_omap")) {
     _check_no_per_pg_or_pool_omap_alert();
+  }
+  if (changed.count("bluestore_warn_on_no_db_sharding")) {
+    _check_no_db_sharding_alert();
   }
 
   if (changed.count("bluestore_csum_type")) {
@@ -9219,7 +9223,7 @@ bool BlueStore::get_db_sharding(std::string& res_sharding)
 {
   bool ret = false;
   RocksDBStore* rdb = dynamic_cast<RocksDBStore*>(db);
-  if (db) {
+  if (rdb) {
     ret = rdb->get_sharding(res_sharding);
   }
   return ret;
@@ -12565,6 +12569,21 @@ void BlueStore::_check_no_per_pg_or_pool_omap_alert()
   no_per_pool_omap_alert = per_pool;
 }
 
+void BlueStore::_check_no_db_sharding_alert()
+{
+  string s;
+  if (db && cct->_conf->bluestore_warn_on_no_db_sharding) {
+    std::string sharding;
+    if (!get_db_sharding(sharding)) {
+      s = "no RocksDB column family sharding detected, "
+	"suggest to run 'ceph-bluestore-tool reshard' to benefit from "
+	"a sharded RocksDB layout";
+    }
+  }
+  std::lock_guard l(qlock);
+  no_db_sharding_alert = s;
+}
+
 // ---------------
 // cache
 
@@ -14518,6 +14537,8 @@ int BlueStore::_open_super_meta()
 	     << std::dec << dendl;
     logger->set(l_bluestore_alloc_unit, min_alloc_size);
   }
+
+  _check_no_db_sharding_alert();
 
   _set_per_pool_omap();
 
@@ -19817,6 +19838,11 @@ void BlueStore::_log_alerts(osd_alert_list_t& alerts)
     alerts.emplace(
       "BLUESTORE_NO_PER_POOL_OMAP",
       no_per_pool_omap_alert);
+  }
+  if (!no_db_sharding_alert.empty()) {
+    alerts.emplace(
+      "BLUESTORE_NO_DB_SHARDING",
+      no_db_sharding_alert);
   }
   string s0(failed_cmode);
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5910,6 +5910,7 @@ std::vector<std::string> BlueStore::get_tracked_keys() const noexcept
     "bluestore_warn_on_legacy_statfs"s,
     "bluestore_warn_on_no_per_pool_omap"s,
     "bluestore_warn_on_no_per_pg_omap"s,
+    "bluestore_warn_on_no_db_sharding"s,
     "bluestore_max_defer_interval"s,
     "bluestore_onode_segment_size"s,
     "bluestore_allocator_lookup_policy"s,
@@ -5928,6 +5929,9 @@ void BlueStore::handle_conf_change(const ConfigProxy& conf,
   if (changed.count("bluestore_warn_on_no_per_pool_omap") ||
       changed.count("bluestore_warn_on_no_per_pg_omap")) {
     _check_no_per_pg_or_pool_omap_alert();
+  }
+  if (changed.count("bluestore_warn_on_no_db_sharding")) {
+    _check_no_db_sharding_alert();
   }
 
   if (changed.count("bluestore_csum_type")) {
@@ -9245,7 +9249,7 @@ bool BlueStore::get_db_sharding(std::string& res_sharding)
 {
   bool ret = false;
   RocksDBStore* rdb = dynamic_cast<RocksDBStore*>(db);
-  if (db) {
+  if (rdb) {
     ret = rdb->get_sharding(res_sharding);
   }
   return ret;
@@ -12627,6 +12631,21 @@ void BlueStore::_check_no_per_pg_or_pool_omap_alert()
   no_per_pool_omap_alert = per_pool;
 }
 
+void BlueStore::_check_no_db_sharding_alert()
+{
+  string s;
+  if (db && cct->_conf->bluestore_warn_on_no_db_sharding) {
+    std::string sharding;
+    if (!get_db_sharding(sharding)) {
+      s = "no RocksDB column family sharding detected, "
+	"suggest to run 'ceph-bluestore-tool reshard' to benefit from "
+	"a sharded RocksDB layout";
+    }
+  }
+  std::lock_guard l(qlock);
+  no_db_sharding_alert = s;
+}
+
 // ---------------
 // cache
 
@@ -14580,6 +14599,8 @@ int BlueStore::_open_super_meta()
 	     << std::dec << dendl;
     logger->set(l_bluestore_alloc_unit, min_alloc_size);
   }
+
+  _check_no_db_sharding_alert();
 
   _set_per_pool_omap();
 
@@ -19879,6 +19900,11 @@ void BlueStore::_log_alerts(osd_alert_list_t& alerts)
     alerts.emplace(
       "BLUESTORE_NO_PER_POOL_OMAP",
       no_per_pool_omap_alert);
+  }
+  if (!no_db_sharding_alert.empty()) {
+    alerts.emplace(
+      "BLUESTORE_NO_DB_SHARDING",
+      no_db_sharding_alert);
   }
   string s0(failed_cmode);
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3730,6 +3730,7 @@ private:
   std::string no_per_pg_omap_alert;
   std::string disk_size_mismatch_alert;
   std::string spurious_read_errors_alert;
+  std::string no_db_sharding_alert;
   std::queue <std::pair<ceph::mono_clock::time_point, bool>> slow_op_event_queue;
   size_t slow_op_event_count = 0;
   size_t slow_scrub_op_event_count = 0;
@@ -3755,6 +3756,7 @@ private:
 
   void _check_legacy_statfs_alert();
   void _check_no_per_pg_or_pool_omap_alert();
+  void _check_no_db_sharding_alert();
   void _set_disk_size_mismatch_alert(const std::string& s) {
     std::lock_guard l(qlock);
     disk_size_mismatch_alert = s;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3716,6 +3716,7 @@ private:
   std::string no_per_pg_omap_alert;
   std::string disk_size_mismatch_alert;
   std::string spurious_read_errors_alert;
+  std::string no_db_sharding_alert;
   std::queue <std::pair<ceph::mono_clock::time_point, bool>> slow_op_event_queue;
   size_t slow_op_event_count = 0;
   size_t slow_scrub_op_event_count = 0;
@@ -3741,6 +3742,7 @@ private:
 
   void _check_legacy_statfs_alert();
   void _check_no_per_pg_or_pool_omap_alert();
+  void _check_no_db_sharding_alert();
   void _set_disk_size_mismatch_alert(const std::string& s) {
     std::lock_guard l(qlock);
     disk_size_mismatch_alert = s;

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -12631,6 +12631,50 @@ TEST_P(StoreTestSpecificAUSize, SpilloverFixedPartialTest) {
     << std::endl;
 }
 
+TEST_P(StoreTestSpecificAUSize, BluestoreNoDBShardingAlertTest) {
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  // create a store with a non-sharded RocksDB database, as created by
+  // OSDs deployed prior to Pacific
+  SetVal(g_conf(), "bluestore_rocksdb_cf", "false");
+  g_conf().apply_changes(nullptr);
+
+  StartDeferred(4096);
+
+  struct store_statfs_t statfs;
+  osd_alert_list_t alerts;
+  int r = store->statfs(&statfs, &alerts);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(alerts.count("BLUESTORE_NO_DB_SHARDING"), 1);
+  std::cout << "no_db_sharding_alert:"
+	    << alerts.find("BLUESTORE_NO_DB_SHARDING")->second
+	    << std::endl;
+
+  // the alert can be disabled at runtime
+  SetVal(g_conf(), "bluestore_warn_on_no_db_sharding", "false");
+  g_conf().apply_changes(nullptr);
+
+  alerts.clear();
+  r = store->statfs(&statfs, &alerts);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(alerts.count("BLUESTORE_NO_DB_SHARDING"), 0);
+}
+
+TEST_P(StoreTestSpecificAUSize, BluestoreDBShardingNoAlertTest) {
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  // RocksDB column family sharding is enabled by default at mkfs
+  StartDeferred(4096);
+
+  struct store_statfs_t statfs;
+  osd_alert_list_t alerts;
+  int r = store->statfs(&statfs, &alerts);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(alerts.count("BLUESTORE_NO_DB_SHARDING"), 0);
+}
+
 TEST_P(StoreTestSpecificAUSize, Ticket45195Repro) {
   if (string(GetParam()) != "bluestore")
     return;

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -12401,6 +12401,50 @@ TEST_P(StoreTestSpecificAUSize, SpilloverFixedPartialTest) {
     << std::endl;
 }
 
+TEST_P(StoreTestSpecificAUSize, BluestoreNoDBShardingAlertTest) {
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  // create a store with a non-sharded RocksDB database, as created by
+  // OSDs deployed prior to Pacific
+  SetVal(g_conf(), "bluestore_rocksdb_cf", "false");
+  g_conf().apply_changes(nullptr);
+
+  StartDeferred(4096);
+
+  struct store_statfs_t statfs;
+  osd_alert_list_t alerts;
+  int r = store->statfs(&statfs, &alerts);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(alerts.count("BLUESTORE_NO_DB_SHARDING"), 1);
+  std::cout << "no_db_sharding_alert:"
+	    << alerts.find("BLUESTORE_NO_DB_SHARDING")->second
+	    << std::endl;
+
+  // the alert can be disabled at runtime
+  SetVal(g_conf(), "bluestore_warn_on_no_db_sharding", "false");
+  g_conf().apply_changes(nullptr);
+
+  alerts.clear();
+  r = store->statfs(&statfs, &alerts);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(alerts.count("BLUESTORE_NO_DB_SHARDING"), 0);
+}
+
+TEST_P(StoreTestSpecificAUSize, BluestoreDBShardingNoAlertTest) {
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  // RocksDB column family sharding is enabled by default at mkfs
+  StartDeferred(4096);
+
+  struct store_statfs_t statfs;
+  osd_alert_list_t alerts;
+  int r = store->statfs(&statfs, &alerts);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(alerts.count("BLUESTORE_NO_DB_SHARDING"), 0);
+}
+
 TEST_P(StoreTestSpecificAUSize, Ticket45195Repro) {
   if (string(GetParam()) != "bluestore")
     return;


### PR DESCRIPTION
Add a new **BLUESTORE_NO_DB_SHARDING** health warning, raised by OSDs whose RocksDB database does not use column family sharding, i.e. OSDs created prior to Pacific that have not been resharded yet. Such OSDs suffer from less efficient caching and compaction and can be migrated to a sharded layout offline with 'ceph-bluestore-tool reshard'.

The alert can be disabled with the new **bluestore_warn_on_no_db_sharding** option (default: true).

Also fix a latent nullptr dereference in BlueStore::get_db_sharding() when the KV backend is not RocksDB.

Fixes: https://tracker.ceph.com/issues/78784

Assisted-by: Claude Fable 5 High.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [X] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
