### PR TITLE
doc/start: point beginners at cephadm instead of a source build

### DIFF
--- a/doc/start/beginners-guide.rst
+++ b/doc/start/beginners-guide.rst
@@ -103,8 +103,49 @@ MDS
 A metadata server (MDS) is necessary for the proper functioning of CephFS.
 See :ref:`orchestrator-cli-cephfs` and :ref:`arch-cephfs`.
 
-Vstart Cluster Installation and Configuration Procedure
-=======================================================
+Deploying Your First Ceph Cluster
+=================================
+
+The recommended way to deploy a Ceph cluster is with ``cephadm``, which
+bootstraps a cluster on a single host from a container image and then
+expands it to additional hosts. A minimal deployment looks like this:
+
+#. Install the ``cephadm`` package on the first host. It is available in
+   the repositories of most major Linux distributions, for example:
+
+   .. prompt:: bash #
+
+      dnf install cephadm
+
+   or:
+
+   .. prompt:: bash #
+
+      apt install cephadm
+
+#. Bootstrap the cluster, supplying the IP address of the first host:
+
+   .. prompt:: bash #
+
+      cephadm bootstrap --mon-ip <ip-of-this-host>
+
+This creates a working single-host cluster, complete with a web-based
+dashboard, that can then be expanded with additional hosts and storage
+devices. See :ref:`cephadm_deploying_new_cluster` for the complete
+procedure, including requirements, adding hosts, and deploying OSDs.
+
+If you are running Ceph inside Kubernetes, use `Rook
+<https://rook.io>`_ instead. An overview of all installation methods is
+in :ref:`install-overview`.
+
+Building a Development Cluster from Source (vstart)
+===================================================
+
+.. note:: This procedure is intended for developers who want to modify
+   or contribute to Ceph. It compiles Ceph from source, which can take
+   several hours, and produces a throwaway development cluster. If you
+   want to deploy Ceph to store data, use ``cephadm`` as described
+   above instead.
 
 #. Clone the ``ceph/ceph`` repository:
 

--- a/doc/start/beginners-guide.rst
+++ b/doc/start/beginners-guide.rst
@@ -108,31 +108,19 @@ Deploying Your First Ceph Cluster
 
 The recommended way to deploy a Ceph cluster is with ``cephadm``, which
 bootstraps a cluster on a single host from a container image and then
-expands it to additional hosts. A minimal deployment looks like this:
+expands it to additional hosts. Once the ``cephadm`` command is
+available on the first host, creating a cluster comes down to a single
+command:
 
-#. Install the ``cephadm`` package on the first host. It is available in
-   the repositories of most major Linux distributions, for example:
+.. prompt:: bash #
 
-   .. prompt:: bash #
-
-      dnf install cephadm
-
-   or:
-
-   .. prompt:: bash #
-
-      apt install cephadm
-
-#. Bootstrap the cluster, supplying the IP address of the first host:
-
-   .. prompt:: bash #
-
-      cephadm bootstrap --mon-ip <ip-of-this-host>
+   cephadm bootstrap --mon-ip <ip-of-this-host>
 
 This creates a working single-host cluster, complete with a web-based
 dashboard, that can then be expanded with additional hosts and storage
-devices. See :ref:`cephadm_deploying_new_cluster` for the complete
-procedure, including requirements, adding hosts, and deploying OSDs.
+devices. Follow :ref:`cephadm_deploying_new_cluster` for the complete
+procedure: it covers the host requirements, how to obtain ``cephadm``
+for your distribution, and how to add hosts and deploy OSDs.
 
 If you are running Ceph inside Kubernetes, use `Rook
 <https://rook.io>`_ instead. An overview of all installation methods is


### PR DESCRIPTION
The Beginner's Guide's only installation path was the vstart developer cluster, sending newcomers into a multi-hour source build and contradicting the install guide. Add a cephadm bootstrap quick start and label the vstart procedure as developer-only.

Fixes: https://tracker.ceph.com/issues/79040

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
