### PR TITLE
mgr/dashboard: avoid empty CephFS mirror peer rows

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -1430,6 +1430,23 @@ class CephFSMirror(RESTController):
             )
         return json.loads(out) if out else {}
 
+    @EndpointDoc("Disable mirroring for a filesystem",
+                 parameters={
+                     'fs_name': (str, 'File system name'),
+                 },
+                 responses={200: {}})
+    @RESTController.Collection('POST', path='/disable')
+    @DeletePermission
+    def disable(self, fs_name: str):
+        error_code, out, err = mgr.remote('mirroring', 'snapshot_mirror_disable', fs_name)
+        if error_code != 0:
+            raise DashboardException(
+                msg=f'Failed to disable Cephfs mirroring: {err}',
+                code=error_code,
+                component='cephfs.mirror'
+            )
+        return json.loads(out) if out else {}
+
     @EndpointDoc("Create bootstrap token",
                  parameters={
                      'fs_name': (str, 'File system name'),

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.spec.ts
@@ -148,7 +148,7 @@ describe('CephfsMirroringListComponent', () => {
     );
   });
 
-  it('should handle empty peers and map "-" values', () => {
+  it('should omit filesystems with empty peers and peers without remote info', () => {
     const mockData: Daemon[] = [
       {
         daemon_id: 2,
@@ -158,6 +158,13 @@ describe('CephfsMirroringListComponent', () => {
             name: 'fs2',
             directory_count: 5,
             peers: [],
+            id: ''
+          },
+          {
+            filesystem_id: 21,
+            name: 'fs3',
+            directory_count: 1,
+            peers: [{ uuid: 'empty-peer', remote: {}, stats: {} } as any],
             id: ''
           }
         ]
@@ -172,20 +179,8 @@ describe('CephfsMirroringListComponent', () => {
     component.daemonStatus$.subscribe((v) => (emitted = v || []));
     component.loadDaemonStatus();
 
-    expect(emitted.length).toBe(1);
+    expect(emitted.length).toBe(0);
     expect(cephfsServiceMock.getMirrorStatus).not.toHaveBeenCalled();
-    expect(emitted[0]).toEqual({
-      remote_cluster_name: '-',
-      local_fs_name: 'fs2',
-      fs_name: 'fs2',
-      client_name: '-',
-      directory_count: 5,
-      filesystem_id: 20,
-      peerId: '-',
-      id: '2-20',
-      bytes_replicated: '-',
-      last_sync: '-'
-    });
   });
 
   it('should not navigate to add path modal when filesystem_id is missing', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
@@ -209,16 +209,23 @@ export class CephfsMirroringListComponent implements OnInit, OnDestroy {
         continue;
       }
       for (const fs of daemon.filesystems) {
-        if (fs.peers?.length) {
-          for (const peer of fs.peers) {
-            rows.push(this.peerToRow(daemon, fs, peer));
+        if (!fs.peers?.length) {
+          continue;
+        }
+        for (const peer of fs.peers) {
+          if (!this.hasPeerInfo(peer)) {
+            continue;
           }
-        } else {
-          rows.push(this.noPeerRow(daemon, fs));
+          rows.push(this.peerToRow(daemon, fs, peer));
         }
       }
     }
     return rows;
+  }
+
+  private hasPeerInfo(peer: Peer): boolean {
+    const remote = peer?.remote;
+    return !!(remote?.cluster_name || remote?.fs_name || remote?.client_name);
   }
 
   private peerToRow(daemon: Daemon, fs: Filesystem, peer: Peer): MirroringRow {
@@ -231,21 +238,6 @@ export class CephfsMirroringListComponent implements OnInit, OnDestroy {
       filesystem_id: fs.filesystem_id,
       peer_uuid: peer.uuid,
       id: `${daemon.daemon_id}-${fs.filesystem_id}`
-    };
-  }
-
-  private noPeerRow(daemon: Daemon, fs: Filesystem): MirroringRow {
-    return {
-      remote_cluster_name: '-',
-      local_fs_name: fs.name,
-      fs_name: fs.name,
-      client_name: '-',
-      directory_count: fs.directory_count ?? 0,
-      filesystem_id: fs.filesystem_id,
-      peerId: '-',
-      id: `${daemon.daemon_id}-${fs.filesystem_id}`,
-      bytes_replicated: '-',
-      last_sync: '-'
     };
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-setup-mirroring/cephfs-setup-mirroring.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-setup-mirroring/cephfs-setup-mirroring.component.spec.ts
@@ -17,6 +17,7 @@ describe('CephfsSetupMirroringComponent', () => {
     list: jest.fn().mockReturnValue(of([])),
     listDaemonStatus: jest.fn().mockReturnValue(of([])),
     enableMirror: jest.fn().mockReturnValue(of(null)),
+    disableMirror: jest.fn().mockReturnValue(of(null)),
     createBootstrapPeer: jest.fn().mockReturnValue(of(null))
   };
 
@@ -33,7 +34,9 @@ describe('CephfsSetupMirroringComponent', () => {
     cephfsServiceMock.list.mockReturnValue(of([]));
     cephfsServiceMock.listDaemonStatus.mockReturnValue(of([]));
     cephfsServiceMock.enableMirror.mockReturnValue(of(null));
+    cephfsServiceMock.disableMirror.mockReturnValue(of(null));
     cephfsServiceMock.createBootstrapPeer.mockReturnValue(of(null));
+    taskWrapperMock.wrapTaskAroundCall.mockImplementation(({ call }) => call);
 
     await TestBed.configureTestingModule({
       declarations: [CephfsSetupMirroringComponent],
@@ -212,6 +215,45 @@ describe('CephfsSetupMirroringComponent', () => {
       component.onSetupMirroring();
 
       expect(component.isSubmitting).toBe(false);
+      expect(setErrorsSpy).toHaveBeenCalledWith({ cdSubmitButton: true });
+      expect(emitSpy).not.toHaveBeenCalled();
+    });
+
+    it('should disable mirroring when bootstrap peer import fails', () => {
+      const emitSpy = jest.spyOn(component.mirroringSetup, 'emit');
+      const setErrorsSpy = jest.spyOn(component.setupForm, 'setErrors');
+      cephfsServiceMock.createBootstrapPeer.mockReturnValue(
+        throwError(() => new Error('import failed'))
+      );
+      component.setupForm.setValue({ filesystem: 'myfs', token: 'eyJrZXkiOiJ2YWx1ZSJ9' });
+
+      component.onSetupMirroring();
+
+      expect(cephfsServiceMock.enableMirror).toHaveBeenCalledWith('myfs');
+      expect(cephfsServiceMock.createBootstrapPeer).toHaveBeenCalledWith(
+        'myfs',
+        'eyJrZXkiOiJ2YWx1ZSJ9'
+      );
+      expect(cephfsServiceMock.disableMirror).toHaveBeenCalledWith('myfs');
+      expect(component.isSubmitting).toBe(false);
+      expect(setErrorsSpy).toHaveBeenCalledWith({ cdSubmitButton: true });
+      expect(emitSpy).not.toHaveBeenCalled();
+    });
+
+    it('should still surface the import error if disable mirroring also fails', () => {
+      const emitSpy = jest.spyOn(component.mirroringSetup, 'emit');
+      const setErrorsSpy = jest.spyOn(component.setupForm, 'setErrors');
+      cephfsServiceMock.createBootstrapPeer.mockReturnValue(
+        throwError(() => new Error('import failed'))
+      );
+      cephfsServiceMock.disableMirror.mockReturnValue(
+        throwError(() => new Error('disable failed'))
+      );
+      component.setupForm.setValue({ filesystem: 'myfs', token: 'eyJrZXkiOiJ2YWx1ZSJ9' });
+
+      component.onSetupMirroring();
+
+      expect(cephfsServiceMock.disableMirror).toHaveBeenCalledWith('myfs');
       expect(setErrorsSpy).toHaveBeenCalledWith({ cdSubmitButton: true });
       expect(emitSpy).not.toHaveBeenCalled();
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-setup-mirroring/cephfs-setup-mirroring.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-setup-mirroring/cephfs-setup-mirroring.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, Output, EventEmitter, inject } from '@angular/core';
 import { Validators } from '@angular/forms';
-import { concat, forkJoin, of } from 'rxjs';
-import { catchError, finalize, last } from 'rxjs/operators';
+import { concat, forkJoin, of, throwError } from 'rxjs';
+import { catchError, finalize, last, switchMap } from 'rxjs/operators';
 
 import { CephfsService } from '~/app/shared/api/cephfs.service';
 import { CephServiceService } from '~/app/shared/api/ceph-service.service';
@@ -69,7 +69,15 @@ export class CephfsSetupMirroringComponent extends CdForm implements OnInit {
         service_type: 'cephfs-mirror'
       }),
       this.cephfsService.enableMirror(filesystem),
-      this.cephfsService.createBootstrapPeer(filesystem, token.replace(/\s/g, ''))
+      this.cephfsService.createBootstrapPeer(filesystem, token.replace(/\s/g, '')).pipe(
+        catchError((err) =>
+          // otherwise empty peer list is created
+          this.cephfsService.disableMirror(filesystem).pipe(
+            catchError(() => of(null)),
+            switchMap(() => throwError(() => err))
+          )
+        )
+      )
     ).pipe(last());
 
     this.taskWrapper

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
@@ -122,6 +122,13 @@ describe('CephfsService', () => {
     });
   });
 
+  it('should disable mirroring for a filesystem', () => {
+    service.disableMirror('myfs').subscribe();
+    const req = httpTesting.expectOne('api/cephfs/mirror/disable');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ fs_name: 'myfs' });
+  });
+
   it('should add mirror directory without encoding path in request body', () => {
     const path = '/volumes/Group1/A1/64446b51-d39b-436b-991f-0f8e713067ff';
     service.addMirrorDirectory('testfs', path).subscribe();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
@@ -144,6 +144,12 @@ export class CephfsService {
     });
   }
 
+  disableMirror(@cdEncodeNot fsName: string): Observable<any> {
+    return this.http.post(`${this.baseURL}/mirror/disable`, {
+      fs_name: fsName
+    });
+  }
+
   createBootstrapToken(fsName: string, clientName: string, siteName: string): Observable<any> {
     return this.http.post(`${this.baseURL}/mirror/token`, {
       fs_name: fsName,

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -3458,6 +3458,53 @@ paths:
       summary: List snapshot mirrored directories
       tags:
       - CephfsMirror
+  /api/cephfs/mirror/disable:
+    post:
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                fs_name:
+                  description: File system name
+                  type: string
+              required:
+              - fs_name
+              type: object
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                type: object
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                type: object
+          description: Resource created.
+        '202':
+          content:
+            application/json:
+              schema:
+                type: object
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                type: object
+          description: Operation is still executing. Please check the task queue.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Disable mirroring for a filesystem
+      tags:
+      - CephfsMirror
   /api/cephfs/mirror/enable:
     post:
       parameters: []

--- a/src/pybind/mgr/dashboard/tests/test_cephfs.py
+++ b/src/pybind/mgr/dashboard/tests/test_cephfs.py
@@ -144,6 +144,31 @@ class CephFSMirrorTest(ControllerTestCase):  # pylint: disable=too-many-public-m
         self.assertIn(error_message, response.get('detail', ''))
         mgr.remote.assert_called_once_with('mirroring', 'snapshot_mirror_enable', fs_name)
 
+    def test_disable_success(self):
+        fs_name = 'test_fs'
+        mgr.remote = Mock(return_value=(0, '{}', ''))
+
+        self._post('/api/cephfs/mirror/disable', {
+            'fs_name': fs_name
+        })
+        self.assertStatus(200)
+        self.assertJsonBody({})
+        mgr.remote.assert_called_once_with('mirroring', 'snapshot_mirror_disable', fs_name)
+
+    def test_disable_error(self):
+        fs_name = 'test_fs'
+        error_message = 'Failed to disable mirroring'
+        mgr.remote = Mock(return_value=(1, '', error_message))
+
+        self._post('/api/cephfs/mirror/disable', {
+            'fs_name': fs_name
+        })
+        self.assertStatus(400)
+        response = self.json_body()
+        self.assertIn('Failed to disable Cephfs mirroring', response.get('detail', ''))
+        self.assertIn(error_message, response.get('detail', ''))
+        mgr.remote.assert_called_once_with('mirroring', 'snapshot_mirror_disable', fs_name)
+
     def test_create_success(self):
         fs_name = 'test_fs'
         token = 'bootstrap-token-12345'


### PR DESCRIPTION
Disable mirroring when bootstrap token import fails after enable, and omit filesystems/peers with no remote information from the list.

**Before:**

[screen-capture (28).webm](https://github.com/user-attachments/assets/da439b1b-2062-40e8-a9a0-85350f5569e9)

**After fix:**

[screen-capture (29).webm](https://github.com/user-attachments/assets/ff922b0d-bd4d-4356-9704-a7862eccb6cb)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
