### PR TITLE
umbrella: crimson/seastore: keep on-page checksum in sync after merge_content_to

### DIFF
--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -543,8 +543,10 @@ struct FixedKVInternalNode
       }
       if (pending_version.get_last_committed_crc()) {
         // if pending_version has already calculated its crc,
-        // calculate it again.
-        pending_version.set_last_committed_crc(pending_version.calc_crc32c());
+        // calculate it again and keep the on-page checksum in sync.
+        auto crc = pending_version.calc_crc32c();
+        pending_version.set_last_committed_crc(crc);
+        pending_version.update_in_extent_chksum_field(crc);
       }
     }
   }

--- a/src/crimson/os/seastore/lba/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba/lba_btree_node.h
@@ -364,8 +364,10 @@ struct LBALeafNode
     if (pending_version.is_initial_pending() &&
         pending_version.get_last_committed_crc()) {
       // if pending_version has already calculated its crc,
-      // calculate it again.
-      pending_version.set_last_committed_crc(pending_version.calc_crc32c());
+      // calculate it again and keep the on-page checksum in sync.
+      auto crc = pending_version.calc_crc32c();
+      pending_version.set_last_committed_crc(crc);
+      pending_version.update_in_extent_chksum_field(crc);
     }
     return modified;
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79021

---

backport of https://github.com/ceph/ceph/pull/70418
parent tracker: https://tracker.ceph.com/issues/77022

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh