### PR TITLE
encoding: simplify encoding internals

### DIFF
--- a/src/common/container_concepts.h
+++ b/src/common/container_concepts.h
@@ -171,6 +171,17 @@ concept has_insert_append = requires(ContainerT& c, T&& v) {
   c.insert(std::end(c), std::forward<T>(v));
 };
 
+template <typename ContainerT>
+concept has_subscript_operator = requires(ContainerT& c, typename ContainerT::key_type& key) {
+  { c[std::move(key)] } -> std::same_as<typename ContainerT::mapped_type&>;
+};
+
+template <typename ContainerT>
+concept has_try_emplace_key = requires(ContainerT& c, typename ContainerT::key_type& key) {
+  { c.try_emplace(std::move(key)) } ->
+    std::same_as<std::pair<typename ContainerT::iterator, bool>>;
+};
+
 template <typename ContainerT, typename IteratorT, typename... ArgsT>
 concept has_emplace_after = requires(ContainerT& c, IteratorT pos, ArgsT&&... args) {
   c.emplace_after(pos, std::forward<ArgsT>(args)...);

--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -422,7 +422,7 @@ RecoveryBackend::handle_scan_digest(
   bi.end = m.end;
   {
     auto p = m.get_data().cbegin();
-    // take care to preserve ordering!
+    // Preserve ordering:
     bi.clear_objects();
     ::decode_noclear(bi.objects, p);
   }

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -49,6 +49,7 @@
 #include "buffer.h"
 #include "byteorder.h"
 
+#include "common/container_concepts.h"
 #include "common/convenience.h"
 #include "common/error_code.h"
 #include "common/likely.h"
@@ -276,15 +277,11 @@ namespace _denc {
 template<typename T, typename... U>
 concept is_any_of = (std::same_as<T, U> || ...);
 
-template<typename T, typename=void> struct underlying_type {
-  using type = T;
-};
 template<typename T>
-struct underlying_type<T, std::enable_if_t<std::is_enum_v<T>>> {
-  using type = std::underlying_type_t<T>;
-};
-template<typename T>
-using underlying_type_t = typename underlying_type<T>::type;
+using underlying_type_t = typename std::conditional_t<
+  std::is_enum_v<T>,
+  std::underlying_type<T>,
+  std::type_identity<T>>::type;
 }
 
 template<class It>
@@ -346,37 +343,20 @@ struct denc_traits<T> {
 // up a contiguous_appender etc is likely to be slower.
 namespace _denc {
 
-template<typename T> struct ExtType {
-  using type = void;
-};
-
 template<typename T>
-requires _denc::is_any_of<T,
-			  int16_t, uint16_t>
-struct ExtType<T> {
-  using type = ceph_le16;
-};
-
-template<typename T>
-requires _denc::is_any_of<T,
-			  int32_t, uint32_t>
-struct ExtType<T> {
-  using type = ceph_le32;
-};
-
-template<typename T>
-requires _denc::is_any_of<T,
-			  int64_t, uint64_t>
-struct ExtType<T> {
-  using type = ceph_le64;
-};
-
-template<>
-struct ExtType<bool> {
-  using type = uint8_t;
-};
-template<typename T>
-using ExtType_t = typename ExtType<T>::type;
+using ExtType_t = std::conditional_t<
+  std::same_as<T, bool>,
+  uint8_t,
+  std::conditional_t<
+    _denc::is_any_of<T, int16_t, uint16_t>,
+    ceph_le16,
+    std::conditional_t<
+      _denc::is_any_of<T, int32_t, uint32_t>,
+      ceph_le32,
+      std::conditional_t<
+        _denc::is_any_of<T, int64_t, uint64_t>,
+        ceph_le64,
+        void>>>>;
 } // namespace _denc
 
 template<typename T>
@@ -407,16 +387,17 @@ struct denc_traits<T>
   }
 };
 
-// varint
-//
-// high bit of each byte indicates another byte follows.
-template<typename T>
-inline void denc_varint(T v, size_t& p) {
-  p += sizeof(T) + 1;
-}
+namespace _denc {
 
+// Maximum bytes needed when each byte carries seven payload bits.
 template<typename T>
-inline void denc_varint(T v, ceph::buffer::list::contiguous_appender& p) {
+inline constexpr size_t varint_bound =
+  (sizeof(_denc::underlying_type_t<T>) * 8 + 6) / 7;
+
+template<typename T, class It>
+inline void encode_varint(T v, It& p)
+{
+  // Low 7 bits are payload; high bit means another byte follows.
   uint8_t byte = v & 0x7f;
   v >>= 7;
   while (v) {
@@ -428,16 +409,100 @@ inline void denc_varint(T v, ceph::buffer::list::contiguous_appender& p) {
   get_pos_add<__u8>(p) = byte;
 }
 
-template<typename T>
-inline void denc_varint(T& v, ceph::buffer::ptr::const_iterator& p) {
-  uint8_t byte = *(__u8*)p.get_pos_add(1);
-  v = byte & 0x7f;
+template<typename T, is_const_iterator It>
+inline T decode_varint(It& p)
+{
+  using U = std::make_unsigned_t<_denc::underlying_type_t<T>>;
+  auto byte = get_pos_add<__u8>(p);
+  U v = byte & 0x7f;
   int shift = 7;
   while (byte & 0x80) {
     byte = get_pos_add<__u8>(p);
-    v |= (T)(byte & 0x7f) << shift;
+    // Reassemble subsequent 7-bit payload groups above the previous ones.
+    v |= static_cast<U>(byte & 0x7f) << shift;
     shift += 7;
   }
+  return static_cast<T>(v);
+}
+
+inline unsigned low_zero_nibbles(uint64_t v)
+{
+  auto nibbles = v ? std::countr_zero(v) / 4 : 0u;
+  // The lowz encoding reserves only two bits for this count.
+  return nibbles > 3 ? 3 : nibbles;
+}
+
+inline uint64_t signed_magnitude(int64_t v)
+{
+  // Avoid negating INT64_MIN in the signed domain.
+  return v < 0 ?
+    static_cast<uint64_t>(-(v + 1)) + 1 :
+    static_cast<uint64_t>(v);
+}
+
+inline int64_t apply_signed_magnitude(uint64_t magnitude, bool negative)
+{
+  return negative ? -static_cast<int64_t>(magnitude) :
+    static_cast<int64_t>(magnitude);
+}
+
+inline uint64_t pack_signed_varint(int64_t v)
+{
+  // Low bit carries the sign; upper bits carry the magnitude.
+  return (signed_magnitude(v) << 1) | static_cast<uint64_t>(v < 0);
+}
+
+inline int64_t unpack_signed_varint(uint64_t v)
+{
+  return apply_signed_magnitude(v >> 1, v & 1);
+}
+
+inline uint64_t pack_lowz_varint(uint64_t v)
+{
+  const auto lowznib = low_zero_nibbles(v);
+  // Low two bits carry the stripped zero-nibble count.
+  return (v >> (lowznib * 4) << 2) | lowznib;
+}
+
+inline uint64_t unpack_lowz_varint(uint64_t v)
+{
+  const auto lowznib = v & 3;
+  return (v >> 2) << (lowznib * 4);
+}
+
+inline uint64_t pack_signed_lowz_varint(int64_t v)
+{
+  const auto magnitude = signed_magnitude(v);
+  const auto lowznib = low_zero_nibbles(magnitude);
+  // Bit 0 carries sign; bits 1-2 carry the stripped zero-nibble count.
+  return ((magnitude >> (lowznib * 4)) << 3) |
+    (static_cast<uint64_t>(lowznib) << 1) |
+    static_cast<uint64_t>(v < 0);
+}
+
+inline int64_t unpack_signed_lowz_varint(uint64_t v)
+{
+  const auto lowznib = (v & 6) >> 1;
+  const auto magnitude = (v >> 3) << (lowznib * 4);
+  return apply_signed_magnitude(magnitude, v & 1);
+}
+
+} // namespace _denc
+
+// Variable-length integer encodings, with signed and low-zero variants.
+template<typename T>
+inline void denc_varint(T v, size_t& p) {
+  p += _denc::varint_bound<T>;
+}
+
+template<typename T>
+inline void denc_varint(T v, ceph::buffer::list::contiguous_appender& p) {
+  _denc::encode_varint(v, p);
+}
+
+template<typename T>
+inline void denc_varint(T& v, ceph::buffer::ptr::const_iterator& p) {
+  v = _denc::decode_varint<T>(p);
 }
 
 
@@ -446,48 +511,33 @@ inline void denc_varint(T& v, ceph::buffer::ptr::const_iterator& p) {
 // low bit = 1 = negative, 0 = positive
 // high bit of every byte indicates whether another byte follows.
 inline void denc_signed_varint(int64_t v, size_t& p) {
-  p += sizeof(v) + 2;
+  denc_varint(_denc::pack_signed_varint(v), p);
 }
 template<class It>
 requires (!is_const_iterator<It>)
 void denc_signed_varint(int64_t v, It& p) {
-  if (v < 0) {
-    v = (-v << 1) | 1;
-  } else {
-    v <<= 1;
-  }
-  denc_varint(v, p);
+  denc_varint(_denc::pack_signed_varint(v), p);
 }
 
 template<typename T, is_const_iterator It>
 inline void denc_signed_varint(T& v, It& p)
 {
-  int64_t i = 0;
+  uint64_t i = 0;
   denc_varint(i, p);
-  if (i & 1) {
-    v = -(i >> 1);
-  } else {
-    v = i >> 1;
-  }
+  v = _denc::unpack_signed_varint(i);
 }
 
-// varint + lowz encoding
+// varint and lowz (low-zero) encoding:
 //
 // first(low) 2 bits = how many low zero bits (nibbles)
 // high bit of each byte = another byte follows
 // (so, 5 bits data in first byte, 7 bits data thereafter)
 inline void denc_varint_lowz(uint64_t v, size_t& p) {
-  p += sizeof(v) + 2;
+  denc_varint(_denc::pack_lowz_varint(v), p);
 }
 inline void denc_varint_lowz(uint64_t v,
 			     ceph::buffer::list::contiguous_appender& p) {
-  int lowznib = v ? (std::countr_zero(v) / 4) : 0;
-  if (lowznib > 3)
-    lowznib = 3;
-  v >>= lowznib * 4;
-  v <<= 2;
-  v |= lowznib;
-  denc_varint(v, p);
+  denc_varint(_denc::pack_lowz_varint(v), p);
 }
 
 template<typename T>
@@ -495,10 +545,7 @@ inline void denc_varint_lowz(T& v, ceph::buffer::ptr::const_iterator& p)
 {
   uint64_t i = 0;
   denc_varint(i, p);
-  int lowznib = (i & 3);
-  i >>= 2;
-  i <<= lowznib * 4;
-  v = i;
+  v = _denc::unpack_lowz_varint(i);
 }
 
 // signed varint + lowz encoding
@@ -508,41 +555,20 @@ inline void denc_varint_lowz(T& v, ceph::buffer::ptr::const_iterator& p)
 // high bit of each byte = another byte follows
 // (so, 4 bits data in first byte, 7 bits data thereafter)
 inline void denc_signed_varint_lowz(int64_t v, size_t& p) {
-  p += sizeof(v) + 2;
+  denc_varint(_denc::pack_signed_lowz_varint(v), p);
 }
 template<class It>
 requires (!is_const_iterator<It>)
 inline void denc_signed_varint_lowz(int64_t v, It& p) {
-  bool negative = false;
-  if (v < 0) {
-    v = -v;
-    negative = true;
-  }
-  unsigned lowznib = v ? (std::countr_zero(std::bit_cast<uint64_t>(v)) / 4) : 0u;
-  if (lowznib > 3)
-    lowznib = 3;
-  v >>= lowznib * 4;
-  v <<= 3;
-  v |= lowznib << 1;
-  v |= (int)negative;
-  denc_varint(v, p);
+  denc_varint(_denc::pack_signed_lowz_varint(v), p);
 }
 
 template<typename T, is_const_iterator It>
 inline void denc_signed_varint_lowz(T& v, It& p)
 {
-  int64_t i = 0;
+  uint64_t i = 0;
   denc_varint(i, p);
-  int lowznib = (i & 6) >> 1;
-  if (i & 1) {
-    i >>= 3;
-    i <<= lowznib * 4;
-    v = -i;
-  } else {
-    i >>= 3;
-    i <<= lowznib * 4;
-    v = i;
-  }
+  v = _denc::unpack_signed_lowz_varint(i);
 }
 
 
@@ -677,21 +703,29 @@ denc(T& o,
 }
 
 namespace _denc {
-template<typename T, typename = void>
-struct has_legacy_denc : std::false_type {};
 template<typename T>
-struct has_legacy_denc<T, decltype(std::declval<T&>()
-				   .decode(std::declval<
-					   ceph::buffer::list::const_iterator&>()))>
-  : std::true_type {
+concept has_legacy_decode = requires(
+  T& v,
+  ceph::buffer::list::const_iterator& p) {
+    v.decode(p);
+  };
+
+// Prefer an explicit legacy member decode; otherwise use non-contiguous traits.
+template<typename T, bool = has_legacy_decode<T>, typename = void>
+struct has_legacy_denc : std::false_type {};
+
+template<typename T>
+struct has_legacy_denc<T, true> : std::true_type {
   static void decode(T& v, ceph::buffer::list::const_iterator& p) {
     v.decode(p);
   }
 };
+
 template<typename T>
-struct has_legacy_denc<T,
-		       std::enable_if_t<
-			 !denc_traits<T>::need_contiguous>> : std::true_type {
+struct has_legacy_denc<
+  T,
+  false,
+  std::enable_if_t<!denc_traits<T>::need_contiguous>> : std::true_type {
   static void decode(T& v, ceph::buffer::list::const_iterator& p) {
     denc_traits<T>::decode(v, p);
   }
@@ -918,10 +952,11 @@ struct denc_traits<
 };
 
 namespace _denc {
-  template<template<class...> class C, typename Details, typename ...Ts>
+  // Shared container codec; Details supplies reserve and insertion policy.
+  template<typename Container, typename Details>
   struct container_base {
   private:
-    using container = C<Ts...>;
+    using container = Container;
     using T = typename Details::T;
 
   public:
@@ -1028,30 +1063,11 @@ namespace _denc {
     }
   };
 
-  template<typename T>
-  class container_has_reserve {
-    template<typename U, U> struct SFINAE_match;
-    template<typename U>
-    static std::true_type test(SFINAE_match<T(*)(typename T::size_type),
-			       &U::reserve>*);
-
-    template<typename U>
-    static std::false_type test(...);
-
-  public:
-    static constexpr bool value = decltype(
-      test<denc_traits<T>>(0))::value;
-  };
-  template<typename T>
-  inline constexpr bool container_has_reserve_v =
-    container_has_reserve<T>::value;
-
-
   template<typename Container>
   struct container_details_base {
     using T = typename Container::value_type;
     static void reserve(Container& c, size_t s) {
-      if constexpr (container_has_reserve_v<Container>) {
+      if constexpr (ceph::concepts::has_reserve<Container>) {
         c.reserve(s);
       }
     }
@@ -1070,117 +1086,26 @@ template<typename T, typename ...Ts>
 struct denc_traits<
   std::list<T, Ts...>,
   typename std::enable_if_t<denc_traits<T>::supported>>
-  : public _denc::container_base<std::list,
-				 _denc::pushback_details<std::list<T, Ts...>>,
-				 T, Ts...> {};
+  : public _denc::container_base<
+      std::list<T, Ts...>,
+      _denc::pushback_details<std::list<T, Ts...>>> {};
 
 template<typename T, typename ...Ts>
 struct denc_traits<
   std::vector<T, Ts...>,
   typename std::enable_if_t<denc_traits<T>::supported>>
-  : public _denc::container_base<std::vector,
-				 _denc::pushback_details<std::vector<T, Ts...>>,
-				 T, Ts...> {};
+  : public _denc::container_base<
+      std::vector<T, Ts...>,
+      _denc::pushback_details<std::vector<T, Ts...>>> {};
 
 template<typename T, std::size_t N, typename ...Ts>
 struct denc_traits<
   boost::container::small_vector<T, N, Ts...>,
-  typename std::enable_if_t<denc_traits<T>::supported>> {
-private:
-  using container = boost::container::small_vector<T, N, Ts...>;
-public:
-  using traits = denc_traits<T>;
-
-  static constexpr bool supported = true;
-  static constexpr bool featured = traits::featured;
-  static constexpr bool bounded = false;
-  static constexpr bool need_contiguous = traits::need_contiguous;
-
-  template<typename U=T>
-  static void bound_encode(const container& s, size_t& p, uint64_t f = 0) {
-    p += sizeof(uint32_t);
-    if constexpr (traits::bounded) {
-      if (!s.empty()) {
-	const auto elem_num = s.size();
-	size_t elem_size = 0;
-	if constexpr (traits::featured) {
-	  denc(*s.begin(), elem_size, f);
-        } else {
-          denc(*s.begin(), elem_size);
-        }
-        p += elem_size * elem_num;
-      }
-    } else {
-      for (const T& e : s) {
-	if constexpr (traits::featured) {
-	  denc(e, p, f);
-	} else {
-	  denc(e, p);
-	}
-      }
-    }
-  }
-
-  template<typename U=T>
-  static void encode(const container& s,
-		     ceph::buffer::list::contiguous_appender& p,
-		     uint64_t f = 0) {
-    denc((uint32_t)s.size(), p);
-    if constexpr (traits::featured) {
-      encode_nohead(s, p, f);
-    } else {
-      encode_nohead(s, p);
-    }
-  }
-  static void decode(container& s, ceph::buffer::ptr::const_iterator& p,
-		     uint64_t f = 0) {
-    uint32_t num;
-    denc(num, p);
-    decode_nohead(num, s, p, f);
-  }
-  template<typename U=T>
-  static std::enable_if_t<!!sizeof(U) && !need_contiguous>
-  decode(container& s, ceph::buffer::list::const_iterator& p) {
-    uint32_t num;
-    denc(num, p);
-    decode_nohead(num, s, p);
-  }
-
-  // nohead
-  static void encode_nohead(const container& s, ceph::buffer::list::contiguous_appender& p,
-			    uint64_t f = 0) {
-    for (const T& e : s) {
-      if constexpr (traits::featured) {
-        denc(e, p, f);
-      } else {
-        denc(e, p);
-      }
-    }
-  }
-  static void decode_nohead(size_t num, container& s,
-			    ceph::buffer::ptr::const_iterator& p,
-			    uint64_t f=0) {
-    s.clear();
-    s.reserve(num);
-    while (num--) {
-      T t;
-      denc(t, p, f);
-      s.push_back(std::move(t));
-    }
-  }
-  template<typename U=T>
-  static std::enable_if_t<!!sizeof(U) && !need_contiguous>
-  decode_nohead(size_t num, container& s,
-		ceph::buffer::list::const_iterator& p) {
-    s.clear();
-    s.reserve(num);
-    while (num--) {
-      T t;
-      denc(t, p);
-      s.push_back(std::move(t));
-    }
-  }
-};
+  typename std::enable_if_t<denc_traits<T>::supported>>
+  : public _denc::container_base<
+      boost::container::small_vector<T, N, Ts...>,
+      _denc::pushback_details<
+        boost::container::small_vector<T, N, Ts...>>> {};
 
 namespace _denc {
   template<typename Container>
@@ -1197,28 +1122,22 @@ template<typename T, typename ...Ts>
 struct denc_traits<
   std::set<T, Ts...>,
   std::enable_if_t<denc_traits<T>::supported>>
-  : public _denc::container_base<std::set,
-				 _denc::setlike_details<std::set<T, Ts...>>,
-				 T, Ts...> {};
+  : public _denc::container_base<
+      std::set<T, Ts...>,
+      _denc::setlike_details<std::set<T, Ts...>>> {};
 
 template<typename T, typename ...Ts>
 struct denc_traits<
   boost::container::flat_set<T, Ts...>,
   std::enable_if_t<denc_traits<T>::supported>>
   : public _denc::container_base<
-  boost::container::flat_set,
-  _denc::setlike_details<boost::container::flat_set<T, Ts...>>,
-  T, Ts...> {};
+      boost::container::flat_set<T, Ts...>,
+      _denc::setlike_details<boost::container::flat_set<T, Ts...>>> {};
 
 namespace _denc {
+  // Maps use the same hinted emplacement path as sets.
   template<typename Container>
-  struct maplike_details : public container_details_base<Container> {
-    using T = typename Container::value_type;
-    template<typename ...Args>
-    static void insert(Container& c, Args&& ...args) {
-      c.emplace_hint(c.cend(), std::forward<Args>(args)...);
-    }
-  };
+  using maplike_details = setlike_details<Container>;
 }
 
 template<typename A, typename B, typename ...Ts>
@@ -1226,9 +1145,9 @@ struct denc_traits<
   std::map<A, B, Ts...>,
   std::enable_if_t<denc_traits<A>::supported &&
 		   denc_traits<B>::supported>>
-  : public _denc::container_base<std::map,
-				 _denc::maplike_details<std::map<A, B, Ts...>>,
-				 A, B, Ts...> {};
+  : public _denc::container_base<
+      std::map<A, B, Ts...>,
+      _denc::maplike_details<std::map<A, B, Ts...>>> {};
 
 template<typename A, typename B, typename ...Ts>
 struct denc_traits<
@@ -1236,10 +1155,8 @@ struct denc_traits<
   std::enable_if_t<denc_traits<A>::supported &&
 		   denc_traits<B>::supported>>
   : public _denc::container_base<
-  boost::container::flat_map,
-  _denc::maplike_details<boost::container::flat_map<
-			   A, B, Ts...>>,
-  A, B, Ts...> {};
+      boost::container::flat_map<A, B, Ts...>,
+      _denc::maplike_details<boost::container::flat_map<A, B, Ts...>>> {};
 
 template<typename T, size_t N>
 struct denc_traits<
@@ -1377,93 +1294,81 @@ public:
   }
 };
 
+namespace _denc {
+  template<typename Optional, typename T>
+  struct optional_base {
+    using traits = denc_traits<T>;
+
+    static constexpr bool supported = true;
+    static constexpr bool featured = traits::featured;
+    static constexpr bool bounded = false;
+    static constexpr bool need_contiguous = traits::need_contiguous;
+
+    static void bound_encode(const Optional& v, size_t& p, uint64_t f = 0) {
+      p += sizeof(bool);
+      if (v) {
+        denc(*v, p, f);
+      }
+    }
+
+    static void encode(const Optional& v,
+                       ceph::buffer::list::contiguous_appender& p,
+                       uint64_t f = 0) {
+      denc((bool)v, p);
+      encode_nohead(v, p, f);
+    }
+
+    static void decode(Optional& v, ceph::buffer::ptr::const_iterator& p,
+                       uint64_t f = 0) {
+      bool x;
+      denc(x, p, f);
+      decode_nohead(x, v, p, f);
+    }
+
+    static void decode(Optional& v, ceph::buffer::list::const_iterator& p)
+    requires (!need_contiguous)
+    {
+      bool x;
+      denc(x, p);
+      if (x) {
+        v = T{};
+        denc(*v, p);
+        return;
+      }
+
+      v.reset();
+    }
+
+    static void encode_nohead(const Optional& v,
+                              ceph::buffer::list::contiguous_appender& p,
+                              uint64_t f = 0) {
+      if (v) {
+        denc(*v, p, f);
+      }
+    }
+
+    static void decode_nohead(bool present, Optional& v,
+                              ceph::buffer::ptr::const_iterator& p,
+                              uint64_t f = 0) {
+      if (present) {
+        v = T{};
+        denc(*v, p, f);
+        return;
+      }
+
+      v.reset();
+    }
+  };
+}
+
 //
 // boost::optional<T>
 //
 template<typename T>
 struct denc_traits<
   boost::optional<T>,
-  std::enable_if_t<denc_traits<T>::supported>> {
-  using traits = denc_traits<T>;
-
-  static constexpr bool supported = true;
-  static constexpr bool featured = traits::featured;
-  static constexpr bool bounded = false;
-  static constexpr bool need_contiguous = traits::need_contiguous;
-
-  static void bound_encode(const boost::optional<T>& v, size_t& p,
-			   uint64_t f = 0) {
-    p += sizeof(bool);
-    if (v) {
-      if constexpr (featured) {
-        denc(*v, p, f);
-      } else {
-        denc(*v, p);
-      }
-    }
-  }
-
-  static void encode(const boost::optional<T>& v,
-		     ceph::buffer::list::contiguous_appender& p,
-		     uint64_t f = 0) {
-    denc((bool)v, p);
-    if (v) {
-      if constexpr (featured) {
-        denc(*v, p, f);
-      } else {
-        denc(*v, p);
-      }
-    }
-  }
-
-  static void decode(boost::optional<T>& v, ceph::buffer::ptr::const_iterator& p,
-		     uint64_t f = 0) {
-    bool x;
-    denc(x, p, f);
-    if (x) {
-      v = T{};
-      denc(*v, p, f);
-    } else {
-      v = boost::none;
-    }
-  }
-
-  template<typename U = T>
-  static std::enable_if_t<!!sizeof(U) && !need_contiguous>
-  decode(boost::optional<T>& v, ceph::buffer::list::const_iterator& p) {
-    bool x;
-    denc(x, p);
-    if (x) {
-      v = T{};
-      denc(*v, p);
-    } else {
-      v = boost::none;
-    }
-  }
-
-  template<typename U = T>
-  static void encode_nohead(const boost::optional<T>& v,
-			    ceph::buffer::list::contiguous_appender& p,
-			    uint64_t f = 0) {
-    if (v) {
-      if constexpr (featured) {
-        denc(*v, p, f);
-      } else {
-        denc(*v, p);
-      }
-    }
-  }
-
-  static void decode_nohead(bool num, boost::optional<T>& v,
-			    ceph::buffer::ptr::const_iterator& p, uint64_t f = 0) {
-    if (num) {
-      v = T();
-      denc(*v, p, f);
-    } else {
-      v = boost::none;
-    }
-  }
-};
+  std::enable_if_t<denc_traits<T>::supported>>
+  : public _denc::optional_base<boost::optional<T>, T> {};
 
 template<>
 struct denc_traits<boost::none_t> {
@@ -1488,86 +1393,8 @@ struct denc_traits<boost::none_t> {
 template<typename T>
 struct denc_traits<
   std::optional<T>,
-  std::enable_if_t<denc_traits<T>::supported>> {
-  using traits = denc_traits<T>;
-
-  static constexpr bool supported = true;
-  static constexpr bool featured = traits::featured;
-  static constexpr bool bounded = false;
-  static constexpr bool need_contiguous = traits::need_contiguous;
-
-  static void bound_encode(const std::optional<T>& v, size_t& p,
-			   uint64_t f = 0) {
-    p += sizeof(bool);
-    if (v) {
-      if constexpr (featured) {
-        denc(*v, p, f);
-      } else {
-        denc(*v, p);
-      }
-    }
-  }
-
-  static void encode(const std::optional<T>& v,
-		     ceph::buffer::list::contiguous_appender& p,
-		     uint64_t f = 0) {
-    denc((bool)v, p);
-    if (v) {
-      if constexpr (featured) {
-        denc(*v, p, f);
-      } else {
-        denc(*v, p);
-      }
-    }
-  }
-
-  static void decode(std::optional<T>& v, ceph::buffer::ptr::const_iterator& p,
-		     uint64_t f = 0) {
-    bool x;
-    denc(x, p, f);
-    if (x) {
-      v = T{};
-      denc(*v, p, f);
-    } else {
-      v = std::nullopt;
-    }
-  }
-
-  template<typename U = T>
-  static std::enable_if_t<!!sizeof(U) && !need_contiguous>
-  decode(std::optional<T>& v, ceph::buffer::list::const_iterator& p) {
-    bool x;
-    denc(x, p);
-    if (x) {
-      v = T{};
-      denc(*v, p);
-    } else {
-      v = std::nullopt;
-    }
-  }
-
-  static void encode_nohead(const std::optional<T>& v,
-			    ceph::buffer::list::contiguous_appender& p,
-			    uint64_t f = 0) {
-    if (v) {
-      if constexpr (featured) {
-        denc(*v, p, f);
-      } else {
-        denc(*v, p);
-      }
-    }
-  }
-
-  static void decode_nohead(bool num, std::optional<T>& v,
-			    ceph::buffer::ptr::const_iterator& p, uint64_t f = 0) {
-    if (num) {
-      v = T();
-      denc(*v, p, f);
-    } else {
-      v = std::nullopt;
-    }
-  }
-};
+  std::enable_if_t<denc_traits<T>::supported>>
+  : public _denc::optional_base<std::optional<T>, T> {};
 
 template<>
 struct denc_traits<std::nullopt_t> {
@@ -1792,6 +1619,80 @@ inline std::enable_if_t<traits::supported && !traits::featured> decode_nohead(
     " minimal_decoder=" + std::to_string(struct_compat));
 }
 
+namespace ceph::denc_detail {
+
+// Fixed size of the DENC wrapper header written by DENC_START:
+inline constexpr auto struct_header_len() noexcept
+{
+  return    sizeof(__u8)      // 1 byte: encoded struct version
+          + sizeof(__u8)      // 1 byte: oldest decoder version accepted
+          + sizeof(uint32_t); // 4 bytes: payload length following header
+}
+
+// Bound-size pass: account for the fixed DENC header without writing it:
+// The unused parameters are an artifact of the DENC_HELPERS macros.
+inline void start(size_t& p, __u8 *, __u8 *, char **, uint32_t *)
+{
+  p += struct_header_len();
+}
+
+// Bound-size pass: all body sizing already happened, so nothing is patched:
+inline void finish(size_t&, char **, uint32_t *) {}
+
+// Encode pass: write version/compat and reserve space for payload length:
+inline void start(::ceph::buffer::list::contiguous_appender& p,
+		  __u8 *struct_v, __u8 *struct_compat,
+		  char **len_pos, uint32_t *start_oob_off)
+{
+  ::denc(*struct_v, p);
+  ::denc(*struct_compat, p);
+  *len_pos = p.get_pos_add(sizeof(uint32_t));
+  *start_oob_off = p.get_out_of_band_offset();
+}
+
+// Encode pass: patch the reserved length, including out-of-band bytes:
+inline void finish(::ceph::buffer::list::contiguous_appender& p,
+		   char **len_pos, uint32_t *start_oob_off)
+{
+  ceph_le32 struct_len;
+  struct_len = p.get_pos() - *len_pos - sizeof(uint32_t) +
+    p.get_out_of_band_offset() - *start_oob_off;
+  std::memcpy(*len_pos, &struct_len, sizeof(struct_len));
+}
+
+// Decode pass: read and validate the header before decoding body fields:
+inline void start(::ceph::buffer::ptr::const_iterator& p,
+		  __u8 *struct_v, __u8 *struct_compat,
+		  char **start_pos, uint32_t *struct_len,
+		  const char *func)
+{
+  const auto code_v = *struct_v;
+  ::denc(*struct_v, p);
+  ::denc(*struct_compat, p);
+  if (unlikely(code_v < *struct_compat)) {
+    ::denc_compat_throw(func, code_v, *struct_v, *struct_compat);
+  }
+  ::denc(*struct_len, p);
+  *start_pos = const_cast<char *>(p.get_pos());
+}
+
+// Decode pass: reject overread and skip unread fields from newer encoders:
+inline void finish(::ceph::buffer::ptr::const_iterator& p,
+		   char **start_pos, uint32_t *struct_len,
+		   const char *func)
+{
+  const auto pos = p.get_pos();
+  const auto end = *start_pos + *struct_len;
+  if (pos > end) {
+    throw ::ceph::buffer::malformed_input(func);
+  }
+  if (pos < end) {
+    p += end - pos;
+  }
+}
+
+} // namespace ceph::denc_detail
+
 // compile-time  checker for struct_v to detect mismatch of declared
 // decoder version with actually implemented blocks like "struct_v < 100".
 // it addresses the common problem of forgetting to bump the version up
@@ -1832,27 +1733,27 @@ struct StructVChecker
   static void _denc_start(size_t& p,					\
 			  __u8 *struct_v,				\
 			  __u8 *struct_compat,				\
-			  char **, uint32_t *) {			\
-    p += 2 + 4;								\
+			  char **len_pos, uint32_t *start_oob_off) {	\
+    ::ceph::denc_detail::start(p, struct_v, struct_compat, len_pos,	\
+			       start_oob_off);				\
   }									\
   static void _denc_finish(size_t& p,					\
-			   char **, uint32_t *) { }			\
+			   char **len_pos, uint32_t *start_oob_off) {	\
+    ::ceph::denc_detail::finish(p, len_pos, start_oob_off);		\
+  }									\
   /* encode */								\
   static void _denc_start(::ceph::buffer::list::contiguous_appender& p,	\
 			  __u8 *struct_v,				\
 			  __u8 *struct_compat,				\
 			  char **len_pos,				\
 			  uint32_t *start_oob_off) {			\
-    denc(*struct_v, p);							\
-    denc(*struct_compat, p);						\
-    *len_pos = p.get_pos_add(4);					\
-    *start_oob_off = p.get_out_of_band_offset();			\
+    ::ceph::denc_detail::start(p, struct_v, struct_compat, len_pos,	\
+			       start_oob_off);				\
   }									\
   static void _denc_finish(::ceph::buffer::list::contiguous_appender& p, \
 			   char **len_pos,				\
 			   uint32_t *start_oob_off) {			\
-    *(ceph_le32*)*len_pos = p.get_pos() - *len_pos - sizeof(uint32_t) +	\
-      p.get_out_of_band_offset() - *start_oob_off;			\
+    ::ceph::denc_detail::finish(p, len_pos, start_oob_off);		\
   }									\
   /* decode */								\
   static void _denc_start(::ceph::buffer::ptr::const_iterator& p,	\
@@ -1860,25 +1761,14 @@ struct StructVChecker
 			  __u8 *struct_compat,				\
 			  char **start_pos,				\
 			  uint32_t *struct_len) {			\
-    __u8 code_v = *struct_v;						\
-    denc(*struct_v, p);							\
-    denc(*struct_compat, p);						\
-    if (unlikely(code_v < *struct_compat))				\
-      denc_compat_throw(__PRETTY_FUNCTION__, code_v, *struct_v, *struct_compat);\
-    denc(*struct_len, p);						\
-    *start_pos = const_cast<char*>(p.get_pos());			\
+    ::ceph::denc_detail::start(p, struct_v, struct_compat, start_pos,	\
+			       struct_len, __PRETTY_FUNCTION__);		\
   }									\
   static void _denc_finish(::ceph::buffer::ptr::const_iterator& p,	\
 			   char **start_pos,				\
 			   uint32_t *struct_len) {			\
-    const char *pos = p.get_pos();					\
-    char *end = *start_pos + *struct_len;				\
-    if (pos > end) {							\
-      throw ::ceph::buffer::malformed_input(__PRETTY_FUNCTION__);	\
-    }									\
-    if (pos < end) {							\
-      p += end - pos;							\
-    }									\
+    ::ceph::denc_detail::finish(p, start_pos, struct_len,		\
+				__PRETTY_FUNCTION__);			\
   }
 
 // Helpers for versioning the encoding.  These correspond to the

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -1,16 +1,17 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*- 
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 sts=2 expandtab
 
 /*
  * Ceph - scalable distributed file system
  *
  * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ * Copyright (C) 2026 International Business Machines Corp. (IBM)
  *
  * This is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software 
+ * License version 2.1, as published by the Free Software
  * Foundation.  See file COPYING.
- * 
+ *
  */
 #ifndef CEPH_ENCODING_H
 #define CEPH_ENCODING_H
@@ -27,16 +28,35 @@
 #include <optional>
 #include <unordered_map>
 #include <unordered_set>
+#include <array>
+#include <bit>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <list>
+#include <memory>
+#include <utility>
 
 #include <boost/container/small_vector.hpp>
 #include <boost/optional/optional_io.hpp>
 #include <boost/tuple/tuple.hpp>
 
+#ifdef ENCODE_DUMP_PATH
+#include <climits>
+#include <cstdio>
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
 #include "common/ceph_time.h"
 
+#include "include/compat.h"
 #include "include/int_types.h"
 
 #include "common/convenience.h"
+#include "common/container_concepts.h"
 
 #include "byteorder.h"
 #include "buffer.h"
@@ -139,8 +159,8 @@ WRITE_INTTYPE_ENCODER(int16_t, le16)
 // Under this assumption, we can use raw encoding of floating-point types
 // on little-endian machines, but we still need to perform a byte swap
 // on big-endian machines to ensure cross-architecture compatibility.
-// To achive that, we reinterpret the values as integers first, which are
-// byte-swapped via the ceph_le types as above.  The extra conversions
+// To achieve that, we bit-cast the values as integers first, which are
+// byte-swapped via the ceph_le types as above. The extra conversions
 // are optimized away on little-endian machines by the compiler.
 #define WRITE_FLTTYPE_ENCODER(type, itype, etype)			\
   static_assert(sizeof(type) == sizeof(itype));				\
@@ -148,13 +168,14 @@ WRITE_INTTYPE_ENCODER(int16_t, le16)
 	      "floating-point type not using IEEE754 format");		\
   inline void encode(type v, ::ceph::bufferlist& bl, uint64_t features=0) { \
     ceph_##etype e;							\
-    e = *reinterpret_cast<itype *>(&v);					\
+    e = std::bit_cast<itype>(v);					\
     ::ceph::encode_raw(e, bl);						\
   }									\
   inline void decode(type &v, ::ceph::bufferlist::const_iterator& p) {	\
     ceph_##etype e;							\
     ::ceph::decode_raw(e, p);						\
-    *reinterpret_cast<itype *>(&v) = e;					\
+    itype raw = e;							\
+    v = std::bit_cast<type>(raw);					\
   }
 
 WRITE_FLTTYPE_ENCODER(float, uint32_t, le32)
@@ -224,13 +245,38 @@ inline void decode_assign(auto& t, ::ceph::bufferlist::const_iterator& p)
   t = static_cast<std::remove_reference_t<decltype(t)>>(i);
 }
 
-// string
+namespace encoding_detail {
+
+inline void encode_count(size_t n, bufferlist& bl)
+{
+  // Legacy container/string lengths are stored as 32-bit values on the wire.
+  encode(static_cast<__u32>(n), bl);
+}
+
+inline __u32 decode_count(bufferlist::const_iterator& p)
+{
+  __u32 n;
+  decode(n, p);
+  return n;
+}
+
+inline void append_bytes(const void *data, size_t len, bufferlist& bl)
+{
+  if (len)
+    bl.append(static_cast<const char *>(data), len);
+}
+
+inline void encode_bytes(const void *data, size_t len, bufferlist& bl)
+{
+  encode_count(len, bl);
+  append_bytes(data, len, bl);
+}
+
+} // namespace encoding_detail
+
 inline void encode(std::string_view s, bufferlist& bl, uint64_t features=0)
 {
-  __u32 len = s.length();
-  encode(len, bl);
-  if (len)
-    bl.append(s.data(), len);
+  encoding_detail::encode_bytes(s.data(), s.length(), bl);
 }
 inline void encode(const std::string& s, bufferlist& bl, uint64_t features=0)
 {
@@ -238,15 +284,14 @@ inline void encode(const std::string& s, bufferlist& bl, uint64_t features=0)
 }
 inline void decode(std::string& s, bufferlist::const_iterator& p)
 {
-  __u32 len;
-  decode(len, p);
+  const auto len = encoding_detail::decode_count(p);
   s.clear();
   p.copy(len, s);
 }
 
 inline void encode_nohead(std::string_view s, bufferlist& bl)
 {
-  bl.append(s.data(), s.length());
+  encoding_detail::append_bytes(s.data(), s.length(), bl);
 }
 inline void encode_nohead(const std::string& s, bufferlist& bl)
 {
@@ -259,7 +304,7 @@ inline void decode_nohead(unsigned len, std::string& s, bufferlist::const_iterat
 }
 
 // const char* (encode only, string compatible)
-inline void encode(const char *s, bufferlist& bl) 
+inline void encode(const char *s, bufferlist& bl)
 {
   encode(std::string_view(s, strlen(s)), bl);
 }
@@ -267,17 +312,12 @@ inline void encode(const char *s, bufferlist& bl)
 // opaque byte vectors
 inline void encode(std::vector<uint8_t>& v, bufferlist& bl)
 {
-  uint32_t len = v.size();
-  encode(len, bl);
-  if (len)
-    bl.append((char *)v.data(), len);
+  encoding_detail::encode_bytes(v.data(), v.size(), bl);
 }
 
 inline void decode(std::vector<uint8_t>& v, bufferlist::const_iterator& p)
 {
-  uint32_t len;
-
-  decode(len, p);
+  const auto len = encoding_detail::decode_count(p);
   v.resize(len);
   p.copy(len, (char *)v.data());
 }
@@ -286,51 +326,55 @@ inline void decode(std::vector<uint8_t>& v, bufferlist::const_iterator& p)
 // buffers
 
 // bufferptr (encapsulated)
-inline void encode(const buffer::ptr& bp, bufferlist& bl) 
+inline void encode(const buffer::ptr& bp, bufferlist& bl)
 {
-  __u32 len = bp.length();
-  encode(len, bl);
+  const auto len = bp.length();
+  encoding_detail::encode_count(len, bl);
   if (len)
     bl.append(bp);
 }
 inline void decode(buffer::ptr& bp, bufferlist::const_iterator& p)
 {
-  __u32 len;
-  decode(len, p);
+  const auto len = encoding_detail::decode_count(p);
 
   bufferlist s;
   p.copy(len, s);
 
-  if (len) {
-    if (s.get_num_buffers() == 1)
-      bp = s.front();
-    else
-      bp = buffer::copy(s.c_str(), s.length());
+  // Return without assignment:
+  if (!len) {
+    return;
   }
+
+  // ...if the buffer::list contains only a single buffer, we
+  // re-use it:
+  if (1 == s.get_num_buffers()) {
+    bp = s.front();
+    return;
+  }
+
+  // ...flatten the buffer::list:
+  bp = buffer::copy(s.c_str(), s.length());
 }
 
 // bufferlist (encapsulated)
-inline void encode(const bufferlist& s, bufferlist& bl) 
+inline void encode(const bufferlist& s, bufferlist& bl)
 {
-  __u32 len = s.length();
-  encode(len, bl);
+  encoding_detail::encode_count(s.length(), bl);
   bl.append(s);
 }
-inline void encode_destructively(bufferlist& s, bufferlist& bl) 
+inline void encode_destructively(bufferlist& s, bufferlist& bl)
 {
-  __u32 len = s.length();
-  encode(len, bl);
+  encoding_detail::encode_count(s.length(), bl);
   bl.claim_append(s);
 }
 inline void decode(bufferlist& s, bufferlist::const_iterator& p)
 {
-  __u32 len;
-  decode(len, p);
+  const auto len = encoding_detail::decode_count(p);
   s.clear();
   p.copy(len, s);
 }
 
-inline void encode_nohead(const bufferlist& s, bufferlist& bl) 
+inline void encode_nohead(const bufferlist& s, bufferlist& bl)
 {
   bl.append(s);
 }
@@ -421,294 +465,206 @@ void round_trip_decode(std::chrono::time_point<Clock, Duration>& t,
   t = std::chrono::time_point<Clock, Duration>(dur);
 }
 
-// -----------------------------
-// STL container types
+// STL container types and helper Concepts:
+namespace encoding_detail {
+
+template<typename... TraitsT>
+concept needs_legacy_encoding = (not TraitsT::supported || ...);
+
+template<typename MapT>
+concept map_emplaces_key_value =
+  std::constructible_from<typename MapT::value_type,
+                          typename MapT::key_type,
+                          typename MapT::mapped_type> &&
+  requires(MapT& m, typename MapT::key_type& k,
+           typename MapT::mapped_type& v) {
+    m.emplace(std::move(k), std::move(v));
+  };
+
+template<typename OptionalT>
+void encode_optional(const OptionalT& p, bufferlist& bl);
 
 template<typename T>
-inline void encode(const boost::optional<T> &p, bufferlist &bl);
-template<typename T>
-inline void decode(boost::optional<T> &p, bufferlist::const_iterator &bp);
-template<typename T>
-inline void encode(const std::optional<T> &p, bufferlist &bl);
-template<typename T>
-inline void decode(std::optional<T> &p, bufferlist::const_iterator &bp);
-template<class A, class B, class C>
-inline void encode(const boost::tuple<A, B, C> &t, bufferlist& bl);
-template<class A, class B, class C>
-inline void decode(boost::tuple<A, B, C> &t, bufferlist::const_iterator &bp);
-template<class A, class B,
-	 typename a_traits=denc_traits<A>, typename b_traits=denc_traits<B>>
-inline std::enable_if_t<!a_traits::supported || !b_traits::supported>
-encode(const std::pair<A,B> &p, bufferlist &bl, uint64_t features);
-template<class A, class B,
-	 typename a_traits=denc_traits<A>, typename b_traits=denc_traits<B>>
-inline std::enable_if_t<!a_traits::supported ||
-			!b_traits::supported>
-encode(const std::pair<A,B> &p, bufferlist &bl);
-template<class A, class B,
-	 typename a_traits=denc_traits<A>, typename b_traits=denc_traits<B>>
-inline std::enable_if_t<!a_traits::supported ||
-			!b_traits::supported>
-decode(std::pair<A,B> &pa, bufferlist::const_iterator &p);
-template<class T, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode(const std::list<T, Alloc>& ls, bufferlist& bl);
-template<class T, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode(const std::list<T,Alloc>& ls, bufferlist& bl, uint64_t features);
-template<class T, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-decode(std::list<T,Alloc>& ls, bufferlist::const_iterator& p);
-template<class T, class Alloc>
-inline void encode(const std::list<std::shared_ptr<T>, Alloc>& ls,
-		   bufferlist& bl);
-template<class T, class Alloc>
-inline void encode(const std::list<std::shared_ptr<T>, Alloc>& ls,
-		   bufferlist& bl, uint64_t features);
-template<class T, class Alloc>
-inline void decode(std::list<std::shared_ptr<T>, Alloc>& ls,
-		   bufferlist::const_iterator& p);
-template<class T, class Comp, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode(const std::set<T,Comp,Alloc>& s, bufferlist& bl);
-template<class T, class Comp, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-decode(std::set<T,Comp,Alloc>& s, bufferlist::const_iterator& p);
-template<class T, class Comp, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode_nohead(const std::set<T,Comp,Alloc>& s, bufferlist& bl);
-template<class T, class Comp, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-decode_nohead(unsigned len, std::set<T,Comp,Alloc>& s, bufferlist::iterator& p);
-template<class T, class Comp, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode(const boost::container::flat_set<T, Comp, Alloc>& s, bufferlist& bl);
-template<class T, class Comp, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-decode(boost::container::flat_set<T, Comp, Alloc>& s, bufferlist::const_iterator& p);
-template<class T, class Comp, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode_nohead(const boost::container::flat_set<T, Comp, Alloc>& s,
-	      bufferlist& bl);
-template<class T, class Comp, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-decode_nohead(unsigned len, boost::container::flat_set<T, Comp, Alloc>& s,
-	      bufferlist::iterator& p);
-template<class T, class Comp, class Alloc>
-inline void encode(const std::multiset<T,Comp,Alloc>& s, bufferlist& bl);
-template<class T, class Comp, class Alloc>
-inline void decode(std::multiset<T,Comp,Alloc>& s, bufferlist::const_iterator& p);
-template<class T, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode(const std::vector<T,Alloc>& v, bufferlist& bl, uint64_t features);
-template<class T, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode(const std::vector<T,Alloc>& v, bufferlist& bl);
-template<class T, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-decode(std::vector<T,Alloc>& v, bufferlist::const_iterator& p);
-template<class T, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode_nohead(const std::vector<T,Alloc>& v, bufferlist& bl);
-template<class T, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-decode_nohead(unsigned len, std::vector<T,Alloc>& v, bufferlist::const_iterator& p);
-template<class T,class Alloc>
-inline void encode(const std::vector<std::shared_ptr<T>,Alloc>& v,
-		   bufferlist& bl,
-		   uint64_t features);
-template<class T, class Alloc>
-inline void encode(const std::vector<std::shared_ptr<T>,Alloc>& v,
-		   bufferlist& bl);
-template<class T, class Alloc>
-inline void decode(std::vector<std::shared_ptr<T>,Alloc>& v,
-		   bufferlist::const_iterator& p);
-// small_vector
-template<class T, std::size_t N, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode(const boost::container::small_vector<T,N,Alloc>& v, bufferlist& bl, uint64_t features);
-template<class T, std::size_t N, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode(const boost::container::small_vector<T,N,Alloc>& v, bufferlist& bl);
-template<class T, std::size_t N, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-decode(boost::container::small_vector<T,N,Alloc>& v, bufferlist::const_iterator& p);
-template<class T, std::size_t N, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode_nohead(const boost::container::small_vector<T,N,Alloc>& v, bufferlist& bl);
-template<class T, std::size_t N, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-decode_nohead(unsigned len, boost::container::small_vector<T,N,Alloc>& v, bufferlist::const_iterator& p);
-// std::map
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported ||
-			!u_traits::supported>
-encode(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-encode(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl, uint64_t features);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-decode(std::map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p);
-template<class T, class U, class Comp, class Alloc>
-inline void decode_noclear(std::map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-encode_nohead(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-encode_nohead(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl, uint64_t features);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-decode_nohead(unsigned n, std::map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-  inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-encode(const boost::container::flat_map<T,U,Comp,Alloc>& m, bufferlist& bl);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-encode(const boost::container::flat_map<T,U,Comp,Alloc>& m, bufferlist& bl,
-       uint64_t features);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-decode(boost::container::flat_map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p);
-template<class T, class U, class Comp, class Alloc>
-inline void decode_noclear(boost::container::flat_map<T,U,Comp,Alloc>& m,
-			   bufferlist::const_iterator& p);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-encode_nohead(const boost::container::flat_map<T,U,Comp,Alloc>& m,
-	      bufferlist& bl);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-encode_nohead(const boost::container::flat_map<T,U,Comp,Alloc>& m,
-	      bufferlist& bl, uint64_t features);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-decode_nohead(unsigned n, boost::container::flat_map<T,U,Comp,Alloc>& m,
-	      bufferlist::const_iterator& p);
-template<class T, class U, class Comp, class Alloc>
-inline void encode(const std::multimap<T,U,Comp,Alloc>& m, bufferlist& bl);
-template<class T, class U, class Comp, class Alloc>
-inline void decode(std::multimap<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p);
-template<class T, class U, class Hash, class Pred, class Alloc>
-inline void encode(const std::unordered_map<T,U,Hash,Pred,Alloc>& m, bufferlist& bl,
-		   uint64_t features);
-template<class T, class U, class Hash, class Pred, class Alloc>
-inline void encode(const std::unordered_map<T,U,Hash,Pred,Alloc>& m, bufferlist& bl);
-template<class T, class U, class Hash, class Pred, class Alloc>
-inline void decode(std::unordered_map<T,U,Hash,Pred,Alloc>& m, bufferlist::const_iterator& p);
-template<class T, class Hash, class Pred, class Alloc>
-inline void encode(const std::unordered_set<T,Hash,Pred,Alloc>& m, bufferlist& bl);
-template<class T, class Hash, class Pred, class Alloc>
-inline void decode(std::unordered_set<T,Hash,Pred,Alloc>& m, bufferlist::const_iterator& p);
-template<class T, class Alloc>
-inline void encode(const std::deque<T,Alloc>& ls, bufferlist& bl, uint64_t features);
-template<class T, class Alloc>
-inline void encode(const std::deque<T,Alloc>& ls, bufferlist& bl);
-template<class T, class Alloc>
-inline void decode(std::deque<T,Alloc>& ls, bufferlist::const_iterator& p);
-template<class T, size_t N, typename traits = denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode(const std::array<T, N>& v, bufferlist& bl, uint64_t features);
-template<class T, size_t N, typename traits = denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode(const std::array<T, N>& v, bufferlist& bl);
-template<class T, size_t N, typename traits = denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-decode(std::array<T, N>& v, bufferlist::const_iterator& p);
+std::optional<T> decode_optional(bufferlist::const_iterator& p);
 
-// full bl decoder
-template<class T>
-inline void decode(T &o, const bufferlist& bl)
-{
-  auto p = bl.begin();
-  decode(o, p);
-  ceph_assert(p.end());
-}
+template<typename FnT>
+void for_each_count(unsigned n, FnT&& fn);
+
+// "nohead" as in just the elements, without the container length:
+// (i.e.: [x][x][x] rather than [sz][x][x][x], like encode_range())
+template<typename RangeT>
+void encode_range_nohead(const RangeT& r, bufferlist& bl);
+
+template<typename RangeT>
+void encode_range_nohead(const RangeT& r, bufferlist& bl, uint64_t features);
+
+template<typename RangeT, typename IteratorT>
+void decode_range_nohead(RangeT& r, IteratorT& p);
+
+template<typename RangeT>
+void encode_range(const RangeT& r, bufferlist& bl);
+
+template<typename RangeT>
+void encode_range(const RangeT& r, bufferlist& bl, uint64_t features);
+
+template<typename ContainerT, typename IteratorT>
+void decode_by_resize_nohead(unsigned len, ContainerT& c,
+                             IteratorT& p);
+
+template<typename ContainerT>
+void decode_by_resize(ContainerT& c, bufferlist::const_iterator& p);
+
+template<typename ContainerT, typename IteratorT>
+void decode_by_emplace_back(unsigned len, ContainerT& c,
+                            IteratorT& p);
+
+template<typename ContainerT>
+void decode_by_emplace_back(ContainerT& c, bufferlist::const_iterator& p);
+
+template<typename ContainerT>
+void clear_and_reserve(ContainerT& c, size_t n);
+
+template<typename ContainerT, typename IteratorT>
+void decode_by_insert(unsigned len, ContainerT& c,
+                      IteratorT& p);
+
+template<typename ContainerT>
+void decode_by_insert(ContainerT& c, bufferlist::const_iterator& p);
+
+template<typename RangeT>
+void encode_shared_ptr_range(const RangeT& r, bufferlist& bl);
+
+template<typename RangeT>
+void encode_shared_ptr_range(const RangeT& r, bufferlist& bl,
+                             uint64_t features);
+
+template<typename ValueT, typename EncodeFnT>
+void append_cached_default_encoding(std::optional<std::string>& bytes,
+                                    bufferlist& bl,
+                                    EncodeFnT&& encode_value);
+
+template<typename RangeT, typename EncodeFnT>
+void encode_shared_ptr_range_with(const RangeT& r, bufferlist& bl,
+                                  EncodeFnT&& encode_value);
+
+template<typename ContainerT>
+void decode_shared_ptr_sequence(ContainerT& c,
+                                bufferlist::const_iterator& p);
+
+template<typename PairT>
+void decode_pair_members(PairT& item, bufferlist::const_iterator& p);
+
+template<typename MapT>
+void encode_pair_range_nohead(const MapT& m, bufferlist& bl);
+
+template<typename MapT>
+void encode_pair_range_nohead(const MapT& m, bufferlist& bl,
+                              uint64_t features);
+
+template<typename MapT>
+void encode_pair_range(const MapT& m, bufferlist& bl);
+
+template<typename MapT>
+void encode_pair_range(const MapT& m, bufferlist& bl, uint64_t features);
+
+template<typename MapT, typename IteratorT>
+void decode_map_entries_by_subscript(unsigned n, MapT& m,
+                                     IteratorT& p);
+
+template<typename MapT, typename IteratorT>
+void decode_map_entries_by_emplace(unsigned n, MapT& m,
+                                   IteratorT& p);
+
+template<typename MapT, typename IteratorT>
+void decode_map_entries_by_try_emplace(unsigned n, MapT& m,
+                                       IteratorT& p);
+
+template<typename MapT, typename IteratorT>
+requires map_emplaces_key_value<MapT>
+void decode_map_entries_no_clear(unsigned n, MapT& m, IteratorT& p);
+
+template<typename MapT, typename IteratorT>
+requires (!map_emplaces_key_value<MapT> &&
+          ceph::concepts::has_try_emplace_key<MapT>)
+void decode_map_entries_no_clear(unsigned n, MapT& m, IteratorT& p);
+
+template<typename MapT, typename IteratorT>
+requires map_emplaces_key_value<MapT>
+void decode_map_entries(unsigned n, MapT& m, IteratorT& p);
+
+template<typename MapT, typename IteratorT>
+requires (!map_emplaces_key_value<MapT> &&
+          ceph::concepts::has_subscript_operator<MapT>)
+void decode_map_entries(unsigned n, MapT& m, IteratorT& p);
+
+template<typename MapT>
+void decode_map_by_subscript(unsigned n, MapT& m,
+                             bufferlist::const_iterator& p);
+
+template<typename MapT>
+void decode_map_by_subscript(MapT& m, bufferlist::const_iterator& p);
+
+template<typename MapT>
+void decode_map(unsigned n, MapT& m, bufferlist::const_iterator& p);
+
+template<typename MapT>
+void decode_map(MapT& m, bufferlist::const_iterator& p);
+
+} // namespace encoding_detail
 
 // boost optional
 template<typename T>
 inline void encode(const boost::optional<T> &p, bufferlist &bl)
 {
-  __u8 present = static_cast<bool>(p);
-  encode(present, bl);
-  if (p)
-    encode(p.get(), bl);
+  encoding_detail::encode_optional(p, bl);
 }
 
-#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wuninitialized"
 template<typename T>
 inline void decode(boost::optional<T> &p, bufferlist::const_iterator &bp)
 {
-  __u8 present;
-  decode(present, bp);
-  if (present) {
-    p = T{};
-    decode(p.get(), bp);
-  } else {
-    p = boost::none;
+  auto decoded = encoding_detail::decode_optional<T>(bp);
+  if (decoded) {
+    p = std::move(*decoded);
+    return;
   }
+
+  p.reset();
 }
-#pragma GCC diagnostic pop
-#pragma GCC diagnostic warning "-Wpragmas"
 
 // std optional
 template<typename T>
 inline void encode(const std::optional<T> &p, bufferlist &bl)
 {
-  __u8 present = static_cast<bool>(p);
-  encode(present, bl);
-  if (p)
-    encode(*p, bl);
+  encoding_detail::encode_optional(p, bl);
 }
 
-#pragma GCC diagnostic ignored "-Wpragmas"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuninitialized"
 template<typename T>
 inline void decode(std::optional<T> &p, bufferlist::const_iterator &bp)
 {
-  __u8 present;
-  decode(present, bp);
-  if (present) {
-    p = T{};
-    decode(*p, bp);
-  } else {
-    p = std::nullopt;
-  }
+  p = encoding_detail::decode_optional<T>(bp);
 }
+#pragma GCC diagnostic pop
 
 // std::tuple
 template<typename... Ts>
 inline void encode(const std::tuple<Ts...> &t, bufferlist& bl)
 {
   ceph::for_each(t, [&bl](const auto& e) {
-      encode(e, bl);
-    });
+    encode(e, bl);
+  });
 }
 template<typename... Ts>
 inline void decode(std::tuple<Ts...> &t, bufferlist::const_iterator &bp)
 {
   ceph::for_each(t, [&bp](auto& e) {
-      decode(e, bp);
-    });
+    decode(e, bp);
+  });
 }
 
-//triple boost::tuple
+// triple boost::tuple
 template<class A, class B, class C>
 inline void encode(const boost::tuple<A, B, C> &t, bufferlist& bl)
 {
@@ -724,720 +680,814 @@ inline void decode(boost::tuple<A, B, C> &t, bufferlist::const_iterator &bp)
   decode(boost::get<2>(t), bp);
 }
 
-// std::pair<A,B>
+// std::pair<A, B>
 template<class A, class B,
-	 typename a_traits, typename b_traits>
-inline std::enable_if_t<!a_traits::supported || !b_traits::supported>
-  encode(const std::pair<A,B> &p, bufferlist &bl, uint64_t features)
+	 typename a_traits = denc_traits<A>, typename b_traits = denc_traits<B>>
+requires encoding_detail::needs_legacy_encoding<a_traits, b_traits>
+inline void encode(const std::pair<A,B> &p, bufferlist &bl, uint64_t features)
 {
   encode(p.first, bl, features);
   encode(p.second, bl, features);
 }
 template<class A, class B,
-	 typename a_traits, typename b_traits>
-inline std::enable_if_t<!a_traits::supported ||
-			!b_traits::supported>
-  encode(const std::pair<A,B> &p, bufferlist &bl)
+	 typename a_traits = denc_traits<A>, typename b_traits = denc_traits<B>>
+requires encoding_detail::needs_legacy_encoding<a_traits, b_traits>
+inline void encode(const std::pair<A,B> &p, bufferlist &bl)
 {
   encode(p.first, bl);
   encode(p.second, bl);
 }
-template<class A, class B, typename a_traits, typename b_traits>
-inline std::enable_if_t<!a_traits::supported ||
-			!b_traits::supported>
-  decode(std::pair<A,B> &pa, bufferlist::const_iterator &p)
+template<class A, class B,
+	 typename a_traits = denc_traits<A>, typename b_traits = denc_traits<B>>
+requires encoding_detail::needs_legacy_encoding<a_traits, b_traits>
+inline void decode(std::pair<A,B> &pa, bufferlist::const_iterator &p)
 {
-  decode(pa.first, p);
-  decode(pa.second, p);
+  encoding_detail::decode_pair_members(pa, p);
 }
 
 // std::list<T>
-template<class T, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  encode(const std::list<T, Alloc>& ls, bufferlist& bl)
+template<class T, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode(const std::list<T, Alloc>& ls, bufferlist& bl)
 {
-  __u32 n = (__u32)(ls.size());  // c++11 std::list::size() is O(1)
-  encode(n, bl);
-  for (auto p = ls.begin(); p != ls.end(); ++p)
-    encode(*p, bl);
+  encoding_detail::encode_range(ls, bl);
 }
-template<class T, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  encode(const std::list<T,Alloc>& ls, bufferlist& bl, uint64_t features)
+template<class T, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode(const std::list<T,Alloc>& ls, bufferlist& bl, uint64_t features)
 {
-  using counter_encode_t = ceph_le32;
-  unsigned n = 0;
-  auto filler = bl.append_hole(sizeof(counter_encode_t));
-  for (const auto& item : ls) {
-    // we count on our own because of buggy std::list::size() implementation
-    // which doesn't follow the O(1) complexity constraint C++11 has brought.
-    ++n;
-    encode(item, bl, features);
-  }
-  counter_encode_t en;
-  en = n;
-  filler.copy_in(sizeof(en), reinterpret_cast<char*>(&en));
+  encoding_detail::encode_range(ls, bl, features);
 }
 
-template<class T, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  decode(std::list<T,Alloc>& ls, bufferlist::const_iterator& p)
+template<class T, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void decode(std::list<T,Alloc>& ls, bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  ls.clear();
-  while (n--) {
-    ls.emplace_back();
-    decode(ls.back(), p);
-  }
+  encoding_detail::decode_by_emplace_back(ls, p);
 }
 
 // std::list<std::shared_ptr<T>>
 template<class T, class Alloc>
 inline void encode(const std::list<std::shared_ptr<T>, Alloc>& ls,
-		   bufferlist& bl)
+                   bufferlist& bl)
 {
-  __u32 n = (__u32)(ls.size());  // c++11 std::list::size() is O(1)
-  encode(n, bl);
-  for (const auto& ref : ls) {
-    encode(*ref, bl);
-  }
+  encoding_detail::encode_shared_ptr_range(ls, bl);
 }
 template<class T, class Alloc>
 inline void encode(const std::list<std::shared_ptr<T>, Alloc>& ls,
-		   bufferlist& bl, uint64_t features)
+                   bufferlist& bl, uint64_t features)
 {
-  __u32 n = (__u32)(ls.size());  // c++11 std::list::size() is O(1)
-  encode(n, bl);
-  for (const auto& ref : ls) {
-    encode(*ref, bl, features);
-  }
+  encoding_detail::encode_shared_ptr_range(ls, bl, features);
 }
 template<class T, class Alloc>
 inline void decode(std::list<std::shared_ptr<T>, Alloc>& ls,
-		   bufferlist::const_iterator& p)
+                   bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  ls.clear();
-  while (n--) {
-    auto ref = std::make_shared<T>();
-    decode(*ref, p);
-    ls.emplace_back(std::move(ref));
-  }
+  encoding_detail::decode_shared_ptr_sequence(ls, p);
 }
 
 // std::set<T>
-template<class T, class Comp, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  encode(const std::set<T,Comp,Alloc>& s, bufferlist& bl)
+template<class T, class Comp, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode(const std::set<T,Comp,Alloc>& s, bufferlist& bl)
 {
-  __u32 n = (__u32)(s.size());
-  encode(n, bl);
-  for (auto p = s.begin(); p != s.end(); ++p)
-    encode(*p, bl);
+  encoding_detail::encode_range(s, bl);
 }
-template<class T, class Comp, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  decode(std::set<T,Comp,Alloc>& s, bufferlist::const_iterator& p)
+template<class T, class Comp, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void decode(std::set<T,Comp,Alloc>& s, bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  s.clear();
-  while (n--) {
-    T v;
-    decode(v, p);
-    s.insert(v);
-  }
+  encoding_detail::decode_by_insert(s, p);
 }
 
-template<class T, class Comp, class Alloc, typename traits>
-inline typename std::enable_if<!traits::supported>::type
-  encode_nohead(const std::set<T,Comp,Alloc>& s, bufferlist& bl)
+template<class T, class Comp, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode_nohead(const std::set<T,Comp,Alloc>& s, bufferlist& bl)
 {
-  for (auto p = s.begin(); p != s.end(); ++p)
-    encode(*p, bl);
+  encoding_detail::encode_range_nohead(s, bl);
 }
-template<class T, class Comp, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  decode_nohead(unsigned len, std::set<T,Comp,Alloc>& s, bufferlist::const_iterator& p)
+template<class T, class Comp, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void decode_nohead(unsigned len, std::set<T,Comp,Alloc>& s,
+                          bufferlist::const_iterator& p)
 {
-  for (unsigned i=0; i<len; i++) {
-    T v;
-    decode(v, p);
-    s.insert(v);
-  }
+  encoding_detail::decode_by_insert(len, s, p);
 }
 
 // boost::container::flat_set<T>
-template<class T, class Comp, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-encode(const boost::container::flat_set<T, Comp, Alloc>& s, bufferlist& bl)
+template<class T, class Comp, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode(const boost::container::flat_set<T, Comp, Alloc>& s,
+                   bufferlist& bl)
 {
-  __u32 n = (__u32)(s.size());
-  encode(n, bl);
-  for (const auto& e : s)
-    encode(e, bl);
+  encoding_detail::encode_range(s, bl);
 }
-template<class T, class Comp, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-decode(boost::container::flat_set<T, Comp, Alloc>& s, bufferlist::const_iterator& p)
+template<class T, class Comp, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void decode(boost::container::flat_set<T, Comp, Alloc>& s,
+                   bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  s.clear();
-  s.reserve(n);
-  while (n--) {
-    T v;
-    decode(v, p);
-    s.insert(v);
-  }
+  encoding_detail::decode_by_insert(s, p);
 }
 
-template<class T, class Comp, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-encode_nohead(const boost::container::flat_set<T, Comp, Alloc>& s,
-	      bufferlist& bl)
+template<class T, class Comp, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode_nohead(const boost::container::flat_set<T, Comp, Alloc>& s,
+                          bufferlist& bl)
 {
-  for (const auto& e : s)
-    encode(e, bl);
+  encoding_detail::encode_range_nohead(s, bl);
 }
-template<class T, class Comp, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-decode_nohead(unsigned len, boost::container::flat_set<T, Comp, Alloc>& s,
-	      bufferlist::iterator& p)
+template<class T, class Comp, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void decode_nohead(unsigned len,
+                          boost::container::flat_set<T, Comp, Alloc>& s,
+                          bufferlist::const_iterator& p)
 {
-  s.reserve(len);
-  for (unsigned i=0; i<len; i++) {
-    T v;
-    decode(v, p);
-    s.insert(v);
-  }
+  encoding_detail::decode_by_insert(len, s, p);
 }
 
 // multiset
 template<class T, class Comp, class Alloc>
 inline void encode(const std::multiset<T,Comp,Alloc>& s, bufferlist& bl)
 {
-  __u32 n = (__u32)(s.size());
-  encode(n, bl);
-  for (auto p = s.begin(); p != s.end(); ++p)
-    encode(*p, bl);
+  encoding_detail::encode_range(s, bl);
 }
 template<class T, class Comp, class Alloc>
 inline void decode(std::multiset<T,Comp,Alloc>& s, bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  s.clear();
-  while (n--) {
-    T v;
-    decode(v, p);
-    s.insert(v);
-  }
+  encoding_detail::decode_by_insert(s, p);
 }
 
-template<class T, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  encode(const std::vector<T,Alloc>& v, bufferlist& bl, uint64_t features)
+template<class T, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode(const std::vector<T,Alloc>& v, bufferlist& bl, uint64_t features)
 {
-  __u32 n = (__u32)(v.size());
-  encode(n, bl);
-  for (auto p = v.begin(); p != v.end(); ++p)
-    encode(*p, bl, features);
+  encoding_detail::encode_range(v, bl, features);
 }
-template<class T, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  encode(const std::vector<T,Alloc>& v, bufferlist& bl)
+template<class T, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode(const std::vector<T,Alloc>& v, bufferlist& bl)
 {
-  __u32 n = (__u32)(v.size());
-  encode(n, bl);
-  for (auto p = v.begin(); p != v.end(); ++p)
-    encode(*p, bl);
+  encoding_detail::encode_range(v, bl);
 }
-template<class T, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  decode(std::vector<T,Alloc>& v, bufferlist::const_iterator& p)
+template<class T, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void decode(std::vector<T,Alloc>& v, bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  v.resize(n);
-  for (__u32 i=0; i<n; i++) 
-    decode(v[i], p);
+  encoding_detail::decode_by_resize(v, p);
 }
 
-template<class T, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  encode_nohead(const std::vector<T,Alloc>& v, bufferlist& bl)
+template<class T, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode_nohead(const std::vector<T,Alloc>& v, bufferlist& bl)
 {
-  for (auto p = v.begin(); p != v.end(); ++p)
-    encode(*p, bl);
+  encoding_detail::encode_range_nohead(v, bl);
 }
-template<class T, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  decode_nohead(unsigned len, std::vector<T,Alloc>& v, bufferlist::const_iterator& p)
+template<class T, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void decode_nohead(unsigned len, std::vector<T,Alloc>& v,
+                          bufferlist::const_iterator& p)
 {
-  v.resize(len);
-  for (__u32 i=0; i<v.size(); i++) 
-    decode(v[i], p);
+  encoding_detail::decode_by_resize_nohead(len, v, p);
 }
 
 // small vector
-template<class T, std::size_t N, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  encode(const boost::container::small_vector<T,N,Alloc>& v, bufferlist& bl, uint64_t features)
+template<class T, std::size_t N, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode(const boost::container::small_vector<T,N,Alloc>& v,
+                   bufferlist& bl, uint64_t features)
 {
-  __u32 n = (__u32)(v.size());
-  encode(n, bl);
-  for (const auto& i : v)
-    encode(i, bl, features);
+  encoding_detail::encode_range(v, bl, features);
 }
-template<class T, std::size_t N, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  encode(const boost::container::small_vector<T,N,Alloc>& v, bufferlist& bl)
+template<class T, std::size_t N, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode(const boost::container::small_vector<T,N,Alloc>& v,
+                   bufferlist& bl)
 {
-  __u32 n = (__u32)(v.size());
-  encode(n, bl);
-  for (const auto& i : v)
-    encode(i, bl);
+  encoding_detail::encode_range(v, bl);
 }
-template<class T, std::size_t N, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  decode(boost::container::small_vector<T,N,Alloc>& v, bufferlist::const_iterator& p)
+template<class T, std::size_t N, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void decode(boost::container::small_vector<T,N,Alloc>& v,
+                   bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  v.resize(n);
-  for (auto& i : v)
-    decode(i, p);
+  encoding_detail::decode_by_resize(v, p);
 }
 
-template<class T, std::size_t N, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  encode_nohead(const boost::container::small_vector<T,N,Alloc>& v, bufferlist& bl)
+template<class T, std::size_t N, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode_nohead(const boost::container::small_vector<T,N,Alloc>& v,
+                          bufferlist& bl)
 {
-  for (const auto& i : v)
-    encode(i, bl);
+  encoding_detail::encode_range_nohead(v, bl);
 }
-template<class T, std::size_t N, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  decode_nohead(unsigned len, boost::container::small_vector<T,N,Alloc>& v, bufferlist::const_iterator& p)
+template<class T, std::size_t N, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void decode_nohead(unsigned len,
+                          boost::container::small_vector<T,N,Alloc>& v,
+                          bufferlist::const_iterator& p)
 {
-  v.resize(len);
-  for (auto& i : v)
-    decode(i, p);
+  encoding_detail::decode_by_resize_nohead(len, v, p);
 }
 
 
 // vector (shared_ptr)
-template<class T,class Alloc>
+template<class T, class Alloc>
 inline void encode(const std::vector<std::shared_ptr<T>,Alloc>& v,
-		   bufferlist& bl,
-		   uint64_t features)
+                   bufferlist& bl,
+                   uint64_t features)
 {
-  __u32 n = (__u32)(v.size());
-  encode(n, bl);
-  for (const auto& ref : v) {
-    if (ref)
-      encode(*ref, bl, features);
-    else
-      encode(T(), bl, features);
-  }
+  encoding_detail::encode_shared_ptr_range(v, bl, features);
 }
 template<class T, class Alloc>
 inline void encode(const std::vector<std::shared_ptr<T>,Alloc>& v,
-		   bufferlist& bl)
+                   bufferlist& bl)
 {
-  __u32 n = (__u32)(v.size());
-  encode(n, bl);
-  for (const auto& ref : v) {
-    if (ref)
-      encode(*ref, bl);
-    else
-      encode(T(), bl);
-  }
+  encoding_detail::encode_shared_ptr_range(v, bl);
 }
 template<class T, class Alloc>
 inline void decode(std::vector<std::shared_ptr<T>,Alloc>& v,
-		   bufferlist::const_iterator& p)
+                   bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  v.clear();
-  v.reserve(n);
-  while (n--) {
-    auto ref = std::make_shared<T>();
-    decode(*ref, p);
-    v.emplace_back(std::move(ref));
-  }
+  encoding_detail::decode_shared_ptr_sequence(v, p);
 }
 
 // map
 template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-inline std::enable_if_t<!t_traits::supported ||
-			!u_traits::supported>
-  encode(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl)
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void encode(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl)
 {
-  __u32 n = (__u32)(m.size());
-  encode(n, bl);
-  for (auto p = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl);
-    encode(p->second, bl);
-  }
+  encoding_detail::encode_pair_range(m, bl);
 }
 template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  encode(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl, uint64_t features)
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void encode(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl,
+                   uint64_t features)
 {
-  __u32 n = (__u32)(m.size());
-  encode(n, bl);
-  for (auto p = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl, features);
-    encode(p->second, bl, features);
-  }
+  encoding_detail::encode_pair_range(m, bl, features);
 }
 template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  decode(std::map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p)
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void decode(std::map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  m.clear();
-  while (n--) {
-    T k;
-    decode(k, p);
-    decode(m[k], p);
-  }
-}
-template <std::move_constructible T, std::move_constructible U, class Comp, class Alloc,
-    typename t_traits, typename u_traits>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-decode(std::map<T, U, Comp, Alloc>& m, bufferlist::const_iterator& p)
-{
-  __u32 n;
-  decode(n, p);
-  m.clear();
-  while (n--) {
-    T k;
-    U v;
-    decode(k, p);
-    decode(v, p);
-    m.emplace(std::move(k), std::move(v));
-  }
-}
-template<class T, class U, class Comp, class Alloc>
-inline void decode_noclear(std::map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p)
-{
-  __u32 n;
-  decode(n, p);
-  while (n--) {
-    T k;
-    decode(k, p);
-    decode(m[k], p);
-  }
-}
-template<std::move_constructible T, std::move_constructible U, class Comp, class Alloc>
-inline void decode_noclear(std::map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p)
-{
-  __u32 n;
-  decode(n, p);
-  while (n--) {
-    T k;
-    U v;
-    decode(k, p);
-    decode(v, p);
-    m.emplace(std::move(k), std::move(v));
-  }
-}
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  encode_nohead(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl)
-{
-  for (auto p = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl);
-    encode(p->second, bl);
-  }
-}
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  encode_nohead(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl, uint64_t features)
-{
-  for (auto p = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl, features);
-    encode(p->second, bl, features);
-  }
-}
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  decode_nohead(unsigned n, std::map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p)
-{
-  m.clear();
-  while (n--) {
-    T k;
-    decode(k, p);
-    decode(m[k], p);
-  }
+  encoding_detail::decode_map(m, p);
 }
 
-template <std::move_constructible T, std::move_constructible U, class Comp, class Alloc,
-    typename t_traits, typename u_traits>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-decode_nohead(unsigned n, std::map<T, U, Comp, Alloc>& m, bufferlist::const_iterator& p)
+// Compatibility helper for callers that intentionally manage clearing:
+// actual deprecation is a separate public-header compatibility decision.
+// Duplicate decoded keys intentionally preserve the existing mapped value for
+// std::map.
+template<class T, class U, class Comp, class Alloc>
+inline void decode_noclear(std::map<T,U,Comp,Alloc>& m,
+                           bufferlist::const_iterator& p)
 {
-  m.clear();
-  while (n--) {
-    T k;
-    U v;
-    decode(k, p);
-    decode(v, p);
-    m.emplace(std::move(k), std::move(v));
-  }
+  encoding_detail::decode_map_entries_no_clear(
+    encoding_detail::decode_count(p), m, p);
+}
+template<class T, class U, class Comp, class Alloc,
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void encode_nohead(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl)
+{
+  encoding_detail::encode_pair_range_nohead(m, bl);
+}
+template<class T, class U, class Comp, class Alloc,
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void encode_nohead(const std::map<T,U,Comp,Alloc>& m,
+                          bufferlist& bl,
+                          uint64_t features)
+{
+  encoding_detail::encode_pair_range_nohead(m, bl, features);
+}
+template<class T, class U, class Comp, class Alloc,
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void decode_nohead(unsigned n, std::map<T,U,Comp,Alloc>& m,
+                          bufferlist::const_iterator& p)
+{
+  encoding_detail::decode_map(n, m, p);
 }
 
 // boost::container::flat-map
 template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-  inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  encode(const boost::container::flat_map<T,U,Comp,Alloc>& m, bufferlist& bl)
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void encode(const boost::container::flat_map<T,U,Comp,Alloc>& m,
+                   bufferlist& bl)
 {
-  __u32 n = (__u32)(m.size());
-  encode(n, bl);
-  for (typename boost::container::flat_map<T,U,Comp>::const_iterator p
-	 = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl);
-    encode(p->second, bl);
-  }
+  encoding_detail::encode_pair_range(m, bl);
 }
 template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-  inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  encode(const boost::container::flat_map<T,U,Comp,Alloc>& m, bufferlist& bl,
-	 uint64_t features)
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void encode(const boost::container::flat_map<T,U,Comp,Alloc>& m,
+                   bufferlist& bl, uint64_t features)
 {
-  __u32 n = (__u32)(m.size());
-  encode(n, bl);
-  for (auto p = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl, features);
-    encode(p->second, bl, features);
-  }
+  encoding_detail::encode_pair_range(m, bl, features);
 }
 template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-  inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  decode(boost::container::flat_map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p)
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void decode(boost::container::flat_map<T,U,Comp,Alloc>& m,
+                   bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  m.clear();
-  m.reserve(n);
-  while (n--) {
-    T k;
-    decode(k, p);
-    decode(m[k], p);
-  }
+  encoding_detail::decode_map_by_subscript(m, p);
 }
+
+// Compatibility-only: no production callers were found in-tree. Do not add new
+// callers unless preserving the destination's current entries is necessary.
+// Actual deprecation is a separate public-header compatibility decision.
+// Duplicate decoded keys intentionally replace the existing mapped value for
+// boost::container::flat_map.
 template<class T, class U, class Comp, class Alloc>
-inline void decode_noclear(boost::container::flat_map<T,U,Comp,Alloc>& m,
-			   bufferlist::const_iterator& p)
+[[maybe_unused]] inline void decode_noclear(
+  boost::container::flat_map<T,U,Comp,Alloc>& m,
+  bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
+  const auto n = encoding_detail::decode_count(p);
   m.reserve(m.size() + n);
-  while (n--) {
-    T k;
-    decode(k, p);
-    decode(m[k], p);
-  }
+  encoding_detail::decode_map_entries_by_subscript(n, m, p);
 }
 template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-  inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  encode_nohead(const boost::container::flat_map<T,U,Comp,Alloc>& m,
-		bufferlist& bl)
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void encode_nohead(const boost::container::flat_map<T,U,Comp,Alloc>& m,
+                          bufferlist& bl)
 {
-  for (auto p = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl);
-    encode(p->second, bl);
-  }
+  encoding_detail::encode_pair_range_nohead(m, bl);
 }
 template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-  inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  encode_nohead(const boost::container::flat_map<T,U,Comp,Alloc>& m,
-		bufferlist& bl, uint64_t features)
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void encode_nohead(const boost::container::flat_map<T,U,Comp,Alloc>& m,
+                          bufferlist& bl, uint64_t features)
 {
-  for (auto p = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl, features);
-    encode(p->second, bl, features);
-  }
+  encoding_detail::encode_pair_range_nohead(m, bl, features);
 }
 template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  decode_nohead(unsigned n, boost::container::flat_map<T,U,Comp,Alloc>& m,
-		bufferlist::const_iterator& p)
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void decode_nohead(unsigned n,
+                          boost::container::flat_map<T,U,Comp,Alloc>& m,
+                          bufferlist::const_iterator& p)
 {
-  m.clear();
-  while (n--) {
-    T k;
-    decode(k, p);
-    decode(m[k], p);
-  }
+  encoding_detail::decode_map_by_subscript(n, m, p);
 }
 
 // multimap
 template<class T, class U, class Comp, class Alloc>
 inline void encode(const std::multimap<T,U,Comp,Alloc>& m, bufferlist& bl)
 {
-  __u32 n = (__u32)(m.size());
-  encode(n, bl);
-  for (auto p = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl);
-    encode(p->second, bl);
-  }
+  encoding_detail::encode_pair_range(m, bl);
 }
 template<class T, class U, class Comp, class Alloc>
-inline void decode(std::multimap<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p)
+inline void decode(std::multimap<T,U,Comp,Alloc>& m,
+                   bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
   m.clear();
-  while (n--) {
-    typename std::pair<T,U> tu = std::pair<T,U>();
+
+  encoding_detail::for_each_count(encoding_detail::decode_count(p), [&m, &p] {
+    auto tu = std::pair<T, U> {};
     decode(tu.first, p);
-    typename std::multimap<T,U,Comp,Alloc>::iterator it = m.insert(tu);
+    auto it = m.insert(std::move(tu));
     decode(it->second, p);
-  }
+  });
 }
 
 // std::unordered_map
 template<class T, class U, class Hash, class Pred, class Alloc>
-inline void encode(const std::unordered_map<T,U,Hash,Pred,Alloc>& m, bufferlist& bl,
-		   uint64_t features)
+inline void encode(const std::unordered_map<T,U,Hash,Pred,Alloc>& m,
+                   bufferlist& bl,
+                   uint64_t features)
 {
-  __u32 n = (__u32)(m.size());
-  encode(n, bl);
-  for (auto p = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl, features);
-    encode(p->second, bl, features);
-  }
+  encoding_detail::encode_pair_range(m, bl, features);
 }
 template<class T, class U, class Hash, class Pred, class Alloc>
-inline void encode(const std::unordered_map<T,U,Hash,Pred,Alloc>& m, bufferlist& bl)
+inline void encode(const std::unordered_map<T,U,Hash,Pred,Alloc>& m,
+                   bufferlist& bl)
 {
-  __u32 n = (__u32)(m.size());
-  encode(n, bl);
-  for (auto p = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl);
-    encode(p->second, bl);
-  }
+  encoding_detail::encode_pair_range(m, bl);
 }
 template<class T, class U, class Hash, class Pred, class Alloc>
-inline void decode(std::unordered_map<T,U,Hash,Pred,Alloc>& m, bufferlist::const_iterator& p)
+inline void decode(std::unordered_map<T,U,Hash,Pred,Alloc>& m,
+                   bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  m.clear();
-  while (n--) {
-    T k;
-    decode(k, p);
-    decode(m[k], p);
-  }
-}
-
-template <std::move_constructible T, std::move_constructible U, class Hash, class Pred, class Alloc>
-inline void decode(std::unordered_map<T, U, Hash, Pred, Alloc>& m, bufferlist::const_iterator& p)
-{
-  __u32 n;
-  decode(n, p);
-  m.clear();
-  while (n--) {
-    T k;
-    U v;
-    decode(k, p);
-    decode(v, p);
-    m.emplace(std::move(k), std::move(v));
-  }
+  encoding_detail::decode_map(m, p);
 }
 
 // std::unordered_set
 template<class T, class Hash, class Pred, class Alloc>
-inline void encode(const std::unordered_set<T,Hash,Pred,Alloc>& m, bufferlist& bl)
+inline void encode(const std::unordered_set<T,Hash,Pred,Alloc>& m,
+                   bufferlist& bl)
 {
-  __u32 n = (__u32)(m.size());
-  encode(n, bl);
-  for (auto p = m.begin(); p != m.end(); ++p)
-    encode(*p, bl);
+  encoding_detail::encode_range(m, bl);
 }
 template<class T, class Hash, class Pred, class Alloc>
-inline void decode(std::unordered_set<T,Hash,Pred,Alloc>& m, bufferlist::const_iterator& p)
+inline void decode(std::unordered_set<T,Hash,Pred,Alloc>& m,
+                   bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  m.clear();
-  while (n--) {
-    T k;
-    decode(k, p);
-    m.insert(k);
-  }
+  encoding_detail::decode_by_insert(m, p);
 }
 
 // deque
 template<class T, class Alloc>
-inline void encode(const std::deque<T,Alloc>& ls, bufferlist& bl, uint64_t features)
+inline void encode(const std::deque<T,Alloc>& ls, bufferlist& bl,
+                   uint64_t features)
 {
-  __u32 n = ls.size();
-  encode(n, bl);
-  for (auto p = ls.begin(); p != ls.end(); ++p)
-    encode(*p, bl, features);
+  encoding_detail::encode_range(ls, bl, features);
 }
 template<class T, class Alloc>
 inline void encode(const std::deque<T,Alloc>& ls, bufferlist& bl)
 {
-  __u32 n = ls.size();
-  encode(n, bl);
-  for (auto p = ls.begin(); p != ls.end(); ++p)
-    encode(*p, bl);
+  encoding_detail::encode_range(ls, bl);
 }
 template<class T, class Alloc>
 inline void decode(std::deque<T,Alloc>& ls, bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  ls.clear();
-  while (n--) {
-    ls.emplace_back();
-    decode(ls.back(), p);
-  }
+  encoding_detail::decode_by_emplace_back(ls, p);
 }
 
 // std::array<T, N>
-template<class T, size_t N, typename traits>
-inline std::enable_if_t<!traits::supported>
-encode(const std::array<T, N>& v, bufferlist& bl, uint64_t features)
+template<class T, size_t N, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode(const std::array<T, N>& v, bufferlist& bl, uint64_t features)
 {
-  for (const auto& e : v)
-    encode(e, bl, features);
+  encoding_detail::encode_range_nohead(v, bl, features);
 }
-template<class T, size_t N, typename traits>
-inline std::enable_if_t<!traits::supported>
-encode(const std::array<T, N>& v, bufferlist& bl)
+template<class T, size_t N, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode(const std::array<T, N>& v, bufferlist& bl)
 {
-  for (const auto& e : v)
-    encode(e, bl);
+  encoding_detail::encode_range_nohead(v, bl);
 }
-template<class T, size_t N, typename traits>
-inline std::enable_if_t<!traits::supported>
-decode(std::array<T, N>& v, bufferlist::const_iterator& p)
+template<class T, size_t N, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void decode(std::array<T, N>& v, bufferlist::const_iterator& p)
 {
-  for (auto& e : v)
-    decode(e, p);
+  encoding_detail::decode_range_nohead(v, p);
+}
+
+namespace encoding_detail {
+
+template<typename OptionalT>
+void encode_optional(const OptionalT& p, bufferlist& bl)
+{
+  __u8 present = static_cast<bool>(p);
+  encode(present, bl);
+  if (!p) {
+    return;
+  }
+
+  encode(*p, bl);
+}
+
+template<typename T>
+std::optional<T> decode_optional(bufferlist::const_iterator& p)
+{
+  __u8 present;
+  decode(present, p);
+  if (!present) {
+    return std::nullopt;
+  }
+
+  T value{};
+  decode(value, p);
+  return value;
+}
+
+template<typename FnT>
+void for_each_count(unsigned n, FnT&& fn)
+{
+  for (auto i = 0u; i < n; ++i) {
+    fn();
+  }
+}
+
+template<typename RangeT>
+void encode_range_nohead(const RangeT& r, bufferlist& bl)
+{
+  for (const auto& item : r) {
+    encode(item, bl);
+  }
+}
+
+template<typename RangeT>
+void encode_range_nohead(const RangeT& r, bufferlist& bl, uint64_t features)
+{
+  for (const auto& item : r) {
+    encode(item, bl, features);
+  }
+}
+
+template<typename RangeT, typename IteratorT>
+void decode_range_nohead(RangeT& r, IteratorT& p)
+{
+  for (auto& item : r) {
+    decode(item, p);
+  }
+}
+
+template<typename RangeT>
+void encode_range(const RangeT& r, bufferlist& bl)
+{
+  encode_count(r.size(), bl);
+  encode_range_nohead(r, bl);
+}
+
+template<typename RangeT>
+void encode_range(const RangeT& r, bufferlist& bl, uint64_t features)
+{
+  encode_count(r.size(), bl);
+  encode_range_nohead(r, bl, features);
+}
+
+template<typename ContainerT>
+void reserve_if_possible(ContainerT& c, size_t n)
+{
+  if constexpr (requires { c.reserve(n); }) {
+    c.reserve(n);
+  }
+}
+
+template<typename ContainerT>
+void clear_and_reserve(ContainerT& c, size_t n)
+{
+  c.clear();
+  reserve_if_possible(c, n);
+}
+
+template<typename ContainerT, typename IteratorT>
+void decode_by_resize_nohead(unsigned len, ContainerT& c,
+                             IteratorT& p)
+{
+  c.resize(len);
+  decode_range_nohead(c, p);
+}
+
+template<typename ContainerT>
+void decode_by_resize(ContainerT& c, bufferlist::const_iterator& p)
+{
+  decode_by_resize_nohead(decode_count(p), c, p);
+}
+
+template<typename ContainerT, typename IteratorT>
+void decode_by_emplace_back(unsigned len, ContainerT& c,
+                            IteratorT& p)
+{
+  clear_and_reserve(c, len);
+
+  for_each_count(len, [&c, &p] {
+    c.emplace_back();
+    decode(c.back(), p);
+  });
+}
+
+template<typename ContainerT>
+void decode_by_emplace_back(ContainerT& c, bufferlist::const_iterator& p)
+{
+  decode_by_emplace_back(decode_count(p), c, p);
+}
+
+template<typename ContainerT, typename IteratorT>
+void decode_by_insert(unsigned len, ContainerT& c,
+                      IteratorT& p)
+{
+  clear_and_reserve(c, len);
+
+  for_each_count(len, [&c, &p] {
+    typename ContainerT::value_type v;
+    decode(v, p);
+    c.insert(std::move(v));
+  });
+}
+
+template<typename ContainerT>
+void decode_by_insert(ContainerT& c, bufferlist::const_iterator& p)
+{
+  decode_by_insert(decode_count(p), c, p);
+}
+
+template<typename RangeT>
+void encode_shared_ptr_range(const RangeT& r, bufferlist& bl)
+{
+  encode_shared_ptr_range_with(r, bl, [](const auto& value, auto& out) {
+    encode(value, out);
+  });
+}
+
+template<typename RangeT>
+void encode_shared_ptr_range(const RangeT& r, bufferlist& bl,
+                             uint64_t features)
+{
+  encode_shared_ptr_range_with(r, bl, [features](const auto& value, auto& out) {
+    encode(value, out, features);
+  });
+}
+
+template<typename ValueT, typename EncodeFnT>
+void append_cached_default_encoding(std::optional<std::string>& bytes,
+                                    bufferlist& bl,
+                                    EncodeFnT&& encode_value)
+{
+  if (!bytes) {
+    auto tmp = bufferlist {};
+    encode_value(ValueT {}, tmp);
+    bytes = tmp.to_str();
+  }
+
+  bl.append(std::string_view { *bytes });
+}
+
+template<typename RangeT, typename EncodeFnT>
+void encode_shared_ptr_range_with(const RangeT& r, bufferlist& bl,
+                                  EncodeFnT&& encode_value)
+{
+  using value_type = typename RangeT::value_type::element_type;
+
+  encode_count(r.size(), bl);
+
+  auto null_bytes = std::optional<std::string> {};
+
+  for (const auto& ref : r) {
+    if (ref) {
+      encode_value(*ref, bl);
+      continue;
+    }
+
+    append_cached_default_encoding<value_type>(null_bytes, bl, encode_value);
+  }
+}
+
+template<typename ContainerT>
+void decode_shared_ptr_sequence(ContainerT& c,
+                                bufferlist::const_iterator& p)
+{
+  const auto n = decode_count(p);
+  clear_and_reserve(c, n);
+
+  for_each_count(n, [&c, &p] {
+    auto ref = std::make_shared<typename ContainerT::value_type::element_type>();
+    decode(*ref, p);
+    c.emplace_back(std::move(ref));
+  });
+}
+
+template<typename PairT>
+void decode_pair_members(PairT& item, bufferlist::const_iterator& p)
+{
+  decode(item.first, p);
+  decode(item.second, p);
+}
+
+template<typename MapT>
+void encode_pair_range_nohead(const MapT& m, bufferlist& bl)
+{
+  for (const auto& item : m) {
+    encode(item.first, bl);
+    encode(item.second, bl);
+  }
+}
+
+template<typename MapT>
+void encode_pair_range_nohead(const MapT& m, bufferlist& bl,
+                              uint64_t features)
+{
+  for (const auto& item : m) {
+    encode(item.first, bl, features);
+    encode(item.second, bl, features);
+  }
+}
+
+template<typename MapT>
+void encode_pair_range(const MapT& m, bufferlist& bl)
+{
+  encode_count(m.size(), bl);
+  encode_pair_range_nohead(m, bl);
+}
+
+template<typename MapT>
+void encode_pair_range(const MapT& m, bufferlist& bl, uint64_t features)
+{
+  encode_count(m.size(), bl);
+  encode_pair_range_nohead(m, bl, features);
+}
+
+// Decodes n kv entries into containers that support operator[]:
+template<typename MapT, typename IteratorT>
+void decode_map_entries_by_subscript(unsigned n, MapT& m,
+                                     IteratorT& p)
+{
+  for_each_count(n, [&m, &p] {
+    typename MapT::key_type k;
+    decode(k, p);
+    decode(m[std::move(k)], p);
+  });
+}
+
+template<typename MapT, typename IteratorT>
+void decode_map_entries_by_emplace(unsigned n, MapT& m,
+                                   IteratorT& p)
+{
+  for_each_count(n, [&m, &p] {
+    typename MapT::key_type k;
+    typename MapT::mapped_type v;
+    decode(k, p);
+    decode(v, p);
+    m.emplace(std::move(k), std::move(v));
+  });
+}
+
+// Decide between encoding associative containers by operator[] or by
+// emplace():
+template<typename MapT, typename IteratorT>
+void decode_map_entries_by_try_emplace(unsigned n, MapT& m,
+                                       IteratorT& p)
+{
+  for_each_count(n, [&m, &p] {
+    typename MapT::key_type k;
+    decode(k, p);
+    // Preserve an existing mapped value, but still consume the encoded value.
+    auto [it, inserted] = m.try_emplace(std::move(k));
+    if (inserted) {
+      decode(it->second, p);
+      return;
+    }
+
+    typename MapT::mapped_type discarded;
+    decode(discarded, p);
+  });
+}
+
+template<typename MapT, typename IteratorT>
+requires map_emplaces_key_value<MapT>
+void decode_map_entries_no_clear(unsigned n, MapT& m, IteratorT& p)
+{
+  decode_map_entries_by_emplace(n, m, p);
+}
+
+template<typename MapT, typename IteratorT>
+requires (!map_emplaces_key_value<MapT> &&
+          ceph::concepts::has_try_emplace_key<MapT>)
+void decode_map_entries_no_clear(unsigned n, MapT& m, IteratorT& p)
+{
+  decode_map_entries_by_try_emplace(n, m, p);
+}
+
+template<typename MapT, typename IteratorT>
+requires map_emplaces_key_value<MapT>
+void decode_map_entries(unsigned n, MapT& m, IteratorT& p)
+{
+  decode_map_entries_by_emplace(n, m, p);
+}
+
+template<typename MapT, typename IteratorT>
+requires (!map_emplaces_key_value<MapT> &&
+          ceph::concepts::has_subscript_operator<MapT>)
+void decode_map_entries(unsigned n, MapT& m, IteratorT& p)
+{
+  decode_map_entries_by_subscript(n, m, p);
+}
+
+template<typename MapT>
+void decode_map_by_subscript(unsigned n, MapT& m,
+                             bufferlist::const_iterator& p)
+{
+  clear_and_reserve(m, n);
+  decode_map_entries_by_subscript(n, m, p);
+}
+
+template<typename MapT>
+void decode_map_by_subscript(MapT& m, bufferlist::const_iterator& p)
+{
+  decode_map_by_subscript(decode_count(p), m, p);
+}
+
+template<typename MapT>
+void decode_map(unsigned n, MapT& m, bufferlist::const_iterator& p)
+{
+  clear_and_reserve(m, n);
+  decode_map_entries(n, m, p);
+}
+
+template<typename MapT>
+void decode_map(MapT& m, bufferlist::const_iterator& p)
+{
+  decode_map(decode_count(p), m, p);
+}
+
+} // namespace encoding_detail
+
+// full bl decoder
+template<class T>
+inline void decode(T &o, const bufferlist& bl)
+{
+  auto p = bl.begin();
+  decode(o, p);
+  ceph_assert(p.end());
 }
 }
 
@@ -1457,8 +1507,8 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
   __u8 struct_v = v;                                         \
   __u8 struct_compat = compat;		                     \
   ceph_le32 struct_len;				             \
-  auto filler = (bl).append_hole(sizeof(struct_v) +	     \
-    sizeof(struct_compat) + sizeof(struct_len));	     \
+  auto filler = (bl).append_hole(			     \
+    ::ceph::encoding_detail::struct_header_len());	     \
   const auto starting_bl_len = (bl).length();		     \
   using ::ceph::encode;					     \
   do {
@@ -1471,19 +1521,15 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
  */
 #define ENCODE_FINISH_NEW_COMPAT(bl, new_struct_compat)      \
   } while (false);                                           \
-  if (new_struct_compat) {                                   \
-    struct_compat = new_struct_compat;                       \
-  }                                                          \
-  struct_len = (bl).length() - starting_bl_len;              \
-  filler.copy_in(sizeof(struct_v), (char *)&struct_v);       \
-  filler.copy_in(sizeof(struct_compat),			     \
-    (char *)&struct_compat);				     \
-  filler.copy_in(sizeof(struct_len), (char *)&struct_len);
+  ::ceph::encoding_detail::finish_encode_struct(              \
+    filler, struct_v, struct_compat, struct_len,              \
+    new_struct_compat, (bl), starting_bl_len);
 
 #define ENCODE_FINISH(bl) ENCODE_FINISH_NEW_COMPAT(bl, 0)
 
-#define DECODE_ERR_OLDVERSION(func, v, compatv)					\
-  (std::string(func) + " no longer understands old encoding version " #v " < " + std::to_string(compatv))
+#define DECODE_ERR_OLDVERSION(func, v, compatv)				\
+  (std::string(func) + " no longer understands old encoding version " #v \
+   " < " + std::to_string(compatv))
 
 #define DECODE_ERR_NO_COMPAT(func, code_v, v, compatv)					\
   ("Decoder at '" + std::string(func) + "' v=" + std::to_string(code_v) +		\
@@ -1491,6 +1537,163 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
 
 #define DECODE_ERR_PAST(func) \
   (std::string(func) + " decode past end of struct encoding")
+
+namespace ceph::encoding_detail {
+
+// Fixed size of the versioned encode/decode wrapper header.
+inline constexpr auto struct_header_len() noexcept
+{
+  return sizeof(__u8) + sizeof(__u8) + sizeof(ceph_le32);
+}
+
+struct struct_header final {
+  __u8 v = 0;
+  __u8 compat = 0;
+  __u32 len = 0;
+};
+
+// Read the encoded version, compatibility version, and payload length.
+template<typename IteratorT>
+struct_header read_struct_header(IteratorT& bl)
+{
+  using ::ceph::decode;
+
+  struct_header header;
+  decode(header.v, bl);
+  decode(header.compat, bl);
+  decode(header.len, bl);
+
+  return header;
+}
+
+// Reject payloads that require a newer decoder than this code provides.
+inline void check_decode_compat(__u8 code_v, __u8 struct_v,
+                                __u8 struct_compat,
+                                const char *func)
+{
+  if (struct_compat > code_v) {
+    throw ::ceph::buffer::malformed_input(
+      DECODE_ERR_NO_COMPAT(func, code_v, struct_v, struct_compat));
+  }
+}
+
+// Compute the payload end offset after checking that the body is present.
+template<typename IteratorT>
+unsigned checked_struct_end(IteratorT& bl, __u32 struct_len,
+                            const char *func)
+{
+  if (struct_len > bl.get_remaining()) {
+    throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(func));
+  }
+
+  return bl.get_off() + struct_len;
+}
+
+// DECODE_START path: read and validate the standard wrapper header.
+template<typename VersionT, typename IteratorT>
+unsigned decode_struct_start(__u8 code_v, VersionT& struct_v,
+                             __u8& struct_compat, __u32& struct_len,
+                             IteratorT& bl, const char *func)
+{
+  const auto header = read_struct_header(bl);
+  struct_v = header.v;
+  struct_compat = header.compat;
+  struct_len = header.len;
+
+  check_decode_compat(code_v, struct_v, struct_compat, func);
+  return checked_struct_end(bl, struct_len, func);
+}
+
+// Legacy decode path: read only the wrapper fields present in this version.
+template<typename VersionT, typename IteratorT>
+unsigned decode_legacy_struct_start(__u8 code_v, VersionT& struct_v,
+                                    __u8 compat_v, __u8 len_v,
+                                    unsigned skip_v, IteratorT& bl,
+                                    const char *func)
+{
+  using ::ceph::decode;
+
+  decode(struct_v, bl);
+
+  if (compat_v <= struct_v) {
+    __u8 struct_compat;
+    decode(struct_compat, bl);
+    check_decode_compat(code_v, struct_v, struct_compat, func);
+  }
+
+  if (skip_v && compat_v > struct_v) {
+    if (skip_v > bl.get_remaining()) {
+      throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(func));
+    }
+
+    bl += skip_v;
+  }
+
+  if (len_v > struct_v) {
+    return 0;
+  }
+
+  __u32 struct_len;
+  decode(struct_len, bl);
+  return checked_struct_end(bl, struct_len, func);
+}
+
+// ENCODE_FINISH path: patch version, compatibility, and payload length.
+template<typename FillerT>
+void finish_encode_struct(FillerT& filler, __u8 struct_v,
+                          __u8& struct_compat, ceph_le32& struct_len,
+                          __u8 new_struct_compat, const bufferlist& bl,
+                          size_t starting_bl_len)
+{
+  if (new_struct_compat) {
+    struct_compat = new_struct_compat;
+  }
+
+  struct_len = static_cast<__u32>(bl.length() - starting_bl_len);
+  filler.copy_in(sizeof(struct_v),
+                 reinterpret_cast<const char *>(&struct_v));
+  filler.copy_in(sizeof(struct_compat),
+                 reinterpret_cast<const char *>(&struct_compat));
+  filler.copy_in(sizeof(struct_len),
+                 reinterpret_cast<const char *>(&struct_len));
+}
+
+// DECODE_FINISH path: reject overread and skip unread trailing fields.
+template<typename IteratorT>
+void finish_decode_struct(IteratorT& bl, unsigned struct_end,
+                          const char *func)
+{
+  if (!struct_end) {
+    return;
+  }
+
+  if (struct_end < bl.get_off()) {
+    throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(func));
+  }
+
+  if (struct_end > bl.get_off()) {
+    bl += struct_end - bl.get_off();
+  }
+}
+
+// Preserve an unknown encoded payload, including its wrapper header.
+template<typename PayloadT, typename IteratorT>
+void decode_unknown(PayloadT& payload, IteratorT& bl, const char *func)
+{
+  const auto header = read_struct_header(bl);
+  checked_struct_end(bl, header.len, func);
+
+  payload.clear();
+
+  using ::ceph::encode;
+
+  encode(header.v, payload);
+  encode(header.compat, payload);
+  encode(header.len, payload);
+  bl.copy(header.len, payload);
+}
+
+} // namespace ceph::encoding_detail
 
 /**
  * check for very old encoding
@@ -1500,8 +1703,8 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
  * @param oldestv oldest version of the code we can successfully decode.
  */
 #define DECODE_OLDEST(oldestv)						\
-  if (struct_v < oldestv)						\
-    throw ::ceph::buffer::malformed_input(DECODE_ERR_OLDVERSION(__PRETTY_FUNCTION__, v, oldestv)); 
+  if (oldestv > struct_v)						\
+    throw ::ceph::buffer::malformed_input(DECODE_ERR_OLDVERSION(__PRETTY_FUNCTION__, v, oldestv));
 
 /**
  * start a decoding block
@@ -1512,74 +1715,33 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
 #define DECODE_START(_v, bl)						\
   StructVChecker<_v> struct_v;						\
   __u8 struct_compat;							\
-  using ::ceph::decode;							\
-  decode(struct_v.v, bl);						\
-  decode(struct_compat, bl);						\
-  if (_v < struct_compat)						\
-    throw ::ceph::buffer::malformed_input(DECODE_ERR_NO_COMPAT(__PRETTY_FUNCTION__, _v, struct_v.v, struct_compat)); \
   __u32 struct_len;							\
-  decode(struct_len, bl);						\
-  if (struct_len > bl.get_remaining())					\
-    throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
-  unsigned struct_end = bl.get_off() + struct_len;			\
+  using ::ceph::decode;							\
+  unsigned struct_end = ::ceph::encoding_detail::decode_struct_start( \
+    _v, struct_v.v, struct_compat, struct_len, bl, __PRETTY_FUNCTION__); \
   do {
 
 #define DECODE_START_UNCHECKED(v, bl)					\
   __u8 struct_v, struct_compat;						\
-  using ::ceph::decode;							\
-  decode(struct_v, bl);						\
-  decode(struct_compat, bl);						\
-  if (v < struct_compat)						\
-    throw ::ceph::buffer::malformed_input(DECODE_ERR_NO_COMPAT(__PRETTY_FUNCTION__, v, struct_v, struct_compat)); \
   __u32 struct_len;							\
-  decode(struct_len, bl);						\
-  if (struct_len > bl.get_remaining())					\
-    throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
-  unsigned struct_end = bl.get_off() + struct_len;			\
+  using ::ceph::decode;							\
+  unsigned struct_end = ::ceph::encoding_detail::decode_struct_start( \
+    v, struct_v, struct_compat, struct_len, bl, __PRETTY_FUNCTION__); \
   do {
 
 #define DECODE_UNKNOWN(payload, bl)					\
   do {                                                                  \
-    __u8 struct_v, struct_compat;					\
-    using ::ceph::decode;						\
-    decode(struct_v, bl);						\
-    decode(struct_compat, bl);						\
-    __u32 struct_len;							\
-    decode(struct_len, bl);						\
-    if (struct_len > bl.get_remaining())				\
-      throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
-    payload.clear();                                                    \
-    using ::ceph::encode;						\
-    encode(struct_v, payload);                                          \
-    encode(struct_compat, payload);                                     \
-    encode(struct_len, payload);                                        \
-    bl.copy(struct_len, payload);                                       \
+    ::ceph::encoding_detail::decode_unknown(                           \
+      payload, bl, __PRETTY_FUNCTION__);                               \
   } while (0)
 
-/* BEWARE: any change to this macro MUST be also reflected in the duplicative
- * DECODE_START_LEGACY_COMPAT_LEN! */
+/* The checked and unchecked legacy wrappers intentionally differ only in the
+ * local struct_v type. Keep shared behavior in decode_legacy_struct_start(). */
 #define __DECODE_START_LEGACY_COMPAT_LEN(_v, compatv, lenv, skip_v, bl)	\
   using ::ceph::decode;							\
   StructVChecker<_v> struct_v;						\
-  decode(struct_v.v, bl);						\
-  if (struct_v.v >= compatv) {						\
-    __u8 struct_compat;							\
-    decode(struct_compat, bl);					\
-    if (_v < struct_compat)						\
-      throw ::ceph::buffer::malformed_input(DECODE_ERR_NO_COMPAT(__PRETTY_FUNCTION__, _v, struct_v.v, struct_compat)); \
-  } else if (skip_v) {							\
-    if (bl.get_remaining() < skip_v)					\
-      throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
-    bl +=  skip_v;							\
-  }									\
-  unsigned struct_end = 0;						\
-  if (struct_v.v >= lenv) {						\
-    __u32 struct_len;							\
-    decode(struct_len, bl);						\
-    if (struct_len > bl.get_remaining())				\
-      throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
-    struct_end = bl.get_off() + struct_len;				\
-  }									\
+  unsigned struct_end = ::ceph::encoding_detail::decode_legacy_struct_start( \
+    _v, struct_v.v, compatv, lenv, skip_v, bl, __PRETTY_FUNCTION__);	\
   do {
 
 /**
@@ -1597,28 +1759,11 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
  * @param bl bufferlist::iterator containing the encoded data
  */
 
-/* BEWARE: this is duplication of __DECODE_START_LEGACY_COMPAT_LEN which
- * MUST be changed altogether. For the rationale behind code duplication,
- * please `git blame` and refer to the commit message. */
 #define DECODE_START_LEGACY_COMPAT_LEN(v, compatv, lenv, bl)		\
   using ::ceph::decode;							\
   __u8 struct_v;							\
-  decode(struct_v, bl);							\
-  if (struct_v >= compatv) {						\
-    __u8 struct_compat;							\
-    decode(struct_compat, bl);						\
-    if (v < struct_compat)						\
-      throw ::ceph::buffer::malformed_input(DECODE_ERR_NO_COMPAT(	\
-	__PRETTY_FUNCTION__, v, struct_v, struct_compat));		\
-  }									\
-  unsigned struct_end = 0;						\
-  if (struct_v >= lenv) {						\
-    __u32 struct_len;							\
-    decode(struct_len, bl);						\
-    if (struct_len > bl.get_remaining())				\
-      throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
-    struct_end = bl.get_off() + struct_len;				\
-  }									\
+  unsigned struct_end = ::ceph::encoding_detail::decode_legacy_struct_start( \
+    v, struct_v, compatv, lenv, 0, bl, __PRETTY_FUNCTION__);		\
   do {
 
 /**
@@ -1651,12 +1796,8 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
  */
 #define DECODE_FINISH(bl)						\
   } while (false);							\
-  if (struct_end) {							\
-    if (bl.get_off() > struct_end)					\
-      throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
-    if (bl.get_off() < struct_end)					\
-      bl += struct_end - bl.get_off();					\
-  }
+  ::ceph::encoding_detail::finish_decode_struct(		\
+    bl, struct_end, __PRETTY_FUNCTION__);
 
 namespace ceph {
 

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -1,16 +1,17 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*- 
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 sts=2 expandtab
 
 /*
  * Ceph - scalable distributed file system
  *
  * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ * Copyright (C) 2026 International Business Machines Corp. (IBM)
  *
  * This is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software 
+ * License version 2.1, as published by the Free Software
  * Foundation.  See file COPYING.
- * 
+ *
  */
 #ifndef CEPH_ENCODING_H
 #define CEPH_ENCODING_H
@@ -26,16 +27,35 @@
 #include <optional>
 #include <unordered_map>
 #include <unordered_set>
+#include <array>
+#include <bit>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <list>
+#include <memory>
+#include <utility>
 
 #include <boost/container/small_vector.hpp>
 #include <boost/optional/optional_io.hpp>
 #include <boost/tuple/tuple.hpp>
 
+#ifdef ENCODE_DUMP_PATH
+#include <climits>
+#include <cstdio>
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
 #include "common/ceph_time.h"
 
+#include "include/compat.h"
 #include "include/int_types.h"
 
 #include "common/convenience.h"
+#include "common/container_concepts.h"
 
 #include "byteorder.h"
 #include "buffer.h"
@@ -138,8 +158,8 @@ WRITE_INTTYPE_ENCODER(int16_t, le16)
 // Under this assumption, we can use raw encoding of floating-point types
 // on little-endian machines, but we still need to perform a byte swap
 // on big-endian machines to ensure cross-architecture compatibility.
-// To achive that, we reinterpret the values as integers first, which are
-// byte-swapped via the ceph_le types as above.  The extra conversions
+// To achieve that, we bit-cast the values as integers first, which are
+// byte-swapped via the ceph_le types as above. The extra conversions
 // are optimized away on little-endian machines by the compiler.
 #define WRITE_FLTTYPE_ENCODER(type, itype, etype)			\
   static_assert(sizeof(type) == sizeof(itype));				\
@@ -147,13 +167,14 @@ WRITE_INTTYPE_ENCODER(int16_t, le16)
 	      "floating-point type not using IEEE754 format");		\
   inline void encode(type v, ::ceph::bufferlist& bl, uint64_t features=0) { \
     ceph_##etype e;							\
-    e = *reinterpret_cast<itype *>(&v);					\
+    e = std::bit_cast<itype>(v);					\
     ::ceph::encode_raw(e, bl);						\
   }									\
   inline void decode(type &v, ::ceph::bufferlist::const_iterator& p) {	\
     ceph_##etype e;							\
     ::ceph::decode_raw(e, p);						\
-    *reinterpret_cast<itype *>(&v) = e;					\
+    itype raw = e;							\
+    v = std::bit_cast<type>(raw);					\
   }
 
 WRITE_FLTTYPE_ENCODER(float, uint32_t, le32)
@@ -208,14 +229,38 @@ WRITE_FLTTYPE_ENCODER(double, uint64_t, le64)
     ENCODE_DUMP_PRE(); c.encode(bl, features); ENCODE_DUMP_POST(cl); }	\
   inline void decode(cl &c, ::ceph::bufferlist::const_iterator &p) { c.decode(p); }
 
+namespace encoding_detail {
 
-// string
+inline void encode_count(size_t n, bufferlist& bl)
+{
+  // Legacy container/string lengths are stored as 32-bit values on the wire.
+  encode(static_cast<__u32>(n), bl);
+}
+
+inline __u32 decode_count(bufferlist::const_iterator& p)
+{
+  __u32 n;
+  decode(n, p);
+  return n;
+}
+
+inline void append_bytes(const void *data, size_t len, bufferlist& bl)
+{
+  if (len)
+    bl.append(static_cast<const char *>(data), len);
+}
+
+inline void encode_bytes(const void *data, size_t len, bufferlist& bl)
+{
+  encode_count(len, bl);
+  append_bytes(data, len, bl);
+}
+
+} // namespace encoding_detail
+
 inline void encode(std::string_view s, bufferlist& bl, uint64_t features=0)
 {
-  __u32 len = s.length();
-  encode(len, bl);
-  if (len)
-    bl.append(s.data(), len);
+  encoding_detail::encode_bytes(s.data(), s.length(), bl);
 }
 inline void encode(const std::string& s, bufferlist& bl, uint64_t features=0)
 {
@@ -223,15 +268,14 @@ inline void encode(const std::string& s, bufferlist& bl, uint64_t features=0)
 }
 inline void decode(std::string& s, bufferlist::const_iterator& p)
 {
-  __u32 len;
-  decode(len, p);
+  const auto len = encoding_detail::decode_count(p);
   s.clear();
   p.copy(len, s);
 }
 
 inline void encode_nohead(std::string_view s, bufferlist& bl)
 {
-  bl.append(s.data(), s.length());
+  encoding_detail::append_bytes(s.data(), s.length(), bl);
 }
 inline void encode_nohead(const std::string& s, bufferlist& bl)
 {
@@ -244,7 +288,7 @@ inline void decode_nohead(unsigned len, std::string& s, bufferlist::const_iterat
 }
 
 // const char* (encode only, string compatible)
-inline void encode(const char *s, bufferlist& bl) 
+inline void encode(const char *s, bufferlist& bl)
 {
   encode(std::string_view(s, strlen(s)), bl);
 }
@@ -252,17 +296,12 @@ inline void encode(const char *s, bufferlist& bl)
 // opaque byte vectors
 inline void encode(std::vector<uint8_t>& v, bufferlist& bl)
 {
-  uint32_t len = v.size();
-  encode(len, bl);
-  if (len)
-    bl.append((char *)v.data(), len);
+  encoding_detail::encode_bytes(v.data(), v.size(), bl);
 }
 
 inline void decode(std::vector<uint8_t>& v, bufferlist::const_iterator& p)
 {
-  uint32_t len;
-
-  decode(len, p);
+  const auto len = encoding_detail::decode_count(p);
   v.resize(len);
   p.copy(len, (char *)v.data());
 }
@@ -271,51 +310,55 @@ inline void decode(std::vector<uint8_t>& v, bufferlist::const_iterator& p)
 // buffers
 
 // bufferptr (encapsulated)
-inline void encode(const buffer::ptr& bp, bufferlist& bl) 
+inline void encode(const buffer::ptr& bp, bufferlist& bl)
 {
-  __u32 len = bp.length();
-  encode(len, bl);
+  const auto len = bp.length();
+  encoding_detail::encode_count(len, bl);
   if (len)
     bl.append(bp);
 }
 inline void decode(buffer::ptr& bp, bufferlist::const_iterator& p)
 {
-  __u32 len;
-  decode(len, p);
+  const auto len = encoding_detail::decode_count(p);
 
   bufferlist s;
   p.copy(len, s);
 
-  if (len) {
-    if (s.get_num_buffers() == 1)
-      bp = s.front();
-    else
-      bp = buffer::copy(s.c_str(), s.length());
+  // Return without assignment: 
+  if (!len) {
+    return;
   }
+
+  // ...if the buffer::list contains only a single buffer, we
+  // re-use it:
+  if (1 == s.get_num_buffers()) {
+    bp = s.front();
+    return;
+  }
+
+  // ...flatten the buffer::list:
+  bp = buffer::copy(s.c_str(), s.length());
 }
 
 // bufferlist (encapsulated)
-inline void encode(const bufferlist& s, bufferlist& bl) 
+inline void encode(const bufferlist& s, bufferlist& bl)
 {
-  __u32 len = s.length();
-  encode(len, bl);
+  encoding_detail::encode_count(s.length(), bl);
   bl.append(s);
 }
-inline void encode_destructively(bufferlist& s, bufferlist& bl) 
+inline void encode_destructively(bufferlist& s, bufferlist& bl)
 {
-  __u32 len = s.length();
-  encode(len, bl);
+  encoding_detail::encode_count(s.length(), bl);
   bl.claim_append(s);
 }
 inline void decode(bufferlist& s, bufferlist::const_iterator& p)
 {
-  __u32 len;
-  decode(len, p);
+  const auto len = encoding_detail::decode_count(p);
   s.clear();
   p.copy(len, s);
 }
 
-inline void encode_nohead(const bufferlist& s, bufferlist& bl) 
+inline void encode_nohead(const bufferlist& s, bufferlist& bl)
 {
   bl.append(s);
 }
@@ -406,294 +449,213 @@ void round_trip_decode(std::chrono::time_point<Clock, Duration>& t,
   t = std::chrono::time_point<Clock, Duration>(dur);
 }
 
-// -----------------------------
-// STL container types
+// STL container types and helper Concepts:
+namespace encoding_detail {
+
+template<typename... TraitsT>
+concept needs_legacy_encoding = (not TraitsT::supported || ...);
+
+template<typename MapT>
+concept map_emplaces_key_value =
+  std::constructible_from<typename MapT::value_type,
+                          typename MapT::key_type,
+                          typename MapT::mapped_type> &&
+  requires(MapT& m, typename MapT::key_type& k,
+           typename MapT::mapped_type& v) {
+    m.emplace(std::move(k), std::move(v));
+  };
+
+template<typename OptionalT>
+void encode_optional(const OptionalT& p, bufferlist& bl);
 
 template<typename T>
-inline void encode(const boost::optional<T> &p, bufferlist &bl);
-template<typename T>
-inline void decode(boost::optional<T> &p, bufferlist::const_iterator &bp);
-template<typename T>
-inline void encode(const std::optional<T> &p, bufferlist &bl);
-template<typename T>
-inline void decode(std::optional<T> &p, bufferlist::const_iterator &bp);
-template<class A, class B, class C>
-inline void encode(const boost::tuple<A, B, C> &t, bufferlist& bl);
-template<class A, class B, class C>
-inline void decode(boost::tuple<A, B, C> &t, bufferlist::const_iterator &bp);
-template<class A, class B,
-	 typename a_traits=denc_traits<A>, typename b_traits=denc_traits<B>>
-inline std::enable_if_t<!a_traits::supported || !b_traits::supported>
-encode(const std::pair<A,B> &p, bufferlist &bl, uint64_t features);
-template<class A, class B,
-	 typename a_traits=denc_traits<A>, typename b_traits=denc_traits<B>>
-inline std::enable_if_t<!a_traits::supported ||
-			!b_traits::supported>
-encode(const std::pair<A,B> &p, bufferlist &bl);
-template<class A, class B,
-	 typename a_traits=denc_traits<A>, typename b_traits=denc_traits<B>>
-inline std::enable_if_t<!a_traits::supported ||
-			!b_traits::supported>
-decode(std::pair<A,B> &pa, bufferlist::const_iterator &p);
-template<class T, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode(const std::list<T, Alloc>& ls, bufferlist& bl);
-template<class T, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode(const std::list<T,Alloc>& ls, bufferlist& bl, uint64_t features);
-template<class T, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-decode(std::list<T,Alloc>& ls, bufferlist::const_iterator& p);
-template<class T, class Alloc>
-inline void encode(const std::list<std::shared_ptr<T>, Alloc>& ls,
-		   bufferlist& bl);
-template<class T, class Alloc>
-inline void encode(const std::list<std::shared_ptr<T>, Alloc>& ls,
-		   bufferlist& bl, uint64_t features);
-template<class T, class Alloc>
-inline void decode(std::list<std::shared_ptr<T>, Alloc>& ls,
-		   bufferlist::const_iterator& p);
-template<class T, class Comp, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode(const std::set<T,Comp,Alloc>& s, bufferlist& bl);
-template<class T, class Comp, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-decode(std::set<T,Comp,Alloc>& s, bufferlist::const_iterator& p);
-template<class T, class Comp, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode_nohead(const std::set<T,Comp,Alloc>& s, bufferlist& bl);
-template<class T, class Comp, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-decode_nohead(unsigned len, std::set<T,Comp,Alloc>& s, bufferlist::iterator& p);
-template<class T, class Comp, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode(const boost::container::flat_set<T, Comp, Alloc>& s, bufferlist& bl);
-template<class T, class Comp, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-decode(boost::container::flat_set<T, Comp, Alloc>& s, bufferlist::const_iterator& p);
-template<class T, class Comp, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode_nohead(const boost::container::flat_set<T, Comp, Alloc>& s,
-	      bufferlist& bl);
-template<class T, class Comp, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-decode_nohead(unsigned len, boost::container::flat_set<T, Comp, Alloc>& s,
-	      bufferlist::iterator& p);
-template<class T, class Comp, class Alloc>
-inline void encode(const std::multiset<T,Comp,Alloc>& s, bufferlist& bl);
-template<class T, class Comp, class Alloc>
-inline void decode(std::multiset<T,Comp,Alloc>& s, bufferlist::const_iterator& p);
-template<class T, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode(const std::vector<T,Alloc>& v, bufferlist& bl, uint64_t features);
-template<class T, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode(const std::vector<T,Alloc>& v, bufferlist& bl);
-template<class T, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-decode(std::vector<T,Alloc>& v, bufferlist::const_iterator& p);
-template<class T, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode_nohead(const std::vector<T,Alloc>& v, bufferlist& bl);
-template<class T, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-decode_nohead(unsigned len, std::vector<T,Alloc>& v, bufferlist::const_iterator& p);
-template<class T,class Alloc>
-inline void encode(const std::vector<std::shared_ptr<T>,Alloc>& v,
-		   bufferlist& bl,
-		   uint64_t features);
-template<class T, class Alloc>
-inline void encode(const std::vector<std::shared_ptr<T>,Alloc>& v,
-		   bufferlist& bl);
-template<class T, class Alloc>
-inline void decode(std::vector<std::shared_ptr<T>,Alloc>& v,
-		   bufferlist::const_iterator& p);
-// small_vector
-template<class T, std::size_t N, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode(const boost::container::small_vector<T,N,Alloc>& v, bufferlist& bl, uint64_t features);
-template<class T, std::size_t N, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode(const boost::container::small_vector<T,N,Alloc>& v, bufferlist& bl);
-template<class T, std::size_t N, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-decode(boost::container::small_vector<T,N,Alloc>& v, bufferlist::const_iterator& p);
-template<class T, std::size_t N, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode_nohead(const boost::container::small_vector<T,N,Alloc>& v, bufferlist& bl);
-template<class T, std::size_t N, class Alloc, typename traits=denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-decode_nohead(unsigned len, boost::container::small_vector<T,N,Alloc>& v, bufferlist::const_iterator& p);
-// std::map
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported ||
-			!u_traits::supported>
-encode(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-encode(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl, uint64_t features);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-decode(std::map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p);
-template<class T, class U, class Comp, class Alloc>
-inline void decode_noclear(std::map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-encode_nohead(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-encode_nohead(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl, uint64_t features);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-decode_nohead(unsigned n, std::map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-  inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-encode(const boost::container::flat_map<T,U,Comp,Alloc>& m, bufferlist& bl);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-encode(const boost::container::flat_map<T,U,Comp,Alloc>& m, bufferlist& bl,
-       uint64_t features);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-decode(boost::container::flat_map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p);
-template<class T, class U, class Comp, class Alloc>
-inline void decode_noclear(boost::container::flat_map<T,U,Comp,Alloc>& m,
-			   bufferlist::const_iterator& p);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-encode_nohead(const boost::container::flat_map<T,U,Comp,Alloc>& m,
-	      bufferlist& bl);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-encode_nohead(const boost::container::flat_map<T,U,Comp,Alloc>& m,
-	      bufferlist& bl, uint64_t features);
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-decode_nohead(unsigned n, boost::container::flat_map<T,U,Comp,Alloc>& m,
-	      bufferlist::const_iterator& p);
-template<class T, class U, class Comp, class Alloc>
-inline void encode(const std::multimap<T,U,Comp,Alloc>& m, bufferlist& bl);
-template<class T, class U, class Comp, class Alloc>
-inline void decode(std::multimap<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p);
-template<class T, class U, class Hash, class Pred, class Alloc>
-inline void encode(const std::unordered_map<T,U,Hash,Pred,Alloc>& m, bufferlist& bl,
-		   uint64_t features);
-template<class T, class U, class Hash, class Pred, class Alloc>
-inline void encode(const std::unordered_map<T,U,Hash,Pred,Alloc>& m, bufferlist& bl);
-template<class T, class U, class Hash, class Pred, class Alloc>
-inline void decode(std::unordered_map<T,U,Hash,Pred,Alloc>& m, bufferlist::const_iterator& p);
-template<class T, class Hash, class Pred, class Alloc>
-inline void encode(const std::unordered_set<T,Hash,Pred,Alloc>& m, bufferlist& bl);
-template<class T, class Hash, class Pred, class Alloc>
-inline void decode(std::unordered_set<T,Hash,Pred,Alloc>& m, bufferlist::const_iterator& p);
-template<class T, class Alloc>
-inline void encode(const std::deque<T,Alloc>& ls, bufferlist& bl, uint64_t features);
-template<class T, class Alloc>
-inline void encode(const std::deque<T,Alloc>& ls, bufferlist& bl);
-template<class T, class Alloc>
-inline void decode(std::deque<T,Alloc>& ls, bufferlist::const_iterator& p);
-template<class T, size_t N, typename traits = denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode(const std::array<T, N>& v, bufferlist& bl, uint64_t features);
-template<class T, size_t N, typename traits = denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-encode(const std::array<T, N>& v, bufferlist& bl);
-template<class T, size_t N, typename traits = denc_traits<T>>
-inline std::enable_if_t<!traits::supported>
-decode(std::array<T, N>& v, bufferlist::const_iterator& p);
+std::optional<T> decode_optional(bufferlist::const_iterator& p);
 
-// full bl decoder
-template<class T>
-inline void decode(T &o, const bufferlist& bl)
-{
-  auto p = bl.begin();
-  decode(o, p);
-  ceph_assert(p.end());
-}
+template<typename FnT>
+void for_each_count(unsigned n, FnT&& fn);
+
+// "nohead" as in just the elements, without the container length:
+// (i.e.: [x][x][x] rather than [sz][x][x][x], like encode_range())
+template<typename RangeT>
+void encode_range_nohead(const RangeT& r, bufferlist& bl);
+
+template<typename RangeT>
+void encode_range_nohead(const RangeT& r, bufferlist& bl, uint64_t features);
+
+template<typename RangeT, typename IteratorT>
+void decode_range_nohead(RangeT& r, IteratorT& p);
+
+template<typename RangeT>
+void encode_range(const RangeT& r, bufferlist& bl);
+
+template<typename RangeT>
+void encode_range(const RangeT& r, bufferlist& bl, uint64_t features);
+
+template<typename ContainerT, typename IteratorT>
+void decode_by_resize_nohead(unsigned len, ContainerT& c,
+                             IteratorT& p);
+
+template<typename ContainerT>
+void decode_by_resize(ContainerT& c, bufferlist::const_iterator& p);
+
+template<typename ContainerT, typename IteratorT>
+void decode_by_emplace_back(unsigned len, ContainerT& c,
+                            IteratorT& p);
+
+template<typename ContainerT>
+void decode_by_emplace_back(ContainerT& c, bufferlist::const_iterator& p);
+
+template<typename ContainerT>
+void clear_and_reserve(ContainerT& c, size_t n);
+
+template<typename ContainerT, typename IteratorT>
+void decode_by_insert(unsigned len, ContainerT& c,
+                      IteratorT& p);
+
+template<typename ContainerT>
+void decode_by_insert(ContainerT& c, bufferlist::const_iterator& p);
+
+template<typename RangeT>
+void encode_shared_ptr_range(const RangeT& r, bufferlist& bl);
+
+template<typename RangeT>
+void encode_shared_ptr_range(const RangeT& r, bufferlist& bl,
+                             uint64_t features);
+
+template<typename ValueT, typename EncodeFnT>
+void append_cached_default_encoding(std::optional<std::string>& bytes,
+                                    bufferlist& bl,
+                                    EncodeFnT&& encode_value);
+
+template<typename RangeT, typename EncodeFnT>
+void encode_shared_ptr_range_with(const RangeT& r, bufferlist& bl,
+                                  EncodeFnT&& encode_value);
+
+template<typename ContainerT>
+void decode_shared_ptr_sequence(ContainerT& c,
+                                bufferlist::const_iterator& p);
+
+template<typename PairT>
+void encode_pair_members(const PairT& item, bufferlist& bl);
+
+template<typename PairT>
+void encode_pair_members(const PairT& item, bufferlist& bl,
+                         uint64_t features);
+
+template<typename PairT>
+void decode_pair_members(PairT& item, bufferlist::const_iterator& p);
+
+template<typename MapT>
+void encode_pair_range_nohead(const MapT& m, bufferlist& bl);
+
+template<typename MapT>
+void encode_pair_range_nohead(const MapT& m, bufferlist& bl,
+                              uint64_t features);
+
+template<typename MapT>
+void encode_pair_range(const MapT& m, bufferlist& bl);
+
+template<typename MapT>
+void encode_pair_range(const MapT& m, bufferlist& bl, uint64_t features);
+
+template<typename MapT, typename IteratorT>
+void decode_map_entries_by_subscript(unsigned n, MapT& m,
+                                     IteratorT& p);
+
+template<typename MapT, typename IteratorT>
+void decode_map_entries_by_emplace(unsigned n, MapT& m,
+                                   IteratorT& p);
+
+template<typename MapT, typename IteratorT>
+void decode_map_entries_by_try_emplace(unsigned n, MapT& m,
+                                       IteratorT& p);
+
+template<typename MapT, typename IteratorT>
+requires map_emplaces_key_value<MapT>
+void decode_map_entries_no_clear(unsigned n, MapT& m, IteratorT& p);
+
+template<typename MapT, typename IteratorT>
+requires (!map_emplaces_key_value<MapT> &&
+          ceph::concepts::has_try_emplace_key<MapT>)
+void decode_map_entries_no_clear(unsigned n, MapT& m, IteratorT& p);
+
+template<typename MapT, typename IteratorT>
+requires map_emplaces_key_value<MapT>
+void decode_map_entries(unsigned n, MapT& m, IteratorT& p);
+
+template<typename MapT, typename IteratorT>
+requires (!map_emplaces_key_value<MapT> &&
+          ceph::concepts::has_subscript_operator<MapT>)
+void decode_map_entries(unsigned n, MapT& m, IteratorT& p);
+
+template<typename MapT>
+void decode_map_by_subscript(unsigned n, MapT& m,
+                             bufferlist::const_iterator& p);
+
+template<typename MapT>
+void decode_map_by_subscript(MapT& m, bufferlist::const_iterator& p);
+
+template<typename MapT>
+void decode_map(unsigned n, MapT& m, bufferlist::const_iterator& p);
+
+template<typename MapT>
+void decode_map(MapT& m, bufferlist::const_iterator& p);
+
+} // namespace encoding_detail
 
 // boost optional
 template<typename T>
 inline void encode(const boost::optional<T> &p, bufferlist &bl)
 {
-  __u8 present = static_cast<bool>(p);
-  encode(present, bl);
-  if (p)
-    encode(p.get(), bl);
+  encoding_detail::encode_optional(p, bl);
 }
 
-#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wuninitialized"
 template<typename T>
 inline void decode(boost::optional<T> &p, bufferlist::const_iterator &bp)
 {
-  __u8 present;
-  decode(present, bp);
-  if (present) {
-    p = T{};
-    decode(p.get(), bp);
-  } else {
-    p = boost::none;
+  auto decoded = encoding_detail::decode_optional<T>(bp);
+  if (decoded) {
+    p = std::move(*decoded);
+    return;
   }
+
+  p.reset();
 }
-#pragma GCC diagnostic pop
-#pragma GCC diagnostic warning "-Wpragmas"
 
 // std optional
 template<typename T>
 inline void encode(const std::optional<T> &p, bufferlist &bl)
 {
-  __u8 present = static_cast<bool>(p);
-  encode(present, bl);
-  if (p)
-    encode(*p, bl);
+  encoding_detail::encode_optional(p, bl);
 }
 
-#pragma GCC diagnostic ignored "-Wpragmas"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuninitialized"
 template<typename T>
 inline void decode(std::optional<T> &p, bufferlist::const_iterator &bp)
 {
-  __u8 present;
-  decode(present, bp);
-  if (present) {
-    p = T{};
-    decode(*p, bp);
-  } else {
-    p = std::nullopt;
-  }
+  p = encoding_detail::decode_optional<T>(bp);
 }
+#pragma GCC diagnostic pop
 
 // std::tuple
 template<typename... Ts>
 inline void encode(const std::tuple<Ts...> &t, bufferlist& bl)
 {
   ceph::for_each(t, [&bl](const auto& e) {
-      encode(e, bl);
-    });
+    encode(e, bl);
+  });
 }
 template<typename... Ts>
 inline void decode(std::tuple<Ts...> &t, bufferlist::const_iterator &bp)
 {
   ceph::for_each(t, [&bp](auto& e) {
-      decode(e, bp);
-    });
+    decode(e, bp);
+  });
 }
 
-//triple boost::tuple
+// triple boost::tuple
 template<class A, class B, class C>
 inline void encode(const boost::tuple<A, B, C> &t, bufferlist& bl)
 {
@@ -709,720 +671,825 @@ inline void decode(boost::tuple<A, B, C> &t, bufferlist::const_iterator &bp)
   decode(boost::get<2>(t), bp);
 }
 
-// std::pair<A,B>
+// std::pair<A, B>
 template<class A, class B,
-	 typename a_traits, typename b_traits>
-inline std::enable_if_t<!a_traits::supported || !b_traits::supported>
-  encode(const std::pair<A,B> &p, bufferlist &bl, uint64_t features)
+	 typename a_traits = denc_traits<A>, typename b_traits = denc_traits<B>>
+requires encoding_detail::needs_legacy_encoding<a_traits, b_traits>
+inline void encode(const std::pair<A,B> &p, bufferlist &bl, uint64_t features)
 {
-  encode(p.first, bl, features);
-  encode(p.second, bl, features);
+  encoding_detail::encode_pair_members(p, bl, features);
 }
 template<class A, class B,
-	 typename a_traits, typename b_traits>
-inline std::enable_if_t<!a_traits::supported ||
-			!b_traits::supported>
-  encode(const std::pair<A,B> &p, bufferlist &bl)
+	 typename a_traits = denc_traits<A>, typename b_traits = denc_traits<B>>
+requires encoding_detail::needs_legacy_encoding<a_traits, b_traits>
+inline void encode(const std::pair<A,B> &p, bufferlist &bl)
 {
-  encode(p.first, bl);
-  encode(p.second, bl);
+  encoding_detail::encode_pair_members(p, bl);
 }
-template<class A, class B, typename a_traits, typename b_traits>
-inline std::enable_if_t<!a_traits::supported ||
-			!b_traits::supported>
-  decode(std::pair<A,B> &pa, bufferlist::const_iterator &p)
+template<class A, class B,
+	 typename a_traits = denc_traits<A>, typename b_traits = denc_traits<B>>
+requires encoding_detail::needs_legacy_encoding<a_traits, b_traits>
+inline void decode(std::pair<A,B> &pa, bufferlist::const_iterator &p)
 {
-  decode(pa.first, p);
-  decode(pa.second, p);
+  encoding_detail::decode_pair_members(pa, p);
 }
 
 // std::list<T>
-template<class T, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  encode(const std::list<T, Alloc>& ls, bufferlist& bl)
+template<class T, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode(const std::list<T, Alloc>& ls, bufferlist& bl)
 {
-  __u32 n = (__u32)(ls.size());  // c++11 std::list::size() is O(1)
-  encode(n, bl);
-  for (auto p = ls.begin(); p != ls.end(); ++p)
-    encode(*p, bl);
+  encoding_detail::encode_range(ls, bl);
 }
-template<class T, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  encode(const std::list<T,Alloc>& ls, bufferlist& bl, uint64_t features)
+template<class T, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode(const std::list<T,Alloc>& ls, bufferlist& bl, uint64_t features)
 {
-  using counter_encode_t = ceph_le32;
-  unsigned n = 0;
-  auto filler = bl.append_hole(sizeof(counter_encode_t));
-  for (const auto& item : ls) {
-    // we count on our own because of buggy std::list::size() implementation
-    // which doesn't follow the O(1) complexity constraint C++11 has brought.
-    ++n;
-    encode(item, bl, features);
-  }
-  counter_encode_t en;
-  en = n;
-  filler.copy_in(sizeof(en), reinterpret_cast<char*>(&en));
+  encoding_detail::encode_range(ls, bl, features);
 }
 
-template<class T, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  decode(std::list<T,Alloc>& ls, bufferlist::const_iterator& p)
+template<class T, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void decode(std::list<T,Alloc>& ls, bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  ls.clear();
-  while (n--) {
-    ls.emplace_back();
-    decode(ls.back(), p);
-  }
+  encoding_detail::decode_by_emplace_back(ls, p);
 }
 
 // std::list<std::shared_ptr<T>>
 template<class T, class Alloc>
 inline void encode(const std::list<std::shared_ptr<T>, Alloc>& ls,
-		   bufferlist& bl)
+                   bufferlist& bl)
 {
-  __u32 n = (__u32)(ls.size());  // c++11 std::list::size() is O(1)
-  encode(n, bl);
-  for (const auto& ref : ls) {
-    encode(*ref, bl);
-  }
+  encoding_detail::encode_shared_ptr_range(ls, bl);
 }
 template<class T, class Alloc>
 inline void encode(const std::list<std::shared_ptr<T>, Alloc>& ls,
-		   bufferlist& bl, uint64_t features)
+                   bufferlist& bl, uint64_t features)
 {
-  __u32 n = (__u32)(ls.size());  // c++11 std::list::size() is O(1)
-  encode(n, bl);
-  for (const auto& ref : ls) {
-    encode(*ref, bl, features);
-  }
+  encoding_detail::encode_shared_ptr_range(ls, bl, features);
 }
 template<class T, class Alloc>
 inline void decode(std::list<std::shared_ptr<T>, Alloc>& ls,
-		   bufferlist::const_iterator& p)
+                   bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  ls.clear();
-  while (n--) {
-    auto ref = std::make_shared<T>();
-    decode(*ref, p);
-    ls.emplace_back(std::move(ref));
-  }
+  encoding_detail::decode_shared_ptr_sequence(ls, p);
 }
 
 // std::set<T>
-template<class T, class Comp, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  encode(const std::set<T,Comp,Alloc>& s, bufferlist& bl)
+template<class T, class Comp, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode(const std::set<T,Comp,Alloc>& s, bufferlist& bl)
 {
-  __u32 n = (__u32)(s.size());
-  encode(n, bl);
-  for (auto p = s.begin(); p != s.end(); ++p)
-    encode(*p, bl);
+  encoding_detail::encode_range(s, bl);
 }
-template<class T, class Comp, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  decode(std::set<T,Comp,Alloc>& s, bufferlist::const_iterator& p)
+template<class T, class Comp, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void decode(std::set<T,Comp,Alloc>& s, bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  s.clear();
-  while (n--) {
-    T v;
-    decode(v, p);
-    s.insert(v);
-  }
+  encoding_detail::decode_by_insert(s, p);
 }
 
-template<class T, class Comp, class Alloc, typename traits>
-inline typename std::enable_if<!traits::supported>::type
-  encode_nohead(const std::set<T,Comp,Alloc>& s, bufferlist& bl)
+template<class T, class Comp, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode_nohead(const std::set<T,Comp,Alloc>& s, bufferlist& bl)
 {
-  for (auto p = s.begin(); p != s.end(); ++p)
-    encode(*p, bl);
+  encoding_detail::encode_range_nohead(s, bl);
 }
-template<class T, class Comp, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  decode_nohead(unsigned len, std::set<T,Comp,Alloc>& s, bufferlist::const_iterator& p)
+template<class T, class Comp, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void decode_nohead(unsigned len, std::set<T,Comp,Alloc>& s,
+                          bufferlist::const_iterator& p)
 {
-  for (unsigned i=0; i<len; i++) {
-    T v;
-    decode(v, p);
-    s.insert(v);
-  }
+  encoding_detail::decode_by_insert(len, s, p);
 }
 
 // boost::container::flat_set<T>
-template<class T, class Comp, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-encode(const boost::container::flat_set<T, Comp, Alloc>& s, bufferlist& bl)
+template<class T, class Comp, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode(const boost::container::flat_set<T, Comp, Alloc>& s,
+                   bufferlist& bl)
 {
-  __u32 n = (__u32)(s.size());
-  encode(n, bl);
-  for (const auto& e : s)
-    encode(e, bl);
+  encoding_detail::encode_range(s, bl);
 }
-template<class T, class Comp, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-decode(boost::container::flat_set<T, Comp, Alloc>& s, bufferlist::const_iterator& p)
+template<class T, class Comp, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void decode(boost::container::flat_set<T, Comp, Alloc>& s,
+                   bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  s.clear();
-  s.reserve(n);
-  while (n--) {
-    T v;
-    decode(v, p);
-    s.insert(v);
-  }
+  encoding_detail::decode_by_insert(s, p);
 }
 
-template<class T, class Comp, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-encode_nohead(const boost::container::flat_set<T, Comp, Alloc>& s,
-	      bufferlist& bl)
+template<class T, class Comp, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode_nohead(const boost::container::flat_set<T, Comp, Alloc>& s,
+                          bufferlist& bl)
 {
-  for (const auto& e : s)
-    encode(e, bl);
+  encoding_detail::encode_range_nohead(s, bl);
 }
-template<class T, class Comp, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-decode_nohead(unsigned len, boost::container::flat_set<T, Comp, Alloc>& s,
-	      bufferlist::iterator& p)
+template<class T, class Comp, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void decode_nohead(unsigned len,
+                          boost::container::flat_set<T, Comp, Alloc>& s,
+                          bufferlist::const_iterator& p)
 {
-  s.reserve(len);
-  for (unsigned i=0; i<len; i++) {
-    T v;
-    decode(v, p);
-    s.insert(v);
-  }
+  encoding_detail::decode_by_insert(len, s, p);
 }
 
 // multiset
 template<class T, class Comp, class Alloc>
 inline void encode(const std::multiset<T,Comp,Alloc>& s, bufferlist& bl)
 {
-  __u32 n = (__u32)(s.size());
-  encode(n, bl);
-  for (auto p = s.begin(); p != s.end(); ++p)
-    encode(*p, bl);
+  encoding_detail::encode_range(s, bl);
 }
 template<class T, class Comp, class Alloc>
 inline void decode(std::multiset<T,Comp,Alloc>& s, bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  s.clear();
-  while (n--) {
-    T v;
-    decode(v, p);
-    s.insert(v);
-  }
+  encoding_detail::decode_by_insert(s, p);
 }
 
-template<class T, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  encode(const std::vector<T,Alloc>& v, bufferlist& bl, uint64_t features)
+template<class T, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode(const std::vector<T,Alloc>& v, bufferlist& bl, uint64_t features)
 {
-  __u32 n = (__u32)(v.size());
-  encode(n, bl);
-  for (auto p = v.begin(); p != v.end(); ++p)
-    encode(*p, bl, features);
+  encoding_detail::encode_range(v, bl, features);
 }
-template<class T, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  encode(const std::vector<T,Alloc>& v, bufferlist& bl)
+template<class T, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode(const std::vector<T,Alloc>& v, bufferlist& bl)
 {
-  __u32 n = (__u32)(v.size());
-  encode(n, bl);
-  for (auto p = v.begin(); p != v.end(); ++p)
-    encode(*p, bl);
+  encoding_detail::encode_range(v, bl);
 }
-template<class T, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  decode(std::vector<T,Alloc>& v, bufferlist::const_iterator& p)
+template<class T, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void decode(std::vector<T,Alloc>& v, bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  v.resize(n);
-  for (__u32 i=0; i<n; i++) 
-    decode(v[i], p);
+  encoding_detail::decode_by_resize(v, p);
 }
 
-template<class T, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  encode_nohead(const std::vector<T,Alloc>& v, bufferlist& bl)
+template<class T, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode_nohead(const std::vector<T,Alloc>& v, bufferlist& bl)
 {
-  for (auto p = v.begin(); p != v.end(); ++p)
-    encode(*p, bl);
+  encoding_detail::encode_range_nohead(v, bl);
 }
-template<class T, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  decode_nohead(unsigned len, std::vector<T,Alloc>& v, bufferlist::const_iterator& p)
+template<class T, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void decode_nohead(unsigned len, std::vector<T,Alloc>& v,
+                          bufferlist::const_iterator& p)
 {
-  v.resize(len);
-  for (__u32 i=0; i<v.size(); i++) 
-    decode(v[i], p);
+  encoding_detail::decode_by_resize_nohead(len, v, p);
 }
 
 // small vector
-template<class T, std::size_t N, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  encode(const boost::container::small_vector<T,N,Alloc>& v, bufferlist& bl, uint64_t features)
+template<class T, std::size_t N, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode(const boost::container::small_vector<T,N,Alloc>& v,
+                   bufferlist& bl, uint64_t features)
 {
-  __u32 n = (__u32)(v.size());
-  encode(n, bl);
-  for (const auto& i : v)
-    encode(i, bl, features);
+  encoding_detail::encode_range(v, bl, features);
 }
-template<class T, std::size_t N, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  encode(const boost::container::small_vector<T,N,Alloc>& v, bufferlist& bl)
+template<class T, std::size_t N, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode(const boost::container::small_vector<T,N,Alloc>& v,
+                   bufferlist& bl)
 {
-  __u32 n = (__u32)(v.size());
-  encode(n, bl);
-  for (const auto& i : v)
-    encode(i, bl);
+  encoding_detail::encode_range(v, bl);
 }
-template<class T, std::size_t N, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  decode(boost::container::small_vector<T,N,Alloc>& v, bufferlist::const_iterator& p)
+template<class T, std::size_t N, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void decode(boost::container::small_vector<T,N,Alloc>& v,
+                   bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  v.resize(n);
-  for (auto& i : v)
-    decode(i, p);
+  encoding_detail::decode_by_resize(v, p);
 }
 
-template<class T, std::size_t N, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  encode_nohead(const boost::container::small_vector<T,N,Alloc>& v, bufferlist& bl)
+template<class T, std::size_t N, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode_nohead(const boost::container::small_vector<T,N,Alloc>& v,
+                          bufferlist& bl)
 {
-  for (const auto& i : v)
-    encode(i, bl);
+  encoding_detail::encode_range_nohead(v, bl);
 }
-template<class T, std::size_t N, class Alloc, typename traits>
-inline std::enable_if_t<!traits::supported>
-  decode_nohead(unsigned len, boost::container::small_vector<T,N,Alloc>& v, bufferlist::const_iterator& p)
+template<class T, std::size_t N, class Alloc, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void decode_nohead(unsigned len,
+                          boost::container::small_vector<T,N,Alloc>& v,
+                          bufferlist::const_iterator& p)
 {
-  v.resize(len);
-  for (auto& i : v)
-    decode(i, p);
+  encoding_detail::decode_by_resize_nohead(len, v, p);
 }
 
 
 // vector (shared_ptr)
-template<class T,class Alloc>
+template<class T, class Alloc>
 inline void encode(const std::vector<std::shared_ptr<T>,Alloc>& v,
-		   bufferlist& bl,
-		   uint64_t features)
+                   bufferlist& bl,
+                   uint64_t features)
 {
-  __u32 n = (__u32)(v.size());
-  encode(n, bl);
-  for (const auto& ref : v) {
-    if (ref)
-      encode(*ref, bl, features);
-    else
-      encode(T(), bl, features);
-  }
+  encoding_detail::encode_shared_ptr_range(v, bl, features);
 }
 template<class T, class Alloc>
 inline void encode(const std::vector<std::shared_ptr<T>,Alloc>& v,
-		   bufferlist& bl)
+                   bufferlist& bl)
 {
-  __u32 n = (__u32)(v.size());
-  encode(n, bl);
-  for (const auto& ref : v) {
-    if (ref)
-      encode(*ref, bl);
-    else
-      encode(T(), bl);
-  }
+  encoding_detail::encode_shared_ptr_range(v, bl);
 }
 template<class T, class Alloc>
 inline void decode(std::vector<std::shared_ptr<T>,Alloc>& v,
-		   bufferlist::const_iterator& p)
+                   bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  v.clear();
-  v.reserve(n);
-  while (n--) {
-    auto ref = std::make_shared<T>();
-    decode(*ref, p);
-    v.emplace_back(std::move(ref));
-  }
+  encoding_detail::decode_shared_ptr_sequence(v, p);
 }
 
 // map
 template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-inline std::enable_if_t<!t_traits::supported ||
-			!u_traits::supported>
-  encode(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl)
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void encode(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl)
 {
-  __u32 n = (__u32)(m.size());
-  encode(n, bl);
-  for (auto p = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl);
-    encode(p->second, bl);
-  }
+  encoding_detail::encode_pair_range(m, bl);
 }
 template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  encode(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl, uint64_t features)
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void encode(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl,
+                   uint64_t features)
 {
-  __u32 n = (__u32)(m.size());
-  encode(n, bl);
-  for (auto p = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl, features);
-    encode(p->second, bl, features);
-  }
+  encoding_detail::encode_pair_range(m, bl, features);
 }
 template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  decode(std::map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p)
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void decode(std::map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  m.clear();
-  while (n--) {
-    T k;
-    decode(k, p);
-    decode(m[k], p);
-  }
-}
-template <std::move_constructible T, std::move_constructible U, class Comp, class Alloc,
-    typename t_traits, typename u_traits>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-decode(std::map<T, U, Comp, Alloc>& m, bufferlist::const_iterator& p)
-{
-  __u32 n;
-  decode(n, p);
-  m.clear();
-  while (n--) {
-    T k;
-    U v;
-    decode(k, p);
-    decode(v, p);
-    m.emplace(std::move(k), std::move(v));
-  }
-}
-template<class T, class U, class Comp, class Alloc>
-inline void decode_noclear(std::map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p)
-{
-  __u32 n;
-  decode(n, p);
-  while (n--) {
-    T k;
-    decode(k, p);
-    decode(m[k], p);
-  }
-}
-template<std::move_constructible T, std::move_constructible U, class Comp, class Alloc>
-inline void decode_noclear(std::map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p)
-{
-  __u32 n;
-  decode(n, p);
-  while (n--) {
-    T k;
-    U v;
-    decode(k, p);
-    decode(v, p);
-    m.emplace(std::move(k), std::move(v));
-  }
-}
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  encode_nohead(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl)
-{
-  for (auto p = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl);
-    encode(p->second, bl);
-  }
-}
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  encode_nohead(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl, uint64_t features)
-{
-  for (auto p = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl, features);
-    encode(p->second, bl, features);
-  }
-}
-template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  decode_nohead(unsigned n, std::map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p)
-{
-  m.clear();
-  while (n--) {
-    T k;
-    decode(k, p);
-    decode(m[k], p);
-  }
+  encoding_detail::decode_map(m, p);
 }
 
-template <std::move_constructible T, std::move_constructible U, class Comp, class Alloc,
-    typename t_traits, typename u_traits>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-decode_nohead(unsigned n, std::map<T, U, Comp, Alloc>& m, bufferlist::const_iterator& p)
+// Compatibility helper for callers that intentionally manage clearing:
+// actual deprecation is a separate public-header compatibility decision.
+// Duplicate decoded keys intentionally preserve the existing mapped value for
+// std::map.
+template<class T, class U, class Comp, class Alloc>
+inline void decode_noclear(std::map<T,U,Comp,Alloc>& m,
+                           bufferlist::const_iterator& p)
 {
-  m.clear();
-  while (n--) {
-    T k;
-    U v;
-    decode(k, p);
-    decode(v, p);
-    m.emplace(std::move(k), std::move(v));
-  }
+  encoding_detail::decode_map_entries_no_clear(
+    encoding_detail::decode_count(p), m, p);
+}
+template<class T, class U, class Comp, class Alloc,
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void encode_nohead(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl)
+{
+  encoding_detail::encode_pair_range_nohead(m, bl);
+}
+template<class T, class U, class Comp, class Alloc,
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void encode_nohead(const std::map<T,U,Comp,Alloc>& m,
+                          bufferlist& bl,
+                          uint64_t features)
+{
+  encoding_detail::encode_pair_range_nohead(m, bl, features);
+}
+template<class T, class U, class Comp, class Alloc,
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void decode_nohead(unsigned n, std::map<T,U,Comp,Alloc>& m,
+                          bufferlist::const_iterator& p)
+{
+  encoding_detail::decode_map(n, m, p);
 }
 
 // boost::container::flat-map
 template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-  inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  encode(const boost::container::flat_map<T,U,Comp,Alloc>& m, bufferlist& bl)
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void encode(const boost::container::flat_map<T,U,Comp,Alloc>& m,
+                   bufferlist& bl)
 {
-  __u32 n = (__u32)(m.size());
-  encode(n, bl);
-  for (typename boost::container::flat_map<T,U,Comp>::const_iterator p
-	 = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl);
-    encode(p->second, bl);
-  }
+  encoding_detail::encode_pair_range(m, bl);
 }
 template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-  inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  encode(const boost::container::flat_map<T,U,Comp,Alloc>& m, bufferlist& bl,
-	 uint64_t features)
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void encode(const boost::container::flat_map<T,U,Comp,Alloc>& m,
+                   bufferlist& bl, uint64_t features)
 {
-  __u32 n = (__u32)(m.size());
-  encode(n, bl);
-  for (auto p = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl, features);
-    encode(p->second, bl, features);
-  }
+  encoding_detail::encode_pair_range(m, bl, features);
 }
 template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-  inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  decode(boost::container::flat_map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p)
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void decode(boost::container::flat_map<T,U,Comp,Alloc>& m,
+                   bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  m.clear();
-  m.reserve(n);
-  while (n--) {
-    T k;
-    decode(k, p);
-    decode(m[k], p);
-  }
+  encoding_detail::decode_map_by_subscript(m, p);
 }
+
+// Compatibility-only: no production callers were found in-tree. Do not add new
+// callers unless preserving the destination's current entries is necessary.
+// Actual deprecation is a separate public-header compatibility decision.
+// Duplicate decoded keys intentionally replace the existing mapped value for
+// boost::container::flat_map.
 template<class T, class U, class Comp, class Alloc>
-inline void decode_noclear(boost::container::flat_map<T,U,Comp,Alloc>& m,
-			   bufferlist::const_iterator& p)
+[[maybe_unused]] inline void decode_noclear(
+  boost::container::flat_map<T,U,Comp,Alloc>& m,
+  bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
+  const auto n = encoding_detail::decode_count(p);
   m.reserve(m.size() + n);
-  while (n--) {
-    T k;
-    decode(k, p);
-    decode(m[k], p);
-  }
+  encoding_detail::decode_map_entries_by_subscript(n, m, p);
 }
 template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-  inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  encode_nohead(const boost::container::flat_map<T,U,Comp,Alloc>& m,
-		bufferlist& bl)
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void encode_nohead(const boost::container::flat_map<T,U,Comp,Alloc>& m,
+                          bufferlist& bl)
 {
-  for (auto p = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl);
-    encode(p->second, bl);
-  }
+  encoding_detail::encode_pair_range_nohead(m, bl);
 }
 template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-  inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  encode_nohead(const boost::container::flat_map<T,U,Comp,Alloc>& m,
-		bufferlist& bl, uint64_t features)
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void encode_nohead(const boost::container::flat_map<T,U,Comp,Alloc>& m,
+                          bufferlist& bl, uint64_t features)
 {
-  for (auto p = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl, features);
-    encode(p->second, bl, features);
-  }
+  encoding_detail::encode_pair_range_nohead(m, bl, features);
 }
 template<class T, class U, class Comp, class Alloc,
-	 typename t_traits, typename u_traits>
-inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
-  decode_nohead(unsigned n, boost::container::flat_map<T,U,Comp,Alloc>& m,
-		bufferlist::const_iterator& p)
+	 typename t_traits = denc_traits<T>, typename u_traits = denc_traits<U>>
+requires encoding_detail::needs_legacy_encoding<t_traits, u_traits>
+inline void decode_nohead(unsigned n,
+                          boost::container::flat_map<T,U,Comp,Alloc>& m,
+                          bufferlist::const_iterator& p)
 {
-  m.clear();
-  while (n--) {
-    T k;
-    decode(k, p);
-    decode(m[k], p);
-  }
+  encoding_detail::decode_map_by_subscript(n, m, p);
 }
 
 // multimap
 template<class T, class U, class Comp, class Alloc>
 inline void encode(const std::multimap<T,U,Comp,Alloc>& m, bufferlist& bl)
 {
-  __u32 n = (__u32)(m.size());
-  encode(n, bl);
-  for (auto p = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl);
-    encode(p->second, bl);
-  }
+  encoding_detail::encode_pair_range(m, bl);
 }
 template<class T, class U, class Comp, class Alloc>
-inline void decode(std::multimap<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p)
+inline void decode(std::multimap<T,U,Comp,Alloc>& m,
+                   bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
   m.clear();
-  while (n--) {
-    typename std::pair<T,U> tu = std::pair<T,U>();
+
+  encoding_detail::for_each_count(encoding_detail::decode_count(p), [&m, &p] {
+    auto tu = std::pair<T, U> {};
     decode(tu.first, p);
-    typename std::multimap<T,U,Comp,Alloc>::iterator it = m.insert(tu);
+    auto it = m.insert(std::move(tu));
     decode(it->second, p);
-  }
+  });
 }
 
 // std::unordered_map
 template<class T, class U, class Hash, class Pred, class Alloc>
-inline void encode(const std::unordered_map<T,U,Hash,Pred,Alloc>& m, bufferlist& bl,
-		   uint64_t features)
+inline void encode(const std::unordered_map<T,U,Hash,Pred,Alloc>& m,
+                   bufferlist& bl,
+                   uint64_t features)
 {
-  __u32 n = (__u32)(m.size());
-  encode(n, bl);
-  for (auto p = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl, features);
-    encode(p->second, bl, features);
-  }
+  encoding_detail::encode_pair_range(m, bl, features);
 }
 template<class T, class U, class Hash, class Pred, class Alloc>
-inline void encode(const std::unordered_map<T,U,Hash,Pred,Alloc>& m, bufferlist& bl)
+inline void encode(const std::unordered_map<T,U,Hash,Pred,Alloc>& m,
+                   bufferlist& bl)
 {
-  __u32 n = (__u32)(m.size());
-  encode(n, bl);
-  for (auto p = m.begin(); p != m.end(); ++p) {
-    encode(p->first, bl);
-    encode(p->second, bl);
-  }
+  encoding_detail::encode_pair_range(m, bl);
 }
 template<class T, class U, class Hash, class Pred, class Alloc>
-inline void decode(std::unordered_map<T,U,Hash,Pred,Alloc>& m, bufferlist::const_iterator& p)
+inline void decode(std::unordered_map<T,U,Hash,Pred,Alloc>& m,
+                   bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  m.clear();
-  while (n--) {
-    T k;
-    decode(k, p);
-    decode(m[k], p);
-  }
-}
-
-template <std::move_constructible T, std::move_constructible U, class Hash, class Pred, class Alloc>
-inline void decode(std::unordered_map<T, U, Hash, Pred, Alloc>& m, bufferlist::const_iterator& p)
-{
-  __u32 n;
-  decode(n, p);
-  m.clear();
-  while (n--) {
-    T k;
-    U v;
-    decode(k, p);
-    decode(v, p);
-    m.emplace(std::move(k), std::move(v));
-  }
+  encoding_detail::decode_map(m, p);
 }
 
 // std::unordered_set
 template<class T, class Hash, class Pred, class Alloc>
-inline void encode(const std::unordered_set<T,Hash,Pred,Alloc>& m, bufferlist& bl)
+inline void encode(const std::unordered_set<T,Hash,Pred,Alloc>& m,
+                   bufferlist& bl)
 {
-  __u32 n = (__u32)(m.size());
-  encode(n, bl);
-  for (auto p = m.begin(); p != m.end(); ++p)
-    encode(*p, bl);
+  encoding_detail::encode_range(m, bl);
 }
 template<class T, class Hash, class Pred, class Alloc>
-inline void decode(std::unordered_set<T,Hash,Pred,Alloc>& m, bufferlist::const_iterator& p)
+inline void decode(std::unordered_set<T,Hash,Pred,Alloc>& m,
+                   bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  m.clear();
-  while (n--) {
-    T k;
-    decode(k, p);
-    m.insert(k);
-  }
+  encoding_detail::decode_by_insert(m, p);
 }
 
 // deque
 template<class T, class Alloc>
-inline void encode(const std::deque<T,Alloc>& ls, bufferlist& bl, uint64_t features)
+inline void encode(const std::deque<T,Alloc>& ls, bufferlist& bl,
+                   uint64_t features)
 {
-  __u32 n = ls.size();
-  encode(n, bl);
-  for (auto p = ls.begin(); p != ls.end(); ++p)
-    encode(*p, bl, features);
+  encoding_detail::encode_range(ls, bl, features);
 }
 template<class T, class Alloc>
 inline void encode(const std::deque<T,Alloc>& ls, bufferlist& bl)
 {
-  __u32 n = ls.size();
-  encode(n, bl);
-  for (auto p = ls.begin(); p != ls.end(); ++p)
-    encode(*p, bl);
+  encoding_detail::encode_range(ls, bl);
 }
 template<class T, class Alloc>
 inline void decode(std::deque<T,Alloc>& ls, bufferlist::const_iterator& p)
 {
-  __u32 n;
-  decode(n, p);
-  ls.clear();
-  while (n--) {
-    ls.emplace_back();
-    decode(ls.back(), p);
-  }
+  encoding_detail::decode_by_emplace_back(ls, p);
 }
 
 // std::array<T, N>
-template<class T, size_t N, typename traits>
-inline std::enable_if_t<!traits::supported>
-encode(const std::array<T, N>& v, bufferlist& bl, uint64_t features)
+template<class T, size_t N, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode(const std::array<T, N>& v, bufferlist& bl, uint64_t features)
 {
-  for (const auto& e : v)
-    encode(e, bl, features);
+  encoding_detail::encode_range_nohead(v, bl, features);
 }
-template<class T, size_t N, typename traits>
-inline std::enable_if_t<!traits::supported>
-encode(const std::array<T, N>& v, bufferlist& bl)
+template<class T, size_t N, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void encode(const std::array<T, N>& v, bufferlist& bl)
 {
-  for (const auto& e : v)
-    encode(e, bl);
+  encoding_detail::encode_range_nohead(v, bl);
 }
-template<class T, size_t N, typename traits>
-inline std::enable_if_t<!traits::supported>
-decode(std::array<T, N>& v, bufferlist::const_iterator& p)
+template<class T, size_t N, typename traits = denc_traits<T>>
+requires encoding_detail::needs_legacy_encoding<traits>
+inline void decode(std::array<T, N>& v, bufferlist::const_iterator& p)
 {
-  for (auto& e : v)
-    decode(e, p);
+  encoding_detail::decode_range_nohead(v, p);
+}
+
+namespace encoding_detail {
+
+template<typename OptionalT>
+void encode_optional(const OptionalT& p, bufferlist& bl)
+{
+  __u8 present = static_cast<bool>(p);
+  encode(present, bl);
+  if (!p) {
+    return;
+  }
+
+  encode(*p, bl);
+}
+
+template<typename T>
+std::optional<T> decode_optional(bufferlist::const_iterator& p)
+{
+  __u8 present;
+  decode(present, p);
+  if (!present) {
+    return std::nullopt;
+  }
+
+  T value{};
+  decode(value, p);
+  return value;
+}
+
+template<typename FnT>
+void for_each_count(unsigned n, FnT&& fn)
+{
+  for (auto i = 0u; i < n; ++i) {
+    fn();
+  }
+}
+
+template<typename RangeT>
+void encode_range_nohead(const RangeT& r, bufferlist& bl)
+{
+  for (const auto& item : r) {
+    encode(item, bl);
+  }
+}
+
+template<typename RangeT>
+void encode_range_nohead(const RangeT& r, bufferlist& bl, uint64_t features)
+{
+  for (const auto& item : r) {
+    encode(item, bl, features);
+  }
+}
+
+template<typename RangeT, typename IteratorT>
+void decode_range_nohead(RangeT& r, IteratorT& p)
+{
+  for (auto& item : r) {
+    decode(item, p);
+  }
+}
+
+template<typename RangeT>
+void encode_range(const RangeT& r, bufferlist& bl)
+{
+  encode_count(r.size(), bl);
+  encode_range_nohead(r, bl);
+}
+
+template<typename RangeT>
+void encode_range(const RangeT& r, bufferlist& bl, uint64_t features)
+{
+  encode_count(r.size(), bl);
+  encode_range_nohead(r, bl, features);
+}
+
+template<typename ContainerT>
+void reserve_if_possible(ContainerT& c, size_t n)
+{
+  if constexpr (requires { c.reserve(n); }) {
+    c.reserve(n);
+  }
+}
+
+template<typename ContainerT>
+void clear_and_reserve(ContainerT& c, size_t n)
+{
+  c.clear();
+  reserve_if_possible(c, n);
+}
+
+template<typename ContainerT, typename IteratorT>
+void decode_by_resize_nohead(unsigned len, ContainerT& c,
+                             IteratorT& p)
+{
+  c.resize(len);
+  decode_range_nohead(c, p);
+}
+
+template<typename ContainerT>
+void decode_by_resize(ContainerT& c, bufferlist::const_iterator& p)
+{
+  decode_by_resize_nohead(decode_count(p), c, p);
+}
+
+template<typename ContainerT, typename IteratorT>
+void decode_by_emplace_back(unsigned len, ContainerT& c,
+                            IteratorT& p)
+{
+  clear_and_reserve(c, len);
+
+  for_each_count(len, [&c, &p] {
+    c.emplace_back();
+    decode(c.back(), p);
+  });
+}
+
+template<typename ContainerT>
+void decode_by_emplace_back(ContainerT& c, bufferlist::const_iterator& p)
+{
+  decode_by_emplace_back(decode_count(p), c, p);
+}
+
+template<typename ContainerT, typename IteratorT>
+void decode_by_insert(unsigned len, ContainerT& c,
+                      IteratorT& p)
+{
+  clear_and_reserve(c, len);
+
+  for_each_count(len, [&c, &p] {
+    typename ContainerT::value_type v;
+    decode(v, p);
+    c.insert(std::move(v));
+  });
+}
+
+template<typename ContainerT>
+void decode_by_insert(ContainerT& c, bufferlist::const_iterator& p)
+{
+  decode_by_insert(decode_count(p), c, p);
+}
+
+template<typename RangeT>
+void encode_shared_ptr_range(const RangeT& r, bufferlist& bl)
+{
+  encode_shared_ptr_range_with(r, bl, [](const auto& value, auto& out) {
+    encode(value, out);
+  });
+}
+
+template<typename RangeT>
+void encode_shared_ptr_range(const RangeT& r, bufferlist& bl,
+                             uint64_t features)
+{
+  encode_shared_ptr_range_with(r, bl, [features](const auto& value, auto& out) {
+    encode(value, out, features);
+  });
+}
+
+template<typename ValueT, typename EncodeFnT>
+void append_cached_default_encoding(std::optional<std::string>& bytes,
+                                    bufferlist& bl,
+                                    EncodeFnT&& encode_value)
+{
+  if (!bytes) {
+    auto tmp = bufferlist {};
+    encode_value(ValueT {}, tmp);
+    bytes = tmp.to_str();
+  }
+
+  bl.append(std::string_view { *bytes });
+}
+
+template<typename RangeT, typename EncodeFnT>
+void encode_shared_ptr_range_with(const RangeT& r, bufferlist& bl,
+                                  EncodeFnT&& encode_value)
+{
+  using value_type = typename RangeT::value_type::element_type;
+
+  encode_count(r.size(), bl);
+
+  auto null_bytes = std::optional<std::string> {};
+
+  for (const auto& ref : r) {
+    if (ref) {
+      encode_value(*ref, bl);
+      continue;
+    }
+
+    append_cached_default_encoding<value_type>(null_bytes, bl, encode_value);
+  }
+}
+
+template<typename ContainerT>
+void decode_shared_ptr_sequence(ContainerT& c,
+                                bufferlist::const_iterator& p)
+{
+  const auto n = decode_count(p);
+  clear_and_reserve(c, n);
+
+  for_each_count(n, [&c, &p] {
+    auto ref = std::make_shared<typename ContainerT::value_type::element_type>();
+    decode(*ref, p);
+    c.emplace_back(std::move(ref));
+  });
+}
+
+template<typename PairT>
+void encode_pair_members(const PairT& item, bufferlist& bl)
+{
+  encode(item.first, bl);
+  encode(item.second, bl);
+}
+
+template<typename PairT>
+void encode_pair_members(const PairT& item, bufferlist& bl,
+                         uint64_t features)
+{
+  encode(item.first, bl, features);
+  encode(item.second, bl, features);
+}
+
+template<typename PairT>
+void decode_pair_members(PairT& item, bufferlist::const_iterator& p)
+{
+  decode(item.first, p);
+  decode(item.second, p);
+}
+
+template<typename MapT>
+void encode_pair_range_nohead(const MapT& m, bufferlist& bl)
+{
+  for (const auto& item : m) {
+    encode_pair_members(item, bl);
+  }
+}
+
+template<typename MapT>
+void encode_pair_range_nohead(const MapT& m, bufferlist& bl,
+                              uint64_t features)
+{
+  for (const auto& item : m) {
+    encode_pair_members(item, bl, features);
+  }
+}
+
+template<typename MapT>
+void encode_pair_range(const MapT& m, bufferlist& bl)
+{
+  encode_count(m.size(), bl);
+  encode_pair_range_nohead(m, bl);
+}
+
+template<typename MapT>
+void encode_pair_range(const MapT& m, bufferlist& bl, uint64_t features)
+{
+  encode_count(m.size(), bl);
+  encode_pair_range_nohead(m, bl, features);
+}
+
+// Decodes n kv entries into containers that support operator[]:
+template<typename MapT, typename IteratorT>
+void decode_map_entries_by_subscript(unsigned n, MapT& m,
+                                     IteratorT& p)
+{
+  for_each_count(n, [&m, &p] {
+    typename MapT::key_type k;
+    decode(k, p);
+    decode(m[std::move(k)], p);
+  });
+}
+
+template<typename MapT, typename IteratorT>
+void decode_map_entries_by_emplace(unsigned n, MapT& m,
+                                   IteratorT& p)
+{
+  for_each_count(n, [&m, &p] {
+    typename MapT::key_type k;
+    typename MapT::mapped_type v;
+    decode(k, p);
+    decode(v, p);
+    m.emplace(std::move(k), std::move(v));
+  });
+}
+
+// Decide between encoding associative containers by operator[] or by
+// emplace():
+template<typename MapT, typename IteratorT>
+void decode_map_entries_by_try_emplace(unsigned n, MapT& m,
+                                       IteratorT& p)
+{
+  for_each_count(n, [&m, &p] {
+    typename MapT::key_type k;
+    decode(k, p);
+    // Preserve an existing mapped value, but still consume the encoded value.
+    auto [it, inserted] = m.try_emplace(std::move(k));
+    if (inserted) {
+      decode(it->second, p);
+      return;
+    }
+
+    typename MapT::mapped_type discarded;
+    decode(discarded, p);
+  });
+}
+
+template<typename MapT, typename IteratorT>
+requires map_emplaces_key_value<MapT>
+void decode_map_entries_no_clear(unsigned n, MapT& m, IteratorT& p)
+{
+  decode_map_entries_by_emplace(n, m, p);
+}
+
+template<typename MapT, typename IteratorT>
+requires (!map_emplaces_key_value<MapT> &&
+          ceph::concepts::has_try_emplace_key<MapT>)
+void decode_map_entries_no_clear(unsigned n, MapT& m, IteratorT& p)
+{
+  decode_map_entries_by_try_emplace(n, m, p);
+}
+
+template<typename MapT, typename IteratorT>
+requires map_emplaces_key_value<MapT>
+void decode_map_entries(unsigned n, MapT& m, IteratorT& p)
+{
+  decode_map_entries_by_emplace(n, m, p);
+}
+
+template<typename MapT, typename IteratorT>
+requires (!map_emplaces_key_value<MapT> &&
+          ceph::concepts::has_subscript_operator<MapT>)
+void decode_map_entries(unsigned n, MapT& m, IteratorT& p)
+{
+  decode_map_entries_by_subscript(n, m, p);
+}
+
+template<typename MapT>
+void decode_map_by_subscript(unsigned n, MapT& m,
+                             bufferlist::const_iterator& p)
+{
+  clear_and_reserve(m, n);
+  decode_map_entries_by_subscript(n, m, p);
+}
+
+template<typename MapT>
+void decode_map_by_subscript(MapT& m, bufferlist::const_iterator& p)
+{
+  decode_map_by_subscript(decode_count(p), m, p);
+}
+
+template<typename MapT>
+void decode_map(unsigned n, MapT& m, bufferlist::const_iterator& p)
+{
+  clear_and_reserve(m, n);
+  decode_map_entries(n, m, p);
+}
+
+template<typename MapT>
+void decode_map(MapT& m, bufferlist::const_iterator& p)
+{
+  decode_map(decode_count(p), m, p);
+}
+
+} // namespace encoding_detail
+
+// full bl decoder
+template<class T>
+inline void decode(T &o, const bufferlist& bl)
+{
+  auto p = bl.begin();
+  decode(o, p);
+  ceph_assert(p.end());
 }
 }
 
@@ -1442,8 +1509,8 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
   __u8 struct_v = v;                                         \
   __u8 struct_compat = compat;		                     \
   ceph_le32 struct_len;				             \
-  auto filler = (bl).append_hole(sizeof(struct_v) +	     \
-    sizeof(struct_compat) + sizeof(struct_len));	     \
+  auto filler = (bl).append_hole(			     \
+    ::ceph::encoding_detail::struct_header_len());	     \
   const auto starting_bl_len = (bl).length();		     \
   using ::ceph::encode;					     \
   do {
@@ -1456,19 +1523,15 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
  */
 #define ENCODE_FINISH_NEW_COMPAT(bl, new_struct_compat)      \
   } while (false);                                           \
-  if (new_struct_compat) {                                   \
-    struct_compat = new_struct_compat;                       \
-  }                                                          \
-  struct_len = (bl).length() - starting_bl_len;              \
-  filler.copy_in(sizeof(struct_v), (char *)&struct_v);       \
-  filler.copy_in(sizeof(struct_compat),			     \
-    (char *)&struct_compat);				     \
-  filler.copy_in(sizeof(struct_len), (char *)&struct_len);
+  ::ceph::encoding_detail::finish_encode_struct(              \
+    filler, struct_v, struct_compat, struct_len,              \
+    new_struct_compat, (bl), starting_bl_len);
 
 #define ENCODE_FINISH(bl) ENCODE_FINISH_NEW_COMPAT(bl, 0)
 
-#define DECODE_ERR_OLDVERSION(func, v, compatv)					\
-  (std::string(func) + " no longer understands old encoding version " #v " < " + std::to_string(compatv))
+#define DECODE_ERR_OLDVERSION(func, v, compatv)				\
+  (std::string(func) + " no longer understands old encoding version " #v \
+   " < " + std::to_string(compatv))
 
 #define DECODE_ERR_NO_COMPAT(func, code_v, v, compatv)					\
   ("Decoder at '" + std::string(func) + "' v=" + std::to_string(code_v) +		\
@@ -1476,6 +1539,163 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
 
 #define DECODE_ERR_PAST(func) \
   (std::string(func) + " decode past end of struct encoding")
+
+namespace ceph::encoding_detail {
+
+// Fixed size of the versioned encode/decode wrapper header.
+inline constexpr auto struct_header_len() noexcept
+{
+  return sizeof(__u8) + sizeof(__u8) + sizeof(ceph_le32);
+}
+
+struct struct_header final {
+  __u8 v = 0;
+  __u8 compat = 0;
+  __u32 len = 0;
+};
+
+// Read the encoded version, compatibility version, and payload length.
+template<typename IteratorT>
+struct_header read_struct_header(IteratorT& bl)
+{
+  using ::ceph::decode;
+
+  struct_header header;
+  decode(header.v, bl);
+  decode(header.compat, bl);
+  decode(header.len, bl);
+
+  return header;
+}
+
+// Reject payloads that require a newer decoder than this code provides.
+inline void check_decode_compat(__u8 code_v, __u8 struct_v,
+                                __u8 struct_compat,
+                                const char *func)
+{
+  if (struct_compat > code_v) {
+    throw ::ceph::buffer::malformed_input(
+      DECODE_ERR_NO_COMPAT(func, code_v, struct_v, struct_compat));
+  }
+}
+
+// Compute the payload end offset after checking that the body is present.
+template<typename IteratorT>
+unsigned checked_struct_end(IteratorT& bl, __u32 struct_len,
+                            const char *func)
+{
+  if (struct_len > bl.get_remaining()) {
+    throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(func));
+  }
+
+  return bl.get_off() + struct_len;
+}
+
+// DECODE_START path: read and validate the standard wrapper header.
+template<typename VersionT, typename IteratorT>
+unsigned decode_struct_start(__u8 code_v, VersionT& struct_v,
+                             __u8& struct_compat, __u32& struct_len,
+                             IteratorT& bl, const char *func)
+{
+  const auto header = read_struct_header(bl);
+  struct_v = header.v;
+  struct_compat = header.compat;
+  struct_len = header.len;
+
+  check_decode_compat(code_v, struct_v, struct_compat, func);
+  return checked_struct_end(bl, struct_len, func);
+}
+
+// Legacy decode path: read only the wrapper fields present in this version.
+template<typename VersionT, typename IteratorT>
+unsigned decode_legacy_struct_start(__u8 code_v, VersionT& struct_v,
+                                    __u8 compat_v, __u8 len_v,
+                                    unsigned skip_v, IteratorT& bl,
+                                    const char *func)
+{
+  using ::ceph::decode;
+
+  decode(struct_v, bl);
+
+  if (compat_v <= struct_v) {
+    __u8 struct_compat;
+    decode(struct_compat, bl);
+    check_decode_compat(code_v, struct_v, struct_compat, func);
+  }
+
+  if (skip_v && compat_v > struct_v) {
+    if (skip_v > bl.get_remaining()) {
+      throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(func));
+    }
+
+    bl += skip_v;
+  }
+
+  if (len_v > struct_v) {
+    return 0;
+  }
+
+  __u32 struct_len;
+  decode(struct_len, bl);
+  return checked_struct_end(bl, struct_len, func);
+}
+
+// ENCODE_FINISH path: patch version, compatibility, and payload length.
+template<typename FillerT>
+void finish_encode_struct(FillerT& filler, __u8 struct_v,
+                          __u8& struct_compat, ceph_le32& struct_len,
+                          __u8 new_struct_compat, const bufferlist& bl,
+                          size_t starting_bl_len)
+{
+  if (new_struct_compat) {
+    struct_compat = new_struct_compat;
+  }
+
+  struct_len = static_cast<__u32>(bl.length() - starting_bl_len);
+  filler.copy_in(sizeof(struct_v),
+                 reinterpret_cast<const char *>(&struct_v));
+  filler.copy_in(sizeof(struct_compat),
+                 reinterpret_cast<const char *>(&struct_compat));
+  filler.copy_in(sizeof(struct_len),
+                 reinterpret_cast<const char *>(&struct_len));
+}
+
+// DECODE_FINISH path: reject overread and skip unread trailing fields.
+template<typename IteratorT>
+void finish_decode_struct(IteratorT& bl, unsigned struct_end,
+                          const char *func)
+{
+  if (!struct_end) {
+    return;
+  }
+
+  if (struct_end < bl.get_off()) {
+    throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(func));
+  }
+
+  if (struct_end > bl.get_off()) {
+    bl += struct_end - bl.get_off();
+  }
+}
+
+// Preserve an unknown encoded payload, including its wrapper header.
+template<typename PayloadT, typename IteratorT>
+void decode_unknown(PayloadT& payload, IteratorT& bl, const char *func)
+{
+  const auto header = read_struct_header(bl);
+  checked_struct_end(bl, header.len, func);
+
+  payload.clear();
+
+  using ::ceph::encode;
+
+  encode(header.v, payload);
+  encode(header.compat, payload);
+  encode(header.len, payload);
+  bl.copy(header.len, payload);
+}
+
+} // namespace ceph::encoding_detail
 
 /**
  * check for very old encoding
@@ -1485,8 +1705,8 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
  * @param oldestv oldest version of the code we can successfully decode.
  */
 #define DECODE_OLDEST(oldestv)						\
-  if (struct_v < oldestv)						\
-    throw ::ceph::buffer::malformed_input(DECODE_ERR_OLDVERSION(__PRETTY_FUNCTION__, v, oldestv)); 
+  if (oldestv > struct_v)						\
+    throw ::ceph::buffer::malformed_input(DECODE_ERR_OLDVERSION(__PRETTY_FUNCTION__, v, oldestv));
 
 /**
  * start a decoding block
@@ -1497,74 +1717,33 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
 #define DECODE_START(_v, bl)						\
   StructVChecker<_v> struct_v;						\
   __u8 struct_compat;							\
-  using ::ceph::decode;							\
-  decode(struct_v.v, bl);						\
-  decode(struct_compat, bl);						\
-  if (_v < struct_compat)						\
-    throw ::ceph::buffer::malformed_input(DECODE_ERR_NO_COMPAT(__PRETTY_FUNCTION__, _v, struct_v.v, struct_compat)); \
   __u32 struct_len;							\
-  decode(struct_len, bl);						\
-  if (struct_len > bl.get_remaining())					\
-    throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
-  unsigned struct_end = bl.get_off() + struct_len;			\
+  using ::ceph::decode;							\
+  unsigned struct_end = ::ceph::encoding_detail::decode_struct_start( \
+    _v, struct_v.v, struct_compat, struct_len, bl, __PRETTY_FUNCTION__); \
   do {
 
 #define DECODE_START_UNCHECKED(v, bl)					\
   __u8 struct_v, struct_compat;						\
-  using ::ceph::decode;							\
-  decode(struct_v, bl);						\
-  decode(struct_compat, bl);						\
-  if (v < struct_compat)						\
-    throw ::ceph::buffer::malformed_input(DECODE_ERR_NO_COMPAT(__PRETTY_FUNCTION__, v, struct_v, struct_compat)); \
   __u32 struct_len;							\
-  decode(struct_len, bl);						\
-  if (struct_len > bl.get_remaining())					\
-    throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
-  unsigned struct_end = bl.get_off() + struct_len;			\
+  using ::ceph::decode;							\
+  unsigned struct_end = ::ceph::encoding_detail::decode_struct_start( \
+    v, struct_v, struct_compat, struct_len, bl, __PRETTY_FUNCTION__); \
   do {
 
 #define DECODE_UNKNOWN(payload, bl)					\
   do {                                                                  \
-    __u8 struct_v, struct_compat;					\
-    using ::ceph::decode;						\
-    decode(struct_v, bl);						\
-    decode(struct_compat, bl);						\
-    __u32 struct_len;							\
-    decode(struct_len, bl);						\
-    if (struct_len > bl.get_remaining())				\
-      throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
-    payload.clear();                                                    \
-    using ::ceph::encode;						\
-    encode(struct_v, payload);                                          \
-    encode(struct_compat, payload);                                     \
-    encode(struct_len, payload);                                        \
-    bl.copy(struct_len, payload);                                       \
+    ::ceph::encoding_detail::decode_unknown(                           \
+      payload, bl, __PRETTY_FUNCTION__);                               \
   } while (0)
 
-/* BEWARE: any change to this macro MUST be also reflected in the duplicative
- * DECODE_START_LEGACY_COMPAT_LEN! */
+/* The checked and unchecked legacy wrappers intentionally differ only in the
+ * local struct_v type. Keep shared behavior in decode_legacy_struct_start(). */
 #define __DECODE_START_LEGACY_COMPAT_LEN(_v, compatv, lenv, skip_v, bl)	\
   using ::ceph::decode;							\
   StructVChecker<_v> struct_v;						\
