### PR TITLE
exporter: fix RGW sync metrics for zone names with special chars

### DIFF
--- a/src/exporter/DaemonMetricCollector.cc
+++ b/src/exporter/DaemonMetricCollector.cc
@@ -7,7 +7,6 @@
 #include <iostream>
 #include <map>
 #include <memory>
-#include <regex>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -137,7 +136,6 @@ void DaemonMetricCollector::parse_asok_metrics(
               std::string counter_name_init = {counter.key().begin(),
                                                counter.key().end()};
               std::string counter_name = perf_group + "_" + counter_name_init;
-              promethize(counter_name);
 
               auto extra_labels = get_extra_labels(daemon_name);
               if (extra_labels.empty()) {
@@ -147,13 +145,14 @@ void DaemonMetricCollector::parse_asok_metrics(
               }
               labels.insert(extra_labels.begin(), extra_labels.end());
 
-              // For now this is only required for rgw multi-site metrics
-              auto multisite_labels_and_name = add_fixed_name_metrics(counter_name);
+              auto multisite_labels_and_name =
+                  add_fixed_name_metrics(perf_group, counter_name_init);
               if (!multisite_labels_and_name.first.empty()) {
                 labels.insert(multisite_labels_and_name.first.begin(),
                               multisite_labels_and_name.first.end());
                 counter_name = multisite_labels_and_name.second;
               }
+              promethize(counter_name);
               auto perf_values = counters_values.at(counter_name_init);
               dump_asok_metric(counter_group, perf_values, counter_name, labels);
             } catch (const std::exception &e) {
@@ -453,23 +452,20 @@ labels_t DaemonMetricCollector::get_extra_labels(std::string daemon_name) {
   return labels;
 }
 
-// Add fixed name metrics from existing ones that have details in their names
-// that should be in labels (not in name). For backward compatibility,
-// a new fixed name metric is created (instead of replacing)and details are put
-// in new labels. Intended for RGW sync perf. counters but extendable as required.
+// Extract structured details from perf group names into labels.
+// e.g. perf_group "data-sync-from-data-xyz" → source_zone="data-xyz"
 // See: https://tracker.ceph.com/issues/45311
 std::pair<labels_t, std::string>
-DaemonMetricCollector::add_fixed_name_metrics(std::string metric_name) {
-  std::string new_metric_name;
-  labels_t labels;
-  new_metric_name = metric_name;
-
-  std::regex re("data_sync_from_([^_]*)");
-  std::smatch match;
-  if (std::regex_search(metric_name, match, re)) {
-      new_metric_name = std::regex_replace(metric_name, re, "data_sync_from_zone");
-      labels["source_zone"] = quote(match.str(1));
-      return {labels, new_metric_name};
+DaemonMetricCollector::add_fixed_name_metrics(
+    const std::string &perf_group, const std::string &counter_name) {
+  static const std::string RGW_SYNC_PREFIX = "data-sync-from-";
+  if (perf_group.compare(0, RGW_SYNC_PREFIX.size(), RGW_SYNC_PREFIX) == 0) {
+    std::string source_zone = perf_group.substr(RGW_SYNC_PREFIX.size());
+    labels_t labels;
+    labels["source_zone"] = quote(source_zone);
+    std::string new_metric_name =
+        RGW_SYNC_PREFIX + "zone_" + counter_name;
+    return {labels, new_metric_name};
   }
 
   return {};

--- a/src/exporter/DaemonMetricCollector.h
+++ b/src/exporter/DaemonMetricCollector.h
@@ -44,7 +44,8 @@ public:
                          bool config_show_response);
   std::map<std::string, AdminSocketClient> clients;
   std::string metrics;
-  std::pair<labels_t, std::string> add_fixed_name_metrics(std::string metric_name);
+  std::pair<labels_t, std::string> add_fixed_name_metrics(
+      const std::string &perf_group, const std::string &counter_name);
   void update_sockets();
   void shutdown();
 

--- a/src/test/exporter/test_exporter.cc
+++ b/src/test/exporter/test_exporter.cc
@@ -1447,37 +1447,73 @@ ceph_rbd_mirror_snapshot_image_sync_time_sum{ceph_daemon="rbd-mirror.a",image="i
 }
 
 TEST(Exporter, add_fixed_name_metrics) {
-    std::vector<std::string> metrics = {
-      "ceph_data_sync_from_zone2-zg1-realm1_fetch_bytes",
-      "ceph_data_sync_from_zone2-zg1-realm1_fetch_bytes_sum",
-      "ceph_data_sync_from_zone2-zg1-realm1_poll_latency_sum",
-    };
-    std::vector<std::string> expected_metrics = {
-      "ceph_data_sync_from_zone_fetch_bytes",
-      "ceph_data_sync_from_zone_fetch_bytes_sum",
-      "ceph_data_sync_from_zone_poll_latency_sum",
-    };
-    std::string metric_name;
-    std::pair<labels_t, std::string> new_metric;
-    labels_t expected_labels;
-    std::string expected_metric_name;
-    for (std::size_t index = 0; index < metrics.size(); ++index) {
-        std::string &metric_name = metrics[index];
-        DaemonMetricCollector &collector = collector_instance();
-        auto new_metric = collector.add_fixed_name_metrics(metric_name);
-        expected_labels = {{"source_zone", "\"zone2-zg1-realm1\""}};
-        std::string expected_metric_name = expected_metrics[index];
-        EXPECT_EQ(new_metric.first, expected_labels);
-        ASSERT_EQ(new_metric.second, expected_metric_name);
-    }
-
-    metric_name = "ceph_data_sync_from_zone2_fetch_bytes_count";
     DaemonMetricCollector &collector = collector_instance();
-    new_metric = collector.add_fixed_name_metrics(metric_name);
-    expected_labels = {{"source_zone", "\"zone2\""}};
-    expected_metric_name = "ceph_data_sync_from_zone_fetch_bytes_count";
-    EXPECT_EQ(new_metric.first, expected_labels);
-    ASSERT_TRUE(new_metric.second == expected_metric_name);
+
+    // Hyphenated zone name
+    auto result = collector.add_fixed_name_metrics(
+        "data-sync-from-data-xyz", "fetch_bytes_sum");
+    ASSERT_FALSE(result.first.empty());
+    std::string counter_name = result.second;
+    promethize(counter_name);
+    EXPECT_EQ(counter_name, "ceph_data_sync_from_zone_fetch_bytes_sum");
+    EXPECT_EQ(result.first.at("source_zone"), "\"data-xyz\"");
+
+    // Simple zone name
+    result = collector.add_fixed_name_metrics(
+        "data-sync-from-zone2", "fetch_bytes_count");
+    ASSERT_FALSE(result.first.empty());
+    counter_name = result.second;
+    promethize(counter_name);
+    EXPECT_EQ(counter_name, "ceph_data_sync_from_zone_fetch_bytes_count");
+    EXPECT_EQ(result.first.at("source_zone"), "\"zone2\"");
+
+    // Zone name with multiple hyphens (e.g. zone2-zg1-realm1)
+    result = collector.add_fixed_name_metrics(
+        "data-sync-from-zone2-zg1-realm1", "fetch_bytes");
+    ASSERT_FALSE(result.first.empty());
+    counter_name = result.second;
+    promethize(counter_name);
+    EXPECT_EQ(counter_name, "ceph_data_sync_from_zone_fetch_bytes");
+    EXPECT_EQ(result.first.at("source_zone"), "\"zone2-zg1-realm1\"");
+
+    // Zone name with multiple hyphens and poll_latency counter
+    result = collector.add_fixed_name_metrics(
+        "data-sync-from-zone2-zg1-realm1", "poll_latency_sum");
+    ASSERT_FALSE(result.first.empty());
+    counter_name = result.second;
+    promethize(counter_name);
+    EXPECT_EQ(counter_name, "ceph_data_sync_from_zone_poll_latency_sum");
+    EXPECT_EQ(result.first.at("source_zone"), "\"zone2-zg1-realm1\"");
+
+    // Zone name with dots
+    result = collector.add_fixed_name_metrics(
+        "data-sync-from-us.east.1", "fetch_bytes_count");
+    ASSERT_FALSE(result.first.empty());
+    counter_name = result.second;
+    promethize(counter_name);
+    EXPECT_EQ(counter_name, "ceph_data_sync_from_zone_fetch_bytes_count");
+    EXPECT_EQ(result.first.at("source_zone"), "\"us.east.1\"");
+
+    // Zone name with underscores
+    result = collector.add_fixed_name_metrics(
+        "data-sync-from-my_zone_01", "fetch_bytes_sum");
+    ASSERT_FALSE(result.first.empty());
+    counter_name = result.second;
+    promethize(counter_name);
+    EXPECT_EQ(counter_name, "ceph_data_sync_from_zone_fetch_bytes_sum");
+    EXPECT_EQ(result.first.at("source_zone"), "\"my_zone_01\"");
+
+    // Non-matching perf group
+    result = collector.add_fixed_name_metrics(
+        "rgw", "op_get_obj_lat_count");
+    EXPECT_TRUE(result.first.empty());
+    EXPECT_TRUE(result.second.empty());
+
+    // Non-matching prefix (partial match)
+    result = collector.add_fixed_name_metrics(
+        "data-sync-to-zone1", "fetch_bytes_sum");
+    EXPECT_TRUE(result.first.empty());
+    EXPECT_TRUE(result.second.empty());
 }
 
 TEST(Exporter, UpdateSockets) {


### PR DESCRIPTION
Pass `perf_group` and `counter_name` as separate arguments to `add_fixed_name_metrics()` instead of joining them with underscore then parsing back with regex. This avoids the ambiguity that broke hyphenated zone names (e.g. `data-xyz`) and would also break zone names containing underscores or dots.

Fixes: https://tracker.ceph.com/issues/78992





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
