### PR TITLE
  doc/cephfs: fix broken :doc: reference to cephadm mds service page

### DIFF
--- a/doc/cephfs/add-remove-mds.rst
+++ b/doc/cephfs/add-remove-mds.rst
@@ -6,7 +6,7 @@
    instructions on this page.
 
 .. note:: If you are certain that you know what you are doing and you intend to
-   manually deploy MDS daemons, see :doc:`/cephadm/services/mds/` before
+   manually deploy MDS daemons, see :doc:`/cephadm/services/mds` before
    proceeding.
 
 ============================


### PR DESCRIPTION
 The note in `doc/cephfs/add-remove-mds.rst` links to
  `:doc:`/cephadm/services/mds/`` (with a trailing slash), which Sphinx
  resolves as a directory reference and looks for
  `cephadm/services/mds/index.rst`. That file doesn't exist — `mds` is a
  single page at `doc/cephadm/services/mds.rst`, not a directory — so the
  cross-reference is broken.
  
  This PR removes the trailing slash so the reference correctly resolves
  to the existing `mds.rst` page.
  
  Signed-off-by: Manjunatha MB <mmanjuna@redhat.com>
  ## Checklist
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)

  ## Component Impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs tracking

  ## Documentation
  - [x] Updates relevant documentation
  - [ ] No doc update appropriate

  ## Tests
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Bug fix tracker ticket has a regression test
  - [x] No tests