### PR TITLE
umbrella: crimson/seastore: batch same-collection transactions

### DIFF
--- a/src/crimson/os/seastore/omap_manager/log/log_manager.cc
+++ b/src/crimson/os/seastore/omap_manager/log/log_manager.cc
@@ -153,7 +153,8 @@ LogManager::omap_set_keys(
 	  continue;
 	}
 	if (cur->expect_overflow(p.first, p.second.length(),
-	    !is_ow_key(p.first) ? cur->can_ow() : false)) {
+	    (!is_ow_key(p.first) && !cur->is_initial_pending())
+	      ? cur->can_ow() : false)) {
 	  // This means the first entry of the new LogNode is not _fastinfo
 	  if (!is_ow_key(p.first)) {
 	    // remove _fastinfo in old LogNode

--- a/src/crimson/os/seastore/omap_manager/log/log_node.cc
+++ b/src/crimson/os/seastore/omap_manager/log/log_node.cc
@@ -324,14 +324,14 @@ bool LogNode::expect_overflow(const std::string &key,
   size_t ksize = key.size();
   if (can_ow) { 
     int gap = ow_gap_from_last_entry(key.size(), vsize);
-    uint64_t remain = capacity() - get_last_pos() - reserved_len;
     if (gap >= 0) {
       gap += static_cast<uint64_t>(gap);
     } else {
       uint64_t d = static_cast<uint64_t>(-gap);
       gap -= d;
     }
-    return remain < get_entry_size(ksize, vsize);
+    return get_last_pos() + reserved_len + get_entry_size(ksize, vsize)
+           > capacity();
   } else if (get_size() + reserved_size + 1 > d_bitmap_t::MAX_ENTRY) {
     return true;
   } else if (is_ow_key(key) && !can_ow) {

--- a/src/crimson/os/seastore/omap_manager/log/log_node.cc
+++ b/src/crimson/os/seastore/omap_manager/log/log_node.cc
@@ -323,15 +323,10 @@ bool LogNode::expect_overflow(const std::string &key,
   size_t vsize, bool can_ow) {
   size_t ksize = key.size();
   if (can_ow) { 
-    int gap = ow_gap_from_last_entry(key.size(), vsize);
-    if (gap >= 0) {
-      gap += static_cast<uint64_t>(gap);
-    } else {
-      uint64_t d = static_cast<uint64_t>(-gap);
-      gap -= d;
-    }
-    return get_last_pos() + reserved_len + get_entry_size(ksize, vsize)
-           > capacity();
+    // Reserve only the additional space required by the overwrite.
+    int gap = ow_gap_from_last_entry(ksize, vsize);
+    return gap > 0 &&
+      free_space() < static_cast<size_t>(gap) + reserved_len;
   } else if (get_size() + reserved_size + 1 > d_bitmap_t::MAX_ENTRY) {
     return true;
   } else if (is_ow_key(key) && !can_ow) {

--- a/src/crimson/os/seastore/omap_manager/log/log_node.cc
+++ b/src/crimson/os/seastore/omap_manager/log/log_node.cc
@@ -346,8 +346,10 @@ int LogNode::ow_gap_from_last_entry(const size_t key, const size_t val) {
   if (p) {
     auto ret = p->get_latest_write_delta();
     if (ret && (*ret).key == get_ow_key()) {
-      if ((*ret).val.length() < val) {
-	gap = val - (*ret).val.length();
+      auto old_size = get_entry_size((*ret).key.size(), (*ret).val.length());
+      auto new_size = get_entry_size(key, val);
+      if (new_size > old_size) {
+        gap = new_size - old_size;
       }
     } else {
       gap = _ow_gap_from_last_entry(key, val);

--- a/src/crimson/os/seastore/omap_manager/log/log_node.h
+++ b/src/crimson/os/seastore/omap_manager/log/log_node.h
@@ -664,8 +664,10 @@ public:
   void _append(const std::string &key, const ceph::bufferlist &val) {
     iterator prev_iter(this, get_last_pos());
     auto last = prev_iter->get_node_key();
-    iterator next_iter(this, get_size() == 0 ? get_last_pos() :
-      get_last_pos() + get_entry_size(last.key_len, last.val_len));
+    uint32_t pos = get_size() == 0 ? get_last_pos() :
+      get_last_pos() + get_entry_size(last.key_len, last.val_len);
+    assert(pos + get_entry_size(key.size(), val.length()) <= capacity());
+    iterator next_iter(this, pos);
     next_iter.set_node_key(log_key_t(key.size(), val.length()));
     next_iter.set_node_val(key, val);
     if (get_size() >= 1) {
@@ -687,6 +689,8 @@ public:
   }
 
   void _overwrite(const std::string &key, const ceph::bufferlist &val) {
+    assert(get_last_pos() + get_entry_size(key.size(), val.length())
+      <= capacity());
     iterator iter(this, get_last_pos());
     iter.set_node_key(log_key_t(key.size(), val.length()));
     iter.set_node_val(key, val);

--- a/src/crimson/os/seastore/ordering_handle.h
+++ b/src/crimson/os/seastore/ordering_handle.h
@@ -120,29 +120,12 @@ struct OrderingHandle {
   // we can easily optimize this dynalloc out as all concretes are
   // supposed to have exactly the same size.
   std::unique_ptr<OperationProxy> op;
-  seastar::shared_mutex *collection_ordering_lock = nullptr;
 
   // in the future we might add further constructors / template to type
   // erasure while extracting the location of tracking events.
   OrderingHandle(std::unique_ptr<OperationProxy> op) : op(std::move(op)) {}
   OrderingHandle(OrderingHandle &&other)
-    : op(std::move(other.op)),
-      collection_ordering_lock(other.collection_ordering_lock) {
-    other.collection_ordering_lock = nullptr;
-  }
-
-  seastar::future<> take_collection_lock(seastar::shared_mutex &mutex) {
-    ceph_assert(!collection_ordering_lock);
-    collection_ordering_lock = &mutex;
-    return collection_ordering_lock->lock();
-  }
-
-  void maybe_release_collection_lock() {
-    if (collection_ordering_lock) {
-      collection_ordering_lock->unlock();
-      collection_ordering_lock = nullptr;
-    }
-  }
+    : op(std::move(other.op)) {}
 
   template <typename T>
   seastar::future<> enter(T &t) {
@@ -155,10 +138,6 @@ struct OrderingHandle {
 
   seastar::future<> complete() {
     return op->complete();
-  }
-
-  ~OrderingHandle() {
-    maybe_release_collection_lock();
   }
 };
 

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -806,14 +806,13 @@ seastar::future<> SeaStore::report_stats()
          calc_conflicts(io_total.read_num, io_total.repeat_read_num),
          calc_conflicts(io_total.get_bg_num(), io_total.get_repeat_bg_num()));
     INFO("trans outstanding: {},{},{},{} "
-         "per-shard: {:.2f}({:.2f},{:.2f},{:.2f},{:.2f},{:.2f}),{:.2f},{:.2f},{:.2f}",
+         "per-shard: {:.2f}({:.2f},{:.2f},{:.2f},{:.2f}),{:.2f},{:.2f},{:.2f}",
          io_total.pending_io_num,
          io_total.pending_read_num,
          io_total.pending_bg_num,
          io_total.pending_flush_num,
          (double)io_total.pending_io_num/seastar::smp::count,
          (double)io_total.starting_io_num/seastar::smp::count,
-         (double)io_total.waiting_collock_io_num/seastar::smp::count,
          (double)io_total.waiting_throttler_io_num/seastar::smp::count,
          (double)io_total.processing_inlock_io_num/seastar::smp::count,
          (double)io_total.processing_postlock_io_num/seastar::smp::count,
@@ -825,7 +824,6 @@ seastar::future<> SeaStore::report_stats()
     for (const auto &s : shard_io_stats) {
       oss_pending << s.pending_io_num
                  << "(" << s.starting_io_num
-                 << "," << s.waiting_collock_io_num
                  << "," << s.waiting_throttler_io_num
                  << "," << s.processing_inlock_io_num
                  << "," << s.processing_postlock_io_num
@@ -2891,7 +2889,7 @@ shard_stats_t SeaStore::Shard::get_io_stats(
     };
     INFO("iops={:.2f},{:.2f},{:.2f}({:.2f},{:.2f},{:.2f},{:.2f}),{:.2f} "
          "conflicts={:.2f},{:.2f},{:.2f}({:.2f},{:.2f},{:.2f},{:.2f}) "
-         "outstanding={}({},{},{},{},{}),{},{},{}",
+         "outstanding={}({},{},{},{}),{},{},{}",
          // iops
          ret.io_num/seconds,
          ret.read_num/seconds,
@@ -2912,7 +2910,6 @@ shard_stats_t SeaStore::Shard::get_io_stats(
          // outstanding
          ret.pending_io_num,
          ret.starting_io_num,
-         ret.waiting_collock_io_num,
          ret.waiting_throttler_io_num,
          ret.processing_inlock_io_num,
          ret.processing_postlock_io_num,

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1618,9 +1618,69 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
   CollectionRef _ch,
   ceph::os::Transaction&& _t)
 {
-  assert(store_active);
   LOG_PREFIX(SeaStoreS::do_transaction_no_callbacks);
+  assert(store_active);
   ++(shard_stats.io_num);
+
+  auto& coll = static_cast<SeastoreCollection&>(*_ch);
+  auto& entry = coll.pending_txns.emplace_back();
+  entry.txn = std::move(_t);
+  auto fut = entry.pr.get_future();
+  DEBUG("enqueue cid={} queue_depth={} in_flight={}",
+        coll.get_cid(), coll.pending_txns.size(), coll.collection_in_flight);
+  if (!coll.collection_in_flight) {
+    coll.collection_in_flight = true;
+    DEBUG("cid={} gate closed, starting dispatch", coll.get_cid());
+    std::ignore = dispatch_collection(_ch);
+  }
+  return fut;
+}
+
+ceph::os::Transaction SeaStore::Shard::build_next_batch(
+  SeastoreCollection& coll,
+  std::vector<seastar::promise<>>& pending_txns_promises)
+{
+  ceph::os::Transaction merged;
+  bool first = true;
+  while (!coll.pending_txns.empty()) {
+    auto e = std::move(coll.pending_txns.front());
+    coll.pending_txns.pop_front();
+    if (first) {
+      merged = std::move(e.txn);
+      first = false;
+    } else {
+      merged.append(e.txn);
+    }
+    pending_txns_promises.push_back(std::move(e.pr));
+  }
+  return merged;
+}
+
+seastar::future<> SeaStore::Shard::dispatch_collection(CollectionRef ch)
+{
+  LOG_PREFIX(SeaStoreS::dispatch_collection);
+  auto& coll = static_cast<SeastoreCollection&>(*ch);
+  while (!coll.pending_txns.empty()) {
+    std::vector<seastar::promise<>> pending_txns_promises;
+    auto merged = build_next_batch(coll, pending_txns_promises);
+    DEBUG("draining {} txns from cid={}, committing batch ({} ops)",
+          pending_txns_promises.size(), coll.get_cid(), merged.get_num_ops());
+    co_await run_one_batch(ch, std::move(merged));
+    DEBUG("committed batch of {} txns for cid={}",
+          pending_txns_promises.size(), coll.get_cid());
+    for (auto& p : pending_txns_promises) {
+      p.set_value();
+    }
+  }
+  DEBUG("cid={} drained, gate open", coll.get_cid());
+  coll.collection_in_flight = false;
+}
+
+seastar::future<> SeaStore::Shard::run_one_batch(
+  CollectionRef _ch,
+  ceph::os::Transaction&& _t)
+{
+  LOG_PREFIX(SeaStoreS::run_one_batch);
   ++(shard_stats.pending_io_num);
   ++(shard_stats.starting_io_num);
 
@@ -1635,14 +1695,6 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
 
   assert(shard_stats.starting_io_num);
   --(shard_stats.starting_io_num);
-  ++(shard_stats.waiting_collock_io_num);
-
-  co_await ctx.transaction->get_handle().take_collection_lock(
-    static_cast<SeastoreCollection&>(*(ctx.ch)).ordering_lock
-  );
-
-  assert(shard_stats.waiting_collock_io_num);
-  --(shard_stats.waiting_collock_io_num);
   ++(shard_stats.waiting_throttler_io_num);
 
   co_await throttler.get(1);
@@ -1725,16 +1777,15 @@ seastar::future<> SeaStore::Shard::flush(CollectionRef ch)
   ++(shard_stats.flush_num);
   ++(shard_stats.pending_flush_num);
 
-  return seastar::do_with(
-    get_dummy_ordering_handle(),
-    [this, ch](auto &handle) {
-      return handle.take_collection_lock(
-	static_cast<SeastoreCollection&>(*ch).ordering_lock
-      ).then([this, &handle] {
+  return do_transaction_no_callbacks(
+    ch, ceph::os::Transaction{}
+  ).then([this] {
+    return seastar::do_with(
+      get_dummy_ordering_handle(),
+      [this](auto &handle) {
 	return transaction_manager->flush(handle);
       });
-    }
-  ).finally([this] {
+  }).finally([this] {
     assert(shard_stats.pending_flush_num);
     --(shard_stats.pending_flush_num);
   });

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1612,6 +1612,24 @@ void SeaStore::Shard::transaction_dump(ceph::os::Transaction &t) {
   ERROR("{}", str.str());
 }
 
+// Whether a client txn may be merged with others into one seastore batch
+// (build_next_batch). Default is yes, specific op patterns opt out and run solo.
+
+// Bathced pg-log trim (OP_OMAP_RMKEYS / OP_OMAP_RMKEYRANGE)
+static bool txn_is_batchable(ceph::os::Transaction& t)
+{
+  using ceph::os::Transaction;
+  auto i = t.begin();
+  while (i.have_op()) {
+    auto op = i.decode_op();
+    if (op->op == Transaction::OP_OMAP_RMKEYS ||
+        op->op == Transaction::OP_OMAP_RMKEYRANGE) {
+      return false;
+    }
+  }
+  return true;
+}
+
 seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
   CollectionRef _ch,
   ceph::os::Transaction&& _t)
@@ -1623,6 +1641,7 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
   auto& coll = static_cast<SeastoreCollection&>(*_ch);
   auto& entry = coll.pending_txns.emplace_back();
   entry.txn = std::move(_t);
+  entry.batchable = txn_is_batchable(entry.txn);
   auto fut = entry.pr.get_future();
   DEBUG("enqueue cid={} queue_depth={} in_flight={}",
         coll.get_cid(), coll.pending_txns.size(), coll.collection_in_flight);
@@ -1641,6 +1660,12 @@ ceph::os::Transaction SeaStore::Shard::build_next_batch(
   ceph::os::Transaction merged;
   bool first = true;
   while (!coll.pending_txns.empty()) {
+    const bool no_batch = !coll.pending_txns.front().batchable;
+    if (no_batch && !first) {
+      // Mid-batch: seal what we have and leave this txn to run as its own
+      // next batch (it will be `first` there and take the solo path below).
+      break;
+    }
     auto e = std::move(coll.pending_txns.front());
     coll.pending_txns.pop_front();
     if (first) {
@@ -1650,6 +1675,9 @@ ceph::os::Transaction SeaStore::Shard::build_next_batch(
       merged.append(e.txn);
     }
     pending_txns_promises.push_back(std::move(e.pr));
+    if (no_batch) {
+      break;
+    }
   }
   return merged;
 }

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1659,16 +1659,18 @@ ceph::os::Transaction SeaStore::Shard::build_next_batch(
 {
   ceph::os::Transaction merged;
   bool first = true;
+  uint64_t batch_features = 0;
   while (!coll.pending_txns.empty()) {
     const bool no_batch = !coll.pending_txns.front().batchable;
-    if (no_batch && !first) {
-      // Mid-batch: seal what we have and leave this txn to run as its own
-      // next batch (it will be `first` there and take the solo path below).
+    if (!first &&
+        (no_batch || coll.pending_txns.front().txn.get_data_features() != batch_features)) {
+      // Batch boundary: seal what we have so far in the batch
       break;
     }
     auto e = std::move(coll.pending_txns.front());
     coll.pending_txns.pop_front();
     if (first) {
+      batch_features = e.txn.get_data_features();
       merged = std::move(e.txn);
       first = false;
     } else {
@@ -1676,6 +1678,7 @@ ceph::os::Transaction SeaStore::Shard::build_next_batch(
     }
     pending_txns_promises.push_back(std::move(e.pr));
     if (no_batch) {
+      // no_batch runs solo (never is appended)
       break;
     }
   }

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <deque>
 #include <map>
 #include <optional>
 #include <string>
@@ -54,6 +55,13 @@ public:
     FuturizedCollection(std::forward<T>(args)...) {}
 
   seastar::shared_mutex ordering_lock;
+
+  struct batch_entry_t {
+    ceph::os::Transaction txn;
+    seastar::promise<> pr;
+  };
+  std::deque<batch_entry_t> pending_txns;
+  bool collection_in_flight = false;
 };
 
 /**
@@ -251,6 +259,12 @@ public:
         iter = ext_transaction.begin();
       }
     };
+
+    seastar::future<> dispatch_collection(CollectionRef ch);
+    ceph::os::Transaction build_next_batch(
+      SeastoreCollection& coll,
+      std::vector<seastar::promise<>>& pending_txns_promises);
+    seastar::future<> run_one_batch(CollectionRef ch, ceph::os::Transaction&& t);
 
     TransactionManager::read_extent_iertr::future<std::optional<unsigned>>
     get_coll_bits(CollectionRef ch, Transaction &t) const;

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -57,6 +57,7 @@ public:
   struct batch_entry_t {
     ceph::os::Transaction txn;
     seastar::promise<> pr;
+    bool batchable = true;
   };
   std::deque<batch_entry_t> pending_txns;
   bool collection_in_flight = false;

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -54,8 +54,6 @@ public:
   SeastoreCollection(T&&... args) :
     FuturizedCollection(std::forward<T>(args)...) {}
 
-  seastar::shared_mutex ordering_lock;
-
   struct batch_entry_t {
     ceph::os::Transaction txn;
     seastar::promise<> pr;

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -3292,7 +3292,6 @@ struct shard_stats_t {
   uint64_t repeat_io_num = 0;
   uint64_t pending_io_num = 0;
   uint64_t starting_io_num = 0;
-  uint64_t waiting_collock_io_num = 0;
   uint64_t waiting_throttler_io_num = 0;
   uint64_t processing_inlock_io_num = 0;
   uint64_t processing_postlock_io_num = 0;
@@ -3335,7 +3334,6 @@ struct shard_stats_t {
     repeat_io_num += o.repeat_io_num;
     pending_io_num += o.pending_io_num;
     starting_io_num += o.starting_io_num;
-    waiting_collock_io_num += o.waiting_collock_io_num;
     waiting_throttler_io_num += o.waiting_throttler_io_num;
     processing_inlock_io_num += o.processing_inlock_io_num;
     processing_postlock_io_num += o.processing_postlock_io_num;

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -622,7 +622,6 @@ TransactionManager::do_submit_transaction(
     journal->get_trimmer().get_journal_head(),
     journal->get_trimmer().get_dirty_tail());
 
-  tref.get_handle().maybe_release_collection_lock();
   if (tref.get_src() == Transaction::src_t::MUTATE) {
     --(shard_stats.processing_inlock_io_num);
     ++(shard_stats.processing_postlock_io_num);
@@ -664,7 +663,6 @@ seastar::future<> TransactionManager::flush(OrderingHandle &handle)
   }).then([this, &handle] {
     return handle.enter(write_pipeline.prepare);
   }).then([this, &handle] {
-    handle.maybe_release_collection_lock();
     return journal->flush(handle);
   }).then([FNAME, &handle] {
     SUBDEBUG(seastore_t, "H{} completed", (void*)&handle);

--- a/src/os/Transaction.h
+++ b/src/os/Transaction.h
@@ -395,6 +395,8 @@ public:
   }
   uint32_t get_fadvise_flags() { return data.fadvise_flags; }
 
+  uint64_t get_data_features() const { return data_features; }
+
   void swap(Transaction& other) noexcept {
     std::swap(data, other.data);
     std::swap(on_applied, other.on_applied);


### PR DESCRIPTION
backport of: https://github.com/ceph/ceph/pull/70180

note: the recent transaction breakdown metrics are not part of Umbrella, so this is not a manual backport.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
