### PR TITLE
mgr/dashboard: replace customer-facing daemon terminology with service instance

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/logs.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/logs.e2e-spec.ts
@@ -39,7 +39,7 @@ describe('Logs page', () => {
     });
 
     it('should show daemon logs as a third tab', () => {
-      logs.getTabText(2).should('eq', 'Daemon Logs');
+      logs.getTabText(2).should('eq', 'Service instance logs');
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -187,7 +187,7 @@ const routes: Routes = [
           {
             path: 'daemons',
             component: HostResourcePageComponent,
-            data: { breadcrumbs: 'Daemons', section: 'daemons' }
+            data: { breadcrumbs: 'Service instances', section: 'daemons' }
           },
           {
             path: 'performance',

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -181,7 +181,7 @@ const routes: Routes = [
           {
             path: 'daemons',
             component: HostResourcePageComponent,
-            data: { breadcrumbs: 'Daemons', section: 'daemons' }
+            data: { breadcrumbs: 'Service instances', section: 'daemons' }
           },
           {
             path: 'performance',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/overview/overview.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/overview/overview.component.html
@@ -84,7 +84,7 @@
 
 <div class="row">
   <div class="col-sm-6">
-    <legend i18n>Daemons</legend>
+    <legend i18n>Service instances</legend>
     <div>
       <cd-mirroring-daemons> </cd-mirroring-daemons>
     </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.spec.ts
@@ -50,6 +50,6 @@ describe('CephfsDetailComponent', () => {
   });
 
   it('prepares standby on change', () => {
-    expect(component.standbys).toEqual([{ key: 'Standby daemons', value: 'b' }]);
+    expect(component.standbys).toEqual([{ key: 'Standby service instances', value: 'b' }]);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.ts
@@ -45,7 +45,7 @@ export class CephfsDetailComponent implements OnChanges, OnInit {
   private setStandbys() {
     this.standbys = [
       {
-        key: $localize`Standby daemons`,
+        key: $localize`Standby service instances`,
         value: this.data.standbys
       }
     ];
@@ -56,7 +56,7 @@ export class CephfsDetailComponent implements OnChanges, OnInit {
       ranks: [
         { prop: 'rank', name: $localize`Rank` },
         { prop: 'state', name: $localize`State` },
-        { prop: 'mds', name: $localize`Daemon` },
+        { prop: 'mds', name: $localize`Service instance` },
         { prop: 'activity', name: $localize`Activity`, cellTemplate: this.activityTmpl },
         { prop: 'dns', name: $localize`Dentries`, pipe: this.dimless },
         { prop: 'inos', name: $localize`Inodes`, pipe: this.dimless },

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.html
@@ -24,8 +24,8 @@
             spacingClass="mb-2"
             i18n
             *ngIf="!editing"
-            >Orchestrator is not configured. Deploy MDS daemons manually after creating the
-            volume.</cd-alert-panel
+            >Orchestrator is not configured. Deploy MDS service instances manually after creating
+            the volume.</cd-alert-panel
           >
         </ng-container>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.html
@@ -54,8 +54,8 @@
     type="danger"
     i18n
   >
-    This will remove its data and metadata pools. It'll also remove the MDS daemon associated with
-    the volume.
+    This will remove its data and metadata pools. It'll also remove the MDS service instance
+    associated with the volume.
   </cd-alert-panel>
 </ng-template>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mount-details/cephfs-mount-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mount-details/cephfs-mount-details.component.ts
@@ -27,7 +27,7 @@ export class CephfsMountDetailsComponent extends BaseModal implements OnInit {
   ngOnInit(): void {
     this.mount = `sudo mount -t ceph <CLIENT_USER>@${this.mountData?.clusterFSID}.${this.mountData?.fsName}=${this.mountData?.path} ${this.MOUNT_DIRECTORY}`;
     this.fuse = `sudo ceph-fuse  ${this.MOUNT_DIRECTORY} -r ${this.mountData?.path} --client_mds_namespace=${this.mountData?.fsName}`;
-    this.nfs = `sudo mount -t nfs -o port=<PORT> <IP of active_nfs daemon>:<export_name> ${this.MOUNT_DIRECTORY}`;
+    this.nfs = `sudo mount -t nfs -o port=<PORT> <IP of active_nfs service instance>:<export_name> ${this.MOUNT_DIRECTORY}`;
   }
 
   cancel() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-details/configuration-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-details/configuration-details.component.html
@@ -58,7 +58,7 @@
           i18n
           class="bold"
         >
-          Daemon default
+          Service instance default
         </td>
         <td>{{ selection.daemon_default }}</td>
       </tr>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-details/configuration-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-details/configuration-details.component.ts
@@ -13,13 +13,13 @@ export class ConfigurationDetailsComponent implements OnChanges {
   selection: any;
   flags = {
     runtime: $localize`The value can be updated at runtime.`,
-    no_mon_update: $localize`Daemons/clients do not pull this value from the
+    no_mon_update: $localize`Service instances/clients do not pull this value from the
       monitor config database. We disallow setting this option via 'ceph config
       set ...'. This option should be configured via ceph.conf or via the
       command line.`,
-    startup: $localize`Option takes effect only during daemon startup.`,
+    startup: $localize`Option takes effect only during service instance startup.`,
     cluster_create: $localize`Option only affects cluster creation.`,
-    create: $localize`Option only affects daemon creation.`
+    create: $localize`Option only affects service instance creation.`
   };
 
   ngOnChanges() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
@@ -88,7 +88,7 @@
               labelInputID="daemon_default"
               i18n
             >
-              Daemon default
+              Service instance default
               <input
                 cdsText
                 type="text"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-resource-sidebar/host-resource-sidebar.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-resource-sidebar/host-resource-sidebar.component.spec.ts
@@ -82,7 +82,7 @@ describe('HostSidebarComponent', () => {
       expect(component.sidebarItems.map((item) => item.label)).toEqual([
         'Overview',
         'Storage Devices',
-        'Daemons',
+        'Service instances',
         'Performance'
       ]);
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-resource-sidebar/host-resource-sidebar.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-resource-sidebar/host-resource-sidebar.component.ts
@@ -146,7 +146,7 @@ export class HostSidebarComponent implements OnInit, OnDestroy {
 
     if (permissions.hosts?.read) {
       items.push({
-        label: $localize`Daemons`,
+        label: $localize`Service instances`,
         route: [this.basePath, this.hostname, 'daemons'],
         routerLinkActiveOptions: { exact: true }
       });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-resource-sidebar/host-resource-sidebar.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-resource-sidebar/host-resource-sidebar.component.ts
@@ -119,7 +119,7 @@ export class HostSidebarComponent implements OnInit, OnDestroy {
 
     if (permissions.hosts?.read) {
       items.push({
-        label: $localize`Daemons`,
+        label: $localize`Service instances`,
         route: [this.basePath, this.hostname, 'daemons'],
         routerLinkActiveOptions: { exact: true }
       });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.html
@@ -122,7 +122,7 @@
       <a
         ngbNavLink
         i18n
-        >Daemon Logs</a
+        >Service instance logs</a
       >
       <ng-template ngbNavContent>
         <ng-container
@@ -134,7 +134,7 @@
           <div *ngIf="alloyServiceStatus$ | async as alloyServiceStatus; else daemonLogsTpl">
             <cd-grafana
               i18n-title
-              title="Daemon logs"
+              title="Service instance logs"
               [grafanaPath]="'explore?'"
               [type]="'logs'"
               uid="CrAHE0iZz"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.ts
@@ -171,7 +171,7 @@ export class ServiceDaemonListComponent implements OnInit, OnChanges, AfterViewI
         filterable: true
       },
       {
-        name: $localize`Daemon name`,
+        name: $localize`Service instance name`,
         prop: 'daemon_name',
         flexGrow: 1,
         filterable: true
@@ -209,7 +209,7 @@ export class ServiceDaemonListComponent implements OnInit, OnChanges, AfterViewI
         cellClass: 'text-right'
       },
       {
-        name: $localize`Daemon Events`,
+        name: $localize`Service instance events`,
         prop: 'events',
         flexGrow: 2,
         cellTemplate: this.listTpl
@@ -336,10 +336,10 @@ export class ServiceDaemonListComponent implements OnInit, OnChanges, AfterViewI
     ) {
       this.modalService.show(DeleteConfirmationModalComponent, {
         impact: DeletionImpact.medium,
-        itemDescription: 'daemon',
+        itemDescription: 'service instance',
         itemNames: [daemon.daemon_name],
         actionDescription: actionType,
-        infoMessage: $localize`Stopping or restarting this ${daemon.daemon_type}:daemonType: daemon can disrupt clients or services that depend on it. The orchestrator may require acknowledging risk, confirm only if you accept it. This action uses the orchestrator force option.`,
+        infoMessage: $localize`Stopping or restarting this ${daemon.daemon_type}:daemonType: service instance can disrupt clients or services that depend on it. The orchestrator may require acknowledging risk, confirm only if you accept it. This action uses the orchestrator force option.`,
         submitActionObservable: () =>
           this.executeDaemonActionObservable(daemon.daemon_name, actionType, true)
       });
@@ -363,7 +363,7 @@ export class ServiceDaemonListComponent implements OnInit, OnChanges, AfterViewI
         next: (resp: HttpResponse<object>) => {
           this.notificationService.show(
             NotificationType.success,
-            `Daemon ${actionType} scheduled`,
+            `Service instance ${actionType} scheduled`,
             resp.body?.toString() ?? ''
           );
         },
@@ -371,7 +371,7 @@ export class ServiceDaemonListComponent implements OnInit, OnChanges, AfterViewI
           const err = resp as { body?: { toString?: () => string }; message?: string };
           this.notificationService.show(
             NotificationType.error,
-            'Daemon action failed',
+            'Service instance action failed',
             err?.body?.toString?.() ?? err?.message ?? ''
           );
         }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-details/service-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-details/service-details.component.html
@@ -1,7 +1,7 @@
 @if (service) {
   <cds-tabs [cacheActive]="false">
     <cds-tab
-      heading="Daemons"
+      heading="Service instances"
       i18n-heading
     >
       <cd-service-daemon-list

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -355,7 +355,7 @@
             spacingClass="mb-3"
             i18n
           >
-            The RGW daemons for this service must be restarted to apply the updated realm,
+            The RGW service instances for this service must be restarted to apply the updated realm,
             zonegroup, or zone configuration.
           </cd-alert-panel>
         }
@@ -377,8 +377,9 @@
           >
             Enable
             <cd-help-text i18n>
-              If Unmanaged is selected, the orchestrator will not start or stop any daemons
-              associated with this service. Placement and all other properties will be ignored.
+              If Unmanaged is selected, the orchestrator will not start or stop any service
+              instances associated with this service. Placement and all other properties will be
+              ignored.
             </cd-help-text>
           </cds-checkbox>
         </fieldset>
@@ -473,7 +474,7 @@
             formControlName="count"
             id="count"
             min="1"
-            helperText="Number of deamons that will be deployed"
+            helperText="Number of service instances that will be deployed"
             i18n-helperText
           >
           </cds-number>
@@ -492,7 +493,7 @@
             id="rgw_frontend_port"
             min="1"
             max="65535"
-            helperText="Number of deamons that will be deployed"
+            helperText="Port on which the service listens for client requests."
             i18n-helperText
             [invalid]="
               serviceForm.controls.rgw_frontend_port.invalid &&

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
@@ -63,7 +63,8 @@
                   <ul>
                     <li i18n>Capacity of the cluster</li>
                     <li i18n>
-                      Number of monitors, managers, OSDs, MDSs, object gateways, or other daemons
+                      Number of monitors, managers, OSDs, MDSs, object gateways, or other service
+                      instances
                     </li>
                     <li i18n>Software version currently being used</li>
                     <li i18n>Number and types of RADOS pools and CephFS file systems</li>
@@ -98,10 +99,12 @@
               >
                 <ng-container i18n>Crash</ng-container>
                 <cd-helper>
-                  <ng-container i18n>Includes information about daemon crashes:</ng-container>
+                  <ng-container i18n
+                    >Includes information about service instance crashes:</ng-container
+                  >
                   <ul>
-                    <li i18n>Type of daemon</li>
-                    <li i18n>Version of the daemon</li>
+                    <li i18n>Type of service instance</li>
+                    <li i18n>Version of the service instance</li>
                     <li i18n>Operating system (OS distribution, kernel version)</li>
                     <li i18n>Stack trace identifying where in the Ceph code the crash occurred</li>
                   </ul>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
@@ -69,7 +69,8 @@
                   <ul>
                     <li i18n>Capacity of the cluster</li>
                     <li i18n>
-                      Number of monitors, managers, OSDs, MDSs, object gateways, or other daemons
+                      Number of monitors, managers, OSDs, MDSs, object gateways, or other service
+                      instances
                     </li>
                     <li i18n>Software version currently being used</li>
                     <li i18n>Number and types of RADOS pools and CephFS file systems</li>
@@ -104,10 +105,12 @@
               >
                 <ng-container i18n>Crash</ng-container>
                 <cd-helper>
-                  <ng-container i18n>Includes information about daemon crashes:</ng-container>
+                  <ng-container i18n
+                    >Includes information about service instance crashes:</ng-container
+                  >
                   <ul>
-                    <li i18n>Type of daemon</li>
-                    <li i18n>Version of the daemon</li>
+                    <li i18n>Type of service instance</li>
+                    <li i18n>Version of the service instance</li>
                     <li i18n>Operating system (OS distribution, kernel version)</li>
                     <li i18n>Stack trace identifying where in the Ceph code the crash occurred</li>
                   </ul>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/upgrade/upgrade.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/upgrade/upgrade.component.html
@@ -214,7 +214,7 @@
             class="cds--type-heading-03 tile-title"
             i18n
           >
-            Daemon Versions
+            Service instance versions
           </h4>
           <div>
             <cd-table
@@ -270,7 +270,7 @@
           <div
             [cdsTip]="
               (healthData.mgr_map | mgrSummary)?.total <= 1
-                ? 'To upgrade, you need minimum 2 mgr daemons.'
+                ? 'To upgrade, you need minimum 2 mgr service instances.'
                 : ''
             "
             i18n-cdsTip
@@ -324,7 +324,7 @@
 <ng-template #warningIcon>
   <cd-icon
     type="warning"
-    title="To upgrade, you need minimum 2 mgr daemons."
+    title="To upgrade, you need minimum 2 mgr service instances."
   >
   </cd-icon>
 </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/upgrade/upgrade.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/upgrade/upgrade.component.ts
@@ -59,7 +59,7 @@ export class UpgradeComponent implements OnInit, OnDestroy {
 
     this.columns = [
       {
-        name: $localize`Daemon name`,
+        name: $localize`Service instance name`,
         prop: 'daemon_name',
         flexGrow: 1,
         filterable: true

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-import/rgw-multisite-import.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-import/rgw-multisite-import.component.html
@@ -134,8 +134,9 @@
         >
           <span i18n>Unmanaged</span>
           <cd-help-text i18n
-            >If set to true, the orchestrator will not start nor stop any daemon associated with
-            this service. Placement and all other properties will be ignored.</cd-help-text
+            >If set to true, the orchestrator will not start nor stop any service instance
+            associated with this service. Placement and all other properties will be
+            ignored.</cd-help-text
           >
         </cds-checkbox>
       </div>
@@ -256,7 +257,7 @@
               [helperText]="countHelper"
             ></cds-number>
             <ng-template #countHelper>
-              <span i18n>Only that number of daemons will be created.</span>
+              <span i18n>Only that number of service instances will be created.</span>
             </ng-template>
             <ng-template #countError>
               <ng-container

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/device-list/device-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/device-list/device-list.component.ts
@@ -75,7 +75,7 @@ export class DeviceListComponent implements OnChanges, OnInit {
         isHidden: true
       },
       { prop: 'location', name: $localize`Device Name`, cellTemplate: this.locationTemplate },
-      { prop: 'daemons', name: $localize`Daemons`, cellTemplate: this.daemonNameTemplate }
+      { prop: 'daemons', name: $localize`Service instances`, cellTemplate: this.daemonNameTemplate }
     ];
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-daemon.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-daemon.service.spec.ts
@@ -57,7 +57,7 @@ describe('RgwDaemonService', () => {
   });
 
   it('should call request and not select any daemon from empty daemon list', fakeAsync(() => {
-    expect(() => retrieveDaemonList([], null)).toThrowError('No RGW daemons found!');
+    expect(() => retrieveDaemonList([], null)).toThrowError('No RGW service instances found!');
     expect(selectDaemonSpy).toHaveBeenCalledTimes(0);
   }));
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-daemon.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-daemon.service.ts
@@ -66,7 +66,9 @@ export class RgwDaemonService {
         _.isEmpty(daemon)
           ? this.list().pipe(
               mergeMap((daemons) =>
-                _.isEmpty(daemons) ? throwError('No RGW daemons found!') : this.selectedDaemon$
+                _.isEmpty(daemons)
+                  ? throwError('No RGW service instances found!')
+                  : this.selectedDaemon$
               )
             )
           : of(daemon)

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/certificate-authority-form/certificate-authority-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/certificate-authority-form/certificate-authority-form.component.html
@@ -170,8 +170,8 @@
       spacingClass="mb-3"
       i18n
     >
-      Changing the certificate source will redeploy the service daemons to apply the new certificate
-      configuration.
+      Changing the certificate source will redeploy the service instances to apply the new
+      certificate configuration.
     </cd-alert-panel>
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/certificate-authority-form/certificate-authority-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/certificate-authority-form/certificate-authority-form.component.html
@@ -178,8 +178,8 @@
       spacingClass="mb-3"
       i18n
     >
-      Changing the certificate source will redeploy the service daemons to apply the new certificate
-      configuration.
+      Changing the certificate source will redeploy the service instances to apply the new
+      certificate configuration.
     </cd-alert-panel>
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/mgr-summary.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/mgr-summary.pipe.ts
@@ -15,7 +15,7 @@ export class MgrSummaryPipe implements PipeTransform {
     let activeCount: number;
     const activeTitleText = _.isUndefined(value.active_name)
       ? ''
-      : `${$localize`active daemon`}: ${value.active_name}`;
+      : `${$localize`active service instance`}: ${value.active_name}`;
     // There is always one standbyreplay to replace active daemon, if active one is down
     if (activeTitleText.length > 0) {
       activeCount = 1;


### PR DESCRIPTION
mgr/dashboard: replace customer-facing daemon terminology with service instance

Fixes: https://tracker.ceph.com/issues/79112

Signed-off-by: Sagar Gopale <sagar.gopale@ibm.com>

### Description
This PR replaces customer-facing "daemon" / "daemons" terminology with "service instance" / "service instances" across all Ceph Dashboard UI components as per JIRA IBMCEPH-17479.

### Highlights & Design Parity
* **IBM Carbon Design System Compliance**: All updated UI strings strictly adhere to IBM Carbon Design System content guidelines using sentence-case capitalization (`Service instance` / `Service instances`) for tabs, datatable column headers, section titles, form labels, tooltips, toast notifications, breadcrumbs, and helper texts.
* **Backend & API Safety**: Internal API endpoints, URL routes (`/rgw/daemon`), backend functions, data models, and variable identifiers remain untouched.
* **Unit Test Coverage**: Updated corresponding Jest unit test assertions across component spec files (100% passing).

---

### UI Verification Checklist for Reviewers
Please follow the navigation paths below to cross-check each updated UI string:

#### 1. Block Mirroring Overview
* **Path**: `Block` ➔ `Mirroring`
* **Location**: Section title header at bottom.
* **Text**: `Service instances` (previously "Daemons").

#### 2. File Systems Details, Ranks & Mount Instructions
* **Path**: `File` ➔ `File Systems` ➔ Click any filesystem row ➔ `Ranks` tab.
* **Text**: Column header `Service instance` & standby detail row label `Standby service instances`.
* **Path (Mount Modal)**: `File` ➔ `File Systems` ➔ Click `Mount instructions` ➔ `NFS` tab.
* **Text**: Mount command placeholder `<IP of active_nfs service instance>` (previously `<IP of active_nfs daemon>`).

#### 3. Create File System Form
* **Path**: `File` ➔ `File Systems` ➔ Click `Create`.
* **Text**: Info alert banner (when Orchestrator is not configured): *"Deploy MDS service instances manually after creating the volume."*

#### 4. Delete File System Modal
* **Path**: `File` ➔ `File Systems` ➔ Select row ➔ `Actions` ➔ `Delete`.
* **Text**: Warning alert panel: *"This will remove its data and metadata pools. It'll also remove the MDS service instance associated with the volume."*

#### 5. Configuration Details & Edit Form
* **Path**: `Administration` ➔ `Configuration` ➔ Click any row to expand details or click `Edit`.
* **Text**: Key detail label & Edit form field label `Service instance default` (previously "Daemon default") & startup/creation flag descriptions.

#### 6. Host Details, Breadcrumbs & Side Drawer
* **Path**: `Cluster` ➔ `Hosts` ➔ Click any Host row.
* **Text**: Header breadcrumb trail `Service instances` (`Cluster / Hosts / <hostname> / Service instances`) & Drawer tab label `Service instances`.

#### 7. Observability Logs
* **Path**: `Observability` ➔ `Logs`
* **Text**: Main tab header `Service instance logs`.

#### 8. Cluster Services & Details
* **Path**: `Administration` ➔ `Services` ➔ Click any service row to expand details.
* **Text**:
  * Details tab header: `Service instances`
  * Datatable column headers: `Service instance name` & `Service instance events`
  * Restart/Stop Action Modal: *"Stopping or restarting this [type] service instance can disrupt clients..."*
  * Toast Notifications (on action trigger): `"Service instance [action] scheduled"` & `"Service instance action failed"`

#### 9. Create Service Modal
* **Path**: `Administration` ➔ `Services` ➔ Click `Create`.
* **Text**:
  * Count field helper text: *Number of service instances that will be deployed*
  * RGW Port field helper text: *Port on which the service listens for client requests.*
  * Unmanaged checkbox helper text: *"If Unmanaged is selected, the orchestrator will not start or stop any service instances associated with this service."*

#### 10. Telemetry Configuration
* **Path**: Top Right Gear Icon (⚙️) ➔ `Telemetry configuration`
* **Text**:
  * Basic channel tooltip: *"..or other service instances"*
  * Crash channel tooltip: *"Includes information about service instance crashes:"*, bullets *Type of service instance*, *Version of the service instance*.

#### 11. Cluster Upgrade Page & Buttons
* **Path**: `Administration` ➔ `Upgrade`
* **Text**:
  * Section title: `Service instance versions`
  * Datatable column header: `Service instance name`
  * MGR Count Warning Tooltip (when < 2 MGRs): *"To upgrade, you need minimum 2 mgr service instances."*
  * Disabled Upgrade Button Tooltip (when < 2 MGRs): *"To upgrade, you need minimum 2 mgr service instances."*

#### 12. Object Gateway & Multisite Import Modal
* **Path**: `Object` ➔ `Multisite` ➔ Click `Import`.
* **Text**: Unmanaged tooltip & Count field helper text (*service instances*).
* **Path (No Daemons Toast)**: Access RGW features when no RGW instance exists.
* **Text**: Toast/Error message: `"No RGW service instances found!"`

#### 13. Physical Disks / Devices Table
* **Path**: `Cluster` ➔ `OSDs` ➔ Click row ➔ `Devices` tab (or `Cluster` ➔ `Hosts` ➔ `Storage devices`).
* **Text**: Datatable column header `Service instances`.

#### 14. Certificate Authority Form
* **Path**: `Administration` ➔ `Services` ➔ `Create` ➔ Under *Choose Certificate Authority* select *External*.
* **Text**: Warning banner: *"Changing the certificate source will redeploy the service instances to apply the new certificate configuration."*

#### 15. Manager Health Summary (mgrSummary Pipe)
* **Path**: `Administration` ➔ `Upgrade` (URL: `/upgrade`)
* **Location**: Top Cluster Information summary card.
* **Metric**: MGR Count summary tile (processes active and standby manager service instances via `mgrSummary`).





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
