### PR TITLE
doc: Add complete service specification parameter reference for MON service

### DIFF
--- a/doc/cephadm/services/mon.rst
+++ b/doc/cephadm/services/mon.rst
@@ -38,9 +38,9 @@ the placement of daemons.
 Service Specification
 =====================
 
-A MON service can be deployed or updated using a YAML service specification
+The Monitor service can be deployed or updated via a YAML specification
 file with ``ceph orch apply -i``. The following is a complete example
-showing all available parameters:
+showing all parameters available as of August 2026:
 
 .. code-block:: yaml
 
@@ -92,16 +92,16 @@ showing all available parameters:
 Top-level Parameters
 --------------------
 
-The following parameters are available at the top level of the MON service
+The following parameters are available at the top level of the Monitor service
 specification:
 
 ``service_type``
     **Required.** Must be ``mon``.
 
 ``placement``
-    Specifies where and how many monitor daemons to deploy. See
+    Specifies where and how many Monitor daemons to deploy. See
     `Placement Parameters`_ below for available sub-fields. If omitted,
-    cephadm uses its default placement strategy (up to 5 monitors).
+    cephadm uses its default placement strategy (up to 5 Monitors).
 
 ``config``
     A mapping of Ceph configuration option names to values. These are
@@ -116,7 +116,7 @@ specification:
 
 ``unmanaged``
     Boolean (default: ``false``). When ``true``, cephadm will not
-    automatically deploy, remove, or reconfig monitor daemons. Daemons
+    automatically deploy, remove, or reconfig Monitor daemons. Daemons
     must be manually added with ``ceph orch daemon add mon``.
 
 ``preview_only``
@@ -125,7 +125,7 @@ specification:
 
 ``networks``
     A list of IP networks in CIDR notation (e.g., ``10.1.2.0/24``) to
-    which monitor daemons should bind. If specified, monitors will only
+    which Monitor daemons should bind. If specified, Monitors will only
     be deployed on hosts with IP addresses matching one of the listed
     networks.
 
@@ -137,7 +137,7 @@ specification:
 
 ``extra_container_args``
     A list of additional arguments passed to the container runtime
-    (podman/docker) when starting the monitor container. Each entry can
+    (podman/docker) when starting the Monitor container. Each entry can
     be a plain string or an object with ``argument`` and ``split`` fields.
 
     .. code-block:: yaml
@@ -148,7 +148,7 @@ specification:
             split: false
 
 ``extra_entrypoint_args``
-    A list of additional arguments appended to the monitor daemon's
+    A list of additional arguments appended to the Monitor daemon's
     entrypoint command. Each entry can be a plain string or an object with
     ``argument`` and ``split`` fields.
 
@@ -158,7 +158,7 @@ specification:
           - "--mon-data=/var/lib/ceph/mon"
 
 ``custom_configs``
-    A list of custom configuration files to mount inside the monitor
+    A list of custom configuration files to mount inside the Monitor
     container. Each entry has ``mount_path`` (the path inside the
     container) and ``content`` (the file contents).
 
@@ -173,11 +173,12 @@ specification:
 Placement Parameters
 --------------------
 
-The ``placement`` section controls which hosts monitors are deployed on and
-how many. The following sub-fields are available:
+The ``placement`` section specifies the number of Monitors to deploy and
+the hosts on which they may be placed. The following sub-fields are
+available:
 
 ``hosts``
-    A list of hostnames where monitors should be deployed. Each entry can
+    A list of hostnames where Monitors should be deployed. Each entry can
     be a simple hostname or an extended format with network and name:
 
     - ``hostname`` — deploy on this host
@@ -194,7 +195,7 @@ how many. The following sub-fields are available:
             - host3=custom-name
 
 ``count``
-    Integer (>= 1). The total number of monitor daemons to deploy.
+    Integer (>= 1). The total number of Monitor daemons to deploy.
     Cephadm will choose hosts automatically if ``hosts`` is not specified.
     Mutually exclusive with ``count_per_host``.
 
@@ -204,8 +205,8 @@ how many. The following sub-fields are available:
     Mutually exclusive with ``count``.
 
 ``label``
