### PR TITLE
mgr/cephadm: write agent required_files on SSH reconfig

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1201,6 +1201,14 @@ def deploy_daemon(
             else:
                 raise RuntimeError('attempting to deploy a daemon without a container image')
     else:
+        # Agent reconfig must apply the same required_files as HTTP config push
+        # (agent.json, keyring, certs). Without this, SSH reconfig only restarts
+        # the unit and leaves a stale target_ip after mgr failover.
+        if daemon_type == CephadmAgent.daemon_type:
+            config_js = fetch_configs(ctx)
+            assert isinstance(config_js, dict)
+            cephadm_agent = CephadmAgent(ctx, ident.fsid, ident.daemon_id)
+            cephadm_agent.write_required_files(config_js)
         # On reconfig, update unit.meta so that port metadata
         # stays current without requiring a full redeploy.
         meta_path = os.path.join(data_dir, 'unit.meta')
@@ -1521,12 +1529,7 @@ class MgrListener(Thread):
             self.agent.ack = int(data['counter'])
             if 'config' in data:
                 logger.info('Received new config from mgr')
-                config = data['config']
-                for filename in config:
-                    if filename in self.agent.required_files:
-                        file_path = os.path.join(self.agent.daemon_dir, filename)
-                        with write_new(file_path) as f:
-                            f.write(config[filename])
+                self.agent.write_required_files(data['config'])
                 self.agent.pull_conf_settings()
                 self.agent.wakeup()
         else:
@@ -1595,18 +1598,28 @@ class CephadmAgent(DaemonForm):
             if fname not in config:
                 raise Error('required file missing from config: %s' % fname)
 
-    def deploy_daemon_unit(self, config: Dict[str, str] = {}) -> None:
+    def write_required_files(self, config: Dict[str, str]) -> None:
+        """Write agent required config files. These are the same set that
+        HTTP config push applies to mgr.
+
+        Used by HTTP MgrListener updates, full deploy, and SSH reconfig so
+        target_ip, certs, and keyring are in sync across delivery paths.
+        """
         if not config:
             raise Error('Agent needs a config')
         assert isinstance(config, dict)
         self.validate(config)
-
-        # Create the required config files in the daemons dir, with restricted permissions
         for filename in config:
             if filename in self.required_files:
                 file_path = os.path.join(self.daemon_dir, filename)
                 with write_new(file_path) as f:
                     f.write(config[filename])
+
+    def deploy_daemon_unit(self, config: Dict[str, str] = {}) -> None:
+        if not config:
+            raise Error('Agent needs a config')
+        assert isinstance(config, dict)
+        self.write_required_files(config)
 
         unit_run_path = os.path.join(self.daemon_dir, 'unit.run')
         with write_new(unit_run_path) as f:

--- a/src/cephadm/tests/test_agent.py
+++ b/src/cephadm/tests/test_agent.py
@@ -39,6 +39,119 @@ def _check_file(path, content):
         assert fcontent == content
 
 
+def test_agent_write_required_files(cephadm_fs):
+    with with_cephadm_ctx([]) as ctx:
+        agent = _cephadm.CephadmAgent(ctx, FSID, AGENT_ID)
+        cephadm_fs.create_dir(AGENT_DIR)
+
+        with pytest.raises(_cephadm.Error, match='Agent needs a config'):
+            agent.write_required_files({})
+
+        incomplete = {
+            s: 'text' for s in agent.required_files if s != 'agent.json'
+        }
+        with pytest.raises(
+                _cephadm.Error,
+                match='required file missing from config: agent.json'):
+            agent.write_required_files(incomplete)
+
+        config = {s: f'content-{s}' for s in agent.required_files}
+        config['extra.txt'] = 'do-not-write'
+        agent.write_required_files(config)
+
+        for fname in agent.required_files:
+            _check_file(f'{AGENT_DIR}/{fname}', f'content-{fname}')
+        assert not os.path.exists(f'{AGENT_DIR}/extra.txt')
+
+        # overwrite agent.json with a new target_ip (mgr failover style update)
+        new_agent_json = json.dumps({
+            'target_ip': '192.168.100.101',
+            'target_port': 7150,
+            'host': AGENT_ID,
+        })
+        config['agent.json'] = new_agent_json
+        agent.write_required_files(config)
+        _check_file(f'{AGENT_DIR}/agent.json', new_agent_json)
+
+
+@mock.patch('cephadm.call_throws')
+@mock.patch('cephadm.update_firewalld')
+def test_agent_reconfig_writes_required_files(_update_firewalld, _call_throws, cephadm_fs):
+    """SSH agent reconfig must rewrite required_files (e.g. target_ip), not only restart."""
+    _call_throws.return_value = ('', '', 0)
+
+    old_agent_json = json.dumps({
+        'target_ip': '192.168.100.100',
+        'target_port': 7150,
+        'refresh_period': 20,
+        'listener_port': 4721,
+        'host': AGENT_ID,
+        'device_enhanced_scan': 'False',
+    })
+    new_agent_json = json.dumps({
+        'target_ip': '192.168.100.101',
+        'target_port': 7150,
+        'refresh_period': 20,
+        'listener_port': 4721,
+        'host': AGENT_ID,
+        'device_enhanced_scan': 'False',
+    })
+    old_unit_run = 'OLD UNIT RUN - should not be rewritten on reconfig\n'
+
+    with with_cephadm_ctx([]) as ctx:
+        ctx.fsid = FSID
+        ctx.name = f'agent.{AGENT_ID}'
+        ctx.skip_firewalld = True
+        ctx.skip_restart_for_reconfig = False
+        ctx.config_blobs = {
+            'agent.json': new_agent_json,
+            'keyring': 'new-keyring',
+            'root_cert.pem': 'new-ca',
+            'listener.crt': 'new-crt',
+            'listener.key': 'new-key',
+            'not-required-file.txt': 'should-not-be-written',
+        }
+
+        cephadm_fs.create_dir(AGENT_DIR)
+        with open(f'{AGENT_DIR}/agent.json', 'w') as f:
+            f.write(old_agent_json)
+        with open(f'{AGENT_DIR}/keyring', 'w') as f:
+            f.write('old-keyring')
+        with open(f'{AGENT_DIR}/root_cert.pem', 'w') as f:
+            f.write('old-ca')
+        with open(f'{AGENT_DIR}/listener.crt', 'w') as f:
+            f.write('old-crt')
+        with open(f'{AGENT_DIR}/listener.key', 'w') as f:
+            f.write('old-key')
+        with open(f'{AGENT_DIR}/unit.run', 'w') as f:
+            f.write(old_unit_run)
+
+        ident = _cephadm.DaemonIdentity.from_name(FSID, f'agent.{AGENT_ID}')
+        _cephadm.deploy_daemon(
+            ctx,
+            ident,
+            None,
+            os.getuid(),
+            os.getgid(),
+            deployment_type=_cephadm.DeploymentType.RECONFIG,
+            endpoints=[],
+        )
+
+        _check_file(f'{AGENT_DIR}/agent.json', new_agent_json)
+        _check_file(f'{AGENT_DIR}/keyring', 'new-keyring')
+        _check_file(f'{AGENT_DIR}/root_cert.pem', 'new-ca')
+        _check_file(f'{AGENT_DIR}/listener.crt', 'new-crt')
+        _check_file(f'{AGENT_DIR}/listener.key', 'new-key')
+        # reconfig must not rewrite unit.run (unlike full deploy_daemon_unit)
+        _check_file(f'{AGENT_DIR}/unit.run', old_unit_run)
+        assert not os.path.exists(f'{AGENT_DIR}/not-required-file.txt')
+
+        _call_throws.assert_has_calls([
+            mock.call(ctx, ['systemctl', 'reset-failed', ident.unit_name]),
+            mock.call(ctx, ['systemctl', 'restart', ident.unit_name]),
+        ])
+
+
 # FIXME(refactor): call is handled by with_cephadm_ctx but not call_throws
 # this leaves the test somewhat inconsistent and slightly confusing but we
 # are not going to change this while we break cephadm up into multiple files.
@@ -573,18 +686,22 @@ def test_mgr_listener_handle_json_payload(_agent_wakeup, _pull_conf_settings, ce
         _pull_conf_settings.assert_not_called()
         assert not any(os.path.exists(os.path.join(AGENT_DIR, s)) for s in agent.required_files)
 
+        # Production HTTP config push always includes the full required_files set
+        # (from prepare_create / generate_config). Also include an unrequired key
+        # to verify it is ignored.
         data_with_config = {
             'counter': 7,
             'config': {
-                'unrequired-file': 'unrequired-text'
+                'unrequired-file': 'unrequired-text',
             }
         }
-        data_with_config['config'].update({s: f'{s} text' for s in agent.required_files if s != agent.required_files[2]})
+        data_with_config['config'].update({s: f'{s} text' for s in agent.required_files})
         agent.mgr_listener.handle_json_payload(data_with_config)
         _agent_wakeup.assert_called()
         _pull_conf_settings.assert_called()
-        assert all(os.path.exists(os.path.join(AGENT_DIR, s)) for s in agent.required_files if s != agent.required_files[2])
-        assert not os.path.exists(os.path.join(AGENT_DIR, agent.required_files[2]))
+        assert all(os.path.exists(os.path.join(AGENT_DIR, s)) for s in agent.required_files)
+        for fname in agent.required_files:
+            _check_file(os.path.join(AGENT_DIR, fname), f'{fname} text')
         assert not os.path.exists(os.path.join(AGENT_DIR, 'unrequired-file'))
 
 

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -852,6 +852,9 @@ class AgentMessageThread(threading.Thread):
                 self.mgr.log.debug(f'Received "{self.agent_response}" from agent on host {self.host}')
                 if self.daemon_spec:
                     self.mgr.agent_cache.agent_config_successfully_delivered(self.daemon_spec)
+                    self.mgr.log.info(
+                        f'HTTP config push to agent on {self.host} acknowledged; '
+                        f'agent config deps updated (deps={self.daemon_spec.deps})')
                 self.mgr.agent_cache.sending_agent_message[self.host] = False
                 return
             except ConnectionError as e:
@@ -862,10 +865,16 @@ class AgentMessageThread(threading.Thread):
                 time.sleep(retry_wait)
             except Exception as e:
                 # if it's not a connection error, something has gone wrong. Give up.
-                self.mgr.log.error(f'Failed to contact agent on host {self.host}: {e}')
+                # Leave agent config deps unchanged so _check_agent can retry.
+                self.mgr.log.error(
+                    f'Failed to contact agent on host {self.host}: {e}. '
+                    f'Agent config deps left unchanged for retry')
                 self.mgr.agent_cache.sending_agent_message[self.host] = False
                 return
-        self.mgr.log.error(f'Could not connect to agent on host {self.host}')
+        # Leave agent config deps unchanged so _check_agent can retry next cycle.
+        self.mgr.log.error(
+            f'Could not connect to agent on host {self.host}. '
+            f'Agent config deps left unchanged for retry')
         self.mgr.agent_cache.sending_agent_message[self.host] = False
         return
 
@@ -1011,9 +1020,14 @@ class CephadmAgentHelpers:
                 except Exception:
                     pass
                 daemon_spec = CephadmDaemonDeploySpec.from_daemon_description(agent)
+                has_agent_port = host in self.mgr.agent_cache.agent_ports
                 # we need to know the agent port to try to reconfig w/ http
                 # otherwise there is no choice but a full ssh reconfig
-                if host in self.mgr.agent_cache.agent_ports and root_cert_match and not down:
+                if has_agent_port and root_cert_match and not down:
+                    self.mgr.log.info(
+                        f'Agent config deps changed on {host} '
+                        f'(last_deps={last_deps} -> deps={deps}); '
+                        f'pushing updated config via HTTP')
                     daemon_spec = service_registry.get_service(daemon_type_to_service(
                         daemon_spec.daemon_type)).prepare_create(daemon_spec)
                     self.mgr.agent_helpers._request_agent_acks(
@@ -1022,10 +1036,24 @@ class CephadmAgentHelpers:
                         daemon_spec=daemon_spec,
                     )
                 else:
-                    self.mgr._daemon_action(daemon_spec, action='reconfig')
+                    self.mgr.log.info(
+                        f'Agent config deps changed on {host} '
+                        f'(last_deps={last_deps} -> deps={deps}); '
+                        f'reconfiguring via SSH '
+                        f'(agent_down={down}, has_agent_port={has_agent_port}, '
+                        f'root_cert_match={root_cert_match})')
+                    try:
+                        self.mgr._daemon_action(daemon_spec, action='reconfig')
+                    except Exception as e:
+                        # Deps are only stamped on successful deploy/reconfig.
+                        # Leaving them unchanged keeps last_deps != deps so we
+                        # retry on the next serve cycle.
+                        self.mgr.log.warning(
+                            f'SSH reconfig of agent on {host} failed: {e}. '
+                            f'Leaving agent config deps unchanged for retry')
                 return down
         except Exception as e:
-            self.mgr.log.debug(
+            self.mgr.log.warning(
                 f'Agent on host {host} not ready to have config and deps checked: {e}')
         action = self.mgr.cache.get_scheduled_daemon_action(agent.hostname, agent.name())
         if action:

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -1936,13 +1936,18 @@ class AgentCache():
         return True
 
     def agent_config_successfully_delivered(self, daemon_spec: CephadmDaemonDeploySpec) -> None:
-        # agent successfully received new config. Update config/deps
-        assert daemon_spec.service_name == 'agent'
+        # agent successfully received new config (HTTP ACK or successful SSH
+        # deploy/reconfig). Only call this after confirmed delivery so
+        # last_deps tracks what the agent actually has.
+        assert daemon_spec.daemon_type == 'agent'
         self.update_agent_config_deps(
             daemon_spec.host, daemon_spec.deps, datetime_now())
         self.agent_timestamp[daemon_spec.host] = datetime_now()
         self.agent_counter[daemon_spec.host] = 1
         self.save_agent(daemon_spec.host)
+        self.mgr.log.debug(
+            f'Marked agent config delivered for {daemon_spec.host} '
+            f'(deps={daemon_spec.deps})')
 
 
 class EventStore():

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1204,11 +1204,10 @@ class CephadmServe:
                 continue
 
             if dd.daemon_type == 'agent':
-                try:
-                    self.mgr.agent_helpers._check_agent(dd.hostname)
-                except Exception as e:
-                    self.log.debug(
-                        f'Agent {dd.name()} could not be checked in _check_daemons: {e}')
+                # Agent config/deps checks and HTTP/SSH reconfig run once per
+                # serve cycle from _refresh_hosts_and_daemons -> _check_agent.
+                # Skipping a second call here avoids duplicate SSH reconfigs
+                # while an agent is down after mgr failover.
                 continue
 
             # These daemon types require additional configs after creation
@@ -1625,10 +1624,6 @@ class CephadmServe:
                     raise OrchestratorError(
                         f'cephadm exited with an error code: {code}, stderr: {err}')
 
-                if daemon_spec.daemon_type == 'agent':
-                    self.mgr.agent_cache.agent_timestamp[daemon_spec.host] = datetime_now()
-                    self.mgr.agent_cache.agent_counter[daemon_spec.host] = 1
-
                 # refresh daemon state?  (ceph daemon reconfig does not need it)
                 if not reconfig or daemon_spec.daemon_type not in CEPH_TYPES:
                     if not code and daemon_spec.host in self.mgr.cache.daemons:
@@ -1654,10 +1649,22 @@ class CephadmServe:
                     self.mgr.cache.update_daemon_config_deps(
                         daemon_spec.host, daemon_spec.name(), daemon_spec.deps, start_time)
                     self.mgr.cache.save_host(daemon_spec.host)
+                elif not code:
+                    # Only mark agent config current after a confirmed successful
+                    # deploy/reconfig. Agent reconfig/deploy writes required_files
+                    # (including agent.json) before restart, so code == 0 means the
+                    # new MGR endpoint was applied. On failure, leave deps unchanged
+                    # so _check_agent keeps retrying (last_deps != deps) until the
+                    # new MGR endpoint is actually delivered.
+                    self.mgr.agent_cache.agent_config_successfully_delivered(daemon_spec)
+                    self.log.info(
+                        f"Agent config deps updated on {daemon_spec.host} after successful "
+                        f"{'reconfig' if reconfig else 'deploy'} (deps={daemon_spec.deps})")
                 else:
-                    self.mgr.agent_cache.update_agent_config_deps(
-                        daemon_spec.host, daemon_spec.deps, start_time)
-                    self.mgr.agent_cache.save_agent(daemon_spec.host)
+                    self.log.warning(
+                        f"Agent {'reconfig' if reconfig else 'deploy'} on {daemon_spec.host} "
+                        f"exited with code {code}; leaving agent config deps unchanged so "
+                        f"delivery of updated MGR endpoint can be retried")
                 msg = "{} {} on host '{}'".format(
                     'Reconfigured' if reconfig else 'Deployed', daemon_spec.name(), daemon_spec.host)
                 if not code:


### PR DESCRIPTION
SSH agent reconfig returned success and restarted the unit but did not rewrite agent.json, so after mgr failover agents kept a stale target_ip. Reuse the same required_files write path as HTTP config push, with tests.

Fixes: https://tracker.ceph.com/issues/78887
Signed-off-by: Ashwin M. Joshi <ashjosh1@in.ibm.com>




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
