### PR TITLE
src/crimson/osd/ec_backend.cc: improve logging 

### DIFF
--- a/src/crimson/osd/ec_backend.cc
+++ b/src/crimson/osd/ec_backend.cc
@@ -87,10 +87,10 @@ ECBackend::_read(const hobject_t& hoid,
 	auto range = got.emap.get_containing_range(off, len);
 	ceph_assert(range.first != range.second);
 	ceph_assert(range.first.get_off() <= off);
-        DEBUGDPP("offset: {}", dpp, off);
-        DEBUGDPP("range offset: {}", dpp, range.first.get_off());
-        DEBUGDPP("length: {}", dpp, len);
-        DEBUGDPP("range length: {}", dpp, range.first.get_len());
+        DEBUGDPP("hoid={} offset={}", dpp, hoid, off);
+        DEBUGDPP("hoid={} range_offset={}", dpp, hoid, range.first.get_off());
+        DEBUGDPP("hoid={} length={}", dpp, hoid, len);
+        DEBUGDPP("hoid={} range_length={}", dpp, hoid, range.first.get_len());
 	ceph_assert(
 	  (off + len) <=
 	  (range.first.get_off() + range.first.get_len()));
@@ -117,7 +117,7 @@ struct ECCrimsonOp : ECCommon::RMWPipeline::Op {
     auto i = std::begin(t);
     while (i.have_op()) {
       auto* op = i.decode_op();
-      logger().debug("ECBackend::{} decoded op={} oid={} dest_oid={}",
+      logger().debug("ECBackend::{} decoded op={} ghobj={} dest_ghobj={}",
 		     __func__,
 		     static_cast<uint32_t>(op->op),
 		     i.get_oid(op->oid),
@@ -322,7 +322,7 @@ ECBackend::submit_transaction(const std::set<pg_shard_t> &pg_shards,
 {
   LOG_PREFIX(ECBackend::submit_transaction);
   const hobject_t& hoid = obc->obs.oi.soid;
-  DEBUGDPP("hoid={} obc->attr_cache={}", dpp, hoid, obc->attr_cache);
+  DEBUGDPP("hoid={} attr_cache={}", dpp, hoid, obc->attr_cache);
   auto op =
     std::make_unique<ECCrimsonOp>(
       std::move(txn), std::move(obc), pg_log, rmw_pipeline);
@@ -348,13 +348,14 @@ ECBackend::submit_transaction(const std::set<pg_shard_t> &pg_shards,
     read_pipeline,
     rmw_pipeline,
     &dpp);
-  INFODPP("op {} starting", dpp, ""); //*op);
+  const auto tid = op->tid;
+  INFODPP("tid={} hoid={} starting", dpp, tid, op->hoid);
   rmw_pipeline.start_rmw(std::move(op));
-  DEBUGDPP("started ec op", dpp);
+  DEBUGDPP("tid={} started ec op", dpp, tid);
   return make_ready_future<rep_op_ret_t>(
     seastar::now(),
-    on_all_commit->get_future().then_interruptible([FNAME, &dpp=this->dpp] {
-      DEBUGDPP("op {} finished completely", dpp, "");
+    on_all_commit->get_future().then_interruptible([FNAME, tid, &dpp=this->dpp] {
+      DEBUGDPP("tid={} finished completely", dpp, tid);
       return seastar::now();
     })
   );
@@ -367,30 +368,30 @@ ECBackend::handle_sub_write(
   ECListener& pg)
 {
   LOG_PREFIX(ECBackend::handle_sub_write);
-  INFODPP("from {}", dpp, from);
+  INFODPP("tid={} hoid={} from={}", dpp, op.tid, op.soid, from);
   if (!op.temp_added.empty()) {
     add_temp_obj(std::begin(op.temp_added), std::end(op.temp_added));
   }
   ceph::os::Transaction txn;
   if (op.backfill_or_async_recovery) {
     for (const auto& obj : op.temp_removed) {
-      INFODPP("removing object {} since we won't get the transaction",
-	      dpp, obj);
+      INFODPP("tid={} hoid={} removing object since we won't get the transaction",
+	      dpp, op.tid, obj);
       txn.remove(coll->get_cid(),
 		 ghobject_t{obj, ghobject_t::NO_GEN, get_shard()});
     }
   }
   clear_temp_objs(op.temp_removed);
-  DEBUGDPP("missing before {}", dpp, "");
+  DEBUGDPP("tid={} hoid={} missing before", dpp, op.tid, op.soid);
 
   // flag set to true during async recovery
   bool async = false;
   if (pg.is_missing_object(op.soid)) {
     async = true;
-    DEBUGDPP("{} is missing", dpp, op.soid);
+    DEBUGDPP("tid={} hoid={} is missing", dpp, op.tid, op.soid);
     for (const auto& e: op.log_entries) {
-      DEBUGDPP("add_next_event entry {}, is_delete {}",
-	       dpp, e, e.is_delete());
+      DEBUGDPP("tid={} add_next_event entry={} is_delete={}",
+	       dpp, op.tid, e, e.is_delete());
       pg.add_local_next_event(e);
     }
   }
@@ -404,16 +405,16 @@ ECBackend::handle_sub_write(
     txn,
     async);
   txn.append(op.t); // hack warn
-  DEBUGDPP("line {}", dpp, __LINE__);
+  DEBUGDPP("line={}", dpp, __LINE__);
   if (op.at_version != eversion_t()) {
     // dummy rollforward transaction doesn't get at_version
     // (and doesn't advance it)
     pg.op_applied(op.at_version);
   }
-  DEBUGDPP("line {}", dpp, __LINE__);
+  DEBUGDPP("line={}", dpp, __LINE__);
   return crimson::os::with_store_do_transaction(
-      store, coll, std::move(txn)).then([FNAME, &dpp=this->dpp] {
-    DEBUGDPP("transaction commited!", dpp);
+      store, coll, std::move(txn)).then([FNAME, tid=op.tid, &dpp=this->dpp] {
+    DEBUGDPP("tid={} transaction commited!", dpp, tid);
     return write_iertr::now();
   });
 }
@@ -439,7 +440,7 @@ void ECBackend::handle_sub_write(
 {
   LOG_PREFIX(ECBackend::handle_sub_write);
   const auto tid = op.tid;
-  DEBUGDPP("tid {}", dpp, tid);
+  DEBUGDPP("tid={} hoid={}", dpp, tid, op.soid);
   std::ignore = handle_sub_write(
     from, std::move(op), eclistener
   ).si_then([tid, &eclistener, FNAME, this] {
@@ -450,7 +451,7 @@ void ECBackend::handle_sub_write(
     reply.committed = true;
     reply.applied = true;
     reply.from = eclistener.whoami_shard();
-    DEBUGDPP("reply from {}", dpp, reply.from);
+    DEBUGDPP("tid={} reply_from={}", dpp, tid, reply.from);
     return handle_rep_write_reply(std::move(reply));
   }, crimson::ct_error::assert_all("unexpected error"));
 }
@@ -462,7 +463,7 @@ ECBackend::handle_rep_write_op(
 {
   LOG_PREFIX(ECBackend::handle_rep_write_op);
   const auto tid = m->op.tid;
-  DEBUGDPP("tid {} from {}", dpp, tid, m->op.from);
+  DEBUGDPP("tid={} hoid={} from={}", dpp, tid, m->op.soid, m->op.from);
   return handle_sub_write(
     m->op.from, std::move(m->op), pg
   ).si_then([&pg] {
@@ -476,14 +477,14 @@ ECBackend::write_iertr::future<>
 ECBackend::handle_rep_write_reply(ECSubWriteReply&& op)
 {
   LOG_PREFIX(ECBackend::handle_rep_write_reply);
-  DEBUGDPP("handling reply from osd.{}, tid {}", dpp, op.from.osd, op.tid);
+  DEBUGDPP("tid={} handling reply from osd={}", dpp, op.tid, op.from.osd);
   assert(rmw_pipeline.tid_to_op_map.contains(op.tid));
   const auto& from = op.from;
   auto& wop = *rmw_pipeline.tid_to_op_map.at(op.tid);
   if (op.committed) {
     // TODO: trace.event("sub write committed");
-    DEBUGDPP("from {} pending_commits {}",
-	     dpp, from, wop.pending_commits);
+    DEBUGDPP("tid={} hoid={} from={} pending_commits={}",
+	     dpp, op.tid, wop.hoid, from, wop.pending_commits);
     ceph_assert(wop.pending_commits > 0);
     --wop.pending_commits;
     // update_peer_last_complete_ondisk() is called by the higher
@@ -511,8 +512,8 @@ ECBackend::maybe_chunked_read(
   const uint32_t flags)
 {
   LOG_PREFIX(ECBackend::maybe_chunked_read);
-  DEBUGDPP("obj {} off {} size {} flags {}", dpp, obj, off, size, flags);
-  DEBUGDPP("oid is: {}", dpp, ghobject_t{obj, ghobject_t::NO_GEN, get_shard()});
+  DEBUGDPP("tid={} hoid={} off={} size={} flags={}", dpp, op.tid, obj, off, size, flags);
+  DEBUGDPP("tid={} ghobj={}", dpp, op.tid, ghobject_t{obj, ghobject_t::NO_GEN, get_shard()});
   if (is_single_chunk(obj, op)) {
     return crimson::os::with_store<&crimson::os::FuturizedStore::Shard::read>(
       store,
@@ -586,7 +587,7 @@ ECBackend::handle_rep_read_op(ECSubRead& op)
     reply.from = whoami;
     reply.tid = op.tid;
     using read_ertr = crimson::os::FuturizedStore::Shard::read_errorator;
-    DEBUGDPP("op_list {}", dpp, op.to_read);
+    DEBUGDPP("tid={} to_read={}", dpp, op.tid, op.to_read);
     return interruptor::do_for_each(op.to_read, [FNAME, &op, &reply, this] (auto read_item) {
       const auto& [obj, op_list] = read_item;
       // `obj=obj` is workaround for Clang's bug:
@@ -597,15 +598,15 @@ ECBackend::handle_rep_read_op(ECSubRead& op)
           obj, op, off, size, flags
         ).safe_then([&reply, obj, off=off, size=size, FNAME,
 		     &dpp=this->dpp] (auto&& result_bl) {
-	  DEBUGDPP("read requested={} len={}", dpp, size, result_bl.length());
+	  DEBUGDPP("tid={} hoid={} requested={} len={}", dpp, reply.tid, obj, size, result_bl.length());
 	  reply.buffers_read[obj].emplace_back(off, std::move(result_bl));
 	  return read_ertr::now();
 	}).handle_error(read_ertr::all_same_way([&reply, obj, FNAME, this] (const auto& e) {
           assert(e.value() > 0);
 	  if (e.value() == ENOENT && fast_read) {
-	    INFODPP("ENOENT reading {}, fast, read, probably ok", dpp, obj);
+	    INFODPP("tid={} hoid={} ENOENT reading, fast read, probably ok", dpp, reply.tid, obj);
 	  } else {
-	    ERRORDPP("Error {} reading {}", dpp, e.value(), obj);
+	    ERRORDPP("tid={} hoid={} error={} reading", dpp, reply.tid, obj, e.value());
 	    // TODO: clog error logging
             reply.buffers_read.erase(obj);
             reply.errors[obj] = -e.value();
@@ -614,10 +615,10 @@ ECBackend::handle_rep_read_op(ECSubRead& op)
         }));
       });
     }).si_then([&op, &reply, FNAME, this] {
-      DEBUGDPP("attrs_to_read {}", dpp, op.attrs_to_read.size());
+      DEBUGDPP("tid={} attrs_to_read={}", dpp, op.tid, op.attrs_to_read.size());
       return interruptor::do_for_each(op.attrs_to_read,
 		                      [&reply, FNAME, this] (auto obj_attr) {
-	DEBUGDPP("fulfilling attr request on obj {}", dpp, obj_attr);
+	DEBUGDPP("tid={} hoid={} fulfilling attr request", dpp, reply.tid, obj_attr);
 	if (reply.errors.count(obj_attr)) {
           return read_ertr::now();
 	}
@@ -651,10 +652,10 @@ ECBackend::handle_rep_read_reply(ECSubReadReply& mop)
 {
   LOG_PREFIX(ECBackend::handle_rep_read_reply);
   const auto& from = mop.from;
-  DEBUGDPP("reply {} from {}", dpp, mop, from);
+  DEBUGDPP("from={} reply={}", dpp, from, mop);
   if (!read_pipeline.tid_to_read_map.contains(mop.tid)) {
     //canceled
-    DEBUGDPP("canceled", dpp);
+    DEBUGDPP("tid={} canceled", dpp, mop.tid);
     return ll_read_ierrorator::now();
   }
   auto& rop = read_pipeline.tid_to_read_map.at(mop.tid);
@@ -665,7 +666,7 @@ ECBackend::handle_rep_read_reply(ECSubReadReply& mop)
     assert(!mop.errors.contains(obj));
     if (!rop.to_read.contains(obj)) {
       // We canceled this read! @see filter_read_op
-      DEBUGDPP("to_read skipping", dpp);
+      DEBUGDPP("tid={} hoid={} to_read skipping", dpp, mop.tid, obj);
       continue;
     }
     if (!rop.complete.contains(obj)) {
@@ -703,7 +704,7 @@ ECBackend::handle_rep_read_reply(ECSubReadReply& mop)
     // if read error better not have sent an attribute
     if (!rop.to_read.count(hoid)) {
       // we canceled this read! @see filter_read_op
-      DEBUGDPP("to_read skipping", dpp);
+      DEBUGDPP("tid={} hoid={} to_read skipping", dpp, mop.tid, hoid);
       continue;
     }
     if (!rop.complete.contains(hoid)) {
@@ -728,7 +729,7 @@ ECBackend::handle_rep_read_reply(ECSubReadReply& mop)
       rop.to_read.at(hoid).zeros_for_decode.erase(from.shard);
     }
     complete.processed_read_requests.erase(from.shard);
-    DEBUGDPP("shard={} error={}", dpp, from, err);
+    DEBUGDPP("tid={} hoid={} shard={} error={}", dpp, mop.tid, hoid, from, err);
   }
   {
     auto it = read_pipeline.shard_to_read_map.find(from);
@@ -767,7 +768,7 @@ ECBackend::handle_rep_read_reply(ECSubReadReply& mop)
       }
 
       if (err) {
-	DEBUGDPP("minimum_to_decode failed {}", dpp, err);
+	DEBUGDPP("tid={} hoid={} minimum_to_decode failed err={}", dpp, mop.tid, oid, err);
         if (all_sub_reads_done) {
           // If we don't have enough copies, try other pg_shard_ts if available.
           // During recovery there may be multiple osds with copies of the same shard,
@@ -796,13 +797,13 @@ ECBackend::handle_rep_read_reply(ECSubReadReply& mop)
         if (!rop.complete.at(oid).errors.empty()) {
 	  using crimson::common::local_conf;
 	  if (local_conf()->osd_read_ec_check_for_errors) {
-	    INFODPP("not ignoring errors, use one shard err={}",
-		    dpp, err);
             err = rop.complete.at(oid).errors.begin()->second;
+	    INFODPP("tid={} hoid={} not ignoring errors, use one shard err={}",
+		    dpp, mop.tid, oid, err);
             rop.complete.at(oid).r = err;
 	  } else {
-	    INFODPP("error(s) ignored for {} enough copies available",
-		    dpp, oid);
+	    INFODPP("tid={} hoid={} error(s) ignored, enough copies available",
+		    dpp, mop.tid, oid);
             rop.complete.at(oid).errors.clear();
 	  }
         }
@@ -817,7 +818,7 @@ ECBackend::handle_rep_read_reply(ECSubReadReply& mop)
     read_pipeline.do_read_op(rop);
   } else if (rop.in_progress.empty() ||
              is_complete == rop.complete.size()) {
-    DEBUGDPP("complete {}", dpp, rop);
+    DEBUGDPP("complete readop={}", dpp, rop);
     /* If do_redundant_reads is set then there might be some in progress
      * reads remaining.  We need to make sure that these non-read shards
      * do not get padded. If there was no in progress read, then the zero
@@ -830,7 +831,7 @@ ECBackend::handle_rep_read_reply(ECSubReadReply& mop)
     }
     read_pipeline.complete_read_op(std::move(rop));
   } else {
-    INFODPP("readop not completed yet: {}", dpp, rop);
+    INFODPP("readop={} not completed yet", dpp, rop);
   }
   return ll_read_ierrorator::now();
 }

--- a/src/crimson/osd/ec_backend.cc
+++ b/src/crimson/osd/ec_backend.cc
@@ -75,7 +75,8 @@ ECBackend::_read(const hobject_t& hoid,
     fast_read,
     object_size,
     make_gen_lambda_context<ec_extents_t &&>(
-      [hoid, off, len, promise=std::move(promise), FNAME](auto&& results) mutable {
+      [hoid, off, len, promise=std::move(promise), FNAME,
+       &dpp=this->dpp](auto&& results) mutable {
         ceph_assert(results.size() == 1);
         ceph_assert(results.count(hoid) == 1);
         auto& got = results.at(hoid);
@@ -86,10 +87,10 @@ ECBackend::_read(const hobject_t& hoid,
 	auto range = got.emap.get_containing_range(off, len);
 	ceph_assert(range.first != range.second);
 	ceph_assert(range.first.get_off() <= off);
-        DEBUG("offset: {}", off);
-        DEBUG("range offset: {}", range.first.get_off());
-        DEBUG("length: {}", len);
-        DEBUG("range length: {}", range.first.get_len());
+        DEBUGDPP("offset: {}", dpp, off);
+        DEBUGDPP("range offset: {}", dpp, range.first.get_off());
+        DEBUGDPP("length: {}", dpp, len);
+        DEBUGDPP("range length: {}", dpp, range.first.get_len());
 	ceph_assert(
 	  (off + len) <=
 	  (range.first.get_off() + range.first.get_len()));
@@ -319,8 +320,9 @@ ECBackend::submit_transaction(const std::set<pg_shard_t> &pg_shards,
 			      std::vector<pg_log_entry_t>&& log_entries,
                               const PGLog &pg_log)
 {
+  LOG_PREFIX(ECBackend::submit_transaction);
   const hobject_t& hoid = obc->obs.oi.soid;
-  logger().debug("{} hoid={} obc->attr_cache={}", __func__, hoid, obc->attr_cache);
+  DEBUGDPP("hoid={} obc->attr_cache={}", dpp, hoid, obc->attr_cache);
   auto op =
     std::make_unique<ECCrimsonOp>(
       std::move(txn), std::move(obc), pg_log, rmw_pipeline);
@@ -346,13 +348,13 @@ ECBackend::submit_transaction(const std::set<pg_shard_t> &pg_shards,
     read_pipeline,
     rmw_pipeline,
     &dpp);
-  logger().info("{}: op {} starting", "_submit_transaction", ""); //*op);
+  INFODPP("op {} starting", dpp, ""); //*op);
   rmw_pipeline.start_rmw(std::move(op));
-  logger().debug("ECBackend::{} started ec op", "_submit_transaction");
+  DEBUGDPP("started ec op", dpp);
   return make_ready_future<rep_op_ret_t>(
     seastar::now(),
-    on_all_commit->get_future().then_interruptible([] {
-      logger().debug("{}: op {} finished completely", "_submit_transaction", "");
+    on_all_commit->get_future().then_interruptible([FNAME, &dpp=this->dpp] {
+      DEBUGDPP("op {} finished completely", dpp, "");
       return seastar::now();
     })
   );
@@ -365,30 +367,30 @@ ECBackend::handle_sub_write(
   ECListener& pg)
 {
   LOG_PREFIX(ECBackend::handle_sub_write);
-  logger().info("{} from {}", __func__, from);
+  INFODPP("from {}", dpp, from);
   if (!op.temp_added.empty()) {
     add_temp_obj(std::begin(op.temp_added), std::end(op.temp_added));
   }
   ceph::os::Transaction txn;
   if (op.backfill_or_async_recovery) {
     for (const auto& obj : op.temp_removed) {
-      logger().info("{}: removing object {} since we won't get the transaction",
-		    __func__, obj);
+      INFODPP("removing object {} since we won't get the transaction",
+	      dpp, obj);
       txn.remove(coll->get_cid(),
 		 ghobject_t{obj, ghobject_t::NO_GEN, get_shard()});
     }
   }
   clear_temp_objs(op.temp_removed);
-  logger().debug("{}: missing before {}", __func__, "");
+  DEBUGDPP("missing before {}", dpp, "");
 
   // flag set to true during async recovery
   bool async = false;
   if (pg.is_missing_object(op.soid)) {
     async = true;
-    logger().debug("{}: {} is missing", __func__, op.soid);
+    DEBUGDPP("{} is missing", dpp, op.soid);
     for (const auto& e: op.log_entries) {
-      logger().debug("{}: add_next_event entry {}, is_delete {}",
-		      __func__, e, e.is_delete());
+      DEBUGDPP("add_next_event entry {}, is_delete {}",
+	       dpp, e, e.is_delete());
       pg.add_local_next_event(e);
     }
   }
@@ -402,16 +404,16 @@ ECBackend::handle_sub_write(
     txn,
     async);
   txn.append(op.t); // hack warn
-  logger().debug("{}:{}", __func__, __LINE__);
+  DEBUGDPP("line {}", dpp, __LINE__);
   if (op.at_version != eversion_t()) {
     // dummy rollforward transaction doesn't get at_version
     // (and doesn't advance it)
     pg.op_applied(op.at_version);
   }
-  logger().debug("{}:{}", __func__, __LINE__);
+  DEBUGDPP("line {}", dpp, __LINE__);
   return crimson::os::with_store_do_transaction(
-      store, coll, std::move(txn)).then([FNAME] {
-    DEBUG("transaction commited!");
+      store, coll, std::move(txn)).then([FNAME, &dpp=this->dpp] {
+    DEBUGDPP("transaction commited!", dpp);
     return write_iertr::now();
   });
 }
@@ -437,10 +439,10 @@ void ECBackend::handle_sub_write(
 {
   LOG_PREFIX(ECBackend::handle_sub_write);
   const auto tid = op.tid;
-  DEBUG("tid {}", tid);
+  DEBUGDPP("tid {}", dpp, tid);
   std::ignore = handle_sub_write(
     from, std::move(op), eclistener
-  ).si_then([tid, &eclistener, this] {
+  ).si_then([tid, &eclistener, FNAME, this] {
     assert(eclistener.pgb_is_primary());
     ECSubWriteReply reply;
     reply.tid = tid;
@@ -448,8 +450,7 @@ void ECBackend::handle_sub_write(
     reply.committed = true;
     reply.applied = true;
     reply.from = eclistener.whoami_shard();
-    logger().debug("ECBackend::{} from {}",
-		    "handle_sub_write::reply", reply.from);
+    DEBUGDPP("reply from {}", dpp, reply.from);
     return handle_rep_write_reply(std::move(reply));
   }, crimson::ct_error::assert_all("unexpected error"));
 }
@@ -461,7 +462,7 @@ ECBackend::handle_rep_write_op(
 {
   LOG_PREFIX(ECBackend::handle_rep_write_op);
   const auto tid = m->op.tid;
-  DEBUG("tid {} from {}", tid, m->op.from);
+  DEBUGDPP("tid {} from {}", dpp, tid, m->op.from);
   return handle_sub_write(
     m->op.from, std::move(m->op), pg
   ).si_then([&pg] {
@@ -475,14 +476,14 @@ ECBackend::write_iertr::future<>
 ECBackend::handle_rep_write_reply(ECSubWriteReply&& op)
 {
   LOG_PREFIX(ECBackend::handle_rep_write_reply);
-  DEBUG("handling reply from osd.{}, tid {}",  op.from.osd, op.tid);
+  DEBUGDPP("handling reply from osd.{}, tid {}", dpp, op.from.osd, op.tid);
   assert(rmw_pipeline.tid_to_op_map.contains(op.tid));
   const auto& from = op.from;
   auto& wop = *rmw_pipeline.tid_to_op_map.at(op.tid);
   if (op.committed) {
     // TODO: trace.event("sub write committed");
-    logger().debug("ECBackend::{} from {} pending_commits {}",
-		    __func__, from, wop.pending_commits);
+    DEBUGDPP("from {} pending_commits {}",
+	     dpp, from, wop.pending_commits);
     ceph_assert(wop.pending_commits > 0);
     --wop.pending_commits;
     // update_peer_last_complete_ondisk() is called by the higher
@@ -510,8 +511,8 @@ ECBackend::maybe_chunked_read(
   const uint32_t flags)
 {
   LOG_PREFIX(ECBackend::maybe_chunked_read);
-  DEBUG("obj {} off {} size {} flags {}", obj, off, size, flags);
-  DEBUG("oid is: {}", ghobject_t{obj, ghobject_t::NO_GEN, get_shard()});
+  DEBUGDPP("obj {} off {} size {} flags {}", dpp, obj, off, size, flags);
+  DEBUGDPP("oid is: {}", dpp, ghobject_t{obj, ghobject_t::NO_GEN, get_shard()});
   if (is_single_chunk(obj, op)) {
     return crimson::os::with_store<&crimson::os::FuturizedStore::Shard::read>(
       store,
@@ -585,7 +586,7 @@ ECBackend::handle_rep_read_op(ECSubRead& op)
     reply.from = whoami;
     reply.tid = op.tid;
     using read_ertr = crimson::os::FuturizedStore::Shard::read_errorator;
-    DEBUG("op_list {}", op.to_read);
+    DEBUGDPP("op_list {}", dpp, op.to_read);
     return interruptor::do_for_each(op.to_read, [FNAME, &op, &reply, this] (auto read_item) {
       const auto& [obj, op_list] = read_item;
       // `obj=obj` is workaround for Clang's bug:
@@ -594,16 +595,17 @@ ECBackend::handle_rep_read_op(ECSubRead& op)
         const auto& [off, size, flags] = op_spec;
         return maybe_chunked_read(
           obj, op, off, size, flags
-        ).safe_then([&reply, obj, off=off, size=size, FNAME] (auto&& result_bl) {
-	  DEBUG("read requested={} len={}", size, result_bl.length());
+        ).safe_then([&reply, obj, off=off, size=size, FNAME,
+		     &dpp=this->dpp] (auto&& result_bl) {
+	  DEBUGDPP("read requested={} len={}", dpp, size, result_bl.length());
 	  reply.buffers_read[obj].emplace_back(off, std::move(result_bl));
 	  return read_ertr::now();
 	}).handle_error(read_ertr::all_same_way([&reply, obj, FNAME, this] (const auto& e) {
           assert(e.value() > 0);
 	  if (e.value() == ENOENT && fast_read) {
-	    INFO("ENOENT reading {}, fast, read, probably ok", obj);
+	    INFODPP("ENOENT reading {}, fast, read, probably ok", dpp, obj);
 	  } else {
-	    ERROR("Error {} reading {}", e.value(), obj);
+	    ERRORDPP("Error {} reading {}", dpp, e.value(), obj);
 	    // TODO: clog error logging
             reply.buffers_read.erase(obj);
             reply.errors[obj] = -e.value();
@@ -612,10 +614,10 @@ ECBackend::handle_rep_read_op(ECSubRead& op)
         }));
       });
     }).si_then([&op, &reply, FNAME, this] {
-      DEBUG("attrs_to_read {}", op.attrs_to_read.size());
+      DEBUGDPP("attrs_to_read {}", dpp, op.attrs_to_read.size());
       return interruptor::do_for_each(op.attrs_to_read,
 		                      [&reply, FNAME, this] (auto obj_attr) {
-	DEBUG("fulfilling attr request on obj {}", obj_attr);
+	DEBUGDPP("fulfilling attr request on obj {}", dpp, obj_attr);
 	if (reply.errors.count(obj_attr)) {
           return read_ertr::now();
 	}
@@ -647,11 +649,12 @@ ECBackend::handle_rep_read_reply(Ref<MOSDECSubOpReadReply> m)
 ECBackend::ll_read_ierrorator::future<>
 ECBackend::handle_rep_read_reply(ECSubReadReply& mop)
 {
+  LOG_PREFIX(ECBackend::handle_rep_read_reply);
   const auto& from = mop.from;
-  logger().debug("{}: reply {} from {}", __func__, mop, from);
+  DEBUGDPP("reply {} from {}", dpp, mop, from);
   if (!read_pipeline.tid_to_read_map.contains(mop.tid)) {
     //canceled
-    logger().debug("{}: canceled", __func__);
+    DEBUGDPP("canceled", dpp);
     return ll_read_ierrorator::now();
   }
   auto& rop = read_pipeline.tid_to_read_map.at(mop.tid);
@@ -662,7 +665,7 @@ ECBackend::handle_rep_read_reply(ECSubReadReply& mop)
     assert(!mop.errors.contains(obj));
     if (!rop.to_read.contains(obj)) {
       // We canceled this read! @see filter_read_op
-      logger().debug("{}: to_read skipping", __func__);
+      DEBUGDPP("to_read skipping", dpp);
       continue;
     }
     if (!rop.complete.contains(obj)) {
@@ -700,7 +703,7 @@ ECBackend::handle_rep_read_reply(ECSubReadReply& mop)
     // if read error better not have sent an attribute
     if (!rop.to_read.count(hoid)) {
       // we canceled this read! @see filter_read_op
-      logger().debug("{}: to_read skipping", __func__);
+      DEBUGDPP("to_read skipping", dpp);
       continue;
     }
     if (!rop.complete.contains(hoid)) {
@@ -725,7 +728,7 @@ ECBackend::handle_rep_read_reply(ECSubReadReply& mop)
       rop.to_read.at(hoid).zeros_for_decode.erase(from.shard);
     }
     complete.processed_read_requests.erase(from.shard);
-    logger().debug("{} shard={} error={}", __func__, from, err);
+    DEBUGDPP("shard={} error={}", dpp, from, err);
   }
   {
     auto it = read_pipeline.shard_to_read_map.find(from);
@@ -764,7 +767,7 @@ ECBackend::handle_rep_read_reply(ECSubReadReply& mop)
       }
 
       if (err) {
-	logger().debug("{} minimum_to_decode failed {}", __func__, err);
+	DEBUGDPP("minimum_to_decode failed {}", dpp, err);
         if (all_sub_reads_done) {
           // If we don't have enough copies, try other pg_shard_ts if available.
           // During recovery there may be multiple osds with copies of the same shard,
@@ -793,13 +796,13 @@ ECBackend::handle_rep_read_reply(ECSubReadReply& mop)
         if (!rop.complete.at(oid).errors.empty()) {
 	  using crimson::common::local_conf;
 	  if (local_conf()->osd_read_ec_check_for_errors) {
-	    logger().info("{}: not ignoring errors, use one shard err={}",
-			  __func__, err);
+	    INFODPP("not ignoring errors, use one shard err={}",
+		    dpp, err);
             err = rop.complete.at(oid).errors.begin()->second;
             rop.complete.at(oid).r = err;
 	  } else {
-	    logger().info("{}: error(s) ignored for {} enough copies available",
-			  __func__, oid);
+	    INFODPP("error(s) ignored for {} enough copies available",
+		    dpp, oid);
             rop.complete.at(oid).errors.clear();
 	  }
         }
@@ -814,7 +817,7 @@ ECBackend::handle_rep_read_reply(ECSubReadReply& mop)
     read_pipeline.do_read_op(rop);
   } else if (rop.in_progress.empty() ||
              is_complete == rop.complete.size()) {
-    logger().debug("{}: complete {}", __func__, rop);
+    DEBUGDPP("complete {}", dpp, rop);
     /* If do_redundant_reads is set then there might be some in progress
      * reads remaining.  We need to make sure that these non-read shards
      * do not get padded. If there was no in progress read, then the zero
@@ -827,7 +830,7 @@ ECBackend::handle_rep_read_reply(ECSubReadReply& mop)
     }
     read_pipeline.complete_read_op(std::move(rop));
   } else {
-    logger().info("{}: readop not completed yet: {}", __func__, rop);
+    INFODPP("readop not completed yet: {}", dpp, rop);
   }
   return ll_read_ierrorator::now();
 }


### PR DESCRIPTION
This PR does the following to improve logging across the file `src/crimson/osd/ec_backend.cc`: 

1. changes to using `DEBUGDPP` / `INFODPP` instead of logger. 
2. adds `hoid` / `tid` wherever available in logs to make them easier to follow. 
3. normalises all log sites to use key=value formatting. 

## Examples 

Logs before this PR: 

```
DEBUG 2026-08-04 08:08:25,429 [shard 1:main] osd - ECBackend::handle_rep_read_op: read requested=4096 len=4096
DEBUG 2026-08-04 08:08:25,429 [shard 1:main] osd - ECBackend::handle_rep_read_op: attrs_to_read 0
DEBUG 2026-08-04 08:08:25,429 [shard 1:main] osd - handle_rep_read_reply: reply ECSubReadReply(tid=72057594037927945, attrs_read=0, omap_headers_read=0, omap_entries_read=0, omaps_complete=[]) from 1(0)
DEBUG 2026-08-04 08:08:25,429 [shard 1:main] osd - handle_rep_read_reply: complete ReadOp(tid=72057594037927945, to_read={69:602f83fe:::foo:head=read_request_t(to_read=[0,8192,0], flags=0, shard_want_to_read={0:[0~4096],1:[0~4096]}, zeros_for_decode={1:[0~4096]}, shard_reads={}, want_attrs=0, want_omap_header=0, want_omap_keys=0, omap_read_from=, omap_max_bytes=0)}, complete={69:602f83fe:::foo:head=read_result_t(r=0, errors={}, noattrs, no_omap_header, no_omap_entries, omap_complete=0, buffers_read=shard_extent_map: ({0~4096}, maps={0:{0~4096(4096)}}), processed_read_requests={0:[0~4096]}, zero_length_reads={})}, priority=127, obj_to_source={69:602f83fe:::foo:head=1(0)}, source_to_obj={1(0)=69:602f83fe:::foo:head}, in_progress=, debug_log=READ_REQUEST[1(0)]->[0~4096]
DEBUG 2026-08-04 08:08:25,429 [shard 1:main] osd -  pg_epoch 256 pg[69.6s0( v 256'1 (0'0,256'1] local-lis/les=255/256 n=1 ec=255/255 lis/c=255/255 les/c/f=256/256/0 sis=255) [1,0,3]p1(0) r=0 lpr=255 pct=0'0 crt=256'1 lcod 0'0 mlcod 0'0 active+clean complete_read_op completing ReadOp(tid=72057594037927945, to_read={69:602f83fe:::foo:head=read_request_t(to_read=[0,8192,0], flags=0, shard_want_to_read={0:[0~4096],1:[0~4096]}, zeros_for_decode={1:[0~4096]}, shard_reads={}, want_attrs=0, want_omap_header=0, want_omap_keys=0, omap_read_from=, omap_max_bytes=0)}, complete={69:602f83fe:::foo:head=read_result_t(r=0, errors={}, noattrs, no_omap_header, no_omap_entries, omap_complete=0, buffers_read=shard_extent_map: ({0~4096}, maps={0:{0~4096(4096)}}), processed_read_requests={0:[0~4096]}, zero_length_reads={})}, priority=127, obj_to_source={69:602f83fe:::foo:head=1(0)}, source_to_obj={1(0)=69:602f83fe:::foo:head}, in_progress=, debug_log=READ_REQUEST[1(0)]->[0~4096]
DEBUG 2026-08-04 08:08:25,429 [shard 1:main] osd -  pg_epoch 256 pg[69.6s0( v 256'1 (0'0,256'1] local-lis/les=255/256 n=1 ec=255/255 lis/c=255/255 les/c/f=256/256/0 sis=255) [1,0,3]p1(0) r=0 lpr=255 pct=0'0 crt=256'1 lcod 0'0 mlcod 0'0 active+clean finish_single_request completing hoid=69:602f83fe:::foo:head res=read_result_t(r=0, errors={}, noattrs, no_omap_header, no_omap_entries, omap_complete=0, buffers_read=shard_extent_map: ({0~4096}, maps={0:{0~4096(4096)}}), processed_read_requests={0:[0~4096]}, zero_length_reads={}) req=read_request_t(to_read=[0,8192,0], flags=0, shard_want_to_read={0:[0~4096],1:[0~4096]}, zeros_for_decode={1:[0~4096]}, shard_reads={}, want_attrs=0, want_omap_header=0, want_omap_keys=0, omap_read_from=, omap_max_bytes=0)
DEBUG 2026-08-04 08:08:25,429 [shard 1:main] osd -  pg_epoch 256 pg[69.6s0( v 256'1 (0'0,256'1] local-lis/les=255/256 n=1 ec=255/255 lis/c=255/255 les/c/f=256/256/0 sis=255) [1,0,3]p1(0) r=0 lpr=255 pct=0'0 crt=256'1 lcod 0'0 mlcod 0'0 active+clean finish_single_request calling complete_object with result={0~8192(8192)}
DEBUG 2026-08-04 08:08:25,429 [shard 1:main] osd - ECBackend::_read: offset: 0
DEBUG 2026-08-04 08:08:25,429 [shard 1:main] osd - ECBackend::_read: range offset: 0
DEBUG 2026-08-04 08:08:25,429 [shard 1:main] osd - ECBackend::_read: length: 128
DEBUG 2026-08-04 08:08:25,429 [shard 1:main] osd - ECBackend::_read: range length: 8192
```

Logs after changes: 

```
DEBUG 2026-08-04 19:23:51,441 [shard 0:main] osd -  pg_epoch 25 pg[4.6s0( v 25'1 (0'0,25'1] local-lis/les=23/24 n=1 ec=23/23 lis/c=23/23 les/c/f=24/24/0 sis=23) [0,1,2]p0(0) r=0 lpr=23 pct=0'0 crt=25'1 lcod 0'0 mlcod 0'0 active+clean  ECBackend::handle_rep_read_op: hoid=4:602f83fe:::foo:head requested=4096 len=4096
DEBUG 2026-08-04 19:23:51,441 [shard 0:main] osd -  pg_epoch 25 pg[4.6s0( v 25'1 (0'0,25'1] local-lis/les=23/24 n=1 ec=23/23 lis/c=23/23 les/c/f=24/24/0 sis=23) [0,1,2]p0(0) r=0 lpr=23 pct=0'0 crt=25'1 lcod 0'0 mlcod 0'0 active+clean  ECBackend::handle_rep_read_op: tid=35 attrs_to_read=0
DEBUG 2026-08-04 19:23:51,441 [shard 0:main] osd -  pg_epoch 25 pg[4.6s0( v 25'1 (0'0,25'1] local-lis/les=23/24 n=1 ec=23/23 lis/c=23/23 les/c/f=24/24/0 sis=23) [0,1,2]p0(0) r=0 lpr=23 pct=0'0 crt=25'1 lcod 0'0 mlcod 0'0 active+clean  ECBackend::handle_rep_read_reply: from=0(0) reply=ECSubReadReply(tid=35, attrs_read=0, omap_headers_read=0, omap_entries_read=0, omaps_complete=[])
DEBUG 2026-08-04 19:23:51,441 [shard 0:main] osd -  pg_epoch 25 pg[4.6s0( v 25'1 (0'0,25'1] local-lis/les=23/24 n=1 ec=23/23 lis/c=23/23 les/c/f=24/24/0 sis=23) [0,1,2]p0(0) r=0 lpr=23 pct=0'0 crt=25'1 lcod 0'0 mlcod 0'0 active+clean  ECBackend::handle_rep_read_reply: complete readop=ReadOp(tid=35, to_read={4:602f83fe:::foo:head=read_request_t(to_read=[0,8192,0], flags=0, shard_want_to_read={0:[0~4096],1:[0~4096]}, zeros_for_decode={1:[0~4096]}, shard_reads={}, want_attrs=0, want_omap_header=0, want_omap_keys=0, omap_read_from=, omap_max_bytes=0)}, complete={4:602f83fe:::foo:head=read_result_t(r=0, errors={}, noattrs, no_omap_header, no_omap_entries, omap_complete=0, buffers_read=shard_extent_map: ({0~4096}, maps={0:{0~4096(4096)}}), processed_read_requests={0:[0~4096]}, zero_length_reads={})}, priority=127, obj_to_source={4:602f83fe:::foo:head=0(0)}, source_to_obj={0(0)=4:602f83fe:::foo:head}, in_progress=, debug_log=READ_REQUEST[0(0)]->[0~4096]
DEBUG 2026-08-04 19:23:51,441 [shard 0:main] osd -  pg_epoch 25 pg[4.6s0( v 25'1 (0'0,25'1] local-lis/les=23/24 n=1 ec=23/23 lis/c=23/23 les/c/f=24/24/0 sis=23) [0,1,2]p0(0) r=0 lpr=23 pct=0'0 crt=25'1 lcod 0'0 mlcod 0'0 active+clean complete_read_op completing ReadOp(tid=35, to_read={4:602f83fe:::foo:head=read_request_t(to_read=[0,8192,0], flags=0, shard_want_to_read={0:[0~4096],1:[0~4096]}, zeros_for_decode={1:[0~4096]}, shard_reads={}, want_attrs=0, want_omap_header=0, want_omap_keys=0, omap_read_from=, omap_max_bytes=0)}, complete={4:602f83fe:::foo:head=read_result_t(r=0, errors={}, noattrs, no_omap_header, no_omap_entries, omap_complete=0, buffers_read=shard_extent_map: ({0~4096}, maps={0:{0~4096(4096)}}), processed_read_requests={0:[0~4096]}, zero_length_reads={})}, priority=127, obj_to_source={4:602f83fe:::foo:head=0(0)}, source_to_obj={0(0)=4:602f83fe:::foo:head}, in_progress=, debug_log=READ_REQUEST[0(0)]->[0~4096]
DEBUG 2026-08-04 19:23:51,441 [shard 0:main] osd -  pg_epoch 25 pg[4.6s0( v 25'1 (0'0,25'1] local-lis/les=23/24 n=1 ec=23/23 lis/c=23/23 les/c/f=24/24/0 sis=23) [0,1,2]p0(0) r=0 lpr=23 pct=0'0 crt=25'1 lcod 0'0 mlcod 0'0 active+clean finish_single_request completing hoid=4:602f83fe:::foo:head res=read_result_t(r=0, errors={}, noattrs, no_omap_header, no_omap_entries, omap_complete=0, buffers_read=shard_extent_map: ({0~4096}, maps={0:{0~4096(4096)}}), processed_read_requests={0:[0~4096]}, zero_length_reads={}) req=read_request_t(to_read=[0,8192,0], flags=0, shard_want_to_read={0:[0~4096],1:[0~4096]}, zeros_for_decode={1:[0~4096]}, shard_reads={}, want_attrs=0, want_omap_header=0, want_omap_keys=0, omap_read_from=, omap_max_bytes=0)
DEBUG 2026-08-04 19:23:51,441 [shard 0:main] osd -  pg_epoch 25 pg[4.6s0( v 25'1 (0'0,25'1] local-lis/les=23/24 n=1 ec=23/23 lis/c=23/23 les/c/f=24/24/0 sis=23) [0,1,2]p0(0) r=0 lpr=23 pct=0'0 crt=25'1 lcod 0'0 mlcod 0'0 active+clean finish_single_request calling complete_object with result={0~8192(8192)}
DEBUG 2026-08-04 19:23:51,441 [shard 0:main] osd -  pg_epoch 25 pg[4.6s0( v 25'1 (0'0,25'1] local-lis/les=23/24 n=1 ec=23/23 lis/c=23/23 les/c/f=24/24/0 sis=23) [0,1,2]p0(0) r=0 lpr=23 pct=0'0 crt=25'1 lcod 0'0 mlcod 0'0 active+clean  ECBackend::_read: hoid=4:602f83fe:::foo:head offset=0
DEBUG 2026-08-04 19:23:51,441 [shard 0:main] osd -  pg_epoch 25 pg[4.6s0( v 25'1 (0'0,25'1] local-lis/les=23/24 n=1 ec=23/23 lis/c=23/23 les/c/f=24/24/0 sis=23) [0,1,2]p0(0) r=0 lpr=23 pct=0'0 crt=25'1 lcod 0'0 mlcod 0'0 active+clean  ECBackend::_read: hoid=4:602f83fe:::foo:head range_offset=0
DEBUG 2026-08-04 19:23:51,441 [shard 0:main] osd -  pg_epoch 25 pg[4.6s0( v 25'1 (0'0,25'1] local-lis/les=23/24 n=1 ec=23/23 lis/c=23/23 les/c/f=24/24/0 sis=23) [0,1,2]p0(0) r=0 lpr=23 pct=0'0 crt=25'1 lcod 0'0 mlcod 0'0 active+clean  ECBackend::_read: hoid=4:602f83fe:::foo:head length=128
DEBUG 2026-08-04 19:23:51,441 [shard 0:main] osd -  pg_epoch 25 pg[4.6s0( v 25'1 (0'0,25'1] local-lis/les=23/24 n=1 ec=23/23 lis/c=23/23 les/c/f=24/24/0 sis=23) [0,1,2]p0(0) r=0 lpr=23 pct=0'0 crt=25'1 lcod 0'0 mlcod 0'0 active+clean  ECBackend::_read: hoid=4:602f83fe:::foo:head range_length=8192
```

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