-    A host label string. Monitors will be deployed on all hosts that
-    have this label assigned. Mutually exclusive with ``hosts``.
+    A host label string. Monitor daemons will be deployed on all hosts
+    that have this label assigned. Mutually exclusive with ``hosts``.
 
     .. code-block:: yaml
 
@@ -213,9 +214,10 @@ how many. The following sub-fields are available:
           label: mon
 
 ``host_pattern``
-    An fnmatch-style pattern or regex to select hosts by name.
-    Mutually exclusive with ``hosts``. Can be a string (fnmatch) or
-    an object with ``pattern`` and ``pattern_type`` fields:
+    An `fnmatch <https://docs.python.org/3/library/fnmatch.html>`_-style
+    pattern or regex to select hosts by name. Mutually exclusive with
+    ``hosts``. Can be a string (fnmatch) or an object with ``pattern``
+    and ``pattern_type`` fields:
 
     .. code-block:: yaml
 
@@ -229,10 +231,10 @@ how many. The following sub-fields are available:
             pattern: "mon[0-9]+"
             pattern_type: regex
 
-MON-Specific Parameters (``spec`` section)
-------------------------------------------
+``mon``-Specific Parameters (``spec`` section)
+-----------------------------------------------
 
-The following parameters are specific to the MON service and are placed
+The following parameters are specific to the ``mon`` service and are placed
 under the ``spec:`` section:
 
 ``crush_locations``
@@ -260,20 +262,21 @@ under the ``spec:`` section:
     .. note::
 
        Setting the CRUSH location in the spec is the recommended way of
-       replacing tiebreaker mon daemons, as they require having a location
-       set when they are added.
+       replacing tiebreaker Monitor daemons, as they require having a
+       location set when they are added. Tiebreaker Monitors are only
+       relevant for stretch mode clusters; see :ref:`stretch_mode`.
 
     .. note::
 
-       Mon daemons will only get the ``--set-crush-location`` flag set
-       when cephadm actually deploys them. If a spec is applied that
-       includes a CRUSH location for a mon that is already deployed, the
-       flag may not be set until a redeploy command is issued.
+       Monitor daemons will only get the ``--set-crush-location`` flag
+       set when cephadm actually deploys them. If a spec is applied that
+       includes a CRUSH location for a Monitor that is already deployed,
+       the flag may not be set until a ``redeploy`` command is issued.
 
 Complete Minimal Examples
 -------------------------
 
-Deploy 5 monitors on labeled hosts:
+Deploy 5 Monitors on labeled hosts:
 
 .. code-block:: yaml
 
@@ -282,7 +285,7 @@ Deploy 5 monitors on labeled hosts:
       count: 5
       label: mon
 
-Deploy monitors on specific hosts with network binding:
+Deploy Monitors on specific hosts with network binding:
 
 .. code-block:: yaml
 
@@ -295,7 +298,7 @@ Deploy monitors on specific hosts with network binding:
     networks:
     - 10.1.2.0/24
 
-Deploy monitors with CRUSH locations for stretch mode:
+Deploy Monitors with CRUSH locations for stretch mode:
 
 .. code-block:: yaml
 

--- a/doc/cephadm/services/mon.rst
+++ b/doc/cephadm/services/mon.rst
@@ -32,6 +32,290 @@ By default, cephadm will deploy 5 daemons on arbitrary hosts. See
 :ref:`orchestrator-cli-placement-spec` for details of specifying
 the placement of daemons.
 
+
+.. _mon-service-spec:
+
+Service Specification
+=====================
+
+A MON service can be deployed or updated using a YAML service specification
+file with ``ceph orch apply -i``. The following is a complete example
+showing all available parameters:
+
+.. code-block:: yaml
+
+    service_type: mon
+    placement:
+      hosts:
+        - host1
+        - host2
+        - host3
+      count: 5
+      label: mon
+      host_pattern: "mon*"
+      count_per_host: 1
+    config:
+      mon_warn_on_pool_no_redundancy: "false"
+    unmanaged: false
+    preview_only: false
+    networks:
+    - 10.1.2.0/24
+    extra_container_args:
+      - "--cpus=2"
+    extra_entrypoint_args:
+      - "--mon-data=/var/lib/ceph/mon"
+    custom_configs:
+      - mount_path: /etc/custom/mon.conf
+        content: |
+          [custom]
+          setting = value
+    spec:
+      crush_locations:
+        host1:
+          - datacenter=a
+        host2:
+          - datacenter=b
+          - rack=2
+        host3:
+          - datacenter=a
+
+.. note::
+
+   The ``placement`` fields (``hosts``, ``label``, ``host_pattern``,
+   ``count``, ``count_per_host``) are mutually exclusive in certain
+   combinations. See :ref:`orchestrator-cli-placement-spec` for details.
+
+.. note::
+
+   The ``mon`` service type does **not** use a ``service_id``.
+
+Top-level Parameters
+--------------------
+
+The following parameters are available at the top level of the MON service
+specification:
+
+``service_type``
+    **Required.** Must be ``mon``.
+
+``placement``
+    Specifies where and how many monitor daemons to deploy. See
+    `Placement Parameters`_ below for available sub-fields. If omitted,
+    cephadm uses its default placement strategy (up to 5 monitors).
+
+``config``
+    A mapping of Ceph configuration option names to values. These are
+    applied via ``ceph config set mon <key> <value>`` when the spec is
+    applied. Example:
+
+    .. code-block:: yaml
+
+        config:
+          mon_warn_on_pool_no_redundancy: "false"
+          mon_osd_full_ratio: "0.95"
+
+``unmanaged``
+    Boolean (default: ``false``). When ``true``, cephadm will not
+    automatically deploy, remove, or reconfig monitor daemons. Daemons
+    must be manually added with ``ceph orch daemon add mon``.
+
+``preview_only``
+    Boolean (default: ``false``). When ``true``, changes are previewed
+    but not applied.
+
+``networks``
+    A list of IP networks in CIDR notation (e.g., ``10.1.2.0/24``) to
+    which monitor daemons should bind. If specified, monitors will only
+    be deployed on hosts with IP addresses matching one of the listed
+    networks.
+
+    .. code-block:: yaml
+
+        networks:
+        - 10.1.2.0/24
+        - 192.168.1.0/24
+
+``extra_container_args``
+    A list of additional arguments passed to the container runtime
+    (podman/docker) when starting the monitor container. Each entry can
+    be a plain string or an object with ``argument`` and ``split`` fields.
+
+    .. code-block:: yaml
+
+        extra_container_args:
+          - "--cpus=2"
+          - argument: "--memory=4g"
+            split: false
+
+``extra_entrypoint_args``
+    A list of additional arguments appended to the monitor daemon's
+    entrypoint command. Each entry can be a plain string or an object with
+    ``argument`` and ``split`` fields.
+
+    .. code-block:: yaml
+
+        extra_entrypoint_args:
+          - "--mon-data=/var/lib/ceph/mon"
+
+``custom_configs``
+    A list of custom configuration files to mount inside the monitor
+    container. Each entry has ``mount_path`` (the path inside the
+    container) and ``content`` (the file contents).
+
+    .. code-block:: yaml
+
+        custom_configs:
+          - mount_path: /etc/custom/mon.conf
+            content: |
+              [custom]
+              setting = value
+
+Placement Parameters
+--------------------
+
+The ``placement`` section controls which hosts monitors are deployed on and
+how many. The following sub-fields are available:
+
+``hosts``
+    A list of hostnames where monitors should be deployed. Each entry can
+    be a simple hostname or an extended format with network and name:
+
+    - ``hostname`` — deploy on this host
+    - ``hostname:network`` — deploy on this host, binding to the specified
+      IP or network
+    - ``hostname=name`` — deploy with a custom daemon name suffix
+
+    .. code-block:: yaml
+
+        placement:
+          hosts:
+            - host1
+            - host2:10.1.2.0/24
+            - host3=custom-name
+
+``count``
+    Integer (>= 1). The total number of monitor daemons to deploy.
+    Cephadm will choose hosts automatically if ``hosts`` is not specified.
+    Mutually exclusive with ``count_per_host``.
+
+``count_per_host``
+    Integer (>= 1). Number of daemons to deploy per matching host.
+    Requires ``label``, ``hosts``, or ``host_pattern`` to be set.
+    Mutually exclusive with ``count``.
+
+``label``
+    A host label string. Monitors will be deployed on all hosts that
+    have this label assigned. Mutually exclusive with ``hosts``.
+
+    .. code-block:: yaml
+
+        placement:
+          label: mon
+
+``host_pattern``
+    An fnmatch-style pattern or regex to select hosts by name.
+    Mutually exclusive with ``hosts``. Can be a string (fnmatch) or
+    an object with ``pattern`` and ``pattern_type`` fields:
+
+    .. code-block:: yaml
+
+        # fnmatch pattern (default)
+        placement:
+          host_pattern: "mon*"
+
+        # regex pattern
+        placement:
+          host_pattern:
+            pattern: "mon[0-9]+"
+            pattern_type: regex
+
+MON-Specific Parameters (``spec`` section)
+------------------------------------------
+
+The following parameters are specific to the MON service and are placed
+under the ``spec:`` section:
+
+``crush_locations``
+    A mapping of hostnames to lists of CRUSH location strings. Each
+    CRUSH location must be in the format ``<bucket_type>=<location>``
+    (e.g., ``datacenter=dc1``, ``rack=rack2``).
+
+    When cephadm deploys a monitor on a host listed here, it sets the
+    CRUSH location via ``--set-crush-location``. If multiple CRUSH
+    locations are specified for a host, the first is used at deploy time
+    and additional locations are applied via ``ceph mon set_location``.
+
+    .. code-block:: yaml
+
+        spec:
+          crush_locations:
+            host1:
+              - datacenter=a
+            host2:
+              - datacenter=b
+              - rack=2
+            host3:
+              - datacenter=a
+
+    .. note::
+
+       Setting the CRUSH location in the spec is the recommended way of
+       replacing tiebreaker mon daemons, as they require having a location
+       set when they are added.
+
+    .. note::
+
+       Mon daemons will only get the ``--set-crush-location`` flag set
+       when cephadm actually deploys them. If a spec is applied that
+       includes a CRUSH location for a mon that is already deployed, the
+       flag may not be set until a redeploy command is issued.
+
+Complete Minimal Examples
+-------------------------
+
+Deploy 5 monitors on labeled hosts:
+
+.. code-block:: yaml
+
+    service_type: mon
+    placement:
+      count: 5
+      label: mon
+
+Deploy monitors on specific hosts with network binding:
+
+.. code-block:: yaml
+
+    service_type: mon
+    placement:
+      hosts:
+        - host1:10.1.2.0/24
+        - host2:10.1.2.0/24
+        - host3:10.1.2.0/24
+    networks:
+    - 10.1.2.0/24
+
+Deploy monitors with CRUSH locations for stretch mode:
+
+.. code-block:: yaml
+
+    service_type: mon
+    placement:
+      count: 5
+    spec:
+      crush_locations:
+        host1:
+          - datacenter=a
+        host2:
+          - datacenter=a
+        host3:
+          - datacenter=b
+        host4:
+          - datacenter=b
+        host5:
+          - datacenter=c
+
+
 Designating a Particular Subnet for Monitors
 --------------------------------------------
 
@@ -184,13 +468,16 @@ host. If multiple CRUSH locations are set for one host, cephadm
 will attempt to set the additional locations using the
 "ceph mon set_location" command.
 
+See the ``crush_locations`` parameter in :ref:`mon-service-spec` for the
+full specification reference.
+
 .. note::
 
    Setting the CRUSH location in the spec is the recommended way of
    replacing tiebreaker mon daemons, as they require having a location
    set when they are added.
 
- .. note::
+.. note::
 
    Tiebreaker mon daemons are a part of stretch mode clusters. For more
    info on stretch mode clusters see :ref:`stretch_mode`


### PR DESCRIPTION
**Summary**

Adds a complete parameter reference for the MON service specification in doc/cephadm/services/mon.rst, documenting all supported fields (top-level, placement, and spec-specific) with validated YAML examples.

Currently implemented for MON only. The same approach can be extended to:
MGR, MDS, Monitoring, Tracing, SNMP Gateway, and Custom Container services.

Fixes: https://tracker.ceph.com/issues/79153
Signed-off-by: Shubha Jain [SHUBHA.JAIN1@ibm.com]

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [X] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
