### PR TITLE
tentacle: rgw: update rpm and debian builds

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1762,6 +1762,7 @@ exit 0
 %{_bindir}/ceph-authtool
 %{_bindir}/ceph-conf
 %{_bindir}/ceph-dencoder
+%{_bindir}/ceph-diff-sorted
 %{_bindir}/ceph-rbdnamer
 %{_bindir}/ceph-syn
 %{_bindir}/cephfs-data-scan
@@ -2243,9 +2244,17 @@ fi
 %{_bindir}/radosgw-token
 %{_bindir}/radosgw-es
 %{_bindir}/radosgw-object-expirer
+%{_bindir}/rgw-gap-list
+%{_bindir}/rgw-gap-list-comparator
+%{_bindir}/rgw-orphan-list
 %{_bindir}/rgw-policy-check
+%{_bindir}/rgw-restore-bucket-index
+%{_mandir}/man8/ceph-diff-sorted.8*
 %{_mandir}/man8/radosgw.8*
+%{_mandir}/man8/rgw-gap-list.8*
+%{_mandir}/man8/rgw-orphan-list.8*
 %{_mandir}/man8/rgw-policy-check.8*
+%{_mandir}/man8/rgw-restore-bucket-index.8*
 %dir %{_localstatedir}/lib/ceph/radosgw
 %{_unitdir}/ceph-radosgw@.service
 %{_unitdir}/ceph-radosgw.target

--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -10,6 +10,7 @@ usr/bin/ceph
 usr/bin/ceph-authtool
 usr/bin/ceph-conf
 usr/bin/ceph-dencoder
+usr/bin/ceph-diff-sorted
 usr/bin/ceph-rbdnamer
 usr/bin/ceph-syn
 usr/bin/cephfs-data-scan
@@ -33,6 +34,7 @@ usr/lib/ceph/crypto/* [amd64]
 usr/share/man/man8/ceph-authtool.8
 usr/share/man/man8/ceph-conf.8
 usr/share/man/man8/ceph-dencoder.8
+usr/share/man/man8/ceph-diff-sorted.8
 usr/share/man/man8/ceph-rbdnamer.8
 usr/share/man/man8/ceph-syn.8
 usr/share/man/man8/ceph-post-file.8
@@ -42,6 +44,10 @@ usr/share/man/man8/mount.ceph.8
 usr/share/man/man8/rados.8
 usr/share/man/man8/radosgw-admin.8
 usr/share/man/man8/rgw-policy-check.8
+usr/share/man/man8/rgw-policy-test.8
+usr/share/man/man8/rgw-gap-list.8
+usr/share/man/man8/rgw-orphan-list.8
+usr/share/man/man8/rgw-restore-bucket-index.8
 usr/share/man/man8/rbd.8
 usr/share/man/man8/rbdmap.8
 usr/share/man/man8/rbd-replay*.8

--- a/debian/radosgw.install
+++ b/debian/radosgw.install
@@ -4,7 +4,11 @@ usr/bin/radosgw
 usr/bin/radosgw-es
 usr/bin/radosgw-object-expirer
 usr/bin/radosgw-token
+usr/bin/rgw-gap-list
+usr/bin/rgw-gap-list-comparator
+usr/bin/rgw-orphan-list
 usr/share/man/man8/ceph-diff-sorted.8
 usr/share/man/man8/radosgw.8
+usr/share/man/man8/rgw-gap-list.8
 usr/share/man/man8/rgw-orphan-list.8
 usr/share/man/man8/rgw-restore-bucket-index.8


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78794

---

backport of https://github.com/ceph/ceph/pull/70505
parent tracker: https://tracker.ceph.com/issues/78735

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh