### PR TITLE
umbrella: mgr/dashboard: updating SMB rate limiting form fields

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.html
@@ -300,33 +300,37 @@
       <div class="form-item form-item-append"
            cdsRow>
         <div cdsCol>
-          <cds-number formControlName="read_delay_max"
-                      cdValidate
-                      #readDelayRef="cdValidate"
-                      label="Read delay max (s)"
-                      i18n-label
-                      [min]="0"
-                      [max]="300"
-                      helperText="Max allowed delay for read operations in seconds"
-                      i18n-helperText
-                      [invalid]="readDelayRef.isInvalid"
-                      invalidText="Value must be between 0 and 300"
-                      i18n-invalidText>
+          <cds-number
+            formControlName="read_burst_mult"
+            cdValidate
+            #readBurstRef="cdValidate"
+            label="Read burst mult"
+            i18n-label
+            [min]="10"
+            [max]="100"
+            helperText="Burst multiplier for read operations, allowing temporary bursts above the configured limit."
+            i18n-helperText
+            [invalid]="readBurstRef.isInvalid"
+            invalidText="Value must be between 10 and 100"
+            i18n-invalidText
+          >
           </cds-number>
         </div>
         <div cdsCol>
-          <cds-number formControlName="write_delay_max"
-                      cdValidate
-                      #writeDelayRef="cdValidate"
-                      label="Write delay max (s)"
-                      i18n-label
-                      [min]="0"
-                      [max]="300"
-                      helperText="Max allowed delay for write operations in seconds"
-                      i18n-helperText
-                      [invalid]="writeDelayRef.isInvalid"
-                      invalidText="Value must be between 0 and 300"
-                      i18n-invalidText>
+          <cds-number
+            formControlName="write_burst_mult"
+            cdValidate
+            #writeBurstRef="cdValidate"
+            label="Write burst mult"
+            i18n-label
+            [min]="10"
+            [max]="100"
+            helperText="Burst multiplier for write operations, allowing temporary bursts above the configured limit."
+            i18n-helperText
+            [invalid]="writeBurstRef.isInvalid"
+            invalidText="Value must be between 10 and 100"
+            i18n-invalidText
+          >
           </cds-number>
         </div>
       </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.spec.ts
@@ -42,6 +42,7 @@ describe('SmbShareFormComponent', () => {
 
     fixture = TestBed.createComponent(SmbShareFormComponent);
     component = fixture.componentInstance;
+    component.ngOnInit();
     fixture.detectChanges();
   });
 
@@ -50,7 +51,6 @@ describe('SmbShareFormComponent', () => {
   });
 
   it('should create the form', () => {
-    component.ngOnInit();
     expect(component.smbShareForm).toBeDefined();
     expect(component.smbShareForm.get('share_id')).toBeTruthy();
     expect(component.smbShareForm.get('volume')).toBeTruthy();
@@ -97,8 +97,8 @@ describe('SmbShareFormComponent', () => {
       read_bw_limit_unit: 'MiB',
       write_bw_limit: 0,
       write_bw_limit_unit: 'MiB',
-      read_delay_max: 30,
-      write_delay_max: 30
+      read_burst_mult: 15,
+      write_burst_mult: 15
     });
     component.submitAction();
     expect(component).toBeTruthy();
@@ -106,17 +106,16 @@ describe('SmbShareFormComponent', () => {
 
   describe('QoS', () => {
     it('should have QoS form controls with default values', () => {
-      component.ngOnInit();
       expect(component.smbShareForm.get('read_iops_limit')).toBeTruthy();
       expect(component.smbShareForm.get('write_iops_limit')).toBeTruthy();
       expect(component.smbShareForm.get('read_bw_limit')).toBeTruthy();
       expect(component.smbShareForm.get('read_bw_limit_unit')).toBeTruthy();
       expect(component.smbShareForm.get('write_bw_limit')).toBeTruthy();
       expect(component.smbShareForm.get('write_bw_limit_unit')).toBeTruthy();
-      expect(component.smbShareForm.get('read_delay_max')).toBeTruthy();
-      expect(component.smbShareForm.get('write_delay_max')).toBeTruthy();
+      expect(component.smbShareForm.get('read_burst_mult')).toBeTruthy();
+      expect(component.smbShareForm.get('write_burst_mult')).toBeTruthy();
       expect(component.smbShareForm.get('read_iops_limit').value).toBe(0);
-      expect(component.smbShareForm.get('write_delay_max').value).toBe(30);
+      expect(component.smbShareForm.get('write_burst_mult').value).toBe(15);
     });
 
     it('should include QoS fields in buildRequest when set', () => {
@@ -130,13 +129,13 @@ describe('SmbShareFormComponent', () => {
         write_iops_limit: 500,
         read_bw_limit: 100,
         read_bw_limit_unit: 'MiB',
-        write_delay_max: 60
+        write_burst_mult: 60
       });
       const request = component.buildRequest();
       expect(request.share_resource.cephfs.qos.read_iops_limit).toBe(1000);
       expect(request.share_resource.cephfs.qos.write_iops_limit).toBe(500);
       expect(request.share_resource.cephfs.qos.read_bw_limit).toBe(100 * 1024 * 1024);
-      expect(request.share_resource.cephfs.qos.write_delay_max).toBe(60);
+      expect(request.share_resource.cephfs.qos.write_burst_mult).toBe(60);
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.ts
@@ -33,8 +33,9 @@ const UNIT_TO_BYTES: Record<string, number> = {
   GiB: 2 ** 30,
   TiB: 2 ** 40
 };
-const QOS_DELAY_MAX = 300;
-const QOS_DELAY_DEFAULT = 30;
+const QOS_BURST_MULT_MIN = 10;
+const QOS_BURST_MULT_MAX = 100;
+const QOS_BURST_MULT_DEFAULT = 15;
 const QOS_BW_UNITS = ['KiB', 'MiB', 'GiB', 'TiB'];
 
 function getBwMaxForUnit(unit: string): number {
@@ -106,8 +107,8 @@ export class SmbShareFormComponent extends CdForm implements OnInit {
           browseable: this.shareResponse.browseable ?? true,
           read_iops_limit: qos?.read_iops_limit,
           write_iops_limit: qos?.write_iops_limit,
-          read_delay_max: qos?.read_delay_max,
-          write_delay_max: qos?.write_delay_max
+          read_burst_mult: qos?.read_burst_mult,
+          write_burst_mult: qos?.write_burst_mult
         });
         this.smbShareForm.get('share_id').disable();
         this.smbShareForm.get('name').disable();
@@ -167,13 +168,13 @@ export class SmbShareFormComponent extends CdForm implements OnInit {
       read_bw_limit_unit: new FormControl(QOS_BW_UNITS[1]),
       write_bw_limit: new FormControl(0, [Validators.min(0), Validators.max(this.writeBwMax)]),
       write_bw_limit_unit: new FormControl(QOS_BW_UNITS[1]),
-      read_delay_max: new FormControl(QOS_DELAY_DEFAULT, [
-        Validators.min(0),
-        Validators.max(QOS_DELAY_MAX)
+      read_burst_mult: new FormControl(QOS_BURST_MULT_DEFAULT, [
+        Validators.min(QOS_BURST_MULT_MIN),
+        Validators.max(QOS_BURST_MULT_MAX)
       ]),
-      write_delay_max: new FormControl(QOS_DELAY_DEFAULT, [
-        Validators.min(0),
-        Validators.max(QOS_DELAY_MAX)
+      write_burst_mult: new FormControl(QOS_BURST_MULT_DEFAULT, [
+        Validators.min(QOS_BURST_MULT_MIN),
+        Validators.max(QOS_BURST_MULT_MAX)
       ])
     });
   }
@@ -298,8 +299,8 @@ export class SmbShareFormComponent extends CdForm implements OnInit {
                 ' ' +
                 this.smbShareForm.get('write_bw_limit_unit').value
             ),
-            read_delay_max: rawFormValue.read_delay_max,
-            write_delay_max: rawFormValue.write_delay_max
+            read_burst_mult: rawFormValue.read_burst_mult,
+            write_burst_mult: rawFormValue.write_burst_mult
           }
         },
         browseable: rawFormValue.browseable,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb.model.ts
@@ -83,8 +83,8 @@ export interface SMBShareQoS {
   write_iops_limit?: number;
   read_bw_limit?: number;
   write_bw_limit?: number;
-  read_delay_max?: number;
-  write_delay_max?: number;
+  read_burst_mult?: number;
+  write_burst_mult?: number;
 }
 
 export interface SMBShare {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78525

---

backport of https://github.com/ceph/ceph/pull/69830
parent tracker: https://tracker.ceph.com/issues/77815

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh