### PR TITLE
umbrella: qa/workunits/smb: work around test failures by pinning smbprotocol version

### DIFF
--- a/qa/workunits/smb/smb_tests.sh
+++ b/qa/workunits/smb/smb_tests.sh
@@ -23,5 +23,5 @@ fi
 trap cleanup EXIT
 
 cd "${HERE}"
-"${VENV}/bin/${PY}" -m pip install pytest smbprotocol
+"${VENV}/bin/${PY}" -m pip install pytest 'smbprotocol<1.17.0'
 "${VENV}/bin/${PY}" -m pytest -v "$@"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78123

---

backport of https://github.com/ceph/ceph/pull/70083
parent tracker: https://tracker.ceph.com/issues/78116

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh