### PR TITLE
umbrella: mgr/dashboard: add text/javascript to gzip mime types 

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -106,7 +106,8 @@ class CherryPyConfig(object):
             'tools.gzip.on': True,
             'tools.gzip.mime_types': [
                 'text/html', 'text/plain', 'application/json',
-                'application/*+json', 'application/javascript', 'text/css'
+                'application/*+json', 'application/javascript',
+                'text/javascript', 'text/css'
             ],
             'tools.json_in.on': True,
             'tools.json_in.force': True,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78827

---

backport of https://github.com/ceph/ceph/pull/70625
parent tracker: https://tracker.ceph.com/issues/78788

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh