### PR TITLE
tentacle: mds/Server: return after responding on error paths

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -490,6 +490,7 @@ void Server::reclaim_session(Session *session, const cref_t<MClientReclaim> &m)
 	       << " != target auth_name " << target->info.auth_name << dendl;
       reply->set_result(-EPERM);
       mds->send_message_client(reply, session);
+      return;
     }
 
     ceph_assert(!target->reclaiming_from);
@@ -7564,6 +7565,7 @@ void Server::handle_client_symlink(const MDRequestRef& mdr)
   if (req->get_alternate_name().size() > alternate_name_max) {
     dout(10) << " alternate_name longer than " << alternate_name_max << dendl;
     respond_to_request(mdr, -ENAMETOOLONG);
+    return;
   }
   dn->set_alternate_name(req->get_alternate_name());
 
@@ -11969,6 +11971,7 @@ void Server::handle_client_readdir_snapdiff(const MDRequestRef& mdr)
       mdr->snapid_diff_other == CEPH_NOSNAP) {
     dout(10) << "reply to " << *req << " snapdiff -EINVAL" << dendl;
     respond_to_request(mdr, -EINVAL);
+    return;
   }
 
   unsigned max = req->head.args.snapdiff.max_entries;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78869

---

backport of https://github.com/ceph/ceph/pull/69835
parent tracker: https://tracker.ceph.com/issues/77862

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh