### PR TITLE
doc: compute footer copyright year dynamically

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,3 +1,4 @@
+import datetime
 import fileinput
 import glob
 import logging
@@ -55,7 +56,7 @@ def is_release_eol(codename):
 
 # project information
 project = 'Ceph'
-copyright = ('2016, Ceph authors and contributors. '
+copyright = (f'2016-{datetime.date.today().year}, Ceph authors and contributors. '
              'Licensed under Creative Commons Attribution Share Alike 3.0 '
              '(CC-BY-SA-3.0)')
 version, codename, release = parse_ceph_release()


### PR DESCRIPTION
Every page on docs.ceph.com rendered a hardcoded 2016 copyright in the footer. Render it as a range ending in the current build year instead.

Fixes: https://tracker.ceph.com/issues/79036

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
