### PR TITLE
mon: add dispatch thread watchdog

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,10 @@
+* RADOS: Monitors now arm a dispatch-thread watchdog while processing
+  messenger dispatch work. If the dispatch path stops making progress for
+  longer than ``mon_dispatch_watchdog_timeout``, the monitor aborts through
+  the existing heartbeat suicide path so service management can restart it.
+  The ``mon_inject_dispatch_delay`` developer option is available for
+  fault-injection testing of this watchdog.
+
 * CephFS: The ``client_force_lazyio`` configuration option is now correctly marked
   as not supporting runtime updates. Previously, the configuration schema indicated
   this option could be changed at runtime, but changes had no effect on opened file

--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -439,6 +439,18 @@ provides reasonable default settings for Monitor/OSD interaction; however,  you
 may modify them as needed. See `Monitor/OSD Interaction`_ for details.
 
 
+Monitor dispatch watchdog
+-------------------------
+
+Ceph Monitors can use an internal heartbeat watchdog to detect when the
+messenger dispatch path stops making progress. If the dispatch path remains
+stalled for longer than the configured timeout, the Monitor aborts through the
+existing heartbeat suicide path so that service management can restart it.
+
+.. confval:: mon_dispatch_watchdog_timeout
+.. confval:: mon_inject_dispatch_delay
+
+
 .. index:: Ceph Monitor; leader, Ceph Monitor; provider, Ceph Monitor; requester, Ceph Monitor; synchronization
 
 Monitor Store Synchronization

--- a/qa/standalone/mon/mon-dispatch-watchdog.sh
+++ b/qa/standalone/mon/mon-dispatch-watchdog.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# Validate that the monitor dispatch watchdog aborts a monitor whose messenger
+# dispatch thread stops making progress after the watchdog has been armed.
+
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+function run() {
+    local dir=$1
+    shift
+
+    export CEPH_MON="127.0.0.1:7213" # git grep '\<7213\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON "
+
+    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        setup $dir || return 1
+        if ! $func $dir ; then
+            teardown $dir 1
+            return 1
+        fi
+        teardown $dir || return 1
+    done
+}
+
+function wait_for_log() {
+    local logfile=$1
+    local pattern=$2
+    local timeout=${3:-30}
+
+    for ((i=0; i < timeout; i++)); do
+        if grep -q "$pattern" "$logfile" 2>/dev/null ; then
+            return 0
+        fi
+        sleep 1
+    done
+
+    echo "timed out waiting for '$pattern' in $logfile"
+    tail -n 80 "$logfile" || true
+    return 1
+}
+
+function wait_for_pid_exit() {
+    local pidfile=$1
+    local timeout=${2:-30}
+    local pid
+
+    test -s "$pidfile" || {
+        echo "missing pid file: $pidfile"
+        return 1
+    }
+    pid=$(cat "$pidfile")
+
+    for ((i=0; i < timeout; i++)); do
+        if ! kill -0 "$pid" 2>/dev/null ; then
+            return 0
+        fi
+        sleep 1
+    done
+
+    echo "process $pid from $pidfile did not exit"
+    return 1
+}
+
+function TEST_mon_dispatch_watchdog_aborts_stalled_dispatch() {
+    local dir=$1
+    local mon_log="$dir/mon.a.log"
+    local mon_pidfile="$dir/mon.a.pid"
+
+    # This test expects ceph-mon to abort. Avoid turning the expected abort into
+    # a standalone failure caused only by a generated core file.
+    ulimit -c 0 || true
+
+    run_mon $dir a \
+        --heartbeat-interval=1 \
+        --mon-dispatch-watchdog-timeout=2 || return 1
+
+    ceph ping mon.a || return 1
+    ceph tell mon.a injectargs -- --mon-inject-dispatch-delay=10 || return 1
+
+    if timeout 12 ceph ping mon.a ; then
+        echo "ceph ping unexpectedly succeeded while dispatch delay was injected"
+        return 1
+    fi
+
+    wait_for_log "$mon_log" "injecting monitor dispatch delay" 15 || return 1
+    wait_for_log "$mon_log" "had suicide timed out" 15 || return 1
+    wait_for_pid_exit "$mon_pidfile" 15 || return 1
+}
+
+main mon-dispatch-watchdog "$@"

