### PR TITLE
umbrella: mgr/cephadm: deduplicate HAProxy_Hosts in NFS ganesha.conf

### DIFF
--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 import tempfile
 from threading import Lock
-from typing import Dict, Tuple, Any, List, cast, Optional, TYPE_CHECKING
+from typing import Dict, Tuple, Any, List, Set, cast, Optional, TYPE_CHECKING
 from configparser import ConfigParser
 from io import StringIO
 from cephadm import utils
@@ -266,7 +266,7 @@ class NFSService(CephService):
             }
             if spec.enable_haproxy_protocol:
                 context["haproxy_hosts"] = self._haproxy_hosts()
-                if spec.virtual_ip:
+                if spec.virtual_ip and spec.virtual_ip not in context["haproxy_hosts"]:
                     context["haproxy_hosts"].append(spec.virtual_ip)
                 logger.debug("selected haproxy_hosts: %r", context["haproxy_hosts"])
             return self.mgr.template.render('services/nfs/ganesha.conf.j2', context)
@@ -526,10 +526,10 @@ class NFSService(CephService):
         # good enough to prevent acceping haproxy protocol messages
         # from "rouge" systems that are not under our control. At
         # least until we learn otherwise.
-        cluster_ips: List[str] = []
+        cluster_ips: Set[str] = set()
         for host in self.mgr.inventory.keys():
             default_addr = self.mgr.inventory.get_addr(host)
-            cluster_ips.append(default_addr)
+            cluster_ips.add(default_addr)
             nets = self.mgr.cache.networks.get(host)
             if not nets:
                 continue
@@ -542,8 +542,8 @@ class NFSService(CephService):
                 addrs: List[str] = sum((addr_list for addr_list in iface.values()), [])
                 if addrs:
                     # one address per interface/subnet is enough
-                    cluster_ips.append(addrs[0])
-        return cluster_ips
+                    cluster_ips.add(addrs[0])
+        return list(cluster_ips)
 
     def get_monitoring_details(
         self,

--- a/src/pybind/mgr/cephadm/tests/services/test_ingress.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_ingress.py
@@ -1193,7 +1193,6 @@ class TestIngressService:
             '        Enable_UDP = false;\n'
             '        NFS_Port = 2049;\n'
             '        allow_set_io_flusher_fail = true;\n'
-            '        HAProxy_Hosts = 192.168.122.111, 10.10.2.20, 192.168.122.222;\n'
             '        Monitoring_Port = 9587;\n'
             '}\n'
             '\n'
@@ -1329,6 +1328,29 @@ class TestIngressService:
                 service_name=nfs_service.service_name(),
                 rank=0,
             ),
+        )
+        ganesha_conf = nfs_generated_conf['files']['ganesha.conf']
+        haproxy_hosts = {
+            ip.strip()
+            for line in ganesha_conf.splitlines()
+            if 'HAProxy_Hosts' in line
+            for ip in line.split('=', 1)[1].strip().rstrip(';').split(',')
+        }
+        assert haproxy_hosts == {
+            '192.168.122.111',
+            '10.10.2.20',
+            '192.168.122.222',
+        }
+
+        def without_haproxy_hosts(conf: str) -> str:
+            return '\n'.join(
+                line for line in conf.splitlines()
+                if 'HAProxy_Hosts' not in line
+            )
+
+        nfs_generated_conf['files']['ganesha.conf'] = without_haproxy_hosts(ganesha_conf)
+        nfs_expected_conf['files']['ganesha.conf'] = without_haproxy_hosts(
+            nfs_ganesha_txt
         )
         assert nfs_generated_conf == nfs_expected_conf
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78205

---

backport of https://github.com/ceph/ceph/pull/70079
parent tracker: https://tracker.ceph.com/issues/78094

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh