### PR TITLE
mgr/dashboard: fix cephfs mirroring issues

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -52,7 +52,7 @@ DAEMON_STATUS_SCHEMA = [{
             'uuid': (str, 'Peer UUID'),
             'remote': ({
                 'client_name': (str, 'Ceph client name'),
-                'cluster_name': (str, 'Remote cluster name'),
+                'cluster_name': (str, 'Remote site name'),
                 'fs_name': (str, 'Remote filesystem name'),
             }, 'Remote peer information'),
             'stats': ({

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.html
@@ -158,9 +158,7 @@
                   </cds-progress-bar>
                 </div>
 
-                @if (
-                  selectedPath.filesSynced !== undefined && selectedPath.totalFiles !== undefined
-                ) {
+                @if (selectedPath.filesSynced !== undefined) {
                   <div class="cds-mb-4">
                     <div
                       class="cds--type-label-01 cds-mb-2"
@@ -169,14 +167,12 @@
                       Files Synced
                     </div>
                     <div class="cds--type-body-01">
-                      {{ selectedPath.filesSynced }}/{{ selectedPath.totalFiles }}
+                      {{ selectedPath.filesSynced }}
                     </div>
                   </div>
                 }
 
-                @if (
-                  selectedPath.bytesSynced !== undefined && selectedPath.totalBytes !== undefined
-                ) {
+                @if (selectedPath.bytesSynced !== undefined) {
                   <div class="cds-mb-4">
                     <div
                       class="cds--type-label-01 cds-mb-2"
@@ -185,9 +181,7 @@
                       Bytes Synced
                     </div>
                     <div class="cds--type-body-01">
-                      {{ selectedPath.bytesSynced | dimlessBinary }}/{{
-                        selectedPath.totalBytes | dimlessBinary
-                      }}
+                      {{ selectedPath.bytesSynced | dimlessBinary }}
                     </div>
                   </div>
                 }
@@ -317,16 +311,12 @@
                         </div>
                       </div>
 
-                      <div
-                        cdsGrid
-                        [narrow]="true"
-                        class="cds-mb-5 padding-inline-0"
-                      >
+                      <div class="cds-mb-5">
                         <div
-                          cdsCol
-                          [columnNumbers]="{ lg: 4, md: 4, sm: 4 }"
+                          cdsStack="horizontal"
+                          [gap]="7"
                         >
-                          <div class="cds-mb-4">
+                          <div>
                             <div
                               class="cds--type-label-01 cds-mb-2"
                               i18n
@@ -337,28 +327,7 @@
                               {{ snapshot.replicationStatusLabel }}
                             </div>
                           </div>
-                        </div>
-                        <div
-                          cdsCol
-                          [columnNumbers]="{ lg: 4, md: 4, sm: 4 }"
-                        >
-                          <div class="cds-mb-4">
-                            <div
-                              class="cds--type-label-01 cds-mb-2"
-                              i18n
-                            >
-                              Created
-                            </div>
-                            <div class="cds--type-body-01">
-                              {{ formatScheduleDate(snapshot.createdAt) }}
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          cdsCol
-                          [columnNumbers]="{ lg: 4, md: 4, sm: 4 }"
-                        >
-                          <div class="cds-mb-4">
+                          <div>
                             <div
                               class="cds--type-label-01 cds-mb-2"
                               i18n
@@ -366,15 +335,10 @@
                               Files synced
                             </div>
                             <div class="cds--type-body-01">
-                              {{ formatSnapshotFiles(snapshot.filesSynced, snapshot.totalFiles) }}
+                              {{ formatSnapshotFiles(snapshot.filesSynced) }}
                             </div>
                           </div>
-                        </div>
-                        <div
-                          cdsCol
-                          [columnNumbers]="{ lg: 4, md: 4, sm: 4 }"
-                        >
-                          <div class="cds-mb-4">
+                          <div>
                             <div
                               class="cds--type-label-01 cds-mb-2"
                               i18n
@@ -382,13 +346,8 @@
                               Size
                             </div>
                             <div class="cds--type-body-01">
-                              @if (
-                                snapshot.bytesSynced !== undefined &&
-                                snapshot.totalBytes !== undefined
-                              ) {
-                                {{ snapshot.bytesSynced | dimlessBinary }}/{{
-                                  snapshot.totalBytes | dimlessBinary
-                                }}
+                              @if (snapshot.bytesSynced !== undefined) {
+                                {{ snapshot.bytesSynced | dimlessBinary }}
                               } @else {
                                 -
                               }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.html
@@ -76,6 +76,7 @@
     size="xl"
     (closed)="closeSidePanel()"
   >
+    @let checkpointState = checkpointState$ | async;
     <div class="panel-content">
       <cds-tabs type="line">
         <cds-tab
@@ -224,7 +225,7 @@
               <span class="cds--type-body-compact-01">|</span>
               <span class="cds--type-body-compact-01">
                 <ng-container i18n>Checkpoints</ng-container>:
-                <strong>{{ selectedPathCheckpointCount }}</strong>
+                <strong>{{ checkpointState?.checkpoints?.length ?? 0 }}</strong>
               </span>
               <span class="cds--type-body-compact-01">|</span>
               <span class="cds--type-body-compact-01">
@@ -243,7 +244,7 @@
               }
             </div>
 
-            @if (checkpointsLoading) {
+            @if (checkpointState?.loading) {
               <cds-inline-loading
                 [isActive]="true"
                 loadingText="Loading snapshots"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.spec.ts
@@ -64,7 +64,9 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
             last_synced_snap: {
               id: 1,
               name: 'snap-last',
-              sync_time_stamp: '1583.101609s'
+              sync_time_stamp: '1583.101609s',
+              sync_bytes: '150 MiB',
+              sync_files: 5000
             },
             snaps_synced: 10,
             snaps_deleted: 2,
@@ -93,7 +95,9 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
             },
             last_synced_snap: {
               id: 2,
-              name: 'snap-last-2'
+              name: 'snap-last-2',
+              sync_bytes: '50 MiB',
+              sync_files: 100
             },
             snaps_synced: 5,
             snaps_deleted: 1
@@ -326,9 +330,7 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
           iconClass: 'info',
           statusLabel: 'replication in-progress',
           filesSynced: 100,
-          totalFiles: 200,
-          bytesSynced: 1610612736,
-          totalBytes: 3221225472
+          bytesSynced: 1610612736
         },
         {
           name: 'snap-last',
@@ -336,10 +338,8 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
           icon: 'checkMarkOutline',
           iconClass: 'success',
           statusLabel: 'replicated.',
-          filesSynced: undefined,
-          totalFiles: undefined,
-          bytesSynced: 0,
-          createdAt: '1583.101609s'
+          filesSynced: 5000,
+          bytesSynced: 157286400
         }
       ]);
       expect(result[0].renamedSnapshotCount).toBe(1);
@@ -367,9 +367,7 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
           iconClass: 'muted',
           statusLabel: 'replication pending',
           filesSynced: 50,
-          totalFiles: 100,
-          bytesSynced: 1073741824,
-          totalBytes: 2147483648
+          bytesSynced: 1073741824
         },
         {
           name: 'snap-last-2',
@@ -377,16 +375,39 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
           icon: 'checkMarkOutline',
           iconClass: 'success',
           statusLabel: 'replicated.',
-          filesSynced: undefined,
-          totalFiles: undefined,
-          bytesSynced: 0,
-          createdAt: undefined
+          filesSynced: 100,
+          bytesSynced: 52428800
         }
       ]);
       expect(result[1].filesSynced).toBe(50);
       expect(result[1].totalFiles).toBe(100);
       expect(result[1].totalBytes).toBe(2147483648);
       expect(result[1].syncProgress).toBe(50);
+    });
+
+    it('should leave Size undefined when last synced snap has no sync_bytes', () => {
+      const data: MirrorStatusResponse = {
+        metrics: {
+          '/path1': {
+            peer: {
+              'peer-1': {
+                state: 'idle',
+                last_synced_snap: {
+                  id: 1,
+                  name: 'snap-only-name'
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const result = component.parseMirrorStatus(data);
+
+      expect(result[0].snapshots).toHaveLength(1);
+      expect(result[0].snapshots[0].name).toBe('snap-only-name');
+      expect(result[0].snapshots[0].status).toBe('replicated');
+      expect(result[0].snapshots[0].bytesSynced).toBeUndefined();
     });
 
     it('should skip paths without peer data', () => {
@@ -628,9 +649,7 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
         iconClass: 'info',
         statusLabel: 'replication in-progress',
         filesSynced: 100,
-        totalFiles: 200,
-        bytesSynced: 1024,
-        totalBytes: 2048
+        bytesSynced: 1024
       },
       {
         name: 'snap-last',
@@ -639,9 +658,7 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
         iconClass: 'success',
         statusLabel: 'replicated.',
         filesSynced: 50,
-        totalFiles: 50,
-        bytesSynced: 512,
-        totalBytes: 512
+        bytesSynced: 512
       }
     ];
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.spec.ts
@@ -256,14 +256,11 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
     component.openAddPath();
 
     expect(cephfsService.list).toHaveBeenCalled();
-    expect(navigateByUrlSpy).toHaveBeenCalledWith(
-      '/cephfs/mirroring/(modal:add-path/7/test-fs)',
-      {
-        state: {
-          returnUrl: '/cephfs/mirroring/test-fs/mirror-paths'
-        }
+    expect(navigateByUrlSpy).toHaveBeenCalledWith('/cephfs/mirroring/(modal:add-path/7/test-fs)', {
+      state: {
+        returnUrl: '/cephfs/mirroring/test-fs/mirror-paths'
       }
-    );
+    });
   });
 
   it('should not open add-path wizard when fsName is missing', () => {
@@ -671,7 +668,10 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
 
       expect(component.snapshotPanels.length).toBe(2);
       expect(component.snapshotPanels[1].hasCheckpoint).toBe(true);
+      expect(component.snapshotPanels[1].statusLabel).toBe('checkpoint complete');
+      expect(component.snapshotPanels[1].replicationStatusLabel).toBe('Complete');
       expect(component.snapshotPanels[0].hasCheckpoint).toBe(false);
+      expect(component.snapshotPanels[0].statusLabel).toBe('replication in-progress');
       expect(component.pathCheckpoints.length).toBe(1);
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.spec.ts
@@ -231,13 +231,12 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
     component.ngOnInit();
 
     expect(component.columns).toBeDefined();
-    expect(component.columns.length).toBe(6);
+    expect(component.columns.length).toBe(5);
     expect(component.columns[0].prop).toBe('path');
     expect(component.columns[1].prop).toBe('syncStatus');
     expect(component.columns[2].prop).toBe('snapshotCount');
-    expect(component.columns[3].prop).toBe('checkpointCount');
-    expect(component.columns[4].prop).toBe('currentSyncSnapshot');
-    expect(component.columns[5].prop).toBe('lastSyncedSnapshot');
+    expect(component.columns[3].prop).toBe('currentSyncSnapshot');
+    expect(component.columns[4].prop).toBe('lastSyncedSnapshot');
 
     // Verify fsName is fetched and data is loaded
     expect(component.fsName).toBe('test-fs');
@@ -257,11 +256,14 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
     component.openAddPath();
 
     expect(cephfsService.list).toHaveBeenCalled();
-    expect(navigateByUrlSpy).toHaveBeenCalledWith('/cephfs/mirroring/(modal:add-path/7/test-fs)', {
-      state: {
-        returnUrl: '/cephfs/mirroring/test-fs/mirror-paths'
+    expect(navigateByUrlSpy).toHaveBeenCalledWith(
+      '/cephfs/mirroring/(modal:add-path/7/test-fs)',
+      {
+        state: {
+          returnUrl: '/cephfs/mirroring/test-fs/mirror-paths'
+        }
       }
-    });
+    );
   });
 
   it('should not open add-path wizard when fsName is missing', () => {
@@ -537,29 +539,15 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
   });
 
   describe('loadMirrorPaths', () => {
-    it('should load mirror paths successfully', () => {
+    it('should load mirror paths successfully without fetching checkpoints', () => {
       cephfsService.getMirrorStatus.mockReturnValue(of(mockMirrorStatusResponse));
-      cephfsService.listMirrorCheckpoints.mockImplementation((_, path: string) =>
-        of({
-          dir_root: path,
-          checkpoints:
-            path === '/path1'
-              ? [
-                  { snap_id: 1, snap_name: 'snap1' },
-                  { snap_id: 2, snap_name: 'snap2' }
-                ]
-              : [{ snap_id: 3, snap_name: 'snap3' }]
-        })
-      );
       component.fsName = 'test-fs';
 
       component.loadMirrorPaths();
 
       expect(cephfsService.getMirrorStatus).toHaveBeenCalledWith('test-fs');
-      expect(cephfsService.listMirrorCheckpoints).toHaveBeenCalledTimes(2);
+      expect(cephfsService.listMirrorCheckpoints).not.toHaveBeenCalled();
       expect(component.mirrorPaths.length).toBe(2);
-      expect(component.mirrorPaths[0].checkpointCount).toBe(2);
-      expect(component.mirrorPaths[1].checkpointCount).toBe(1);
     });
 
     it('should set empty array on error', () => {
@@ -620,12 +608,16 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
       };
 
       component.fsName = 'test-fs';
+      component.ngOnInit();
+      // Simulate the template async pipe so checkpoint loading runs.
+      const checkpointSub = component.checkpointState$.subscribe();
       component.onPathClick(mockPath as any);
       tick();
 
       expect(component.selectedPath?.path).toBe('/test');
       expect(component.sidePanelOpen).toBe(true);
       expect(cephfsService.listMirrorCheckpoints).toHaveBeenCalledWith('test-fs', '/test');
+      checkpointSub.unsubscribe();
     }));
   });
 
@@ -680,7 +672,7 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
       expect(component.snapshotPanels.length).toBe(2);
       expect(component.snapshotPanels[1].hasCheckpoint).toBe(true);
       expect(component.snapshotPanels[0].hasCheckpoint).toBe(false);
-      expect(component.selectedPathCheckpointCount).toBe(1);
+      expect(component.pathCheckpoints.length).toBe(1);
     });
 
     it('should toggle snapshot expansion', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.ts
@@ -45,10 +45,7 @@ interface SnapshotEntry {
   iconClass: string;
   statusLabel: string;
   filesSynced?: number;
-  totalFiles?: number;
   bytesSynced?: number;
-  totalBytes?: number;
-  createdAt?: string;
 }
 
 interface SnapshotPanelViewModel extends SnapshotEntry {
@@ -492,9 +489,10 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
             status: 'in-progress',
             eta: currentSnap?.eta,
             filesSynced: currentSnap?.files?.sync_files,
-            totalFiles: currentSnap?.files?.total_files,
-            bytesSynced: this.parseByteValue(currentSnap?.bytes?.sync_bytes),
-            totalBytes: this.parseByteValue(currentSnap?.bytes?.total_bytes)
+            bytesSynced:
+              currentSnap?.bytes?.sync_bytes != null
+                ? this.parseByteValue(String(currentSnap.bytes.sync_bytes))
+                : undefined
           })
         );
       } else if (currentName !== lastName) {
@@ -503,9 +501,10 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
             name: currentName,
             status: syncStatus === 'failed' ? 'failed' : 'pending',
             filesSynced: currentSnap?.files?.sync_files,
-            totalFiles: currentSnap?.files?.total_files,
-            bytesSynced: this.parseByteValue(currentSnap?.bytes?.sync_bytes),
-            totalBytes: this.parseByteValue(currentSnap?.bytes?.total_bytes)
+            bytesSynced:
+              currentSnap?.bytes?.sync_bytes != null
+                ? this.parseByteValue(String(currentSnap.bytes.sync_bytes))
+                : undefined
           })
         );
       }
@@ -517,12 +516,10 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
           name: lastName,
           status: 'replicated',
           filesSynced: lastSnap?.sync_files,
-          totalFiles: lastSnap?.sync_files,
-          bytesSynced: this.parseByteValue(
-            lastSnap?.sync_bytes != null ? String(lastSnap.sync_bytes) : undefined
-          ),
-          createdAt:
-            lastSnap?.sync_time_stamp != null ? String(lastSnap.sync_time_stamp) : undefined
+          bytesSynced:
+            lastSnap?.sync_bytes != null
+              ? this.parseByteValue(String(lastSnap.sync_bytes))
+              : undefined
         })
       );
     }
@@ -535,10 +532,7 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
     status: SnapshotReplicationStatus;
     eta?: string;
     filesSynced?: number;
-    totalFiles?: number;
     bytesSynced?: number;
-    totalBytes?: number;
-    createdAt?: string;
   }): SnapshotEntry {
     return {
       ...entry,
@@ -658,8 +652,7 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
         this.buildSnapshotPanel(
           this.createSnapshotEntry({
             name: checkpoint.snap_name,
-            status: 'replicated',
-            createdAt: checkpoint.created_at
+            status: 'replicated'
           }),
           checkpoint
         )
@@ -685,7 +678,6 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
       expanded: this.expandedSnapshotNames.has(snapshot.name),
       hasCheckpoint: !!checkpoint,
       checkpoint,
-      createdAt: checkpoint?.created_at ?? snapshot.createdAt,
       icon: display.icon,
       iconClass: display.iconClass,
       statusLabel: display.statusLabel,
@@ -806,11 +798,8 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
     });
   }
 
-  formatSnapshotFiles(filesSynced?: number, totalFiles?: number): string {
-    if (filesSynced === undefined || totalFiles === undefined) {
-      return '-';
-    }
-    return `${filesSynced}/${totalFiles}`;
+  formatSnapshotFiles(filesSynced?: number): string {
+    return filesSynced === undefined ? '-' : String(filesSynced);
   }
 
   private replicationStatusLabel(status: SnapshotReplicationStatus): string {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.ts
@@ -21,7 +21,12 @@ import { CdTableColumn } from '~/app/shared/models/cd-table-column';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import { FinishedTask } from '~/app/shared/models/finished-task';
 import { FormatterService } from '~/app/shared/services/formatter.service';
-import { MirrorDirStatus, MirrorCheckpoint, MirrorStatusResponse } from '~/app/shared/models/cephfs.model';
+import {
+  MirrorDirStatus,
+  MirrorCheckpoint,
+  MirrorCheckpointStatus,
+  MirrorStatusResponse
+} from '~/app/shared/models/cephfs.model';
 import { MirrorPathSchedule } from '~/app/shared/models/snapshot-schedule';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
@@ -262,8 +267,7 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
     this.subscriptions.add(
       this.cephfsService.list().subscribe({
         next: (filesystems: { id?: number; mdsmap?: { fs_name?: string } }[]) => {
-          const fsId =
-            filesystems.find((fs) => fs.mdsmap?.fs_name === this.fsName)?.id ?? 0;
+          const fsId = filesystems.find((fs) => fs.mdsmap?.fs_name === this.fsName)?.id ?? 0;
           const encodedFsName = encodeURIComponent(this.fsName);
           // Absolute URL avoids NG04006 when leaving /mirroring/:fsName for the list modal outlet
           this.router.navigateByUrl(
@@ -667,14 +671,64 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
     snapshot: SnapshotEntry,
     checkpoint?: MirrorCheckpoint
   ): SnapshotPanelViewModel {
+    const display = checkpoint
+      ? this.checkpointStatusDisplay(checkpoint.status)
+      : {
+          icon: snapshot.icon,
+          iconClass: snapshot.iconClass,
+          statusLabel: snapshot.statusLabel,
+          replicationStatusLabel: this.replicationStatusLabel(snapshot.status)
+        };
+
     return {
       ...snapshot,
       expanded: this.expandedSnapshotNames.has(snapshot.name),
       hasCheckpoint: !!checkpoint,
       checkpoint,
       createdAt: checkpoint?.created_at ?? snapshot.createdAt,
-      replicationStatusLabel: this.replicationStatusLabel(snapshot.status)
+      icon: display.icon,
+      iconClass: display.iconClass,
+      statusLabel: display.statusLabel,
+      replicationStatusLabel: display.replicationStatusLabel
     };
+  }
+
+  private checkpointStatusDisplay(status: MirrorCheckpointStatus): {
+    icon: keyof typeof ICON_TYPE;
+    iconClass: string;
+    statusLabel: string;
+    replicationStatusLabel: string;
+  } {
+    switch (status) {
+      case 'created':
+        return {
+          icon: 'inProgress',
+          iconClass: 'info',
+          statusLabel: $localize`checkpoint created`,
+          replicationStatusLabel: $localize`Created`
+        };
+      case 'complete':
+        return {
+          icon: 'checkMarkOutline',
+          iconClass: 'success',
+          statusLabel: $localize`checkpoint complete`,
+          replicationStatusLabel: $localize`Complete`
+        };
+      case 'failed':
+        return {
+          icon: 'danger',
+          iconClass: 'danger',
+          statusLabel: $localize`checkpoint failed`,
+          replicationStatusLabel: $localize`Failed`
+        };
+      default:
+        return {
+          icon: 'warning',
+          iconClass: 'muted',
+          statusLabel: $localize`checkpoint unknown`,
+          replicationStatusLabel: $localize`Unknown`
+        };
+    }
   }
 
   toggleSnapshotExpanded(snapshotName: string): void {
@@ -707,15 +761,13 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
             path,
             snapName
           }),
-          call: this.cephfsService
-            .addMirrorCheckpoint(this.fsName, path, snapName)
-            .pipe(
-              tap(() => {
-                this.checkpointActionInProgress = '';
-                this.loadPathCheckpoints(path);
-                this.loadMirrorPaths();
-              })
-            )
+          call: this.cephfsService.addMirrorCheckpoint(this.fsName, path, snapName).pipe(
+            tap(() => {
+              this.checkpointActionInProgress = '';
+              this.loadPathCheckpoints(path);
+              this.loadMirrorPaths();
+            })
+          )
         })
         .subscribe({
           error: () => {
@@ -738,20 +790,19 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
       itemNames: [snapName],
       actionDescription: 'remove',
       submitActionObservable: () =>
-        this.taskWrapper
-          .wrapTaskAroundCall({
-            task: new FinishedTask('cephfs/mirroring/checkpoint/remove', {
-              fsName: this.fsName,
-              path,
-              snapName
-            }),
-            call: this.cephfsService.removeMirrorCheckpoint(this.fsName, path, snapName).pipe(
-              tap(() => {
-                this.loadPathCheckpoints(path);
-                this.loadMirrorPaths();
-              })
-            )
-          })
+        this.taskWrapper.wrapTaskAroundCall({
+          task: new FinishedTask('cephfs/mirroring/checkpoint/remove', {
+            fsName: this.fsName,
+            path,
+            snapName
+          }),
+          call: this.cephfsService.removeMirrorCheckpoint(this.fsName, path, snapName).pipe(
+            tap(() => {
+              this.loadPathCheckpoints(path);
+              this.loadMirrorPaths();
+            })
+          )
+        })
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.ts
@@ -8,8 +8,8 @@ import {
   inject
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { forkJoin, of, Subscription } from 'rxjs';
-import { catchError, map, switchMap, tap } from 'rxjs/operators';
+import { BehaviorSubject, of, Subscription } from 'rxjs';
+import { catchError, map, shareReplay, startWith, switchMap, tap } from 'rxjs/operators';
 import { CephfsService } from '~/app/shared/api/cephfs.service';
 import { CephfsSnapshotScheduleService } from '~/app/shared/api/cephfs-snapshot-schedule.service';
 import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
@@ -21,11 +21,7 @@ import { CdTableColumn } from '~/app/shared/models/cd-table-column';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import { FinishedTask } from '~/app/shared/models/finished-task';
 import { FormatterService } from '~/app/shared/services/formatter.service';
-import {
-  MirrorDirStatus,
-  MirrorCheckpoint,
-  MirrorStatusResponse
-} from '~/app/shared/models/cephfs.model';
+import { MirrorDirStatus, MirrorCheckpoint, MirrorStatusResponse } from '~/app/shared/models/cephfs.model';
 import { MirrorPathSchedule } from '~/app/shared/models/snapshot-schedule';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
@@ -153,12 +149,40 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
   removingSchedule = '';
   snapshotPanels: SnapshotPanelViewModel[] = [];
   pathCheckpoints: MirrorCheckpoint[] = [];
-  checkpointsLoading = false;
   checkpointActionInProgress = '';
   expandedSnapshotNames = new Set<string>();
 
   private subscriptions = new Subscription();
   private mirrorPathsSubscription?: Subscription;
+  private readonly checkpointPath$ = new BehaviorSubject<string | null>(null);
+
+  readonly checkpointState$ = this.checkpointPath$.pipe(
+    switchMap((path) => {
+      if (!path || !this.fsName) {
+        this.pathCheckpoints = [];
+        this.refreshSnapshotPanels();
+        return of({ loading: false, checkpoints: [] as MirrorCheckpoint[] });
+      }
+
+      return this.cephfsService.listMirrorCheckpoints(this.fsName, path).pipe(
+        map((response) => ({
+          loading: false,
+          checkpoints: response.checkpoints ?? []
+        })),
+        catchError(() => of({ loading: false, checkpoints: [] as MirrorCheckpoint[] })),
+        tap((state) => {
+          if (this.selectedPath?.path !== path) {
+            return;
+          }
+          this.pathCheckpoints = state.checkpoints;
+          this.selectedPath.checkpointCount = state.checkpoints.length;
+          this.refreshSnapshotPanels();
+        }),
+        startWith({ loading: true, checkpoints: this.pathCheckpoints })
+      );
+    }),
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
 
   ngOnInit(): void {
     this.initializeColumns();
@@ -167,6 +191,7 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
   }
 
   ngOnDestroy(): void {
+    this.checkpointPath$.complete();
     this.subscriptions.unsubscribe();
   }
 
@@ -190,12 +215,6 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
         name: $localize`Snapshots synced`,
         prop: 'snapshotCount',
         flexGrow: 1.5
-      },
-      {
-        name: $localize`Checkpoints`,
-        prop: 'checkpointCount',
-        flexGrow: 1.5,
-        sortable: true
       },
       {
         name: $localize`Current sync snapshot`,
@@ -243,7 +262,8 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
     this.subscriptions.add(
       this.cephfsService.list().subscribe({
         next: (filesystems: { id?: number; mdsmap?: { fs_name?: string } }[]) => {
-          const fsId = filesystems.find((fs) => fs.mdsmap?.fs_name === this.fsName)?.id ?? 0;
+          const fsId =
+            filesystems.find((fs) => fs.mdsmap?.fs_name === this.fsName)?.id ?? 0;
           const encodedFsName = encodeURIComponent(this.fsName);
           // Absolute URL avoids NG04006 when leaving /mirroring/:fsName for the list modal outlet
           this.router.navigateByUrl(
@@ -308,51 +328,28 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
     }
 
     this.mirrorPathsSubscription?.unsubscribe();
-    this.mirrorPathsSubscription = this.cephfsService
-      .getMirrorStatus(this.fsName)
-      .pipe(
-        switchMap((data: MirrorStatusResponse) => {
-          const paths = this.parseMirrorStatus(data);
-          if (!paths.length) {
-            return of(paths);
-          }
-
-          return forkJoin(
-            paths.map((mirrorPath) =>
-              this.cephfsService.listMirrorCheckpoints(this.fsName, mirrorPath.path).pipe(
-                map((response) => response.checkpoints?.length ?? 0),
-                catchError(() => of(0))
-              )
-            )
-          ).pipe(
-            map((checkpointCounts) => {
-              paths.forEach((mirrorPath, index) => {
-                mirrorPath.checkpointCount = checkpointCounts[index];
-              });
-              return paths;
-            })
-          );
-        })
-      )
-      .subscribe({
-        next: (mirrorPaths) => {
-          this.mirrorPaths = mirrorPaths;
+    this.mirrorPathsSubscription = this.cephfsService.getMirrorStatus(this.fsName).subscribe({
+      next: (data: MirrorStatusResponse) => {
+        this.mirrorPaths = this.parseMirrorStatus(data);
+        if (this.selectedPath) {
+          this.selectedPath =
+            this.mirrorPaths.find((mirrorPath) => mirrorPath.path === this.selectedPath?.path) ??
+            null;
+          this.sidePanelOpen = !!this.selectedPath;
           if (this.selectedPath) {
-            this.selectedPath =
-              this.mirrorPaths.find((mirrorPath) => mirrorPath.path === this.selectedPath?.path) ??
-              null;
-            this.sidePanelOpen = !!this.selectedPath;
-            if (this.selectedPath) {
-              this.refreshSnapshotPanels();
-            }
+            this.loadPathCheckpoints(this.selectedPath.path);
+          } else {
+            this.clearCheckpoints();
           }
-        },
-        error: () => {
-          this.mirrorPaths = [];
-          this.selectedPath = null;
-          this.sidePanelOpen = false;
         }
-      });
+      },
+      error: () => {
+        this.mirrorPaths = [];
+        this.selectedPath = null;
+        this.sidePanelOpen = false;
+        this.clearCheckpoints();
+      }
+    });
     this.subscriptions.add(this.mirrorPathsSubscription);
   }
 
@@ -580,10 +577,6 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
     );
   }
 
-  get selectedPathCheckpointCount(): number {
-    return this.pathCheckpoints.length;
-  }
-
   get canMarkCheckpoint(): boolean {
     return !!this.permission?.create;
   }
@@ -596,7 +589,7 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
     this.sidePanelOpen = false;
     this.selectedPath = null;
     this.snapshotPanels = [];
-    this.pathCheckpoints = [];
+    this.clearCheckpoints();
     this.expandedSnapshotNames.clear();
 
     setTimeout(() => {
@@ -615,43 +608,23 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
     this.schedulePoliciesLoading = false;
     this.removingSchedule = '';
     this.snapshotPanels = [];
-    this.pathCheckpoints = [];
-    this.checkpointsLoading = false;
     this.checkpointActionInProgress = '';
     this.expandedSnapshotNames.clear();
+    this.clearCheckpoints();
+  }
+
+  private clearCheckpoints(): void {
+    this.checkpointPath$.next(null);
+    this.pathCheckpoints = [];
+    this.refreshSnapshotPanels();
   }
 
   loadPathCheckpoints(path: string): void {
-    if (!this.fsName || !path) {
-      this.pathCheckpoints = [];
-      this.refreshSnapshotPanels();
+    if (!this.fsName || !path || !this.sidePanelOpen) {
+      this.clearCheckpoints();
       return;
     }
-
-    this.checkpointsLoading = true;
-    this.subscriptions.add(
-      this.cephfsService.listMirrorCheckpoints(this.fsName, path).subscribe({
-        next: (response) => {
-          if (this.selectedPath?.path !== path) {
-            this.checkpointsLoading = false;
-            return;
-          }
-          this.pathCheckpoints = response.checkpoints ?? [];
-          if (this.selectedPath) {
-            this.selectedPath.checkpointCount = this.pathCheckpoints.length;
-          }
-          this.refreshSnapshotPanels();
-          this.checkpointsLoading = false;
-        },
-        error: () => {
-          if (this.selectedPath?.path === path) {
-            this.pathCheckpoints = [];
-            this.refreshSnapshotPanels();
-          }
-          this.checkpointsLoading = false;
-        }
-      })
-    );
+    this.checkpointPath$.next(path);
   }
 
   refreshSnapshotPanels(): void {
@@ -734,13 +707,15 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
             path,
             snapName
           }),
-          call: this.cephfsService.addMirrorCheckpoint(this.fsName, path, snapName).pipe(
-            tap(() => {
-              this.checkpointActionInProgress = '';
-              this.loadPathCheckpoints(path);
-              this.loadMirrorPaths();
-            })
-          )
+          call: this.cephfsService
+            .addMirrorCheckpoint(this.fsName, path, snapName)
+            .pipe(
+              tap(() => {
+                this.checkpointActionInProgress = '';
+                this.loadPathCheckpoints(path);
+                this.loadMirrorPaths();
+              })
+            )
         })
         .subscribe({
           error: () => {
@@ -763,19 +738,20 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
       itemNames: [snapName],
       actionDescription: 'remove',
       submitActionObservable: () =>
-        this.taskWrapper.wrapTaskAroundCall({
-          task: new FinishedTask('cephfs/mirroring/checkpoint/remove', {
-            fsName: this.fsName,
-            path,
-            snapName
-          }),
-          call: this.cephfsService.removeMirrorCheckpoint(this.fsName, path, snapName).pipe(
-            tap(() => {
-              this.loadPathCheckpoints(path);
-              this.loadMirrorPaths();
-            })
-          )
-        })
+        this.taskWrapper
+          .wrapTaskAroundCall({
+            task: new FinishedTask('cephfs/mirroring/checkpoint/remove', {
+              fsName: this.fsName,
+              path,
+              snapName
+            }),
+            call: this.cephfsService.removeMirrorCheckpoint(this.fsName, path, snapName).pipe(
+              tap(() => {
+                this.loadPathCheckpoints(path);
+                this.loadMirrorPaths();
+              })
+            )
+          })
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-overview/cephfs-mirroring-fs-overview.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-overview/cephfs-mirroring-fs-overview.component.html
@@ -98,9 +98,9 @@
         <span
           class="cds--type-label-01"
           i18n
-          >Cluster name</span
+          >Site name</span
         >
-        <span class="cds--type-body-compact-01">{{ fsData?.destination?.clusterName }}</span>
+        <span class="cds--type-body-compact-01">{{ fsData?.destination?.siteName }}</span>
       </div>
       <div
         cdsStack="vertical"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-overview/cephfs-mirroring-fs-overview.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-overview/cephfs-mirroring-fs-overview.component.spec.ts
@@ -140,11 +140,10 @@ describe('CephfsMirroringFsOverviewComponent', () => {
     expect(cephfsServiceMock.getMirrorStatus).toHaveBeenCalledWith('myfs', undefined, 'peer-uuid');
     expect(fsData?.stats.mirrorPaths).toBe(5);
     expect(fsData?.stats.failures).toBe(2);
-    expect(fsData?.destination.clusterName).toBe('remote-cluster');
+    expect(fsData?.destination.siteName).toBe('remote-site');
     expect(fsData?.destination.destinationFsName).toBe('remote_fs');
     expect(fsData?.destination.fsid).toBe('abc-123');
     expect(fsData?.destination.monitorEndpoint).toBe('10.0.0.1:6789');
-    expect(fsData?.destination.siteName).toBe('remote-site');
     expect(fsData?.stats.syncingPaths).toBe(1);
     expect(fsData?.sync.bytesSynced).toBe('1.00 KiB');
     expect(fsData?.sync.path).toBe('/dir1');
@@ -227,7 +226,7 @@ describe('CephfsMirroringFsOverviewComponent helpers', () => {
     expect(info.mirrorPaths).toBe(3);
     expect(info.failures).toBe(1);
     expect(info.peerUuid).toBe('peer-1');
-    expect(info.clusterName).toBe('remote');
+    expect(info.siteName).toBe('remote');
   });
 
   it('buildMirroringFsOverviewData uses empty sync when status is null', () => {
@@ -237,7 +236,7 @@ describe('CephfsMirroringFsOverviewComponent helpers', () => {
       {
         mirrorPaths: 2,
         failures: 0,
-        clusterName: 'c',
+        siteName: 'c',
         destinationFsName: 'd',
         fsid: 'f',
         monitorEndpoint: 'm',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-overview/cephfs-mirroring-fs-overview.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-overview/cephfs-mirroring-fs-overview.component.ts
@@ -79,7 +79,7 @@ export class CephfsMirroringFsOverviewComponent {
     const empty: DaemonOverviewInfo = {
       mirrorPaths: 0,
       failures: 0,
-      clusterName: '-',
+      siteName: '-',
       destinationFsName: '-',
       fsid: '-',
       monitorEndpoint: '-'
@@ -95,7 +95,7 @@ export class CephfsMirroringFsOverviewComponent {
       return {
         mirrorPaths: fs.directory_count ?? 0,
         failures: (fs.peers ?? []).reduce((sum, item) => sum + (item.stats?.failure_count ?? 0), 0),
-        clusterName: peer?.remote?.cluster_name ?? '-',
+        siteName: peer?.remote?.cluster_name ?? '-',
         destinationFsName: peer?.remote?.fs_name ?? '-',
         fsid: peer?.remote?.fsid ?? '-',
         monitorEndpoint: peer?.remote?.mon_host ?? '-',
@@ -124,8 +124,9 @@ export class CephfsMirroringFsOverviewComponent {
         syncingPaths: sync.syncingPaths
       },
       destination: {
-        clusterName: daemonInfo.clusterName,
-        siteName: daemonInfo.peerUuid ? (peers[daemonInfo.peerUuid]?.site_name ?? '-') : '-',
+        siteName: daemonInfo.peerUuid
+          ? peers[daemonInfo.peerUuid]?.site_name || daemonInfo.siteName
+          : daemonInfo.siteName,
         destinationFsName: daemonInfo.destinationFsName,
         fsid: daemonInfo.fsid,
         monitorEndpoint: daemonInfo.monitorEndpoint

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.spec.ts
@@ -134,7 +134,7 @@ describe('CephfsMirroringListComponent', () => {
     expect(cephfsServiceMock.getMirrorStatus).toHaveBeenCalledWith('fs1', undefined, 'peer-uuid');
     expect(emitted[0]).toEqual(
       expect.objectContaining({
-        remote_cluster_name: 'clusterA',
+        remote_site_name: 'clusterA',
         local_fs_name: 'fs1',
         fs_name: 'fsA',
         client_name: 'clientA',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
@@ -69,7 +69,7 @@ export class CephfsMirroringListComponent implements OnInit, OnDestroy {
           redirectLink: [CEPHFS_MIRRORING_URL, '::prop', 'overview']
         }
       },
-      { name: $localize`Destination cluster`, prop: 'remote_cluster_name', flexGrow: 2 },
+      { name: $localize`Site name`, prop: 'remote_site_name', flexGrow: 2 },
       { name: $localize`Bytes replicated`, prop: 'bytes_replicated', flexGrow: 2 },
       { name: $localize`Last sync`, prop: 'last_sync', flexGrow: 2 },
       { name: $localize`Replicated paths`, prop: 'directory_count', flexGrow: 2 }
@@ -230,7 +230,7 @@ export class CephfsMirroringListComponent implements OnInit, OnDestroy {
 
   private peerToRow(daemon: Daemon, fs: Filesystem, peer: Peer): MirroringRow {
     return {
-      remote_cluster_name: peer.remote?.cluster_name ?? '-',
+      remote_site_name: peer.remote?.cluster_name ?? '-',
       local_fs_name: fs.name,
       fs_name: peer.remote?.fs_name ?? '-',
       client_name: peer.remote?.client_name ?? '-',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-snapshotschedule-form/cephfs-snapshotschedule-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-snapshotschedule-form/cephfs-snapshotschedule-form.component.spec.ts
@@ -85,4 +85,27 @@ describe('CephfsSnapshotscheduleFormComponent', () => {
     expect(createSpy).toHaveBeenCalled();
     discardPeriodicTasks();
   }));
+
+  it('should derive subvol/group from each targetPath when building create payloads', () => {
+    formHelper.setMultipleValues({
+      directory: '/volumes/g1/sv1',
+      startDate: '2023-11-14 00:06:22',
+      repeatInterval: 1,
+      repeatFrequency: 'd'
+    });
+    component.isSubvolume = true;
+    component.subvolume = 'sv1';
+    component.subvolumeGroup = 'g1';
+    component.isDefaultSubvolumeGroup = false;
+
+    const first = component.buildCreatePayload('/volumes/g1/sv1');
+    const second = component.buildCreatePayload('/volumes/g1/sv2');
+
+    expect(first).toEqual(
+      expect.objectContaining({ path: '/volumes/g1/sv1', subvol: 'sv1', group: 'g1' })
+    );
+    expect(second).toEqual(
+      expect.objectContaining({ path: '/volumes/g1/sv2', subvol: 'sv2', group: 'g1' })
+    );
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-snapshotschedule-form/cephfs-snapshotschedule-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-snapshotschedule-form/cephfs-snapshotschedule-form.component.ts
@@ -347,11 +347,18 @@ export class CephfsSnapshotscheduleFormComponent
     }
 
     if (this.isSubvolume) {
-      snapScheduleObj['subvol'] = this.subvolume;
-    }
+      // When targetPath is provided (multi-path mirroring), derive subvol/group
+      // from that path so we don't reuse the first path's subvolume context.
+      const subvolumeGroup = targetPath ? path?.split?.('/')?.[2] : this.subvolumeGroup;
+      const subvolume = targetPath ? path?.split?.('/')?.[3] : this.subvolume;
+      const isDefaultSubvolumeGroup = targetPath
+        ? subvolumeGroup === DEFAULT_SUBVOLUME_GROUP
+        : this.isDefaultSubvolumeGroup;
 
-    if (this.isSubvolume && !this.isDefaultSubvolumeGroup) {
-      snapScheduleObj['group'] = this.subvolumeGroup;
+      snapScheduleObj['subvol'] = subvolume;
+      if (!isDefaultSubvolumeGroup) {
+        snapScheduleObj['group'] = subvolumeGroup;
+      }
     }
 
     return snapScheduleObj;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cephfs.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cephfs.model.ts
@@ -45,7 +45,7 @@ export interface Daemon {
 }
 
 export interface MirroringRow {
-  remote_cluster_name: string;
+  remote_site_name: string;
   fs_name: string;
   local_fs_name?: string;
   client_name: string;
@@ -268,7 +268,7 @@ export interface MirrorCheckpointMutationResponse {
 export interface DaemonOverviewInfo {
   mirrorPaths: number;
   failures: number;
-  clusterName: string;
+  siteName: string;
   destinationFsName: string;
   fsid: string;
   monitorEndpoint: string;
@@ -282,7 +282,6 @@ export interface MirroringFsOverviewStats {
 }
 
 export interface MirroringFsDestinationCluster {
-  clusterName: string;
   siteName: string;
   destinationFsName: string;
   fsid: string;

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -3207,7 +3207,7 @@ paths:
                                       description: Ceph client name
                                       type: string
                                     cluster_name:
-                                      description: Remote cluster name
+                                      description: Remote site name
                                       type: string
                                     fs_name:
                                       description: Remote filesystem name
@@ -3282,7 +3282,7 @@ paths:
                                       description: Ceph client name
                                       type: string
                                     cluster_name:
-                                      description: Remote cluster name
+                                      description: Remote site name
                                       type: string
                                     fs_name:
                                       description: Remote filesystem name


### PR DESCRIPTION
----------------------

- Fix multiple add mirror schedule policy

    Before
    
[befores_schedule_fix.webm](https://github.com/user-attachments/assets/2bd93354-bc47-4e8b-aa40-dddfa9b9e03c)

    
   
     After


[after_schedule_fix.webm](https://github.com/user-attachments/assets/22946a32-37a5-4be1-a56a-f299e5bb0140)


----------------------

- Rename cluster name to site name references

----------------------


- Load checkpoint data on side tab open 
- Use proper checkpoint status for snapshot info
- Remove fake total sync files
- Remove fake created file that was using daemon clock time

----------------------


After fixes 

[screen-capture (33).webm](https://github.com/user-attachments/assets/37f2e460-8f8c-4367-b9f8-cc30ca094b98)



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
