### PR TITLE
osd: Fix bug with zero of whole object + truncate in same request

### DIFF
--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -748,10 +748,12 @@ ECTransaction::Generate::Generate(PGTransaction &t,
     entry->mod_desc.update_snaps(op.updated_snaps->first);
   }
 
+  bool did_zero_truncate_to_delete = false;
   if (op.is_none() && op.truncate && op.truncate->first == 0) {
     // Skip zero_truncate_to_delete if object has omap data to preserve it
     if (!obc || !obc->obs.oi.is_omap()) {
       zero_truncate_to_delete();
+      did_zero_truncate_to_delete = true;
     }
   }
 
@@ -784,7 +786,10 @@ ECTransaction::Generate::Generate(PGTransaction &t,
   debug(oid, "to_write", to_write, dpp);
   ldpp_dout(dpp, 20) << " generate_transactions: plan: " << plan << dendl;
 
-  if (op.truncate && op.truncate->first < plan.orig_size) {
+  if (op.truncate &&
+      op.truncate->first < plan.orig_size &&
+      !did_zero_truncate_to_delete) {
+    // Deal with object getting smaller
     truncate();
   }
 
@@ -797,7 +802,9 @@ ECTransaction::Generate::Generate(PGTransaction &t,
 
   written_map->emplace(oid, std::move(to_write));
 
-  if (entry && plan.orig_size < plan.projected_size) {
+  if (entry &&
+      plan.orig_size < plan.projected_size &&
+      !did_zero_truncate_to_delete) {
     entry->mod_desc.append(ECUtil::align_next(plan.orig_size));
   }
 

--- a/src/test/librados/io_cxx.cc
+++ b/src/test/librados/io_cxx.cc
@@ -992,6 +992,123 @@ TEST_P(LibRadosIoPP, CmpExtMismatchPP) {
   ASSERT_EQ(0, memcmp(bl.c_str(), "ceph", 4));
 }
 
+TEST_P(LibRadosIoPP, ZeroAndTruncateSameRequest) {
+  constexpr size_t obj_size = 4096;
+  constexpr size_t smaller = 2048;
+  constexpr size_t larger = 8192;
+
+  auto write_4k_object = [&](const char* oid) {
+      char buf[obj_size];
+      memset(buf, 0, sizeof(buf));
+      bufferlist bl;
+      bl.append(buf, sizeof(buf));
+      ObjectWriteOperation op;
+      op.write(0, bl);
+      ASSERT_TRUE(AssertOperateWithoutSplitOp(0, oid, &op));
+  };
+
+  auto stat_object = [&](const char* oid, int rc) {
+      ObjectReadOperation op;
+      op.stat(nullptr, nullptr, nullptr);
+      ASSERT_TRUE(AssertOperateWithoutSplitOp(rc, oid, &op, nullptr,
+					      librados::OPERATION_BALANCE_READS));
+  };
+
+  auto expect_object = [&](const char* oid, size_t expected_size) {
+      char buf[expected_size];
+      memset(buf, 0, sizeof(buf));
+      bufferlist bl;
+      ObjectReadOperation op;
+      op.read(0, expected_size, nullptr, nullptr);
+      ASSERT_TRUE(AssertOperateWithoutSplitOp(0, oid, &op, &bl,
+					      librados::OPERATION_BALANCE_READS));
+      ASSERT_EQ(expected_size, bl.length());
+      ASSERT_EQ(0, memcmp(bl.c_str(), buf, sizeof(buf)));
+  };
+
+  {
+    write_4k_object("zero_trunc_2k");
+    ObjectWriteOperation op;
+    op.zero(0, obj_size);
+    op.truncate(smaller);
+    ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "zero_trunc_2k", &op));
+    expect_object("zero_trunc_2k", smaller);
+  }
+
+  {
+    write_4k_object("zero_trunc_4k");
+    ObjectWriteOperation op;
+    op.zero(0, obj_size);
+    op.truncate(obj_size);
+    ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "zero_trunc_4k", &op));
+    expect_object("zero_trunc_4k", obj_size);
+  }
+
+  {
+    write_4k_object("zero_trunc_8k");
+    ObjectWriteOperation op;
+    op.zero(0, obj_size);
+    op.truncate(larger);
+    ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "zero_trunc_8k", &op));
+    expect_object("zero_trunc_8k", larger);
+  }
+
+  {
+    write_4k_object("trunc0_trunc2k");
+    ObjectWriteOperation op;
+    op.truncate(0);
+    op.truncate(smaller);
+    ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "trunc0_trunc2k", &op));
+    expect_object("trunc0_trunc2k", smaller);
+  }
+
+  {
+    write_4k_object("trunc0_trunc4k");
+    ObjectWriteOperation op;
+    op.truncate(0);
+    op.truncate(obj_size);
+    ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "trunc0_trunc4k", &op));
+    expect_object("trunc0_trunc4k", obj_size);
+  }
+
+  {
+    write_4k_object("trunc0_trunc8k");
+    ObjectWriteOperation op;
+    op.truncate(0);
+    op.truncate(larger);
+    ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "trunc0_trunc8k", &op));
+    expect_object("trunc0_trunc8k", larger);
+  }
+
+  {
+    // Truncate to 0 on a non-existent object is successful but doesn't create
+    // the object. See comments on https://tracker.ceph.com/issues/78340 and
+    // commit 86cab4aecc40
+    ObjectWriteOperation op;
+    op.truncate(0);
+    ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "missing_trunc0", &op));
+    stat_object("missing_trunc0", -ENOENT);
+  }
+
+  {
+    // Slightly surprisingly truncate to 4K on a non-existent object is successful
+    // but doesn't create the object.
+    ObjectWriteOperation op;
+    op.truncate(obj_size);
+    ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "missing_trunc4k", &op));
+    stat_object("missing_trunc4k", -ENOENT);
+  }
+
+  {
+    // Similarly for multiple truncates on a non-existent object
+    ObjectWriteOperation op;
+    op.truncate(0);
+    op.truncate(obj_size);
+    ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "missing_trunc0_trunc4k", &op));
+    stat_object("missing_trunc0_trunc4k", -ENOENT);
+  }
+}
+
 TEST_P(LibRadosIoECPP, CmpExtPP) {
   SKIP_IF_CRIMSON();
   bufferlist bl;
@@ -1050,6 +1167,126 @@ TEST_P(LibRadosIoECPP, CmpExtMismatchPP) {
   read.read(0, bl.length(), nullptr, nullptr);
   ASSERT_TRUE(AssertOperateWithSplitOp(0, "foo", &read, &bl, balanced_read_flags));
   ASSERT_EQ(0, memcmp(bl.c_str(), "ceph", 4));
+}
+
+TEST_P(LibRadosIoECPP, ZeroAndTruncateSameRequest) {
+  SKIP_IF_CRIMSON();
+  set_allow_ec_overwrites();
+
+  constexpr size_t chunk_size = 4096;
+  constexpr size_t obj_size = 4096;
+  constexpr size_t smaller = 2048;
+  constexpr size_t larger = 8192;
+
+  auto write_4k_object = [&](const char* oid) {
+      char buf[obj_size];
+      memset(buf, 0, sizeof(buf));
+      bufferlist bl;
+      bl.append(buf, sizeof(buf));
+      ObjectWriteOperation op;
+      op.write(0, bl);
+      ASSERT_TRUE(AssertOperateWithoutSplitOp(0, oid, &op));
+  };
+
+  auto stat_object = [&](const char* oid, int rc) {
+      ObjectReadOperation op;
+      op.stat(nullptr, nullptr, nullptr);
+      ASSERT_TRUE(AssertOperateWithoutSplitOp(rc, oid, &op, nullptr, balanced_read_flags));
+  };
+
+  auto expect_object = [&](const char* oid, size_t expected_size) {
+      char buf[expected_size];
+      memset(buf, 0, sizeof(buf));
+      bufferlist bl;
+      ObjectReadOperation op;
+      op.read(0, expected_size, nullptr, nullptr);
+      int expected_ops = (int)((expected_size + chunk_size - 1) / chunk_size);
+      ASSERT_TRUE(AssertOperateWithSplitOp(0, expected_ops, oid, &op, &bl, balanced_read_flags));
+      ASSERT_EQ(expected_size, bl.length());
+      ASSERT_EQ(0, memcmp(bl.c_str(), buf, sizeof(buf)));
+  };
+
+  {
+    write_4k_object("zero_trunc_2k");
+    ObjectWriteOperation op;
+    op.zero(0, obj_size);
+    op.truncate(smaller);
+    ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "zero_trunc_2k", &op));
+    expect_object("zero_trunc_2k", smaller);
+  }
+
+  {
+    write_4k_object("zero_trunc_4k");
+    ObjectWriteOperation op;
+    op.zero(0, obj_size);
+    op.truncate(obj_size);
+    ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "zero_trunc_4k", &op));
+    expect_object("zero_trunc_4k", obj_size);
+  }
+
+  {
+    write_4k_object("zero_trunc_8k");
+    ObjectWriteOperation op;
+    op.zero(0, obj_size);
+    op.truncate(larger);
+    ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "zero_trunc_8k", &op));
+    expect_object("zero_trunc_8k", larger);
+  }
+
+  {
+    write_4k_object("trunc0_trunc2k");
+    ObjectWriteOperation op;
+    op.truncate(0);
+    op.truncate(smaller);
+    ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "trunc0_trunc2k", &op));
+    expect_object("trunc0_trunc2k", smaller);
+  }
+
+  {
+    write_4k_object("trunc0_trunc4k");
+    ObjectWriteOperation op;
+    op.truncate(0);
+    op.truncate(obj_size);
+    ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "trunc0_trunc4k", &op));
+    expect_object("trunc0_trunc4k", obj_size);
+  }
+
+  {
+    write_4k_object("trunc0_trunc8k");
+    ObjectWriteOperation op;
+    op.truncate(0);
+    op.truncate(larger);
+    ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "trunc0_trunc8k", &op));
+    expect_object("trunc0_trunc8k", larger);
+  }
+
+  {
+    // Truncate to 0 on a non-existent object is successful but doesn't create
+    // the object. See comments on https://tracker.ceph.com/issues/78340 and
+    // commit 86cab4aecc40
+    ObjectWriteOperation op;
+    op.truncate(0);
+    ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "missing_trunc0", &op));
+    stat_object("missing_trunc0", -ENOENT);
+  }
+
+  {
+    // Slightly surprisingly truncate to 4K on a non-existent object is successful
+    // but doesn't create the object.
+    ObjectWriteOperation op;
+    op.truncate(obj_size);
+    ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "missing_trunc4k", &op));
+    stat_object("missing_trunc4k", -ENOENT);
+  }
+
+  {
+    // Similarly for multiple truncates on a non-existent object
+    ObjectWriteOperation op;
+    op.truncate(0);
+    op.truncate(obj_size);
+    ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "missing_trunc0_trunc4k", &op));
+    stat_object("missing_trunc0_trunc4k", -ENOENT);
+  }
 }
 
 INSTANTIATE_TEST_SUITE_P_REPLICA(LibRadosIoPP);


### PR DESCRIPTION
Fast EC asserts if a request contains both a zero for the whole object plus a truncate to less than the original object size in the same request.

An alternative request that produces the same result is a request that truncates an object to 0 and then truncates it to a size less that the original object size.

The problem is an optimization that tries to delete and recreate the object which is then followed by trying to reduce the object size.

Fixes: https://tracker.ceph.com/issues/78340

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
