### PR TITLE
mgr/dashboard: prevent deletion of last user with administrator role

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/user.py
+++ b/src/pybind/mgr/dashboard/controllers/user.py
@@ -7,10 +7,11 @@ import cherrypy
 from ceph_argparse import CephString
 
 from .. import mgr
-from ..exceptions import DashboardException, PasswordPolicyException, \
-    PwdExpirationDateNotValid, UserAlreadyExists, UserDoesNotExist
+from ..exceptions import DashboardException, LastAdminError, \
+    PasswordPolicyException, PwdExpirationDateNotValid, UserAlreadyExists, \
+    UserDoesNotExist
 from ..security import Scope
-from ..services.access_control import SYSTEM_ROLES, PasswordPolicy
+from ..services.access_control import ADMIN_ROLE, SYSTEM_ROLES, PasswordPolicy
 from ..services.auth import JwtManager
 from . import APIDoc, APIRouter, BaseController, Endpoint, EndpointDoc, \
     RESTController, allow_empty_body, validate_ceph_type
@@ -122,6 +123,10 @@ class User(RESTController):
             mgr.ACCESS_CTRL_DB.delete_user(username)
         except UserDoesNotExist:
             raise cherrypy.HTTPError(404)
+        except LastAdminError as ex:
+            raise DashboardException(msg=str(ex),
+                                     code='cannot_delete_last_admin',
+                                     component='user')
         mgr.ACCESS_CTRL_DB.save()
 
     def set(self, username, password=None, name=None, email=None, roles=None,
@@ -146,6 +151,21 @@ class User(RESTController):
             raise DashboardException(
                 msg='Password expiration date must not be in the past',
                 code='pwd_past_expiration_date', component='user')
+        if mgr.ACCESS_CTRL_DB._is_last_admin(username):
+            removing_admin = user_roles and ADMIN_ROLE not in user_roles
+            if removing_admin:
+                raise DashboardException(
+                    msg=f"Cannot remove administrator role from user '{username}': "
+                        "last user with administrator role",
+                    code='cannot_remove_admin_from_last_admin',
+                    component='user')
+            if enabled is False:
+                raise DashboardException(
+                    msg=f"Cannot disable user '{username}': "
+                        "last user with administrator role",
+                    code='cannot_disable_last_admin',
+                    component='user')
+
         user.name = name
         user.email = email
         if enabled is not None:

--- a/src/pybind/mgr/dashboard/exceptions.py
+++ b/src/pybind/mgr/dashboard/exceptions.py
@@ -115,6 +115,12 @@ class PwdExpirationDateNotValid(Exception):
             "The password expiration date must not be in the past")
 
 
+class LastAdminError(Exception):
+    def __init__(self, action: str, username: str):
+        super().__init__(
+            f"Cannot {action} user '{username}': last user with administrator role")
+
+
 class GrafanaError(Exception):
     pass
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
@@ -270,6 +270,7 @@
           id="enabled"
           formControlName="enabled"
           name="enabled"
+          [disabled]="isLastAdminUser"
           i18n
           >Enabled
         </cds-checkbox>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
@@ -214,6 +214,12 @@ describe('UserFormComponent', () => {
 
     beforeEach(() => {
       spyOn(userService, 'get').and.callFake(() => of(user));
+      spyOn(userService, 'list').and.callFake(() =>
+        of([
+          { username: user.username, roles: user.roles, enabled: true },
+          { username: 'admin2', roles: ['administrator'], enabled: true }
+        ])
+      );
       spyOn(TestBed.inject(RoleService), 'list').and.callFake(() => of(roles));
       spyOn(TestBed.inject(AuthStorageService), 'getUsername').and.returnValue(user.username);
       setUrl('/user-management/users/edit/user1');
@@ -311,6 +317,126 @@ describe('UserFormComponent', () => {
       });
       userReq.flush({});
       expect(router.navigate).toHaveBeenCalledWith(['/user-management/users']);
+    });
+  });
+
+  describe('last admin protection in edit mode', () => {
+    const adminUser: UserFormModel = {
+      username: 'otheradmin',
+      password: undefined,
+      name: 'Other Admin',
+      email: 'other@admin.com',
+      roles: ['administrator'],
+      enabled: true,
+      pwdExpirationDate: undefined,
+      pwdUpdateRequired: false
+    };
+    const allUsers = [
+      { username: 'otheradmin', roles: ['administrator'], enabled: true }
+    ];
+    const roles = [
+      {
+        name: 'administrator',
+        description: 'Administrator',
+        scopes_permissions: { user: ['create', 'delete', 'read', 'update'] }
+      },
+      {
+        name: 'read-only',
+        description: 'Read-Only',
+        scopes_permissions: { user: ['read'] }
+      }
+    ];
+
+    beforeEach(() => {
+      spyOn(userService, 'get').and.callFake(() => of(adminUser));
+      spyOn(userService, 'list').and.callFake(() => of(allUsers));
+      spyOn(TestBed.inject(RoleService), 'list').and.callFake(() => of(roles));
+      spyOn(TestBed.inject(AuthStorageService), 'getUsername').and.returnValue('currentuser');
+      setUrl('/user-management/users/edit/otheradmin');
+      spyOn(TestBed.inject(SettingsService), 'getStandardSettings').and.callFake(() =>
+        of({
+          user_pwd_expiration_warning_1: 10,
+          user_pwd_expiration_warning_2: 5,
+          user_pwd_expiration_span: 90
+        })
+      );
+      component.ngOnInit();
+      const req = httpTesting.expectOne('api/role');
+      req.flush(roles);
+      httpTesting.expectOne('ui-api/standard_settings');
+    });
+
+    afterEach(() => {
+      httpTesting.verify();
+    });
+
+    it('should mark user as last admin', () => {
+      expect(component.isLastAdminUser).toBe(true);
+    });
+
+    it('should disable administrator role for last admin user', () => {
+      const administratorRole = component.allRoles.find((role) => role.name === 'administrator');
+      expect(administratorRole.disabled).toBeTruthy();
+    });
+
+    it('should protect roles clear button for last admin', () => {
+      expect(component.disableRolesClearButton()).toBeTruthy();
+    });
+  });
+
+  describe('non-last admin in edit mode', () => {
+    const adminUser: UserFormModel = {
+      username: 'admin1',
+      password: undefined,
+      name: 'Admin 1',
+      email: 'admin1@admin.com',
+      roles: ['administrator'],
+      enabled: true,
+      pwdExpirationDate: undefined,
+      pwdUpdateRequired: false
+    };
+    const allUsers = [
+      { username: 'admin1', roles: ['administrator'], enabled: true },
+      { username: 'admin2', roles: ['administrator'], enabled: true }
+    ];
+    const roles = [
+      {
+        name: 'administrator',
+        description: 'Administrator',
+        scopes_permissions: { user: ['create', 'delete', 'read', 'update'] }
+      }
+    ];
+
+    beforeEach(() => {
+      spyOn(userService, 'get').and.callFake(() => of(adminUser));
+      spyOn(userService, 'list').and.callFake(() => of(allUsers));
+      spyOn(TestBed.inject(RoleService), 'list').and.callFake(() => of(roles));
+      spyOn(TestBed.inject(AuthStorageService), 'getUsername').and.returnValue('currentuser');
+      setUrl('/user-management/users/edit/admin1');
+      spyOn(TestBed.inject(SettingsService), 'getStandardSettings').and.callFake(() =>
+        of({
+          user_pwd_expiration_warning_1: 10,
+          user_pwd_expiration_warning_2: 5,
+          user_pwd_expiration_span: 90
+        })
+      );
+      component.ngOnInit();
+      const req = httpTesting.expectOne('api/role');
+      req.flush(roles);
+      httpTesting.expectOne('ui-api/standard_settings');
+    });
+
+    afterEach(() => {
+      httpTesting.verify();
+    });
+
+    it('should not mark user as last admin when multiple admins exist', () => {
+      expect(component.isLastAdminUser).toBe(false);
+    });
+
+    it('should not disable administrator role for non-last admin', () => {
+      const administratorRole = component.allRoles.find((role) => role.name === 'administrator');
+      expect(administratorRole.disabled).toBeFalsy();
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
@@ -64,6 +64,7 @@ export class UserFormComponent extends CdForm implements OnInit {
   passwordexp: boolean = false;
   isSSO = false;
   isAdminRoleProtected: boolean = false;
+  isLastAdminUser: boolean = false;
 
   constructor(
     private authService: AuthService,
@@ -189,10 +190,23 @@ export class UserFormComponent extends CdForm implements OnInit {
     this.disableForEdit();
     this.route.params.subscribe((params: { username: string }) => {
       const username = params.username;
-      this.userService.get(username).subscribe((userFormModel: UserFormModel) => {
+      observableForkJoin([
+        this.userService.get(username),
+        this.userService.list()
+      ]).subscribe(([userFormModel, allUsers]: [UserFormModel, any[]]) => {
         this.response = _.cloneDeep(userFormModel);
         this.setResponse(userFormModel);
-        if (this.authStorageService.getUsername() === userFormModel.username) {
+
+        const isCurrentUser = this.authStorageService.getUsername() === userFormModel.username;
+        const hasAdminRole = userFormModel.roles?.includes('administrator');
+        if (hasAdminRole) {
+          const enabledAdmins = allUsers.filter(
+            (u) => u.enabled && u.roles?.includes('administrator')
+          );
+          this.isLastAdminUser = enabledAdmins.length <= 1;
+        }
+
+        if (isCurrentUser || this.isLastAdminUser) {
           this.allRoles = _.map(this.allRoles, (role) => ({
             ...role,
             disabled: role.name.toLowerCase() === 'administrator'
@@ -289,7 +303,7 @@ export class UserFormComponent extends CdForm implements OnInit {
   }
 
   disableRolesClearButton(): boolean {
-    if (!this.isCurrentUser() || !this.allRoles) {
+    if ((!this.isCurrentUser() && !this.isLastAdminUser) || !this.allRoles) {
       return false;
     }
     const administratorRole = this.allRoles.find(

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.spec.ts
@@ -117,6 +117,49 @@ describe('UserListComponent', () => {
       }
     });
   });
+  describe('isLastAdmin', () => {
+    const adminUser = { username: 'admin', roles: ['administrator'], enabled: true };
+    const admin2User = { username: 'admin2', roles: ['administrator'], enabled: true };
+    const regularUser = { username: 'regular', roles: ['read-only'], enabled: true };
+    const disabledAdmin = { username: 'disabled', roles: ['administrator'], enabled: false };
+
+    it('should return true when selected user is the only enabled admin', () => {
+      component.users = [adminUser, regularUser];
+      component.selection.selected = [adminUser];
+      expect(component.isLastAdmin()).toBe(true);
+    });
+
+    it('should return false when multiple enabled admins exist', () => {
+      component.users = [adminUser, admin2User];
+      component.selection.selected = [adminUser];
+      expect(component.isLastAdmin()).toBe(false);
+    });
+
+    it('should return false when selected user is not an admin', () => {
+      component.users = [adminUser, regularUser];
+      component.selection.selected = [regularUser];
+      expect(component.isLastAdmin()).toBe(false);
+    });
+
+    it('should return true when other admin exists but is disabled', () => {
+      component.users = [adminUser, disabledAdmin];
+      component.selection.selected = [adminUser];
+      expect(component.isLastAdmin()).toBe(true);
+    });
+
+    it('should return false when no selection', () => {
+      component.users = [adminUser];
+      component.selection.selected = [];
+      expect(component.isLastAdmin()).toBe(false);
+    });
+
+    it('should return false when users not loaded', () => {
+      component.users = undefined;
+      component.selection.selected = [adminUser];
+      expect(component.isLastAdmin()).toBe(false);
+    });
+  });
+
   it('should calculate remaining days', () => {
     const day = 60 * 60 * 24 * 1000;
     let today = Date.now();

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.ts
@@ -77,7 +77,10 @@ export class UserListComponent implements OnInit {
       permission: 'delete',
       icon: Icons.destroy,
       click: () => this.deleteUserModal(),
-      name: this.actionLabels.DELETE
+      name: this.actionLabels.DELETE,
+      disable: () => this.isLastAdmin()
+        ? $localize`Cannot delete the last user with administrator role`
+        : false
     };
     this.tableActions = [addAction, editAction, deleteAction];
   }
@@ -142,6 +145,20 @@ export class UserListComponent implements OnInit {
       });
       this.users = users;
     });
+  }
+
+  isLastAdmin(): boolean {
+    if (!this.selection.hasSingleSelection || !this.users) {
+      return false;
+    }
+    const selected = this.selection.first();
+    if (!selected.roles?.includes('administrator')) {
+      return false;
+    }
+    const enabledAdmins = this.users.filter(
+      (u) => u.enabled && u.roles?.includes('administrator')
+    );
+    return enabledAdmins.length <= 1;
   }
 
   updateSelection(selection: CdTableSelection) {

--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -18,10 +18,10 @@ from mgr_util import password_hash
 
 from .. import mgr
 from ..cli import DBCLICommand
-from ..exceptions import PasswordPolicyException, PermissionNotValid, \
-    PwdExpirationDateNotValid, RoleAlreadyExists, RoleDoesNotExist, \
-    RoleIsAssociatedWithUser, RoleNotInUser, ScopeNotInRole, ScopeNotValid, \
-    UserAlreadyExists, UserDoesNotExist
+from ..exceptions import LastAdminError, PasswordPolicyException, \
+    PermissionNotValid, PwdExpirationDateNotValid, RoleAlreadyExists, \
+    RoleDoesNotExist, RoleIsAssociatedWithUser, RoleNotInUser, \
+    ScopeNotInRole, ScopeNotValid, UserAlreadyExists, UserDoesNotExist
 from ..security import Permission, Scope
 from ..settings import Settings
 
@@ -535,10 +535,23 @@ class AccessControlDB(object):
                 raise UserDoesNotExist(username)
             return self.users[username]
 
+    def _is_last_admin(self, username: str) -> bool:
+        """Check if the given user is the only enabled user with the administrator role."""
+        user = self.users.get(username)
+        if not user or ADMIN_ROLE not in user.roles:
+            return False
+        return not any(
+            u.enabled and ADMIN_ROLE in u.roles
+            for uname, u in self.users.items()
+            if uname != username
+        )
+
     def delete_user(self, username):
         with self.lock:
             if username not in self.users:
                 raise UserDoesNotExist(username)
+            if self._is_last_admin(username):
+                raise LastAdminError('delete', username)
             del self.users[username]
 
     def update_users_with_roles(self, role):
@@ -814,12 +827,16 @@ def ac_user_disable(_, username: str):
     '''
     try:
         user = mgr.ACCESS_CTRL_DB.get_user(username)
+        if mgr.ACCESS_CTRL_DB._is_last_admin(username):
+            raise LastAdminError('disable', username)
         user.enabled = False
 
         mgr.ACCESS_CTRL_DB.save()
         return 0, json.dumps(user.to_dict()), ''
     except UserDoesNotExist as ex:
         return -errno.ENOENT, '', str(ex)
+    except LastAdminError as ex:
+        return -errno.EPERM, '', str(ex)
 
 
 @DBCLICommand.Write('dashboard ac-user-delete')
@@ -830,9 +847,11 @@ def ac_user_delete_cmd(_, username: str):
     try:
         mgr.ACCESS_CTRL_DB.delete_user(username)
         mgr.ACCESS_CTRL_DB.save()
-        return 0, "User '{}' deleted".format(username), ""
+        return 0, f"User '{username}' deleted", ""
     except UserDoesNotExist as ex:
         return -errno.ENOENT, '', str(ex)
+    except LastAdminError as ex:
+        return -errno.EPERM, '', str(ex)
 
 
 @DBCLICommand.Write('dashboard ac-user-set-roles')
@@ -851,11 +870,16 @@ def ac_user_set_roles_cmd(_, username: str, roles: Sequence[str]):
             roles.append(SYSTEM_ROLES[rolename])
     try:
         user = mgr.ACCESS_CTRL_DB.get_user(username)
+        removing_admin = ADMIN_ROLE in user.roles and ADMIN_ROLE not in roles
+        if removing_admin and mgr.ACCESS_CTRL_DB._is_last_admin(username):
+            raise LastAdminError('remove administrator role from', username)
         user.set_roles(roles)
         mgr.ACCESS_CTRL_DB.save()
         return 0, json.dumps(user.to_dict()), ''
     except UserDoesNotExist as ex:
         return -errno.ENOENT, '', str(ex)
+    except LastAdminError as ex:
+        return -errno.EPERM, '', str(ex)
 
 
 @DBCLICommand.Write('dashboard ac-user-add-roles')
@@ -897,6 +921,9 @@ def ac_user_del_roles_cmd(_, username: str, roles: Sequence[str]):
             roles.append(SYSTEM_ROLES[rolename])
     try:
         user = mgr.ACCESS_CTRL_DB.get_user(username)
+        removing_admin = ADMIN_ROLE in roles and ADMIN_ROLE in user.roles
+        if removing_admin and mgr.ACCESS_CTRL_DB._is_last_admin(username):
+            raise LastAdminError('remove administrator role from', username)
         user.del_roles(roles)
         mgr.ACCESS_CTRL_DB.save()
         return 0, json.dumps(user.to_dict()), ''
@@ -904,6 +931,8 @@ def ac_user_del_roles_cmd(_, username: str, roles: Sequence[str]):
         return -errno.ENOENT, '', str(ex)
     except RoleNotInUser as ex:
         return -errno.ENOENT, '', str(ex)
+    except LastAdminError as ex:
+        return -errno.EPERM, '', str(ex)
 
 
 @DBCLICommand.Write('dashboard ac-user-set-password')

--- a/src/pybind/mgr/dashboard/tests/test_access_control.py
+++ b/src/pybind/mgr/dashboard/tests/test_access_control.py
@@ -899,3 +899,85 @@ class AccessControlTest(unittest.TestCase, CLICommandTestMixin):
         Settings.PWD_POLICY_CHECK_OLDPWD_ENABLED = True
         pw_policy = PasswordPolicy('foo', old_password='foo')
         self.assertTrue(pw_policy.check_is_old_password())
+
+    # --- Last admin protection tests ---
+
+    def _create_admin_user(self, username='admin'):
+        self.exec_cmd('ac-user-create', username=username, inbuf='admin',
+                      rolename='administrator',
+                      name=f'{username} User', email=f'{username}@user.com',
+                      force_password=True)
+
+    def test_delete_last_admin_user(self):
+        self._create_admin_user()
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-user-delete', username='admin')
+        self.assertEqual(ctx.exception.retcode, -errno.EPERM)
+        self.assertIn('last user with administrator role', str(ctx.exception))
+        self.validate_persistent_user('admin', ['administrator'])
+
+    def test_delete_admin_when_others_exist(self):
+        self._create_admin_user('admin1')
+        self._create_admin_user('admin2')
+        out = self.exec_cmd('ac-user-delete', username='admin1')
+        self.assertEqual(out, "User 'admin1' deleted")
+        self.validate_persistent_no_user('admin1')
+
+    def test_delete_admin_when_other_is_disabled(self):
+        self._create_admin_user('admin1')
+        self._create_admin_user('admin2')
+        self.exec_cmd('ac-user-disable', username='admin2')
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-user-delete', username='admin1')
+        self.assertEqual(ctx.exception.retcode, -errno.EPERM)
+        self.assertIn('last user with administrator role', str(ctx.exception))
+
+    def test_delete_non_admin_user_freely(self):
+        self._create_admin_user('admin1')
+        self.exec_cmd('ac-user-create', username='regular', inbuf='pass',
+                      name='Regular', email='r@r.com', force_password=True)
+        out = self.exec_cmd('ac-user-delete', username='regular')
+        self.assertEqual(out, "User 'regular' deleted")
+
+    def test_disable_last_admin(self):
+        self._create_admin_user()
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-user-disable', username='admin')
+        self.assertEqual(ctx.exception.retcode, -errno.EPERM)
+        self.assertIn('last user with administrator role', str(ctx.exception))
+
+    def test_disable_admin_when_others_exist(self):
+        self._create_admin_user('admin1')
+        self._create_admin_user('admin2')
+        user = self.exec_cmd('ac-user-disable', username='admin1')
+        self.assertFalse(user['enabled'])
+
+    def test_set_roles_remove_admin_from_last_admin(self):
+        self._create_admin_user()
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-user-set-roles', username='admin',
+                          roles=['read-only'])
+        self.assertEqual(ctx.exception.retcode, -errno.EPERM)
+        self.assertIn('last user with administrator role', str(ctx.exception))
+
+    def test_set_roles_remove_admin_when_others_exist(self):
+        self._create_admin_user('admin1')
+        self._create_admin_user('admin2')
+        user = self.exec_cmd('ac-user-set-roles', username='admin1',
+                             roles=['read-only'])
+        self.assertListEqual(user['roles'], ['read-only'])
+
+    def test_del_roles_remove_admin_from_last_admin(self):
+        self._create_admin_user()
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-user-del-roles', username='admin',
+                          roles=['administrator'])
+        self.assertEqual(ctx.exception.retcode, -errno.EPERM)
+        self.assertIn('last user with administrator role', str(ctx.exception))
+
+    def test_del_roles_remove_admin_when_others_exist(self):
+        self._create_admin_user('admin1')
+        self._create_admin_user('admin2')
+        user = self.exec_cmd('ac-user-del-roles', username='admin1',
+                             roles=['administrator'])
+        self.assertNotIn('administrator', user['roles'])


### PR DESCRIPTION
Add last-admin protection across backend (REST API + CLI) and frontend to prevent losing all admin access. Guards delete, role-strip, and disable operations on the last enabled user with the administrator role.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