--- a/src/common/HeartbeatMap.cc
+++ b/src/common/HeartbeatMap.cc
@@ -169,8 +169,12 @@ int HeartbeatMap::get_total_workers() const
 
 void HeartbeatMap::check_touch_file()
 {
+  if (!is_healthy()) {
+    return;
+  }
+
   string path = m_cct->_conf->heartbeat_file;
-  if (path.length() && is_healthy()) {
+  if (path.length()) {
     int fd = ::open(path.c_str(), O_WRONLY|O_CREAT|O_CLOEXEC, 0644);
     if (fd >= 0) {
       ::utime(path.c_str(), NULL);

--- a/src/common/HeartbeatMap.h
+++ b/src/common/HeartbeatMap.h
@@ -70,7 +70,7 @@ class HeartbeatMap {
   // return false if any of the timeouts are currently expired.
   bool is_healthy();
 
-  // touch cct->_conf->heartbeat_file if is_healthy()
+  // check registered workers and touch cct->_conf->heartbeat_file if healthy
   void check_touch_file();
 
   // get the number of unhealthy workers

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -456,6 +456,25 @@ options:
   services:
   - mon
   with_legacy: true
+- name: mon_dispatch_watchdog_timeout
+  type: float
+  level: advanced
+  desc: Maximum time for monitor dispatch to make progress before aborting
+  long_desc: If positive, a monitor arms an internal heartbeat watchdog while
+    processing dispatch work. If the dispatch path stops making progress for
+    longer than this timeout, the monitor aborts through the existing heartbeat
+    suicide path so service management can restart it.
+  fmt_desc: The maximum time in seconds that a monitor dispatch operation may run
+    without making heartbeat progress before the monitor aborts. Set to ``0`` to
+    disable the dispatch watchdog.
+  default: 30
+  services:
+  - mon
+  see_also:
+  - mon_lease
+  - mon_session_timeout
+  min: 0
+  with_legacy: true
 - name: mon_lease_renew_interval_factor
   type: float
   level: advanced

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -475,6 +475,19 @@ options:
   - mon_session_timeout
   min: 0
   with_legacy: true
+- name: mon_inject_dispatch_delay
+  type: float
+  level: dev
+  desc: Inject a delay after arming the monitor dispatch watchdog
+  long_desc: If positive, the monitor sleeps for this many seconds after arming
+    the dispatch watchdog and before acquiring Monitor::lock in ms_dispatch().
+    This is intended for testing that the dispatch watchdog can abort a monitor
+    whose dispatch thread stops making progress.
+  default: 0
+  services:
+  - mon
+  min: 0
+  with_legacy: true
 - name: mon_lease_renew_interval_factor
   type: float
   level: advanced

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -75,6 +75,7 @@
 #include "common/ceph_argparse.h"
 #include "common/Timer.h"
 #include "common/Clock.h"
+#include "common/HeartbeatMap.h"
 #include "common/errno.h"
 #include "common/perf_counters.h"
 #include "common/admin_socket.h"
@@ -335,6 +336,7 @@ Monitor::Monitor(CephContext* cct_, string nm, MonitorDBStore *s,
 
 Monitor::~Monitor()
 {
+  dispatch_watchdog_shutdown();
   op_tracker.on_shutdown();
   delete logger;
   ceph_assert(session_map.sessions.empty());
@@ -1203,6 +1205,7 @@ void Monitor::shutdown()
   }
 
   state = STATE_SHUTDOWN;
+  dispatch_watchdog_shutdown();
 
   lock.unlock();
   g_conf().remove_observer(this);
@@ -4657,6 +4660,84 @@ void Monitor::waitlist_or_zap_client(MonOpRequestRef op)
     }
     op->mark_zap();
   }
+}
+
+void Monitor::dispatch_watchdog_start()
+{
+  std::lock_guard l(dispatch_watchdog_lock);
+
+  if (dispatch_heartbeat_depth > 0) {
+    ++dispatch_heartbeat_depth;
+    return;
+  }
+
+  const auto timeout = cct->_conf->mon_dispatch_watchdog_timeout;
+  if (timeout <= 0) {
+    if (dispatch_heartbeat) {
+      dout(10) << __func__ << " removing disabled dispatch watchdog" << dendl;
+      cct->get_heartbeat_map()->remove_worker(dispatch_heartbeat);
+      dispatch_heartbeat = nullptr;
+      dispatch_heartbeat_thread = 0;
+      dispatch_heartbeat_depth = 0;
+    }
+    return;
+  }
+
+  auto thread = pthread_self();
+  if (dispatch_heartbeat &&
+      !pthread_equal(dispatch_heartbeat_thread, thread)) {
+    dout(5) << __func__ << " rebinding dispatch watchdog from thread "
+           << dispatch_heartbeat_thread << " to " << thread
+           << dendl;
+    cct->get_heartbeat_map()->remove_worker(dispatch_heartbeat);
+    dispatch_heartbeat = nullptr;
+    dispatch_heartbeat_thread = 0;
+  }
+
+  if (!dispatch_heartbeat) {
+    std::stringstream ss;
+    ss << "mon." << name << " dispatch thread " << thread;
+    dispatch_heartbeat = cct->get_heartbeat_map()->add_worker(ss.str(), thread);
+    dispatch_heartbeat_thread = thread;
+    dout(5) << __func__ << " registered dispatch watchdog for thread "
+           << thread << dendl;
+  }
+
+  ++dispatch_heartbeat_depth;
+  if (dispatch_heartbeat_depth == 1) {
+    auto grace = ceph::make_timespan(timeout);
+    cct->get_heartbeat_map()->reset_timeout(dispatch_heartbeat, grace, grace);
+  }
+}
+
+void Monitor::dispatch_watchdog_finish()
+{
+  std::lock_guard l(dispatch_watchdog_lock);
+
+  if (!dispatch_heartbeat || dispatch_heartbeat_depth == 0) {
+    return;
+  }
+
+  --dispatch_heartbeat_depth;
+  if (dispatch_heartbeat_depth == 0) {
+    cct->get_heartbeat_map()->clear_timeout(dispatch_heartbeat);
+  }
+}
+
+void Monitor::dispatch_watchdog_shutdown()
+{
+  std::lock_guard l(dispatch_watchdog_lock);
+
+  if (!dispatch_heartbeat) {
+    return;
+  }
+
+  dout(10) << __func__ << " removing dispatch watchdog for thread "
+          << dispatch_heartbeat_thread << dendl;
+  cct->get_heartbeat_map()->remove_worker(dispatch_heartbeat);
+  dispatch_heartbeat = nullptr;
+  dispatch_heartbeat_thread = 0;
+  dispatch_heartbeat_depth = 0;
 }
 
 void Monitor::_ms_dispatch(Message *m)

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4740,6 +4740,18 @@ void Monitor::dispatch_watchdog_shutdown()
   dispatch_heartbeat_depth = 0;
 }
 
+void Monitor::dispatch_watchdog_inject_delay()
+{
+  const auto delay = cct->_conf->mon_inject_dispatch_delay;
+  if (delay <= 0) {
+    return;
+  }
+
+  dout(1) << __func__ << " injecting monitor dispatch delay of "
+         << delay << " seconds" << dendl;
+  usleep((long long)(delay * 1000000.0));
+}
+
 void Monitor::_ms_dispatch(Message *m)
 {
   if (is_shutdown()) {

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -28,6 +28,7 @@
 #include <cmath>
 #include <string>
 #include <array>
+#include <pthread.h>
 
 #include "include/types.h"
 #include "include/health.h"
@@ -61,6 +62,10 @@
 struct health_check_map_t;
 class Messenger;
 class MonMap;
+
+namespace ceph {
+  struct heartbeat_handle_d;
+}
 
 using namespace TOPNSPC::common;
 
@@ -941,10 +946,32 @@ public:
     }
   };
 
+  ceph::mutex dispatch_watchdog_lock =
+    ceph::make_mutex("Monitor::dispatch_watchdog_lock");
+  ceph::heartbeat_handle_d *dispatch_heartbeat = nullptr;
+  pthread_t dispatch_heartbeat_thread = 0;
+  unsigned dispatch_heartbeat_depth = 0;
+
+  void dispatch_watchdog_start();
+  void dispatch_watchdog_finish();
+  void dispatch_watchdog_shutdown();
+
+  class DispatchWatchdogGuard {
+    Monitor *mon;
+  public:
+    explicit DispatchWatchdogGuard(Monitor *m) : mon(m) {
+      mon->dispatch_watchdog_start();
+    }
+    ~DispatchWatchdogGuard() {
+      mon->dispatch_watchdog_finish();
+    }
+  };
+
   //ms_dispatch handles a lot of logic and we want to reuse it
   //on forwarded messages, so we create a non-locking version for this class
   void _ms_dispatch(Message *m);
   bool ms_dispatch(Message *m) override {
+    DispatchWatchdogGuard dispatch_watchdog_guard(this);
     std::lock_guard l{lock};
     _ms_dispatch(m);
     return true;

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -955,6 +955,7 @@ public:
   void dispatch_watchdog_start();
   void dispatch_watchdog_finish();
   void dispatch_watchdog_shutdown();
+  void dispatch_watchdog_inject_delay();
 
   class DispatchWatchdogGuard {
     Monitor *mon;
@@ -972,6 +973,7 @@ public:
   void _ms_dispatch(Message *m);
   bool ms_dispatch(Message *m) override {
     DispatchWatchdogGuard dispatch_watchdog_guard(this);
+    dispatch_watchdog_inject_delay();
     std::lock_guard l{lock};
     _ms_dispatch(m);
     return true;

--- a/src/test/heartbeat_map.cc
+++ b/src/test/heartbeat_map.cc
@@ -43,3 +43,15 @@ TEST(HeartbeatMap, Unhealth) {
 
   hm.remove_worker(h);
 }
+
+TEST(HeartbeatMap, CheckTouchFileChecksHealth) {
+  HeartbeatMap hm(g_ceph_context);
+  heartbeat_handle_d *h = hm.add_worker("one", pthread_self());
+
+  hm.reset_timeout(h, ceph::make_timespan(1), ceph::make_timespan(0));
+  sleep(2);
+  hm.check_touch_file();
+  ASSERT_EQ(1, hm.get_unhealthy_workers());
+
+  hm.remove_worker(h);
+}


### PR DESCRIPTION
    A zombie monitor can keep the process alive while the dispatch path
    stops making progress, including while the messenger dispatch thread
    is blocked on Monitor::lock. Add a monitor dispatch watchdog backed by
    HeartbeatMap so the existing heartbeat suicide path can restart the
    monitor when dispatch stalls too long.

    Register the watchdog lazily from the actual dispatch pthread, protect
    watchdog state with its own lock, arm it before acquiring Monitor::lock
    in ms_dispatch(), and clear it after normal dispatch completion or monitor
    shutdown. The new mon_dispatch_watchdog_timeout option controls the timeout
    and can be disabled with zero.

    Signed-off-by: Yite Gu <guyite@bytedance.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
