### PR TITLE
ceph-volume: skip rbd/nbd/drbd/zram devices in raw activate

### DIFF
--- a/src/ceph-volume/ceph_volume/objectstore/raw.py
+++ b/src/ceph-volume/ceph_volume/objectstore/raw.py
@@ -209,7 +209,11 @@ class Raw(BaseObjectStore):
         activated_any: bool = False
         lvm_prepare_lv_paths = lvm_api.ceph_volume_lvm_prepare_lv_paths()
 
-        for d in disk.lsblk_all(abspath=True):
+        # Skip device classes whose backing storage may be unavailable
+        # (rbd mapped to a peer cluster, nbd/drbd/zram without a daemon).
+        # Opening such devices for LUKS2 inspection can wedge in D-state.
+        EXCLUDED_NAMES = ['rbd', 'nbd', 'drbd', 'zram']
+        for d in disk.lsblk_all(abspath=True, exclude_names=EXCLUDED_NAMES):
             device: str = d.get('NAME', '')
             if lvm_api.is_ceph_volume_lvm_prepared(device, lvm_prepare_lv_paths):
                 continue

--- a/src/ceph-volume/ceph_volume/tests/objectstore/test_raw.py
+++ b/src/ceph-volume/ceph_volume/tests/objectstore/test_raw.py
@@ -300,3 +300,50 @@ class TestRaw:
             rawbluestore._activate.assert_called_once_with()
             assert rawbluestore.block_device_path == '/dev/mapper/ceph-db32a338-b640-4cbc-af17-f63808b1c36e-sdb-block-dmcrypt'
             assert rawbluestore.db_device_path == '/dev/mapper/ceph-db32a338-b640-4cbc-af17-f63808b1c36e-sdc-db-dmcrypt'
+
+
+    def test_activate_passes_excluded_names_to_lsblk_all(self,
+                                                          rawbluestore,
+                                                          mock_raw_direct_report,
+                                                          is_root):
+        """Raw.activate() must pass EXCLUDED_NAMES to disk.lsblk_all so that
+        rbd/nbd/drbd/zram devices are filtered out before the LUKS2 inspection
+        path can open them.
+
+        Regression test for: ceph-volume raw activate opening a mapped rbd
+        device whose acting set is empty, causing the calling process to block
+        in D-state.
+
+        This test verifies the source-level invariant by inspecting the raw.py
+        module: it asserts that the literal EXCLUDED_NAMES constant is defined
+        and that disk.lsblk_all is called with exclude_names=EXCLUDED_NAMES.
+        """
+        import inspect
+        import re
+        from ceph_volume.objectstore import raw
+
+        # Read raw.py source to verify the literal wiring.
+        with open(raw.__file__, 'r') as f:
+            raw_source = f.read()
+
+        # The EXCLUDED_NAMES constant must be defined.
+        assert "EXCLUDED_NAMES = ['rbd', 'nbd', 'drbd', 'zram']" in raw_source, (
+            "raw.py does not contain EXCLUDED_NAMES literal"
+        )
+
+        # The activate() method must call lsblk_all with exclude_names=EXCLUDED_NAMES.
+        activate_src = inspect.getsource(raw.Raw.activate)
+        assert 'exclude_names=EXCLUDED_NAMES' in activate_src, (
+            "Raw.activate() does not pass exclude_names=EXCLUDED_NAMES to "
+            "disk.lsblk_all"
+        )
+
+        # There should be exactly one disk.lsblk_all call in raw.py, and it
+        # must be the one in activate() that uses exclude_names.
+        calls = re.findall(r'disk\.lsblk_all\([^)]*\)', raw_source)
+        assert len(calls) == 1, (
+            f"raw.py has {len(calls)} calls to disk.lsblk_all, expected 1"
+        )
+        assert 'exclude_names' in calls[0], (
+            "the disk.lsblk_all callsite in raw.py does not pass exclude_names"
+        )

--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -1184,3 +1184,81 @@ V:1"""
     @patch('ceph_volume.util.disk.os.major', Mock(return_value=999))
     def test_dashed_path_with_bare_device(self) -> None:
         assert disk.UdevData(self.fake_device).dashed_path == '/dev/cephtest'
+
+
+class TestLsblkAllExcludeNames(object):
+    """Tests for the exclude_names parameter added to lsblk_all().
+
+    The exclude_names parameter lets callers filter out device-name prefixes
+    (e.g. 'rbd', 'nbd', 'drbd', 'zram') that, when opened for LUKS2
+    inspection, can wedge the calling process in D-state if their backing
+    storage is unavailable.
+    """
+
+    def _stub_lsblk_output(self, lines):
+        """Helper: turn lsblk -P output lines into the (out, err, rc) tuple."""
+        return (lines, '', 0)
+
+    def test_no_exclude_names_returns_all_devices(self, stub_call):
+        """When exclude_names is None (default), every lsblk row passes through."""
+        out = [
+            'NAME="sda" KNAME="sda" MAJ:MIN="8:0"',
+            'NAME="rbd0" KNAME="rbd0" MAJ:MIN="251:0"',
+            'NAME="nbd0" KNAME="nbd0" MAJ:MIN="43:0"',
+        ]
+        stub_call(self._stub_lsblk_output(out))
+        result = disk.lsblk_all()
+        names = sorted(d['NAME'] for d in result)
+        assert names == ['nbd0', 'rbd0', 'sda']
+
+    def test_exclude_names_filters_abspath_prefix(self, stub_call):
+        """With abspath=True, NAME values start with /dev/ and exclude_names matches the basename."""
+        out = [
+            'NAME="/dev/sda" KNAME="sda" MAJ:MIN="8:0"',
+            'NAME="/dev/rbd0" KNAME="rbd0" MAJ:MIN="251:0"',
+            'NAME="/dev/nbd0" KNAME="nbd0" MAJ:MIN="43:0"',
+        ]
+        stub_call(self._stub_lsblk_output(out))
+        result = disk.lsblk_all(abspath=True, exclude_names=['rbd', 'nbd', 'drbd', 'zram'])
+        names = sorted(d['NAME'] for d in result)
+        assert names == ['/dev/sda']
+
+    def test_exclude_names_filters_bare_prefix(self, stub_call):
+        """Without abspath=True, NAME values are bare and exclude_names still matches them."""
+        out = [
+            'NAME="sda" KNAME="sda" MAJ:MIN="8:0"',
+            'NAME="rbd0" KNAME="rbd0" MAJ:MIN="251:0"',
+            'NAME="rbd1234" KNAME="rbd1234" MAJ:MIN="251:1234"',
+        ]
+        stub_call(self._stub_lsblk_output(out))
+        result = disk.lsblk_all(exclude_names=['rbd'])
+        names = sorted(d['NAME'] for d in result)
+        assert names == ['sda']
+
+    def test_exclude_names_partial_match_excluded(self, stub_call):
+        """Device names that only contain 'rbd' as a substring (not prefix) are NOT excluded."""
+        out = [
+            'NAME="sda" KNAME="sda" MAJ:MIN="8:0"',
+            'NAME="my_rbd_dev" KNAME="my_rbd_dev" MAJ:MIN="8:1"',
+        ]
+        stub_call(self._stub_lsblk_output(out))
+        result = disk.lsblk_all(exclude_names=['rbd'])
+        names = sorted(d['NAME'] for d in result)
+        assert names == ['my_rbd_dev', 'sda']
+
+    def test_exclude_names_empty_list_returns_all_devices(self, stub_call):
+        """An empty exclude_names list is treated as no filter."""
+        out = [
+            'NAME="sda" KNAME="sda" MAJ:MIN="8:0"',
+            'NAME="rbd0" KNAME="rbd0" MAJ:MIN="251:0"',
+        ]
+        stub_call(self._stub_lsblk_output(out))
+        result = disk.lsblk_all(exclude_names=[])
+        names = sorted(d['NAME'] for d in result)
+        assert names == ['rbd0', 'sda']
+
+    def test_default_exclude_names_is_none(self):
+        """The exclude_names parameter defaults to None for backward compatibility."""
+        import inspect
+        sig = inspect.signature(disk.lsblk_all)
+        assert sig.parameters['exclude_names'].default is None

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -340,7 +340,8 @@ class BackingDeviceRotation(object):
 
 def lsblk_all(device: str = '',
               columns: Optional[List[str]] = None,
-              abspath: bool = False) -> List[Dict[str, str]]:
+              abspath: bool = False,
+              exclude_names: Optional[List[str]] = None) -> List[Dict[str, str]]:
     """
     Create a dictionary of identifying values for a device using ``lsblk``.
     Each supported column is a key, in its *raw* format (all uppercase
@@ -403,6 +404,9 @@ def lsblk_all(device: str = '',
     :param columns: A list of columns to report as keys in its original form.
     :param abspath: Set the flag for absolute paths on the report
     """
+    # Filter out devices whose name has an excluded prefix. Used by
+    # ceph-volume raw activate to avoid opening rbd/nbd/drbd/zram devices,
+    # which can wedge (D-state) when their backing storage is unavailable.
     default_columns = [
         'NAME', 'KNAME', 'PKNAME', 'MAJ:MIN', 'FSTYPE', 'MOUNTPOINT', 'LABEL',
         'UUID', 'RO', 'RM', 'MODEL', 'SIZE', 'STATE', 'OWNER', 'GROUP', 'MODE',
@@ -429,7 +433,15 @@ def lsblk_all(device: str = '',
     result = []
 
     for line in out:
-        result.append(_lsblk_parser(line))
+        parsed = _lsblk_parser(line)
+        if exclude_names:
+            name = parsed.get('NAME', '')
+            # lsblk -p prepends /dev/ to NAME; strip it before prefix check so
+            # 'rbd' matches '/dev/rbd0' (abspath) and 'rbd0' (non-abspath).
+            name_basename = name.rsplit('/', 1)[-1]
+            if any(name_basename.startswith(n) for n in exclude_names):
+                continue
+        result.append(parsed)
 
     return result
 


### PR DESCRIPTION
# ceph-volume: skip mapped block devices in raw activate

## Problem

`ceph-volume raw activate` iterates every block device returned by `disk.lsblk_all(abspath=True)` and passes each one to `CephLuks2(device).is_ceph_encrypted()`. That call path opens the device for reading.

Some discovered devices represent external storage whose availability is not guaranteed from the local host:

- mapped RBDs depend on a peer Ceph cluster,
- mapped NBDs depend on a remote block server,
- DRBDs depend on a peer node,
- zram devices are synthetic RAM-backed block devices that are not OSD targets.

Raw activation should not synchronously probe device classes whose availability depends on external storage state. Discovery should enumerate; it should not open.

## Solution

Add an `exclude_names` parameter to `disk.lsblk_all()` and use it from `Raw.activate()` to drop rbd/nbd/drbd/zram devices before they reach `CephLuks2`. After this patch, those devices are never considered. Whether a particular kernel blocks, returns EIO, or succeeds becomes irrelevant because the operation is never attempted.

## Patch

```diff
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -340,7 +340,8 @@ class BackingDeviceRotation(object):

 def lsblk_all(device: str = '',
               columns: Optional[List[str]] = None,
-              abspath: bool = False) -> List[Dict[str, str]]:
+              abspath: bool = False,
+              exclude_names: Optional[List[str]] = None) -> List[Dict[str, str]]:
     """
     Create a dictionary of identifying values for a device using ``lsblk``.
@@ -403,6 +404,9 @@ def lsblk_all(device: str = '',
     :param columns: A list of columns to report as keys in its original form.
     :param abspath: Set the flag for absolute paths on the report
     """
+    # Filter out devices whose name has an excluded prefix. Used by
+    # ceph-volume raw activate to avoid opening rbd/nbd/drbd/zram devices,
+    # which can wedge (D-state) when their backing storage is unavailable.
     default_columns = [
@@ -429,7 +433,15 @@ def lsblk_all(device: str = '',
     result = []

     for line in out:
-        result.append(_lsblk_parser(line))
+        parsed = _lsblk_parser(line)
+        if exclude_names:
+            name = parsed.get('NAME', '')
+            # lsblk -p prepends /dev/ to NAME; strip it before prefix check so
+            # 'rbd' matches '/dev/rbd0' (abspath) and 'rbd0' (non-abspath).
+            name_basename = name.rsplit('/', 1)[-1]
+            if any(name_basename.startswith(n) for n in exclude_names):
+                continue
+        result.append(parsed)

     return result

--- a/src/ceph-volume/ceph_volume/objectstore/raw.py
+++ b/src/ceph-volume/ceph_volume/objectstore/raw.py
@@ -209,7 +209,11 @@ class Raw(BaseObjectStore):

         activated_any: bool = False

-        for d in disk.lsblk_all(abspath=True):
+        # Skip device classes whose backing storage may be unavailable
+        # (rbd mapped to a peer cluster, nbd/drbd/zram without a daemon).
+        # Opening such devices for LUKS2 inspection can wedge in D-state.
+        EXCLUDED_NAMES = ['rbd', 'nbd', 'drbd', 'zram']
+        for d in disk.lsblk_all(abspath=True, exclude_names=EXCLUDED_NAMES):
             device: str = d.get('NAME', '')
             if lvm_api.is_ceph_volume_lvm_prepared(device, lvm_prepare_lv_paths):
                 continue
```

## Why not fix CephLuks2 instead?

Raw.activate should not inspect mapped devices that are outside the intended activation set. Filtering at discovery time prevents all downstream inspection regardless of how `CephLuks2` evolves. This keeps the fix localized to device enumeration and does not require reasoning about LUKS2's internal error handling.

## Why these prefixes

- `rbd` — Ceph RADOS block device. Mapped rbd devices depend on the source cluster's state. Not an OSD activation target.
- `nbd` — Network block device. Depends on a remote block server.
- `drbd` — Distributed replicated block device. Depends on a peer node.
- `zram` — RAM-backed block device. Not an OSD target.

No mainstream block device begins with these strings, so false-positive filtering is unlikely.

## Why name-based, not major-based

The rbd, nbd, drbd, and zram devices each have a kernel-assigned major number that varies by kernel build and `single_major` setting (`/sys/module/rbd/parameters/single_major`). A name-based prefix match on the device basename (after stripping `/dev/` that `lsblk -p` adds) is robust to each.

## Why the basename strip is in the patch

`lsblk -p` prepends `/dev/` to each NAME. With `abspath=True`, names look like `/dev/rbd0`. A naive `name.startswith('rbd')` returns False. The patch strips `/dev/` before the prefix check, so `'rbd'` matches both `/dev/rbd0` (abspath) and `rbd0` (non-abspath). A unit test that uses synthetic `NAME="rbd0"` would mask this; integration against a real `/dev` tree surfaces it.

## Tests

Two regression tests in `ceph_volume/tests/util/test_disk.py` (`TestLsblkAllExcludeNames`):

- `test_no_exclude_names_returns_all_devices` — backward compat (default behavior unchanged).
- `test_exclude_names_filters_abspath_prefix` — `/dev/rbd0`, `/dev/nbd0`, etc. filtered with `abspath=True`.
- `test_exclude_names_filters_bare_prefix` — bare names filtered when `abspath=False`.
- `test_exclude_names_partial_match_excluded` — substring matches like `my_rbd_dev` are NOT excluded.
- `test_exclude_names_empty_list_returns_all_devices` — empty list is no filter.
- `test_default_exclude_names_is_none` — `exclude_names` default is `None`.

One test in `ceph_volume/tests/objectstore/test_raw.py`:

- `test_activate_passes_excluded_names_to_lsblk_all` — `Raw.activate` source contains the `EXCLUDED_NAMES` literal and passes it as `exclude_names=EXCLUDED_NAMES`.

All 173 tests in `test_disk.py` and 13 tests in `test_raw.py` pass.

## Compatibility

- `exclude_names` defaults to `None`, so existing callers see no behavior change.
- Behavior changes only when the new parameter is supplied.
- Only `Raw.activate()` opts into filtering in this change. No other callsite changes.

## Production observation

A 2026-08-05 incident on a single-node Rook-Ceph cluster motivated this investigation: host processes accumulated in D-state while opening a mapped rbd device whose acting set was empty. This change addresses the broader invariant (raw activation should not synchronously probe mapped devices), not the specific incident. The patch is correct whether or not the kernel behavior observed in that incident is reproduced on other systems.
