### PR TITLE
tentacle: mgr/nvmeof: dont strip dot from pool name in service creation

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -2152,9 +2152,8 @@ Usage:
         if pool == ".nvmeof":
             self._create_nvmeof_metadata_pool_if_needed()
 
-        cleanpool = pool.lstrip('.')
         spec = NvmeofServiceSpec(
-            service_id=f'{cleanpool}.{group}' if group else cleanpool,
+            service_id=f'{pool}.{group}' if group else pool,
             pool=pool,
             group=group,
             placement=PlacementSpec.from_string(placement),


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79027

---

backport of https://github.com/ceph/ceph/pull/70803
parent tracker: https://tracker.ceph.com/issues/78998

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh