### PR TITLE
os/bluestore: implement claim_range()

### DIFF
--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -53,6 +53,78 @@ public:
     return allocate(want_size, block_size, want_size, hint, extents);
   }
 
+  /*
+   * Reports whether this allocator implements claim_range().
+   *
+   * Support is all-or-nothing: an implementation that returns true must
+   * handle *every* legal range. It is illegal to support claim_range() for
+   * some ranges only - callers have no way to discover such a restriction
+   * and would silently skip the unsupported ones.
+   *
+   * Defaults to false: an allocator that does not opt in fails safe.
+   */
+  virtual bool supports_claim_range() const {
+    return false;
+  }
+
+  /*
+   * Claim an exact range of disk space, whatever its current state.
+   *
+   * Unlike allocate(), where 'hint' is advisory, [offset, offset + length)
+   * is binding: no space outside it is ever touched, and no space inside it
+   * is ever skipped.
+   * 
+   * Returns, the number of bytes newly allocated by this call, Zero means
+   * the range was fully allocated (or length was 0) and caller has nothing
+   * to do.
+   *
+   * POSTCONDITION
+   *   On return, every byte of [offset, offset + length) is allocated. The
+   *   parts that were already allocated are left as they were; the parts
+   *   that were free have been allocated by this call and are the ones
+   *   reported back.
+   *
+   * OUTPUT
+   *   Extents are appended to *extents, preserving existing entries as
+   *   allocate() does; callers should pass a fresh vector. Returned extents are
+   *   neither sorted nor coalesced. Extents are split at p2align(UINT32_MAX,
+   *   block_size) because bluestore_pextent_t::length is 32-bit.
+   *
+   * PRECONDITIONS (asserted - these are caller bugs, not runtime states)
+   *   - offset and length are multiples of block_size. 
+   *   - offset + length does not exceed the device capacity.
+   * 
+   *   Note this differs from init_rm_free(), which asserts on *state* (the
+   *   range not being free). claim_range() never asserts on state: any mix
+   *   of free and allocated space in the range is legal input.
+   *
+   * ATOMICITY
+   *   The whole operation runs under the allocator lock, so the range is
+   *   fully allocated by the time this returns and no concurrent allocate()
+   *   can hand out any part of it. This is why the interface exists at all:
+   *   the equivalent foreach() + init_rm_free() sequence has a window
+   *   between the two calls in which the free space can be given away.
+   *
+   * PERSISTENCE
+   *   Space claimed here is not recorded in the FreelistManager. On an
+   *   unclean shutdown it is simply free again after the allocator is
+   *   rebuilt at mount, which is the desired behaviour for transient
+   *   claims.
+   *
+   * INTENDED USE
+   *   Temporarily taking back space that was released but not yet acted on
+   *   - e.g. deferring BlockDevice::discard() past Allocator::release().
+   *   The range may by then be free, fully re-allocated, or partly both;
+   *   claim_range() pins whatever is still free so it cannot be handed out
+   *   while the operation is in flight, and reports exactly that subset so
+   *   the caller can release it again afterwards.
+   */
+  virtual int64_t claim_range(uint64_t offset, uint64_t length,
+                              PExtentVector *extents) {
+    ceph_abort_msg("claim_range() not implemented; "
+                   "check supports_claim_range() first");
+  }
+
   /* Bulk release. Implementations may override this method to handle the whole
    * set at once. This could save e.g. unnecessary mutex dance. */
   virtual void release(const release_set_t& release_set) = 0;

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -60,6 +60,61 @@ public:
     return allocate(want_size, block_size, want_size, hint, extents);
   }
 
+  /*
+   * Claim an exact range of disk space, whatever its current state.
+   *
+   * Unlike allocate(), where 'hint' is advisory, [offset, offset + length)
+   * is binding: no space outside it is ever touched, and no space inside it
+   * is ever skipped.
+   * 
+   * Returns, the number of bytes newly allocated by this call, Zero means
+   * the range was fully allocated (or length was 0) and caller has nothing
+   * to do.
+   *
+   * POSTCONDITION
+   *   On return, every byte of [offset, offset + length) is allocated. The
+   *   parts that were already allocated are left as they were; the parts
+   *   that were free have been allocated by this call and are the ones
+   *   reported back.
+   *
+   * OUTPUT
+   *   Extents are appended to *extents, preserving existing entries as
+   *   allocate() does; callers should pass a fresh vector. Returned extents are
+   *   neither sorted nor coalesced. Extents are split at p2align(UINT32_MAX,
+   *   block_size) because bluestore_pextent_t::length is 32-bit.
+   *
+   * PRECONDITIONS (asserted - these are caller bugs, not runtime states)
+   *   - offset and length are multiples of block_size. 
+   *   - offset + length does not exceed the device capacity.
+   * 
+   *   Note this differs from init_rm_free(), which asserts on *state* (the
+   *   range not being free). claim_range() never asserts on state: any mix
+   *   of free and allocated space in the range is legal input.
+   *
+   * ATOMICITY
+   *   The whole operation runs under the allocator lock, so the range is
+   *   fully allocated by the time this returns and no concurrent allocate()
+   *   can hand out any part of it. This is why the interface exists at all:
+   *   the equivalent foreach() + init_rm_free() sequence has a window
+   *   between the two calls in which the free space can be given away.
+   *
+   * PERSISTENCE
+   *   Space claimed here is not recorded in the FreelistManager. On an
+   *   unclean shutdown it is simply free again after the allocator is
+   *   rebuilt at mount, which is the desired behaviour for transient
+   *   claims.
+   *
+   * INTENDED USE
+   *   Temporarily taking back space that was released but not yet acted on
+   *   - e.g. deferring BlockDevice::discard() past Allocator::release().
+   *   The range may by then be free, fully re-allocated, or partly both;
+   *   claim_range() pins whatever is still free so it cannot be handed out
+   *   while the operation is in flight, and reports exactly that subset so
+   *   the caller can release it again afterwards.
+   */
+  virtual int64_t claim_range(uint64_t offset, uint64_t length,
+                              PExtentVector *extents) = 0;
+
   /* Bulk release. Implementations may override this method to handle the whole
    * set at once. This could save e.g. unnecessary mutex dance. */
   virtual void release(const release_set_t& release_set) = 0;

--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -332,6 +332,51 @@ int AvlAllocator::_allocate(
   return 0;
 }
 
+int64_t AvlAllocator::claim_range(
+  uint64_t offset,
+  uint64_t length,
+  PExtentVector *extents)
+{
+  std::lock_guard l(lock);
+  return _claim_range(offset, length, extents);
+}
+
+int64_t AvlAllocator::_claim_range(
+  uint64_t offset,
+  uint64_t length,
+  PExtentVector *extents)
+{
+  if (length == 0) {
+    return 0;
+  }
+  ceph_assert(p2aligned(offset, (uint64_t)block_size));
+  ceph_assert(p2aligned(length, (uint64_t)block_size));
+  ceph_assert(offset <= uint64_t(device_size));
+  ceph_assert(length <= uint64_t(device_size) - offset);
+
+  // bluestore_pextent_t::length is 32 bit, so a longer run has to be reported
+  // as several extents. Round down and align - the cap itself is not a
+  // multiple of block_size.
+  constexpr auto cap =
+    std::numeric_limits<decltype(bluestore_pextent_t::length)>::max();
+  const uint64_t max_extent_len = p2align(uint64_t(cap), (uint64_t)block_size);
+
+  uint64_t sum = 0;
+  _try_remove_from_tree(offset, length,
+    [&](uint64_t o, uint64_t l, bool found){
+      if (found) {
+        sum += l;
+        while (l > max_extent_len) {
+          extents->emplace_back(o, max_extent_len);
+          o += max_extent_len;
+          l -= max_extent_len;
+        }
+        extents->emplace_back(o, l);
+      }
+  });
+  return sum;
+}
+
 void AvlAllocator::_release(const release_set_t& release_set)
 {
   for (auto p = release_set.begin(); p != release_set.end(); ++p) {

--- a/src/os/bluestore/AvlAllocator.h
+++ b/src/os/bluestore/AvlAllocator.h
@@ -97,6 +97,8 @@ public:
   void init_add_free(uint64_t offset, uint64_t length) override;
   void init_rm_free(uint64_t offset, uint64_t length) override;
   void shutdown() override;
+  int64_t claim_range(uint64_t offset, uint64_t length,
+                       PExtentVector *extents) override;
 
 private:
   CephContext* cct;
@@ -293,6 +295,8 @@ protected:
   void _remove_from_tree(uint64_t start, uint64_t size);
   void _try_remove_from_tree(uint64_t start, uint64_t size,
     std::function<void(uint64_t offset, uint64_t length, bool found)> cb);
+  int64_t _claim_range(uint64_t offset, uint64_t length,
+                        PExtentVector *extents);
 
   uint64_t _get_free() const {
     return num_free;

--- a/src/os/bluestore/BitmapAllocator.cc
+++ b/src/os/bluestore/BitmapAllocator.cc
@@ -79,6 +79,24 @@ uint64_t BitmapAllocator::get_free_extents(
     });
 }
 
+int64_t BitmapAllocator::claim_range(
+  uint64_t offset,
+  uint64_t length,
+  PExtentVector* extents)
+{
+  if (length == 0) {
+    return 0;
+  }
+  auto mas = get_min_alloc_size();
+  ceph_assert(p2aligned(offset, (uint64_t)mas));
+  ceph_assert(p2aligned(length, (uint64_t)mas));
+  ceph_assert(offset <= uint64_t(device_size));
+  // written as a subtraction rather than 'offset + length <= device_size'
+  // so that a length near UINT64_MAX cannot wrap past the check
+  ceph_assert(length <= uint64_t(device_size) - offset);
+  return claim_range_internal(offset, length, extents);
+}
+
 void BitmapAllocator::init_add_free(uint64_t offset, uint64_t length)
 {
   ldout(cct, 10) << __func__ << " 0x" << std::hex << offset << "~" << length

--- a/src/os/bluestore/BitmapAllocator.h
+++ b/src/os/bluestore/BitmapAllocator.h
@@ -59,6 +59,9 @@ public:
     return get_fragmentation_internal();
   }
 
+  int64_t claim_range(uint64_t offset, uint64_t length,
+                       PExtentVector *extents) override;
+
   void init_add_free(uint64_t offset, uint64_t length) override;
   void init_rm_free(uint64_t offset, uint64_t length) override;
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7039,6 +7039,7 @@ void BlueStore::_main_bdev_label_try_reserve()
       }
     }
   };
+  // TODO: Naveen: allocate_here() will help here ?
   // Iterating over free is very inefficient.
   // We can do it here only because its only on init, otherwise it would be unacceptable.
   // Here we could use some API like: alloc->allocate_at().

--- a/src/os/bluestore/Btree2Allocator.cc
+++ b/src/os/bluestore/Btree2Allocator.cc
@@ -2,6 +2,9 @@
 // vim: ts=8 sw=2 sts=2 expandtab
 
 #include "Btree2Allocator.h"
+
+#include <limits>
+
 #include "common/debug.h"
 
 #define dout_context (get_context())
@@ -406,6 +409,51 @@ void Btree2Allocator::_try_remove_from_tree(uint64_t start, uint64_t size,
   if (start < end) {
     cb(start, end - start, false);
   }
+}
+
+int64_t Btree2Allocator::claim_range(
+  uint64_t offset,
+  uint64_t length,
+  PExtentVector *extents)
+{
+  std::lock_guard l(lock);
+  return _claim_range(offset, length, extents);
+}
+
+int64_t Btree2Allocator::_claim_range(
+  uint64_t offset,
+  uint64_t length,
+  PExtentVector *extents)
+{
+  if (length == 0) {
+    return 0;
+  }
+  ceph_assert(p2aligned(offset, (uint64_t)block_size));
+  ceph_assert(p2aligned(length, (uint64_t)block_size));
+  ceph_assert(offset <= uint64_t(device_size));
+  ceph_assert(length <= uint64_t(device_size) - offset);
+
+  // bluestore_pextent_t::length is 32 bit, so a longer run has to be reported
+  // as several extents. Round down and align - the cap itself is not a
+  // multiple of block_size.
+  constexpr auto cap =
+    std::numeric_limits<decltype(bluestore_pextent_t::length)>::max();
+  const uint64_t max_extent_len = p2align(uint64_t(cap), (uint64_t)block_size);
+
+  uint64_t sum = 0;
+  _try_remove_from_tree(offset, length,
+    [&](uint64_t o, uint64_t l, bool found){
+      if (found) {
+        sum += l;
+        while (l > max_extent_len) {
+          extents->emplace_back(o, max_extent_len);
+          o += max_extent_len;
+          l -= max_extent_len;
+        }
+        extents->emplace_back(o, l);
+      }
+  });
+  return sum;
 }
 
 int64_t Btree2Allocator::__allocate(

--- a/src/os/bluestore/Btree2Allocator.h
+++ b/src/os/bluestore/Btree2Allocator.h
@@ -103,6 +103,9 @@ public:
 
   void release(const release_set_t& release_set) override;
 
+  int64_t claim_range(uint64_t offset, uint64_t length,
+                       PExtentVector *extents) override;
+
   uint64_t get_free() override {
     return num_free;
   }
@@ -266,6 +269,8 @@ protected:
    */
   void _try_remove_from_tree(uint64_t start, uint64_t size,
     std::function<void(uint64_t offset, uint64_t length, bool found)> cb);
+  int64_t _claim_range(uint64_t offset, uint64_t length,
+                        PExtentVector *extents);
   bool has_cache() const {
     return !!cache;
   }

--- a/src/os/bluestore/BtreeAllocator.cc
+++ b/src/os/bluestore/BtreeAllocator.cc
@@ -222,6 +222,56 @@ void BtreeAllocator::_try_remove_from_tree(uint64_t start, uint64_t size,
   }
 }
 
+int64_t BtreeAllocator::claim_range(
+  uint64_t offset,
+  uint64_t length,
+  PExtentVector *extents)
+{
+  std::lock_guard l(lock);
+  return _claim_range(offset, length, extents);
+}
+
+int64_t BtreeAllocator::_claim_range(
+  uint64_t offset,
+  uint64_t length,
+  PExtentVector *extents)
+{
+  if (length == 0) {
+    return 0;
+  }
+  ceph_assert(p2aligned(offset, (uint64_t)block_size));
+  ceph_assert(p2aligned(length, (uint64_t)block_size));
+  ceph_assert(offset <= uint64_t(device_size));
+  ceph_assert(length <= uint64_t(device_size) - offset);
+
+  ldout(cct, 10) << __func__ << std::hex
+                 << " offset 0x" << offset
+                 << " length 0x" << length
+                 << std::dec << dendl;
+
+  // bluestore_pextent_t::length is 32 bit, so a longer run has to be reported
+  // as several extents. Round down and align - the cap itself is not a
+  // multiple of block_size.
+  constexpr auto cap =
+    std::numeric_limits<decltype(bluestore_pextent_t::length)>::max();
+  const uint64_t max_extent_len = p2align(uint64_t(cap), (uint64_t)block_size);
+
+  uint64_t sum = 0;
+  _try_remove_from_tree(offset, length,
+    [&](uint64_t o, uint64_t l, bool found){
+      if (found) {
+        sum += l;
+        while (l > max_extent_len) {
+          extents->emplace_back(o, max_extent_len);
+          o += max_extent_len;
+          l -= max_extent_len;
+        }
+        extents->emplace_back(o, l);
+      }
+  });
+  return sum;
+}
+
 int64_t BtreeAllocator::_allocate(
   uint64_t want,
   uint64_t unit,

--- a/src/os/bluestore/BtreeAllocator.h
+++ b/src/os/bluestore/BtreeAllocator.h
@@ -80,6 +80,10 @@ public:
     int64_t  hint,
     PExtentVector *extents) override;
   void release(const interval_set<uint64_t>& release_set) override;
+
+  int64_t claim_range(uint64_t offset, uint64_t length,
+                      PExtentVector *extents) override;
+
   uint64_t get_free() override;
   double get_fragmentation() override;
 
@@ -202,6 +206,8 @@ private:
   void _remove_from_tree(uint64_t start, uint64_t size);
   void _try_remove_from_tree(uint64_t start, uint64_t size,
     std::function<void(uint64_t offset, uint64_t length, bool found)> cb);
+  int64_t _claim_range(uint64_t offset, uint64_t length,
+    PExtentVector *extents);
 
   uint64_t _get_free() const {
     return num_free;

--- a/src/os/bluestore/HybridAllocator.h
+++ b/src/os/bluestore/HybridAllocator.h
@@ -56,6 +56,8 @@ public:
     }
   }
   void init_rm_free(uint64_t offset, uint64_t length) override;
+  int64_t claim_range(uint64_t offset, uint64_t length,
+                      PExtentVector *extents) override;
 
   void expand(int64_t new_size) override {
     std::lock_guard l(PrimaryAllocator::get_lock());

--- a/src/os/bluestore/HybridAllocator_impl.h
+++ b/src/os/bluestore/HybridAllocator_impl.h
@@ -117,6 +117,23 @@ void HybridAllocatorBase<T>::init_rm_free(uint64_t offset, uint64_t length)
 }
 
 template <typename T>
+int64_t HybridAllocatorBase<T>::claim_range(
+  uint64_t offset,
+  uint64_t length,
+  PExtentVector *extents)
+{
+  if (length == 0) {
+    return 0;
+  }
+  std::lock_guard l(T::get_lock());
+  int64_t claimed = T::_claim_range(offset, length, extents);
+  if (bmap_alloc) {
+    claimed += bmap_alloc->claim_range(offset, length, extents);
+  }
+  return claimed;
+}
+
+template <typename T>
 void HybridAllocatorBase<T>::_spillover_range(uint64_t start, uint64_t end)
 {
   auto size = end - start;

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -2,6 +2,9 @@
 // vim: ts=8 sw=2 sts=2 expandtab
 
 #include "StupidAllocator.h"
+
+#include <limits>
+
 #include "bluestore_types.h"
 #include "common/debug.h"
 
@@ -401,6 +404,73 @@ void StupidAllocator::init_rm_free(uint64_t offset, uint64_t length)
   ceph_assert(num_free >= 0);
 }
 
+int64_t StupidAllocator::claim_range(uint64_t offset, uint64_t length, PExtentVector *extents)
+{
+  if (length == 0) {
+    return 0;
+  }
+
+  ceph_assert(p2aligned(offset, (uint64_t)block_size));
+  ceph_assert(p2aligned(length, (uint64_t)block_size));
+  ceph_assert(offset <= uint64_t(device_size));
+  ceph_assert(length <= uint64_t(device_size) - offset);
+
+  // bluestore_pextent_t::length is 32 bit, so a longer run has to be reported
+  // as several extents. Round down and align - the cap itself is not a
+  // multiple of block_size.
+  constexpr auto cap =
+    std::numeric_limits<decltype(bluestore_pextent_t::length)>::max();
+  const uint64_t max_extent_len = p2align(uint64_t(cap), (uint64_t)block_size);
+
+  std::lock_guard l(lock);
+  uint64_t sum = 0;
+  ldout(cct, 10) << __func__ << " 0x" << std::hex << offset << "~" << length
+	   	 << std::dec << dendl;
+  interval_set_t rm;
+  rm.insert(offset, length);
+  for (unsigned i = 0; i < free.size() && !rm.empty(); ++i) {
+    interval_set_t overlap;
+    overlap.intersection_of(rm, free[i]);
+    if (!overlap.empty()) {
+      ldout(cct, 20) << __func__ << " bin " << i << " rm 0x" << std::hex << overlap
+		     << std::dec << dendl;
+      auto it = overlap.begin();
+      auto it_end = overlap.end();
+      while (it != it_end) {
+        auto o = it.get_start();
+        auto l = it.get_len();
+
+        free[i].erase(o, l,
+          [&](uint64_t off, uint64_t len) {
+            unsigned newbin = _choose_bin(len);
+            if (newbin != i) {
+              ldout(cct, 30) << __func__ << " demoting1 0x" << std::hex << off << "~" << len
+                             << std::dec << " to bin " << newbin << dendl;
+              _insert_free(off, len);
+              return true;
+            }
+            return false;
+          });
+        
+        // Add the allocated extent to the PExtentVector
+        sum += l;
+        while (l > max_extent_len) {
+          extents->emplace_back(o, max_extent_len);
+          o += max_extent_len;
+          l -= max_extent_len;
+        }
+        extents->emplace_back(o, l);
+
+        ++it;
+      }
+
+      rm.subtract(overlap);
+    }
+  }
+  ceph_assert(uint64_t(num_free) >= sum);
+  num_free -= sum;
+  return sum;
+}
 
 void StupidAllocator::shutdown()
 {

--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -68,6 +68,8 @@ public:
   void init_add_free(uint64_t offset, uint64_t length) override;
   void init_rm_free(uint64_t offset, uint64_t length) override;
 
+  int64_t claim_range(uint64_t offset, uint64_t length,
+                       PExtentVector *extents) override;
   void shutdown() override;
 };
 

--- a/src/os/bluestore/fastbmap_allocator_impl.h
+++ b/src/os/bluestore/fastbmap_allocator_impl.h
@@ -14,6 +14,7 @@
 #include <bit>
 #include <vector>
 #include <algorithm>
+#include <limits>
 #include <mutex>
 #include <string_view>
 #include <utility>
@@ -766,6 +767,73 @@ public:
     uint64_t cursor =
       l1.get_free_extents_internal(l0_pos_start, l0_pos_end, max_count, emit);
     return cursor >= l0_pos_end ? range_end : cursor * alloc_size;
+  }
+
+  // [start, end) L0 bits covering the byte range.
+  std::pair<uint64_t, uint64_t> bytes_to_l0_bit(
+    uint64_t offset, uint64_t length) const
+  {
+    auto au = get_min_alloc_size();
+    return { offset / au, p2roundup(offset + length, au) / au };
+  }
+
+  // [start, end) L2 bits covering the byte range.
+  std::pair<uint64_t, uint64_t> bytes_to_l2_bit(
+    uint64_t offset, uint64_t length) const
+  {
+    return { offset / l2_granularity,
+             p2roundup(offset + length, l2_granularity) / l2_granularity };
+  }
+
+  int64_t claim_range_internal(
+    uint64_t offset,
+    uint64_t length,
+    PExtentVector* extents)
+  {
+    const uint64_t alloc_size = get_min_alloc_size();
+
+    // bluestore_pextent_t::length is 32 bit, so a longer run has to be
+    // reported as several extents. Round down and align -- the cap itself
+    // is not a multiple of the allocation unit.
+    constexpr uint64_t cap =
+      std::numeric_limits<decltype(bluestore_pextent_t::length)>::max();
+    const uint64_t max_units = p2align(cap, alloc_size) / alloc_size;
+
+    // (start, len) pairs in L0 units. Collected before anything is marked:
+    // we must not mutate l0/l1 while the walk is reading them.
+    std::vector<std::pair<uint64_t, uint64_t>> free_runs;
+    uint64_t units = 0;
+
+    auto [l0_pos_start, l0_pos_end] = bytes_to_l0_bit(offset, length);
+
+    std::lock_guard l(lock);
+    l1.get_free_extents_internal(
+      l0_pos_start, l0_pos_end, 0,
+      [&](uint64_t o, uint64_t len) {
+        units += len;
+        while (len > max_units) {
+          free_runs.emplace_back(o, max_units);
+          o += max_units;
+          len -= max_units;
+        }
+        free_runs.emplace_back(o, len);
+      });
+
+    // Mark each run allocated at L0 and refresh the L1 summaries covering it,
+    // then report it in bytes. Runs are alloc-unit aligned by construction.
+    for (auto& [start, len] : free_runs) {
+      l1._mark_alloc_l1_l0(int64_t(start), int64_t(start + len));
+      extents->emplace_back(start * alloc_size, len * alloc_size);
+    }
+
+    // Re-summarize L2 over the whole window in one pass.
+    auto [l2_pos_start, l2_pos_end] = bytes_to_l2_bit(offset, length);
+    _mark_l2_on_l1(l2_pos_start, l2_pos_end);
+
+    const int64_t claimed = units * alloc_size;
+    ceph_assert(available >= claimed);
+    available -= claimed;
+    return claimed;
   }
 
   double get_fragmentation_internal() {

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -6,6 +6,7 @@
  * Author: Ramesh Chander, Ramesh.Chander@sandisk.com
  */
 #include <iostream>
+#include <thread>
 #include <boost/random/mersenne_twister.hpp> // for boost::mt11213b
 #include <boost/scoped_ptr.hpp>
 #include <gtest/gtest.h>
@@ -19,6 +20,7 @@
 using namespace std;
 
 typedef boost::mt11213b gen_type;
+
 
 class AllocTest : public ::testing::TestWithParam<const char*> {
 
@@ -794,6 +796,225 @@ TEST_P(AllocTest, test_alloc_spatial_locality)
   }
 }
 
