### PR TITLE
script/ptl-tool: add real QA-tag labels alongside nvme/orch/upgrades

### DIFF
--- a/src/script/ptl-tool.py
+++ b/src/script/ptl-tool.py
@@ -126,6 +126,18 @@ except FileNotFoundError:
     pass
 REDMINE_API_KEY = os.getenv("PTL_TOOL_REDMINE_API_KEY", REDMINE_API_KEY)
 SPECIAL_BRANCHES = ('main', 'luminous', 'jewel', 'HEAD')
+# 'nvme', 'orch', and 'upgrades' never match a real GitHub label on ceph/ceph
+# (verified via `gh api repos/ceph/ceph/labels/<name>`, 404 on all three) --
+# 'nvmeof', 'orchestrator', and 'needs-upgrade-testing' are the labels that
+# actually exist and are added alongside, kept rather than replaced in case
+# a future label reintroduces the shorter/older name.
+# Cross-checked against .github/labeler.yml (commit a391fef144a7): this whitelist
+# covers 14 of labeler.yml's 27 categories -- 13 more (mon, mgr, pybind, rook,
+# bluestore, nfs, monitoring, telemetry, documentation, api-change, CI, script,
+# config-change) exist in the auto-labeler but have no SUPPORTED_QA_TAGS entry.
+# Left out of this change deliberately -- several of those (documentation, CI,
+# script, config-change) aren't QA-testing-relevant categories, and expanding
+# the whole list needs its own discussion.
 SUPPORTED_QA_TAGS = {
     'build/ops',
     'ceph-volume',
@@ -136,8 +148,11 @@ SUPPORTED_QA_TAGS = {
     'crimson',
     'dashboard',
     'libcephsqlite',
+    'needs-upgrade-testing',
     'nvme',
+    'nvmeof',
     'orch',
+    'orchestrator',
     'rbd',
     'rgw',
     'tests',

--- a/src/script/ptl-tool.py
+++ b/src/script/ptl-tool.py
@@ -126,18 +126,6 @@ except FileNotFoundError:
     pass
 REDMINE_API_KEY = os.getenv("PTL_TOOL_REDMINE_API_KEY", REDMINE_API_KEY)
 SPECIAL_BRANCHES = ('main', 'luminous', 'jewel', 'HEAD')
-# 'nvme', 'orch', and 'upgrades' never match a real GitHub label on ceph/ceph
-# (verified via `gh api repos/ceph/ceph/labels/<name>`, 404 on all three) --
-# 'nvmeof', 'orchestrator', and 'needs-upgrade-testing' are the labels that
-# actually exist and are added alongside, kept rather than replaced in case
-# a future label reintroduces the shorter/older name.
-# Cross-checked against .github/labeler.yml (commit a391fef144a7): this whitelist
-# covers 14 of labeler.yml's 27 categories -- 13 more (mon, mgr, pybind, rook,
-# bluestore, nfs, monitoring, telemetry, documentation, api-change, CI, script,
-# config-change) exist in the auto-labeler but have no SUPPORTED_QA_TAGS entry.
-# Left out of this change deliberately -- several of those (documentation, CI,
-# script, config-change) aren't QA-testing-relevant categories, and expanding
-# the whole list needs its own discussion.
 SUPPORTED_QA_TAGS = {
     'build/ops',
     'ceph-volume',


### PR DESCRIPTION
## Summary

`SUPPORTED_QA_TAGS` in `src/script/ptl-tool.py` is a whitelist of GitHub PR labels that
auto-populate a Redmine QA ticket's tag list. Three entries — `nvme`, `orch`, and
`upgrades` — never matched a real GitHub label on `ceph/ceph`: verified via
`gh api repos/ceph/ceph/labels/<name>`, all three return 404. This PR adds the labels
that actually exist — `nvmeof`, `orchestrator`, and `needs-upgrade-testing` — alongside
the originals rather than replacing them, in case a future label reintroduces the
shorter/older name.

**3 additions here vs. 15 possible for full parity:**

Cross-checked the whole whitelist against `.github/labeler.yml` (commit `a391fef144a7`).
That file defines 27 auto-labeler categories; `SUPPORTED_QA_TAGS` covers 14 of them after
this change. The other 13 (`mon`, `mgr`, `pybind`, `rook`, `bluestore`, `nfs`,
`monitoring`, `telemetry`, `documentation`, `api-change`, `CI`, `script`,
`config-change`) exist in the auto-labeler but have no `SUPPORTED_QA_TAGS` entry. This PR
deliberately does **not** add those — several (`documentation`, `CI`, `script`,
`config-change`) aren't QA-testing-relevant categories, and expanding the full list is a
separate decision from adding entries that were simply missing.

## Test plan

- `python3 -m py_compile src/script/ptl-tool.py` — clean
- `python3 -m pytest src/script/test_ptl_tool.py -q` — 20/20 pass (no test references the
  tag names, so none needed updating)

## Checklist
- Tracker (select at least one)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] No tests

<!-- amended to fix a stale count in the code comment (bob-delegate review, round 2) -->
