### PR TITLE
cmake: emit a manifest of Catch2-based unittest binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -919,6 +919,18 @@ option(WITH_SYSTEMD "build with systemd support" ON)
 
 add_subdirectory(src)
 
+# Manifest of Catch2-based unit test binaries (see add_catch2_test in
+# cmake/modules/AddCephTest.cmake), one name per line, written next to the
+# built binaries. Consumers - e.g. the Windows test runner in
+# ceph-win32-tests - can read this to classify test binaries without a
+# hand-maintained, easily-stale list.
+get_property(ceph_catch2_test_binaries GLOBAL PROPERTY CEPH_CATCH2_TEST_BINARIES)
+if(ceph_catch2_test_binaries)
+  list(JOIN ceph_catch2_test_binaries "\n" ceph_catch2_test_binaries_joined)
+  file(WRITE "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/catch2_tests.list"
+    "${ceph_catch2_test_binaries_joined}\n")
+endif()
+
 add_subdirectory(qa)
 add_subdirectory(doc)
 if(WITH_MANPAGE)

--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -202,4 +202,10 @@ target_include_directories(unittest_${test_name}
 
 add_ceph_unittest(unittest_${test_name})
 
+# Record this binary so the generated manifest (see the bottom of the
+# top-level CMakeLists.txt) can tell consumers - e.g. the Windows test
+# runner in ceph-win32-tests - which built binaries are Catch2-based
+# without having to hardcode a list of names.
+set_property(GLOBAL APPEND PROPERTY CEPH_CATCH2_TEST_BINARIES unittest_${test_name})
+
 endfunction()


### PR DESCRIPTION
## Summary

`add_catch2_test`/`add_catch2_test_rgw` build `unittest_*` binaries that use Catch2's own CLI rather than GoogleTest's. Consumers that need to invoke them differently from the surrounding GoogleTest-based `unittest_*`/`ceph_test_*` binaries currently have to hardcode the list of Catch2 binary names by hand - see [ceph/ceph-win32-tests#24](https://github.com/ceph/ceph-win32-tests/pull/24), whose Windows test runner needs to dispatch each binary with framework-appropriate flags, and currently maintains a manual `$catch2List` for this. That list silently goes stale whenever a new `add_catch2_test` call is added elsewhere in the tree - the exact failure mode that PR's own change (detecting and invoking Catch2 binaries correctly) exists to fix, just relocated to "did the reviewer remember to update the PowerShell list."

## Changes

- `cmake/modules/AddCephTest.cmake`: `add_catch2_test` records `unittest_${test_name}` into a global CMake property (`CEPH_CATCH2_TEST_BINARIES`) as it runs.
- `CMakeLists.txt`: after `add_subdirectory(src)` (so every nested `add_catch2_test` call, including the ones in `src/test/rgw/CMakeLists.txt`, has already run), read that property and write it - one name per line - to `catch2_tests.list` in `CMAKE_RUNTIME_OUTPUT_DIRECTORY`.

## Why this location, why no packaging changes

`catch2_tests.list` lands in the same directory as the built `unittest_*.exe` binaries (`CMAKE_RUNTIME_OUTPUT_DIRECTORY` = `$binDir` in `win32_build.sh`), so it rides along with the existing Windows packaging step without any changes there:
- The default (stripped debug symbols) path in `win32_build.sh` strips `.exe`/`.dll` files individually, then copies any *other* file under `$binDir` into the stripped directory as-is (`for file in $binDir/*; do [[ ! -f $strippedBinDir/$(basename $file) ]] && cp $file $strippedBinDir; done`) - this plain-text file falls into that catch-all.
- The `EMBEDDED_DBG_SYM` path symlinks the whole `$binDir` into the zip staging tree, so it's included automatically either way.

## Behavior

No existing behavior changes. The property is only appended to, and the file only written, when `WITH_CATCH2` causes `add_catch2_test` to actually register a binary (it returns early otherwise) - `if(ceph_catch2_test_binaries)` guards against writing an empty manifest.

## Test plan

- [x] Verified the CMake mechanics (global property accumulation across nested `add_subdirectory` scopes, `list(JOIN)`, `file(WRITE)`) in an isolated CMake project mirroring `CMakeLists.txt` → `src/test/CMakeLists.txt` → `src/test/rgw/CMakeLists.txt`'s exact nesting and the 4 current `add_catch2_test`/`add_catch2_test_rgw` call sites; the generated manifest matches expected output exactly.
- [ ] Full ceph CMake configure (not run here - happy to have this verified in CI, or would appreciate a pointer if there's a lighter-weight way to sanity-check just the top-level configure step)

## Related

Companion change: [ceph/ceph-win32-tests#24](https://github.com/ceph/ceph-win32-tests/pull/24) will read this manifest instead of its hardcoded list, falling back to the static list if the file isn't present yet.