### PR TITLE
cephfs-mirror: sync file size when blockdiff is empty

### DIFF
--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -2518,6 +2518,83 @@ class TestMirroring(CephFSTestCase):
             self.assertEqual(source_states[path][:3],
                              destination_states[path][:3])
 
+    def test_cephfs_mirror_blockdiff_pure_truncate(self):
+        """Verify incremental sync when only the file size changes."""
+
+        self.setup_mount_b(mds_perm='rw')
+        self.config_set(
+            'client.mirror',
+            'cephfs_mirror_blockdiff_min_file_size', 16777216)
+        peer_spec = "client.mirror_remote@ceph"
+        dir_name = 'd0'
+        cases = [
+            ('object_boundary_shrink', 64, 32),
+            ('partial_object_shrink', 64, 33),
+            ('same_object_shrink', 19, 18),
+            ('sparse_grow', 20, 40),
+        ]
+
+        def snapshot_file_state(mount, snap_name, file_name):
+            path = f'{dir_name}/.snap/{snap_name}/{file_name}'
+            stat = mount.run_shell(
+                ['stat', '-c', '%F:%s', path]
+            ).stdout.getvalue().strip()
+            file_type, size = stat.rsplit(':', 1)
+            digest = mount.run_shell(
+                ['sha256sum', path]
+            ).stdout.getvalue().split()[0]
+            return file_type, int(size), digest
+
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        self.peer_add(self.primary_fs_name, self.primary_fs_id,
+                      peer_spec, self.secondary_fs_name)
+        self.mount_a.run_shell(['mkdir', dir_name])
+        self.add_directory(self.primary_fs_name, self.primary_fs_id,
+                           f'/{dir_name}')
+
+        for file_name, initial_size_mb, _ in cases:
+            self.mount_a.run_shell([
+                'dd', 'if=/dev/zero', f'of={dir_name}/{file_name}',
+                'bs=1M', f'count={initial_size_mb}', 'conv=fsync'
+            ])
+
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/snap_a'])
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, f'/{dir_name}', 'snap_a', 1)
+        self.verify_snapshot(dir_name, 'snap_a')
+
+        for file_name, initial_size_mb, final_size_mb in cases:
+            self.mount_a.run_shell([
+                'truncate', '-s', f'{final_size_mb}M',
+                f'{dir_name}/{file_name}'
+            ])
+            if final_size_mb > initial_size_mb:
+                # Ensure snapdiff reports sparse growth without writing data.
+                self.mount_a.run_shell([
+                    'touch', '-m', f'{dir_name}/{file_name}'
+                ])
+
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/snap_b'])
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, f'/{dir_name}', 'snap_b', 2)
+        self.assertIn('snap_b', self.mount_b.ls(path=f'{dir_name}/.snap'))
+
+        mismatches = []
+        for file_name, _, _ in cases:
+            source_state = snapshot_file_state(
+                self.mount_a, 'snap_b', file_name)
+            destination_state = snapshot_file_state(
+                self.mount_b, 'snap_b', file_name)
+            log.info('pure truncate case %s: source=%s destination=%s',
+                     file_name, source_state, destination_state)
+            if source_state != destination_state:
+                mismatches.append((file_name, source_state, destination_state))
+
+        self.remove_directory(self.primary_fs_name, self.primary_fs_id,
+                              f'/{dir_name}')
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        self.assertEqual([], mismatches)
+
     def test_cephfs_mirror_incremental_sync_with_type_mixup(self):
         """ Test incremental snapshot synchronization with file type changes.
 

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -2754,6 +2754,7 @@ int PeerReplayer::SnapDiffSync::get_changed_blocks(const std::string &epath,
   }
 
   r = 1;
+  bool callback_invoked = false;
   auto bd_s = clock::now();
   while (true) {
     ceph_file_blockdiff_changedblocks blocks;
@@ -2767,6 +2768,7 @@ int PeerReplayer::SnapDiffSync::get_changed_blocks(const std::string &epath,
     if (blocks.num_blocks) {
       auto bd_num_blocks = blocks.num_blocks;
       auto bd_cblock = blocks.b;
+      callback_invoked = true;
       r = callback(blocks.num_blocks, blocks.b);
       ceph_free_file_blockdiff_buffer(&blocks);
       if (r < 0) {
@@ -2785,6 +2787,16 @@ int PeerReplayer::SnapDiffSync::get_changed_blocks(const std::string &epath,
     }
     // else fetch next changed blocks
   }
+
+  // A size-only change can produce no changed data blocks. Still invoke the
+  // callback so copy_to_remote() can update the remote file size.
+  if (r == 0 && !callback_invoked) {
+    r = callback(0, nullptr);
+    if (r < 0) {
+      derr << ": blockdiff callback returned error: r=" << r << dendl;
+    }
+  }
+
   // blockdiff throughput
   auto bd_e = clock::now();
   blockdiff_time = seconds(bd_e - bd_s);


### PR DESCRIPTION
## Summary

Fix cephfs-mirror incremental synchronization when file blockdiff succeeds
without returning changed data extents.

For size-only changes, the mirror previously skipped the datasync callback
when `blocks.num_blocks` was zero. As a result, `copy_to_remote()` was never
called, the destination file was not truncated to the current snapshot size,
and the mirror could still create the remote snapshot and advance its
checkpoint.

Invoke the callback once with an empty block list after a successful blockdiff
that produced no extents. This reaches the existing `ceph_ftruncate()` path
without copying file data.

The regression test pins `cephfs_mirror_blockdiff_min_file_size` to 16 MiB so
the cases cannot silently fall back to a full copy. It covers object-boundary,
partial-object and same-object shrink operations, along with sparse growth.

Fixes: https://tracker.ceph.com/issues/79156

## Validation

- `git diff --check`
- `python3 -m py_compile qa/tasks/cephfs/test_mirroring.py`
- `cmake --build build --target cephfs-mirror -j 8`
- `TestMirroring.test_cephfs_mirror_blockdiff_pure_truncate`
  - repeated clean runs with exact type, byte-size and SHA-256 comparison
  - runtime blockdiff threshold verified as 16 MiB
  - zero-block callback observed for all three shrink cases
  - sparse growth verified with the expected EOF extent
- `TestMirroring.test_cephfs_mirror_incremental_sync_with_type_mixup`

## Checklist

- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [x] Includes integration test(s)
  - [x] Includes bug reproducer
  - [ ] No tests
