### PR TITLE
doc/csi: encourage deployment through Ceph-CSI Operator

### DIFF
--- a/doc/csi/deployment.rst
+++ b/doc/csi/deployment.rst
@@ -41,6 +41,7 @@ Ceph-CSI-Operator (Recommended)
 
 The `Ceph-CSI-Operator`_ manages the deployment, configuration, and
 lifecycle of Ceph-CSI drivers through Kubernetes custom resources.
+For complete documentation, see the `Ceph-CSI Operator documentation`_.
 To install the operator:
 
 .. prompt:: bash $
@@ -58,18 +59,24 @@ deploy the RBD driver:
      name: rbd.csi.ceph.com
      namespace: ceph-csi-operator-system
 
-The CephFS and NFS drivers are deployed the same way, using the names
-``cephfs.csi.ceph.com`` and ``nfs.csi.ceph.com``. Connection details
-for the Ceph cluster are supplied through the operator's
-``CephConnection`` and ``ClientProfile`` resources; CephX credentials
-are stored in Kubernetes Secrets referenced from the StorageClass. See
-the `operator quick start`_ and `operator installation guide`_ pages
-for complete walkthroughs, supported Kubernetes versions, and
-Helm-based installation of the operator itself.
+The CephFS, NFS, and NVMe-oF drivers are deployed the same way, using
+the names ``cephfs.csi.ceph.com``, ``nfs.csi.ceph.com``, and
+``nvmeof.csi.ceph.com``. Connection details for the Ceph cluster are
+supplied through the operator's ``CephConnection`` and
+``ClientProfile`` resources; CephX credentials are stored in
+Kubernetes Secrets referenced from the StorageClass. See the
+`operator quick start`_ and `operator installation guide`_ pages for
+complete walkthroughs, supported Kubernetes versions, and Helm-based
+installation of the operator itself.
 
 
-Helm Charts
-===========
+Helm Charts (Deprecated)
+========================
+
+.. note::
+
+   For new deployments, the `Ceph-CSI-Operator`_ is recommended over
+   Helm charts. See the `Ceph-CSI Operator documentation`_ for details.
 
 The Ceph-CSI project publishes per-driver Helm charts:
 
@@ -83,8 +90,13 @@ A ``ceph-csi-cephfs`` chart is available for the CephFS driver. Chart
 values are documented in the `Ceph-CSI charts`_ directory.
 
 
-Raw Manifests
-=============
+Raw Manifests (Deprecated)
+==========================
+
+.. note::
+
+   For new deployments, the `Ceph-CSI-Operator`_ is recommended over
+   Raw Manifests. See the `Ceph-CSI Operator documentation`_ for details.
 
 Per-driver Kubernetes manifests are maintained in the ``deploy/``
 directory of the Ceph-CSI repository, together with deployment
@@ -93,6 +105,7 @@ most control but requires you to track and apply manifest changes on
 every upgrade.
 
 .. _Ceph-CSI-Operator: https://github.com/ceph/ceph-csi-operator
+.. _Ceph-CSI Operator documentation: https://ceph.github.io/ceph-csi-operator
 .. _Rook: https://rook.io
 .. _operator quick start: https://github.com/ceph/ceph-csi-operator/blob/main/docs/quick-start.md
 .. _operator installation guide: https://github.com/ceph/ceph-csi-operator/blob/main/docs/installation.md


### PR DESCRIPTION
Ceph-CSI ideally gets deployed by Ceph-CSI Operator, the other methods (Helm Charts and Raw Manifests) are deprecated.

Include links to the newly published Ceph-CSI Operator documentation, and mention NVMe-oF support as well.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
