### PR TITLE
cephfs_mirror: Fix files with restored mtime in incremental sync

### DIFF
--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -2295,6 +2295,68 @@ class TestMirroring(CephFSTestCase):
 
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
 
+    def test_cephfs_mirror_incremental_sync_preserved_mtime(self):
+        """Incremental sync when content changes but mtime is restored.
+
+        snapdiff defaults to mtime-only; mirror uses mtime|ctime|size so a
+        write that restores mtime is still detected (via size and/or ctime).
+        """
+        self.setup_mount_b(mds_perm='rw')
+        self.mount_a.run_shell(["mkdir", "d0"])
+        self.mount_a.write_file("d0/file1", data="some text\n")
+
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
+        self.peer_add(self.primary_fs_name, self.primary_fs_id,
+                      "client.mirror_remote@ceph", self.secondary_fs_name)
+
+        self.mount_a.run_shell(["mkdir", "d0/.snap/snap0"])
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               "client.mirror_remote@ceph", '/d0', 'snap0', 1)
+        self.verify_snapshot('d0', 'snap0')
+
+        def file_mtime(path):
+            return self.mount_a.run_shell(
+                ["stat", "-c", "%y", path]).stdout.getvalue().strip()
+
+        def file_size(path):
+            return int(self.mount_a.run_shell(
+                ["stat", "-c", "%s", path]).stdout.getvalue().strip())
+
+        # size changes, mtime restored — caught via size (and ctime)
+        self.mount_a.run_shell(["cp", "-a", "d0/file1", "d0/file1.ref"])
+        mtime_before = file_mtime("d0/file1")
+        size_before = file_size("d0/file1")
+        self.mount_a.run_shell_payload(
+            'printf "your data\\n" >> d0/file1 && sync')
+        self.mount_a.run_shell(["touch", "-r", "d0/file1.ref", "d0/file1"])
+        self.mount_a.run_shell(["rm", "-f", "d0/file1.ref"])
+        self.assertEqual(mtime_before, file_mtime("d0/file1"))
+        self.assertGreater(file_size("d0/file1"), size_before)
+
+        self.mount_a.run_shell(["mkdir", "d0/.snap/snap1"])
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               "client.mirror_remote@ceph", '/d0', 'snap1', 2)
+        self.verify_snapshot('d0', 'snap1')
+
+        # same size rewrite, mtime restored — caught via ctime
+        self.mount_a.run_shell(["cp", "-a", "d0/file1", "d0/file1.ref"])
+        mtime_before = file_mtime("d0/file1")
+        size_before = file_size("d0/file1")
+        self.mount_a.write_file("d0/file1", data="X" * size_before)
+        self.mount_a.run_shell(["sync"])
+        self.mount_a.run_shell(["touch", "-r", "d0/file1.ref", "d0/file1"])
+        self.mount_a.run_shell(["rm", "-f", "d0/file1.ref"])
+        self.assertEqual(mtime_before, file_mtime("d0/file1"))
+        self.assertEqual(size_before, file_size("d0/file1"))
+
+        self.mount_a.run_shell(["mkdir", "d0/.snap/snap2"])
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               "client.mirror_remote@ceph", '/d0', 'snap2', 3)
+        self.verify_snapshot('d0', 'snap2')
+
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
     def test_cephfs_mirror_sync_with_purged_snapshot(self):
         """Test snapshot synchronization in midst of snapshot deletes.
 

--- a/src/test/libcephfs/snapdiff.cc
+++ b/src/test/libcephfs/snapdiff.cc
@@ -15,6 +15,7 @@
 #include "include/interval_set.h"
 #include "gtest/gtest.h"
 #include "include/cephfs/libcephfs.h"
+#include "include/fs_types.h"
 #include "include/stat.h"
 #include "include/ceph_assert.h"
 #include "include/object.h"
@@ -505,6 +506,36 @@ public:
 
   ceph_mount_info* get_cmount() {
     return cmount;
+  }
+
+  string make_snap_file_path(const char* snap, const char* relpath) {
+    char path[PATH_MAX];
+    string snap_name = make_snap_name(snap);
+    sprintf(path, "%s/.snap/%s/%s", dir_path, snap_name.c_str(), relpath);
+    return string(path);
+  }
+
+  int read_path(const string& path, string& out) {
+    int fd = ceph_open(cmount, path.c_str(), O_RDONLY, 0);
+    if (fd < 0) {
+      return fd;
+    }
+    out.clear();
+    while (true) {
+      char buf[4096];
+      int64_t off = out.size();
+      int r = ceph_read(cmount, fd, buf, sizeof(buf), off);
+      if (r < 0) {
+	ceph_close(cmount, fd);
+	return r;
+      }
+      if (r == 0) {
+	break;
+      }
+      out.append(buf, r);
+    }
+    ceph_close(cmount, fd);
+    return 0;
   }
 
   void verify_snap_diff(vector<pair<string, uint64_t>>& expected,
@@ -2292,4 +2323,79 @@ TEST(LibCephFS, SnapDiffStatDelta) {
 
   test_mount.rmsnap("snap1");
   test_mount.rmsnap("snap2");
+}
+
+TEST(LibCephFS, SnapDiffChangedContentPreservedMtime)
+{
+  TestMount test_mount("/SnapDiffChangeAttr");
+  const char *fname = "file1";
+  const string initial = "some text\n";
+  const string extra = "your data\n";
+
+  ASSERT_LE(0, test_mount.write_full(fname, initial));
+
+  struct ceph_statx stx = {};
+  auto path = test_mount.make_file_path(fname);
+  ASSERT_EQ(0, ceph_statx(test_mount.get_cmount(), path.c_str(), &stx,
+			  CEPH_STATX_MTIME, 0));
+
+  ASSERT_EQ(0, test_mount.mksnap("snap1"));
+
+  int fd = ceph_open(test_mount.get_cmount(), path.c_str(), O_RDWR, 0);
+  ASSERT_GE(fd, 0);
+  ASSERT_EQ((int)extra.size(),
+	    ceph_write(test_mount.get_cmount(), fd, extra.c_str(), extra.size(),
+		       initial.size()));
+  ASSERT_EQ(0, ceph_fsync(test_mount.get_cmount(), fd, 0));
+  ceph_close(test_mount.get_cmount(), fd);
+
+  struct timespec ts[2];
+  ts[0] = stx.stx_atime;
+  ts[1] = stx.stx_mtime;
+  ASSERT_EQ(0, ceph_utimensat(test_mount.get_cmount(), CEPHFS_AT_FDCWD,
+			      path.c_str(), ts, 0));
+
+  struct ceph_statx stx_head = {};
+  ASSERT_EQ(0, ceph_statx(test_mount.get_cmount(), path.c_str(), &stx_head,
+			  CEPH_STATX_MTIME, 0));
+  ASSERT_EQ(stx.stx_mtime.tv_sec, stx_head.stx_mtime.tv_sec);
+  ASSERT_EQ(stx.stx_mtime.tv_nsec, stx_head.stx_mtime.tv_nsec);
+
+  ASSERT_EQ(0, test_mount.mksnap("snap2"));
+
+  struct ceph_statx stx_snap1 = {};
+  struct ceph_statx stx_snap2 = {};
+  auto snap1_path = test_mount.make_snap_file_path("snap1", fname);
+  auto snap2_path = test_mount.make_snap_file_path("snap2", fname);
+  ASSERT_EQ(0, ceph_statx(test_mount.get_cmount(), snap1_path.c_str(), &stx_snap1,
+			  CEPH_STATX_MTIME | CEPH_STATX_SIZE, 0));
+  ASSERT_EQ(0, ceph_statx(test_mount.get_cmount(), snap2_path.c_str(), &stx_snap2,
+			  CEPH_STATX_MTIME | CEPH_STATX_SIZE, 0));
+  ASSERT_EQ(stx_snap1.stx_mtime.tv_sec, stx_snap2.stx_mtime.tv_sec);
+  ASSERT_EQ(stx_snap1.stx_mtime.tv_nsec, stx_snap2.stx_mtime.tv_nsec);
+  ASSERT_EQ(stx_snap1.stx_size, initial.size());
+  ASSERT_EQ(stx_snap2.stx_size, initial.size() + extra.size());
+
+  uint64_t snapid2 = 0;
+  ASSERT_EQ(0, test_mount.get_snapid("snap2", &snapid2));
+  ASSERT_GT(snapid2, 0u);
+
+  // mtime-only (mask 0) misses this case; mirror uses mtime|ctime|size.
+  test_mount.set_diff_mask(
+    CEPH_SNAPDIFF_MTIME | CEPH_SNAPDIFF_CTIME | CEPH_SNAPDIFF_SIZE);
+  vector<pair<string, uint64_t>> expected;
+  expected.emplace_back(fname, snapid2);
+  test_mount.verify_snap_diff(expected, "", "snap1", "snap2");
+
+  string snap1_data;
+  string snap2_data;
+  ASSERT_EQ(0, test_mount.read_path(test_mount.make_snap_file_path("snap1", fname),
+				    snap1_data));
+  ASSERT_EQ(0, test_mount.read_path(test_mount.make_snap_file_path("snap2", fname),
+				    snap2_data));
+  ASSERT_EQ(initial, snap1_data);
+  ASSERT_EQ(initial + extra, snap2_data);
+
+  ASSERT_EQ(0, test_mount.rmsnap("snap1"));
+  ASSERT_EQ(0, test_mount.rmsnap("snap2"));
 }

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -2045,7 +2045,10 @@ int PeerReplayer::should_sync_entry(const std::string &epath, const struct ceph_
     *need_data_sync = true;
     *need_attr_sync = true;
   } else {
-    *need_data_sync = (cstx.stx_size != pstx.stx_size) || (cstx.stx_mtime != pstx.stx_mtime);
+    // ctime covers same-size rewrites that restore mtime (size/mtime unchanged).
+    *need_data_sync = (cstx.stx_size != pstx.stx_size) ||
+                      (cstx.stx_mtime != pstx.stx_mtime) ||
+                      (cstx.stx_ctime != pstx.stx_ctime);
     *need_attr_sync = (cstx.stx_ctime != pstx.stx_ctime);
   }
 
@@ -2480,7 +2483,8 @@ int PeerReplayer::SnapDiffSync::init_sync() {
 
   ceph_snapdiff_info info;
   r = ceph_open_snapdiff(m_local, m_dir_root.c_str(), ".",
-                         stringify((*m_prev).first).c_str(), stringify(m_current.first).c_str(), 0, &info);
+                         stringify((*m_prev).first).c_str(), stringify(m_current.first).c_str(),
+                         MIRROR_SNAPDIFF_DEFAULT_MASK, &info);
   if (r != 0) {
     derr << ": failed to open snapdiff for " << m_dir_root << ": r=" << r << dendl;
     return r;
@@ -2512,7 +2516,8 @@ int PeerReplayer::SnapDiffSync::init_directory(const std::string &epath,
 
     ceph_snapdiff_info info;
     r = ceph_open_snapdiff(m_local, m_dir_root.c_str(), epath.c_str(),
-                           stringify((*m_prev).first).c_str(), stringify(m_current.first).c_str(), 0, &info);
+                           stringify((*m_prev).first).c_str(), stringify(m_current.first).c_str(),
+                           MIRROR_SNAPDIFF_DEFAULT_MASK, &info);
     if (r != 0) {
       derr << ": failed to open snapdiff for " << m_dir_root << ", r=" << r << dendl;
       return r;

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -2052,7 +2052,10 @@ int PeerReplayer::should_sync_entry(const std::string &epath, const struct ceph_
     *need_data_sync = true;
     *need_attr_sync = true;
   } else {
-    *need_data_sync = (cstx.stx_size != pstx.stx_size) || (cstx.stx_mtime != pstx.stx_mtime);
+    // ctime covers same-size rewrites that restore mtime (size/mtime unchanged).
+    *need_data_sync = (cstx.stx_size != pstx.stx_size) ||
+                      (cstx.stx_mtime != pstx.stx_mtime) ||
+                      (cstx.stx_ctime != pstx.stx_ctime);
     *need_attr_sync = (cstx.stx_ctime != pstx.stx_ctime);
   }
 
@@ -2487,7 +2490,8 @@ int PeerReplayer::SnapDiffSync::init_sync() {
 
   ceph_snapdiff_info info;
   r = ceph_open_snapdiff(m_local, m_dir_root.c_str(), ".",
-                         stringify((*m_prev).first).c_str(), stringify(m_current.first).c_str(), 0, &info);
+                         stringify((*m_prev).first).c_str(), stringify(m_current.first).c_str(),
+                         MIRROR_SNAPDIFF_DEFAULT_MASK, &info);
   if (r != 0) {
     derr << ": failed to open snapdiff for " << m_dir_root << ": r=" << r << dendl;
     return r;
@@ -2519,7 +2523,8 @@ int PeerReplayer::SnapDiffSync::init_directory(const std::string &epath,
 
     ceph_snapdiff_info info;
     r = ceph_open_snapdiff(m_local, m_dir_root.c_str(), epath.c_str(),
-                           stringify((*m_prev).first).c_str(), stringify(m_current.first).c_str(), 0, &info);
+                           stringify((*m_prev).first).c_str(), stringify(m_current.first).c_str(),
+                           MIRROR_SNAPDIFF_DEFAULT_MASK, &info);
     if (r != 0) {
       derr << ": failed to open snapdiff for " << m_dir_root << ", r=" << r << dendl;
       return r;

--- a/src/tools/cephfs_mirror/Types.h
+++ b/src/tools/cephfs_mirror/Types.h
@@ -21,6 +21,11 @@ namespace mirror {
 static const std::string CEPHFS_MIRROR_OBJECT("cephfs_mirror");
 static const std::string CEPHFS_MIRROR_SYNC_STAT_OMAP_PREFIX("sync_stat");
 
+// Attrs used for incremental snapdiff sync. mtime alone misses content
+// updates that restore mtime (e.g. via utimensat); include ctime/size too.
+constexpr unsigned MIRROR_SNAPDIFF_DEFAULT_MASK =
+  CEPH_SNAPDIFF_MTIME | CEPH_SNAPDIFF_CTIME | CEPH_SNAPDIFF_SIZE;
+
 typedef std::variant<bool, uint64_t, std::string> AttributeValue;
 typedef std::map<std::string, AttributeValue> Attributes;
 


### PR DESCRIPTION

The mirror doesn't sync a file during incremental sync if the
 file is modified and mtime is restored between two snapshots.

 Fix is to use mtime|ctime|size as a mask in open_snapdiff which would
 report files whose content changed between snapshots when mtime is
 restored. Mask 0 defaults to mtime-only and misses that case.

 Also, should_sync_entry needs to accomodate ctime, since it can
 miss same size file modification with preserved mtime.

 Fixes: https://tracker.ceph.com/issues/77892
 Signed-off-by: Kotresh HR <khiremat@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
