### PR TITLE
umbrella: rgw: update rpm and debian builds

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2152,6 +2152,7 @@ exit 0
 %{_bindir}/ceph-authtool
 %{_bindir}/ceph-conf
 %{_bindir}/ceph-dencoder
+%{_bindir}/ceph-diff-sorted
 %{_bindir}/ceph-rbdnamer
 %{_bindir}/ceph-syn
 %{_bindir}/cephfs-data-scan
@@ -2670,9 +2671,17 @@ fi
 %{_bindir}/radosgw-token
 %{_bindir}/radosgw-es
 %{_bindir}/radosgw-object-expirer
+%{_bindir}/rgw-gap-list
+%{_bindir}/rgw-gap-list-comparator
+%{_bindir}/rgw-orphan-list
 %{_bindir}/rgw-policy-check
+%{_bindir}/rgw-restore-bucket-index
+%{_mandir}/man8/ceph-diff-sorted.8*
 %{_mandir}/man8/radosgw.8*
+%{_mandir}/man8/rgw-gap-list.8*
+%{_mandir}/man8/rgw-orphan-list.8*
 %{_mandir}/man8/rgw-policy-check.8*
+%{_mandir}/man8/rgw-restore-bucket-index.8*
 %dir %{_localstatedir}/lib/ceph/radosgw
 %{_unitdir}/ceph-radosgw@.service
 %{_unitdir}/ceph-radosgw.target

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2159,6 +2159,7 @@ exit 0
 %{_bindir}/ceph-authtool
 %{_bindir}/ceph-conf
 %{_bindir}/ceph-dencoder
+%{_bindir}/ceph-diff-sorted
 %{_bindir}/ceph-rbdnamer
 %{_bindir}/ceph-syn
 %{_bindir}/cephfs-data-scan
@@ -2677,11 +2678,19 @@ fi
 %{_bindir}/radosgw-token
 %{_bindir}/radosgw-es
 %{_bindir}/radosgw-object-expirer
+%{_bindir}/rgw-gap-list
+%{_bindir}/rgw-gap-list-comparator
+%{_bindir}/rgw-orphan-list
 %{_bindir}/rgw-policy-check
 %{_bindir}/rgw-policy-test
+%{_bindir}/rgw-restore-bucket-index
+%{_mandir}/man8/ceph-diff-sorted.8*
 %{_mandir}/man8/radosgw.8*
+%{_mandir}/man8/rgw-gap-list.8*
+%{_mandir}/man8/rgw-orphan-list.8*
 %{_mandir}/man8/rgw-policy-check.8*
 %{_mandir}/man8/rgw-policy-test.8*
+%{_mandir}/man8/rgw-restore-bucket-index.8*
 %dir %{_localstatedir}/lib/ceph/radosgw
 %{_unitdir}/ceph-radosgw@.service
 %{_unitdir}/ceph-radosgw.target

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2673,24 +2673,15 @@ fi
 %{_libexecdir}/rbd-nbd/rbd-nbd_quiesce
 
 %files radosgw
-%{_bindir}/ceph-diff-sorted
 %{_bindir}/radosgw
 %{_bindir}/radosgw-token
 %{_bindir}/radosgw-es
 %{_bindir}/radosgw-object-expirer
-%{_bindir}/rgw-gap-list
-%{_bindir}/rgw-gap-list-comparator
-%{_bindir}/rgw-orphan-list
 %{_bindir}/rgw-policy-check
 %{_bindir}/rgw-policy-test
-%{_bindir}/rgw-restore-bucket-index
-%{_mandir}/man8/ceph-diff-sorted.8*
 %{_mandir}/man8/radosgw.8*
-%{_mandir}/man8/rgw-gap-list.8*
-%{_mandir}/man8/rgw-orphan-list.8*
 %{_mandir}/man8/rgw-policy-check.8*
 %{_mandir}/man8/rgw-policy-test.8*
-%{_mandir}/man8/rgw-restore-bucket-index.8*
 %dir %{_localstatedir}/lib/ceph/radosgw
 %{_unitdir}/ceph-radosgw@.service
 %{_unitdir}/ceph-radosgw.target

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2176,6 +2176,8 @@ exit 0
 %{_bindir}/rgw-gap-list
 %{_bindir}/rgw-gap-list-comparator
 %{_bindir}/rgw-orphan-list
