### PR TITLE
doc/mgr/nfs: replace stale ingress completion note

### DIFF
--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -70,13 +70,12 @@ To deploy NFS with a high-availability front-end (virtual IP and load balancer),
 of keepalived and haproxy to provide an high-availability NFS frontend for the NFS
 service.
 
-.. note:: The ingress implementation is not yet complete.  Enabling
-	  ingress will deploy multiple ganesha instances and balance
-	  load across them, but a host failure will not immediately
-	  cause cephadm to deploy a replacement daemon before the NFS
-	  grace period expires.  This high-availability functionality
-	  is expected to be completed by the Quincy release (March
-	  2022).
+.. note:: Enabling ingress provides a stable virtual IP for the NFS
+	  service, failover between hosts if a host fails, and load
+	  distribution across the NFS gateways. Client recovery after a
+	  failover is still subject to the NFS grace period. See
+	  :ref:`cephadm-ha-nfs` for details and additional deployment
+	  options.
 
 For more details, refer :ref:`orchestrator-cli-placement-spec` but keep
 in mind that specifying the placement via a YAML file is not supported.


### PR DESCRIPTION
The ingress note still promised HA completion by Quincy (March 2022). Replace it with a description of current behavior and a pointer to the cephadm HA NFS docs.

Fixes: https://tracker.ceph.com/issues/79034

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
