### PR TITLE
mgr/dashboard: Cephfs Mirroring - Enable Snapshot Schedule

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-error/cephfs-mirroring-error.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-error/cephfs-mirroring-error.component.spec.ts
@@ -19,8 +19,7 @@ describe('CephfsMirroringErrorComponent', () => {
   };
 
   const mgrModuleServiceMock = {
-    updateModuleState: jest.fn(),
-    updateCompleted$: { subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }) }
+    updateModuleState: jest.fn()
   };
 
   beforeEach(async () => {
@@ -45,11 +44,11 @@ describe('CephfsMirroringErrorComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should call mgrModuleService.updateModuleState when enableModule is called', () => {
+  it('should enable mirroring and snap_schedule modules when enableModule is called', () => {
     fixture.detectChanges();
     component.enableModule();
     expect(mgrModuleServiceMock.updateModuleState).toHaveBeenCalledWith(
-      'mirroring',
+      ['mirroring', 'snap_schedule'],
       false,
       null,
       'cephfs/mirroring',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-error/cephfs-mirroring-error.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-error/cephfs-mirroring-error.component.ts
@@ -13,13 +13,13 @@ export class CephfsMirroringErrorComponent {
 
   enableModule(): void {
     this.mgrModuleService.updateModuleState(
-      'mirroring',
+      ['mirroring', 'snap_schedule'],
       false,
       null,
       'cephfs/mirroring',
-      $localize`CephFS Mirroring module enabled`,
+      $localize`CephFS Mirroring and Snapshot Schedule modules enabled`,
       false,
-      $localize`Enabling CephFS Mirroring. Reconnecting, please wait ...`
+      $localize`Enabling CephFS Mirroring and Snapshot Schedule modules. Reconnecting, please wait ...`
     );
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/mgr-module.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/mgr-module.service.spec.ts
@@ -1,5 +1,12 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  discardPeriodicTasks,
+  fakeAsync,
+  flush,
+  TestBed,
+  tick
+} from '@angular/core/testing';
 import { of as observableOf, throwError as observableThrowError } from 'rxjs';
 
 import { configureTestBed } from '~/testing/unit-test-helper';
@@ -144,6 +151,38 @@ describe('MgrModuleService', () => {
       expect(notificationService.suspendToasties).toHaveBeenCalledTimes(2);
       expect(blockUIService.start).toHaveBeenCalled();
       expect(blockUIService.stop).toHaveBeenCalled();
+    }));
+
+    it('should enable multiple modules sequentially', fakeAsync(() => {
+      const summaryService = TestBed.inject(SummaryService);
+      spyOn(service, 'enable').and.returnValues(
+        observableThrowError('mirroring reconnect'),
+        observableOf(null)
+      );
+      spyOn(service, 'list').and.returnValue(observableOf([]));
+      spyOn(notificationService, 'show');
+      spyOn(service.updateCompleted$, 'next');
+
+      service.updateModuleState(
+        ['mirroring', 'snap_schedule'],
+        false,
+        null,
+        '',
+        'Enabled mirroring modules'
+      );
+      tick(service.REFRESH_INTERVAL);
+      flush();
+
+      expect(service.enable).toHaveBeenCalledWith('mirroring', false);
+      expect(service.enable).toHaveBeenCalledWith('snap_schedule', false);
+      expect(service.list).toHaveBeenCalledTimes(1);
+      expect(notificationService.show).toHaveBeenCalledWith(
+        jasmine.any(Number),
+        jasmine.any(String)
+      );
+      expect(service.updateCompleted$.next).toHaveBeenCalled();
+      expect(summaryService.startPolling).toHaveBeenCalled();
+      discardPeriodicTasks();
     }));
 
     it('should not disable module without selecting one', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/mgr-module.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/mgr-module.service.ts
@@ -2,13 +2,13 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { BlockUIService } from 'ng-block-ui';
 
-import { Observable, Subject, timer } from 'rxjs';
+import { from, Observable, Subject, timer } from 'rxjs';
 import { NotificationService } from '../services/notification.service';
 import { TableComponent } from '../datatable/table/table.component';
 import { Router } from '@angular/router';
 import { MgrModuleInfo } from '../models/mgr-modules.interface';
 import { NotificationType } from '../enum/notification-type.enum';
-import { delay, retryWhen, switchMap, tap } from 'rxjs/operators';
+import { catchError, concatMap, delay, map, retryWhen, switchMap, tap } from 'rxjs/operators';
 import { SummaryService } from '../services/summary.service';
 
 const GLOBAL = 'global';
@@ -89,9 +89,10 @@ export class MgrModuleService {
 
   /**
    * Update the Ceph Mgr module state to enabled or disabled.
+   * @param modules One module name or a list of module names to enable/disable sequentially.
    */
   updateModuleState(
-    module: string,
+    modules: string | string[],
     enabled: boolean = false,
     table: TableComponent = null,
     navigateTo: string = '',
@@ -100,61 +101,81 @@ export class MgrModuleService {
     reconnectingMessage: string = $localize`Reconnecting, please wait ...`,
     force: boolean = false
   ): void {
+    const moduleList = Array.isArray(modules) ? modules : [modules];
+
+    from(moduleList)
+      .pipe(
+        concatMap((module) =>
+          this.toggleModuleWithReconnect(module, enabled, force, reconnectingMessage)
+        )
+      )
+      .subscribe({
+        complete: () => {
+          this.completeModuleStateUpdate(table, navigateTo, notificationText, navigateByUrl);
+        }
+      });
+  }
+
+  private toggleModuleWithReconnect(
+    module: string,
+    enabled: boolean,
+    force: boolean,
+    reconnectingMessage: string
+  ): Observable<void> {
     const moduleToggle$ = enabled ? this.disable(module) : this.enable(module, force);
 
-    moduleToggle$.subscribe({
-      next: () => {
-        // Module toggle succeeded
-        this.updateCompleted$.next();
-      },
-      error: () => {
-        // Module toggle failed, trigger reconnect flow
-        this.notificationService.suspendToasties(true);
-        this.blockUI.start(GLOBAL, reconnectingMessage);
+    return moduleToggle$.pipe(
+      map(() => undefined),
+      catchError(() => this.reconnectAfterModuleToggle(reconnectingMessage))
+    );
+  }
 
-        timer(this.REFRESH_INTERVAL)
-          .pipe(
-            switchMap(() => this.list()),
-            retryWhen((errors) =>
-              errors.pipe(
-                tap(() => {
-                  // Keep retrying until list() succeeds
-                }),
-                delay(this.REFRESH_INTERVAL)
-              )
-            )
-          )
-          .subscribe({
-            next: () => {
-              // Reconnection successful
-              this.notificationService.suspendToasties(false);
-              this.blockUI.stop(GLOBAL);
+  private reconnectAfterModuleToggle(reconnectingMessage: string): Observable<void> {
+    this.notificationService.suspendToasties(true);
+    this.blockUI.start(GLOBAL, reconnectingMessage);
 
-              if (table) {
-                table.refreshBtn();
-              }
+    return timer(this.REFRESH_INTERVAL).pipe(
+      switchMap(() => this.list()),
+      retryWhen((errors) =>
+        errors.pipe(
+          tap(() => {
+            // Keep retrying until list() succeeds
+          }),
+          delay(this.REFRESH_INTERVAL)
+        )
+      ),
+      tap(() => {
+        this.notificationService.suspendToasties(false);
+        this.blockUI.stop(GLOBAL);
+      }),
+      map(() => undefined)
+    );
+  }
 
-              if (notificationText) {
-                this.notificationService.show(
-                  NotificationType.success,
-                  $localize`${notificationText}`
-                );
-              }
+  private completeModuleStateUpdate(
+    table: TableComponent,
+    navigateTo: string,
+    notificationText?: string,
+    navigateByUrl?: boolean
+  ): void {
+    if (table) {
+      table.refreshBtn();
+    }
 
-              if (navigateTo) {
-                const navigate = () => this.router.navigate([navigateTo]);
-                if (navigateByUrl) {
-                  this.router.navigateByUrl('/', { skipLocationChange: true }).then(navigate);
-                } else {
-                  navigate();
-                }
-              }
+    if (notificationText) {
+      this.notificationService.show(NotificationType.success, $localize`${notificationText}`);
+    }
 
-              this.updateCompleted$.next();
-              this.summaryService.startPolling();
-            }
-          });
+    if (navigateTo) {
+      const navigate = () => this.router.navigate([navigateTo]);
+      if (navigateByUrl) {
+        this.router.navigateByUrl('/', { skipLocationChange: true }).then(navigate);
+      } else {
+        navigate();
       }
-    });
+    }
+
+    this.updateCompleted$.next();
+    this.summaryService.startPolling();
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/permission.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/permission.spec.ts
@@ -28,6 +28,7 @@ describe('cd-notification classes', () => {
   it('should show full permissions', () => {
     const fullyGranted = {
       cephfs: ['create', 'read', 'update', 'delete'],
+      'cephfs-mirror': ['create', 'read', 'update', 'delete'],
       'config-opt': ['create', 'read', 'update', 'delete'],
       grafana: ['create', 'read', 'update', 'delete'],
       hosts: ['create', 'read', 'update', 'delete'],
@@ -47,7 +48,7 @@ describe('cd-notification classes', () => {
     };
     expect(new Permissions(fullyGranted)).toEqual({
       cephfs: { create: true, delete: true, read: true, update: true },
-      cephfsMirror: { create: false, delete: false, read: false, update: false },
+      cephfsMirror: { create: true, delete: true, read: true, update: true },
       configOpt: { create: true, delete: true, read: true, update: true },
       grafana: { create: true, delete: true, read: true, update: true },
       hosts: { create: true, delete: true, read: true, update: true },


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
