### PR TITLE
mgr/nfs: skip restart for LOG-only cluster config changes

### DIFF
--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -39,6 +39,26 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+def _is_log_only_config(nfs_config: str) -> bool:
+    """Return True if nfs_config contains only LOG block(s).
+
+    NFS-Ganesha picks up LOG changes via RADOS watch/notify without
+    requiring a daemon restart.  If the config is empty, unparseable,
+    or contains any non-LOG top-level block, return False so the caller
+    falls back to the safe restart path.
+    """
+    try:
+        blocks = GaneshaConfParser(nfs_config).parse()
+    except Exception:
+        log.warning("Failed to parse user config, assuming restart is needed")
+        return False
+    if not blocks:
+        return False
+    block_names = [b.block_name for b in blocks]
+    log.debug("Parsed user config blocks: %s", block_names)
+    return all(name == 'LOG' for name in block_names)
+
+
 def resolve_ip(hostname: str) -> str:
     try:
         r = socket.getaddrinfo(hostname, None, flags=socket.AI_CANONNAME,
@@ -532,7 +552,14 @@ class NFSCluster:
                 rados_obj.write_obj(nfs_config, user_conf_obj_name(cluster_id),
                                     conf_obj_name(cluster_id))
                 log.debug("Successfully saved %s's user config: \n %s", cluster_id, nfs_config)
-                restart_nfs_service(self.mgr, cluster_id)
+                if _is_log_only_config(nfs_config):
+                    log.debug("LOG-only config detected for %s, "
+                              "skipping restart (RADOS notify will reload)",
+                              cluster_id)
+                else:
+                    log.debug("Non-LOG config detected for %s, "
+                              "restarting NFS service", cluster_id)
+                    restart_nfs_service(self.mgr, cluster_id)
                 return
             raise ClusterNotFound()
         except NotImplementedError:
@@ -547,9 +574,17 @@ class NFSCluster:
                 rados_obj = self._rados(cluster_id)
                 if not rados_obj.check_config(USER_CONF_PREFIX):
                     raise NonFatalError("NFS-Ganesha User Config does not exist")
+                existing_conf = rados_obj.read_obj(user_conf_obj_name(cluster_id))
                 rados_obj.remove_obj(user_conf_obj_name(cluster_id),
                                      conf_obj_name(cluster_id))
-                restart_nfs_service(self.mgr, cluster_id)
+                if existing_conf and _is_log_only_config(existing_conf):
+                    log.debug("LOG-only config removed for %s, "
+                              "skipping restart (RADOS notify will reload)",
+                              cluster_id)
+                else:
+                    log.debug("Non-LOG config removed for %s, "
+                              "restarting NFS service", cluster_id)
+                    restart_nfs_service(self.mgr, cluster_id)
                 return
             raise ClusterNotFound()
         except NotImplementedError:

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -39,6 +39,34 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+_RADOS_READ_MAX = 1024 * 1024  # read_obj() ceiling; see rados_utils.py
+
+
+def _is_log_only_config(nfs_config: str) -> bool:
+    """Return True if nfs_config contains only LOG block(s).
+
+    NFS-Ganesha picks up LOG changes via RADOS watch/notify without
+    requiring a daemon restart.  If the config is empty, unparseable,
+    potentially truncated by read_obj(), or contains any non-LOG
+    top-level block, return False so the caller falls back to the safe
+    restart path.
+    """
+    if len(nfs_config.encode('utf-8')) >= _RADOS_READ_MAX:
+        log.warning("User config may be truncated (%d bytes), "
+                     "assuming restart is needed", len(nfs_config))
+        return False
+    try:
+        blocks = GaneshaConfParser(nfs_config).parse()
+    except Exception:
+        log.warning("Failed to parse user config, assuming restart is needed")
+        return False
+    if not blocks:
+        return False
+    block_names = [b.block_name for b in blocks]
+    log.debug("Parsed user config blocks: %s", block_names)
+    return all(name == 'LOG' for name in block_names)
+
+
 def resolve_ip(hostname: str) -> str:
     try:
         r = socket.getaddrinfo(hostname, None, flags=socket.AI_CANONNAME,
@@ -532,7 +560,14 @@ class NFSCluster:
                 rados_obj.write_obj(nfs_config, user_conf_obj_name(cluster_id),
                                     conf_obj_name(cluster_id))
                 log.debug("Successfully saved %s's user config: \n %s", cluster_id, nfs_config)
-                restart_nfs_service(self.mgr, cluster_id)
+                if _is_log_only_config(nfs_config):
+                    log.info("LOG-only config detected for %s, "
+                             "skipping restart (RADOS notify will reload)",
+                             cluster_id)
+                else:
+                    log.info("Non-LOG config detected for %s, "
+                             "restarting NFS service", cluster_id)
+                    restart_nfs_service(self.mgr, cluster_id)
                 return
             raise ClusterNotFound()
         except NotImplementedError:
@@ -547,9 +582,17 @@ class NFSCluster:
                 rados_obj = self._rados(cluster_id)
                 if not rados_obj.check_config(USER_CONF_PREFIX):
                     raise NonFatalError("NFS-Ganesha User Config does not exist")
+                existing_conf = rados_obj.read_obj(user_conf_obj_name(cluster_id))
                 rados_obj.remove_obj(user_conf_obj_name(cluster_id),
                                      conf_obj_name(cluster_id))
-                restart_nfs_service(self.mgr, cluster_id)
+                if existing_conf and _is_log_only_config(existing_conf):
+                    log.info("LOG-only config removed for %s, "
+                             "skipping restart (RADOS notify will reload)",
+                             cluster_id)
+                else:
+                    log.info("Non-LOG config removed for %s, "
+                             "restarting NFS service", cluster_id)
+                    restart_nfs_service(self.mgr, cluster_id)
                 return
             raise ClusterNotFound()
         except NotImplementedError:

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -1462,6 +1462,92 @@ EXPORT {
     def test_cluster_config(self):
         self._do_mock_test(self._do_test_cluster_config)
 
+    def test_is_log_only_config(self):
+        from nfs.cluster import _is_log_only_config
+
+        assert _is_log_only_config("LOG { Default_log_level = FULL_DEBUG; }")
+        assert _is_log_only_config(
+            "LOG { COMPONENTS { FSAL = FULL_DEBUG; NFS4 = FULL_DEBUG; } }")
+
+        assert not _is_log_only_config("EXPORT { Export_Id = 1; }")
+        assert not _is_log_only_config("NFS_CORE_PARAM { some_val = 1; }")
+
+        assert not _is_log_only_config(
+            "LOG { Default_log_level = FULL_DEBUG; } EXPORT { Export_Id = 1; }")
+
+        assert not _is_log_only_config("not valid ganesha config {{{")
+        assert not _is_log_only_config("")
+
+        # GaneshaConfParser does not strip comments; a comment before the
+        # LOG block gets merged into the block name, so the config is not
+        # recognised as LOG-only.  This is the safe fallback (restart).
+        assert not _is_log_only_config(
+            "# Enable debug\nLOG { Default_log_level = FULL_DEBUG; }")
+
+
+    def _do_test_cluster_config_log_only_no_restart(self):
+        nfs_mod = Module('nfs', '', '')
+        cluster = NFSCluster(nfs_mod)
+
+        log_config = "LOG {\n    Default_log_level = FULL_DEBUG;\n}\n"
+        with mock.patch('nfs.cluster.restart_nfs_service') as mock_restart:
+            cluster.set_nfs_cluster_config(self.cluster_id, log_config)
+            mock_restart.assert_not_called()
+
+    def test_cluster_config_log_only_no_restart(self):
+        self._do_mock_test(self._do_test_cluster_config_log_only_no_restart)
+
+    def _do_test_cluster_config_non_log_restarts(self):
+        nfs_mod = Module('nfs', '', '')
+        cluster = NFSCluster(nfs_mod)
+
+        export_config = "EXPORT {\n    Export_Id = 100;\n}\n"
+        with mock.patch('nfs.cluster.restart_nfs_service') as mock_restart:
+            cluster.set_nfs_cluster_config(self.cluster_id, export_config)
+            mock_restart.assert_called_once()
+
+    def test_cluster_config_non_log_restarts(self):
+        self._do_mock_test(self._do_test_cluster_config_non_log_restarts)
+
+    def _do_test_cluster_config_mixed_restarts(self):
+        nfs_mod = Module('nfs', '', '')
+        cluster = NFSCluster(nfs_mod)
+
+        mixed_config = ("LOG {\n    Default_log_level = FULL_DEBUG;\n}\n"
+                        "EXPORT {\n    Export_Id = 100;\n}\n")
+        with mock.patch('nfs.cluster.restart_nfs_service') as mock_restart:
+            cluster.set_nfs_cluster_config(self.cluster_id, mixed_config)
+            mock_restart.assert_called_once()
+
+    def test_cluster_config_mixed_restarts(self):
+        self._do_mock_test(self._do_test_cluster_config_mixed_restarts)
+
+    def _do_test_cluster_config_reset_log_only_no_restart(self):
+        nfs_mod = Module('nfs', '', '')
+        cluster = NFSCluster(nfs_mod)
+
+        log_config = "LOG {\n    Default_log_level = FULL_DEBUG;\n}\n"
+        cluster.set_nfs_cluster_config(self.cluster_id, log_config)
+        with mock.patch('nfs.cluster.restart_nfs_service') as mock_restart:
+            cluster.reset_nfs_cluster_config(self.cluster_id)
+            mock_restart.assert_not_called()
+
+    def test_cluster_config_reset_log_only_no_restart(self):
+        self._do_mock_test(self._do_test_cluster_config_reset_log_only_no_restart)
+
+    def _do_test_cluster_config_reset_non_log_restarts(self):
+        nfs_mod = Module('nfs', '', '')
+        cluster = NFSCluster(nfs_mod)
+
+        export_config = "EXPORT {\n    Export_Id = 100;\n}\n"
+        cluster.set_nfs_cluster_config(self.cluster_id, export_config)
+        with mock.patch('nfs.cluster.restart_nfs_service') as mock_restart:
+            cluster.reset_nfs_cluster_config(self.cluster_id)
+            mock_restart.assert_called_once()
+
+    def test_cluster_config_reset_non_log_restarts(self):
+        self._do_mock_test(self._do_test_cluster_config_reset_non_log_restarts)
+
     def test_qos_from_dict(self):
         qos = QOS.from_dict(self.qos_cluster_dict, True)
         assert qos.to_dict() == self.qos_cluster_dict

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -1462,6 +1462,97 @@ EXPORT {
     def test_cluster_config(self):
         self._do_mock_test(self._do_test_cluster_config)
 
+    def test_is_log_only_config(self):
+        from nfs.cluster import _is_log_only_config
+
+        assert _is_log_only_config("LOG { Default_log_level = FULL_DEBUG; }")
+        assert _is_log_only_config(
+            "LOG { COMPONENTS { FSAL = FULL_DEBUG; NFS4 = FULL_DEBUG; } }")
+
+        assert not _is_log_only_config("EXPORT { Export_Id = 1; }")
+        assert not _is_log_only_config("NFS_CORE_PARAM { some_val = 1; }")
+
+        assert not _is_log_only_config(
+            "LOG { Default_log_level = FULL_DEBUG; } EXPORT { Export_Id = 1; }")
+
+        assert not _is_log_only_config("not valid ganesha config {{{")
+        assert not _is_log_only_config("")
+
+        # GaneshaConfParser does not strip comments; a comment before the
+        # LOG block gets merged into the block name, so the config is not
+        # recognised as LOG-only.  This is the safe fallback (restart).
+        assert not _is_log_only_config(
+            "# Enable debug\nLOG { Default_log_level = FULL_DEBUG; }")
+
+        # Config at or above the read_obj() 1 MiB ceiling is treated as
+        # potentially truncated and conservatively triggers a restart.
+        from nfs.cluster import _RADOS_READ_MAX
+        huge_config = "LOG { x = y; }" + " " * _RADOS_READ_MAX
+        assert not _is_log_only_config(huge_config)
+
+    def _do_test_cluster_config_log_only_no_restart(self):
+        nfs_mod = Module('nfs', '', '')
+        cluster = NFSCluster(nfs_mod)
+
+        log_config = "LOG {\n    Default_log_level = FULL_DEBUG;\n}\n"
+        with mock.patch('nfs.cluster.restart_nfs_service') as mock_restart:
+            cluster.set_nfs_cluster_config(self.cluster_id, log_config)
+            mock_restart.assert_not_called()
+
+    def test_cluster_config_log_only_no_restart(self):
+        self._do_mock_test(self._do_test_cluster_config_log_only_no_restart)
+
+    def _do_test_cluster_config_non_log_restarts(self):
+        nfs_mod = Module('nfs', '', '')
+        cluster = NFSCluster(nfs_mod)
+
+        export_config = "EXPORT {\n    Export_Id = 100;\n}\n"
+        with mock.patch('nfs.cluster.restart_nfs_service') as mock_restart:
+            cluster.set_nfs_cluster_config(self.cluster_id, export_config)
+            mock_restart.assert_called_once()
+
+    def test_cluster_config_non_log_restarts(self):
+        self._do_mock_test(self._do_test_cluster_config_non_log_restarts)
+
+    def _do_test_cluster_config_mixed_restarts(self):
+        nfs_mod = Module('nfs', '', '')
+        cluster = NFSCluster(nfs_mod)
+
+        mixed_config = ("LOG {\n    Default_log_level = FULL_DEBUG;\n}\n"
+                        "EXPORT {\n    Export_Id = 100;\n}\n")
+        with mock.patch('nfs.cluster.restart_nfs_service') as mock_restart:
+            cluster.set_nfs_cluster_config(self.cluster_id, mixed_config)
+            mock_restart.assert_called_once()
+
+    def test_cluster_config_mixed_restarts(self):
+        self._do_mock_test(self._do_test_cluster_config_mixed_restarts)
+
+    def _do_test_cluster_config_reset_log_only_no_restart(self):
+        nfs_mod = Module('nfs', '', '')
+        cluster = NFSCluster(nfs_mod)
+
+        log_config = "LOG {\n    Default_log_level = FULL_DEBUG;\n}\n"
+        cluster.set_nfs_cluster_config(self.cluster_id, log_config)
+        with mock.patch('nfs.cluster.restart_nfs_service') as mock_restart:
+            cluster.reset_nfs_cluster_config(self.cluster_id)
+            mock_restart.assert_not_called()
+
+    def test_cluster_config_reset_log_only_no_restart(self):
+        self._do_mock_test(self._do_test_cluster_config_reset_log_only_no_restart)
+
+    def _do_test_cluster_config_reset_non_log_restarts(self):
+        nfs_mod = Module('nfs', '', '')
+        cluster = NFSCluster(nfs_mod)
+
+        export_config = "EXPORT {\n    Export_Id = 100;\n}\n"
+        cluster.set_nfs_cluster_config(self.cluster_id, export_config)
+        with mock.patch('nfs.cluster.restart_nfs_service') as mock_restart:
+            cluster.reset_nfs_cluster_config(self.cluster_id)
+            mock_restart.assert_called_once()
+
+    def test_cluster_config_reset_non_log_restarts(self):
+        self._do_mock_test(self._do_test_cluster_config_reset_non_log_restarts)
+
     def test_qos_from_dict(self):
         qos = QOS.from_dict(self.qos_cluster_dict, True)
         assert qos.to_dict() == self.qos_cluster_dict


### PR DESCRIPTION
### Summary

- This PR avoids unnecessary NFS service restarts when applying cluster configuration that contains only LOG blocks.
- NFS-Ganesha already reloads logging configuration through the existing RADOS watch/notify mechanism, so restarting the NFS service is unnecessary for LOG-only configuration changes.
- The change introduces _is_log_only_config() to detect whether the user configuration contains only top-level LOG blocks.

Behavior after this change:

```
ceph nfs cluster config set
LOG-only config → Skip restart and rely on RADOS notify.
Non-LOG or mixed config → Restart NFS service.
ceph nfs cluster config reset
Read the existing user configuration before removing it.
LOG-only config → Skip restart.
Non-LOG config → Restart NFS service.

```
This preserves the existing behavior for functional configuration changes while avoiding unnecessary restarts for logging updates.

Fixes: https://tracker.ceph.com/issues/79109
Signed-off-by: Shubha Jain [SHUBHA.JAIN1@ibm.com]
Resolves: IBMCEPH-17371

### Testing

**Before this change**

Applying a LOG-only configuration restarted the NFS service.

**Apply LOG-only config**

`ceph nfs cluster config set cephfs-nfs -i debug.conf
`
**cephadm logs**
Restart service nfs.cephfs-nfs

**Container IDs changed**
```
before:
05145d644e88
0601fbf82002

after:
69385163c7d8
8d91a276321d
```


**After this change**

**LOG-only config**

`ceph nfs cluster config set cephfs-nfs -i debug.conf
`
Verified:

- No Restart service nfs log.
- Container IDs unchanged.
- NFS daemon uptime continued increasing.

```
before:
cc3eebe9cc0a
627531ec3c12

after:
cc3eebe9cc0a
627531ec3c12
```

**LOG-only reset**

`ceph nfs cluster config reset cephfs-nfs`

Verified:

- No restart.
- Container IDs unchanged.

**Non-LOG config**

`ceph nfs cluster config set cephfs-nfs -i nonlog.conf
`
Verified:

- Restart service nfs logged.
- Container IDs changed.

```
before:
71c94859242c
398a89fc61cb

after:
996836f0dd49
fc34c33ab668
```

**Non-LOG reset**

`ceph nfs cluster config reset cephfs-nfs`

Verified:

- Restart service nfs logged.
- Container IDs changed.

```
before:
996836f0dd49
fc34c33ab668

after:
2db63726aa1d
0f9e038dbf4d
```


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
