### PR TITLE
mgr/dashboard: Display pattern validation error for bad numeric inputs

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/ng-bootstrap-form-validation/cd-form-control.directive.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/ng-bootstrap-form-validation/cd-form-control.directive.spec.ts
@@ -25,13 +25,61 @@
  * Based on https://github.com/third774/ng-bootstrap-form-validation
  */
 
-import { NgForm } from '@angular/forms';
+import { ElementRef } from '@angular/core';
+import { NgForm, UntypedFormControl, Validators } from '@angular/forms';
 
 import { CdFormControlDirective } from './cd-form-control.directive';
 
 describe('CdFormControlDirective', () => {
+  let directive: CdFormControlDirective;
+  let mockControl: UntypedFormControl;
+  let mockElementRef: ElementRef;
+
+  beforeEach(() => {
+    mockControl = new UntypedFormControl('', [Validators.required]);
+    mockElementRef = {
+      nativeElement: {
+        validity: {
+          badInput: false
+        }
+      }
+    } as ElementRef;
+    directive = new CdFormControlDirective(new NgForm([], []), mockElementRef);
+    jest.spyOn(directive, 'control', 'get').mockReturnValue(mockControl);
+  });
+
   it('should create an instance', () => {
-    const directive = new CdFormControlDirective(new NgForm([], []));
     expect(directive).toBeTruthy();
+  });
+
+  it('should set pattern error and remove required error when badInput is true', () => {
+    mockControl.setErrors({ required: true });
+    (mockElementRef.nativeElement as any).validity.badInput = true;
+
+    directive.onInput();
+
+    expect(mockControl.hasError('pattern')).toBe(true);
+    expect(mockControl.hasError('required')).toBe(false);
+  });
+
+  it('should preserve other errors like min and remove required when badInput is true', () => {
+    mockControl.setErrors({ required: true, min: true });
+    (mockElementRef.nativeElement as any).validity.badInput = true;
+
+    directive.onInput();
+
+    expect(mockControl.hasError('pattern')).toBe(true);
+    expect(mockControl.hasError('min')).toBe(true);
+    expect(mockControl.hasError('required')).toBe(false);
+  });
+
+  it('should not modify errors when badInput is false', () => {
+    mockControl.setErrors({ required: true });
+    (mockElementRef.nativeElement as any).validity.badInput = false;
+
+    directive.onInput();
+
+    expect(mockControl.hasError('required')).toBe(true);
+    expect(mockControl.hasError('pattern')).toBe(false);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/ng-bootstrap-form-validation/cd-form-control.directive.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/ng-bootstrap-form-validation/cd-form-control.directive.ts
@@ -25,7 +25,16 @@
  * Based on https://github.com/third774/ng-bootstrap-form-validation
  */
 
-import { Directive, Host, HostBinding, Input, Optional, SkipSelf } from '@angular/core';
+import {
+  Directive,
+  ElementRef,
+  Host,
+  HostBinding,
+  HostListener,
+  Input,
+  Optional,
+  SkipSelf
+} from '@angular/core';
 import { ControlContainer, UntypedFormControl } from '@angular/forms';
 
 export function controlPath(name: string, parent: ControlContainer): string[] {
@@ -72,12 +81,27 @@ export class CdFormControlDirective {
     return this.parent ? this.parent.formDirective : null;
   }
 
+  @HostListener('input')
+  @HostListener('blur')
+  onInput() {
+    if (!this.control) {
+      return;
+    }
+    const nativeElement = this.elRef.nativeElement as HTMLInputElement;
+    if (nativeElement?.validity?.badInput) {
+      const errors: Record<string, any> = { ...this.control.errors, pattern: true };
+      delete errors['required'];
+      this.control.setErrors(errors);
+    }
+  }
+
   constructor(
     // this value might be null, but we union type it as such until
     // this issue is resolved: https://github.com/angular/angular/issues/25544
     @Optional()
     @Host()
     @SkipSelf()
-    private parent: ControlContainer
+    private parent: ControlContainer,
+    private elRef: ElementRef
   ) {}
 }


### PR DESCRIPTION
mgr/dashboard: Display pattern validation error for bad numeric inputs

Fixes: https://tracker.ceph.com/issues/78969

Signed-off-by: Sagar Gopale <sagar.gopale@ibm.com>

Screencast : 

https://github.com/user-attachments/assets/e9a79671-5ce3-4e3d-8764-8caccf72d4af

PR Description : 
Fixes an issue where entering invalid non-numeric text into numeric input fields displayed a misleading "This field is required!" validation error.

Ensures form controls display appropriate numeric validation messages when invalid characters are entered into number fields.

Retains the "This field is required!" error message exclusively for completely empty input fields.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
