### PR TITLE
mgr/alerts: add PagerDuty support

### DIFF
--- a/doc/mgr/alerts.rst
+++ b/doc/mgr/alerts.rst
@@ -2,8 +2,7 @@ Alerts module
 =============
 
 The alerts module can send simple alert messages about cluster health
-via e-mail. In the future, it will support other notification methods
-as well.
+via e-mail or by opening, updating, and resolving incidents in PagerDuty.
 
 :note: This module is *not* intended to be a robust monitoring
        solution. The fact that it is run as part of the Ceph cluster
@@ -59,11 +58,52 @@ following form:
 
 By default, the alert module checks the cluster health once per minute and
 sends a message if there a change to the cluster's health status. Change the
-frequency of the alert module's cluster health checks by running a command of the following form: 
+frequency of the alert module's cluster health checks by running a command of the following form:
 
 .. prompt:: bash #
 
    ceph config set mgr mgr/alerts/interval <interval>   # e.g., "5m" for 5 minutes
+
+PagerDuty
+---------
+
+The alerts module can also open, update, and resolve incidents in PagerDuty
+using the `Events API v2
+<https://developer.pagerduty.com/docs/events-api-v2/overview/>`_. Configure a
+PagerDuty service with an *Events API v2* integration and copy its
+*Integration Key* (also called the *routing key*).
+
+.. prompt:: bash #
+
+   ceph config set mgr mgr/alerts/pagerduty_routing_key <integration-key>
+
+Each Ceph health check becomes a separate PagerDuty incident (deduplicated by
+health check code). New checks trigger new incidents, checks whose count
+increases update the existing incident, and cleared checks resolve the
+incident. ``HEALTH_ERR`` maps to PagerDuty severity ``critical``,
+``HEALTH_WARN`` maps to ``warning``.
+
+By default the cluster's ``fsid`` is used as the PagerDuty event ``source``
+field (and as a prefix on the dedup key so that multiple clusters sharing an
+integration key don't collide). To override:
+
+.. prompt:: bash #
+
+   ceph config set mgr mgr/alerts/pagerduty_source <source-name>
+   ceph config set mgr mgr/alerts/pagerduty_component <component-name>  # default: ceph
+
+If your environment requires an alternate endpoint (for example, an on-prem
+PagerDuty EU endpoint or a proxy), override the URL:
+
+.. prompt:: bash #
+
+   ceph config set mgr mgr/alerts/pagerduty_url https://events.eu.pagerduty.com/v2/enqueue
+
+Each PagerDuty API request uses a 10 second timeout by default. Adjust with:
+
+.. prompt:: bash #
+
+   ceph config set mgr mgr/alerts/pagerduty_timeout 30
 
 Commands
 --------

--- a/src/pybind/mgr/alerts/module.py
+++ b/src/pybind/mgr/alerts/module.py
@@ -7,11 +7,20 @@ from mgr_module import HandleCommandResult, MgrModule, Option
 from email.utils import formatdate, make_msgid
 from threading import Event
 from typing import Any, Optional, Dict, List, TYPE_CHECKING, Union
+from urllib.parse import urlparse
+import http.client
 import json
 import smtplib
 import ssl
 
 from .cli import AlertsCLICommand
+
+
+PAGERDUTY_SEVERITY_MAP = {
+    'HEALTH_ERR': 'critical',
+    'HEALTH_WARN': 'warning',
+    'HEALTH_OK': 'info',
+}
 
 
 class Alerts(MgrModule):
@@ -65,7 +74,34 @@ class Alerts(MgrModule):
             name='smtp_from_name',
             default='Ceph',
             desc='Email From: name',
-            runtime=True)
+            runtime=True),
+        # pagerduty
+        Option(
+            name='pagerduty_routing_key',
+            default='',
+            desc='PagerDuty Events API v2 integration/routing key',
+            runtime=True),
+        Option(
+            name='pagerduty_url',
+            default='https://events.pagerduty.com/v2/enqueue',
+            desc='PagerDuty Events API v2 endpoint URL',
+            runtime=True),
+        Option(
+            name='pagerduty_source',
+            default='',
+            desc='PagerDuty event source (defaults to cluster fsid)',
+            runtime=True),
+        Option(
+            name='pagerduty_component',
+            default='ceph',
+            desc='PagerDuty event component field',
+            runtime=True),
+        Option(
+            name='pagerduty_timeout',
+            type='secs',
+            default=10,
+            desc='Timeout for PagerDuty API requests',
+            runtime=True),
     ]
 
     # These are "native" Ceph options that this module cares about.
@@ -94,6 +130,11 @@ class Alerts(MgrModule):
             self.smtp_password = ''
             self.smtp_sender = ''
             self.smtp_from_name = ''
+            self.pagerduty_routing_key = ''
+            self.pagerduty_url = ''
+            self.pagerduty_source = ''
+            self.pagerduty_component = ''
+            self.pagerduty_timeout = 10
 
     def config_notify(self) -> None:
         """
@@ -154,6 +195,11 @@ class Alerts(MgrModule):
                     checks[code] = alert
         else:
             self.log.warning('Alert is not sent because smtp_host is not configured')
+        if self.pagerduty_routing_key:
+            r = self._send_alert_pagerduty(status, diff)
+            if r:
+                for code, alert in r.items():
+                    checks[code] = alert
         self.set_health_checks(checks)
 
     def serve(self) -> None:
@@ -260,4 +306,124 @@ class Alerts(MgrModule):
                 }
             }
         self.log.debug('Sent email to %s' % self.smtp_destination)
+        return None
+
+    # PagerDuty
+    def _pagerduty_get_source(self) -> str:
+        if self.pagerduty_source:
+            return self.pagerduty_source
+        try:
+            return self.get('mon_map')['fsid']
+        except Exception:
+            return 'ceph'
+
+    def _pagerduty_dedup_key(self, source: str, code: str) -> str:
+        if source:
+            return '{s}/{c}'.format(s=source, c=code)
+        return code
+
+    def _pagerduty_severity(self, alert: Dict[str, Any]) -> str:
+        return PAGERDUTY_SEVERITY_MAP.get(alert.get('severity', ''), 'warning')
+
+    def _pagerduty_enqueue(self, payload: Dict[str, Any]) -> None:
+        url = self.pagerduty_url or 'https://events.pagerduty.com/v2/enqueue'
+        parsed = urlparse(url)
+        host = parsed.netloc or parsed.path
+        path = parsed.path if parsed.netloc else '/v2/enqueue'
+        if not path:
+            path = '/v2/enqueue'
+        timeout = self.pagerduty_timeout or 10
+        conn: Union[http.client.HTTPSConnection, http.client.HTTPConnection]
+        if parsed.scheme == 'http':
+            conn = http.client.HTTPConnection(host, timeout=timeout)
+        else:
+            conn = http.client.HTTPSConnection(host, timeout=timeout)
+        try:
+            headers = {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+            }
+            conn.request('POST', path, json.dumps(payload), headers)
+            res = conn.getresponse()
+            data = res.read()
+            body = data.decode(errors='replace')
+            if res.status >= 300:
+                raise RuntimeError(
+                    'PagerDuty API returned {s}: {b}'.format(s=res.status, b=body))
+            self.log.debug('PagerDuty response: %s', body)
+        finally:
+            conn.close()
+
+    def _pagerduty_trigger(self,
+                           code: str,
+                           alert: Dict[str, Any],
+                           source: str) -> None:
+        payload = {
+            'routing_key': self.pagerduty_routing_key,
+            'event_action': 'trigger',
+            'dedup_key': self._pagerduty_dedup_key(source, code),
+            'payload': {
+                'summary': '[{code}] {msg}'.format(
+                    code=code,
+                    msg=alert.get('summary', {}).get('message', code)),
+                'source': source,
+                'severity': self._pagerduty_severity(alert),
+                'component': self.pagerduty_component or 'ceph',
+                'class': code,
+                'custom_details': {
+                    'code': code,
+                    'severity': alert.get('severity', ''),
+                    'count': alert.get('summary', {}).get('count', 0),
+                    'detail': [d.get('message', '')
+                               for d in alert.get('detail', [])],
+                },
+            },
+        }
+        self._pagerduty_enqueue(payload)
+
+    def _pagerduty_resolve(self, code: str, source: str) -> None:
+        payload = {
+            'routing_key': self.pagerduty_routing_key,
+            'event_action': 'resolve',
+            'dedup_key': self._pagerduty_dedup_key(source, code),
+        }
+        self._pagerduty_enqueue(payload)
+
+    def _send_alert_pagerduty(self,
+                              status: Dict[str, Any],
+                              diff: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        self.log.debug('_send_alert_pagerduty')
+        source = self._pagerduty_get_source()
+        # An empty diff means this is an on-demand `alerts send`; re-trigger
+        # every currently-active check so PagerDuty state matches the cluster.
+        if not diff:
+            diff = {'new': dict(status.get('checks', {}))}
+        errors: List[str] = []
+        for code, alert in diff.get('new', {}).items():
+            try:
+                self._pagerduty_trigger(code, alert, source)
+            except Exception as e:
+                self.log.exception('PagerDuty trigger failed for %s', code)
+                errors.append('trigger {c}: {e}'.format(c=code, e=e))
+        for code, alert in diff.get('updated', {}).items():
+            try:
+                self._pagerduty_trigger(code, alert, source)
+            except Exception as e:
+                self.log.exception('PagerDuty update failed for %s', code)
+                errors.append('update {c}: {e}'.format(c=code, e=e))
+        for code, alert in diff.get('cleared', {}).items():
+            try:
+                self._pagerduty_resolve(code, source)
+            except Exception as e:
+                self.log.exception('PagerDuty resolve failed for %s', code)
+                errors.append('resolve {c}: {e}'.format(c=code, e=e))
+        if errors:
+            return {
+                'ALERTS_PAGERDUTY_ERROR': {
+                    'severity': 'warning',
+                    'summary': 'unable to send one or more PagerDuty events',
+                    'count': len(errors),
+                    'detail': errors,
+                }
+            }
         return None


### PR DESCRIPTION
## Summary

Extend the `alerts` mgr module to open, update, and resolve incidents in PagerDuty via the Events API v2, in parallel with the existing SMTP delivery.

Each Ceph health check maps to a separate PagerDuty incident, deduplicated by check code (prefixed by the cluster fsid so a single routing key can be shared across clusters):

- new check → `trigger`
- check count increased → `trigger` again (same dedup key updates the incident)
- cleared check → `resolve`

`HEALTH_ERR` maps to severity `critical`, `HEALTH_WARN` to `warning`. An on-demand `ceph alerts send` re-triggers all currently active checks so PagerDuty state is reconciled with the cluster.

### New module options

| Option | Default | Description |
| --- | --- | --- |
| `pagerduty_routing_key` | *(empty)* | PagerDuty integration/routing key; PagerDuty is disabled when unset |
| `pagerduty_url` | `https://events.pagerduty.com/v2/enqueue` | Events API endpoint |
| `pagerduty_source` | *(cluster fsid)* | Event `source` field |
| `pagerduty_component` | `ceph` | Event `component` field |
| `pagerduty_timeout` | `10s` | Per-request timeout |

Failures to reach PagerDuty are surfaced as an `ALERTS_PAGERDUTY_ERROR` health check, mirroring the existing `ALERTS_SMTP_ERROR` pattern. Only stdlib (`http.client`, `urllib.parse`) is used — no new dependencies.

Docs updated in `doc/mgr/alerts.rst` with a new "PagerDuty" section.

## Test plan

- [ ] Enable alerts module, set `pagerduty_routing_key` on a live cluster, generate a health warning, and confirm an incident is opened.
- [ ] Increase the count of an active check and confirm the incident is updated (not duplicated).
- [ ] Clear the check and confirm the incident is auto-resolved.
- [ ] Run `ceph alerts send` and confirm all active checks are re-triggered idempotently (dedup-key stable).
- [ ] Set `pagerduty_url` to an unreachable host and confirm `ALERTS_PAGERDUTY_ERROR` appears in `ceph health detail` and the mgr thread is not blocked past the timeout.