### PR TITLE
WIP: RGW Adaptive Concurrency (Gradient2)

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3954,6 +3954,7 @@ options:
   default: static
   enum_values:
   - static
+  - gradient2
   tags:
   - performance
   services:
@@ -3962,6 +3963,73 @@ options:
   - rgw_max_concurrent_requests
   - rgw_thread_pool_size
   with_legacy: true
+- name: rgw_min_concurrent_requests
+  type: int
+  level: basic
+  desc: Minium number of concurrent HTTP requests for dynamic concurrency limiters (e.g gradient2)
+  default: 20
+  tags:
+  - performance
+  services:
+  - rgw
+  see_also:
+  - rgw_frontends
+  - rgw_thread_pool_size
+- name: rgw_gradient2_smoothing
+  type: float
+  level: advanced
+  desc: Grandient2
+  default: 0.2
+  tags:
+  - performance
+  services:
+  - rgw
+  see_also:
+  - rgw_concurrency_limiter
+- name: rgw_gradient2_rtt_tolerance
+  type: float
+  level: advanced
+  desc: Grandient2
+  default: 1.5
+  tags:
+  - performance
+  services:
+  - rgw
+  see_also:
+  - rgw_concurrency_limiter
+- name: rgw_gradient2_long_window
+  type: int
+  level: advanced
+  desc: Grandient2
+  default: 600
+  tags:
+  - performance
+  services:
+  - rgw
+  see_also:
+  - rgw_concurrency_limiter
+- name: rgw_gradient2_estimate_growth
+  type: int
+  level: advanced
+  desc: Grandient2
+  default: 4
+  tags:
+  - performance
+  services:
+  - rgw
+  see_also:
+  - rgw_concurrency_limiter
+- name: rgw_gradient2_initial_concurrent_requests
+  type: int
+  level: advanced
+  desc: Grandient2
+  default: 32
+  tags:
+  - performance
+  services:
+  - rgw
+  see_also:
+  - rgw_concurrency_limiter
 - name: rgw_scheduler_type
   type: str
   level: advanced

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3947,6 +3947,21 @@ options:
   see_also:
   - rgw_frontends
   - rgw_thread_pool_size
+- name: rgw_concurrency_limiter
+  type: str
+  level: advanced
+  desc: Set the concurrency limiter, defaults to static which uses rgw_max_concurrent_requests as its limit.
+  default: static
+  enum_values:
+  - static
+  tags:
+  - performance
+  services:
+  - rgw
+  see_also:
+  - rgw_max_concurrent_requests
+  - rgw_thread_pool_size
+  with_legacy: true
 - name: rgw_scheduler_type
   type: str
   level: advanced

--- a/src/rgw/rgw_dmclock_async_scheduler.h
+++ b/src/rgw/rgw_dmclock_async_scheduler.h
@@ -20,6 +20,7 @@
 
 #include <boost/asio/basic_waitable_timer.hpp>
 #include <boost/asio/io_context.hpp>
+#include <chrono>
 #include "rgw_dmclock_scheduler.h"
 #include "rgw_dmclock_scheduler_ctx.h"
 
@@ -170,6 +171,12 @@ class SimpleThrottler : public dmclock::Scheduler {
     if (auto c = counters(); c != nullptr) {
       c->inc(throttle_counters::l_outstanding, -1);
     }
+  }
+
+  void report_completion(std::chrono::nanoseconds rtt, bool dropped) {
+    limit->sample(limiter::ConcurrencyLimiter::Sample{.rtt = rtt,
+        .inflight = outstanding_requests.load(),
+        .dropped = dropped});
   }
 
  private:

--- a/src/rgw/rgw_dmclock_async_scheduler.h
+++ b/src/rgw/rgw_dmclock_async_scheduler.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include "rgw_limiter.h"
 #include "common/async/completion.h"
 
 #include <boost/asio/basic_waitable_timer.hpp>
@@ -157,59 +158,38 @@ auto AsyncScheduler::async_request(const client_id& client,
       }, token, get_executor(), client, params, time, cost);
 }
 
-class SimpleThrottler : public md_config_obs_t, public dmclock::Scheduler {
-public:
-  SimpleThrottler(CephContext *cct) :
-    max_requests(cct->_conf.get_val<int64_t>("rgw_max_concurrent_requests")),
-    counters(cct, "simple-throttler")
-  {
-    if (max_requests <= 0) {
-      max_requests = std::numeric_limits<int64_t>::max();
-    }
-    cct->_conf.add_observer(this);
-  }
-
-  std::vector<std::string> get_tracked_keys() const noexcept override {
-    return {std::string{"rgw_max_concurrent_requests"}};
-  }
-
-  void handle_conf_change(const ConfigProxy& conf,
-                          const std::set<std::string>& changed) override
-  {
-    if (changed.count("rgw_max_concurrent_requests")) {
-      auto new_max = conf.get_val<int64_t>("rgw_max_concurrent_requests");
-      max_requests = new_max > 0 ? new_max : std::numeric_limits<int64_t>::max();
-    }
-  }
+class SimpleThrottler : public dmclock::Scheduler {
+ public:
+  SimpleThrottler(CephContext* cct)
+      : limit(rgw::limiter::create_by_name(
+            cct, cct->_conf->rgw_concurrency_limiter)),
+        counters(cct, "simple-throttler") {}
 
   void request_complete() override {
     --outstanding_requests;
-    if (auto c = counters();
-        c != nullptr) {
+    if (auto c = counters(); c != nullptr) {
       c->inc(throttle_counters::l_outstanding, -1);
     }
-
   }
 
-private:
-  int schedule_request_impl(const client_id&, const ReqParams&,
-                            const Time&, const Cost&,
-                            optional_yield) override {
+ private:
+  int schedule_request_impl(const client_id&, const ReqParams&, const Time&,
+      const Cost&, optional_yield) override {
     auto c = counters();
     if (c != nullptr) {
       c->inc(throttle_counters::l_outstanding);
     }
-    if (outstanding_requests++ >= max_requests) {
+    if (outstanding_requests++ >= limit->limit()) {
       if (c != nullptr) {
         c->inc(throttle_counters::l_throttle);
       }
       return -EAGAIN;
     }
 
-    return 0 ;
+    return 0;
   }
 
-  std::atomic<int64_t> max_requests;
+  std::unique_ptr<limiter::ConcurrencyLimiter> limit;
   std::atomic<int64_t> outstanding_requests = 0;
   ThrottleCounters counters;
 };

--- a/src/rgw/rgw_dmclock_scheduler.h
+++ b/src/rgw/rgw_dmclock_scheduler.h
@@ -76,6 +76,7 @@ public:
     return std::make_pair(r,SchedulerCompleter(std::bind(&Scheduler::request_complete,this)));
   }
   virtual void request_complete() {};
+  virtual void report_completion(std::chrono::nanoseconds rtt, bool dropped) {};
 
   virtual ~Scheduler() {};
 private:

--- a/src/rgw/rgw_limiter.h
+++ b/src/rgw/rgw_limiter.h
@@ -1,0 +1,95 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <common/dout.h>
+#include <common/dout_fmt.h>
+
+#include <atomic>
+#include <boost/asio/basic_waitable_timer.hpp>
+#include <boost/asio/io_context.hpp>
+
+#include "common/async/completion.h"
+#include "common/ceph_context.h"
+#include "common/config.h"
+#include "common/perf_counters.h"
+#include "common/perf_counters_collection.h"
+
+namespace rgw::limiter {
+namespace async = ceph::async;
+
+class StaticLimiter;
+
+class ConcurrencyLimiter {
+ public:
+  struct Sample {
+    std::chrono::nanoseconds rtt{0};
+    int64_t inflight = 0;
+    bool dropped = false;
+  };
+
+  virtual ~ConcurrencyLimiter() = default;
+
+  // current ceiling of cuncurrent in-flight requests
+  virtual int64_t limit() const = 0;
+
+  // per completion feedback: adaptive filters use this to update
+  // their internal estimates
+  virtual void sample(const Sample&) = 0;
+};
+
+class StaticLimiter : public ConcurrencyLimiter, public md_config_obs_t {
+ private:
+  CephContext* cct;
+  std::atomic<int64_t> max_requests;
+
+ public:
+   explicit StaticLimiter(CephContext* cct) :
+     cct(cct),
+     max_requests(cct->_conf.get_val<int64_t>("rgw_max_concurrent_requests"))
+   {
+     if (max_requests <= 0) {
+       max_requests = std::numeric_limits<int64_t>::max();
+     }
+     cct->_conf.add_observer(this);
+   }
+  ~StaticLimiter() override = default;
+
+  int64_t limit() const override { return max_requests.load(); }
+
+  void sample(const Sample&) override {};
+
+  std::vector<std::string> get_tracked_keys() const noexcept override {
+    return {std::string{"rgw_max_concurrent_requests"}};
+  }
+
+  void handle_conf_change(const ConfigProxy& conf,
+                          const std::set<std::string>& changed) override
+  {
+    if (changed.contains("rgw_max_concurrent_requests")) {
+      auto new_max = conf.get_val<int64_t>("rgw_max_concurrent_requests");
+      max_requests = new_max > 0 ? new_max : std::numeric_limits<int64_t>::max();
+    }
+  }
+};
+
+static std::unique_ptr<ConcurrencyLimiter> create_by_name(
+    CephContext* cct, std::string_view name) {
+  if (name == "static") {
+    return std::make_unique<StaticLimiter>(cct);
+  }
+  return nullptr;
+}
+
+}  // namespace rgw::limiter

--- a/src/rgw/rgw_limiter.h
+++ b/src/rgw/rgw_limiter.h
@@ -13,12 +13,18 @@
 
 #pragma once
 
+#include <common/ceph_mutex.h>
+#include <common/ceph_time.h>
 #include <common/dout.h>
 #include <common/dout_fmt.h>
 
+#include <algorithm>
 #include <atomic>
 #include <boost/asio/basic_waitable_timer.hpp>
 #include <boost/asio/io_context.hpp>
+#include <cmath>
+#include <limits>
+#include <mutex>
 
 #include "common/async/completion.h"
 #include "common/ceph_context.h"
@@ -84,10 +90,284 @@ class StaticLimiter : public ConcurrencyLimiter, public md_config_obs_t {
   }
 };
 
+/// A port of Netflix's Gradient2 Concurrency Limiter
+/// https://github.com/Netflix/concurrency-limits
+class Gradient2 : public ConcurrencyLimiter, public md_config_obs_t {
+ protected:
+  enum class Metric {
+    metrics_start = 94000,
+    long_rtt,
+    last_rtt,
+    gradient,
+    limit,
+    effective_limit,
+    min,
+    max,
+    samples_total,
+    app_limited_total,
+    drops_total,
+    rtt,
+    min_rtt,
+    metrics_stop,
+  };
+
+  class ExpAvg {
+ private:
+    double _value = 0.0;
+    double _sum = 0;
+    const int _window;
+    const int _warmup_window;
+    int _count = 0;
+
+   public:
+    ExpAvg(int window, int warmup_window)
+        : _window(window), _warmup_window(warmup_window) {}
+    double add(double sample) {
+      if (_count < _warmup_window) {
+        _count++;
+        _sum += sample;
+        _value = _sum / _count;  // XXX handle sum overflow and things
+      } else {
+        const double factor = 2.00 / (_window + 1);
+        _value = _value * (1 - factor) + sample * factor;
+      }
+      return _value;
+    }
+    void decay(double factor) {
+      _value = _value * factor;
+    }
+    double get() const { return _value; }
+  };
+
+  // Alternate way to ExpAvg to track long term rtt
+  class WindowedMin {
+   private:
+    double _current = std::numeric_limits<double>::max();
+    double _published = 0.0;
+    const int _window;
+    int _count = 0;
+
+   public:
+    explicit WindowedMin(int window) : _window(window) {}
+    void add(double sample) {
+      _current = std::min(_current, sample);
+      if (++_count >= _window) {
+        _published = _current;
+        _current = std::numeric_limits<double>::max();
+        _count = 0;
+      }
+    }
+    double get() const { return _published; }
+  };
+
+ private:
+  CephContext* _cct;
+  PerfCountersRef _perf;
+  const DoutPrefix _dp;
+  mutable ceph::mutex _mutex = ceph::make_mutex("Gradient2::lock");
+
+  // config
+  std::atomic<int64_t> _min_requests;
+  std::atomic<int64_t> _max_requests;
+  std::atomic<double> _smoothing;
+  std::atomic<double> _tolerance;
+  // other implementations call this queue size, but since we have no
+  // standing queue here this becomes the amount of concurrency steps
+  // we are willing to probe for
+  std::atomic<int64_t> _probe_step;
+
+  // updated on sample()
+  std::atomic<double> _estimated_requests;
+  ExpAvg _long_rtt_sec;
+  WindowedMin _min_rtt_sec;
+
+ public:
+  explicit Gradient2(CephContext* cct)
+      : _cct(cct),
+        _perf(initialize_perf_counters(cct, "rgw-limiter")),
+        _dp(cct, ceph_subsys_rgw, "limiter/gradient2: "),
+        _min_requests(
+            cct->_conf.get_val<int64_t>("rgw_min_concurrent_requests")),
+        _max_requests(
+            cct->_conf.get_val<int64_t>("rgw_max_concurrent_requests")),
+        _smoothing(cct->_conf.get_val<double>("rgw_gradient2_smoothing")),
+        _tolerance(cct->_conf.get_val<double>("rgw_gradient2_rtt_tolerance")),
+        _probe_step(
+            cct->_conf.get_val<int64_t>("rgw_gradient2_estimate_growth")),
+        _estimated_requests(cct->_conf.get_val<int64_t>(
+            "rgw_gradient2_initial_concurrent_requests")),
+        _long_rtt_sec(ExpAvg(
+            cct->_conf.get_val<int64_t>("rgw_gradient2_long_window"), 10)),
+        _min_rtt_sec(
+            cct->_conf.get_val<int64_t>("rgw_gradient2_long_window")) {
+    if (_max_requests <= 0) {
+      _max_requests = std::numeric_limits<int64_t>::max();
+    }
+    if (_min_requests <= 0) {
+      _min_requests = 1;
+    }
+    _estimated_requests = std::clamp(_estimated_requests.load(),
+        static_cast<double>(_min_requests.load()),
+        static_cast<double>(_max_requests.load()));
+
+    cct->_conf.add_observer(this);
+    _perf->set(static_cast<int>(Metric::min), _min_requests);
+    _perf->set(static_cast<int>(Metric::max), _max_requests);
+    _perf->set(static_cast<int>(Metric::effective_limit), _estimated_requests);
+  }
+  ~Gradient2() override = default;
+
+  std::vector<std::string> get_tracked_keys() const noexcept override {
+    return {
+        std::string{"rgw_max_concurrent_requests"},
+        std::string{"rgw_min_concurrent_requests"},
+        std::string{"rgw_gradient2_smoothing"},
+        std::string{"rgw_gradient2_rtt_tolerance"},
+        std::string{"rgw_gradient2_estimate_growth"},
+    };
+  }
+
+  void handle_conf_change(
+      const ConfigProxy& conf, const std::set<std::string>& changed) override {
+    if (changed.contains("rgw_max_concurrent_requests")) {
+      auto new_max = conf.get_val<int64_t>("rgw_max_concurrent_requests");
+      _max_requests =
+          new_max > 0 ? new_max : std::numeric_limits<int64_t>::max();
+      _perf->set(static_cast<int>(Metric::max), _max_requests);
+    }
+    if (changed.contains("rgw_min_concurrent_requests")) {
+      auto new_min = conf.get_val<int64_t>("rgw_min_concurrent_requests");
+      _min_requests = new_min > 0 ? new_min : 1;
+      _perf->set(static_cast<int>(Metric::min), _min_requests);
+    }
+    if (changed.contains("rgw_gradient2_smoothing")) {
+      _smoothing = conf.get_val<double>("rgw_gradient2_smoothing");
+    }
+    if (changed.contains("rgw_gradient2_rtt_tolerance")) {
+      _tolerance = conf.get_val<double>("rgw_gradient2_rtt_tolerance");
+    }
+    if (changed.contains("rgw_gradient2_estimate_growth")) {
+      _probe_step = conf.get_val<int64_t>("rgw_gradient2_estimate_growth");
+    }
+  }
+
+  int64_t limit() const override {
+    return static_cast<int64_t>(
+        _estimated_requests.load(std::memory_order_relaxed));
+  }
+
+  void sample(const Sample& sample) override {
+    std::lock_guard<ceph::mutex> lock(_mutex);
+    _perf->inc(static_cast<int>(Metric::samples_total));
+    if (sample.dropped) {  // use this signal somehow?
+      _perf->inc(static_cast<int>(Metric::drops_total));
+    }
+
+    const double estimated_limit = _estimated_requests.load();
+    _perf->tset(static_cast<int>(Metric::last_rtt), sample.rtt);
+
+    // Sum and count of the sampled RTTs. rate(rtt_sum) is seconds of work
+    // completed per second, i.e. the concurrency implied by the completion
+    // flow -- the lambda*W term of a Little's-law residual against the
+    // in-flight gauge. Recorded before the app-limited return below so the
+    // sum covers every sampled request, matching what the gauge counts.
+    _perf->tinc(static_cast<int>(Metric::rtt), sample.rtt);
+
+    const auto short_rtt_sec =
+        std::chrono::duration<double>(sample.rtt).count();
+    _min_rtt_sec.add(short_rtt_sec);
+    _perf->tset(static_cast<int>(Metric::min_rtt),
+        make_timespan(_min_rtt_sec.get()));
+
+    const auto long_rtt_sec_now = _long_rtt_sec.add(short_rtt_sec);
+
+    // If the long RTT is substantially larger than the short RTT then
+    // reduce the long RTT measurement. This can happen when latency
+    // returns to normal after a prolonged prior of excessive load.
+    // Reducing the long RTT without waiting for the exponential
+    // smoothing helps bring the system back to steady state.
+    if (short_rtt_sec > 0 && long_rtt_sec_now / short_rtt_sec > 2) {
+      _long_rtt_sec.decay(0.95);
+    }
+    // Exported after the decay so it reflects the stored baseline. The
+    // gradient below deliberately uses the pre-decay value, as upstream does.
+    _perf->tset(static_cast<int>(Metric::long_rtt),
+        make_timespan(_long_rtt_sec.get()));
+
+    // Don't grow the limit if we are app limited
+    if (sample.inflight < estimated_limit / 2) {
+      _perf->inc(static_cast<int>(Metric::app_limited_total));
+      return;
+    }
+
+    // Rtt could be higher than rtt_noload because of smoothing rtt
+    // noload updates so set to 1.0 to indicate no queuing. Otherwise
+    // calculate the slope and don't allow it to be reduced by more
+    // than half to avoid aggressive load-shedding due to outliers.
+
+    double gradient = 1.0;
+    if (short_rtt_sec > 0 && long_rtt_sec_now > 0) {
+      const auto g = _tolerance * long_rtt_sec_now / short_rtt_sec;
+      gradient = std::clamp(g, 0.5, 1.0);
+    }
+    double new_limit = (estimated_limit * gradient) + _probe_step.load();
+    new_limit = estimated_limit * (1 - _smoothing.load()) + new_limit * _smoothing.load();
+
+    const auto clamped = std::clamp(new_limit,
+        static_cast<double>(_min_requests.load()),
+        static_cast<double>(_max_requests.load()));
+    const auto previous =
+        _estimated_requests.exchange(clamped, std::memory_order_relaxed);
+    if (clamped != previous) {
+      ldpp_dout_fmt(&_dp, 10,
+          "new limit: {} -> {} short_rtt:{}s long_rtt:{}s gradient:{} "
+          "growth:{} min:{} max:{}",
+          previous, clamped, short_rtt_sec, long_rtt_sec_now, gradient,
+          _probe_step.load(), _min_requests.load(), _max_requests.load());
+    }
+    _perf->set(static_cast<int>(Metric::gradient), llround(gradient * 1000));
+    _perf->set(static_cast<int>(Metric::limit), new_limit);
+    _perf->set(static_cast<int>(Metric::effective_limit), _estimated_requests.load());
+  }
+
+  static PerfCountersRef initialize_perf_counters(
+      CephContext* cct, const std::string& name) {
+    PerfCountersBuilder pcb(cct, name, static_cast<int>(Metric::metrics_start),
+        static_cast<int>(Metric::metrics_stop));
+    pcb.set_prio_default(PerfCountersBuilder::PRIO_USEFUL);
+    pcb.add_time(static_cast<int>(Metric::last_rtt), "last_rtt", "");
+    pcb.add_time(static_cast<int>(Metric::long_rtt), "long_rtt",
+        "Exponentially averaged RTT baseline");
+    pcb.add_time(static_cast<int>(Metric::min_rtt), "min_rtt",
+        "Windowed-minimum RTT: no-load service time");
+    pcb.add_time_avg(static_cast<int>(Metric::rtt), "rtt",
+        "Sum and count of sampled RTTs; rate(rtt_sum) is the concurrency "
+        "implied by the completion flow");
+    pcb.add_u64(static_cast<int>(Metric::gradient), "gradient", "");
+    pcb.add_u64(static_cast<int>(Metric::limit), "limit", "");
+    pcb.add_u64(
+        static_cast<int>(Metric::effective_limit), "effective_limit", "");
+    pcb.add_u64(static_cast<int>(Metric::min), "min", "");
+    pcb.add_u64(static_cast<int>(Metric::max), "max", "");
+    pcb.add_u64_counter(
+        static_cast<int>(Metric::samples_total), "samples_total", "");
+    pcb.add_u64_counter(
+        static_cast<int>(Metric::app_limited_total), "app_limited_total", "");
+    pcb.add_u64_counter(
+        static_cast<int>(Metric::drops_total), "drops_total", "");
+
+    auto logger = PerfCountersRef{pcb.create_perf_counters(), cct};
+    cct->get_perfcounters_collection()->add(logger.get());
+    return logger;
+  }
+};
+
 static std::unique_ptr<ConcurrencyLimiter> create_by_name(
     CephContext* cct, std::string_view name) {
   if (name == "static") {
     return std::make_unique<StaticLimiter>(cct);
+  } else if (name == "gradient2") {
+    return std::make_unique<Gradient2>(cct);
   }
   return nullptr;
 }

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -6,6 +6,7 @@
 #include "common/WorkQueue.h"
 #include "include/scope_guard.h"
 
+#include <chrono>
 #include <utility>
 #include "rgw_auth_registry.h"
 #include "rgw_dmclock_scheduler.h"
@@ -352,6 +353,7 @@ int process_request(const RGWProcessEnv& penv,
   RGWOp* op = nullptr;
   int init_error = 0;
   bool should_log = false;
+  bool admitted = false;
   RGWREST* rest = penv.rest;
   RGWRESTMgr *mgr;
   bool is_health_request = false;
@@ -384,6 +386,7 @@ int process_request(const RGWProcessEnv& penv,
     abort_early(s, op, ret, handler, yield);
     goto done;
   }
+  admitted = true;
   req->op = op;
   ldpp_dout(op, 10) << "op=" << typeid(*op).name() << " " << dendl;
   s->op_type = op->get_type();
@@ -557,6 +560,27 @@ done:
           << " request_id=" << s->trans_id
           << " ======"
           << dendl;
+
+  if (scheduler != nullptr) {
+    const int err_no = -(op_ret < 0 ? op_ret : s->err.ret);
+    const bool self_shed = !admitted || err_no == ERR_RATE_LIMITED;
+
+    if (!self_shed) {
+      const bool dropped = [err_no]() {
+        switch (err_no) {
+        case ERR_SERVICE_UNAVAILABLE:
+        case ERR_INTERNAL_ERROR:
+        case EBUSY:
+        case ETIMEDOUT:
+          return true;
+        default:
+          return false;
+      }
+    }();
+    scheduler->report_completion(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(lat), dropped);
+  }
+  }
 
   if (handler)
     handler->put_op(op);

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -506,3 +506,9 @@ if(WITH_RADOSGW_FDB)
  add_catch2_test_rgw(fdb NO_CATCH2_MAIN)
  add_catch2_test_rgw(fdb_ceph NO_CATCH2_MAIN)
 endif()
+
+# unittest_rgw_limiter
+add_executable(unittest_rgw_limiter test_rgw_limiter.cc)
+add_ceph_unittest(unittest_rgw_limiter)
+target_link_libraries(unittest_rgw_limiter
+  rgw_common ${rgw_libs} ${UNITTEST_LIBS})

--- a/src/test/rgw/test_rgw_limiter.cc
+++ b/src/test/rgw/test_rgw_limiter.cc
@@ -1,0 +1,97 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2026 CLYSO
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "common/ceph_context.h"
+#include "rgw_limiter.h"
+
+namespace rgw::limiter {
+
+using namespace std::chrono_literals;
+using Sample = ConcurrencyLimiter::Sample;
+
+static Sample ok(int64_t inflight, std::chrono::nanoseconds rtt = 1ms) {
+  return Sample{rtt, inflight, /*dropped=*/false};
+}
+static Sample dropped(int64_t inflight, std::chrono::nanoseconds rtt = 100ms) {
+  return Sample{rtt, inflight, /*dropped=*/true};
+}
+
+class ConcurrencyLimiterTest
+    : public ::testing::TestWithParam<std::string_view> {
+ protected:
+  const std::unique_ptr<CephContext> cct;
+  const std::unique_ptr<ConcurrencyLimiter> limiter;
+  ConcurrencyLimiterTest()
+      : cct(new CephContext(CEPH_ENTITY_TYPE_ANY)),
+        limiter(create_by_name(cct.get(), GetParam())) {}
+};
+
+TEST_P(ConcurrencyLimiterTest, StartsWithPositiveLimit) {
+  EXPECT_GT(limiter->limit(), 0);
+}
+
+TEST_P(ConcurrencyLimiterTest, LimitIsStableWithoutFeedback) {
+  const int64_t first = limiter->limit();
+  EXPECT_EQ(first, limiter->limit());
+  EXPECT_EQ(first, limiter->limit());
+}
+
+TEST_P(ConcurrencyLimiterTest, StaysPositiveUnderHealthyLoad) {
+  for (int i = 0; i < 100; i++) {
+    limiter->sample(ok(limiter->limit()));
+    EXPECT_GT(limiter->limit(), 0);
+  }
+}
+
+TEST_P(ConcurrencyLimiterTest, NeverCollapsesToZero) {
+  for (int i = 0; i < 100; i++) {
+    limiter->sample(dropped(limiter->limit()));
+    EXPECT_GT(limiter->limit(), 0) << "limit collapsed to " << limiter->limit()
+                                   << " after " << i << " drops";
+  }
+}
+
+TEST_P(ConcurrencyLimiterTest, ToleratesDegenerateSamples) {
+  limiter->sample(Sample{std::chrono::nanoseconds{0}, 0, false});
+  EXPECT_GT(limiter->limit(), 0);
+  limiter->sample(Sample{1h, 0, false});
+  EXPECT_GT(limiter->limit(), 0);
+  limiter->sample(Sample{1h, 1'000'000, true});
+  EXPECT_GT(limiter->limit(), 0);
+}
+
+TEST_P(ConcurrencyLimiterTest, LimitStaysBounded) {
+  constexpr int64_t sane_ceiling = 1'000'000;
+  for (int i = 0; i < 1000; i++) {
+    limiter->sample(ok(limiter->limit()));
+    ASSERT_GT(limiter->limit(), 0);
+    ASSERT_LT(limiter->limit(), sane_ceiling);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(Implementations, ConcurrencyLimiterTest,
+    ::testing::Values("static"),
+    [](const ::testing::TestParamInfo<std::string_view>& info) {
+      return std::string(info.param);
+    });
+
+}  // namespace rgw::limiter

--- a/src/test/rgw/test_rgw_limiter.cc
+++ b/src/test/rgw/test_rgw_limiter.cc
@@ -88,8 +88,40 @@ TEST_P(ConcurrencyLimiterTest, LimitStaysBounded) {
   }
 }
 
+// Basisc Gradient2 behaviour: Contract on latency
+class Gradient2Test : public ::testing::Test {
+ protected:
+  const std::unique_ptr<CephContext> cct;
+  Gradient2 limiter;
+  Gradient2Test()
+      : cct(new CephContext(CEPH_ENTITY_TYPE_ANY)), limiter(cct.get()) {}
+
+  void feed(std::chrono::nanoseconds rtt, int count) {
+    for (int i = 0; i < count; i++) {
+      limiter.sample(ok(limiter.limit(), rtt));
+    }
+  }
+};
+
+TEST_F(Gradient2Test, ContractsWhenLatencyDegrades) {
+  feed(1ms, 200);
+  const int64_t settled = limiter.limit();
+
+  feed(50ms, 200);
+  EXPECT_LT(limiter.limit(), settled)
+      << "limit stayed at " << limiter.limit() << " after a 50x latency jump";
+}
+
+TEST_F(Gradient2Test, AccumulatesFractionalGrowth) {
+  const int64_t initial = limiter.limit();
+
+  feed(1ms, 2);
+  EXPECT_GT(limiter.limit(), initial)
+      << "fractional growth was discarded between samples";
+}
+
 INSTANTIATE_TEST_SUITE_P(Implementations, ConcurrencyLimiterTest,
-    ::testing::Values("static"),
+    ::testing::Values("static", "gradient2"),
     [](const ::testing::TestParamInfo<std::string_view>& info) {
       return std::string(info.param);
     });


### PR DESCRIPTION
This series demonstrates a scheduler neutral admission interface with completion feedback. Gradient2 is the first experimental consumer of that interface.

The interface integrates with the simple throttle, but should also work with dmclock to set the currently static/configurable 1024 requests limit.

Gradient2 is an adaptive concurrency control algorithm from:
- https://github.com/Netflix/concurrency-limits 
- https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/adaptive_concurrency_filter

Still open questions:
- What is the right feedback signal? end-to-end request latency? RADOS-only latency?
- Should drops cause backoff?
- What are sensible defaults?
- How to integrate non-RADOS sources of latency like KMS, Keystone, etc.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