-  decode(struct_v.v, bl);						\
-  if (struct_v.v >= compatv) {						\
-    __u8 struct_compat;							\
-    decode(struct_compat, bl);					\
-    if (_v < struct_compat)						\
-      throw ::ceph::buffer::malformed_input(DECODE_ERR_NO_COMPAT(__PRETTY_FUNCTION__, _v, struct_v.v, struct_compat)); \
-  } else if (skip_v) {							\
-    if (bl.get_remaining() < skip_v)					\
-      throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
-    bl +=  skip_v;							\
-  }									\
-  unsigned struct_end = 0;						\
-  if (struct_v.v >= lenv) {						\
-    __u32 struct_len;							\
-    decode(struct_len, bl);						\
-    if (struct_len > bl.get_remaining())				\
-      throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
-    struct_end = bl.get_off() + struct_len;				\
-  }									\
+  unsigned struct_end = ::ceph::encoding_detail::decode_legacy_struct_start( \
+    _v, struct_v.v, compatv, lenv, skip_v, bl, __PRETTY_FUNCTION__);	\
   do {
 
 /**
@@ -1582,28 +1761,11 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
  * @param bl bufferlist::iterator containing the encoded data
  */
 
-/* BEWARE: this is duplication of __DECODE_START_LEGACY_COMPAT_LEN which
- * MUST be changed altogether. For the rationale behind code duplication,
- * please `git blame` and refer to the commit message. */
 #define DECODE_START_LEGACY_COMPAT_LEN(v, compatv, lenv, bl)		\
   using ::ceph::decode;							\
   __u8 struct_v;							\
-  decode(struct_v, bl);							\
-  if (struct_v >= compatv) {						\
-    __u8 struct_compat;							\
-    decode(struct_compat, bl);						\
-    if (v < struct_compat)						\
-      throw ::ceph::buffer::malformed_input(DECODE_ERR_NO_COMPAT(	\
-	__PRETTY_FUNCTION__, v, struct_v, struct_compat));		\
-  }									\
-  unsigned struct_end = 0;						\
-  if (struct_v >= lenv) {						\
-    __u32 struct_len;							\
-    decode(struct_len, bl);						\
-    if (struct_len > bl.get_remaining())				\
-      throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
-    struct_end = bl.get_off() + struct_len;				\
-  }									\
+  unsigned struct_end = ::ceph::encoding_detail::decode_legacy_struct_start( \
+    v, struct_v, compatv, lenv, 0, bl, __PRETTY_FUNCTION__);		\
   do {
 
 /**
@@ -1636,12 +1798,8 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
  */
 #define DECODE_FINISH(bl)						\
   } while (false);							\
-  if (struct_end) {							\
-    if (bl.get_off() > struct_end)					\
-      throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
-    if (bl.get_off() < struct_end)					\
-      bl += struct_end - bl.get_off();					\
-  }
+  ::ceph::encoding_detail::finish_decode_struct(		\
+    bl, struct_end, __PRETTY_FUNCTION__);
 
 namespace ceph {
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -105,7 +105,6 @@ using ceph::bufferlist;
 using ceph::bufferptr;
 using ceph::Formatter;
 using ceph::decode;
-using ceph::decode_noclear;
 using ceph::encode;
 using ceph::encode_destructively;
 
@@ -4650,8 +4649,7 @@ void PrimaryLogPG::do_scan(
       auto p = m->get_data().cbegin();
 
       // take care to preserve ordering!
-      bi.clear_objects();
-      decode_noclear(bi.objects, p);
+      decode(bi.objects, p);
       dout(10) << __func__ << " bi.begin=" << bi.begin << " bi.end=" << bi.end
                << " bi.objects.size()=" << bi.objects.size() << dendl;
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -105,7 +105,6 @@ using ceph::bufferlist;
 using ceph::bufferptr;
 using ceph::Formatter;
 using ceph::decode;
-using ceph::decode_noclear;
 using ceph::encode;
 using ceph::encode_destructively;
 
@@ -4665,8 +4664,7 @@ void PrimaryLogPG::do_scan(
       auto p = m->get_data().cbegin();
 
       // take care to preserve ordering!
-      bi.clear_objects();
-      decode_noclear(bi.objects, p);
+      decode(bi.objects, p);
       dout(10) << __func__ << " bi.begin=" << bi.begin << " bi.end=" << bi.end
                << " bi.objects.size()=" << bi.objects.size() << dendl;
 

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -5906,11 +5906,6 @@ int RGWRados::restore_obj_from_cloud(RGWLCCloudTierCtx& tier_ctx,
   void (*progress_cb)(off_t, void *) = NULL;
   void *progress_data = NULL;
   bool cb_processed = false;
-  RGWFetchObjFilter *filter;
-  RGWFetchObjFilter_Default source_filter;
-  if (!filter) {
-    filter = &source_filter;
-  }
   boost::optional<RGWPutObj_Compress> compressor;
   CompressorRef plugin;
   rgw_placement_rule dest_placement(dest_bucket_info.placement_rule, tier_ctx.restore_storage_class);

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -5900,11 +5900,6 @@ int RGWRados::restore_obj_from_cloud(RGWLCCloudTierCtx& tier_ctx,
   void (*progress_cb)(off_t, void *) = NULL;
   void *progress_data = NULL;
   bool cb_processed = false;
-  RGWFetchObjFilter *filter;
-  RGWFetchObjFilter_Default source_filter;
-  if (!filter) {
-    filter = &source_filter;
-  }
   boost::optional<RGWPutObj_Compress> compressor;
   CompressorRef plugin;
   rgw_placement_rule dest_placement(dest_bucket_info.placement_rule, tier_ctx.restore_storage_class);

--- a/src/rgw/rgw_cksum_pipe.h
+++ b/src/rgw/rgw_cksum_pipe.h
@@ -119,7 +119,7 @@ namespace rgw::putobj {
   using GetHeaderCksumResult = std::pair<cksum::Cksum, std::string_view>;
 
   static inline GetHeaderCksumResult get_hdr_cksum(const RGWEnv& env) {
-    cksum::Type cksum_type;
+    cksum::Type cksum_type{cksum::Type::none};
     auto algo_hdr = cksum_algorithm_hdr(env);
     if (algo_hdr.first) {
       if (algo_hdr.second) {

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3804,7 +3804,7 @@ void RGWRestoreObj_ObjStore_S3::send_response()
     } else if (st == rgw::sal::RGWRestoreStatus::CloudRestored) {
       rgw::sal::Attrs attrs;
       ceph::real_time expiration_date;
-      rgw::sal::RGWRestoreType rt;
+      rgw::sal::RGWRestoreType rt = rgw::sal::RGWRestoreType::None;
       attrs = s->object->get_attrs();
       auto expire_iter = attrs.find(RGW_ATTR_RESTORE_EXPIRY_DATE);
       auto type_iter = attrs.find(RGW_ATTR_RESTORE_TYPE);

--- a/src/test/encoding.cc
+++ b/src/test/encoding.cc
@@ -1,22 +1,53 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2026 International Business Machines Corp. (IBM)
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
 #include "include/buffer.h"
 #include "include/encoding.h"
 
 #include <fmt/format.h>
 #include "gtest/gtest.h"
 
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cstdint>
+#include <functional>
 #include <iostream> // for std::cout
+#include <list>
+#include <map>
+#include <memory>
+#include <set>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <boost/container/flat_map.hpp>
+#include <boost/container/flat_set.hpp>
+#include <boost/container/small_vector.hpp>
+#include <boost/optional.hpp>
+#include <boost/tuple/tuple.hpp>
 
 using namespace std;
 
 template < typename T >
 static void test_encode_and_decode(const T& src)
 {
-  bufferlist bl(1000000);
+  buffer::list bl(1000000);
   encode(src, bl);
   T dst;
   auto i = bl.cbegin();
   decode(dst, i);
-  ASSERT_EQ(src, dst) << "Encoding roundtrip changed the string: orig=" << src << ", but new=" << dst;
+  ASSERT_EQ(src, dst)
+    << "Encoding roundtrip changed the string: orig=" << src
+    << ", but new=" << dst;
 }
 
 TEST(EncodingRoundTrip, StringSimple) {
@@ -37,14 +68,16 @@ TEST(EncodingRoundTrip, StringNewline) {
 template <typename Size, typename T>
 static void test_encode_and_nohead_nohead(Size len, const T& src)
 {
-  bufferlist bl(1000000);
+  buffer::list bl(1000000);
   encode(len, bl);
   encode_nohead(src, bl);
   T dst;
   auto i = bl.cbegin();
   decode(len, i);
   decode_nohead(len, dst, i);
-  ASSERT_EQ(src, dst) << "Encoding roundtrip changed the string: orig=" << src << ", but new=" << dst;
+  ASSERT_EQ(src, dst)
+    << "Encoding roundtrip changed the string: orig=" << src
+    << ", but new=" << dst;
 }
 
 TEST(EncodingRoundTrip, StringNoHead) {
@@ -58,7 +91,7 @@ TEST(EncodingRoundTrip, StringNoHead) {
 }
 
 TEST(EncodingRoundTrip, BufferListNoHead) {
-  bufferlist bl;
+  buffer::list bl;
   bl.append("is this a dagger which i see before me?");
   auto size = bl.length();
   test_encode_and_nohead_nohead(static_cast<int>(size), bl);
@@ -166,12 +199,12 @@ public:
     return data == rhs.data;
   }
 
-  friend void decode(ConstructorCounter &s, bufferlist::const_iterator& p)
+  friend void decode(ConstructorCounter &s, buffer::list::const_iterator& p)
   {
     decode(s.data, p);
   }
 
-  friend void encode(const ConstructorCounter &s, bufferlist& p)
+  friend void encode(const ConstructorCounter &s, buffer::list& p)
   {
     encode(s.data, p);
   }
@@ -226,15 +259,15 @@ TEST(EncodingRoundTrip, MultimapConstructorCounter) {
   my_val_t::init();
   test_encode_and_decode < multimap2_t >(multimap2);
 
-  EXPECT_EQ(my_key_t::get_default_ctor(), 5);
-  EXPECT_EQ(my_key_t::get_one_arg_ctor(), 0);
-  EXPECT_EQ(my_key_t::get_copy_ctor(), 5);
-  EXPECT_EQ(my_key_t::get_assigns(), 0);
+  EXPECT_EQ(5, my_key_t::get_default_ctor());
+  EXPECT_EQ(0, my_key_t::get_one_arg_ctor());
+  EXPECT_EQ(5, my_key_t::get_copy_ctor());
+  EXPECT_EQ(0, my_key_t::get_assigns());
 
-  EXPECT_EQ(my_val_t::get_default_ctor(), 5);
-  EXPECT_EQ(my_val_t::get_one_arg_ctor(), 0);
-  EXPECT_EQ(my_val_t::get_copy_ctor(), 5);
-  EXPECT_EQ(my_val_t::get_assigns(), 0);
+  EXPECT_EQ(5, my_val_t::get_default_ctor());
+  EXPECT_EQ(0, my_val_t::get_one_arg_ctor());
+  EXPECT_EQ(5, my_val_t::get_copy_ctor());
+  EXPECT_EQ(0, my_val_t::get_assigns());
 }
 
 namespace ceph {
@@ -244,26 +277,26 @@ namespace ceph {
 // include/denc.h
 template<>
 void encode<uint64_t, denc_traits<uint64_t>>(const uint64_t&,
-                                             bufferlist&,
-                                             uint64_t f) {
+                                             buffer::list&,
+                                             uint64_t features) {
   static_assert(denc_traits<uint64_t>::supported,
                 "should support new encoder");
   static_assert(!denc_traits<uint64_t>::featured,
                 "should not be featured");
-  ASSERT_EQ(0UL, f);
+  ASSERT_EQ(0UL, features);
   // make sure the test fails if i get called
   ASSERT_TRUE(false);
 }
 
 template<>
 void encode<ceph_le64, denc_traits<ceph_le64>>(const ceph_le64&,
-                                               bufferlist&,
-                                               uint64_t f) {
+                                               buffer::list&,
+                                               uint64_t features) {
   static_assert(denc_traits<ceph_le64>::supported,
                 "should support new encoder");
   static_assert(!denc_traits<ceph_le64>::featured,
                 "should not be featured");
-  ASSERT_EQ(0UL, f);
+  ASSERT_EQ(0UL, features);
   // make sure the test fails if i get called
   ASSERT_TRUE(false);
 }
@@ -342,7 +375,7 @@ TEST(EncodingException, Macros) {
     try {
       throw exec;
     } catch (const exception& e) {
-      ASSERT_NE(string(e.what()).find(expected_what), string::npos);
+      ASSERT_NE(string::npos, string(e.what()).find(expected_what));
     }
   }
 }
@@ -378,7 +411,7 @@ TEST(small_encoding, varint) {
   };
   for (unsigned i=0; v[i][1]; ++i) {
     {
-      bufferlist bl;
+      buffer::list bl;
       {
          auto app = bl.get_contiguous_appender(16, true);
          denc_varint(v[i][0], app);
@@ -386,14 +419,14 @@ TEST(small_encoding, varint) {
       cout << std::hex << v[i][0] << "\t" << v[i][1] << "\t";
       bl.hexdump(cout, false);
       cout << std::endl;
-      ASSERT_EQ(bl.length(), v[i][1]);
+      ASSERT_EQ(v[i][1], bl.length());
       uint32_t u;
       auto p = bl.begin().get_current_ptr().cbegin();
       denc_varint(u, p);
       ASSERT_EQ(v[i][0], u);
     }
     {
-      bufferlist bl;
+      buffer::list bl;
       {
          auto app = bl.get_contiguous_appender(16, true);
          denc_signed_varint(v[i][0], app);
@@ -401,14 +434,14 @@ TEST(small_encoding, varint) {
       cout << std::hex << v[i][0] << "\t" << v[i][2] << "\t";
       bl.hexdump(cout, false);
       cout << std::endl;
-      ASSERT_EQ(bl.length(), v[i][2]);
+      ASSERT_EQ(v[i][2], bl.length());
       int32_t u;
       auto p = bl.begin().get_current_ptr().cbegin();
       denc_signed_varint(u, p);
       ASSERT_EQ((int32_t)v[i][0], u);
     }
     {
-      bufferlist bl;
+      buffer::list bl;
       int64_t x = -(int64_t)v[i][0];
       {
          auto app = bl.get_contiguous_appender(16, true);
@@ -417,7 +450,7 @@ TEST(small_encoding, varint) {
       cout << std::dec << x << std::hex << "\t" << v[i][3] << "\t";
       bl.hexdump(cout, false);
       cout << std::endl;
-      ASSERT_EQ(bl.length(), v[i][3]);
+      ASSERT_EQ(v[i][3], bl.length());
       int64_t u;
       auto p = bl.begin().get_current_ptr().cbegin();
       denc_signed_varint(u, p);
@@ -456,7 +489,7 @@ TEST(small_encoding, varint_lowz) {
   };
   for (unsigned i=0; v[i][1]; ++i) {
     {
-      bufferlist bl;
+      buffer::list bl;
       {
          auto app = bl.get_contiguous_appender(16, true);
          denc_varint_lowz(v[i][0], app);
@@ -464,14 +497,14 @@ TEST(small_encoding, varint_lowz) {
       cout << std::hex << v[i][0] << "\t" << v[i][1] << "\t";
       bl.hexdump(cout, false);
       cout << std::endl;
-      ASSERT_EQ(bl.length(), v[i][1]);
+      ASSERT_EQ(v[i][1], bl.length());
       uint32_t u;
       auto p = bl.begin().get_current_ptr().cbegin();
       denc_varint_lowz(u, p);
       ASSERT_EQ(v[i][0], u);
     }
     {
-      bufferlist bl;
+      buffer::list bl;
       int64_t x = v[i][0];
       {
          auto app = bl.get_contiguous_appender(16, true);
@@ -480,14 +513,14 @@ TEST(small_encoding, varint_lowz) {
       cout << std::hex << x << "\t" << v[i][1] << "\t";
       bl.hexdump(cout, false);
       cout << std::endl;
-      ASSERT_EQ(bl.length(), v[i][2]);
+      ASSERT_EQ(v[i][2], bl.length());
       int64_t u;
       auto p = bl.begin().get_current_ptr().cbegin();
       denc_signed_varint_lowz(u, p);
       ASSERT_EQ(x, u);
     }
     {
-      bufferlist bl;
+      buffer::list bl;
       int64_t x = -(int64_t)v[i][0];
       {
          auto app = bl.get_contiguous_appender(16, true);
@@ -496,7 +529,7 @@ TEST(small_encoding, varint_lowz) {
       cout << std::dec << x << "\t" << v[i][1] << "\t";
       bl.hexdump(cout, false);
       cout << std::endl;
-      ASSERT_EQ(bl.length(), v[i][3]);
+      ASSERT_EQ(v[i][3], bl.length());
       int64_t u;
       auto p = bl.begin().get_current_ptr().cbegin();
       denc_signed_varint_lowz(u, p);
@@ -527,7 +560,7 @@ TEST(small_encoding, lba) {
     {0, 0}
   };
   for (unsigned i=0; v[i][1]; ++i) {
-    bufferlist bl;
+    buffer::list bl;
     {
        auto app = bl.get_contiguous_appender(16, true);
        denc_lba(v[i][0], app);
@@ -535,11 +568,1048 @@ TEST(small_encoding, lba) {
     cout << std::hex << v[i][0] << "\t" << v[i][1] << "\t";
     bl.hexdump(cout, false);
     cout << std::endl;
-    ASSERT_EQ(bl.length(), v[i][1]);
+    ASSERT_EQ(v[i][1], bl.length());
     uint64_t u;
     auto p = bl.begin().get_current_ptr().cbegin();
     denc_lba(u, p);
     ASSERT_EQ(v[i][0], u);
   }
 
+}
+
+/*
+ * encoding.h Compatibility Coverage
+ *
+ * New tests for interface-preserving modernization of
+ * include/encoding.h belong below this section.
+ */
+
+namespace {
+
+struct encoding_compat_record final {
+  uint32_t n = 0;
+  std::string s;
+
+  static inline uint64_t last_features = 0;
+  static inline unsigned feature_encode_calls = 0;
+
+  static void reset_counters()
+  {
+    last_features = 0;
+    feature_encode_calls = 0;
+  }
+
+  friend bool operator==(const encoding_compat_record& lhs,
+                         const encoding_compat_record& rhs)
+  {
+    return lhs.n == rhs.n && lhs.s == rhs.s;
+  }
+
+  friend bool operator<(const encoding_compat_record& lhs,
+                        const encoding_compat_record& rhs)
+  {
+    return std::tie(lhs.n, lhs.s) < std::tie(rhs.n, rhs.s);
+  }
+
+  friend void encode(const encoding_compat_record& v, buffer::list& bl)
+  {
+    encode(v.n, bl);
+    encode(v.s, bl);
+  }
+
+  friend void encode(const encoding_compat_record& v,
+                     buffer::list& bl,
+                     uint64_t features)
+  {
+    last_features = features;
+    ++feature_encode_calls;
+    encode(v, bl);
+  }
+
+  friend void decode(encoding_compat_record& v, buffer::list::const_iterator& p)
+  {
+    decode(v.n, p);
+    decode(v.s, p);
+  }
+
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const encoding_compat_record& v)
+  {
+    return os << "{n=" << v.n << ", s=" << v.s << "}";
+  }
+};
+
+struct encoding_compat_record_hash final {
+  std::size_t operator()(const encoding_compat_record& v) const
+  {
+    return std::hash<uint32_t> {}(v.n) ^ (std::hash<std::string> {}(v.s) << 1);
+  }
+};
+
+struct immovable_decoded_value final {
+  uint32_t n = 0;
+
+  immovable_decoded_value() = default;
+  immovable_decoded_value(const immovable_decoded_value&) = delete;
+  immovable_decoded_value& operator=(const immovable_decoded_value&) = delete;
+  immovable_decoded_value(immovable_decoded_value&&) = delete;
+  immovable_decoded_value& operator=(immovable_decoded_value&&) = delete;
+
+  friend void encode(const immovable_decoded_value& v, buffer::list& bl)
+  {
+    encode(v.n, bl);
+  }
+
+  friend void decode(immovable_decoded_value& v,
+                     buffer::list::const_iterator& p)
+  {
+    decode(v.n, p);
+  }
+};
+
+struct encoding_compat_v1_record final {
+  uint32_t n = 0;
+  std::string s;
+
+  void decode(buffer::list::const_iterator& p)
+  {
+    DECODE_START(1, p);
+    decode(n, p);
+    decode(s, p);
+    DECODE_FINISH(p);
+  }
+
+  friend bool operator==(const encoding_compat_v1_record& lhs,
+                         const encoding_compat_v1_record& rhs)
+  {
+    return lhs.n == rhs.n && lhs.s == rhs.s;
+  }
+};
+
+struct encoding_compat_v2_record final {
+  uint32_t n = 0;
+  std::string s;
+  std::string extra;
+
+  void encode(buffer::list& bl) const
+  {
+    ENCODE_START(2, 1, bl);
+    encode(n, bl);
+    encode(s, bl);
+    encode(extra, bl);
+    ENCODE_FINISH(bl);
+  }
+};
+
+struct encoding_macro_record final {
+  __u8 value = 0;
+
+  void encode(buffer::list& bl) const
+  {
+    ENCODE_START(1, 1, bl);
+    encode(value, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(buffer::list::const_iterator& p)
+  {
+    DECODE_START(1, p);
+    decode(value, p);
+    DECODE_FINISH(p);
+  }
+};
+
+struct encoding_new_compat_record final {
+  __u8 value = 0;
+
+  void encode(buffer::list& bl) const
+  {
+    ENCODE_START(1, 1, bl);
+    encode(value, bl);
+    ENCODE_FINISH_NEW_COMPAT(bl, 2);
+  }
+};
+
+static const encoding_compat_record alpha { 1, "alpha" };
+static const encoding_compat_record bravo { 2, "bravo" };
+static const encoding_compat_record bravo_alt { 2, "bravo-alt" };
+static const encoding_compat_record charlie { 3, "charlie" };
+
+template <typename T>
+T encoding_compat_round_trip(const T& src)
+{
+  buffer::list bl;
+  encode(src, bl);
+
+  T dst;
+  auto p = bl.cbegin();
+  decode(dst, p);
+
+  EXPECT_TRUE(p.end());
+  return dst;
+}
+
+template <typename T>
+void expect_encoding_compat_round_trip(const T& src)
+{
+  EXPECT_EQ(src, encoding_compat_round_trip(src));
+}
+
+template <typename T>
+void expect_encoding_compat_nohead_round_trip(const T& src, unsigned n)
+{
+  buffer::list bl;
+  encode_nohead(src, bl);
+
+  T dst;
+  auto p = bl.cbegin();
+  decode_nohead(n, dst, p);
+
+  EXPECT_TRUE(p.end());
+  EXPECT_EQ(src, dst);
+}
+
+template <typename T>
+void expect_nohead_decode_replaces_existing(const T& src, T dst)
+{
+  buffer::list bl;
+  encode_nohead(src, bl);
+
+  auto p = bl.cbegin();
+  decode_nohead(src.size(), dst, p);
+
+  EXPECT_TRUE(p.end());
+  EXPECT_EQ(src, dst);
+}
+
+void append_compat_le32(std::string& out, uint32_t v)
+{
+  for (unsigned i = 0; i < 4; ++i) {
+    out.push_back(static_cast<char>(v >> (i * 8)));
+  }
+}
+
+void append_compat_le64(std::string& out, uint64_t v)
+{
+  for (unsigned i = 0; i < 8; ++i) {
+    out.push_back(static_cast<char>(v >> (i * 8)));
+  }
+}
+
+std::string float_wire_bytes(uint32_t raw)
+{
+  auto out = std::string {};
+  append_compat_le32(out, raw);
+  return out;
+}
+
+std::string float_wire_bytes(uint64_t raw)
+{
+  auto out = std::string {};
+  append_compat_le64(out, raw);
+  return out;
+}
+
+void expect_float_wire_format(float v, uint32_t raw)
+{
+  buffer::list bl;
+  encode(v, bl);
+
+  EXPECT_EQ(float_wire_bytes(raw), bl.to_str());
+
+  float out = 0;
+  auto p = bl.cbegin();
+  decode(out, p);
+
+  EXPECT_TRUE(p.end());
+  EXPECT_EQ(raw, std::bit_cast<uint32_t>(out));
+}
+
+void expect_float_wire_format(double v, uint64_t raw)
+{
+  buffer::list bl;
+  encode(v, bl);
+
+  EXPECT_EQ(float_wire_bytes(raw), bl.to_str());
+
+  double out = 0;
+  auto p = bl.cbegin();
+  decode(out, p);
+
+  EXPECT_TRUE(p.end());
+  EXPECT_EQ(raw, std::bit_cast<uint64_t>(out));
+}
+
+void append_compat_string(std::string& out, std::string_view v)
+{
+  append_compat_le32(out, v.size());
+  out.append(v);
+}
+
+void append_compat_record(std::string& out, const encoding_compat_record& v)
+{
+  append_compat_le32(out, v.n);
+  append_compat_string(out, v.s);
+}
+
+void encode_macro_header(buffer::list& bl, __u8 struct_v,
+                         __u8 struct_compat, __u32 struct_len)
+{
+  encode(struct_v, bl);
+  encode(struct_compat, bl);
+  encode(struct_len, bl);
+}
+
+void decode_macro_overread(buffer::list::const_iterator& p)
+{
+  DECODE_START(1, p);
+  p += 2;
+  DECODE_FINISH(p);
+}
+
+void decode_macro_unknown(buffer::list& payload,
+                          buffer::list::const_iterator& p)
+{
+  DECODE_UNKNOWN(payload, p);
+}
+
+std::pair<__u8, __u32> decode_unchecked_macro_header(buffer::list::const_iterator& p)
+{
+  DECODE_START_UNCHECKED(3, p);
+  DECODE_FINISH(p);
+
+  return { struct_v, struct_len };
+}
+
+__u8 decode_legacy_macro_value(buffer::list::const_iterator& p)
+{
+  __u8 value = 0;
+
+  DECODE_START_LEGACY_COMPAT_LEN(2, 2, 2, p);
+  decode(value, p);
+  DECODE_FINISH(p);
+
+  return value;
+}
+
+__u8 decode_legacy_macro_value_16(buffer::list::const_iterator& p)
+{
+  __u8 value = 0;
+
+  DECODE_START_LEGACY_COMPAT_LEN_16(2, 2, 2, p);
+  decode(value, p);
+  DECODE_FINISH(p);
+
+  return value;
+}
+
+__u8 decode_legacy_macro_value_32(buffer::list::const_iterator& p)
+{
+  __u8 value = 0;
+
+  DECODE_START_LEGACY_COMPAT_LEN_32(2, 2, 2, p);
+  decode(value, p);
+  DECODE_FINISH(p);
+
+  return value;
+}
+
+template <typename T>
+std::string encode_compat_to_string(const T& v)
+{
+  buffer::list bl;
+  encode(v, bl);
+  return bl.to_str();
+}
+
+template <typename T>
+void expect_compat_wire_format(const T& v, std::string_view expected)
+{
+  EXPECT_EQ(expected, encode_compat_to_string(v));
+}
+
+template <typename T>
+void expect_feature_compat_wire_format(const T& v, std::string_view expected)
+{
+  buffer::list bl;
+  encode(v, bl, 123);
+
+  EXPECT_EQ(expected, bl.to_str());
+}
+
+template <typename T>
+void expect_feature_encode_calls(const T& v, std::size_t expected_calls)
+{
+  buffer::list bl;
+
+  encoding_compat_record::reset_counters();
+  encode(v, bl, 123);
+
+  EXPECT_EQ(uint64_t { 123 }, encoding_compat_record::last_features);
+  EXPECT_EQ(expected_calls, encoding_compat_record::feature_encode_calls);
+}
+
+template <std::ranges::sized_range RangeT>
+buffer::list make_decode_noclear_payload(const RangeT& entries)
+{
+  auto bl = buffer::list {};
+  encode(static_cast<__u32>(std::ranges::size(entries)), bl);
+
+  std::ranges::for_each(entries, [&bl](const auto& item) {
+    encode(item.first, bl);
+    encode(item.second, bl);
+  });
+
+  return bl;
+}
+
+} // namespace
+
+TEST(EncodingCompatibility, LegacySequenceContainersRoundTrip)
+{
+  expect_encoding_compat_round_trip(
+    std::vector<encoding_compat_record> { alpha, bravo, charlie });
+  expect_encoding_compat_round_trip(
+    std::list<encoding_compat_record> { alpha, bravo, charlie });
+  expect_encoding_compat_round_trip(
+    std::deque<encoding_compat_record> { alpha, bravo, charlie });
+  expect_encoding_compat_round_trip(
+    boost::container::small_vector<encoding_compat_record, 4> {
+      alpha, bravo, charlie });
+  expect_encoding_compat_round_trip(
+    std::array<encoding_compat_record, 3> { alpha, bravo, charlie });
+}
+
+TEST(EncodingCompatibility, BufferTypesRoundTrip)
+{
+  bufferptr ptr_src("bufferptr-value", 15);
+  auto ptr_dst = encoding_compat_round_trip(ptr_src);
+
+  ASSERT_EQ(ptr_src.length(), ptr_dst.length());
+  EXPECT_EQ(std::string_view(ptr_src.c_str(), ptr_src.length()),
+            std::string_view(ptr_dst.c_str(), ptr_dst.length()));
+
+  buffer::list list_src;
+  list_src.append("first-", 6);
+  list_src.append("second", 6);
+  auto list_dst = encoding_compat_round_trip(list_src);
+
+  EXPECT_EQ(list_src.length(), list_dst.length());
+  EXPECT_EQ(list_src.to_str(), list_dst.to_str());
+}
+
+TEST(EncodingCompatibility, FloatingPointWireFormat)
+{
+  expect_float_wire_format(std::bit_cast<float>(uint32_t { 0x00000000 }),
+                           uint32_t { 0x00000000 });
+  expect_float_wire_format(std::bit_cast<float>(uint32_t { 0x80000000 }),
+                           uint32_t { 0x80000000 });
+  expect_float_wire_format(std::bit_cast<float>(uint32_t { 0x3f800000 }),
+                           uint32_t { 0x3f800000 });
+  expect_float_wire_format(std::bit_cast<float>(uint32_t { 0x3dfbe76d }),
+                           uint32_t { 0x3dfbe76d });
+  expect_float_wire_format(std::bit_cast<float>(uint32_t { 0x7fc00001 }),
+                           uint32_t { 0x7fc00001 });
+
+  expect_float_wire_format(std::bit_cast<double>(uint64_t { 0x0000000000000000 }),
+                           uint64_t { 0x0000000000000000 });
+  expect_float_wire_format(std::bit_cast<double>(uint64_t { 0x8000000000000000 }),
+                           uint64_t { 0x8000000000000000 });
+  expect_float_wire_format(std::bit_cast<double>(uint64_t { 0x3ff0000000000000 }),
+                           uint64_t { 0x3ff0000000000000 });
+  expect_float_wire_format(std::bit_cast<double>(uint64_t { 0x3fbf7ced916872b0 }),
+                           uint64_t { 0x3fbf7ced916872b0 });
+  expect_float_wire_format(std::bit_cast<double>(uint64_t { 0x7ff8000000000001 }),
+                           uint64_t { 0x7ff8000000000001 });
+}
+
+TEST(EncodingCompatibility, LegacySetContainersRoundTrip)
+{
+  expect_encoding_compat_round_trip(
+    std::set<encoding_compat_record> { alpha, bravo, charlie });
+  expect_encoding_compat_round_trip(
+    boost::container::flat_set<encoding_compat_record> { alpha, bravo, charlie });
+  expect_encoding_compat_round_trip(
+    std::multiset<encoding_compat_record> { alpha, bravo, bravo, charlie });
+  expect_encoding_compat_round_trip(
+    std::unordered_set<encoding_compat_record, encoding_compat_record_hash> {
+      alpha, bravo, charlie });
+}
+
+TEST(EncodingCompatibility, LegacyMapContainersRoundTrip)
+{
+  expect_encoding_compat_round_trip(
+    std::map<encoding_compat_record, encoding_compat_record> {
+      { alpha, bravo },
+      { bravo, charlie },
+    });
+  expect_encoding_compat_round_trip(
+    boost::container::flat_map<encoding_compat_record, encoding_compat_record> {
+      { alpha, bravo },
+      { bravo, charlie },
+    });
+  expect_encoding_compat_round_trip(
+    std::multimap<encoding_compat_record, encoding_compat_record> {
+      { alpha, bravo },
+      { alpha, bravo_alt },
+      { bravo, charlie },
+    });
+  expect_encoding_compat_round_trip(
+    std::unordered_map<encoding_compat_record,
+                       encoding_compat_record,
+                       encoding_compat_record_hash> {
+      { alpha, bravo },
+      { bravo, charlie },
+    });
+}
+
+TEST(EncodingCompatibility, MapDecodesImmovableMappedValues)
+{
+  std::map<uint32_t, immovable_decoded_value> src;
+  src[7].n = 11;
+  src[13].n = 17;
+
+  buffer::list bl;
+  encode(src, bl);
+
+  std::map<uint32_t, immovable_decoded_value> dst;
+  auto p = bl.cbegin();
+  decode(dst, p);
+
+  EXPECT_TRUE(p.end());
+  ASSERT_EQ(2u, dst.size());
+  EXPECT_EQ(11u, dst.at(7).n);
+  EXPECT_EQ(17u, dst.at(13).n);
+}
+
+TEST(EncodingCompatibility, DecodeNoClearMapPreservesImmovableMappedValues)
+{
+  std::map<uint32_t, immovable_decoded_value> src;
+  src[7].n = 11;
+  src[13].n = 17;
+
+  buffer::list bl;
+  encode(src, bl);
+
+  std::map<uint32_t, immovable_decoded_value> dst;
+  dst[7].n = 99;
+  dst[19].n = 23;
+
+  auto p = bl.cbegin();
+  decode_noclear(dst, p);
+
+  EXPECT_TRUE(p.end());
+  ASSERT_EQ(3u, dst.size());
+  EXPECT_EQ(99u, dst.at(7).n);
+  EXPECT_EQ(17u, dst.at(13).n);
+  EXPECT_EQ(23u, dst.at(19).n);
+}
+
+TEST(EncodingCompatibility, LegacyNoHeadRoundTrip)
+{
+  expect_encoding_compat_nohead_round_trip(
+    std::vector<encoding_compat_record> { alpha, bravo, charlie }, 3);
+  expect_encoding_compat_nohead_round_trip(
+    boost::container::small_vector<encoding_compat_record, 4> {
+      alpha, bravo, charlie }, 3);
+  expect_encoding_compat_nohead_round_trip(
+    std::set<encoding_compat_record> { alpha, bravo, charlie }, 3);
+  expect_encoding_compat_nohead_round_trip(
+    boost::container::flat_set<encoding_compat_record> {
+      alpha, bravo, charlie }, 3);
+  expect_encoding_compat_nohead_round_trip(
+    std::map<encoding_compat_record, encoding_compat_record> {
+      { alpha, bravo },
+      { bravo, charlie },
+    }, 2);
+  expect_encoding_compat_nohead_round_trip(
+    boost::container::flat_map<encoding_compat_record, encoding_compat_record> {
+      { alpha, bravo },
+      { bravo, charlie },
+    }, 2);
+}
+
+TEST(EncodingCompatibility, LegacyNoHeadDecodeClearsDestination)
+{
+  expect_nohead_decode_replaces_existing(
+    std::vector<encoding_compat_record> { alpha, bravo },
+    std::vector<encoding_compat_record> { charlie });
+  expect_nohead_decode_replaces_existing(
+    boost::container::small_vector<encoding_compat_record, 4> { alpha, bravo },
+    boost::container::small_vector<encoding_compat_record, 4> { charlie });
+  expect_nohead_decode_replaces_existing(
+    std::set<encoding_compat_record> { alpha, bravo },
+    std::set<encoding_compat_record> { charlie });
+  expect_nohead_decode_replaces_existing(
+    boost::container::flat_set<encoding_compat_record> { alpha, bravo },
+    boost::container::flat_set<encoding_compat_record> { charlie });
+  expect_nohead_decode_replaces_existing(
+    std::map<encoding_compat_record, encoding_compat_record> {
+      { alpha, bravo },
+    },
+    std::map<encoding_compat_record, encoding_compat_record> {
+      { charlie, alpha },
+    });
+  expect_nohead_decode_replaces_existing(
+    boost::container::flat_map<encoding_compat_record,
+                               encoding_compat_record> {
+      { alpha, bravo },
+    },
+    boost::container::flat_map<encoding_compat_record,
+                               encoding_compat_record> {
+      { charlie, alpha },
+    });
+}
+
+TEST(EncodingCompatibility, LegacySetNoHeadEncodingWireFormat)
+{
+  const std::set<encoding_compat_record> src { alpha, bravo };
+  std::string expected;
+  append_compat_record(expected, alpha);
+  append_compat_record(expected, bravo);
+
+  buffer::list bl;
+  encode_nohead(src, bl);
+
+  EXPECT_EQ(expected, bl.to_str());
+}
+
+TEST(EncodingCompatibility, LegacyFlatSetNoHeadEncodingWireFormat)
+{
+  const boost::container::flat_set<encoding_compat_record> src { alpha, bravo };
+  std::string expected;
+  append_compat_record(expected, alpha);
+  append_compat_record(expected, bravo);
+
+  buffer::list bl;
+  encode_nohead(src, bl);
+
+  EXPECT_EQ(expected, bl.to_str());
+}
+
+TEST(EncodingCompatibility, LegacyOptionalTupleAndPairRoundTrip)
+{
+  expect_encoding_compat_round_trip(
+    std::optional<encoding_compat_record> { alpha });
+  expect_encoding_compat_round_trip(
+    std::optional<encoding_compat_record> {});
+  expect_encoding_compat_round_trip(
+    boost::optional<encoding_compat_record> { bravo });
+  expect_encoding_compat_round_trip(
+    boost::optional<encoding_compat_record> {});
+  expect_encoding_compat_round_trip(
+    std::tuple<encoding_compat_record, std::string, uint32_t> {
+      alpha, "tuple", 7 });
+  expect_encoding_compat_round_trip(
+    std::pair<encoding_compat_record, encoding_compat_record> {
+      alpha, bravo });
+
+  buffer::list bl;
+  encode(std::string_view { "string-view" }, bl);
+
+  std::string string_view_out;
+  auto p = bl.cbegin();
+  decode(string_view_out, p);
+
+  EXPECT_TRUE(p.end());
+  EXPECT_EQ("string-view", string_view_out);
+
+  const auto src = boost::make_tuple(alpha, bravo, charlie);
+  const auto dst = encoding_compat_round_trip(src);
+  EXPECT_EQ(boost::get<0>(src), boost::get<0>(dst));
+  EXPECT_EQ(boost::get<1>(src), boost::get<1>(dst));
+  EXPECT_EQ(boost::get<2>(src), boost::get<2>(dst));
+}
+
+TEST(EncodingCompatibility, SharedPtrContainersRoundTrip)
+{
+  using compat_ptr = std::shared_ptr<encoding_compat_record>;
+
+  const std::list<compat_ptr> list_src {
+    std::make_shared<encoding_compat_record>(alpha),
+    nullptr,
+    std::make_shared<encoding_compat_record>(bravo),
+  };
+  auto list_dst = encoding_compat_round_trip(list_src);
+
+  ASSERT_EQ(list_src.size(), list_dst.size());
+  auto list_it = list_dst.begin();
+  ASSERT_TRUE(*list_it);
+  EXPECT_EQ(alpha, **list_it);
+  ++list_it;
+  ASSERT_TRUE(*list_it);
+  EXPECT_EQ(encoding_compat_record {}, **list_it);
+  ++list_it;
+  ASSERT_TRUE(*list_it);
+  EXPECT_EQ(bravo, **list_it);
+
+  const std::vector<compat_ptr> vector_src {
+    std::make_shared<encoding_compat_record>(alpha),
+    nullptr,
+    std::make_shared<encoding_compat_record>(bravo),
+  };
+  auto vector_dst = encoding_compat_round_trip(vector_src);
+
+  ASSERT_EQ(vector_src.size(), vector_dst.size());
+  ASSERT_TRUE(vector_dst[0]);
+  ASSERT_TRUE(vector_dst[1]);
+  ASSERT_TRUE(vector_dst[2]);
+  EXPECT_EQ(alpha, *vector_dst[0]);
+  EXPECT_EQ(encoding_compat_record {}, *vector_dst[1]);
+  EXPECT_EQ(bravo, *vector_dst[2]);
+}
+
+TEST(EncodingCompatibility, FeatureEncodingPropagatesToLegacyContainerElements)
+{
+  expect_feature_encode_calls(
+    std::vector<encoding_compat_record> { alpha, bravo, charlie }, 3);
+  expect_feature_encode_calls(
+    std::list<encoding_compat_record> { alpha, bravo, charlie }, 3);
+  expect_feature_encode_calls(
+    std::deque<encoding_compat_record> { alpha, bravo, charlie }, 3);
+  expect_feature_encode_calls(
+    boost::container::small_vector<encoding_compat_record, 4> {
+      alpha, bravo, charlie }, 3);
+  expect_feature_encode_calls(
+    std::array<encoding_compat_record, 3> { alpha, bravo, charlie }, 3);
+  expect_feature_encode_calls(
+    std::map<encoding_compat_record, encoding_compat_record> {
+      { alpha, bravo },
+      { bravo, charlie },
+    }, 4);
+  expect_feature_encode_calls(
+    boost::container::flat_map<encoding_compat_record, encoding_compat_record> {
+      { alpha, bravo },
+      { bravo, charlie },
+    }, 4);
+  expect_feature_encode_calls(
+    std::unordered_map<encoding_compat_record,
+                       encoding_compat_record,
+                       encoding_compat_record_hash> {
+      { alpha, bravo },
+      { bravo, charlie },
+    }, 4);
+  expect_feature_encode_calls(
+    std::vector<std::shared_ptr<encoding_compat_record>> {
+      std::make_shared<encoding_compat_record>(alpha),
+      nullptr,
+      std::make_shared<encoding_compat_record>(bravo),
+    }, 3);
+}
+
+TEST(EncodingCompatibility, DecodeNoClearMapPreservesDuplicateKeys)
+{
+  const std::map<encoding_compat_record, encoding_compat_record> src {
+    { alpha, bravo },
+  };
+  buffer::list bl;
+  encode(src, bl);
+
+  std::map<encoding_compat_record, encoding_compat_record> dst {
+    { alpha, charlie },
+    { charlie, alpha },
+  };
+  auto p = bl.cbegin();
+  decode_noclear(dst, p);
+
+  EXPECT_TRUE(p.end());
+  EXPECT_EQ(charlie, dst.at(alpha));
+  EXPECT_EQ(alpha, dst.at(charlie));
+}
+
+TEST(EncodingCompatibility, DecodeNoClearFlatMapReplacesDuplicateKeys)
+{
+  const boost::container::flat_map<encoding_compat_record,
+                                  encoding_compat_record> src {
+    { alpha, bravo },
+  };
+  buffer::list bl;
+  encode(src, bl);
+
+  boost::container::flat_map<encoding_compat_record,
+                             encoding_compat_record> dst {
+    { alpha, charlie },
+    { charlie, alpha },
+  };
+  auto p = bl.cbegin();
+  decode_noclear(dst, p);
+
+  EXPECT_TRUE(p.end());
+  EXPECT_EQ(bravo, dst.at(alpha));
+  EXPECT_EQ(alpha, dst.at(charlie));
+}
+
+TEST(EncodingCompatibility, DecodeNoClearPrimitiveMapPreservesDuplicateKeys)
+{
+  const auto entries = std::array {
+    std::pair { uint64_t { 7 }, std::bit_cast<float>(uint32_t { 0x3f800000 }) },
+    std::pair { uint64_t { 11 }, std::bit_cast<float>(uint32_t { 0x40000000 }) },
+  };
+  auto bl = make_decode_noclear_payload(entries);
+
+  std::map<uint64_t, float> dst {
+    { uint64_t { 7 }, std::bit_cast<float>(uint32_t { 0x40400000 }) },
+    { uint64_t { 13 }, std::bit_cast<float>(uint32_t { 0x40800000 }) },
+  };
+  auto p = bl.cbegin();
+  decode_noclear(dst, p);
+
+  EXPECT_TRUE(p.end());
+  EXPECT_EQ(3u, dst.size());
+  EXPECT_EQ(uint32_t { 0x40400000 }, std::bit_cast<uint32_t>(dst.at(7)));
+  EXPECT_EQ(uint32_t { 0x40000000 }, std::bit_cast<uint32_t>(dst.at(11)));
+  EXPECT_EQ(uint32_t { 0x40800000 }, std::bit_cast<uint32_t>(dst.at(13)));
+}
+
+TEST(EncodingCompatibility, DecodeNoClearPrimitiveFlatMapReplacesDuplicateKeys)
+{
+  const auto entries = std::array {
+    std::pair { uint64_t { 7 }, std::bit_cast<float>(uint32_t { 0x3f800000 }) },
+    std::pair { uint64_t { 11 }, std::bit_cast<float>(uint32_t { 0x40000000 }) },
+  };
+  auto bl = make_decode_noclear_payload(entries);
+
+  boost::container::flat_map<uint64_t, float> dst {
+    { uint64_t { 7 }, std::bit_cast<float>(uint32_t { 0x40400000 }) },
+    { uint64_t { 13 }, std::bit_cast<float>(uint32_t { 0x40800000 }) },
+  };
+  auto p = bl.cbegin();
+  decode_noclear(dst, p);
+
+  EXPECT_TRUE(p.end());
+  EXPECT_EQ(3u, dst.size());
+  EXPECT_EQ(uint32_t { 0x3f800000 }, std::bit_cast<uint32_t>(dst.at(7)));
+  EXPECT_EQ(uint32_t { 0x40000000 }, std::bit_cast<uint32_t>(dst.at(11)));
+  EXPECT_EQ(uint32_t { 0x40800000 }, std::bit_cast<uint32_t>(dst.at(13)));
+}
+
+TEST(EncodingCompatibility, DecodeFinishSkipsUnknownTrailingFields)
+{
+  const encoding_compat_v2_record src { 7, "known", "unknown" };
+  buffer::list bl;
+  src.encode(bl);
+
+  encoding_compat_v1_record dst;
+  auto p = bl.cbegin();
+  dst.decode(p);
+
+  EXPECT_TRUE(p.end());
+  EXPECT_EQ((encoding_compat_v1_record { 7, "known" }), dst);
+}
+
+TEST(EncodingCompatibility, MacroDecodeRejectsNewerCompat)
+{
+  buffer::list bl;
+  encode_macro_header(bl, 2, 2, 0);
+
+  encoding_macro_record dst;
+  auto p = bl.cbegin();
+
+  EXPECT_THROW(dst.decode(p), buffer::malformed_input);
+}
+
+TEST(EncodingCompatibility, MacroDecodeRejectsShortPayload)
+{
+  buffer::list bl;
+  encode_macro_header(bl, 1, 1, 1);
+
+  encoding_macro_record dst;
+  auto p = bl.cbegin();
+
+  EXPECT_THROW(dst.decode(p), buffer::malformed_input);
+}
+
+TEST(EncodingCompatibility, MacroDecodeFinishSkipsUnreadBytes)
+{
+  buffer::list bl;
+  encode_macro_header(bl, 1, 1, 2);
+  encode(__u8 { 17 }, bl);
+  encode(__u8 { 19 }, bl);
+
+  encoding_macro_record dst;
+  auto p = bl.cbegin();
+  dst.decode(p);
+
+  EXPECT_TRUE(p.end());
+  EXPECT_EQ(__u8 { 17 }, dst.value);
+}
+
+TEST(EncodingCompatibility, MacroDecodeFinishRejectsOverread)
+{
+  buffer::list bl;
+  encode_macro_header(bl, 1, 1, 1);
+  encode(__u8 { 17 }, bl);
+  encode(__u8 { 19 }, bl);
+
+  auto p = bl.cbegin();
+
+  EXPECT_THROW(decode_macro_overread(p), buffer::malformed_input);
+}
+
+TEST(EncodingCompatibility, MacroDecodeUnknownPreservesEnvelope)
+{
+  const encoding_macro_record src { 42 };
+  buffer::list bl;
+  src.encode(bl);
+
+  buffer::list payload;
+  auto p = bl.cbegin();
+  decode_macro_unknown(payload, p);
+
+  EXPECT_TRUE(p.end());
+  EXPECT_EQ(bl.to_str(), payload.to_str());
+}
+
+TEST(EncodingCompatibility, MacroEncodeFinishNewCompatUpdatesEnvelope)
+{
+  const encoding_new_compat_record src { 43 };
+  buffer::list bl;
+  src.encode(bl);
+
+  encoding_macro_record dst;
+  auto p = bl.cbegin();
+
+  EXPECT_THROW(dst.decode(p), buffer::malformed_input);
+}
+
+TEST(EncodingCompatibility, MacroDecodeStartUncheckedExposesHeaderFields)
+{
+  buffer::list bl;
+  encode_macro_header(bl, 2, 1, 0);
+
+  auto p = bl.cbegin();
+  const auto [struct_v, struct_len] = decode_unchecked_macro_header(p);
+
+  EXPECT_TRUE(p.end());
+  EXPECT_EQ(__u8 { 2 }, struct_v);
+  EXPECT_EQ(__u32 { 0 }, struct_len);
+}
+
+TEST(EncodingCompatibility, MacroLegacyCompatLenDecodesOldPayload)
+{
+  buffer::list bl;
+  encode(__u8 { 1 }, bl);
+  encode(__u8 { 23 }, bl);
+
+  auto p = bl.cbegin();
+
+  EXPECT_EQ(__u8 { 23 }, decode_legacy_macro_value(p));
+  EXPECT_TRUE(p.end());
+}
+
+TEST(EncodingCompatibility, MacroLegacyCompatLenDecodesCurrentPayload)
+{
+  buffer::list bl;
+  encode_macro_header(bl, 2, 1, 1);
+  encode(__u8 { 29 }, bl);
+
+  auto p = bl.cbegin();
+
+  EXPECT_EQ(__u8 { 29 }, decode_legacy_macro_value(p));
+  EXPECT_TRUE(p.end());
+}
+
+TEST(EncodingCompatibility, MacroLegacyCompatLenRejectsNewerCompat)
+{
+  buffer::list bl;
+  encode_macro_header(bl, 2, 3, 0);
+
+  auto p = bl.cbegin();
+
+  EXPECT_THROW(decode_legacy_macro_value(p), buffer::malformed_input);
+}
+
+TEST(EncodingCompatibility, MacroLegacyCompatLen16SkipsOldVersionBytes)
+{
+  buffer::list bl;
+  encode(__u16 { 1 }, bl);
+  encode(__u8 { 31 }, bl);
+
+  auto p = bl.cbegin();
+
+  EXPECT_EQ(__u8 { 31 }, decode_legacy_macro_value_16(p));
+  EXPECT_TRUE(p.end());
+}
+
+TEST(EncodingCompatibility, MacroLegacyCompatLen32SkipsOldVersionBytes)
+{
+  buffer::list bl;
+  encode(__u32 { 1 }, bl);
+  encode(__u8 { 37 }, bl);
+
+  auto p = bl.cbegin();
+
+  EXPECT_EQ(__u8 { 37 }, decode_legacy_macro_value_32(p));
+  EXPECT_TRUE(p.end());
+}
+
+TEST(EncodingCompatibility, RepresentativeWireFormats)
+{
+  std::string string_wire;
+  append_compat_string(string_wire, "hello");
+  expect_compat_wire_format(std::string { "hello" }, string_wire);
+
+  std::string vector_u64_wire;
+  append_compat_le32(vector_u64_wire, 2);
+  append_compat_le64(vector_u64_wire, 11);
+  append_compat_le64(vector_u64_wire, 22);
+  expect_compat_wire_format(std::vector<uint64_t> { 11, 22 },
+                            vector_u64_wire);
+
+  std::string vector_record_wire;
+  append_compat_le32(vector_record_wire, 2);
+  append_compat_record(vector_record_wire, alpha);
+  append_compat_record(vector_record_wire, bravo);
+  expect_compat_wire_format(std::vector<encoding_compat_record> { alpha, bravo },
+                            vector_record_wire);
+
+  std::string array_record_wire;
+  append_compat_record(array_record_wire, alpha);
+  append_compat_record(array_record_wire, bravo);
+  expect_compat_wire_format(std::array<encoding_compat_record, 2> { alpha, bravo },
+                            array_record_wire);
+
+  std::string shared_ptr_vector_wire;
+  append_compat_le32(shared_ptr_vector_wire, 5);
+  append_compat_record(shared_ptr_vector_wire, alpha);
+  append_compat_record(shared_ptr_vector_wire, encoding_compat_record {});
+  append_compat_record(shared_ptr_vector_wire, encoding_compat_record {});
+  append_compat_record(shared_ptr_vector_wire, bravo);
+  append_compat_record(shared_ptr_vector_wire, encoding_compat_record {});
+  expect_compat_wire_format(
+    std::vector<std::shared_ptr<encoding_compat_record>> {
+      std::make_shared<encoding_compat_record>(alpha),
+      nullptr,
+      nullptr,
+      std::make_shared<encoding_compat_record>(bravo),
+      nullptr,
+    },
+    shared_ptr_vector_wire);
+
+  std::string shared_ptr_list_wire;
+  append_compat_le32(shared_ptr_list_wire, 5);
+  append_compat_record(shared_ptr_list_wire, alpha);
+  append_compat_record(shared_ptr_list_wire, encoding_compat_record {});
+  append_compat_record(shared_ptr_list_wire, encoding_compat_record {});
+  append_compat_record(shared_ptr_list_wire, bravo);
+  append_compat_record(shared_ptr_list_wire, encoding_compat_record {});
+  expect_compat_wire_format(
+    std::list<std::shared_ptr<encoding_compat_record>> {
+      std::make_shared<encoding_compat_record>(alpha),
+      nullptr,
+      nullptr,
+      std::make_shared<encoding_compat_record>(bravo),
+      nullptr,
+    },
+    shared_ptr_list_wire);
+
+  expect_feature_compat_wire_format(
+    std::vector<std::shared_ptr<encoding_compat_record>> {
+      std::make_shared<encoding_compat_record>(alpha),
+      nullptr,
+      nullptr,
+      std::make_shared<encoding_compat_record>(bravo),
+      nullptr,
+    },
+    shared_ptr_vector_wire);
 }

--- a/src/test/mds/TestQuiesceAgent.cc
+++ b/src/test/mds/TestQuiesceAgent.cc
@@ -35,10 +35,9 @@ class QuiesceAgentTest : public testing::Test {
       std::promise<void> done;
       auto future = done.get_future();
 
-      auto job = std::bind(f, args...);
-
-      auto tt = std::thread([job=std::move(job)](std::promise<void> done) {
-        job();
+      auto tt = std::thread([f=std::forward<Function>(f),
+                             ... args=std::forward<Args>(args)](std::promise<void> done) mutable {
+        std::invoke(std::move(f), std::move(args)...);
         done.set_value();
       }, std::move(done));
 

--- a/src/test/mds/TestQuiesceDb.cc
+++ b/src/test/mds/TestQuiesceDb.cc
@@ -58,10 +58,9 @@ class QuiesceDbTest: public testing::Test {
       std::promise<void> done;
       auto future = done.get_future();
 
-      auto job = std::bind(f, args...);
-
-      auto tt = std::thread([job = std::move(job)](std::promise<void> done) {
-        job();
+      auto tt = std::thread([f = std::forward<Function>(f),
+                             ... args = std::forward<Args>(args)](std::promise<void> done) mutable {
+        std::invoke(std::move(f), std::move(args)...);
         done.set_value();
       },
           std::move(done));

--- a/src/test/rgw/test_rgw_posix_driver.cc
+++ b/src/test/rgw/test_rgw_posix_driver.cc
@@ -1223,7 +1223,6 @@ TEST_F(POSIXDriverTest, Bucket)
 TEST_F(POSIXDriverTest, BucketCreate)
 {
   std::unique_ptr<rgw::sal::Bucket> bucket;
-  bool bucket_exists;
   rgw::sal::Bucket::CreateParams createparams;
 
   RGWBucketInfo info;
@@ -1233,6 +1232,9 @@ TEST_F(POSIXDriverTest, BucketCreate)
   bucket = driver->get_bucket(info);
   EXPECT_NE(bucket.get(), nullptr);
 
+  sf::path tp{bp / "root" / testname};
+  EXPECT_FALSE(sf::exists(tp));
+
   createparams.owner = owner;
 
   int ret = bucket->create(env->dpp, createparams, null_yield);
@@ -1241,9 +1243,7 @@ TEST_F(POSIXDriverTest, BucketCreate)
   EXPECT_EQ(bucket->get_key().name, testname);
   EXPECT_EQ(bucket->get_key().tenant, "");
   EXPECT_EQ(bucket->get_key().bucket_id, "");
-  EXPECT_FALSE(bucket_exists);
 
-  sf::path tp{bp / "root" / testname};
   EXPECT_TRUE(sf::exists(tp));
   EXPECT_TRUE(sf::is_directory(tp));
 }

--- a/src/test/test_concepts.cc
+++ b/src/test/test_concepts.cc
@@ -121,6 +121,8 @@ using int_predicate = bool (*)(int);
 using int_deque = std::deque<int>;
 using int_forward_list = std::forward_list<int>;
 using int_list = std::list<int>;
+using int_map = std::map<int, int>;
+using int_multimap = std::multimap<int, int>;
 using int_set = std::set<int>;
 using int_vector = std::vector<int>;
 using small_array = std::array<int, 3>;
@@ -531,6 +533,10 @@ TEST_CASE("optional sizing helpers call supported operations only",
     (ceph::concepts::has_emplace_append<int_set, int>))                         \
   X(insert_append, (ceph::concepts::has_insert_append<int_vector, int>),        \
     (ceph::concepts::has_insert_append<int_forward_list, int>))                 \
+  X(subscript_operator, (ceph::concepts::has_subscript_operator<int_map>),      \
+    (ceph::concepts::has_subscript_operator<int_set>))                          \
+  X(try_emplace_key, (ceph::concepts::has_try_emplace_key<int_map>),            \
+    (ceph::concepts::has_try_emplace_key<int_multimap>))                        \
   X(emplace_after, (ceph::concepts::has_emplace_after<int_forward_list, int_forward_list::iterator, int>), \
     (ceph::concepts::has_emplace_after<int_vector, int_vector::iterator, int>)) \
   X(insert_after, (ceph::concepts::has_insert_after<int_forward_list, int_forward_list::iterator, int>), \

--- a/src/test/test_denc.cc
+++ b/src/test/test_denc.cc
@@ -36,6 +36,39 @@ using namespace std;
 // test helpers
 
 template<typename T>
+std::string encode_to_string(const T& v) {
+  bufferlist bl;
+  encode(v, bl);
+  return bl.to_str();
+}
+
+template<typename T>
+void expect_wire_format(const T& v, const std::string& wire) {
+  ASSERT_EQ(wire, encode_to_string(v));
+
+  bufferlist bl;
+  bl.append(wire);
+  auto p = bl.cbegin();
+  T out;
+  decode(out, p);
+  ASSERT_EQ(v, out);
+  ASSERT_EQ(wire.size(), p.get_off());
+}
+
+static void append_le32(std::string& s, uint32_t v) {
+  for (unsigned i = 0; i < 4; ++i) {
+    s.push_back(static_cast<char>(v >> (i * 8)));
+  }
+}
+
+static void append_denc_header(std::string& s, uint8_t v,
+                               uint8_t compat, uint32_t len) {
+  s.push_back(static_cast<char>(v));
+  s.push_back(static_cast<char>(compat));
+  append_le32(s, len);
+}
+
+template<typename T>
 void test_encode_decode(T v) {
   bufferlist bl;
   encode(v, bl);
@@ -390,6 +423,17 @@ struct foo2_only2_t {
   }
 };
 WRITE_CLASS_DENC_BOUNDED(foo2_only2_t)
+
+struct denc_overread_t {
+  DENC(denc_overread_t, v, p) {
+    DENC_START(1, 1, p);
+    __u8 value = 0;
+    ::denc(value, p);
+    ::denc(value, p);
+    DENC_FINISH(p);
+  }
+};
+WRITE_CLASS_DENC_BOUNDED(denc_overread_t)
 
 struct bar_t {
   int32_t a = 0;
@@ -800,4 +844,44 @@ TEST(denc, compat_disallows)
   v1.a = 111; v1.b = 111;
   auto bpi = bl.front().begin();
   ASSERT_ANY_THROW(denc(v1,bpi));
+}
+
+TEST(denc, finish_skips_unread_fields)
+{
+  foo2_accept1_t v2;
+  v2.a = 5001;
+  v2.b = 6002;
+  v2.c = 7003;
+
+  size_t s = 0;
+  denc(v2, s);
+  bufferlist bl;
+  {
+    auto app = bl.get_contiguous_appender(s);
+    denc(v2, app);
+  }
+
+  foo_t v1;
+  auto bpi = bl.front().begin();
+  denc(v1, bpi);
+
+  ASSERT_EQ(v2.a, v1.a);
+  ASSERT_EQ(v2.b, v1.b);
+  ASSERT_EQ(bpi.get_pos(), bl.c_str() + bl.length());
+}
+
+TEST(denc, finish_rejects_overread)
+{
+  std::string wire;
+  append_denc_header(wire, 1, 1, 1);
+  wire.push_back(17);
+  wire.push_back(19);
+
+  bufferlist bl;
+  bl.append(wire);
+
+  denc_overread_t value;
+  auto bpi = bl.front().begin();
+
+  ASSERT_THROW(denc(value, bpi), buffer::malformed_input);
 }


### PR DESCRIPTION


Encoding had quite heroic use of enable_if, but now that Concepts are available it is well-worth some reorganization and clarification:

* Concept-ifed internals to make overload selection clearer, reduce SFINAE noise, and give container/encoding
  support stronger compile-time boundaries.

* Expands regression coverage around legacy container encoding, nohead decode behavior, macro compatibility handling, and representative wire formats.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
