### PR TITLE
cephadm: update smb server to use unlimited pids

### DIFF
--- a/src/cephadm/cephadmlib/daemons/smb.py
+++ b/src/cephadm/cephadmlib/daemons/smb.py
@@ -987,6 +987,7 @@ class SMB(ContainerDaemonForm):
     def customize_container_args(
         self, ctx: CephadmContext, args: List[str]
     ) -> None:
+        args.append(ctx.container_engine.unlimited_pids_option)
         args.extend(self._layout().primary.container_args())
 
     def customize_container_mounts(


### PR DESCRIPTION
The new RGW backed shares feature embeds a librgw in each smbd child. The rgw library spawns many threads at init-time. With the default pid limit this only allows fewer than 5-6 smbds to spawn before additional children are blocked from starting.

This also brings us in line with the nfs behavior.


Fixes: https://tracker.ceph.com/issues/79159

---
With this change in place and the default number of threads for librgw I was able to connect
around 14 clients, which produced around 3000 threads
```
[ceph: root@rgwc1-ceph2 /]# smbstatus -p | grep DOMAIN | wc -l
14

[ceph: root@rgwc1-ceph2 /]# pstree -lap | grep smbd | wc -l
3002
```

I tried increasing the number of default threads using `ceph config set client.rgw rgw_thread_pool_size  512` but that did not affect the smbds. I tried `ceph config set client.smb rgw_thread_pool_size  512` (and restarting the service) and this seems to increase the default threads as desired. With this option in place I connected around 10 clients to produce around 5978 threads.
```
[root@ceph2 ~]# cephadm enter -i smb pstree -lap | grep smbd | wc -l
Inferring fsid 5883ca48-9281-11f1-ad6c-525400220000
Inferring daemon smb.rgwc1.ceph2.rnmddz
5978


[root@ceph2 ~]# cephadm enter -i smb  smbstatus -p | grep DOMAIN | wc -l
Inferring fsid 5883ca48-9281-11f1-ad6c-525400220000
Inferring daemon smb.rgwc1.ceph2.rnmddz
10
```

After this I manually removed the --pids-limit option from the unit.run file and restated the service. I was able to connect 3 clients but no more. System logs showed errors like (truncated):
```
  -281> 2026-08-07T17:45:32.580+0000 7f7778ff5c80 -1 *** Caught signal (Aborted) **
 in thread 7f7778ff5c80 thread_name:smbd[192.168.76
 ceph version 21.3.0-1797-gdf247cde (df247cde746d08d54e941e86143e18b7835520bd) umbrella (dev - RelWithDebInfo)
 1: /lib64/libc.so.6(+0x41140) [0x7f777d71d140]
 2: /lib64/libc.so.6(+0x9779c) [0x7f777d77379c]
 3: gsignal()
 4: abort()
 5: /lib64/libstdc++.so.6(+0xa5ffa) [0x7f777b071ffa]
 6: /lib64/libstdc++.so.6(+0xbc02c) [0x7f777b08802c]
 7: (std::unexpected()+0) [0x7f777b0719f9]
 8: /lib64/libstdc++.so.6(+0xbc2b8) [0x7f777b0882b8]
 9: (std::__throw_system_error(int)+0xa4) [0x7f777b0768a1]
 10: /lib64/libstdc++.so.6(+0xaa953) [0x7f777b076953]
 11: (rgw::AppMain::IOContextPoolHolder::get()+0x214) [0x7f7776f78474]
 12: (rgw::AppMain::init_storage()+0x1da) [0x7f7776f5497a]
 13: (rgw::RGWLib::init(std::vector<char const*, std::allocator<char const*> >&)+0x2bf) [0x7f777707b2cf]
 14: librgw_create()
 15: /usr/lib64/samba/vfs/ceph_rgw.so(+0xe160) [0x7f77788d0160]
 16: make_connection_snum()
 17: make_connection_smb2()
 18: smbd_smb2_request_process_tcon()
 19: smbd_smb2_request_dispatch()
 20: /usr/lib64/samba/libsmbd-base-private-samba.so(+0xc3ecd) [0x7f777dde2ecd]
 21: tevent_common_invoke_fd_handler()
 22: /usr/lib64/samba/libtevent-private-samba.so(+0xf5ee) [0x7f777dabf5ee]
 23: /usr/lib64/samba/libtevent-private-samba.so(+0x605b) [0x7f777dab605b]
 24: _tevent_loop_once()
 25: tevent_common_loop_wait()
 26: /usr/lib64/samba/libtevent-private-samba.so(+0x60cb) [0x7f777dab60cb]
 27: smbd_process()
 28: /usr/sbin/smbd(+0xb6ac) [0x5595463246ac]
 29: tevent_common_invoke_fd_handler()
 30: /usr/lib64/samba/libtevent-private-samba.so(+0xf5ee) [0x7f777dabf5ee]
 31: /usr/lib64/samba/libtevent-private-samba.so(+0x605b) [0x7f777dab605b]
 NOTE: a copy of the executable, or `objdump -rdS <executable>` is needed to interpret this.
```
 


---



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] Manually tested

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
