### PR TITLE
kv/RocksDBStore: refuse to open a db with an interrupted resharding, fix repair with extra column families

### DIFF
--- a/doc/man/8/ceph-bluestore-tool.rst
+++ b/doc/man/8/ceph-bluestore-tool.rst
@@ -175,9 +175,8 @@ Commands
    Resharding is usually a long process, which involves walking through entire RocksDB key space
    and moving some of them to different column families.
    Option --resharding-ctrl provides performance control over resharding process.
-   Interrupted resharding will prevent OSD from running.
-   Interrupted resharding does not corrupt data. It is always possible to continue previous resharding,
-   or select any other sharding scheme, including reverting to original one.
+   Resharding must not be interrupted: an interrupted resharding leaves the database in a state
+   that cannot be safely resumed or reverted, the OSD will not start anymore and has to be redeployed.
 
 :command:`show-sharding` --path *osd path*
 

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1109,9 +1109,21 @@ int RocksDBStore::verify_sharding(const rocksdb::Options& opt,
  if (existing_cfs.size() != rocksdb_cfs.size()) {
    std::vector<std::string> columns_from_stored;
    sharding_def_to_columns(stored_sharding_def, columns_from_stored);
-   derr << __func__ << " extra columns in rocksdb. rocksdb columns = " << rocksdb_cfs
-	<< " target columns = " << columns_from_stored << dendl;
-   return -EIO;
+   if (is_reshard_interrupted(stored_sharding_text)) {
+     // An interrupted resharding left column families that are not part of
+     // the stored sharding definition: the (partially populated) target
+     // columns of the resharding. Do not treat them as an error. Opening
+     // the database read-write is still refused by the resharding lock
+     // check in do_open(), while a read-only open is valid on a subset of
+     // column families and gives access to the not-yet-moved keys.
+     dout(5) << __func__ << " resharding in progress, ignoring extra columns"
+	     << " in rocksdb. rocksdb columns = " << rocksdb_cfs
+	     << " stored sharding = " << columns_from_stored << dendl;
+   } else {
+     derr << __func__ << " extra columns in rocksdb. rocksdb columns = " << rocksdb_cfs
+	  << " target columns = " << columns_from_stored << dendl;
+     return -EIO;
+   }
  }
   return 0;
 }
@@ -3856,23 +3868,33 @@ int RocksDBStore::reshard(const std::string& new_sharding, const RocksDBStore::r
   return r;
 }
 
-bool RocksDBStore::get_sharding(std::string& sharding) {
-  rocksdb::Status status;
-  std::string stored_sharding_text;
-  bool result = false;
+int RocksDBStore::read_sharding_def(std::string& sharding)
+{
   sharding.clear();
-
-  status = env->FileExists(sharding_def_file);
-  if (status.ok()) {
-    status = rocksdb::ReadFileToString(env,
-				       sharding_def_file,
-				       &stored_sharding_text);
-    if(status.ok()) {
-      result = true;
-      sharding = stored_sharding_text;
-    }
+  rocksdb::Status status = env->FileExists(sharding_def_file);
+  if (status.IsNotFound()) {
+    return 0;
   }
-  return result;
+  if (!status.ok()) {
+    derr << __func__ << " cannot access " << sharding_def_file << dendl;
+    return -EIO;
+  }
+  status = rocksdb::ReadFileToString(env, sharding_def_file, &sharding);
+  if (!status.ok()) {
+    derr << __func__ << " cannot read from " << sharding_def_file << dendl;
+    sharding.clear();
+    return -EIO;
+  }
+  return 1;
+}
+
+bool RocksDBStore::get_sharding(std::string& sharding) {
+  return read_sharding_def(sharding) == 1;
+}
+
+bool RocksDBStore::is_reshard_interrupted(const std::string& sharding)
+{
+  return sharding.find(resharding_column_lock) != std::string::npos;
 }
 
 // Find a key that is lexicographically between low and high.

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1069,7 +1069,8 @@ int RocksDBStore::verify_sharding(const rocksdb::Options& opt,
 				  std::vector<rocksdb::ColumnFamilyDescriptor>& existing_cfs,
 				  std::vector<std::pair<size_t, RocksDBStore::ColumnFamily> >& existing_cfs_shard,
 				  std::vector<rocksdb::ColumnFamilyDescriptor>& missing_cfs,
-				  std::vector<std::pair<size_t, RocksDBStore::ColumnFamily> >& missing_cfs_shard)
+				  std::vector<std::pair<size_t, RocksDBStore::ColumnFamily> >& missing_cfs_shard,
+				  std::vector<std::string>& extra_cfs)
 {
   rocksdb::Status status;
   std::string stored_sharding_text;
@@ -1131,15 +1132,69 @@ int RocksDBStore::verify_sharding(const rocksdb::Options& opt,
       }
     }
   }
-  existing_cfs.emplace_back("default", opt);
+  // repair() may have left a request to recreate missing column families;
+  // read it here as it also drives the handling of extra column families,
+  // do_open() reads it again to recreate the missing ones
+  std::string sharding_recreate_text;
+  rocksdb::ReadFileToString(opt.env, sharding_recreate, &sharding_recreate_text);
+  bool recreate_mode = sharding_recreate_text == "1";
+  bool resharding = is_reshard_interrupted(stored_sharding_text);
 
- if (existing_cfs.size() != rocksdb_cfs.size()) {
-   std::vector<std::string> columns_from_stored;
-   sharding_def_to_columns(stored_sharding_def, columns_from_stored);
-   derr << __func__ << " extra columns in rocksdb. rocksdb columns = " << rocksdb_cfs
-	<< " target columns = " << columns_from_stored << dendl;
-   return -EIO;
- }
+  if (recreate_mode && resharding) {
+    derr << __func__ << " cannot repair column families while resharding is"
+	 << " in progress, complete or continue resharding first" << dendl;
+    return -EIO;
+  }
+
+  // column families present in rocksdb but not part of the stored sharding
+  // definition
+  for (const auto& full_name : rocksdb_cfs) {
+    if (full_name == rocksdb::kDefaultColumnFamilyName) {
+      continue;
+    }
+    bool found = false;
+    for (const auto& e : existing_cfs) {
+      if (e.name == full_name) {
+	found = true;
+	break;
+      }
+    }
+    if (!found) {
+      extra_cfs.push_back(full_name);
+    }
+  }
+  if (!extra_cfs.empty()) {
+    std::vector<std::string> columns_from_stored;
+    sharding_def_to_columns(stored_sharding_def, columns_from_stored);
+    if (resharding) {
+      // An interrupted resharding left column families that are not part of
+      // the stored sharding definition: the (partially populated) target
+      // columns of the resharding. Do not treat them as an error. Opening
+      // the database read-write is still refused by the resharding lock
+      // check in do_open(), while a read-only open is valid on a subset of
+      // column families and gives access to the not-yet-moved keys.
+      dout(5) << __func__ << " resharding in progress, ignoring extra columns"
+	      << " in rocksdb. rocksdb columns = " << rocksdb_cfs
+	      << " stored sharding = " << columns_from_stored << dendl;
+      extra_cfs.clear();
+    } else if (recreate_mode) {
+      // typically column families resurrected by rocksdb::RepairDB(), which
+      // rebuilds the manifest from the data files it finds; report them to
+      // do_open() so they get opened (a read-write open must list all
+      // existing column families) and dropped, allowing repair to complete
+      dout(1) << __func__ << " extra columns in rocksdb will be dropped."
+	      << " rocksdb columns = " << rocksdb_cfs
+	      << " target columns = " << columns_from_stored << dendl;
+      for (const auto& full_name : extra_cfs) {
+	existing_cfs.emplace_back(full_name, rocksdb::ColumnFamilyOptions(opt));
+      }
+    } else {
+      derr << __func__ << " extra columns in rocksdb. rocksdb columns = " << rocksdb_cfs
+	   << " target columns = " << columns_from_stored << dendl;
+      return -EIO;
+    }
+  }
+  existing_cfs.emplace_back("default", opt);
   return 0;
 }
 
@@ -1192,9 +1247,11 @@ int RocksDBStore::do_open(ostream &out,
     std::vector<rocksdb::ColumnFamilyDescriptor> missing_cfs;
     std::vector<std::pair<size_t, RocksDBStore::ColumnFamily> > missing_cfs_shard;
 
+    std::vector<std::string> extra_cfs;
     r = verify_sharding(opt,
 			existing_cfs, existing_cfs_shard,
-			missing_cfs, missing_cfs_shard);
+			missing_cfs, missing_cfs_shard,
+			extra_cfs);
     if (r < 0) {
       return r;
     }
@@ -1246,7 +1303,8 @@ int RocksDBStore::do_open(ostream &out,
 	derr << status.ToString() << dendl;
 	return -EINVAL;
       }
-      ceph_assert(existing_cfs.size() == existing_cfs_shard.size() + 1);
+      ceph_assert(existing_cfs.size() ==
+		  existing_cfs_shard.size() + extra_cfs.size() + 1);
       ceph_assert(handles.size() == existing_cfs.size());
       dout(10) << __func__ << " existing_cfs=" << existing_cfs.size() << dendl;
       for (size_t i = 0; i < existing_cfs_shard.size(); i++) {
@@ -1258,6 +1316,22 @@ int RocksDBStore::do_open(ostream &out,
       }
       default_cf = handles[handles.size() - 1];
       must_close_default_cf = true;
+
+      // drop the extra column families accepted by verify_sharding() in
+      // recreate (repair) mode; their handles directly follow the sharded
+      // ones
+      for (size_t i = existing_cfs_shard.size();
+	   i < existing_cfs_shard.size() + extra_cfs.size(); i++) {
+	dout(1) << __func__ << " dropping extra column family "
+		<< existing_cfs[i].name << dendl;
+	status = db->DropColumnFamily(handles[i]);
+	if (!status.ok()) {
+	  derr << __func__ << " failed to drop extra column family "
+	       << existing_cfs[i].name << ": " << status.ToString() << dendl;
+	  return -EINVAL;
+	}
+	db->DestroyColumnFamilyHandle(handles[i]);
+      }
 
       if (missing_cfs.size() > 0 &&
 	  std::find_if(missing_cfs.begin(), missing_cfs.end(),
@@ -1281,6 +1355,9 @@ int RocksDBStore::do_open(ostream &out,
 			    missing_cfs_shard[i].first,
 			    cf);
 	}
+      }
+      if (recreate_mode) {
+	// repair completed, consume the recreate request marker
 	opt.env->DeleteFile(sharding_recreate);
       }
     }
@@ -3922,23 +3999,33 @@ int RocksDBStore::reshard(const std::string& new_sharding, const RocksDBStore::r
   return r;
 }
 
-bool RocksDBStore::get_sharding(std::string& sharding) {
-  rocksdb::Status status;
-  std::string stored_sharding_text;
-  bool result = false;
+int RocksDBStore::read_sharding_def(std::string& sharding)
+{
   sharding.clear();
-
-  status = env->FileExists(sharding_def_file);
-  if (status.ok()) {
-    status = rocksdb::ReadFileToString(env,
-				       sharding_def_file,
-				       &stored_sharding_text);
-    if(status.ok()) {
-      result = true;
-      sharding = stored_sharding_text;
-    }
+  rocksdb::Status status = env->FileExists(sharding_def_file);
+  if (status.IsNotFound()) {
+    return 0;
   }
-  return result;
+  if (!status.ok()) {
+    derr << __func__ << " cannot access " << sharding_def_file << dendl;
+    return -EIO;
+  }
+  status = rocksdb::ReadFileToString(env, sharding_def_file, &sharding);
+  if (!status.ok()) {
+    derr << __func__ << " cannot read from " << sharding_def_file << dendl;
+    sharding.clear();
+    return -EIO;
+  }
+  return 1;
+}
+
+bool RocksDBStore::get_sharding(std::string& sharding) {
+  return read_sharding_def(sharding) == 1;
+}
+
+bool RocksDBStore::is_reshard_interrupted(const std::string& sharding)
+{
+  return sharding.find(resharding_column_lock) != std::string::npos;
 }
 
 // Find a key that is lexicographically between low and high.

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1066,6 +1066,8 @@ int RocksDBStore::apply_block_cache_options(const std::string& column_name,
 }
 
 int RocksDBStore::verify_sharding(const rocksdb::Options& opt,
+				  std::vector<ColumnFamily>& stored_sharding_def,
+				  std::vector<std::string>& rocksdb_cfs,
 				  std::vector<rocksdb::ColumnFamilyDescriptor>& existing_cfs,
 				  std::vector<std::pair<size_t, RocksDBStore::ColumnFamily> >& existing_cfs_shard,
 				  std::vector<rocksdb::ColumnFamilyDescriptor>& missing_cfs,
@@ -1074,28 +1076,15 @@ int RocksDBStore::verify_sharding(const rocksdb::Options& opt,
 {
   rocksdb::Status status;
   std::string stored_sharding_text;
-  status = opt.env->FileExists(sharding_def_file);
-  if (status.ok()) {
-    status = rocksdb::ReadFileToString(opt.env,
-				       sharding_def_file,
-				       &stored_sharding_text);
-    if(!status.ok()) {
-      derr << __func__ << " cannot read from " << sharding_def_file << dendl;
-      return -EIO;
-    }
-    dout(20) << __func__ << " sharding=" << stored_sharding_text << dendl;
-  } else {
-    dout(30) << __func__ << " no sharding" << dendl;
-    //no "sharding_def" present
+  int r = read_sharding_def(stored_sharding_text);
+  if (r < 0) {
+    return r;
   }
   //check if sharding_def matches stored_sharding_def
-  std::vector<ColumnFamily> stored_sharding_def;
   parse_sharding_def(stored_sharding_text, stored_sharding_def);
-
   std::sort(stored_sharding_def.begin(), stored_sharding_def.end(),
 	    [](ColumnFamily& a, ColumnFamily& b) { return a.name < b.name; } );
 
-  std::vector<string> rocksdb_cfs;
   status = rocksdb::DB::ListColumnFamilies(rocksdb::DBOptions(opt),
 					   path, &rocksdb_cfs);
   if (!status.ok()) {
@@ -1132,19 +1121,6 @@ int RocksDBStore::verify_sharding(const rocksdb::Options& opt,
       }
     }
   }
-  // repair() may have left a request to recreate missing column families;
-  // read it here as it also drives the handling of extra column families,
-  // do_open() reads it again to recreate the missing ones
-  std::string sharding_recreate_text;
-  rocksdb::ReadFileToString(opt.env, sharding_recreate, &sharding_recreate_text);
-  bool recreate_mode = sharding_recreate_text == "1";
-  bool resharding = is_reshard_interrupted(stored_sharding_text);
-
-  if (recreate_mode && resharding) {
-    derr << __func__ << " cannot repair column families while resharding is"
-	 << " in progress, complete or continue resharding first" << dendl;
-    return -EIO;
-  }
 
   // column families present in rocksdb but not part of the stored sharding
   // definition
@@ -1152,46 +1128,12 @@ int RocksDBStore::verify_sharding(const rocksdb::Options& opt,
     if (full_name == rocksdb::kDefaultColumnFamilyName) {
       continue;
     }
-    bool found = false;
-    for (const auto& e : existing_cfs) {
-      if (e.name == full_name) {
-	found = true;
-	break;
-      }
-    }
-    if (!found) {
+    if (existing_cfs.end() ==
+          std::find_if(existing_cfs.begin(), existing_cfs.end(),
+            [&](rocksdb::ColumnFamilyDescriptor& e) {
+              return e.name == full_name;
+            })) {
       extra_cfs.push_back(full_name);
-    }
-  }
-  if (!extra_cfs.empty()) {
-    std::vector<std::string> columns_from_stored;
-    sharding_def_to_columns(stored_sharding_def, columns_from_stored);
-    if (resharding) {
-      // An interrupted resharding left column families that are not part of
-      // the stored sharding definition: the (partially populated) target
-      // columns of the resharding. Do not treat them as an error. Opening
-      // the database read-write is still refused by the resharding lock
-      // check in do_open(), while a read-only open is valid on a subset of
-      // column families and gives access to the not-yet-moved keys.
-      dout(5) << __func__ << " resharding in progress, ignoring extra columns"
-	      << " in rocksdb. rocksdb columns = " << rocksdb_cfs
-	      << " stored sharding = " << columns_from_stored << dendl;
-      extra_cfs.clear();
-    } else if (recreate_mode) {
-      // typically column families resurrected by rocksdb::RepairDB(), which
-      // rebuilds the manifest from the data files it finds; report them to
-      // do_open() so they get opened (a read-write open must list all
-      // existing column families) and dropped, allowing repair to complete
-      dout(1) << __func__ << " extra columns in rocksdb will be dropped."
-	      << " rocksdb columns = " << rocksdb_cfs
-	      << " target columns = " << columns_from_stored << dendl;
-      for (const auto& full_name : extra_cfs) {
-	existing_cfs.emplace_back(full_name, rocksdb::ColumnFamilyOptions(opt));
-      }
-    } else {
-      derr << __func__ << " extra columns in rocksdb. rocksdb columns = " << rocksdb_cfs
-	   << " target columns = " << columns_from_stored << dendl;
-      return -EIO;
     }
   }
   existing_cfs.emplace_back("default", opt);
@@ -1242,6 +1184,8 @@ int RocksDBStore::do_open(ostream &out,
     }
     default_cf = db->DefaultColumnFamily();
   } else {
+    std::vector<ColumnFamily> stored_sharding_def;
+    std::vector<std::string> rocksdb_cfs;
     std::vector<rocksdb::ColumnFamilyDescriptor> existing_cfs;
     std::vector<std::pair<size_t, RocksDBStore::ColumnFamily> > existing_cfs_shard;
     std::vector<rocksdb::ColumnFamilyDescriptor> missing_cfs;
@@ -1249,6 +1193,8 @@ int RocksDBStore::do_open(ostream &out,
 
     std::vector<std::string> extra_cfs;
     r = verify_sharding(opt,
+			stored_sharding_def,
+			rocksdb_cfs,
 			existing_cfs, existing_cfs_shard,
 			missing_cfs, missing_cfs_shard,
 			extra_cfs);
@@ -1260,108 +1206,134 @@ int RocksDBStore::do_open(ostream &out,
 				       sharding_recreate,
 				       &sharding_recreate_text);
     bool recreate_mode = status.ok() && sharding_recreate_text == "1";
+    bool resharding = missing_cfs.end() !=
+      std::find_if(missing_cfs.begin(), missing_cfs.end(),
+        [](const rocksdb::ColumnFamilyDescriptor& c) {
+          return c.name == resharding_column_lock;
+        });
 
+    if (recreate_mode && resharding) {
+      derr << __func__ << " cannot repair column families while resharding is"
+	   << " in progress, complete or continue resharding first" << dendl;
+      return -EINTR;
+    }
     ceph_assert(!recreate_mode || !open_readonly);
-    if (recreate_mode == false && missing_cfs.size() != 0) {
-      // We do not accept when there are missing column families, except case that we are during resharding.
-      // We can get into this case if resharding was interrupted. It gives a chance to continue.
-      // Opening DB is only allowed in read-only mode.
-      if (open_readonly == false &&
-	  std::find_if(missing_cfs.begin(), missing_cfs.end(),
-		       [](const rocksdb::ColumnFamilyDescriptor& c) { return c.name == resharding_column_lock; }
-		       ) != missing_cfs.end()) {
-	derr << __func__ << " missing column families: " << missing_cfs_shard << dendl;
+
+    // We do not accept when there are missing column families, except case that we are during resharding.
+    // We can get into this case if resharding was interrupted. It gives a chance to continue.
+    // Opening DB is only allowed in read-only mode.
+    if (missing_cfs.size() != 0 && open_readonly == false && resharding){
+      derr << __func__ << " missing column families: " << missing_cfs_shard << dendl;
+      return -EIO;
+    }
+
+    // verify_sharding adds at least default cf to existing_cfs
+    ceph_assert(!existing_cfs.empty());
+    if (!extra_cfs.empty()) {
+      std::vector<std::string> columns_from_stored;
+      sharding_def_to_columns(stored_sharding_def, columns_from_stored);
+      if (resharding) {
+	// An interrupted resharding left column families that are not part of
+	// the stored sharding definition: the (partially populated) target
+	// columns of the resharding. Do not treat them as an error. Opening
+	// the database read-write is still refused by the resharding lock
+	// check in do_open(), while a read-only open is valid on a subset of
+	// column families and gives access to the not-yet-moved keys.
+	dout(5) << __func__ << " resharding in progress, ignoring extra columns"
+		<< " in rocksdb. rocksdb columns = " << rocksdb_cfs
+		<< " stored sharding = " << columns_from_stored << dendl;
+	extra_cfs.clear();
+      } else if (recreate_mode) {
+	// typically column families resurrected by rocksdb::RepairDB(), which
+	// rebuilds the manifest from the data files it finds; report them to
+	// do_open() so they get opened (a read-write open must list all
+	// existing column families) and dropped, allowing repair to complete
+	dout(5) << __func__ << " extra columns in rocksdb will be dropped."
+		<< " rocksdb columns = " << rocksdb_cfs
+		<< " target columns = " << columns_from_stored
+		<< " extra columns = " << extra_cfs
+                << dendl;
+	for (const auto& full_name : extra_cfs) {
+          // keep default cf at the end
+	  existing_cfs.emplace(--existing_cfs.end(),
+            full_name, rocksdb::ColumnFamilyOptions(opt));
+	}
+      } else {
+	derr << __func__ << " extra columns in rocksdb. rocksdb columns = " << rocksdb_cfs
+	     << " target columns = " << columns_from_stored << dendl;
 	return -EIO;
       }
     }
 
-    if (existing_cfs.empty()) {
-      // no column families
-      if (open_readonly) {
-        status = rocksdb::DB::OpenForReadOnly(opt, path, &db);
-      } else {
-        status = rocksdb::DB::Open(opt, path, &db);
-      }
-      if (!status.ok()) {
-	out << status.ToString();
-	derr << status.ToString() << dendl;
-	return -EINVAL;
-      }
-      default_cf = db->DefaultColumnFamily();
+    std::vector<rocksdb::ColumnFamilyHandle*> handles;
+    if (open_readonly) {
+      status = rocksdb::DB::OpenForReadOnly(rocksdb::DBOptions(opt),
+				            path, existing_cfs,
+					    &handles, &db);
     } else {
-      std::vector<rocksdb::ColumnFamilyHandle*> handles;
-      if (open_readonly) {
-        status = rocksdb::DB::OpenForReadOnly(rocksdb::DBOptions(opt),
-				              path, existing_cfs,
-					      &handles, &db);
-      } else {
-        status = rocksdb::DB::Open(rocksdb::DBOptions(opt),
-				   path, existing_cfs, &handles, &db);
-      }
+      status = rocksdb::DB::Open(rocksdb::DBOptions(opt),
+				 path, existing_cfs, &handles, &db);
+    }
+    if (!status.ok()) {
+      out << status.ToString();
+      derr << status.ToString() << dendl;
+      return -EINVAL;
+    }
+    ceph_assert(existing_cfs.size() ==
+		existing_cfs_shard.size() + extra_cfs.size() + 1);
+    ceph_assert(handles.size() == existing_cfs.size());
+    dout(10) << __func__ << " existing_cfs=" << existing_cfs.size() << dendl;
+    for (size_t i = 0; i < existing_cfs_shard.size(); i++) {
+      add_column_family(existing_cfs_shard[i].second.name,
+			existing_cfs_shard[i].second.hash_l,
+			existing_cfs_shard[i].second.hash_h,
+			existing_cfs_shard[i].first,
+			handles[i]);
+    }
+    default_cf = handles[handles.size() - 1];
+    must_close_default_cf = true;
+
+    // drop the extra column families accepted by verify_sharding() in
+    // recreate (repair) mode; their handles directly follow the sharded
+    // ones
+    for (size_t i = existing_cfs_shard.size();
+	 i < existing_cfs_shard.size() + extra_cfs.size(); i++) {
+      dout(1) << __func__ << " dropping extra column family "
+	      << existing_cfs[i].name << dendl;
+      status = db->DropColumnFamily(handles[i]);
       if (!status.ok()) {
-	out << status.ToString();
-	derr << status.ToString() << dendl;
+	derr << __func__ << " failed to drop extra column family "
+	     << existing_cfs[i].name << ": " << status.ToString() << dendl;
 	return -EINVAL;
       }
-      ceph_assert(existing_cfs.size() ==
-		  existing_cfs_shard.size() + extra_cfs.size() + 1);
-      ceph_assert(handles.size() == existing_cfs.size());
-      dout(10) << __func__ << " existing_cfs=" << existing_cfs.size() << dendl;
-      for (size_t i = 0; i < existing_cfs_shard.size(); i++) {
-	add_column_family(existing_cfs_shard[i].second.name,
-			  existing_cfs_shard[i].second.hash_l,
-			  existing_cfs_shard[i].second.hash_h,
-			  existing_cfs_shard[i].first,
-			  handles[i]);
-      }
-      default_cf = handles[handles.size() - 1];
-      must_close_default_cf = true;
+      db->DestroyColumnFamilyHandle(handles[i]);
+    }
 
-      // drop the extra column families accepted by verify_sharding() in
-      // recreate (repair) mode; their handles directly follow the sharded
-      // ones
-      for (size_t i = existing_cfs_shard.size();
-	   i < existing_cfs_shard.size() + extra_cfs.size(); i++) {
-	dout(1) << __func__ << " dropping extra column family "
-		<< existing_cfs[i].name << dendl;
-	status = db->DropColumnFamily(handles[i]);
+    if (missing_cfs.size() > 0 && !resharding) {
+      dout(10) << __func__ << " missing_cfs=" << missing_cfs.size() << dendl;
+      ceph_assert(recreate_mode);
+      ceph_assert(missing_cfs.size() == missing_cfs_shard.size());
+      for (size_t i = 0; i < missing_cfs.size(); i++) {
+	rocksdb::ColumnFamilyHandle *cf;
+	status = db->CreateColumnFamily(missing_cfs[i].options, missing_cfs[i].name, &cf);
 	if (!status.ok()) {
-	  derr << __func__ << " failed to drop extra column family "
-	       << existing_cfs[i].name << ": " << status.ToString() << dendl;
+	  derr << __func__ << " Failed to create rocksdb column family: "
+	       << missing_cfs[i].name << dendl;
 	  return -EINVAL;
 	}
-	db->DestroyColumnFamilyHandle(handles[i]);
-      }
-
-      if (missing_cfs.size() > 0 &&
-	  std::find_if(missing_cfs.begin(), missing_cfs.end(),
-		       [](const rocksdb::ColumnFamilyDescriptor& c) { return c.name == resharding_column_lock; }
-		       ) == missing_cfs.end())
-	{
-	dout(10) << __func__ << " missing_cfs=" << missing_cfs.size() << dendl;
-	ceph_assert(recreate_mode);
-	ceph_assert(missing_cfs.size() == missing_cfs_shard.size());
-	for (size_t i = 0; i < missing_cfs.size(); i++) {
-	  rocksdb::ColumnFamilyHandle *cf;
-	  status = db->CreateColumnFamily(missing_cfs[i].options, missing_cfs[i].name, &cf);
-	  if (!status.ok()) {
-	    derr << __func__ << " Failed to create rocksdb column family: "
-		 << missing_cfs[i].name << dendl;
-	    return -EINVAL;
-	  }
-	  add_column_family(missing_cfs_shard[i].second.name,
-			    missing_cfs_shard[i].second.hash_l,
-			    missing_cfs_shard[i].second.hash_h,
-			    missing_cfs_shard[i].first,
-			    cf);
-	}
-      }
-      if (recreate_mode) {
-	// repair completed, consume the recreate request marker
-	opt.env->DeleteFile(sharding_recreate);
+	add_column_family(missing_cfs_shard[i].second.name,
+			  missing_cfs_shard[i].second.hash_l,
+			  missing_cfs_shard[i].second.hash_h,
+			  missing_cfs_shard[i].first,
+			  cf);
       }
     }
-  }
+    if (recreate_mode) {
+      // repair completed, consume the recreate request marker
+      opt.env->DeleteFile(sharding_recreate);
+    }
+  } // if (create_if_missing) .. else
+
   ceph_assert(default_cf != nullptr);
   
   PerfCountersBuilder plb(cct, "rocksdb", l_rocksdb_first, l_rocksdb_last);
@@ -4004,6 +3976,7 @@ int RocksDBStore::read_sharding_def(std::string& sharding)
   sharding.clear();
   rocksdb::Status status = env->FileExists(sharding_def_file);
   if (status.IsNotFound()) {
+    dout(10) << __func__ << " no sharding" << dendl;
     return 0;
   }
   if (!status.ok()) {
@@ -4016,6 +3989,7 @@ int RocksDBStore::read_sharding_def(std::string& sharding)
     sharding.clear();
     return -EIO;
   }
+  dout(10) << __func__ << " sharding=" << sharding << dendl;
   return 1;
 }
 

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1212,38 +1212,27 @@ int RocksDBStore::do_open(ostream &out,
           return c.name == resharding_column_lock;
         });
 
-    if (recreate_mode && resharding) {
-      derr << __func__ << " cannot repair column families while resharding is"
-	   << " in progress, complete or continue resharding first" << dendl;
-      return -EINTR;
-    }
-    ceph_assert(!recreate_mode || !open_readonly);
-
-    // We do not accept when there are missing column families, except case that we are during resharding.
-    // We can get into this case if resharding was interrupted. It gives a chance to continue.
-    // Opening DB is only allowed in read-only mode.
-    if (missing_cfs.size() != 0 && open_readonly == false && resharding){
-      derr << __func__ << " missing column families: " << missing_cfs_shard << dendl;
+    if (resharding) {
+      // An interrupted resharding leaves keys split between the old and the
+      // new column families. The db must not be opened, not even read-only:
+      // BlueStore initializes its allocator from the freelist or the onodes
+      // stored in the db and would only get a partial view of them, so any
+      // subsequent write to BlueFS, including resuming the resharding, could
+      // overwrite live data. Reverting or resuming is not supported until
+      // the allocator can be recovered from such a db.
+      derr << __func__ << " resharding was interrupted, the db cannot be"
+	   << " safely resumed or reverted, the OSD has to be redeployed"
+	   << dendl;
       return -EIO;
     }
+    ceph_assert(!recreate_mode || !open_readonly);
 
     // verify_sharding adds at least default cf to existing_cfs
     ceph_assert(!existing_cfs.empty());
     if (!extra_cfs.empty()) {
       std::vector<std::string> columns_from_stored;
       sharding_def_to_columns(stored_sharding_def, columns_from_stored);
-      if (resharding) {
-	// An interrupted resharding left column families that are not part of
-	// the stored sharding definition: the (partially populated) target
-	// columns of the resharding. Do not treat them as an error. Opening
-	// the database read-write is still refused by the resharding lock
-	// check in do_open(), while a read-only open is valid on a subset of
-	// column families and gives access to the not-yet-moved keys.
-	dout(5) << __func__ << " resharding in progress, ignoring extra columns"
-		<< " in rocksdb. rocksdb columns = " << rocksdb_cfs
-		<< " stored sharding = " << columns_from_stored << dendl;
-	extra_cfs.clear();
-      } else if (recreate_mode) {
+      if (recreate_mode) {
 	// typically column families resurrected by rocksdb::RepairDB(), which
 	// rebuilds the manifest from the data files it finds; report them to
 	// do_open() so they get opened (a read-write open must list all
@@ -1309,7 +1298,7 @@ int RocksDBStore::do_open(ostream &out,
       db->DestroyColumnFamilyHandle(handles[i]);
     }
 
-    if (missing_cfs.size() > 0 && !resharding) {
+    if (missing_cfs.size() > 0) {
       dout(10) << __func__ << " missing_cfs=" << missing_cfs.size() << dendl;
       ceph_assert(recreate_mode);
       ceph_assert(missing_cfs.size() == missing_cfs_shard.size());
@@ -3995,11 +3984,6 @@ int RocksDBStore::read_sharding_def(std::string& sharding)
 
 bool RocksDBStore::get_sharding(std::string& sharding) {
   return read_sharding_def(sharding) == 1;
-}
-
-bool RocksDBStore::is_reshard_interrupted(const std::string& sharding)
-{
-  return sharding.find(resharding_column_lock) != std::string::npos;
 }
 
 // Find a key that is lexicographically between low and high.

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -173,7 +173,8 @@ private:
 		      std::vector<rocksdb::ColumnFamilyDescriptor>& existing_cfs,
 		      std::vector<std::pair<size_t, RocksDBStore::ColumnFamily> >& existing_cfs_shard,
 		      std::vector<rocksdb::ColumnFamilyDescriptor>& missing_cfs,
-		      std::vector<std::pair<size_t, RocksDBStore::ColumnFamily> >& missing_cfs_shard);
+		      std::vector<std::pair<size_t, RocksDBStore::ColumnFamily> >& missing_cfs_shard,
+		      std::vector<std::string>& extra_cfs);
   std::shared_ptr<rocksdb::Cache> create_block_cache(
     const std::string& name,
     const std::string& cache_type, size_t cache_size, double cache_prio_high = 0.0);
@@ -590,6 +591,15 @@ public:
   };
   int reshard(const std::string& new_sharding, const resharding_ctrl* ctrl = nullptr);
   bool get_sharding(std::string& sharding);
+  /// Read the stored sharding definition.
+  /// Returns 1 and fills @sharding if a definition is stored, 0 if no
+  /// definition is stored (non-sharded db), -EIO if a definition exists
+  /// but cannot be read.
+  int read_sharding_def(std::string& sharding);
+  /// Check whether a sharding definition, as returned by get_sharding(),
+  /// indicates an interrupted resharding that must be completed (by calling
+  /// reshard() again) before the database can be opened read-write.
+  static bool is_reshard_interrupted(const std::string& sharding);
   void util_divide_key_range(
     const std::string& prefix,        // Table to operate on.
     const std::string& starting_key,  // Included if exists.

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -590,6 +590,15 @@ public:
   };
   int reshard(const std::string& new_sharding, const resharding_ctrl* ctrl = nullptr);
   bool get_sharding(std::string& sharding);
+  /// Read the stored sharding definition.
+  /// Returns 1 and fills @sharding if a definition is stored, 0 if no
+  /// definition is stored (non-sharded db), -EIO if a definition exists
+  /// but cannot be read.
+  int read_sharding_def(std::string& sharding);
+  /// Check whether a sharding definition, as returned by get_sharding(),
+  /// indicates an interrupted resharding that must be completed (by calling
+  /// reshard() again) before the database can be opened read-write.
+  static bool is_reshard_interrupted(const std::string& sharding);
   void util_divide_key_range(
     const std::string& prefix,        // Table to operate on.
     const std::string& starting_key,  // Included if exists.

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -170,6 +170,8 @@ private:
   int apply_sharding(const rocksdb::Options& opt,
 		     const std::string& sharding_text);
   int verify_sharding(const rocksdb::Options& opt,
+                      std::vector<ColumnFamily>& stored_sharding_def,
+                      std::vector<std::string>& rocksdb_cfs,
 		      std::vector<rocksdb::ColumnFamilyDescriptor>& existing_cfs,
 		      std::vector<std::pair<size_t, RocksDBStore::ColumnFamily> >& existing_cfs_shard,
 		      std::vector<rocksdb::ColumnFamilyDescriptor>& missing_cfs,

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -598,10 +598,6 @@ public:
   /// definition is stored (non-sharded db), -EIO if a definition exists
   /// but cannot be read.
   int read_sharding_def(std::string& sharding);
-  /// Check whether a sharding definition, as returned by get_sharding(),
-  /// indicates an interrupted resharding that must be completed (by calling
-  /// reshard() again) before the database can be opened read-write.
-  static bool is_reshard_interrupted(const std::string& sharding);
   void util_divide_key_range(
     const std::string& prefix,        // Table to operate on.
     const std::string& starting_key,  // Included if exists.

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -1255,6 +1255,9 @@ TEST_F(RocksDBResharding, resume_interrupted_at_batch) {
   ctrl.unittest_fail_after_first_batch = true;
   ASSERT_EQ(db->reshard("Evade(4)", &ctrl), -1000);
   ASSERT_NE(db->open(cout), 0);
+  // but a read-only open of the interrupted db is possible
+  ASSERT_EQ(db->open_read_only(cout), 0);
+  db->close();
   ASSERT_EQ(db->reshard("Evade(4)"), 0);
   ASSERT_EQ(db->open(cout), 0);
   check_db();
@@ -1271,6 +1274,9 @@ TEST_F(RocksDBResharding, resume_interrupted_at_column) {
   ctrl.unittest_fail_after_processing_column = true;
   ASSERT_EQ(db->reshard("Evade(4)", &ctrl), -1001);
   ASSERT_NE(db->open(cout), 0);
+  // but a read-only open of the interrupted db is possible
+  ASSERT_EQ(db->open_read_only(cout), 0);
+  db->close();
   ASSERT_EQ(db->reshard("Evade(4)"), 0);
   ASSERT_EQ(db->open(cout), 0);
   check_db();
@@ -1287,6 +1293,9 @@ TEST_F(RocksDBResharding, resume_interrupted_before_commit) {
   ctrl.unittest_fail_after_successful_processing = true;
   ASSERT_EQ(db->reshard("Evade(4)", &ctrl), -1002);
   ASSERT_NE(db->open(cout), 0);
+  // but a read-only open of the interrupted db is possible
+  ASSERT_EQ(db->open_read_only(cout), 0);
+  db->close();
   ASSERT_EQ(db->reshard("Evade(4)"), 0);
   ASSERT_EQ(db->open(cout), 0);
   check_db();

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -1257,6 +1257,9 @@ TEST_F(RocksDBResharding, resume_interrupted_at_batch) {
   ctrl.unittest_fail_after_first_batch = true;
   ASSERT_EQ(db->reshard("Evade(4)", &ctrl), -1000);
   ASSERT_NE(db->open(cout), 0);
+  // but a read-only open of the interrupted db is possible
+  ASSERT_EQ(db->open_read_only(cout), 0);
+  db->close();
   ASSERT_EQ(db->reshard("Evade(4)"), 0);
   ASSERT_EQ(db->open(cout), 0);
   check_db();
@@ -1273,6 +1276,9 @@ TEST_F(RocksDBResharding, resume_interrupted_at_column) {
   ctrl.unittest_fail_after_processing_column = true;
   ASSERT_EQ(db->reshard("Evade(4)", &ctrl), -1001);
   ASSERT_NE(db->open(cout), 0);
+  // but a read-only open of the interrupted db is possible
+  ASSERT_EQ(db->open_read_only(cout), 0);
+  db->close();
   ASSERT_EQ(db->reshard("Evade(4)"), 0);
   ASSERT_EQ(db->open(cout), 0);
   check_db();
@@ -1289,6 +1295,46 @@ TEST_F(RocksDBResharding, resume_interrupted_before_commit) {
   ctrl.unittest_fail_after_successful_processing = true;
   ASSERT_EQ(db->reshard("Evade(4)", &ctrl), -1002);
   ASSERT_NE(db->open(cout), 0);
+  // but a read-only open of the interrupted db is possible
+  ASSERT_EQ(db->open_read_only(cout), 0);
+  db->close();
+  ASSERT_EQ(db->reshard("Evade(4)"), 0);
+  ASSERT_EQ(db->open(cout), 0);
+  check_db();
+  db->close();
+}
+
+TEST_F(RocksDBResharding, repair_with_extra_columns) {
+  ASSERT_EQ(0, db->create_and_open(cout, "Ad(1) Betelgeuse(1)"));
+  db->close();
+  // simulate rocksdb::RepairDB() resurrecting a dropped column family:
+  // remove Betelgeuse from the stored sharding definition
+  ASSERT_EQ(::system("echo -n 'Ad(1)' > sharding/def"), 0);
+  // extra columns must still refuse to open outside of repair
+  ASSERT_NE(db->open(cout), 0);
+  // in repair (recreate) mode, extra columns are opened and dropped
+  ASSERT_EQ(::system("echo -n 1 > sharding/recreate_columns"), 0);
+  ASSERT_EQ(db->open(cout), 0);
+  db->close();
+  // the repair is durable: marker consumed, extra columns dropped
+  ASSERT_EQ(db->open(cout), 0);
+  db->close();
+}
+
+TEST_F(RocksDBResharding, no_repair_during_resharding) {
+  ASSERT_EQ(0, db->create_and_open(cout, ""));
+  generate_data();
+  data_to_db();
+  check_db();
+  db->close();
+  RocksDBStore::resharding_ctrl ctrl;
+  ctrl.unittest_fail_after_first_batch = true;
+  ASSERT_EQ(db->reshard("Evade(4)", &ctrl), -1000);
+  // repair must refuse to touch a db with an interrupted resharding
+  ASSERT_EQ(::system("echo -n 1 > sharding/recreate_columns"), 0);
+  ASSERT_NE(db->open(cout), 0);
+  ASSERT_EQ(::system("rm sharding/recreate_columns"), 0);
+  // resuming the resharding is still possible
   ASSERT_EQ(db->reshard("Evade(4)"), 0);
   ASSERT_EQ(db->open(cout), 0);
   check_db();

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -1257,9 +1257,8 @@ TEST_F(RocksDBResharding, resume_interrupted_at_batch) {
   ctrl.unittest_fail_after_first_batch = true;
   ASSERT_EQ(db->reshard("Evade(4)", &ctrl), -1000);
   ASSERT_NE(db->open(cout), 0);
-  // but a read-only open of the interrupted db is possible
-  ASSERT_EQ(db->open_read_only(cout), 0);
-  db->close();
+  // not even read-only, see do_open()
+  ASSERT_NE(db->open_read_only(cout), 0);
   ASSERT_EQ(db->reshard("Evade(4)"), 0);
   ASSERT_EQ(db->open(cout), 0);
   check_db();
@@ -1276,9 +1275,8 @@ TEST_F(RocksDBResharding, resume_interrupted_at_column) {
   ctrl.unittest_fail_after_processing_column = true;
   ASSERT_EQ(db->reshard("Evade(4)", &ctrl), -1001);
   ASSERT_NE(db->open(cout), 0);
-  // but a read-only open of the interrupted db is possible
-  ASSERT_EQ(db->open_read_only(cout), 0);
-  db->close();
+  // not even read-only, see do_open()
+  ASSERT_NE(db->open_read_only(cout), 0);
   ASSERT_EQ(db->reshard("Evade(4)"), 0);
   ASSERT_EQ(db->open(cout), 0);
   check_db();
@@ -1295,9 +1293,8 @@ TEST_F(RocksDBResharding, resume_interrupted_before_commit) {
   ctrl.unittest_fail_after_successful_processing = true;
   ASSERT_EQ(db->reshard("Evade(4)", &ctrl), -1002);
   ASSERT_NE(db->open(cout), 0);
-  // but a read-only open of the interrupted db is possible
-  ASSERT_EQ(db->open_read_only(cout), 0);
-  db->close();
+  // not even read-only, see do_open()
+  ASSERT_NE(db->open_read_only(cout), 0);
   ASSERT_EQ(db->reshard("Evade(4)"), 0);
   ASSERT_EQ(db->open(cout), 0);
   check_db();


### PR DESCRIPTION
Resuming an interrupted resharding with `ceph-bluestore-tool` reshard fails with "extra columns in rocksdb" (#73507), while the man page promises it can always be continued or reverted.

As Adam pointed out, the promise cannot be kept today: BlueStore initializes its allocator from the freelist or the onodes stored in the db, which are only partially visible on a half-resharded db, so resuming could overwrite live data. This PR therefore:

refuses to open a db with an interrupted resharding, read-only included, with an explicit message, and updates the ceph-bluestore-tool man page to say such an OSD has to be redeployed (last commit);
fixes repair mode when RepairDB() has resurrected column families that are not part of the sharding definition: they are now opened and dropped instead of making the db unopenable (Igor's refactoring included, thanks);
adds `read_sharding_def()` and unit tests for both cases.

Fixes: https://tracker.ceph.com/issues/73507

Assisted-by: Claude Fable 5 High.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
