### PR TITLE
mgr/dashboard: Fix routing issue when clicking Next button in create subsystem wizard

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-1/nvmeof-subsystem-step-1.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-1/nvmeof-subsystem-step-1.component.spec.ts
@@ -79,5 +79,29 @@ describe('NvmeofSubsystemsStepOneComponent', () => {
 
       expect(form.get('subnetMask')?.hasError('required')).toBeTruthy();
     });
+
+    it('should not require subnet mask when add manually is selected', () => {
+      formHelper.setValue('listenerMode', component.LISTENER_MODE.MANUAL);
+      formHelper.setValue('subnetMask', '');
+      form.get('subnetMask')?.updateValueAndValidity();
+
+      expect(form.get('subnetMask')?.hasError('required')).toBeFalsy();
+    });
+
+    it('should require listeners when add manually is selected and none are chosen', () => {
+      formHelper.setValue('listenerMode', component.LISTENER_MODE.MANUAL);
+      formHelper.setValue('listeners', []);
+      form.get('listeners')?.updateValueAndValidity();
+
+      expect(form.get('listeners')?.hasError('required')).toBeTruthy();
+    });
+
+    it('should not require listeners when auto-fetch is selected', () => {
+      formHelper.setValue('listenerMode', component.LISTENER_MODE.AUTO_FETCH);
+      formHelper.setValue('listeners', []);
+      form.get('listeners')?.updateValueAndValidity();
+
+      expect(form.get('listeners')?.hasError('required')).toBeFalsy();
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-1/nvmeof-subsystem-step-1.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-1/nvmeof-subsystem-step-1.component.ts
@@ -86,8 +86,14 @@ export class NvmeofSubsystemsStepOneComponent implements OnInit, TearsheetStep {
     const subnetMaskValidators = [
       CdValidators.composeIf({ listenerMode: this.LISTENER_MODE.AUTO_FETCH }, [Validators.required])
     ];
+    // Empty array is a valid value for Validators.required in some paths; require
+    // at least one selected listener when Add manually is active.
+    const requireListeners = CdValidators.custom(
+      'required',
+      (value: ListenerItem[] | null | undefined) => !value || value.length === 0
+    );
     const listenersValidators = [
-      CdValidators.composeIf({ listenerMode: this.LISTENER_MODE.MANUAL }, [Validators.required])
+      CdValidators.composeIf({ listenerMode: this.LISTENER_MODE.MANUAL }, [requireListeners])
     ];
 
     if (this.listenersOnly) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.html
@@ -120,7 +120,6 @@
                 type="button"
                 cdsButton="primary"
                 size="xl"
-                [disabled]="steps[currentStep]?.invalid"
                 (click)="onNext()"
                 i18n
               >
@@ -277,7 +276,6 @@
               type="button"
               cdsButton="primary"
               size="xl"
-              [disabled]="steps[currentStep]?.invalid"
               (click)="onNext()"
               i18n
             >

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.spec.ts
@@ -1,11 +1,13 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { Component, ViewChild } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { AbstractControl, FormControl, FormGroup, Validators } from '@angular/forms';
 import { SharedModule } from '../../shared.module';
 import { TearsheetStepComponent } from '../tearsheet-step/tearsheet-step.component';
 import { TearsheetComponent, TearsheetOverflowScroll } from './tearsheet.component';
 import { ActivatedRoute } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { delay } from 'rxjs/operators';
 
 // Mock Component that uses tearsheet
 @Component({
@@ -62,6 +64,56 @@ class MockFormStepComponent {
 }
 
 @Component({
+  selector: 'cd-mock-async-form-step',
+  template: '',
+  standalone: false
+})
+class MockAsyncFormStepComponent {
+  formGroup = new FormGroup({
+    name: new FormControl('default-name', {
+      validators: [Validators.required],
+      asyncValidators: [
+        (_control: AbstractControl): Observable<{ notUnique: boolean } | null> =>
+          of(null).pipe(delay(10))
+      ]
+    }),
+    requiredField: new FormControl('', Validators.required)
+  });
+}
+
+@Component({
+  template: `
+    <cd-tearsheet
+      [steps]="steps"
+      [title]="title"
+      [description]="description"
+    >
+      <cd-tearsheet-step>
+        <cd-mock-async-form-step #tearsheetStep></cd-mock-async-form-step>
+      </cd-tearsheet-step>
+      <cd-tearsheet-step>
+        <div>Step 2</div>
+      </cd-tearsheet-step>
+    </cd-tearsheet>
+  `,
+  standalone: false
+})
+class MockAsyncFormHostComponent {
+  steps = [
+    { label: 'Step 1', complete: false },
+    { label: 'Step 2', complete: false }
+  ];
+  title = 'Async Form Host';
+  description = 'Async Form Host Description';
+
+  @ViewChild(TearsheetComponent)
+  tearsheet!: TearsheetComponent;
+
+  @ViewChild(MockAsyncFormStepComponent)
+  formStep!: MockAsyncFormStepComponent;
+}
+
+@Component({
   template: `
     <cd-tearsheet
       [steps]="steps"
@@ -105,7 +157,9 @@ describe('TearsheetComponent', () => {
         TearsheetStepComponent,
         MockHostComponent,
         MockFormStepComponent,
-        MockFormHostComponent
+        MockFormHostComponent,
+        MockAsyncFormStepComponent,
+        MockAsyncFormHostComponent
       ],
       imports: [SharedModule],
       providers: [
@@ -218,7 +272,7 @@ describe('TearsheetComponent', () => {
       expect(tearsheetComponent.currentStep).toBe(0);
     });
 
-    it('should disable next button when current step is invalid', () => {
+    it('should keep Next enabled when current step is invalid so users can retry', () => {
       hostComponent.steps = hostComponent.steps.map((step, i) =>
         i === 0 ? { ...step, invalid: true } : step
       );
@@ -228,12 +282,12 @@ describe('TearsheetComponent', () => {
       );
       const nextBtn = buttons.find((btn) => btn.nativeElement.textContent.trim() === 'Next');
       expect(nextBtn).toBeTruthy();
-      expect(nextBtn?.nativeElement.disabled).toBe(true);
+      expect(nextBtn?.nativeElement.disabled).toBe(false);
     });
   });
 
   describe('nested form validation on next', () => {
-    it('should mark nested controls dirty and touched on next', () => {
+    it('should mark nested controls touched on next without dirtying them', () => {
       const formHostFixture = TestBed.createComponent(MockFormHostComponent);
       formHostFixture.detectChanges();
       const formHost = formHostFixture.componentInstance;
@@ -245,10 +299,121 @@ describe('TearsheetComponent', () => {
 
       formHost.tearsheet.onNext();
 
-      expect(childControl?.dirty).toBe(true);
+      // Touch shows errors; do not mark dirty (that re-triggers async validators).
+      expect(childControl?.dirty).toBe(false);
       expect(childControl?.touched).toBe(true);
       expect(childControl?.hasError('required')).toBe(true);
+      expect(formHost.tearsheet.currentStep).toBe(0);
     });
+
+    it('should advance after async validators complete when required fields are filled', fakeAsync(() => {
+      const formHostFixture = TestBed.createComponent(MockAsyncFormHostComponent);
+      formHostFixture.detectChanges();
+      const formHost = formHostFixture.componentInstance;
+
+      formHost.formStep.formGroup.get('requiredField')?.setValue('filled');
+      formHostFixture.detectChanges();
+
+      formHost.tearsheet.onNext();
+      expect(formHost.tearsheet.currentStep).toBe(0);
+
+      tick(10);
+      formHostFixture.detectChanges();
+
+      expect(formHost.tearsheet.currentStep).toBe(1);
+      expect(formHost.tearsheet.steps[0].invalid).toBe(false);
+    }));
+
+    it('should stay on step when invalid then advance after the field is fixed', fakeAsync(() => {
+      const formHostFixture = TestBed.createComponent(MockAsyncFormHostComponent);
+      formHostFixture.detectChanges();
+      const formHost = formHostFixture.componentInstance;
+
+      // First Next with empty required field: stay on step; Next remains usable.
+      formHost.tearsheet.onNext();
+      tick(10);
+      formHostFixture.detectChanges();
+      expect(formHost.tearsheet.currentStep).toBe(0);
+
+      formHost.formStep.formGroup.get('requiredField')?.setValue('filled');
+      tick(10);
+      formHostFixture.detectChanges();
+
+      formHost.tearsheet.onNext();
+      tick(10);
+      formHostFixture.detectChanges();
+      expect(formHost.tearsheet.currentStep).toBe(1);
+    }));
+
+    it('should submit after validity refresh settles async validators', fakeAsync(() => {
+      const formHostFixture = TestBed.createComponent(MockAsyncFormHostComponent);
+      formHostFixture.detectChanges();
+      const formHost = formHostFixture.componentInstance;
+      const submitSpy = jest.spyOn(formHost.tearsheet.submitRequested, 'emit');
+
+      formHost.formStep.formGroup.get('requiredField')?.setValue('filled');
+      // Settle the initial async validator from control creation.
+      tick(10);
+      formHostFixture.detectChanges();
+
+      formHost.tearsheet.currentStep = 1;
+      formHostFixture.detectChanges();
+
+      formHost.tearsheet.onSubmit();
+      // refreshControlValidity re-runs async validators; wait for them to settle.
+      expect(submitSpy).not.toHaveBeenCalled();
+      tick(10);
+      formHostFixture.detectChanges();
+
+      expect(submitSpy).toHaveBeenCalledTimes(1);
+      expect(submitSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'default-name', requiredField: 'filled' })
+      );
+    }));
+
+    it('should navigate to the first invalid step instead of silently blocking Create', fakeAsync(() => {
+      const formHostFixture = TestBed.createComponent(MockAsyncFormHostComponent);
+      formHostFixture.detectChanges();
+      const formHost = formHostFixture.componentInstance;
+      const submitSpy = jest.spyOn(formHost.tearsheet.submitRequested, 'emit');
+
+      tick(10);
+      formHost.tearsheet.currentStep = 1;
+      formHostFixture.detectChanges();
+
+      formHost.tearsheet.onSubmit();
+      tick(10);
+      formHostFixture.detectChanges();
+
+      expect(submitSpy).not.toHaveBeenCalled();
+      expect(formHost.tearsheet.currentStep).toBe(0);
+      expect(formHost.tearsheet.steps[0].invalid).toBe(true);
+    }));
+
+    it('should not advance if the user navigated away before the async validator settled', fakeAsync(() => {
+      const formHostFixture = TestBed.createComponent(MockAsyncFormHostComponent);
+      formHostFixture.detectChanges();
+      const formHost = formHostFixture.componentInstance;
+
+      // Fill the required field so the form would be valid once async settles.
+      formHost.formStep.formGroup.get('requiredField')?.setValue('filled');
+      formHostFixture.detectChanges();
+
+      // Trigger Next — async validator is in-flight, step stays at 0.
+      formHost.tearsheet.onNext();
+      expect(formHost.tearsheet.currentStep).toBe(0);
+
+      // User navigates back to step 0 then clicks step 1 directly (or onStepSelect),
+      // simulating navigation away while the validator is still pending.
+      formHost.tearsheet.currentStep = 1;
+      formHostFixture.detectChanges();
+
+      // Async validator settles — callback must not advance further (step should stay at 1).
+      tick(10);
+      formHostFixture.detectChanges();
+
+      expect(formHost.tearsheet.currentStep).toBe(1);
+    }));
   });
 
   describe('[stepValid] seeding and live sync', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/tearsheet/tearsheet.component.ts
@@ -24,8 +24,8 @@ import { ActivatedRoute } from '@angular/router';
 import { Location } from '@angular/common';
 import { ConfirmationModalComponent } from '../confirmation-modal/confirmation-modal.component';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { forkJoin, Subject } from 'rxjs';
+import { filter, finalize, startWith, take, takeUntil } from 'rxjs/operators';
 
 export type TearsheetOverflowScroll = 'auto' | 'hidden' | 'visible' | 'scroll';
 
@@ -79,13 +79,19 @@ export class TearsheetComponent implements OnInit, AfterViewInit, OnDestroy, OnC
   @Input() successIcon: boolean = false;
   @Input() headerTestId?: string;
 
-  @Output() submitRequested = new EventEmitter<void>();
+  /** Merged step form values for consumers that bind `(submitRequested)="onSubmit($event)"`. */
+  @Output() submitRequested = new EventEmitter<Record<string, unknown>>();
   @Output() closeRequested = new EventEmitter<void>();
   @Output() stepChanged = new EventEmitter<{ current: number }>();
   @Output() validateStep = new EventEmitter<{ step: number }>();
 
   @ContentChildren(TearsheetStepComponent)
   stepContents!: QueryList<TearsheetStepComponent>;
+
+  private advancingDueToAsync = false;
+  private submittingDueToAsync = false;
+  /** Snapshot of each step's form value taken when leaving the step. */
+  private stepValueCache = new WeakMap<TearsheetStepComponent, Record<string, unknown>>();
 
   get activeStepTemplate() {
     return this.stepContents?.toArray()[this.currentStep]?.template;
@@ -154,6 +160,9 @@ export class TearsheetComponent implements OnInit, AfterViewInit, OnDestroy, OnC
 
   private _updateStepInvalid(index: number, invalid: boolean) {
     this.steps = this.steps.map((step, i) => (i === index ? { ...step, invalid } : step));
+    // statusChanges / async validators run outside the OnPush event path;
+    // mark dirty so Next button disabled state re-renders.
+    this.cdr.markForCheck();
   }
 
   onStepSelect(event: { step: Step; index: number }) {
@@ -213,58 +222,170 @@ export class TearsheetComponent implements OnInit, AfterViewInit, OnDestroy, OnC
     this.validateStep.emit({ step: this.currentStep });
     const wrapper = this.stepContents?.toArray()?.[this.currentStep];
     const currentForm = wrapper?.resolvedFormGroup;
+    // Touch for error display, then refresh each control so cdValidate /
+    // Carbon invalid bindings update. Do NOT markAsDirty — that re-triggers
+    // pristine-skipping async validators (e.g. NQN unique).
     currentForm?.markAllAsTouched();
-    this.markControlsDirtyAndValidate(currentForm);
-    if (currentForm) {
-      this._updateStepInvalid(this.currentStep, currentForm.invalid);
+    this.refreshControlValidity(currentForm);
+
+    // If an async validator is already in-flight (user edited NQN), wait for it.
+    if (currentForm?.pending) {
+      if (this.advancingDueToAsync) {
+        return;
+      }
+      this.advancingDueToAsync = true;
+      // Snapshot the step index now; the user may navigate away before the
+      // validator settles, so we must re-check both the index and the active
+      // wrapper on arrival and skip the advance if either has changed.
+      const stepBeingValidated = this.currentStep;
+      currentForm.statusChanges
+        .pipe(
+          startWith(currentForm.status),
+          filter((status) => status !== 'PENDING'),
+          take(1),
+          takeUntil(this.setupTeardown$),
+          finalize(() => {
+            this.advancingDueToAsync = false;
+          })
+        )
+        .subscribe(() => {
+          const activeWrapper = this.stepContents?.toArray()?.[stepBeingValidated];
+          if (this.currentStep === stepBeingValidated && activeWrapper === wrapper) {
+            this.advanceFromCurrentStep(wrapper);
+          }
+        });
+      return;
     }
 
+    this.advanceFromCurrentStep(wrapper);
+  }
+
+  /**
+   * Re-run validators and emit statusChanges on every control without marking
+   * them dirty. Needed so cdValidate picks up touched+invalid after Next.
+   */
+  private refreshControlValidity(control: AbstractControl | null) {
+    if (!control) {
+      return;
+    }
+    if (control instanceof FormGroup || control instanceof FormArray) {
+      Object.values(control.controls).forEach((child) => this.refreshControlValidity(child));
+    }
+    control.updateValueAndValidity({ onlySelf: true, emitEvent: true });
+  }
+
+  private advanceFromCurrentStep(wrapper: TearsheetStepComponent | undefined) {
+    // canProceed uses form.valid, so PENDING/INVALID both block advance.
+    // Next stays enabled; we only show field errors and refuse to leave the step.
     const canAdvance = wrapper ? wrapper.canProceed : true;
-    this._updateStepInvalid(this.currentStep, !canAdvance);
     if (this.currentStep !== this.lastStep && canAdvance) {
+      this._updateStepInvalid(this.currentStep, false);
+      if (wrapper) {
+        this.cacheStepValue(wrapper);
+      }
       this.currentStep = this.currentStep + 1;
       this.stepChanged.emit({ current: this.currentStep });
-      this.cdr.markForCheck();
-    } else if (!canAdvance) {
-      this.cdr.markForCheck();
+    }
+  }
+
+  private cacheStepValue(wrapper: TearsheetStepComponent) {
+    const value = wrapper.stepComponent?.formGroup?.value as Record<string, unknown> | null;
+    if (value) {
+      this.stepValueCache.set(wrapper, { ...value });
     }
   }
 
   getMergedPayload(): any {
     return this.stepContents.toArray().reduce((acc, wrapper) => {
-      const stepFormValue = wrapper.stepComponent?.formGroup?.value;
-      return { ...acc, ...stepFormValue };
+      const liveValue = wrapper.stepComponent?.formGroup?.value;
+      const cachedValue = this.stepValueCache.get(wrapper);
+      return { ...acc, ...(liveValue ?? cachedValue ?? {}) };
     }, {});
   }
 
   onSubmit() {
-    this.stepContents?.forEach((wrapper, index) => {
+    if (this.submittingDueToAsync) {
+      return;
+    }
+
+    // Cache whatever is still mounted before validating/submitting.
+    this.stepContents?.forEach((wrapper) => this.cacheStepValue(wrapper));
+
+    const wrappers = this.stepContents?.toArray() ?? [];
+    wrappers.forEach((wrapper) => {
       const form = wrapper.resolvedFormGroup;
       if (!form) return;
       form.markAllAsTouched();
-      this.markControlsDirtyAndValidate(form);
-      this._updateStepInvalid(index, form.invalid);
+      this.refreshControlValidity(form);
     });
 
-    const wrappers = this.stepContents?.toArray() ?? [];
-    const anyStepInvalid = this.steps.some(
-      (step, index) => step?.invalid || (wrappers[index] ? !wrappers[index].canProceed : false)
-    );
-    if (anyStepInvalid) return;
-
-    const mergedPayloads = this.getMergedPayload();
-    this.submitRequested.emit(mergedPayloads);
+    this.finishSubmit();
   }
 
-  private markControlsDirtyAndValidate(control: AbstractControl | null) {
-    if (!control) {
+  private waitForFormsToSettle(forms: FormGroup[], onSettled: () => void) {
+    if (!forms.length) {
+      onSettled();
       return;
     }
-    if (control instanceof FormGroup || control instanceof FormArray) {
-      Object.values(control.controls).forEach((child) => this.markControlsDirtyAndValidate(child));
+    this.submittingDueToAsync = true;
+    forkJoin(
+      forms.map((form) =>
+        form.statusChanges.pipe(
+          startWith(form.status),
+          filter((status) => status !== 'PENDING'),
+          take(1)
+        )
+      )
+    )
+      .pipe(
+        takeUntil(this.setupTeardown$),
+        finalize(() => {
+          this.submittingDueToAsync = false;
+        })
+      )
+      .subscribe(() => onSettled());
+  }
+
+  private finishSubmit() {
+    const wrappers = this.stepContents?.toArray() ?? [];
+    const forms = wrappers
+      .map((wrapper) => wrapper.resolvedFormGroup)
+      .filter((form): form is FormGroup => !!form);
+
+    const pendingForms = forms.filter((form) => form.pending);
+    if (pendingForms.length) {
+      this.waitForFormsToSettle(pendingForms, () => this.finishSubmit());
+      return;
     }
-    control.markAsDirty({ onlySelf: true });
-    control.updateValueAndValidity({ onlySelf: true, emitEvent: true });
+
+    let firstInvalid = -1;
+    wrappers.forEach((wrapper, index) => {
+      const form = wrapper.resolvedFormGroup;
+      if (form) {
+        this._updateStepInvalid(index, form.invalid);
+        if (form.invalid && firstInvalid < 0) {
+          firstInvalid = index;
+        }
+      } else if (wrapper.stepValid !== null && !wrapper.canProceed) {
+        this._updateStepInvalid(index, true);
+        if (firstInvalid < 0) {
+          firstInvalid = index;
+        }
+      } else {
+        // Form not currently resolvable (step content unmounted). Trust cache /
+        // earlier navigation — do not block Create on a stale steps[].invalid flag.
+        this._updateStepInvalid(index, false);
+      }
+    });
+
+    if (firstInvalid >= 0) {
+      this.currentStep = firstInvalid;
+      this.stepChanged.emit({ current: this.currentStep });
+      this.cdr.markForCheck();
+      return;
+    }
+
+    this.submitRequested.emit(this.getMergedPayload());
   }
 
   closeFullTearsheet() {
@@ -302,9 +423,19 @@ export class TearsheetComponent implements OnInit, AfterViewInit, OnDestroy, OnC
         // with Next enabled so the user can navigate freely before touching fields.
         const form = wrapper.resolvedFormGroup;
         if (form) {
-          form.statusChanges
-            .pipe(takeUntil(this.setupTeardown$))
-            .subscribe(() => this._updateStepInvalid(index, form.invalid));
+          // Do not seed or sync form.invalid onto the Next button — Next stays
+          // enabled so users can click it, see field errors (e.g. subnet-mask),
+          // fix them, and click Next again. Advance is still gated in onNext().
+          form.statusChanges.pipe(takeUntil(this.setupTeardown$)).subscribe(() => {
+            if (form.pending) {
+              return;
+            }
+            // Clear step invalid once the form becomes valid again after a
+            // failed Next attempt (field-level errors are handled by cdValidate).
+            if (form.valid) {
+              this._updateStepInvalid(index, false);
+            }
+          });
         }
 
         // Path 2: step uses [stepValid] input binding (no formGroup reference).


### PR DESCRIPTION

https://github.com/user-attachments/assets/87c62a72-e2f2-49b1-a578-940f94a0ff6f

https://github.com/user-attachments/assets/b9deab64-8fff-4ed9-a9a7-919de288d7a7


Fixes: https://tracker.ceph.com/issues/78875
Signed-off-by: pujashahu <pshahu@redhat.com>

Regression of Tracker :  https://tracker.ceph.com/issues/78641


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
