### PR TITLE
doc: document collocated DB LV split for ceph-volume lvm batch

### DIFF
--- a/doc/ceph-volume/lvm/batch.rst
+++ b/doc/ceph-volume/lvm/batch.rst
@@ -160,6 +160,55 @@ It is also possible to provide explicit sizes to `ceph-volume` via the arguments
 this is not possible, no OSDs will be deployed.
 
 
+Collocated DB on the same device
+---------------------------------
+
+.. versionadded:: Squid 19.2.3
+
+It is possible to deploy a non-collocated BlueStore layout where the ``block.db``
+LV is carved out of the **same physical device** as the data LV, without needing
+a separate device. This helps mitigate BlueStore fragmentation by isolating metadata
+writes.
+
+To enable this, pass ``--block-db-size`` **without** ``--db-devices``.
+``ceph-volume`` will create two LVs on each data device: one for data and one for
+``block.db``::
+
+    $ ceph-volume lvm batch --report /dev/sdb /dev/sdc --block-db-size 4G
+
+Example output::
+
+    Total OSDs: 2
+
+      Type            Path                                                    LV Size         % of device
+    ----------------------------------------------------------------------------------------------------
+      data            /dev/sdb                                                196.00 GB       98.00%
+      block_db        /dev/sdb                                                4.00 GB         2.00%
+    ----------------------------------------------------------------------------------------------------
+      data            /dev/sdc                                                196.00 GB       98.00%
+      block_db        /dev/sdc                                                4.00 GB         2.00%
+
+This also works with ``--osds-per-device``::
+
+    $ ceph-volume lvm batch --report /dev/sdb --osds-per-device 2 --block-db-size 4G
+
+Example output::
+
+    Total OSDs: 2
+
+      Type            Path                                                    LV Size         % of device
+    ----------------------------------------------------------------------------------------------------
+      data            /dev/sdb                                                96.00 GB        48.00%
+      block_db        /dev/sdb                                                4.00 GB         2.00%
+    ----------------------------------------------------------------------------------------------------
+      data            /dev/sdb                                                96.00 GB        48.00%
+      block_db        /dev/sdb                                                4.00 GB         2.00%
+
+.. note:: ``ceph-volume`` cannot derive a sensible default DB size automatically
+          in this scenario, so ``--block-db-size`` is mandatory. If the requested
+          size cannot be accommodated, no OSDs will be deployed.
+
+
 Idempotency and disk replacements
 =================================
 `ceph-volume lvm batch` intends to be idempotent, i.e. calling the same command

--- a/doc/cephadm/services/osd.rst
+++ b/doc/cephadm/services/osd.rst
@@ -1138,6 +1138,73 @@ via the ``paths`` keyword with the following syntax:
         paths:
         - /dev/sde
 
+
+.. _cephadm-osd-collocated-db:
+
+DB on the Same Device (Collocated LV Split)
+-------------------------------------------
+
+.. versionadded:: Squid 19.2.1
+
+It is possible to deploy OSDs where the ``block.db`` LV is carved out of the
+**same physical device** as the data LV, without requiring a separate DB device.
+This provides the BlueStore non-collocated layout (data and metadata on separate
+LVs) using only a single device per OSD which helps to mitigate BlueStore fragmentation.
+
+This is achieved by specifying ``block_db_size`` **without** ``db_devices`` in
+the OSD spec. ``cephadm`` will instruct ``ceph-volume lvm batch`` to create two
+LVs per disk: one for data and one for ``block.db``.
+
+.. code-block:: yaml
+
+    service_type: osd
+    service_id: osd_collocated_db
+    placement:
+      host_pattern: '*'
+    spec:
+      data_devices:
+        paths:
+          - /dev/sdb
+          - /dev/sdc
+      block_db_size: 4G           # Carve a 4 GB DB LV out of each data device
+
+The result is that each HDD will host two LVs:
+
+.. code-block:: none
+
+    data     /dev/sdb   196.00 GB   98.00%
+    block_db /dev/sdb     4.00 GB    2.00%
+
+This also works with explicit device paths and ``osds_per_device``:
+
+.. code-block:: yaml
+
+    service_type: osd
+    service_id: osd_collocated_db_paths
+    placement:
+      hosts:
+        - node01
+        - node02
+    spec:
+      data_devices:
+        paths:
+          - /dev/sdb
+          - /dev/sdc
+      block_db_size: 4G           # Carve a DB LV out of each data device
+      osds_per_device: 2          # Multiple OSDs per disk, each with its own DB LV
+
+.. note::
+
+    ``block_db_size`` is mandatory for this configuration. ``ceph-volume`` cannot
+    derive a sensible default DB size when both data and DB share the same device.
+    If the requested size cannot be satisfied, no OSDs will be deployed.
+
+.. note::
+
+    This feature was introduced in Squid 19.2.3. On older releases, you can achieve
+    the same result by manually creating the LVs in advance and passing them
+    explicitly to ``ceph-volume lvm prepare --bluestore --data <data-vg/lv> --block.db <db-vg/lv>``.
+
 .. _cephadm-osd-activate:
 
 Activate Existing OSDs


### PR DESCRIPTION
This commits documents the ability to deploy OSDs where the block.db LV is carved out of the same physical device as the data LV, without requiring a dedicated DB disk.

This can be done by passing --block-db-size without --db-devices to `ceph-volume lvm batch`. The feature was introduced in Squid as part of tracker #69996.

Fixes: https://tracker.ceph.com/issues/69996

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
