### PR TITLE
mgr/dashboard: improve unit test performance

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -19,7 +19,7 @@
     "i18n:merge": "npx i18ntool merge -c i18n.config.json",
     "i18n:token": "npx i18ntool config token",
     "test": "jest --watch",
-    "test:ci": "jest --clearCache && JEST_SILENT_REPORTER_DOTS=true jest --detectOpenHandles --coverage --reporters jest-silent-reporter",
+    "test:ci": "jest --clearCache && JEST_SILENT_REPORTER_DOTS=true jest --runInBand --forceExit --coverage --reporters jest-silent-reporter",
     "pree2e": "rm -f cypress/reports/results-*.xml || true",
     "e2e": "start-test 4200 'cypress open'",
     "pree2e:ci": "npm run pree2e",

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi/iscsi.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi/iscsi.component.spec.ts
@@ -36,7 +36,7 @@ describe('IscsiComponent', () => {
       DimlessPipe,
       FormatterService,
       IscsiBackstorePipe,
-      { provide: IscsiService, useValue: fakeService }
+      { provide: IscsiService, useFactory: () => fakeService }
     ]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvme-gateway-view/nvme-gateway-view-breadcrumb.resolver.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvme-gateway-view/nvme-gateway-view-breadcrumb.resolver.spec.ts
@@ -2,15 +2,17 @@ import { TestBed } from '@angular/core/testing';
 import { ActivatedRouteSnapshot } from '@angular/router';
 
 import { NvmeGatewayViewBreadcrumbResolver } from './nvme-gateway-view-breadcrumb.resolver';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('NvmeGatewayViewBreadcrumbResolver', () => {
   let resolver: NvmeGatewayViewBreadcrumbResolver;
   let route: ActivatedRouteSnapshot;
 
+  configureTestBed({
+    providers: [NvmeGatewayViewBreadcrumbResolver]
+  });
+
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [NvmeGatewayViewBreadcrumbResolver]
-    });
     resolver = TestBed.inject(NvmeGatewayViewBreadcrumbResolver);
     route = new ActivatedRouteSnapshot();
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvme-gateway-view/nvme-gateway-view.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvme-gateway-view/nvme-gateway-view.component.spec.ts
@@ -1,21 +1,20 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SideNavModule, ThemeModule } from 'carbon-components-angular';
 
 import { RouterTestingModule } from '@angular/router/testing';
 import { NvmeGatewayViewComponent } from './nvme-gateway-view.component';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('NvmeGatewayViewComponent', () => {
   let component: NvmeGatewayViewComponent;
   let fixture: ComponentFixture<NvmeGatewayViewComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [NvmeGatewayViewComponent],
-      imports: [RouterTestingModule, SideNavModule, ThemeModule],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [NvmeGatewayViewComponent],
+    imports: [RouterTestingModule, SideNavModule, ThemeModule],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NvmeGatewayViewComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvme-subsystem-view/nvme-subsystem-view-breadcrumb.resolver.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvme-subsystem-view/nvme-subsystem-view-breadcrumb.resolver.spec.ts
@@ -6,7 +6,6 @@ describe('NvmeSubsystemViewBreadcrumbResolver', () => {
   let resolver: NvmeSubsystemViewBreadcrumbResolver;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     resolver = TestBed.inject(NvmeSubsystemViewBreadcrumbResolver);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvme-subsystem-view/nvme-subsystem-view.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvme-subsystem-view/nvme-subsystem-view.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
@@ -6,6 +6,7 @@ import { of } from 'rxjs';
 
 import { NvmeSubsystemViewComponent } from './nvme-subsystem-view.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { configureTestBed } from '~/testing/unit-test-helper';
 describe('NvmeSubsystemViewComponent', () => {
   let component: NvmeSubsystemViewComponent;
   let fixture: ComponentFixture<NvmeSubsystemViewComponent>;
@@ -20,14 +21,12 @@ describe('NvmeSubsystemViewComponent', () => {
     queryParams: of(mockQueryParams)
   };
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [NvmeSubsystemViewComponent],
-      imports: [RouterTestingModule, HttpClientTestingModule],
-      providers: [{ provide: ActivatedRoute, useValue: mockActivatedRoute }],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [NvmeSubsystemViewComponent],
+    imports: [RouterTestingModule, HttpClientTestingModule],
+    providers: [{ provide: ActivatedRoute, useFactory: () => mockActivatedRoute }],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NvmeSubsystemViewComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-edit-authentication/nvmeof-edit-authentication.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-edit-authentication/nvmeof-edit-authentication.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -17,15 +17,20 @@ import {
   GROUP_NAME_TOKEN
 } from './nvmeof-edit-authentication.component';
 import { NvmeofSubsystemsStepThreeComponent } from '../nvmeof-subsystems-form/nvmeof-subsystem-step-3/nvmeof-subsystem-step-3.component';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('NvmeofEditAuthenticationComponent', () => {
   let component: NvmeofEditAuthenticationComponent;
   let fixture: ComponentFixture<NvmeofEditAuthenticationComponent>;
   let nvmeofService: jest.Mocked<
     Pick<NvmeofService, 'getInitiators' | 'getSubsystem' | 'updateAuthenticationKey'>
-  >;
-  let notificationService: { show: jest.Mock };
-  let modalService: { dismissAll: jest.Mock };
+  > = {
+    getInitiators: jest.fn().mockReturnValue(of([])),
+    getSubsystem: jest.fn().mockReturnValue(of({ has_dhchap_key: false })),
+    updateAuthenticationKey: jest.fn().mockReturnValue(of(undefined))
+  };
+  let notificationService: { show: jest.Mock } = { show: jest.fn() };
+  let modalService: { dismissAll: jest.Mock } = { dismissAll: jest.fn() };
 
   const mockSubsystemNQN = 'nqn.2014-08.org.nvmexpress:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6';
   const mockGroupName = 'default';
@@ -35,41 +40,31 @@ describe('NvmeofEditAuthenticationComponent', () => {
   ];
   const mockHostsWithKey = [{ nqn: 'nqn.2014-08.org.nvmexpress:uuid:host-1', use_dhchap: true }];
 
-  beforeEach(waitForAsync(() => {
-    nvmeofService = {
-      getInitiators: jest.fn().mockReturnValue(of([])),
-      getSubsystem: jest.fn().mockReturnValue(of({ has_dhchap_key: false })),
-      updateAuthenticationKey: jest.fn().mockReturnValue(of(undefined))
-    };
-    notificationService = { show: jest.fn() };
-    modalService = { dismissAll: jest.fn() };
-
-    TestBed.configureTestingModule({
-      declarations: [NvmeofEditAuthenticationComponent, NvmeofSubsystemsStepThreeComponent],
-      imports: [
-        ReactiveFormsModule,
-        HttpClientTestingModule,
-        RouterTestingModule,
-        SharedModule,
-        GridModule,
-        InputModule,
-        RadioModule,
-        TagModule
-      ],
-      providers: [
-        { provide: NvmeofService, useValue: nvmeofService },
-        { provide: NotificationService, useValue: notificationService },
-        { provide: ModalCdsService, useValue: modalService },
-        { provide: SUBSYSTEM_NQN_TOKEN, useValue: mockSubsystemNQN },
-        { provide: GROUP_NAME_TOKEN, useValue: mockGroupName }
-      ]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [NvmeofEditAuthenticationComponent, NvmeofSubsystemsStepThreeComponent],
+    imports: [
+      ReactiveFormsModule,
+      HttpClientTestingModule,
+      RouterTestingModule,
+      SharedModule,
+      GridModule,
+      InputModule,
+      RadioModule,
+      TagModule
+    ],
+    providers: [
+      { provide: NvmeofService, useFactory: () => nvmeofService },
+      { provide: NotificationService, useFactory: () => notificationService },
+      { provide: ModalCdsService, useFactory: () => modalService },
+      { provide: SUBSYSTEM_NQN_TOKEN, useFactory: () => mockSubsystemNQN },
+      { provide: GROUP_NAME_TOKEN, useFactory: () => mockGroupName }
+    ]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NvmeofEditAuthenticationComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges(); // runs ngOnInit + ngAfterViewInit
+    fixture.detectChanges();
   });
 
   it('should create', () => {
@@ -115,6 +110,7 @@ describe('NvmeofEditAuthenticationComponent', () => {
       nvmeofService.getSubsystem.mockReturnValue(of({ has_dhchap_key: true }));
       nvmeofService.getInitiators.mockReturnValue(of(mockHostsWithKey));
       component.ngOnInit();
+      fixture.detectChanges();
       expect(component.initialAuthType).toBe(AUTHENTICATION.Bidirectional);
       component.authStep.initialAuthType = component.initialAuthType;
       expect(component.authStep.formGroup.get('authType')?.value).toBe(
@@ -126,6 +122,7 @@ describe('NvmeofEditAuthenticationComponent', () => {
       nvmeofService.getSubsystem.mockReturnValue(of({ has_dhchap_key: false }));
       nvmeofService.getInitiators.mockReturnValue(of(mockHostsWithKey));
       component.ngOnInit();
+      fixture.detectChanges();
       expect(component.initialAuthType).toBe(AUTHENTICATION.Unidirectional);
       expect(component.authStep.formGroup.get('authType')?.value).toBe(
         AUTHENTICATION.Unidirectional
@@ -168,6 +165,14 @@ describe('NvmeofEditAuthenticationComponent', () => {
   });
 
   describe('onSubmit', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      nvmeofService.updateAuthenticationKey.mockReturnValue(of(undefined));
+      fixture = TestBed.createComponent(NvmeofEditAuthenticationComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
     it('should not call updateAuthenticationKey when form is invalid', () => {
       const form = component.authStep?.formGroup;
       if (form) {
@@ -231,7 +236,7 @@ describe('NvmeofEditAuthenticationComponent', () => {
       component.onSubmit();
     });
 
-    it('should mark form with submission error on API failure', (done) => {
+    it('should mark form with submission error on API failure', fakeAsync(() => {
       const form = component.authStep?.formGroup;
       form?.get('authType')?.setValue(AUTHENTICATION.Unidirectional);
       nvmeofService.updateAuthenticationKey.mockReturnValue(
@@ -239,15 +244,16 @@ describe('NvmeofEditAuthenticationComponent', () => {
       );
 
       component.onSubmit();
+      tick();
+      fixture.detectChanges();
 
       setTimeout(() => {
         expect(component.isSubmitLoading).toBe(false);
         expect(form?.hasError('cdSubmitButton')).toBe(true);
         expect(notificationService.show).not.toHaveBeenCalled();
         expect(modalService.dismissAll).not.toHaveBeenCalled();
-        done();
       }, 0);
-    });
+    }));
 
     it('should clear isSubmitLoading after error', (done) => {
       const form = component.authStep?.formGroup;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-edit-host-key-modal/nvmeof-edit-host-key-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-edit-host-key-modal/nvmeof-edit-host-key-modal.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -10,6 +10,7 @@ import { SharedModule } from '~/app/shared/shared.module';
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { NvmeofEditHostKeyModalComponent } from './nvmeof-edit-host-key-modal.component';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('NvmeofEditHostKeyModalComponent', () => {
   let component: NvmeofEditHostKeyModalComponent;
@@ -29,20 +30,18 @@ describe('NvmeofEditHostKeyModalComponent', () => {
     wrapTaskAroundCall: jasmine.createSpy('wrapTaskAroundCall').and.callFake(({ call }) => call)
   };
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [NvmeofEditHostKeyModalComponent],
-      imports: [ReactiveFormsModule, HttpClientTestingModule, RouterTestingModule, SharedModule],
-      providers: [
-        { provide: NvmeofService, useValue: nvmeofServiceSpy },
-        { provide: TaskWrapperService, useValue: taskWrapperServiceSpy },
-        { provide: 'subsystemNQN', useValue: mockSubsystemNQN },
-        { provide: 'hostNQN', useValue: mockHostNQN },
-        { provide: 'group', useValue: mockGroup },
-        { provide: 'dhchapKey', useValue: '' }
-      ]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [NvmeofEditHostKeyModalComponent],
+    imports: [ReactiveFormsModule, HttpClientTestingModule, RouterTestingModule, SharedModule],
+    providers: [
+      { provide: NvmeofService, useFactory: () => nvmeofServiceSpy },
+      { provide: TaskWrapperService, useFactory: () => taskWrapperServiceSpy },
+      { provide: 'subsystemNQN', useValue: mockSubsystemNQN },
+      { provide: 'hostNQN', useValue: mockHostNQN },
+      { provide: 'group', useValue: mockGroup },
+      { provide: 'dhchapKey', useValue: '' }
+    ]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NvmeofEditHostKeyModalComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component.spec.ts
@@ -4,6 +4,7 @@ import { of, throwError } from 'rxjs';
 
 import { NvmeofGatewayGroupFilterComponent } from './nvmeof-gateway-group-filter.component';
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 const MOCK_GROUPS_RESPONSE = [
   [
@@ -15,35 +16,29 @@ const MOCK_GROUPS_RESPONSE = [
 describe('NvmeofGatewayGroupFilterComponent', () => {
   let fixture: ComponentFixture<NvmeofGatewayGroupFilterComponent>;
   let component: NvmeofGatewayGroupFilterComponent;
-  let nvmeofService: Partial<NvmeofService>;
-  let routerSpy: Partial<Router>;
-  let activatedRoute: Partial<ActivatedRoute>;
+  let nvmeofService: Partial<NvmeofService> = {
+    listGatewayGroups: jest.fn().mockReturnValue(of(MOCK_GROUPS_RESPONSE)),
+    formatGwGroupsList: jest.fn().mockReturnValue([{ content: 'grp1' }, { content: 'grp2' }])
+  };
+  let routerSpy: Partial<Router> = {
+    navigate: jest.fn().mockResolvedValue(true)
+  };
+  let activatedRoute: Partial<ActivatedRoute> = {
+    snapshot: {
+      queryParams: {}
+    } as any
+  };
 
-  beforeEach(async () => {
-    nvmeofService = {
-      listGatewayGroups: jest.fn().mockReturnValue(of(MOCK_GROUPS_RESPONSE)),
-      formatGwGroupsList: jest.fn().mockReturnValue([{ content: 'grp1' }, { content: 'grp2' }])
-    };
+  configureTestBed({
+    imports: [NvmeofGatewayGroupFilterComponent],
+    providers: [
+      { provide: NvmeofService, useFactory: () => nvmeofService },
+      { provide: Router, useFactory: () => routerSpy },
+      { provide: ActivatedRoute, useFactory: () => activatedRoute }
+    ]
+  });
 
-    routerSpy = {
-      navigate: jest.fn().mockResolvedValue(true)
-    };
-
-    activatedRoute = {
-      snapshot: {
-        queryParams: {}
-      } as any
-    };
-
-    await TestBed.configureTestingModule({
-      imports: [NvmeofGatewayGroupFilterComponent],
-      providers: [
-        { provide: NvmeofService, useValue: nvmeofService },
-        { provide: Router, useValue: routerSpy },
-        { provide: ActivatedRoute, useValue: activatedRoute }
-      ]
-    }).compileComponents();
-
+  beforeEach(() => {
     fixture = TestBed.createComponent(NvmeofGatewayGroupFilterComponent);
     component = fixture.componentInstance;
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group-delete-guard-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group-delete-guard-modal.component.spec.ts
@@ -3,25 +3,24 @@ import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { NvmeofGatewayGroupDeleteGuardModalComponent } from './nvmeof-gateway-group-delete-guard-modal.component';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('NvmeofGatewayGroupDeleteGuardModalComponent', () => {
   let component: NvmeofGatewayGroupDeleteGuardModalComponent;
   let fixture: ComponentFixture<NvmeofGatewayGroupDeleteGuardModalComponent>;
   let router: Router;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
-      declarations: [NvmeofGatewayGroupDeleteGuardModalComponent],
-      providers: [
-        { provide: 'gatewayName', useValue: 'gateway-dev' },
-        {
-          provide: 'connectedSubsystems',
-          useValue: [{ nqn: 'subsystem-1' }, { nqn: 'subsystem-2' }]
-        }
-      ],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
+  configureTestBed({
+    imports: [RouterTestingModule],
+    declarations: [NvmeofGatewayGroupDeleteGuardModalComponent],
+    providers: [
+      { provide: 'gatewayName', useValue: 'gateway-dev' },
+      {
+        provide: 'connectedSubsystems',
+        useValue: [{ nqn: 'subsystem-1' }, { nqn: 'subsystem-2' }]
+      }
+    ],
+    schemas: [NO_ERRORS_SCHEMA]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-group/nvmeof-gateway-group.component.spec.ts
@@ -11,36 +11,37 @@ import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete
 import { NvmeofGatewayGroupDeleteGuardModalComponent } from './nvmeof-gateway-group-delete-guard-modal.component';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { NvmeofStateService } from '../nvmeof-state.service';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('NvmeofGatewayGroupComponent', () => {
   let component: NvmeofGatewayGroupComponent;
   let fixture: ComponentFixture<NvmeofGatewayGroupComponent>;
   let nvmeofService: any;
+  let nvmeofServiceSpy = {
+    listGatewayGroups: jest.fn().mockReturnValue(of([])),
+    listSubsystems: jest.fn().mockReturnValue(of([]))
+  };
+  let nvmeofStateServiceMock = {
+    refresh$: new Subject<void>(),
+    requestRefresh: jest.fn()
+  };
 
-  beforeEach(async () => {
-    const nvmeofServiceSpy = {
-      listGatewayGroups: jest.fn().mockReturnValue(of([])),
-      listSubsystems: jest.fn().mockReturnValue(of([]))
-    };
-    const nvmeofStateServiceMock = {
-      refresh$: new Subject<void>(),
-      requestRefresh: jest.fn()
-    };
+  configureTestBed({
+    imports: [HttpClientModule, SharedModule, TabsModule, GridModule, ModalModule],
+    declarations: [NvmeofGatewayGroupComponent],
+    providers: [
+      { provide: NvmeofService, useFactory: () => nvmeofServiceSpy },
+      {
+        provide: ModalCdsService,
+        useValue: { show: jest.fn() }
+      },
+      { provide: NvmeofStateService, useFactory: () => nvmeofStateServiceMock }
+    ],
+    schemas: [NO_ERRORS_SCHEMA]
+  });
 
-    await TestBed.configureTestingModule({
-      imports: [HttpClientModule, SharedModule, TabsModule, GridModule, ModalModule],
-      declarations: [NvmeofGatewayGroupComponent],
-      providers: [
-        { provide: NvmeofService, useValue: nvmeofServiceSpy },
-        {
-          provide: ModalCdsService,
-          useValue: { show: jest.fn() }
-        },
-        { provide: NvmeofStateService, useValue: nvmeofStateServiceMock }
-      ],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
-
+  beforeEach(() => {
+    jest.clearAllMocks();
     fixture = TestBed.createComponent(NvmeofGatewayGroupComponent);
     component = fixture.componentInstance;
     nvmeofService = TestBed.inject(NvmeofService);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-node/nvmeof-gateway-node-add-modal/nvmeof-gateway-node-add-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-node/nvmeof-gateway-node-add-modal/nvmeof-gateway-node-add-modal.component.spec.ts
@@ -52,11 +52,11 @@ describe('NvmeofGatewayNodeAddModalComponent', () => {
     imports: [SharedModule, HttpClientTestingModule, RouterTestingModule],
     declarations: [NvmeofGatewayNodeAddModalComponent],
     providers: [
-      { provide: HostService, useValue: mockHostService },
-      { provide: NvmeofService, useValue: mockNvmeofService },
-      { provide: CephServiceService, useValue: mockCephServiceService },
-      { provide: NotificationService, useValue: mockNotificationService },
-      { provide: TaskMessageService, useValue: mockTaskMessageService },
+      { provide: HostService, useFactory: () => mockHostService },
+      { provide: NvmeofService, useFactory: () => mockNvmeofService },
+      { provide: CephServiceService, useFactory: () => mockCephServiceService },
+      { provide: NotificationService, useFactory: () => mockNotificationService },
+      { provide: TaskMessageService, useFactory: () => mockTaskMessageService },
       { provide: 'groupName', useValue: 'group1' },
       { provide: 'usedHostnames', useValue: ['host1'] },
       { provide: 'serviceSpec', useValue: mockServiceSpec }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-node/nvmeof-gateway-node.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-node/nvmeof-gateway-node.component.spec.ts
@@ -108,7 +108,7 @@ describe('NvmeofGatewayNodeComponent', () => {
       TagModule
     ],
     providers: [
-      { provide: AuthStorageService, useValue: fakeAuthStorageService },
+      { provide: AuthStorageService, useFactory: () => fakeAuthStorageService },
       {
         provide: ActivatedRoute,
         useValue: {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-subsystem/nvmeof-gateway-subsystem.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway-subsystem/nvmeof-gateway-subsystem.component.spec.ts
@@ -8,6 +8,7 @@ import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 import { NvmeofSubsystem } from '~/app/shared/models/nvmeof';
 
 import { SharedModule } from '~/app/shared/shared.module';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('NvmeofGatewaySubsystemComponent', () => {
   let component: NvmeofGatewaySubsystemComponent;
@@ -50,38 +51,35 @@ describe('NvmeofGatewaySubsystemComponent', () => {
   const mockInitiators1 = [{ nqn: 'host1' }, { nqn: 'host2' }];
   const mockInitiators2 = [{ nqn: 'host3' }];
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [NvmeofGatewaySubsystemComponent],
-      imports: [HttpClientTestingModule, SharedModule],
-      providers: [
-        {
-          provide: NvmeofService,
-          useValue: {
-            listSubsystems: jest.fn(() => of(mockSubsystems)),
-            getInitiators: jest.fn((nqn) => {
-              if (nqn === 'nqn.2014-08.org.nvmexpress:uuid:1111') {
-                return of(mockInitiators1);
-              }
-              return of(mockInitiators2);
-            })
-          }
-        },
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            parent: {
-              params: of({ group: 'group1' })
+  configureTestBed({
+    declarations: [NvmeofGatewaySubsystemComponent],
+    imports: [HttpClientTestingModule, SharedModule],
+    providers: [
+      {
+        provide: NvmeofService,
+        useValue: {
+          listSubsystems: jest.fn(() => of(mockSubsystems)),
+          getInitiators: jest.fn((nqn) => {
+            if (nqn === 'nqn.2014-08.org.nvmexpress:uuid:1111') {
+              return of(mockInitiators1);
             }
+            return of(mockInitiators2);
+          })
+        }
+      },
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          parent: {
+            params: of({ group: 'group1' })
           }
         }
-      ]
-    }).compileComponents();
-
-    nvmeofService = TestBed.inject(NvmeofService);
+      }
+    ]
   });
 
   beforeEach(() => {
+    nvmeofService = TestBed.inject(NvmeofService);
     fixture = TestBed.createComponent(NvmeofGatewaySubsystemComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.spec.ts
@@ -9,34 +9,35 @@ import { SharedModule } from '~/app/shared/shared.module';
 import { ComboBoxModule, GridModule, TabsModule } from 'carbon-components-angular';
 import { of } from 'rxjs';
 import { BreadcrumbService } from '~/app/shared/services/breadcrumb.service';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('NvmeofGatewayComponent', () => {
   let component: NvmeofGatewayComponent;
   let fixture: ComponentFixture<NvmeofGatewayComponent>;
   let breadcrumbService: BreadcrumbService;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [NvmeofGatewayComponent],
-      imports: [
-        HttpClientModule,
-        RouterTestingModule,
-        SharedModule,
-        ComboBoxModule,
-        GridModule,
-        TabsModule
-      ],
-      providers: [
-        BreadcrumbService,
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            queryParams: of({})
-          }
+  configureTestBed({
+    declarations: [NvmeofGatewayComponent],
+    imports: [
+      HttpClientModule,
+      RouterTestingModule,
+      SharedModule,
+      ComboBoxModule,
+      GridModule,
+      TabsModule
+    ],
+    providers: [
+      BreadcrumbService,
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          queryParams: of({})
         }
-      ]
-    }).compileComponents();
+      }
+    ]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(NvmeofGatewayComponent);
     component = fixture.componentInstance;
     breadcrumbService = TestBed.inject(BreadcrumbService);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.spec.ts
@@ -17,7 +17,7 @@ import { CheckboxModule, GridModule, InputModule, SelectModule } from 'carbon-co
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { CephServiceService } from '~/app/shared/api/ceph-service.service';
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
-import { FormHelper } from '~/testing/unit-test-helper';
+import { configureTestBed, FormHelper } from '~/testing/unit-test-helper';
 
 describe('NvmeofGroupFormComponent', () => {
   let component: NvmeofGroupFormComponent;
@@ -29,26 +29,24 @@ describe('NvmeofGroupFormComponent', () => {
   let nvmeofService: NvmeofService;
   let router: Router;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [NvmeofGroupFormComponent],
-      providers: [NgbActiveModal],
-      imports: [
-        HttpClientTestingModule,
-        NgbTypeaheadModule,
-        ReactiveFormsModule,
-        RouterTestingModule,
-        SharedModule,
-        CheckboxModule,
-        GridModule,
-        InputModule,
-        SelectModule
-      ],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA]
-    })
-      .overrideTemplate(NvmeofGroupFormComponent, '')
-      .compileComponents();
+  configureTestBed({
+    declarations: [NvmeofGroupFormComponent],
+    providers: [NgbActiveModal],
+    imports: [
+      HttpClientTestingModule,
+      NgbTypeaheadModule,
+      ReactiveFormsModule,
+      RouterTestingModule,
+      SharedModule,
+      CheckboxModule,
+      GridModule,
+      InputModule,
+      SelectModule
+    ],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(NvmeofGroupFormComponent);
     component = fixture.componentInstance;
     taskWrapperService = TestBed.inject(TaskWrapperService);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-form/nvmeof-initiators-form.component.spec.ts
@@ -13,41 +13,40 @@ import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 import { ALLOW_ALL_HOST, HOST_TYPE } from '~/app/shared/models/nvmeof';
 
 import { NvmeofInitiatorsFormComponent } from './nvmeof-initiators-form.component';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('NvmeofInitiatorsFormComponent', () => {
   let component: NvmeofInitiatorsFormComponent;
   let fixture: ComponentFixture<NvmeofInitiatorsFormComponent>;
   let nvmeofService: NvmeofService;
-  const mockTimestamp = 1720693470789;
   const mockGroupName = 'default';
 
-  beforeEach(async () => {
-    spyOn(Date, 'now').and.returnValue(mockTimestamp);
-    await TestBed.configureTestingModule({
-      declarations: [NvmeofInitiatorsFormComponent],
-      schemas: [NO_ERRORS_SCHEMA],
-      providers: [
-        NgbActiveModal,
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            queryParamMap: of(convertToParamMap({ group: 'test-group' })),
-            params: of({ subsystem_nqn: 'nqn.test' }),
-            parent: {
-              params: of({ subsystem_nqn: 'nqn.test' })
-            }
+  configureTestBed({
+    declarations: [NvmeofInitiatorsFormComponent],
+    schemas: [NO_ERRORS_SCHEMA],
+    providers: [
+      NgbActiveModal,
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          queryParamMap: of(convertToParamMap({ group: 'test-group' })),
+          params: of({ subsystem_nqn: 'nqn.test' }),
+          parent: {
+            params: of({ subsystem_nqn: 'nqn.test' })
           }
         }
-      ],
-      imports: [
-        HttpClientTestingModule,
-        NgbTypeaheadModule,
-        ReactiveFormsModule,
-        RouterTestingModule,
-        SharedModule
-      ]
-    }).compileComponents();
+      }
+    ],
+    imports: [
+      HttpClientTestingModule,
+      NgbTypeaheadModule,
+      ReactiveFormsModule,
+      RouterTestingModule,
+      SharedModule
+    ]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(NvmeofInitiatorsFormComponent);
     component = fixture.componentInstance;
     component.ngOnInit();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.spec.ts
@@ -13,6 +13,7 @@ import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { ALLOW_ALL_HOST } from '~/app/shared/models/nvmeof';
 
 import { NvmeofInitiatorsListComponent } from './nvmeof-initiators-list.component';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 const mockInitiators = [
   {
@@ -51,39 +52,33 @@ describe('NvmeofInitiatorsListComponent', () => {
   let component: NvmeofInitiatorsListComponent;
   let fixture: ComponentFixture<NvmeofInitiatorsListComponent>;
   let nvmeofService: NvmeofService;
-  let routeParams$: Subject<any>;
-  let queryParams$: Subject<any>;
-  let routerEvents$: Subject<any>;
+  let routeParams$: Subject<any> = new Subject<any>();
+  let queryParams$: Subject<any> = new Subject<any>();
+  let routerEvents$: Subject<any> = new Subject<any>();
 
-  beforeEach(async () => {
-    routeParams$ = new Subject<any>();
-    queryParams$ = new Subject<any>();
-    routerEvents$ = new Subject<any>();
-
-    await TestBed.configureTestingModule({
-      declarations: [NvmeofInitiatorsListComponent],
-      imports: [HttpClientModule, RouterTestingModule, SharedModule],
-      providers: [
-        { provide: NvmeofService, useClass: MockNvmeOfService },
-        { provide: AuthStorageService, useClass: MockAuthStorageService },
-        { provide: ModalCdsService, useClass: MockModalCdsService },
-        { provide: TaskWrapperService, useClass: MockTaskWrapperService },
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            parent: { params: routeParams$.asObservable() },
-            queryParams: queryParams$.asObservable()
-          }
-        },
-        {
-          provide: Router,
-          useValue: {
-            events: routerEvents$.asObservable(),
-            navigate: jasmine.createSpy('navigate')
-          }
+  configureTestBed({
+    declarations: [NvmeofInitiatorsListComponent],
+    imports: [HttpClientModule, RouterTestingModule, SharedModule],
+    providers: [
+      { provide: NvmeofService, useClass: MockNvmeOfService },
+      { provide: AuthStorageService, useClass: MockAuthStorageService },
+      { provide: ModalCdsService, useClass: MockModalCdsService },
+      { provide: TaskWrapperService, useClass: MockTaskWrapperService },
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          parent: { params: routeParams$.asObservable() },
+          queryParams: queryParams$.asObservable()
         }
-      ]
-    }).compileComponents();
+      },
+      {
+        provide: Router,
+        useValue: {
+          events: routerEvents$.asObservable(),
+          navigate: jasmine.createSpy('navigate')
+        }
+      }
+    ]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-listeners-form/nvmeof-listeners-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-listeners-form/nvmeof-listeners-form.component.spec.ts
@@ -7,32 +7,33 @@ import { SharedModule } from '~/app/shared/shared.module';
 import { NvmeofListenersFormComponent } from './nvmeof-listeners-form.component';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('NvmeofListenersFormComponent', () => {
   let component: NvmeofListenersFormComponent;
   let fixture: ComponentFixture<NvmeofListenersFormComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [NvmeofListenersFormComponent],
-      providers: [
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            params: of({ subsystem_nqn: 'nqn.2001-07.com.ceph:1' }),
-            queryParams: of({ group: 'group1' }),
+  configureTestBed({
+    declarations: [NvmeofListenersFormComponent],
+    providers: [
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          params: of({ subsystem_nqn: 'nqn.2001-07.com.ceph:1' }),
+          queryParams: of({ group: 'group1' }),
+          snapshot: { params: { subsystem_nqn: 'nqn.2001-07.com.ceph:1' } },
+          parent: {
             snapshot: { params: { subsystem_nqn: 'nqn.2001-07.com.ceph:1' } },
-            parent: {
-              snapshot: { params: { subsystem_nqn: 'nqn.2001-07.com.ceph:1' } },
-              params: of({ subsystem_nqn: 'nqn.2001-07.com.ceph:1' })
-            }
+            params: of({ subsystem_nqn: 'nqn.2001-07.com.ceph:1' })
           }
         }
-      ],
-      imports: [HttpClientTestingModule, RouterTestingModule, SharedModule],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA]
-    }).compileComponents();
+      }
+    ],
+    imports: [HttpClientTestingModule, RouterTestingModule, SharedModule],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(NvmeofListenersFormComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-listeners-list/nvmeof-listeners-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-listeners-list/nvmeof-listeners-list.component.spec.ts
@@ -9,6 +9,7 @@ import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { ModalService } from '~/app/shared/services/modal.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { of } from 'rxjs';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 const mockListeners = [
   {
@@ -40,18 +41,18 @@ describe('NvmeofListenersListComponent', () => {
   let component: NvmeofListenersListComponent;
   let fixture: ComponentFixture<NvmeofListenersListComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [NvmeofListenersListComponent],
-      imports: [HttpClientModule, RouterTestingModule, SharedModule],
-      providers: [
-        { provide: NvmeofService, useClass: MockNvmeOfService },
-        { provide: AuthStorageService, useClass: MockAuthStorageService },
-        { provide: ModalService, useClass: MockModalService },
-        { provide: TaskWrapperService, useClass: MockTaskWrapperService }
-      ]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [NvmeofListenersListComponent],
+    imports: [HttpClientModule, RouterTestingModule, SharedModule],
+    providers: [
+      { provide: NvmeofService, useClass: MockNvmeOfService },
+      { provide: AuthStorageService, useClass: MockAuthStorageService },
+      { provide: ModalService, useClass: MockModalService },
+      { provide: TaskWrapperService, useClass: MockTaskWrapperService }
+    ]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(NvmeofListenersListComponent);
     component = fixture.componentInstance;
     component.ngOnInit();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespace-expand-modal/nvmeof-namespace-expand-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespace-expand-modal/nvmeof-namespace-expand-modal.component.spec.ts
@@ -52,8 +52,8 @@ describe('NvmeofNamespaceExpandModalComponent', () => {
       NumberModule
     ],
     providers: [
-      { provide: NvmeofService, useValue: mockNvmeofService },
-      { provide: ActivatedRoute, useValue: activatedRouteStub }
+      { provide: NvmeofService, useFactory: () => mockNvmeofService },
+      { provide: ActivatedRoute, useFactory: () => activatedRouteStub }
     ]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.spec.ts
@@ -9,7 +9,7 @@ import { NgbActiveModal, NgbTypeaheadModule } from '@ng-bootstrap/ng-bootstrap';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { SharedModule } from '~/app/shared/shared.module';
 import { NvmeofNamespacesFormComponent } from './nvmeof-namespaces-form.component';
-import { FormHelper, Mocks } from '~/testing/unit-test-helper';
+import { configureTestBed, FormHelper, Mocks } from '~/testing/unit-test-helper';
 import { FormatterService } from '~/app/shared/services/formatter.service';
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 import { RbdService } from '~/app/shared/api/rbd.service';
@@ -106,38 +106,36 @@ describe('NvmeofNamespacesFormComponent', () => {
   let router: Router;
   let form: CdFormGroup;
   let formHelper: FormHelper;
-  let activatedRouteStub: ActivatedRouteStub;
   const MOCK_RANDOM_STRING = 1720693470789;
   const MOCK_SUBSYSTEM = 'nqn.2021-11.com.example:subsystem';
   const MOCK_GROUP = 'default';
   const MOCK_NSID = String(MOCK_NS_RESPONSE['nsid']);
+  let activatedRouteStub: ActivatedRouteStub = new ActivatedRouteStub(
+    { subsystem_nqn: MOCK_SUBSYSTEM, nsid: MOCK_NSID },
+    { group: MOCK_GROUP }
+  );
 
-  beforeEach(async () => {
-    activatedRouteStub = new ActivatedRouteStub(
-      { subsystem_nqn: MOCK_SUBSYSTEM, nsid: MOCK_NSID },
-      { group: MOCK_GROUP }
-    );
-    await TestBed.configureTestingModule({
-      declarations: [NvmeofNamespacesFormComponent],
-      providers: [
-        NgbActiveModal,
-        { provide: PoolService, useClass: MockPoolsService },
-        { provide: ActivatedRoute, useValue: activatedRouteStub },
-        { provide: TaskWrapperService, useClass: MockTaskWrapperService }
-      ],
-      imports: [
-        HttpClientTestingModule,
-        NgbTypeaheadModule,
-        ReactiveFormsModule,
-        RouterTestingModule,
-        SharedModule,
-        NumberModule,
-        RadioModule,
-        ComboBoxModule,
-        SelectModule
-      ]
-    }).compileComponents();
-
+  configureTestBed({
+    declarations: [NvmeofNamespacesFormComponent],
+    providers: [
+      NgbActiveModal,
+      { provide: PoolService, useClass: MockPoolsService },
+      { provide: ActivatedRoute, useFactory: () => activatedRouteStub },
+      { provide: TaskWrapperService, useClass: MockTaskWrapperService }
+    ],
+    imports: [
+      HttpClientTestingModule,
+      NgbTypeaheadModule,
+      ReactiveFormsModule,
+      RouterTestingModule,
+      SharedModule,
+      NumberModule,
+      RadioModule,
+      ComboBoxModule,
+      SelectModule
+    ]
+  });
+  beforeEach(() => {
     fixture = TestBed.createComponent(NvmeofNamespacesFormComponent);
     component = fixture.componentInstance;
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-list/nvmeof-namespaces-list.component.spec.ts
@@ -15,6 +15,7 @@ import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { NvmeofSubsystemsDetailsComponent } from '../nvmeof-subsystems-details/nvmeof-subsystems-details.component';
 import { NvmeofNamespacesListComponent } from './nvmeof-namespaces-list.component';
 import { NvmeofGatewayGroupFilterComponent } from '../nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 const mockNamespaces = [
   {
@@ -85,42 +86,38 @@ class MockTaskWrapperService {}
 describe('NvmeofNamespacesListComponent', () => {
   let component: NvmeofNamespacesListComponent;
   let fixture: ComponentFixture<NvmeofNamespacesListComponent>;
-  let queryParams$: BehaviorSubject<Record<string, string>>;
   let modalService: MockModalCdsService;
   let nvmeofService: MockNvmeOfService;
+  let queryParams$: BehaviorSubject<Record<string, string>> = new BehaviorSubject({});
   const activatedRouteMock = {
-    queryParams: null as any,
+    queryParams: queryParams$.asObservable(),
     snapshot: { queryParams: {} as Record<string, string> }
   };
+  const refresh$ = new Subject<void>();
 
-  beforeEach(async () => {
-    const refresh$ = new Subject<void>();
-    queryParams$ = new BehaviorSubject<Record<string, string>>({});
-    activatedRouteMock.queryParams = queryParams$.asObservable();
-    activatedRouteMock.snapshot.queryParams = queryParams$.value;
+  configureTestBed({
+    declarations: [NvmeofNamespacesListComponent, NvmeofSubsystemsDetailsComponent],
+    imports: [
+      HttpClientModule,
+      RouterTestingModule,
+      SharedModule,
+      NvmeofGatewayGroupFilterComponent
+    ],
+    providers: [
+      { provide: NvmeofService, useClass: MockNvmeOfService },
+      { provide: AuthStorageService, useClass: MockAuthStorageService },
+      { provide: ModalCdsService, useClass: MockModalCdsService },
+      { provide: TaskWrapperService, useClass: MockTaskWrapperService },
+      { provide: ActivatedRoute, useFactory: () => activatedRouteMock },
+      {
+        provide: NvmeofStateService,
+        useValue: { refresh$: refresh$.asObservable(), requestRefresh: jest.fn() }
+      }
+    ],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  });
 
-    await TestBed.configureTestingModule({
-      declarations: [NvmeofNamespacesListComponent, NvmeofSubsystemsDetailsComponent],
-      imports: [
-        HttpClientModule,
-        RouterTestingModule,
-        SharedModule,
-        NvmeofGatewayGroupFilterComponent
-      ],
-      providers: [
-        { provide: NvmeofService, useClass: MockNvmeOfService },
-        { provide: AuthStorageService, useClass: MockAuthStorageService },
-        { provide: ModalCdsService, useClass: MockModalCdsService },
-        { provide: TaskWrapperService, useClass: MockTaskWrapperService },
-        { provide: ActivatedRoute, useValue: activatedRouteMock },
-        {
-          provide: NvmeofStateService,
-          useValue: { refresh$: refresh$.asObservable(), requestRefresh: jest.fn() }
-        }
-      ],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA]
-    }).compileComponents();
-
+  beforeEach(() => {
     const router = TestBed.inject(Router);
     jest.spyOn(router, 'navigate').mockImplementation((_commands, extras?) => {
       const group = extras?.queryParams?.['group'];

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-setup-cards/nvmeof-setup-cards.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-setup-cards/nvmeof-setup-cards.component.spec.ts
@@ -2,16 +2,17 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterModule } from '@angular/router';
 
 import { NvmeofSetupCardsComponent } from './nvmeof-setup-cards.component';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('NvmeofSetupCardsComponent', () => {
   let component: NvmeofSetupCardsComponent;
   let fixture: ComponentFixture<NvmeofSetupCardsComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [NvmeofSetupCardsComponent, RouterModule.forRoot([])]
-    }).compileComponents();
+  configureTestBed({
+    imports: [NvmeofSetupCardsComponent, RouterModule.forRoot([])]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(NvmeofSetupCardsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-state.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-state.service.spec.ts
@@ -4,26 +4,27 @@ import { Subject } from 'rxjs';
 
 import { NvmeofStateService } from './nvmeof-state.service';
 import { SummaryService } from '~/app/shared/services/summary.service';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('NvmeofStateService', () => {
   let service: NvmeofStateService;
-  let summaryData$: Subject<any>;
-  let summaryServiceSpy: any;
+  let summaryData$ = new Subject<any>();
+  let summaryServiceSpy = {
+    subscribe: jest.fn().mockImplementation((callback: (s: any) => void) => {
+      return summaryData$.subscribe(callback);
+    })
+  };
+
+  configureTestBed({
+    providers: [
+      NvmeofStateService,
+      { provide: SummaryService, useFactory: () => summaryServiceSpy }
+    ]
+  });
 
   const emitSummary = (tasks: any[]) => summaryData$.next({ finished_tasks: tasks });
 
   beforeEach(() => {
-    summaryData$ = new Subject<any>();
-    summaryServiceSpy = {
-      subscribe: jest.fn().mockImplementation((callback: (s: any) => void) => {
-        return summaryData$.subscribe(callback);
-      })
-    };
-
-    TestBed.configureTestingModule({
-      providers: [NvmeofStateService, { provide: SummaryService, useValue: summaryServiceSpy }]
-    });
-
     service = TestBed.inject(NvmeofStateService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-namespaces-list/nvmeof-subsystem-namespaces-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-namespaces-list/nvmeof-subsystem-namespaces-list.component.spec.ts
@@ -9,6 +9,7 @@ import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 import { NvmeofStateService } from '../nvmeof-state.service';
 import { SharedModule } from '~/app/shared/shared.module';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('NvmeofSubsystemNamespacesListComponent', () => {
   let component: NvmeofSubsystemNamespacesListComponent;
@@ -42,34 +43,32 @@ describe('NvmeofSubsystemNamespacesListComponent', () => {
     }
   }
 
-  beforeEach(async () => {
-    const refresh$ = new Subject<void>();
-    await TestBed.configureTestingModule({
-      declarations: [NvmeofSubsystemNamespacesListComponent],
-      imports: [HttpClientTestingModule, RouterTestingModule, SharedModule],
-      providers: [
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            parent: {
-              params: of({ subsystem_nqn: 'nqn.2016-06.io.spdk:cnode1', group: 'group1' })
-            },
-            queryParams: of({ group: 'group1' })
-          }
-        },
-        {
-          provide: NvmeofService,
-          useValue: {
-            listNamespaces: jest.fn().mockReturnValue(of(mockNamespaces))
-          }
-        },
-        { provide: AuthStorageService, useClass: MockAuthStorageService },
-        {
-          provide: NvmeofStateService,
-          useValue: { refresh$: refresh$.asObservable(), requestRefresh: jest.fn() }
+  const refresh$ = new Subject<void>();
+  configureTestBed({
+    declarations: [NvmeofSubsystemNamespacesListComponent],
+    imports: [HttpClientTestingModule, RouterTestingModule, SharedModule],
+    providers: [
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          parent: {
+            params: of({ subsystem_nqn: 'nqn.2016-06.io.spdk:cnode1', group: 'group1' })
+          },
+          queryParams: of({ group: 'group1' })
         }
-      ]
-    }).compileComponents();
+      },
+      {
+        provide: NvmeofService,
+        useValue: {
+          listNamespaces: jest.fn().mockReturnValue(of(mockNamespaces))
+        }
+      },
+      { provide: AuthStorageService, useClass: MockAuthStorageService },
+      {
+        provide: NvmeofStateService,
+        useValue: { refresh$: refresh$.asObservable(), requestRefresh: jest.fn() }
+      }
+    ]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
-import { of, Subject } from 'rxjs';
+import { of, Subject, BehaviorSubject } from 'rxjs';
 
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { GridModule, TilesModule } from 'carbon-components-angular';
@@ -11,7 +11,8 @@ import { NvmeofSubsystemOverviewComponent } from './nvmeof-subsystem-overview.co
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 import { URLVerbs } from '~/app/shared/constants/app.constants';
 import { SharedModule } from '~/app/shared/shared.module';
-import { NvmeofSubsystem, NvmeofSubsystemInitiator } from '~/app/shared/models/nvmeof';
+import { NvmeofSubsystem } from '~/app/shared/models/nvmeof';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('NvmeofSubsystemOverviewComponent', () => {
   let component: NvmeofSubsystemOverviewComponent;
@@ -20,6 +21,9 @@ describe('NvmeofSubsystemOverviewComponent', () => {
   let router: Router;
   let activatedRoute: ActivatedRoute;
   let routerEvents$: Subject<any>;
+
+  let parentParams$: BehaviorSubject<any>;
+  let queryParams$: BehaviorSubject<any>;
 
   const mockSubsystem: NvmeofSubsystem = {
     nqn: 'nqn.2016-06.io.spdk:cnode1',
@@ -37,90 +41,54 @@ describe('NvmeofSubsystemOverviewComponent', () => {
     network_mask: []
   };
 
-  const defaultActivatedRoute = {
-    parent: { params: of({ subsystem_nqn: 'nqn.2016-06.io.spdk:cnode1' }) },
-    queryParams: of({ group: 'group1' })
+  let nvmeofServiceMock = {
+    getSubsystem: jest.fn().mockReturnValue(of(mockSubsystem)),
+    getInitiators: jest.fn().mockReturnValue(of([]))
   };
 
-  /**
-   * Creates a TestBed configuration with custom service overrides.
-   * Avoids repeating the full module declaration in tests that need different mock data.
-   */
-  function createTestBed(
-    initiators: NvmeofSubsystemInitiator[],
-    subsystem: NvmeofSubsystem = mockSubsystem,
-    activatedRoute: object = defaultActivatedRoute
-  ): Promise<ComponentFixture<NvmeofSubsystemOverviewComponent>> {
-    return TestBed.configureTestingModule({
-      declarations: [NvmeofSubsystemOverviewComponent],
-      imports: [
-        HttpClientTestingModule,
-        RouterTestingModule,
-        SharedModule,
-        NgbTooltipModule,
-        TilesModule,
-        GridModule
-      ],
-      providers: [
-        { provide: ActivatedRoute, useValue: activatedRoute },
-        {
-          provide: NvmeofService,
-          useValue: {
-            getSubsystem: jest.fn().mockReturnValue(of(subsystem)),
-            getInitiators: jest.fn().mockReturnValue(of(initiators))
-          }
-        }
-      ]
-    })
-      .compileComponents()
-      .then(() => {
-        const f = TestBed.createComponent(NvmeofSubsystemOverviewComponent);
-        f.detectChanges();
-        tick();
-        f.detectChanges();
-        return f;
-      });
-  }
-
-  beforeEach(async () => {
-    routerEvents$ = new Subject<any>();
-
-    await TestBed.configureTestingModule({
-      declarations: [NvmeofSubsystemOverviewComponent],
-      imports: [
-        HttpClientTestingModule,
-        RouterTestingModule,
-        SharedModule,
-        NgbTooltipModule,
-        TilesModule,
-        GridModule
-      ],
-      providers: [
-        { provide: ActivatedRoute, useValue: defaultActivatedRoute },
-        {
-          provide: NvmeofService,
-          useValue: {
-            getSubsystem: jest.fn().mockReturnValue(of(mockSubsystem)),
-            getInitiators: jest.fn().mockReturnValue(of([]))
-          }
-        },
-        {
-          provide: Router,
-          useValue: {
-            events: routerEvents$.asObservable(),
-            navigate: jest.fn().mockResolvedValue(true)
-          }
-        }
-      ]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [NvmeofSubsystemOverviewComponent],
+    imports: [
+      HttpClientTestingModule,
+      RouterTestingModule,
+      SharedModule,
+      NgbTooltipModule,
+      TilesModule,
+      GridModule
+    ],
+    providers: [
+      {
+        provide: ActivatedRoute,
+        useFactory: () => ({
+          parent: { params: parentParams$.asObservable() },
+          queryParams: queryParams$.asObservable()
+        })
+      },
+      { provide: NvmeofService, useFactory: () => nvmeofServiceMock }
+    ]
   });
 
   beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Reset route streams for each test
+    parentParams$ = new BehaviorSubject({ subsystem_nqn: 'nqn.2016-06.io.spdk:cnode1' });
+    queryParams$ = new BehaviorSubject({ group: 'group1' });
+
+    nvmeofServiceMock.getSubsystem.mockReturnValue(of(mockSubsystem));
+    nvmeofServiceMock.getInitiators.mockReturnValue(of([]));
+
+    routerEvents$ = new Subject<any>();
+
     fixture = TestBed.createComponent(NvmeofSubsystemOverviewComponent);
     component = fixture.componentInstance;
     nvmeofService = TestBed.inject(NvmeofService);
     router = TestBed.inject(Router);
     activatedRoute = TestBed.inject(ActivatedRoute);
+
+    Object.defineProperty(router, 'events', { get: () => routerEvents$.asObservable() });
+    jest.spyOn(router, 'navigate').mockResolvedValue(true);
+
     fixture.detectChanges();
   });
 
@@ -148,13 +116,21 @@ describe('NvmeofSubsystemOverviewComponent', () => {
     expect(component.subsystem.subtype).toBe('NVMe');
   }));
 
-  it('should not fetch when subsystemNQN is missing', fakeAsync(async () => {
-    TestBed.resetTestingModule();
-    const noNqnRoute = { parent: { params: of({}) }, queryParams: of({ group: 'group1' }) };
-    const f = await createTestBed([], mockSubsystem, noNqnRoute);
-    const newService = TestBed.inject(NvmeofService);
-    expect(newService.getSubsystem).not.toHaveBeenCalled();
-    expect(f.componentInstance.subsystem).toBeUndefined();
+  it('should not fetch when subsystemNQN is missing', fakeAsync(() => {
+    // Clear the call history from the initial fixture.detectChanges()
+    nvmeofServiceMock.getSubsystem.mockClear();
+
+    // Push empty params to simulate missing NQN
+    parentParams$.next({});
+
+    // Force a fresh component lifecycle
+    fixture = TestBed.createComponent(NvmeofSubsystemOverviewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    tick();
+
+    expect(nvmeofServiceMock.getSubsystem).not.toHaveBeenCalled();
+    expect(component.subsystem).toBeUndefined();
   }));
 
   it('should render detail labels in the template', fakeAsync(() => {
@@ -185,24 +161,38 @@ describe('NvmeofSubsystemOverviewComponent', () => {
 
     const hostAccessText = fixture.nativeElement.textContent;
     expect(hostAccessText).toContain('Allow all hosts');
-    // has_dhchap_key=true but no initiators with use_dhchap → No authentication
     expect(hostAccessText).toContain('No authentication');
     expect(hostAccessText).toContain('Edit');
   }));
 
-  it('should display Bidirectional when subsystem and host both have keys', fakeAsync(async () => {
-    TestBed.resetTestingModule();
-    const f = await createTestBed([{ nqn: 'nqn.host-1', use_dhchap: true }]);
-    expect(f.nativeElement.textContent).toContain('Bi-directional');
+  it('should display Bidirectional when subsystem and host both have keys', fakeAsync(() => {
+    nvmeofServiceMock.getInitiators.mockReturnValue(of([{ nqn: 'nqn.host-1', use_dhchap: true }]));
+
+    fixture = TestBed.createComponent(NvmeofSubsystemOverviewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Bi-directional');
   }));
 
-  it('should display Unidirectional when only host has a key', fakeAsync(async () => {
-    TestBed.resetTestingModule();
-    const f = await createTestBed([{ nqn: 'nqn.host-1', use_dhchap: true }], {
-      ...mockSubsystem,
-      has_dhchap_key: false
-    });
-    expect(f.nativeElement.textContent).toContain('Unidirectional');
+  it('should display Unidirectional when only host has a key', fakeAsync(() => {
+    nvmeofServiceMock.getInitiators.mockReturnValue(of([{ nqn: 'nqn.host-1', use_dhchap: true }]));
+    nvmeofServiceMock.getSubsystem.mockReturnValue(
+      of({
+        ...mockSubsystem,
+        has_dhchap_key: false
+      })
+    );
+
+    fixture = TestBed.createComponent(NvmeofSubsystemOverviewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Unidirectional');
   }));
 
   it('should open host access edit modal route when edit is clicked', () => {
@@ -220,7 +210,7 @@ describe('NvmeofSubsystemOverviewComponent', () => {
   });
 
   it('should refresh subsystem on non-modal navigation end', () => {
-    (nvmeofService.getSubsystem as jest.Mock).mockClear();
+    nvmeofServiceMock.getSubsystem.mockClear();
 
     routerEvents$.next(new NavigationEnd(1, '/nvmeof/(modal:add)', '/nvmeof/(modal:add)'));
     expect(nvmeofService.getSubsystem).not.toHaveBeenCalled();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-performance/nvmeof-subsystem-performance.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-performance/nvmeof-subsystem-performance.component.spec.ts
@@ -8,6 +8,7 @@ import { NvmeofSubsystemPerformanceComponent } from './nvmeof-subsystem-performa
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { Permissions } from '~/app/shared/models/permissions';
 import { SharedModule } from '~/app/shared/shared.module';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('NvmeofSubsystemPerformanceComponent', () => {
   let component: NvmeofSubsystemPerformanceComponent;
@@ -15,28 +16,26 @@ describe('NvmeofSubsystemPerformanceComponent', () => {
 
   const mockPermissions = new Permissions({ grafana: ['read'] });
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [NvmeofSubsystemPerformanceComponent],
-      imports: [HttpClientTestingModule, RouterTestingModule, SharedModule],
-      providers: [
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            parent: {
-              params: of({ subsystem_nqn: 'nqn.2016-06.io.spdk:cnode1' })
-            },
-            queryParams: of({ group: 'group1' })
-          }
-        },
-        {
-          provide: AuthStorageService,
-          useValue: {
-            getPermissions: jest.fn().mockReturnValue(mockPermissions)
-          }
+  configureTestBed({
+    declarations: [NvmeofSubsystemPerformanceComponent],
+    imports: [HttpClientTestingModule, RouterTestingModule, SharedModule],
+    providers: [
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          parent: {
+            params: of({ subsystem_nqn: 'nqn.2016-06.io.spdk:cnode1' })
+          },
+          queryParams: of({ group: 'group1' })
         }
-      ]
-    }).compileComponents();
+      },
+      {
+        provide: AuthStorageService,
+        useValue: {
+          getPermissions: jest.fn().mockReturnValue(mockPermissions)
+        }
+      }
+    ]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-details/nvmeof-subsystems-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-details/nvmeof-subsystems-details.component.spec.ts
@@ -7,17 +7,18 @@ import { Permissions } from '~/app/shared/models/permissions';
 import { SharedModule } from '~/app/shared/shared.module';
 import { NvmeofSubsystemsDetailsComponent } from './nvmeof-subsystems-details.component';
 import { DEFAULT_MAX_NAMESPACE_PER_SUBSYSTEM } from '~/app/shared/api/nvmeof.service';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('NvmeofSubsystemsDetailsComponent', () => {
   let component: NvmeofSubsystemsDetailsComponent;
   let fixture: ComponentFixture<NvmeofSubsystemsDetailsComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [NvmeofSubsystemsDetailsComponent],
-      imports: [BrowserAnimationsModule, SharedModule, HttpClientTestingModule, NgbNavModule]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [NvmeofSubsystemsDetailsComponent],
+    imports: [BrowserAnimationsModule, SharedModule, HttpClientTestingModule, NgbNavModule]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(NvmeofSubsystemsDetailsComponent);
     component = fixture.componentInstance;
     component.selection = {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-1/nvmeof-subsystem-step-1.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-1/nvmeof-subsystem-step-1.component.spec.ts
@@ -9,7 +9,7 @@ import { NgbActiveModal, NgbTypeaheadModule } from '@ng-bootstrap/ng-bootstrap';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { SharedModule } from '~/app/shared/shared.module';
 import { NvmeofSubsystemsStepOneComponent } from './nvmeof-subsystem-step-1.component';
-import { FormHelper } from '~/testing/unit-test-helper';
+import { configureTestBed, FormHelper } from '~/testing/unit-test-helper';
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 import { ComboBoxModule, GridModule, InputModule, RadioModule } from 'carbon-components-angular';
 
@@ -25,23 +25,21 @@ describe('NvmeofSubsystemsStepOneComponent', () => {
   let formHelper: FormHelper;
   const mockGroupName = 'default';
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [NvmeofSubsystemsStepOneComponent],
-      imports: [
-        HttpClientTestingModule,
-        SharedModule,
-        ReactiveFormsModule,
-        RouterTestingModule,
-        NgbTypeaheadModule,
-        InputModule,
-        GridModule,
-        ComboBoxModule,
-        RadioModule
-      ],
-      providers: [NgbActiveModal],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [NvmeofSubsystemsStepOneComponent],
+    imports: [
+      HttpClientTestingModule,
+      SharedModule,
+      ReactiveFormsModule,
+      RouterTestingModule,
+      NgbTypeaheadModule,
+      InputModule,
+      GridModule,
+      ComboBoxModule,
+      RadioModule
+    ],
+    providers: [NgbActiveModal],
+    schemas: [NO_ERRORS_SCHEMA]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-2/nvmeof-subsystem-step-2.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-2/nvmeof-subsystem-step-2.component.spec.ts
@@ -15,6 +15,7 @@ import {
   RadioModule,
   TagModule
 } from 'carbon-components-angular';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('NvmeofSubsystemsStepTwoComponent', () => {
   let component: NvmeofSubsystemsStepTwoComponent;
@@ -22,24 +23,24 @@ describe('NvmeofSubsystemsStepTwoComponent', () => {
   let form: CdFormGroup;
   const mockGroupName = 'default';
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [NvmeofSubsystemsStepTwoComponent],
-      providers: [NgbActiveModal],
-      imports: [
-        HttpClientTestingModule,
-        NgbTypeaheadModule,
-        ReactiveFormsModule,
-        RouterTestingModule,
-        SharedModule,
-        FileUploaderModule,
-        InputModule,
-        GridModule,
-        RadioModule,
-        TagModule
-      ]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [NvmeofSubsystemsStepTwoComponent],
+    providers: [NgbActiveModal],
+    imports: [
+      HttpClientTestingModule,
+      NgbTypeaheadModule,
+      ReactiveFormsModule,
+      RouterTestingModule,
+      SharedModule,
+      FileUploaderModule,
+      InputModule,
+      GridModule,
+      RadioModule,
+      TagModule
+    ]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(NvmeofSubsystemsStepTwoComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-3/nvmeof-subsystem-step-3.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-3/nvmeof-subsystem-step-3.component.spec.ts
@@ -11,6 +11,7 @@ import { NvmeofSubsystemsStepThreeComponent } from './nvmeof-subsystem-step-3.co
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 import { GridModule, InputModule, RadioModule, TagModule } from 'carbon-components-angular';
 import { AUTHENTICATION } from '~/app/shared/models/nvmeof';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('NvmeofSubsystemsStepThreeComponent', () => {
   let component: NvmeofSubsystemsStepThreeComponent;
@@ -19,23 +20,23 @@ describe('NvmeofSubsystemsStepThreeComponent', () => {
   let form: CdFormGroup;
   const mockGroupName = 'default';
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [NvmeofSubsystemsStepThreeComponent],
-      providers: [NgbActiveModal],
-      imports: [
-        HttpClientTestingModule,
-        NgbTypeaheadModule,
-        ReactiveFormsModule,
-        RouterTestingModule,
-        SharedModule,
-        GridModule,
-        RadioModule,
-        TagModule,
-        InputModule
-      ]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [NvmeofSubsystemsStepThreeComponent],
+    providers: [NgbActiveModal],
+    imports: [
+      HttpClientTestingModule,
+      NgbTypeaheadModule,
+      ReactiveFormsModule,
+      RouterTestingModule,
+      SharedModule,
+      GridModule,
+      RadioModule,
+      TagModule,
+      InputModule
+    ]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(NvmeofSubsystemsStepThreeComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-4/nvmeof-subsystem-step-4.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-4/nvmeof-subsystem-step-4.component.spec.ts
@@ -9,24 +9,25 @@ import { SharedModule } from '~/app/shared/shared.module';
 import { NvmeofSubsystemsStepFourComponent } from './nvmeof-subsystem-step-4.component';
 import { GridModule } from 'carbon-components-angular';
 import { AUTHENTICATION, HOST_TYPE } from '~/app/shared/models/nvmeof';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('NvmeofSubsystemsStepFourComponent', () => {
   let component: NvmeofSubsystemsStepFourComponent;
   let fixture: ComponentFixture<NvmeofSubsystemsStepFourComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [NvmeofSubsystemsStepFourComponent],
-      providers: [NgbActiveModal],
-      imports: [
-        HttpClientTestingModule,
-        ReactiveFormsModule,
-        RouterTestingModule,
-        SharedModule,
-        GridModule
-      ]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [NvmeofSubsystemsStepFourComponent],
+    providers: [NgbActiveModal],
+    imports: [
+      HttpClientTestingModule,
+      ReactiveFormsModule,
+      RouterTestingModule,
+      SharedModule,
+      GridModule
+    ]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(NvmeofSubsystemsStepFourComponent);
     component = fixture.componentInstance;
     component.group = 'default';

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.spec.ts
@@ -25,6 +25,7 @@ import { AUTHENTICATION, HOST_TYPE } from '~/app/shared/models/nvmeof';
 import { NvmeofSubsystemsStepTwoComponent } from './nvmeof-subsystem-step-2/nvmeof-subsystem-step-2.component';
 import { NvmeofSubsystemsStepFourComponent } from './nvmeof-subsystem-step-4/nvmeof-subsystem-step-4.component';
 import { of } from 'rxjs';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('NvmeofSubsystemsFormComponent', () => {
   let component: NvmeofSubsystemsFormComponent;
@@ -43,40 +44,40 @@ describe('NvmeofSubsystemsFormComponent', () => {
     authType: AUTHENTICATION.Bidirectional
   };
 
+  configureTestBed({
+    declarations: [
+      NvmeofSubsystemsFormComponent,
+      NvmeofSubsystemsStepOneComponent,
+      NvmeofSubsystemsStepThreeComponent,
+      NvmeofSubsystemsStepTwoComponent,
+      NvmeofSubsystemsStepFourComponent
+    ],
+    providers: [
+      NgbActiveModal,
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          queryParams: of({ group: mockGroupName })
+        }
+      }
+    ],
+    imports: [
+      HttpClientTestingModule,
+      NgbTypeaheadModule,
+      ReactiveFormsModule,
+      RouterTestingModule,
+      SharedModule,
+      InputModule,
+      GridModule,
+      RadioModule,
+      TagModule,
+      FileUploaderModule,
+      ComboBoxModule
+    ]
+  });
+
   beforeEach(async () => {
     spyOn(Date, 'now').and.returnValue(mockTimestamp);
-    await TestBed.configureTestingModule({
-      declarations: [
-        NvmeofSubsystemsFormComponent,
-        NvmeofSubsystemsStepOneComponent,
-        NvmeofSubsystemsStepThreeComponent,
-        NvmeofSubsystemsStepTwoComponent,
-        NvmeofSubsystemsStepFourComponent
-      ],
-      providers: [
-        NgbActiveModal,
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            queryParams: of({ group: mockGroupName })
-          }
-        }
-      ],
-      imports: [
-        HttpClientTestingModule,
-        NgbTypeaheadModule,
-        ReactiveFormsModule,
-        RouterTestingModule,
-        SharedModule,
-        InputModule,
-        GridModule,
-        RadioModule,
-        TagModule,
-        FileUploaderModule,
-        ComboBoxModule
-      ]
-    }).compileComponents();
-
     fixture = TestBed.createComponent(NvmeofSubsystemsFormComponent);
     component = fixture.componentInstance;
     component.ngOnInit();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.spec.ts
@@ -14,6 +14,7 @@ import { NvmeofSubsystemsComponent } from './nvmeof-subsystems.component';
 import { NvmeofSubsystemsDetailsComponent } from '../nvmeof-subsystems-details/nvmeof-subsystems-details.component';
 import { NvmeofGatewayGroupFilterComponent } from '../nvmeof-gateway-group-filter/nvmeof-gateway-group-filter.component';
 import { NvmeofStateService } from '../nvmeof-state.service';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 const mockSubsystems = [
   {
@@ -83,39 +84,35 @@ class MockTaskWrapperService {}
 describe('NvmeofSubsystemsComponent', () => {
   let component: NvmeofSubsystemsComponent;
   let fixture: ComponentFixture<NvmeofSubsystemsComponent>;
-  let queryParams$: BehaviorSubject<Record<string, string>>;
+  let queryParams$: BehaviorSubject<Record<string, string>> = new BehaviorSubject({});
   const activatedRouteMock = {
-    queryParams: null as any,
+    queryParams: queryParams$.asObservable(),
     snapshot: { queryParams: {} as Record<string, string> }
   };
+  const refresh$ = new Subject<void>();
 
-  beforeEach(async () => {
-    const refresh$ = new Subject<void>();
-    queryParams$ = new BehaviorSubject<Record<string, string>>({});
-    activatedRouteMock.queryParams = queryParams$.asObservable();
-    activatedRouteMock.snapshot.queryParams = queryParams$.value;
+  configureTestBed({
+    declarations: [NvmeofSubsystemsComponent, NvmeofSubsystemsDetailsComponent],
+    imports: [
+      HttpClientModule,
+      RouterTestingModule,
+      SharedModule,
+      NvmeofGatewayGroupFilterComponent
+    ],
+    providers: [
+      { provide: NvmeofService, useClass: MockNvmeOfService },
+      { provide: AuthStorageService, useClass: MockAuthStorageService },
+      { provide: ModalCdsService, useClass: MockModalService },
+      { provide: TaskWrapperService, useClass: MockTaskWrapperService },
+      { provide: ActivatedRoute, useFactory: () => activatedRouteMock },
+      {
+        provide: NvmeofStateService,
+        useValue: { refresh$: refresh$.asObservable(), requestRefresh: jest.fn() }
+      }
+    ]
+  });
 
-    await TestBed.configureTestingModule({
-      declarations: [NvmeofSubsystemsComponent, NvmeofSubsystemsDetailsComponent],
-      imports: [
-        HttpClientModule,
-        RouterTestingModule,
-        SharedModule,
-        NvmeofGatewayGroupFilterComponent
-      ],
-      providers: [
-        { provide: NvmeofService, useClass: MockNvmeOfService },
-        { provide: AuthStorageService, useClass: MockAuthStorageService },
-        { provide: ModalCdsService, useClass: MockModalService },
-        { provide: TaskWrapperService, useClass: MockTaskWrapperService },
-        { provide: ActivatedRoute, useValue: activatedRouteMock },
-        {
-          provide: NvmeofStateService,
-          useValue: { refresh$: refresh$.asObservable(), requestRefresh: jest.fn() }
-        }
-      ]
-    }).compileComponents();
-
+  beforeEach(() => {
     const router = TestBed.inject(Router);
     jest.spyOn(router, 'navigate').mockImplementation((_commands, extras?) => {
       const group = extras?.queryParams?.['group'];

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-tabs/nvmeof-tabs.component.spec.ts
@@ -11,6 +11,7 @@ import { NvmeofStateService } from '../nvmeof-state.service';
 import { NvmeofTabsComponent } from './nvmeof-tabs.component';
 import { SharedModule } from '~/app/shared/shared.module';
 import { NvmeofSetupCardsComponent } from '../nvmeof-setup-cards/nvmeof-setup-cards.component';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 type SetupState = {
   hasGatewayGroups: boolean;
@@ -22,12 +23,16 @@ describe('NvmeofTabsComponent', () => {
   let component: NvmeofTabsComponent;
   let fixture: ComponentFixture<NvmeofTabsComponent>;
   let router: Router;
-  let nvmeofServiceSpy: any;
+
   let queryParams$: BehaviorSubject<any>;
   let refresh$: Subject<void>;
   let routerEvents$: Subject<RouterEvent>;
+
   let currentSetupState: SetupState;
   let routerUrl = '/block/nvmeof/gateways';
+
+  // Instantiate the spy object at the describe level so it exists when configureTestBed evaluates
+  const nvmeofServiceSpy: any = { fetchSetupState: jest.fn() };
 
   const setQueryParams = (params: any) => queryParams$.next(params);
   const emitRefresh = () => refresh$.next();
@@ -39,48 +44,58 @@ describe('NvmeofTabsComponent', () => {
     nvmeofServiceSpy.fetchSetupState.mockReturnValue(of(currentSetupState));
   };
 
+  configureTestBed({
+    declarations: [NvmeofTabsComponent],
+    imports: [
+      HttpClientTestingModule,
+      RouterTestingModule,
+      SharedModule,
+      TabsModule,
+      NvmeofSetupCardsComponent
+    ],
+    providers: [
+      { provide: NvmeofService, useFactory: () => nvmeofServiceSpy },
+      {
+        provide: ActivatedRoute,
+        // useFactory defers execution until the test actually runs and queryParams$ exists
+        useFactory: () => ({ queryParams: queryParams$.asObservable() })
+      }
+    ]
+  });
+
   beforeEach(async () => {
+    // Create fresh subjects for every single test to guarantee zero state leakage
     queryParams$ = new BehaviorSubject<any>({ group: 'grp1' });
     refresh$ = new Subject<void>();
+    routerEvents$ = new Subject<RouterEvent>();
+
     routerUrl = '/block/nvmeof/gateways';
     currentSetupState = { hasGatewayGroups: true, hasSubsystems: true, hasNamespaces: true };
-    nvmeofServiceSpy = {
-      fetchSetupState: jest.fn().mockImplementation(() => of(currentSetupState))
-    };
 
-    TestBed.configureTestingModule({
-      declarations: [NvmeofTabsComponent],
-      imports: [
-        HttpClientTestingModule,
-        RouterTestingModule,
-        SharedModule,
-        TabsModule,
-        NvmeofSetupCardsComponent
-      ],
-      providers: [
-        { provide: NvmeofService, useValue: nvmeofServiceSpy },
-        { provide: ActivatedRoute, useValue: { queryParams: queryParams$.asObservable() } }
-      ]
-    })
-      .overrideComponent(NvmeofTabsComponent, {
-        set: {
-          providers: [
-            {
-              provide: NvmeofStateService,
-              useValue: {
-                refresh$: refresh$.asObservable(),
-                requestRefresh: jest.fn()
-              }
-            }
-          ]
-        }
-      })
-      .compileComponents();
+    nvmeofServiceSpy.fetchSetupState.mockClear();
+    nvmeofServiceSpy.fetchSetupState.mockReturnValue(of(currentSetupState));
+
+    // Override must happen inside beforeEach but before compileComponents
+    TestBed.overrideComponent(NvmeofTabsComponent, {
+      set: {
+        providers: [
+          {
+            provide: NvmeofStateService,
+            useFactory: () => ({
+              refresh$: refresh$.asObservable(),
+              requestRefresh: jest.fn()
+            })
+          }
+        ]
+      }
+    });
+
+    await TestBed.compileComponents();
 
     fixture = TestBed.createComponent(NvmeofTabsComponent);
     component = fixture.componentInstance;
     router = TestBed.inject(Router);
-    routerEvents$ = new Subject<RouterEvent>();
+
     Object.defineProperty(router, 'events', {
       configurable: true,
       get: () => routerEvents$.asObservable()

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-image-resource-page/rbd-image-resource-breadcrumb.resolver.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-image-resource-page/rbd-image-resource-breadcrumb.resolver.spec.ts
@@ -3,15 +3,16 @@ import { ActivatedRouteSnapshot } from '@angular/router';
 
 import { RbdImageResourceBreadcrumbResolver } from './rbd-image-resource-breadcrumb.resolver';
 import { ImageSpec } from '~/app/shared/models/image-spec';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('RbdImageResourceBreadcrumbResolver', () => {
   let resolver: RbdImageResourceBreadcrumbResolver;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [RbdImageResourceBreadcrumbResolver]
-    });
+  configureTestBed({
+    providers: [RbdImageResourceBreadcrumbResolver]
+  });
 
+  beforeEach(() => {
     resolver = TestBed.inject(RbdImageResourceBreadcrumbResolver);
     jest.spyOn(resolver as any, 'getFullPath').mockReturnValue('/mock/full/path');
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-image-resource-page/rbd-image-resource-page.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-image-resource-page/rbd-image-resource-page.component.spec.ts
@@ -10,12 +10,23 @@ import { CdDatePipe } from '~/app/shared/pipes/cd-date.pipe';
 import { DimlessBinaryPipe } from '~/app/shared/pipes/dimless-binary.pipe';
 import { DimlessPipe } from '~/app/shared/pipes/dimless.pipe';
 import { RbdFormModel } from '../rbd-form/rbd-form.model';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('RbdImageResourcePageComponent', () => {
   let component: RbdImageResourcePageComponent;
   let fixture: ComponentFixture<RbdImageResourcePageComponent>;
-  let rbdConfigurationServiceSpy: jest.Mocked<RbdConfigurationService>;
-  let imageSubject: BehaviorSubject<RbdFormModel | null>;
+  let rbdConfigurationServiceSpy: jest.Mocked<RbdConfigurationService> = {
+    getOptionByName: jest.fn().mockReturnValue({ displayName: 'RBD Cache', type: 'boolean' })
+  } as any;
+  let imageSubject: BehaviorSubject<RbdFormModel | null> = new BehaviorSubject<RbdFormModel | null>(
+    null
+  );
+  const rbdImageResourceStateServiceMock = {
+    image$: imageSubject.asObservable()
+  };
+  const activatedRouteMock = {
+    snapshot: { data: { section: 'overview' } }
+  };
 
   const baseMockImage: any = {
     name: 'test-image',
@@ -63,34 +74,17 @@ describe('RbdImageResourcePageComponent', () => {
     }
   }
 
-  beforeEach(async () => {
-    imageSubject = new BehaviorSubject<RbdFormModel | null>(null);
-
-    // Create Jest mocks for services
-    const rbdImageResourceStateServiceMock = {
-      image$: imageSubject.asObservable()
-    };
-
-    rbdConfigurationServiceSpy = {
-      getOptionByName: jest.fn().mockReturnValue({ displayName: 'RBD Cache', type: 'boolean' })
-    } as any;
-
-    const activatedRouteMock = {
-      snapshot: { data: { section: 'overview' } }
-    };
-
-    await TestBed.configureTestingModule({
-      declarations: [RbdImageResourcePageComponent],
-      providers: [
-        { provide: ActivatedRoute, useValue: activatedRouteMock },
-        { provide: RbdImageResourceStateService, useValue: rbdImageResourceStateServiceMock },
-        { provide: RbdConfigurationService, useValue: rbdConfigurationServiceSpy },
-        { provide: DimlessBinaryPipe, useClass: MockDimlessBinaryPipe },
-        { provide: DimlessPipe, useClass: MockDimlessPipe },
-        { provide: CdDatePipe, useClass: MockCdDatePipe }
-      ],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [RbdImageResourcePageComponent],
+    providers: [
+      { provide: ActivatedRoute, useFactory: () => activatedRouteMock },
+      { provide: RbdImageResourceStateService, useFactory: () => rbdImageResourceStateServiceMock },
+      { provide: RbdConfigurationService, useFactory: () => rbdConfigurationServiceSpy },
+      { provide: DimlessBinaryPipe, useClass: MockDimlessBinaryPipe },
+      { provide: DimlessPipe, useClass: MockDimlessPipe },
+      { provide: CdDatePipe, useClass: MockCdDatePipe }
+    ],
+    schemas: [NO_ERRORS_SCHEMA]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-image-resource-sidebar/rbd-image-resource-sidebar.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-image-resource-sidebar/rbd-image-resource-sidebar.component.spec.ts
@@ -1,43 +1,44 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Subject } from 'rxjs';
 
 import { RbdImageResourceSidebarComponent } from './rbd-image-resource-sidebar.component';
 import { RbdImageResourceStateService } from '../../../shared/services/rbd-image-resource-state.service';
 import { ImageSpec } from '~/app/shared/models/image-spec';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('RbdImageResourceSidebarComponent', () => {
   let component: RbdImageResourceSidebarComponent;
   let fixture: ComponentFixture<RbdImageResourceSidebarComponent>;
-  let stateServiceMock: any;
+  let stateServiceMock: any = { load: jest.fn() };
   let paramMapSubject: Subject<any>;
+
+  configureTestBed({
+    declarations: [RbdImageResourceSidebarComponent],
+    imports: [HttpClientTestingModule],
+    providers: [
+      {
+        provide: ActivatedRoute,
+        useFactory: () => ({ paramMap: paramMapSubject.asObservable() })
+      }
+    ],
+    schemas: [NO_ERRORS_SCHEMA]
+  });
 
   beforeEach(async () => {
     paramMapSubject = new Subject();
-    const activatedRouteMock = {
-      paramMap: paramMapSubject.asObservable()
-    };
+    stateServiceMock.load.mockClear();
 
-    stateServiceMock = {
-      load: jest.fn()
-    };
+    TestBed.overrideComponent(RbdImageResourceSidebarComponent, {
+      set: {
+        providers: [{ provide: RbdImageResourceStateService, useFactory: () => stateServiceMock }]
+      }
+    });
 
-    await TestBed.configureTestingModule({
-      declarations: [RbdImageResourceSidebarComponent],
-      providers: [{ provide: ActivatedRoute, useValue: activatedRouteMock }],
-      schemas: [NO_ERRORS_SCHEMA]
-    })
-      // Crucial: Override the component's internal provider to use our mock
-      .overrideComponent(RbdImageResourceSidebarComponent, {
-        set: {
-          providers: [{ provide: RbdImageResourceStateService, useValue: stateServiceMock }]
-        }
-      })
-      .compileComponents();
-  });
+    await TestBed.compileComponents();
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(RbdImageResourceSidebarComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -68,13 +69,11 @@ describe('RbdImageResourceSidebarComponent', () => {
       expect(component.imageSpecRoute).toBe(testRoute);
       expect(component.sidebarItems.length).toBe(4);
 
-      // Verify the generated routes
       expect(component.sidebarItems[0].route).toEqual(['/block/rbd', testRoute, 'overview']);
       expect(component.sidebarItems[1].route).toEqual(['/block/rbd', testRoute, 'snapshots']);
       expect(component.sidebarItems[2].route).toEqual(['/block/rbd', testRoute, 'configuration']);
       expect(component.sidebarItems[3].route).toEqual(['/block/rbd', testRoute, 'performance']);
 
-      // Verify the state service was told to load the route
       expect(stateServiceMock.load).toHaveBeenCalledWith(testRoute);
     });
   });
@@ -83,28 +82,25 @@ describe('RbdImageResourceSidebarComponent', () => {
     it('should parse a valid image spec string', () => {
       const testRoute = 'test-pool%2Ftest-image';
 
-      // Mock ImageSpec.fromString to return a successful parsed object
       jest.spyOn(ImageSpec, 'fromString').mockReturnValue({
         imageName: 'test-image'
       } as any);
 
       paramMapSubject.next({ get: () => testRoute });
 
-      expect(ImageSpec.fromString).toHaveBeenCalledWith('test-pool/test-image'); // URL decoded
+      expect(ImageSpec.fromString).toHaveBeenCalledWith('test-pool/test-image');
       expect(component.imageName).toBe('test-image');
     });
 
     it('should fallback to the raw route string if parsing fails', () => {
       const invalidRoute = 'malformed-spec-string';
 
-      // Force ImageSpec.fromString to throw an error simulating a parsing failure
       jest.spyOn(ImageSpec, 'fromString').mockImplementation(() => {
         throw new Error('Invalid format');
       });
 
       paramMapSubject.next({ get: () => invalidRoute });
 
-      // Component should catch the error and fallback to the raw string
       expect(component.imageName).toBe(invalidRoute);
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
@@ -74,7 +74,7 @@ describe('RbdSnapshotListComponent', () => {
       CoreModule
     ],
     providers: [
-      { provide: AuthStorageService, useValue: fakeAuthStorageService },
+      { provide: AuthStorageService, useFactory: () => fakeAuthStorageService },
       TaskListService,
       ModalService,
       PlaceholderService,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-auth-modal/cephfs-auth-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-auth-modal/cephfs-auth-modal.component.spec.ts
@@ -7,26 +7,27 @@ import { SharedModule } from '~/app/shared/shared.module';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 import { CheckboxModule, InputModule, ModalModule } from 'carbon-components-angular';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('CephfsAuthModalComponent', () => {
   let component: CephfsAuthModalComponent;
   let fixture: ComponentFixture<CephfsAuthModalComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [CephfsAuthModalComponent],
-      imports: [
-        HttpClientTestingModule,
-        SharedModule,
-        ReactiveFormsModule,
-        RouterTestingModule,
-        NgbTypeaheadModule,
-        ModalModule,
-        InputModule,
-        CheckboxModule
-      ]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [CephfsAuthModalComponent],
+    imports: [
+      HttpClientTestingModule,
+      SharedModule,
+      ReactiveFormsModule,
+      RouterTestingModule,
+      NgbTypeaheadModule,
+      ModalModule,
+      InputModule,
+      CheckboxModule
+    ]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(CephfsAuthModalComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-filesystem-selector/cephfs-filesystem-selector.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-filesystem-selector/cephfs-filesystem-selector.component.spec.ts
@@ -6,6 +6,7 @@ import { CephfsService } from '~/app/shared/api/cephfs.service';
 import { DimlessBinaryPipe } from '~/app/shared/pipes/dimless-binary.pipe';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import { CephfsFilesystemSelectorComponent } from './cephfs-filesystem-selector.component';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 const createDetail = (
   id: number,
@@ -26,22 +27,20 @@ const createDetail = (
 describe('CephfsFilesystemSelectorComponent', () => {
   let component: CephfsFilesystemSelectorComponent;
   let fixture: ComponentFixture<CephfsFilesystemSelectorComponent>;
-  let cephfsServiceMock: jest.Mocked<Pick<CephfsService, 'list' | 'getCephfs'>>;
+  let cephfsServiceMock: jest.Mocked<Pick<CephfsService, 'list' | 'getCephfs'>> = {
+    list: jest.fn(),
+    getCephfs: jest.fn()
+  };
+
+  configureTestBed({
+    declarations: [CephfsFilesystemSelectorComponent],
+    providers: [{ provide: CephfsService, useFactory: () => cephfsServiceMock }, DimlessBinaryPipe],
+    schemas: [NO_ERRORS_SCHEMA]
+  });
 
   beforeEach(async () => {
-    cephfsServiceMock = {
-      list: jest.fn(),
-      getCephfs: jest.fn()
-    };
-
     cephfsServiceMock.list.mockReturnValue(of([]));
     cephfsServiceMock.getCephfs.mockReturnValue(of(null));
-
-    await TestBed.configureTestingModule({
-      declarations: [CephfsFilesystemSelectorComponent],
-      providers: [{ provide: CephfsService, useValue: cephfsServiceMock }, DimlessBinaryPipe],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
 
     fixture = TestBed.createComponent(CephfsFilesystemSelectorComponent);
     component = fixture.componentInstance;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-entity/cephfs-mirroring-entity.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-entity/cephfs-mirroring-entity.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { ReactiveFormsModule } from '@angular/forms';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { of } from 'rxjs';
 
 import { CephfsMirroringEntityComponent } from './cephfs-mirroring-entity.component';
@@ -8,6 +9,7 @@ import { ClusterService } from '~/app/shared/api/cluster.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('CephfsMirroringEntityComponent', () => {
   let component: CephfsMirroringEntityComponent;
@@ -16,6 +18,18 @@ describe('CephfsMirroringEntityComponent', () => {
   let clusterServiceMock: any;
   let cephfsServiceMock: any;
   let taskWrapperServiceMock: any;
+
+  configureTestBed({
+    declarations: [CephfsMirroringEntityComponent],
+    imports: [ReactiveFormsModule, FormsModule],
+    schemas: [NO_ERRORS_SCHEMA],
+    providers: [
+      CdFormBuilder,
+      { provide: ClusterService, useFactory: () => clusterServiceMock },
+      { provide: CephfsService, useFactory: () => cephfsServiceMock },
+      { provide: TaskWrapperService, useFactory: () => taskWrapperServiceMock }
+    ]
+  });
 
   beforeEach(async () => {
     clusterServiceMock = {
@@ -31,20 +45,11 @@ describe('CephfsMirroringEntityComponent', () => {
       wrapTaskAroundCall: jest.fn()
     };
 
-    await TestBed.configureTestingModule({
-      declarations: [CephfsMirroringEntityComponent],
-      imports: [ReactiveFormsModule],
-      providers: [
-        CdFormBuilder,
-        { provide: ClusterService, useValue: clusterServiceMock },
-        { provide: CephfsService, useValue: cephfsServiceMock },
-        { provide: TaskWrapperService, useValue: taskWrapperServiceMock }
-      ]
-    })
-      .overrideComponent(CephfsMirroringEntityComponent, {
-        set: { template: '' }
-      })
-      .compileComponents();
+    TestBed.overrideComponent(CephfsMirroringEntityComponent, {
+      set: { template: '' }
+    });
+
+    await TestBed.compileComponents();
 
     fixture = TestBed.createComponent(CephfsMirroringEntityComponent);
     component = fixture.componentInstance;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-error/cephfs-mirroring-error.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-error/cephfs-mirroring-error.component.spec.ts
@@ -7,6 +7,7 @@ import { CephfsMirroringErrorComponent } from './cephfs-mirroring-error.componen
 import { MgrModuleService } from '~/app/shared/api/mgr-module.service';
 import { SharedModule } from '~/app/shared/shared.module';
 import { RouterTestingModule } from '@angular/router/testing';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('CephfsMirroringErrorComponent', () => {
   let component: CephfsMirroringErrorComponent;
@@ -23,18 +24,18 @@ describe('CephfsMirroringErrorComponent', () => {
     updateCompleted$: { subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }) }
   };
 
+  configureTestBed({
+    declarations: [CephfsMirroringErrorComponent],
+    imports: [SharedModule, RouterTestingModule],
+    providers: [
+      { provide: Router, useFactory: () => routerMock },
+      { provide: MgrModuleService, useFactory: () => mgrModuleServiceMock }
+    ],
+    schemas: [NO_ERRORS_SCHEMA]
+  });
+
   beforeEach(async () => {
     jest.clearAllMocks();
-
-    await TestBed.configureTestingModule({
-      declarations: [CephfsMirroringErrorComponent],
-      imports: [SharedModule, RouterTestingModule],
-      providers: [
-        { provide: Router, useValue: routerMock },
-        { provide: MgrModuleService, useValue: mgrModuleServiceMock }
-      ],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
 
     fixture = TestBed.createComponent(CephfsMirroringErrorComponent);
     component = fixture.componentInstance;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.spec.ts
@@ -5,6 +5,7 @@ import { CephfsMirroringListComponent } from './cephfs-mirroring-list.component'
 import { CephfsService } from '~/app/shared/api/cephfs.service';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { Daemon, MirroringRow } from '~/app/shared/models/cephfs.model';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('CephfsMirroringListComponent', () => {
   let component: CephfsMirroringListComponent;
@@ -14,13 +15,13 @@ describe('CephfsMirroringListComponent', () => {
     listDaemonStatus: jest.fn()
   };
 
-  beforeEach(async () => {
-    jest.clearAllMocks();
+  configureTestBed({
+    declarations: [CephfsMirroringListComponent],
+    providers: [ActionLabelsI18n, { provide: CephfsService, useFactory: () => cephfsServiceMock }]
+  });
 
-    await TestBed.configureTestingModule({
-      declarations: [CephfsMirroringListComponent],
-      providers: [ActionLabelsI18n, { provide: CephfsService, useValue: cephfsServiceMock }]
-    }).compileComponents();
+  beforeEach(() => {
+    jest.clearAllMocks();
 
     fixture = TestBed.createComponent(CephfsMirroringListComponent);
     component = fixture.componentInstance;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-wizard/cephfs-mirroring-wizard.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-wizard/cephfs-mirroring-wizard.component.spec.ts
@@ -12,40 +12,36 @@ import {
 import { WizardStepModel } from '~/app/shared/models/wizard-steps';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { RadioModule } from 'carbon-components-angular';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('CephfsMirroringWizardComponent', () => {
-  let component: CephfsMirroringWizardComponent;
-  let fixture: ComponentFixture<CephfsMirroringWizardComponent>;
-  let wizardStepsService: jest.Mocked<WizardStepsService>;
-  let router: jest.Mocked<Router>;
-
   const mockSteps: WizardStepModel[] = [
     { stepIndex: 0, isComplete: false },
     { stepIndex: 1, isComplete: false }
   ];
+  let component: CephfsMirroringWizardComponent;
+  let fixture: ComponentFixture<CephfsMirroringWizardComponent>;
+  let wizardStepsService: jest.Mocked<WizardStepsService> = {
+    setTotalSteps: jest.fn(),
+    setCurrentStep: jest.fn(),
+    steps$: new BehaviorSubject<WizardStepModel[]>(mockSteps)
+  } as unknown as jest.Mocked<WizardStepsService>;
+  let router: jest.Mocked<Router> = {
+    navigate: jest.fn()
+  } as unknown as jest.Mocked<Router>;
 
-  beforeEach(async () => {
-    wizardStepsService = {
-      setTotalSteps: jest.fn(),
-      setCurrentStep: jest.fn(),
-      steps$: new BehaviorSubject<WizardStepModel[]>(mockSteps)
-    } as unknown as jest.Mocked<WizardStepsService>;
+  configureTestBed({
+    imports: [ReactiveFormsModule, RadioModule],
+    declarations: [CephfsMirroringWizardComponent],
+    providers: [
+      FormBuilder,
+      { provide: WizardStepsService, useFactory: () => wizardStepsService },
+      { provide: Router, useFactory: () => router }
+    ],
+    schemas: [NO_ERRORS_SCHEMA]
+  });
 
-    router = {
-      navigate: jest.fn()
-    } as unknown as jest.Mocked<Router>;
-
-    await TestBed.configureTestingModule({
-      imports: [ReactiveFormsModule, RadioModule],
-      declarations: [CephfsMirroringWizardComponent],
-      providers: [
-        FormBuilder,
-        { provide: WizardStepsService, useValue: wizardStepsService },
-        { provide: Router, useValue: router }
-      ],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
-
+  beforeEach(() => {
     fixture = TestBed.createComponent(CephfsMirroringWizardComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-snapshots-list/cephfs-subvolume-snapshots-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-snapshots-list/cephfs-subvolume-snapshots-list.component.spec.ts
@@ -3,17 +3,18 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CephfsSubvolumeSnapshotsListComponent } from './cephfs-subvolume-snapshots-list.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { SharedModule } from '~/app/shared/shared.module';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('CephfsSubvolumeSnapshotsListComponent', () => {
   let component: CephfsSubvolumeSnapshotsListComponent;
   let fixture: ComponentFixture<CephfsSubvolumeSnapshotsListComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [CephfsSubvolumeSnapshotsListComponent],
-      imports: [HttpClientTestingModule, SharedModule]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [CephfsSubvolumeSnapshotsListComponent],
+    imports: [HttpClientTestingModule, SharedModule]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(CephfsSubvolumeSnapshotsListComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-resource-page/host-resource-page.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-resource-page/host-resource-page.component.spec.ts
@@ -48,10 +48,7 @@ describe('HostResourcePageComponent', () => {
           snapshot: { data: { section: 'overview' } }
         }
       },
-      {
-        provide: HostService,
-        useValue: hostServiceSpy
-      },
+      { provide: HostService, useFactory: () => hostServiceSpy },
       {
         provide: AuthStorageService,
         useValue: {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
@@ -67,7 +67,7 @@ describe('HostsComponent', () => {
       TagModule
     ],
     providers: [
-      { provide: AuthStorageService, useValue: fakeAuthStorageService },
+      { provide: AuthStorageService, useFactory: () => fakeAuthStorageService },
       TableActionsComponent
     ]
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory-devices/inventory-devices.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory-devices/inventory-devices.component.spec.ts
@@ -49,7 +49,7 @@ describe('InventoryDevicesComponent', () => {
       RouterTestingModule
     ],
     providers: [
-      { provide: AuthStorageService, useValue: fakeAuthStorageService },
+      { provide: AuthStorageService, useFactory: () => fakeAuthStorageService },
       TableActionsComponent
     ],
     declarations: [InventoryDevicesComponent]

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster-details/multi-cluster-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster-details/multi-cluster-details.component.spec.ts
@@ -1,16 +1,17 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MultiClusterDetailsComponent } from './multi-cluster-details.component';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('MultiClusterDetailsComponent', () => {
   let component: MultiClusterDetailsComponent;
   let fixture: ComponentFixture<MultiClusterDetailsComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [MultiClusterDetailsComponent]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [MultiClusterDetailsComponent]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(MultiClusterDetailsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster-form/multi-cluster-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster-form/multi-cluster-form.component.spec.ts
@@ -11,29 +11,30 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 import { SharedModule } from '~/app/shared/shared.module';
 import { CheckboxModule, GridModule, InputModule, SelectModule } from 'carbon-components-angular';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('MultiClusterFormComponent', () => {
   let component: MultiClusterFormComponent;
   let fixture: ComponentFixture<MultiClusterFormComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [
-        SharedModule,
-        CommonModule,
-        FormsModule,
-        CheckboxModule,
-        GridModule,
-        ReactiveFormsModule,
-        InputModule,
-        SelectModule,
-        RouterTestingModule,
-        HttpClientTestingModule
-      ],
-      declarations: [MultiClusterFormComponent],
-      providers: [NgbActiveModal, NotificationService, CdDatePipe, DatePipe]
-    }).compileComponents();
+  configureTestBed({
+    imports: [
+      SharedModule,
+      CommonModule,
+      FormsModule,
+      CheckboxModule,
+      GridModule,
+      ReactiveFormsModule,
+      InputModule,
+      SelectModule,
+      RouterTestingModule,
+      HttpClientTestingModule
+    ],
+    declarations: [MultiClusterFormComponent],
+    providers: [NgbActiveModal, NotificationService, CdDatePipe, DatePipe]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(MultiClusterFormComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster-list/multi-cluster-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster-list/multi-cluster-list.component.spec.ts
@@ -7,18 +7,19 @@ import { CdDatePipe } from '~/app/shared/pipes/cd-date.pipe';
 import { TableActionsComponent } from '~/app/shared/datatable/table-actions/table-actions.component';
 import { SharedModule } from '~/app/shared/shared.module';
 import { ActivatedRoute } from '@angular/router';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('MultiClusterListComponent', () => {
   let component: MultiClusterListComponent;
   let fixture: ComponentFixture<MultiClusterListComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, NgbNavModule, SharedModule],
-      declarations: [MultiClusterListComponent],
-      providers: [CdDatePipe, TableActionsComponent, { provide: ActivatedRoute, useValue: {} }]
-    }).compileComponents();
+  configureTestBed({
+    imports: [HttpClientTestingModule, NgbNavModule, SharedModule],
+    declarations: [MultiClusterListComponent],
+    providers: [CdDatePipe, TableActionsComponent, { provide: ActivatedRoute, useValue: {} }]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(MultiClusterListComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster.component.spec.ts
@@ -4,18 +4,19 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { MultiClusterComponent } from './multi-cluster.component';
 import { SharedModule } from '~/app/shared/shared.module';
 import { DimlessBinaryPipe } from '~/app/shared/pipes/dimless-binary.pipe';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('MultiClusterComponent', () => {
   let component: MultiClusterComponent;
   let fixture: ComponentFixture<MultiClusterComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, SharedModule],
-      declarations: [MultiClusterComponent],
-      providers: [NgbActiveModal, DimlessBinaryPipe]
-    }).compileComponents();
+  configureTestBed({
+    imports: [HttpClientTestingModule, SharedModule],
+    declarations: [MultiClusterComponent],
+    providers: [NgbActiveModal, DimlessBinaryPipe]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(MultiClusterComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
@@ -107,7 +107,7 @@ describe('OsdListComponent', () => {
       RouterTestingModule
     ],
     providers: [
-      { provide: AuthStorageService, useValue: fakeAuthStorageService },
+      { provide: AuthStorageService, useFactory: () => fakeAuthStorageService },
       TableActionsComponent,
       ModalService
     ]

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.spec.ts
@@ -33,8 +33,8 @@ describe('OsdScrubModalComponent', () => {
     providers: [
       NgbActiveModal,
       JoinPipe,
-      { provide: OsdService, useValue: fakeService },
-      { provide: NotificationService, useValue: fakeService }
+      { provide: OsdService, useFactory: () => fakeService },
+      { provide: NotificationService, useFactory: () => fakeService }
     ]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-cert-details/service-certificate-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-cert-details/service-certificate-details.component.spec.ts
@@ -10,6 +10,7 @@ import {
   CephServiceCertificate
 } from '~/app/shared/models/service.interface';
 import { ServiceCertificateDetailsComponent } from './service-certificate-details.component';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('ServiceCertificateDetailsComponent', () => {
   let component: ServiceCertificateDetailsComponent;
@@ -32,13 +33,13 @@ describe('ServiceCertificateDetailsComponent', () => {
     ...override
   });
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ServiceCertificateDetailsComponent, IconComponent],
-      imports: [ComponentsModule],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [ServiceCertificateDetailsComponent, IconComponent],
+    imports: [ComponentsModule],
+    schemas: [NO_ERRORS_SCHEMA]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(ServiceCertificateDetailsComponent);
     component = fixture.componentInstance;
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.spec.ts
@@ -59,7 +59,7 @@ describe('ServicesComponent', () => {
       HttpClientTestingModule,
       RouterTestingModule
     ],
-    providers: [{ provide: AuthStorageService, useValue: fakeAuthStorageService }]
+    providers: [{ provide: AuthStorageService, useFactory: () => fakeAuthStorageService }]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/alerts-card/overview-alerts-card.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/alerts-card/overview-alerts-card.component.spec.ts
@@ -6,6 +6,7 @@ import { PrometheusAlertService } from '~/app/shared/services/prometheus-alert.s
 import { provideHttpClient } from '@angular/common/http';
 import { provideRouter, RouterModule } from '@angular/router';
 import { take } from 'rxjs/operators';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 class MockPrometheusAlertService {
   private totalSub = new BehaviorSubject<number>(0);
@@ -28,19 +29,26 @@ class MockPrometheusAlertService {
 describe('OverviewAlertsCardComponent', () => {
   let component: OverviewAlertsCardComponent;
   let fixture: ComponentFixture<OverviewAlertsCardComponent>;
-  let mockSvc: MockPrometheusAlertService;
+  let mockSvc: MockPrometheusAlertService = new MockPrometheusAlertService();
+
+  configureTestBed({
+    imports: [OverviewAlertsCardComponent, RouterModule],
+    providers: [
+      provideRouter([]),
+      provideHttpClient(),
+      { provide: PrometheusAlertService, useFactory: () => mockSvc }
+    ]
+  });
 
   beforeEach(async () => {
-    mockSvc = new MockPrometheusAlertService();
-
-    await TestBed.configureTestingModule({
+    configureTestBed({
       imports: [OverviewAlertsCardComponent, RouterModule],
       providers: [
         provideRouter([]),
         provideHttpClient(),
-        { provide: PrometheusAlertService, useValue: mockSvc }
+        { provide: PrometheusAlertService, useFactory: () => mockSvc }
       ]
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(OverviewAlertsCardComponent);
     component = fixture.componentInstance;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/health-card/overview-health-card.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/health-card/overview-health-card.component.spec.ts
@@ -16,6 +16,7 @@ import { MgrModuleService } from '~/app/shared/api/mgr-module.service';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { HardwareNameMapping } from '~/app/shared/enum/hardware.enum';
 import { PrometheusAlertService } from '~/app/shared/services/prometheus-alert.service';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 const MOCK_HW_SUMMARY = {
   total: {
@@ -74,31 +75,31 @@ describe('OverviewHealthCardComponent', () => {
     getTelemetryStatus: jest.fn(() => of(false))
   };
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [
-        OverviewHealthCardComponent,
-        CommonModule,
-        ProductiveCardComponent,
-        SkeletonModule,
-        ButtonModule,
-        RouterModule,
-        ComponentsModule,
-        LinkModule,
-        PipesModule
-      ],
-      providers: [
-        { provide: SummaryService, useValue: summaryServiceMock },
-        { provide: UpgradeService, useValue: upgradeServiceMock },
-        { provide: AuthStorageService, useValue: mockAuthStorageService },
-        { provide: MgrModuleService, useValue: mockMgrModuleService },
-        { provide: HardwareService, useValue: mockHardwareService },
-        { provide: HealthService, useValue: mockHealthService },
-        { provide: PrometheusAlertService, useValue: { totalAlerts$: of(0), alerts: [] } },
-        provideRouter([])
-      ]
-    }).compileComponents();
+  configureTestBed({
+    imports: [
+      OverviewHealthCardComponent,
+      CommonModule,
+      ProductiveCardComponent,
+      SkeletonModule,
+      ButtonModule,
+      RouterModule,
+      ComponentsModule,
+      LinkModule,
+      PipesModule
+    ],
+    providers: [
+      { provide: SummaryService, useFactory: () => summaryServiceMock },
+      { provide: UpgradeService, useFactory: () => upgradeServiceMock },
+      { provide: AuthStorageService, useFactory: () => mockAuthStorageService },
+      { provide: MgrModuleService, useFactory: () => mockMgrModuleService },
+      { provide: HardwareService, useFactory: () => mockHardwareService },
+      { provide: HealthService, useFactory: () => mockHealthService },
+      { provide: PrometheusAlertService, useValue: { totalAlerts$: of(0), alerts: [] } },
+      provideRouter([])
+    ]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(OverviewHealthCardComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -222,41 +223,40 @@ describe('OverviewHealthCardComponent (all healthy)', () => {
     },
     host: { flawed: 0 }
   };
+  configureTestBed({
+    imports: [
+      OverviewHealthCardComponent,
+      CommonModule,
+      ProductiveCardComponent,
+      SkeletonModule,
+      ButtonModule,
+      RouterModule,
+      ComponentsModule,
+      LinkModule,
+      PipesModule
+    ],
+    providers: [
+      {
+        provide: SummaryService,
+        useValue: { summaryData$: of({ version: 'ceph version 18.0.0 reef (dev)' }) }
+      },
+      { provide: UpgradeService, useValue: { listCached: jest.fn(() => of(null)) } },
+      {
+        provide: AuthStorageService,
+        useValue: { getPermissions: jest.fn(() => ({ configOpt: { read: true } })) }
+      },
+      {
+        provide: MgrModuleService,
+        useValue: { getConfig: jest.fn(() => of({ hw_monitoring: true })) }
+      },
+      { provide: HardwareService, useValue: { getSummary: jest.fn(() => of(healthyMock)) } },
+      { provide: HealthService, useValue: { getTelemetryStatus: jest.fn(() => of(false)) } },
+      { provide: PrometheusAlertService, useValue: { totalAlerts$: of(0), alerts: [] } },
+      provideRouter([])
+    ]
+  });
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [
-        OverviewHealthCardComponent,
-        CommonModule,
-        ProductiveCardComponent,
-        SkeletonModule,
-        ButtonModule,
-        RouterModule,
-        ComponentsModule,
-        LinkModule,
-        PipesModule
-      ],
-      providers: [
-        {
-          provide: SummaryService,
-          useValue: { summaryData$: of({ version: 'ceph version 18.0.0 reef (dev)' }) }
-        },
-        { provide: UpgradeService, useValue: { listCached: jest.fn(() => of(null)) } },
-        {
-          provide: AuthStorageService,
-          useValue: { getPermissions: jest.fn(() => ({ configOpt: { read: true } })) }
-        },
-        {
-          provide: MgrModuleService,
-          useValue: { getConfig: jest.fn(() => of({ hw_monitoring: true })) }
-        },
-        { provide: HardwareService, useValue: { getSummary: jest.fn(() => of(healthyMock)) } },
-        { provide: HealthService, useValue: { getTelemetryStatus: jest.fn(() => of(false)) } },
-        { provide: PrometheusAlertService, useValue: { totalAlerts$: of(0), alerts: [] } },
-        provideRouter([])
-      ]
-    }).compileComponents();
-
+  beforeEach(() => {
     fixture = TestBed.createComponent(OverviewHealthCardComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -300,40 +300,40 @@ describe('OverviewHealthCardComponent (warn only)', () => {
     host: { flawed: 1 }
   };
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [
-        OverviewHealthCardComponent,
-        CommonModule,
-        ProductiveCardComponent,
-        SkeletonModule,
-        ButtonModule,
-        RouterModule,
-        ComponentsModule,
-        LinkModule,
-        PipesModule
-      ],
-      providers: [
-        {
-          provide: SummaryService,
-          useValue: { summaryData$: of({ version: 'ceph version 18.0.0 reef (dev)' }) }
-        },
-        { provide: UpgradeService, useValue: { listCached: jest.fn(() => of(null)) } },
-        {
-          provide: AuthStorageService,
-          useValue: { getPermissions: jest.fn(() => ({ configOpt: { read: true } })) }
-        },
-        {
-          provide: MgrModuleService,
-          useValue: { getConfig: jest.fn(() => of({ hw_monitoring: true })) }
-        },
-        { provide: HardwareService, useValue: { getSummary: jest.fn(() => of(warnMock)) } },
-        { provide: HealthService, useValue: { getTelemetryStatus: jest.fn(() => of(false)) } },
-        { provide: PrometheusAlertService, useValue: { totalAlerts$: of(0), alerts: [] } },
-        provideRouter([])
-      ]
-    }).compileComponents();
+  configureTestBed({
+    imports: [
+      OverviewHealthCardComponent,
+      CommonModule,
+      ProductiveCardComponent,
+      SkeletonModule,
+      ButtonModule,
+      RouterModule,
+      ComponentsModule,
+      LinkModule,
+      PipesModule
+    ],
+    providers: [
+      {
+        provide: SummaryService,
+        useValue: { summaryData$: of({ version: 'ceph version 18.0.0 reef (dev)' }) }
+      },
+      { provide: UpgradeService, useValue: { listCached: jest.fn(() => of(null)) } },
+      {
+        provide: AuthStorageService,
+        useValue: { getPermissions: jest.fn(() => ({ configOpt: { read: true } })) }
+      },
+      {
+        provide: MgrModuleService,
+        useValue: { getConfig: jest.fn(() => of({ hw_monitoring: true })) }
+      },
+      { provide: HardwareService, useValue: { getSummary: jest.fn(() => of(warnMock)) } },
+      { provide: HealthService, useValue: { getTelemetryStatus: jest.fn(() => of(false)) } },
+      { provide: PrometheusAlertService, useValue: { totalAlerts$: of(0), alerts: [] } },
+      provideRouter([])
+    ]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(OverviewHealthCardComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -362,40 +362,39 @@ describe('OverviewHealthCardComponent (hw disabled)', () => {
   let component: OverviewHealthCardComponent;
   let fixture: ComponentFixture<OverviewHealthCardComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [
-        OverviewHealthCardComponent,
-        CommonModule,
-        ProductiveCardComponent,
-        SkeletonModule,
-        ButtonModule,
-        RouterModule,
-        ComponentsModule,
-        LinkModule,
-        PipesModule
-      ],
-      providers: [
-        {
-          provide: SummaryService,
-          useValue: { summaryData$: of({ version: 'ceph version 18.0.0 reef (dev)' }) }
-        },
-        { provide: UpgradeService, useValue: { listCached: jest.fn(() => of(null)) } },
-        {
-          provide: AuthStorageService,
-          useValue: { getPermissions: jest.fn(() => ({ configOpt: { read: true } })) }
-        },
-        {
-          provide: MgrModuleService,
-          useValue: { getConfig: jest.fn(() => of({ hw_monitoring: false })) }
-        },
-        { provide: HardwareService, useValue: { getSummary: jest.fn(() => of(null)) } },
-        { provide: HealthService, useValue: { getTelemetryStatus: jest.fn(() => of(false)) } },
-        { provide: PrometheusAlertService, useValue: { totalAlerts$: of(0), alerts: [] } },
-        provideRouter([])
-      ]
-    }).compileComponents();
-
+  configureTestBed({
+    imports: [
+      OverviewHealthCardComponent,
+      CommonModule,
+      ProductiveCardComponent,
+      SkeletonModule,
+      ButtonModule,
+      RouterModule,
+      ComponentsModule,
+      LinkModule,
+      PipesModule
+    ],
+    providers: [
+      {
+        provide: SummaryService,
+        useValue: { summaryData$: of({ version: 'ceph version 18.0.0 reef (dev)' }) }
+      },
+      { provide: UpgradeService, useValue: { listCached: jest.fn(() => of(null)) } },
+      {
+        provide: AuthStorageService,
+        useValue: { getPermissions: jest.fn(() => ({ configOpt: { read: true } })) }
+      },
+      {
+        provide: MgrModuleService,
+        useValue: { getConfig: jest.fn(() => of({ hw_monitoring: false })) }
+      },
+      { provide: HardwareService, useValue: { getSummary: jest.fn(() => of(null)) } },
+      { provide: HealthService, useValue: { getTelemetryStatus: jest.fn(() => of(false)) } },
+      { provide: PrometheusAlertService, useValue: { totalAlerts$: of(0), alerts: [] } },
+      provideRouter([])
+    ]
+  });
+  beforeEach(() => {
     fixture = TestBed.createComponent(OverviewHealthCardComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -419,38 +418,37 @@ describe('OverviewHealthCardComponent (hw disabled)', () => {
 describe('OverviewHealthCardComponent (no permissions)', () => {
   let component: OverviewHealthCardComponent;
   let fixture: ComponentFixture<OverviewHealthCardComponent>;
+  configureTestBed({
+    imports: [
+      OverviewHealthCardComponent,
+      CommonModule,
+      ProductiveCardComponent,
+      SkeletonModule,
+      ButtonModule,
+      RouterModule,
+      ComponentsModule,
+      LinkModule,
+      PipesModule
+    ],
+    providers: [
+      {
+        provide: SummaryService,
+        useValue: { summaryData$: of({ version: 'ceph version 18.0.0 reef (dev)' }) }
+      },
+      { provide: UpgradeService, useValue: { listCached: jest.fn(() => of(null)) } },
+      {
+        provide: AuthStorageService,
+        useValue: { getPermissions: jest.fn(() => ({ configOpt: { read: false } })) }
+      },
+      { provide: MgrModuleService, useValue: { getConfig: jest.fn(() => of({})) } },
+      { provide: HardwareService, useValue: { getSummary: jest.fn(() => of(null)) } },
+      { provide: HealthService, useValue: { getTelemetryStatus: jest.fn(() => of(false)) } },
+      { provide: PrometheusAlertService, useValue: { totalAlerts$: of(0), alerts: [] } },
+      provideRouter([])
+    ]
+  });
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [
-        OverviewHealthCardComponent,
-        CommonModule,
-        ProductiveCardComponent,
-        SkeletonModule,
-        ButtonModule,
-        RouterModule,
-        ComponentsModule,
-        LinkModule,
-        PipesModule
-      ],
-      providers: [
-        {
-          provide: SummaryService,
-          useValue: { summaryData$: of({ version: 'ceph version 18.0.0 reef (dev)' }) }
-        },
-        { provide: UpgradeService, useValue: { listCached: jest.fn(() => of(null)) } },
-        {
-          provide: AuthStorageService,
-          useValue: { getPermissions: jest.fn(() => ({ configOpt: { read: false } })) }
-        },
-        { provide: MgrModuleService, useValue: { getConfig: jest.fn(() => of({})) } },
-        { provide: HardwareService, useValue: { getSummary: jest.fn(() => of(null)) } },
-        { provide: HealthService, useValue: { getTelemetryStatus: jest.fn(() => of(false)) } },
-        { provide: PrometheusAlertService, useValue: { totalAlerts$: of(0), alerts: [] } },
-        provideRouter([])
-      ]
-    }).compileComponents();
-
+  beforeEach(() => {
     fixture = TestBed.createComponent(OverviewHealthCardComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/overview.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/overview.component.spec.ts
@@ -20,13 +20,20 @@ import { MgrModuleService } from '~/app/shared/api/mgr-module.service';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { OverviewStorageService } from '~/app/shared/api/storage-overview.service';
 import { PrometheusService } from '~/app/shared/api/prometheus.service';
+import { configureTestBed } from '~/testing/unit-test-helper';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('OverviewComponent', () => {
   let component: OverviewComponent;
   let fixture: ComponentFixture<OverviewComponent>;
 
-  let mockHealthService: { getHealthSnapshot: jest.Mock; getTelemetryStatus: jest.Mock };
-  let mockRefreshIntervalService: { intervalData$: Subject<void> };
+  let mockHealthService: { getHealthSnapshot: jest.Mock; getTelemetryStatus: jest.Mock } = {
+    getHealthSnapshot: jest.fn(),
+    getTelemetryStatus: jest.fn().mockReturnValue(of(false))
+  };
+  let mockRefreshIntervalService: { intervalData$: Subject<void> } = {
+    intervalData$: new Subject<void>()
+  };
   let mockOverviewStorageService: {
     getTrendData: jest.Mock;
     getAverageConsumption: jest.Mock;
@@ -36,6 +43,37 @@ describe('OverviewComponent', () => {
     mapStorageChartData: jest.Mock;
     getThresholdStatus: jest.Mock;
     getRawCapacityThresholds: jest.Mock;
+  } = {
+    getTrendData: jest.fn().mockReturnValue(
+      of({
+        TOTAL_RAW_USED: [
+          [0, '512'],
+          [60, '1024']
+        ]
+      })
+    ),
+    getAverageConsumption: jest.fn().mockReturnValue(of('12 GiB/day')),
+    getTimeUntilFull: jest.fn().mockReturnValue(of('30 days')),
+    getStorageBreakdown: jest.fn().mockReturnValue(
+      of({
+        result: [
+          { metric: { application: 'Block' }, value: [0, '1024'] },
+          { metric: { application: 'Filesystem' }, value: [0, '2048'] }
+        ]
+      })
+    ),
+    formatBytesForChart: jest.fn().mockReturnValue([3, 'GiB']),
+    mapStorageChartData: jest.fn().mockReturnValue([
+      { group: 'Block', value: 1 },
+      { group: 'File system', value: 2 }
+    ]),
+    getThresholdStatus: jest.fn().mockReturnValue(null),
+    getRawCapacityThresholds: jest.fn().mockReturnValue(
+      of({
+        osdFullRatio: 0.99,
+        osdNearfullRatio: 0.85
+      })
+    )
   };
 
   const mockAuthStorageService = {
@@ -54,69 +92,32 @@ describe('OverviewComponent', () => {
 
   let mockPrometheusService: {
     refreshPrometheusUsable: jest.Mock;
+  } = {
+    refreshPrometheusUsable: jest.fn().mockReturnValue(of(true))
   };
 
+  configureTestBed({
+    imports: [OverviewComponent, HttpClientTestingModule],
+    providers: [
+      provideRouter([]),
+      { provide: HealthService, useFactory: () => mockHealthService },
+      { provide: RefreshIntervalService, useFactory: () => mockRefreshIntervalService },
+      { provide: OverviewStorageService, useFactory: () => mockOverviewStorageService },
+      { provide: PrometheusService, useFactory: () => mockPrometheusService },
+      { provide: AuthStorageService, useFactory: () => mockAuthStorageService },
+      { provide: MgrModuleService, useFactory: () => mockMgrModuleService },
+      { provide: HardwareService, useFactory: () => mockHardwareService }
+    ]
+  });
+
   beforeEach(async () => {
-    mockPrometheusService = {
-      refreshPrometheusUsable: jest.fn().mockReturnValue(of(true))
-    };
+    mockRefreshIntervalService.intervalData$ = new Subject<void>();
 
-    mockHealthService = {
-      getHealthSnapshot: jest.fn(),
-      getTelemetryStatus: jest.fn().mockReturnValue(of(false))
-    };
-    mockRefreshIntervalService = { intervalData$: new Subject<void>() };
+    TestBed.overrideComponent(OverviewComponent, {
+      set: { template: '' }
+    });
 
-    mockOverviewStorageService = {
-      getTrendData: jest.fn().mockReturnValue(
-        of({
-          TOTAL_RAW_USED: [
-            [0, '512'],
-            [60, '1024']
-          ]
-        })
-      ),
-      getAverageConsumption: jest.fn().mockReturnValue(of('12 GiB/day')),
-      getTimeUntilFull: jest.fn().mockReturnValue(of('30 days')),
-      getStorageBreakdown: jest.fn().mockReturnValue(
-        of({
-          result: [
-            { metric: { application: 'Block' }, value: [0, '1024'] },
-            { metric: { application: 'Filesystem' }, value: [0, '2048'] }
-          ]
-        })
-      ),
-      formatBytesForChart: jest.fn().mockReturnValue([3, 'GiB']),
-      mapStorageChartData: jest.fn().mockReturnValue([
-        { group: 'Block', value: 1 },
-        { group: 'File system', value: 2 }
-      ]),
-      getThresholdStatus: jest.fn().mockReturnValue(null),
-      getRawCapacityThresholds: jest.fn().mockReturnValue(
-        of({
-          osdFullRatio: 0.99,
-          osdNearfullRatio: 0.85
-        })
-      )
-    };
-
-    await TestBed.configureTestingModule({
-      imports: [OverviewComponent],
-      providers: [
-        provideRouter([]),
-        { provide: HealthService, useValue: mockHealthService },
-        { provide: RefreshIntervalService, useValue: mockRefreshIntervalService },
-        { provide: OverviewStorageService, useValue: mockOverviewStorageService },
-        { provide: PrometheusService, useValue: mockPrometheusService },
-        { provide: AuthStorageService, useValue: mockAuthStorageService },
-        { provide: MgrModuleService, useValue: mockMgrModuleService },
-        { provide: HardwareService, useValue: mockHardwareService }
-      ]
-    })
-      .overrideComponent(OverviewComponent, {
-        set: { template: '' }
-      })
-      .compileComponents();
+    await TestBed.compileComponents();
 
     fixture = TestBed.createComponent(OverviewComponent);
     component = fixture.componentInstance;
@@ -129,7 +130,7 @@ describe('OverviewComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('healthCardVm$ should emit HealthCardVM correctly', (done) => {
+  it('healthCardVm$ should emit HealthCardVM correctly', fakeAsync(() => {
     const mockData: HealthSnapshotMap = {
       fsid: 'fsid-123',
       health: {
@@ -199,15 +200,14 @@ describe('OverviewComponent', () => {
       );
 
       expect(vm.overallSystemSev).toEqual(expect.any(String));
-
-      sub.unsubscribe();
-      done();
     });
 
     mockRefreshIntervalService.intervalData$.next();
-  });
+    tick();
+    sub.unsubscribe();
+  }));
 
-  it('healthCardVm$ should compute overallSystemSev as worst subsystem severity', (done) => {
+  it('healthCardVm$ should compute overallSystemSev as worst subsystem severity', fakeAsync(() => {
     const mockData: HealthSnapshotMap = {
       fsid: 'fsid-999',
       health: { status: 'HEALTH_OK', checks: {} },
@@ -232,14 +232,14 @@ describe('OverviewComponent', () => {
 
     const sub = component.healthCardVm$.subscribe((vm) => {
       expect(vm.overallSystemSev).toBe(SeverityIconMap[2]);
-      sub.unsubscribe();
-      done();
     });
 
     mockRefreshIntervalService.intervalData$.next();
-  });
+    tick();
+    sub.unsubscribe();
+  }));
 
-  it('healthCardVm$ should not emit if healthService throws (EMPTY)', (done) => {
+  it('healthCardVm$ should not emit if healthService throws (EMPTY)', fakeAsync(() => {
     mockHealthService.getHealthSnapshot.mockReturnValue(throwError(() => new Error('API Error')));
 
     let emitted = false;
@@ -248,15 +248,15 @@ describe('OverviewComponent', () => {
       next: () => (emitted = true),
       complete: () => {
         expect(emitted).toBe(false);
-        done();
       }
     });
 
     mockRefreshIntervalService.intervalData$.next();
+    tick();
     mockRefreshIntervalService.intervalData$.complete();
-  });
+  }));
 
-  it('storageCardVm$ should emit storage view model with mapped fields', fakeAsync((done) => {
+  it('storageCardVm$ should emit storage view model with mapped fields', fakeAsync(() => {
     const mockData: HealthSnapshotMap = {
       fsid: 'fsid-storage',
       health: { status: 'HEALTH_OK', checks: {} },
@@ -306,17 +306,16 @@ describe('OverviewComponent', () => {
 
       expect(mockOverviewStorageService.formatBytesForChart).toHaveBeenCalledWith(3236978688);
       expect(mockOverviewStorageService.mapStorageChartData).toHaveBeenCalled();
-
-      sub.unsubscribe();
-      done();
     });
 
     tick(0);
     mockRefreshIntervalService.intervalData$.next();
+    tick();
     discardPeriodicTasks();
+    sub.unsubscribe();
   }));
 
-  it('storageCardVm$ should emit safe defaults before storage side streams resolve', (done) => {
+  it('storageCardVm$ should emit safe defaults before storage side streams resolve', fakeAsync(() => {
     const mockData: HealthSnapshotMap = {
       fsid: 'fsid-storage',
       health: { status: 'HEALTH_OK', checks: {} },
@@ -345,13 +344,12 @@ describe('OverviewComponent', () => {
       expect(vm.usedCapacity).toBe(100);
       expect(vm.breakdownData).toEqual([]);
       expect(vm.isBreakdownLoaded).toBe(false);
-
-      sub.unsubscribe();
-      done();
     });
 
     mockRefreshIntervalService.intervalData$.next();
-  });
+    tick();
+    sub.unsubscribe();
+  }));
 
   it('should toggle panel open/close', () => {
     expect(component.isHealthPanelOpen).toBe(false);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/storage-card/overview-storage-card.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/storage-card/overview-storage-card.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { OverviewStorageCardComponent } from './overview-storage-card.component';
 import { FormatterService } from '~/app/shared/services/formatter.service';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('OverviewStorageCardComponent', () => {
   let component: OverviewStorageCardComponent;
@@ -12,7 +13,17 @@ describe('OverviewStorageCardComponent', () => {
     convertToUnit: jest.Mock;
   };
 
-  beforeEach(async () => {
+  configureTestBed({
+    imports: [OverviewStorageCardComponent, HttpClientTestingModule],
+    providers: [
+      {
+        provide: FormatterService,
+        useFactory: () => mockFormatterService
+      }
+    ]
+  });
+
+  beforeEach(() => {
     mockFormatterService = {
       formatToBinary: jest.fn((value: number) => {
         if (value === 1024) return [20, 'TiB'];
@@ -26,11 +37,6 @@ describe('OverviewStorageCardComponent', () => {
         return value;
       })
     };
-
-    await TestBed.configureTestingModule({
-      imports: [OverviewStorageCardComponent, HttpClientTestingModule],
-      providers: [{ provide: FormatterService, useValue: mockFormatterService }]
-    }).compileComponents();
 
     fixture = TestBed.createComponent(OverviewStorageCardComponent);
     component = fixture.componentInstance;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/bucket-tag-modal/bucket-tag-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/bucket-tag-modal/bucket-tag-modal.component.spec.ts
@@ -5,19 +5,20 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA } from '@angular/core';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('BucketTagModalComponent', () => {
   let component: BucketTagModalComponent;
   let fixture: ComponentFixture<BucketTagModalComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [BucketTagModalComponent],
-      imports: [HttpClientTestingModule, ReactiveFormsModule],
-      schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA],
-      providers: [NgbActiveModal]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [BucketTagModalComponent],
+    imports: [HttpClientTestingModule, ReactiveFormsModule],
+    schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA],
+    providers: [NgbActiveModal]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(BucketTagModalComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-form/rgw-account-role-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-form/rgw-account-role-form.component.spec.ts
@@ -6,17 +6,18 @@ import { ReactiveFormsModule } from '@angular/forms';
 
 import { RgwAccountRoleFormComponent } from './rgw-account-role-form.component';
 import { SharedModule } from '~/app/shared/shared.module';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('RgwAccountRoleFormComponent', () => {
   let component: RgwAccountRoleFormComponent;
   let fixture: ComponentFixture<RgwAccountRoleFormComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule, SharedModule, ReactiveFormsModule],
-      declarations: [RgwAccountRoleFormComponent]
-    }).compileComponents();
+  configureTestBed({
+    imports: [HttpClientTestingModule, RouterTestingModule, SharedModule, ReactiveFormsModule],
+    declarations: [RgwAccountRoleFormComponent]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(RgwAccountRoleFormComponent);
     component = fixture.componentInstance;
     component.accountId = 'test-account';

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-roles-list/rgw-account-roles-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-roles-list/rgw-account-roles-list.component.spec.ts
@@ -10,6 +10,7 @@ import { SharedModule } from '~/app/shared/shared.module';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('RgwAccountRolesListComponent', () => {
   let component: RgwAccountRolesListComponent;
@@ -17,20 +18,20 @@ describe('RgwAccountRolesListComponent', () => {
   let rgwRoleService: RgwRoleService;
   let notificationService: NotificationService;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule, SharedModule],
-      declarations: [RgwAccountRolesListComponent],
-      providers: [
-        {
-          provide: AuthStorageService,
-          useValue: {
-            getPermissions: () => ({ rgw: { create: true, update: true, delete: true } })
-          }
+  configureTestBed({
+    imports: [HttpClientTestingModule, RouterTestingModule, SharedModule],
+    declarations: [RgwAccountRolesListComponent],
+    providers: [
+      {
+        provide: AuthStorageService,
+        useValue: {
+          getPermissions: () => ({ rgw: { create: true, update: true, delete: true } })
         }
-      ]
-    }).compileComponents();
+      }
+    ]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(RgwAccountRolesListComponent);
     component = fixture.componentInstance;
     rgwRoleService = TestBed.inject(RgwRoleService);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-details/rgw-config-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-details/rgw-config-details.component.spec.ts
@@ -1,16 +1,17 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { RgwConfigDetailsComponent } from './rgw-config-details.component';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('RgwConfigDetailsComponent', () => {
   let component: RgwConfigDetailsComponent;
   let fixture: ComponentFixture<RgwConfigDetailsComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [RgwConfigDetailsComponent]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [RgwConfigDetailsComponent]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(RgwConfigDetailsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-configuration-page/rgw-configuration-page.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-configuration-page/rgw-configuration-page.component.spec.ts
@@ -6,18 +6,19 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { SharedModule } from '~/app/shared/shared.module';
 import { RgwModule } from '../rgw.module';
 import { RouterTestingModule } from '@angular/router/testing';
+import { configureTestBed } from '~/testing/unit-test-helper';
 
 describe('RgwConfigurationPageComponent', () => {
   let component: RgwConfigurationPageComponent;
   let fixture: ComponentFixture<RgwConfigurationPageComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [RgwConfigurationPageComponent],
-      providers: [NgbActiveModal],
-      imports: [HttpClientTestingModule, SharedModule, NgbNavModule, RgwModule, RouterTestingModule]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [RgwConfigurationPageComponent],
+    providers: [NgbActiveModal],
+    imports: [HttpClientTestingModule, SharedModule, NgbNavModule, RgwModule, RouterTestingModule]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(RgwConfigurationPageComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-flow-modal/rgw-multisite-sync-flow-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-flow-modal/rgw-multisite-sync-flow-modal.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RgwMultisiteSyncFlowModalComponent } from './rgw-multisite-sync-flow-modal.component';
 
@@ -24,31 +25,31 @@ describe('RgwMultisiteSyncFlowModalComponent', () => {
   let fixture: ComponentFixture<RgwMultisiteSyncFlowModalComponent>;
   let multisiteServiceMock: MultisiteServiceMock;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [RgwMultisiteSyncFlowModalComponent],
-      imports: [
-        HttpClientTestingModule,
-        PipesModule,
-        ReactiveFormsModule,
-        CommonModule,
-        SelectModule,
-        ModalModule,
-        ComboBoxModule
-      ],
-      schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA],
-      providers: [
-        { provide: RgwMultisiteService, useClass: MultisiteServiceMock },
-        { provide: 'groupType', useValue: FlowType.symmetrical },
-        { provide: 'groupExpandedRow', useValue: { groupName: 'new', bucket: 'bucket1' } },
-        {
-          provide: 'flowSelectedRow',
-          useValue: { id: 'symmetrical', zones: ['zone1-zg1-realm1'] }
-        },
-        { provide: 'action', useValue: 'create' }
-      ]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [RgwMultisiteSyncFlowModalComponent],
+    imports: [
+      HttpClientTestingModule,
+      PipesModule,
+      ReactiveFormsModule,
+      CommonModule,
+      SelectModule,
+      ModalModule,
+      ComboBoxModule
+    ],
+    schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA],
+    providers: [
+      { provide: RgwMultisiteService, useClass: MultisiteServiceMock },
+      { provide: 'groupType', useValue: FlowType.symmetrical },
+      { provide: 'groupExpandedRow', useValue: { groupName: 'new', bucket: 'bucket1' } },
+      {
+        provide: 'flowSelectedRow',
+        useValue: { id: 'symmetrical', zones: ['zone1-zg1-realm1'] }
+      },
+      { provide: 'action', useValue: 'create' }
+    ]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(RgwMultisiteSyncFlowModalComponent);
     multisiteServiceMock = TestBed.inject(RgwMultisiteService) as unknown as MultisiteServiceMock;
     component = fixture.componentInstance;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-pipe-modal/rgw-multisite-sync-pipe-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-pipe-modal/rgw-multisite-sync-pipe-modal.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { RgwMultisiteSyncPipeModalComponent } from './rgw-multisite-sync-pipe-modal.component';
@@ -22,35 +23,35 @@ describe('RgwMultisiteSyncPipeModalComponent', () => {
   let fixture: ComponentFixture<RgwMultisiteSyncPipeModalComponent>;
   let multisiteServiceMock: MultisiteServiceMock;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [RgwMultisiteSyncPipeModalComponent],
-      imports: [
-        HttpClientTestingModule,
-        PipesModule,
-        ReactiveFormsModule,
-        CommonModule,
-        ComboBoxModule
-      ],
-      schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA],
-      providers: [
-        NgbActiveModal,
-        { provide: RgwMultisiteService, useClass: MultisiteServiceMock },
-        { provide: 'groupType', useValue: FlowType.symmetrical },
-        { provide: 'groupExpandedRow', useValue: { groupName: 'new', bucket: 'bucket1' } },
-        {
-          provide: 'pipeSelectedRow',
-          useValue: {
-            source: { zones: ['zone1-zg1-realm1'], bucket: 'bucket1' },
-            dest: { zones: ['zone2-zg1-realm1'], bucket: 'bucket1' },
-            id: 'pipe1',
-            params: { user: 'dashboard', mode: USER }
-          }
-        },
-        { provide: 'action', useValue: 'create' }
-      ]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [RgwMultisiteSyncPipeModalComponent],
+    imports: [
+      HttpClientTestingModule,
+      PipesModule,
+      ReactiveFormsModule,
+      CommonModule,
+      ComboBoxModule
+    ],
+    schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA],
+    providers: [
+      NgbActiveModal,
+      { provide: RgwMultisiteService, useClass: MultisiteServiceMock },
+      { provide: 'groupType', useValue: FlowType.symmetrical },
+      { provide: 'groupExpandedRow', useValue: { groupName: 'new', bucket: 'bucket1' } },
+      {
+        provide: 'pipeSelectedRow',
+        useValue: {
+          source: { zones: ['zone1-zg1-realm1'], bucket: 'bucket1' },
+          dest: { zones: ['zone2-zg1-realm1'], bucket: 'bucket1' },
+          id: 'pipe1',
+          params: { user: 'dashboard', mode: USER }
+        }
+      },
+      { provide: 'action', useValue: 'create' }
+    ]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(RgwMultisiteSyncPipeModalComponent);
     multisiteServiceMock = TestBed.inject(RgwMultisiteService) as unknown as MultisiteServiceMock;
     component = fixture.componentInstance;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-policy-details/rgw-multisite-sync-policy-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-policy-details/rgw-multisite-sync-policy-details.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { RgwMultisiteSyncPolicyDetailsComponent } from './rgw-multisite-sync-policy-details.component';
@@ -10,12 +11,12 @@ describe('RgwMultisiteSyncPolicyDetailsComponent', () => {
   let component: RgwMultisiteSyncPolicyDetailsComponent;
   let fixture: ComponentFixture<RgwMultisiteSyncPolicyDetailsComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [RgwMultisiteSyncPolicyDetailsComponent],
-      imports: [HttpClientTestingModule, PipesModule, ModalModule, SharedModule]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [RgwMultisiteSyncPolicyDetailsComponent],
+    imports: [HttpClientTestingModule, PipesModule, ModalModule, SharedModule]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(RgwMultisiteSyncPolicyDetailsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-policy-form/rgw-multisite-sync-policy-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-policy-form/rgw-multisite-sync-policy-form.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RgwMultisiteSyncPolicyFormComponent } from './rgw-multisite-sync-policy-form.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -13,23 +14,23 @@ describe('RgwMultisiteSyncPolicyFormComponent', () => {
   let component: RgwMultisiteSyncPolicyFormComponent;
   let fixture: ComponentFixture<RgwMultisiteSyncPolicyFormComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [RgwMultisiteSyncPolicyFormComponent],
-      imports: [
-        HttpClientTestingModule,
-        ReactiveFormsModule,
-        PipesModule,
-        ComponentsModule,
-        SharedModule,
-        RouterTestingModule,
-        ModalModule,
-        SelectModule
-      ],
-      schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA],
-      providers: []
-    }).compileComponents();
+  configureTestBed({
+    declarations: [RgwMultisiteSyncPolicyFormComponent],
+    imports: [
+      HttpClientTestingModule,
+      ReactiveFormsModule,
+      PipesModule,
+      ComponentsModule,
+      SharedModule,
+      RouterTestingModule,
+      ModalModule,
+      SelectModule
+    ],
+    schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA],
+    providers: []
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(RgwMultisiteSyncPolicyFormComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-policy/rgw-multisite-sync-policy.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-policy/rgw-multisite-sync-policy.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { RgwMultisiteSyncPolicyComponent } from './rgw-multisite-sync-policy.component';
@@ -15,17 +16,17 @@ describe('RgwMultisiteSyncPolicyComponent', () => {
   let component: RgwMultisiteSyncPolicyComponent;
   let fixture: ComponentFixture<RgwMultisiteSyncPolicyComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [
-        RgwMultisiteSyncPolicyComponent,
-        RgwMultisiteTabsComponent,
-        RgwMultisiteSyncPolicyDetailsComponent
-      ],
-      imports: [HttpClientModule, PipesModule, ModalModule, SharedModule, RouterTestingModule],
-      providers: [TitleCasePipe]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [
+      RgwMultisiteSyncPolicyComponent,
+      RgwMultisiteTabsComponent,
+      RgwMultisiteSyncPolicyDetailsComponent
+    ],
+    imports: [HttpClientModule, PipesModule, ModalModule, SharedModule, RouterTestingModule],
+    providers: [TitleCasePipe]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(RgwMultisiteSyncPolicyComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-tabs/rgw-multisite-tabs.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-tabs/rgw-multisite-tabs.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { RgwMultisiteTabsComponent } from './rgw-multisite-tabs.component';
@@ -6,11 +7,11 @@ describe('RgwMultisiteTabsComponent', () => {
   let component: RgwMultisiteTabsComponent;
   let fixture: ComponentFixture<RgwMultisiteTabsComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [RgwMultisiteTabsComponent]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [RgwMultisiteTabsComponent]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(RgwMultisiteTabsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-wizard/rgw-multisite-wizard.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-wizard/rgw-multisite-wizard.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { RgwMultisiteWizardComponent } from './rgw-multisite-wizard.component';
@@ -63,6 +64,53 @@ describe('RgwMultisiteWizardComponent', () => {
   let summarySubscribeSpy: jasmine.Spy;
   let mgrModuleUpdateCompleted$: Subject<void>;
 
+  configureTestBed({
+    declarations: [RgwMultisiteWizardComponent],
+    imports: [HttpClientTestingModule, SharedModule, ReactiveFormsModule, RouterTestingModule],
+    schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA],
+    providers: [
+      NgbActiveModal,
+      {
+        provide: RgwDaemonService,
+        useFactory: () => ({ list: daemonSpy, get: daemonGetSpy })
+      },
+      {
+        provide: MultiClusterService,
+        useFactory: () => ({ getCluster: multiClusterSpy })
+      },
+      {
+        provide: RgwRealmService,
+        useFactory: () => ({ list: realmListSpy })
+      },
+      {
+        provide: RgwMultisiteService,
+        useFactory: () => ({
+          setUpMultisiteReplication: setupReplicationSpy,
+          setRestartGatewayMessage: jasmine.createSpy('setRestartGatewayMessage'),
+          getRgwModuleStatus: rgwModuleStatusSpy
+        })
+      },
+      {
+        provide: MgrModuleService,
+        useFactory: () => ({
+          get updateCompleted$() {
+            return mgrModuleUpdateCompleted$.asObservable();
+          },
+          updateModuleState: jasmine.createSpy('updateModuleState'),
+          list: jasmine.createSpy('list').and.returnValue(of([]))
+        })
+      },
+      {
+        provide: SummaryService,
+        useFactory: () => ({ subscribe: summarySubscribeSpy })
+      },
+      {
+        provide: NotificationService,
+        useFactory: () => ({ show: jasmine.createSpy('show') })
+      }
+    ]
+  });
+
   beforeEach(async () => {
     mgrModuleUpdateCompleted$ = new Subject<void>();
 
@@ -75,51 +123,6 @@ describe('RgwMultisiteWizardComponent', () => {
     rgwModuleStatusSpy = jasmine.createSpy('getRgwModuleStatus').and.returnValue(of(true));
     setupReplicationSpy = jasmine.createSpy('setUpMultisiteReplication').and.returnValue(of([]));
     summarySubscribeSpy = jasmine.createSpy('subscribe').and.returnValue({ unsubscribe: () => {} });
-
-    await TestBed.configureTestingModule({
-      declarations: [RgwMultisiteWizardComponent],
-      imports: [HttpClientTestingModule, SharedModule, ReactiveFormsModule, RouterTestingModule],
-      schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA],
-      providers: [
-        NgbActiveModal,
-        {
-          provide: RgwDaemonService,
-          useValue: { list: daemonSpy, get: daemonGetSpy }
-        },
-        {
-          provide: MultiClusterService,
-          useValue: { getCluster: multiClusterSpy }
-        },
-        {
-          provide: RgwRealmService,
-          useValue: { list: realmListSpy }
-        },
-        {
-          provide: RgwMultisiteService,
-          useValue: {
-            setUpMultisiteReplication: setupReplicationSpy,
-            setRestartGatewayMessage: jasmine.createSpy('setRestartGatewayMessage'),
-            getRgwModuleStatus: rgwModuleStatusSpy
-          }
-        },
-        {
-          provide: MgrModuleService,
-          useValue: {
-            updateCompleted$: mgrModuleUpdateCompleted$,
-            updateModuleState: jasmine.createSpy('updateModuleState'),
-            list: jasmine.createSpy('list').and.returnValue(of([]))
-          }
-        },
-        {
-          provide: SummaryService,
-          useValue: { subscribe: summarySubscribeSpy }
-        },
-        {
-          provide: NotificationService,
-          useValue: { show: jasmine.createSpy('show') }
-        }
-      ]
-    }).compileComponents();
 
     fixture = TestBed.createComponent(RgwMultisiteWizardComponent);
     component = fixture.componentInstance;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-zone-form/rgw-multisite-zone-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-zone-form/rgw-multisite-zone-form.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RgwMultisiteZoneFormComponent } from './rgw-multisite-zone-form.component'; // Adjust path as necessary
@@ -19,32 +20,32 @@ describe('RgwMultisiteZoneFormComponent', () => {
   let rgwZoneService: RgwZoneService;
   let rgwZoneServiceSpy: jasmine.Spy;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        SharedModule,
-        ReactiveFormsModule,
-        RouterTestingModule,
-        HttpClientTestingModule,
-        ModalModule,
-        InputModule,
-        CheckboxModule,
-        SelectModule
-      ],
-      providers: [
-        NgbActiveModal,
-        { provide: 'multisiteInfo', useValue: [[]] },
-        { provide: 'info', useValue: { data: { name: 'null' } } },
-        { provide: 'defaultsInfo', useValue: { defaultZonegroupName: 'zonegroup1' } },
-        {
-          provide: ActionLabelsI18n,
-          useValue: { CREATE: 'create', EDIT: 'edit', DELETE: 'delete' }
-        }
-      ],
-      schemas: [NO_ERRORS_SCHEMA],
-      declarations: [RgwMultisiteZoneFormComponent]
-    }).compileComponents();
+  configureTestBed({
+    imports: [
+      SharedModule,
+      ReactiveFormsModule,
+      RouterTestingModule,
+      HttpClientTestingModule,
+      ModalModule,
+      InputModule,
+      CheckboxModule,
+      SelectModule
+    ],
+    providers: [
+      NgbActiveModal,
+      { provide: 'multisiteInfo', useValue: [[]] },
+      { provide: 'info', useValue: { data: { name: 'null' } } },
+      { provide: 'defaultsInfo', useValue: { defaultZonegroupName: 'zonegroup1' } },
+      {
+        provide: ActionLabelsI18n,
+        useValue: { CREATE: 'create', EDIT: 'edit', DELETE: 'delete' }
+      }
+    ],
+    schemas: [NO_ERRORS_SCHEMA],
+    declarations: [RgwMultisiteZoneFormComponent]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(RgwMultisiteZoneFormComponent);
     component = fixture.componentInstance;
     rgwZoneService = TestBed.inject(RgwZoneService);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-notification-form/rgw-notification-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-notification-form/rgw-notification-form.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RgwNotificationFormComponent } from './rgw-notification-form.component';
 import { CdLabelComponent } from '~/app/shared/components/cd-label/cd-label.component';
@@ -30,32 +31,32 @@ describe('RgwNotificationFormComponent', () => {
   let fixture: ComponentFixture<RgwNotificationFormComponent>;
   let rgwBucketService: MockRgwBucketService;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [RgwNotificationFormComponent, CdLabelComponent],
-      imports: [
-        ReactiveFormsModule,
-        HttpClientTestingModule,
-        RadioModule,
-        SelectModule,
-        NumberModule,
-        InputModule,
-        ComponentsModule,
-        ModalModule,
-        ComboBoxModule,
-        ReactiveFormsModule,
-        ComponentsModule,
-        InputModule,
-        RouterTestingModule
-      ],
-      schemas: [NO_ERRORS_SCHEMA],
-      providers: [
-        ModalService,
-        { provide: 'bucket', useValue: { bucket: 'bucket1', owner: 'dashboard' } },
-        { provide: RgwBucketService, useClass: MockRgwBucketService }
-      ]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [RgwNotificationFormComponent, CdLabelComponent],
+    imports: [
+      ReactiveFormsModule,
+      HttpClientTestingModule,
+      RadioModule,
+      SelectModule,
+      NumberModule,
+      InputModule,
+      ComponentsModule,
+      ModalModule,
+      ComboBoxModule,
+      ReactiveFormsModule,
+      ComponentsModule,
+      InputModule,
+      RouterTestingModule
+    ],
+    schemas: [NO_ERRORS_SCHEMA],
+    providers: [
+      ModalService,
+      { provide: 'bucket', useValue: { bucket: 'bucket1', owner: 'dashboard' } },
+      { provide: RgwBucketService, useClass: MockRgwBucketService }
+    ]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(RgwNotificationFormComponent);
     component = fixture.componentInstance;
     rgwBucketService = TestBed.inject(RgwBucketService) as unknown as MockRgwBucketService;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-overview-dashboard/rgw-overview-dashboard.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-overview-dashboard/rgw-overview-dashboard.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { of, BehaviorSubject, combineLatest } from 'rxjs';
 import { RgwOverviewDashboardComponent } from './rgw-overview-dashboard.component';
@@ -62,37 +63,38 @@ describe('RgwOverviewDashboardComponent', () => {
     zones: ['zone4', 'zone5', 'zone6', 'zone7']
   };
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [
-        RgwOverviewDashboardComponent,
-        CardComponent,
-        CardRowComponent,
-        DimlessBinaryPipe
-      ],
-      schemas: [NO_ERRORS_SCHEMA],
-      providers: [
-        { provide: RgwDaemonService, useValue: { list: jest.fn() } },
-        { provide: RgwRealmService, useValue: { list: jest.fn() } },
-        { provide: RgwZonegroupService, useValue: { list: jest.fn() } },
-        { provide: RgwZoneService, useValue: { list: jest.fn() } },
-        {
-          provide: RgwBucketService,
-          useValue: {
-            fetchAndTransformBuckets: jest.fn(),
-            totalNumObjects$: totalNumObjectsSubject.asObservable(),
-            totalUsedCapacity$: totalUsedCapacitySubject.asObservable(),
-            averageObjectSize$: averageObjectSizeSubject.asObservable(),
-            getTotalBucketsAndUsersLength: jest.fn()
-          }
-        },
-        {
-          provide: ActivatedRoute,
-          useValue: { params: { subscribe: (fn: Function) => fn(params) } }
+  configureTestBed({
+    declarations: [
+      RgwOverviewDashboardComponent,
+      CardComponent,
+      CardRowComponent,
+      DimlessBinaryPipe
+    ],
+    schemas: [NO_ERRORS_SCHEMA],
+    providers: [
+      { provide: RgwDaemonService, useValue: { list: jest.fn() } },
+      { provide: RgwRealmService, useValue: { list: jest.fn() } },
+      { provide: RgwZonegroupService, useValue: { list: jest.fn() } },
+      { provide: RgwZoneService, useValue: { list: jest.fn() } },
+      {
+        provide: RgwBucketService,
+        useValue: {
+          fetchAndTransformBuckets: jest.fn(),
+          totalNumObjects$: totalNumObjectsSubject.asObservable(),
+          totalUsedCapacity$: totalUsedCapacitySubject.asObservable(),
+          averageObjectSize$: averageObjectSizeSubject.asObservable(),
+          getTotalBucketsAndUsersLength: jest.fn()
         }
-      ],
-      imports: [HttpClientTestingModule, SharedModule, CommonModule]
-    }).compileComponents();
+      },
+      {
+        provide: ActivatedRoute,
+        useValue: { params: { subscribe: (fn: Function) => fn(params) } }
+      }
+    ],
+    imports: [HttpClientTestingModule, SharedModule, CommonModule]
+  });
+
+  beforeEach(() => {
     fixture = TestBed.createComponent(RgwOverviewDashboardComponent);
     component = fixture.componentInstance;
     listDaemonsSpy = jest

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-details/rgw-storage-class-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-details/rgw-storage-class-details.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RgwStorageClassDetailsComponent } from './rgw-storage-class-details.component';
 import { StorageClassDetails } from '../models/rgw-storage-class.model';
@@ -24,17 +25,12 @@ describe('RgwStorageClassDetailsComponent', () => {
     acl_mappings: []
   };
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [
-        BrowserAnimationsModule,
-        SharedModule,
-        HttpClientTestingModule,
-        RouterTestingModule
-      ],
-      declarations: [RgwStorageClassDetailsComponent]
-    }).compileComponents();
+  configureTestBed({
+    imports: [BrowserAnimationsModule, SharedModule, HttpClientTestingModule, RouterTestingModule],
+    declarations: [RgwStorageClassDetailsComponent]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(RgwStorageClassDetailsComponent);
     component = fixture.componentInstance;
     component.selection = mockSelection;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -26,24 +27,24 @@ describe('RgwStorageClassFormComponent', () => {
   let fixture: ComponentFixture<RgwStorageClassFormComponent>;
   let router: Router;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [
-        BrowserAnimationsModule,
-        SharedModule,
-        HttpClientTestingModule,
-        RouterTestingModule,
-        ReactiveFormsModule,
-        GridModule,
-        InputModule,
-        CoreModule,
-        SelectModule,
-        ComboBoxModule,
-        CheckboxModule
-      ],
-      declarations: [RgwStorageClassFormComponent]
-    }).compileComponents();
+  configureTestBed({
+    imports: [
+      BrowserAnimationsModule,
+      SharedModule,
+      HttpClientTestingModule,
+      RouterTestingModule,
+      ReactiveFormsModule,
+      GridModule,
+      InputModule,
+      CoreModule,
+      SelectModule,
+      ComboBoxModule,
+      CheckboxModule
+    ],
+    declarations: [RgwStorageClassFormComponent]
+  });
 
+  beforeEach(async () => {
     spyOn(TestBed.inject(RgwZonegroupService), 'getAllZonegroupsInfo').and.returnValue(
       of({ zonegroups: [], default_zonegroup: '' })
     );

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-list/rgw-storage-class-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-list/rgw-storage-class-list.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { RgwStorageClassListComponent } from './rgw-storage-class-list.component';
@@ -11,13 +12,13 @@ describe('RgwStorageClassListComponent', () => {
   let component: RgwStorageClassListComponent;
   let fixture: ComponentFixture<RgwStorageClassListComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, SharedModule, RouterTestingModule],
-      providers: [NgbActiveModal],
-      declarations: [RgwStorageClassListComponent]
-    }).compileComponents();
+  configureTestBed({
+    imports: [HttpClientTestingModule, SharedModule, RouterTestingModule],
+    providers: [NgbActiveModal],
+    declarations: [RgwStorageClassListComponent]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(RgwStorageClassListComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-form/rgw-topic-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-form/rgw-topic-form.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RgwTopicFormComponent } from './rgw-topic-form.component';
 import { RgwTopicService } from '~/app/shared/api/rgw-topic.service';
@@ -32,34 +33,29 @@ describe('RgwTopicFormComponent', () => {
       }
     }
   };
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [RgwTopicFormComponent],
-      imports: [
-        ReactiveFormsModule,
-        RouterTestingModule,
-        HttpClientTestingModule,
-        SharedModule,
-        SelectModule,
-        GridModule,
-        InputModule
-      ],
-      providers: [
-        RgwTopicService,
-        TextAreaJsonFormatterService,
-        {
-          provide: ActionLabelsI18n,
-          useValue: { CREATE: 'Create', EDIT: 'Edit', Delete: 'Delete' }
-        },
-        {
-          provide: NotificationService,
-          useValue: mockNotificationService
-        },
-        { provide: 'Router', useValue: mockRouter },
-        { provide: 'ActivatedRoute', useValue: mockActivatedRoute }
-      ],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [RgwTopicFormComponent],
+    imports: [
+      ReactiveFormsModule,
+      RouterTestingModule,
+      HttpClientTestingModule,
+      SharedModule,
+      SelectModule,
+      GridModule,
+      InputModule
+    ],
+    providers: [
+      RgwTopicService,
+      TextAreaJsonFormatterService,
+      {
+        provide: ActionLabelsI18n,
+        useValue: { CREATE: 'Create', EDIT: 'Edit', Delete: 'Delete' }
+      },
+      { provide: NotificationService, useFactory: () => mockNotificationService },
+      { provide: 'Router', useValue: mockRouter },
+      { provide: 'ActivatedRoute', useValue: mockActivatedRoute }
+    ],
+    schemas: [NO_ERRORS_SCHEMA]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-list/rgw-topic-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-list/rgw-topic-list.component.spec.ts
@@ -21,17 +21,12 @@ describe('RgwTopicListComponent', () => {
     imports: [BrowserAnimationsModule, RouterTestingModule, HttpClientTestingModule, SharedModule]
   });
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [
-        BrowserAnimationsModule,
-        SharedModule,
-        HttpClientTestingModule,
-        RouterTestingModule
-      ],
-      declarations: [RgwTopicListComponent, RgwTopicResourceSidebarComponent]
-    }).compileComponents();
+  configureTestBed({
+    imports: [BrowserAnimationsModule, SharedModule, HttpClientTestingModule, RouterTestingModule],
+    declarations: [RgwTopicListComponent, RgwTopicResourceSidebarComponent]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(RgwTopicListComponent);
     component = fixture.componentInstance;
     rgwtTopicService = TestBed.inject(RgwTopicService);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-resource-page/rgw-topic-resource-page.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-resource-page/rgw-topic-resource-page.component.spec.ts
@@ -1,7 +1,8 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 
 import { ComponentsModule } from '~/app/shared/components/components.module';
@@ -11,10 +12,6 @@ import { RgwTopicService } from '~/app/shared/api/rgw-topic.service';
 import { Topic } from '~/app/shared/models/topic.model';
 
 describe('RgwTopicResourcePageComponent', () => {
-  let component: RgwTopicResourcePageComponent;
-  let fixture: ComponentFixture<RgwTopicResourcePageComponent>;
-  let rgwTopicServiceSpy: { getTopic: jest.Mock };
-
   const mockTopic: Topic = {
     name: 'test-topic',
     owner: 'test-user',
@@ -35,29 +32,27 @@ describe('RgwTopicResourcePageComponent', () => {
     key: 'test-key',
     opaqueData: ''
   };
+  let component: RgwTopicResourcePageComponent;
+  let fixture: ComponentFixture<RgwTopicResourcePageComponent>;
+  let rgwTopicServiceSpy: { getTopic: jest.Mock } = {
+    getTopic: jest.fn().mockReturnValue(of(mockTopic))
+  };
+
+  configureTestBed({
+    declarations: [RgwTopicResourcePageComponent],
+    imports: [ComponentsModule, HttpClientTestingModule, PipesModule, RouterTestingModule],
+    providers: [
+      { provide: RgwTopicService, useFactory: () => rgwTopicServiceSpy },
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          data: of({ section: 'overview' })
+        }
+      }
+    ]
+  });
 
   beforeEach(async () => {
-    rgwTopicServiceSpy = {
-      getTopic: jest.fn().mockReturnValue(of(mockTopic))
-    };
-
-    await TestBed.configureTestingModule({
-      declarations: [RgwTopicResourcePageComponent],
-      imports: [ComponentsModule, HttpClientTestingModule, PipesModule, RouterTestingModule],
-      providers: [
-        { provide: RgwTopicService, useValue: rgwTopicServiceSpy },
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            data: of({ section: 'overview' }),
-            parent: {
-              paramMap: of(convertToParamMap({ name: 'test-topic' }))
-            }
-          }
-        }
-      ]
-    }).compileComponents();
-
     fixture = TestBed.createComponent(RgwTopicResourcePageComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-resource-sidebar/rgw-topic-resource-sidebar.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-topic-resource-sidebar/rgw-topic-resource-sidebar.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, convertToParamMap } from '@angular/router';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
@@ -35,36 +36,36 @@ describe('RgwTopicResourceSidebarComponent', () => {
   let component: RgwTopicResourceSidebarComponent;
   let fixture: ComponentFixture<RgwTopicResourceSidebarComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [RgwTopicResourceSidebarComponent],
-      providers: [
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            paramMap: of(convertToParamMap({ name: 'topic:ownerName:testHttp' }))
-          }
-        },
-        {
-          provide: RgwTopicService,
-          useValue: {
-            getTopic: () =>
-              of({
-                name: 'testHttp',
-                owner: 'ownerName',
-                arn: 'arnValue',
-                dest: mockDestination,
-                policy: '{}',
-                key: 'topic:ownerName:testHttp',
-                opaqueData: 'test@12345',
-                subscribed_buckets: []
-              } as Topic)
-          }
+  configureTestBed({
+    declarations: [RgwTopicResourceSidebarComponent],
+    providers: [
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          paramMap: of(convertToParamMap({ name: 'topic:ownerName:testHttp' }))
         }
-      ],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
+      },
+      {
+        provide: RgwTopicService,
+        useValue: {
+          getTopic: () =>
+            of({
+              name: 'testHttp',
+              owner: 'ownerName',
+              arn: 'arnValue',
+              dest: mockDestination,
+              policy: '{}',
+              key: 'topic:ownerName:testHttp',
+              opaqueData: 'test@12345',
+              subscribed_buckets: []
+            } as Topic)
+        }
+      }
+    ],
+    schemas: [NO_ERRORS_SCHEMA]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(RgwTopicResourceSidebarComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-form/rgw-user-accounts-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-form/rgw-user-accounts-form.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed, fakeAsync, tick, flush } from '@angular/core/testing';
 
 import { RgwUserAccountsFormComponent } from './rgw-user-accounts-form.component';
@@ -24,22 +25,22 @@ describe('RgwUserAccountsFormComponent', () => {
   let fixture: ComponentFixture<RgwUserAccountsFormComponent>;
   let rgwUserAccountsService: MockRgwUserAccountsService;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [RgwUserAccountsFormComponent],
-      imports: [
-        ComponentsModule,
-        HttpClientTestingModule,
-        PipesModule,
-        RouterTestingModule.withRoutes([
-          { path: 'rgw/accounts', component: RgwUserAccountsComponent }
-        ]),
-        ModalModule,
-        ReactiveFormsModule
-      ],
-      providers: [{ provide: RgwUserAccountsService, useClass: MockRgwUserAccountsService }]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [RgwUserAccountsFormComponent],
+    imports: [
+      ComponentsModule,
+      HttpClientTestingModule,
+      PipesModule,
+      RouterTestingModule.withRoutes([
+        { path: 'rgw/accounts', component: RgwUserAccountsComponent }
+      ]),
+      ModalModule,
+      ReactiveFormsModule
+    ],
+    providers: [{ provide: RgwUserAccountsService, useClass: MockRgwUserAccountsService }]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(RgwUserAccountsFormComponent);
     rgwUserAccountsService = TestBed.inject(
       RgwUserAccountsService

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-resource-page/rgw-account-details.resolver.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-resource-page/rgw-account-details.resolver.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { TestBed } from '@angular/core/testing';
 import { convertToParamMap } from '@angular/router';
 import { of } from 'rxjs';
@@ -8,29 +9,29 @@ import { RgwAccountDetailsResolver } from './rgw-account-details.resolver';
 describe('RgwAccountDetailsResolver', () => {
   let resolver: RgwAccountDetailsResolver;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [
-        RgwAccountDetailsResolver,
-        {
-          provide: RgwUserAccountsService,
-          useValue: {
-            list: () =>
-              of([
-                {
-                  id: 'RGW11111111111111111',
-                  name: 'account1'
-                },
-                {
-                  id: 'RGW22222222222222222',
-                  name: 'account2'
-                }
-              ])
-          }
+  configureTestBed({
+    providers: [
+      RgwAccountDetailsResolver,
+      {
+        provide: RgwUserAccountsService,
+        useValue: {
+          list: () =>
+            of([
+              {
+                id: 'RGW11111111111111111',
+                name: 'account1'
+              },
+              {
+                id: 'RGW22222222222222222',
+                name: 'account2'
+              }
+            ])
         }
-      ]
-    });
+      }
+    ]
+  });
 
+  beforeEach(() => {
     resolver = TestBed.inject(RgwAccountDetailsResolver);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-resource-page/rgw-user-accounts-resource-page.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-resource-page/rgw-user-accounts-resource-page.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
@@ -10,54 +11,54 @@ describe('RgwUserAccountsResourcePageComponent', () => {
   let component: RgwUserAccountsResourcePageComponent;
   let fixture: ComponentFixture<RgwUserAccountsResourcePageComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [RgwUserAccountsResourcePageComponent],
-      providers: [
-        DimlessBinaryPipe,
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            parent: {
-              data: of({
-                account: {
-                  id: 'RGW11111111111111111',
-                  tenant: '',
-                  name: 'account1',
-                  email: 'account1@ceph.com',
-                  quota: {
-                    enabled: false,
-                    check_on_raw: false,
-                    max_size: -1,
-                    max_size_kb: -1,
-                    max_objects: -1
-                  },
-                  bucket_quota: {
-                    enabled: false,
-                    check_on_raw: false,
-                    max_size: -1,
-                    max_size_kb: -1,
-                    max_objects: -1
-                  },
-                  max_users: 1000,
-                  max_roles: 1000,
-                  max_groups: 1000,
-                  max_buckets: 1000,
-                  max_access_keys: 4
-                }
-              })
-            },
-            snapshot: {
-              data: {
-                section: 'overview'
+  configureTestBed({
+    declarations: [RgwUserAccountsResourcePageComponent],
+    providers: [
+      DimlessBinaryPipe,
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          parent: {
+            data: of({
+              account: {
+                id: 'RGW11111111111111111',
+                tenant: '',
+                name: 'account1',
+                email: 'account1@ceph.com',
+                quota: {
+                  enabled: false,
+                  check_on_raw: false,
+                  max_size: -1,
+                  max_size_kb: -1,
+                  max_objects: -1
+                },
+                bucket_quota: {
+                  enabled: false,
+                  check_on_raw: false,
+                  max_size: -1,
+                  max_size_kb: -1,
+                  max_objects: -1
+                },
+                max_users: 1000,
+                max_roles: 1000,
+                max_groups: 1000,
+                max_buckets: 1000,
+                max_access_keys: 4
               }
+            })
+          },
+          snapshot: {
+            data: {
+              section: 'overview'
             }
           }
         }
-      ],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
+      }
+    ],
+    schemas: [NO_ERRORS_SCHEMA]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(RgwUserAccountsResourcePageComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-resource-sidebar/rgw-user-accounts-resource-sidebar.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-resource-sidebar/rgw-user-accounts-resource-sidebar.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, convertToParamMap } from '@angular/router';
 import { of } from 'rxjs';
@@ -9,26 +10,26 @@ describe('RgwUserAccountsResourceSidebarComponent', () => {
   let component: RgwUserAccountsResourceSidebarComponent;
   let fixture: ComponentFixture<RgwUserAccountsResourceSidebarComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [RgwUserAccountsResourceSidebarComponent],
-      providers: [
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            paramMap: of(convertToParamMap({ accountName: 'account1' })),
-            data: of({
-              account: {
-                id: 'RGW11111111111111111',
-                name: 'account1'
-              }
-            })
-          }
+  configureTestBed({
+    declarations: [RgwUserAccountsResourceSidebarComponent],
+    providers: [
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          paramMap: of(convertToParamMap({ accountName: 'account1' })),
+          data: of({
+            account: {
+              id: 'RGW11111111111111111',
+              name: 'account1'
+            }
+          })
         }
-      ],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
+      }
+    ],
+    schemas: [NO_ERRORS_SCHEMA]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(RgwUserAccountsResourceSidebarComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts/rgw-user-accounts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts/rgw-user-accounts.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { RgwUserAccountsComponent } from './rgw-user-accounts.component';
@@ -10,12 +11,12 @@ describe('RgwUserAccountsComponent', () => {
   let component: RgwUserAccountsComponent;
   let fixture: ComponentFixture<RgwUserAccountsComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [RgwUserAccountsComponent],
-      imports: [ComponentsModule, HttpClientTestingModule, PipesModule, RouterTestingModule]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [RgwUserAccountsComponent],
+    imports: [ComponentsModule, HttpClientTestingModule, PipesModule, RouterTestingModule]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(RgwUserAccountsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/health-checks/health-checks.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/health-checks/health-checks.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HealthChecksComponent } from './health-checks.component';
@@ -9,13 +10,13 @@ describe('HealthChecksComponent', () => {
   let component: HealthChecksComponent;
   let fixture: ComponentFixture<HealthChecksComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [HealthChecksComponent, HealthColorPipe],
-      providers: [CssHelper],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [HealthChecksComponent, HealthColorPipe],
+    providers: [CssHelper],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(HealthChecksComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-form/smb-cluster-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-form/smb-cluster-form.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { SmbClusterFormComponent } from './smb-cluster-form.component';
@@ -17,22 +18,22 @@ describe('SmbClusterFormComponent', () => {
   let component: SmbClusterFormComponent;
   let fixture: ComponentFixture<SmbClusterFormComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [
-        BrowserAnimationsModule,
-        SharedModule,
-        HttpClientTestingModule,
-        RouterTestingModule,
-        ReactiveFormsModule,
-        GridModule,
-        InputModule,
-        SelectModule,
-        ComboBoxModule
-      ],
-      declarations: [SmbClusterFormComponent]
-    }).compileComponents();
+  configureTestBed({
+    imports: [
+      BrowserAnimationsModule,
+      SharedModule,
+      HttpClientTestingModule,
+      RouterTestingModule,
+      ReactiveFormsModule,
+      GridModule,
+      InputModule,
+      SelectModule,
+      ComboBoxModule
+    ],
+    declarations: [SmbClusterFormComponent]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(SmbClusterFormComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-list/smb-cluster-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-list/smb-cluster-list.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SmbClusterListComponent } from './smb-cluster-list.component';
@@ -10,17 +11,12 @@ describe('SmbClusterListComponent', () => {
   let component: SmbClusterListComponent;
   let fixture: ComponentFixture<SmbClusterListComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [
-        BrowserAnimationsModule,
-        SharedModule,
-        HttpClientTestingModule,
-        RouterTestingModule
-      ],
-      declarations: [SmbClusterListComponent]
-    }).compileComponents();
+  configureTestBed({
+    imports: [BrowserAnimationsModule, SharedModule, HttpClientTestingModule, RouterTestingModule],
+    declarations: [SmbClusterListComponent]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(SmbClusterListComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-tabs/smb-cluster-tabs.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-tabs/smb-cluster-tabs.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SmbClusterTabsComponent } from './smb-cluster-tabs.component';
@@ -6,11 +7,11 @@ describe('SmbClusterTabsComponent', () => {
   let component: SmbClusterTabsComponent;
   let fixture: ComponentFixture<SmbClusterTabsComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [SmbClusterTabsComponent]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [SmbClusterTabsComponent]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(SmbClusterTabsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-domain-setting-modal/smb-domain-setting-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-domain-setting-modal/smb-domain-setting-modal.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SmbDomainSettingModalComponent } from './smb-domain-setting-modal.component';
@@ -17,23 +18,23 @@ describe('SmbDomainSettingModalComponent', () => {
   let component: SmbDomainSettingModalComponent;
   let fixture: ComponentFixture<SmbDomainSettingModalComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [SmbDomainSettingModalComponent],
-      imports: [
-        SharedModule,
-        ReactiveFormsModule,
-        HttpClientTestingModule,
-        RouterTestingModule,
-        NgbTypeaheadModule,
-        ModalModule,
-        InputModule,
-        SelectModule
-      ],
-      schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA],
-      providers: [NgbActiveModal, { provide: 'domainSettingsObject', useValue: [[]] }]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [SmbDomainSettingModalComponent],
+    imports: [
+      SharedModule,
+      ReactiveFormsModule,
+      HttpClientTestingModule,
+      RouterTestingModule,
+      NgbTypeaheadModule,
+      ModalModule,
+      InputModule,
+      SelectModule
+    ],
+    schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA],
+    providers: [NgbActiveModal, { provide: 'domainSettingsObject', useValue: [[]] }]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(SmbDomainSettingModalComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-join-auth-form/smb-join-auth-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-join-auth-form/smb-join-auth-form.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SmbJoinAuthFormComponent } from './smb-join-auth-form.component';
@@ -27,13 +28,13 @@ describe('SmbJoinAuthFormComponent', () => {
   let createJoinAuth: jasmine.Spy;
   let getJoinAuth: jasmine.Spy;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [SharedModule, ReactiveFormsModule],
-      declarations: [SmbJoinAuthFormComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])]
-    }).compileComponents();
+  configureTestBed({
+    imports: [SharedModule, ReactiveFormsModule],
+    declarations: [SmbJoinAuthFormComponent],
+    providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(SmbJoinAuthFormComponent);
     component = fixture.componentInstance;
     component.ngOnInit();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-join-auth-list/smb-join-auth-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-join-auth-list/smb-join-auth-list.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SmbJoinAuthListComponent } from './smb-join-auth-list.component';
@@ -10,12 +11,12 @@ describe('SmbJoinAuthListComponent', () => {
   let component: SmbJoinAuthListComponent;
   let fixture: ComponentFixture<SmbJoinAuthListComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [SmbJoinAuthListComponent],
-      imports: [SharedModule, HttpClientTestingModule, RouterTestingModule]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [SmbJoinAuthListComponent],
+    imports: [SharedModule, HttpClientTestingModule, RouterTestingModule]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(SmbJoinAuthListComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-overview/smb-overview.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-overview/smb-overview.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SmbOverviewComponent } from './smb-overview.component';
@@ -9,13 +10,13 @@ describe('SmbOverviewComponent', () => {
   let component: SmbOverviewComponent;
   let fixture: ComponentFixture<SmbOverviewComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [SharedModule],
-      declarations: [SmbOverviewComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting()]
-    }).compileComponents();
+  configureTestBed({
+    imports: [SharedModule],
+    declarations: [SmbOverviewComponent],
+    providers: [provideHttpClient(), provideHttpClientTesting()]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(SmbOverviewComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SmbShareFormComponent } from './smb-share-form.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -21,25 +22,25 @@ describe('SmbShareFormComponent', () => {
   let component: SmbShareFormComponent;
   let fixture: ComponentFixture<SmbShareFormComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [
-        BrowserAnimationsModule,
-        SharedModule,
-        HttpClientTestingModule,
-        RouterTestingModule,
-        ReactiveFormsModule,
-        GridModule,
-        InputModule,
-        NumberModule,
-        SelectModule,
-        ComboBoxModule,
-        CheckboxModule
-      ],
-      declarations: [SmbShareFormComponent],
-      providers: [SmbService, TaskWrapperService]
-    }).compileComponents();
+  configureTestBed({
+    imports: [
+      BrowserAnimationsModule,
+      SharedModule,
+      HttpClientTestingModule,
+      RouterTestingModule,
+      ReactiveFormsModule,
+      GridModule,
+      InputModule,
+      NumberModule,
+      SelectModule,
+      ComboBoxModule,
+      CheckboxModule
+    ],
+    declarations: [SmbShareFormComponent],
+    providers: [SmbService, TaskWrapperService]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(SmbShareFormComponent);
     component = fixture.componentInstance;
     component.ngOnInit();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-list/smb-share-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-list/smb-share-list.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SmbShareListComponent } from './smb-share-list.component';
@@ -10,13 +11,13 @@ describe('SmbShareListComponent', () => {
   let component: SmbShareListComponent;
   let fixture: ComponentFixture<SmbShareListComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [SharedModule],
-      declarations: [SmbShareListComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting()]
-    }).compileComponents();
+  configureTestBed({
+    imports: [SharedModule],
+    declarations: [SmbShareListComponent],
+    providers: [provideHttpClient(), provideHttpClientTesting()]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(SmbShareListComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-tabs/smb-tabs.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-tabs/smb-tabs.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SmbTabsComponent } from './smb-tabs.component';
@@ -7,11 +8,11 @@ describe('SmbTabsComponent', () => {
   let component: SmbTabsComponent;
   let fixture: ComponentFixture<SmbTabsComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [SmbTabsComponent]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [SmbTabsComponent]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(SmbTabsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-usersgroups-details/smb-usersgroups-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-usersgroups-details/smb-usersgroups-details.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SmbUsersgroupsDetailsComponent } from './smb-usersgroups-details.component';
@@ -6,11 +7,11 @@ describe('SmbUsersgroupsDetailsComponent', () => {
   let component: SmbUsersgroupsDetailsComponent;
   let fixture: ComponentFixture<SmbUsersgroupsDetailsComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [SmbUsersgroupsDetailsComponent]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [SmbUsersgroupsDetailsComponent]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(SmbUsersgroupsDetailsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-usersgroups-form/smb-usersgroups-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-usersgroups-form/smb-usersgroups-form.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SmbUsersgroupsFormComponent } from './smb-usersgroups-form.component';
@@ -36,13 +37,13 @@ describe('SmbUsersgroupsFormComponent', () => {
   let createUsersGroups: jasmine.Spy;
   let getUsersGroups: jasmine.Spy;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [SharedModule, ReactiveFormsModule],
-      declarations: [SmbUsersgroupsFormComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])]
-    }).compileComponents();
+  configureTestBed({
+    imports: [SharedModule, ReactiveFormsModule],
+    declarations: [SmbUsersgroupsFormComponent],
+    providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(SmbUsersgroupsFormComponent);
     component = fixture.componentInstance;
     component.ngOnInit();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-usersgroups-list/smb-usersgroups-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-usersgroups-list/smb-usersgroups-list.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SmbUsersgroupsListComponent } from './smb-usersgroups-list.component';
@@ -10,12 +11,12 @@ describe('SmbUsersgroupsListComponent', () => {
   let component: SmbUsersgroupsListComponent;
   let fixture: ComponentFixture<SmbUsersgroupsListComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [SmbUsersgroupsListComponent],
-      imports: [SharedModule, HttpClientTestingModule, RouterTestingModule]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [SmbUsersgroupsListComponent],
+    imports: [SharedModule, HttpClientTestingModule, RouterTestingModule]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(SmbUsersgroupsListComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-footer/notification-footer.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-footer/notification-footer.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NotificationFooterComponent } from './notification-footer.component';
 import { NotificationService } from '~/app/shared/services/notification.service';
@@ -11,12 +12,10 @@ describe('NotificationFooterComponent', () => {
   let component: NotificationFooterComponent;
   let fixture: ComponentFixture<NotificationFooterComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [NotificationFooterComponent],
-      providers: [{ provide: NotificationService, useClass: MockNotificationService }],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [NotificationFooterComponent],
+    providers: [{ provide: NotificationService, useClass: MockNotificationService }],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-header/notification-header.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-header/notification-header.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NotificationHeaderComponent } from './notification-header.component';
 import { NotificationService } from '../../../../shared/services/notification.service';
@@ -8,25 +9,24 @@ describe('NotificationHeaderComponent', () => {
   let component: NotificationHeaderComponent;
   let fixture: ComponentFixture<NotificationHeaderComponent>;
   let notificationService: NotificationService;
-  let muteStateSubject: BehaviorSubject<boolean>;
+  let muteStateSubject: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+
+  configureTestBed({
+    declarations: [NotificationHeaderComponent],
+    imports: [ToggleModule, GridModule],
+    providers: [
+      {
+        provide: NotificationService,
+        useValue: {
+          muteState$: muteStateSubject.asObservable(),
+          removeAll: jasmine.createSpy('removeAll'),
+          suspendToasties: jasmine.createSpy('suspendToasties')
+        }
+      }
+    ]
+  });
 
   beforeEach(async () => {
-    muteStateSubject = new BehaviorSubject<boolean>(false);
-    await TestBed.configureTestingModule({
-      declarations: [NotificationHeaderComponent],
-      imports: [ToggleModule, GridModule],
-      providers: [
-        {
-          provide: NotificationService,
-          useValue: {
-            muteState$: muteStateSubject.asObservable(),
-            removeAll: jasmine.createSpy('removeAll'),
-            suspendToasties: jasmine.createSpy('suspendToasties')
-          }
-        }
-      ]
-    }).compileComponents();
-
     fixture = TestBed.createComponent(NotificationHeaderComponent);
     component = fixture.componentInstance;
     notificationService = TestBed.inject(NotificationService);

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-item/notification-item.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-item/notification-item.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -48,12 +49,10 @@ describe('NotificationItemComponent', () => {
   let hostComponent: TestHostComponent;
   let notificationService: NotificationService;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [SharedModule, HttpClientTestingModule],
-      declarations: [NotificationItemComponent, TestHostComponent],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA]
-    }).compileComponents();
+  configureTestBed({
+    imports: [SharedModule, HttpClientTestingModule],
+    declarations: [NotificationItemComponent, TestHostComponent],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-panel/notification-panel.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-panel/notification-panel.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NotificationPanelComponent } from './notification-panel.component';
 
@@ -5,10 +6,8 @@ describe('NotificationPanelComponent', () => {
   let component: NotificationPanelComponent;
   let fixture: ComponentFixture<NotificationPanelComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [NotificationPanelComponent]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [NotificationPanelComponent]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { Location } from '@angular/common';
@@ -21,8 +22,23 @@ describe('NotificationsPageComponent', () => {
   let dataSourceSubject: BehaviorSubject<CdNotification[]>;
   let readMapSubject: BehaviorSubject<Record<string, boolean>>;
   let notificationService: any;
-  let mockLocation: any;
+  let mockLocation: any = { back: jasmine.createSpy('back') };
   let queryParamsSubject: BehaviorSubject<any>;
+
+  const mockPrometheusAlertService = {
+    refresh: jasmine.createSpy('refresh')
+  };
+
+  const mockPrometheusNotificationService = {
+    refresh: jasmine.createSpy('refresh')
+  };
+
+  const mockAuthStorageService = {
+    getPermissions: jasmine.createSpy('getPermissions').and.returnValue({
+      prometheus: { read: false },
+      configOpt: { read: false }
+    })
+  };
 
   const createMockNotificationService = () => {
     dataSourceSubject = new BehaviorSubject<CdNotification[]>([]);
@@ -56,21 +72,6 @@ describe('NotificationsPageComponent', () => {
     };
   };
 
-  const mockPrometheusAlertService = {
-    refresh: jasmine.createSpy('refresh')
-  };
-
-  const mockPrometheusNotificationService = {
-    refresh: jasmine.createSpy('refresh')
-  };
-
-  const mockAuthStorageService = {
-    getPermissions: jasmine.createSpy('getPermissions').and.returnValue({
-      prometheus: { read: false },
-      configOpt: { read: false }
-    })
-  };
-
   const createMockNotification = (overrides: any): CdNotification => {
     return {
       id: overrides.id,
@@ -89,7 +90,36 @@ describe('NotificationsPageComponent', () => {
     } as CdNotification;
   };
 
-  beforeEach(async () => {
+  configureTestBed({
+    imports: [GridModule, IconModule, LinkModule, SharedModule],
+    declarations: [NotificationsPageComponent],
+    providers: [
+      {
+        provide: NotificationService,
+        useFactory: () => notificationService
+      },
+      { provide: PrometheusAlertService, useFactory: () => mockPrometheusAlertService },
+      {
+        provide: PrometheusNotificationService,
+        useFactory: () => mockPrometheusNotificationService
+      },
+      { provide: AuthStorageService, useFactory: () => mockAuthStorageService },
+      { provide: Location, useFactory: () => mockLocation },
+      {
+        provide: ActivatedRoute,
+        useFactory: () => ({
+          snapshot: { queryParams: {} },
+          queryParams: queryParamsSubject.asObservable()
+        })
+      }
+    ],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  });
+
+  beforeEach(() => {
+    localStorage.removeItem('cdNotificationsRead');
+    queryParamsSubject = new BehaviorSubject<any>({});
+
     mockNotifications = [
       createMockNotification({
         id: '1',
@@ -117,35 +147,8 @@ describe('NotificationsPageComponent', () => {
       })
     ];
 
-    mockLocation = { back: jasmine.createSpy('back') };
-    const mockNotificationService = createMockNotificationService();
-    notificationService = mockNotificationService;
-    queryParamsSubject = new BehaviorSubject<any>({});
+    notificationService = createMockNotificationService();
 
-    localStorage.removeItem('cdNotificationsRead');
-
-    await TestBed.configureTestingModule({
-      imports: [GridModule, IconModule, LinkModule, SharedModule],
-      declarations: [NotificationsPageComponent],
-      providers: [
-        { provide: NotificationService, useValue: mockNotificationService },
-        { provide: PrometheusAlertService, useValue: mockPrometheusAlertService },
-        { provide: PrometheusNotificationService, useValue: mockPrometheusNotificationService },
-        { provide: AuthStorageService, useValue: mockAuthStorageService },
-        { provide: Location, useValue: mockLocation },
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            snapshot: { queryParams: {} },
-            queryParams: queryParamsSubject.asObservable()
-          }
-        }
-      ],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA]
-    }).compileComponents();
-  });
-
-  beforeEach(() => {
     fixture = TestBed.createComponent(NotificationsPageComponent);
     component = fixture.componentInstance;
     dataSourceSubject.next(mockNotifications);
@@ -247,7 +250,7 @@ describe('NotificationsPageComponent', () => {
 
     it('should persist read state to localStorage via service', () => {
       component.onNotificationSelect(component.notifications()[0]);
-      const stored = JSON.parse(localStorage.getItem('cdNotificationsRead'));
+      const stored = JSON.parse(localStorage.getItem('cdNotificationsRead')!);
       expect(stored['1']).toBe(true);
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.spec.ts
@@ -26,7 +26,7 @@ describe('NotificationsComponent', () => {
   configureTestBed({
     imports: [HttpClientTestingModule],
     declarations: [NotificationsComponent],
-    providers: [{ provide: NotificationService, useValue: notificationServiceMock }],
+    providers: [{ provide: NotificationService, useFactory: () => notificationServiceMock }],
     schemas: [CUSTOM_ELEMENTS_SCHEMA]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs-subvolume-group.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs-subvolume-group.service.spec.ts
@@ -11,8 +11,9 @@ describe('CephfsSubvolumeGroupService', () => {
     providers: [CephfsSubvolumeGroupService]
   });
 
+  configureTestBed({});
+
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(CephfsSubvolumeGroupService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs-subvolume.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs-subvolume.service.spec.ts
@@ -13,8 +13,9 @@ describe('CephfsSubvolumeService', () => {
     providers: [CephfsSubvolumeService]
   });
 
+  configureTestBed({});
+
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(CephfsSubvolumeService);
     httpTesting = TestBed.inject(HttpTestingController);
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cluster.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cluster.service.spec.ts
@@ -13,8 +13,9 @@ describe('ClusterService', () => {
     providers: [ClusterService]
   });
 
+  configureTestBed({});
+
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(ClusterService);
     httpTesting = TestBed.inject(HttpTestingController);
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/directory-store.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/directory-store.service.spec.ts
@@ -12,8 +12,9 @@ describe('DirectoryStoreService', () => {
     providers: [CephfsService]
   });
 
+  configureTestBed({});
+
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(DirectoryStoreService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/hardware.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/hardware.service.spec.ts
@@ -12,8 +12,9 @@ describe('HardwareService', () => {
     imports: [HttpClientTestingModule]
   });
 
+  configureTestBed({});
+
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(HardwareService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/host.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/host.service.spec.ts
@@ -22,8 +22,8 @@ describe('HostService', () => {
   configureTestBed({
     providers: [
       HostService,
-      { provide: DeviceService, useValue: deviceServiceStub },
-      { provide: OrchestratorService, useValue: orchestratorServiceStub }
+      { provide: DeviceService, useFactory: () => deviceServiceStub },
+      { provide: OrchestratorService, useFactory: () => orchestratorServiceStub }
     ],
     imports: [HttpClientTestingModule]
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/multi-cluster.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/multi-cluster.service.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { TestBed } from '@angular/core/testing';
 
 import { MultiClusterService } from './multi-cluster.service';
@@ -5,10 +6,11 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 describe('MultiClusterService', () => {
   let service: MultiClusterService;
 
+  configureTestBed({
+    imports: [HttpClientTestingModule]
+  });
+
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule]
-    });
     service = TestBed.inject(MultiClusterService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
@@ -26,8 +26,8 @@ describe('NvmeofService', () => {
   configureTestBed({
     providers: [
       NvmeofService,
-      { provide: HostService, useValue: mockHostService },
-      { provide: OrchestratorService, useValue: mockOrchService }
+      { provide: HostService, useFactory: () => mockHostService },
+      { provide: OrchestratorService, useFactory: () => mockOrchService }
     ],
     imports: [HttpClientTestingModule]
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-card.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-card.service.spec.ts
@@ -12,17 +12,18 @@ describe('PerformanceCardService', () => {
     imports: [HttpClientTestingModule]
   });
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [
-        {
-          provide: PrometheusService,
-          useValue: {
-            getRangeQueriesData: jest.fn()
-          }
+  configureTestBed({
+    providers: [
+      {
+        provide: PrometheusService,
+        useValue: {
+          getRangeQueriesData: jest.fn()
         }
-      ]
-    });
+      }
+    ]
+  });
+
+  beforeEach(() => {
     service = TestBed.inject(PerformanceCardService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-realm.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-realm.service.spec.ts
@@ -11,8 +11,9 @@ describe('RgwRealmService', () => {
     imports: [HttpClientTestingModule]
   });
 
+  configureTestBed({});
+
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(RgwRealmService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-role.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-role.service.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
@@ -7,10 +8,11 @@ describe('RgwRoleService', () => {
   let service: RgwRoleService;
   let httpTesting: HttpTestingController;
 
+  configureTestBed({
+    imports: [HttpClientTestingModule]
+  });
+
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule]
-    });
     service = TestBed.inject(RgwRoleService);
     httpTesting = TestBed.inject(HttpTestingController);
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-storage-class.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-storage-class.service.spec.ts
@@ -14,8 +14,9 @@ describe('RgwStorageClassService', () => {
     providers: [RgwStorageClassService],
     imports: [HttpClientTestingModule]
   });
+  configureTestBed({});
+
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(RgwStorageClassService);
     httpTesting = TestBed.inject(HttpTestingController);
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user-accounts.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user-accounts.service.spec.ts
@@ -1,9 +1,9 @@
+import { configureTestBed, RgwHelper } from '~/testing/unit-test-helper';
 import { TestBed } from '@angular/core/testing';
 
 import { RgwUserAccountsService } from './rgw-user-accounts.service';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { Account } from '~/app/ceph/rgw/models/rgw-user-accounts';
-import { RgwHelper } from '~/testing/unit-test-helper';
 
 const mockAccountData: Account[] = [
   {
@@ -62,11 +62,12 @@ describe('RgwUserAccountsService', () => {
   let service: RgwUserAccountsService;
   let httpTesting: HttpTestingController;
 
+  configureTestBed({
+    providers: [RgwUserAccountsService],
+    imports: [HttpClientTestingModule]
+  });
+
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [RgwUserAccountsService],
-      imports: [HttpClientTestingModule]
-    });
     service = TestBed.inject(RgwUserAccountsService);
     httpTesting = TestBed.inject(HttpTestingController);
     RgwHelper.selectDaemon();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-zone.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-zone.service.spec.ts
@@ -11,8 +11,9 @@ describe('RgwZoneService', () => {
     imports: [HttpClientTestingModule]
   });
 
+  configureTestBed({});
+
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(RgwZoneService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-zonegroup.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-zonegroup.service.spec.ts
@@ -11,8 +11,9 @@ describe('RgwZonegroupService', () => {
     imports: [HttpClientTestingModule]
   });
 
+  configureTestBed({});
+
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(RgwZonegroupService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/smb.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/smb.service.spec.ts
@@ -25,8 +25,9 @@ describe('SmbService', () => {
     imports: [SharedModule]
   });
 
+  configureTestBed({});
+
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(SmbService);
     httpTesting = TestBed.inject(HttpTestingController);
     notificationShowSpy = spyOn(TestBed.inject(NotificationService), 'show');

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/storage-overview.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/storage-overview.service.spec.ts
@@ -25,8 +25,8 @@ describe('OverviewStorageService', () => {
   configureTestBed({
     imports: [HttpClientTestingModule],
     providers: [
-      { provide: PrometheusService, useValue: prometheusServiceMock },
-      { provide: FormatterService, useValue: formatterServiceMock }
+      { provide: PrometheusService, useFactory: () => prometheusServiceMock },
+      { provide: FormatterService, useFactory: () => formatterServiceMock }
     ]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/area-chart/area-chart.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/area-chart/area-chart.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CUSTOM_ELEMENTS_SCHEMA, SimpleChange } from '@angular/core';
 import { DatePipe } from '@angular/common';
@@ -22,30 +23,33 @@ describe('AreaChartComponent', () => {
     }
   ];
 
+  const numberFormatterMock = {
+    formatFromTo: jest.fn().mockReturnValue('1.00'),
+    bytesPerSecondLabels: [
+      'B/s',
+      'KiB/s',
+      'MiB/s',
+      'GiB/s',
+      'TiB/s',
+      'PiB/s',
+      'EiB/s',
+      'ZiB/s',
+      'YiB/s'
+    ],
+    bytesLabels: ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'YiB'],
+    unitlessLabels: ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
+  };
+
+  configureTestBed({
+    imports: [ChartsModule, AreaChartComponent],
+    providers: [
+      DatePipe,
+      { provide: NumberFormatterService, useFactory: () => numberFormatterMock }
+    ],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  });
+
   beforeEach(async () => {
-    const numberFormatterMock = {
-      formatFromTo: jest.fn().mockReturnValue('1.00'),
-      bytesPerSecondLabels: [
-        'B/s',
-        'KiB/s',
-        'MiB/s',
-        'GiB/s',
-        'TiB/s',
-        'PiB/s',
-        'EiB/s',
-        'ZiB/s',
-        'YiB/s'
-      ],
-      bytesLabels: ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'YiB'],
-      unitlessLabels: ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
-    };
-
-    await TestBed.configureTestingModule({
-      imports: [ChartsModule, AreaChartComponent],
-      providers: [DatePipe, { provide: NumberFormatterService, useValue: numberFormatterMock }],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA]
-    }).compileComponents();
-
     fixture = TestBed.createComponent(AreaChartComponent);
     component = fixture.componentInstance;
     numberFormatterService = TestBed.inject(NumberFormatterService);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/card-group/card-group.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/card-group/card-group.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CardGroupComponent } from './card-group.component';
@@ -6,11 +7,11 @@ describe('CardGroupComponent', () => {
   let component: CardGroupComponent;
   let fixture: ComponentFixture<CardGroupComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [CardGroupComponent]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [CardGroupComponent]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(CardGroupComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/certificate-authority-form/certificate-authority-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/certificate-authority-form/certificate-authority-form.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { expect as jestExpect } from '@jest/globals';
@@ -11,11 +12,11 @@ describe('CertificateAuthorityFormComponent', () => {
   let fixture: ComponentFixture<CertificateAuthorityFormComponent>;
   let formBuilder: CdFormBuilder;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [ReactiveFormsModule, CertificateAuthorityFormComponent]
-    }).compileComponents();
+  configureTestBed({
+    imports: [ReactiveFormsModule, CertificateAuthorityFormComponent]
+  });
 
+  beforeEach(async () => {
     formBuilder = new CdFormBuilder();
     fixture = TestBed.createComponent(CertificateAuthorityFormComponent);
     component = fixture.componentInstance;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/details-card/details-card.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/details-card/details-card.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { DetailsCardComponent } from './details-card.component';
@@ -7,12 +8,12 @@ describe('DetailsCardComponent', () => {
   let component: DetailsCardComponent;
   let fixture: ComponentFixture<DetailsCardComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [DetailsCardComponent],
-      imports: [ProductiveCardComponent]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [DetailsCardComponent],
+    imports: [ProductiveCardComponent]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(DetailsCardComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/empty-state/empty-state.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/empty-state/empty-state.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { EmptyStateComponent } from './empty-state.component';
@@ -7,11 +8,11 @@ describe('ProductiveCardComponent', () => {
   let component: EmptyStateComponent;
   let fixture: ComponentFixture<EmptyStateComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [EmptyStateComponent, GridModule, LayerModule, TilesModule]
-    }).compileComponents();
+  configureTestBed({
+    imports: [EmptyStateComponent, GridModule, LayerModule, TilesModule]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(EmptyStateComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-advanced-fieldset/form-advanced-fieldset.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-advanced-fieldset/form-advanced-fieldset.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FormAdvancedFieldsetComponent } from './form-advanced-fieldset.component';
@@ -7,12 +8,12 @@ describe('FormAdvancedFieldsetComponent', () => {
   let component: FormAdvancedFieldsetComponent;
   let fixture: ComponentFixture<FormAdvancedFieldsetComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [FormAdvancedFieldsetComponent],
-      schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [FormAdvancedFieldsetComponent],
+    schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(FormAdvancedFieldsetComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/help-text/help-text.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/help-text/help-text.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HelpTextComponent } from './help-text.component';
@@ -6,11 +7,11 @@ describe('HelpTextComponent', () => {
   let component: HelpTextComponent;
   let fixture: ComponentFixture<HelpTextComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [HelpTextComponent]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [HelpTextComponent]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(HelpTextComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/inline-message/inline-message.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/inline-message/inline-message.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { InlineMessageComponent } from './inline-message.component';
 import { ButtonModule, IconModule, LayoutModule } from 'carbon-components-angular';
@@ -5,12 +6,12 @@ import { ButtonModule, IconModule, LayoutModule } from 'carbon-components-angula
 describe('InlineMessageComponent', () => {
   let component: InlineMessageComponent;
   let fixture: ComponentFixture<InlineMessageComponent>;
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [InlineMessageComponent],
-      imports: [LayoutModule, IconModule, ButtonModule]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [InlineMessageComponent],
+    imports: [LayoutModule, IconModule, ButtonModule]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(InlineMessageComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.spec.ts
@@ -30,11 +30,11 @@ describe('ToastComponent', () => {
     providers: [
       {
         provide: NotificationService,
-        useValue: mockNotificationService
+        useFactory: () => mockNotificationService
       },
       {
         provide: Router,
-        useValue: mockRouter
+        useFactory: () => mockRouter
       }
     ]
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/page-header/page-header.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/page-header/page-header.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
@@ -7,12 +8,12 @@ describe('PageHeaderComponent', () => {
   let component: PageHeaderComponent;
   let fixture: ComponentFixture<PageHeaderComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [PageHeaderComponent],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [PageHeaderComponent],
+    schemas: [NO_ERRORS_SCHEMA]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(PageHeaderComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/performance-card/performance-card.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/performance-card/performance-card.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { PerformanceCardComponent } from './performance-card.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -22,51 +23,51 @@ describe('PerformanceCardComponent', () => {
     ]
   };
 
+  const prometheusServiceMock = {
+    lastHourDateObject: { start: 1000, end: 2000, step: 14 }
+  };
+
+  const performanceCardServiceMock = {
+    getChartData: jest.fn().mockReturnValue(of(mockChartData))
+  };
+
+  const numberFormatterMock = {
+    formatFromTo: jest.fn().mockReturnValue('1.00'),
+    bytesPerSecondLabels: [
+      'B/s',
+      'KiB/s',
+      'MiB/s',
+      'GiB/s',
+      'TiB/s',
+      'PiB/s',
+      'EiB/s',
+      'ZiB/s',
+      'YiB/s'
+    ],
+    bytesLabels: ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'YiB'],
+    unitlessLabels: ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
+  };
+
+  const datePipeMock = {
+    transform: jest.fn().mockReturnValue('01 Jan, 00:00:00')
+  };
+
+  const authStorageServiceMock = {
+    getPermissions: jest.fn().mockReturnValue(new Permissions({ 'config-opt': ['read'] }))
+  };
+
+  configureTestBed({
+    imports: [HttpClientTestingModule, PerformanceCardComponent],
+    providers: [
+      { provide: PrometheusService, useFactory: () => prometheusServiceMock },
+      { provide: PerformanceCardService, useFactory: () => performanceCardServiceMock },
+      { provide: NumberFormatterService, useFactory: () => numberFormatterMock },
+      { provide: DatePipe, useFactory: () => datePipeMock },
+      { provide: AuthStorageService, useFactory: () => authStorageServiceMock }
+    ]
+  });
+
   beforeEach(async () => {
-    const prometheusServiceMock = {
-      lastHourDateObject: { start: 1000, end: 2000, step: 14 }
-    };
-
-    const performanceCardServiceMock = {
-      getChartData: jest.fn().mockReturnValue(of(mockChartData))
-    };
-
-    const numberFormatterMock = {
-      formatFromTo: jest.fn().mockReturnValue('1.00'),
-      bytesPerSecondLabels: [
-        'B/s',
-        'KiB/s',
-        'MiB/s',
-        'GiB/s',
-        'TiB/s',
-        'PiB/s',
-        'EiB/s',
-        'ZiB/s',
-        'YiB/s'
-      ],
-      bytesLabels: ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'YiB'],
-      unitlessLabels: ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
-    };
-
-    const datePipeMock = {
-      transform: jest.fn().mockReturnValue('01 Jan, 00:00:00')
-    };
-
-    const authStorageServiceMock = {
-      getPermissions: jest.fn().mockReturnValue(new Permissions({ 'config-opt': ['read'] }))
-    };
-
-    await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, PerformanceCardComponent],
-      providers: [
-        { provide: PrometheusService, useValue: prometheusServiceMock },
-        { provide: PerformanceCardService, useValue: performanceCardServiceMock },
-        { provide: NumberFormatterService, useValue: numberFormatterMock },
-        { provide: DatePipe, useValue: datePipeMock },
-        { provide: AuthStorageService, useValue: authStorageServiceMock }
-      ]
-    }).compileComponents();
-
     fixture = TestBed.createComponent(PerformanceCardComponent);
     component = fixture.componentInstance;
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/pie-chart/pie-chart.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/pie-chart/pie-chart.component.spec.ts
@@ -1,8 +1,8 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { PieChartComponent } from './pie-chart.component';
 import { ChartsModule } from '@carbon/charts-angular';
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy } from '@angular/core';
 import { By } from '@angular/platform-browser';
 
 describe('PieChartComponent', () => {
@@ -14,16 +14,11 @@ describe('PieChartComponent', () => {
     { group: 'B', value: 70 }
   ];
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [PieChartComponent, ChartsModule, CommonModule]
-    })
-      // disable OnPush for test environment
-      .overrideComponent(PieChartComponent, {
-        set: { changeDetection: ChangeDetectionStrategy.Default }
-      })
-      .compileComponents();
+  configureTestBed({
+    imports: [PieChartComponent, ChartsModule, CommonModule]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(PieChartComponent);
     component = fixture.componentInstance;
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/productive-card/productive-card.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/productive-card/productive-card.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ProductiveCardComponent } from './productive-card.component';
@@ -7,11 +8,11 @@ describe('ProductiveCardComponent', () => {
   let component: ProductiveCardComponent;
   let fixture: ComponentFixture<ProductiveCardComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [ProductiveCardComponent, GridModule, LayerModule, TilesModule]
-    }).compileComponents();
+  configureTestBed({
+    imports: [ProductiveCardComponent, GridModule, LayerModule, TilesModule]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(ProductiveCardComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/progress/progress.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/progress/progress.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ProgressComponent } from './progress.component';
@@ -7,12 +8,12 @@ describe('ProgressComponent', () => {
   let component: ProgressComponent;
   let fixture: ComponentFixture<ProgressComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ProgressComponent],
-      schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [ProgressComponent],
+    schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(ProgressComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/resource-overview-card/resource-overview-card.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/resource-overview-card/resource-overview-card.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { beforeEach, describe, expect, it } from '@jest/globals';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -10,13 +11,13 @@ describe('OverviewComponent', () => {
   let component: OverviewComponent;
   let fixture: ComponentFixture<OverviewComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [OverviewComponent],
-      imports: [PipesModule],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [OverviewComponent],
+    imports: [PipesModule],
+    schemas: [NO_ERRORS_SCHEMA]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(OverviewComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/setup-step-card/setup-step-card.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/setup-step-card/setup-step-card.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SetupStepCardComponent } from './setup-step-card.component';
@@ -11,11 +12,11 @@ describe('SetupStepCardComponent', () => {
   const SUCCESS_MESSAGE = 'Example configured successfully.';
   const INFO_MESSAGE = 'Example not configured yet.';
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [SetupStepCardComponent]
-    }).compileComponents();
+  configureTestBed({
+    imports: [SetupStepCardComponent]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(SetupStepCardComponent);
     component = fixture.componentInstance;
     component.stepNumber = 1;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/sidebar-layout/sidebar-layout.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/sidebar-layout/sidebar-layout.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { SideNavModule, ThemeModule } from 'carbon-components-angular';
@@ -7,11 +8,9 @@ describe('SidebarLayoutComponent', () => {
   let component: SidebarLayoutComponent;
   let fixture: ComponentFixture<SidebarLayoutComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [SidebarLayoutComponent],
-      imports: [RouterTestingModule, SideNavModule, ThemeModule]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [SidebarLayoutComponent],
+    imports: [RouterTestingModule, SideNavModule, ThemeModule]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component, ViewChild } from '@angular/core';
 import { By } from '@angular/platform-browser';
@@ -52,17 +53,15 @@ describe('TearsheetComponent', () => {
   let hostComponent: MockHostComponent;
   let tearsheetComponent: TearsheetComponent;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [TearsheetComponent, TearsheetStepComponent, MockHostComponent],
-      imports: [SharedModule],
-      providers: [
-        {
-          provide: ActivatedRoute,
-          useValue: { outlet: 'modal' }
-        }
-      ]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [TearsheetComponent, TearsheetStepComponent, MockHostComponent],
+    imports: [SharedModule],
+    providers: [
+      {
+        provide: ActivatedRoute,
+        useValue: { outlet: 'modal' }
+      }
+    ]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/text-label-list/text-label-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/text-label-list/text-label-list.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TextLabelListComponent } from './text-label-list.component';
 import { By } from '@angular/platform-browser';
@@ -6,11 +7,11 @@ describe('TextLabelListComponent', () => {
   let component: TextLabelListComponent;
   let fixture: ComponentFixture<TextLabelListComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [TextLabelListComponent]
-    }).compileComponents();
+  configureTestBed({
+    imports: [TextLabelListComponent]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(TextLabelListComponent);
     component = fixture.componentInstance;
     component.registerOnChange(jasmine.createSpy('onChange'));

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.spec.ts
@@ -17,7 +17,7 @@ describe('UsageBarComponent', () => {
   configureTestBed({
     imports: [PipesModule, NgbTooltipModule],
     declarations: [UsageBarComponent],
-    providers: [{ provide: ElementRef, useValue: mockElementRef }, CssHelper]
+    providers: [{ provide: ElementRef, useFactory: () => mockElementRef }, CssHelper]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/vertical-navigation/vertical-navigation.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/vertical-navigation/vertical-navigation.component.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { VerticalNavigationComponent } from './vertical-navigation.component';
@@ -7,11 +8,11 @@ describe('VerticalNavigationComponent', () => {
   let component: VerticalNavigationComponent;
   let fixture: ComponentFixture<VerticalNavigationComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [VerticalNavigationComponent]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [VerticalNavigationComponent]
+  });
 
+  beforeEach(async () => {
     fixture = TestBed.createComponent(VerticalNavigationComponent);
     component = fixture.componentInstance;
     component.items = ['item1', 'item2', 'item3'];

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/dynamic-input-combobox.directive.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/dynamic-input-combobox.directive.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { DEBOUNCE_TIMER, DynamicInputComboboxDirective } from './dynamic-input-combobox.directive';
 import { Subject } from 'rxjs';
@@ -22,11 +23,11 @@ describe('DynamicInputComboboxDirective', () => {
   let fixture: ComponentFixture<MockComponent>;
   let directive: DynamicInputComboboxDirective;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [DynamicInputComboboxDirective, MockComponent]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [DynamicInputComboboxDirective, MockComponent]
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(MockComponent);
 
     directive = fixture.debugElement.children[0].injector.get(DynamicInputComboboxDirective);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/stateful-tab.directive.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/stateful-tab.directive.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { NgbNav, NgbNavChangeEvent } from '@ng-bootstrap/ng-bootstrap';
 import { CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA } from '@angular/core';
 
@@ -9,12 +10,10 @@ class NgbNavMock {
 }
 
 describe('StatefulTabDirective', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [StatefulTabDirective],
-      providers: [{ provide: NgbNav, useClass: NgbNavMock }],
-      schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [StatefulTabDirective],
+    providers: [{ provide: NgbNav, useClass: NgbNavMock }],
+    schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA]
   });
 
   it('should create an instance', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/validate.directive.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/validate.directive.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { Component, DebugElement, ChangeDetectionStrategy } from '@angular/core';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -45,11 +46,9 @@ describe('ValidateDirective', () => {
   let formGroupDir: FormGroupDirective;
   let control: FormControl;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ValidateDirective, TestHostComponent],
-      imports: [ReactiveFormsModule]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [ValidateDirective, TestHostComponent],
+    imports: [ReactiveFormsModule]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/cd-table-server-side.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/cd-table-server-side.service.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { TestBed } from '@angular/core/testing';
 
 import { CdTableServerSideService } from './cd-table-server-side.service';
@@ -5,8 +6,9 @@ import { CdTableServerSideService } from './cd-table-server-side.service';
 describe('CdTableServerSideService', () => {
   let service: CdTableServerSideService;
 
+  configureTestBed({});
+
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(CdTableServerSideService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/combo-box.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/combo-box.service.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { TestBed } from '@angular/core/testing';
 
 import { ComboBoxService } from './combo-box.service';
@@ -5,8 +6,9 @@ import { ComboBoxService } from './combo-box.service';
 describe('ComboBoxService', () => {
   let service: ComboBoxService;
 
+  configureTestBed({});
+
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(ComboBoxService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/cookie.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/cookie.service.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { TestBed } from '@angular/core/testing';
 
 import { CookiesService } from './cookie.service';
@@ -5,8 +6,9 @@ import { CookiesService } from './cookie.service';
 describe('CookieService', () => {
   let service: CookiesService;
 
+  configureTestBed({});
+
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(CookiesService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/crud-form-adapter.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/crud-form-adapter.service.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { TestBed } from '@angular/core/testing';
 
 import { CrudFormAdapterService } from './crud-form-adapter.service';
@@ -6,10 +7,11 @@ import { RouterTestingModule } from '@angular/router/testing';
 describe('CrudFormAdapterService', () => {
   let service: CrudFormAdapterService;
 
+  configureTestBed({
+    imports: [RouterTestingModule]
+  });
+
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [RouterTestingModule]
-    });
     service = TestBed.inject(CrudFormAdapterService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/data-gateway.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/data-gateway.service.spec.ts
@@ -1,17 +1,16 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 /* tslint:disable:no-unused-variable */
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { inject, TestBed } from '@angular/core/testing';
+import { inject } from '@angular/core/testing';
 
 import { DataGatewayService } from './data-gateway.service';
 import { RouterTestingModule } from '@angular/router/testing';
 
 describe('Service: DataGateway', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [DataGatewayService]
-    });
+  configureTestBed({
+    imports: [HttpClientTestingModule, RouterTestingModule],
+    providers: [DataGatewayService]
   });
 
   it('should ...', inject([DataGatewayService], (service: DataGatewayService) => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/device.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/device.service.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { TestBed } from '@angular/core/testing';
 
 import moment from 'moment';
@@ -8,8 +9,9 @@ import { DeviceService } from './device.service';
 describe('DeviceService', () => {
   let service: DeviceService;
 
+  configureTestBed({});
+
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(DeviceService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/json-to-xml.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/json-to-xml.service.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { TestBed } from '@angular/core/testing';
 
 import { JsonToXmlService } from './json-to-xml.service';
@@ -5,8 +6,9 @@ import { JsonToXmlService } from './json-to-xml.service';
 describe('JsonToXmlService', () => {
   let service: JsonToXmlService;
 
+  configureTestBed({});
+
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(JsonToXmlService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.spec.ts
@@ -59,7 +59,7 @@ describe('ModuleStatusGuardService', () => {
     imports: [RouterTestingModule.withRoutes(routes), SharedModule],
     providers: [
       ModuleStatusGuardService,
-      { provide: HttpClient, useValue: fakeService },
+      { provide: HttpClient, useFactory: () => fakeService },
       CdDatePipe
     ],
     declarations: [FooComponent]

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/number-formatter.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/number-formatter.service.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { TestBed } from '@angular/core/testing';
 
 import { NumberFormatterService } from './number-formatter.service';
@@ -5,8 +6,9 @@ import { NumberFormatterService } from './number-formatter.service';
 describe('FormatToService', () => {
   let service: NumberFormatterService;
 
+  configureTestBed({});
+
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(NumberFormatterService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/rbd-image-resource-state.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/rbd-image-resource-state.service.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { TestBed } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
 import { take } from 'rxjs/operators';
@@ -11,14 +12,17 @@ describe('RbdImageResourceStateService', () => {
   let service: RbdImageResourceStateService;
   let rbdServiceSpy: any;
 
+  configureTestBed({
+    providers: [
+      RbdImageResourceStateService,
+      { provide: RbdService, useFactory: () => rbdServiceSpy }
+    ]
+  });
+
   beforeEach(() => {
     rbdServiceSpy = {
       get: jest.fn()
     };
-
-    TestBed.configureTestingModule({
-      providers: [RbdImageResourceStateService, { provide: RbdService, useValue: rbdServiceSpy }]
-    });
 
     service = TestBed.inject(RbdImageResourceStateService);
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.spec.ts
@@ -37,7 +37,7 @@ describe('SummaryService', () => {
     providers: [
       SummaryService,
       AuthStorageService,
-      { provide: HttpClient, useValue: httpClientSpy }
+      { provide: HttpClient, useFactory: () => httpClientSpy }
     ]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/text-area-json-formatter.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/text-area-json-formatter.service.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { TestBed } from '@angular/core/testing';
 
 import { TextAreaJsonFormatterService } from './text-area-json-formatter.service';
@@ -5,8 +6,9 @@ import { TextAreaJsonFormatterService } from './text-area-json-formatter.service
 describe('TextAreaJsonFormatterService', () => {
   let service: TextAreaJsonFormatterService;
 
+  configureTestBed({});
+
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(TextAreaJsonFormatterService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/text-area-xml-formatter.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/text-area-xml-formatter.service.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { TestBed } from '@angular/core/testing';
 
 import { TextAreaXmlFormatterService } from './text-area-xml-formatter.service';
@@ -5,8 +6,9 @@ import { TextAreaXmlFormatterService } from './text-area-xml-formatter.service';
 describe('TextAreaXmlFormatterService', () => {
   let service: TextAreaXmlFormatterService;
 
+  configureTestBed({});
+
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(TextAreaXmlFormatterService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/tree-view.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/tree-view.service.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { TestBed } from '@angular/core/testing';
 
 import { TreeViewService } from './tree-view.service';
@@ -7,8 +8,9 @@ import _ from 'lodash';
 describe('TreeViewService', () => {
   let service: TreeViewService;
 
+  configureTestBed({});
+
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(TreeViewService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/wizard-steps.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/wizard-steps.service.spec.ts
@@ -1,3 +1,4 @@
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { TestBed } from '@angular/core/testing';
 
 import { WizardStepsService } from './wizard-steps.service';
@@ -5,8 +6,9 @@ import { WizardStepsService } from './wizard-steps.service';
 describe('WizardStepsService', () => {
   let service: WizardStepsService;
 
+  configureTestBed({});
+
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(WizardStepsService);
   });
 


### PR DESCRIPTION
In our make check I saw the dashboard unit tests takes awefully longer to finish, infact its one of the last one to finish which almost takes around 45m on average which is not good for a unit test.

```
341/341 Test #213: mgr-dashboard-frontend-unittests ..........   Passed  2791.34 sec
```
and the above translates to exactly 45m which is an example from one of the run.

so trying to address it with

- use configureTestBed helper instead of creating Testbed for each suite which creates and destroys things on every test suite.
- remove `detectOpenHandles` from jest ci. not meant for CI. used for debugging mostly.
- add `runInBand` so that jest run in a single thread so that it doesnt context switch a lot.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
