### PR TITLE
rgw: fix use-after-free on cancellation in shard_io::async_reads()

### DIFF
--- a/src/rgw/driver/rados/shard_io.h
+++ b/src/rgw/driver/rados/shard_io.h
@@ -198,10 +198,16 @@ struct WaitCancellation {
           sending = std::move(*completed);
         }
       }
+
       auto i = outstanding.begin();
-      while (i != outstanding.end()) {
+      // the final completion may wake the calling coroutine and cause it
+      // to return, so we can't safely access 'outstanding' from its stack
+      // afterwards. use a local variable 'done' for the loop condition
+      bool done = (i == outstanding.end());
+      while (!done) {
         // emit() may dispatch the completion that removes i from outstanding
         auto& shard = *i++;
+        done = (i == outstanding.end());
         shard.signal.emit(type);
       }
     }
@@ -530,45 +536,46 @@ struct ReadHandler {
   }
 
   void operator()(error_code ec, version_t = {}, bufferlist = {}) {
-    outstanding.erase(outstanding.iterator_to(shard));
-
-    bool need_cancel = false;
+    auto self = outstanding.iterator_to(shard);
 
     const auto result = reader.on_complete(shard.id(), ec);
     switch (result) {
       case Result::Retry:
         // reschedule the shard for sending
+        outstanding.erase(self);
         sending.push_back(shard);
         ldpp_dout(&reader, 20) << "read on '" << shard.object()
             << "' needs retry: " << ec.message() << dendl;
         break;
       case Result::Success:
+        outstanding.erase(self);
         break;
       case Result::Error:
         ldpp_dout(&reader, 4) << "read on '" << shard.object()
             << "' failed: " << ec.message() << dendl;
         if (!failure) {
           failure = ec;
-          // trigger cancellations after our call to maybe_complete(). one of
-          // the cancellations may trigger completion and cause async_reads()
-          // to co_return. our call to maybe_complete() would then access
-          // variables that were destroyed with async_reads()'s stack
-          need_cancel = !outstanding.empty();
+
+          // cancel other outstanding requests
+          auto i = outstanding.begin();
+          while (i != outstanding.end()) {
+            if (i == self) {
+              ++i;
+              continue;
+            }
+            // emit() may recurse and remove i
+            auto& s = *i++;
+            s.signal.emit(boost::asio::cancellation_type::terminal);
+          }
         }
+
+        // remove this shard after any cancellations, which could otherwise
+        // cause async_reads() to return while we're still accessing its memory
+        outstanding.erase(self);
         break;
     }
 
     maybe_complete(waiter, sending, outstanding, terminal);
-
-    if (need_cancel) {
-      // cancel outstanding requests
-      auto i = outstanding.begin();
-      while (i != outstanding.end()) {
-        // emit() may recurse and remove i
-        auto& s = *i++;
-        s.signal.emit(boost::asio::cancellation_type::terminal);
-      }
-    }
   }
 }; // struct ReadHandler
 


### PR DESCRIPTION
when ReadHandler encounters an error and cancels other outstanding requests, its calls to emit() likely execute those cancellation handlers inline. these can cause async_reads() to wake up and co_return prematurely while the initial ReadHandler is still looping over the 'outstanding' list on its stack

prevent this early return by leaving this initial shard in the 'outstanding' list during the cancellation loop

Fixes: https://tracker.ceph.com/issues/79095

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
