### PR TITLE
tentacle: qa: fixed the NFS protocol version in test_nfs.py

### DIFF
--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -55,7 +55,7 @@ class TestNFS(MgrTestCase):
          "squash": "none",
          "security_label": True,
          "protocols": [
-           3, 4
+           4
          ],
          "transports": [
            "TCP"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78927

---

backport of https://github.com/ceph/ceph/pull/70084
parent tracker: https://tracker.ceph.com/issues/78099

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh