### PR TITLE
doc: stop presenting EOL distros as current requirements

### DIFF
--- a/doc/cephfs/cephfs-top.rst
+++ b/doc/cephfs/cephfs-top.rst
@@ -169,4 +169,6 @@ Sample screenshot running `cephfs-top` with 2 filesystems:
 
 .. image:: cephfs-top.png
 
-.. note:: Minimum compatible Python version for cephfs-top is 3.6.0. cephfs-top is supported on distributions RHEL 8, Ubuntu 18.04, CentOS 8 and above.
+.. note:: The minimum compatible Python version for cephfs-top is 3.6.0.
+   cephfs-top runs on any distribution that provides a compatible Python
+   version; see :ref:`os-recommendations` for the supported platforms.

--- a/doc/cephfs/cephfs-top.rst
+++ b/doc/cephfs/cephfs-top.rst
@@ -170,5 +170,5 @@ Sample screenshot running `cephfs-top` with 2 filesystems:
 .. image:: cephfs-top.png
 
 .. note:: The minimum compatible Python version for cephfs-top is 3.6.0.
-   cephfs-top runs on any distribution that provides a compatible Python
-   version; see :ref:`os-recommendations` for the supported platforms.
+   cephfs-top runs on any distribution that provides a compatible
+   Python version.

--- a/doc/rbd/iscsi-target-ansible.rst
+++ b/doc/rbd/iscsi-target-ansible.rst
@@ -11,7 +11,8 @@ install and configure the Ceph iSCSI gateway for basic operation.
 
 -  A running Ceph Luminous (12.2.x) cluster or newer
 
--  Red Hat Enterprise Linux/CentOS 7.5 (or newer); Linux kernel v4.16 (or newer)
+-  Linux kernel v4.16 (or newer); all currently supported distributions
+   satisfy this requirement
 
 -  The ``ceph-iscsi`` package installed on all the iSCSI gateway nodes
 

--- a/doc/rbd/iscsi-target-ansible.rst
+++ b/doc/rbd/iscsi-target-ansible.rst
@@ -11,8 +11,8 @@ install and configure the Ceph iSCSI gateway for basic operation.
 
 -  A running Ceph Luminous (12.2.x) cluster or newer
 
--  Linux kernel v4.16 (or newer); all currently supported distributions
-   satisfy this requirement
+-  Linux kernel v4.16 (or newer), or Enterprise Linux (EL) 7.5 (or
+   newer), in which the required iSCSI support is backported
 
 -  The ``ceph-iscsi`` package installed on all the iSCSI gateway nodes
 

--- a/doc/rbd/iscsi-target-cli-manual-install.rst
+++ b/doc/rbd/iscsi-target-cli-manual-install.rst
@@ -67,8 +67,9 @@ To know more about Git and how it works, please, visit https://git-scm.com
 
 Ensure you use a supported kernel that contains the required Ceph iSCSI patches:
 
--  any Linux distribution with a kernel v4.16 or newer; all currently
-   supported distributions satisfy this requirement
+-  any Linux distribution with a kernel v4.16 or newer, or
+-  Enterprise Linux (EL) 7.5 or later, in which ceph-iscsi support is
+   backported
 
 If you are already using a compatible kernel, you can go to next step.
 However, if you are NOT using a compatible kernel then check your distro's

--- a/doc/rbd/iscsi-target-cli-manual-install.rst
+++ b/doc/rbd/iscsi-target-cli-manual-install.rst
@@ -67,8 +67,8 @@ To know more about Git and how it works, please, visit https://git-scm.com
 
 Ensure you use a supported kernel that contains the required Ceph iSCSI patches:
 
--  all Linux distribution with a kernel v4.16 or newer, or
--  Red Hat Enterprise Linux or CentOS 7.5 or later (in these distributions ceph-iscsi support is backported)
+-  any Linux distribution with a kernel v4.16 or newer; all currently
+   supported distributions satisfy this requirement
 
 If you are already using a compatible kernel, you can go to next step.
 However, if you are NOT using a compatible kernel then check your distro's

--- a/doc/rbd/iscsi-target-cli.rst
+++ b/doc/rbd/iscsi-target-cli.rst
@@ -14,7 +14,8 @@ The following steps install and configure the Ceph iSCSI gateway for basic opera
 
 -  A running Ceph Luminous or later storage cluster
 
