### PR TITLE
mgr/cephadm: fix nvmeof service_id mismatch for default .nvmeof pool …

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -4581,9 +4581,31 @@ Then run the following:
                     )
             for sspec in [s.spec for s in self.spec_store.get_by_service_type('nvmeof')]:
                 nspec = cast(NvmeofServiceSpec, sspec)
-                if nvmeof_spec.group == nspec.group and nvmeof_spec.service_id != nspec.service_id:
+                same_group = nvmeof_spec.group == nspec.group
+                # The pool field is always stored exactly as provided — only the service_id
+                # was affected by the historical lstrip('.') bug.  Use exact pool equality
+                # here so that a genuinely different pool (e.g. 'nvmeof' vs '.nvmeof') is
+                # never silently aliased.  The service_id branch handles the compat case:
+                # 'nvmeof.group' and '.nvmeof.group' share the same pool+group in practice,
+                # and the normalisation below will correct the stored key if needed.
+                same_service = (nvmeof_spec.service_id == nspec.service_id
+                                or (nvmeof_spec.pool == nspec.pool
+                                    and nvmeof_spec.group == nspec.group))
+                if same_group and not same_service:
                     raise OrchestratorError(f"Cannot create nvmeof service with group {nvmeof_spec.group}. That group is already "
                                             f"being used by the service {nspec.service_name()}")
+                # If it is the same service but the service_id differs (e.g. incoming spec
+                # uses the old lstrip('.') form 'nvmeof.group' while the stored one uses
+                # '.nvmeof.group' or vice versa), normalise the incoming spec to use the
+                # stored service_id so the spec_store updates the existing entry rather
+                # than inserting a duplicate under a different key.
+                if same_service and nvmeof_spec.service_id != nspec.service_id and nspec.service_id is not None:
+                    self.log.info(
+                        f"Normalising nvmeof service_id from '{nvmeof_spec.service_id}' "
+                        f"to existing '{nspec.service_id}'"
+                    )
+                    nvmeof_spec.service_id = nspec.service_id
+                    spec = nvmeof_spec
 
         if spec.placement.count is not None:
             if spec.service_type in ['mon', 'mgr']:

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -4581,7 +4581,17 @@ Then run the following:
                     )
             for sspec in [s.spec for s in self.spec_store.get_by_service_type('nvmeof')]:
                 nspec = cast(NvmeofServiceSpec, sspec)
-                if nvmeof_spec.group == nspec.group and nvmeof_spec.service_id != nspec.service_id:
+                same_group = nvmeof_spec.group == nspec.group
+                # Consider two specs the same service if their (pool, group) pair matches.
+                # The pools_are_equivalent check is limited to the '.nvmeof'/'nvmeof' pair:
+                # that is the only pool whose name has a leading dot in standard NVMeoF
+                # usage, and the only one affected by the historical lstrip('.') bug where
+                # the default pool ".nvmeof" was stored as "nvmeof" in the service_id.
+                pools_are_equivalent = (nvmeof_spec.pool == nspec.pool
+                                        or {nvmeof_spec.pool, nspec.pool} == {'.nvmeof', 'nvmeof'})
+                same_service = (nvmeof_spec.service_id == nspec.service_id
+                                or (pools_are_equivalent and nvmeof_spec.group == nspec.group))
+                if same_group and not same_service:
                     raise OrchestratorError(f"Cannot create nvmeof service with group {nvmeof_spec.group}. That group is already "
                                             f"being used by the service {nspec.service_name()}")
 

--- a/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
@@ -275,6 +275,138 @@ timeout = 1.0\n"""
             assert len(cephadm_module.spec_store.get_by_service_type('nvmeof')) == 1
 
     @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @patch("cephadm.module.NvmeofMetadataPoolHelper.create_pool_if_needed")
+    def test_apply_with_dotted_pool_accepted_over_existing_trimmed_service_id(
+            self, _create_pool, cephadm_module: CephadmOrchestrator):
+        """Backward-compat: a service stored with the old trimmed service_id ('nvmeof.gw_group1',
+        produced by the lstrip('.') bug) must not block a subsequent apply that uses the correct
+        dotted service_id ('.nvmeof.gw_group1'), since both refer to the same pool+group."""
+        old_spec = NvmeofServiceSpec(
+            service_id='nvmeof.gw_group1',   # old trimmed form (bug)
+            group='gw_group1',
+            pool='.nvmeof'
+        )
+        new_spec = NvmeofServiceSpec(
+            service_id='.nvmeof.gw_group1',  # correct dotted form (fixed)
+            group='gw_group1',
+            pool='.nvmeof'
+        )
+        with with_host(cephadm_module, 'test'):
+            cephadm_module._apply_service_spec(old_spec)
+            assert len(cephadm_module.spec_store.get_by_service_type('nvmeof')) == 1
+            # Must NOT raise — same pool+group, just a different service_id string
+            cephadm_module._apply_service_spec(new_spec)
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @patch("cephadm.module.NvmeofMetadataPoolHelper.create_pool_if_needed")
+    def test_apply_mismatched_service_id_does_not_create_duplicate(
+            self, _create_pool, cephadm_module: CephadmOrchestrator):
+        """Regression: applying a spec whose service_id uses a different form of the same
+        pool+group (e.g. 'nvmeof.mygroup1' when '.nvmeof.mygroup1' is already stored) must
+        update the existing service in-place, not create a second service under a new key.
+
+        Reproduces the scenario:
+          1. Fixed cluster has service stored as '.nvmeof.mygroup1'
+          2. User exports spec via 'ceph orch ls --export', edits it (or gets old form),
+             yielding service_id='nvmeof.mygroup1'
+          3. 'ceph orch apply -i spec.yml' must update, not duplicate.
+        """
+        stored_spec = NvmeofServiceSpec(
+            service_id='.nvmeof.mygroup1',
+            group='mygroup1',
+            pool='.nvmeof'
+        )
+        incoming_spec = NvmeofServiceSpec(
+            service_id='nvmeof.mygroup1',   # old trimmed form in the YAML
+            group='mygroup1',
+            pool='.nvmeof'
+        )
+        with with_host(cephadm_module, 'test'):
+            cephadm_module._apply_service_spec(stored_spec)
+            assert len(cephadm_module.spec_store.get_by_service_type('nvmeof')) == 1
+
+            cephadm_module._apply_service_spec(incoming_spec)
+
+            # Must still be exactly one service — no duplicate created
+            specs = cephadm_module.spec_store.get_by_service_type('nvmeof')
+            assert len(specs) == 1
+            # The stored service_id must win — incoming spec normalised to it
+            assert specs[0].spec.service_id == '.nvmeof.mygroup1'
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @patch("cephadm.module.NvmeofMetadataPoolHelper.create_pool_if_needed")
+    def test_apply_with_identical_dotted_pool_not_blocked(
+            self, _create_pool, cephadm_module: CephadmOrchestrator):
+        """Applying the same '.nvmeof' pool+group twice must update the existing service,
+        not raise the duplicate-group error."""
+        spec_first = NvmeofServiceSpec(
+            service_id='.nvmeof.gw_group1',
+            group='gw_group1',
+            pool='.nvmeof'
+        )
+        spec_second = NvmeofServiceSpec(
+            service_id='.nvmeof.gw_group1',
+            group='gw_group1',
+            pool='.nvmeof'
+        )
+        with with_host(cephadm_module, 'test'):
+            cephadm_module._apply_service_spec(spec_first)
+            # Must NOT raise — identical service
+            cephadm_module._apply_service_spec(spec_second)
+            assert len(cephadm_module.spec_store.get_by_service_type('nvmeof')) == 1
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_apply_nvmeof_pool_and_dotted_nvmeof_pool_are_different_services(
+            self, cephadm_module: CephadmOrchestrator):
+        """'nvmeof' and '.nvmeof' are distinct RADOS pools — pool identity uses exact
+        comparison so applying both for the same group must raise, even though their
+        names differ only by a leading dot."""
+        spec_undotted = NvmeofServiceSpec(
+            service_id='nvmeof.gw_group1',
+            group='gw_group1',
+            pool='nvmeof'
+        )
+        spec_dotted = NvmeofServiceSpec(
+            service_id='.nvmeof.gw_group1',
+            group='gw_group1',
+            pool='.nvmeof'
+        )
+        with with_host(cephadm_module, 'test'):
+            cephadm_module._apply_service_spec(spec_undotted)
+            with pytest.raises(
+                OrchestratorError,
+                match='Cannot create nvmeof service with group gw_group1'
+            ):
+                NvmeofMetadataPoolHelper_mock = patch(
+                    "cephadm.module.NvmeofMetadataPoolHelper.create_pool_if_needed"
+                )
+                with NvmeofMetadataPoolHelper_mock:
+                    cephadm_module._apply_service_spec(spec_dotted)
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_apply_dotted_custom_pool_and_undotted_custom_pool_are_different_services(
+            self, cephadm_module: CephadmOrchestrator):
+        """'.mypool' and 'mypool' are distinct pools — applying both for the same group
+        must raise."""
+        spec_undotted = NvmeofServiceSpec(
+            service_id='mypool.gw_group1',
+            group='gw_group1',
+            pool='mypool'
+        )
+        spec_dotted = NvmeofServiceSpec(
+            service_id='.mypool.gw_group1',
+            group='gw_group1',
+            pool='.mypool'
+        )
+        with with_host(cephadm_module, 'test'):
+            cephadm_module._apply_service_spec(spec_undotted)
+            with pytest.raises(
+                OrchestratorError,
+                match='Cannot create nvmeof service with group gw_group1'
+            ):
+                cephadm_module._apply_service_spec(spec_dotted)
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     def test_validate_service_id_matches_group_on_apply(self, cephadm_module: CephadmOrchestrator):
         matching_nvmeof_spec_group_service_id = NvmeofServiceSpec(
             service_id='pool1.right_group',

--- a/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
@@ -275,6 +275,75 @@ timeout = 1.0\n"""
             assert len(cephadm_module.spec_store.get_by_service_type('nvmeof')) == 1
 
     @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @patch("cephadm.module.NvmeofMetadataPoolHelper.create_pool_if_needed")
+    def test_apply_with_dotted_pool_accepted_over_existing_trimmed_service_id(
+            self, _create_pool, cephadm_module: CephadmOrchestrator):
+        """Backward-compat: a service stored with the old trimmed service_id ('nvmeof.gw_group1',
+        produced by the lstrip('.') bug) must not block a subsequent apply that uses the correct
+        dotted service_id ('.nvmeof.gw_group1'), since both refer to the same pool+group."""
+        old_spec = NvmeofServiceSpec(
+            service_id='nvmeof.gw_group1',   # old trimmed form (bug)
+            group='gw_group1',
+            pool='.nvmeof'
+        )
+        new_spec = NvmeofServiceSpec(
+            service_id='.nvmeof.gw_group1',  # correct dotted form (fixed)
+            group='gw_group1',
+            pool='.nvmeof'
+        )
+        with with_host(cephadm_module, 'test'):
+            cephadm_module._apply_service_spec(old_spec)
+            assert len(cephadm_module.spec_store.get_by_service_type('nvmeof')) == 1
+            # Must NOT raise — same pool+group, just a different service_id string
+            cephadm_module._apply_service_spec(new_spec)
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @patch("cephadm.module.NvmeofMetadataPoolHelper.create_pool_if_needed")
+    def test_apply_with_identical_dotted_pool_not_blocked(
+            self, _create_pool, cephadm_module: CephadmOrchestrator):
+        """Applying the same '.nvmeof' pool+group twice must update the existing service,
+        not raise the duplicate-group error."""
+        spec_first = NvmeofServiceSpec(
+            service_id='.nvmeof.gw_group1',
+            group='gw_group1',
+            pool='.nvmeof'
+        )
+        spec_second = NvmeofServiceSpec(
+            service_id='.nvmeof.gw_group1',
+            group='gw_group1',
+            pool='.nvmeof'
+        )
+        with with_host(cephadm_module, 'test'):
+            cephadm_module._apply_service_spec(spec_first)
+            # Must NOT raise — identical service
+            cephadm_module._apply_service_spec(spec_second)
+            assert len(cephadm_module.spec_store.get_by_service_type('nvmeof')) == 1
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_apply_dotted_custom_pool_and_undotted_custom_pool_are_different_services(
+            self, cephadm_module: CephadmOrchestrator):
+        """'.mypool' and 'mypool' are distinct pools — applying both for the same group
+        must raise, confirming the equivalence shortcut for .nvmeof pool
+        does not apply to arbitrary pools."""
+        spec_undotted = NvmeofServiceSpec(
+            service_id='mypool.gw_group1',
+            group='gw_group1',
+            pool='mypool'
+        )
+        spec_dotted = NvmeofServiceSpec(
+            service_id='.mypool.gw_group1',
+            group='gw_group1',
+            pool='.mypool'
+        )
+        with with_host(cephadm_module, 'test'):
+            cephadm_module._apply_service_spec(spec_undotted)
+            with pytest.raises(
+                OrchestratorError,
+                match='Cannot create nvmeof service with group gw_group1'
+            ):
+                cephadm_module._apply_service_spec(spec_dotted)
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     def test_validate_service_id_matches_group_on_apply(self, cephadm_module: CephadmOrchestrator):
         matching_nvmeof_spec_group_service_id = NvmeofServiceSpec(
             service_id='pool1.right_group',

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -2228,8 +2228,23 @@ Usage:
             nvmeof_pool_helper = NvmeofMetadataPoolHelper(self)
             nvmeof_pool_helper.create_pool_if_needed()
 
+        # If a service already exists for this (pool, group) pair — potentially stored
+        # with the old lstrip('.') service_id form (bug: '.nvmeof' was trimmed to 'nvmeof')
+        # — reuse its service_id so we update the existing service rather than creating a
+        # duplicate.  The equivalence check is intentionally limited to the '.nvmeof'/'nvmeof'
+        # pair: that is the only pool whose name has a leading dot in standard NVMeoF usage.
+        service_id = f'{pool}.{group}' if group else pool
+        existing = raise_if_exception(self.describe_service(service_type='nvmeof'))
+        for svc in existing:
+            esvc = cast(NvmeofServiceSpec, svc.spec)
+            pools_are_equivalent = (esvc.pool == pool
+                                    or {esvc.pool, pool} == {'.nvmeof', 'nvmeof'})
+            if esvc.group == group and pools_are_equivalent:
+                service_id = esvc.service_id
+                break
+
         spec = NvmeofServiceSpec(
-            service_id=f'{pool}.{group}' if group else pool,
+            service_id=service_id,
             pool=pool,
             group=group,
             placement=PlacementSpec.from_string(placement),

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -2228,8 +2228,25 @@ Usage:
             nvmeof_pool_helper = NvmeofMetadataPoolHelper(self)
             nvmeof_pool_helper.create_pool_if_needed()
 
+        # If a service already exists for this (pool, group) pair — potentially stored
+        # with the old lstrip('.') service_id form (bug: '.nvmeof' was trimmed to 'nvmeof')
+        # — reuse its service_id so we update the existing service rather than creating a
+        # duplicate.  The equivalence check is intentionally limited to the '.nvmeof'/'nvmeof'
+        # pair: that is the only pool whose name has a leading dot in standard NVMeoF usage.
+        service_id = f'{pool}.{group}' if group else pool
+        existing = raise_if_exception(self.describe_service(service_type='nvmeof'))
+        for svc in existing:
+            if svc.deleted is not None:
+                continue
+            esvc = cast(NvmeofServiceSpec, svc.spec)
+            pools_are_equivalent = (esvc.pool == pool
+                                    or {esvc.pool, pool} == {'.nvmeof', 'nvmeof'})
+            if esvc.group == group and pools_are_equivalent and esvc.service_id is not None:
+                service_id = esvc.service_id
+                break
+
         spec = NvmeofServiceSpec(
-            service_id=f'{pool}.{group}' if group else pool,
+            service_id=service_id,
             pool=pool,
             group=group,
             placement=PlacementSpec.from_string(placement),

--- a/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
@@ -7,7 +7,7 @@ import yaml
 
 from ceph.deployment.hostspec import HostSpec
 from ceph.deployment.inventory import Devices, Device
-from ceph.deployment.service_spec import ServiceSpec
+from ceph.deployment.service_spec import NvmeofServiceSpec, ServiceSpec
 from ceph.deployment import inventory
 from ceph.utils import datetime_now
 from mgr_module import HandleCommandResult
@@ -300,26 +300,28 @@ def test_preview_table_osd_smoke():
 @mock.patch("orchestrator.module.OrchestratorCli._apply_misc")
 @mock.patch("orchestrator.module.OrchestratorCli.remote")
 @mock.patch("orchestrator.module.OrchestratorCli.get")
+@mock.patch("orchestrator.module.OrchestratorCli.describe_service")
 class TestApplyNvmeof:
 
     def setup_method(self):
         self.m = OrchestratorCli('orchestrator', 0, 0)
 
-    def test_missing_group_raises_validation_error(self, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+    def test_missing_group_raises_validation_error(self, mock_describe, mock_get, mock_remote, mock_apply_misc, mock_release_name):
         res = self.m._apply_nvmeof(pool="mypool", group="")
 
         assert res.retval != 0
         assert "The --group argument is required" in res.stderr
         mock_apply_misc.assert_not_called()
 
-    def test_inbuf_raises_validation_error(self, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+    def test_inbuf_raises_validation_error(self, mock_describe, mock_get, mock_remote, mock_apply_misc, mock_release_name):
         res = self.m._apply_nvmeof(pool="mypool", group="mygroup", inbuf="some_yaml_content")
 
         assert res.retval != 0
         assert "unrecognized command -i; -h or --help for usage" in res.stderr
         mock_apply_misc.assert_not_called()
 
-    def test_custom_pool_skips_metadata_pool_creation(self, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+    def test_custom_pool_skips_metadata_pool_creation(self, mock_describe, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+        mock_describe.return_value = OrchResult([])
         mock_apply_misc.return_value = HandleCommandResult(retval=0, stdout="Success")
 
         res = self.m._apply_nvmeof(pool="custompool", group="mygroup")
@@ -328,7 +330,7 @@ class TestApplyNvmeof:
         mock_apply_misc.assert_called_once()
         assert res.retval == 0
 
-    def test_default_pool_fails_if_module_disabled(self, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+    def test_default_pool_fails_if_module_disabled(self, mock_describe, mock_get, mock_remote, mock_apply_misc, mock_release_name):
         mock_release_name.return_value = "squid"
         mock_get.return_value = {'modules': [], 'always_on_modules': {}}
 
@@ -342,7 +344,8 @@ class TestApplyNvmeof:
         mock_remote.assert_not_called()
         mock_apply_misc.assert_not_called()
 
-    def test_default_pool_creates_metadata_pool_if_module_enabled(self, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+    def test_default_pool_creates_metadata_pool_if_module_enabled(self, mock_describe, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+        mock_describe.return_value = OrchResult([])
         mock_release_name.return_value = "squid"
         mock_get.return_value = {'modules': ['nvmeof'], 'always_on_modules': {}}
         mock_apply_misc.return_value = HandleCommandResult(retval=0, stdout="Success")
@@ -352,6 +355,103 @@ class TestApplyNvmeof:
         mock_remote.assert_called_once_with('nvmeof', 'create_pool_if_not_exists')
         mock_apply_misc.assert_called_once()
         assert res.retval == 0
+
+    def test_yaml_and_cli_produce_same_service_name_for_default_pool(
+            self, mock_describe, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+        """Regression: 'ceph orch apply -i spec.yaml' and 'ceph orch apply nvmeof --group ...'
+        must produce the same service_name so they address the same stored service.
+
+        Before the fix, the CLI stripped the leading dot from '.nvmeof' via lstrip('.'),
+        generating service_id='nvmeof.gw_group1' while the YAML path kept the dot,
+        generating service_id='.nvmeof.gw_group1'.  The resulting service_names differed:
+          YAML: nvmeof..nvmeof.gw_group1
+          CLI:  nvmeof.nvmeof.gw_group1
+        """
+        mock_describe.return_value = OrchResult([])
+        mock_release_name.return_value = "squid"
+        mock_get.return_value = {'modules': ['nvmeof'], 'always_on_modules': {}}
+        mock_apply_misc.return_value = HandleCommandResult(retval=0, stdout="Success")
+
+        # Simulate 'ceph orch apply -i spec.yaml' — service_id taken verbatim from YAML
+        yaml_spec_str = textwrap.dedent("""
+            service_type: nvmeof
+            service_id: .nvmeof.gw_group1
+            spec:
+              pool: .nvmeof
+              group: gw_group1
+        """).strip()
+        yaml_spec = ServiceSpec.from_json(yaml.safe_load(yaml_spec_str))
+
+        # Simulate 'ceph orch apply nvmeof --group gw_group1'
+        self.m._apply_nvmeof(pool=".nvmeof", group="gw_group1")
+        cli_spec = mock_apply_misc.call_args[0][0][0]
+
+        assert yaml_spec.service_name() == cli_spec.service_name()
+
+    def test_cli_reuses_existing_service_id_from_old_trimmed_form(
+            self, mock_describe, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+        """Backward-compat: if a service already exists with the old trimmed service_id
+        ('nvmeof.mygroup1', produced by the lstrip('.') bug), a subsequent CLI apply must
+        reuse that service_id rather than generating a new '.nvmeof.mygroup1', which would
+        create a second duplicate service alongside the existing one."""
+        existing_spec = NvmeofServiceSpec(
+            service_id='nvmeof.mygroup1',   # old trimmed form stored on disk
+            group='mygroup1',
+            pool='.nvmeof'
+        )
+        mock_describe.return_value = OrchResult(
+            [ServiceDescription(spec=existing_spec)]
+        )
+        mock_release_name.return_value = "squid"
+        mock_get.return_value = {'modules': ['nvmeof'], 'always_on_modules': {}}
+        mock_apply_misc.return_value = HandleCommandResult(retval=0, stdout="Success")
+
+        self.m._apply_nvmeof(pool=".nvmeof", group="mygroup1")
+
+        submitted_spec = mock_apply_misc.call_args[0][0][0]
+        assert submitted_spec.service_id == 'nvmeof.mygroup1'
+        assert submitted_spec.service_name() == 'nvmeof.nvmeof.mygroup1'
+
+    def test_cli_reuses_existing_service_id_when_both_pools_identical_dotted(
+            self, mock_describe, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+        """Applying against an existing service whose pool is already '.nvmeof' (correct form)
+        must also reuse the stored service_id — not just the old trimmed form."""
+        existing_spec = NvmeofServiceSpec(
+            service_id='.nvmeof.mygroup1',
+            group='mygroup1',
+            pool='.nvmeof'
+        )
+        mock_describe.return_value = OrchResult(
+            [ServiceDescription(spec=existing_spec)]
+        )
+        mock_release_name.return_value = "squid"
+        mock_get.return_value = {'modules': ['nvmeof'], 'always_on_modules': {}}
+        mock_apply_misc.return_value = HandleCommandResult(retval=0, stdout="Success")
+
+        self.m._apply_nvmeof(pool=".nvmeof", group="mygroup1")
+
+        submitted_spec = mock_apply_misc.call_args[0][0][0]
+        assert submitted_spec.service_id == '.nvmeof.mygroup1'
+
+    def test_cli_does_not_conflate_dotted_custom_pool_with_undotted(
+            self, mock_describe, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+        """'.mypool' and 'mypool' are distinct pools — the equivalence shortcut must only
+        apply to the '.nvmeof'/'nvmeof' pair, not to arbitrary dot-prefixed pool names."""
+        existing_spec = NvmeofServiceSpec(
+            service_id='mypool.mygroup1',
+            group='mygroup1',
+            pool='mypool'
+        )
+        mock_describe.return_value = OrchResult(
+            [ServiceDescription(spec=existing_spec)]
+        )
+        mock_apply_misc.return_value = HandleCommandResult(retval=0, stdout="Success")
+
+        # Applying with '.mypool' must NOT reuse the 'mypool' service — different pools
+        self.m._apply_nvmeof(pool=".mypool", group="mygroup1")
+
+        submitted_spec = mock_apply_misc.call_args[0][0][0]
+        assert submitted_spec.service_id == '.mypool.mygroup1'  # new service_id, not reused
 
 
 @mock.patch("orchestrator.module.OrchestratorCli._apply_misc")

--- a/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
@@ -7,7 +7,7 @@ import yaml
 
 from ceph.deployment.hostspec import HostSpec
 from ceph.deployment.inventory import Devices, Device
-from ceph.deployment.service_spec import ServiceSpec
+from ceph.deployment.service_spec import NvmeofServiceSpec, ServiceSpec
 from ceph.deployment import inventory
 from ceph.utils import datetime_now
 from mgr_module import HandleCommandResult
@@ -300,26 +300,28 @@ def test_preview_table_osd_smoke():
 @mock.patch("orchestrator.module.OrchestratorCli._apply_misc")
 @mock.patch("orchestrator.module.OrchestratorCli.remote")
 @mock.patch("orchestrator.module.OrchestratorCli.get")
+@mock.patch("orchestrator.module.OrchestratorCli.describe_service")
 class TestApplyNvmeof:
 
     def setup_method(self):
         self.m = OrchestratorCli('orchestrator', 0, 0)
 
-    def test_missing_group_raises_validation_error(self, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+    def test_missing_group_raises_validation_error(self, mock_describe, mock_get, mock_remote, mock_apply_misc, mock_release_name):
         res = self.m._apply_nvmeof(pool="mypool", group="")
 
         assert res.retval != 0
         assert "The --group argument is required" in res.stderr
         mock_apply_misc.assert_not_called()
 
-    def test_inbuf_raises_validation_error(self, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+    def test_inbuf_raises_validation_error(self, mock_describe, mock_get, mock_remote, mock_apply_misc, mock_release_name):
         res = self.m._apply_nvmeof(pool="mypool", group="mygroup", inbuf="some_yaml_content")
 
         assert res.retval != 0
         assert "unrecognized command -i; -h or --help for usage" in res.stderr
         mock_apply_misc.assert_not_called()
 
-    def test_custom_pool_skips_metadata_pool_creation(self, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+    def test_custom_pool_skips_metadata_pool_creation(self, mock_describe, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+        mock_describe.return_value = OrchResult([])
         mock_apply_misc.return_value = HandleCommandResult(retval=0, stdout="Success")
 
         res = self.m._apply_nvmeof(pool="custompool", group="mygroup")
@@ -328,7 +330,7 @@ class TestApplyNvmeof:
         mock_apply_misc.assert_called_once()
         assert res.retval == 0
 
-    def test_default_pool_fails_if_module_disabled(self, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+    def test_default_pool_fails_if_module_disabled(self, mock_describe, mock_get, mock_remote, mock_apply_misc, mock_release_name):
         mock_release_name.return_value = "squid"
         mock_get.return_value = {'modules': [], 'always_on_modules': {}}
 
@@ -342,7 +344,8 @@ class TestApplyNvmeof:
         mock_remote.assert_not_called()
         mock_apply_misc.assert_not_called()
 
-    def test_default_pool_creates_metadata_pool_if_module_enabled(self, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+    def test_default_pool_creates_metadata_pool_if_module_enabled(self, mock_describe, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+        mock_describe.return_value = OrchResult([])
         mock_release_name.return_value = "squid"
         mock_get.return_value = {'modules': ['nvmeof'], 'always_on_modules': {}}
         mock_apply_misc.return_value = HandleCommandResult(retval=0, stdout="Success")
@@ -352,6 +355,126 @@ class TestApplyNvmeof:
         mock_remote.assert_called_once_with('nvmeof', 'create_pool_if_not_exists')
         mock_apply_misc.assert_called_once()
         assert res.retval == 0
+
+    def test_yaml_and_cli_produce_same_service_name_for_default_pool(
+            self, mock_describe, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+        """Regression: 'ceph orch apply -i spec.yaml' and 'ceph orch apply nvmeof --group ...'
+        must produce the same service_name so they address the same stored service.
+
+        Before the fix, the CLI stripped the leading dot from '.nvmeof' via lstrip('.'),
+        generating service_id='nvmeof.gw_group1' while the YAML path kept the dot,
+        generating service_id='.nvmeof.gw_group1'.  The resulting service_names differed:
+          YAML: nvmeof..nvmeof.gw_group1
+          CLI:  nvmeof.nvmeof.gw_group1
+        """
+        mock_describe.return_value = OrchResult([])
+        mock_release_name.return_value = "squid"
+        mock_get.return_value = {'modules': ['nvmeof'], 'always_on_modules': {}}
+        mock_apply_misc.return_value = HandleCommandResult(retval=0, stdout="Success")
+
+        # Simulate 'ceph orch apply -i spec.yaml' — service_id taken verbatim from YAML
+        yaml_spec_str = textwrap.dedent("""
+            service_type: nvmeof
+            service_id: .nvmeof.gw_group1
+            spec:
+              pool: .nvmeof
+              group: gw_group1
+        """).strip()
+        yaml_spec = ServiceSpec.from_json(yaml.safe_load(yaml_spec_str))
+
+        self.m._apply_nvmeof(pool=".nvmeof", group="gw_group1")
+        cli_spec = mock_apply_misc.call_args[0][0][0]
+
+        assert yaml_spec.service_name() == cli_spec.service_name()
+
+    def test_cli_reuses_existing_service_id_from_old_trimmed_form(
+            self, mock_describe, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+        """Backward-compatibility: if a service already exists with the old trimmed service_id
+        ('nvmeof.mygroup1', produced by the lstrip('.') bug), a subsequent CLI apply must
+        reuse that service_id rather than generating a new '.nvmeof.mygroup1', which would
+        create a second duplicate service alongside the existing one."""
+        existing_spec = NvmeofServiceSpec(
+            service_id='nvmeof.mygroup1',   # old trimmed form stored on disk
+            group='mygroup1',
+            pool='.nvmeof'
+        )
+        mock_describe.return_value = OrchResult(
+            [ServiceDescription(spec=existing_spec)]
+        )
+        mock_release_name.return_value = "squid"
+        mock_get.return_value = {'modules': ['nvmeof'], 'always_on_modules': {}}
+        mock_apply_misc.return_value = HandleCommandResult(retval=0, stdout="Success")
+
+        self.m._apply_nvmeof(pool=".nvmeof", group="mygroup1")
+
+        submitted_spec = mock_apply_misc.call_args[0][0][0]
+        assert submitted_spec.service_id == 'nvmeof.mygroup1'
+        assert submitted_spec.service_name() == 'nvmeof.nvmeof.mygroup1'
+
+    def test_cli_reuses_existing_service_id_when_both_pools_identical_dotted(
+            self, mock_describe, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+        """Applying against an existing service whose pool is already '.nvmeof' (correct form)
+        must also reuse the stored service_id — not just the old trimmed form."""
+        existing_spec = NvmeofServiceSpec(
+            service_id='.nvmeof.mygroup1',
+            group='mygroup1',
+            pool='.nvmeof'
+        )
+        mock_describe.return_value = OrchResult(
+            [ServiceDescription(spec=existing_spec)]
+        )
+        mock_release_name.return_value = "squid"
+        mock_get.return_value = {'modules': ['nvmeof'], 'always_on_modules': {}}
+        mock_apply_misc.return_value = HandleCommandResult(retval=0, stdout="Success")
+
+        self.m._apply_nvmeof(pool=".nvmeof", group="mygroup1")
+
+        submitted_spec = mock_apply_misc.call_args[0][0][0]
+        assert submitted_spec.service_id == '.nvmeof.mygroup1'
+
+    def test_cli_does_not_conflate_dotted_custom_pool_with_undotted(
+            self, mock_describe, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+        """'.mypool' and 'mypool' are distinct pools — service_id must not be reused
+        across different pool names."""
+        existing_spec = NvmeofServiceSpec(
+            service_id='mypool.mygroup1',
+            group='mygroup1',
+            pool='mypool'
+        )
+        mock_describe.return_value = OrchResult(
+            [ServiceDescription(spec=existing_spec)]
+        )
+        mock_apply_misc.return_value = HandleCommandResult(retval=0, stdout="Success")
+
+        # Applying with '.mypool' must NOT reuse the 'mypool' service — different pools
+        self.m._apply_nvmeof(pool=".mypool", group="mygroup1")
+
+        submitted_spec = mock_apply_misc.call_args[0][0][0]
+        assert submitted_spec.service_id == '.mypool.mygroup1'  # new service_id, not reused
+
+    def test_cli_skips_deleted_service_when_looking_up_existing_id(
+            self, mock_describe, mock_get, mock_remote, mock_apply_misc, mock_release_name):
+        """A service that is pending deletion must not have its service_id reused.
+        If the CLI adopted it, SpecStore.save() would preserve the deletion marker,
+        leaving the service scheduled for removal while reporting a successful update."""
+        import datetime
+        deleted_spec = NvmeofServiceSpec(
+            service_id='nvmeof.mygroup1',
+            group='mygroup1',
+            pool='.nvmeof'
+        )
+        mock_describe.return_value = OrchResult(
+            [ServiceDescription(spec=deleted_spec, deleted=datetime.datetime.now())]
+        )
+        mock_release_name.return_value = "squid"
+        mock_get.return_value = {'modules': ['nvmeof'], 'always_on_modules': {}}
+        mock_apply_misc.return_value = HandleCommandResult(retval=0, stdout="Success")
+
+        self.m._apply_nvmeof(pool=".nvmeof", group="mygroup1")
+
+        # Must use the fresh generated service_id, not the deleted service's id
+        submitted_spec = mock_apply_misc.call_args[0][0][0]
+        assert submitted_spec.service_id == '.nvmeof.mygroup1'
 
 
 @mock.patch("orchestrator.module.OrchestratorCli._apply_misc")


### PR DESCRIPTION
after fixing the nvmeof service name dot bug(The CLI path (c`eph orch apply nvmeof`) was stripping the leading dot from .nvmeof via lstrip('.')) in https://github.com/ceph/ceph/pull/70803 we had to take care of backward compatibilty. 
If a cluster was installed with the version with the bug, it will have an NVMeoF service with 1 dot(`nvmeof.nvmeof.mygroup`), 
which means, it fails when trying to `ceph orch apply nvmeof `since it now tries to create a new service with 2 dots in its name (`nvmeof..nvmeof.mygroup`) and there is a guard to block creation of two services with the same group.
The fix is making the treatment more permissive specifically for this case (.nvmeof pool only) will treat `nvmeof.nvmeof.mygroup` and `nvmeof..nvmeof.mygroup` indiscriminately to allow `ceph orch apply nvmeof` as usual

example:
```
[xxx@xxx ~]# ceph orch ls
NAME                       PORTS                   RUNNING  REFRESHED  AGE  PLACEMENT
alertmanager               ?:9093,9094                 1/1  19s ago    5h   count:1
ceph-exporter              ?:9926                      2/2  57s ago    5h   *
crash                                                  2/2  57s ago    5h   *
grafana                    ?:3000                      1/1  19s ago    5h   count:1
mgr                                                    2/2  57s ago    5h   label:mgr
mon                                                    2/2  57s ago    5h   label:mon
node-exporter              ?:9100                      2/2  57s ago    5h   *
nvmeof.nvmeof.mygroup1     ?:4420,5500,8009,10008      1/2  57s ago    5h   compat-tomer-cluster-node1;compat-tomer-cluster-node2
osd.all-available-devices                                2  57s ago    5h   *
prometheus                 ?:9095                      1/1  19s ago    5h   count:1
[xxx@xxx ~]# ceph orch apply nvmeof --pool=.nvmeof --group=mygroup1
Scheduled nvmeof.nvmeof.mygroup1 update...
[xxx@xxx ~]# ceph orch ls
NAME                       PORTS                   RUNNING  REFRESHED  AGE  PLACEMENT
alertmanager               ?:9093,9094                 1/1  46s ago    5h   count:1
ceph-exporter              ?:9926                      2/2  84s ago    5h   *
crash                                                  2/2  84s ago    5h   *
grafana                    ?:3000                      1/1  46s ago    5h   count:1
mgr                                                    2/2  84s ago    5h   label:mgr
mon                                                    2/2  84s ago    5h   label:mon
node-exporter              ?:9100                      2/2  84s ago    5h   *
nvmeof.nvmeof.mygroup1     ?:4420,5500,8009,10008      1/1  84s ago    8s   count:1
osd.all-available-devices                                2  84s ago    5h   *
prometheus                 ?:9095                      1/1  46s ago    5h   count:1
[xxx@xxx ~]# ceph orch rm nvmeof.nvmeof.mygroup1
Removed service nvmeof.nvmeof.mygroup1
[xxx@xxx ~]# ceph orch apply nvmeof --pool=.nvmeof --group=mygroup1
Scheduled nvmeof..nvmeof.mygroup1 update...
[xxx@xxx ~]# ceph orch ls
NAME                       PORTS                   RUNNING  REFRESHED  AGE  PLACEMENT
alertmanager               ?:9093,9094                 1/1  2m ago     5h   count:1
ceph-exporter              ?:9926                      2/2  2m ago     5h   *
crash                                                  2/2  2m ago     5h   *
grafana                    ?:3000                      1/1  2m ago     5h   count:1
mgr                                                    2/2  2m ago     5h   label:mgr
mon                                                    2/2  2m ago     5h   label:mon
node-exporter              ?:9100                      2/2  2m ago     5h   *
nvmeof..nvmeof.mygroup1    ?:4420,5500,8009,10008      1/1  2m ago     3m   count:1
osd.all-available-devices                                2  2m ago     5h   *
prometheus                 ?:9095                      1/1  2m ago     5h   count:1
```

fixes: https://tracker.ceph.com/issues/78998

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
