### PR TITLE
mgr/cephadm: Dict size change nfs deprovision

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -1206,7 +1206,7 @@ class HostCache():
         if host in self.last_tuned_profile_update:
             j['last_tuned_profile_update'] = datetime_to_str(self.last_tuned_profile_update[host])
         if host in self.daemons:
-            for name, dd in self.daemons[host].items():
+            for name, dd in list(self.daemons[host].items()):
                 j['daemons'][name] = dd.to_json()
         if host in self.networks:
             j['networks_and_interfaces'] = self.networks[host]
@@ -1443,12 +1443,12 @@ class HostCache():
         return self.facts.get(host, {})
 
     def _get_daemons(self) -> Iterator[orchestrator.DaemonDescription]:
-        for dm in self.daemons.copy().values():
-            yield from dm.values()
+        for dm in list(self.daemons.values()):
+            yield from list(dm.values())
 
     def _get_tmp_daemons(self) -> Iterator[orchestrator.DaemonDescription]:
-        for dm in self._tmp_daemons.copy().values():
-            yield from dm.values()
+        for dm in list(self._tmp_daemons.values()):
+            yield from list(dm.values())
 
     def get_daemons(self):
         # type: () -> List[orchestrator.DaemonDescription]
@@ -1496,7 +1496,8 @@ class HostCache():
             dd.events = self.mgr.events.get_for_daemon(dd.name())
             return dd
 
-        for host, dm in self.daemons.copy().items():
+        snapshot = {host: dict(dm) for host, dm in list(self.daemons.items())}
+        for host, dm in snapshot.items():
             yield host, {name: alter(host, d) for name, d in dm.items()}
 
     def get_daemons_by_service(self, service_name):
@@ -1525,7 +1526,7 @@ class HostCache():
         assert service_type not in ['keepalived', 'haproxy']
         if host:
             host = normalize_hostname(host)
-        daemons = self.daemons[host].values() if host else self._get_daemons()
+        daemons = list(self.daemons[host].values()) if host else self._get_daemons()
         return [d for d in daemons if d.daemon_type in service_to_daemon_types(service_type)]
 
     def get_daemons_by_types(self, daemon_types: List[str]) -> List[str]:
@@ -1538,7 +1539,7 @@ class HostCache():
     def get_daemon_types(self, hostname: str) -> Set[str]:
         """Provide a list of the types of daemons on the host"""
         hostname = normalize_hostname(hostname)
-        return cast(Set[str], {d.daemon_type for d in self.daemons[hostname].values()})
+        return cast(Set[str], {d.daemon_type for d in list(self.daemons[hostname].values())})
 
     def get_daemon_names(self):
         # type: () -> List[str]

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -209,14 +209,14 @@ class Inventory:
 
     def __contains__(self, host: str) -> bool:
         host = normalize_hostname(host)
-        return host in self._inventory or host in itertools.chain.from_iterable(self._all_known_names.values())
+        return host in self._inventory or host in itertools.chain.from_iterable(list(self._all_known_names.values()))
 
     def _get_stored_name(self, host: str) -> str:
         host = normalize_hostname(host)
         self.assert_host(host)
         if host in self._inventory:
             return host
-        for stored_name, all_names in self._all_known_names.items():
+        for stored_name, all_names in list(self._all_known_names.items()):
             if host in all_names:
                 return stored_name
         return host
@@ -309,11 +309,11 @@ class Inventory:
         )
 
     def all_specs(self) -> List[HostSpec]:
-        return list(map(self.spec_from_dict, self._inventory.values()))
+        return [self.spec_from_dict(v) for v in list(self._inventory.values())]
 
     def get_host_with_state(self, state: str = "") -> List[str]:
         """return a list of host names in a specific state"""
-        return [h for h in self._inventory if self._inventory[h].get("status", "").lower() == state]
+        return [h for h in list(self._inventory) if self._inventory[h].get("status", "").lower() == state]
 
     def save(self) -> None:
         self.mgr.set_store('inventory', json.dumps(self._inventory))
@@ -1211,7 +1211,7 @@ class HostCache():
         if host in self.networks:
             j['networks_and_interfaces'] = self.networks[host]
         if host in self.daemon_config_deps:
-            for name, depi in self.daemon_config_deps[host].items():
+            for name, depi in list(self.daemon_config_deps[host].items()):
                 j['daemon_config_deps'][name] = {
                     'deps': depi.get('deps', []),
                     'last_config': datetime_to_str(depi['last_config']),
@@ -1219,16 +1219,16 @@ class HostCache():
         if host in self.osdspec_previews and self.osdspec_previews[host]:
             j['osdspec_previews'] = self.osdspec_previews[host]
         if host in self.osdspec_last_applied:
-            for name, ts in self.osdspec_last_applied[host].items():
+            for name, ts in list(self.osdspec_last_applied[host].items()):
                 j['osdspec_last_applied'][name] = datetime_to_str(ts)
 
         if host in self.last_host_check:
             j['last_host_check'] = datetime_to_str(self.last_host_check[host])
 
         if host in self.last_client_files:
-            j['last_client_files'] = self.last_client_files[host]
+            j['last_client_files'] = dict(self.last_client_files[host])
         if host in self.scheduled_daemon_actions:
-            j['scheduled_daemon_actions'] = self.scheduled_daemon_actions[host]
+            j['scheduled_daemon_actions'] = dict(self.scheduled_daemon_actions[host])
         if host in self.metadata_up_to_date:
             j['metadata_up_to_date'] = self.metadata_up_to_date[host]
         if host in self.devices:

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3285,7 +3285,7 @@ Then run the following:
                                   <fsid>/removed/.
         """
         args = []
-        for host, dm in self.cache.daemons.items():
+        for host, dm in list(self.cache.daemons.items()):
             for name in names:
                 if name in dm:
                     args.append((name, host, force_delete_data))
@@ -4778,8 +4778,8 @@ Then run the following:
             'up_to_date': list(),
             'non_ceph_image_daemons': list()
         }
-        for host, dm in self.cache.daemons.items():
-            for name, dd in dm.items():
+        for host, dm in list(self.cache.daemons.items()):
+            for name, dd in list(dm.items()):
                 # check if the container digest for the digest we're checking upgrades for matches
                 # the container digests for the daemon if "use_repo_digest" setting is true
                 # or that the image name matches the daemon's image name if "use_repo_digest"

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -506,7 +506,7 @@ class CephadmServe:
             self.mgr.remove_health_warning(k)
         # clear recently altered daemons that were created/removed more than 60 seconds ago
         self.mgr.recently_altered_daemons = {
-            d: t for (d, t) in self.mgr.recently_altered_daemons.items()
+            d: t for (d, t) in list(self.mgr.recently_altered_daemons.items())
             if ((datetime_now() - t).total_seconds() < 60)
         }
         if self.mgr.warn_on_stray_hosts or self.mgr.warn_on_stray_daemons:
@@ -1422,7 +1422,7 @@ class CephadmServe:
                     f'unable to calc conf hosts: {self.mgr.manage_etc_ceph_ceph_conf_hosts}: {e}')
 
         # client keyrings
-        for ks in self.mgr.keys.keys.values():
+        for ks in list(self.mgr.keys.keys.values()):
             try:
                 ret, keyring, err = self.mgr.mon_command({
                     'prefix': 'auth get',


### PR DESCRIPTION
Module 'cephadm' has failed: dictionary changed size during iteration in NFS deprovisioning can happen, this adds protections to the self.daemons dictionary that causes this and it additional adds protections for other dictionaries that are vulnerable of the same error.

Fixes: https://tracker.ceph.com/issues/79135

Signed-off-by: Timothy Q Nguyen <timqn22@gmail.com>

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