--  Red Hat Enterprise Linux/CentOS 7.5 (or newer); Linux kernel v4.16 (or newer)
+-  Linux kernel v4.16 (or newer); all currently supported distributions
+   satisfy this requirement
 
 -  The following packages must be installed from your Linux distribution's software repository:
 

--- a/doc/rbd/iscsi-target-cli.rst
+++ b/doc/rbd/iscsi-target-cli.rst
@@ -14,8 +14,8 @@ The following steps install and configure the Ceph iSCSI gateway for basic opera
 
 -  A running Ceph Luminous or later storage cluster
 
--  Linux kernel v4.16 (or newer); all currently supported distributions
-   satisfy this requirement
+-  Linux kernel v4.16 (or newer), or Enterprise Linux (EL) 7.5 (or
+   newer), in which the required iSCSI support is backported
 
 -  The following packages must be installed from your Linux distribution's software repository:
 

--- a/doc/rbd/rbd-cloudstack.rst
+++ b/doc/rbd/rbd-cloudstack.rst
@@ -41,19 +41,13 @@ CloudStack integrates with Ceph's block devices to provide CloudStack with a
 back end for CloudStack's Primary Storage. The instructions below detail the
 setup for CloudStack Primary Storage.
 
-.. note:: We recommend installing with Ubuntu 14.04 or later so that 
-   you can use package installation instead of having to compile 
-   libvirt from source.
-
 Installing and configuring QEMU for use with CloudStack doesn't require any
 special handling. Ensure that you have a running Ceph Storage Cluster. Install
-QEMU and configure it for use with Ceph; then, install ``libvirt`` version
-0.9.13 or higher (you may need to compile from source) and ensure it is running
-with Ceph.
+QEMU and configure it for use with Ceph; then, install ``libvirt`` and ensure
+it is running with Ceph.
 
-
-.. note:: Ubuntu 14.04 and CentOS 7.2 will have ``libvirt`` with RBD storage
-   pool support enabled by default.
+.. note:: All currently supported distributions ship ``libvirt`` with RBD
+   storage pool support enabled by default.
 
 .. index:: pools; CloudStack
 

--- a/doc/start/os-recommendations.rst
+++ b/doc/start/os-recommendations.rst
@@ -45,7 +45,7 @@ Linux Kernel
   Older kernel client versions may not support your :ref:`CRUSH
   tunables <crush-map-tunables>` profile or other newer features of the Ceph
   cluster, requiring the storage cluster to be configured with those features
-  disabled. For RBD, a kernel of version 5.3 or later is the minimum
+  disabled. For RBD, a kernel of version 5.3 or EL 8.2 is the minimum
   necessary for reasonable support for RBD image features.
 
 - **Ceph MS Windows Client**

--- a/doc/start/os-recommendations.rst
+++ b/doc/start/os-recommendations.rst
@@ -45,7 +45,7 @@ Linux Kernel
   Older kernel client versions may not support your :ref:`CRUSH
   tunables <crush-map-tunables>` profile or other newer features of the Ceph
   cluster, requiring the storage cluster to be configured with those features
-  disabled. For RBD, a kernel of version 5.3 or CentOS 8.2 is the minimum
+  disabled. For RBD, a kernel of version 5.3 or later is the minimum
   necessary for reasonable support for RBD image features.
 
 - **Ceph MS Windows Client**

--- a/doc/start/os-recommendations.rst
+++ b/doc/start/os-recommendations.rst
@@ -45,7 +45,7 @@ Linux Kernel
   Older kernel client versions may not support your :ref:`CRUSH
   tunables <crush-map-tunables>` profile or other newer features of the Ceph
   cluster, requiring the storage cluster to be configured with those features
-  disabled. For RBD, a kernel of version 5.3 or EL 8.2 is the minimum
+  disabled. For RBD, a kernel of version 5.3 or Enterprise Linux (EL) 8.2 is the minimum
   necessary for reasonable support for RBD image features.
 
 - **Ceph MS Windows Client**


### PR DESCRIPTION
Several user-facing pages still stated EOL distributions (RHEL/CentOS 7.x and 8, Ubuntu 14.04/18.04, CentOS 8.2) as current requirements or support floors. Restate them against kernel versions or the currently supported platforms in the OS recommendations.

Note: the operating.rst instance listed in the tracker was already fixed by #69360.

Fixes: https://tracker.ceph.com/issues/79037


