### PR TITLE
os/bluestore: Fix hanging Collection::flush()

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -14827,7 +14827,7 @@ void BlueStore::_txc_finish_io(TransContext *txc)
    */
 
   OpSequencer *osr = txc->osr.get();
-  std::lock_guard l(osr->qlock);
+  std::unique_lock l(osr->qlock);
   txc->set_state(TransContext::STATE_IO_DONE);
   txc->ioc.release_running_aios();
   OpSequencer::q_list_t::iterator p = osr->q.iterator_to(*txc);
@@ -14849,6 +14849,7 @@ void BlueStore::_txc_finish_io(TransContext *txc)
 	   p->get_state() == TransContext::STATE_IO_DONE);
 
   if (osr->kv_submitted_waiters) {
+    l.unlock(); // notify waiters outside the lock
     osr->qcond.notify_all();
   }
 }
@@ -14987,7 +14988,7 @@ void BlueStore::_txc_apply_kv(TransContext *txc, bool sync_submit_transaction)
     ceph_assert(r == 0);
     txc->set_state(TransContext::STATE_KV_SUBMITTED);
     if (txc->osr->kv_submitted_waiters) {
-      std::lock_guard l(txc->osr->qlock);
+      // No need to take a lock.
       txc->osr->qcond.notify_all();
     }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5270,8 +5270,51 @@ void BlueStore::DeferredBatch::_audit(CephContext *cct)
 }
 #endif
 
-// Collection
+// OpSequencer
+#undef dout_prefix
+#define dout_prefix *_dout << "bluestore.OpSequencer "
+#undef dout_context
+#define dout_context store->cct
 
+inline void BlueStore::OpSequencer::flush()
+{
+  bool res;
+  std::unique_lock l(qlock);
+  ++kv_submitted_waiters;
+  do {
+    res = qcond.wait_for(l, std::chrono::seconds(1), [&]() {
+      return q.empty() || _is_all_kv_submitted();
+    });
+    if (!res) {
+      dout(1) << "flush() timeouted after 1s" << dendl;
+    }
+  } while (!res);
+  --kv_submitted_waiters;
+}
+
+inline void BlueStore::OpSequencer::flush_all_but_last()
+{
+  bool res;
+  std::unique_lock l(qlock);
+  ceph_assert(q.size() >= 1);
+  ++kv_submitted_waiters;
+  do {
+    res = qcond.wait_for(l, std::chrono::seconds(1), [&]() {
+      if (q.size() <= 1) {
+        return true;
+      }
+      auto it = q.rbegin();
+      it++;
+      return it->get_state() >= TransContext::STATE_KV_SUBMITTED;
+    });
+    if (!res) {
+      dout(1) << "flush_all_but_last() timeouted after 1s" << dendl;
+    }
+  } while (!res);
+  --kv_submitted_waiters;
+}
+
+// Collection
 #undef dout_prefix
 #define dout_prefix *_dout << "bluestore(" << store->path << ").collection(" << cid << " " << this << ") "
 
@@ -14987,8 +15030,14 @@ void BlueStore::_txc_apply_kv(TransContext *txc, bool sync_submit_transaction)
     ceph_assert(r == 0);
     txc->set_state(TransContext::STATE_KV_SUBMITTED);
     if (txc->osr->kv_submitted_waiters) {
-      std::lock_guard l(txc->osr->qlock);
-      txc->osr->qcond.notify_all();
+      if (sync_submit_transaction) {
+        // We already have the lock
+        txc->osr->qcond.notify_all();
+      } else {
+        // We need to take a lock.
+        std::lock_guard l(txc->osr->qlock);
+        txc->osr->qcond.notify_all();
+      }
     }
 
 #if defined(WITH_LTTNG)

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2231,7 +2231,7 @@ public:
   class OpSequencer : public RefCountedObject {
   public:
     ceph::mutex qlock = ceph::make_mutex("BlueStore::OpSequencer::qlock");
-    ceph::condition_variable qcond;
+    std::condition_variable qcond; //ceph::condition_variable (_debug) requires lock to be held
     typedef boost::intrusive::list<
       TransContext,
       boost::intrusive::member_hook<
@@ -2298,18 +2298,14 @@ public:
 
     void flush() {
       std::unique_lock l(qlock);
+      ++kv_submitted_waiters;
       while (true) {
-	// std::set flag before the check because the condition
-	// may become true outside qlock, and we need to make
-	// sure those threads see waiters and signal qcond.
-	++kv_submitted_waiters;
-	if (q.empty() || _is_all_kv_submitted()) {
-	  --kv_submitted_waiters;
-	  return;
-	}
-	qcond.wait(l);
-	--kv_submitted_waiters;
+        if (q.empty() || _is_all_kv_submitted()) {
+          break;
+        }
+        qcond.wait_for(l, std::chrono::seconds(1));
       }
+      --kv_submitted_waiters;
     }
 
     void flush_all_but_last() {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2296,45 +2296,8 @@ public:
       return false;
     }
 
-    void flush() {
-      std::unique_lock l(qlock);
-      while (true) {
-	// std::set flag before the check because the condition
-	// may become true outside qlock, and we need to make
-	// sure those threads see waiters and signal qcond.
-	++kv_submitted_waiters;
-	if (q.empty() || _is_all_kv_submitted()) {
-	  --kv_submitted_waiters;
-	  return;
-	}
-	qcond.wait(l);
-	--kv_submitted_waiters;
-      }
-    }
-
-    void flush_all_but_last() {
-      std::unique_lock l(qlock);
-      ceph_assert (q.size() >= 1);
-      while (true) {
-	// std::set flag before the check because the condition
-	// may become true outside qlock, and we need to make
-	// sure those threads see waiters and signal qcond.
-	++kv_submitted_waiters;
-	if (q.size() <= 1) {
-	  --kv_submitted_waiters;
-	  return;
-	} else {
-	  auto it = q.rbegin();
-	  it++;
-	  if (it->get_state() >= TransContext::STATE_KV_SUBMITTED) {
-	    --kv_submitted_waiters;
-	    return;
-          }
-	}
-	qcond.wait(l);
-	--kv_submitted_waiters;
-      }
-      }
+    void flush();
+    void flush_all_but_last();
 
     bool flush_commit(Context *c) {
       std::lock_guard l(qlock);


### PR DESCRIPTION
The testing showed that sometimes BlueStore::OpSequencer::flush() hangs.

A script that replicates the problem (sometimes, patience needed).

```
\#!/bin/bash
\# best execute from /dev/shm
export CBIN=/home/akupczyk/ceph-2/build/

for ((t=0; t<20; t++))
do
  {
  for ((i=0; i<100; i++))
  do
    rm log$t.txt
    rm out$t.$i.txt
    ${CBIN}/bin/ceph_test_objectstore --gtest_filter=\*BlueStore\*Matrix\* \
      --bluestore_debug_enforce_settings=ssd --debug_rocksdb=0/0 --plugin_dir=${CBIN}/lib \
      --log_to_stderr=false --log_file=log$t.txt > out$t.$i.txt 2>&1 || exit
    echo THREAD $t ITERATION $i DONE
  done
  } &
done
wait
echo ALL DONE
```

The captures hangs show all transactions in sequencer in STATE_DONE, and a thread waiting on
```
  void flush() {
    ...
    qcond.wait(l);
    ...
  }
```

I was unable to find exact execution sequence that leads to the hang. The path I suspected was that flush() sleeps waiting on qcong for youngest transaction to progress further than STATE_KV_SUBMITTED, but that transaction was able to pass through execution without signalling qcond.

Actions:
1) Added locks around `qcond.notify_all()`.
2) Moved to `qcond.wait(.., predicate)`

 https://tracker.ceph.com/issues/72031



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
