### PR TITLE
mds: avoid resizing an inconsistent MDSMap

### DIFF
--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -1279,6 +1279,18 @@ bool MDSMap::is_laggy_gid(mds_gid_t gid) const {
 bool MDSMap::is_degraded() const {
   if (!failed.empty() || !damaged.empty())
     return true;
+
+  // When no rank is failed, every rank in the cluster must have a daemon
+  // assigned to it.  An inconsistent map must not be treated as resizeable.
+  if (in.size() != up.size()) {
+    return true;
+  }
+  for (const auto& p : up) {
+    if (!in.count(p.first)) {
+      return true;
+    }
+  }
+
   for (const auto& p : mds_info) {
     if (p.second.is_degraded())
       return true;

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -2184,8 +2184,8 @@ bool MDSMonitor::maybe_resize_cluster(FSMap &fsmap, const Filesystem& fs)
     return true;
   } else if (in > max) {
     mds_rank_t target = in - 1;
-    const auto &info = mds_map.get_info(target);
     if (mds_map.is_active(target)) {
+      const auto& info = mds_map.get_info(target);
       dout(1) << "stopping " << target << dendl;
       mon.clog->info() << "stopping " << info.human_name();
       auto f = [](auto& info) {

--- a/src/test/mds/CMakeLists.txt
+++ b/src/test/mds/CMakeLists.txt
@@ -6,6 +6,14 @@ add_executable(unittest_mds_authcap
 add_ceph_unittest(unittest_mds_authcap)
 target_link_libraries(unittest_mds_authcap mds global ${BLKID_LIBRARIES})
 
+# unittest_mds_map
+add_executable(unittest_mds_map
+  TestMDSMap.cc
+  $<TARGET_OBJECTS:unit-main>
+  )
+add_ceph_unittest(unittest_mds_map)
+target_link_libraries(unittest_mds_map mds global)
+
 # unittest_mds_sessionfilter
 add_executable(unittest_mds_sessionfilter
   TestSessionFilter.cc

--- a/src/test/mds/TestMDSMap.cc
+++ b/src/test/mds/TestMDSMap.cc
@@ -1,0 +1,62 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2026 Ceph contributors
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "gtest/gtest.h"
+#include "mds/MDSMap.h"
+
+namespace {
+
+class TestableMDSMap : public MDSMap {
+public:
+  using MDSMap::in;
+  using MDSMap::mds_info;
+  using MDSMap::up;
+};
+
+} // anonymous namespace
+
+TEST(MDSMap, Issue72895RankSetMismatchIsDegraded)
+{
+  TestableMDSMap map;
+  for (mds_rank_t rank = 0; rank < 5; ++rank) {
+    map.in.insert(rank);
+  }
+
+  EXPECT_TRUE(map.is_degraded());
+  EXPECT_FALSE(map.is_resizeable());
+}
+
+TEST(MDSMap, UpRankOutsideInIsDegraded)
+{
+  TestableMDSMap map;
+  map.in.insert(1);
+  map.up.emplace(0, 1);
+
+  EXPECT_TRUE(map.is_degraded());
+  EXPECT_FALSE(map.is_resizeable());
+}
+
+TEST(MDSMap, MatchingInAndUpIsNotDegraded)
+{
+  TestableMDSMap map;
+  map.in.insert(0);
+  map.up.emplace(0, 1);
+  map.mds_info[mds_gid_t(1)].global_id = mds_gid_t(1);
+  map.mds_info[mds_gid_t(1)].rank = 0;
+  map.mds_info[mds_gid_t(1)].state = MDSMap::STATE_ACTIVE;
+
+  EXPECT_FALSE(map.is_degraded());
+  EXPECT_TRUE(map.is_resizeable());
+}


### PR DESCRIPTION
## Description

When `MDSMap::in` contains a rank that is absent from `MDSMap::up`, `MDSMap::is_degraded()` may still return false. In that state, `MDSMonitor::maybe_resize_cluster()` can select the missing rank for resizing and call `MDSMap::get_info()` before checking `is_active()`.

For an empty `up` map, this reaches `up.at(target)` and aborts with `std::out_of_range`.

This was observed in our Ceph 20.2.0 (Tentacle) cluster with the following `archive` MDSMap state:

    max_mds = 0
    in      = {0}
    up      = {}
    failed  = {}
    damaged = {}
    stopped = {}

The same failure path is reported by tracker #72895 on Ceph 19.2.3 (Squid), with a different rank configuration.

This change:

* treats an MDSMap as degraded when the rank sets represented by `in` and `up` are inconsistent;
* moves the `get_info(target)` lookup inside the `is_active(target)` branch as an additional safety guard;
* adds unit regression tests for the rank-set mismatch, an invalid `up` rank, and a valid matching map.

## Tracker

Fixes: https://tracker.ceph.com/issues/72895

## Checklist

- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

Validation performed:

* `ninja unittest_mds_map -j2`: passed;
* CTest: passed, 1/1 test;
* `clang-format`: passed;
* `git diff --check`: passed.

The full `make check` suite has not been run locally.