### PR TITLE
rgw,common: replace no-op MD5 FIPS flag with explicit MD5NonCrypto type

### DIFF
--- a/src/common/ceph_crypto.cc
+++ b/src/common/ceph_crypto.cc
@@ -87,6 +87,26 @@ void ssl::OpenSSLDigest::Restart() {
   }
 }
 
+const EVP_MD *ssl::MD5NonCrypto::digest_type() {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+  // An explicit "fips=no" query term overrides the same term in the
+  // default property query, and matches the default provider's MD5
+  // (which does not define the "fips" property at all).
+  // Process-lifetime cache, deliberately never freed.
+  static const EVP_MD * const md = []() -> const EVP_MD * {
+    if (EVP_MD * const fetched = EVP_MD_fetch(nullptr, "MD5", "fips=no")) {
+      return fetched;
+    }
+    return EVP_md5();  // no provider offers non-FIPS MD5; legacy fallback
+  }();
+  return md;
+#else
+  // Pre-3.0: EVP_MD_CTX_FLAG_NON_FIPS_ALLOW was already a no-op outside
+  // the ancient 1.0.x FIPS module, so plain MD5 is behavior-identical.
+  return EVP_md5();
+#endif
+}
+
 void ssl::OpenSSLDigest::SetFlags(int flags) {
   if (flags == EVP_MD_CTX_FLAG_NON_FIPS_ALLOW && OpenSSL_version_num() >= 0x30000000L && mpType == EVP_md5() && !mpType_FIPS) {
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L

--- a/src/common/ceph_crypto.cc
+++ b/src/common/ceph_crypto.cc
@@ -57,17 +57,11 @@ ssl::OpenSSLDigest::OpenSSLDigest(const EVP_MD * _type)
 
 ssl::OpenSSLDigest::~OpenSSLDigest() {
   EVP_MD_CTX_destroy(mpContext);
-  if (mpType_FIPS) {
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-    EVP_MD_free(mpType_FIPS);
-#endif  // OPENSSL_VERSION_NUMBER >= 0x30000000L
-  }
 }
 
 ssl::OpenSSLDigest::OpenSSLDigest(OpenSSLDigest&& o) noexcept
   : mpContext(std::exchange(o.mpContext, nullptr)),
-    mpType(std::exchange(o.mpType, nullptr)),
-    mpType_FIPS(std::exchange(o.mpType_FIPS, nullptr))
+    mpType(std::exchange(o.mpType, nullptr))
 {
 }
 
@@ -75,16 +69,11 @@ ssl::OpenSSLDigest& ssl::OpenSSLDigest::operator=(OpenSSLDigest&& o) noexcept
 {
   std::swap(mpContext, o.mpContext);
   std::swap(mpType, o.mpType);
-  std::swap(mpType_FIPS, o.mpType_FIPS);
   return *this;
 }
 
 void ssl::OpenSSLDigest::Restart() {
-  if (mpType_FIPS) {
-    EVP_DigestInit_ex(mpContext, mpType_FIPS, NULL);
-  } else {
-    EVP_DigestInit_ex(mpContext, mpType, NULL);
-  }
+  EVP_DigestInit_ex(mpContext, mpType, NULL);
 }
 
 const EVP_MD *ssl::MD5NonCrypto::digest_type() {
@@ -105,17 +94,6 @@ const EVP_MD *ssl::MD5NonCrypto::digest_type() {
   // the ancient 1.0.x FIPS module, so plain MD5 is behavior-identical.
   return EVP_md5();
 #endif
-}
-
-void ssl::OpenSSLDigest::SetFlags(int flags) {
-  if (flags == EVP_MD_CTX_FLAG_NON_FIPS_ALLOW && OpenSSL_version_num() >= 0x30000000L && mpType == EVP_md5() && !mpType_FIPS) {
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-    mpType_FIPS = EVP_MD_fetch(NULL, "MD5", "fips=no");
-#endif  // OPENSSL_VERSION_NUMBER >= 0x30000000L
-  } else {
-    EVP_MD_CTX_set_flags(mpContext, flags);
-  }
-  this->Restart();
 }
 
 void ssl::OpenSSLDigest::Update(const unsigned char *input, size_t length) {

--- a/src/common/ceph_crypto.h
+++ b/src/common/ceph_crypto.h
@@ -56,14 +56,12 @@ namespace TOPNSPC::crypto {
       private:
 	EVP_MD_CTX *mpContext;
 	const EVP_MD *mpType;
-        EVP_MD *mpType_FIPS = nullptr;
       public:
 	OpenSSLDigest (const EVP_MD *_type);
 	~OpenSSLDigest ();
 	OpenSSLDigest(OpenSSLDigest&& o) noexcept;
 	OpenSSLDigest& operator=(OpenSSLDigest&& o) noexcept;
 	void Restart();
-	void SetFlags(int flags);
 	void Update (const unsigned char *input, size_t length);
 	void Final (unsigned char *digest);
     };

--- a/src/common/ceph_crypto.h
+++ b/src/common/ceph_crypto.h
@@ -74,6 +74,19 @@ namespace TOPNSPC::crypto {
 	MD5 () : OpenSSLDigest(EVP_md5()) { }
     };
 
+    // MD5 for non-cryptographic purposes (S3/Swift ETags, object names,
+    // cache keys).  On OpenSSL 3+ the digest is fetched with a "fips=no"
+    // property query so it stays available when the default property
+    // query is "fips=yes"; this replaces the former
+    // SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW), which has been a no-op
+    // since OpenSSL 3.0.
+    class MD5NonCrypto : public OpenSSLDigest {
+	static const EVP_MD *digest_type();  // in ceph_crypto.cc
+      public:
+	static constexpr size_t digest_size = CEPH_CRYPTO_MD5_DIGESTSIZE;
+	MD5NonCrypto () : OpenSSLDigest(digest_type()) { }
+    };
+
     class SHA1 : public OpenSSLDigest {
       public:
         static constexpr size_t digest_size = CEPH_CRYPTO_SHA1_DIGESTSIZE;
@@ -199,6 +212,7 @@ namespace TOPNSPC::crypto {
 
   using ssl::SHA256;
   using ssl::MD5;
+  using ssl::MD5NonCrypto;
   using ssl::SHA1;
   using ssl::SHA512;
 

--- a/src/rgw/driver/daos/rgw_sal_daos.cc
+++ b/src/rgw/driver/daos/rgw_sal_daos.cc
@@ -1696,9 +1696,7 @@ int DaosMultipartUpload::complete(
     prefix_map_t& processed_prefixes) {
   ldpp_dout(dpp, 20) << "DEBUG: complete" << dendl;
   char final_etag[CEPH_CRYPTO_MD5_DIGESTSIZE];
-  MD5 hash;
-  // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-  hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+  MD5NonCrypto hash;
   bool truncated;
   int ret;
 

--- a/src/rgw/driver/motr/rgw_sal_motr.cc
+++ b/src/rgw/driver/motr/rgw_sal_motr.cc
@@ -2681,9 +2681,7 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
            const char *if_nomatch)
 {
   char final_etag[CEPH_CRYPTO_MD5_DIGESTSIZE];
-  MD5 hash;
-  // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-  hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+  MD5NonCrypto hash;
   bool truncated;
   int rc;
 
@@ -3751,10 +3749,7 @@ enum {
 void MotrStore::index_name_to_motr_fid(string iname, struct m0_uint128 *id)
 {
   unsigned char md5[16];  // 128/8 = 16
-  MD5 hash;
-
-  // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-  hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+  MD5NonCrypto hash;
   hash.Update((const unsigned char *)iname.c_str(), iname.length());
   hash.Final(md5);
 

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -3994,9 +3994,7 @@ int POSIXObject::generate_etag(const DoutPrefixProvider* dpp, optional_yield y)
 {
   int64_t left = get_size();
   int64_t cur_ofs = 0;
-  MD5 hash;
-  // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-  hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+  MD5NonCrypto hash;
   unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
 
   while (left > 0) {
@@ -4340,9 +4338,7 @@ int POSIXMultipartUpload::complete(const DoutPrefixProvider *dpp,
             const char *if_nomatch)
 {
   char final_etag[CEPH_CRYPTO_MD5_DIGESTSIZE];
-  MD5 hash;
-  // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-  hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+  MD5NonCrypto hash;
   bool truncated;
   int ret;
 

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -2668,9 +2668,7 @@ static void get_md5_digest(const RGWBucketEntryPoint *be, string& md5_digest) {
    be->dump(f);
    f->flush(bl);
 
-   MD5 hash;
-   // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-   hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+   MD5NonCrypto hash;
    hash.Update((const unsigned char *)bl.c_str(), bl.length());
    hash.Final(m);
 

--- a/src/rgw/driver/rados/rgw_etag_verifier.h
+++ b/src/rgw/driver/rados/rgw_etag_verifier.h
@@ -25,15 +25,12 @@ class ETagVerifier : public rgw::putobj::Pipe
 {
 protected:
   CephContext* cct;
-  MD5 hash;
+  MD5NonCrypto hash;
   std::string calculated_etag;
 
 public:
   ETagVerifier(CephContext* cct_, rgw::sal::DataProcessor *next)
-    : Pipe(next), cct(cct_) {
-      // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-      hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
-    }
+    : Pipe(next), cct(cct_) {}
 
   virtual void calculate_etag() = 0;
   std::string get_calculated_etag() { return calculated_etag;}
@@ -55,7 +52,7 @@ class ETagVerifier_MPU : public ETagVerifier
 {
   std::vector<uint64_t> part_ofs;
   uint64_t cur_part_index{0}, next_part_index{1};
-  MD5 mpu_etag_hash;
+  MD5NonCrypto mpu_etag_hash;
  
   void process_end_of_MPU_part();
 
@@ -65,10 +62,7 @@ public:
                              rgw::sal::DataProcessor *next)
     : ETagVerifier(cct, next),
       part_ofs(std::move(part_ofs))
-  {
-    // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-    hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
-  }
+  {}
 
   int process(bufferlist&& data, uint64_t logical_offset) override;
   void calculate_etag() override;

--- a/src/rgw/driver/rados/rgw_putobj_processor.cc
+++ b/src/rgw/driver/rados/rgw_putobj_processor.cc
@@ -811,9 +811,7 @@ int AppendObjectProcessor::complete(
   attrs[RGW_ATTR_APPEND_PART_NUM] = cur_part_num_bl;
   //calculate the etag
   if (!cur_etag.empty()) {
-    MD5 hash;
-    // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-    hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+    MD5NonCrypto hash;
     char petag[CEPH_CRYPTO_MD5_DIGESTSIZE];
     char final_etag[CEPH_CRYPTO_MD5_DIGESTSIZE];
     hex_to_buf(cur_etag.c_str(), petag, CEPH_CRYPTO_MD5_DIGESTSIZE);

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -7170,9 +7170,7 @@ static void generate_fake_tag(const DoutPrefixProvider *dpp, RGWRados* store, ma
   }
 
   unsigned char md5[CEPH_CRYPTO_MD5_DIGESTSIZE];
-  MD5 hash;
-  // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-  hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+  MD5NonCrypto hash;
   hash.Update((const unsigned char *)manifest_bl.c_str(), manifest_bl.length());
 
   map<string, bufferlist>::iterator iter = attrset.find(RGW_ATTR_ETAG);

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -1510,7 +1510,7 @@ int RadosBucket::commit_logging_object(const std::string& obj_name,
     std::ignore = store->getRados()->decode_policy(dpp, i->second, &owner);
   }
   head_obj_wop.meta.owner = owner;
-  const auto etag = TOPNSPC::crypto::digest<TOPNSPC::crypto::MD5>(bl_data).to_str();
+  const auto etag = TOPNSPC::crypto::digest<TOPNSPC::crypto::MD5NonCrypto>(bl_data).to_str();
   bufferlist bl_etag;
   bl_etag.append(etag.c_str());
   obj_attrs.emplace(RGW_ATTR_ETAG, std::move(bl_etag));
@@ -4268,9 +4268,7 @@ int RadosMultipartUpload::complete(const DoutPrefixProvider *dpp,
            const char *if_nomatch)
 {
   char final_etag[CEPH_CRYPTO_MD5_DIGESTSIZE];
-  MD5 hash;
-  // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-  hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+  MD5NonCrypto hash;
   bool truncated;
   int ret;
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -70,6 +70,7 @@ namespace rgw::lua {
 struct RGWProcessEnv;
 
 using ceph::crypto::MD5;
+using ceph::crypto::MD5NonCrypto;
 
 #define RGW_ATTR_PREFIX  "user.rgw."
 

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -2083,9 +2083,7 @@ int rgw_s3_prepare_encrypt(req_state* s, optional_yield y,
         return -EINVAL;
       }
 
-      MD5 key_hash;
-      // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-      key_hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+      MD5NonCrypto key_hash;
       unsigned char key_hash_res[CEPH_CRYPTO_MD5_DIGESTSIZE];
       key_hash.Update(reinterpret_cast<const unsigned char*>(key_bin.c_str()), key_bin.size());
       key_hash.Final(key_hash_res);
@@ -2562,9 +2560,7 @@ int rgw_s3_prepare_decrypt(req_state* s, optional_yield y,
       return -EINVAL;
     }
 
-    MD5 key_hash;
-    // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-    key_hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+    MD5NonCrypto key_hash;
     uint8_t key_hash_res[CEPH_CRYPTO_MD5_DIGESTSIZE];
     key_hash.Update(reinterpret_cast<const unsigned char*>(key_bin.c_str()), key_bin.size());
     key_hash.Final(key_hash_res);
@@ -2652,9 +2648,7 @@ int rgw_s3_prepare_decrypt(req_state* s, optional_yield y,
       return -EINVAL;
     }
 
-    MD5 key_hash;
-    // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-    key_hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+    MD5NonCrypto key_hash;
     uint8_t key_hash_res[CEPH_CRYPTO_MD5_DIGESTSIZE];
     key_hash.Update(reinterpret_cast<const unsigned char*>(key_bin.c_str()), key_bin.size());
     key_hash.Final(key_hash_res);

--- a/src/rgw/rgw_data_access.cc
+++ b/src/rgw/rgw_data_access.cc
@@ -17,13 +17,6 @@ class RGWEtag
   H hash;
 
 public:
-  RGWEtag() {
-    if constexpr (std::is_same_v<H, MD5>) {
-      // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-      hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
-    }
-  }
-
   void update(const char *buf, size_t len) {
     hash.Update((const unsigned char *)buf, len);
   }
@@ -51,7 +44,7 @@ public:
   }
 };
 
-using RGWMD5Etag = RGWEtag<MD5, CEPH_CRYPTO_MD5_DIGESTSIZE>;
+using RGWMD5Etag = RGWEtag<MD5NonCrypto, CEPH_CRYPTO_MD5_DIGESTSIZE>;
 
 RGWDataAccess::RGWDataAccess(rgw::sal::Driver* _driver) : driver(_driver)
 {

--- a/src/rgw/rgw_file_int.h
+++ b/src/rgw/rgw_file_int.h
@@ -2448,7 +2448,7 @@ public:
   CompressorRef plugin;
   buffer::list data;
   uint64_t timer_id;
-  MD5 hash;
+  MD5NonCrypto hash;
   off_t real_ofs;
   size_t bytes_written;
   bool eio;
@@ -2467,8 +2467,6 @@ public:
     // invoking this classes's header_init()
     (void) RGWWriteRequest::header_init();
     op = this;
-    // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-    hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
   }
 
   bool only_bucket() override { return true; }

--- a/src/rgw/rgw_keystone.cc
+++ b/src/rgw/rgw_keystone.cc
@@ -40,9 +40,7 @@ void rgw_get_token_id(const string& token, string& token_id)
 
   unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
 
-  MD5 hash;
-  // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-  hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+  MD5NonCrypto hash;
   hash.Update((const unsigned char *)token.c_str(), token.size());
   hash.Final(m);
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -101,7 +101,7 @@
 
 using namespace std;
 using namespace librados;
-using ceph::crypto::MD5;
+using ceph::crypto::MD5NonCrypto;
 using boost::optional;
 using boost::none;
 
@@ -2168,9 +2168,7 @@ static int iterate_user_manifest_parts(const DoutPrefixProvider *dpp,
   params.delim = delim;
 
   rgw::sal::Bucket::ListResults results;
-  MD5 etag_sum;
-  // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-  etag_sum.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+  MD5NonCrypto etag_sum;
   do {
     static constexpr auto MAX_LIST_OBJS = 100u;
     int r = bucket->list(dpp, params, MAX_LIST_OBJS, results, y);
@@ -2453,9 +2451,7 @@ int RGWGetObj::handle_slo_manifest(bufferlist& bl, optional_yield y)
 
   map<uint64_t, rgw_slo_part> slo_parts;
 
-  MD5 etag_sum;
-  // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-  etag_sum.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+  MD5NonCrypto etag_sum;
   total_len = 0;
 
   for (const auto& entry : slo_info.entries) {
@@ -4702,9 +4698,7 @@ void RGWPutObj::execute(optional_yield y)
   std::string calc_md5;
   calc_md5.reserve(CEPH_CRYPTO_MD5_DIGESTSIZE * 2);
   unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
-  MD5 hash;
-  // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-  hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+  MD5NonCrypto hash;
   bufferlist bl, aclbl, bs;
   int len;
   
@@ -5285,9 +5279,7 @@ void RGWPostObj::execute(optional_yield y)
    * is capable to handle multiple files in single form. */
   do {
     unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
-    MD5 hash;
-    // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-    hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+    MD5NonCrypto hash;
     ceph::buffer::list bl, aclbl;
 
     op_ret = s->bucket->check_quota(this, quota, s->content_length, y);
@@ -7012,9 +7004,7 @@ void RGWPutLC::execute(optional_yield y)
   ldpp_dout(this, 15) << "read len=" << data.length() << " data=" << (buf ? buf : "") << dendl;
 
   if (content_md5_bin) {
-    MD5 data_hash;
-    // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-    data_hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+    MD5NonCrypto data_hash;
     unsigned char data_hash_res[CEPH_CRYPTO_MD5_DIGESTSIZE];
     data_hash.Update(reinterpret_cast<const unsigned char*>(buf), data.length());
     data_hash.Final(data_hash_res);
@@ -7845,9 +7835,7 @@ bool RGWCompleteMultipart::check_previously_completed(const RGWMultiCompleteUplo
   rgw::sal::Attrs sattrs = s->object->get_attrs();
   string oetag = sattrs[RGW_ATTR_ETAG].to_str();
 
-  MD5 hash;
-  // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-  hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+  MD5NonCrypto hash;
   for (const auto& [index, part] : parts->parts) {
     std::string partetag = rgw_string_unquote(part);
     char petag[CEPH_CRYPTO_MD5_DIGESTSIZE];
@@ -8838,9 +8826,7 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
   /* Upload file content. */
   ssize_t len = 0;
   size_t ofs = 0;
-  MD5 hash;
-  // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-  hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+  MD5NonCrypto hash;
   do {
     ceph::bufferlist data;
     len = body.get_at_most(s->cct->_conf->rgw_max_chunk_size, data);

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -2504,7 +2504,7 @@ inline int encode_dlo_manifest_attr(const char * const dlo_manifest,
   return 0;
 } /* encode_dlo_manifest_attr */
 
-inline void complete_etag(MD5& hash, std::string* etag)
+inline void complete_etag(MD5NonCrypto& hash, std::string* etag)
 {
   if (!etag) {
     return;

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1087,9 +1087,7 @@ int RGWPutObj_ObjStore_SWIFT::get_params(optional_yield y)
       return -EINVAL;
     }
 
-    MD5 etag_sum;
-    // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-    etag_sum.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+    MD5NonCrypto etag_sum;
     uint64_t total_size = 0;
     for (auto& entry : slo_info->entries) {
       etag_sum.Update((const unsigned char *)entry.etag.c_str(),

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -951,7 +951,7 @@ namespace rgw::sal {
            const char *if_nomatch)
   {
     char final_etag[CEPH_CRYPTO_MD5_DIGESTSIZE];
-    MD5 hash;
+    MD5NonCrypto hash;
     bool truncated;
     int ret;
 

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -317,9 +317,7 @@ const string& RGWZoneParams::get_compression_type(const rgw_placement_rule& plac
 static uint32_t gen_short_zone_id(const std::string zone_id)
 {
   unsigned char md5[CEPH_CRYPTO_MD5_DIGESTSIZE];
-  MD5 hash;
-  // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-  hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+  MD5NonCrypto hash;
   hash.Update((const unsigned char *)zone_id.c_str(), zone_id.size());
   hash.Final(md5);
 

--- a/src/test/ceph_crypto.cc
+++ b/src/test/ceph_crypto.cc
@@ -5,6 +5,8 @@
 #include "global/global_init.h"
 #include "global/global_context.h"
 
+#include <openssl/evp.h>
+
 class CryptoEnvironment: public ::testing::Environment {
 public:
   void SetUp() override {
@@ -58,6 +60,83 @@ TEST(MD5, Restart) {
   };
   err = memcmp(digest, want_digest, CEPH_CRYPTO_MD5_DIGESTSIZE);
   ASSERT_EQ(0, err);
+}
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+namespace {
+
+// Restores the default property query on scope exit, so that a failed
+// assertion cannot leak "fips=yes" into the rest of the suite.  Round-tripping
+// through EVP_default_properties_enable_fips() keeps whatever else an
+// openssl.cnf put in the query, which resetting it outright would discard.
+class ScopedFipsDefaultProperty {
+  const int was_enabled;
+public:
+  ScopedFipsDefaultProperty()
+    : was_enabled(EVP_default_properties_is_fips_enabled(nullptr)) {}
+  ~ScopedFipsDefaultProperty() {
+    EVP_default_properties_enable_fips(nullptr, was_enabled);
+  }
+};
+
+} // anonymous namespace
+#endif
+
+// MD5NonCrypto exists so that the protocol-mandated MD5 uses in rgw (ETags,
+// object and cache keys) keep working when the default property query is
+// "fips=yes", where an unqualified MD5 fetch resolves to nothing.
+//
+// Keep this test first in the suite.  MD5NonCrypto fetches its EVP_MD once and
+// caches it for the lifetime of the process, so if anything constructs one
+// before the property query changes, this checks a digest that was fetched
+// under the permissive default and proves nothing.  gtest runs a suite's tests
+// in definition order, and nothing outside this suite builds an MD5NonCrypto.
+TEST(MD5NonCrypto, FipsDefaultProperty) {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+  ScopedFipsDefaultProperty restore_on_exit;
+  ASSERT_EQ(1, EVP_default_properties_enable_fips(nullptr, 1));
+
+  // Control.  Everything below passes trivially if MD5 is still reachable
+  // under "fips=yes" -- no provider that withholds it, a permissive build --
+  // so establish that the query really does bite before trusting the result.
+  EVP_MD *plain = EVP_MD_fetch(nullptr, "MD5", nullptr);
+  const bool plain_resolved = (plain != nullptr);
+  EVP_MD_free(plain);
+  if (plain_resolved) {
+    GTEST_SKIP() << "MD5 resolves even with fips=yes; test would be vacuous";
+  }
+
+  // The mechanism MD5NonCrypto relies on: an explicit "fips=no" term overrides
+  // the same term in the default query.
+  EVP_MD *non_fips = EVP_MD_fetch(nullptr, "MD5", "fips=no");
+  ASSERT_NE(nullptr, non_fips);
+  EVP_MD_free(non_fips);
+
+  // ...and what it produces is still MD5.  Vector from RFC 1321 appendix A.5.
+  ceph::crypto::MD5NonCrypto h;
+  h.Update((const unsigned char*)"abc", 3);
+  unsigned char digest[CEPH_CRYPTO_MD5_DIGESTSIZE];
+  h.Final(digest);
+  unsigned char want_digest[CEPH_CRYPTO_MD5_DIGESTSIZE] = {
+    0x90, 0x01, 0x50, 0x98, 0x3c, 0xd2, 0x4f, 0xb0,
+    0xd6, 0x96, 0x3f, 0x7d, 0x28, 0xe1, 0x7f, 0x72,
+  };
+  ASSERT_EQ(0, memcmp(digest, want_digest, CEPH_CRYPTO_MD5_DIGESTSIZE));
+#else
+  GTEST_SKIP() << "property queries require OpenSSL 3";
+#endif
+}
+
+TEST(MD5NonCrypto, Simple) {
+  ceph::crypto::MD5NonCrypto h;
+  h.Update((const unsigned char*)"abc", 3);
+  unsigned char digest[CEPH_CRYPTO_MD5_DIGESTSIZE];
+  h.Final(digest);
+  unsigned char want_digest[CEPH_CRYPTO_MD5_DIGESTSIZE] = {
+    0x90, 0x01, 0x50, 0x98, 0x3c, 0xd2, 0x4f, 0xb0,
+    0xd6, 0x96, 0x3f, 0x7d, 0x28, 0xe1, 0x7f, 0x72,
+  };
+  ASSERT_EQ(0, memcmp(digest, want_digest, CEPH_CRYPTO_MD5_DIGESTSIZE));
 }
 
 TEST(HMACSHA1, Simple) {

--- a/src/test/ceph_crypto.cc
+++ b/src/test/ceph_crypto.cc
@@ -7,6 +7,13 @@
 
 #include <openssl/evp.h>
 
+#ifndef _WIN32
+#include <cerrno>
+#include <cstring>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
 class CryptoEnvironment: public ::testing::Environment {
 public:
   void SetUp() override {
@@ -62,22 +69,57 @@ TEST(MD5, Restart) {
   ASSERT_EQ(0, err);
 }
 
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#if !defined(_WIN32) && OPENSSL_VERSION_NUMBER >= 0x30000000L
 namespace {
 
-// Restores the default property query on scope exit, so that a failed
-// assertion cannot leak "fips=yes" into the rest of the suite.  Round-tripping
-// through EVP_default_properties_enable_fips() keeps whatever else an
-// openssl.cnf put in the query, which resetting it outright would discard.
-class ScopedFipsDefaultProperty {
-  const int was_enabled;
-public:
-  ScopedFipsDefaultProperty()
-    : was_enabled(EVP_default_properties_is_fips_enabled(nullptr)) {}
-  ~ScopedFipsDefaultProperty() {
-    EVP_default_properties_enable_fips(nullptr, was_enabled);
-  }
+// How the child of MD5NonCrypto.FipsDefaultProperty reports back.
+enum fips_md5_result {
+  FIPS_MD5_OK = 0,
+  FIPS_MD5_SET_FAILED = 2,    // could not turn on the fips default property
+  FIPS_MD5_VACUOUS = 3,       // plain MD5 still resolved; nothing was proven
+  FIPS_MD5_FETCH_FAILED = 4,  // the explicit "fips=no" query did not resolve
+  FIPS_MD5_WRONG_DIGEST = 5,  // what came out was not MD5
 };
+
+// Runs in the forked child and never returns.  Turning on the fips default
+// property is a one-way door: OpenSSL 3 offers no way to read the default
+// property query back out, and EVP_default_properties_enable_fips(ctx, 0)
+// clears the "fips" term rather than restoring an explicit "fips=no" that an
+// openssl.cnf may have set.  Nothing here can restore the query faithfully,
+// so confine the change to a process nothing else runs in.
+[[noreturn]] void check_md5_non_crypto_under_fips() {
+  if (EVP_default_properties_enable_fips(nullptr, 1) != 1) {
+    _exit(FIPS_MD5_SET_FAILED);
+  }
+
+  // Control.  Everything below passes trivially if MD5 is still reachable
+  // under "fips=yes" -- no provider that withholds it, a permissive build --
+  // so establish that the query really does bite before trusting the result.
+  if (EVP_MD * const plain = EVP_MD_fetch(nullptr, "MD5", nullptr)) {
+    EVP_MD_free(plain);
+    _exit(FIPS_MD5_VACUOUS);
+  }
+
+  // The mechanism MD5NonCrypto relies on: an explicit "fips=no" term overrides
+  // the same term in the default query.
+  EVP_MD * const non_fips = EVP_MD_fetch(nullptr, "MD5", "fips=no");
+  if (non_fips == nullptr) {
+    _exit(FIPS_MD5_FETCH_FAILED);
+  }
+  EVP_MD_free(non_fips);
+
+  // ...and what it produces is still MD5.  Vector from RFC 1321 appendix A.5.
+  ceph::crypto::MD5NonCrypto h;
+  h.Update((const unsigned char*)"abc", 3);
+  unsigned char digest[CEPH_CRYPTO_MD5_DIGESTSIZE];
+  h.Final(digest);
+  const unsigned char want_digest[CEPH_CRYPTO_MD5_DIGESTSIZE] = {
+    0x90, 0x01, 0x50, 0x98, 0x3c, 0xd2, 0x4f, 0xb0,
+    0xd6, 0x96, 0x3f, 0x7d, 0x28, 0xe1, 0x7f, 0x72,
+  };
+  _exit(memcmp(digest, want_digest, CEPH_CRYPTO_MD5_DIGESTSIZE) == 0
+        ? FIPS_MD5_OK : FIPS_MD5_WRONG_DIGEST);
+}
 
 } // anonymous namespace
 #endif
@@ -87,43 +129,39 @@ public:
 // "fips=yes", where an unqualified MD5 fetch resolves to nothing.
 //
 // Keep this test first in the suite.  MD5NonCrypto fetches its EVP_MD once and
-// caches it for the lifetime of the process, so if anything constructs one
-// before the property query changes, this checks a digest that was fetched
-// under the permissive default and proves nothing.  gtest runs a suite's tests
-// in definition order, and nothing outside this suite builds an MD5NonCrypto.
+// caches it for the lifetime of the process, and the child inherits that cache
+// across the fork, so if anything constructs one before this runs it checks a
+// digest that was fetched under the permissive default and proves nothing.
+// gtest runs a suite's tests in definition order, and nothing outside this
+// suite builds an MD5NonCrypto.
 TEST(MD5NonCrypto, FipsDefaultProperty) {
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-  ScopedFipsDefaultProperty restore_on_exit;
-  ASSERT_EQ(1, EVP_default_properties_enable_fips(nullptr, 1));
-
-  // Control.  Everything below passes trivially if MD5 is still reachable
-  // under "fips=yes" -- no provider that withholds it, a permissive build --
-  // so establish that the query really does bite before trusting the result.
-  EVP_MD *plain = EVP_MD_fetch(nullptr, "MD5", nullptr);
-  const bool plain_resolved = (plain != nullptr);
-  EVP_MD_free(plain);
-  if (plain_resolved) {
-    GTEST_SKIP() << "MD5 resolves even with fips=yes; test would be vacuous";
-  }
-
-  // The mechanism MD5NonCrypto relies on: an explicit "fips=no" term overrides
-  // the same term in the default query.
-  EVP_MD *non_fips = EVP_MD_fetch(nullptr, "MD5", "fips=no");
-  ASSERT_NE(nullptr, non_fips);
-  EVP_MD_free(non_fips);
-
-  // ...and what it produces is still MD5.  Vector from RFC 1321 appendix A.5.
-  ceph::crypto::MD5NonCrypto h;
-  h.Update((const unsigned char*)"abc", 3);
-  unsigned char digest[CEPH_CRYPTO_MD5_DIGESTSIZE];
-  h.Final(digest);
-  unsigned char want_digest[CEPH_CRYPTO_MD5_DIGESTSIZE] = {
-    0x90, 0x01, 0x50, 0x98, 0x3c, 0xd2, 0x4f, 0xb0,
-    0xd6, 0x96, 0x3f, 0x7d, 0x28, 0xe1, 0x7f, 0x72,
-  };
-  ASSERT_EQ(0, memcmp(digest, want_digest, CEPH_CRYPTO_MD5_DIGESTSIZE));
+#if defined(_WIN32) || OPENSSL_VERSION_NUMBER < 0x30000000L
+  GTEST_SKIP() << "needs fork() and OpenSSL 3 property queries";
 #else
-  GTEST_SKIP() << "property queries require OpenSSL 3";
+  const pid_t pid = fork();
+  ASSERT_NE(-1, pid) << "fork: " << strerror(errno);
+  if (pid == 0) {
+    check_md5_non_crypto_under_fips();
+  }
+  int status = 0;
+  ASSERT_EQ(pid, waitpid(pid, &status, 0)) << "waitpid: " << strerror(errno);
+  ASSERT_TRUE(WIFEXITED(status))
+    << "child killed by signal " << WTERMSIG(status);
+
+  switch (WEXITSTATUS(status)) {
+  case FIPS_MD5_OK:
+    break;
+  case FIPS_MD5_VACUOUS:
+    GTEST_SKIP() << "MD5 resolves even with fips=yes; test would be vacuous";
+  case FIPS_MD5_SET_FAILED:
+    FAIL() << "could not enable the fips default property";
+  case FIPS_MD5_FETCH_FAILED:
+    FAIL() << "MD5 with an explicit fips=no query did not resolve";
+  case FIPS_MD5_WRONG_DIGEST:
+    FAIL() << "MD5NonCrypto did not produce the MD5 of \"abc\"";
+  default:
+    FAIL() << "unexpected child exit status " << WEXITSTATUS(status);
+  }
 #endif
 }
 


### PR DESCRIPTION
rgw computes MD5 in 29 places that are not cryptography: S3/Swift ETags, cache
keys, short zone-id hashes. Each has to be tagged by hand with
`SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW)` to survive a FIPS configuration.
This replaces the flag with a type, `ceph::crypto::MD5NonCrypto`.

The flag does not do what its name says. `EVP_MD_CTX_FLAG_NON_FIPS_ALLOW` was
only ever read by the OpenSSL 1.x FIPS module; 3.0 keeps the macro and ignores
it. The sites that set it work because `OpenSSLDigest::SetFlags` intercepts the
flag and re-fetches MD5 with a `fips=no` property query.

Being a separate statement after construction, it is also easy to forget.
Three sites never got it:

* `ETagVerifier_MPU` — the constructor flags the base class's `hash` a second
  time and never its own `mpu_etag_hash`
* `DBMultipartUpload::complete` in `rgw_sal_dbstore.cc` — same etag-of-etags
  pattern, no flag at all
* the bucket-logging object-commit ETag in `rgw_sal_rados.cc`

Under a strict FIPS configuration (default property query `fips=yes`) those
three crash radosgw. `Restart()` ignores the `EVP_DigestInit_ex` return value,
so `ctx->digest` is left NULL and the next `Update()` sends `EVP_DigestUpdate`
down its legacy branch into a NULL `ctx->update`. Measured on OpenSSL 3.0.13
with only the default provider loaded; no FIPS module is needed to reproduce,
since a `fips=yes` query already fails to resolve MD5.

A type cannot be forgotten. `MD5NonCrypto` fetches MD5 with an explicit
`fips=no` query, cached for process lifetime, falling back to `EVP_md5()`;
below 3.0 it is `EVP_md5()`. The second commit converts the 26 flagged sites
and the 3 unflagged ones; the third deletes `SetFlags` and the `mpType_FIPS`
plumbing.

Digest bytes are unchanged, so ETags stay wire-identical. The only behavior
difference is in FIPS mode, where those three sites stop crashing.

API impact: `OpenSSLDigest::SetFlags()` is removed, rgw held the only callers.
`complete_etag()` now takes `MD5NonCrypto&`, and `RGWEtag`'s user-declared
constructor is deleted — it existed only to hold the flag block. I can add a
deprecated `SetFlags` alias rather than remove it outright, if you prefer.

Two things deliberately left out. The `-Wdeprecated-declarations` pragmas stay:
they still cover the `HMAC` class, whose `HMAC_CTX_*` calls are
`OSSL_DEPRECATEDIN_3_0` on 3.x, so they cannot go until `HMAC` moves to
`EVP_MAC`. (#70125's commit message said they would come out with this PR; that
was wrong.) And `Restart()`/`Final()` still discard their return values, which
is why these sites crash rather than error — fixing that lets the constructor
throw, so every construction site needs an audit first. Happy to fold either in.

Testing: 20.2.2-based package build clean, radosgw up and serving. Single-PUT
ETag matched `md5sum`; multipart (5+5+3 MiB) ETag matched an independent Python
`hashlib` etag-of-etags, every part ETag equal. A standalone harness anchors
`MD5NonCrypto` against the RFC 1321 vectors under both the default and a
`fips=yes` property query, and confirms the old flagged path produces identical
bytes.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
