### PR TITLE
test/osd: add op scheduler isolation benchmarks

### DIFF
--- a/src/test/osd/CMakeLists.txt
+++ b/src/test/osd/CMakeLists.txt
@@ -215,6 +215,24 @@ target_link_libraries(unittest_mclock_scheduler
   global osd dmclock os
 )
 
+# unittest_scheduler_isolation
+add_executable(unittest_scheduler_isolation
+  TestSchedulerIsolation.cc
+)
+add_ceph_unittest(unittest_scheduler_isolation)
+target_link_libraries(unittest_scheduler_isolation
+  global osd dmclock os
+)
+
+# ceph_bench_op_scheduler: isolation micro benchmarks across the op
+# schedulers; a manual tool, not part of the unit test suite
+add_executable(ceph_bench_op_scheduler
+  bench_op_scheduler.cc
+)
+target_link_libraries(ceph_bench_op_scheduler
+  global osd dmclock os
+)
+
 # unittest ECOmapJournal
 add_executable(unittest_ec_omap_journal
   test_ec_omap_journal.cc
@@ -243,6 +261,7 @@ set(OSD_UNITTESTS
   unittest_peeringstate
   unittest_pg_transaction
   unittest_pglog
+  unittest_scheduler_isolation
   unittest_scrubber_be
 )
 

--- a/src/test/osd/TestSchedulerIsolation.cc
+++ b/src/test/osd/TestSchedulerIsolation.cc
@@ -1,0 +1,98 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Sanity checks for the scheduler_bench.h harness, run against the
+ * in-tree op schedulers.  The harness paces in wall time, which is
+ * unfit for shared CI executors, so these tests SKIP unless
+ * CEPH_TEST_SCHEDULER_ISOLATION is set in the environment.  Bounds
+ * are deliberately loose even then.  The full comparative study lives
+ * in ceph_bench_op_scheduler.
+ */
+
+#include <cstdlib>
+
+#include "gtest/gtest.h"
+
+#include "global/global_context.h"
+#include "global/global_init.h"
+#include "common/common_init.h"
+
+#include "scheduler_bench.h"
+
+using namespace scheduler_bench;
+
+int main(int argc, char **argv) {
+  std::vector<const char*> args(argv, argv+argc);
+  auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_OSD,
+			 CODE_ENVIRONMENT_UTILITY,
+			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  common_init_finish(g_ceph_context);
+
+  // calibrate mclock's capacity model to the simulated device rate
+  // used below, as ceph_bench_op_scheduler does
+  g_ceph_context->_conf.set_val(
+    "osd_mclock_max_sequential_bandwidth_ssd", "100000000");
+  g_ceph_context->_conf.set_val(
+    "osd_mclock_max_capacity_iops_ssd",
+    std::to_string(100e6 / 65536.0));
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+namespace {
+
+constexpr double kRate = 100e6;  // simulated device, bytes/sec
+
+const std::vector<op_queue_type_t> kTypes = {
+  op_queue_type_t::WeightedPriorityQueue,
+  op_queue_type_t::mClockScheduler,
+};
+
+}
+
+// wall-clock pacing is unreliable on shared CI executors; opt in
+#define REQUIRE_ISOLATION_ENV()						\
+  do {									\
+    if (!std::getenv("CEPH_TEST_SCHEDULER_ISOLATION")) {		\
+      GTEST_SKIP()							\
+	<< "set CEPH_TEST_SCHEDULER_ISOLATION=1 to run "		\
+	   "wall-clock isolation checks";				\
+    }									\
+  } while (0)
+
+// A single backlogged stream must be served at ~the simulated device
+// rate: the harness pacing is intact and the scheduler under test is
+// work conserving.
+TEST(SchedulerBenchSmoke, WorkConserving) {
+  REQUIRE_ISOLATION_ENV();
+  for (auto type : kTypes) {
+    std::vector<StreamSpec> specs = {
+      {.name = "only", .pool = 1, .first_owner = 1, .num_owners = 1},
+    };
+    auto r = run_cell(g_ceph_context, type, specs, kRate, 2.0, 0.5);
+    EXPECT_GT(r.total_mbps, 50.0)
+      << get_op_queue_type_name(type) << " under-served the device";
+    EXPECT_LT(r.total_mbps, 140.0)
+      << get_op_queue_type_name(type) << " overran the simulated device";
+  }
+}
+
+// Two identical backlogged single-session streams must both make
+// sustained progress; neither wpq (owner round robin) nor mclock
+// (FIFO within a class) may starve one outright.
+TEST(SchedulerBenchSmoke, EqualStreamsBothServed) {
+  REQUIRE_ISOLATION_ENV();
+  for (auto type : kTypes) {
+    std::vector<StreamSpec> specs = {
+      {.name = "a", .pool = 1, .first_owner = 1, .num_owners = 1},
+      {.name = "b", .pool = 2, .first_owner = 100, .num_owners = 1},
+    };
+    auto r = run_cell(g_ceph_context, type, specs, kRate, 2.0, 0.5);
+    EXPECT_GT(r.streams.at("a").share, 0.2)
+      << get_op_queue_type_name(type) << " starved stream a";
+    EXPECT_GT(r.streams.at("b").share, 0.2)
+      << get_op_queue_type_name(type) << " starved stream b";
+  }
+}

--- a/src/test/osd/bench_op_scheduler.cc
+++ b/src/test/osd/bench_op_scheduler.cc
@@ -1,0 +1,179 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * ceph_bench_op_scheduler
+ *
+ * Isolation micro benchmarks comparing the OSD op schedulers (wpq,
+ * mclock_scheduler) on identical synthetic workloads with a simulated
+ * device drain rate.  See scheduler_bench.h for the harness.
+ *
+ * Usage:
+ *   ceph_bench_op_scheduler [--rate-mb N] [--secs S] [--csv FILE]
+ *                           [--scenario share|latency|recovery|all]
+ */
+
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "global/global_context.h"
+#include "global/global_init.h"
+#include "common/common_init.h"
+
+#include "scheduler_bench.h"
+
+using namespace scheduler_bench;
+
+namespace {
+
+struct Options {
+  double rate_mb = 100.0;
+  double secs = 3.0;
+  double warmup = 0.5;
+  std::string scenario = "all";
+  std::string csv_path;
+};
+
+const std::vector<op_queue_type_t> kTypes = {
+  op_queue_type_t::WeightedPriorityQueue,
+  op_queue_type_t::mClockScheduler,
+};
+
+std::ofstream csv;
+
+void report_cell(const std::string &scenario, const std::string &cell,
+		 op_queue_type_t type,
+		 const std::vector<StreamSpec> &specs,
+		 const CellResult &r)
+{
+  for (const auto &s : specs) {
+    const auto &sr = r.streams.at(s.name);
+    std::printf("  %-16s %-14s %8.1f %7.3f %8.1f %9.1f\n",
+		std::string(get_op_queue_type_name(type)).c_str(),
+		s.name.c_str(), sr.mbps, sr.share, sr.p50_ms, sr.p99_ms);
+    if (csv.is_open()) {
+      csv << scenario << ',' << cell << ','
+	  << get_op_queue_type_name(type) << ',' << s.name << ','
+	  << sr.ops << ',' << sr.bytes << ',' << sr.share << ','
+	  << sr.mbps << ',' << sr.p50_ms << ',' << sr.p99_ms << '\n';
+    }
+  }
+}
+
+void run_matrix(const Options &opt, const std::string &scenario,
+		const std::string &cell,
+		const std::vector<StreamSpec> &specs)
+{
+  std::printf("--- %s / %s (device %.0f MB/s, %.1fs)\n",
+	      scenario.c_str(), cell.c_str(), opt.rate_mb, opt.secs);
+  std::printf("  %-16s %-14s %8s %7s %8s %9s\n",
+	      "scheduler", "stream", "MB/s", "share", "p50ms", "p99ms");
+  for (auto type : kTypes) {
+    auto r = run_cell(g_ceph_context, type, specs,
+		      opt.rate_mb * 1e6, opt.secs, opt.warmup);
+    report_cell(scenario, cell, type, specs, r);
+  }
+  std::printf("\n");
+}
+
+// A1: both streams saturating; the aggressor fans out over K client
+// sessions.  Isolation == the victim's share is insensitive to K.
+void scenario_share(const Options &opt)
+{
+  for (unsigned k : {1u, 4u, 16u}) {
+    std::vector<StreamSpec> specs = {
+      {.name = "victim_rbd", .pool = 1, .first_owner = 1, .num_owners = 1},
+      {.name = "aggr_rgw", .pool = 2, .first_owner = 100, .num_owners = k},
+    };
+    run_matrix(opt, "share", "sessions=" + std::to_string(k), specs);
+  }
+}
+
+// A2: paced victim (20% of device rate) vs a saturating 8-session
+// aggressor.  Isolation == the victim keeps its offered throughput
+// with bounded queueing delay.
+void scenario_latency(const Options &opt)
+{
+  const double victim_ops = opt.rate_mb * 1e6 * 0.2 / 65536.0;
+  std::vector<StreamSpec> specs = {
+    {.name = "victim_rbd", .pool = 1, .first_owner = 1, .num_owners = 1,
+     .offered_ops_per_sec = victim_ops},
+    {.name = "aggr_rgw", .pool = 2, .first_owner = 100, .num_owners = 8},
+  };
+  run_matrix(opt, "latency", "victim=20%,sessions=8", specs);
+}
+
+// B: saturating client stream vs saturating recovery stream (1M
+// chunks, DEGRADED priority encoding).
+void scenario_recovery(const Options &opt)
+{
+  std::vector<StreamSpec> specs = {
+    {.name = "client_rbd", .pool = 1, .first_owner = 1, .num_owners = 2},
+    {.name = "recovery",
+     .klass = SchedulerClass::background_recovery,
+     .pool = 9, .first_owner = 500, .num_owners = 1,
+     .op_size = 1048576, .priority = 10, .backlog_per_owner = 16},
+  };
+  run_matrix(opt, "recovery", "client-vs-recovery", specs);
+}
+
+} // anonymous namespace
+
+int main(int argc, char **argv)
+{
+  std::vector<const char*> args(argv, argv + argc);
+  auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_OSD,
+			 CODE_ENVIRONMENT_UTILITY,
+			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  common_init_finish(g_ceph_context);
+
+  Options opt;
+  for (size_t i = 1; i < args.size(); ++i) {
+    auto need_val = [&](const char *flag) -> const char * {
+      if (i + 1 >= args.size()) {
+	std::fprintf(stderr, "%s requires a value\n", flag);
+	exit(1);
+      }
+      return args[++i];
+    };
+    if (!std::strcmp(args[i], "--rate-mb")) {
+      opt.rate_mb = std::stod(need_val("--rate-mb"));
+    } else if (!std::strcmp(args[i], "--secs")) {
+      opt.secs = std::stod(need_val("--secs"));
+    } else if (!std::strcmp(args[i], "--csv")) {
+      opt.csv_path = need_val("--csv");
+    } else if (!std::strcmp(args[i], "--scenario")) {
+      opt.scenario = need_val("--scenario");
+    }
+  }
+  opt.warmup = std::min(opt.warmup, opt.secs / 4);
+
+  // calibrate mclock's capacity model to the simulated device so we
+  // benchmark mclock, not a misconfigured mclock
+  g_ceph_context->_conf.set_val(
+    "osd_mclock_max_sequential_bandwidth_ssd",
+    std::to_string(static_cast<uint64_t>(opt.rate_mb * 1e6)));
+  g_ceph_context->_conf.set_val(
+    "osd_mclock_max_capacity_iops_ssd",
+    std::to_string(opt.rate_mb * 1e6 / 65536.0));
+
+  if (!opt.csv_path.empty()) {
+    csv.open(opt.csv_path);
+    csv << "scenario,cell,scheduler,stream,ops,bytes,share,mbps,"
+	   "p50_ms,p99_ms\n";
+  }
+
+  if (opt.scenario == "all" || opt.scenario == "share") {
+    scenario_share(opt);
+  }
+  if (opt.scenario == "all" || opt.scenario == "latency") {
+    scenario_latency(opt);
+  }
+  if (opt.scenario == "all" || opt.scenario == "recovery") {
+    scenario_recovery(opt);
+  }
+  return 0;
+}

--- a/src/test/osd/bench_op_scheduler.cc
+++ b/src/test/osd/bench_op_scheduler.cc
@@ -1,0 +1,179 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * ceph_bench_op_scheduler
+ *
+ * Isolation micro benchmarks comparing the OSD op schedulers (wpq,
+ * mclock_scheduler) on identical synthetic workloads with a simulated
+ * device drain rate.  See scheduler_bench.h for the harness.
+ *
+ * Usage:
+ *   ceph_bench_op_scheduler [--rate-mb N] [--secs S] [--csv FILE]
+ *                           [--scenario share|latency|recovery|all]
+ */
+
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "global/global_context.h"
+#include "global/global_init.h"
+#include "common/common_init.h"
+
+#include "scheduler_bench.h"
+
+using namespace scheduler_bench;
+
+namespace {
+
+struct Options {
+  double rate_mb = 100.0;
+  double secs = 3.0;
+  double warmup = 0.5;
+  std::string scenario = "all";
+  std::string csv_path;
+};
+
+const std::vector<op_queue_type_t> kTypes = {
+  op_queue_type_t::WeightedPriorityQueue,
+  op_queue_type_t::mClockScheduler,
+};
+
+std::ofstream csv;
+
+void report_cell(const std::string &scenario, const std::string &cell,
+		 op_queue_type_t type,
+		 const std::vector<StreamSpec> &specs,
+		 const CellResult &r)
+{
+  for (const auto &s : specs) {
+    const auto &sr = r.streams.at(s.name);
+    std::printf("  %-16s %-14s %8.1f %7.3f %8.1f %9.1f\n",
+		std::string(get_op_queue_type_name(type)).c_str(),
+		s.name.c_str(), sr.mbps, sr.share, sr.p50_ms, sr.p99_ms);
+    if (csv.is_open()) {
+      csv << scenario << ',' << cell << ','
+	  << get_op_queue_type_name(type) << ',' << s.name << ','
+	  << sr.ops << ',' << sr.bytes << ',' << sr.share << ','
+	  << sr.mbps << ',' << sr.p50_ms << ',' << sr.p99_ms << '\n';
+    }
+  }
+}
+
+void run_matrix(const Options &opt, const std::string &scenario,
+		const std::string &cell,
+		const std::vector<StreamSpec> &specs)
+{
+  std::printf("--- %s / %s (device %.0f MB/s, %.1fs)\n",
+	      scenario.c_str(), cell.c_str(), opt.rate_mb, opt.secs);
+  std::printf("  %-16s %-14s %8s %7s %8s %9s\n",
+	      "scheduler", "stream", "MB/s", "share", "p50ms", "p99ms");
+  for (auto type : kTypes) {
+    auto r = run_cell(g_ceph_context, type, specs,
+		      opt.rate_mb * 1e6, opt.secs, opt.warmup);
+    report_cell(scenario, cell, type, specs, r);
+  }
+  std::printf("\n");
+}
+
+// A1: both streams saturating; the aggressor fans out over K client
+// sessions.  Isolation == the victim's share is insensitive to K.
+void scenario_share(const Options &opt)
+{
+  for (unsigned k : {1u, 4u, 16u}) {
+    std::vector<StreamSpec> specs = {
+      {.name = "victim_rbd", .pool = 1, .first_owner = 1, .num_owners = 1},
+      {.name = "aggr_rgw", .pool = 2, .first_owner = 100, .num_owners = k},
+    };
+    run_matrix(opt, "share", "sessions=" + std::to_string(k), specs);
+  }
+}
+
+// A2: paced victim (20% of device rate) vs a saturating 8-session
+// aggressor.  Isolation == the victim keeps its offered throughput
+// with bounded queueing delay.
+void scenario_latency(const Options &opt)
+{
+  const double victim_ops = opt.rate_mb * 1e6 * 0.2 / 65536.0;
+  std::vector<StreamSpec> specs = {
+    {.name = "victim_rbd", .pool = 1, .first_owner = 1, .num_owners = 1,
+     .offered_ops_per_sec = victim_ops},
+    {.name = "aggr_rgw", .pool = 2, .first_owner = 100, .num_owners = 8},
+  };
+  run_matrix(opt, "latency", "victim20pct_sessions8", specs);
+}
+
+// B: saturating client stream vs saturating recovery stream (1M
+// chunks, DEGRADED priority encoding).
+void scenario_recovery(const Options &opt)
+{
+  std::vector<StreamSpec> specs = {
+    {.name = "client_rbd", .pool = 1, .first_owner = 1, .num_owners = 2},
+    {.name = "recovery",
+     .klass = SchedulerClass::background_recovery,
+     .pool = 9, .first_owner = 500, .num_owners = 1,
+     .op_size = 1048576, .priority = 10, .backlog_per_owner = 16},
+  };
+  run_matrix(opt, "recovery", "client-vs-recovery", specs);
+}
+
+} // anonymous namespace
+
+int main(int argc, char **argv)
+{
+  std::vector<const char*> args(argv, argv + argc);
+  auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_OSD,
+			 CODE_ENVIRONMENT_UTILITY,
+			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  common_init_finish(g_ceph_context);
+
+  Options opt;
+  for (size_t i = 1; i < args.size(); ++i) {
+    auto need_val = [&](const char *flag) -> const char * {
+      if (i + 1 >= args.size()) {
+	std::fprintf(stderr, "%s requires a value\n", flag);
+	exit(1);
+      }
+      return args[++i];
+    };
+    if (!std::strcmp(args[i], "--rate-mb")) {
+      opt.rate_mb = std::stod(need_val("--rate-mb"));
+    } else if (!std::strcmp(args[i], "--secs")) {
+      opt.secs = std::stod(need_val("--secs"));
+    } else if (!std::strcmp(args[i], "--csv")) {
+      opt.csv_path = need_val("--csv");
+    } else if (!std::strcmp(args[i], "--scenario")) {
+      opt.scenario = need_val("--scenario");
+    }
+  }
+  opt.warmup = std::min(opt.warmup, opt.secs / 4);
+
+  // calibrate mclock's capacity model to the simulated device so we
+  // benchmark mclock, not a misconfigured mclock
+  g_ceph_context->_conf.set_val(
+    "osd_mclock_max_sequential_bandwidth_ssd",
+    std::to_string(static_cast<uint64_t>(opt.rate_mb * 1e6)));
+  g_ceph_context->_conf.set_val(
+    "osd_mclock_max_capacity_iops_ssd",
+    std::to_string(opt.rate_mb * 1e6 / 65536.0));
+
+  if (!opt.csv_path.empty()) {
+    csv.open(opt.csv_path);
+    csv << "scenario,cell,scheduler,stream,ops,bytes,share,mbps,"
+	   "p50_ms,p99_ms\n";
+  }
+
+  if (opt.scenario == "all" || opt.scenario == "share") {
+    scenario_share(opt);
+  }
+  if (opt.scenario == "all" || opt.scenario == "latency") {
+    scenario_latency(opt);
+  }
+  if (opt.scenario == "all" || opt.scenario == "recovery") {
+    scenario_recovery(opt);
+  }
+  return 0;
+}

--- a/src/test/osd/scheduler_bench.h
+++ b/src/test/osd/scheduler_bench.h
@@ -1,0 +1,216 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Shared harness for op-scheduler isolation micro benchmarks.
+ *
+ * Drives synthetic per-stream workloads through any OpScheduler
+ * implementation in-process, pacing dequeues at a simulated device
+ * rate so that saturation dynamics (and therefore isolation) are
+ * meaningful.  Runs in real time because mclock's dmclock tags are
+ * wall-clock based; wpq is indifferent.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "common/Clock.h"
+#include "common/ceph_context.h"
+#include "osd/scheduler/OpScheduler.h"
+#include "osd/scheduler/OpSchedulerItem.h"
+
+namespace scheduler_bench {
+
+using namespace ceph::osd::scheduler;
+
+struct MockItem : public PGOpQueueable {
+  SchedulerClass klass;
+
+  MockItem(spg_t pgid, SchedulerClass k)
+    : PGOpQueueable(pgid), klass(k) {}
+
+  std::ostream &print(std::ostream &rhs) const final { return rhs; }
+  std::string print() const final { return std::string(); }
+  std::optional<OpRequestRef> maybe_get_op() const final {
+    return std::nullopt;
+  }
+  SchedulerClass get_scheduler_class() const final { return klass; }
+  void run(OSD *osd, OSDShard *sdata, PGRef &pg,
+	   ThreadPool::TPHandle &handle) final {}
+};
+
+struct StreamSpec {
+  std::string name;
+  SchedulerClass klass = SchedulerClass::client;
+  int64_t pool = 1;
+  uint64_t first_owner = 1;      ///< owners model client sessions
+  unsigned num_owners = 1;
+  uint64_t op_size = 65536;      ///< item cost in bytes
+  unsigned priority = 63;        ///< osd_client_op_priority default
+  double offered_ops_per_sec = 0;  ///< 0 => saturating
+  unsigned backlog_per_owner = 64; ///< target queue depth when saturating
+};
+
+struct StreamResult {
+  uint64_t ops = 0;
+  uint64_t bytes = 0;
+  double share = 0;    ///< of post-warmup dequeued bytes
+  double mbps = 0;
+  double p50_ms = 0;
+  double p99_ms = 0;
+};
+
+struct CellResult {
+  std::map<std::string, StreamResult> streams;
+  double total_mbps = 0;
+};
+
+inline double percentile(std::vector<double> &v, double p)
+{
+  if (v.empty()) {
+    return 0;
+  }
+  std::sort(v.begin(), v.end());
+  return v[std::min(v.size() - 1, static_cast<size_t>(p * v.size()))];
+}
+
+/**
+ * Run one benchmark cell: a fresh scheduler of the given type, the
+ * given streams, a simulated device draining rate_bytes_per_sec, for
+ * duration_sec of wall time.  Samples from the first warmup_sec are
+ * discarded.
+ */
+inline CellResult run_cell(
+  CephContext *cct,
+  op_queue_type_t type,
+  const std::vector<StreamSpec> &specs,
+  double rate_bytes_per_sec,
+  double duration_sec,
+  double warmup_sec)
+{
+  using steady = std::chrono::steady_clock;
+
+  auto sched = make_scheduler(cct, 0, 1, 0, false /*is_rotational*/,
+			      "bluestore", type, 196 /*cutoff*/);
+
+  std::unordered_map<uint64_t, size_t> owner_stream;
+  std::unordered_map<uint64_t, unsigned> owner_queued;
+  for (size_t i = 0; i < specs.size(); ++i) {
+    for (unsigned o = 0; o < specs[i].num_owners; ++o) {
+      owner_stream[specs[i].first_owner + o] = i;
+      owner_queued[specs[i].first_owner + o] = 0;
+    }
+  }
+
+  std::vector<uint64_t> bytes(specs.size(), 0), ops(specs.size(), 0);
+  std::vector<std::vector<double>> lat(specs.size());
+  std::vector<double> credit(specs.size(), 0.0);
+  std::vector<unsigned> paced_rr(specs.size(), 0);
+  epoch_t epoch = 1;
+
+  auto enqueue_one = [&](size_t si, uint64_t owner) {
+    const auto &s = specs[si];
+    sched->enqueue(OpSchedulerItem(
+      std::make_unique<MockItem>(spg_t(pg_t(0, s.pool)), s.klass),
+      static_cast<int>(s.op_size), s.priority, ceph_clock_now(), owner,
+      epoch++));
+    ++owner_queued[owner];
+  };
+
+  const auto t0 = steady::now();
+  const auto t_warm =
+    t0 + std::chrono::duration_cast<steady::duration>(
+      std::chrono::duration<double>(warmup_sec));
+  const auto t_end =
+    t0 + std::chrono::duration_cast<steady::duration>(
+      std::chrono::duration<double>(duration_sec));
+  auto last = t0;
+  double tokens = 0;
+  const double burst_cap = rate_bytes_per_sec / 4;
+
+  while (true) {
+    const auto now = steady::now();
+    if (now >= t_end) {
+      break;
+    }
+    const double dt = std::chrono::duration<double>(now - last).count();
+    last = now;
+    tokens = std::min(tokens + rate_bytes_per_sec * dt, burst_cap);
+
+    // load generators
+    for (size_t i = 0; i < specs.size(); ++i) {
+      const auto &s = specs[i];
+      if (s.offered_ops_per_sec > 0) {
+	credit[i] = std::min(credit[i] + s.offered_ops_per_sec * dt, 1000.0);
+	while (credit[i] >= 1.0) {
+	  enqueue_one(i, s.first_owner + (paced_rr[i]++ % s.num_owners));
+	  credit[i] -= 1.0;
+	}
+      } else {
+	for (unsigned o = 0; o < s.num_owners; ++o) {
+	  const uint64_t owner = s.first_owner + o;
+	  while (owner_queued[owner] < s.backlog_per_owner) {
+	    enqueue_one(i, owner);
+	  }
+	}
+      }
+    }
+
+    // simulated device drain
+    bool progressed = false;
+    while (tokens > 0 && !sched->empty()) {
+      WorkItem wi = sched->dequeue();
+      if (std::holds_alternative<double>(wi)) {
+	// mclock says "not ready until later"; let wall time advance
+	break;
+      }
+      auto &item = std::get<OpSchedulerItem>(wi);
+      const uint64_t owner = item.get_owner();
+      const size_t si = owner_stream.at(owner);
+      if (owner_queued[owner] > 0) {
+	--owner_queued[owner];
+      }
+      tokens -= static_cast<double>(item.get_cost());
+      progressed = true;
+      if (now >= t_warm) {
+	bytes[si] += item.get_cost();
+	++ops[si];
+	const utime_t sojourn = ceph_clock_now() - item.get_start_time();
+	lat[si].push_back(sojourn.to_nsec() / 1e6);
+      }
+    }
+    if (!progressed) {
+      std::this_thread::sleep_for(std::chrono::microseconds(200));
+    }
+  }
+
+  CellResult result;
+  const double measured_sec = duration_sec - warmup_sec;
+  uint64_t total_bytes = 0;
+  for (auto b : bytes) {
+    total_bytes += b;
+  }
+  for (size_t i = 0; i < specs.size(); ++i) {
+    StreamResult r;
+    r.ops = ops[i];
+    r.bytes = bytes[i];
+    r.share = total_bytes ? static_cast<double>(bytes[i]) / total_bytes : 0;
+    r.mbps = bytes[i] / 1e6 / measured_sec;
+    r.p50_ms = percentile(lat[i], 0.50);
+    r.p99_ms = percentile(lat[i], 0.99);
+    result.streams[specs[i].name] = r;
+  }
+  result.total_mbps = total_bytes / 1e6 / measured_sec;
+  return result;
+}
+
+} // namespace scheduler_bench

--- a/src/test/osd/vstart_bench_scheduler.sh
+++ b/src/test/osd/vstart_bench_scheduler.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+#
+# Tier-2 op scheduler isolation benchmark: drives real rados bench
+# workloads through a single-OSD vstart cluster, cycling osd_op_queue
+# across schedulers.  The tier-1 in-process companion is
+# ceph_bench_op_scheduler; this script validates that dispatch-level
+# isolation survives the full OSD pipeline with BlueStore underneath.
+#
+# Run from a built build directory:
+#   ../src/test/osd/vstart_bench_scheduler.sh
+#
+# Tunables (env):
+#   SCHEDULERS      default "wpq mclock_scheduler"
+#   SESSIONS        aggressor session counts, default "1 4 16"
+#   SECS            victim measurement window per cell, default 12
+#   BLOCK           op size in bytes, default 65536
+#   AGGR_QD         queue depth per aggressor session, default 8
+#   VICTIM_QD       victim queue depth in share cells, default 16
+#   THROTTLE_BYTES  bluestore throttle, default 4194304; 0 disables
+#
+# THROTTLE_BYTES bounds BlueStore's in-flight window so that, on fast
+# devices, contention surfaces at the op queue where the scheduler can
+# act on it.  Without it a fast NVMe absorbs the offered load below
+# the scheduler and every scheduler degenerates to FIFO passthrough --
+# the same reason the mclock tuning guide recommends constraining
+# bluestore_throttle_bytes.
+#
+# Scenarios per scheduler:
+#   share_k<K>   victim (rbd pool) saturating vs K saturating rgw
+#                sessions; isolation == victim MB/s insensitive to K
+#   latency_qd1  victim at queue depth 1 (latency probe) vs 8
+#                saturating sessions; isolation == bounded avg/max lat
+#
+# Results: CSV + per-cell dump_op_pq_state snapshots under
+# ./scheduler-isolation-results/
+
+set -uo pipefail
+
+BUILD_DIR=${BUILD_DIR:-$PWD}
+SCHEDULERS=${SCHEDULERS:-"wpq mclock_scheduler"}
+SESSIONS=${SESSIONS:-"1 4 16"}
+SECS=${SECS:-12}
+BLOCK=${BLOCK:-65536}
+AGGR_QD=${AGGR_QD:-8}
+# The victim must be able to consume its fair share: by Little's law
+# it needs QD >= share * op_rate * latency, or it self-caps below any
+# scheduler's allocation and every scheduler looks identical.
+VICTIM_QD=${VICTIM_QD:-64}
+THROTTLE_BYTES=${THROTTLE_BYTES:-4194304}
+
+cd "$BUILD_DIR"
+CEPH=./bin/ceph
+RADOS=./bin/rados
+if [ ! -x "$CEPH" ] || [ ! -x "$RADOS" ]; then
+    echo "run from a built build directory (./bin/ceph missing)" >&2
+    exit 1
+fi
+
+RESULTS_DIR=$BUILD_DIR/scheduler-isolation-results
+CSV=$RESULTS_DIR/results.csv
+mkdir -p "$RESULTS_DIR"
+echo "scheduler,cell,victim_mbps,victim_avg_lat_s,victim_max_lat_s,aggr_mbps_total,victim_share" > "$CSV"
+
+THROTTLE_OPTS=()
+if [ "$THROTTLE_BYTES" -gt 0 ]; then
+    THROTTLE_OPTS=(-o "bluestore_throttle_bytes = $THROTTLE_BYTES"
+		   -o "bluestore_throttle_deferred_bytes = $THROTTLE_BYTES")
+fi
+
+start_cluster() {
+    local sched=$1
+    ../src/stop.sh >/dev/null 2>&1 || true
+    if ! MON=1 OSD=1 MGR=1 MDS=0 RGW=0 ../src/vstart.sh -n --without-dashboard \
+        -o "osd_op_queue = $sched" \
+        -o "osd_op_num_shards = 1" \
+        -o "osd_pool_default_size = 1" \
+        -o "osd_pool_default_min_size = 1" \
+        -o "mon_allow_pool_size_one = true" \
+        -o "mon_allow_pool_delete = true" \
+        "${THROTTLE_OPTS[@]}" \
+        > "$RESULTS_DIR/vstart_$sched.log" 2>&1; then
+        echo "vstart failed for $sched, see $RESULTS_DIR/vstart_$sched.log" >&2
+        exit 1
+    fi
+    $CEPH osd set noscrub >/dev/null 2>&1
+    $CEPH osd set nodeep-scrub >/dev/null 2>&1
+    local active
+    active=$($CEPH daemon osd.0 config get osd_op_queue 2>/dev/null |
+                 python3 -c 'import json,sys; print(json.load(sys.stdin)["osd_op_queue"])')
+    if [ "$active" != "$sched" ]; then
+        echo "expected osd_op_queue=$sched, got '$active'" >&2
+        exit 1
+    fi
+}
+
+wait_clean() {
+    for _ in $(seq 90); do
+        if $CEPH pg stat --format json 2>/dev/null | python3 -c '
+import json, sys
+states = json.load(sys.stdin)["pg_summary"]["num_pg_by_state"]
+total = sum(s["num"] for s in states)
+clean = sum(s["num"] for s in states if s["name"] == "active+clean")
+sys.exit(0 if total > 0 and total == clean else 1)'; then
+            return 0
+        fi
+        sleep 1
+    done
+    echo "timed out waiting for active+clean pgs" >&2
+    return 1
+}
+
+make_pools() {
+    $CEPH osd pool create victim 32 >/dev/null 2>&1
+    $CEPH osd pool create aggr 32 >/dev/null 2>&1
+    $CEPH osd pool application enable victim rbd >/dev/null 2>&1
+    $CEPH osd pool application enable aggr rgw >/dev/null 2>&1
+    wait_clean
+}
+
+destroy_pools() {
+    $CEPH osd pool rm victim victim --yes-i-really-really-mean-it >/dev/null 2>&1
+    $CEPH osd pool rm aggr aggr --yes-i-really-really-mean-it >/dev/null 2>&1
+}
+
+# run_cell <scheduler> <aggr_sessions> <victim_qd> <label>
+run_cell() {
+    local sched=$1 k=$2 victim_qd=$3 label=$4
+    local tmp="$RESULTS_DIR/${sched}_${label}"
+    mkdir -p "$tmp"
+    make_pools
+
+    local pids=()
+    for i in $(seq 1 "$k"); do
+        $RADOS -p aggr bench $((SECS + 25)) write -b "$BLOCK" -t "$AGGR_QD" \
+            --no-cleanup > "$tmp/aggr_$i.log" 2>&1 &
+        pids+=($!)
+    done
+    sleep 4  # let the aggressor backlog build
+
+    $RADOS -p victim bench "$SECS" write -b "$BLOCK" -t "$victim_qd" \
+        --no-cleanup > "$tmp/victim.log" 2>&1
+
+    # snapshot scheduler state while the aggressors are still running
+    $CEPH daemon osd.0 dump_op_pq_state > "$tmp/pq_state.json" 2>/dev/null || true
+
+    kill "${pids[@]}" >/dev/null 2>&1 || true
+    wait >/dev/null 2>&1 || true
+
+    local vbw vavg vmax abw share
+    vbw=$(awk '/^Bandwidth \(MB\/sec\)/ {print $3}' "$tmp/victim.log")
+    vavg=$(awk '/^Average Latency\(s\)/ {print $3}' "$tmp/victim.log")
+    vmax=$(awk '/^Max latency\(s\)/ {print $3}' "$tmp/victim.log")
+    # killed benches never print a final summary; use each aggressor's
+    # last per-second progress line ("avg MB/s" column).  Approximate:
+    # their window is slightly wider than the victim's.
+    abw=$(for f in "$tmp"/aggr_*.log; do
+	      awk '$1 ~ /^[0-9]+$/ && $5 ~ /^[0-9.]+$/ {last=$5}
+		   END {if (last) print last}' "$f"
+	  done | awk '{s += $1} END {printf "%.1f", s}')
+    share=$(awk -v v="${vbw:-0}" -v a="${abw:-0}" \
+		'BEGIN {t = v + a; printf "%.3f", (t > 0 ? v / t : 0)}')
+
+    echo "$sched,$label,${vbw:-0},${vavg:-0},${vmax:-0},${abw:-0},$share" >> "$CSV"
+    printf '  %-16s %-12s victim %8s MB/s  share %-6s avg %8ss  max %8ss  (aggr ~%s MB/s)\n' \
+        "$sched" "$label" "${vbw:-?}" "$share" "${vavg:-?}" "${vmax:-?}" "${abw:-?}"
+
+    destroy_pools
+}
+
+echo "device: single vstart OSD, 1 op shard, ${BLOCK}B writes"
+for sched in $SCHEDULERS; do
+    echo "=== $sched ==="
+    start_cluster "$sched"
+    for k in $SESSIONS; do
+        run_cell "$sched" "$k" "$VICTIM_QD" "share_k$k"
+    done
+    run_cell "$sched" 8 1 "latency_qd1"
+done
+../src/stop.sh >/dev/null 2>&1 || true
+
+echo
+echo "results: $CSV"
+column -s, -t < "$CSV"

--- a/src/test/osd/vstart_bench_scheduler.sh
+++ b/src/test/osd/vstart_bench_scheduler.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+#
+# Tier-2 op scheduler isolation benchmark: drives real rados bench
+# workloads through a single-OSD vstart cluster, cycling osd_op_queue
+# across schedulers.  The tier-1 in-process companion is
+# ceph_bench_op_scheduler; this script validates that dispatch-level
+# isolation survives the full OSD pipeline with BlueStore underneath.
+#
+# Run from a built build directory:
+#   ../src/test/osd/vstart_bench_scheduler.sh
+#
+# Tunables (env):
+#   SCHEDULERS      default "wpq mclock_scheduler"
+#   SESSIONS        aggressor session counts, default "1 4 16"
+#   SECS            victim measurement window per cell, default 12
+#   BLOCK           op size in bytes, default 65536
+#   AGGR_QD         queue depth per aggressor session, default 8
+#   VICTIM_QD       victim queue depth in share cells, default 16
+#   THROTTLE_BYTES  bluestore throttle, default 4194304; 0 disables
+#
+# THROTTLE_BYTES bounds BlueStore's in-flight window so that, on fast
+# devices, contention surfaces at the op queue where the scheduler can
+# act on it.  Without it a fast NVMe absorbs the offered load below
+# the scheduler and every scheduler degenerates to FIFO passthrough --
+# the same reason the mclock tuning guide recommends constraining
+# bluestore_throttle_bytes.
+#
+# Scenarios per scheduler:
+#   share_k<K>   victim (rbd pool) saturating vs K saturating rgw
+#                sessions; isolation == victim MB/s insensitive to K
+#   latency_qd1  victim at queue depth 1 (latency probe) vs 8
+#                saturating sessions; isolation == bounded avg/max lat
+#
+# Results: CSV + per-cell dump_op_pq_state snapshots under
+# ./scheduler-isolation-results/
+
+set -uo pipefail
+
+BUILD_DIR=${BUILD_DIR:-$PWD}
+SCHEDULERS=${SCHEDULERS:-"wpq mclock_scheduler"}
+SESSIONS=${SESSIONS:-"1 4 16"}
+SECS=${SECS:-12}
+BLOCK=${BLOCK:-65536}
+AGGR_QD=${AGGR_QD:-8}
+# The victim must be able to consume its fair share: by Little's law
+# it needs QD >= share * op_rate * latency, or it self-caps below any
+# scheduler's allocation and every scheduler looks identical.
+VICTIM_QD=${VICTIM_QD:-64}
+THROTTLE_BYTES=${THROTTLE_BYTES:-4194304}
+
+cd "$BUILD_DIR" || exit 1
+CEPH=./bin/ceph
+RADOS=./bin/rados
+if [ ! -x "$CEPH" ] || [ ! -x "$RADOS" ]; then
+    echo "run from a built build directory (./bin/ceph missing)" >&2
+    exit 1
+fi
+
+RESULTS_DIR=$BUILD_DIR/scheduler-isolation-results
+CSV=$RESULTS_DIR/results.csv
+mkdir -p "$RESULTS_DIR"
+echo "scheduler,cell,victim_mbps,victim_avg_lat_s,victim_max_lat_s,aggr_mbps_total,victim_share" > "$CSV"
+
+THROTTLE_OPTS=()
+if [ "$THROTTLE_BYTES" -gt 0 ]; then
+    THROTTLE_OPTS=(-o "bluestore_throttle_bytes = $THROTTLE_BYTES"
+		   -o "bluestore_throttle_deferred_bytes = $THROTTLE_BYTES")
+fi
+
+start_cluster() {
+    local sched=$1
+    ../src/stop.sh >/dev/null 2>&1 || true
+    if ! MON=1 OSD=1 MGR=1 MDS=0 RGW=0 ../src/vstart.sh -n --without-dashboard \
+        -o "osd_op_queue = $sched" \
+        -o "osd_op_num_shards = 1" \
+        -o "osd_pool_default_size = 1" \
+        -o "osd_pool_default_min_size = 1" \
+        -o "mon_allow_pool_size_one = true" \
+        -o "mon_allow_pool_delete = true" \
+        "${THROTTLE_OPTS[@]}" \
+        > "$RESULTS_DIR/vstart_$sched.log" 2>&1; then
+        echo "vstart failed for $sched, see $RESULTS_DIR/vstart_$sched.log" >&2
+        exit 1
+    fi
+    $CEPH osd set noscrub >/dev/null 2>&1
+    $CEPH osd set nodeep-scrub >/dev/null 2>&1
+    local active
+    active=$($CEPH daemon osd.0 config get osd_op_queue 2>/dev/null |
+                 python3 -c 'import json,sys; print(json.load(sys.stdin)["osd_op_queue"])')
+    if [ "$active" != "$sched" ]; then
+        echo "expected osd_op_queue=$sched, got '$active'" >&2
+        exit 1
+    fi
+}
+
+wait_clean() {
+    for _ in $(seq 90); do
+        if $CEPH pg stat --format json 2>/dev/null | python3 -c '
+import json, sys
+states = json.load(sys.stdin)["pg_summary"]["num_pg_by_state"]
+total = sum(s["num"] for s in states)
+clean = sum(s["num"] for s in states if s["name"] == "active+clean")
+sys.exit(0 if total > 0 and total == clean else 1)'; then
+            return 0
+        fi
+        sleep 1
+    done
+    echo "timed out waiting for active+clean pgs" >&2
+    return 1
+}
+
+make_pools() {
+    $CEPH osd pool create victim 32 || return 1
+    $CEPH osd pool create aggr 32 || return 1
+    $CEPH osd pool application enable victim rbd || return 1
+    $CEPH osd pool application enable aggr rgw || return 1
+    wait_clean
+}
+
+destroy_pools() {
+    $CEPH osd pool rm victim victim --yes-i-really-really-mean-it >/dev/null 2>&1
+    $CEPH osd pool rm aggr aggr --yes-i-really-really-mean-it >/dev/null 2>&1
+}
+
+FAILED_CELLS=0
+
+# fail_cell <scheduler> <label> <tmp> <reason>
+#
+# A cell with any missing measurement is rejected outright rather than
+# reported with zeros in the gaps: a failed aggressor would otherwise
+# contribute 0 MB/s and make the victim's share look like perfect
+# isolation.  The row is marked in the CSV, the pools are torn down,
+# and the run continues with the next cell (exiting non-zero at the
+# end).
+fail_cell() {
+    local sched=$1 label=$2 tmp=$3 reason=$4
+    echo "  $sched $label FAILED: $reason (logs under $tmp)" >&2
+    echo "$sched,$label,failed,failed,failed,failed,failed" >> "$CSV"
+    FAILED_CELLS=$((FAILED_CELLS + 1))
+    destroy_pools
+}
+
+# run_cell <scheduler> <aggr_sessions> <victim_qd> <label>
+run_cell() {
+    local sched=$1 k=$2 victim_qd=$3 label=$4
+    local tmp="$RESULTS_DIR/${sched}_${label}"
+    mkdir -p "$tmp"
+    if ! make_pools > "$tmp/setup.log" 2>&1; then
+        fail_cell "$sched" "$label" "$tmp" "pool setup failed"
+        return 1
+    fi
+
+    local pids=()
+    for i in $(seq 1 "$k"); do
+        $RADOS -p aggr bench $((SECS + 25)) write -b "$BLOCK" -t "$AGGR_QD" \
+            --no-cleanup > "$tmp/aggr_$i.log" 2>&1 &
+        pids+=($!)
+    done
+    sleep 4  # let the aggressor backlog build
+
+    local victim_rc=0
+    $RADOS -p victim bench "$SECS" write -b "$BLOCK" -t "$victim_qd" \
+        --no-cleanup > "$tmp/victim.log" 2>&1 || victim_rc=$?
+
+    # snapshot scheduler state while the aggressors are still running
+    $CEPH daemon osd.0 dump_op_pq_state > "$tmp/pq_state.json" 2>/dev/null || true
+
+    kill "${pids[@]}" >/dev/null 2>&1 || true
+    wait >/dev/null 2>&1 || true
+
+    if [ "$victim_rc" -ne 0 ]; then
+        fail_cell "$sched" "$label" "$tmp" "victim rados bench exited $victim_rc"
+        return 1
+    fi
+
+    local vbw vavg vmax abw share
+    vbw=$(awk '/^Bandwidth \(MB\/sec\)/ {print $3}' "$tmp/victim.log")
+    vavg=$(awk '/^Average Latency\(s\)/ {print $3}' "$tmp/victim.log")
+    vmax=$(awk '/^Max latency\(s\)/ {print $3}' "$tmp/victim.log")
+    if [ -z "$vbw" ] || [ -z "$vavg" ] || [ -z "$vmax" ]; then
+        fail_cell "$sched" "$label" "$tmp" "victim summary incomplete"
+        return 1
+    fi
+
+    # killed benches never print a final summary; use each aggressor's
+    # last per-second progress line ("avg MB/s" column).  Approximate:
+    # their window is slightly wider than the victim's.  Every
+    # aggressor must have produced at least one sample, or the cell
+    # ran with fewer competitors than its label claims.
+    abw=0
+    local f a
+    for f in "$tmp"/aggr_*.log; do
+        a=$(awk '$1 ~ /^[0-9]+$/ && $5 ~ /^[0-9.]+$/ {last=$5}
+                 END {if (last) print last}' "$f")
+        if [ -z "$a" ]; then
+            fail_cell "$sched" "$label" "$tmp" \
+                "no throughput samples in $(basename "$f")"
+            return 1
+        fi
+        abw=$(awk -v s="$abw" -v a="$a" 'BEGIN {printf "%.1f", s + a}')
+    done
+    share=$(awk -v v="$vbw" -v a="$abw" \
+                'BEGIN {t = v + a; printf "%.3f", (t > 0 ? v / t : 0)}')
+
+    echo "$sched,$label,$vbw,$vavg,$vmax,$abw,$share" >> "$CSV"
+    printf '  %-16s %-12s victim %8s MB/s  share %-6s avg %8ss  max %8ss  (aggr ~%s MB/s)\n' \
+        "$sched" "$label" "$vbw" "$share" "$vavg" "$vmax" "$abw"
+
+    destroy_pools
+}
+
+echo "device: single vstart OSD, 1 op shard, ${BLOCK}B writes"
+for sched in $SCHEDULERS; do
+    echo "=== $sched ==="
+    start_cluster "$sched"
+    for k in $SESSIONS; do
+        run_cell "$sched" "$k" "$VICTIM_QD" "share_k$k"
+    done
+    run_cell "$sched" 8 1 "latency_qd1"
+done
+../src/stop.sh >/dev/null 2>&1 || true
+
+echo
+echo "results: $CSV"
+column -s, -t < "$CSV"
+if [ "$FAILED_CELLS" -gt 0 ]; then
+    echo "$FAILED_CELLS cell(s) failed; see the per-cell logs" >&2
+    exit 1
+fi


### PR DESCRIPTION
Isolation benchmarks for the OSD op schedulers, split out of #70627 per @markhpc's suggestion so they can land independently and be used against the existing schedulers. Everything here is scheduler agnostic: the harness takes an `op_queue_type_t` and drives whatever `make_scheduler()` returns, so a new scheduler is covered by adding it to a type list — which is exactly what the bfq RFC now does on top of this.

Two tiers:

**Tier 1 — `ceph_bench_op_scheduler`** (in-process): drives identical synthetic workloads through wpq and mclock, pacing dequeues at a simulated device rate. mclock's capacity options are calibrated to the same rate and its future-time dequeue results are honored, so scenarios run in real time. Streams model client sessions via distinct owners; metrics are per-stream share, throughput, and sojourn-time percentiles. Scenarios: victim share vs aggressor session fan-out (1..16), paced-victim latency under a saturating aggressor, and client-vs-recovery class weighting.

Representative results at 100 MB/s simulated, one victim client vs an aggressor fanning out over K sessions (both saturating):

| K sessions | wpq victim share | mclock victim share |
|---|---|---|
| 1 | 50.0% | 50.3% |
| 4 | 20.0% | 20.1% |
| 16 | 5.9% | 6.7% |

Both schedulers dilute the victim as 1/(K+1): wpq round-robins owners, and mclock maps all client ops to a single dmclock client (`client_profile_id_t` is always default-constructed), so neither can hold a per-workload share as session count scales. A paced victim offered 20% of the device under a saturating 8-session aggressor: mclock delivers the offered 20 MB/s but at p99 419 ms (FIFO behind the aggressor backlog); wpq caps the victim below its offered rate (11 MB/s) at p99 1.3 s. Client-vs-recovery follows each scheduler's own dial: mclock 50/50 per the balanced profile, wpq 79/21 by priority tokens.

**Tier 2 — `src/test/osd/vstart_bench_scheduler.sh`**: the same isolation matrix with real `rados bench` clients against a single-OSD, single-op-shard vstart cluster, cycling `osd_op_queue` per cell; reports victim bandwidth and latency plus a mid-cell `dump_op_pq_state` snapshot. The script header documents the two things that otherwise silently invalidate the experiment on fast devices: constraining `bluestore_throttle_bytes` (default 4 MiB here) so contention actually surfaces at the op queue rather than being absorbed by BlueStore, and giving the victim enough queue depth that it does not self-cap below its fair share (Little's law; default QD=64).

`unittest_scheduler_isolation` carries harness sanity checks (work conservation, no outright starvation of equal streams). It skips unless `CEPH_TEST_SCHEDULER_ISOLATION` is set, because the harness paces in wall time and shared CI executors are too noisy for that.

## Checklist
- Tracker (select at least one):
  - [x] No tracker needed
- Component impact
  - [x] No component impact: test-only change
- Documentation (select at least one):
  - [x] No doc update is appropriate
- Tests (select at least one):
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
