### PR TITLE
mds: add heartbeat_reset in open_undef_inodes_dirfrags

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -6056,9 +6056,12 @@ bool MDCache::open_undef_inodes_dirfrags()
 
   // dirfrag -> (fetch_complete, keys_to_fetch)
   map<CDir*, pair<bool, std::vector<dentry_key_t> > > fetch_queue;
+  int count = 0;
   for (auto& dir : rejoin_undef_dirfrags) {
     ceph_assert(dir->get_version() == 0);
     fetch_queue.emplace(std::piecewise_construct, std::make_tuple(dir), std::make_tuple());
+    if (!(++count % mds->heartbeat_reset_grace()))
+      mds->heartbeat_reset();
   }
 
   if (g_conf().get_val<bool>("mds_dir_prefetch")) {
@@ -6066,6 +6069,8 @@ bool MDCache::open_undef_inodes_dirfrags()
       ceph_assert(!in->is_base());
       ceph_assert(in->get_parent_dir());
       fetch_queue.emplace(std::piecewise_construct, std::make_tuple(in->get_parent_dir()), std::make_tuple());
+      if (!(++count % mds->heartbeat_reset_grace()))
+        mds->heartbeat_reset();
     }
   } else {
     for (auto& in : rejoin_undef_inodes) {
@@ -6079,6 +6084,8 @@ bool MDCache::open_undef_inodes_dirfrags()
       } else if (!p.first) {
         p.second.push_back(dn->key());
       }
+      if (!(++count % mds->heartbeat_reset_grace()))
+        mds->heartbeat_reset();
     }
   }
 
@@ -6106,6 +6113,8 @@ bool MDCache::open_undef_inodes_dirfrags()
     } else {
       dir->fetch_keys(p.second.second, gather.new_sub());
     }
+    if (!(++count % mds->heartbeat_reset_grace()))
+      mds->heartbeat_reset();
   }
   ceph_assert(gather.has_subs());
   gather.activate();


### PR DESCRIPTION
During a cold rejoin, open_undef_inodes_dirfrags() iterates rejoin_undef_inodes without heartbeat_reset().  The set can contain millions of entries, and the single unbroken iteration within one fin->complete(0) exceeds mds_heartbeat_grace, starving the beacon and triggering a self-reinforcing respawn loop.

Background: how a cold rejoin rebuilds the cache

When a rank recovers, surviving ranks walk their own caches and send dentry trees belonging to the recovering rank:

```
  Surviving ranks (0,2,3,4,5)
  ============================
  rejoin_send_rejoins()
    |
    +-- for each subtree:
    |     if (dir->is_auth()) continue;          // skip own
    |     auth = dir->get_dir_auth().first;
    |     if (auth != recovering_rank) continue;
    |     rejoin_walk(dir, rejoins[auth])
    |       |
    |       +-- add_strong_dirfrag(dirfrag, nonce, dir_rep)
    |       +-- for each dentry:
    |             add_strong_dentry(name, ino, lock_state, ...)
    |
    +-- send MMDSCacheRejoin(OP_STRONG)
            |
            v
  Recovering rank (1)
  ===================
  handle_cache_rejoin_strong()
    |
    +-- for each dentry in the message:
          dn = dir->lookup(name);
          if (!dn) {
            in = get_inode(d.ino);
            if (!in)
              in = rejoin_invent_inode(...)
                |
                +-- new CInode()
                +-- state_set(REJOINUNDEF)
                +-- rejoin_undef_inodes.insert() // populates the set
          }
```

On a cold rejoin the cache is empty, so every dentry produces a new REJOINUNDEF placeholder.  For a rank with a ~43M steady-state working set, the set reaches ~43M entries.

Timeline of the stall


```
  Phase 1: accumulation (cache rejoin protocol)
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  Each rejoin message is dispatched under mds_lock:

    _dispatch()                          // holds mds_lock
      handle_cache_rejoin_strong()
        for each dentry:
          get_inode() -> null -> rejoin_invent_inode()
            new CInode()
            state_set(REJOINUNDEF)
            rejoin_undef_inodes.insert()
      heartbeat_reset()                  // OK: called after each dispatch

  Heartbeats are safe: work is spread across many dispatches.

  Phase 2: traversal (a single fin->complete(0))
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  When the last rejoin ack arrives and the gather empties:

    _advance_queues()                    // holds mds_lock
      fin->complete(0)                   // ONE callback, no yield
        rejoin_gather_finish()
          open_undef_inodes_dirfrags()
            for (auto& in : rejoin_undef_inodes)  // ~43M iterations
              fetch_queue.emplace(...)            // no heartbeat_reset
            for (auto& p : fetch_queue)           // no heartbeat_reset
              dir->fetch(...)
            gather.activate()
      heartbeat_reset()                  // TOO LATE: ~129s without reset

```
  43M * 3us = ~129s >> mds_heartbeat_grace (15s)
  -> HeartbeatMap::is_healthy() = false
  -> Beacon::_send() skips beacon
  -> mon marks rank laggy -> respawn -> next cold rejoin -> flap

  When mds_dir_prefetch=true, _omap_fetched() resolves undefs and
  exposes children, triggering additional open_undef_inodes_dirfrags()
  calls on the still-large remaining set, amplifying the stall.

To fix it just call heartbeat_reset() every heartbeat_reset_grace() iterations in all four loops to keep the heartbeat alive regardless of the undef set size.

Fixes: https://tracker.ceph.com/issues/78863





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
