### PR TITLE
mgr: drop the duplicate heap asok command from DaemonServer

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -49,7 +49,6 @@
 #include "common/pick_address.h"
 #include "common/TextTable.h"
 #include "crush/CrushWrapper.h"
-#include "perfglue/heap_profiler.h"
 
 #include <boost/algorithm/string.hpp>
 
@@ -271,14 +270,6 @@ int DaemonServer::init(uint64_t gid, entity_addrvec_t client_addrs)
              "name=filterstr,type=CephString,n=N,req=false",
              asok_hook,
              "show slowest recent ops, sorted by duration");
-  ceph_assert(r == 0);
-  r = admin_socket->register_command(
-    "heap " \
-    "name=heapcmd,type=CephChoices,strings=" \
-    "dump|start_profiler|stop_profiler|release|get_release_rate|set_release_rate|stats " \
-    "name=value,type=CephString,req=false",
-    asok_hook,
-    "show heap usage info (available only if compiled with tcmalloc)");
   ceph_assert(r == 0);
   return 0;
 }
@@ -3855,22 +3846,6 @@ will start to track new ops received afterwards.";
         goto out;
       }
     }
-  } else if (admin_command == "heap") {
-    if (!ceph_using_tcmalloc()) {
-      ss << "not using tcmalloc";
-      ret = -EOPNOTSUPP;
-      goto out;
-    }
-    string heapcmd;
-    cmd_getval(cmdmap, "heapcmd", heapcmd);
-    vector<string> heapcmd_vec;
-    get_str_vec(heapcmd, heapcmd_vec);
-    string value;
-    if (cmd_getval(cmdmap, "value", value)) {
-      heapcmd_vec.push_back(value);
-    }
-    ceph_heap_profiler_handle_command(heapcmd_vec, ss);
-    ret = 0;
   }
   dout(10) << "ret := " << ret << dendl;
   return true;


### PR DESCRIPTION
every ceph-mgr dies with an assert the moment it wins the election:
```
    asok(...) register_command heap cmddesc heap name=heapcmd,... EEXIST
    src/mgr/DaemonServer.cc: 282: FAILED ceph_assert(r == 0)
     5: (DaemonServer::init(unsigned long, entity_addrvec_t)+0x10ba)
     6: (Mgr::init()+0xc25)
```
d8dde402b6d and e8e47abef6c both register a "heap" admin socket command for the mgr: one in `MgrStandby::init()`, which runs at process startup, the other in `DaemonServer::init()`, which runs when the mgr
goes active. each passed CI on its own, and the merge raised no textual conflict. so nothing noticed that the second
`register_command()` now returns `EEXIST` and trips the assert sitting right next to it, until the ceph-api job hit it with both in main.

keep the `MgrStandby` registration and drop the `DaemonServer` one. the `MgrStandby` hook lives as long as the process, so "heap" works on a standby mgr as well as an active one, while the dropped one only existed after activation. and tcmalloc heap profiling is process-wide state anyway, it needs nothing from `DaemonServer`.

Fixes: e8e47abef6cd7f9de46ce603c675b6bc478eb0e5



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