+%{_bindir}/rgw-policy-check
+%{_bindir}/rgw-policy-test
 %{_bindir}/rgw-restore-bucket-index
 %{_sbindir}/mount.ceph
 %if 0%{?suse_version} && 0%{?suse_version} < 1550
@@ -2207,6 +2209,8 @@ exit 0
 %{_mandir}/man8/rbd-replay-prep.8*
 %{_mandir}/man8/rgw-orphan-list.8*
 %{_mandir}/man8/rgw-gap-list.8*
+%{_mandir}/man8/rgw-policy-check.8*
+%{_mandir}/man8/rgw-policy-test.8*
 %{_mandir}/man8/rgw-restore-bucket-index.8*
 %dir %{_datadir}/ceph/
 %{_datadir}/ceph/known_hosts_drop.ceph.com
@@ -2677,11 +2681,7 @@ fi
 %{_bindir}/radosgw-token
 %{_bindir}/radosgw-es
 %{_bindir}/radosgw-object-expirer
-%{_bindir}/rgw-policy-check
-%{_bindir}/rgw-policy-test
 %{_mandir}/man8/radosgw.8*
-%{_mandir}/man8/rgw-policy-check.8*
-%{_mandir}/man8/rgw-policy-test.8*
 %dir %{_localstatedir}/lib/ceph/radosgw
 %{_unitdir}/ceph-radosgw@.service
 %{_unitdir}/ceph-radosgw.target

--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -10,6 +10,7 @@ usr/bin/ceph
 usr/bin/ceph-authtool
 usr/bin/ceph-conf
 usr/bin/ceph-dencoder
+usr/bin/ceph-diff-sorted
 usr/bin/ceph-rbdnamer
 usr/bin/ceph-syn
 usr/bin/cephfs-data-scan
@@ -36,6 +37,7 @@ usr/lib/ceph/crypto/* [amd64]
 usr/share/man/man8/ceph-authtool.8
 usr/share/man/man8/ceph-conf.8
 usr/share/man/man8/ceph-dencoder.8
+usr/share/man/man8/ceph-diff-sorted.8
 usr/share/man/man8/ceph-rbdnamer.8
 usr/share/man/man8/ceph-syn.8
 usr/share/man/man8/ceph-post-file.8
@@ -47,6 +49,8 @@ usr/share/man/man8/radosgw-admin.8
 usr/share/man/man8/rgw-policy-check.8
 usr/share/man/man8/rgw-policy-test.8
 usr/share/man/man8/rgw-gap-list.8
+usr/share/man/man8/rgw-orphan-list.8
+usr/share/man/man8/rgw-restore-bucket-index.8
 usr/share/man/man8/rbd.8
 usr/share/man/man8/rbdmap.8
 usr/share/man/man8/rbd-replay*.8

--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -10,6 +10,7 @@ usr/bin/ceph
 usr/bin/ceph-authtool
 usr/bin/ceph-conf
 usr/bin/ceph-dencoder
+usr/bin/ceph-diff-sorted
 usr/bin/ceph-rbdnamer
 usr/bin/ceph-syn
 usr/bin/cephfs-data-scan
@@ -35,6 +36,7 @@ usr/lib/ceph/crypto/* [amd64]
 usr/share/man/man8/ceph-authtool.8
 usr/share/man/man8/ceph-conf.8
 usr/share/man/man8/ceph-dencoder.8
+usr/share/man/man8/ceph-diff-sorted.8
 usr/share/man/man8/ceph-rbdnamer.8
 usr/share/man/man8/ceph-syn.8
 usr/share/man/man8/ceph-post-file.8
@@ -45,6 +47,8 @@ usr/share/man/man8/rados.8
 usr/share/man/man8/radosgw-admin.8
 usr/share/man/man8/rgw-policy-check.8
 usr/share/man/man8/rgw-gap-list.8
+usr/share/man/man8/rgw-orphan-list.8
+usr/share/man/man8/rgw-restore-bucket-index.8
 usr/share/man/man8/rbd.8
 usr/share/man/man8/rbdmap.8
 usr/share/man/man8/rbd-replay*.8

--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -10,7 +10,6 @@ usr/bin/ceph
 usr/bin/ceph-authtool
 usr/bin/ceph-conf
 usr/bin/ceph-dencoder
-usr/bin/ceph-diff-sorted
 usr/bin/ceph-rbdnamer
 usr/bin/ceph-syn
 usr/bin/cephfs-data-scan
@@ -37,7 +36,6 @@ usr/lib/ceph/crypto/* [amd64]
 usr/share/man/man8/ceph-authtool.8
 usr/share/man/man8/ceph-conf.8
 usr/share/man/man8/ceph-dencoder.8
-usr/share/man/man8/ceph-diff-sorted.8
 usr/share/man/man8/ceph-rbdnamer.8
 usr/share/man/man8/ceph-syn.8
 usr/share/man/man8/ceph-post-file.8
@@ -49,8 +47,6 @@ usr/share/man/man8/radosgw-admin.8
 usr/share/man/man8/rgw-policy-check.8
 usr/share/man/man8/rgw-policy-test.8
 usr/share/man/man8/rgw-gap-list.8
-usr/share/man/man8/rgw-orphan-list.8
-usr/share/man/man8/rgw-restore-bucket-index.8
 usr/share/man/man8/rbd.8
 usr/share/man/man8/rbdmap.8
 usr/share/man/man8/rbd-replay*.8

--- a/debian/control
+++ b/debian/control
@@ -1120,13 +1120,13 @@ Replaces: ceph (<< 10),
           ceph-test (<< 9.0.3-1646),
           librbd1 (<< 0.92-1238),
           python-ceph (<< 0.92-1223),
-	  radosgw (<< 12.0.3)
+	  radosgw (<< 21.0.0)
 Breaks: ceph (<< 10),
         ceph-fs-common (<< 11.0),
         ceph-test (<< 9.0.3-1646),
         librbd1 (<< 0.92-1238),
         python-ceph (<< 0.92-1223),
-	radosgw (<< 12.0.3)
+	radosgw (<< 21.0.0)
 Suggests: ceph-base (= ${binary:Version}),
           ceph-mds (= ${binary:Version}),
 Description: common utilities to mount and interact with a ceph storage cluster

--- a/debian/radosgw.install
+++ b/debian/radosgw.install
@@ -3,5 +3,4 @@ usr/bin/radosgw
 usr/bin/radosgw-es
 usr/bin/radosgw-object-expirer
 usr/bin/radosgw-token
-usr/share/man/man8/ceph-diff-sorted.8
 usr/share/man/man8/radosgw.8

--- a/debian/radosgw.install
+++ b/debian/radosgw.install
@@ -4,7 +4,11 @@ usr/bin/radosgw
 usr/bin/radosgw-es
 usr/bin/radosgw-object-expirer
 usr/bin/radosgw-token
+usr/bin/rgw-gap-list
+usr/bin/rgw-gap-list-comparator
+usr/bin/rgw-orphan-list
 usr/share/man/man8/ceph-diff-sorted.8
 usr/share/man/man8/radosgw.8
+usr/share/man/man8/rgw-gap-list.8
 usr/share/man/man8/rgw-orphan-list.8
 usr/share/man/man8/rgw-restore-bucket-index.8

--- a/debian/radosgw.install
+++ b/debian/radosgw.install
@@ -4,11 +4,7 @@ usr/bin/radosgw
 usr/bin/radosgw-es
 usr/bin/radosgw-object-expirer
 usr/bin/radosgw-token
-usr/bin/rgw-gap-list
-usr/bin/rgw-gap-list-comparator
-usr/bin/rgw-orphan-list
 usr/share/man/man8/ceph-diff-sorted.8
 usr/share/man/man8/radosgw.8
-usr/share/man/man8/rgw-gap-list.8
 usr/share/man/man8/rgw-orphan-list.8
 usr/share/man/man8/rgw-restore-bucket-index.8

--- a/debian/radosgw.install
+++ b/debian/radosgw.install
@@ -1,10 +1,7 @@
 {usr/,}lib/systemd/system/ceph-radosgw*
-usr/bin/ceph-diff-sorted
 usr/bin/radosgw
 usr/bin/radosgw-es
 usr/bin/radosgw-object-expirer
 usr/bin/radosgw-token
 usr/share/man/man8/ceph-diff-sorted.8
 usr/share/man/man8/radosgw.8
-usr/share/man/man8/rgw-orphan-list.8
-usr/share/man/man8/rgw-restore-bucket-index.8


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78795

---

backport of https://github.com/ceph/ceph/pull/70505
parent tracker: https://tracker.ceph.com/issues/78735

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh