### PR TITLE
crimson/osd/pg: keep pg_committed_to from going backwards

### DIFF
--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -1100,7 +1100,7 @@ PG::interruptible_future<> PG::complete_error_log(const ceph_tid_t& rep_tid,
   log_update.waiting_on.erase(pg_whoami);
   if (log_update.waiting_on.empty()) {
     log_entry_update_waiting_on.erase(rep_tid);
-    peering_state.complete_write(version, last_complete);
+    complete_write(version, last_complete);
     logger().debug("complete_error_log: write complete,"
                    " erasing rep_tid {}", rep_tid);
   } else {
@@ -1110,7 +1110,7 @@ PG::interruptible_future<> PG::complete_error_log(const ceph_tid_t& rep_tid,
       log_update.all_committed.get_shared_future()
     ).then_interruptible([this, last_complete, rep_tid, version] {
       logger().debug("complete_error_log: rep_tid {} awaited ", rep_tid);
-      peering_state.complete_write(version, last_complete);
+      complete_write(version, last_complete);
       ceph_assert(!log_entry_update_waiting_on.contains(rep_tid));
       return seastar::now();
     });

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -807,6 +807,20 @@ public:
   }
 
   void complete_write(eversion_t v, eversion_t lc) {
+    // Crimson can finish different client writes out of at_version order
+    // (repop replies / local vs remote). PeeringState::complete_write()
+    // assigns pg_committed_to and last_complete_ondisk unconditionally, so a
+    // late older completion would move those watermarks backwards and can
+    // trip ceph_assert(trim_to <= get_pg_committed_to()) in log_operation().
+    // A higher all-shard commit already covers every lower version, so drop
+    // the stale completion instead of applying it.
+    // See https://tracker.ceph.com/issues/72342
+    if (v < peering_state.get_pg_committed_to()) {
+      LOG_PREFIX(PG::complete_write);
+      SUBDEBUGDPP(osd, "dropping stale completion v {} lc {} pct {}",
+		  *this, v, lc, peering_state.get_pg_committed_to());
+      return;
+    }
     peering_state.complete_write(v, lc);
   }
 

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -807,6 +807,17 @@ public:
   }
 
   void complete_write(eversion_t v, eversion_t lc) {
+    // Crimson can finish different client writes out of at_version order
+    // (repop replies / local vs remote). PeeringState::complete_write()
+    // assigns pg_committed_to and last_complete_ondisk unconditionally, so a
+    // late older completion would move those watermarks backwards and can
+    // trip ceph_assert(trim_to <= get_pg_committed_to()) in log_operation().
+    // A higher all-shard commit already covers every lower version, so drop
+    // the stale completion instead of applying it.
+    // See https://tracker.ceph.com/issues/72342
+    if (v < peering_state.get_pg_committed_to()) {
+      return;
+    }
     peering_state.complete_write(v, lc);
   }
 


### PR DESCRIPTION
Crimson can finish different client writes out of at_version order
(repop replies / local vs remote). PeeringState::complete_write()
assigns pg_committed_to and last_complete_ondisk unconditionally, so a
late older completion would move those watermarks backwards and can
trip ceph_assert(trim_to <= get_pg_committed_to()) in log_operation().
A higher all-shard commit already covers every lower version, so drop
the stale completion in PG::complete_write() instead of applying it.
Also route complete_error_log() through that wrapper so failed writes
cannot bypass the check.

Fixes: https://tracker.ceph.com/issues/72342


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
