### PR TITLE
RGW: Verify non-preflight authenticated cross origin requests

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2009,6 +2009,53 @@ bool RGWOp::generate_cors_headers(string& origin, string& method, string& header
   return false;
 }
 
+int RGWOp::verify_cors_match()
+{
+  if (get_type() == RGW_OP_OPTIONS_CORS) {
+    return 0;
+  }
+
+  const char *orig = s->info.env->get("HTTP_ORIGIN");
+  if (!orig || !*orig) {
+    return 0;
+  }
+
+  // if we have global/bucket cors config, it will set cors_exist=true
+  cors_exist = false;
+  read_global_cors();
+  read_bucket_cors();
+
+  if (!cors_exist) {
+    /* No CORS configuration at all — nothing to enforce. */
+    ldpp_dout(this, 20) << "verify_cors_origin: no CORS config, skipping verification" << dendl;
+    return -EACCES;
+  }
+
+  const char *req_meth = s->info.method;
+  if (!req_meth || strcmp(req_meth, "") == 0) {
+    return 0;
+  }
+
+  RGWCORSRule *rule = bucket_cors.match_rule(orig, req_meth, nullptr);
+  if (rule) {
+    ldpp_dout(this, 10) << "verify_cors_match: origin=" << orig
+                        << " method=" << req_meth << " allowed by bucket CORS rule" << dendl;
+    return 0;
+  }
+
+  if (optional_global_cors.has_value() &&
+      optional_global_cors->matches(orig, req_meth, nullptr)) {
+    ldpp_dout(this, 10) << "verify_cors_match: origin=" << orig
+                        << " method=" << req_meth << " allowed by global CORS rule" << dendl;
+    return 0;
+  }
+
+  ldpp_dout(this, 5) << "verify_cors_match: origin=" << orig
+                     << " method=" << req_meth
+                     << " rejected — not in CORS AllowedMethods" << dendl;
+  return -EACCES;
+}
+
 int rgw_policy_from_attrset(const DoutPrefixProvider *dpp, CephContext *cct, map<string, bufferlist>& attrset, RGWAccessControlPolicy *policy)
 {
   map<string, bufferlist>::iterator aiter = attrset.find(RGW_ATTR_ACL);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2028,7 +2028,7 @@ int RGWOp::verify_cors_match()
   if (!cors_exist) {
     /* No CORS configuration at all — nothing to enforce. */
     ldpp_dout(this, 20) << "verify_cors_origin: no CORS config, skipping verification" << dendl;
-    return -EACCES;
+    return 0;
   }
 
   const char *req_meth = s->info.method;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1884,20 +1884,24 @@ int RGWOp::read_global_cors()
   string allow_origins, allow_headers, allow_methods, expose_headers;
   int ret = g_conf().get_val("rgw_gcors_allow_origins", &allow_origins);
   if (ret < 0 || allow_origins.empty()) {
-    return -EINVAL;
+    ldpp_dout(this, 20) << "no global CORS allow origins found, ret=" << cpp_strerror(ret) << dendl;
+    return 0;
   }
   ret = g_conf().get_val("rgw_gcors_allow_headers", &allow_headers);
   if (ret < 0 || allow_headers.empty()) {
-    return -EINVAL;
+    ldpp_dout(this, 20) << "no global CORS allow headers found, ret=" << cpp_strerror(ret) << dendl;
+    return 0;
   }
   ret = g_conf().get_val("rgw_gcors_allow_methods", &allow_methods);
   if (ret < 0 || allow_methods.empty()) {
-    return -EINVAL;
+    ldpp_dout(this, 20) << "no global CORS allow methods found, ret=" << cpp_strerror(ret) << dendl;
+    return 0;
   }
   g_conf().get_val("rgw_gcors_expose_headers", &expose_headers);
   if (RGWCORSRule::create_rule(allow_origins.c_str(), allow_headers.c_str(), expose_headers.c_str(), allow_methods.c_str(),
                                optional_global_cors) < 0) {
-    return -EINVAL;
+    ldpp_dout(this, 20) << "no global CORS configuration found" << dendl;
+    return 0;
   }
 
   cors_exist = true;
@@ -1953,11 +1957,10 @@ bool RGWOp::generate_cors_headers(string& origin, string& method, string& header
   cors_exist = false;
   origin = orig;
 
-  const int read_global_cors_ret = read_global_cors();
-  const int temp_op_ret = read_bucket_cors();
+  read_global_cors();
+  op_ret = read_bucket_cors();
   if (!cors_exist) {
     ldpp_dout(this, 2) << "No global CORS or bucket CORS configuration set yet" << dendl;
-    op_ret = std::min(temp_op_ret, read_global_cors_ret);
     return false;
   }
 
@@ -7272,8 +7275,8 @@ int RGWOptionsCORS::validate_global_cors_request(RGWCORSRule *global_cors_rule) 
 void RGWOptionsCORS::execute(optional_yield y)
 {
   op_ret = read_bucket_cors();
-  int ret = read_global_cors();
-  if (ret < 0 && op_ret < 0) {
+  read_global_cors();
+  if (!cors_exist) {
       ldpp_dout(this, 2) << "No CORS configuration set yet for this bucket nor globally" << dendl;
       return;
   }

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -284,6 +284,15 @@ public:
   int read_global_cors();
   bool generate_cors_headers(std::string& origin, std::string& method, std::string& headers, std::string& exp_headers, unsigned *max_age);
 
+  /* Enforce CORS policy for cross-origin non-preflight requests.
+   *
+   * The check is skipped when:
+   *  - no Origin header is present
+   *  - getting a preflight request (handled entirely by RGWOptionsCORS)
+   *  - no bucket/global CORS configuration exists
+   */
+  int verify_cors_match();
+
   virtual int verify_params() { return 0; }
   virtual bool prefetch_data() { return false; }
 

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -228,6 +228,12 @@ int rgw_process_authenticated(RGWHandler_REST * const handler,
     return ret;
   }
 
+  ldpp_dout(op, 2) << "verifying CORS origin matches" << dendl;
+  ret = op->verify_cors_match();
+  if (ret < 0) {
+    return ret;
+  }
+
   /* Check if OPA is used to authorize requests */
   if (s->cct->_conf->rgw_use_opa_authz) {
     ret = rgw_opa_authorize(op, s);

--- a/src/test/rgw/s3-tests/s3tests/functional/test_s3.py
+++ b/src/test/rgw/s3-tests/s3tests/functional/test_s3.py
@@ -7057,15 +7057,15 @@ def test_cors_origin_response():
 
     _cors_request_and_check(requests.get, url, None, 200, None, None)
     _cors_request_and_check(requests.get, url, {'Origin': 'foo.suffix'}, 200, 'foo.suffix', 'GET')
-    _cors_request_and_check(requests.get, url, {'Origin': 'foo.bar'}, 200, None, None)
-    _cors_request_and_check(requests.get, url, {'Origin': 'foo.suffix.get'}, 200, None, None)
+    _cors_request_and_check(requests.get, url, {'Origin': 'foo.bar'}, 403, None, None)
+    _cors_request_and_check(requests.get, url, {'Origin': 'foo.get.suffix'}, 200, 'foo.get.suffix', 'GET')
     _cors_request_and_check(requests.get, url, {'Origin': 'startend'}, 200, 'startend', 'GET')
     _cors_request_and_check(requests.get, url, {'Origin': 'start1end'}, 200, 'start1end', 'GET')
     _cors_request_and_check(requests.get, url, {'Origin': 'start12end'}, 200, 'start12end', 'GET')
-    _cors_request_and_check(requests.get, url, {'Origin': '0start12end'}, 200, None, None)
+    _cors_request_and_check(requests.get, url, {'Origin': '0start12end'}, 403, None, None)
     _cors_request_and_check(requests.get, url, {'Origin': 'prefix'}, 200, 'prefix', 'GET')
     _cors_request_and_check(requests.get, url, {'Origin': 'prefix.suffix'}, 200, 'prefix.suffix', 'GET')
-    _cors_request_and_check(requests.get, url, {'Origin': 'bla.prefix'}, 200, None, None)
+    _cors_request_and_check(requests.get, url, {'Origin': 'bla.prefix'}, 403, None, None)
 
     obj_url = '{u}/{o}'.format(u=url, o='bar')
     _cors_request_and_check(requests.get, obj_url, {'Origin': 'foo.suffix'}, 404, 'foo.suffix', 'GET')
@@ -21011,3 +21011,27 @@ def test_lifecycle_transition_encrypted(source_mode_key, source_storage_class, d
         f"Testing lifecycle transition of {source_mode_key} with storage class {source_storage_class} -> {dest_storage_class}"
     )
     _test_lifecycle_transition(source_mode_key, source_storage_class, dest_storage_class)
+
+
+def test_cors_presigned_url_non_preflight():
+    bucket_name = _setup_bucket_acl(bucket_acl='public-read')
+    client = get_client()
+
+    cors_config ={
+        'CORSRules': [
+            {'AllowedMethods': ['GET'],
+             'AllowedOrigins': ['*'],
+            },
+        ]
+    }
+    client.put_bucket_cors(Bucket=bucket_name, CORSConfiguration=cors_config)
+
+    key = 'foo'
+    # Generate the presigned URL
+    presigned_url = client.generate_presigned_url(
+        ClientMethod="create_multipart_upload",
+        HttpMethod="POST",
+        Params={"Bucket": bucket_name, "Key": key},
+    )
+
+    _cors_request_and_check(requests.post, presigned_url, {'Origin':'example1.com', 'Access-Control-Request-Method': 'POST'}, 403, None, None)

--- a/src/test/rgw/s3-tests/s3tests/functional/test_s3.py
+++ b/src/test/rgw/s3-tests/s3tests/functional/test_s3.py
@@ -6950,15 +6950,15 @@ def test_cors_origin_response():
 
     _cors_request_and_check(requests.get, url, None, 200, None, None)
     _cors_request_and_check(requests.get, url, {'Origin': 'foo.suffix'}, 200, 'foo.suffix', 'GET')
-    _cors_request_and_check(requests.get, url, {'Origin': 'foo.bar'}, 200, None, None)
-    _cors_request_and_check(requests.get, url, {'Origin': 'foo.suffix.get'}, 200, None, None)
+    _cors_request_and_check(requests.get, url, {'Origin': 'foo.bar'}, 403, None, None)
+    _cors_request_and_check(requests.get, url, {'Origin': 'foo.get.suffix'}, 200, 'foo.get.suffix', 'GET')
     _cors_request_and_check(requests.get, url, {'Origin': 'startend'}, 200, 'startend', 'GET')
     _cors_request_and_check(requests.get, url, {'Origin': 'start1end'}, 200, 'start1end', 'GET')
     _cors_request_and_check(requests.get, url, {'Origin': 'start12end'}, 200, 'start12end', 'GET')
-    _cors_request_and_check(requests.get, url, {'Origin': '0start12end'}, 200, None, None)
+    _cors_request_and_check(requests.get, url, {'Origin': '0start12end'}, 403, None, None)
     _cors_request_and_check(requests.get, url, {'Origin': 'prefix'}, 200, 'prefix', 'GET')
     _cors_request_and_check(requests.get, url, {'Origin': 'prefix.suffix'}, 200, 'prefix.suffix', 'GET')
-    _cors_request_and_check(requests.get, url, {'Origin': 'bla.prefix'}, 200, None, None)
+    _cors_request_and_check(requests.get, url, {'Origin': 'bla.prefix'}, 403, None, None)
 
     obj_url = '{u}/{o}'.format(u=url, o='bar')
     _cors_request_and_check(requests.get, obj_url, {'Origin': 'foo.suffix'}, 404, 'foo.suffix', 'GET')
@@ -20904,3 +20904,27 @@ def test_lifecycle_transition_encrypted(source_mode_key, source_storage_class, d
         f"Testing lifecycle transition of {source_mode_key} with storage class {source_storage_class} -> {dest_storage_class}"
     )
     _test_lifecycle_transition(source_mode_key, source_storage_class, dest_storage_class)
+
+
+def test_cors_presigned_url_non_preflight():
+    bucket_name = _setup_bucket_acl(bucket_acl='public-read')
+    client = get_client()
+
+    cors_config ={
+        'CORSRules': [
+            {'AllowedMethods': ['GET'],
+             'AllowedOrigins': ['*'],
+            },
+        ]
+    }
+    client.put_bucket_cors(Bucket=bucket_name, CORSConfiguration=cors_config)
+
+    key = 'foo'
+    # Generate the presigned URL
+    presigned_url = client.generate_presigned_url(
+        ClientMethod="create_multipart_upload",
+        HttpMethod="POST",
+        Params={"Bucket": bucket_name, "Key": key},
+    )
+
+    _cors_request_and_check(requests.post, presigned_url, {'Origin':'example1.com', 'Access-Control-Request-Method': 'POST'}, 403, None, None)

--- a/src/test/rgw/s3-tests/s3tests/functional/test_s3.py
+++ b/src/test/rgw/s3-tests/s3tests/functional/test_s3.py
@@ -21014,8 +21014,22 @@ def test_lifecycle_transition_encrypted(source_mode_key, source_storage_class, d
 
 
 def test_cors_presigned_url_non_preflight():
-    bucket_name = _setup_bucket_acl(bucket_acl='public-read')
     client = get_client()
+    bucket_name = _setup_bucket_acl(bucket_acl='public-read')
+    key = 'foo'
+    response = client.put_object(Bucket=bucket_name, Key=key, Body='str')
+    assert response['ResponseMetadata']['HTTPStatusCode'] == 200
+
+    # Generate the presigned URL
+    presigned_url = client.generate_presigned_url(
+        ClientMethod='get_object',
+        HttpMethod='GET',
+        Params={'Bucket': bucket_name, 'Key': key},
+    )
+
+    _cors_request_and_check(requests.get, presigned_url,
+                            {'Origin':'example1.com'},
+                            200, None, None)
 
     cors_config ={
         'CORSRules': [
@@ -21026,12 +21040,13 @@ def test_cors_presigned_url_non_preflight():
     }
     client.put_bucket_cors(Bucket=bucket_name, CORSConfiguration=cors_config)
 
-    key = 'foo'
     # Generate the presigned URL
     presigned_url = client.generate_presigned_url(
-        ClientMethod="create_multipart_upload",
-        HttpMethod="POST",
-        Params={"Bucket": bucket_name, "Key": key},
+        ClientMethod='create_multipart_upload',
+        HttpMethod='POST',
+        Params={'Bucket': bucket_name, 'Key': key},
     )
 
-    _cors_request_and_check(requests.post, presigned_url, {'Origin':'example1.com', 'Access-Control-Request-Method': 'POST'}, 403, None, None)
+    _cors_request_and_check(requests.post, presigned_url,
+                            {'Origin':'example1.com'},
+                            403, None, None)


### PR DESCRIPTION
https://ibm-ceph.atlassian.net/browse/IBMCEPH-9464
https://ibm-ceph.atlassian.net/browse/IBMCEPH-16988





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