+// ====================================================================
+// claim_range
+// ====================================================================
+
+struct ClaimResult {
+  PExtentVector extents;
+  uint64_t claimed;
+};
+
+ClaimResult check_claim(Allocator *a, uint64_t offset, uint64_t length)
+{
+  // free space before the allocate call
+  interval_set<uint64_t> f_before;
+  a->foreach([&](uint64_t off, uint64_t len){
+    f_before.insert(off, len);
+  });
+  uint64_t free_before = a->get_free();
+
+  PExtentVector extents;
+  int64_t claimed = a->claim_range(offset, length, &extents);
+
+  interval_set<uint64_t> claimed_space;
+  for (auto& e : extents) {
+    claimed_space.insert(e.offset, e.length);
+  }
+
+  // claimed is the count of bytes newly allocated
+  EXPECT_EQ(claimed, static_cast<int64_t>(claimed_space.size()));
+
+  // Nothing outside [offset, offset+length) was reported.
+  // interval_set is strict - insert() asserts on a zero length - so the
+  // range-based invariants below are expressed against the empty set when
+  // length == 0. A zero-length claim can only be a no-op, which is exactly
+  // what "claimed_space is empty" says.
+  interval_set<uint64_t> requested;
+  if (length) {
+    requested.insert(offset, length);
+  }
+  EXPECT_TRUE(requested.contains(claimed_space))
+    << "claim_range() reported space outside the requested range";
+
+  interval_set<uint64_t> f_after;
+  a->foreach([&](uint64_t off, uint64_t len){
+    f_after.insert(off, len);
+  });
+
+  // free space lost exactly the claimed bytes
+  f_before.subtract(claimed_space);
+  EXPECT_EQ(f_before, f_after);
+
+  // no free space was left in the requested range
+  if (length) {
+    EXPECT_FALSE(f_after.intersects(offset, length));
+  }
+
+  // get_free() is a hand-maintained counter in some backends; check it
+  // independently of the foreach()-derived view above.
+  EXPECT_EQ(free_before - claimed, a->get_free());
+
+  return {std::move(extents), static_cast<uint64_t>(claimed)};
+}
+
+TEST_P(AllocTest, test_claim_range_zero_length)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 1024 * block_size;
+
+  init_alloc(capacity, block_size);
+  alloc->init_add_free(0, capacity);
+
+  auto free_before = alloc->get_free();
+
+  // length == 0 in the middle of a free range
+  auto result = check_claim(alloc.get(), block_size * 4, 0);
+  EXPECT_EQ(0u, result.claimed);
+  EXPECT_TRUE(result.extents.empty());
+  EXPECT_EQ(free_before, alloc->get_free());
+
+  // length == 0 at offset == capacity
+  result = check_claim(alloc.get(), capacity, 0);
+  EXPECT_EQ(0u, result.claimed);
+  EXPECT_TRUE(result.extents.empty());
+  EXPECT_EQ(free_before, alloc->get_free());
+}
+
+TEST_P(AllocTest, test_claim_range_geometry)
+{
+  int64_t block_size = 4096;
+
+  struct GeometryCase {
+    const char *name;
+    uint64_t capacity_blocks;
+    uint64_t req_off_blocks;
+    uint64_t req_len_blocks;
+    // {offset, length} pairs, in blocks, passed to init_add_free()
+    std::vector<std::pair<uint64_t, uint64_t>> free_runs_blocks;
+    uint64_t expected_claimed_blocks;
+  };
+
+  // unless noted, request range is blocks [8, 16) on a 32-block device
+  const std::vector<GeometryCase> cases = {
+    {"interior",         32, 8, 8, {{10, 4}},                     4},
+    {"left_flush",       32, 8, 8, {{8, 4}},                      4},
+    {"right_flush",      32, 8, 8, {{12, 4}},                     4},
+    {"straddle_left",    32, 8, 8, {{4, 8}},                      4},
+    {"straddle_right",   32, 8, 8, {{12, 8}},                     4},
+    {"straddle_both",    32, 8, 8, {{2, 24}},                     8},
+    {"outside_left",     32, 8, 8, {{4, 4}},                      0},
+    {"outside_right",    32, 8, 8, {{16, 4}},                     0},
+    {"fully_free",       32, 8, 8, {{0, 32}},                     8},
+    {"fully_allocated",  32, 8, 8, {},                            0},
+    {"alternating",      32, 8, 8, {{8, 1}, {10, 1}, {12, 1}, {14, 1}}, 4},
+    {"starts_at_zero",    8, 0, 4, {{0, 8}},                      4},
+    {"ends_at_capacity",  8, 4, 4, {{0, 8}},                      4},
+    {"single_block",     32, 8, 1, {{8, 1}},                      1},
+  };
+
+  for (auto& c : cases) {
+    SCOPED_TRACE(c.name);
+    init_alloc(c.capacity_blocks * block_size, block_size);
+    for (auto& [off, len] : c.free_runs_blocks) {
+      alloc->init_add_free(off * block_size, len * block_size);
+    }
+
+    auto result = check_claim(alloc.get(),
+                               c.req_off_blocks * block_size,
+                               c.req_len_blocks * block_size);
+    EXPECT_EQ(c.expected_claimed_blocks * block_size, result.claimed);
+    if (c.expected_claimed_blocks == 0) {
+      EXPECT_TRUE(result.extents.empty());
+    }
+  }
+}
+
+TEST_P(AllocTest, test_claim_range_round_trip)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 32 * block_size;
+
+  init_alloc(capacity, block_size);
+
+  // partial overlap: free run [10,14) sits inside the request range [8,16),
+  // so the claim actually changes state instead of being a degenerate
+  // fully-free/fully-allocated case.
+  alloc->init_add_free(10 * block_size, 4 * block_size);
+
+  interval_set<uint64_t> f_before;
+  alloc->foreach([&](uint64_t off, uint64_t len) {
+    f_before.insert(off, len);
+  });
+  uint64_t free_before = alloc->get_free();
+
+  auto claim1 = check_claim(alloc.get(), 8 * block_size, 8 * block_size);
+  EXPECT_EQ(4u * block_size, claim1.claimed);
+
+  // idempotency: claiming the same range again, without releasing first,
+  // must report nothing new - the range is now fully allocated.
+  auto claim2 = check_claim(alloc.get(), 8 * block_size, 8 * block_size);
+  EXPECT_EQ(0u, claim2.claimed);
+  EXPECT_TRUE(claim2.extents.empty());
+
+  // round trip: releasing exactly what claim_range() reported must restore
+  // the free set byte-identically to what it was before the claim.
+  alloc->release(claim1.extents);
+
+  interval_set<uint64_t> f_after_release;
+  alloc->foreach([&](uint64_t off, uint64_t len) {
+    f_after_release.insert(off, len);
+  });
+  EXPECT_EQ(f_before, f_after_release);
+  EXPECT_EQ(free_before, alloc->get_free());
+}
+
+TEST_P(AllocTest, test_claim_range_concurrent)
+{
+  int64_t block_size = 4096;
+  int64_t capacity = 1024 * block_size;
+
+  init_alloc(capacity, block_size);
+  alloc->init_add_free(0, capacity);
+
+  uint64_t free_before = alloc->get_free();
+
+  const size_t num_threads = 8;
+  uint64_t claim_offset = 0;
+  uint64_t claim_length = capacity;
+
+  // Each thread writes only its own slot - no data race on these vectors.
+  // The only shared touchpoint is alloc itself, which is what's under test.
+  std::vector<int64_t> claimed_per_thread(num_threads, 0);
+  std::vector<PExtentVector> extents_per_thread(num_threads);
+  std::vector<std::thread> threads;
+
+  for (size_t i = 0; i < num_threads; ++i) {
+    threads.push_back(std::thread([&, i]() {
+      claimed_per_thread[i] =
+        alloc->claim_range(claim_offset, claim_length, &extents_per_thread[i]);
+    }));
+  }
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  // Every free byte went to exactly one thread: never zero, never two.
+  // A missing or wrong lock around claim_range() fails this immediately,
+  // either as a size mismatch below or as an overlap assert on insert().
+  int64_t total_claimed = 0;
+  interval_set<uint64_t> all_claimed;
+  for (size_t i = 0; i < num_threads; ++i) {
+    total_claimed += claimed_per_thread[i];
+    for (auto& e : extents_per_thread[i]) {
+      all_claimed.insert(e.offset, e.length);
+    }
+  }
+
+  EXPECT_EQ(static_cast<uint64_t>(total_claimed), free_before);
+  EXPECT_EQ(all_claimed.size(), free_before);
+  EXPECT_EQ(0u, alloc->get_free());
+}
 
 // ====================================================================
 // get_free_extents tests


### PR DESCRIPTION
Closes: https://tracker.ceph.com/issues/76421

### NOTE:

This PR depends on the PR https://github.com/ceph/ceph/pull/71656 to be merged. That PR fixes some lookup bugs in BtreeAllocator and Btree2Allocator which becomes evident when used with claim_range

## Brief Explanation

Currently `BlueStore::Allocator::allocate()` accepts a hint, but it is purely advisory, the allocator is free to ignore it. There is no way to take a specific range of disk space atomically. This is required for a future lazy discard policy.

Discards and Release are currently tightly coupled in `BlueStore::_txc_release_alloc`. The released space is not immediately usable by `allocate()` until the discard has happened. This coupling is wasteful as the space that got discarded might get reused anyway - wasting precious compute and time. Lazy discard wants to flip this: we want to release immediately (space reusable right away), and defer/batch the actual discard. 

When the discard thread is ready to act on a released range, that range may still be free, may be fully re-allocated (re-used by new writes), or partially both. The equivalent foreach() + init_rm_free() sequence has a window between the two calls in which free space can be given away by a concurrent allocate().

For example:

```
(T0): space is released
(T1): space reused by a new write 
(T2): deferred discard finally fires
```

A discard issued at T2 based on stale info would wipe out the T1 write's live data. 

`claim_range()` closes this: right before firing the deferred discard, atomically re-claim whatever part of the range is *still* free (excluding whatever got reused), and only discard that returned sub-range.

This PR adds `claim_range(offset, length, *extents)` as a pure virtual on Allocator. It atomically marks the entire `[offset, offset+length)` range as allocated under the allocator lock, and reports back only the sub-ranges that were previously free (i.e. what was actually newly claimed). Already-allocated parts are untouched. Unlike `init_rm_free()`, `claim_range()` never asserts on state: any mix of free and allocated space in the range is legal input.

In future, one can use this function like so:

```
discard(start, end):
   extents <- claim_range(start, end)
   actual_discard(extents)
```

## Implementation

  claim_range() is implemented for all six in-tree backends:

  - AvlAllocator — thin wrapper around _try_remove_from_tree()
  - BtreeAllocator — same shape, after fixing _try_remove_from_tree() bugs
  - Btree2Allocator — same shape, after fixing _try_remove_from_tree() bugs
  - BitmapAllocator — new walk over the L0/L1/L2 bitmap hierarchy
  - StupidAllocator — adapted from init_rm_free(), drops the state assert, fixes num_free accounting
  - HybridAllocator — delegates to primary tree + fallback bitmap

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
