### PR TITLE
mgr/cephadm: set filesystems joinable immediately after MDS daemons are upgraded

### DIFF
--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -204,6 +204,7 @@ class UpgradeState:
                  crush_bucket_name: Optional[str] = None,
                  noautoscale_set: Optional[bool] = False,
                  prior_autoscale: Optional[bool] = True,
+                 mds_upgrade_completed: Optional[bool] = False,
                  ):
 
         self._target_name: str = target_name  # Use CephadmUpgrade.target_image instead.
@@ -226,6 +227,7 @@ class UpgradeState:
         self.crush_bucket_name = crush_bucket_name
         self.noautoscale_set = noautoscale_set
         self.prior_autoscale = prior_autoscale
+        self.mds_upgrade_completed = mds_upgrade_completed
 
     def to_json(self) -> dict:
         return {
@@ -248,6 +250,7 @@ class UpgradeState:
             'crush_bucket_name': self.crush_bucket_name,
             'noautoscale_set': self.noautoscale_set,
             'prior_autoscale': self.prior_autoscale,
+            'mds_upgrade_completed': self.mds_upgrade_completed,
         }
 
     @classmethod
@@ -1679,6 +1682,22 @@ class CephadmUpgrade:
                 else:
                     raise
 
+    def _verify_all_mds_upgraded(self, target_version: str) -> bool:
+        ret, out_ver, err = self.mgr.check_mon_command({
+            'prefix': 'versions',
+        })
+        j = json.loads(out_ver)
+        mds_versions = j.get('mds', {})
+        all_upgraded = True
+        for version, count in mds_versions.items():
+            short_version = version.split(' ')[2]
+            if short_version != target_version:
+                logger.warning(
+                    'Upgrade: %d mds daemon(s) are %s != target %s' %
+                    (count, short_version, target_version))
+                all_upgraded = False
+        return all_upgraded
+
     def _complete_mds_upgrade(self) -> None:
         assert self.upgrade_state is not None
         if self.upgrade_state.fail_fs:
@@ -1976,6 +1995,17 @@ class CephadmUpgrade:
                 return
             self._upgrade_daemons(to_upgrade, target_image, target_digests)
             if to_upgrade:
+                if daemon_type == 'mds' and self.upgrade_state.fail_fs:
+                    if self._verify_all_mds_upgraded(target_version):
+                        logger.info('Upgrade: All MDS daemons upgraded to %s, '
+                                    'setting filesystems joinable' % target_version)
+                        self._complete_mds_upgrade()
+                        self.upgrade_state.mds_upgrade_completed = True
+                        self._save_upgrade_state()
+                    else:
+                        logger.info('Upgrade: Waiting for all MDS daemons to report '
+                                    'target version %s before setting filesystems '
+                                    'joinable' % target_version)
                 return
 
             self._handle_need_upgrade_self(need_upgrade_self, daemon_type == 'mgr')
@@ -2015,7 +2045,7 @@ class CephadmUpgrade:
                 self._complete_osd_upgrade(target_major, target_major_name)
 
             # complete mds upgrade?
-            if daemon_type == 'mds':
+            if daemon_type == 'mds' and not self.upgrade_state.mds_upgrade_completed:
                 self._complete_mds_upgrade()
 
             # Make sure all metadata is up to date before saying we are done upgrading this daemon type

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -1683,20 +1683,35 @@ class CephadmUpgrade:
                     raise
 
     def _verify_all_mds_upgraded(self, target_version: str) -> bool:
-        ret, out_ver, err = self.mgr.check_mon_command({
-            'prefix': 'versions',
-        })
-        j = json.loads(out_ver)
-        mds_versions = j.get('mds', {})
-        all_upgraded = True
-        for version, count in mds_versions.items():
-            short_version = version.split(' ')[2]
-            if short_version != target_version:
+        deadline = time.time() + 10
+        while True:
+            ret, out_ver, err = self.mgr.check_mon_command({
+                'prefix': 'versions',
+            })
+            j = json.loads(out_ver)
+            mds_versions = j.get('mds', {})
+            all_upgraded = True
+            for version, count in mds_versions.items():
+                short_version = version.split(' ')[2]
+                if short_version != target_version:
+                    logger.warning(
+                        'Upgrade: %d mds daemon(s) are %s != target %s' %
+                        (count, short_version, target_version))
+                    all_upgraded = False
+
+            if all_upgraded:
+                return True
+
+            if time.time() >= deadline:
                 logger.warning(
-                    'Upgrade: %d mds daemon(s) are %s != target %s' %
-                    (count, short_version, target_version))
-                all_upgraded = False
-        return all_upgraded
+                    'Upgrade: timed out waiting for all mds daemons to report '
+                    'target version %s' % target_version)
+                return False
+
+            logger.info(
+                'Upgrade: Waiting for mds daemons to report target version %s, '
+                'retrying...' % target_version)
+            time.sleep(2)
 
     def _complete_mds_upgrade(self) -> None:
         assert self.upgrade_state is not None


### PR DESCRIPTION
    Previously, after upgrading MDS daemons, the code would return control
    to the serve loop and rely on the next iteration to detect (via cephadm
    cache) that no more MDS daemons need upgrading, then call
    _complete_mds_upgrade(). This added an unnecessary serve loop iteration
    delay before filesystems were set joinable again.
    
    Now, immediately after upgrading MDS daemons, _verify_all_mds_upgraded()
    queries 'ceph versions' to confirm all MDS daemons report the target
    version. If verified, _complete_mds_upgrade() is called right away
    before returning to the serve loop, reducing the window during which
    filesystems remain not-joinable
    
    Fixes: https://tracker.ceph.com/issues/78826
    Signed-off-by: Shweta Bhosale <Shweta.Bhosale1@ibm.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
