### PR TITLE
mgr/prometheus: export cached RBD provisioned counts

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -132,6 +132,33 @@ RBD_MIRROR_METADATA = ('ceph_daemon', 'id', 'instance_id', 'hostname',
 
 RBD_IMAGE_METADATA = ('pool_id', 'image_name')
 
+RBD_POOL_STAT_METRICS = {
+    'rbd_image_count': (
+        'image_count',
+        'RBD image count per pool',
+    ),
+    'rbd_image_provisioned_bytes': (
+        'image_provisioned_bytes',
+        'RBD image total HEAD provisioned bytes per pool',
+    ),
+    'rbd_image_snap_count': (
+        'image_snap_count',
+        'RBD image snapshot count per pool',
+    ),
+    'rbd_trash_image_count': (
+        'trash_count',
+        'RBD trash image count per pool',
+    ),
+    'rbd_trash_image_provisioned_bytes': (
+        'trash_provisioned_bytes',
+        'RBD trash image total HEAD provisioned bytes per pool',
+    ),
+    'rbd_trash_image_snap_count': (
+        'trash_snap_count',
+        'RBD trash image snapshot count per pool',
+    ),
+}
+
 DISK_OCCUPATION = ('ceph_daemon', 'device', 'db_device',
                    'wal_device', 'instance', 'devices', 'device_ids')
 
@@ -911,6 +938,14 @@ class Module(MgrModule, OrchestratorClientMixin):
             RBD_IMAGE_METADATA
         )
 
+        for metric_name, (_, metric_desc) in RBD_POOL_STAT_METRICS.items():
+            metrics[metric_name] = Metric(
+                'gauge',
+                metric_name,
+                metric_desc,
+                ('pool_id',)
+            )
+
         metrics['pg_total'] = Metric(
             'gauge',
             'pg_total',
@@ -1626,6 +1661,11 @@ class Module(MgrModule, OrchestratorClientMixin):
                 pool_name = pool['pool_name']
                 if 'rbd' in pool.get('application_metadata', {}):
                     with self.rados.open_ioctx(pool_name) as ioctx:
+                        pool_stats = rbd.pool_stats_get(ioctx)
+                        for metric_name, (stat_name, _) in RBD_POOL_STAT_METRICS.items():
+                            self.metrics[metric_name].set(
+                                pool_stats[stat_name], (str(pool_id),)
+                            )
                         for image_meta in rbd.list2(ioctx):
                             image_name = image_meta['name']
                             self.metrics['rbd_image_metadata'].set(

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -132,6 +132,33 @@ RBD_MIRROR_METADATA = ('ceph_daemon', 'id', 'instance_id', 'hostname',
 
 RBD_IMAGE_METADATA = ('pool_id', 'image_name')
 
+RBD_PROVISIONED_COUNT_METRICS = {
+    'rbd_image_count': (
+        'image_count',
+        'RBD image count per pool',
+    ),
+    'rbd_image_provisioned_bytes': (
+        'image_provisioned_bytes',
+        'RBD image total HEAD provisioned bytes per pool',
+    ),
+    'rbd_image_snap_count': (
+        'image_snap_count',
+        'RBD image snapshot count per pool',
+    ),
+    'rbd_trash_image_count': (
+        'trash_count',
+        'RBD trash image count per pool',
+    ),
+    'rbd_trash_image_provisioned_bytes': (
+        'trash_provisioned_bytes',
+        'RBD trash image total HEAD provisioned bytes per pool',
+    ),
+    'rbd_trash_image_snap_count': (
+        'trash_snap_count',
+        'RBD trash image snapshot count per pool',
+    ),
+}
+
 DISK_OCCUPATION = ('ceph_daemon', 'device', 'db_device',
                    'wal_device', 'instance', 'devices', 'device_ids')
 
@@ -721,6 +748,14 @@ class Module(MgrModule, OrchestratorClientMixin):
             default=300
         ),
         Option(
+            name='rbd_provisioned_counts_refresh_interval',
+            type='int',
+            default=3600,
+            min=0,
+            desc='interval in seconds between RBD provisioned counts refreshes',
+            runtime=True
+        ),
+        Option(
             name='standby_behaviour',
             type='str',
             default='default',
@@ -785,6 +820,10 @@ class Module(MgrModule, OrchestratorClientMixin):
                 'read_latency': {'type': self.PERFCOUNTER_LONGRUNAVG,
                                  'desc': 'RBD image reads latency (nsec)'},
             },
+        }  # type: Dict[str, Any]
+        self.rbd_provisioned_counts = {
+            'pools': {},
+            'pools_refresh_time': 0,
         }  # type: Dict[str, Any]
         global _global_instance
         _global_instance = self
@@ -910,6 +949,14 @@ class Module(MgrModule, OrchestratorClientMixin):
             'RBD Image Metadata',
             RBD_IMAGE_METADATA
         )
+
+        for metric_name, (_, metric_desc) in RBD_PROVISIONED_COUNT_METRICS.items():
+            metrics[metric_name] = Metric(
+                'gauge',
+                metric_name,
+                metric_desc,
+                ('pool_name',)
+            )
 
         metrics['pg_total'] = Metric(
             'gauge',
@@ -1401,6 +1448,49 @@ class Module(MgrModule, OrchestratorClientMixin):
                                                                service.get('name', ''))})
         return ret
 
+    def refresh_rbd_provisioned_counts(self, osd_map: Dict[str, Any]) -> None:
+        self.log.debug('refreshing RBD provisioned counts')
+        rbd = RBD()
+        provisioned_counts = {}
+        for pool in osd_map['pools']:
+            if 'rbd' not in pool.get('application_metadata', {}):
+                continue
+
+            pool_id = str(pool['pool'])
+            pool_name = pool['pool_name']
+            try:
+                with self.rados.open_ioctx(pool_name) as ioctx:
+                    provisioned_counts[pool_id] = rbd.pool_stats_get(ioctx)
+            except Exception as e:
+                self.log.error('failed refreshing RBD provisioned counts for pool %s: %s' %
+                               (pool_name, e))
+
+        self.rbd_provisioned_counts['pools'] = provisioned_counts
+        self.rbd_provisioned_counts['pools_refresh_time'] = time.time()
+
+    def get_rbd_provisioned_counts(self, osd_map: Dict[str, Any]) -> None:
+        refresh_interval = cast(int, self.get_localized_module_option(
+            'rbd_provisioned_counts_refresh_interval'))
+        if refresh_interval == 0:
+            self.rbd_provisioned_counts['pools'] = {}
+            self.rbd_provisioned_counts['pools_refresh_time'] = 0
+            return
+
+        next_refresh = self.rbd_provisioned_counts['pools_refresh_time'] + refresh_interval
+        if time.time() >= next_refresh:
+            self.refresh_rbd_provisioned_counts(osd_map)
+
+        rbd_pool_names = {str(pool['pool']): pool['pool_name']
+                          for pool in osd_map['pools']
+                          if 'rbd' in pool.get('application_metadata', {})}
+        for pool_id, provisioned_counts in self.rbd_provisioned_counts['pools'].items():
+            if pool_id not in rbd_pool_names:
+                continue
+            for metric_name, (stat_name, _) in RBD_PROVISIONED_COUNT_METRICS.items():
+                self.metrics[metric_name].set(
+                    provisioned_counts[stat_name], (rbd_pool_names[pool_id],)
+                )
+
     @profile_method()
     def get_metadata_and_osd_status(self) -> None:
         osd_map = self.get('osd_map')
@@ -1619,6 +1709,7 @@ class Module(MgrModule, OrchestratorClientMixin):
                 self.metrics['rbd_mirror_metadata'].set(
                     1, rbd_mirror_metadata
                 )
+        self.get_rbd_provisioned_counts(osd_map)
         try:
             rbd = RBD()
             for pool in osd_map['pools']:


### PR DESCRIPTION
    Add Prometheus metrics for RBD pool-level image and trash counts,
    provisioned bytes, and snapshot counts using librbd pool_stats_get.

    Since pool_stats_get can issue per-image metadata reads, cache the values
    and refresh them through the configurable
    rbd_provisioned_counts_refresh_interval option, defaulting to 3600 seconds.
    A value of 0 disables this periodic collection. Metrics are labeled by
    pool_name, and pools that fail refresh are omitted instead of reporting
    stale values.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
