### PR TITLE
mgr: rate-limit repetitive CherryPy access logs 

### DIFF
--- a/src/pybind/mgr/cherrypy_mgr.py
+++ b/src/pybind/mgr/cherrypy_mgr.py
@@ -33,6 +33,9 @@ Usage:
 """
 import logging
 import cherrypy
+import re
+import threading
+import time
 from cherrypy.process.servers import ServerAdapter
 from cheroot.wsgi import Server as WSGIServer
 from cheroot.ssl.builtin import BuiltinSSLAdapter
@@ -40,6 +43,42 @@ from cherrypy._cptree import Tree
 from typing import Any, Tuple, Optional, Dict
 
 logger = logging.getLogger(__name__)
+
+
+class CherryPyAccessFilter(logging.Filter):
+    """Rate-limits access log to one entry per endpoint per 300 s.
+    Non-200 responses always pass through."""
+    _PATH_RE = re.compile(r'"[A-Z]+\s+(/[^\s]*)')
+
+    def __init__(self, interval: float = 300.0) -> None:
+        super().__init__()
+        self.interval = interval
+        self._last: Dict[str, float] = {}
+        self._calls = 0
+        self._lock = threading.Lock()
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if not record.name.startswith('cherrypy.access'):
+            return True
+        msg = record.getMessage()
+        if '" 200 ' not in msg:
+            return True
+        m = self._PATH_RE.search(msg)
+        key = m.group(1) if m else msg
+        now = time.monotonic()
+        with self._lock:
+            self._calls += 1
+            if self._calls % 500 == 0:
+                cutoff = now - self.interval
+                self._last = {
+                    path: ts for path, ts in self._last.items()
+                    if ts >= cutoff
+                }
+            last = self._last.get(key)
+            if last is not None and now - last < self.interval:
+                return False
+            self._last[key] = now
+        return True
 
 
 class CherryPyErrorFilter(logging.Filter):
@@ -128,7 +167,7 @@ class CherryPyMgr:
 
     @staticmethod
     def configure_logging() -> None:
-        cherrypy.log.access_log.propagate = False
+        cherrypy.log.access_log.propagate = True
         cherrypy.log.error_log.propagate = False
 
         error_log = logging.getLogger('cherrypy.error')
@@ -137,6 +176,14 @@ class CherryPyMgr:
         has_filter = any(isinstance(f, CherryPyErrorFilter) for f in error_log.filters)
         if not has_filter:
             error_log.addFilter(CherryPyErrorFilter())
+
+        access_filter = CherryPyAccessFilter()
+
+        root_log = logging.getLogger()
+
+        for handler in root_log.handlers:
+            if not any(isinstance(f, CherryPyAccessFilter) for f in handler.filters):
+                handler.addFilter(access_filter)
 
     @staticmethod
     def create_adapter(

--- a/src/pybind/mgr/tests/test_cherrypy_mgr.py
+++ b/src/pybind/mgr/tests/test_cherrypy_mgr.py
@@ -2,8 +2,73 @@ import unittest
 from unittest import mock
 import cherrypy
 import cherrypy_mgr
+import logging
 
-from cherrypy_mgr import CherryPyMgr
+from cherrypy_mgr import CherryPyMgr, CherryPyAccessFilter
+
+
+class TestCherryPyAccessFilter(unittest.TestCase):
+    def setUp(self):
+        self.filter = CherryPyAccessFilter(interval=300.0)
+        self.monotonic_patcher = mock.patch('cherrypy_mgr.time.monotonic', return_value=100.0)
+        self.mock_monotonic = self.monotonic_patcher.start()
+
+    def tearDown(self):
+        self.monotonic_patcher.stop()
+
+    def _record(self, name: str, message: str) -> logging.LogRecord:
+        return logging.LogRecord(name, logging.INFO, __file__, 0, message, (), None)
+
+    def test_rate_limits_200_within_interval(self):
+        record = self._record(
+            'cherrypy.access.123',
+            '127.0.0.1 - - [time] "GET /metrics HTTP/1.1" 200 1 "" "Prometheus/3.6.0"'
+        )
+
+        self.assertTrue(self.filter.filter(record))
+        self.assertFalse(self.filter.filter(record))
+
+    def test_non_200_always_passes(self):
+        record = self._record(
+            'cherrypy.access.123',
+            '127.0.0.1 - - [time] "GET /metrics HTTP/1.1" 500 1 "" "Prometheus/3.6.0"'
+        )
+
+        self.assertTrue(self.filter.filter(record))
+        self.assertTrue(self.filter.filter(record))
+        self.assertEqual(self.filter._last, {})
+
+    def test_regex_key_extraction_without_query_params(self):
+        record = self._record(
+            'cherrypy.access.123',
+            '127.0.0.1 - - [time] "GET /metrics HTTP/1.1" 200 1 "" "Prometheus/3.6.0"'
+        )
+
+        self.assertTrue(self.filter.filter(record))
+        self.assertEqual(self.filter._last, {'/metrics': 100.0})
+
+    def test_regex_key_extraction_with_query_params(self):
+        record = self._record(
+            'cherrypy.access.123',
+            '127.0.0.1 - - [time] "GET /sd/prometheus/sd-config?service=ceph HTTP/1.1" 200 1 "" "Prometheus/3.6.0"'
+        )
+
+        self.assertTrue(self.filter.filter(record))
+        self.assertEqual(
+            self.filter._last,
+            {'/sd/prometheus/sd-config?service=ceph': 100.0}
+        )
+
+    def test_fallback_when_regex_does_not_match(self):
+        message = 'raw" 200 message without an HTTP request pattern'
+        record = self._record('cherrypy.access.123', message)
+
+        self.assertTrue(self.filter.filter(record))
+        self.assertEqual(
+            self.filter._last,
+            {'raw" 200 message without an HTTP request pattern': 100.0}
+        )
+
 
 class TestCherryPyMgr(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Prometheus scrapes /metrics every few seconds, and service-discovery endpoints (ceph, node-exporter, alertmanager, ceph-exporter) every minute, causing CherryPy's access logger to emit thousands of routine INFO-level entries per day. Add CherryPyAccessFilter to rate-limit HTTP 200 responses to one log entry per endpoint every 300 seconds (configurable). Non-200 responses continue to be logged unconditionally. Set cherrypy.log.access_log.propagate to True so access log records also propagate into the mgr logging path.

Fixes: https://tracker.ceph.com/issues/77814

Test Results:-

Before Changes:

 No CherryPy access logs were present in the mgr log file
 
 After Changes:
 
 ```
[root@md-test-0 ~]# journalctl -u ceph-5745c364-8f31-11f1-bb33-525400f6469e@mgr.md-test-0.ezqvii -f | grep "cherrypy.access"
Aug 04 01:30:02 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672806428240:::ffff:192.168.124.117 - - [04/Aug/2026:06:30:02] "GET /metrics HTTP/1.1" 200 3362 "" "Prometheus/3.6.0"
Aug 04 01:30:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:30:30] "GET /sd/prometheus/sd-config?service=ceph HTTP/1.1" 200 53 "" "Prometheus/3.6.0"
Aug 04 01:30:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:30:30] "GET /sd/prometheus/sd-config?service=ceph-exporter HTTP/1.1" 200 76 "" "Prometheus/3.6.0"
Aug 04 01:30:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:30:30] "GET /sd/prometheus/sd-config?service=node-exporter HTTP/1.1" 200 76 "" "Prometheus/3.6.0"
Aug 04 01:30:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:30:30] "GET /sd/prometheus/sd-config?service=alertmanager HTTP/1.1" 200 53 "" "Prometheus/3.6.0"
Aug 04 01:35:12 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672806428240:::ffff:192.168.124.117 - - [04/Aug/2026:06:35:12] "GET /metrics HTTP/1.1" 200 3375 "" "Prometheus/3.6.0"
Aug 04 01:36:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:36:30] "GET /sd/prometheus/sd-config?service=ceph HTTP/1.1" 200 53 "" "Prometheus/3.6.0"
Aug 04 01:36:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:36:30] "GET /sd/prometheus/sd-config?service=ceph-exporter HTTP/1.1" 200 76 "" "Prometheus/3.6.0"
Aug 04 01:36:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:36:30] "GET /sd/prometheus/sd-config?service=alertmanager HTTP/1.1" 200 53 "" "Prometheus/3.6.0"
Aug 04 01:36:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:36:30] "GET /sd/prometheus/sd-config?service=node-exporter HTTP/1.1" 200 76 "" "Prometheus/3.6.0"
Aug 04 01:40:22 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672806428240:::ffff:192.168.124.117 - - [04/Aug/2026:06:40:22] "GET /metrics HTTP/1.1" 200 3372 "" "Prometheus/3.6.0"
Aug 04 01:41:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:41:30] "GET /sd/prometheus/sd-config?service=ceph HTTP/1.1" 200 53 "" "Prometheus/3.6.0"
Aug 04 01:41:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:41:30] "GET /sd/prometheus/sd-config?service=ceph-exporter HTTP/1.1" 200 76 "" "Prometheus/3.6.0"
Aug 04 01:41:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:41:30] "GET /sd/prometheus/sd-config?service=node-exporter HTTP/1.1" 200 76 "" "Prometheus/3.6.0"
Aug 04 01:41:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:41:30] "GET /sd/prometheus/sd-config?service=alertmanager HTTP/1.1" 200 53 "" "Prometheus/3.6.0"
Aug 04 01:45:22 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672806428240:::ffff:192.168.124.117 - - [04/Aug/2026:06:45:22] "GET /metrics HTTP/1.1" 200 3376 "" "Prometheus/3.6.0"
Aug 04 01:47:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:47:30] "GET /sd/prometheus/sd-config?service=ceph HTTP/1.1" 200 53 "" "Prometheus/3.6.0"
Aug 04 01:47:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:47:30] "GET /sd/prometheus/sd-config?service=ceph-exporter HTTP/1.1" 200 76 "" "Prometheus/3.6.0"
Aug 04 01:47:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:47:30] "GET /sd/prometheus/sd-config?service=alertmanager HTTP/1.1" 200 53 "" "Prometheus/3.6.0"
Aug 04 01:47:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:47:30] "GET /sd/prometheus/sd-config?service=node-exporter HTTP/1.1" 200 76 "" "Prometheus/3.6.0"
Aug 04 01:50:32 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672806428240:::ffff:192.168.124.117 - - [04/Aug/2026:06:50:32] "GET /metrics HTTP/1.1" 200 3374 "" "Prometheus/3.6.0"
Aug 04 01:52:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:52:30] "GET /sd/prometheus/sd-config?service=ceph HTTP/1.1" 200 53 "" "Prometheus/3.6.0"
Aug 04 01:53:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:53:30] "GET /sd/prometheus/sd-config?service=node-exporter HTTP/1.1" 200 76 "" "Prometheus/3.6.0"
Aug 04 01:53:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:53:30] "GET /sd/prometheus/sd-config?service=ceph-exporter HTTP/1.1" 200 76 "" "Prometheus/3.6.0"
Aug 04 01:53:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:53:30] "GET /sd/prometheus/sd-config?service=alertmanager HTTP/1.1" 200 53 "" "Prometheus/3.6.0"
Aug 04 01:55:32 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672806428240:::ffff:192.168.124.117 - - [04/Aug/2026:06:55:32] "GET /metrics HTTP/1.1" 200 3376 "" "Prometheus/3.6.0"
Aug 04 01:58:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:58:30] "GET /sd/prometheus/sd-config?service=ceph HTTP/1.1" 200 53 "" "Prometheus/3.6.0"
Aug 04 01:58:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:58:30] "GET /sd/prometheus/sd-config?service=node-exporter HTTP/1.1" 200 76 "" "Prometheus/3.6.0"
Aug 04 01:59:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:59:30] "GET /sd/prometheus/sd-config?service=ceph-exporter HTTP/1.1" 200 76 "" "Prometheus/3.6.0"
Aug 04 01:59:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:06:59:30] "GET /sd/prometheus/sd-config?service=alertmanager HTTP/1.1" 200 53 "" "Prometheus/3.6.0"
Aug 04 02:00:32 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672806428240:::ffff:192.168.124.117 - - [04/Aug/2026:07:00:32] "GET /metrics HTTP/1.1" 200 3374 "" "Prometheus/3.6.0"
Aug 04 02:03:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:07:03:30] "GET /sd/prometheus/sd-config?service=ceph HTTP/1.1" 200 53 "" "Prometheus/3.6.0"
Aug 04 02:03:30 md-test-0 ceph-5745c364-8f31-11f1-bb33-525400f6469e-mgr-md-test-0-ezqvii[55244]: INFO:cherrypy.access.140672966215856:192.168.124.117 - - [04/Aug/2026:07:03:30] "GET /sd/prometheus/sd-config?service=node-exporter HTTP/1.1" 200 76 "" "Prometheus/3.6.0"
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
