### PR TITLE
mgr/telemetry: fix 500 error when generating telemetry report

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -27,6 +27,31 @@ from mgr_module import MgrModule, Option, OptionValue, ServiceInfoT
 
 ALL_CHANNELS = ['basic', 'ident', 'crash', 'device', 'perf']
 
+
+def _defaultdict_list() -> defaultdict:
+    return defaultdict(list)
+
+
+def _defaultdict_dict() -> defaultdict:
+    return defaultdict(dict)
+
+
+def _defaultdict_int() -> defaultdict:
+    return defaultdict(int)
+
+
+def _defaultdict_defaultdict_int() -> defaultdict:
+    return defaultdict(_defaultdict_int)
+
+
+def _defaultdict_defaultdict_defaultdict_int() -> defaultdict:
+    return defaultdict(_defaultdict_defaultdict_int)
+
+
+def _defaultdict_histogram() -> defaultdict:
+    """Six-level nested defaultdict(int) used by get_osd_histograms."""
+    return defaultdict(_defaultdict_defaultdict_defaultdict_int)
+
 LICENSE = 'sharing-1-0'
 LICENSE_NAME = 'Community Data License Agreement - Sharing - Version 1.0'
 LICENSE_URL = 'https://cdla.io/sharing-1-0/'
@@ -502,7 +527,7 @@ class Module(MgrModule):
         return  etype + '.' + m.hexdigest()
 
     def get_heap_stats(self) -> Dict[str, dict]:
-        result: Dict[str, dict] = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+        result: Dict[str, dict] = defaultdict(_defaultdict_defaultdict_int)
         anonymized_daemons = {}
         osd_map = self.get('osd_map')
 
@@ -577,7 +602,7 @@ class Module(MgrModule):
         return parsed_output
 
     def get_mempool(self, mode: str = 'separated') -> Dict[str, dict]:
-        result: Dict[str, dict] = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+        result: Dict[str, dict] = defaultdict(_defaultdict_defaultdict_int)
         anonymized_daemons = {}
         osd_map = self.get('osd_map')
 
@@ -633,11 +658,7 @@ class Module(MgrModule):
 
     def get_osd_histograms(self, mode: str = 'separated') -> List[Dict[str, dict]]:
         # Initialize result dict
-        result: Dict[str, dict] = defaultdict(lambda: defaultdict(
-                                              lambda: defaultdict(
-                                              lambda: defaultdict(
-                                              lambda: defaultdict(
-                                              lambda: defaultdict(int))))))
+        result: Dict[str, dict] = defaultdict(_defaultdict_histogram)
 
         # Get list of osd ids from the metadata
         osd_metadata = self.get('osd_metadata')
@@ -839,7 +860,7 @@ class Module(MgrModule):
         perf_counters = self.get_perf_counters()
 
         # Initialize 'result' dict
-        result: Dict[str, dict] = defaultdict(lambda: defaultdict(list))
+        result: Dict[str, dict] = defaultdict(_defaultdict_list)
 
         # 'separated' mode
         anonymized_daemon_dict = {}
@@ -878,7 +899,7 @@ class Module(MgrModule):
                 result[daemon][collection] = []
 
                 for sub_collection in sub_collection_list:
-                    sub_collection_result: Dict[str, dict] = defaultdict(lambda: defaultdict(dict))
+                    sub_collection_result: Dict[str, dict] = defaultdict(_defaultdict_dict)
                     sub_collection_result['labels'] = sub_collection['labels']
                     for sub_collection_counter_name, sub_collection_counter_info in sub_collection['counters'].items():
                         if mode == 'separated':

--- a/src/pybind/mgr/telemetry/tests/test_telemetry.py
+++ b/src/pybind/mgr/telemetry/tests/test_telemetry.py
@@ -1,6 +1,8 @@
 import json
+import pickle
 import pytest
 import unittest
+from collections import defaultdict
 from unittest import mock
 
 import telemetry
@@ -119,3 +121,22 @@ class TestTelemetry:
         assert m.is_opted_in() == expected['is_opted_in']
         assert m.is_enabled_collection(Collection.basic_base) == expected['is_enabled_collection']['basic_base']
         assert m.is_enabled_collection(Collection.basic_mds_metadata) == expected['is_enabled_collection']['basic_mds_metadata']
+
+    def test_defaultdict_helpers_are_picklable(self) -> None:
+        """Regression test for pickle serialization of defaultdict factories.
+
+        The telemetry report returned through mgr.remote() must be pickle-serializable.
+        Verify that the module-level defaultdict factories can be pickled.
+        """
+        factories = [
+            telemetry.module._defaultdict_list,
+            telemetry.module._defaultdict_dict,
+            telemetry.module._defaultdict_defaultdict_int,
+            telemetry.module._defaultdict_histogram,
+        ]
+
+        for factory in factories:
+            d = defaultdict(factory)
+            restored = pickle.loads(pickle.dumps(d))
+            assert restored is not None, \
+                f"defaultdict({factory.__name__}) failed pickle round-trip"


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/79003
Signed-off-by: Anurag Raut <anuragtraut08@ibm.com>

PR Description:

This PR fixes a 500 Internal Server Error encountered while generating the Telemetry report after updating the Telemetry configuration. The failure was caused by non-picklable `defaultdict` factories using local lambda functions during report serialization. The fix replaces these with module-level helper functions, preserving the existing report structure while allowing successful serialization and report generation.

Screencast:

[Screencast From 2026-08-04 14-31-45.webm](https://github.com/user-attachments/assets/b01eab76-bd61-4ae8-ae62-f6c3445eee76)




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
