### PR TITLE
mds: report objects created after the older snapshot in file blockdiff

### DIFF
--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -2048,6 +2048,160 @@ class TestMirroring(CephFSTestCase):
         self.remove_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
 
+    def test_cephfs_mirror_hole_fill_sync(self):
+        """Test snapshot sync of an object first written after the older snapshot.
+
+        Filling a hole in the middle of a sparse file creates an object that
+        did not exist in the older snapshot.  No clone of that object covers
+        the older snapshot -- there was nothing to copy on write -- which
+        blockdiff used to treat as "unchanged since the older snapshot" and
+        silently drop from the diff, leaving the region zeroed on the remote.
+
+        The mtimes are pinned for the reason given in
+        test_cephfs_mirror_sparse_file_sync.
+        """
+        self.setup_mount_b(mds_perm='rw')
+        self.mount_a.run_shell(["mkdir", "d0"])
+
+        # 64MB sparse file with data only in the first object; blockdiff
+        # requires the file to exceed cephfs_mirror_blockdiff_min_file_size.
+        self.mount_a.run_shell(["truncate", "-s", "64M", "d0/sparse"])
+        self.mount_a.run_shell(["dd", "if=/dev/urandom", "of=d0/sparse", "bs=1M",
+                                "count=1", "conv=notrunc"])
+        self.mount_a.run_shell(["touch", "-m", "-d", "2020-01-01 00:00:00 UTC",
+                                "d0/sparse"])
+
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
+        self.peer_add(self.primary_fs_name, self.primary_fs_id,
+                      "client.mirror_remote@ceph", self.secondary_fs_name)
+
+        # snapshot 1: full sync
+        self.mount_a.run_shell(["mkdir", "d0/.snap/snap_a"])
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               "client.mirror_remote@ceph", '/d0', 'snap_a', 1)
+        self.verify_snapshot('d0', 'snap_a')
+
+        # fill the hole at 32MB -- object 8 is created only now, so it has no
+        # clone covering snap_a.  The file is not touched after snap_b, so the
+        # newer side of the diff is the head inode and both ends of the diff
+        # resolve to the same (head) entry of the object's clone list.
+        self.mount_a.run_shell(["dd", "if=/dev/urandom", "of=d0/sparse", "bs=1M",
+                                "seek=32", "count=1", "conv=notrunc"])
+        self.mount_a.run_shell(["touch", "-m", "-d", "2020-01-01 00:00:02 UTC",
+                                "d0/sparse"])
+        self.mount_a.run_shell(["mkdir", "d0/.snap/snap_b"])
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               "client.mirror_remote@ceph", '/d0', 'snap_b', 2)
+        self.verify_snapshot('d0', 'snap_b')
+
+        self.remove_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_cephfs_mirror_hole_fill_sync_snapped_inode(self):
+        """Test hole fill sync when the newer snapshot is not the head version.
+
+        Same as test_cephfs_mirror_hole_fill_sync, except the hole filling
+        object is written again after the newer snapshot.  The older end of
+        the diff then falls back to the (last) "head" entry of the clone list
+        while the newer end resolves to an earlier clone, so the clone walk
+        used to run backwards and copy nothing at all.
+
+        All snapshots are taken before the directory is mirrored so that the
+        writes trailing each snapshot are guaranteed to have landed before
+        the incremental sync computes its diff.  The mtimes are pinned for
+        the reason given in test_cephfs_mirror_sparse_file_sync.
+        """
+        self.setup_mount_b(mds_perm='rw')
+        self.mount_a.run_shell(["mkdir", "d0"])
+
+        self.mount_a.run_shell(["truncate", "-s", "64M", "d0/sparse"])
+        self.mount_a.run_shell(["dd", "if=/dev/urandom", "of=d0/sparse", "bs=1M",
+                                "count=1", "conv=notrunc"])
+        self.mount_a.run_shell(["touch", "-m", "-d", "2020-01-01 00:00:00 UTC",
+                                "d0/sparse"])
+        self.mount_a.run_shell(["mkdir", "d0/.snap/snap_a"])
+
+        # object 8 comes into existence between snap_a and snap_b ...
+        self.mount_a.run_shell(["dd", "if=/dev/urandom", "of=d0/sparse", "bs=1M",
+                                "seek=32", "count=1", "conv=notrunc"])
+        self.mount_a.run_shell(["touch", "-m", "-d", "2020-01-01 00:00:02 UTC",
+                                "d0/sparse"])
+        self.mount_a.run_shell(["mkdir", "d0/.snap/snap_b"])
+
+        # ... and is rewritten after snap_b, so it gets a clone covering
+        # snap_b and .snap/snap_b/sparse resolves to a snapped inode.
+        self.mount_a.run_shell(["dd", "if=/dev/urandom", "of=d0/sparse", "bs=1M",
+                                "seek=32", "count=1", "conv=notrunc"])
+        self.mount_a.run_shell(["touch", "-m", "-d", "2020-01-01 00:00:04 UTC",
+                                "d0/sparse"])
+        self.mount_a.run_shell(["mkdir", "d0/.snap/snap_c"])
+
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
+        self.peer_add(self.primary_fs_name, self.primary_fs_id,
+                      "client.mirror_remote@ceph", self.secondary_fs_name)
+
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               "client.mirror_remote@ceph", '/d0', 'snap_c', 3)
+        self.verify_snapshot('d0', 'snap_a')
+        self.verify_snapshot('d0', 'snap_b')
+        self.verify_snapshot('d0', 'snap_c')
+
+        self.remove_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_cephfs_mirror_blockdiff_untouched_after_snapshot(self):
+        """Test blockdiff for an object left untouched after the newer snapshot.
+
+        An object modified between the two compared snapshots and not written
+        again afterwards has no clone covering the newer snapshot, so the
+        newer end of the diff has to fall back to the "head" entry of the
+        clone list -- head is that object's content as of the newer snapshot.
+        Guards the fallback against being removed while fixing the older end.
+
+        The mtimes are pinned for the reason given in
+        test_cephfs_mirror_sparse_file_sync.
+        """
+        self.setup_mount_b(mds_perm='rw')
+        self.mount_a.run_shell(["mkdir", "d0"])
+
+        # 64MB dense file: every object exists in every snapshot below.
+        self.mount_a.run_shell(["dd", "if=/dev/urandom", "of=d0/dense", "bs=1M",
+                                "count=64"])
+        self.mount_a.run_shell(["touch", "-m", "-d", "2020-01-01 00:00:00 UTC",
+                                "d0/dense"])
+        self.mount_a.run_shell(["mkdir", "d0/.snap/snap_a"])
+
+        # object 0 changes between snap_a and snap_b ...
+        self.mount_a.run_shell(["dd", "if=/dev/urandom", "of=d0/dense", "bs=1M",
+                                "count=1", "conv=notrunc"])
+        self.mount_a.run_shell(["touch", "-m", "-d", "2020-01-01 00:00:02 UTC",
+                                "d0/dense"])
+        self.mount_a.run_shell(["mkdir", "d0/.snap/snap_b"])
+
+        # ... and object 8 -- not object 0 -- changes after snap_b, so the
+        # snap_a to snap_b diff must still report object 0.
+        self.mount_a.run_shell(["dd", "if=/dev/urandom", "of=d0/dense", "bs=1M",
+                                "seek=32", "count=1", "conv=notrunc"])
+        self.mount_a.run_shell(["touch", "-m", "-d", "2020-01-01 00:00:04 UTC",
+                                "d0/dense"])
+        self.mount_a.run_shell(["mkdir", "d0/.snap/snap_c"])
+
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
+        self.peer_add(self.primary_fs_name, self.primary_fs_id,
+                      "client.mirror_remote@ceph", self.secondary_fs_name)
+
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               "client.mirror_remote@ceph", '/d0', 'snap_c', 3)
+        self.verify_snapshot('d0', 'snap_a')
+        self.verify_snapshot('d0', 'snap_b')
+        self.verify_snapshot('d0', 'snap_c')
+
+        self.remove_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
     def test_cephfs_mirror_with_parent_snapshot(self):
         """Test snapshot synchronization with parent directory snapshots"""
         self.mount_a.run_shell(["mkdir", "-p", "d0/d1/d2/d3"])

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -1984,6 +1984,70 @@ class TestMirroring(CephFSTestCase):
         self.remove_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
 
+    def test_cephfs_mirror_sparse_file_sync(self):
+        """Test snapshot sync of a sparse file with hole (absent) objects.
+
+        A sparse file has objects that were never written.  LIST_SNAPS on
+        such an absent object fails at the request level with -ENOENT while
+        the per-op rval is 0 with an empty payload, and Objecter's per-op
+        decoder turns that into -EIO.  blockdiff used to fail the whole
+        incremental sync with -EIO instead of treating the object as a
+        hole; this test guards against regressions of that bug.
+
+        The mtime of each snapshot version of the file is pinned explicitly.
+        The snap diff the MDS computes for an incremental sync drops a file
+        whose two snapshot versions carry the same mtime, and the mtime it
+        compares is the one cached on its own inode, which lags behind the
+        client for as long as the writer still holds unflushed write caps --
+        so a write followed straight away by a snapshot can leave both
+        versions reporting the mtime from before the write (tracker #74984).
+        Leaving the mtimes to chance would make it a coin flip whether the
+        file reaches file_blockdiff() at all, which is what this test needs
+        to exercise.  Pinning an mtime is a setattr, so the MDS picks the
+        value up right away and it writes to no object -- the clone lists
+        the block diff is computed from are left undisturbed.
+        """
+        self.setup_mount_b(mds_perm='rw')
+        self.mount_a.run_shell(["mkdir", "d0"])
+
+        # 64MB sparse file with 1MB of data at offsets 0, 32MB and 60MB.
+        # All other objects (4MB each) are holes and do not exist on the OSD.
+        self.mount_a.run_shell(["truncate", "-s", "64M", "d0/sparse"])
+        self.mount_a.run_shell(["dd", "if=/dev/zero", "of=d0/sparse", "bs=1M",
+                                "count=1", "conv=notrunc"])
+        self.mount_a.run_shell(["dd", "if=/dev/zero", "of=d0/sparse", "bs=1M",
+                                "seek=32", "count=1", "conv=notrunc"])
+        self.mount_a.run_shell(["dd", "if=/dev/zero", "of=d0/sparse", "bs=1M",
+                                "seek=60", "count=1", "conv=notrunc"])
+        self.mount_a.run_shell(["touch", "-m", "-d", "2020-01-01 00:00:00 UTC",
+                                "d0/sparse"])
+
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
+        self.peer_add(self.primary_fs_name, self.primary_fs_id,
+                      "client.mirror_remote@ceph", self.secondary_fs_name)
+
+        # snapshot 1: full sync
+        self.mount_a.run_shell(["mkdir", "d0/.snap/snap_a"])
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               "client.mirror_remote@ceph", '/d0', 'snap_a', 1)
+        self.verify_snapshot('d0', 'snap_a')
+
+        # rewrite 1MB @ 32MB with different content, then snapshot again:
+        # the incremental sync must compute a blockdiff over the sparse
+        # file, which includes many hole objects.
+        self.mount_a.run_shell(["dd", "if=/dev/urandom", "of=d0/sparse", "bs=1M",
+                                "seek=32", "count=1", "conv=notrunc"])
+        self.mount_a.run_shell(["touch", "-m", "-d", "2020-01-01 00:00:02 UTC",
+                                "d0/sparse"])
+        self.mount_a.run_shell(["mkdir", "d0/.snap/snap_b"])
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               "client.mirror_remote@ceph", '/d0', 'snap_b', 2)
+        self.verify_snapshot('d0', 'snap_b')
+
+        self.remove_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
     def test_cephfs_mirror_with_parent_snapshot(self):
         """Test snapshot synchronization with parent directory snapshots"""
         self.mount_a.run_shell(["mkdir", "-p", "d0/d1/d2/d3"])

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -14748,35 +14748,59 @@ void MDCache::aggregate_snap_sets(const std::vector<std::unique_ptr<SnapSetConte
 
     if (snap_set->r == 0) {
       auto &clones = snap_set->snaps.clones;
-      auto it1 = std::find_if(clones.begin(), clones.end(),
-			      [snapid1](const librados::clone_info_t &clone)
-			      {
-				return snapid1 == clone.cloneid ||
-				  (std::find(clone.snaps.begin(), clone.snaps.end(), snapid1) != clone.snaps.end());
-			      });
+      if (clones.empty()) {
+	dout(10) << __func__ << ": no clones for objectid=" << snap_set->objectid << dendl;
+	continue;
+      }
+
+      auto find_clone = [&clones](snapid_t snapid) {
+	return std::find_if(clones.begin(), clones.end(),
+			    [snapid](const librados::clone_info_t &clone)
+			    {
+			      return snapid == clone.cloneid ||
+				(std::find(clone.snaps.begin(), clone.snaps.end(), snapid) != clone.snaps.end());
+			    });
+      };
+
+      auto it1 = find_clone(snapid1);
+      auto it2 = find_clone(snapid2);
+
+      interval_set<uint64_t> extent;
+      uint64_t offset = Striper::get_file_offset(g_ceph_context, &(in2->get_inode()->layout),
+						 snap_set->objectid, 0);
+
+      // No clone covers @snapid1 for one of two reasons: either the object
+      // was never written after @snapid1 -- in which case the newest version
+      // ("head") still holds the data as of @snapid1 -- or the object did not
+      // exist at @snapid1 at all. The clone list alone cannot tell the two
+      // apart since an object that does not exist has nothing to clone from.
+      // snapset.seq -- the seq of the SnapContext of the last write to this
+      // object -- disambiguates: had the object existed at @snapid1, a write
+      // after @snapid1 would have created a clone covering it. So a seq at or
+      // beyond @snapid1 with no matching clone means the object is new.
+      if (it1 == clones.end() && snap_set->snaps.seq >= snapid1) {
+	auto sz = it2 == clones.end() ? clones.back().size : it2->size;
+	dout(10) << __func__ << ": objectid=" << snap_set->objectid << " does not exist in snap "
+		 << snapid1 << " (seq=" << snap_set->snaps.seq << "): [" << offset << "~" << sz
+		 << "]" << dendl;
+	extents.union_insert(offset, sz);
+	dout(20) << __func__ << ": (modified) extents=" << extents << dendl;
+	continue;
+      }
+
       // point to "head" if not found
       if (it1 == clones.end()) {
-	it1 = std::prev(it1);
+	it1 = std::prev(clones.end());
       }
-      auto it2 = std::find_if(clones.begin(), clones.end(),
-			      [snapid2](const librados::clone_info_t &clone)
-			      {
-				return snapid2 == clone.cloneid ||
-				  (std::find(clone.snaps.begin(), clone.snaps.end(), snapid2) != clone.snaps.end());
-			      });
       // point to "head" if not found
       if (it2 == clones.end()) {
-	it2 = std::prev(it2);
+	it2 = std::prev(clones.end());
       }
 
       if (it1 == it2) {
 	dout(10) << __func__ << ": both snaps in same clone" << dendl;
 	continue;
       }
-
-      interval_set<uint64_t> extent;
-      uint64_t offset = Striper::get_file_offset(g_ceph_context, &(in2->get_inode()->layout),
-						 snap_set->objectid, 0);
 
       for (auto hops = std::distance(it1, it2); hops > 0; --hops) {
 	dout(20) << __func__ << ": [cloneid: " << it1->cloneid << " snaps: " << it1->snaps

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -14700,9 +14700,22 @@ void MDCache::file_blockdiff(CInode *in1, CInode *in2, BlockDiff *block_diff, ui
     op.list_snaps(&ssc->snaps, &ssc->r);
     ssc->objectid = scan_idx;
 
-    mds->objecter->read(file_object_t(in1->ino(), scan_idx),
-			OSDMap::file_to_object_locator(in2->get_inode()->layout),
-			op, LIBRADOS_SNAP_DIR, NULL, 0, gather_ctx.new_sub());
+    auto *ssc_ptr = ssc.get();
+    auto *sub = gather_ctx.new_sub();
+
+    mds->objecter->read(
+        file_object_t(in1->ino(), scan_idx),
+        OSDMap::file_to_object_locator(in2->get_inode()->layout),
+        op, LIBRADOS_SNAP_DIR, NULL, 0,
+        new LambdaContext([ssc_ptr, sub](int r) {
+          // LIST_SNAPS on an absent object can fail the request with -ENOENT
+          // while its empty per-op payload leaves the decoder reporting -EIO.
+          // Preserve the request-level error when the request itself failed.
+          if (r < 0) {
+            ssc_ptr->r = r;
+          }
+          sub->complete(r);
+        }));
     on_finish->add_snap_set_context(std::move(ssc));
     ++scan_idx;
     --scans;


### PR DESCRIPTION
Depends on #70780, which preserves request-level errors for absent objects
during blockdiff. The first commit is unchanged from that PR; only the
second commit is for review here.

Filling a hole in a sparse file between snapshots can cause file blockdiff
to omit the newly created object's extents. cephfs-mirror then reports a
successful incremental sync while leaving the corresponding remote region
zero-filled.

In aggregate_snap_sets(), an object with no clone covering the older
snapshot unconditionally falls back to head. For a newly created object,
this either makes both snapshot endpoints resolve to head or, if the object
is rewritten after the newer snapshot, places the older endpoint after the
newer one. Both cases omit the object from the diff.

Use snapset.seq to distinguish an object absent at the older snapshot from
one unchanged since that snapshot. If no clone covers the older snapshot
and snapset.seq >= snapid1, report the object's full extent using the newer
snapshot's size, or head's size when no matching clone exists. Preserve the
head fallback for unchanged objects and for newer snapshots whose data
still resides in head. Also skip empty clone lists.

## Tests

Add three cephfs-mirror regression tests covering:

- Hole filling with both endpoints resolving to head.
- Hole filling followed by another write after the newer snapshot.
- An object modified between snapshots but untouched afterward, protecting
  the newer-end head fallback.

Fixes: https://tracker.ceph.com/issues/79011
## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests
