### PR TITLE
doc/rados: name FastEC and link it from the Tentacle notes

### DIFF
--- a/doc/rados/operations/erasure-code.rst
+++ b/doc/rados/operations/erasure-code.rst
@@ -219,8 +219,8 @@ with a per-pool setting. These optimizations, known collectively as
 *FastEC*, add support for partial reads and partial writes: small
 reads are served directly from the relevant shards, and small writes
 no longer require reading and rewriting the full stripe. This improves
-performance for smaller I/Os and eliminates padding, which can
-significantly reduce space amplification and wasted capacity:
+performance for smaller I/Os and eliminates padding, significantly
+reducing space amplification and wasted capacity:
 
 .. prompt:: bash $
 
@@ -245,12 +245,14 @@ upgrading gateways and clients.
 Optimizations are currently only supported with the ISA-L plugin and with
 the Jerasure plugin when using the ``reed_sol_van`` technique (these are
 the current and previous default plugins and the most widely used
-technique). Attempting to set the flag for a pool using an unsupported
-combination of plugin and technique, such as CLAY, LRC, or SHEC, is
-blocked with an error message.
+technique). Prefer ISA-L for new pools: it is the default plugin for
+pools created on Tentacle or later, and the Jerasure library is no
+longer maintained. Attempting to set the flag for a pool using an
+unsupported combination of plugin and technique, such as CLAY, LRC, or
+SHEC, is blocked with an error message.
 
 The default stripe unit is 4K which works well for standard EC pools.
-The stripe unit must be a multiple of 4K for optimizations to be
+The stripe unit must be a multiple of 4 KiB for optimizations to be
 enabled; enabling the flag on a pool with any other stripe unit is
 rejected.
 For the majority of I/O workloads it is recommended to increase the stripe

--- a/doc/rados/operations/erasure-code.rst
+++ b/doc/rados/operations/erasure-code.rst
@@ -215,9 +215,12 @@ Erasure Coding Optimizations
 ----------------------------
 
 Since Tentacle, an erasure-coded pool may have optimizations enabled
-with a per-pool setting. This improves performance for smaller I/Os and
-eliminates padding, which can significantly reduce space amplification
-and wasted capacity:
+with a per-pool setting. These optimizations, known collectively as
+*FastEC*, add support for partial reads and partial writes: small
+reads are served directly from the relevant shards, and small writes
+no longer require reading and rewriting the full stripe. This improves
+performance for smaller I/Os and eliminates padding, which can
+significantly reduce space amplification and wasted capacity:
 
 .. prompt:: bash $
 
@@ -239,13 +242,17 @@ The flag cannot be set unless all the Monitors and OSDs have been
 upgraded to Tentacle or later. Optimizations can be enabled and used without
 upgrading gateways and clients.
 
-Optimizations are currently only supported with the Jerasure and ISA-L plugins
-when using the ``reed_sol_van`` technique (these are the old and current
-defaults and are the most widely used plugins and technique). Attempting to
-set the flag for a pool using an unsupported combination of plugin and
-technique is blocked with an error message.
+Optimizations are currently only supported with the ISA-L plugin and with
+the Jerasure plugin when using the ``reed_sol_van`` technique (these are
+the current and previous default plugins and the most widely used
+technique). Attempting to set the flag for a pool using an unsupported
+combination of plugin and technique, such as CLAY, LRC, or SHEC, is
+blocked with an error message.
 
 The default stripe unit is 4K which works well for standard EC pools.
+The stripe unit must be a multiple of 4K for optimizations to be
+enabled; enabling the flag on a pool with any other stripe unit is
+rejected.
 For the majority of I/O workloads it is recommended to increase the stripe
 unit to at least 16K when using optimizations. Performance testing
 shows that 16K is the best choice for general purpose I/O workloads. Increasing

--- a/doc/releases/tentacle.rst
+++ b/doc/releases/tentacle.rst
@@ -1048,7 +1048,7 @@ RADOS
   ``allow_ec_optimizations`` must be set on each pool to switch to using the
   new code. Existing pools can be upgraded once the OSD and Monitor daemons
   have been updated. There is no need to update the clients. See
-  :ref:`rados_ops_erasure_coding_optimizations` for how to enable the
+  :ref:`rados_ops_erasure_coding_optimizations` for how to enable
   optimizations and for tuning guidance.
 
 * The default plugin for erasure coded pools has been changed from Jerasure to

--- a/doc/releases/tentacle.rst
+++ b/doc/releases/tentacle.rst
@@ -867,7 +867,8 @@ MGR
 RADOS
 
 * FastEC: Long-anticipated performance and space amplification
-  optimizations are added for erasure-coded pools.
+  optimizations are added for erasure-coded pools. See
+  :ref:`rados_ops_erasure_coding_optimizations`.
 * BlueStore: Improved compression and a new, faster WAL (write-ahead-log).
 * Data Availability Score: Users can now track a data availability score
   for each pool in their cluster.
@@ -1046,7 +1047,9 @@ RADOS
   (RGW), in particular when using smaller sized objects. A new flag
   ``allow_ec_optimizations`` must be set on each pool to switch to using the
   new code. Existing pools can be upgraded once the OSD and Monitor daemons
-  have been updated. There is no need to update the clients.
+  have been updated. There is no need to update the clients. See
+  :ref:`rados_ops_erasure_coding_optimizations` for how to enable the
+  optimizations and for tuning guidance.
 
 * The default plugin for erasure coded pools has been changed from Jerasure to
   ISA-L. Clusters created on Tentacle or later releases will use ISA-L as the


### PR DESCRIPTION
The erasure coding optimizations section never used the FastEC name that the release notes, code, and dev docs use. Name it, describe partial reads/writes briefly, state the 4K stripe unit requirement and unsupported plugins (CLAY/LRC/SHEC), clarify ISA-L is not limited to reed_sol_van, and link both Tentacle release note highlights to the section.

Fixes: https://tracker.ceph.com/issues/79032


