### PR TITLE
umbrella: ceph-volume: fix nvme preformat wiping VG on osds-per-device > 1

### DIFF
--- a/src/ceph-volume/ceph_volume/objectstore/lvm.py
+++ b/src/ceph-volume/ceph_volume/objectstore/lvm.py
@@ -86,7 +86,10 @@ class Lvm(BaseObjectStore):
         if disk.is_partition(device) or disk.is_device(device):
             if device_type == 'block' and self.objectstore == 'bluestore':
                 # NVMe preformat already discards, skip mkfs discard.
-                if nvme_utils.preformat(device):
+                # Only preformat when no ceph VG already exists on the device.
+                # With --osds-per-device > 1, the first OSD creates the VG;
+                # subsequent OSDs reuse it, so reformatting would destroy it.
+                if not api.get_device_vgs(device, 'ceph') and nvme_utils.preformat(device):
                     self.skip_mkfs_discard = True
             # we must create a vg, and then a single lv
             lv_name_prefix = "osd-{}".format(device_type)

--- a/src/ceph-volume/ceph_volume/tests/objectstore/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/objectstore/test_lvm.py
@@ -150,11 +150,13 @@ class TestLvm:
         assert self.lvm.args.data_size == 102400
 
     @patch('ceph_volume.objectstore.lvm.nvme_utils.preformat', Mock(return_value=True))
+    @patch('ceph_volume.objectstore.lvm.api.get_device_vgs', Mock(return_value=[]))
     @patch('ceph_volume.util.disk.is_device', Mock(return_value=True))
     @patch('ceph_volume.api.lvm.create_lv')
     def test_prepare_data_device_preformats_nvme_and_skips_mkfs_discard(self,
                                                                        m_create_lv: MagicMock,
                                                                        factory: Callable[..., Namespace]) -> None:
+        """No existing VG on a fresh device: preformat runs, discard flag is set."""
         args = factory(data='/dev/nvme0n1',
                        data_slots=1,
                        data_size=0)
@@ -167,6 +169,30 @@ class TestLvm:
                                           lv_uuid='abcd')
         self.lvm.prepare_data_device('block', 'abcd')
         assert self.lvm.skip_mkfs_discard is True
+
+    @patch('ceph_volume.util.disk.is_device', Mock(return_value=True))
+    @patch('ceph_volume.api.lvm.create_lv')
+    def test_prepare_data_device_skips_preformat_when_vg_exists(self,
+                                                                 m_create_lv: MagicMock,
+                                                                 factory: Callable[..., Namespace]) -> None:
+        """Existing ceph VG on device (--osds-per-device > 1): preformat must not run."""
+        m_preformat = Mock(return_value=True)
+        fake_vg = Mock()
+        with patch('ceph_volume.objectstore.lvm.nvme_utils.preformat', m_preformat), \
+             patch('ceph_volume.objectstore.lvm.api.get_device_vgs', return_value=[fake_vg]):
+            args = factory(data='/dev/nvme0n1',
+                           data_slots=1,
+                           data_size=0)
+            self.lvm.args = args
+            self.lvm.objectstore = 'bluestore'
+            m_create_lv.return_value = Volume(lv_name='lv_foo',
+                                              lv_path='/fake-path',
+                                              vg_name='vg_foo',
+                                              lv_tags='',
+                                              lv_uuid='abcd')
+            self.lvm.prepare_data_device('block', 'abcd')
+            m_preformat.assert_not_called()
+            assert self.lvm.skip_mkfs_discard is False
 
     @patch('ceph_volume.util.disk.is_device', Mock(return_value=False))
     @patch('ceph_volume.util.disk.is_partition', Mock(return_value=False))


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78813

---

backport of https://github.com/ceph/ceph/pull/70486
parent tracker: https://tracker.ceph.com/issues/78615

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
