### PR TITLE
squid: osd/scrub: fix scrub jobs data race

### DIFF
--- a/src/osd/scrubber/osd_scrub.h
+++ b/src/osd/scrubber/osd_scrub.h
@@ -95,7 +95,7 @@ class OsdScrub {
    *  'scheduled_at' time. This is used whenever the scrub-job schedule is
    *  updated not as a result of a scrub attempt failure.
    *
-   *  locking: not using the jobs_lock
+   *  locking: using the jobs_lock
    */
   void update_job(
       Scrub::ScrubJobRef sjob,
@@ -137,6 +137,8 @@ class OsdScrub {
   /**
    * push the 'not_before' time out by 'delay' seconds, so that this scrub target
    * would not be retried before 'delay' seconds have passed.
+   *
+   * locking: using the jobs_lock
    */
   void delay_on_failure(
       Scrub::ScrubJobRef sjob,

--- a/src/osd/scrubber/osd_scrub_sched.cc
+++ b/src/osd/scrubber/osd_scrub_sched.cc
@@ -110,7 +110,7 @@ void ScrubQueue::register_with_osd(
 	  break;
 	}
 
-	update_job(scrub_job, suggested, true /* resets not_before */);
+	update_job_without_lock(scrub_job, suggested, true /* resets not_before */);
 	to_scrub.push_back(scrub_job);
 	scrub_job->in_queues = true;
 	scrub_job->state = qu_state_t::registered;
@@ -124,7 +124,7 @@ void ScrubQueue::register_with_osd(
 	// at any minute
 	std::lock_guard lck{jobs_lock};
 
-	update_job(scrub_job, suggested, true /* resets not_before */);
+	update_job_without_lock(scrub_job, suggested, true /* resets not_before */);
 	if (scrub_job->state == qu_state_t::not_registered) {
 	  dout(5) << " scrub job state changed to 'not registered'" << dendl;
 	  to_scrub.push_back(scrub_job);
@@ -147,6 +147,14 @@ void ScrubQueue::update_job(Scrub::ScrubJobRef scrub_job,
 			    const sched_params_t& suggested,
                             bool reset_nb)
 {
+  std::lock_guard lck{jobs_lock};
+  update_job_without_lock(scrub_job, suggested, reset_nb);
+}
+
+void ScrubQueue::update_job_without_lock(Scrub::ScrubJobRef scrub_job,
+			    const sched_params_t& suggested,
+                            bool reset_nb)
+{
   // adjust the suggested scrub time according to OSD-wide status
   auto adjusted = adjust_target_time(suggested);
   scrub_job->high_priority = suggested.is_must == must_scrub_t::mandatory;
@@ -165,6 +173,7 @@ void ScrubQueue::delay_on_failure(
 		  "pg[{}] delay_on_failure: delay:{} now:{:s}",
 		  sjob->pgid, delay, now_is)
 	   << dendl;
+  std::lock_guard lck{jobs_lock};
   sjob->delay_on_failure(delay, delay_cause, now_is);
 }
 

--- a/src/osd/scrubber/osd_scrub_sched.h
+++ b/src/osd/scrubber/osd_scrub_sched.h
@@ -219,13 +219,14 @@ class ScrubQueue {
    *  'scheduled_at' time. This is used whenever the scrub-job schedule is
    *  updated not as a result of a scrub attempt failure.
    *
-   *  locking: not using the jobs_lock
+   *  locking: using the jobs_lock
    */
   void update_job(
       Scrub::ScrubJobRef sjob,
       const sched_params_t& suggested,
       bool reset_notbefore);
 
+  // locking: using the jobs_lock
   void delay_on_failure(
       Scrub::ScrubJobRef sjob,
       std::chrono::seconds delay,
@@ -316,6 +317,16 @@ class ScrubQueue {
    */
   Scrub::scrub_schedule_t adjust_target_time(
     const Scrub::sched_params_t& recomputed_params) const;
+
+  /**
+   * Same as update_job(), to use when jobs_lock is already held
+   *
+   * locking: expects jobs_lock to be held by the caller
+   */
+  void update_job_without_lock(
+      Scrub::ScrubJobRef scrub_job,
+      const sched_params_t& suggested,
+      bool reset_nb);
 
 protected: // used by the unit-tests
   /**

--- a/src/test/osd/test_scrub_sched.cc
+++ b/src/test/osd/test_scrub_sched.cc
@@ -7,6 +7,8 @@
 
 #include <algorithm>
 #include <map>
+#include <atomic>
+#include <thread>
 
 #include "common/async/context_pool.h"
 #include "common/ceph_argparse.h"
@@ -450,3 +452,65 @@ TEST_F(TestScrubSched, ready_list)
   EXPECT_EQ(4, ripe_jobs.size());
   debug_print_jobs("ready_list", ripe_jobs);
 }
+
+// regression test for issue 78874
+// collect_ripe_jobs() from osd tick threads reads the jobs
+// schedules while update_job() and delay_on_failure() from PG threads
+// rewrite them
+TEST_F(TestScrubSched, schedule_writers_vs_ready_to_scrub_race)
+{
+  constexpr unsigned num_jobs = 100;
+  constexpr int num_ticks = 1'000;
+  const utime_t tick_time{epoch_2000, 0};
+
+  sched_params_t periodic;
+
+  // choose a time far enough before tick_time so that the jobs are always ripe
+  periodic.proposed_time = tick_time - utime_t{1'000'000, 0};
+  periodic.min_interval = 100.0;
+  periodic.max_interval = 200.0;
+
+  sched_params_t operator_requested;
+  operator_requested.proposed_time = PgScrubber::scrub_must_stamp();
+  operator_requested.is_must = Scrub::must_scrub_t::mandatory;
+
+  std::vector<ScrubJobRef> jobs;
+  for (unsigned i = 0; i < num_jobs; ++i) {
+    auto& job = jobs.emplace_back(
+        ceph::make_ref<Scrub::ScrubJob>(
+          g_ceph_context, spg_t{pg_t{i, 1}},
+          m_osd_num));
+    m_sched->register_with_osd(job, periodic);
+  }
+  ASSERT_EQ(
+      num_jobs,
+      m_sched->ready_to_scrub(Scrub::OSDRestrictions{}, tick_time).size());
+
+  // keep scheduling and delaying scrub jobs
+  std::atomic_bool done{false};
+  std::thread updater{[&] {
+    bool flip = false;
+    while (!done) {
+      const auto reason = flip ? operator_requested : periodic;
+      for (const auto& job : jobs) {
+        m_sched->delay_on_failure(
+            job,
+            std::chrono::seconds::zero(),
+            Scrub::delay_cause_t::none,
+            tick_time);
+        m_sched->update_job(job, reason, true);
+      }
+      flip = !flip;
+    }
+  }};
+
+  for (int i = 0; i < num_ticks; ++i) {
+    EXPECT_EQ(
+        num_jobs,
+        m_sched->ready_to_scrub(Scrub::OSDRestrictions{}, tick_time).size());
+  }
+
+  done = true;
+  updater.join();
+}
+


### PR DESCRIPTION
This MR add a test that reproduce the [issue](https://tracker.ceph.com/issues/78874) in the scrubber code path and a fix for it.

## Description

update_job() and delay_on_failure(), called from PG worker threads, rewrite scrub jobs schedule
without holding jobs_lock while the OSD tick thread reads the same fields when filtering and sorting the queue
in collect_ripe_jobs(). The fix make both take jobs_lock, with update_job_without_lock() for callers that already hold it.

Running `schedule_writers_vs_ready_to_scrub_race` with TSAN without the fix will detect data races.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests
<details>
