### PR TITLE
mgr/rbd_support: Reduce repetitive INFO logs from schedule handlers

### DIFF
--- a/src/pybind/mgr/rbd_support/mirror_snapshot_schedule.py
+++ b/src/pybind/mgr/rbd_support/mirror_snapshot_schedule.py
@@ -247,6 +247,10 @@ class CreateSnapshotRequests:
             self.log.error(
                 "error when creating snapshot for {}/{}/{}: {}".format(
                     pool_id, namespace, image_id, comp.get_return_value()))
+        else:
+            self.log.info(
+                "mirror snapshot created for {}/{}/{}: snap_id={}".format(
+                    pool_id, namespace, image_id, snap_id))
 
         self.close_image(image_spec, image)
 
@@ -369,6 +373,10 @@ class MirrorSnapshotScheduleHandler:
                         self.condition.wait(min(wait_time, refresh_delay))
                         continue
                 pool_id, namespace, image_id = image_spec
+                image_name = self.images.get(pool_id, {}).get(namespace, {}).get(image_id, image_id)
+                self.log.info("MirrorSnapshotScheduleHandler: executing mirror snapshot for "
+                              "pool_id={}, namespace={}, image_id={}, image={}".format(
+                                  pool_id, namespace, image_id, image_name))
                 self.create_snapshot_requests.add(pool_id, namespace, image_id)
                 with self.lock:
                     self.enqueue(datetime.now(timezone.utc), pool_id, namespace, image_id)
@@ -390,7 +398,7 @@ class MirrorSnapshotScheduleHandler:
         self.log.debug("MirrorSnapshotScheduleHandler: queue is initialized")
 
     def load_schedules(self) -> None:
-        self.log.info("MirrorSnapshotScheduleHandler: load_schedules")
+        self.log.debug("MirrorSnapshotScheduleHandler: load_schedules")
         self.schedules.load(namespace_validator, image_validator)
 
     def refresh_images(self) -> float:

--- a/src/pybind/mgr/rbd_support/schedule.py
+++ b/src/pybind/mgr/rbd_support/schedule.py
@@ -463,7 +463,7 @@ class Schedules:
         try:
             while True:
                 with rados.ReadOpCtx() as read_op:
-                    self.handler.log.info(
+                    self.handler.log.debug(
                         "load_schedules: {}, start_after={}".format(
                             pool_name, start_after))
                     it, ret = ioctx.get_omap_vals(read_op, start_after, "", 128)
@@ -473,7 +473,7 @@ class Schedules:
                     for k, v in it:
                         start_after = k
                         v = v.decode()
-                        self.handler.log.info(
+                        self.handler.log.debug(
                             "load_schedule: {} {}".format(k, v))
                         try:
                             try:

--- a/src/pybind/mgr/rbd_support/trash_purge_schedule.py
+++ b/src/pybind/mgr/rbd_support/trash_purge_schedule.py
@@ -50,6 +50,9 @@ class TrashPurgeScheduleHandler:
                         self.condition.wait(min(wait_time, refresh_delay))
                         continue
                 pool_id, namespace = ns_spec
+                self.log.info(
+                    "TrashPurgeScheduleHandler: executing trash purge for "
+                    "pool_id={}, namespace={}".format(pool_id, namespace))
                 self.trash_purge(pool_id, namespace)
                 with self.lock:
                     self.enqueue(datetime.now(timezone.utc), pool_id, namespace)
@@ -66,6 +69,9 @@ class TrashPurgeScheduleHandler:
             with self.module.rados.open_ioctx2(int(pool_id)) as ioctx:
                 ioctx.set_namespace(namespace)
                 rbd.RBD().trash_purge(ioctx, datetime.now(timezone.utc))
+            self.log.info(
+                "trash purge completed for pool_id={}, namespace={}".format(
+                    pool_id, namespace))
         except (rados.ConnectionShutdown, rbd.ConnectionShutdown):
             raise
         except Exception as e:
@@ -81,7 +87,7 @@ class TrashPurgeScheduleHandler:
         self.log.debug("TrashPurgeScheduleHandler: queue is initialized")
 
     def load_schedules(self) -> None:
-        self.log.info("TrashPurgeScheduleHandler: load_schedules")
+        self.log.debug("TrashPurgeScheduleHandler: load_schedules")
         self.schedules.load()
 
     def refresh_pools(self) -> float:


### PR DESCRIPTION
Move periodic schedule-loading messages to DEBUG level and retain  INFO logging only when a scheduled task is actually triggered or  executed.

Fixes: https://tracker.ceph.com/issues/77695

Before Changes:
```
Jul 01 05:04:22 prachi-1 ceph-mgr[108345]: [rbd_support INFO root] TrashPurgeScheduleHandler: load_schedules
Jul 01 05:04:22 prachi-1 ceph-mgr[108345]: [rbd_support INFO root] load_schedules: rbd, start_after=
Jul 01 05:04:22 prachi-1 ceph-mgr[108345]: [rbd_support INFO root] load_schedules: test-rbd-pool, start_after=
Jul 01 05:04:25 prachi-1 ceph-mgr[108345]: [rbd_support INFO root] MirrorSnapshotScheduleHandler: load_schedules
Jul 01 05:04:25 prachi-1 ceph-mgr[108345]: [rbd_support INFO root] load_schedules: rbd, start_after=
Jun 30 22:33:17 prachi-1 ceph-mgr[108345]: [rbd_support INFO root] load_schedule: 2 [
                                               {
                                                   "interval": "1h",
                                                   "start_time": null
                                               }
                                           ]
Jun 30 22:33:17 prachi-1 ceph-mgr[108345]: [rbd_support INFO root] load_schedules: rbd, start_after=2
Jun 30 22:33:17 prachi-1 ceph-mgr[108345]: [rbd_support INFO root] load_schedules: test-rbd-pool, start_after=
Jun 30 22:33:17 prachi-1 ceph-mgr[108345]: [rbd_support INFO root] load_schedule: 3 [
                                               {
                                                   "interval": "1h",
                                                   "start_time": null
                                               }
                                           ]
```
                                           
After Changes:
```
    Sep 22 05:52:00 [rbd_support INFO rbd_support] CreateSnapshotRequests.add: 9//3be88f8c763b
    Sep 22 05:52:00 [rbd_support INFO rbd_support] CreateSnapshotRequests.add: 11//3c48e6fece05
    Sep 22 05:52:00 [rbd_support INFO rbd_support] TrashPurgeScheduleHandler: executing trash purge for pool_id=10, namespace=
    Sep 22 05:52:00 [rbd_support INFO rbd_support] TrashPurgeScheduleHandler: trash purge completed for pool_id=10, namespace=
    Sep 22 05:52:00 [rbd_support INFO rbd_support] CreateSnapshotRequests.finish: 9//3be88f8c763b
    Sep 22 05:52:00 [rbd_support INFO rbd_support] CreateSnapshotRequests.finish: 11//3c48e6fece05

```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
