### PR TITLE
mgr/dashboard: fix notification and tearsheet UI issues

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, OnInit, SecurityContext, ViewChild } from '@angular/core';
+import { Component, DestroyRef, OnInit, ViewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
@@ -19,7 +19,6 @@ import { from, Observable, of } from 'rxjs';
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { catchError, concatMap, map, tap } from 'rxjs/operators';
-import { DomSanitizer } from '@angular/platform-browser';
 
 export type SubsystemPayload = {
   nqn: string;
@@ -92,8 +91,7 @@ export class NvmeofSubsystemsFormComponent implements OnInit {
     private destroyRef: DestroyRef,
     private nvmeofService: NvmeofService,
     private notificationService: NotificationService,
-    private router: Router,
-    private sanitizer: DomSanitizer
+    private router: Router
   ) {}
 
   ngOnInit() {
@@ -265,22 +263,19 @@ export class NvmeofSubsystemsFormComponent implements OnInit {
   private showFinalNotification(stepResults: StepResult[]) {
     this.isSubmitLoading = false;
 
-    const messageLines = stepResults.map((stepResult) =>
-      stepResult.success
-        ? $localize`<div>${stepResult.step} step created successfully</div><br/>`
-        : $localize`<div>${stepResult.step} step failed: <code>${stepResult.error}</code></div><br/>`
-    );
-
-    const rawHtml = messageLines.join('<br/>');
-    const sanitizedHtml = this.sanitizer.sanitize(SecurityContext.HTML, rawHtml) ?? '';
-
     const hasFailure = stepResults.some((r) => !r.success);
     const type = hasFailure ? NotificationType.error : NotificationType.success;
     const title = hasFailure
       ? $localize`Subsystem created (with errors)`
       : $localize`Subsystem created`;
 
-    this.notificationService.show(type, title, sanitizedHtml);
+    const messageLines = stepResults.map((stepResult) =>
+      stepResult.success
+        ? $localize`${stepResult.step}:step: created successfully`
+        : $localize`${stepResult.step}:step: failed (${stepResult.error}:error:)`
+    );
+
+    this.notificationService.show(type, title, messageLines.join('<br>'));
     this.router.navigate(['block/nvmeof/subsystems'], {
       queryParams: {
         group: this.group,

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-area/notification-area.component.html
@@ -13,7 +13,7 @@
           <cd-icon type="infoCircle"></cd-icon>
 
           <div class="notification-content">
-            <div class="notification-title">
+            <div class="notification-title cds--type-body-short-01">
               {{ task.description }}
             </div>
 
@@ -27,7 +27,7 @@
             </cds-progress-bar>
 
             <div class="task-row">
-              <span class="notification-timestamp">
+              <span class="notification-timestamp cds--type-label-01">
                 {{ task.begin_time | relativeDate }}
               </span>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.html
@@ -124,19 +124,23 @@
               Occurrences: {{ selected.occurrences }}
             </p>
           }
-          <p class="notifications-page__detail-text cds--type-body-01">
-            {{ selected.displayPreview }}
-          </p>
+          <p
+            class="notifications-page__detail-text cds--type-body-01"
+            [innerHTML]="selected.displayDetail | sanitizeHtml"
+          ></p>
           @if (selected.prometheusAlert?.sourceUrl) {
             <a
               cdsLink
-              class="cds-mt-5"
+              class="notifications-page__prometheus-link cds-mt-5"
               [href]="selected.prometheusAlert.sourceUrl"
               target="_blank"
               rel="noopener noreferrer"
-              i18n
             >
-              View in Prometheus
+              <span i18n>View in Prometheus</span>
+              <cd-icon
+                type="launch"
+                [useDefault]="true"
+              ></cd-icon>
             </a>
           }
         </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.scss
@@ -67,8 +67,10 @@
 
   &__detail {
     overflow-y: auto;
+    overflow-x: hidden;
     padding: var(--cds-spacing-06) var(--cds-spacing-07);
     background-color: var(--cds-layer-01);
+    min-width: 0;
   }
 
   &__detail-header cd-notification-item {
@@ -87,6 +89,13 @@
   &__detail-text {
     margin: 0;
     color: var(--cds-text-primary);
+    overflow-wrap: break-word;
+  }
+
+  &__prometheus-link {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cds-spacing-02);
   }
 
   &__empty {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.spec.ts
@@ -316,6 +316,28 @@ describe('NotificationsPageComponent', () => {
       fixture.detectChanges();
       expect(component.notifications()[0].displayPreview).toBe('');
     });
+
+    it('should strip HTML tags from displayPreview', () => {
+      const htmlNotification = createMockNotification({
+        id: '6',
+        message: 'Disk full. <a href="http://example.com">View details</a>'
+      });
+      dataSourceSubject.next([htmlNotification]);
+      fixture.detectChanges();
+      expect(component.notifications()[0].displayPreview).toBe('Disk full. View details');
+    });
+
+    it('should preserve HTML in displayDetail', () => {
+      const htmlNotification = createMockNotification({
+        id: '6',
+        message: 'Disk full. <a href="http://example.com">View details</a>'
+      });
+      dataSourceSubject.next([htmlNotification]);
+      fixture.detectChanges();
+      expect(component.notifications()[0].displayDetail).toBe(
+        'Disk full. <a href="http://example.com">View details</a>'
+      );
+    });
   });
 
   describe('query param pre-selection', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notifications-page/notifications-page.component.ts
@@ -20,6 +20,7 @@ import { IconSize } from '~/app/shared/enum/icons.enum';
 interface DisplayNotification extends CdNotification {
   displayTitle: string;
   displayPreview: string;
+  displayDetail: string;
 }
 
 @Component({
@@ -74,12 +75,14 @@ export class NotificationsPageComponent implements OnInit, OnDestroy {
 
     this.sub = this.notificationService.data$.subscribe((notifications) => {
       this.notifications.set(
-        notifications.map((n) =>
-          Object.assign(n, {
+        notifications.map((n) => {
+          const rawMessage = n.prometheusAlert?.description || n.message || '';
+          return Object.assign(n, {
             displayTitle: n.prometheusAlert?.alertName || n.title || '',
-            displayPreview: n.prometheusAlert?.description || n.message || ''
-          })
-        )
+            displayPreview: rawMessage.replace(/<[^>]*>/g, ''),
+            displayDetail: rawMessage
+          });
+        })
       );
 
       this._tryPreselect(notifications);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.scss
@@ -63,6 +63,7 @@
         justify-content: flex-start;
         align-items: center;
         width: 100%;
+        gap: $spacing-03;
       }
 
       .toast-caption-container .date {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.scss
@@ -171,6 +171,8 @@
 
   > div {
     flex: 1;
+    min-height: 0;
+    min-block-size: 0;
   }
 }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.ts
@@ -158,12 +158,13 @@ export class ApiInterceptorService implements HttpInterceptor {
     return this.notificationService.show(() => {
       let message = '';
       if (_.isPlainObject(resp.error) && _.isString(resp.error.detail)) {
-        message = resp.error.detail; // Error was triggered by the backend.
+        message = resp.error.detail;
       } else if (_.isString(resp.error)) {
         message = resp.error;
       } else if (_.isString(resp.message)) {
         message = resp.message;
       }
+
       return new CdNotificationConfig(
         NotificationType.error,
         `${resp.status} - ${resp.statusText}`,

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.ts
@@ -25,6 +25,13 @@ function escapeHtml(str: string): string {
     .replace(/'/g, '&#39;');
 }
 
+function toPlainText(html: string): string {
+  return html
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -310,7 +317,7 @@ export class NotificationService {
     const lowContrast = notification.options?.lowContrast || false;
 
     const escapedTitle = escapeHtml(notification.title || '');
-    const escapedMessage = escapeHtml(notification.message || '');
+    const escapedMessage = escapeHtml(toPlainText(notification.message || ''));
     const existing = this.activeToasts.find(
       (t) =>
         t.title === escapedTitle && t.type === carbonType && t.originalSubtitle === escapedMessage


### PR DESCRIPTION
**Add Carbon typography classes to running tasks section**
_Before/After_
<img width="316" height="131" alt="image" src="https://github.com/user-attachments/assets/8c63a7a7-97aa-425e-b537-88dc720ba93c" /><img width="341" height="195" alt="image" src="https://github.com/user-attachments/assets/fed37764-afce-48df-b3ac-00cd611f8c29" />

**Fix tearsheet footer cutoff**

https://github.com/user-attachments/assets/d6b523b1-5cc3-4a51-b04c-e235fa2c0a3e

<img width="1788" height="855" alt="Screenshot From 2026-07-29 18-57-46" src="https://github.com/user-attachments/assets/4caaa4d2-be00-4c09-a44b-4d19d4796b40" />


**Add launch icon to View in Prometheus link**
_before/After_
<img width="368" height="155" alt="image" src="https://github.com/user-attachments/assets/8ee03250-bc4d-4dd7-895a-8f0283dcd551" /><img width="280" height="155" alt="image" src="https://github.com/user-attachments/assets/c5cbec5e-5ddf-4845-814d-5348eb33c2a7" />

**Render HTML in notification detail view, strip tags in list preview**
<img width="1598" height="800" alt="Screenshot From 2026-07-28 23-21-38" src="https://github.com/user-attachments/assets/5479195a-5b97-44c8-b819-a5f6cf5bb0c6" /><img width="1058" height="338" alt="image" src="https://github.com/user-attachments/assets/7314cff5-ffee-4d77-b0e4-b171f74aa88a" />

**Add gap between timestamp and View more in toast notifications from smaller screen sizes**
_before/after_
<img width="336" height="219" alt="Screenshot From 2026-07-29 16-46-05" src="https://github.com/user-attachments/assets/863c4acd-a253-4130-8540-b5c2bd7d11bd" /><img width="326" height="244" alt="Screenshot From 2026-07-29 19-00-35" src="https://github.com/user-attachments/assets/4a581ce8-3096-4705-9ee4-828aa90bcec4" />




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
