### PR TITLE
doc/install: use ref for intra-docs links

### DIFF
--- a/doc/install/build-ceph.rst
+++ b/doc/install/build-ceph.rst
@@ -42,13 +42,13 @@ repository and execute the following::
     cd build
     ninja
 
-See `Installing a Build`_ to install a build in user space and `Ceph README.md`_
+See :ref:`install-storage-cluster-build` to install a build in user space and `Ceph README.md`_
 doc for more details on build.
 
 Build Ceph Packages
 ===================
 
-To build packages, you must clone the `Ceph`_ repository. You can create 
+To build packages, you must clone the :ref:`Ceph repository <install-clone-source>`. You can create
 installation packages from the latest code using ``dpkg-buildpackage`` for 
 Debian/Ubuntu or ``rpmbuild`` for the RPM Package Manager.
 
@@ -61,7 +61,7 @@ Advanced Package Tool (APT)
 ---------------------------
 
 To create ``.deb`` packages for Debian/Ubuntu, ensure that you have cloned the 
-`Ceph`_ repository, installed the `Build Prerequisites`_ and installed 
+:ref:`Ceph repository <install-clone-source>`, installed the `Build Prerequisites`_ and installed
 ``debhelper``::
 
 	sudo apt-get install debhelper
@@ -76,7 +76,7 @@ For multi-processor CPUs use the ``-j`` option to accelerate the build.
 RPM Package Manager
 -------------------
 
-To create ``.rpm`` packages, ensure that you have cloned the `Ceph`_ repository,
+To create ``.rpm`` packages, ensure that you have cloned the :ref:`Ceph repository <install-clone-source>`,
 installed the `Build Prerequisites`_ and installed ``rpm-build`` and 
 ``rpmdevtools``::
 
@@ -104,6 +104,4 @@ Build the RPM packages::
 
 For multi-processor CPUs use the ``-j`` option to accelerate the build.
 
-.. _Ceph: ../clone-source
-.. _Installing a Build: ../install-storage-cluster#installing-a-build
 .. _Ceph README.md: https://github.com/ceph/ceph#building-ceph

--- a/doc/install/clone-source.rst
+++ b/doc/install/clone-source.rst
@@ -1,3 +1,5 @@
+.. _install-clone-source:
+
 =========================================
  Cloning the Ceph Source Code Repository
 =========================================

--- a/doc/install/get-packages.rst
+++ b/doc/install/get-packages.rst
@@ -123,7 +123,7 @@ For RPMs::
 The major releases of Ceph are summarized at: :ref:`Releases <ceph-releases-index>`
 
 .. tip:: For non-US users: There might be a mirror close to you where
-         to download Ceph from. For more information see: `Ceph Mirrors`_.
+         to download Ceph from. For more information see: :ref:`install-mirrors`.
 
 Debian Packages
 ~~~~~~~~~~~~~~~
@@ -168,7 +168,7 @@ of Debian and Ubuntu releases supported.
    echo deb https://download.ceph.com/debian-testing/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
 
 .. tip:: For non-US users: There might be a mirror close to you where
-         to download Ceph from. For more information see: `Ceph Mirrors`_.
+         to download Ceph from. For more information see: :ref:`install-mirrors`.
 
 
 RPM Packages
@@ -234,7 +234,7 @@ You can download the RPMs directly from
    https://download.ceph.com/rpm-testing
 
 .. tip:: For non-US users: There might be a mirror close to you where
-         to download Ceph from. For more information see: `Ceph Mirrors`_.
+         to download Ceph from. For more information see: :ref:`install-mirrors`.
 
 openSUSE Leap 15.1
 ^^^^^^^^^^^^^^^^^^
@@ -389,4 +389,3 @@ line to get the short codename.
 
 .. _the testing Debian repository: https://download.ceph.com/debian-testing/dists
 .. _the shaman page: https://shaman.ceph.com
-.. _Ceph Mirrors: ../mirrors

--- a/doc/install/get-tarballs.rst
+++ b/doc/install/get-tarballs.rst
@@ -7,8 +7,7 @@ source code. You may download source code tarballs for Ceph releases here:
 
 `Ceph Release Tarballs`_
 
-.. tip:: For international users: There might be a mirror close to you where download Ceph from. For more information see: `Ceph Mirrors`_.
+.. tip:: For international users: There might be a mirror close to you where download Ceph from. For more information see: :ref:`install-mirrors`.
 
 
 .. _Ceph Release Tarballs: https://download.ceph.com/tarballs/
-.. _Ceph Mirrors: ../mirrors

--- a/doc/install/index.rst
+++ b/doc/install/index.rst
@@ -53,6 +53,4 @@ Windows
 ~~~~~~~
 
 For Windows installations, consult this document:
-`Windows installation guide`_.
-
-.. _Windows installation guide: ./windows-install
+:ref:`install-windows`.

--- a/doc/install/install-storage-cluster.rst
+++ b/doc/install/install-storage-cluster.rst
@@ -1,3 +1,5 @@
+.. _install_storage_cluster:
+
 ==============================
  Install Ceph Storage Cluster
 ==============================
@@ -79,6 +81,7 @@ Once you have added either release or development packages, or added a
 
    sudo yum install ceph
 
+.. _install-storage-cluster-build:
 
 Installing a Build
 ==================

--- a/doc/install/mirrors.rst
+++ b/doc/install/mirrors.rst
@@ -1,3 +1,5 @@
+.. _install-mirrors:
+
 =============
  Ceph Mirrors
 =============

--- a/doc/install/windows-basic-config.rst
+++ b/doc/install/windows-basic-config.rst
@@ -1,5 +1,7 @@
 :orphan:
 
+.. _install-windows-basic-config:
+
 ===========================
 Windows basic configuration
 ===========================

--- a/doc/install/windows-install.rst
+++ b/doc/install/windows-install.rst
@@ -1,5 +1,7 @@
 :orphan:
 
+.. _install-windows:
+
 ==========================
 Installing Ceph on Windows
 ==========================
@@ -15,7 +17,7 @@ Supported platforms
 -------------------
 .. note::
 
-  Please see the `OS recommendations`_ regarding client package support.
+  Please see the :ref:`os-recommendations` regarding client package support.
 
 Windows Server 2019 and Windows Server 2016 are supported. Previous Windows
 Server versions, including Windows client versions such as Windows 10, might
@@ -66,7 +68,7 @@ https://github.com/ceph/ceph/blob/master/README.windows.rst
 Configuration
 =============
 
-Please check the `Windows configuration sample`_ to get started.
+Please check the :ref:`Windows configuration sample <install-windows-basic-config>` to get started.
 
 You'll also need a keyring file. The `General CephFS Prerequisites`_ page provides a
 simple example, showing how a new CephX user can be created and how its secret
@@ -80,12 +82,8 @@ Further reading
 
 * `RBD Windows documentation`_
 * :ref:`CephFS Windows documentation <ceph-dokan>`
-* `Windows troubleshooting`_
+* :ref:`install-windows-troubleshooting`
 
-.. _Windows configuration sample: ../windows-basic-config
 .. _RBD Windows documentation: ../../rbd/rbd-windows/
-.. _Windows troubleshooting: ../windows-troubleshooting
 .. _General CephFS Prerequisites: ../../cephfs/mount-prerequisites
 .. _Client Authentication: ../../cephfs/client-auth
-.. _Windows testing: ../dev/tests-windows
-.. _OS recommendations: ../../start/os-recommendations

--- a/doc/install/windows-troubleshooting.rst
+++ b/doc/install/windows-troubleshooting.rst
@@ -1,5 +1,7 @@
 :orphan:
 
+.. _install-windows-troubleshooting:
+
 ===============================
 Troubleshooting Ceph on Windows
 ===============================


### PR DESCRIPTION
Use `:ref:` instead of external link definitions for intra-docs links.

Add labels if necessary in files within the `install/` directory. Use existing labels for links outside the `install/` directory but do not add new labels outside of the `install/` directory.

Delete unused external link definition `Windows testing` in `doc/install/windows-install.rst`.

- Original: https://docs.ceph.com/en/latest/install/build-ceph/
- Rendered PR: https://ceph--70663.org.readthedocs.build/en/70663/install/build-ceph/
- `doc/install/clone-source.rst` no change in rendered docs.
- Original: https://docs.ceph.com/en/latest/install/get-packages/
- Rendered PR: https://ceph--70663.org.readthedocs.build/en/70663/install/get-packages/
- Original: https://docs.ceph.com/en/latest/install/get-tarballs/
- Rendered PR: https://ceph--70663.org.readthedocs.build/en/70663/install/get-tarballs/
- Original: https://docs.ceph.com/en/latest/install/#windows
- Rendered PR: https://ceph--70663.org.readthedocs.build/en/70663/install/#windows
- `doc/install/install-storage-cluster.rst` no change in rendered docs.
- `doc/install/mirrors.rst` no change in rendered docs.
- `doc/install/windows-basic-config.rst` no change in rendered docs.






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
