### PR TITLE
mgr/dashboard: NVMeoF CLI fix the error message when not providing a required param

### DIFF
--- a/src/pybind/mgr/dashboard/services/nvmeof_cli.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_cli.py
@@ -494,12 +494,25 @@ class NvmeofCLICommand(DBCLICommand):
             logger.warning("Success message template failed for %s", self.prefix, exc_info=True)
             return None
 
+    def _check_required_params(self, cmd_dict: Dict[str, Any]) -> Optional[str]:
+        for index, name in enumerate(self.arg_spec):
+            if name in self.KNOWN_ARGS:
+                continue
+            if index >= self.first_default:
+                break
+            if cmd_dict.get(name) is None:
+                return f"missing required parameter: --{name}"
+        return None
+
     def call(self,
              mgr: Any,
              cmd_dict: Dict[str, Any],
              inbuf: Optional[str] = None) -> HandleCommandResult:
         deprecated_warnings = ''
         try:
+            missing = self._check_required_params(cmd_dict)
+            if missing:
+                return HandleCommandResult(-errno.EINVAL, '', missing)
             out_format = cmd_dict.get('format')
             args_map = self._args_map_from_argspec(cmd_dict, inbuf)
 

--- a/src/pybind/mgr/dashboard/tests/test_nvmeof_cli.py
+++ b/src/pybind/mgr/dashboard/tests/test_nvmeof_cli.py
@@ -262,7 +262,7 @@ class TestNvmeofCLICommandSuccessMessage:
 
         result_plain = NvmeofCLICommand.COMMANDS[test_cmd].call(
             MagicMock(),
-            {"format": "plain"}
+            {"format": "plain", "a": "somevalue"}
         )
         assert isinstance(result_plain, HandleCommandResult)
         assert result_plain.retval == 0
@@ -292,7 +292,9 @@ class TestNvmeofCLICommandSuccessMessage:
         def set_log_level(self, a: str):
             return {"a": "b"}
 
-        result_default = NvmeofCLICommand.COMMANDS[test_cmd].call(MagicMock(), {})
+        result_default = NvmeofCLICommand.COMMANDS[test_cmd].call(
+            MagicMock(), {"a": "somevalue"}
+        )
         assert isinstance(result_default, HandleCommandResult)
         assert result_default.retval == 0
         assert result_default.stdout == (
@@ -681,6 +683,38 @@ class TestNvmeofCLICommandSuccessMessage:
         assert result.stdout == (
             "Adding nqn.none.test listener at 127.0.0.1:4420 gw=None: Successful"
         )
+
+    def test_listener_del_without_trsvcid_returns_clear_error(self):
+        class Model(NamedTuple):
+            status: str
+
+        def delete(mgr, nqn: str, host_name: str, traddr: str,
+                   trsvcid: int, adrfam: int = 0,
+                   force: bool = False, gw_group: Optional[str] = None):
+            return dict(status=1)
+
+        cmd = NvmeofCLICommand(
+            "nvmeof listener del test",
+            model=Model,
+            success_message_template=(
+                "Deleting listener {traddr}:{trsvcid} from {nqn}: Successful"
+            ),
+        )
+        cmd(delete)
+
+        try:
+            cmd_dict = {
+                "nqn": "nqn.2001-07.com.ceph:test",
+                "host_name": "ceph-node6",
+                "traddr": "10.0.65.113",
+                # trsvcid intentionally omitted
+            }
+            result = cmd.call(mgr=None, cmd_dict=cmd_dict, inbuf=None)
+            assert result.retval == -errno.EINVAL
+            assert "trsvcid" in result.stderr
+            assert result.stdout == ""
+        finally:
+            del NvmeofCLICommand.COMMANDS["nvmeof listener del test"]
 
     def test_template_can_use_response_fields(self):
         test_cmd = "nvmeof show op status"


### PR DESCRIPTION
replaced the cryptic error message with a clear one for the case of missing required parameter.
before:
```
[xxx@xxx ~]# ceph nvmeof listener del --nqn nqn.2016-06.io.spdk:cnode1.mygroup1 --host_name test-node1 --traddr <node ip>
Error EINVAL: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```
after:
```
[xxx@xxx ~]# ceph nvmeof listener del --nqn nqn.2016-06.io.spdk:cnode1.mygroup1 --host_name test-node1 --traddr <node ip>
Error EINVAL: missing required parameter: --trsvcid
```

fixes: https://tracker.ceph.com/issues/78959


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
