### PR TITLE
mgr/dashboard : Introduce custom option for cert-auth component for backward compatiblity

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
@@ -39,6 +39,7 @@ import {
   CephServiceCertificate,
   CephServiceSpec,
   CertificateType,
+  CertMode,
   QatOptions,
   QatSepcs
 } from '~/app/shared/models/service.interface';
@@ -56,6 +57,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
   public sub = new Subscription();
 
   readonly CertificateType = CertificateType;
+  readonly CertMode = CertMode;
   readonly MDS_SVC_ID_PATTERN = /^[a-zA-Z_.-][a-zA-Z0-9_.-]*$/;
   readonly SNMP_DESTINATION_PATTERN = /^[^\:]+:[0-9]/;
   readonly SNMP_ENGINE_ID_PATTERN = /^[0-9A-Fa-f]{10,64}/g;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/certificate-authority-form/certificate-authority-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/certificate-authority-form/certificate-authority-form.component.html
@@ -133,36 +133,44 @@
     </div>
   }
 
-  <div class="form-item">
-    <label
-      class="cds--label cds--type-heading-compact-01"
-      for="certificateType"
-      i18n
-      >Choose Certificate Authority</label
-    >
-    <cds-radio-group
-      id="certificateType"
-      formControlName="certificateType"
-      orientation="horizontal"
-      helperText="Select how certificates will be signed for this service. Choose internal to use the cluster's CA, or external to upload certificates signed by your organization."
-      i18n-helperText
-    >
-      <cds-radio
-        [value]="CertificateType.internal"
-        (change)="onCertificateTypeChange(CertificateType.internal)"
+  <!--
+    Radio group: shown only when the caller allows more than one option.
+    - CertMode.both        → Internal + External radios
+    - CertMode.internalOnly → no radio needed (only path is internal)
+    - CertMode.externalOnly → no radio needed (only path is external)
+  -->
+  @if (certMode === CertMode.both) {
+    <div class="form-item">
+      <label
+        class="cds--label cds--type-heading-compact-01"
+        for="certificateType"
         i18n
+        >Choose Certificate Authority</label
       >
-        Internal
-      </cds-radio>
-      <cds-radio
-        [value]="CertificateType.external"
-        (change)="onCertificateTypeChange(CertificateType.external)"
-        i18n
+      <cds-radio-group
+        id="certificateType"
+        formControlName="certificateType"
+        orientation="horizontal"
+        helperText="Select how certificates will be signed for this service. Choose internal to use the cluster's CA, or external to upload certificates signed by your organization."
+        i18n-helperText
       >
-        External
-      </cds-radio>
-    </cds-radio-group>
-  </div>
+        <cds-radio
+          [value]="CertificateType.internal"
+          (change)="onCertificateTypeChange(CertificateType.internal)"
+          i18n
+        >
+          Internal
+        </cds-radio>
+        <cds-radio
+          [value]="CertificateType.external"
+          (change)="onCertificateTypeChange(CertificateType.external)"
+          i18n
+        >
+          External
+        </cds-radio>
+      </cds-radio-group>
+    </div>
+  }
 
   @if (showCertSourceChangeWarning) {
     <cd-alert-panel
@@ -175,7 +183,17 @@
     </cd-alert-panel>
   }
 
-  @if (formGroup.controls.certificateType.value === CertificateType.internal) {
+  <!--
+    Internal-cert panels:
+    - Shown when certMode is 'both' and the user selected Internal, OR
+    - Always shown when certMode is 'internalOnly'.
+    - Never shown when certMode is 'externalOnly'.
+  -->
+  @if (
+    certMode === CertMode.internalOnly ||
+    (certMode === CertMode.both &&
+      formGroup.controls.certificateType.value === CertificateType.internal)
+  ) {
     <cd-alert-panel
       type="info"
       spacingClass="mb-3"

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/certificate-authority-form/certificate-authority-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/certificate-authority-form/certificate-authority-form.component.spec.ts
@@ -1,9 +1,10 @@
+import { CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ReactiveFormsModule } from '@angular/forms';
 import { expect as jestExpect } from '@jest/globals';
 
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
-import { CertificateType } from '~/app/shared/models/service.interface';
+import { CertificateType, CertMode } from '~/app/shared/models/service.interface';
+import { ComponentsModule } from '../components.module';
 import { CertificateAuthorityFormComponent } from './certificate-authority-form.component';
 
 describe('CertificateAuthorityFormComponent', () => {
@@ -13,7 +14,8 @@ describe('CertificateAuthorityFormComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ReactiveFormsModule, CertificateAuthorityFormComponent]
+      imports: [ComponentsModule, CertificateAuthorityFormComponent],
+      schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
 
     formBuilder = new CdFormBuilder();
@@ -29,7 +31,6 @@ describe('CertificateAuthorityFormComponent', () => {
   });
 
   it('should create', () => {
-    fixture.detectChanges();
     jestExpect(component).toBeTruthy();
   });
 
@@ -37,5 +38,77 @@ describe('CertificateAuthorityFormComponent', () => {
     const emitSpy = jest.spyOn(component.certificateTypeChange, 'emit');
     component.onCertificateTypeChange(CertificateType.external);
     jestExpect(emitSpy).toHaveBeenCalledWith(CertificateType.external);
+  });
+
+  describe('certMode input', () => {
+    it('should default to CertMode.both', () => {
+      jestExpect(component.certMode).toBe(CertMode.both);
+    });
+
+    it('should accept custom certMode values', () => {
+      component.certMode = CertMode.externalOnly;
+      jestExpect(component.certMode).toBe(CertMode.externalOnly);
+
+      component.certMode = CertMode.internalOnly;
+      jestExpect(component.certMode).toBe(CertMode.internalOnly);
+    });
+  });
+
+  describe('certMode HTML rendering', () => {
+    it('should render the radio group when certMode is both', () => {
+      component.certMode = CertMode.both;
+      fixture.detectChanges();
+      const radioGroup = fixture.nativeElement.querySelector('cds-radio-group');
+      jestExpect(radioGroup).not.toBeNull();
+    });
+
+    it('should not render the radio group when certMode is internalOnly', () => {
+      component.certMode = CertMode.internalOnly;
+      fixture.detectChanges();
+      const radioGroup = fixture.nativeElement.querySelector('cds-radio-group');
+      jestExpect(radioGroup).toBeNull();
+    });
+
+    it('should not render the radio group when certMode is externalOnly', () => {
+      component.certMode = CertMode.externalOnly;
+      fixture.detectChanges();
+      const radioGroup = fixture.nativeElement.querySelector('cds-radio-group');
+      jestExpect(radioGroup).toBeNull();
+    });
+
+    it('should render the internal-cert panel when certMode is internalOnly', () => {
+      component.certMode = CertMode.internalOnly;
+      fixture.detectChanges();
+      const alertPanel = fixture.nativeElement.querySelector('cd-alert-panel');
+      jestExpect(alertPanel).not.toBeNull();
+    });
+
+    it('should not render the internal-cert panel when certMode is externalOnly', () => {
+      component.certMode = CertMode.externalOnly;
+      fixture.detectChanges();
+      const radioGroup = fixture.nativeElement.querySelector('cds-radio-group');
+      const alertPanel = fixture.nativeElement.querySelector('cd-alert-panel');
+      jestExpect(radioGroup).toBeNull();
+      jestExpect(alertPanel).toBeNull();
+    });
+
+    it('should render the internal-cert panel when certMode is both and internal is selected', () => {
+      component.certMode = CertMode.both;
+      component.formGroup.controls['certificateType'].setValue(CertificateType.internal);
+      fixture.detectChanges();
+      const alertPanel = fixture.nativeElement.querySelector('cd-alert-panel');
+      jestExpect(alertPanel).not.toBeNull();
+    });
+
+    it('should not render the internal-cert panel when certMode is both and external is selected', () => {
+      component.certMode = CertMode.both;
+      component.formGroup.controls['certificateType'].setValue(CertificateType.external);
+      fixture.detectChanges();
+      const alertPanels = fixture.nativeElement.querySelectorAll('cd-alert-panel');
+      const hasInternalMsg = Array.from(alertPanels).some((el: any) =>
+        el.textContent?.includes('generated automatically by Cephadm CA')
+      );
+      jestExpect(hasInternalMsg).toBe(false);
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/certificate-authority-form/certificate-authority-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/certificate-authority-form/certificate-authority-form.component.ts
@@ -1,5 +1,13 @@
 import { CommonModule } from '@angular/common';
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges
+} from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { CheckboxModule, GridModule, LayoutModule, RadioModule } from 'carbon-components-angular';
 
@@ -7,6 +15,7 @@ import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import {
   CephServiceCertificate,
   CertificateType,
+  CertMode,
   CERTIFICATE_STATUS_ICON_MAP
 } from '~/app/shared/models/service.interface';
 import { PipesModule } from '~/app/shared/pipes/pipes.module';
@@ -30,16 +39,40 @@ import { TextLabelListComponent } from '../text-label-list/text-label-list.compo
     TextLabelListComponent
   ]
 })
-export class CertificateAuthorityFormComponent {
+export class CertificateAuthorityFormComponent implements OnInit, OnChanges {
   readonly CertificateType = CertificateType;
+  readonly CertMode = CertMode;
   readonly statusIconMap = CERTIFICATE_STATUS_ICON_MAP;
 
   @Input() formGroup: CdFormGroup;
   @Input() editing = false;
   @Input() currentCertificate: CephServiceCertificate = null;
   @Input() showCertSourceChangeWarning = false;
+  @Input() certMode: CertMode = CertMode.both;
 
   @Output() certificateTypeChange = new EventEmitter<CertificateType>();
+
+  ngOnInit(): void {
+    this.setDefaultCertificateType();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['certMode'] && !changes['certMode'].firstChange) {
+      this.setDefaultCertificateType();
+    }
+  }
+
+  private setDefaultCertificateType(): void {
+    if (!this.formGroup) return;
+    const ctrl = this.formGroup.get('certificateType');
+    if (!ctrl) return;
+
+    if (this.certMode === CertMode.externalOnly) {
+      ctrl.setValue(CertificateType.external, { emitEvent: false });
+    } else if (this.certMode === CertMode.internalOnly) {
+      ctrl.setValue(CertificateType.internal, { emitEvent: false });
+    }
+  }
 
   onCertificateTypeChange(type: CertificateType): void {
     this.certificateTypeChange.emit(type);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/service.interface.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/service.interface.ts
@@ -132,6 +132,12 @@ export enum CertificateType {
   external = 'external'
 }
 
+export enum CertMode {
+  externalOnly = 'externalOnly',
+  both = 'both',
+  internalOnly = 'internalOnly'
+}
+
 export enum QatOptions {
   hw = 'hw',
   sw = 'sw',


### PR DESCRIPTION
fixes :
Signed-off-by: Abhishek Desai <abhishek.desai1@ibm.com>

```
Introduces a certMode input to cd-certificate-authority-form that controls which 
certificate-authority options are rendered in the form. 

Three modes:

1. externalOnly — hides the CA radio group entirely and shows only the external certificate upload fields. 
Can use this on branches (e.g. tentacle) that do not yet support cephadm-signed certificates.
3. both (default) — shows both Internal (Cephadm CA) and External radio options. 
Preserves the existing main behaviour
5. internalOnly — shows only the Cephadm CA path with no file-upload inputs.
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
