### PR TITLE
crimson/os/seastore/omap: EXIST_MUTATION_PENDING OMAP extents should also record deltas

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1375,12 +1375,14 @@ CachedExtentRef Cache::duplicate_for_write(
     i->version++;
     i->state = CachedExtent::extent_state_t::EXIST_MUTATION_PENDING;
     i->last_committed_crc = i->calc_crc32c();
-    // deepcopy the buffer of exist clean extent beacuse it shares
-    // buffer with original clean extent.
-    auto bp = i->get_bptr();
-    auto nbp = ceph::bufferptr(buffer::create_page_aligned(bp.length()));
-    bp.copy_out(0, bp.length(), nbp.c_str());
-    i->set_bptr(std::move(nbp));
+    if (needs_deepcopy_on_mutate_exist(i->get_type())) {
+      // deepcopy the buffer of exist clean extent beacuse it shares
+      // buffer with original clean extent.
+      auto bp = i->get_bptr();
+      auto nbp = ceph::bufferptr(buffer::create_page_aligned(bp.length()));
+      bp.copy_out(0, bp.length(), nbp.c_str());
+      i->set_bptr(std::move(nbp));
+    }
 
     t.add_mutated_extent(i);
     DEBUGT("duplicate existing extent {}", t, *i);

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -2302,4 +2302,8 @@ void stage_visibility_handoff(Transaction& t,
 };
 using CacheRef = std::unique_ptr<Cache>;
 
+constexpr bool needs_deepcopy_on_mutate_exist(extent_types_t type) {
+  return type == extent_types_t::LOG_NODE;
+}
+
 }

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -421,6 +421,8 @@ public:
    */
   virtual void on_fully_loaded() {}
 
+  virtual void on_set_bptr() {}
+
   /**
    * on_clean_read
    *
@@ -1185,9 +1187,11 @@ protected:
   /// set bufferptr
   void set_bptr(ceph::bufferptr &&nptr) {
     ptr = nptr;
+    on_set_bptr();
   }
   void set_bptr(ceph::bufferptr &nptr) {
     ptr = nptr;
+    on_set_bptr();
   }
 
   /**

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.h
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.h
@@ -167,7 +167,7 @@ struct OMapInnerNode
 
   delta_inner_buffer_t delta_buffer;
   delta_inner_buffer_t *maybe_get_delta_buffer() {
-    return is_mutation_pending() ? &delta_buffer : nullptr;
+    return has_mutation() ? &delta_buffer : nullptr;
   }
 
   get_value_ret get_value(omap_context_t oc, std::string key) final;
@@ -430,7 +430,7 @@ struct OMapLeafNode
 
   delta_leaf_buffer_t delta_buffer;
   delta_leaf_buffer_t *maybe_get_delta_buffer() {
-    return is_mutation_pending() ? &delta_buffer : nullptr;
+    return has_mutation() ? &delta_buffer : nullptr;
   }
 
   get_value_ret get_value(

--- a/src/crimson/os/seastore/omap_manager/log/log_node.h
+++ b/src/crimson/os/seastore/omap_manager/log/log_node.h
@@ -1015,6 +1015,10 @@ struct LogNode
     this->set_layout_buf(this->get_bptr().c_str(), this->get_bptr().length());
   }
 
+  void on_set_bptr() final {
+    this->set_layout_buf(this->get_bptr().c_str(), this->get_bptr().length());
+  }
+
   void init_range(std::string _begin, std::string _end) {
     assert(begin.empty());
     assert(end.empty());


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/78946
Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
