### PR TITLE
monitoring: show N/A for compression metrics when physical used < 100 GiB

### DIFF
--- a/monitoring/ceph-mixin/dashboards_out/ceph-hardware-compression.json
+++ b/monitoring/ceph-mixin/dashboards_out/ceph-hardware-compression.json
@@ -85,7 +85,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Amount of physical storage capacity saved through hardware compression.",
+      "description": "Amount of physical storage capacity saved through hardware compression. Displays N/A when physical used is below 100 GiB, as small amounts of internal metadata can produce misleading values.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -146,7 +146,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(ceph_extblkdev_dev_log_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}) - sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"})",
+          "expr": "(sum(ceph_extblkdev_dev_log_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}) - sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"})) and (sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}) > 107374182400)",
           "instant": false,
           "legendFormat": "Storage Saved",
           "range": true,
@@ -161,7 +161,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Ratio of logical data to physical storage after compression. Higher values indicate better compression efficiency.",
+      "description": "Ratio of logical data to physical storage after compression. Higher values indicate better compression efficiency. Displays N/A when physical used is below 100 GiB, as small amounts of internal metadata can produce misleading values.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -231,7 +231,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(ceph_extblkdev_dev_log_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}) / clamp_min(sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}), 1)",
+          "expr": "(sum(ceph_extblkdev_dev_log_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}) / clamp_min(sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}), 1)) and (sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}) > 107374182400)",
           "instant": false,
           "legendFormat": "Compression Ratio",
           "range": true,
@@ -246,7 +246,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Percentage of storage capacity saved through compression. Shows cost savings and infrastructure efficiency.",
+      "description": "Percentage of storage capacity saved through compression. Shows cost savings and infrastructure efficiency. Displays N/A when physical used is below 100 GiB, as small amounts of internal metadata can produce misleading values.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -308,7 +308,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "100 * (1 - sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}) / clamp_min(sum(ceph_extblkdev_dev_log_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}), 1))",
+          "expr": "(100 * (1 - sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}) / clamp_min(sum(ceph_extblkdev_dev_log_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}), 1))) and (sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}) > 107374182400)",
           "instant": false,
           "legendFormat": "Efficiency",
           "range": true,
@@ -903,7 +903,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Historical compression effectiveness over time. Stable trend indicates consistent workload. Declining ratios suggest more incompressible data.",
+      "description": "Historical compression effectiveness over time. Stable trend indicates consistent workload. Declining ratios suggest more incompressible data. No data shown when physical used is below 100 GiB.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -987,7 +987,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "round(sum(ceph_extblkdev_dev_log_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}) / sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}), 0.01)",
+          "expr": "(round(sum(ceph_extblkdev_dev_log_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}) / sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}), 0.01)) and (sum(ceph_extblkdev_dev_phy_util{cluster=~\"$cluster\", instance=~\"$instance\", ceph_daemon=~\"$osd\"}) > 107374182400)",
           "instant": false,
           "legendFormat": "Compression Ratio",
           "range": true,


### PR DESCRIPTION
On fresh clusters with no user data, internal metadata compresses at ~10:1, producing misleading ratio/efficiency values. Gate compression ratio, efficiency, storage saved, and ratio trend panels on physical used exceeding 100 GiB.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
