### PR TITLE
tentacle: mon: allow getpoolstats for mgr modules

### DIFF
--- a/src/mon/MonCap.cc
+++ b/src/mon/MonCap.cc
@@ -226,6 +226,8 @@ void MonCapGrant::expand_profile(const EntityName& name) const
     // allow the Telemetry module to gather heap and mempool metrics
     profile_grants.push_back(MonCapGrant("heap"));
     profile_grants.push_back(MonCapGrant("dump_mempools"));
+    // alow getpoolstats for mgr modules
+    profile_grants.push_back(MonCapGrant("pg", MON_CAP_R));
   }
   if (profile == "osd" || profile == "mds" || profile == "mon" ||
       profile == "mgr") {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78805

---

backport of https://github.com/ceph/ceph/pull/67023
parent tracker: https://tracker.ceph.com/issues/74490

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh