### PR TITLE
mgr/cephadm: support port reuse for RGW multi-instance deployments

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1100,9 +1100,11 @@ def deploy_daemon(
 ) -> None:
     endpoints = endpoints or []
     daemon_type = ident.daemon_type
+    allow_port_reuse = bool(fetch_configs(ctx).get('allow_port_reuse', False))
+
     # only check port in use if fresh deployment since service
     # we are redeploying/reconfiguring will already be using the port
-    if deployment_type == DeploymentType.DEFAULT:
+    if deployment_type == DeploymentType.DEFAULT and not allow_port_reuse:
         if any([port_in_use(ctx, e) for e in endpoints]):
             if daemon_type == 'mgr':
                 # non-fatal for mgr when we are in mgr_standby_modules=false, but we can't

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -369,7 +369,10 @@ class HostAssignment(object):
                             r.extend([dp.renumber_ports(i) for dp in ls])
                     return r
             for offset in range(num):
-                r.extend([dp.renumber_ports(offset) for dp in ls])
+                # Check if spec allows port offset incrementing
+                # (e.g., RGW with so_reuseport=1 disables port incrementing)
+                port_offset = offset if not self.spec.allow_port_reuse() else 0
+                r.extend([dp.renumber_ports(port_offset) for dp in ls])
             return r
 
         # consider enough slots to fulfill target count-per-host or count

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1432,6 +1432,10 @@ class RgwService(CephService):
                 ssl_cert = '\n'.join(ssl_cert)
             deps.append(f'ssl-cert:{utils.config_hash(ssl_cert)}')
 
+        rgw_extra_args = getattr(rgw_spec, 'rgw_frontend_extra_args', None)
+        if rgw_extra_args:
+            deps.append(f'rgw_frontend_extra_args:{utils.config_hash(" ".join(rgw_extra_args))}')
+
         parent_deps = super().get_dependencies(mgr, spec, daemon_type)
         return sorted(deps + parent_deps)
 
@@ -1844,6 +1848,9 @@ class RgwService(CephService):
 
         if hasattr(svc_spec, 'rgw_exit_timeout_secs') and svc_spec.rgw_exit_timeout_secs:
             config['rgw_exit_timeout_secs'] = svc_spec.rgw_exit_timeout_secs
+
+        if svc_spec.allow_port_reuse():
+            config['allow_port_reuse'] = True
 
         if svc_spec.qat:
             config['qat'] = svc_spec.qat

--- a/src/pybind/mgr/cephadm/tests/services/test_rgw.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_rgw.py
@@ -4,7 +4,7 @@ from unittest.mock import patch, MagicMock
 
 from cephadm.services.service_registry import service_registry
 from cephadm.module import CephadmOrchestrator
-from ceph.deployment.service_spec import RGWSpec, CertificateSource
+from ceph.deployment.service_spec import RGWSpec, CertificateSource, SpecValidationError
 from cephadm.tests.fixtures import with_host, with_service, _run_cephadm
 from cephadm.tlsobject_types import TLSCredentials
 
@@ -532,3 +532,25 @@ class TestRGWService:
                         assert kwargs == {
                             'custom_sans': ['s3.example.com', '*.s3.example.com'],
                         }
+
+    @pytest.mark.parametrize(
+        "extra_args, expected",
+        [
+            (None, False),
+            ([], False),
+            (['tcp_nodelay=1'], False),
+            (['so_reuseport=1'], True),
+            (['so_reuseport=1', 'tcp_nodelay=1'], True),
+        ]
+    )
+    def test_rgw_allow_port_reuse(self, extra_args, expected):
+        s = RGWSpec(service_id='foo', rgw_frontend_extra_args=extra_args)
+        assert s.allow_port_reuse() == expected
+
+    def test_rgw_allow_port_reuse_conflicting_values(self):
+        s = RGWSpec(
+            service_id='foo',
+            rgw_frontend_extra_args=['so_reuseport=1', 'so_reuseport=0'],
+        )
+        with pytest.raises(SpecValidationError, match='mutually exclusive'):
+            s.validate()

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1199,6 +1199,13 @@ class ServiceSpec(object):
         # point.
         return []
 
+    def allow_port_reuse(self) -> bool:
+        """
+        Whether colocated daemons may reuse the same frontend port.
+        Returns False by default; override in subclasses that support port reuse.
+        """
+        return False
+
     def get_virtual_ip(self) -> Optional[str]:
         return None
 
@@ -1776,6 +1783,57 @@ class RGWSpec(ServiceSpec):
 
         return ports
 
+    def allow_port_reuse(self) -> bool:
+        """
+        Override to enable port reuse when so_reuseport is enabled.
+        When so_reuseport=1, multiple RGW instances can share the same port.
+
+        Returns:
+            bool: True if so_reuseport=1 is set in rgw_frontend_extra_args, False otherwise.
+        """
+        if self.rgw_frontend_extra_args:
+            return any(
+                arg.startswith("so_reuseport=1")
+                for arg in self.rgw_frontend_extra_args
+            )
+        return False
+
+    def _is_so_reuseport_setting_valid(self) -> bool:
+        """
+        Validate that rgw_frontend_extra_args does not contain both so_reuseport=0 and so_reuseport=1.
+        They are mutually exclusive.
+
+        Returns:
+            bool: True if the settings are valid, False if so_reuseport is set with both 0 and 1.
+        """
+        has_reuseport_eq_true = False
+        has_reuseport_eq_false = False
+
+        for arg in self.rgw_frontend_extra_args or []:
+            if not arg.startswith("so_reuseport="):
+                continue
+            value = arg.split("=", 1)[1].strip()
+            if value == '1':
+                has_reuseport_eq_true = True
+            elif value == '0':
+                has_reuseport_eq_false = True
+
+        return not (has_reuseport_eq_false and has_reuseport_eq_true)
+
+    def _validate_rgw_frontend_extra_args(self) -> None:
+        """
+        Validate the rgw_frontend_extra_args for valid options.
+        """
+        if self.rgw_frontend_extra_args is None:
+            return
+
+        if not self._is_so_reuseport_setting_valid():
+            raise SpecValidationError(
+                'Invalid RGW spec: rgw_frontend_extra_args contains both '
+                'so_reuseport=0 and so_reuseport=1; these options are '
+                'mutually exclusive.'
+            )
+
     def validate(self) -> None:
 
         if self.ssl:
@@ -1839,6 +1897,8 @@ class RGWSpec(ServiceSpec):
                 D3NCacheSpec.from_json(self.d3n_cache)
             except D3NCacheError as e:
                 raise SpecValidationError(str(e))
+
+        self._validate_rgw_frontend_extra_args()
 
 
 yaml.add_representer(RGWSpec, ServiceSpec.yaml_representer)

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1201,6 +1201,13 @@ class ServiceSpec(object):
         # point.
         return []
 
+    def allow_port_reuse(self) -> bool:
+        """
+        Whether colocated daemons may reuse the same frontend port.
+        Returns False by default; override in subclasses that support port reuse.
+        """
+        return False
+
     def get_virtual_ip(self) -> Optional[str]:
         return None
 
@@ -1778,6 +1785,57 @@ class RGWSpec(ServiceSpec):
 
         return ports
 
+    def allow_port_reuse(self) -> bool:
+        """
+        Override to enable port reuse when so_reuseport is enabled.
+        When so_reuseport=1, multiple RGW instances can share the same port.
+
+        Returns:
+            bool: True if so_reuseport=1 is set in rgw_frontend_extra_args, False otherwise.
+        """
+        if self.rgw_frontend_extra_args:
+            return any(
+                arg.startswith("so_reuseport=1")
+                for arg in self.rgw_frontend_extra_args
+            )
+        return False
+
+    def _is_so_reuseport_setting_valid(self) -> bool:
+        """
+        Validate that rgw_frontend_extra_args does not contain both so_reuseport=0 and so_reuseport=1.
+        They are mutually exclusive.
+
+        Returns:
+            bool: True if the settings are valid, False if so_reuseport is set with both 0 and 1.
+        """
+        has_reuseport_eq_true = False
+        has_reuseport_eq_false = False
+
+        for arg in self.rgw_frontend_extra_args or []:
+            if not arg.startswith("so_reuseport="):
+                continue
+            value = arg.split("=", 1)[1].strip()
+            if value == '1':
+                has_reuseport_eq_true = True
+            elif value == '0':
+                has_reuseport_eq_false = True
+
+        return not (has_reuseport_eq_false and has_reuseport_eq_true)
+
+    def _validate_rgw_frontend_extra_args(self) -> None:
+        """
+        Validate the rgw_frontend_extra_args for valid options.
+        """
+        if self.rgw_frontend_extra_args is None:
+            return
+
+        if not self._is_so_reuseport_setting_valid():
+            raise SpecValidationError(
+                'Invalid RGW spec: rgw_frontend_extra_args contains both '
+                'so_reuseport=0 and so_reuseport=1; these options are '
+                'mutually exclusive.'
+            )
+
     def validate(self) -> None:
 
         if self.ssl:
@@ -1841,6 +1899,8 @@ class RGWSpec(ServiceSpec):
                 D3NCacheSpec.from_json(self.d3n_cache)
             except D3NCacheError as e:
                 raise SpecValidationError(str(e))
+
+        self._validate_rgw_frontend_extra_args()
 
 
 yaml.add_representer(RGWSpec, ServiceSpec.yaml_representer)


### PR DESCRIPTION
When RGW instances are deployed with so_reuseport=1, multiple daemons can bind to the same port (SO_REUSEPORT socket option). The current scheduler unconditionally increments ports for multi-instance placement, which conflicts with this requirement.

Introduce is_increment_port_offset_enabled() to control port incrementing per service type. RGWSpec detects so_reuseport in rgw_frontend_extra_args and disables port incrementing accordingly. The scheduler respects this setting, and cephadm skips port-in-use checks when allow_port_reuse=True is configured.

This allows RGW to properly share ports across multiple instances on the same host when so_reuseport is enabled, improving resource efficiency for high-performance deployments.

Fixes: https://tracker.ceph.com/issues/78118

Tested on local environment setup:

1) Ceph cluster deployed with 1 host having the rgw label:
```shell
[ceph: root@ceph-node-0 /]# ceph orch host ls
HOST         ADDR             LABELS      STATUS
ceph-node-0  192.168.100.100  _admin,rgw
ceph-node-1  192.168.100.101
ceph-node-2  192.168.100.102
3 hosts in cluster
``` 

2) Executing the following rgw spec via ceph orch apply -i <spec file>:
```shell
[ceph: root@ceph-node-0 /]# cat /mnt/root/rgw.yml
service_type: rgw
service_id: foo
service_name: rgw.foo
placement:
  count_per_host: 2
  label: rgw
spec:
  rgw_exit_timeout_secs: 120
  rgw_frontend_port: 5000
  rgw_frontend_type: beast
  rgw_frontend_extra_args:
  - tcp_nodelay=1
  - max_header_size=65536
  - so_reuseport=1
``` 

3) This resulted in:
```shell
[ceph: root@ceph-node-0 /]# ceph orch ps
NAME                        HOST         PORTS        STATUS          REFRESHED   AGE  MEM USE  MEM LIM  VERSION                IMAGE ID      CONTAINER ID
...
rgw.foo.ceph-node-0.reynzb  ceph-node-0  *:5000       running (12s)      7s ago   11s    32.0M        -  21.3.0-1432-ge781e5a1  78a9fef61b35  99ab90d774f9
rgw.foo.ceph-node-0.urrstf  ceph-node-0  *:5000       running (14s)      7s ago   14s    31.6M        -  21.3.0-1432-ge781e5a1  78a9fef61b35  47ea497f4f92
``` 

And:
```shell
[ceph: root@ceph-node-0 /]# ceph config dump | grep rgw
client.rgw.foo.ceph-node-0.reynzb                    basic     rgw_frontends                          beast port=5000 tcp_nodelay=1 max_header_size=65536 so_reuseport=1                                      *
client.rgw.foo.ceph-node-0.urrstf                    basic     rgw_frontends                          beast port=5000 tcp_nodelay=1 max_header_size=65536 so_reuseport=1                                      *
``` 

4) Then editing and applying the spec as follows:
```shell
[ceph: root@ceph-node-0 /]# cat /mnt/root/rgw.yml
service_type: rgw
service_id: foo
service_name: rgw.foo
placement:
  count_per_host: 2
  label: rgw
spec:
  rgw_exit_timeout_secs: 120
  rgw_frontend_port: 5000
  rgw_frontend_type: beast
  rgw_frontend_extra_args:
  - tcp_nodelay=1
  - max_header_size=65536
  - so_reuseport=0
``` 

5) Resulted in the following:
```shell
[ceph: root@ceph-node-0 /]# ceph orch ps
NAME                        HOST         PORTS        STATUS          REFRESHED   AGE  MEM USE  MEM LIM  VERSION                IMAGE ID      CONTAINER ID
...
rgw.foo.ceph-node-0.urrstf  ceph-node-0  *:5000       running (2m)     16s ago   2m    71.2M        -  21.3.0-1432-ge781e5a1  78a9fef61b35  47ea497f4f92
rgw.foo.ceph-node-0.ztvorw  ceph-node-0  *:5001       running (29s)    16s ago  29s    68.2M        -  21.3.0-1432-ge781e5a1  78a9fef61b35  731c70cb61bd
``` 

And:
```shell
[ceph: root@ceph-node-0 /]# ceph config dump | grep rgw
client.rgw.foo.ceph-node-0.urrstf                    basic     rgw_frontends                          beast port=5000 tcp_nodelay=1 max_header_size=65536 so_reuseport=0                                      *
client.rgw.foo.ceph-node-0.ztvorw                    basic     rgw_frontends                          beast port=5001 tcp_nodelay=1 max_header_size=65536 so_reuseport=0                                      *
``` 

Also, added validation for mutually exclusive case. Applying the following:
```shell
[ceph: root@ceph-node-0 /]# cat rgw.yml
service_type: rgw
service_id: foo
service_name: rgw.foo
placement:
  count_per_host: 2
  label: rgw
spec:
  rgw_exit_timeout_secs: 120
  rgw_frontend_port: 5000
  rgw_frontend_type: beast
  rgw_frontend_extra_args:
  - tcp_nodelay=1
  - max_header_size=65536
  - so_reuseport=0
  - so_reuseport=1
``` 

Will result in:
```shell
[ceph: root@ceph-node-0 /]# ceph orch apply -i rgw.yml
Invalid RGW spec: rgw_frontend_extra_args contains both so_reuseport=0 and so_reuseport=1; these options are mutually exclusive.
``` 

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
