### PR TITLE
umbrella: mgr/nvmeof: dont strip dot from pool name in service creation

### DIFF
--- a/src/pybind/mgr/dashboard/services/nvmeof_client.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_client.py
@@ -328,10 +328,11 @@ def get_gateway_locations(pool: str, group: str, hosts: Optional[List[str]] = No
                     location = gw.get('location', '')
 
                     # Extract hostname from gw-id (format: client.nvmeof.pool.group.hostname.xxx)
+                    # pool might contains '.'
                     if gw_id:
                         parts = gw_id.split('.')
                         if len(parts) >= 5:
-                            hostname = parts[4]
+                            hostname = parts[-2]
                             if location:
                                 host_to_location[hostname] = location
                         else:

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -2184,9 +2184,8 @@ Usage:
             nvmeof_pool_helper = NvmeofMetadataPoolHelper(self)
             nvmeof_pool_helper.create_pool_if_needed()
 
-        cleanpool = pool.lstrip('.')
         spec = NvmeofServiceSpec(
-            service_id=f'{cleanpool}.{group}' if group else cleanpool,
+            service_id=f'{pool}.{group}' if group else pool,
             pool=pool,
             group=group,
             placement=PlacementSpec.from_string(placement),


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79026

---

backport of https://github.com/ceph/ceph/pull/70803
parent tracker: https://tracker.ceph.com/issues/78998

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh