### PR TITLE
umbrella: python-common/smb: work around socket path length limits for grpc lib

### DIFF
--- a/src/python-common/ceph/smb/ctl/__main__.py
+++ b/src/python-common/ceph/smb/ctl/__main__.py
@@ -182,7 +182,14 @@ class Context:
                 f' {len(matches)} sockets found',
                 hints=['select clusters using the --cluster option'],
             )
-        return matches[0]
+        socket = matches[0]
+        # workaround for socket length issues in gRPC library. Because the path
+        # will typically include a long(ish) UUID and a possibly long service
+        # name we can changedir to the parent and only pass the file name along
+        # to grpc. This should be safe as this tool doesn't do much file system
+        # ops beyond this point.
+        os.chdir(socket.parent)
+        return socket.relative_to(socket.parent)
 
     def _ceph_keyrings(self, searchdir: pathlib.Path) -> list[pathlib.Path]:
         try:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78892

---

backport of https://github.com/ceph/ceph/pull/70684
parent tracker: https://tracker.ceph.com/issues/78857

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh