### PR TITLE
cephadm: warn when orch actions are deferred on unmanaged services

### DIFF
--- a/doc/cephadm/services/index.rst
+++ b/doc/cephadm/services/index.rst
@@ -870,10 +870,39 @@ would set ``unmanaged: false`` for the ``mon`` service.
 
 .. note::
 
-  The ``osd`` service used to track OSDs that are not tied to any specific
-  service spec is special and will always be marked unmanaged. Attempting
-  to modify it with ``ceph orch set-unmanaged`` or ``ceph orch set-managed``
-  will result in a message ``No service of name osd found. Check "ceph orch ls" for all known services``.
+  When ``unmanaged: true`` is set on a service spec, cephadm stops reconciling
+  that service: it will not deploy, remove, restart, redeploy, or reconfigure
+  its daemons to match the spec. Running ``ceph orch apply`` still saves the
+  updated spec, but daemon changes take effect only after the service becomes
+  managed again. Commands such as ``ceph orch daemon restart``,
+  ``ceph orch daemon redeploy``, or ``ceph orch daemon reconfig`` print
+  ``Scheduled...`` and append a short ``NOTE`` that the operation will take
+  effect only when the service becomes managed.
+
+  To apply pending spec or scheduled daemon changes, temporarily re-enable
+  automatic management:
+
+  .. prompt:: bash #
+
+      ceph orch set-managed <service-name>
+
+  Wait for the reconciliation loop to apply the changes (check progress with
+  ``ceph orch ls``), then set the service back to unmanaged:
+
+  .. prompt:: bash #
+
+      ceph orch set-unmanaged <service-name>
+
+.. note::
+
+  Daemons whose service has no spec are not subject to the above: actions on
+  those daemons execute normally and no ``NOTE`` is printed. For example, OSD
+  daemons that are no longer tied to a drive-group spec (visible as the ``osd``
+  service in ``ceph orch ls``) fall into this category and respond to
+  ``ceph orch daemon`` commands as usual. That ``osd`` service cannot be
+  toggled with ``ceph orch set-unmanaged`` / ``ceph orch set-managed``;
+  attempting to do so results in
+  ``No service of name osd found. Check "ceph orch ls" for all known services``.
 
 
 Deploying a Daemon on a Host Manually

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3032,6 +3032,26 @@ Then run the following:
                 result.append(dd)
         return result
 
+    def _unmanaged_noop_note(self, service_name: str) -> Optional[str]:
+        """Warn when an orch action is scheduled but deferred by unmanaged.
+
+        Returns a note only when a matching service spec exists with
+        ``unmanaged=True``. That matches serve.py behavior: scheduled daemon
+        actions and reconciliation are skipped for those specs.
+
+        Intentionally returns None for daemons whose service name is not in
+        the spec store (notably adopted OSDs under the bare ``osd`` service).
+        Those are still acted on by explicit ``ceph orch daemon ...`` commands.
+        """
+        spec = self.spec_store.all_specs.get(service_name)
+        if not spec or not spec.unmanaged:
+            return None
+        return (
+            f'NOTE: {service_name} is unmanaged. The operation will take effect'
+            f' only when the service becomes managed'
+            f' (e.g. `ceph orch set-managed {service_name}`).'
+        )
+
     def perform_service_action(self, action: str, service_name: str) -> List[str]:
         dds: List[DaemonDescription] = self.cache.get_daemons_by_service(service_name)
         if not dds:
@@ -3051,7 +3071,11 @@ Then run the following:
         if action == 'stop' and service_name.split('.')[0].lower() in ['mgr', 'mon', 'osd']:
             return [f'Stopping entire {service_name} service is prohibited.']
 
-        return self.perform_service_action(action, service_name)
+        results = self.perform_service_action(action, service_name)
+        note = self._unmanaged_noop_note(service_name)
+        if note:
+            results.append(note)
+        return results
 
     def _rotate_daemon_key(self, daemon_spec: CephadmDaemonDeploySpec) -> str:
         self.log.info(f'Rotating authentication key for {daemon_spec.name()}')
@@ -3243,7 +3267,11 @@ Then run the following:
         self._daemon_action_set_image(action, image, d.daemon_type, d.daemon_id)
 
         self.log.info(f'Schedule {action} daemon {daemon_name}')
-        return self._schedule_daemon_action(daemon_name, action)
+        msg = self._schedule_daemon_action(daemon_name, action)
+        note = self._unmanaged_noop_note(d.service_name())
+        if note:
+            msg += f'\n{note}'
+        return msg
 
     def daemon_is_self(self, daemon_type: str, daemon_id: str) -> bool:
         return daemon_type == 'mgr' and daemon_id == self.get_mgr_id()
@@ -4623,7 +4651,18 @@ Then run the following:
             spec.service_name(), spec.placement.pretty_str()))
         self.spec_store.save(spec)
         self._kick_serve_loop()
-        return f"Scheduled {spec.service_name()} update...{cert_warning}"
+        msg = f"Scheduled {spec.service_name()} update...{cert_warning}"
+        if spec.unmanaged:
+            # Spec is stored, but reconciliation/_check_daemons will no-op until
+            # the service is managed again. Do not special-case OSDs here: an
+            # unmanaged drive-group apply also creates no OSDs.
+            msg += (
+                f'\nNOTE: {spec.service_name()} is unmanaged. The spec has been'
+                f' saved but daemon changes will take effect only when the'
+                f' service becomes managed'
+                f' (e.g. `ceph orch set-managed {spec.service_name()}`).'
+            )
+        return msg
 
     @handle_orch_error
     def apply(

--- a/src/pybind/mgr/cephadm/tests/fixtures.py
+++ b/src/pybind/mgr/cephadm/tests/fixtures.py
@@ -172,16 +172,28 @@ def assert_rm_service(cephadm: CephadmOrchestrator, srv_name):
         assert srv_name not in cephadm.spec_store, f'{cephadm.spec_store[srv_name]!r}'
 
 
+def _scheduled_update_msg(spec: ServiceSpec) -> str:
+    msg = f'Scheduled {spec.service_name()} update...'
+    if spec.unmanaged:
+        msg += (
+            f'\nNOTE: {spec.service_name()} is unmanaged. The spec has been'
+            f' saved but daemon changes will take effect only when the'
+            f' service becomes managed'
+            f' (e.g. `ceph orch set-managed {spec.service_name()}`).'
+        )
+    return msg
+
+
 @contextmanager
 def with_service(cephadm_module: CephadmOrchestrator, spec: ServiceSpec, meth=None, host: str = '', status_running=False) -> Iterator[List[str]]:
     if spec.placement.is_empty() and host:
         spec.placement = PlacementSpec(hosts=[host], count=1)
     if meth is not None:
         c = meth(cephadm_module, spec)
-        assert wait(cephadm_module, c) == f'Scheduled {spec.service_name()} update...'
+        assert wait(cephadm_module, c) == _scheduled_update_msg(spec)
     else:
         c = cephadm_module.apply([spec])
-        assert wait(cephadm_module, c) == [f'Scheduled {spec.service_name()} update...']
+        assert wait(cephadm_module, c) == [_scheduled_update_msg(spec)]
 
     specs = [d.spec for d in wait(cephadm_module, cephadm_module.describe_service())]
     assert spec in specs

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -3042,6 +3042,45 @@ Traceback (most recent call last):
         cephadm_module.spec_store.set_unmanaged('crash', False)
         assert not cephadm_module.spec_store._specs['crash'].unmanaged
 
+    def test_unmanaged_noop_note(self, cephadm_module):
+        # No matching spec (e.g. bare "osd" / adopted OSDs): no note — actions still run.
+        assert cephadm_module._unmanaged_noop_note('osd') is None
+
+        cephadm_module.spec_store._specs['rgw.foo'] = ServiceSpec(
+            'rgw', service_id='foo', unmanaged=False)
+        assert cephadm_module._unmanaged_noop_note('rgw.foo') is None
+
+        cephadm_module.spec_store.set_unmanaged('rgw.foo', True)
+        note = cephadm_module._unmanaged_noop_note('rgw.foo')
+        assert note is not None
+        assert 'rgw.foo is unmanaged' in note
+        assert 'set-managed rgw.foo' in note
+
+        # Unmanaged OSD drive-group: note is expected (apply/reconcile no-ops).
+        cephadm_module.spec_store._specs['osd.hdd'] = DriveGroupSpec(
+            service_id='hdd', unmanaged=True)
+        note = cephadm_module._unmanaged_noop_note('osd.hdd')
+        assert note is not None
+        assert 'osd.hdd is unmanaged' in note
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+    def test_unmanaged_daemon_action_note(self, cephadm_module: CephadmOrchestrator):
+        with with_host(cephadm_module, 'test'):
+            # Deploy managed first, then mark unmanaged (add_daemon would overwrite the flag).
+            with with_service(cephadm_module,
+                              RGWSpec(service_id='myrgw.foobar'),
+                              host='test') as d_names:
+                assert d_names
+                cephadm_module.spec_store.set_unmanaged('rgw.myrgw.foobar', True)
+                d_name = d_names[0]
+                msg = wait(cephadm_module, cephadm_module.daemon_action('redeploy', d_name))
+                assert msg.startswith(f"Scheduled to redeploy {d_name} on host 'test'")
+                assert 'rgw.myrgw.foobar is unmanaged' in msg
+                assert 'set-managed rgw.myrgw.foobar' in msg
+
+                # Bare "osd" (no matching unmanaged drive-group) must not warn.
+                assert cephadm_module._unmanaged_noop_note('osd') is None
+
     def test_inventory_known_hostnames(self, cephadm_module):
         cephadm_module.inventory.add_host(HostSpec('host1', '1.2.3.1'))
         cephadm_module.inventory.add_host(HostSpec('host2', '1.2.3.2'))


### PR DESCRIPTION
When a service is unmanaged, ceph orch apply / daemon restart|redeploy|reconfig still schedule work, but reconciliation no-ops until the service is managed again. Append a clear NOTE to those command responses, document the set-managed → wait → set-unmanaged workflow, and clarify the bare osd special case. Tests updated accordingly.



**Testing**

Covered service types:
- RGW (Ceph service): managed + unmanaged
- Keycloak (non-Ceph container service): managed + unmanaged
- OSD with spec: managed + unmanaged
- Specless OSD (no service spec)

For each mode, these orchestrator operations were exercised:
- `ceph orch redeploy`
- `ceph orch restart`
- `ceph orch reconfig`
- `ceph orch apply -i <service-file>`

Also exercised at least one operation on a specific daemon.

**Expected results**
- **Managed:** same behavior as before; orchestrator operations apply; no new NOTE.
- **Unmanaged (with spec):** same behavior as before (operation not executed); new NOTE is shown when the operation will not run.
- **Specless OSD:** orchestrator operations still apply (as before); no NOTE is shown.

Not every case is written out in full; but the cases below cover the main ones.

---

### A. Unmanaged RGW

Here we expect the same behavior as before, with a new NOTE displayed when needed.

**A.1 Deploy unmanaged RGW**

```yaml
service_type: rgw
service_id: rgw
unmanaged: true
placement:
  host_pattern: '*'
networks:
- "192.168.100.0/24"
spec:
  rgw_frontend_type: "beast"
  ssl: true
  rgw_frontend_extra_args:
    - max_header_size=65536   # used later for reconfig testing
```

```bash
ceph orch apply -i rgw.yaml
```

```
Scheduled rgw.rgw update...
NOTE: rgw.rgw is unmanaged. The spec has been saved but daemon changes will take effect only when the service becomes managed (e.g. `ceph orch set-managed rgw.rgw`).
```

Verified: NOTE shown; daemons not deployed until the service is managed.

**A.2 Set managed and wait for deploy**

```bash
ceph orch set-managed rgw.rgw
watch ceph orch ps --daemon-type rgw
```

Verified: 3 RGW daemons deployed.

**A.3 Return to unmanaged**

```bash
ceph orch set-unmanaged rgw.rgw
```

**A.4 Redeploy service**

```bash
ceph orch redeploy rgw.rgw
```

```
Scheduled to redeploy rgw.rgw.ceph-node-0.pwtalr on host 'ceph-node-0'
Scheduled to redeploy rgw.rgw.ceph-node-1.bxcqes on host 'ceph-node-1'
Scheduled to redeploy rgw.rgw.ceph-node-2.ghsfdj on host 'ceph-node-2'
NOTE: rgw.rgw is unmanaged. The operation will take effect only when the service becomes managed (e.g. `ceph orch set-managed rgw.rgw`).
```

```bash
watch ceph orch ps --daemon-type rgw   # wait ≥ 1 min
```

Verified: NOTE shown; daemons not redeployed (same as before).

**A.5 Restart service**

```bash
ceph orch restart rgw.rgw
```

```
Scheduled to restart ...
NOTE: rgw.rgw is unmanaged. ...
```

```bash
watch ceph orch ps --daemon-type rgw   # wait ≥ 1 min
```

Verified: NOTE shown; daemons not restarted (same as before).

**A.6 Restart specific daemon**

```bash
ceph orch daemon restart rgw.rgw.ceph-node-0.pwtalr --force
```

```
Scheduled to restart rgw.rgw.ceph-node-0.pwtalr on host 'ceph-node-0'
NOTE: rgw.rgw is unmanaged. The operation will take effect only when the service becomes managed (e.g. `ceph orch set-managed rgw.rgw`).
```

Wait ≥ 1 min.

Verified: NOTE shown; daemon **not** restarted (same as before).

---
**A.7 Reconfig**

note: in rgw -  max_header_size is updated by reconfig. 

Check max_header_size current value:

```bash
ceph config get client.rgw.rgw.ceph-node-0.pwtalr rgw_frontends
# ... max_header_size=65536
```

Edit `rgw.yaml` → `max_header_size=9999` (keep `unmanaged: true`), then:

```bash
ceph orch apply -i rgw.yaml
# NOTE shown

ceph orch reconfig rgw.rgw
# NOTE shown
```

Wait ≥ 1 min, then:

Check max_header_size value:
```bash
ceph config get client.rgw.rgw.ceph-node-0.pwtalr rgw_frontends
# still max_header_size=65536
```

Verified: NOTE on apply and reconfig; reconfig does not take effect while unmanaged.

---

**A.8 — Stop unmanaged RGW daemon**

**Command:**
```
ceph orch daemon stop rgw.rgw.ceph-node-0.pwtalr --force
```

**Expected output:**
```
Scheduled to stop rgw.rgw.ceph-node-0.pwtalr on host 'ceph-node-0'
NOTE: rgw.rgw is unmanaged. The operation will take effect only when the service becomes managed (e.g. `ceph orch set-managed rgw.rgw`).
```

**Verification:** NOTE is displayed. Daemon is still running (not stopped).

---

**A.9 — Set service managed so the pending stop takes effect**

**Command:**
```
ceph orch set-managed rgw.rgw
```

**Expected result:** Reconciliation loop runs and stops the daemon (because the scheduled stop is now executed for a managed service).

---

**A.10 — Set service back to unmanaged**

**Command:**
```
ceph orch set-unmanaged rgw.rgw
```

---

**A.11 — Start unmanaged RGW daemon**

**Command:**
```
ceph orch daemon start rgw.rgw.ceph-node-0.pwtalr
```

**Expected output:**
```
Scheduled to start rgw.rgw.ceph-node-0.pwtalr on host 'ceph-node-0'
NOTE: rgw.rgw is unmanaged. The operation will take effect only when the service becomes managed (e.g. `ceph orch set-managed rgw.rgw`).
```

**Verification:** NOTE is displayed. Daemon is still stopped (not started).

---

**B.5 — Stop managed RGW daemon**

**Command:**
```
ceph orch daemon stop rgw.rgw.ceph-node-0.wrygso --force
```

**Expected output:**
```
Scheduled to stop rgw.rgw.ceph-node-0.wrygso on host 'ceph-node-0'
```

**Verification:** No NOTE displayed. Daemon is stopped.

---

### B. Managed RGW

Here we expect the same behavior as before.

**B.1 Deploy managed RGW** (`unmanaged: false`)

```bash
ceph orch apply -i rgw.yaml
# Scheduled rgw.rgw update...   (no NOTE)
watch ceph orch ps --daemon-type rgw
```

Verified: no NOTE; 3 RGW daemons deployed.

**B.2 Redeploy**

```bash
ceph orch redeploy rgw.rgw
watch ceph orch ps --daemon-type rgw
```

Verified: no NOTE; daemons redeployed.

**B.3 Restart**

```bash
ceph orch restart rgw.rgw
watch ceph orch ps --daemon-type rgw
```

Verified: no NOTE; daemons restarted.

**B.4 Reconfig**

```bash
ceph config get client.rgw.rgw.ceph-node-0.wrygso rgw_frontends
# max_header_size=65536
```

Edit yaml → `max_header_size=9999` (`unmanaged: false`):

```bash
ceph orch apply -i rgw.yaml
# Scheduled update... (no NOTE)
# apply alone does not update max_header_size (existing behavior)

ceph orch reconfig rgw.rgw
ceph config get client.rgw.rgw.ceph-node-0.wrygso rgw_frontends
# max_header_size=9999
```

Verified: no NOTE; reconfig updates `max_header_size`.

---

**B.5 — Stop managed RGW daemon**

**Command:**
```
ceph orch daemon stop rgw.rgw.ceph-node-0.wrygso --force
```

**Expected output:**
```
Scheduled to stop rgw.rgw.ceph-node-0.wrygso on host 'ceph-node-0'
```

**Verification:** No NOTE displayed. Daemon is stopped.

---

**B.6 — Start managed RGW daemon**

**Command:**
```
ceph orch daemon start rgw.rgw.ceph-node-0.wrygso
```

**Expected output:**
```
Scheduled to start rgw.rgw.ceph-node-0.wrygso on host 'ceph-node-0'
```

**Verification:** No NOTE displayed. Daemon is started.


---

### C. Unmanaged Keycloak (container)

**C.1 Deploy unmanaged**

```yaml
service_type: container
service_id: keycloak
unmanaged: true
placement:
  host_pattern: '*'
spec:
  image: quay.io/keycloak/keycloak:latest
  args:
    - "--net=host"
  extra_entrypoint_args:
    - "start"
    - "--http-enabled=true"
    - "--hostname-strict=false"
    - "--db=dev-mem"
  envs:
    - "KC_BOOTSTRAP_ADMIN_USERNAME=admin"
    - "KC_BOOTSTRAP_ADMIN_PASSWORD=password123"
```

```bash
ceph orch apply -i keycloak.yaml
# NOTE for container.keycloak
```

Verified: NOTE shown; daemons not deployed until managed.

**C.2 Set managed**

```bash
ceph orch set-managed container.keycloak
watch ceph orch ps --daemon-type container
```

Verified: 3 Keycloak daemons deployed.

**C.3 Set unmanaged again**

```bash
ceph orch set-unmanaged container.keycloak
```

**C.4 Redeploy / C.5 Restart / C.6 Reconfig**

```bash
ceph orch redeploy container.keycloak   # NOTE; not redeployed
ceph orch restart container.keycloak    # NOTE; not restarted
ceph orch reconfig container.keycloak   # NOTE; not reconfigured
```

(Wait ≥ 1 min after redeploy/restart; check with `watch ceph orch ps --daemon-type container`.)

---

### D. Managed Keycloak

Same day-2 operations with managed `container.keycloak`.

Verified: no NOTE; operations execute as before.

---

### E. Managed OSD (with spec)

**E.1** OSDs present (e.g. via `ceph orch daemon add osd ...`), shown under `ceph orch ps --daemon-type osd`.

**E.2**

```bash
ceph orch daemon redeploy osd.1
# Scheduled to redeploy osd.1 on host 'ceph-node-1'   (no NOTE)
```

Verified: no NOTE; OSD redeployed.

**E.3**

```bash
ceph orch daemon restart osd.0
# Scheduled to restart osd.0 on host 'ceph-node-0'   (no NOTE)
```

Verified: no NOTE; OSD restarted.

---

### F. Unmanaged OSD (with spec)

**F.1**

```bash
ceph orch set-unmanaged osd.default
```

**F.2 Redeploy / restart**

```bash
ceph orch daemon redeploy osd.0
# NOTE: osd.default is unmanaged. ...
# wait ≥ 1 min → not redeployed

ceph orch daemon restart osd.1
# NOTE: osd.default is unmanaged. ...
# wait ≥ 1 min → not restarted
```

Verified: NOTE shown; daemon actions not executed (same as before).

---

### G. Specless OSD (no service spec)

**G.1** Detach from service:

```bash
ceph orch rm osd.default --force
```

**G.2 / G.3**

```bash
ceph orch daemon redeploy osd.0   # no NOTE; redeployed
ceph orch daemon restart osd.1    # no NOTE; restarted
```

Verified: day-2 ops still apply; no NOTE (expected for specless OSDs).

Fixes: https://tracker.ceph.com/issues/77593


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
