### PR TITLE
rgw/dedup maintain mtime during dedup

### DIFF
--- a/src/rgw/driver/rados/rgw_dedup.cc
+++ b/src/rgw/driver/rados/rgw_dedup.cc
@@ -946,6 +946,15 @@ namespace rgw::dedup {
   }
 
   //---------------------------------------------------------------------------
+  static struct timespec record_to_timespec(const disk_record_t& rec)
+  {
+    return {
+      .tv_sec  = static_cast<time_t>(rec.s.mtime_sec),
+      .tv_nsec = static_cast<long>(rec.s.mtime_nsec),
+    };
+  }
+
+  //---------------------------------------------------------------------------
   int Background::dedup_object(disk_record_t                *p_src_rec,
                                disk_record_t                *p_tgt_rec,
                                const RGWObjManifest         &src_manifest,
@@ -1030,6 +1039,11 @@ namespace rgw::dedup {
         src_op.truncate(0);
         p_stats->split_head_src++;
       }
+
+      // preserve object timestamp
+      struct timespec src_ts = record_to_timespec(*p_src_rec);
+      src_op.mtime2(&src_ts);
+
       d_ctl.metadata_access_throttle.acquire();
       ldpp_dout(dpp, 20) << __func__ <<"::send SRC CLS"<< dendl;
       ret = src_ioctx.operate(src_oid, &src_op);
@@ -1066,6 +1080,11 @@ namespace rgw::dedup {
       tgt_op.truncate(0);
       p_stats->split_head_tgt++;
     }
+
+    // preserve object timestamp
+    struct timespec tgt_ts = record_to_timespec(*p_tgt_rec);
+    tgt_op.mtime2(&tgt_ts);
+
     d_ctl.metadata_access_throttle.acquire();
     ldpp_dout(dpp, 20) << __func__ << "::send TGT CLS" << dendl;
     ret = tgt_ioctx.operate(tgt_oid, &tgt_op);
@@ -1184,8 +1203,13 @@ namespace rgw::dedup {
   //---------------------------------------------------------------------------
   int Background::add_obj_attrs_to_record(disk_record_t         *p_rec,
                                           const rgw::sal::Attrs &attrs,
-                                          md5_stats_t           *p_stats) /*IN-OUT*/
+                                          md5_stats_t           *p_stats,
+                                          const ceph::real_time& mtime) /*IN-OUT*/
   {
+    struct timespec ts = ceph::real_clock::to_timespec(mtime);
+    p_rec->s.mtime_sec  = ts.tv_sec;
+    p_rec->s.mtime_nsec = ts.tv_nsec;
+
     // if TAIL_TAG exists -> use it as ref-tag, eitherwise take ID_TAG
     auto itr = attrs.find(RGW_ATTR_TAIL_TAG);
     if (itr != attrs.end()) {
@@ -1505,7 +1529,8 @@ namespace rgw::dedup {
 
     // reset flags
     p_rec->s.flags.clear();
-    ret = add_obj_attrs_to_record(p_rec, attrs, p_stats);
+    // safe to use p_obj->get_mtime() after p_obj->get_obj_attrs() was called
+    ret = add_obj_attrs_to_record(p_rec, attrs, p_stats, p_obj->get_mtime());
     if (unlikely(ret != 0)) {
       // don't trace errors for unsupported manifest
       if (ret == -ENOTSUP) {

--- a/src/rgw/driver/rados/rgw_dedup.h
+++ b/src/rgw/driver/rados/rgw_dedup.h
@@ -199,7 +199,8 @@ namespace rgw::dedup {
 
     int add_obj_attrs_to_record(disk_record_t         *p_rec,
                                 const rgw::sal::Attrs &attrs,
-                                md5_stats_t           *p_stats); /* IN-OUT */
+                                md5_stats_t           *p_stats,
+                                const ceph::real_time& mtime); /* IN-OUT */
 
     int read_object_attribute(dedup_table_t    *p_table,
                               disk_record_t    *p_rec,

--- a/src/rgw/driver/rados/rgw_dedup_cluster.cc
+++ b/src/rgw/driver/rados/rgw_dedup_cluster.cc
@@ -100,9 +100,9 @@ namespace rgw::dedup {
       if (ret == 0) {
         ret = -ENODATA;
       }
-      ldpp_dout(dpp, 10) << __func__ << "::" << (caller ? caller : "")
-                         << "::failed ctl_ioctx.getxattr() with: "
-                         << cpp_strerror(-ret) << ", ret=" << ret << dendl;
+      ldpp_dout(dpp, 5) << __func__ << "::" << (caller ? caller : "")
+                        << "::failed ctl_ioctx.getxattr(RGW_DEDUP_ATTR_EPOCH) with: "
+                        << cpp_strerror(-ret) << ", ret=" << ret << dendl;
       return ret;
     }
   }
@@ -1012,8 +1012,9 @@ namespace rgw::dedup {
                                        const DoutPrefixProvider *dpp)
   {
     dedup_epoch_t epoch;
-    int ret = get_epoch(store, dpp, &epoch, nullptr);
+    int ret = get_epoch(store, dpp, &epoch, "radosgw-admin dedup stats");
     if (ret != 0) {
+      ldpp_dout(dpp, 10) << __func__ << "::failed get_epoch(), ret=" << ret << dendl;
       return ret;
     }
 

--- a/src/rgw/driver/rados/rgw_dedup_store.cc
+++ b/src/rgw/driver/rados/rgw_dedup_store.cc
@@ -66,6 +66,8 @@ namespace rgw::dedup {
 
     this->s.shared_manifest = 0;
     memset(this->s.hash, 0, sizeof(this->s.hash));
+    this->s.mtime_sec       = 0;
+    this->s.mtime_nsec      = 0;
     this->ref_tag           = "";
     this->manifest_bl.clear();
   }
@@ -95,6 +97,8 @@ namespace rgw::dedup {
     this->s.stor_class_len  = CEPHTOH_16(p_rec->s.stor_class_len);
     this->s.ref_tag_len     = CEPHTOH_16(p_rec->s.ref_tag_len);
     this->s.manifest_len    = CEPHTOH_16(p_rec->s.manifest_len);
+    this->s.mtime_sec       = CEPHTOH_32(p_rec->s.mtime_sec);
+    this->s.mtime_nsec      = CEPHTOH_32(p_rec->s.mtime_nsec);
 
     const char *p = buff + sizeof(this->s);
     this->obj_name = std::string(p, this->s.obj_name_len);
@@ -154,6 +158,8 @@ namespace rgw::dedup {
     p_rec->s.stor_class_len  = HTOCEPH_16(this->stor_class.length());
     p_rec->s.ref_tag_len     = HTOCEPH_16(this->ref_tag.length());
     p_rec->s.manifest_len    = HTOCEPH_16(this->manifest_bl.length());
+    p_rec->s.mtime_sec       = HTOCEPH_32(this->s.mtime_sec);
+    p_rec->s.mtime_nsec      = HTOCEPH_32(this->s.mtime_nsec);
     char *p = buff + sizeof(this->s);
     unsigned len = this->obj_name.length();
     std::memcpy(p, this->obj_name.data(), len);

--- a/src/rgw/driver/rados/rgw_dedup_store.h
+++ b/src/rgw/driver/rados/rgw_dedup_store.h
@@ -201,6 +201,8 @@ namespace rgw::dedup {
       uint8_t       rec_version;     // allows changing record format
       record_flags_t flags;           // 1 Byte flags
       uint8_t       pad[6];
+      uint32_t      mtime_sec;       // bucket-index mtime, LE on disk
+      uint32_t      mtime_nsec;
     }s;
     std::string obj_name;
     // TBD: find pool name making it easier to get ioctx
@@ -213,7 +215,7 @@ namespace rgw::dedup {
     bufferlist  manifest_bl;
   };
   static_assert(BLAKE3_OUT_LEN == sizeof(disk_record_t::packed_rec_t::hash));
-  static_assert(sizeof(disk_record_t::packed_rec_t) == sizeof(uint64_t)*12);
+  static_assert(sizeof(disk_record_t::packed_rec_t) == sizeof(uint64_t)*13);
   std::ostream &operator<<(std::ostream &stream, const disk_record_t & rec);
 
   static constexpr unsigned BLOCK_MAGIC = 0xFACE;

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -9606,6 +9606,10 @@ next:
       if (ret == 0) {
 	formatter->flush(cout);
       }
+      else if (ret == -ENOENT) {
+        // Dedup Epoch object doesn't exist -> Asking for stats before running dedup
+        cerr << "No dedup estimate/exec found. Please run 'radosgw-admin dedup estimate/exec' first." << std::endl;
+      }
       else {
 	cerr << "ERROR: Failed reading stat counters" << std::endl;
       }

--- a/src/test/rgw/dedup/test_dedup.py
+++ b/src/test/rgw/dedup/test_dedup.py
@@ -4289,3 +4289,57 @@ def test_dedup_filter_bucket_exec():
 
     log.info("dedup_filter_bucket_exec: filter_mode_allow")
     dedup_filter_allow_deny_bucket_common(dry_run, filter_mode_allow=True)
+
+#-------------------------------------------------------------------------------
+def collect_object_mtimes(conn, bucket_name, files):
+    """Return LastModified per S3 key for all copies in files."""
+    mtimes = {}
+
+    for f in files:
+        filename = f[0]
+        num_copies = f[2]
+        for i in range(num_copies):
+            key = gen_object_name(filename, i)
+            resp = conn.head_object(Bucket=bucket_name, Key=key)
+            mtimes[key] = resp['LastModified']
+            log.debug("collect_object_mtimes: %s/%s mtime=%s",
+                      bucket_name, key, mtimes[key])
+
+    return mtimes
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_dedup_maintain_mtime():
+    if full_dedup_is_disabled():
+        return
+
+    prepare_test()
+    bucket_name = gen_bucket_name()
+    conn = get_single_connection()
+    config = default_config
+    files = []
+    for size in (1*MB, 7*MB, 16*MB):
+        gen_files_fixed_copies(files, 1, size, 2)
+
+    try:
+        conn.create_bucket(Bucket=bucket_name)
+        indices = [0] * len(files)
+        ret = upload_objects(bucket_name, files, indices, conn, config, True)
+        dedup_stats = ret[1]
+        mtimes_before = collect_object_mtimes(conn, bucket_name, files)
+        time.sleep(10)
+        exec_dedup(dedup_stats, dry_run=False)
+        mtimes_after = collect_object_mtimes(conn, bucket_name, files)
+
+        success=True
+        for key, mtime_before in mtimes_before.items():
+            assert key in mtimes_after
+            if mtimes_after[key] != mtime_before:
+                log.warning("mtime changed for %s: before=%s, after=%s",
+                            key, mtime_before, mtimes_after[key])
+                success=False
+
+        assert success
+
+    finally:
+        cleanup(bucket_name, conn)


### PR DESCRIPTION
dedup setxattr triggers mtime change causing the object mtime to drift from BI mtime. As a result LC operations fail

Fixes: https://tracker.ceph.com/issues/80312

Tracker: https://ibm-ceph.atlassian.net/browse/IBMCEPH-17201

Tracker: https://ibm-ceph.atlassian.net/browse/IBMCEPH-13092




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
