### PR TITLE
umbrella: test: Remove invalid unit test

### DIFF
--- a/src/test/librados/split_op_cxx.cc
+++ b/src/test/librados/split_op_cxx.cc
@@ -322,25 +322,6 @@ TEST_P(LibRadosSplitOpECPP, ReadSecondShardWithVersion) {
   ASSERT_TRUE(AssertOperateWithSplitOp(0, 2, "foo", &read, &bl, balanced_read_flags));
 }
 
-TEST_P(LibRadosSplitOpECPP, ReadWithIllegalClsOp) {
-  SKIP_IF_CRIMSON();
-  bufferlist bl;
-  bl.append("ceph");
-  ObjectWriteOperation write1;
-  write1.write(0, bl);
-  ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "foo", &write1));
-
-  bufferlist new_bl;
-  new_bl.append("CEPH");
-  ObjectWriteOperation write2;
-  bufferlist exec_inbl, exec_outbl;
-  int exec_rval;
-  rados::cls::fifo::op::init_part op;
-  encode(op, exec_inbl);
-  write2.exec(fifo::method::init_part, exec_inbl, &exec_outbl, &exec_rval);
-  ASSERT_TRUE(AssertOperateWithoutSplitOp(-EOPNOTSUPP, "foo", &write2));
-}
-
 TEST_P(LibRadosSplitOpECPP, XattrReads) {
   SKIP_IF_CRIMSON();
   bufferlist bl, attr_bl, attr_read_bl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78832

---

backport of https://github.com/ceph/ceph/pull/69284
parent tracker: https://tracker.ceph.com/issues/78831

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh