### PR TITLE
cephadm: use RSA SSH keys in FIPS mode

### DIFF
--- a/src/cephadm/cephadmlib/host_facts.py
+++ b/src/cephadm/cephadmlib/host_facts.py
@@ -793,6 +793,11 @@ class HostFacts:
 
         return k_param
 
+    @property
+    def fips_enabled(self) -> bool:
+        """Return whether FIPS mode is enabled on this host."""
+        return is_fips_enabled()
+
     @staticmethod
     def _process_net_data(tcp_file: str, protocol: str = 'tcp') -> List[int]:
         listening_ports = []
@@ -844,6 +849,19 @@ class HostFacts:
             )
         }
         return json.dumps(data, indent=2, sort_keys=True)
+
+
+def is_fips_enabled() -> bool:
+    """Return whether FIPS mode is enabled on the local host."""
+    try:
+        with open('/proc/sys/crypto/fips_enabled', 'r') as f:
+            return f.read().strip() == '1'
+    except OSError as error:
+        logger.debug(
+            'Unable to read /proc/sys/crypto/fips_enabled: %s',
+            error,
+        )
+    return False
 
 
 def list_networks(ctx):

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -1040,6 +1040,15 @@ class HostCache():
         self.mgr.inventory.update_known_hostnames(hostnames[0], hostnames[1], hostnames[2])
         self.last_facts_update[host] = datetime_now()
 
+    def get_host_fips_enabled(self, host: str) -> Optional[bool]:
+        facts = self.get_facts(host)
+        value = facts.get('fips_enabled')
+
+        if isinstance(value, bool):
+            return value
+
+        return None
+
     def update_autotune(self, host: str) -> None:
         host = normalize_hostname(host)
         self.last_autotune[host] = datetime_now()

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -17,6 +17,7 @@ from threading import Event
 
 from ceph.deployment.service_spec import PrometheusSpec
 from cephadm.cert_mgr import CertMgr
+from .utils import get_default_ssh_config
 from cephadm.tlsobject_store import TLSObjectScope, TLSObjectException
 
 import string
@@ -102,7 +103,7 @@ from .inventory import (
 from .upgrade import CephadmUpgrade
 from .template import TemplateMgr
 from .utils import CEPH_IMAGE_TYPES, RESCHEDULE_FROM_OFFLINE_HOSTS_TYPES, forall_hosts, \
-    cephadmNoImage, SpecialHostLabels
+    cephadmNoImage, SpecialHostLabels, is_fips_enabled
 from .configchecks import CephadmConfigChecks
 from .offline_watcher import OfflineHostWatcher
 from .tuned_profiles import TunedProfileUtils
@@ -1388,7 +1389,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         ssh_config = self.get_store("ssh_config")
         if ssh_config:
             return HandleCommandResult(stdout=ssh_config)
-        return HandleCommandResult(stdout=DEFAULT_SSH_CONFIG)
+        return HandleCommandResult(stdout=get_default_ssh_config())
 
     @CephadmCLICommand.Write('cephadm generate-key')
     def _generate_key(self) -> Tuple[int, str, str]:
@@ -1396,16 +1397,31 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         Generate a cluster SSH key (if not present)
         """
         if not self.ssh_pub or not self.ssh_key:
-            self.log.info('Generating ssh key...')
+            fips_enabled = is_fips_enabled()
+            key_type = 'rsa' if fips_enabled else 'ed25519'
+            self.log.info(
+                'Generating %s ssh key%s...',
+                key_type,
+                ' for FIPS mode' if fips_enabled else '',
+            )
             tmp_dir = TemporaryDirectory()
             path = tmp_dir.name + '/key'
+            args = [
+                '/usr/bin/ssh-keygen',
+                '-t', key_type,
+            ]
+
+            if fips_enabled:
+                args.extend(['-b', '4096'])
+
+            args.extend([
+                '-C', 'ceph-%s' % self._cluster_fsid,
+                '-N', '',
+                '-f', path,
+            ])
+
             try:
-                subprocess.check_call([
-                    '/usr/bin/ssh-keygen',
-                    '-C', 'ceph-%s' % self._cluster_fsid,
-                    '-N', '',
-                    '-f', path
-                ])
+                subprocess.check_call(args)
                 with open(path, 'r') as f:
                     secret = f.read()
                 with open(path + '.pub', 'r') as f:

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -101,7 +101,7 @@ from .inventory import (
 from .upgrade import CephadmUpgrade
 from .template import TemplateMgr
 from .utils import CEPH_IMAGE_TYPES, RESCHEDULE_FROM_OFFLINE_HOSTS_TYPES, forall_hosts, \
-    cephadmNoImage, SpecialHostLabels
+    cephadmNoImage, SpecialHostLabels, is_fips_enabled
 from .configchecks import CephadmConfigChecks
 from .offline_watcher import OfflineHostWatcher
 from .tuned_profiles import TunedProfileUtils
@@ -1392,16 +1392,31 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         Generate a cluster SSH key (if not present)
         """
         if not self.ssh_pub or not self.ssh_key:
-            self.log.info('Generating ssh key...')
+            fips_enabled = is_fips_enabled()
+            key_type = 'rsa' if fips_enabled else 'ed25519'
+            self.log.info(
+                'Generating %s ssh key%s...',
+                key_type,
+                ' for FIPS mode' if fips_enabled else '',
+            )
             tmp_dir = TemporaryDirectory()
             path = tmp_dir.name + '/key'
+            args = [
+                '/usr/bin/ssh-keygen',
+                '-t', key_type,
+            ]
+
+            if fips_enabled:
+                args.extend(['-b', '4096'])
+
+            args.extend([
+                '-C', 'ceph-%s' % self._cluster_fsid,
+                '-N', '',
+                '-f', path,
+            ])
+            
             try:
-                subprocess.check_call([
-                    '/usr/bin/ssh-keygen',
-                    '-C', 'ceph-%s' % self._cluster_fsid,
-                    '-N', '',
-                    '-f', path
-                ])
+                subprocess.check_call(args)
                 with open(path, 'r') as f:
                     secret = f.read()
                 with open(path + '.pub', 'r') as f:

--- a/src/pybind/mgr/cephadm/ssh.py
+++ b/src/pybind/mgr/cephadm/ssh.py
@@ -11,6 +11,7 @@ from shlex import quote
 from typing import TYPE_CHECKING, Optional, List, Tuple, Dict, Iterator, TypeVar, Awaitable, Union, Any
 from ceph.deployment.hostspec import normalize_hostname
 from orchestrator import OrchestratorError
+from .utils import is_fips_enabled, get_default_ssh_config
 
 try:
     import asyncssh
@@ -35,15 +36,6 @@ class HostConnectionError(OrchestratorError):
         super().__init__(message)
         self.hostname = hostname
         self.addr = addr
-
-
-DEFAULT_SSH_CONFIG = """
-Host *
-  User root
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  ConnectTimeout=30
-"""
 
 
 class RemoteExecutable(str):
@@ -191,6 +183,27 @@ class SSHManager:
             addr = self.mgr.inventory.get_addr(host)
         if not addr:
             raise OrchestratorError("host address is empty")
+
+        local_fips = is_fips_enabled()
+        target_fips = self.mgr.cache.get_host_fips_enabled(host)
+        logger.debug(
+            'FIPS state for SSH connection to %s: local=%s, target=%s',
+            host,
+            local_fips,
+            target_fips,
+        )
+
+        if local_fips and self.mgr.ssh_pub:
+            key_parts = self.mgr.ssh_pub.strip().split(maxsplit=1)
+
+            if key_parts and key_parts[0] == 'ssh-ed25519':
+                raise HostConnectionError(
+                    'The configured cephadm SSH identity uses ED25519, '
+                    'which is not supported when FIPS mode is enabled. '
+                    'Replace the cephadm SSH identity with an RSA key.',
+                    host,
+                    addr,
+                )
 
         assert self.mgr.ssh_user
         n = self.mgr.ssh_user + '@' + addr
@@ -559,7 +572,7 @@ class SSHManager:
         ssh_config = self.mgr.get_store("ssh_config")
         if ssh_config is not None or self.mgr.ssh_config_fname is None:
             if not ssh_config:
-                ssh_config = DEFAULT_SSH_CONFIG
+                ssh_config = get_default_ssh_config()
             f = NamedTemporaryFile(prefix='cephadm-conf-')
             os.fchmod(f.fileno(), 0o600)
             f.write(ssh_config.encode('utf-8'))

--- a/src/pybind/mgr/cephadm/ssh.py
+++ b/src/pybind/mgr/cephadm/ssh.py
@@ -10,6 +10,7 @@ from io import StringIO
 from shlex import quote
 from typing import TYPE_CHECKING, Optional, List, Tuple, Dict, Iterator, TypeVar, Awaitable, Union, Any
 from orchestrator import OrchestratorError
+from .utils import is_fips_enabled
 
 try:
     import asyncssh
@@ -190,6 +191,18 @@ class SSHManager:
             addr = self.mgr.inventory.get_addr(host)
         if not addr:
             raise OrchestratorError("host address is empty")
+
+        if is_fips_enabled() and self.mgr.ssh_pub:
+            key_parts = self.mgr.ssh_pub.strip().split(maxsplit=1)
+            if key_parts and key_parts[0] == 'ssh-ed25519':
+                raise HostConnectionError(
+                    'The configured cephadm SSH identity uses ED25519, '
+                    'which is not supported when FIPS mode is enabled. '
+                    'Replace the cephadm SSH identity with an RSA key.',
+                    host,
+                    addr,
+                )
+
 
         assert self.mgr.ssh_user
         n = self.mgr.ssh_user + '@' + addr

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -16,6 +16,7 @@ from typing import (
     Union,
 )
 from orchestrator import OrchestratorError
+from functools import lru_cache
 import hashlib
 
 if TYPE_CHECKING:
@@ -53,6 +54,17 @@ NON_CEPH_IMAGE_TYPES = MONITORING_STACK_TYPES + ['nvmeof', 'smb'] + MGMT_GATEWAY
 
 # Used for _run_cephadm used for check-host etc that don't require an --image parameter
 cephadmNoImage = CephadmNoImage.token
+
+
+DEFAULT_SSH_CONFIG = """
+Host *
+  User root
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  ConnectTimeout=30
+"""
+
+FIPS_SSH_CIPHERS = 'aes256-ctr,aes128-ctr'
 
 
 class ContainerInspectInfo(NamedTuple):
@@ -252,3 +264,26 @@ def can_apply_post_create(
     if not meta:
         return False
     return bool(meta.get('can_update_at_runtime', False))
+
+
+@lru_cache(maxsize=1)
+def is_fips_enabled() -> bool:
+    try:
+        with open('/proc/sys/crypto/fips_enabled', 'r') as f:
+            return f.read().strip() == '1'
+    except OSError as error:
+        logger.debug(
+            'Unable to read /proc/sys/crypto/fips_enabled: %s',
+            error,
+        )
+        return False
+
+
+def get_default_ssh_config() -> str:
+    """Return the default cephadm SSH config for the local environment."""
+    ssh_config = DEFAULT_SSH_CONFIG
+
+    if is_fips_enabled():
+        ssh_config += f'  Ciphers {FIPS_SSH_CIPHERS}\n'
+
+    return ssh_config

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -217,3 +217,11 @@ def get_node_proxy_status_value(data: Any, key: str, lower: bool = False) -> str
     if not isinstance(value, str):
         return ''
     return value.lower() if lower else value
+
+
+def is_fips_enabled() -> bool:
+    try:
+        with open('/proc/sys/crypto/fips_enabled', 'r') as f:
+            return f.read().strip() == '1'
+    except OSError:
+        return False


### PR DESCRIPTION
cephadm: use RSA SSH keys in FIPS mode

When FIPS mode is enabled, generate the cephadm SSH identity as a 4096-bit RSA key instead of relying on ssh-keygen's default key type.

Also detect an existing ED25519 cephadm identity before opening an AsyncSSH connection and return an error explaining that the key must be replaced with RSA.

This prevents new FIPS-enabled deployments from generating an incompatible key and improves diagnostics for clusters where FIPS is enabled after an ED25519 key was already created.

Fixes: https://tracker.ceph.com/issues/77941

**Testing logs:**

Baseline -
```
[root@ceph-node-0 ~]# cat /proc/sys/crypto/fips_enabled
0

[root@ceph-node-0 ~]# fips-mode-setup --check
FIPS mode is disabled.
Initramfs fips module is disabled.
The current crypto policy (DEFAULT) neither is the FIPS policy nor is based on the FIPS policy.

```

Enable FIPS:
```
[root@ceph-node-0 ~]# sudo fips-mode-setup --enable

Kernel initramdisks are being regenerated. This might take some time.
Setting system policy to FIPS
Note: System-wide crypto policies are applied on application start-up.
It is recommended to restart the system for the change of policies
to fully take place.
FIPS mode will be enabled.
Please reboot the system for the setting to take effect.

[root@ceph-node-0 ~]# sudo reboot

Broadcast message from root@localhost on pts/2 (Sun 2026-08-02 15:08:44 UTC):

The system will reboot now!
```
==================================================================================================
```

[root@ceph-node-0 ~]# cat /proc/sys/crypto/fips_enabled
fips-mode-setup --check
1
FIPS mode is enabled.
Initramfs fips module is enabled.
The current crypto policy (FIPS) is based on the FIPS policy.


```

```
[ceph: root@ceph-node-0 ~]# ceph mgr fail "$active_mgr"

[ceph: root@ceph-node-0 ~]# ceph cephadm check-host ceph-node-0
check-host failed:
Failed to connect to ceph-node-0 at address (192.168.100.100): The configured cephadm SSH identity uses ED25519, which is not supported when FIPS mode is enabled. Replace the cephadm SSH identity with an RSA key.
```

Health check:
```
[ceph: root@ceph-node-0 ~]# ceph health detail
HEALTH_WARN failed to probe daemons or devices
[WRN] CEPHADM_REFRESH_FAILED: failed to probe daemons or devices
    host ceph-node-1 `cephadm ls` failed: The configured cephadm SSH identity uses ED25519, which is not supported when FIPS mode is enabled. Replace the cephadm SSH identity with an RSA key.
    host ceph-node-2 `cephadm ls` failed: The configured cephadm SSH identity uses ED25519, which is not supported when FIPS mode is enabled. Replace the cephadm SSH identity with an RSA key.
    host ceph-node-0 `cephadm ls` failed: The configured cephadm SSH identity uses ED25519, which is not supported when FIPS mode is enabled. Replace the cephadm SSH identity with an RSA key.
    host ceph-node-2 `cephadm gather-facts` failed: The configured cephadm SSH identity uses ED25519, which is not supported when FIPS mode is enabled. Replace the cephadm SSH identity with an RSA key.
    host ceph-node-0 `cephadm gather-facts` failed: The configured cephadm SSH identity uses ED25519, which is not supported when FIPS mode is enabled. Replace the cephadm SSH identity with an RSA key.
    host ceph-node-1 `cephadm gather-facts` failed: The configured cephadm SSH identity uses ED25519, which is not supported when FIPS mode is enabled. Replace the cephadm SSH identity with an RSA key.
    host ceph-node-2 `cephadm list-networks` failed: The configured cephadm SSH identity uses ED25519, which is not supported when FIPS mode is enabled. Replace the cephadm SSH identity with an RSA key.
    host ceph-node-0 `cephadm list-networks` failed: The configured cephadm SSH identity uses ED25519, which is not supported when FIPS mode is enabled. Replace the cephadm SSH identity with an RSA key.
    host ceph-node-1 `cephadm list-networks` failed: The configured cephadm SSH identity uses ED25519, which is not supported when FIPS mode is enabled. Replace the cephadm SSH identity with an RSA key.

```

```
[ceph: root@ceph-node-0 ~]# ceph config-key get mgr/cephadm/ssh_identity_key > /root/old-cephadm-key
[ceph: root@ceph-node-0 ~]# ceph config-key get mgr/cephadm/ssh_identity_pub > /root/old-cephadm-key.pub
[ceph: root@ceph-node-0 ~]# chmod 600 /root/old-cephadm-key

[ceph: root@ceph-node-0 ~]# ceph cephadm clear-key
[ceph: root@ceph-node-0 ~]# ceph cephadm generate-key

[ceph: root@ceph-node-0 ~]# ceph cephadm get-pub-key
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDvNcCvBDTJUrxotSBN1/ZUsceesh6sIiKyRoibt27OKNKmF2WQUH1TGcXeVoXfQKq2eIWE/4YZTy63ntIDWyaqTnUHMNJb1rlnmisvMFwyEXUgZvp/jmCdHaXMB72zE5uzfEqyB4pZ3CBQaRx1CwhQMS22yDlxEa9syotIEXrEEFNaiJoWDYY6bqMFx7FuxVAa2/5L9tLwqWK0F/8ICnbEOQEA/4O3KNhTc7Uo+Wo9ypJNTzOpCcNXccUjUFiYu6rjMHt+tVYejE2/yPilLbmnjEifdG8YtaFLyj93C+MAf+5Peks73D1F48D7Va3V+7euPMdRLVJ2EsAs5M94uxoSO+ab9r4Hvjk6xXELOw9kpIAMEtq+HGyhj1DwHmkSAh/ItjLIav0v2lMtV0HlEqwMVV4Fl73MlrrbFfP/tvHbInPtUjtzUBVyLRydpk3X/nEimWnn0aEayVuIEzWX16w7vLIJGUAX7dn2SCod/2wf/FP/HEBVkiqAftjy/UoyRmHNb4bAfsPs4mI38DK3In/hn7d0Lj7V7xC0qa1mG4HDQB12aGCLSrvPylDU3pGxaqIdXrBkBuJQyDviKlXQowCvB6oVxiVYsOk+/WrLkSvt9Fh2Kxi4o4oWQ4KO8GofGfUs3sAC70BzbNMJ6JMxfnyfxbqE24gNGejMmVfRXL09Gw== ceph-a38c2610-8e7c-11f1-994f-5254005eae3b

[ceph: root@ceph-node-0 ~]# ceph config-key get mgr/cephadm/ssh_identity_key > /tmp/new-cephadm-key
chmod 600 /tmp/new-cephadm-key
ssh-keygen -lf /tmp/new-cephadm-key

4096 SHA256:eaWhttlGSjbjMRsUEJmes6DY4xth+YjSvJukc6hB8qU ceph-a38c2610-8e7c-11f1-994f-5254005eae3b (RSA)
```

```
[ceph: root@ceph-node-0 ~]# ceph orch host ls
HOST         ADDR             LABELS  STATUS   
ceph-node-0  192.168.100.100  _admin  Offline  
ceph-node-1  192.168.100.101          Offline  
ceph-node-2  192.168.100.102          Offline 

```

Recovering the host:
```

[root@ceph-node-0 ~]# cephadm shell -- ceph cephadm get-pub-key > /root/cephadm-rsa.pub
Inferring fsid a38c2610-8e7c-11f1-994f-5254005eae3b
Inferring config /var/lib/ceph/a38c2610-8e7c-11f1-994f-5254005eae3b/mon.ceph-node-0/config

[root@ceph-node-0 ~]# ls -l /root/cephadm-rsa.pub
-rw-r--r--. 1 root root 767 Aug  2 15:26 /root/cephadm-rsa.pub
[root@ceph-node-0 ~]# head -c 20 /root/cephadm-rsa.pub
ssh-rsa AAAAB3NzaC1y


[root@ceph-node-0 ~]# ssh-copy-id -f -i /root/cephadm-rsa.pub root@192.168.100.102
/usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/root/cephadm-rsa.pub"
sshkey_read: Ed25519 keys are not allowed in FIPS mode
sshkey_read: Ed25519 keys are not allowed in FIPS mode
sshkey_read: Ed25519 keys are not allowed in FIPS mode
sshkey_read: Ed25519 keys are not allowed in FIPS mode

Number of key(s) added: 1

Now try logging into the machine, with:   "ssh 'root@192.168.100.102'"
and check to make sure that only the key(s) you wanted were added.

[ceph: root@ceph-node-0 ~]# ceph orch host ls
HOST         ADDR             LABELS  STATUS  
ceph-node-0  192.168.100.100  _admin          
ceph-node-1  192.168.100.101                  
ceph-node-2  192.168.100.102                  
3 hosts in cluster

[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS  RUNNING  REFRESHED  AGE  PLACEMENT  
crash                                 3/3  2m ago     70m  *          
mgr                                   2/2  2m ago     70m  count:2    
mon                                   3/5  2m ago     70m  count:5    
osd.all-available-devices               3  2m ago     69m  *    

```


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
