### PR TITLE
crimson/os/seastore/async_cleaner: release segments that don't have valid headers

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -6,6 +6,7 @@
 #include <fmt/chrono.h>
 #include <seastar/core/metrics.hh>
 
+#include "crimson/common/coroutine.h"
 #include "crimson/os/seastore/logging.h"
 
 #include "crimson/os/seastore/async_cleaner.h"
@@ -1568,94 +1569,85 @@ SegmentCleaner::mount_ret SegmentCleaner::mount()
   register_metrics();
 
   INFO("{} segments", segments.get_num_segments());
-  return crimson::do_for_each(
-    segments.begin(),
-    segments.end(),
-    [this, FNAME](auto& it)
-  {
-    auto segment_id = it.first;
-    return sm_group->read_segment_header(
-      segment_id
-    ).safe_then([segment_id, this, FNAME](auto header) {
-      DEBUG("segment_id={} -- {}", segment_id, header);
-      auto s_type = header.get_type();
-      if (s_type == segment_type_t::NULL_SEG) {
-        ERROR("got null segment, segment_id={} -- {}", segment_id, header);
-        ceph_abort();
-      }
-      return sm_group->read_segment_tail(
-        segment_id
-      ).safe_then([this, FNAME, segment_id, header](auto tail)
-        -> scan_extents_ertr::future<> {
-	bool tail_valid = (tail.segment_nonce == header.segment_nonce);
-        if (!tail_valid && header.type == segment_type_t::JOURNAL) {
-          return scan_no_tail_segment(header, segment_id);
-        }
-        ceph_assert(header.get_type() == tail.get_type() || !tail_valid);
-
-	sea_time_point header_time = mod_to_timepoint(header.modify_time);
-	if (tail_valid) {
-	  sea_time_point tail_time = mod_to_timepoint(tail.modify_time);
-	  std::size_t num_extents = tail.num_extents;
-	  DEBUG("updating modify time for segment {}, "
-		"mod time {}-{}, num_extents {}",
-		segment_id, header_time, tail_time, num_extents);
-	  if (num_extents == 0) {
-	    ceph_assert(tail_time == NULL_TIME);
-	  } else {
-	    ceph_assert(header_time != NULL_TIME);
-	    ceph_assert(tail_time != NULL_TIME);
-	    sea_time_point avg_time = get_average_time(
-	      header_time, 1, tail_time, 1);
-	    segments.update_modify_time(segment_id, avg_time, num_extents);
-	  }
-	} else {
-	  DEBUG("updating modify time for segment {}, mod time {}, without tail",
-		segment_id, header_time);
-	  segments.init_modify_time(segment_id, header_time);
-	}
-
-        init_mark_segment_closed(
-          segment_id,
-          header.segment_seq,
-          header.type,
-          header.category,
-          header.generation);
-        return seastar::now();
-      }).handle_error(
-        crimson::ct_error::enodata::handle(
-          [this, header, segment_id, FNAME](auto) {
-	  if (header.type == segment_type_t::JOURNAL) {
-	    return scan_no_tail_segment(header, segment_id);
-	  } else {
-	    sea_time_point modify_time = mod_to_timepoint(header.modify_time);
-	    DEBUG("updating modify time for segment {}, mod time {}",
-	      segment_id, modify_time);
-	    segments.init_modify_time(segment_id, modify_time);
-	    init_mark_segment_closed(
-	      segment_id,
-	      header.segment_seq,
-	      header.type,
-	      header.category,
-	      header.generation);
-	    return scan_extents_ertr::now();
-	  }
-        }),
-        crimson::ct_error::pass_further_all{}
-      );
-    }).handle_error(
+  for (auto &[segment_id, _] : segments) {
+    auto header = co_await sm_group->read_segment_header(segment_id
+    ).handle_error(
       crimson::ct_error::enoent::handle([](auto) {
-        return mount_ertr::now();
+        return mount_ertr::make_ready_future<
+          segment_header_t>(NULL_SEGMENT_HEADER);
       }),
       crimson::ct_error::enodata::handle([](auto) {
-        return mount_ertr::now();
+        return mount_ertr::make_ready_future<
+          segment_header_t>(NULL_SEGMENT_HEADER);
       }),
       crimson::ct_error::input_output_error::pass_further{},
       crimson::ct_error::assert_all("unexpected error")
     );
-  }).safe_then([this, FNAME] {
-    INFO("done, {}", segments);
-  });
+    DEBUG("segment_id={} -- {}", segment_id, header);
+    auto s_type = header.get_type();
+    if (s_type == segment_type_t::NULL_SEG) {
+      ERROR("got null segment, segment_id={} -- {}", segment_id, header);
+      ceph_abort();
+    }
+    auto tail = co_await sm_group->read_segment_tail(segment_id
+    ).handle_error(
+      crimson::ct_error::enodata::handle([](auto) {
+        return mount_ertr::make_ready_future<
+          segment_tail_t>(NULL_SEGMENT_TAIL);
+      }),
+      crimson::ct_error::enoent::handle([](auto) {
+        return mount_ertr::make_ready_future<
+          segment_tail_t>(NULL_SEGMENT_TAIL);
+      }),
+      crimson::ct_error::pass_further_all{}
+    );
+    bool tail_valid = (tail.segment_nonce == header.segment_nonce);
+    if (!tail_valid && header.type == segment_type_t::JOURNAL) {
+      co_await scan_no_tail_segment(header, segment_id
+      ).handle_error(
+        crimson::ct_error::enoent::handle([](auto) {
+          return mount_ertr::now();
+        }),
+        crimson::ct_error::enodata::handle([](auto) {
+          return mount_ertr::now();
+        }),
+        crimson::ct_error::input_output_error::pass_further{},
+        crimson::ct_error::assert_all("unexpected error")
+      );
+    } else {
+      ceph_assert(header.get_type() == tail.get_type() || !tail_valid);
+
+      sea_time_point header_time = mod_to_timepoint(header.modify_time);
+      if (tail_valid) {
+        sea_time_point tail_time = mod_to_timepoint(tail.modify_time);
+        std::size_t num_extents = tail.num_extents;
+        DEBUG("updating modify time for segment {}, "
+              "mod time {}-{}, num_extents {}",
+              segment_id, header_time, tail_time, num_extents);
+        if (num_extents == 0) {
+          ceph_assert(tail_time == NULL_TIME);
+        } else {
+          ceph_assert(header_time != NULL_TIME);
+          ceph_assert(tail_time != NULL_TIME);
+          sea_time_point avg_time = get_average_time(
+            header_time, 1, tail_time, 1);
+          segments.update_modify_time(segment_id, avg_time, num_extents);
+        }
+      } else {
+        DEBUG("updating modify time for segment {}, mod time {}, without tail",
+              segment_id, header_time);
+        segments.init_modify_time(segment_id, header_time);
+      }
+
+      init_mark_segment_closed(
+        segment_id,
+        header.segment_seq,
+        header.type,
+        header.category,
+        header.generation);
+    }
+  }
+  INFO("done, {}", segments);
 }
 
 SegmentCleaner::scan_extents_ret SegmentCleaner::scan_no_tail_segment(

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1583,6 +1583,9 @@ SegmentCleaner::mount_ret SegmentCleaner::mount()
       crimson::ct_error::input_output_error::pass_further{},
       crimson::ct_error::assert_all("unexpected error")
     );
+    if (header == NULL_SEGMENT_HEADER) {
+      continue;
+    }
     DEBUG("segment_id={} -- {}", segment_id, header);
     auto s_type = header.get_type();
     if (s_type == segment_type_t::NULL_SEG) {

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1584,6 +1584,14 @@ SegmentCleaner::mount_ret SegmentCleaner::mount()
       crimson::ct_error::assert_all("unexpected error")
     );
     if (header == NULL_SEGMENT_HEADER) {
+      co_await sm_group->release_segment(segment_id
+      ).handle_error(
+        crimson::ct_error::invarg::handle([](auto) {
+          return mount_ertr::now();
+        }),
+        crimson::ct_error::input_output_error::pass_further{},
+        crimson::ct_error::assert_all("unexpected error")
+      );
       continue;
     }
     DEBUG("segment_id={} -- {}", segment_id, header);

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -6,6 +6,7 @@
 #include <fmt/chrono.h>
 #include <seastar/core/metrics.hh>
 
+#include "crimson/common/coroutine.h"
 #include "crimson/os/seastore/logging.h"
 
 #include "crimson/os/seastore/async_cleaner.h"
@@ -1569,94 +1570,88 @@ SegmentCleaner::mount_ret SegmentCleaner::mount()
   register_metrics();
 
   INFO("{} segments", segments.get_num_segments());
-  return crimson::do_for_each(
-    segments.begin(),
-    segments.end(),
-    [this, FNAME](auto& it)
-  {
-    auto segment_id = it.first;
-    return sm_group->read_segment_header(
-      segment_id
-    ).safe_then([segment_id, this, FNAME](auto header) {
-      DEBUG("segment_id={} -- {}", segment_id, header);
-      auto s_type = header.get_type();
-      if (s_type == segment_type_t::NULL_SEG) {
-        ERROR("got null segment, segment_id={} -- {}", segment_id, header);
-        ceph_abort();
-      }
-      return sm_group->read_segment_tail(
-        segment_id
-      ).safe_then([this, FNAME, segment_id, header](auto tail)
-        -> scan_extents_ertr::future<> {
-	bool tail_valid = (tail.segment_nonce == header.segment_nonce);
-        if (!tail_valid && header.type == segment_type_t::JOURNAL) {
-          return scan_no_tail_segment(header, segment_id);
-        }
-        ceph_assert(header.get_type() == tail.get_type() || !tail_valid);
-
-	sea_time_point header_time = mod_to_timepoint(header.modify_time);
-	if (tail_valid) {
-	  sea_time_point tail_time = mod_to_timepoint(tail.modify_time);
-	  std::size_t num_extents = tail.num_extents;
-	  DEBUG("updating modify time for segment {}, "
-		"mod time {}-{}, num_extents {}",
-		segment_id, header_time, tail_time, num_extents);
-	  if (num_extents == 0) {
-	    ceph_assert(tail_time == NULL_TIME);
-	  } else {
-	    ceph_assert(header_time != NULL_TIME);
-	    ceph_assert(tail_time != NULL_TIME);
-	    sea_time_point avg_time = get_average_time(
-	      header_time, 1, tail_time, 1);
-	    segments.update_modify_time(segment_id, avg_time, num_extents);
-	  }
-	} else {
-	  DEBUG("updating modify time for segment {}, mod time {}, without tail",
-		segment_id, header_time);
-	  segments.init_modify_time(segment_id, header_time);
-	}
-
-        init_mark_segment_closed(
-          segment_id,
-          header.segment_seq,
-          header.type,
-          header.category,
-          header.generation);
-        return seastar::now();
-      }).handle_error(
-        crimson::ct_error::enodata::handle(
-          [this, header, segment_id, FNAME](auto) {
-	  if (header.type == segment_type_t::JOURNAL) {
-	    return scan_no_tail_segment(header, segment_id);
-	  } else {
-	    sea_time_point modify_time = mod_to_timepoint(header.modify_time);
-	    DEBUG("updating modify time for segment {}, mod time {}",
-	      segment_id, modify_time);
-	    segments.init_modify_time(segment_id, modify_time);
-	    init_mark_segment_closed(
-	      segment_id,
-	      header.segment_seq,
-	      header.type,
-	      header.category,
-	      header.generation);
-	    return scan_extents_ertr::now();
-	  }
-        }),
-        crimson::ct_error::pass_further_all{}
-      );
-    }).handle_error(
+  for (auto &[segment_id, _] : segments) {
+    auto header = co_await sm_group->read_segment_header(segment_id
+    ).handle_error(
       crimson::ct_error::enoent::handle([](auto) {
-        return mount_ertr::now();
+        return mount_ertr::make_ready_future<
+          segment_header_t>(NULL_SEGMENT_HEADER);
       }),
       crimson::ct_error::enodata::handle([](auto) {
-        return mount_ertr::now();
+        return mount_ertr::make_ready_future<
+          segment_header_t>(NULL_SEGMENT_HEADER);
       }),
       crimson::ct_error::input_output_error::pass_further{},
       crimson::ct_error::assert_all("unexpected error")
     );
-  }).safe_then([this, FNAME] {
-    INFO("done, {}", segments);
-  });
+    if (header == NULL_SEGMENT_HEADER) {
+      continue;
+    }
+    DEBUG("segment_id={} -- {}", segment_id, header);
+    auto s_type = header.get_type();
+    if (s_type == segment_type_t::NULL_SEG) {
+      ERROR("got null segment, segment_id={} -- {}", segment_id, header);
+      ceph_abort();
+    }
+    auto tail = co_await sm_group->read_segment_tail(segment_id
+    ).handle_error(
+      crimson::ct_error::enodata::handle([](auto) {
+        return mount_ertr::make_ready_future<
+          segment_tail_t>(NULL_SEGMENT_TAIL);
+      }),
+      crimson::ct_error::enoent::handle([](auto) {
+        return mount_ertr::make_ready_future<
+          segment_tail_t>(NULL_SEGMENT_TAIL);
+      }),
+      crimson::ct_error::pass_further_all{}
+    );
+    bool tail_valid = (tail.segment_nonce == header.segment_nonce);
+    if (!tail_valid && header.type == segment_type_t::JOURNAL) {
+      co_await scan_no_tail_segment(header, segment_id
+      ).handle_error(
+        crimson::ct_error::enoent::handle([](auto) {
+          return mount_ertr::now();
+        }),
+        crimson::ct_error::enodata::handle([](auto) {
+          return mount_ertr::now();
+        }),
+        crimson::ct_error::input_output_error::pass_further{},
+        crimson::ct_error::assert_all("unexpected error")
+      );
+    } else {
+      ceph_assert(header.get_type() == tail.get_type() || !tail_valid);
+
+      sea_time_point header_time = mod_to_timepoint(header.modify_time);
+      if (tail_valid) {
+        sea_time_point tail_time = mod_to_timepoint(tail.modify_time);
+        std::size_t num_extents = tail.num_extents;
+        DEBUG("updating modify time for segment {}, "
+              "mod time {}-{}, num_extents {}",
+              segment_id, header_time, tail_time, num_extents);
+        if (num_extents == 0) {
+          ceph_assert(tail_time == NULL_TIME);
+        } else {
+          ceph_assert(header_time != NULL_TIME);
+          ceph_assert(tail_time != NULL_TIME);
+          sea_time_point avg_time = get_average_time(
+            header_time, 1, tail_time, 1);
+          segments.update_modify_time(segment_id, avg_time, num_extents);
+        }
+      } else {
+        DEBUG("updating modify time for segment {}, mod time {}, without tail",
+              segment_id, header_time);
+        segments.init_modify_time(segment_id, header_time);
+      }
+
+      init_mark_segment_closed(
+        segment_id,
+        header.segment_seq,
+        header.type,
+        header.category,
+        header.generation);
+      INFO("done, {}", segments);
+    }
+  }
 }
 
 SegmentCleaner::scan_extents_ret SegmentCleaner::scan_no_tail_segment(

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1585,6 +1585,14 @@ SegmentCleaner::mount_ret SegmentCleaner::mount()
       crimson::ct_error::assert_all("unexpected error")
     );
     if (header == NULL_SEGMENT_HEADER) {
+      co_await sm_group->release_segment(segment_id
+      ).handle_error(
+        crimson::ct_error::invarg::handle([](auto) {
+          return mount_ertr::now();
+        }),
+        crimson::ct_error::input_output_error::pass_further{},
+        crimson::ct_error::assert_all("unexpected error")
+      );
       continue;
     }
     DEBUG("segment_id={} -- {}", segment_id, header);

--- a/src/crimson/os/seastore/journal/segment_allocator.cc
+++ b/src/crimson/os/seastore/journal/segment_allocator.cc
@@ -41,7 +41,7 @@ segment_nonce_t calc_new_nonce(
 {
   crc &= std::numeric_limits<uint32_t>::max() >> 1;
   crc |= static_cast<uint32_t>(type) << 31;
-  return ceph_crc32c(crc, data, length);
+  return (ceph_crc32c(crc, data, length) | SEGMENT_NONCE_MASK);
 }
 
 SegmentAllocator::open_ret

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -2678,6 +2678,8 @@ struct segment_header_t {
     return type;
   }
 
+  bool operator==(const segment_header_t &) const = default;
+
   DENC(segment_header_t, v, p) {
     DENC_START(1, 1, p);
     denc(v.modify_time, p);

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -2694,6 +2694,19 @@ struct segment_header_t {
 };
 std::ostream &operator<<(std::ostream &out, const segment_header_t &header);
 
+inline constexpr segment_header_t NULL_SEGMENT_HEADER =
+  segment_header_t{
+    std::numeric_limits<mod_time_point_t>::max(),
+    NULL_SEG_SEQ,
+    NULL_SEG_ID,
+    JOURNAL_SEQ_NULL,
+    JOURNAL_SEQ_NULL,
+    0,
+    segment_type_t::NULL_SEG,
+    data_category_t::NUM,
+    NULL_GENERATION
+  };
+
 struct segment_tail_t {
   segment_seq_t segment_seq;
   segment_id_t physical_segment_id; // debugging
@@ -2721,6 +2734,16 @@ struct segment_tail_t {
   }
 };
 std::ostream &operator<<(std::ostream &out, const segment_tail_t &tail);
+
+inline constexpr segment_tail_t NULL_SEGMENT_TAIL =
+  segment_tail_t{
+    NULL_SEG_SEQ,
+    NULL_SEG_ID,
+    0,
+    segment_type_t::NULL_SEG,
+    std::numeric_limits<mod_time_point_t>::max(),
+    0
+  };
 
 enum class transaction_type_t : uint8_t {
   MUTATE = 0,

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -2648,6 +2648,8 @@ struct extent_info_t {
 std::ostream &operator<<(std::ostream &out, const extent_info_t &header);
 
 using segment_nonce_t = uint32_t;
+inline constexpr segment_nonce_t SEGMENT_NONCE_MASK =
+  (std::numeric_limits<segment_nonce_t>::max() >> 1) + 1;
 
 /**
  * Segment header

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -2667,6 +2667,8 @@ struct segment_header_t {
     return type;
   }
 
+  bool operator==(const segment_header_t &) const = default;
+
   DENC(segment_header_t, v, p) {
     DENC_START(1, 1, p);
     denc(v.modify_time, p);
@@ -2682,6 +2684,19 @@ struct segment_header_t {
   }
 };
 std::ostream &operator<<(std::ostream &out, const segment_header_t &header);
+
+constexpr segment_header_t NULL_SEGMENT_HEADER =
+  segment_header_t{
+    std::numeric_limits<mod_time_point_t>::max(),
+    NULL_SEG_SEQ,
+    NULL_SEG_ID,
+    JOURNAL_SEQ_NULL,
+    JOURNAL_SEQ_NULL,
+    0,
+    segment_type_t::NULL_SEG,
+    data_category_t::NUM,
+    NULL_GENERATION
+  };
 
 struct segment_tail_t {
   segment_seq_t segment_seq;
@@ -2710,6 +2725,16 @@ struct segment_tail_t {
   }
 };
 std::ostream &operator<<(std::ostream &out, const segment_tail_t &tail);
+
+constexpr segment_tail_t NULL_SEGMENT_TAIL =
+  segment_tail_t{
+    NULL_SEG_SEQ,
+    NULL_SEG_ID,
+    0,
+    segment_type_t::NULL_SEG,
+    std::numeric_limits<mod_time_point_t>::max(),
+    0
+  };
 
 enum class transaction_type_t : uint8_t {
   MUTATE = 0,


### PR DESCRIPTION
When opening a segment, BlockSegmentManager's SegmentStateTracker is
first written out and then the segment header is written. And when
scanning segments on startup, SegmentCleaner determines whether a
segment is empty or closed by detecting a valid segment header. So if
the OSD crashes after the SegmentStateTracker is written out and before
the segment header is written, the segment state in SegmentCleaner and
that in the SegmentStateTracker after OSD reboot will be inconsistent.

This commit resolve this issue by making SegmentCleaner try to release
segments that don't have valid headers, after which the segment states
would be consistent

Fixes: https://tracker.ceph.com/issues/78739
Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
