### PR TITLE
umbrella: core: Handle OP_TOUCH_TEMP in BlueStore without any guard(WITH_CRIMSON)

### DIFF
--- a/src/os/Transaction.cc
+++ b/src/os/Transaction.cc
@@ -87,7 +87,6 @@ void Transaction::dump(ceph::Formatter *f)
       }
       break;
 
-#ifdef WITH_CRIMSON
     case Transaction::OP_TOUCH_TEMP:
       {
         coll_t cid = i.get_cid(op->cid);
@@ -99,7 +98,6 @@ void Transaction::dump(ceph::Formatter *f)
         f->dump_stream("oid") << dest_oid;
       }
       break;
-#endif
 
     case Transaction::OP_WRITE:
       {

--- a/src/os/Transaction.h
+++ b/src/os/Transaction.h
@@ -153,9 +153,7 @@ public:
     OP_COLL_SET_BITS = 42, // cid, bits
 
     OP_MERGE_COLLECTION = 43, // cid, destination
-#ifdef WITH_CRIMSON
     OP_TOUCH_TEMP = 44, // cid, temp_oid, target_oid
-#endif
   };
 
   // Transaction hint type
@@ -444,9 +442,7 @@ public:
       op->oid = om[op->oid];
       break;
 
-#ifdef WITH_CRIMSON
     case OP_TOUCH_TEMP:
-#endif
     case OP_CLONERANGE2:
     case OP_CLONE:
       ceph_assert(op->cid < cm.size());
@@ -864,7 +860,6 @@ public:
     _op->oid = _get_object_id(oid);
     data.ops = data.ops + 1;
   }
-#ifdef WITH_CRIMSON
   /**
    * touch_temp
    *
@@ -886,7 +881,7 @@ public:
     _op->dest_oid = _get_object_id(target_oid);
     data.ops = data.ops + 1;
   }
-#endif
+
   /**
    * Write data to an offset within an object. If the object is too
    * small, it is expanded as needed.  It is possible to specify an

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -16226,9 +16226,7 @@ void BlueStore::_txc_add_transaction(TransContext *txc, Transaction *t)
     // these operations implicity create the object
     bool create = false;
     if (op->op == Transaction::OP_TOUCH ||
-#ifdef WITH_CRIMSON
         op->op == Transaction::OP_TOUCH_TEMP ||
-#endif
 	op->op == Transaction::OP_CREATE ||
 	op->op == Transaction::OP_WRITE ||
 	op->op == Transaction::OP_ZERO) {
@@ -16252,9 +16250,7 @@ void BlueStore::_txc_add_transaction(TransContext *txc, Transaction *t)
     switch (op->op) {
     case Transaction::OP_CREATE:
     case Transaction::OP_TOUCH:
-#ifdef WITH_CRIMSON
     case Transaction::OP_TOUCH_TEMP:
-#endif
       r = _touch(txc, c, o);
       break;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79014

---

backport of https://github.com/ceph/ceph/pull/69428
parent tracker: https://tracker.ceph.com/issues/75957

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh