### PR TITLE
rgw/kafka: Add fileless CA certificate support for Kafka bucket notifications

### DIFF
--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -250,6 +250,7 @@ and must be between 1 and 256 characters long. To relax these requirements, use:
    [&Attributes.entry.22.key=sasl-kerberos-service-name&Attributes.entry.22.value=<kerberos-service-name>]
    [&Attributes.entry.23.key=sasl-kerberos-principal&Attributes.entry.23.value=<kerberos-principal>]
    [&Attributes.entry.24.key=sasl-kerberos-keytab&Attributes.entry.24.value=<kerberos-keytab-path>]
+   [&Attributes.entry.25.key=ca-cert&Attributes.entry.25.value=<PEM encoded CA certificate>]
 
 Request parameters:
 
@@ -337,6 +338,10 @@ Request parameters:
  - ``ca-location``: If this is provided and a secure connection is used, the
    specified CA will be used instead of the default CA to authenticate the
    broker.
+ - ``ca-cert``: PEM-encoded CA certificate content passed directly as a string.
+   When provided, this takes precedence over ``ca-location`` and avoids the
+   need for a CA file on the RGW host — useful in Rook/Kubernetes deployments
+   where the CA is available as a Secret. Requires ``use-ssl=true``.
  - ``user``/``password``: This should be provided over HTTPS. If not, the
    config parameter ``rgw_allow_notification_secrets_in_cleartext`` must be
    "true" in order to create topics.
@@ -672,6 +677,8 @@ Valid ``AttributeName`` that can be passed:
 - ``ca-location``: If this is provided and a secure connection is used, the
   specified CA will be used instead of the default CA to authenticate the
   broker.
+- ``ca-cert``: PEM-encoded CA certificate content passed directly as a string.
+  Takes precedence over ``ca-location`` when both are set. Requires ``use-ssl=true``.
 - ``mechanism``: May be provided together with ``user``/``password`` (default: ``PLAIN``)
 - ``kafka-ack-level``: No end2end acknowledgement is required. Messages may persist in the
   broker before being delivered to their final destinations.

--- a/src/rgw/driver/rados/rgw_pubsub_push.cc
+++ b/src/rgw/driver/rados/rgw_pubsub_push.cc
@@ -308,6 +308,7 @@ public:
            conn_id, _endpoint, get_bool(args, "use-ssl", false),
            get_bool(args, "verify-ssl", true),
            args.get_optional("ca-location"),
+           args.get_optional("ca-cert"),
            args.get_optional("mechanism"),
            args.get_optional("user-name"),
            args.get_optional("password"),

--- a/src/rgw/rgw_kafka.cc
+++ b/src/rgw/rgw_kafka.cc
@@ -75,6 +75,7 @@ connection_id_t::connection_id_t(
     const std::string& _user,
     const std::string& _password,
     const boost::optional<const std::string&>& _ca_location,
+    const boost::optional<const std::string&>& _ca_cert,
     const boost::optional<const std::string&>& _mechanism,
     bool _ssl,
     bool _verify_ssl,
@@ -90,6 +91,9 @@ connection_id_t::connection_id_t(
 
   if (_ca_location.has_value()) {
     ca_location = _ca_location.get();
+  }
+  if (_ca_cert.has_value()) {
+    ca_cert = _ca_cert.get();
   }
   if (_mechanism.has_value()) {
     mechanism = _mechanism.get();
@@ -119,6 +123,7 @@ connection_id_t::connection_id_t(
 bool operator==(const connection_id_t& lhs, const connection_id_t& rhs) {
   return lhs.broker == rhs.broker && lhs.user == rhs.user &&
          lhs.password == rhs.password && lhs.ca_location == rhs.ca_location &&
+         lhs.ca_cert == rhs.ca_cert &&
          lhs.mechanism == rhs.mechanism && lhs.ssl == rhs.ssl &&
          lhs.verify_ssl == rhs.verify_ssl &&
          lhs.ssl_certificate == rhs.ssl_certificate &&
@@ -136,6 +141,7 @@ struct connection_id_hasher {
     boost::hash_combine(h, k.user);
     boost::hash_combine(h, k.password);
     boost::hash_combine(h, k.ca_location);
+    boost::hash_combine(h, k.ca_cert);
     boost::hash_combine(h, k.mechanism);
     boost::hash_combine(h, k.ssl);
     boost::hash_combine(h, k.verify_ssl);
@@ -220,6 +226,7 @@ struct connection_t {
   const bool use_ssl;
   const bool verify_ssl;
   const boost::optional<std::string> ca_location;
+  const boost::optional<std::string> ca_cert;
   const std::string user;
   const std::string password;
   const boost::optional<std::string> mechanism;
@@ -259,8 +266,9 @@ struct connection_t {
   }
 
   // ctor for setting immutable values
-  connection_t(CephContext* _cct, const std::string& _broker, bool _use_ssl, bool _verify_ssl, 
+  connection_t(CephContext* _cct, const std::string& _broker, bool _use_ssl, bool _verify_ssl,
           const boost::optional<const std::string&>& _ca_location,
+          const boost::optional<const std::string&>& _ca_cert,
           const std::string& _user, const std::string& _password, const boost::optional<const std::string&>& _mechanism,
           const boost::optional<const std::string&>& _ssl_certificate,
           const boost::optional<const std::string&>& _ssl_key,
@@ -268,7 +276,8 @@ struct connection_t {
           const boost::optional<const std::string&>& _kerberos_service_name,
           const boost::optional<const std::string&>& _kerberos_principal,
           const boost::optional<const std::string&>& _kerberos_keytab) :
-      cct(_cct), broker(_broker), use_ssl(_use_ssl), verify_ssl(_verify_ssl), ca_location(_ca_location), user(_user), password(_password), mechanism(_mechanism),
+      cct(_cct), broker(_broker), use_ssl(_use_ssl), verify_ssl(_verify_ssl), ca_location(_ca_location), ca_cert(_ca_cert),
+      user(_user), password(_password), mechanism(_mechanism),
       ssl_certificate(_ssl_certificate), ssl_key(_ssl_key), ssl_key_password(_ssl_key_password),
       kerberos_service_name(_kerberos_service_name), kerberos_principal(_kerberos_principal), kerberos_keytab(_kerberos_keytab) {}                                                                                                                                                        
 
@@ -421,7 +430,10 @@ bool new_producer(connection_t* conn) {
       if (rd_kafka_conf_set(conf.get(), "security.protocol", "SSL", errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) goto conf_error;
       ldout(conn->cct, 20) << "Kafka connect: successfully configured SSL security" << dendl;
     }
-    if (conn->ca_location) {
+    if (conn->ca_cert) {
+      if (rd_kafka_conf_set(conf.get(), "ssl.ca.pem", conn->ca_cert->c_str(), errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) goto conf_error;
+      ldout(conn->cct, 20) << "Kafka connect: successfully configured CA cert (PEM)" << dendl;
+    } else if (conn->ca_location) {
       if (rd_kafka_conf_set(conf.get(), "ssl.ca.location", conn->ca_location->c_str(), errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) goto conf_error;
       ldout(conn->cct, 20) << "Kafka connect: successfully configured CA location" << dendl;
     } else {
@@ -465,13 +477,16 @@ bool new_producer(connection_t* conn) {
   }
 
   if (is_gssapi && conn->use_ssl) {
-    if (conn->ca_location) {
+    if (conn->ca_cert) {
+      if (rd_kafka_conf_set(conf.get(), "ssl.ca.pem", conn->ca_cert->c_str(), errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) goto conf_error;
+      ldout(conn->cct, 20) << "Kafka connect: successfully configured CA cert (PEM)" << dendl;
+    } else if (conn->ca_location) {
       if (rd_kafka_conf_set(conf.get(), "ssl.ca.location", conn->ca_location->c_str(), errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) goto conf_error;
       ldout(conn->cct, 20) << "Kafka connect: successfully configured CA location" << dendl;
     } else {
       ldout(conn->cct, 20) << "Kafka connect: using default CA location" << dendl;
     }
-    if (rd_kafka_conf_set(conf.get(), "enable.ssl.certificate.verification", conn->verify_ssl ? "true" : "false", errstr, 
+    if (rd_kafka_conf_set(conf.get(), "enable.ssl.certificate.verification", conn->verify_ssl ? "true" : "false", errstr,
                           sizeof(errstr)) != RD_KAFKA_CONF_OK) goto conf_error;
   }
 
@@ -733,6 +748,7 @@ public:
                bool use_ssl,
                bool verify_ssl,
                boost::optional<const std::string&> ca_location,
+               boost::optional<const std::string&> ca_cert,
                boost::optional<const std::string&> mechanism,
                boost::optional<const std::string&> topic_user_name,
                boost::optional<const std::string&> topic_password,
@@ -821,7 +837,7 @@ public:
       broker_list.append(brokers.get());
     }
 
-    connection_id_t tmp_id(broker_list, user, password, ca_location, mechanism,
+    connection_id_t tmp_id(broker_list, user, password, ca_location, ca_cert, mechanism,
                            use_ssl, verify_ssl, ssl_certificate, ssl_key, ssl_key_password,
                            kerberos_service_name, kerberos_principal, kerberos_keytab);
     std::lock_guard lock(connections_lock);
@@ -842,7 +858,7 @@ public:
       return false;
     }
 
-    auto conn = std::make_unique<connection_t>(cct, broker_list, use_ssl, verify_ssl, ca_location, user, password,
+    auto conn = std::make_unique<connection_t>(cct, broker_list, use_ssl, verify_ssl, ca_location, ca_cert, user, password,
                                                mechanism, ssl_certificate, ssl_key, ssl_key_password,
                                                kerberos_service_name, kerberos_principal, kerberos_keytab);
     if (!new_producer(conn.get())) {
@@ -960,6 +976,7 @@ bool connect(connection_id_t& conn_id,
              bool use_ssl,
              bool verify_ssl,
              boost::optional<const std::string&> ca_location,
+             boost::optional<const std::string&> ca_cert,
              boost::optional<const std::string&> mechanism,
              boost::optional<const std::string&> user_name,
              boost::optional<const std::string&> password,
@@ -972,7 +989,7 @@ bool connect(connection_id_t& conn_id,
              boost::optional<const std::string&> kerberos_keytab) {
   std::shared_lock lock(s_manager_mutex);
   if (!s_manager) return false;
-  return s_manager->connect(conn_id, url, use_ssl, verify_ssl, ca_location,
+  return s_manager->connect(conn_id, url, use_ssl, verify_ssl, ca_location, ca_cert,
                             mechanism, user_name, password, brokers,
                             ssl_certificate, ssl_key, ssl_key_password,
                             kerberos_service_name, kerberos_principal, kerberos_keytab);

--- a/src/rgw/rgw_kafka.h
+++ b/src/rgw/rgw_kafka.h
@@ -27,6 +27,7 @@ struct connection_id_t {
   std::string user;
   std::string password;
   std::string ca_location;
+  std::string ca_cert;
   std::string mechanism;
   std::string ssl_certificate;
   std::string ssl_key;
@@ -41,6 +42,7 @@ struct connection_id_t {
                   const std::string& _user,
                   const std::string& _password,
                   const boost::optional<const std::string&>& _ca_location,
+                  const boost::optional<const std::string&>& _ca_cert,
                   const boost::optional<const std::string&>& _mechanism,
                   bool _ssl,
                   bool _verify_ssl,
@@ -60,6 +62,7 @@ bool connect(connection_id_t& conn_id,
              bool use_ssl,
              bool verify_ssl,
              boost::optional<const std::string&> ca_location,
+             boost::optional<const std::string&> ca_cert,
              boost::optional<const std::string&> mechanism,
              boost::optional<const std::string&> user_name,
              boost::optional<const std::string&> password,

--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -305,7 +305,7 @@ class RGWPSCreateTopicOp : public RGWOp {
       if (param.first == "Action" || param.first == "Name" || param.first == "PayloadHash") {
         continue;
       }
-      dest.push_endpoint_args.append(param.first+"="+param.second+"&");
+      dest.push_endpoint_args.append(param.first+"="+url_encode(param.second, true)+"&");
     }
 
     if (!dest.push_endpoint_args.empty()) {
@@ -810,7 +810,7 @@ class RGWPSSetTopicAttributesOp : public RGWOp {
       const auto replace_str = [&](const std::string& param,
                                    const std::string& val) {
         auto& push_endpoint_args = dest.push_endpoint_args;
-        const std::string replaced_str = param + "=" + val;
+        const std::string replaced_str = param + "=" + url_encode(val, true);
         const auto pos = push_endpoint_args.find(param);
         if (pos == std::string::npos) {
           dest.push_endpoint_args.append("&" + replaced_str);
@@ -822,7 +822,7 @@ class RGWPSSetTopicAttributesOp : public RGWOp {
         push_endpoint_args.replace(pos, end_pos - pos, replaced_str);
       };
       static constexpr std::initializer_list<const char*> args = {
-          "verify-ssl",    "use-ssl",         "ca-location", "amqp-ack-level",
+          "verify-ssl",    "use-ssl",         "ca-location", "ca-cert", "amqp-ack-level",
           "amqp-exchange", "kafka-ack-level", "mechanism",   "cloudevents",
           "user-name",     "password",
           "ssl-certificate-location", "ssl-key-location", "ssl-key-password",

--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -22,6 +22,7 @@ import datetime
 from cloudevents.http import from_http
 from dateutil import parser
 import requests
+import urllib.parse
 
 from . import(
     configfile,
@@ -509,6 +510,15 @@ def _kafka_ca_cert_path():
         ca_path = os.path.join(kafka_dir, 'y-ca.crt')
         if os.path.exists(ca_path):
             return ca_path
+    return None
+
+
+def _kafka_ca_cert_pem():
+    """Read and return the PEM content of y-ca.crt as a string, or None."""
+    ca_path = _kafka_ca_cert_path()
+    if ca_path:
+        with open(ca_path) as f:
+            return f.read()
     return None
 
 
@@ -4743,7 +4753,8 @@ def test_topic_no_permissions():
 
 
 def kafka_security(security_type, mechanism='PLAIN', use_topic_attrs_for_creds=False,
-                   verify_ssl=True, include_ca_location=True, use_mtls=False):
+                   verify_ssl=True, include_ca_location=True, use_mtls=False,
+                   use_ca_cert_pem=False):
     """ test pushing kafka notification securly to master """
     # Setup SCRAM users if needed
     if mechanism.startswith('SCRAM'):
@@ -4815,7 +4826,12 @@ def kafka_security(security_type, mechanism='PLAIN', use_topic_attrs_for_creds=F
     else:
         kafka_cert_dir = _kafka_cert_dir()
         endpoint_args = 'push-endpoint='+endpoint_address+'&kafka-ack-level=broker&use-ssl=true'
-        if include_ca_location:
+        if use_ca_cert_pem:
+            pem_content = _kafka_ca_cert_pem()
+            if pem_content is None:
+                pytest.skip('ca-cert PEM test requires KAFKA_CERT_DIR or KAFKA_DIR with y-ca.crt')
+            endpoint_args += '&ca-cert=' + urllib.parse.quote(pem_content, safe='')
+        elif include_ca_location:
             endpoint_args += '&ca-location='+kafka_cert_dir+'/y-ca.crt'
         if not verify_ssl:
             endpoint_args += '&verify-ssl=false'
@@ -4949,6 +4965,11 @@ def test_notification_kafka_security_ssl_sasl_gssapi():
 def test_notification_kafka_security_ssl_mtls():
     """test mTLS client certificate authentication to Kafka"""
     kafka_security('SSL', use_mtls=True)
+
+
+@pytest.mark.kafka_security_test
+def test_notification_kafka_security_ssl_ca_cert_pem():
+    kafka_security('SSL', use_ca_cert_pem=True)
 
 
 @pytest.mark.http_test


### PR DESCRIPTION
## Description

Adds support for passing a CA certificate inline (as a PEM string) when configuring RGW Kafka bucket notification endpoints, removing the requirement for the CA file to be present on the RGW host filesystem. This is particularly useful in Kubernetes/Rook deployments where the CA is available as a Secret rather than a mounted file. The new `ca-cert` topic attribute takes precedence over the existing `ca-location` attribute when both are set.

### Commit 1: RGW-side Implementation

Adds `ca_cert` to the Kafka connection layer and wires it through all call sites. Sets librdkafka's `ssl.ca.pem` when present, falling back to `ssl.ca.location`.

### Commit 2: Integration Testing

Adds `test_notification_kafka_security_ssl_ca_cert_pem` (marked `kafka_security_test`) which exercises a full SSL connection to Kafka using the inline PEM path.
A helper method has also been added `_kafka_ca_cert_pem()` which reads the `ya-ca.crt` from the Kafka directory and returns its content as a string.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
