### PR TITLE
mgr/cephadm: batch MDS upgrades when fail_fs is set

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -789,6 +789,45 @@ def test_enough_mds_for_ok_to_stop(get, get_daemons_by_service, cephadm_module: 
         DaemonDescription(daemon_type='mds', daemon_id='myfs.test.host1.gfknd', service_name='mds.myfs.test'))
 
 
+def _mds_need_upgrade_entries() -> List[Tuple[DaemonDescription, bool]]:
+    return [
+        (DaemonDescription(
+            daemon_type='mds',
+            daemon_id=f'cephfs.host{i}.abcdef',
+            hostname=f'host{i}',
+            container_image_id='old_digest',
+            service_name='mds.cephfs',
+        ), False)
+        for i in range(1, 4)
+    ]
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+@mock.patch.object(CephadmUpgrade, '_enough_mds_for_ok_to_stop', return_value=True)
+@mock.patch.object(CephadmUpgrade, '_wait_for_ok_to_stop', return_value=True)
+def test_to_upgrade_batches_mds_when_fail_fs(
+        _wait_for_ok_to_stop: mock.MagicMock,
+        _enough_mds_for_ok_to_stop: mock.MagicMock,
+        cephadm_module: CephadmOrchestrator):
+    # https://tracker.ceph.com/issues/78304
+    need_upgrade = _mds_need_upgrade_entries()
+
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target_image', 'pid', fail_fs=True)
+    cont, to_upgrade = cephadm_module.upgrade._to_upgrade(need_upgrade, 'target_image')
+    assert cont
+    assert len(to_upgrade) == 3
+    assert [d[0].name() for d in to_upgrade] == [d[0].name() for d in need_upgrade]
+    _wait_for_ok_to_stop.assert_not_called()
+
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target_image', 'pid', fail_fs=False)
+    cont, to_upgrade = cephadm_module.upgrade._to_upgrade(need_upgrade, 'target_image')
+    assert cont
+    assert len(to_upgrade) == 1
+    assert to_upgrade[0][0].name() == need_upgrade[0][0].name()
+
+
 @pytest.mark.parametrize("current_version, use_tags, show_all_versions, tags, result",
                          [
                              # several candidate versions (from different major versions)

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -1481,12 +1481,11 @@ class CephadmUpgrade:
                     return False, to_upgrade
 
             if d.daemon_type == 'mds' and self._enough_mds_for_ok_to_stop(d):
-                # when fail_fs is set to true, all MDS daemons will be moved to
-                # up:standby state, so Cephadm won't be able to upgrade due to
-                # this check and and will warn with "It is NOT safe to stop
-                # mds.<daemon_name> at this time: one or more filesystems is
-                # currently degraded", therefore we bypass this check for that
-                # case.
+                # When fail_fs is set to true, all MDS daemons will be moved to
+                # up:standby state. ok-to-stop would then warn with "It is NOT
+                # safe to stop mds.<daemon_name> at this time: one or more
+                # filesystems is currently degraded", so we bypass this check
+                # when fail_fs is set (via `not self.upgrade_state.fail_fs`).
                 assert self.upgrade_state is not None
                 if not self.upgrade_state.fail_fs \
                         and not self._wait_for_ok_to_stop(d, known_ok_to_stop):
@@ -1511,6 +1510,12 @@ class CephadmUpgrade:
                 # osd ok-to-upgrade batch is not empty, so keep looping to
                 # add more OSDs to the batch
                 if d.daemon_type == 'osd' and self._upgrade_uses_ok_to_upgrade_for_osds() and (len(known_ok_to_upgrade) > 0):
+                    continue  # do not break
+                # fail_fs already took the filesystem down; upgrade all MDS
+                # in one pass rather than one daemon per upgrade cycle.
+                if (d.daemon_type == 'mds'
+                        and self.upgrade_state is not None
+                        and self.upgrade_state.fail_fs):
                     continue  # do not break
                 break
 


### PR DESCRIPTION
## Summary
- When `mgr/orchestrator/fail_fs` is true, queue all MDS daemons needing upgrade in a single `_to_upgrade` pass instead of one per cycle
- Add a unit test covering `fail_fs=True` (batch all) vs `fail_fs=False` (one MDS)

Fixes: https://tracker.ceph.com/issues/78304

## Test plan
- [x] `tox -e py3 -- cephadm/tests/test_upgrade.py::test_to_upgrade_batches_mds_when_fail_fs`
- [ ] Manual: `ceph config set mgr mgr/orchestrator/fail_fs true`, start an upgrade with multiple MDS, confirm MDS redeploys are batched

Signed-off-by: Kobi Ginon <kginon@redhat.com>


Scenario: with 3 ceph nodes created 5 mds's

ceph orch apply mds cephfs --placement="5"

[ceph: root@ceph-node-0 /]# ceph orch ls
NAME                       PORTS  RUNNING  REFRESHED  AGE  PLACEMENT
crash                                 3/3  8s ago     3m   *
mds.cephfs                            5/5  8s ago     69s  count:5
mgr                                   2/2  7s ago     3m   count:2
mon                                   3/5  8s ago     3m   count:5
osd.all-available-devices               3  8s ago     3m   *


[ceph: root@ceph-node-0 /]# ceph orch ps
NAME                           HOST         PORTS        STATUS         REFRESHED  AGE  MEM USE  MEM LIM  VERSION                IMAGE ID      CONTAINER ID
crash.ceph-node-0              ceph-node-0               running (3m)      4s ago   3m    7935k        -  21.3.0-1797-gdf247cde  9a0e76f8aa0c  34792b3c9e58
crash.ceph-node-1              ceph-node-1               running (2m)      4s ago   2m    8011k        -  21.3.0-1797-gdf247cde  9a0e76f8aa0c  80be6bb0230d
crash.ceph-node-2              ceph-node-2               running (55s)     4s ago  55s    8007k        -  21.3.0-1797-gdf247cde  9a0e76f8aa0c  68da937afaf7
mds.cephfs.ceph-node-0.amjowl  ceph-node-0               running (20s)     4s ago  20s    12.0M        -  21.3.0-1797-gdf247cde  9a0e76f8aa0c  1093930c7a34
mds.cephfs.ceph-node-0.zurdac  ceph-node-0               running (9s)      4s ago   9s    12.0M        -  21.3.0-1797-gdf247cde  9a0e76f8aa0c  f66dff18d202
mds.cephfs.ceph-node-1.gdgieh  ceph-node-1               running (17s)     4s ago  17s    12.3M        -  21.3.0-1797-gdf247cde  9a0e76f8aa0c  ab5dc0c88f96
mds.cephfs.ceph-node-2.iweijt  ceph-node-2               running (22s)     4s ago  22s    12.2M        -  21.3.0-1797-gdf247cde  9a0e76f8aa0c  6d81ad7e8020
mds.cephfs.ceph-node-2.ufutez  ceph-node-2               running (13s)     4s ago  12s    12.0M        -  21.3.0-1797-gdf247cde  9a0e76f8aa0c  821993503c6b
mgr.ceph-node-0.ksluhq         ceph-node-0  *:9283,8765  running (4m)      4s ago   4m     204M        -  21.3.0-1797-gdf247cde  9a0e76f8aa0c  55c079b8014a
mgr.ceph-node-1.ftsfts         ceph-node-1  *:8443,8765  running (2m)      4s ago   2m     147M        -  21.3.0-1797-gdf247cde  9a0e76f8aa0c  ebb1726091b2
mon.ceph-node-0                ceph-node-0               running (4m)      4s ago   4m    46.0M    2048M  21.3.0-1797-gdf247cde  9a0e76f8aa0c  1fbd94a34e9e
mon.ceph-node-1                ceph-node-1               running (2m)      4s ago   2m    28.1M    2048M  21.3.0-1797-gdf247cde  9a0e76f8aa0c  b78abe1773d1
mon.ceph-node-2                ceph-node-2               running (31s)     4s ago  31s    26.2M    2048M  21.3.0-1797-gdf247cde  9a0e76f8aa0c  1cf07a300d53
osd.0                          ceph-node-1               running (2m)      4s ago   2m    50.2M    4096M  21.3.0-1797-gdf247cde  9a0e76f8aa0c  93dcde4a31ee
osd.1                          ceph-node-0               running (2m)      4s ago   2m    50.5M    4096M  21.3.0-1797-gdf247cde  9a0e76f8aa0c  2c6bb6424af6
osd.2                          ceph-node-2               running (40s)     4s ago  40s    49.0M    4096M  21.3.0-1797-gdf247cde  9a0e76f8aa0c  503968cab6ee


[ceph: root@ceph-node-0 /]# ceph config set mgr mgr/orchestrator/fail_fs true
[ceph: root@ceph-node-0 /]# ceph orch upgrade start --image 192.168.100.254:5000/ceph/ceph:main1.0.kobi
Initiating upgrade to 192.168.100.254:5000/ceph/ceph:main1.0.kobi

Every 2.0s: ceph orch upgrade status                                                                                                                                                                        ceph-node-0: Thu Aug  6 09:05:20 2026

{
    "in_progress": true,
    "target_image": "192.168.100.254:5000/ceph/ceph@sha256:d5e1e5aa0b7b9debeb6ea6a4aafb83d5482b25104b3b330674c096008844ad53",
    "services_complete": [
        "mgr"
    ],
    "which": "Upgrading all daemon types on all hosts",
    "progress": "2/16 daemons upgraded",
    "message": "Currently upgrading mgr daemons",
    "is_paused": false
}

{
    "in_progress": true,
    "target_image": "192.168.100.254:5000/ceph/ceph@sha256:d5e1e5aa0b7b9debeb6ea6a4aafb83d5482b25104b3b330674c096008844ad53",
    "services_complete": [
        "mon",
        "crash",
        "mgr"
    ],                                                                                                                                                                                                                                               "which": "Upgrading all daemon types on all hosts",                                                                                                                                                                                              "progress": "10/16 daemons upgraded",                                                                                                                                                                                                            "message": "Currently upgrading osd daemons",                                                                                                                                                                                                    "is_paused": false
}

{
    "in_progress": true,
    "target_image": "192.168.100.254:5000/ceph/ceph@sha256:d5e1e5aa0b7b9debeb6ea6a4aafb83d5482b25104b3b330674c096008844ad53",
    "services_complete": [
        "mon",
        "crash",
        "osd",
        "mgr"
    ],                                                                                                                                                                                                                                               "which": "Upgrading all daemon types on all hosts",                                                                                                                                                                                              "progress": "11/16 daemons upgraded",                                                                                                                                                                                                            "message": "Currently upgrading mds daemons",                                                                                                                                                                                                    "is_paused": false
}
test result we can see that the ceph mds's where upgrade on the same minute together

NAME                           HOST         PORTS        STATUS         REFRESHED  AGE  MEM USE  MEM LIM  VERSION                IMAGE ID      CONTAINER ID
crash.ceph-node-0              ceph-node-0               running (4m)     11s ago  19m    7919k        -  21.3.0-1797-gdf247cde  9a0e76f8aa0c  71a6f9a6cc72
crash.ceph-node-1              ceph-node-1               running (4m)     25s ago  18m    7940k        -  21.3.0-1797-gdf247cde  9a0e76f8aa0c  e14ce519f3b3
crash.ceph-node-2              ceph-node-2               running (4m)     45s ago  17m    8000k        -  21.3.0-1797-gdf247cde  9a0e76f8aa0c  8e46cbff89f5
mds.cephfs.ceph-node-0.amjowl  ceph-node-0               running (3m)     11s ago  16m    13.9M        -  21.3.0-1797-gdf247cde  9a0e76f8aa0c  44c0e5707f81
mds.cephfs.ceph-node-0.zurdac  ceph-node-0               running (3m)     11s ago  16m    13.4M        -  21.3.0-1797-gdf247cde  9a0e76f8aa0c  1d5aebd0b21d
mds.cephfs.ceph-node-1.gdgieh  ceph-node-1               running (3m)     25s ago  16m    13.2M        -  21.3.0-1797-gdf247cde  9a0e76f8aa0c  bf7c05009e66
mds.cephfs.ceph-node-2.iweijt  ceph-node-2               running (3m)     45s ago  16m    13.1M        -  21.3.0-1797-gdf247cde  9a0e76f8aa0c  61cd939c16b5
mds.cephfs.ceph-node-2.ufutez  ceph-node-2               running (2m)     45s ago  16m    13.5M        -  21.3.0-1797-gdf247cde  9a0e76f8aa0c  2f64e7c37ee1

Further testing via logs

i have done the upgrade 3 Times
ones without any flag fail_fs not being set 
Second run
ceph config set mgr mgr/orchestrator/fail_fs true
and 3th time
ceph config set mgr mgr/orchestrator/fail_fs false

below is output
ceph log last 10000 cephadm | grep -E 'Upgrade: (failing fs|Updating mds)'ceph log last 10000 cephadm | grep -E 'Upgrade: (failing fs|Updating mds)'[ceph: root@ceph-node-0 /]# ceph log last 10000 cephadm | grep -E 'Upgrade: (failing fs|Updating mds)'
2026-08-06T09:01:42.205045+0000 mgr.ceph-node-0.ksluhq (mgr.14799) 210 : cephadm [INF] Upgrade: Updating mds.cephfs.ceph-node-0.amjowl
2026-08-06T09:01:57.317580+0000 mgr.ceph-node-0.ksluhq (mgr.14799) 233 : cephadm [INF] Upgrade: Updating mds.cephfs.ceph-node-0.zurdac
2026-08-06T09:02:10.050811+0000 mgr.ceph-node-0.ksluhq (mgr.14799) 250 : cephadm [INF] Upgrade: Updating mds.cephfs.ceph-node-1.gdgieh
2026-08-06T09:02:20.490780+0000 mgr.ceph-node-0.ksluhq (mgr.14799) 267 : cephadm [INF] Upgrade: Updating mds.cephfs.ceph-node-2.iweijt
2026-08-06T09:02:33.952609+0000 mgr.ceph-node-0.ksluhq (mgr.14799) 286 : cephadm [INF] Upgrade: Updating mds.cephfs.ceph-node-2.ufutez
2026-08-06T09:07:19.695522+0000 mgr.ceph-node-0.ksluhq (mgr.45432) 224 : cephadm [INF] Upgrade: Updating mds.cephfs.ceph-node-0.amjowl (1/5)
2026-08-06T09:07:25.138581+0000 mgr.ceph-node-0.ksluhq (mgr.45432) 233 : cephadm [INF] Upgrade: Updating mds.cephfs.ceph-node-0.zurdac (2/5)
2026-08-06T09:07:29.434040+0000 mgr.ceph-node-0.ksluhq (mgr.45432) 241 : cephadm [INF] Upgrade: Updating mds.cephfs.ceph-node-1.gdgieh (3/5)
2026-08-06T09:07:33.380323+0000 mgr.ceph-node-0.ksluhq (mgr.45432) 248 : cephadm [INF] Upgrade: Updating mds.cephfs.ceph-node-2.iweijt (4/5)
2026-08-06T09:07:37.493582+0000 mgr.ceph-node-0.ksluhq (mgr.45432) 255 : cephadm [INF] Upgrade: Updating mds.cephfs.ceph-node-2.ufutez (5/5)
2026-08-06T09:12:17.313882+0000 mgr.ceph-node-0.ksluhq (mgr.75243) 220 : cephadm [INF] Upgrade: Updating mds.cephfs.ceph-node-0.amjowl
2026-08-06T09:12:37.877368+0000 mgr.ceph-node-0.ksluhq (mgr.75243) 246 : cephadm [INF] Upgrade: Updating mds.cephfs.ceph-node-0.zurdac
2026-08-06T09:12:53.461538+0000 mgr.ceph-node-0.ksluhq (mgr.75243) 267 : cephadm [INF] Upgrade: Updating mds.cephfs.ceph-node-1.gdgieh
2026-08-06T09:13:04.718380+0000 mgr.ceph-node-0.ksluhq (mgr.75243) 283 : cephadm [INF] Upgrade: Updating mds.cephfs.ceph-node-2.iweijt
2026-08-06T09:13:16.729151+0000 mgr.ceph-node-0.ksluhq (mgr.75243) 300 : cephadm [INF] Upgrade: Updating mds.cephfs.ceph-node-2.ufutez


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
