### PR TITLE
umbrella: osd: Fix valgrind uninitialized variable issues in fast EC

### DIFF
--- a/src/osd/ECCommon.h
+++ b/src/osd/ECCommon.h
@@ -714,7 +714,7 @@ struct ECCommon {
     // Set by on_change, forces first write in each interval to be
     // a full write to avoid PWLC spanning intervals. Fixes
     // https://tracker.ceph.com/issues/73891
-    bool first_write_in_interval;
+    bool first_write_in_interval = false;
 
     RMWPipeline(CephContext *cct,
                 ceph::ErasureCodeInterfaceRef ec_impl,

--- a/src/osd/ECCommon.h
+++ b/src/osd/ECCommon.h
@@ -207,7 +207,7 @@ struct ECCommon {
     std::optional<std::map<std::string, ceph::buffer::list, std::less<>>> attrs;
     std::optional<ceph::buffer::list> omap_header;
     std::optional<std::map<std::string, ceph::buffer::list>> omap_entries;
-    bool omap_complete;
+    bool omap_complete = false;
     ECUtil::shard_extent_map_t buffers_read;
     ECUtil::shard_extent_set_t processed_read_requests;
     shard_id_set zero_length_reads;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78797

---

backport of https://github.com/ceph/ceph/pull/70333
parent tracker: https://tracker.ceph.com/issues/76953

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh