### PR TITLE
Fix squid cephadm e2e 

### DIFF
--- a/src/pybind/mgr/dashboard/ci/cephadm/bootstrap-cluster.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/bootstrap-cluster.sh
@@ -23,11 +23,24 @@ bootstrap_extra_options='--allow-fqdn-hostname --dashboard-password-noupdate'
 # {% if expanded_cluster is not defined %}
 #   bootstrap_extra_options+=" ${bootstrap_extra_options_not_expanded}"
 # {% endif %}
+quick_install_options=''
+{% if quick_install is defined %}
+  quick_install_options="--image localhost:5000/ceph"
+{% endif %}
 
-$CEPHADM bootstrap --mon-ip $mon_ip --initial-dashboard-password {{ admin_password }} --shared_ceph_folder /mnt/{{ ceph_dev_folder }} ${bootstrap_extra_options}
+{% if nodes < 3 %}
+  bootstrap_extra_options+=" --config /root/initial-ceph.conf"
+{% endif %}
+
+{% if ceph_dev_folder is defined %}
+  bootstrap_extra_options+=" --shared_ceph_folder /mnt/{{ ceph_dev_folder }}"
+{% endif %}
+
+$CEPHADM ${quick_install_options} bootstrap --mon-ip $mon_ip --initial-dashboard-password {{ admin_password }} ${bootstrap_extra_options}
 
 fsid=$(cat /etc/ceph/ceph.conf | grep fsid | awk '{ print $3}')
 cephadm_shell="$CEPHADM shell --fsid ${fsid} -c /etc/ceph/ceph.conf -k /etc/ceph/ceph.client.admin.keyring"
+
 
 {% for number in range(1, nodes) %}
   ssh-copy-id -f -i /etc/ceph/ceph.pub  -o StrictHostKeyChecking=no root@192.168.100.10{{ number }}

--- a/src/pybind/mgr/dashboard/ci/cephadm/bootstrap-cluster.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/bootstrap-cluster.sh
@@ -13,7 +13,7 @@ CEPHADM_SRC="/mnt/{{ ceph_dev_folder }}/src/cephadm/cephadm"
 cp $CEPHADM_SRC $CEPHADM
 
 mkdir -p /etc/ceph
-mon_ip=$(ifconfig eth0  | grep 'inet ' | awk '{ print $2}')
+mon_ip=$(ip -4 addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
 
 bootstrap_extra_options='--allow-fqdn-hostname --dashboard-password-noupdate'
 

--- a/src/pybind/mgr/dashboard/ci/cephadm/bootstrap-cluster.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/bootstrap-cluster.sh
@@ -45,7 +45,7 @@ cephadm_shell="$CEPHADM shell --fsid ${fsid} -c /etc/ceph/ceph.conf -k /etc/ceph
 {% for number in range(1, nodes) %}
   ssh-copy-id -f -i /etc/ceph/ceph.pub  -o StrictHostKeyChecking=no root@192.168.100.10{{ number }}
   {% if expanded_cluster is defined %}
-    ${cephadm_shell} ceph orch host add {{ prefix }}-node-0{{ number }}
+    ${cephadm_shell} ceph orch host add {{ prefix }}-node-0{{ number }} 192.168.100.10{{ number }}
   {% endif %}
 {% endfor %}
 

--- a/src/pybind/mgr/dashboard/ci/cephadm/ceph_cluster.yml
+++ b/src/pybind/mgr/dashboard/ci/cephadm/ceph_cluster.yml
@@ -8,7 +8,7 @@ parameters:
  prefix: ceph
  numcpus: 1
  memory: 2048
- image: fedora36
+ image: fedora40
  notify: false
  admin_password: password
  disks:
@@ -35,8 +35,17 @@ parameters:
  sharedfolders: [{{ ceph_dev_folder }}]
  files:
   - bootstrap-cluster.sh
+  - dnf.conf.tpl
+  - load-podman-image.sh
+  - initial-ceph.conf
  cmds:
+ # updating the dnf.conf to make the dnf faster
+ - cp /root/dnf.conf.tpl /etc/dnf/dnf.conf
  - dnf -y install python3 chrony lvm2 podman
+ # setting up an insecure podman registry and then loading the ceph image to all hosts
+ {% if quick_install is defined %}
+ - /root/load-podman-image.sh
+ {% endif %}
  - sed -i "s/SELINUX=enforcing/SELINUX=permissive/" /etc/selinux/config
  - setenforce 0
  {% if number == 0 %}

--- a/src/pybind/mgr/dashboard/ci/cephadm/ceph_cluster.yml
+++ b/src/pybind/mgr/dashboard/ci/cephadm/ceph_cluster.yml
@@ -8,7 +8,7 @@ parameters:
  prefix: ceph
  numcpus: 1
  memory: 2048
- image: fedora40
+ image: fedora44
  notify: false
  admin_password: password
  disks:

--- a/src/pybind/mgr/dashboard/ci/cephadm/dnf.conf.tpl
+++ b/src/pybind/mgr/dashboard/ci/cephadm/dnf.conf.tpl
@@ -1,0 +1,10 @@
+[main]
+fastestmirror=true
+max_parallel_downloads=10
+metadata_expire=1h
+clean_requirements_on_remove=true
+assumeyes=true
+gpgcheck=1
+keepcache=0
+plugins=1
+installonly_limit=3

--- a/src/pybind/mgr/dashboard/ci/cephadm/initial-ceph.conf
+++ b/src/pybind/mgr/dashboard/ci/cephadm/initial-ceph.conf
@@ -1,0 +1,9 @@
+[global]
+osd_pool_default_min_size=1
+osd_pool_default_size=1
+
+[mon]
+mon_allow_pool_size_one=true
+mon_allow_pool_delete=true
+mon_data_avail_crit=1
+mon_data_avail_warn=1

--- a/src/pybind/mgr/dashboard/ci/cephadm/load-podman-image.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/load-podman-image.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+echo -e "[registries.insecure]\n\
+registries = ['localhost:5000']" | sudo tee /etc/containers/registries.conf
+
+podman run -d -p 5000:5000 --name my-registry registry:2
+# Load the image and capture the output
+output=$(podman load -i /root/ceph_image.tar)
+
+# Extract image name from output
+image_name=$(echo "$output" | grep -oP '(?<=^Loaded image: ).*')
+
+if [[ -n "$image_name" ]]; then
+  echo "Image loaded: $image_name"
+  podman tag "$image_name" localhost:5000/ceph
+  echo "Tagged image as localhost:5000/ceph"
+else
+  echo "Failed to load image or extract image name."
+  exit 1
+fi
+
+podman push localhost:5000/ceph
+rm -f /root/ceph_image.tar

--- a/src/pybind/mgr/dashboard/ci/cephadm/quick-bootstrap.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/quick-bootstrap.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+source bootstrap-cluster.sh > /dev/null 2>&1
+
+set +x
+
+show_help() {
+  echo "Usage: ./quick-bootstrap.sh [OPTIONS]"
+  echo ""
+  echo "Options:"
+  echo "  -u, --use-cached-image     Uses the existing podman image in local. Only use this if there is such an image present."
+  echo "  -dir, --ceph-dir             Use this to provide the local ceph directory. eg. --ceph-dir=/path/to/ceph"
+  echo "  -e, --expanded-cluster     To add all the hosts and deploy OSDs on top of it."
+  echo "  -h, --help             Display this help message."
+  echo ""
+  echo "Example:"
+  echo "  ./quick-bootstrap.sh --use-cached-image"
+}
+
+use_cached_image=false
+extra_args="-P quick_install=True"
+
+for arg in "$@"; do
+  case "$arg" in
+    -u|--use-cached-image)
+      use_cached_image=true
+      ;;
+    -dir=*|--ceph-dir=*)
+      extra_args+=" -P ceph_dev_folder=${arg#*=}"
+      ;;
+    -e|--expanded-cluster)
+      extra_args+=" -P expanded_cluster=True"
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg"
+      show_help
+      exit 1
+      ;;
+  esac
+done
+
+image_name=$(echo "$CEPHADM_IMAGE")
+ceph_cluster_yml='ceph_cluster.yml'
+node_count=$(awk '/nodes:/ {print $2}' "${ceph_cluster_yml}")
+
+if [[ ${use_cached_image} == false ]]; then
+    printf "Pulling the image: %s\n" "$image_name"
+    podman pull "${image_name}"
+fi
+
+rm -f ceph_image.tar
+
+printf "Saving the image: %s\n" "$image_name"
+podman save -o ceph_image.tar quay.ceph.io/ceph-ci/ceph:main
+
+printf "Creating the plan\n"
+kcli create plan -f ceph_cluster.yml ${extra_args} ceph
+
+attempt=0
+
+MAX_ATTEMPTS=10
+SLEEP_INTERVAL=5
+
+printf "Waiting for the host to be reachable\n"
+while [[ ${attempt} -lt ${MAX_ATTEMPTS} ]]; do
+    if ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10 root@192.168.100.100 exit; then
+        break
+    else
+        echo "Waiting for ssh connection to be available..., attempt: ${attempt}"
+        ((attempt++))
+        sleep ${SLEEP_INTERVAL}
+    fi
+done
+
+printf "Copying the image to the hosts\n"
+
+for node in $(seq 0 $((node_count - 1))); do
+    scp -o StrictHostKeyChecking=no ceph_image.tar root@192.168.100.10"${node}":/root/
+done
+
+rm -f ceph_image.tar
+kcli ssh -u root -- ceph-node-00 'journalctl -n all -ft cloud-init'

--- a/src/pybind/mgr/dashboard/ci/cephadm/run-cephadm-e2e-tests.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/run-cephadm-e2e-tests.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
 set -ex
 
@@ -9,7 +10,7 @@ set -ex
 : ${DASHBOARD_PORT:='8443'}
 
 get_vm_ip () {
-    local ip=$(kcli info vm "$1" -f ip -v | grep -Eo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
+    local ip=$(with_libvirt "kcli info vm \"$1\" -f ip -v" | grep -Eo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
     echo -n $ip
 }
 

--- a/src/pybind/mgr/dashboard/ci/cephadm/run-cephadm-e2e-tests.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/run-cephadm-e2e-tests.sh
@@ -39,22 +39,4 @@ cypress_run () {
 
 cd ${CEPH_DEV_FOLDER}/src/pybind/mgr/dashboard/frontend
 
-kcli ssh -u root ceph-node-00 'cephadm shell "ceph config set mgr mgr/prometheus/exclude_perf_counters false"'
-
-# check if the prometheus daemon is running
-# before starting the e2e tests
-
-PROMETHEUS_RUNNING_COUNT=$(kcli ssh -u root ceph-node-00 'cephadm shell "ceph orch ls --service_name=prometheus --format=json"' | jq -r '.[] | .status.running')
-while [[ $PROMETHEUS_RUNNING_COUNT -lt 1 ]]; do
-    PROMETHEUS_RUNNING_COUNT=$(kcli ssh -u root ceph-node-00 'cephadm shell "ceph orch ls --service_name=prometheus --format=json"' | jq -r '.[] | .status.running')
-done
-
-# grafana ip address is set to the fqdn by default.
-# kcli is not working with that, so setting the IP manually.
-kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-alertmanager-api-host http://192.168.100.100:9093"'
-kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-prometheus-api-host http://192.168.100.100:9095"'
-kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-grafana-api-url https://192.168.100.100:3000"'
-kcli ssh -u root ceph-node-00 'cephadm shell "ceph orch apply node-exporter --placement 'count:2'"'
-
-cypress_run ["cypress/e2e/orchestrator/workflow/*.feature","cypress/e2e/orchestrator/workflow/*-spec.ts"]
-cypress_run "cypress/e2e/orchestrator/grafana/*.feature"
+cypress_run ["cypress/e2e/orchestrator/workflow/*.feature","cypress/e2e/orchestrator/workflow/*-spec.ts","cypress/e2e/orchestrator/grafana/*.feature"]

--- a/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
@@ -59,8 +59,8 @@ fi
 npm run build ${FRONTEND_BUILD_OPTS} &
 
 cd ${CEPH_DEV_FOLDER}
-: ${VM_IMAGE:='fedora36'}
-: ${VM_IMAGE_URL:='https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-36-1.5.x86_64.qcow2'}
+: ${VM_IMAGE:='fedora40'}
+: ${VM_IMAGE_URL:='https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2'}
 kcli download image -p ceph-dashboard -u ${VM_IMAGE_URL} ${VM_IMAGE}
 kcli delete plan -y ceph || true
 # Compile cephadm locally for the shared_ceph_folder to pick it up

--- a/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
@@ -74,7 +74,7 @@ with_libvirt "kcli create plan -f src/pybind/mgr/dashboard/ci/cephadm/ceph_clust
 
 : ${CLUSTER_DEBUG:=0}
 : ${DASHBOARD_CHECK_INTERVAL:=10}
-while [[ -z $(with_libvirt "kcli ssh -u root -- ceph-node-00 'journalctl --no-tail --no-pager -t cloud-init' | grep "kcli boot finished"") ]]; do
+while [[ -z $(with_libvirt "kcli ssh -u root -- ceph-node-00 'journalctl --no-tail --no-pager -t cloud-init' | grep 'kcli boot finished'") ]]; do
     sleep ${DASHBOARD_CHECK_INTERVAL}
     with_libvirt "kcli list vm"
     if [[ ${CLUSTER_DEBUG} != 0 ]]; then
@@ -84,10 +84,10 @@ while [[ -z $(with_libvirt "kcli ssh -u root -- ceph-node-00 'journalctl --no-ta
     with_libvirt "kcli ssh -u root -- ceph-node-00 'journalctl -n 100 --no-pager -t cloud-init'"
 done
 
-with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph config set mgr mgr/prometheus/exclude_perf_counters false"'"
+with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell ceph config set mgr mgr/prometheus/exclude_perf_counters false'"
 
 get_prometheus_running_count() {
-    echo $(with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph orch ls --service_name=prometheus --format=json"' | jq -r '.[] | .status.running'")
+    echo $(with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell ceph orch ls --service_name=prometheus --format=json' | jq -r '.[] | .status.running'")
 }
 
 # check if the prometheus daemon is running on jenkins node
@@ -112,8 +112,8 @@ if [[ -n "${JENKINS_HOME}" ]]; then
 
     # grafana ip address is set to the fqdn by default.
     # kcli is not working with that, so setting the IP manually.
-    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-alertmanager-api-host http://192.168.100.100:9093"'"
-    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-prometheus-api-host http://192.168.100.100:9095"'"
-    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-grafana-api-url https://192.168.100.100:3000"'"
-    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph orch apply node-exporter --placement 'count:2"'"'
+    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell ceph dashboard set-alertmanager-api-host http://192.168.100.100:9093'"
+    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell ceph dashboard set-prometheus-api-host http://192.168.100.100:9095'"
+    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell ceph dashboard set-grafana-api-url https://192.168.100.100:3000'"
+    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell ceph orch apply node-exporter --placement count:2'"
 fi

--- a/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
 set -eEx
 
@@ -12,16 +13,16 @@ on_error() {
         echo "Saving MGR logs:"
         echo
         mkdir -p ${CEPH_DEV_FOLDER}/logs
-        kcli ssh -u root -- ceph-node-00 'cephadm logs -n \$(cephadm ls | grep -Eo "mgr\.ceph[0-9a-z.-]+" | head -n 1) -- --no-tail --no-pager' > ${CEPH_DEV_FOLDER}/logs/mgr.cephadm.log
+        with_libvirt "kcli ssh -u root -- ceph-node-00 'cephadm logs -n \$(cephadm ls | grep -Eo "mgr\.ceph[0-9a-z.-]+" | head -n 1) -- --no-tail --no-pager' > ${CEPH_DEV_FOLDER}/logs/mgr.cephadm.log"
         for vm_id in {0..3}
         do
             local vm="ceph-node-0${vm_id}"
             echo "Saving journalctl from VM ${vm}:"
             echo
-            kcli ssh -u root -- ${vm} 'journalctl --no-tail --no-pager -t cloud-init' > ${CEPH_DEV_FOLDER}/logs/journal.ceph-node-0${vm_id}.log || true
+            with_libvirt "kcli ssh -u root -- ${vm} 'journalctl --no-tail --no-pager -t cloud-init' > ${CEPH_DEV_FOLDER}/logs/journal.ceph-node-0${vm_id}.log || true"
             echo "Saving container logs:"
             echo
-            kcli ssh -u root -- ${vm} 'podman logs --names --since 30s \$(podman ps -aq)' > ${CEPH_DEV_FOLDER}/logs/container.ceph-node-0${vm_id}.log || true
+            with_libvirt "kcli ssh -u root -- ${vm} 'podman logs --names --since 30s \$(podman ps -aq)' > ${CEPH_DEV_FOLDER}/logs/container.ceph-node-0${vm_id}.log || true"
         done
         echo "TEST FAILED."
     fi
@@ -43,7 +44,7 @@ for arg in "$@"; do
   esac
 done
 
-kcli delete plan -y ceph || true
+with_libvirt "kcli delete plan -y ceph || true"
 
 # Build dashboard frontend (required to start the module).
 cd ${CEPH_DEV_FOLDER}/src/pybind/mgr/dashboard/frontend
@@ -59,26 +60,60 @@ fi
 npm run build ${FRONTEND_BUILD_OPTS} &
 
 cd ${CEPH_DEV_FOLDER}
-: ${VM_IMAGE:='fedora40'}
-: ${VM_IMAGE_URL:='https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2'}
-kcli download image -p ceph-dashboard -u ${VM_IMAGE_URL} ${VM_IMAGE}
-kcli delete plan -y ceph || true
+: ${VM_IMAGE:='fedora42'}
+: ${VM_IMAGE_URL:='https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2'}
+with_libvirt "kcli download image -p ceph-dashboard -u ${VM_IMAGE_URL} ${VM_IMAGE}"
+with_libvirt "kcli delete plan -y ceph || true"
 # Compile cephadm locally for the shared_ceph_folder to pick it up
 cd ${CEPH_DEV_FOLDER}/src/cephadm
 ./build.sh ${CEPH_DEV_FOLDER}/src/cephadm/cephadm
 cd ${CEPH_DEV_FOLDER}
-kcli create plan -f src/pybind/mgr/dashboard/ci/cephadm/ceph_cluster.yml \
+with_libvirt "kcli create plan -f src/pybind/mgr/dashboard/ci/cephadm/ceph_cluster.yml \
     -P ceph_dev_folder=${CEPH_DEV_FOLDER} \
-    ${EXTRA_PARAMS} ceph
+    ${EXTRA_PARAMS} ceph"
 
 : ${CLUSTER_DEBUG:=0}
 : ${DASHBOARD_CHECK_INTERVAL:=10}
-while [[ -z $(kcli ssh -u root -- ceph-node-00 'journalctl --no-tail --no-pager -t cloud-init' | grep "kcli boot finished") ]]; do
+while [[ -z $(with_libvirt "kcli ssh -u root -- ceph-node-00 'journalctl --no-tail --no-pager -t cloud-init' | grep "kcli boot finished"") ]]; do
     sleep ${DASHBOARD_CHECK_INTERVAL}
-    kcli list vm
+    with_libvirt "kcli list vm"
     if [[ ${CLUSTER_DEBUG} != 0 ]]; then
-        kcli ssh -u root -- ceph-node-00 'podman ps -a'
-        kcli ssh -u root -- ceph-node-00 'podman logs --names --since 30s \$(podman ps -aq)'
+        with_libvirt "kcli ssh -u root -- ceph-node-00 'podman ps -a'"
+        with_libvirt "kcli ssh -u root -- ceph-node-00 'podman logs --names --since 30s \$(podman ps -aq)'"
     fi
-    kcli ssh -u root -- ceph-node-00 'journalctl -n 100 --no-pager -t cloud-init'
+    with_libvirt "kcli ssh -u root -- ceph-node-00 'journalctl -n 100 --no-pager -t cloud-init'"
 done
+
+with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph config set mgr mgr/prometheus/exclude_perf_counters false"'"
+
+get_prometheus_running_count() {
+    echo $(with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph orch ls --service_name=prometheus --format=json"' | jq -r '.[] | .status.running'")
+}
+
+# check if the prometheus daemon is running on jenkins node
+# before starting the e2e tests
+if [[ -n "${JENKINS_HOME}" ]]; then
+    retry=0
+    PROMETHEUS_RUNNING_COUNT=$(get_prometheus_running_count)
+    # retrying for 10 times to see if we can get the prometheus count
+    # otherwise this would run indefinitely and bloat up the machine
+    while [[ $retry -lt 10 && $PROMETHEUS_RUNNING_COUNT -lt 1 ]]; do
+        if [[ ${retry} -gt 0 ]]; then
+            echo "Retry attempt to get the prometheus count..." ${retry}
+        fi
+        PROMETHEUS_RUNNING_COUNT=$(get_prometheus_running_count)
+        retry=$((retry +1))
+        sleep 10
+    done
+
+    if [[ ${retry} -ge 10 ]]; then
+        exit 1
+    fi
+
+    # grafana ip address is set to the fqdn by default.
+    # kcli is not working with that, so setting the IP manually.
+    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-alertmanager-api-host http://192.168.100.100:9093"'"
+    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-prometheus-api-host http://192.168.100.100:9095"'"
+    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-grafana-api-url https://192.168.100.100:3000"'"
+    with_libvirt "kcli ssh -u root ceph-node-00 'cephadm shell "ceph orch apply node-exporter --placement 'count:2"'"'
+fi

--- a/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
@@ -60,8 +60,8 @@ fi
 npm run build ${FRONTEND_BUILD_OPTS} &
 
 cd ${CEPH_DEV_FOLDER}
-: ${VM_IMAGE:='fedora42'}
-: ${VM_IMAGE_URL:='https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2'}
+: ${VM_IMAGE:='fedora44'}
+: ${VM_IMAGE_URL:='https://dl.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2'}
 with_libvirt "kcli download image -p ceph-dashboard -u ${VM_IMAGE_URL} ${VM_IMAGE}"
 with_libvirt "kcli delete plan -y ceph || true"
 # Compile cephadm locally for the shared_ceph_folder to pick it up

--- a/src/pybind/mgr/dashboard/ci/cephadm/utils.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/utils.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+with_libvirt() {
+    if [[ -n "${JENKINS_HOME}" ]]; then
+        sg libvirt -c "$1"
+    else
+        eval "$1"
+    fi
+}


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
