### PR TITLE
tentacle: mgr/cephadm: don't let a non-RSA key kill the serve loop

### DIFF
--- a/src/pybind/mgr/tests/test_tls.py
+++ b/src/pybind/mgr/tests/test_tls.py
@@ -1,7 +1,40 @@
 from mgr_util import create_self_signed_cert, verify_tls, ServerConfigException, get_cert_issuer_info, certificate_days_to_expire
 from OpenSSL import crypto, SSL
 
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+import datetime
 import unittest
+
+
+def generate_ec_cert_and_key():
+    """Return a matching cert/key PEM pair using an EC key.
+
+    create_self_signed_cert() only ever produces RSA keys.
+    """
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, 'Ceph'),
+        x509.NameAttribute(NameOID.COMMON_NAME, 'cephadm'),
+    ])
+    now = datetime.datetime.now()
+    crt = (x509.CertificateBuilder()
+           .subject_name(name)
+           .issuer_name(name)
+           .public_key(key.public_key())
+           .serial_number(x509.random_serial_number())
+           .not_valid_before(now - datetime.timedelta(days=1))
+           .not_valid_after(now + datetime.timedelta(days=365))
+           .sign(key, hashes.SHA256()))
+    crt_pem = crt.public_bytes(serialization.Encoding.PEM).decode('utf-8')
+    key_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption()).decode('utf-8')
+    return crt_pem, key_pem
 
 
 valid_ceph_cert = """-----BEGIN CERTIFICATE-----\nMIICxjCCAa4CEQCpHIQuSYhCII1J0SVGYnT1MA0GCSqGSIb3DQEBDQUAMCExDTAL\nBgNVBAoMBENlcGgxEDAOBgNVBAMMB2NlcGhhZG0wHhcNMjIwNzA2MTE1MjUyWhcN\nMzIwNzAzMTE1MjUyWjAhMQ0wCwYDVQQKDARDZXBoMRAwDgYDVQQDDAdjZXBoYWRt\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAn2ApFna2CVYE7RDtjJVk\ncJTcJQrjzDOlCoZtxb1QMCQZMXjx/7d6bseQP+dkkeA0hZxnjJZWeu6c/YnQ1JiT\n2aDuDpWoJAaiinHRJyZuY5tqG+ggn95RdToZVbeC+0uALzYi4UFacC3sfpkyIKBR\nic43+2fQNz0PZ+8INSTtm75Y53gbWuGF7Dv95200AmAN2/u8LKWZIvdhbRborxOF\nlK2T40qbj9eH3ewIN/6Eibxrvg4va3pIoOaq0XdJHAL/MjDGJAtahPIenwcjuega\n4PSlB0h3qiyFXz7BG8P0QsPP6slyD58ZJtCGtJiWPOhlq47DlnWlJzRGDEFLLryf\n8wIDAQABMA0GCSqGSIb3DQEBDQUAA4IBAQBixd7RZawlYiTZaCmv3Vy7X/hhabac\nE/YiuFt1YMe0C9+D8IcCQN/IRww/Bi7Af6tm+ncHT9GsOGWX6hahXDKTw3b9nSDi\nETvjkUTYOayZGfhYpRA6m6e/2ypcUYsiXRDY9zneDKCdPREIA1D6L2fROHetFX9r\nX9rSry01xrYwNlYA1e6GLMXm2NaGsLT3JJlRBtT3P7f1jtRGXcwkc7ns0AtW0uNj\nGqRLHfJazdgWJFsj8vBdMs7Ci0C/b5/f7J/DLpPCvUA3Fqwn9MzHl01UwlDsKy1a\nROi4cfQNOLbWX8g3PfIlqtdGYNA77UPxvy1SUimmtdopZaEVWKkqeWYK\n-----END CERTIFICATE-----\n
@@ -42,6 +75,15 @@ class TLSchecks(unittest.TestCase):
         new_key.generate_key(crypto.TYPE_RSA, 2048)
         new_key = crypto.dump_privatekey(crypto.FILETYPE_PEM, new_key).decode('utf-8')
         self.assertRaises(ServerConfigException, verify_tls, crt, new_key)
+
+    def test_ec_tls(self):
+        crt, key = generate_ec_cert_and_key()
+        verify_tls(crt, key)
+
+    def test_mismatched_ec_tls(self):
+        crt, _ = generate_ec_cert_and_key()
+        _, other_key = generate_ec_cert_and_key()
+        self.assertRaises(ServerConfigException, verify_tls, crt, other_key)
 
     def test_get_cert_issuer_info(self):
 

--- a/src/python-common/ceph/cryptotools/internal.py
+++ b/src/python-common/ceph/cryptotools/internal.py
@@ -109,8 +109,11 @@ class InternalCryptoCaller(CryptoCaller):
     def verify_tls(self, crt: str, key: str) -> None:
         try:
             _key = crypto.load_privatekey(crypto.FILETYPE_PEM, key)
-            _key.check()
-        except (ValueError, crypto.Error) as e:
+            # check() validates an RSA key, which load_privatekey() does not,
+            # but raises TypeError for any other key type
+            if _key.type() == crypto.TYPE_RSA:
+                _key.check()
+        except (ValueError, TypeError, crypto.Error) as e:
             self.fail('Invalid private key: %s' % str(e))
         _crt = self._load_cert(crt)
         try:


### PR DESCRIPTION
pyOpenSSL's PKey.check() only understands RSA and raises TypeError for anything else:
```
    File "OpenSSL/crypto.py", line 414, in check
      raise TypeError("Only RSA keys can currently be checked.")
    TypeError: Only RSA keys can currently be checked.
```
`verify_tls()` caught (`ValueError`, `crypto.Error`), so storing an EC certificate/key pair let that `TypeError` escape all the way out of `_check_certificates()`, which runs early in the cephadm serve loop. The module then failed with `MGR_MODULE_ERROR`, every "ceph orch" command stopped working, and the same crash recurred on each mgr restart.

Limit `check()` to RSA keys instead of dropping it. `load_privatekey()` does not verify that an RSA key is internally consistent, so `check()` is doing real work: of 200 bit-flipped keys fed through the PEM path, 198 parsed fine and were rejected only by check(). Non-RSA keys are still validated against the certificate by `check_privatekey()`.

Also catch the general case in `_check_certificate_state()`, so a future crypto backend failure marks one certificate invalid instead of taking down the orchestrator.

This is not a cherry-pick from main because the offending code no longer exists there. d814088ce7d reimplemented `InternalCryptoCaller` on top of cryptography and dropped pyOpenSSL, which removed the `PKey.check()` call and fixed this as a side effect. That rewrite replaces every method in the class and is not suitable for a stable branch, so the RSA assumption is fixed in place here instead.

Fixes: https://tracker.ceph.com/issues/78939





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
