### PR TITLE
mgr/nfs: add daemon and export rotate-key command

### DIFF
--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -190,6 +190,36 @@ orchestration, these commands check service status:
    ceph orch ls --service_name=ingress.nfs.<cluster_id>
 
 
+Rotate NFS Cluster Keys
+-----------------------
+
+.. prompt:: bash #
+
+   ceph nfs cluster rotate-key <cluster_id> [<entity>...] [--key-type <type>]
+
+Rotate auth keys belonging to an NFS cluster. ``<cluster_id>`` is required.
+
+If no ``<entity>`` values are given, all auth entities for the cluster are
+rotated, including daemon/recovery keyrings (for example
+``client.nfs.<cluster_id>`` and ``client.nfs.<daemon_id>-rgw``) and CephFS
+export keyrings (``client.nfs.<cluster_id>.<fs_name>.<hash>``).
+
+If one or more ``<entity>`` values are given, only those entities are rotated.
+Each entity must belong to the cluster (the ``client.`` prefix is optional).
+
+``--key-type <type>`` is optional and is passed through to ``ceph auth rotate``
+(for example ``aes256k``).
+
+After export keys are rotated, matching CephFS exports are updated with the new
+keyrings. After any daemon keys are rotated, the NFS service is redeployed
+(``ceph orch redeploy nfs.<cluster_id>``).
+
+For example::
+
+   ceph nfs cluster rotate-key cephfs-nfs1 --key-type aes256k
+   ceph nfs cluster rotate-key cephfs-nfs1 client.nfs.cephfs-nfs1.cephfs.c44692f7 --key-type aes256k
+
+
 Updating an NFS Cluster
 -----------------------
 

--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -196,6 +196,43 @@ orchestration, these commands check service status:
    ceph orch ls --service_name=ingress.nfs.<cluster_id>
 
 
+Rotate NFS Cluster Keys
+-----------------------
+
+.. prompt:: bash #
+
+   ceph nfs cluster rotate-key <cluster_id> [--all-daemon-and-export-keys] [--auth-entities <entity>...] [--key-type <type>]
+
+Rotate auth keys belonging to an NFS cluster. ``<cluster_id>`` is required.
+
+Which keys get rotated must be requested explicitly: exactly one of
+``--all-daemon-and-export-keys`` or ``--auth-entities`` has to be given. If
+neither (or both) is given, the command fails without rotating anything.
+
+``--all-daemon-and-export-keys`` rotates every auth entity of the cluster,
+including daemon keyrings (for example ``client.nfs.<cluster_id>`` and
+``client.nfs.<daemon_id>-rgw``) and CephFS export keyrings
+(``client.nfs.<cluster_id>.<fs_name>.<hash>``).
+
+``--auth-entities <entity> [<entity>...]`` rotates only the listed entities.
+The names must match the entity names reported by ``ceph auth ls`` (the
+``client.`` prefix may be omitted) and each entity must belong to the cluster.
+Rotating a subset leaves the cluster with a mix of old and new keys: entities
+that are not listed keep their current key until they are rotated separately.
+
+``--key-type <type>`` is optional and is passed through to ``ceph auth rotate``
+(for example ``aes256k``).
+
+After export keys are rotated, matching CephFS exports are updated with the new
+keyrings. After any daemon keys are rotated, the NFS service is redeployed
+(``ceph orch redeploy nfs.<cluster_id>``).
+
+For example::
+
+   ceph nfs cluster rotate-key cephfs-nfs1 --all-daemon-and-export-keys --key-type aes256k
+   ceph nfs cluster rotate-key cephfs-nfs1 --auth-entities client.nfs.cephfs-nfs1.cephfs.c44692f7 --key-type aes256k
+
+
 Updating an NFS Cluster
 -----------------------
 

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -1,4 +1,5 @@
 import ipaddress
+import json
 import logging
 import re
 import socket
@@ -11,16 +12,19 @@ from object_format import ErrorResponse
 import orchestrator
 from orchestrator.module import IngressType
 
-from .exception import NFSInvalidOperation, ClusterNotFound
+from .exception import NFSInvalidOperation, ClusterNotFound, NFSObjectNotFound
 from .utils import (
     ManualRestartRequired,
     NonFatalError,
     available_clusters,
     conf_obj_name,
     restart_nfs_service,
+    redeploy_nfs_service,
     user_conf_obj_name,
     USER_CONF_PREFIX,
-    qos_conf_obj_name)
+    qos_conf_obj_name,
+    normalize_auth_entity,
+    entity_belongs_to_nfs_cluster)
 from .rados_utils import NFSRados
 from .ganesha_conf import format_block, GaneshaConfParser
 from .qos_conf import (
@@ -366,6 +370,122 @@ class NFSCluster:
             raise NonFatalError("Cluster does not exist")
         except Exception as e:
             log.exception(f"Failed to delete NFS Cluster {cluster_id}")
+            raise ErrorResponse.wrap(e)
+
+    def _resolve_entities(
+            self,
+            cluster_id: str,
+            entity: Optional[List[str]]
+    ) -> List[str]:
+        if not entity:
+            return self._list_cluster_auth_entities(cluster_id)
+        entities: List[str] = []
+        for raw in entity:
+            normalized = normalize_auth_entity(raw)
+            if not entity_belongs_to_nfs_cluster(normalized, cluster_id):
+                raise NFSInvalidOperation(
+                    f"{normalized} does not belong to NFS cluster {cluster_id}"
+                )
+            entities.append(normalized)
+        # remove duplicates if any
+        return list(dict.fromkeys(entities))
+
+    def _list_cluster_auth_entities(self, cluster_id: str) -> List[str]:
+        """Return all auth entities belonging to this NFS cluster."""
+        result = self.mgr.check_mon_command({
+            'prefix': 'auth ls',
+            'format': 'json',
+        })
+        try:
+            auth_data = json.loads(result.stdout)
+        except ValueError as e:
+            raise NFSInvalidOperation(f"Failed to parse auth ls output: {e}")
+
+        auth_dump = auth_data.get('auth_dump', []) if isinstance(auth_data, dict) else auth_data
+        return [
+            entry['entity']
+            for entry in auth_dump
+            if isinstance(entry, dict)
+            and entry.get('entity')
+            and entity_belongs_to_nfs_cluster(entry['entity'], cluster_id)
+        ]
+
+    def _auth_rotate(self, entity: str, cluster_id: str, key_type: Optional[str]) -> None:
+        log.info(
+            "Rotating NFS key %s for cluster %s%s",
+            entity, cluster_id,
+            f" with key_type {key_type}" if key_type else ""
+        )
+        rotate_cmd: Dict[str, str] = {
+            'prefix': 'auth rotate',
+            'entity': entity,
+        }
+        if key_type:
+            rotate_cmd['key_type'] = key_type
+        self.mgr.check_mon_command(rotate_cmd)
+
+    def rotate_keys(
+            self,
+            cluster_id: str,
+            entity: Optional[List[str]] = None,
+            key_type: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Rotate NFS auth keys for a cluster.
+
+        If entities are omitted, rotate all cluster keys (daemon/recovery and
+        CephFS export keys). Export configs are refreshed after export-key
+        rotation. The NFS service is redeployed when any daemon key is rotated.
+        """
+        try:
+            if cluster_id not in available_clusters(self.mgr):
+                raise ClusterNotFound()
+
+            entities = self._resolve_entities(cluster_id, entity)
+            if not entities:
+                raise NFSObjectNotFound(
+                    f"No auth entities found for NFS cluster {cluster_id}"
+                )
+
+            export_user_ids = self.mgr.export_mgr.get_cephfs_export_user_ids(cluster_id)
+            export_entities = [
+                ent for ent in entities if ent[len('client.'):] in export_user_ids
+            ]
+            daemon_entities = [
+                ent for ent in entities if ent[len('client.'):] not in export_user_ids
+            ]
+
+            for ent in entities:
+                self._auth_rotate(ent, cluster_id, key_type)
+
+            updated_exports: List[str] = []
+            if export_entities:
+                updated_exports = self.mgr.export_mgr.refresh_export_keys(
+                    cluster_id, export_entities
+                )
+
+            service_redeployed = False
+            if daemon_entities:
+                log.info(
+                    "Redeploying NFS service nfs.%s after rotating daemon keys: %s",
+                    cluster_id, daemon_entities
+                )
+                redeploy_nfs_service(self.mgr, cluster_id)
+                service_redeployed = True
+
+            result: Dict[str, Any] = {
+                "cluster_id": cluster_id,
+                "rotated": entities,
+                "export_keys": export_entities,
+                "daemon_keys": daemon_entities,
+                "updated_exports": updated_exports,
+                "service_redeployed": service_redeployed,
+            }
+            if key_type:
+                result["key_type"] = key_type
+            return result
+        except Exception as e:
+            log.exception("Failed to rotate NFS keys for cluster %s", cluster_id)
             raise ErrorResponse.wrap(e)
 
     def list_nfs_cluster(self) -> List[str]:

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -1,4 +1,5 @@
 import ipaddress
+import json
 import logging
 import re
 import socket
@@ -11,16 +12,19 @@ from object_format import ErrorResponse
 import orchestrator
 from orchestrator.module import IngressType
 
-from .exception import NFSInvalidOperation, ClusterNotFound
+from .exception import NFSInvalidOperation, ClusterNotFound, NFSObjectNotFound
 from .utils import (
     ManualRestartRequired,
     NonFatalError,
     available_clusters,
     conf_obj_name,
     restart_nfs_service,
+    redeploy_nfs_service,
     user_conf_obj_name,
     USER_CONF_PREFIX,
-    qos_conf_obj_name)
+    qos_conf_obj_name,
+    normalize_auth_entity,
+    entity_belongs_to_nfs_cluster)
 from .rados_utils import NFSRados
 from .ganesha_conf import format_block, GaneshaConfParser
 from .qos_conf import (
@@ -37,6 +41,19 @@ if TYPE_CHECKING:
 
 
 log = logging.getLogger(__name__)
+
+ROTATE_KEY_SELECTION_REQUIRED = (
+    "no keys selected for rotation. Rotating cephx keys must be requested "
+    "explicitly, so pass exactly one of:\n"
+    "  --all-daemon-and-export-keys: rotate every auth entity belonging to NFS "
+    "cluster {cluster_id}, that is the daemon keyrings and the CephFS "
+    "export keyrings\n"
+    "  --auth-entities <entity> [<entity>...]: rotate only the listed entities. "
+    "The names must match the entity names reported by `ceph auth ls` and must "
+    "belong to NFS cluster {cluster_id}\n"
+    "Note that rotating a subset leaves the cluster with a mix of old and new "
+    "keys"
+)
 
 
 def _is_log_only_config(nfs_config: str) -> bool:
@@ -386,6 +403,167 @@ class NFSCluster:
             raise NonFatalError("Cluster does not exist")
         except Exception as e:
             log.exception(f"Failed to delete NFS Cluster {cluster_id}")
+            raise ErrorResponse.wrap(e)
+
+    def _resolve_entities(
+            self,
+            cluster_id: str,
+            auth_entities: List[str]
+    ) -> List[str]:
+        entities: List[str] = []
+        for raw in auth_entities:
+            normalized = normalize_auth_entity(raw)
+            if not entity_belongs_to_nfs_cluster(normalized, cluster_id):
+                raise NFSInvalidOperation(
+                    f"{normalized} does not belong to NFS cluster {cluster_id}"
+                )
+            entities.append(normalized)
+        # remove duplicates if any
+        return list(dict.fromkeys(entities))
+
+    def _list_cluster_auth_entities(self, cluster_id: str) -> List[str]:
+        """Return all auth entities belonging to this NFS cluster."""
+        result = self.mgr.check_mon_command({
+            'prefix': 'auth ls',
+            'format': 'json',
+        })
+        try:
+            auth_data = json.loads(result.stdout)
+        except ValueError as e:
+            raise NFSInvalidOperation(f"Failed to parse auth ls output: {e}")
+
+        auth_dump = auth_data.get('auth_dump', []) if isinstance(auth_data, dict) else auth_data
+        return [
+            entry['entity']
+            for entry in auth_dump
+            if isinstance(entry, dict)
+            and entry.get('entity')
+            and entity_belongs_to_nfs_cluster(entry['entity'], cluster_id)
+        ]
+
+    def _auth_rotate(self, entity: str, cluster_id: str, key_type: Optional[str]) -> None:
+        log.info(
+            "Rotating NFS key %s for cluster %s%s",
+            entity, cluster_id,
+            f" with key_type {key_type}" if key_type else ""
+        )
+        rotate_cmd: Dict[str, str] = {
+            'prefix': 'auth rotate',
+            'entity': entity,
+        }
+        if key_type:
+            rotate_cmd['key_type'] = key_type
+        self.mgr.check_mon_command(rotate_cmd)
+
+    def rotate_keys(
+            self,
+            cluster_id: str,
+            all_daemon_and_export_keys: bool = False,
+            auth_entities: Optional[List[str]] = None,
+            key_type: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Rotate NFS auth keys for a cluster.
+
+        Exactly one of `all_daemon_and_export_keys` (rotate every auth entity
+        of the cluster) or `auth_entities` (rotate only the listed entities)
+        must be given. Export configs are refreshed after export-key rotation.
+        The NFS service is redeployed when any daemon key is rotated.
+        """
+        try:
+            if all_daemon_and_export_keys and auth_entities:
+                raise NFSInvalidOperation(
+                    "--all-daemon-and-export-keys and --auth-entities are mutually "
+                    "exclusive. Pass --all-daemon-and-export-keys to rotate every key "
+                    "of the cluster, or --auth-entities to rotate only specific ones."
+                )
+            if not all_daemon_and_export_keys and not auth_entities:
+                raise NFSInvalidOperation(ROTATE_KEY_SELECTION_REQUIRED.format(
+                    cluster_id=cluster_id))
+
+            if cluster_id not in available_clusters(self.mgr):
+                raise ClusterNotFound()
+
+            if all_daemon_and_export_keys:
+                all_entities = self._list_cluster_auth_entities(cluster_id)
+            else:
+                all_entities = self._resolve_entities(cluster_id, auth_entities or [])
+            if not all_entities:
+                raise NFSObjectNotFound(
+                    f"No auth entities found for NFS cluster {cluster_id}"
+                )
+
+            # A stale cache would make an export look like a daemon key, so it
+            # would be rotated but never refreshed.
+            self.mgr.export_mgr.reload_exports()
+            export_user_ids = self.mgr.export_mgr.get_cephfs_export_user_ids(cluster_id)
+
+            problems: List[str] = []
+            rotated: List[str] = []
+            for ent in all_entities:
+                try:
+                    self._auth_rotate(ent, cluster_id, key_type)
+                except Exception as e:
+                    log.exception("Failed to rotate NFS key %s for cluster %s", ent, cluster_id)
+                    problems.append(f"failed to rotate {ent}: {e}")
+                    break
+                rotated.append(ent)
+
+            export_entities = [
+                ent for ent in rotated if ent[len('client.'):] in export_user_ids
+            ]
+            daemon_entities = [
+                ent for ent in rotated if ent[len('client.'):] not in export_user_ids
+            ]
+
+            updated_exports: List[str] = []
+            if export_entities:
+                try:
+                    updated_exports, stale = self.mgr.export_mgr.refresh_export_keys(
+                        cluster_id, export_entities
+                    )
+                    if stale:
+                        problems.append(
+                            f"exports left with a pre-rotation keyring: {', '.join(stale)}")
+                except Exception as e:
+                    log.exception("Failed to refresh exports of cluster %s", cluster_id)
+                    problems.append(f"failed to refresh export keyrings: {e}")
+
+            service_redeployed = False
+            if daemon_entities:
+                log.info(
+                    "Redeploying NFS service nfs.%s after rotating daemon keys: %s",
+                    cluster_id, daemon_entities
+                )
+                try:
+                    redeploy_nfs_service(self.mgr, cluster_id)
+                    service_redeployed = True
+                except Exception as e:
+                    log.exception("Failed to redeploy NFS service nfs.%s", cluster_id)
+                    problems.append(
+                        f"failed to redeploy nfs.{cluster_id} ({e}); its daemons still "
+                        "run with pre-rotation keyrings and must be redeployed manually"
+                    )
+
+            result: Dict[str, Any] = {
+                "cluster_id": cluster_id,
+                "rotated": rotated,
+                "export_keys": export_entities,
+                "daemon_keys": daemon_entities,
+                "updated_exports": updated_exports,
+                "service_redeployed": service_redeployed,
+            }
+            if key_type:
+                result["key_type"] = key_type
+
+            if problems:
+                raise ErrorResponse(
+                    f"NFS key rotation for cluster {cluster_id} did not complete: "
+                    f"{'; '.join(problems)}."
+                )
+            return result
+        except Exception as e:
+            log.exception("Failed to rotate NFS keys for cluster %s", cluster_id)
             raise ErrorResponse.wrap(e)
 
     def list_nfs_cluster(self) -> List[str]:

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -44,7 +44,8 @@ from .utils import (
     check_fs,
     get_nfs_spec_for_cluster,
     restart_nfs_service,
-    cephfs_path_is_dir)
+    cephfs_path_is_dir,
+    normalize_auth_entity)
 from .rados_utils import NFSRados
 
 if TYPE_CHECKING:
@@ -490,6 +491,49 @@ class ExportMgr:
     ) -> Optional[Dict[str, Any]]:
         export = self._fetch_export(cluster_id, pseudo_path)
         return export.to_dict() if export else None
+
+    def get_cephfs_export_user_ids(self, cluster_id: str) -> Set[str]:
+        """Return CephFS export user_ids for the cluster."""
+        return {
+            export.fsal.user_id
+            for export in self.exports.get(cluster_id, [])
+            if isinstance(export.fsal, CephFSFSAL) and export.fsal.user_id
+        }
+
+    def refresh_export_keys(
+            self,
+            cluster_id: str,
+            entities: List[str]
+    ) -> List[str]:
+        """
+        Re-fetch CephX keys for the given export entities and update matching
+        CephFS exports so Ganesha receives the new keyrings.
+        """
+        entity_set = {normalize_auth_entity(e) for e in entities}
+        updated_pseudos: List[str] = []
+
+        for export in list(self.exports.get(cluster_id, [])):
+            if not isinstance(export.fsal, CephFSFSAL) or not export.fsal.user_id:
+                continue
+            entity = f'client.{export.fsal.user_id}'
+            if entity not in entity_set:
+                continue
+
+            old_key = export.fsal.cephx_key
+            self._ensure_cephfs_export_user(export)
+            if export.fsal.cephx_key == old_key:
+                log.warning(
+                    "Export %s key for user %s did not change after rotate",
+                    export.pseudo, export.fsal.user_id
+                )
+            self.exports[cluster_id].remove(export)
+            self._update_export(cluster_id, export, need_nfs_service_restart=False)
+            updated_pseudos.append(export.pseudo)
+            log.info(
+                "Updated export %s with rotated key for user %s",
+                export.pseudo, export.fsal.user_id
+            )
+        return updated_pseudos
 
     # This method is used by the dashboard module (../dashboard/controllers/nfs.py)
     # Do not change interface without updating the Dashboard code

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -11,6 +11,7 @@ from typing import (
     TypeVar,
     Callable,
     Set,
+    Tuple,
     cast)
 from os.path import normpath
 from ceph.fs.earmarking import EarmarkTopScope
@@ -44,7 +45,8 @@ from .utils import (
     check_fs,
     get_nfs_spec_for_cluster,
     restart_nfs_service,
-    cephfs_path_is_dir)
+    cephfs_path_is_dir,
+    normalize_auth_entity)
 from .rados_utils import NFSRados
 
 if TYPE_CHECKING:
@@ -490,6 +492,64 @@ class ExportMgr:
     ) -> Optional[Dict[str, Any]]:
         export = self._fetch_export(cluster_id, pseudo_path)
         return export.to_dict() if export else None
+
+    def reload_exports(self) -> None:
+        """Drop the cached exports so that they are re-read from RADOS."""
+        self._exports = None
+
+    def get_cephfs_export_user_ids(self, cluster_id: str) -> Set[str]:
+        """Return CephFS export user_ids for the cluster."""
+        return {
+            export.fsal.user_id
+            for export in self.exports.get(cluster_id, [])
+            if isinstance(export.fsal, CephFSFSAL) and export.fsal.user_id
+        }
+
+    def refresh_export_keys(
+            self,
+            cluster_id: str,
+            entities: List[str]
+    ) -> Tuple[List[str], List[str]]:
+        """
+        Re-fetch CephX keys for the given export entities and update matching
+        CephFS exports so Ganesha receives the new keyrings.
+
+        Returns the pseudo paths that were updated and the ones that could not
+        be. One failure must not stop the others: their keys are already
+        rotated, so an export left behind is one Ganesha cannot authenticate.
+        """
+        entity_set = {normalize_auth_entity(e) for e in entities}
+        updated_pseudos: List[str] = []
+        stale_pseudos: List[str] = []
+
+        for export in list(self.exports.get(cluster_id, [])):
+            if not isinstance(export.fsal, CephFSFSAL) or not export.fsal.user_id:
+                continue
+            entity = f'client.{export.fsal.user_id}'
+            if entity not in entity_set:
+                continue
+
+            old_key = export.fsal.cephx_key
+            try:
+                self._ensure_cephfs_export_user(export)
+                if export.fsal.cephx_key == old_key:
+                    log.warning(
+                        "Export %s key for user %s did not change after rotate",
+                        export.pseudo, export.fsal.user_id
+                    )
+                self.exports[cluster_id].remove(export)
+                self._update_export(cluster_id, export, need_nfs_service_restart=False)
+            except Exception:
+                stale_pseudos.append(export.pseudo)
+                log.exception("Failed to update export %s after key rotation", export.pseudo)
+                continue
+
+            updated_pseudos.append(export.pseudo)
+            log.info(
+                "Updated export %s with rotated key for user %s",
+                export.pseudo, export.fsal.user_id
+            )
+        return updated_pseudos, stale_pseudos
 
     # This method is used by the dashboard module (../dashboard/controllers/nfs.py)
     # Do not change interface without updating the Dashboard code

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -155,6 +155,19 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.export_mgr.apply_export(cluster_id, export_config=inbuf,
                                             earmark_resolver=earmark_resolver)
 
+    @NFSCLICommand('nfs cluster rotate-key', perm='rw')
+    @object_format.Responder()
+    def _cmd_nfs_cluster_rotate_key(self,
+                                    cluster_id: str,
+                                    entity: Optional[List[str]] = None,
+                                    key_type: Optional[str] = None) -> Dict[str, Any]:
+        """Rotate NFS cluster/daemon and export auth keys; redeploy service if daemon keys change"""
+        return self.nfs.rotate_keys(
+            cluster_id=cluster_id,
+            entity=entity,
+            key_type=key_type
+        )
+
     @NFSCLICommand('nfs cluster create', perm='rw')
     @object_format.EmptyResponder()
     def _cmd_nfs_cluster_create(self,

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -155,6 +155,21 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.export_mgr.apply_export(cluster_id, export_config=inbuf,
                                             earmark_resolver=earmark_resolver)
 
+    @NFSCLICommand('nfs cluster rotate-key', perm='rw')
+    @object_format.Responder()
+    def _cmd_nfs_cluster_rotate_key(self,
+                                    cluster_id: str,
+                                    all_daemon_and_export_keys: bool = False,
+                                    auth_entities: Optional[List[str]] = None,
+                                    key_type: Optional[str] = None) -> Dict[str, Any]:
+        """Rotate NFS cluster/daemon and export auth keys; redeploy service if daemon keys change"""
+        return self.nfs.rotate_keys(
+            cluster_id=cluster_id,
+            all_daemon_and_export_keys=all_daemon_and_export_keys,
+            auth_entities=auth_entities,
+            key_type=key_type
+        )
+
     @NFSCLICommand('nfs cluster create', perm='rw')
     @object_format.EmptyResponder()
     def _cmd_nfs_cluster_create(self,

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -1270,6 +1270,139 @@ NFS_CORE_PARAM {
         assert export.clients[0].addresses == ["192.168.1.0/8"]
         assert export.cluster_id == self.cluster_id
 
+    def test_rotate_keys(self):
+        self._do_mock_test(self._do_test_rotate_keys)
+
+    def test_rotate_keys_all_entities(self):
+        self._do_mock_test(self._do_test_rotate_keys_all_entities)
+
+    def test_rotate_keys_rejects_foreign_entity(self):
+        self._do_mock_test(self._do_test_rotate_keys_rejects_foreign_entity)
+
+    def _do_test_rotate_keys(self):
+        nfs_mod = Module('nfs', '', '')
+        conf = nfs_mod.export_mgr
+        cluster = nfs_mod.nfs
+
+        conf.create_export(
+            fsal_type='cephfs',
+            cluster_id=self.cluster_id,
+            fs_name='myfs',
+            path='/',
+            pseudo_path='/cephfs_rotate',
+            read_only=False,
+            squash='none',
+        )
+        conf.create_export(
+            fsal_type='cephfs',
+            cluster_id=self.cluster_id,
+            fs_name='myfs',
+            path='/',
+            pseudo_path='/cephfs_rotate2',
+            read_only=False,
+            squash='none',
+        )
+
+        entity = 'client.nfs.foo.myfs.86ca58ef'
+        rotated_key = 'rotated-export-key'
+
+        def mock_create_user_key(self, cluster_id, entity_name, path, fs_name):
+            return rotated_key
+
+        with mock.patch.object(nfs_mod, 'check_mon_command') as check_mon, \
+                mock.patch.object(ExportMgr, '_create_user_key', mock_create_user_key), \
+                mock.patch('nfs.cluster.redeploy_nfs_service') as redeploy:
+            result = cluster.rotate_keys(
+                cluster_id=self.cluster_id,
+                entity=[entity, 'nfs.foo.myfs.86ca58ef'],
+                key_type='aes256k',
+            )
+
+        check_mon.assert_called_once_with({
+            'prefix': 'auth rotate',
+            'entity': entity,
+            'key_type': 'aes256k',
+        })
+        redeploy.assert_not_called()
+        assert result['cluster_id'] == self.cluster_id
+        assert result['rotated'] == [entity]
+        assert result['export_keys'] == [entity]
+        assert result['daemon_keys'] == []
+        assert result['key_type'] == 'aes256k'
+        assert result['service_redeployed'] is False
+        assert sorted(result['updated_exports']) == ['/cephfs_rotate', '/cephfs_rotate2']
+
+        for pseudo in ('/cephfs_rotate', '/cephfs_rotate2'):
+            export = conf._fetch_export(self.cluster_id, pseudo)
+            assert export is not None
+            assert export.fsal.cephx_key == rotated_key
+
+    def _do_test_rotate_keys_all_entities(self):
+        nfs_mod = Module('nfs', '', '')
+        conf = nfs_mod.export_mgr
+        cluster = nfs_mod.nfs
+
+        conf.create_export(
+            fsal_type='cephfs',
+            cluster_id=self.cluster_id,
+            fs_name='myfs',
+            path='/',
+            pseudo_path='/cephfs_rotate_all',
+            read_only=False,
+            squash='none',
+        )
+
+        export_entity = 'client.nfs.foo.myfs.86ca58ef'
+        daemon_entity = 'client.nfs.foo.0.0.host.hash-rgw'
+        cluster_entity = 'client.nfs.foo'
+        rotated_key = 'rotated-export-key'
+
+        def mock_create_user_key(self, cluster_id, entity_name, path, fs_name):
+            return rotated_key
+
+        auth_ls = {
+            'auth_dump': [
+                {'entity': cluster_entity},
+                {'entity': daemon_entity},
+                {'entity': export_entity},
+                {'entity': 'client.nfs.other.fs.deadbeef'},
+            ]
+        }
+
+        def mock_check_mon(cmd):
+            if cmd.get('prefix') == 'auth ls':
+                return mock.Mock(stdout=json.dumps(auth_ls), retval=0, stderr='')
+            return mock.Mock(stdout='', retval=0, stderr='')
+
+        with mock.patch.object(nfs_mod, 'check_mon_command', side_effect=mock_check_mon) as check_mon, \
+                mock.patch.object(ExportMgr, '_create_user_key', mock_create_user_key), \
+                mock.patch('nfs.cluster.redeploy_nfs_service') as redeploy:
+            result = cluster.rotate_keys(cluster_id=self.cluster_id, key_type='aes256k')
+
+        rotate_calls = [
+            c.args[0] for c in check_mon.call_args_list
+            if c.args[0].get('prefix') == 'auth rotate'
+        ]
+        rotated = [c['entity'] for c in rotate_calls]
+        assert sorted(rotated) == sorted([cluster_entity, daemon_entity, export_entity])
+        assert all(c.get('key_type') == 'aes256k' for c in rotate_calls)
+        redeploy.assert_called_once_with(nfs_mod, self.cluster_id)
+        assert result['service_redeployed'] is True
+        assert sorted(result['daemon_keys']) == sorted([cluster_entity, daemon_entity])
+        assert result['export_keys'] == [export_entity]
+        assert result['updated_exports'] == ['/cephfs_rotate_all']
+
+    def _do_test_rotate_keys_rejects_foreign_entity(self):
+        nfs_mod = Module('nfs', '', '')
+        cluster = nfs_mod.nfs
+
+        with pytest.raises(Exception) as e:
+            cluster.rotate_keys(
+                cluster_id=self.cluster_id,
+                entity=['client.nfs.other.fs.deadbeef'],
+            )
+        assert 'does not belong to NFS cluster' in str(e.value)
+
     def test_create_export_default_transports_rdma_cluster(self):
         """When cluster has enable_rdma=True, new exports get default Transports = tcp, RDMA."""
         self._do_mock_test(self._do_test_create_export_default_transports_rdma_cluster)

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -1270,6 +1270,181 @@ NFS_CORE_PARAM {
         assert export.clients[0].addresses == ["192.168.1.0/8"]
         assert export.cluster_id == self.cluster_id
 
+    def test_rotate_keys(self):
+        self._do_mock_test(self._do_test_rotate_keys)
+
+    def test_rotate_keys_all_entities(self):
+        self._do_mock_test(self._do_test_rotate_keys_all_entities)
+
+    def test_rotate_keys_rejects_foreign_entity(self):
+        self._do_mock_test(self._do_test_rotate_keys_rejects_foreign_entity)
+
+    def test_rotate_keys_requires_explicit_selection(self):
+        self._do_mock_test(self._do_test_rotate_keys_requires_explicit_selection)
+
+    def test_rotate_keys_rejects_both_selections(self):
+        self._do_mock_test(self._do_test_rotate_keys_rejects_both_selections)
+
+    def _do_test_rotate_keys(self):
+        nfs_mod = Module('nfs', '', '')
+        conf = nfs_mod.export_mgr
+        cluster = nfs_mod.nfs
+
+        conf.create_export(
+            fsal_type='cephfs',
+            cluster_id=self.cluster_id,
+            fs_name='myfs',
+            path='/',
+            pseudo_path='/cephfs_rotate',
+            read_only=False,
+            squash='none',
+        )
+        conf.create_export(
+            fsal_type='cephfs',
+            cluster_id=self.cluster_id,
+            fs_name='myfs',
+            path='/',
+            pseudo_path='/cephfs_rotate2',
+            read_only=False,
+            squash='none',
+        )
+
+        entity = 'client.nfs.foo.myfs.86ca58ef'
+        rotated_key = 'rotated-export-key'
+
+        def mock_create_user_key(self, cluster_id, entity_name, path, fs_name):
+            return rotated_key
+
+        with mock.patch.object(nfs_mod, 'check_mon_command') as check_mon, \
+                mock.patch.object(ExportMgr, '_create_user_key', mock_create_user_key), \
+                mock.patch('nfs.cluster.redeploy_nfs_service') as redeploy:
+            result = cluster.rotate_keys(
+                cluster_id=self.cluster_id,
+                auth_entities=[entity, 'nfs.foo.myfs.86ca58ef'],
+                key_type='aes256k',
+            )
+
+        check_mon.assert_called_once_with({
+            'prefix': 'auth rotate',
+            'entity': entity,
+            'key_type': 'aes256k',
+        })
+        redeploy.assert_not_called()
+        assert result['cluster_id'] == self.cluster_id
+        assert result['rotated'] == [entity]
+        assert result['export_keys'] == [entity]
+        assert result['daemon_keys'] == []
+        assert result['key_type'] == 'aes256k'
+        assert result['service_redeployed'] is False
+        assert sorted(result['updated_exports']) == ['/cephfs_rotate', '/cephfs_rotate2']
+
+        for pseudo in ('/cephfs_rotate', '/cephfs_rotate2'):
+            export = conf._fetch_export(self.cluster_id, pseudo)
+            assert export is not None
+            assert export.fsal.cephx_key == rotated_key
+
+    def _do_test_rotate_keys_all_entities(self):
+        nfs_mod = Module('nfs', '', '')
+        conf = nfs_mod.export_mgr
+        cluster = nfs_mod.nfs
+
+        conf.create_export(
+            fsal_type='cephfs',
+            cluster_id=self.cluster_id,
+            fs_name='myfs',
+            path='/',
+            pseudo_path='/cephfs_rotate_all',
+            read_only=False,
+            squash='none',
+        )
+
+        export_entity = 'client.nfs.foo.myfs.86ca58ef'
+        daemon_entity = 'client.nfs.foo.0.0.host.hash-rgw'
+        cluster_entity = 'client.nfs.foo'
+        rotated_key = 'rotated-export-key'
+
+        def mock_create_user_key(self, cluster_id, entity_name, path, fs_name):
+            return rotated_key
+
+        auth_ls = {
+            'auth_dump': [
+                {'entity': cluster_entity},
+                {'entity': daemon_entity},
+                {'entity': export_entity},
+                {'entity': 'client.nfs.other.fs.deadbeef'},
+            ]
+        }
+
+        def mock_check_mon(cmd):
+            if cmd.get('prefix') == 'auth ls':
+                return mock.Mock(stdout=json.dumps(auth_ls), retval=0, stderr='')
+            return mock.Mock(stdout='', retval=0, stderr='')
+
+        with mock.patch.object(nfs_mod, 'check_mon_command', side_effect=mock_check_mon) as check_mon, \
+                mock.patch.object(ExportMgr, '_create_user_key', mock_create_user_key), \
+                mock.patch('nfs.cluster.redeploy_nfs_service') as redeploy:
+            result = cluster.rotate_keys(
+                cluster_id=self.cluster_id,
+                all_daemon_and_export_keys=True,
+                key_type='aes256k',
+            )
+
+        rotate_calls = [
+            c.args[0] for c in check_mon.call_args_list
+            if c.args[0].get('prefix') == 'auth rotate'
+        ]
+        rotated = [c['entity'] for c in rotate_calls]
+        assert sorted(rotated) == sorted([cluster_entity, daemon_entity, export_entity])
+        assert all(c.get('key_type') == 'aes256k' for c in rotate_calls)
+        redeploy.assert_called_once_with(nfs_mod, self.cluster_id)
+        assert result['service_redeployed'] is True
+        assert sorted(result['daemon_keys']) == sorted([cluster_entity, daemon_entity])
+        assert result['export_keys'] == [export_entity]
+        assert result['updated_exports'] == ['/cephfs_rotate_all']
+
+    def _do_test_rotate_keys_rejects_foreign_entity(self):
+        nfs_mod = Module('nfs', '', '')
+        cluster = nfs_mod.nfs
+
+        with pytest.raises(Exception) as e:
+            cluster.rotate_keys(
+                cluster_id=self.cluster_id,
+                auth_entities=['client.nfs.other.fs.deadbeef'],
+            )
+        assert 'does not belong to NFS cluster' in str(e.value)
+
+    def _do_test_rotate_keys_requires_explicit_selection(self):
+        nfs_mod = Module('nfs', '', '')
+        cluster = nfs_mod.nfs
+
+        with mock.patch.object(nfs_mod, 'check_mon_command') as check_mon, \
+                mock.patch('nfs.cluster.redeploy_nfs_service') as redeploy:
+            with pytest.raises(Exception) as e:
+                cluster.rotate_keys(cluster_id=self.cluster_id)
+
+        assert '--all-daemon-and-export-keys' in str(e.value)
+        assert '--auth-entities' in str(e.value)
+        assert 'ceph auth ls' in str(e.value)
+        check_mon.assert_not_called()
+        redeploy.assert_not_called()
+
+    def _do_test_rotate_keys_rejects_both_selections(self):
+        nfs_mod = Module('nfs', '', '')
+        cluster = nfs_mod.nfs
+
+        with mock.patch.object(nfs_mod, 'check_mon_command') as check_mon, \
+                mock.patch('nfs.cluster.redeploy_nfs_service') as redeploy:
+            with pytest.raises(Exception) as e:
+                cluster.rotate_keys(
+                    cluster_id=self.cluster_id,
+                    all_daemon_and_export_keys=True,
+                    auth_entities=['client.nfs.foo.myfs.86ca58ef'],
+                )
+
+        assert 'mutually exclusive' in str(e.value)
+        check_mon.assert_not_called()
+        redeploy.assert_not_called()
+
     def test_create_export_default_transports_rdma_cluster(self):
         """When cluster has enable_rdma=True, new exports get default Transports = tcp, RDMA."""
         self._do_mock_test(self._do_test_create_export_default_transports_rdma_cluster)

--- a/src/pybind/mgr/nfs/utils.py
+++ b/src/pybind/mgr/nfs/utils.py
@@ -12,6 +12,8 @@ from mgr_module import NFS_POOL_NAME as POOL_NAME
 
 from rados import Rados, LIBRADOS_ALL_NSPACES, ObjectNotFound
 
+from .exception import NFSInvalidOperation
+
 if TYPE_CHECKING:
     from nfs.module import Module
 
@@ -45,6 +47,22 @@ class ManualRestartRequired(NonFatalError):
 
     def __init__(self, msg: str) -> None:
         super().__init__(" ".join((msg, "(Manual Restart of NFS Pods required)")))
+
+
+def normalize_auth_entity(entity: str) -> str:
+    """Return a full auth entity name (client.<user_id>)."""
+    entity = entity.strip()
+    if not entity:
+        raise NFSInvalidOperation("empty auth entity")
+    if entity.startswith('client.'):
+        return entity
+    return f'client.{entity}'
+
+
+def entity_belongs_to_nfs_cluster(entity: str, cluster_id: str) -> bool:
+    """True if entity is the cluster key or any key under that NFS cluster."""
+    prefix = f'client.nfs.{cluster_id}'
+    return entity == prefix or entity.startswith(prefix + '.')
 
 
 def export_obj_name(export_id: int) -> str:
@@ -126,6 +144,15 @@ def restart_nfs_service(mgr: 'Module', cluster_id: str) -> None:
     This methods restarts the nfs daemons
     '''
     completion = mgr.service_action(action='restart',
+                                    service_name='nfs.' + cluster_id)
+    orchestrator.raise_if_exception(completion)
+
+
+def redeploy_nfs_service(mgr: 'Module', cluster_id: str) -> None:
+    '''
+    Redeploy NFS daemons so they pick up rotated daemon keyrings.
+    '''
+    completion = mgr.service_action(action='redeploy',
                                     service_name='nfs.' + cluster_id)
     orchestrator.raise_if_exception(completion)
 


### PR DESCRIPTION
Add `ceph nfs export rotate-key` to rotate one or more CephFS NFS export auth entities (optional --key-type) and update the exports that use those keys so Ganesha receives the new keyrings.

Fixes: https://tracker.ceph.com/issues/78876





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
