### PR TITLE
cephfs_mirror: fix incremental sync after directory rename

### DIFF
--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -2159,6 +2159,72 @@ class TestMirroring(CephFSTestCase):
 
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
 
+    def test_cephfs_mirror_incremental_sync_with_directory_rename(self):
+        """Unchanged descendants survive directory renames and replacements."""
+        self.setup_mount_b(mds_perm='rw')
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        peer_spec = "client.mirror_remote@ceph"
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec,
+                      self.secondary_fs_name)
+
+        dir_name = 'directory_rename'
+        old_dir = f'{dir_name}/dirB'
+        new_dir = f'{dir_name}/dirB-renamed'
+        renamed_file = 'sub/deeper/unchanged'
+        renamed_contents = 'unchanged across directory rename'
+        cross_old = f'{dir_name}/d1/X'
+        cross_new = f'{dir_name}/d2/Y'
+        cross_file = 'sub/deeper/unchanged'
+        cross_contents = 'unchanged across parent directory rename'
+        replacement_src = f'{dir_name}/replace/A'
+        replacement_dst = f'{dir_name}/replace/B'
+        replacement_file = 'sub/deeper/unchanged'
+        replacement_contents = 'unchanged across same-name directory replacement'
+
+        self.mount_a.run_shell([
+            'mkdir', '-p', f'{old_dir}/sub/deeper', f'{cross_old}/sub/deeper',
+            f'{dir_name}/d2', f'{replacement_src}/sub/deeper', replacement_dst])
+        self.mount_a.write_file(f'{old_dir}/{renamed_file}', data=renamed_contents)
+        self.mount_a.write_file(f'{cross_old}/{cross_file}', data=cross_contents)
+        self.mount_a.write_file(f'{replacement_src}/{replacement_file}',
+                                data=replacement_contents)
+        self.mount_a.write_file(f'{replacement_dst}/old-only', data='stale data')
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+
+        def sync_and_verify(snap_name, snap_count):
+            self.mount_a.run_shell(['sync'])
+            self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/{snap_name}'])
+            self.check_peer_status_idle(self.primary_fs_name, self.primary_fs_id,
+                                        peer_spec, f'/{dir_name}', snap_name, snap_count)
+            self.verify_snapshot(dir_name, snap_name)
+
+        sync_and_verify('snap0', 1)
+
+        self.mount_a.run_shell(['mv', old_dir, new_dir])
+        sync_and_verify('snap1', 2)
+        remote_snap = f'{dir_name}/.snap/snap1'
+        self.assertNotIn('dirB', self.mount_b.ls(path=remote_snap))
+        self.assertEqual(renamed_contents,
+                         self.mount_b.read_file(f'{remote_snap}/dirB-renamed/{renamed_file}'))
+
+        self.mount_a.run_shell(['mv', cross_old, cross_new])
+        sync_and_verify('snap2', 3)
+        self.assertEqual(cross_contents,
+                         self.mount_b.read_file(
+                             f'{dir_name}/.snap/snap2/d2/Y/{cross_file}'))
+
+        self.mount_a.run_shell(['rm', '-rf', replacement_dst])
+        self.mount_a.run_shell(['mv', replacement_src, replacement_dst])
+        sync_and_verify('snap3', 4)
+        remote_replacement = f'{dir_name}/.snap/snap3/replace/B'
+        self.assertNotIn('old-only', self.mount_b.ls(path=remote_replacement))
+        self.assertEqual(replacement_contents,
+                         self.mount_b.read_file(
+                             f'{remote_replacement}/{replacement_file}'))
+
+        self.remove_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
     def test_cephfs_mirror_incremental_sync_with_type_mixup(self):
         """ Test incremental snapshot synchronization with file type changes.
 

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -2518,6 +2518,72 @@ class TestMirroring(CephFSTestCase):
             self.assertEqual(source_states[path][:3],
                              destination_states[path][:3])
 
+    def test_cephfs_mirror_incremental_sync_with_directory_rename(self):
+        """Unchanged descendants survive directory renames and replacements."""
+        self.setup_mount_b(mds_perm='rw')
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        peer_spec = "client.mirror_remote@ceph"
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec,
+                      self.secondary_fs_name)
+
+        dir_name = 'directory_rename'
+        old_dir = f'{dir_name}/dirB'
+        new_dir = f'{dir_name}/dirB-renamed'
+        renamed_file = 'sub/deeper/unchanged'
+        renamed_contents = 'unchanged across directory rename'
+        cross_old = f'{dir_name}/d1/X'
+        cross_new = f'{dir_name}/d2/Y'
+        cross_file = 'sub/deeper/unchanged'
+        cross_contents = 'unchanged across parent directory rename'
+        replacement_src = f'{dir_name}/replace/A'
+        replacement_dst = f'{dir_name}/replace/B'
+        replacement_file = 'sub/deeper/unchanged'
+        replacement_contents = 'unchanged across same-name directory replacement'
+
+        self.mount_a.run_shell([
+            'mkdir', '-p', f'{old_dir}/sub/deeper', f'{cross_old}/sub/deeper',
+            f'{dir_name}/d2', f'{replacement_src}/sub/deeper', replacement_dst])
+        self.mount_a.write_file(f'{old_dir}/{renamed_file}', data=renamed_contents)
+        self.mount_a.write_file(f'{cross_old}/{cross_file}', data=cross_contents)
+        self.mount_a.write_file(f'{replacement_src}/{replacement_file}',
+                                data=replacement_contents)
+        self.mount_a.write_file(f'{replacement_dst}/old-only', data='stale data')
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+
+        def sync_and_verify(snap_name, snap_count):
+            self.mount_a.run_shell(['sync'])
+            self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/{snap_name}'])
+            self.check_peer_status_idle(self.primary_fs_name, self.primary_fs_id,
+                                        peer_spec, f'/{dir_name}', snap_name, snap_count)
+            self.verify_snapshot(dir_name, snap_name)
+
+        sync_and_verify('snap0', 1)
+
+        self.mount_a.run_shell(['mv', old_dir, new_dir])
+        sync_and_verify('snap1', 2)
+        remote_snap = f'{dir_name}/.snap/snap1'
+        self.assertNotIn('dirB', self.mount_b.ls(path=remote_snap))
+        self.assertEqual(renamed_contents,
+                         self.mount_b.read_file(f'{remote_snap}/dirB-renamed/{renamed_file}'))
+
+        self.mount_a.run_shell(['mv', cross_old, cross_new])
+        sync_and_verify('snap2', 3)
+        self.assertEqual(cross_contents,
+                         self.mount_b.read_file(
+                             f'{dir_name}/.snap/snap2/d2/Y/{cross_file}'))
+
+        self.mount_a.run_shell(['rm', '-rf', replacement_dst])
+        self.mount_a.run_shell(['mv', replacement_src, replacement_dst])
+        sync_and_verify('snap3', 4)
+        remote_replacement = f'{dir_name}/.snap/snap3/replace/B'
+        self.assertNotIn('old-only', self.mount_b.ls(path=remote_replacement))
+        self.assertEqual(replacement_contents,
+                         self.mount_b.read_file(
+                             f'{remote_replacement}/{replacement_file}'))
+
+        self.remove_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
     def test_cephfs_mirror_incremental_sync_with_type_mixup(self):
         """ Test incremental snapshot synchronization with file type changes.
 

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -2639,6 +2639,7 @@ int PeerReplayer::SnapDiffSync::get_entry(std::string *epath, struct ceph_statx 
 
         struct ceph_statx estx;
         r = ceph_statxat(m_local, m_fh->c_fd, _epath.c_str(), &estx,
+                         CEPH_STATX_INO |
                          CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
                          CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
                          AT_SYMLINK_NOFOLLOW);
@@ -2649,6 +2650,60 @@ int PeerReplayer::SnapDiffSync::get_entry(std::string *epath, struct ceph_statx 
 
         bool pic = entry.is_purged_or_itype_changed() || m_deleted[entry.epath].contains(e_name);
         if (S_ISDIR(estx.stx_mode)) {
+          bool purge_remote = false;
+          if (!pic) {
+            struct ceph_statx prev_stx;
+            r = ceph_statxat(m_fh->p_mnt, m_fh->p_fd, _epath.c_str(), &prev_stx,
+                             CEPH_STATX_INO | CEPH_STATX_MODE,
+                             AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+            if (r == -ENOENT) {
+              dout(10) << ": directory=" << _epath
+                       << " is absent from the previous snapshot; using full traversal"
+                       << dendl;
+              pic = true;
+            } else if (r < 0) {
+              derr << ": failed to stat previous directory=" << _epath
+                   << ", r=" << r << dendl;
+              return r;
+            } else if (!S_ISDIR(prev_stx.stx_mode)) {
+              // Same-name type changes should normally have been recorded in
+              // m_deleted. Keep this defensive check before trusting snapdiff.
+              pic = true;
+              purge_remote = true;
+            } else if (prev_stx.stx_ino != estx.stx_ino) {
+              dout(10) << ": directory=" << _epath
+                       << " changed inode between snapshots ("
+                       << prev_stx.stx_ino << " -> " << estx.stx_ino
+                       << "); purging remote and using full traversal" << dendl;
+              pic = true;
+              purge_remote = true;
+            }
+          }
+
+          if (purge_remote) {
+            struct ceph_statx remote_stx;
+            r = ceph_statxat(m_remote, m_fh->r_fd_dir_root, _epath.c_str(),
+                             &remote_stx, CEPH_STATX_MODE,
+                             AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+            if (r == 0) {
+              if (S_ISDIR(remote_stx.stx_mode)) {
+                r = purge_func(_epath);
+              } else {
+                r = ceph_unlinkat(m_remote, m_fh->r_fd_dir_root,
+                                  _epath.c_str(), 0);
+              }
+              if (r < 0) {
+                derr << ": failed to purge replaced remote entry=" << _epath
+                     << ", r=" << r << dendl;
+                return r;
+              }
+            } else if (r != -ENOENT) {
+              derr << ": failed to stat replaced remote entry=" << _epath
+                   << ", r=" << r << dendl;
+              return r;
+            }
+          }
+
           SyncEntry se;
           r = init_directory(_epath, estx, pic, &se);
           if (r < 0) {

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -2651,6 +2651,7 @@ int PeerReplayer::SnapDiffSync::get_entry(std::string *epath, struct ceph_statx 
 
         struct ceph_statx estx;
         r = ceph_statxat(m_local, m_fh->c_fd, _epath.c_str(), &estx,
+                         CEPH_STATX_INO |
                          CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
                          CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
                          AT_SYMLINK_NOFOLLOW);
@@ -2661,6 +2662,60 @@ int PeerReplayer::SnapDiffSync::get_entry(std::string *epath, struct ceph_statx 
 
         bool pic = entry.is_purged_or_itype_changed() || m_deleted[entry.epath].contains(e_name);
         if (S_ISDIR(estx.stx_mode)) {
+          bool purge_remote = false;
+          if (!pic) {
+            struct ceph_statx prev_stx;
+            r = ceph_statxat(m_fh->p_mnt, m_fh->p_fd, _epath.c_str(), &prev_stx,
+                             CEPH_STATX_INO | CEPH_STATX_MODE,
+                             AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+            if (r == -ENOENT) {
+              dout(10) << ": directory=" << _epath
+                       << " is absent from the previous snapshot; using full traversal"
+                       << dendl;
+              pic = true;
+            } else if (r < 0) {
+              derr << ": failed to stat previous directory=" << _epath
+                   << ", r=" << r << dendl;
+              return r;
+            } else if (!S_ISDIR(prev_stx.stx_mode)) {
+              // Same-name type changes should normally have been recorded in
+              // m_deleted. Keep this defensive check before trusting snapdiff.
+              pic = true;
+              purge_remote = true;
+            } else if (prev_stx.stx_ino != estx.stx_ino) {
+              dout(10) << ": directory=" << _epath
+                       << " changed inode between snapshots ("
+                       << prev_stx.stx_ino << " -> " << estx.stx_ino
+                       << "); purging remote and using full traversal" << dendl;
+              pic = true;
+              purge_remote = true;
+            }
+          }
+
+          if (purge_remote) {
+            struct ceph_statx remote_stx;
+            r = ceph_statxat(m_remote, m_fh->r_fd_dir_root, _epath.c_str(),
+                             &remote_stx, CEPH_STATX_MODE,
+                             AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+            if (r == 0) {
+              if (S_ISDIR(remote_stx.stx_mode)) {
+                r = purge_func(_epath);
+              } else {
+                r = ceph_unlinkat(m_remote, m_fh->r_fd_dir_root,
+                                  _epath.c_str(), 0);
+              }
+              if (r < 0) {
+                derr << ": failed to purge replaced remote entry=" << _epath
+                     << ", r=" << r << dendl;
+                return r;
+              }
+            } else if (r != -ENOENT) {
+              derr << ": failed to stat replaced remote entry=" << _epath
+                   << ", r=" << r << dendl;
+              return r;
+            }
+          }
+
           SyncEntry se;
           r = init_directory(_epath, estx, pic, &se);
           if (r < 0) {


### PR DESCRIPTION
Incremental (snapdiff-based) sync silently loses every unmodified descendant of
a renamed directory. The remote copy is left with the old name deleted and the
new name present but incomplete, the sync is reported as successful, and no
later snapshot repairs it.

Reproduced deterministically on main (`9b679b22366`) with a two-cluster vstart
setup:

```
snap1:  dirB/fb                      -> replicated, checksums match
        mv dirB dirB-renamed         (fb itself untouched)
snap2:  source   dirB-renamed/fb
        target   dirB-renamed/       <- empty, fb lost
        peer status: last_synced_snap=snap2, state=idle, failure_count=0
snap3:  target   dirB-renamed/fb still missing (no self-heal)
```

Control cases behave correctly, which isolates the defect to directory rename:
modifying a child after the rename syncs it, and a file-level rename copies the
file under its new name.

### Root cause

Three layers combine into a silent hole:

1. snapdiff is inode-scoped. Renaming a directory only changes the parent's
   dentry; the renamed directory keeps its inode and its children's dentries see
   no version split, so the recursive diff for the new path is empty.
2. `ceph_open_snapdiff()` tolerates the path being absent in the older snapshot
   and falls back to opening only the current side (`src/libcephfs.cc:888-897`).
   That is intended for genuinely new directories, but after a rename it turns
   the empty diff into a successful, empty result instead of an error.
3. `PeerReplayer` therefore purges the old name on the remote, creates the new
   name, and recurses with a diff that reports nothing. `dirty_snap_id` still
   matches the synced snapshot, so there is no remote-scan fallback either.

`SnapDiffSync`'s existing `pic` (`purged_or_itype_changed`) machinery does not
cover this: a rename appears as "old name deleted, new name created", and the
new name is not in `m_deleted[parent]`, so `pic` stays false.

### Fix

Before trusting snapdiff for a directory, stat the same path in the previous
snapshot:

- absent -> traverse the current snapshot in full;
- present with a different type or inode -> purge the remote entry first (so old
  and new contents cannot merge on the target), then traverse in full.

The decision propagates to descendants through
`SyncEntry::set_purged_or_itype_changed()`, and files below such a subtree are
queued with `sync_check=false` so they are copied whole.

Both stat calls go through the same mount: `SnapDiffSync` is only used when
`fh.p_mnt == m_local_mount`, so `stx_ino` from the two snapshots is directly
comparable. The inode comparison is defense in depth; normal same-name
replacements are reported delete-before-create and are already selected for full
traversal by `m_deleted`.

Cost is one extra `statxat()` per changed directory, and none inside a subtree
that is already being traversed in full.

### Tests

`src/test/libcephfs/snapdiff.cc` and `qa/tasks/cephfs/test_mirroring.py`
currently have no directory-rename coverage at all, which is why this went
unnoticed. The new integration test covers, against the same mirrored directory:

- a same-parent rename with a nested unchanged descendant
  (`dirB/sub/deeper/unchanged`), which also exercises propagation of the full
  traversal decision to descendants;
- a cross-parent rename (`d1/X` -> `d2/Y`);
- a same-name directory replacement (`rm -rf replace/B; mv replace/A replace/B`),
  asserting that the previously replicated `replace/B/old-only` does not survive
  on the target.

Every round compares full source/target snapshot checksums, so the test fails
without the fix. Pending writes are synced before each snapshot: otherwise
delayed writeback can move a baseline file into a later snapdiff change set and
mask the regression.

## Contribution Guidelines

- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests