### PR TITLE
script/ptl-tool: add 'crimson', 'build/ops', 'common', 'tests' to SUPPORTED_QA_TAGS

### DIFF
--- a/src/script/ptl-tool.py
+++ b/src/script/ptl-tool.py
@@ -127,15 +127,19 @@ except FileNotFoundError:
 REDMINE_API_KEY = os.getenv("PTL_TOOL_REDMINE_API_KEY", REDMINE_API_KEY)
 SPECIAL_BRANCHES = ('main', 'luminous', 'jewel', 'HEAD')
 SUPPORTED_QA_TAGS = {
+    'build/ops',
     'cephadm',
     'cephfs',
+    'common',
     'core',
+    'crimson',
     'dashboard',
     'libcephsqlite',
     'nvme',
     'orch',
     'rbd',
     'rgw',
+    'tests',
     'upgrades',
 }
 TEST_BRANCH = os.getenv("PTL_TOOL_TEST_BRANCH", "wip-{user}-testing-%Y%m%d.%H%M%S")


### PR DESCRIPTION
## Summary
- `SUPPORTED_QA_TAGS` in `src/script/ptl-tool.py` is a fixed whitelist that filters which GitHub PR labels get surfaced into a QA tracker ticket's "Labels" table column and Redmine `tag_list`.
- `crimson`, `build/ops`, `common`, and `tests` were all missing from this whitelist despite being real, actively-used labels in ceph/ceph — PRs carrying them had the label silently dropped in generated tracker tickets.
- Found while investigating https://tracker.ceph.com/issues/78859, where the "Labels" column was blank for two crimson-labeled PRs.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
