### PR TITLE
mgr/dashboard : Subsystem Overview incorrectly displays "Restrict to specific hosts" when no active initiators are configured

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.spec.ts
@@ -229,4 +229,23 @@ describe('NvmeofInitiatorsListComponent', () => {
 
     expect(component.allowAllHosts).toBe(true);
   }));
+
+  it('should keep Add enabled when allow-all hosts is active', fakeAsync(() => {
+    const allowAllSubsystem = { ...mockSubsystem, allow_any_host: true };
+    spyOn(nvmeofService, 'getInitiators').and.returnValue(
+      of([{ nqn: ALLOW_ALL_HOST, use_dhchap: false }])
+    );
+    spyOn(nvmeofService, 'getSubsystem').and.returnValue(of(allowAllSubsystem));
+
+    component.listInitiators();
+    component.getSubsystem();
+    tick();
+
+    const addAction = component.tableActions.find(
+      (action) => action.name === component.actionLabels.ADD
+    );
+    expect(component.hasAllHostsAllowed()).toBe(true);
+    expect(addAction.disable(component.selection)).toBe(false);
+    expect(addAction.canBePrimary(component.selection)).toBe(true);
+  }));
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-initiators-list/nvmeof-initiators-list.component.ts
@@ -16,7 +16,9 @@ import {
   NvmeofSubsystemInitiator,
   ALLOW_ALL_HOST,
   NvmeofSubsystemAuthType,
-  getSubsystemAuthStatus
+  getSubsystemAuthStatus,
+  isSubsystemAllowAllHosts,
+  normalizeInitiators
 } from '~/app/shared/models/nvmeof';
 import { Permission } from '~/app/shared/models/permissions';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
@@ -117,9 +119,10 @@ export class NvmeofInitiatorsListComponent implements OnInit, OnDestroy {
         name: this.actionLabels.ADD,
         permission: 'create',
         icon: Icons.add,
+        buttonKind: 'primary',
         click: () => this.openAddInitiatorForm(),
-        canBePrimary: (selection: CdTableSelection) => !selection.hasSelection,
-        disable: () => this.hasAllHostsAllowed()
+        canBePrimary: () => true,
+        disable: () => false
       },
       {
         name: $localize`Edit host key`,
@@ -183,11 +186,7 @@ export class NvmeofInitiatorsListComponent implements OnInit, OnDestroy {
   }
 
   hasAllHostsAllowed(): boolean {
-    return (
-      !!this.subsystem?.allow_any_host &&
-      (this.initiators.length === 0 ||
-        this.initiators.some((initiator) => initiator.nqn === ALLOW_ALL_HOST))
-    );
+    return isSubsystemAllowAllHosts(this.subsystem, this.initiators);
   }
 
   updateSelection(selection: CdTableSelection) {
@@ -195,13 +194,10 @@ export class NvmeofInitiatorsListComponent implements OnInit, OnDestroy {
   }
 
   listInitiators() {
-    this.nvmeofService
-      .getInitiators(this.subsystemNQN, this.group)
-      .subscribe((response: NvmeofSubsystemInitiator[] | { hosts: NvmeofSubsystemInitiator[] }) => {
-        const initiators = Array.isArray(response) ? response : response?.hosts || [];
-        this.initiators = initiators;
-        this.updateAuthStatus();
-      });
+    this.nvmeofService.getInitiators(this.subsystemNQN, this.group).subscribe((response) => {
+      this.initiators = normalizeInitiators(response);
+      this.updateAuthStatus();
+    });
   }
 
   getSubsystem() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.html
@@ -89,8 +89,10 @@
               [gap]="2"
             >
               <span class="cds--type-label-01">{{ detail.label }}</span>
-              <div class="cds--type-label-02">
-                <span>{{ detail.value ? 'Allow all hosts' : 'Restrict to specific hosts' }}</span>
+              <div>
+                <!-- Host access is a configuration mode (not a health state), so
+                     avoid success/error status icons that imply one mode is broken. -->
+                <span class="cds--type-label-02">{{ detail.value }}</span>
                 <a
                   cdsLink
                   (click)="openEditHostAccessModal()"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.spec.ts
@@ -11,7 +11,11 @@ import { NvmeofSubsystemOverviewComponent } from './nvmeof-subsystem-overview.co
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 import { URLVerbs } from '~/app/shared/constants/app.constants';
 import { SharedModule } from '~/app/shared/shared.module';
-import { NvmeofSubsystem, NvmeofSubsystemInitiator } from '~/app/shared/models/nvmeof';
+import {
+  ALLOW_ALL_HOST,
+  NvmeofSubsystem,
+  NvmeofSubsystemInitiator
+} from '~/app/shared/models/nvmeof';
 
 describe('NvmeofSubsystemOverviewComponent', () => {
   let component: NvmeofSubsystemOverviewComponent;
@@ -188,6 +192,39 @@ describe('NvmeofSubsystemOverviewComponent', () => {
     // has_dhchap_key=true but no initiators with use_dhchap → No authentication
     expect(hostAccessText).toContain('No authentication');
     expect(hostAccessText).toContain('Edit');
+  }));
+
+  it('should show Restrict to specific hosts after allow-all initiator is removed', fakeAsync(async () => {
+    TestBed.resetTestingModule();
+    // allow_any_host may lag true after removing "*", but host list no longer includes it
+    const f = await createTestBed([{ nqn: 'nqn.host-1', use_dhchap: false }], {
+      ...mockSubsystem,
+      allow_any_host: true
+    });
+    expect(f.nativeElement.textContent).toContain('Restrict to specific hosts');
+    expect(f.nativeElement.textContent).not.toContain('Allow all hosts');
+  }));
+
+  it('should treat host access as config text, not a success/error health state', fakeAsync(async () => {
+    TestBed.resetTestingModule();
+    const f = await createTestBed([{ nqn: 'nqn.host-1', use_dhchap: false }], {
+      ...mockSubsystem,
+      allow_any_host: false
+    });
+    // Both modes are valid configuration — neither should map to a health status icon.
+    expect(f.componentInstance.getHostAccessLabel(false)).toBe('Restrict to specific hosts');
+    expect(f.componentInstance.getHostAccessLabel(true)).toBe('Allow all hosts');
+    expect((f.componentInstance as any).getStatusIcon).toBeUndefined();
+    expect(f.nativeElement.textContent).toContain('Restrict to specific hosts');
+  }));
+
+  it('should show Allow all hosts when synthetic Any initiator is present', fakeAsync(async () => {
+    TestBed.resetTestingModule();
+    const f = await createTestBed([{ nqn: ALLOW_ALL_HOST, use_dhchap: false }], {
+      ...mockSubsystem,
+      allow_any_host: true
+    });
+    expect(f.nativeElement.textContent).toContain('Allow all hosts');
   }));
 
   it('should display Bidirectional when subsystem and host both have keys', fakeAsync(async () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.ts
@@ -6,9 +6,10 @@ import { filter } from 'rxjs/operators';
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 import {
   NvmeofSubsystem,
-  NvmeofSubsystemInitiator,
   NO_AUTH,
-  getSubsystemAuthStatus
+  getSubsystemAuthStatus,
+  isSubsystemAllowAllHosts,
+  normalizeInitiators
 } from '~/app/shared/models/nvmeof';
 import { URLVerbs } from '~/app/shared/constants/app.constants';
 import { ICON_TYPE } from '~/app/shared/enum/icons.enum';
@@ -86,13 +87,15 @@ export class NvmeofSubsystemOverviewComponent implements OnInit, OnDestroy {
       initiators: this.nvmeofService.getInitiators(this.subsystemNQN, this.groupName)
     }).subscribe(({ subsystem, initiators }) => {
       this.subsystem = subsystem as NvmeofSubsystem;
-      const initiatorList = initiators as
-        NvmeofSubsystemInitiator[] | { hosts?: NvmeofSubsystemInitiator[] };
-      this.buildDetails(getSubsystemAuthStatus(this.subsystem, initiatorList));
+      const initiatorList = normalizeInitiators(initiators);
+      this.buildDetails(
+        getSubsystemAuthStatus(this.subsystem, initiatorList),
+        isSubsystemAllowAllHosts(this.subsystem, initiatorList)
+      );
     });
   }
 
-  private buildDetails(authStatus: string) {
+  private buildDetails(authStatus: string, allowAllHosts: boolean) {
     this.details = [
       {
         label: $localize`Serial number`,
@@ -115,7 +118,7 @@ export class NvmeofSubsystemOverviewComponent implements OnInit, OnDestroy {
       },
       {
         label: $localize`Host access`,
-        value: this.subsystem.allow_any_host ?? false,
+        value: this.getHostAccessLabel(allowAllHosts),
         type: 'host-access',
         row: 2
       },
@@ -172,12 +175,13 @@ export class NvmeofSubsystemOverviewComponent implements OnInit, OnDestroy {
     return String(value);
   }
 
-  getAuthStatusIcon(authStatus: string): keyof typeof ICON_TYPE {
-    return authStatus === NO_AUTH ? 'error' : 'success';
+  /** Host access is configuration text, not a health state. */
+  getHostAccessLabel(allowAllHosts: boolean): string {
+    return allowAllHosts ? $localize`Allow all hosts` : $localize`Restrict to specific hosts`;
   }
 
-  getStatusIcon(detail: SubsystemDetail): keyof typeof ICON_TYPE {
-    return detail.value ? 'success' : 'error';
+  getAuthStatusIcon(authStatus: string): keyof typeof ICON_TYPE {
+    return authStatus === NO_AUTH ? 'error' : 'success';
   }
 
   getColNumbers(detail: SubsystemDetail): { sm: number; md: number; lg: number } {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
@@ -8,6 +8,7 @@ import { CephServiceSpec } from '../models/service.interface';
 import {
   AUTHENTICATION,
   ListenerItem,
+  NvmeofInitiatorsResponse,
   NvmeofSubsystem,
   NvmeofSubsystemNamespace
 } from '../models/nvmeof';
@@ -296,8 +297,10 @@ export class NvmeofService {
   }
 
   // Initiators
-  getInitiators(subsystemNQN: string, group: string) {
-    return this.http.get(`${API_PATH}/subsystem/${subsystemNQN}/host?gw_group=${group}`);
+  getInitiators(subsystemNQN: string, group: string): Observable<NvmeofInitiatorsResponse> {
+    return this.http.get<NvmeofInitiatorsResponse>(
+      `${API_PATH}/subsystem/${subsystemNQN}/host?gw_group=${group}`
+    );
   }
 
   addSubsystemInitiators(subsystemNQN: string, request: SubsystemInitiatorRequest) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/nvmeof.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/nvmeof.ts
@@ -109,13 +109,44 @@ export interface ListenerItem {
   addr: string;
 }
 
+export type NvmeofInitiatorsResponse =
+  NvmeofSubsystemInitiator[] | { hosts?: NvmeofSubsystemInitiator[] };
+
+export function normalizeInitiators(
+  initiators: NvmeofInitiatorsResponse
+): NvmeofSubsystemInitiator[] {
+  if (initiators && 'hosts' in initiators && Array.isArray(initiators.hosts)) {
+    return initiators.hosts;
+  }
+  if (Array.isArray(initiators)) {
+    return initiators;
+  }
+  return [];
+}
+
+/**
+ * When `allow_any_host` is true, the subsystem allows all hosts unless specific
+ * (non-wildcard) initiators are present, indicating the wildcard was removed and
+ * access is now restricted.
+ */
+export function isSubsystemAllowAllHosts(
+  subsystem: Pick<NvmeofSubsystem, 'allow_any_host'> | null | undefined,
+  initiators: NvmeofInitiatorsResponse
+): boolean {
+  if (!subsystem?.allow_any_host) {
+    return false;
+  }
+  const hostsList = normalizeInitiators(initiators);
+  return hostsList.length === 0 || hostsList.some((initiator) => initiator.nqn === ALLOW_ALL_HOST);
+}
+
 /**
  * Determines the authentication status of a subsystem based on PSK and initiators.
  * Can be reused across subsystem pages.
  */
 export function getSubsystemAuthStatus(
   subsystem: NvmeofSubsystem,
-  _initiators: NvmeofSubsystemInitiator[] | { hosts?: NvmeofSubsystemInitiator[] }
+  _initiators: NvmeofInitiatorsResponse
 ): string {
   // Import enum value strings to avoid circular dependency
   const UNIDIRECTIONAL = 'Unidirectional';
@@ -123,13 +154,7 @@ export function getSubsystemAuthStatus(
 
   let auth = NO_AUTH;
 
-  let hostsList: NvmeofSubsystemInitiator[] = [];
-  if (_initiators && 'hosts' in _initiators && Array.isArray(_initiators.hosts)) {
-    hostsList = _initiators.hosts;
-  } else if (Array.isArray(_initiators)) {
-    hostsList = _initiators as NvmeofSubsystemInitiator[];
-  }
-
+  const hostsList = normalizeInitiators(_initiators);
   const hostHasDhchapKey = hostsList.some((host) => !!host.use_dhchap);
 
   if (hostHasDhchapKey) {


### PR DESCRIPTION



https://github.com/user-attachments/assets/9244182f-325c-4534-bd2a-70e66ff1ebd0


https://github.com/user-attachments/assets/dac215d5-98c8-4e4b-b464-e43329305922





Fixes :https://tracker.ceph.com/issues/78953

Signed-off-by: pujaoshahu <pshahu@redhat.com>

Summary : 
The Subsystem Overview page incorrectly displays the Host Access status as "Restrict to specific hosts" even when there are no active initiators configured for the subsystem. This results in an inaccurate representation of the subsystem's access configuration. The fix updates the logic to display the correct host access status based on the presence of active initiators.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
