### PR TITLE
mgr/dashboard: Fix onboarding page access from overview page

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -50,6 +50,7 @@ import { ChangePasswordGuardService } from './shared/services/change-password-gu
 import { FeatureTogglesGuardService } from './shared/services/feature-toggles-guard.service';
 import { ModuleStatusGuardService } from './shared/services/module-status-guard.service';
 import { NoSsoGuardService } from './shared/services/no-sso-guard.service';
+import { PermissionGuardService } from './shared/services/permission-guard.service';
 import { UpgradeComponent } from './ceph/cluster/upgrade/upgrade.component';
 import { CephfsVolumeFormComponent } from './ceph/cephfs/cephfs-form/cephfs-form.component';
 import { UpgradeProgressComponent } from './ceph/cluster/upgrade/upgrade-progress/upgrade-progress.component';
@@ -135,12 +136,17 @@ const routes: Routes = [
       {
         path: 'add-storage',
         component: CreateClusterComponent,
-        canActivate: [ModuleStatusGuardService],
+        canActivate: [ModuleStatusGuardService, PermissionGuardService],
         data: {
           moduleStatusGuardConfig: {
             uiApiPath: 'orchestrator',
             redirectTo: 'overview',
             backend: 'cephadm'
+          },
+          permissionGuardConfig: {
+            scope: 'configOpt',
+            action: 'update',
+            redirectTo: '/overview'
           }
         }
       },

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.ts
@@ -97,10 +97,12 @@ export class CreateClusterComponent implements OnInit, OnDestroy {
       }
     });
 
-    this.osdService.getDeploymentOptions().subscribe((options) => {
-      this.deploymentOption = options;
-      this.selectedOption = { option: options.recommended_option, encrypted: false };
-    });
+    if (this.permissions.osd?.read) {
+      this.osdService.getDeploymentOptions().subscribe((options) => {
+        this.deploymentOption = options;
+        this.selectedOption = { option: options.recommended_option, encrypted: false };
+      });
+    }
 
     this.steps.forEach((step) => {
       this.stepsToSkip[step.label] = false;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/storage-card/overview-storage-card.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/storage-card/overview-storage-card.component.html
@@ -72,19 +72,21 @@
       i18n-title
       i18n-text
     >
-      <button
-        cdsButton="primary"
-        i18n
-        size="sm"
-        [routerLink]="['/add-storage']"
-        type="button"
-      >
-        Add storage
-        <cd-icon
-          type="add"
-          class="cds--btn__icon"
-        ></cd-icon>
-      </button>
+      @if (canAddStorage) {
+        <button
+          cdsButton="primary"
+          i18n
+          size="sm"
+          [routerLink]="['/add-storage']"
+          type="button"
+        >
+          Add storage
+          <cd-icon
+            type="add"
+            class="cds--btn__icon"
+          ></cd-icon>
+        </button>
+      }
     </cd-empty-state>
   }
   <!-- CAPACITY BREAKDOWN CHART -->

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/storage-card/overview-storage-card.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/overview/storage-card/overview-storage-card.component.ts
@@ -22,6 +22,7 @@ import { ComponentsModule } from '~/app/shared/components/components.module';
 import { BreakdownChartData, CapacityThreshold, TrendPoint } from '~/app/shared/models/overview';
 import { EmptyStateComponent } from '~/app/shared/components/empty-state/empty-state.component';
 import { RouterModule } from '@angular/router';
+import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 
 const CHART_HEIGHT = '45px';
 
@@ -50,6 +51,7 @@ const CHART_HEIGHT = '45px';
 export class OverviewStorageCardComponent {
   private readonly formatterService = inject(FormatterService);
   private readonly cdr = inject(ChangeDetectorRef);
+  readonly canAddStorage = inject(AuthStorageService).getPermissions().configOpt?.update;
 
   @Input() storageEmptyState: boolean = false;
   @Input() prometheusEmptyState: boolean = false;

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.spec.ts
@@ -6,6 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { of } from 'rxjs';
 
 import { AuthService } from '~/app/shared/api/auth.service';
+import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { configureTestBed } from '~/testing/unit-test-helper';
 import { AuthModule } from '../auth.module';
 import { LoginComponent } from './login.component';
@@ -50,6 +51,9 @@ describe('LoginComponent', () => {
 
   it('should show create cluster wizard if cluster creation was failed', () => {
     component.postInstalled = false;
+    spyOn(TestBed.inject(AuthStorageService), 'getPermissions').and.returnValue({
+      configOpt: { create: true, read: true, update: true, delete: true }
+    } as any);
     component.login();
 
     expect(routerNavigateSpy).toHaveBeenCalledTimes(1);

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.ts
@@ -67,9 +67,11 @@ export class LoginComponent implements OnInit {
   login() {
     localStorage.setItem('cluster_api_url', window.location.origin);
     this.authService.login(this.model).subscribe(() => {
-      const urlPath = this.postInstalled ? '/' : '/add-storage';
+      const permissions = this.authStorageService.getPermissions();
+      const canSetupCluster = !this.postInstalled && permissions.configOpt?.update;
+      const urlPath = canSetupCluster ? '/add-storage' : '/';
       let url = _.get(this.route.snapshot.queryParams, 'returnUrl', urlPath);
-      if (!this.postInstalled && this.route.snapshot.queryParams['returnUrl'] === '/overview') {
+      if (canSetupCluster && this.route.snapshot.queryParams['returnUrl'] === '/overview') {
         url = '/add-storage';
       }
       if (url === '/add-storage') {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.spec.ts
@@ -9,6 +9,7 @@ import { of as observableOf, throwError } from 'rxjs';
 import { configureTestBed } from '~/testing/unit-test-helper';
 import { MgrModuleService } from '../api/mgr-module.service';
 import { ModuleStatusGuardService } from './module-status-guard.service';
+import { AuthStorageService } from './auth-storage.service';
 
 import { CdDatePipe } from '../pipes/cd-date.pipe';
 import { SharedModule } from '../shared.module';
@@ -20,6 +21,7 @@ describe('ModuleStatusGuardService', () => {
   let route: ActivatedRouteSnapshot;
   let ngZone: NgZone;
   let mgrModuleService: MgrModuleService;
+  let authStorageService: AuthStorageService;
 
   @Component({ selector: 'cd-foo', template: '', standalone: false })
   class FooComponent {}
@@ -39,11 +41,12 @@ describe('ModuleStatusGuardService', () => {
   ) => {
     let result: boolean;
     spyOn(httpClient, 'get').and.returnValue(observableOf(getResult));
+    spyOn(authStorageService, 'getPermissions').and.returnValue({
+      configOpt: { read: configOptPermission }
+    } as any);
     const orchBackend = { orchestrator: backend };
     const getConfigSpy = spyOn(mgrModuleService, 'getConfig');
-    configOptPermission
-      ? getConfigSpy.and.returnValue(observableOf(orchBackend))
-      : getConfigSpy.and.returnValue(throwError({}));
+    getConfigSpy.and.returnValue(configOptPermission ? observableOf(orchBackend) : throwError({}));
     ngZone.run(() => {
       service.canActivateChild(route).subscribe((resp) => {
         result = resp;
@@ -69,6 +72,7 @@ describe('ModuleStatusGuardService', () => {
     service = TestBed.inject(ModuleStatusGuardService);
     httpClient = TestBed.inject(HttpClient);
     mgrModuleService = TestBed.inject(MgrModuleService);
+    authStorageService = TestBed.inject(AuthStorageService);
     router = TestBed.inject(Router);
     route = new ActivatedRouteSnapshot();
     route.url = [];
@@ -103,7 +107,7 @@ describe('ModuleStatusGuardService', () => {
     testCanActivate({ available: true, message: 'foo' }, true, '/', 'rook');
   }));
 
-  it('should redirect to the "redirectTo" link for user without sufficient permission', fakeAsync(() => {
-    testCanActivate({ available: true, message: 'foo' }, true, '/foo', 'rook', false);
+  it('should skip backend check for user without config-opt permission', fakeAsync(() => {
+    testCanActivate({ available: true, message: 'foo' }, true, '/', 'rook', false);
   }));
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.ts
@@ -7,6 +7,7 @@ import { catchError, map } from 'rxjs/operators';
 
 import { MgrModuleService } from '~/app/shared/api/mgr-module.service';
 import { Icons } from '~/app/shared/enum/icons.enum';
+import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 
 /**
  * This service checks if a route can be activated by executing a
@@ -43,7 +44,8 @@ export class ModuleStatusGuardService {
   constructor(
     private http: HttpClient,
     private router: Router,
-    private mgrModuleService: MgrModuleService
+    private mgrModuleService: MgrModuleService,
+    private authStorageService: AuthStorageService
   ) {}
 
   canActivate(route: ActivatedRouteSnapshot) {
@@ -60,7 +62,7 @@ export class ModuleStatusGuardService {
     }
     const config = route.data['moduleStatusGuardConfig'];
     let backendCheck = false;
-    if (config.backend) {
+    if (config.backend && this.authStorageService.getPermissions().configOpt?.read) {
       this.mgrModuleService.getConfig('orchestrator').subscribe(
         (resp) => {
           backendCheck = config.backend === resp['orchestrator'];

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/permission-guard.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/permission-guard.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Router } from '@angular/router';
+
+import { AuthStorageService } from './auth-storage.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PermissionGuardService {
+  constructor(
+    private router: Router,
+    private authStorageService: AuthStorageService
+  ) {}
+
+  canActivate(route: ActivatedRouteSnapshot): boolean {
+    const permissions = this.authStorageService.getPermissions();
+    const config = route.data?.['permissionGuardConfig'];
+    if (config) {
+      const scope = permissions[config.scope];
+      if (!scope?.[config.action]) {
+        this.router.navigate([config.redirectTo || '/overview']);
+        return false;
+      }
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
Non-admin roles (block-manager, smb-manager) trigger Access Denied on /add-storage hence added gaurds for those.
- /add-storage no longer available for non-admin users as its need cluster API - POST_INSTALLED set which is failing.
- added a  new permission guard - `PermissionGuardService`




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
