### PR TITLE
doc/dev: add missing link text to the Slack section

### DIFF
--- a/doc/dev/developer_guide/essentials.rst
+++ b/doc/dev/developer_guide/essentials.rst
@@ -81,6 +81,8 @@ click on `New issue`_.
 Slack
 -----
 
+Ceph developers and users chat on `Ceph's Slack`_.
+
 .. _`Ceph's Slack`: https://join.slack.com/t/ceph-storage/shared_invite/zt-32hkefbs5-f6qZDZLd5U8CYj7drBTHFw
 
 .. _mailing-list:


### PR DESCRIPTION
The `Slack` section of the developer guide contains only a heading and a
hyperlink target definition. Nothing references the target, so the section
renders as a heading with nothing under it:

https://docs.ceph.com/en/latest/dev/developer_guide/essentials/

This adds a sentence referencing the link, matching the `Mailing lists` section
directly below it.

*Disclosure: an AI assistant helped me find this while reading the developer
guide. I verified the section renders empty on docs.ceph.com and checked the
source myself.*

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
