### PR TITLE
mgr/dashboard: show inline error on failed login instead of toast notification

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.html
@@ -9,6 +9,17 @@
     #loginForm="ngForm"
     novalidate
   >
+    @if (errorMessage) {
+      <cd-alert-panel
+        type="danger"
+        [dismissible]="true"
+        (dismissed)="errorMessage = ''"
+        [showTitle]="false"
+      >
+        {{ errorMessage }}
+      </cd-alert-panel>
+    }
+
     <!-- Username -->
     <div class="form-group has-feedback d-flex flex-column py-3">
       <label

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import { AuthService } from '~/app/shared/api/auth.service';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
@@ -60,5 +60,33 @@ describe('LoginComponent', () => {
     expect(routerNavigateSpy).toHaveBeenCalledWith(['/add-storage'], {
       queryParams: { welcome: true }
     });
+  });
+
+  it('should show inline error on failed login', () => {
+    const err = {
+      error: { detail: 'Invalid credentials', code: 'invalid_credentials', component: 'auth' },
+      status: 400,
+      statusText: 'Bad Request',
+      url: 'api/auth',
+      preventDefault: jasmine.createSpy('preventDefault')
+    };
+    authServiceLoginSpy.and.returnValue(throwError(err));
+    component.model.password = 'secret';
+
+    component.login();
+
+    expect(component.errorMessage).toBe('Invalid credentials');
+    expect(component.model.password).toBe('secret');
+    expect(err.preventDefault).toHaveBeenCalled();
+    expect(routerNavigateSpy).not.toHaveBeenCalled();
+  });
+
+  it('should clear error on retry', () => {
+    component.errorMessage = 'Previous error';
+    authServiceLoginSpy.and.returnValue(of(null));
+
+    component.login();
+
+    expect(component.errorMessage).toBe('');
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.ts
@@ -19,6 +19,7 @@ export class LoginComponent implements OnInit {
   isLoginActive = false;
   returnUrl: string;
   postInstalled = false;
+  errorMessage = '';
 
   constructor(
     private authService: AuthService,
@@ -65,19 +66,27 @@ export class LoginComponent implements OnInit {
   }
 
   login() {
+    this.errorMessage = '';
     localStorage.setItem('cluster_api_url', window.location.origin);
-    this.authService.login(this.model).subscribe(() => {
-      const permissions = this.authStorageService.getPermissions();
-      const canSetupCluster = !this.postInstalled && permissions.configOpt?.update;
-      const urlPath = canSetupCluster ? '/add-storage' : '/';
-      let url = _.get(this.route.snapshot.queryParams, 'returnUrl', urlPath);
-      if (canSetupCluster && this.route.snapshot.queryParams['returnUrl'] === '/overview') {
-        url = '/add-storage';
-      }
-      if (url === '/add-storage') {
-        this.router.navigate([url], { queryParams: { welcome: true } });
-      } else {
-        this.router.navigate([url]);
+    this.authService.login(this.model).subscribe({
+      next: () => {
+        const permissions = this.authStorageService.getPermissions();
+        const canSetupCluster = !this.postInstalled && permissions.configOpt?.update;
+        const urlPath = canSetupCluster ? '/add-storage' : '/';
+        let url = _.get(this.route.snapshot.queryParams, 'returnUrl', urlPath);
+        if (canSetupCluster && this.route.snapshot.queryParams['returnUrl'] === '/overview') {
+          url = '/add-storage';
+        }
+        if (url === '/add-storage') {
+          this.router.navigate([url], { queryParams: { welcome: true } });
+        } else {
+          this.router.navigate([url]);
+        }
+      },
+      error: (err) => {
+        err.preventDefault();
+        this.errorMessage = err.error?.detail || $localize`Invalid credentials`;
+        document.getElementById('username')?.focus();
       }
     });
   }


### PR DESCRIPTION
Added as per https://carbondesignsystem.com/patterns/login-pattern/#errors-and-validation


https://github.com/user-attachments/assets/e4bd032c-7d15-4577-833b-6a399eeee2ae






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
