### PR TITLE
doc/mgr: point users at ceph-exporter for daemon metrics

### DIFF
--- a/doc/mgr/modules.rst
+++ b/doc/mgr/modules.rst
@@ -23,7 +23,9 @@ The most important methods to override are:
   take action when new cluster data is available.
 * a ``handle_command`` member function if your module
   exposes CLI commands. But this approach for exposing commands
-  is deprecated. For more details, see :ref:`mgr-module-exposing-commands`.
+  is deprecated: new modules should register commands with the
+  ``CLICommand`` decorator instead. For details on both approaches,
+  see :ref:`mgr-module-exposing-commands`.
 
 Some modules interface with external orchestrators to deploy
 Ceph services.  These also inherit from ``Orchestrator``, which adds

--- a/doc/mgr/prometheus.rst
+++ b/doc/mgr/prometheus.rst
@@ -15,6 +15,16 @@ counters for all reporting entities are returned in the Prometheus exposition
 format.  (See the Prometheus `documentation
 <https://prometheus.io/docs/instrumenting/exposition_formats/#text-format-details>`_.)
 
+.. note:: Ceph daemon performance counters are no longer exported by
+   this module by default. That job has moved to the ``ceph-exporter``
+   daemon, which cephadm deploys on every host and which reads the
+   counters directly from the local daemon admin sockets. The
+   ``prometheus`` module continues to provide cluster-level metrics,
+   the service discovery endpoint, and RBD image metrics. See
+   :ref:`monitoring` for an overview of the monitoring stack and
+   `Ceph daemon performance counters metrics`_ below for how to
+   re-enable the old behavior.
+
 Enabling Prometheus output
 ==========================
 


### PR DESCRIPTION
The prometheus module page only mentioned deep in the page that daemon perf counters moved to ceph-exporter. Add a prominent note at the top, and name the CLICommand decorator as the replacement for the deprecated handle_command mechanism in modules.rst.

Fixes: https://tracker.ceph.com/issues/77190


