### PR TITLE
mgr/dashboard: avoid re-enabling telemetry

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
@@ -288,7 +288,8 @@ describe('TelemetryComponent', () => {
       });
     });
 
-    it('should submit', () => {
+    it('should submit when telemetry is not yet enabled', () => {
+      component.moduleEnabled = false;
       component.onSubmit();
       const req1 = httpTesting.expectOne('api/telemetry');
       expect(req1.request.method).toBe('PUT');
@@ -305,6 +306,21 @@ describe('TelemetryComponent', () => {
         config: {}
       });
       req2.flush({});
+      expect(router.url).toBe('/');
+    });
+
+    it('should only update config when telemetry is already enabled', () => {
+      component.moduleEnabled = true;
+      component.onSubmit();
+      httpTesting.expectNone('api/telemetry');
+      const req = httpTesting.expectOne({
+        url: 'api/mgr/module/telemetry',
+        method: 'PUT'
+      });
+      expect(req.request.body).toEqual({
+        config: {}
+      });
+      req.flush({});
       expect(router.url).toBe('/');
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
@@ -276,18 +276,24 @@ export class TelemetryComponent extends CdForm implements OnInit {
 
   onSubmit() {
     const updatedConfig = this.getChangedConfig();
-    const observables = [
-      this.telemetryService.enable(),
-      this.mgrModuleService.updateConfig('telemetry', updatedConfig)
-    ];
+    const observables = this.moduleEnabled
+      ? [this.mgrModuleService.updateConfig('telemetry', updatedConfig)]
+      : [
+          this.telemetryService.enable(),
+          this.mgrModuleService.updateConfig('telemetry', updatedConfig)
+        ];
 
     observableForkJoin(observables).subscribe(
       () => {
         this.telemetryNotificationService.setVisibility(false);
         this.notificationService.show(
           NotificationType.success,
-          $localize`The Telemetry module has been configured and activated successfully.`
+          this.moduleEnabled
+            ? $localize`Telemetry configuration has been updated successfully.`
+            : $localize`The Telemetry module has been configured and activated successfully.`
         );
+        this.newConfig = {};
+        this.router.navigate(['']);
       },
       () => {
         this.telemetryNotificationService.setVisibility(false);
@@ -296,12 +302,8 @@ export class TelemetryComponent extends CdForm implements OnInit {
           $localize`An Error occurred while updating the Telemetry module configuration.\
              Please Try again`
         );
-        // Reset the 'Update' button.
+        // Reset the submit button.
         this.previewForm.setErrors({ cdSubmitButton: true });
-      },
-      () => {
-        this.newConfig = {};
-        this.router.navigate(['']);
       }
     );
   }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/78958
Signed-off-by: Anurag Raut <anuragtraut08@ibm.com>

PR Description:

This PR avoids re-enabling the Telemetry module when it is already enabled.

During the initial Telemetry configuration, the dashboard enables the Telemetry module and applies the selected configuration. For subsequent configuration updates, the dashboard now updates only the configuration without issuing another Telemetry enable request, preventing redundant activation attempts. The success notification is also updated to distinguish between initial activation and subsequent configuration updates, and the user is redirected after a successful operation to prevent repeated submissions.


Screencast:

[Screencast From 2026-08-03 13-25-42.webm](https://github.com/user-attachments/assets/2f3b63e6-f2b3-4fc1-8a66-86a033524749)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
