### PR TITLE
mgr/cephadm: put the NVMe-oF gateway address in one place

### DIFF
--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -1,7 +1,7 @@
 import errno
 import logging
 import json
-from typing import List, cast, Optional, NamedTuple
+from typing import Dict, List, cast, Optional, NamedTuple
 from ipaddress import ip_address, IPv6Address
 
 from mgr_module import HandleCommandResult
@@ -116,14 +116,29 @@ class NvmeofService(CephService):
             'root_ca_cert': tls_creds.ca_cert,
         })
 
+    def bind_addr(self,
+                  listener: str,
+                  host: str,
+                  placement_addr: Optional[str],
+                  addr_map: Optional[Dict[str, str]],
+                  addr: Optional[str]) -> str:
+        """Where a gateway's `listener` listens on `host`: the per host map,
+        then the service wide address, then what the scheduler resolved for the
+        placement from `networks`, and only then the address cephadm reaches
+        the host at.
+        """
+        mapped_addr = addr_map.get(host) if addr_map else None
+        host_addr = self.mgr.inventory.get_addr(host)
+        chosen = mapped_addr or addr or placement_addr or host_addr
+        self.mgr.log.info(f'{listener} address on {host}: {chosen}, from '
+                          f'{mapped_addr=} {addr=} {placement_addr=} {host_addr=}')
+        return chosen
+
     def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
 
         spec = cast(NvmeofServiceSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
         nvmeof_gw_id = daemon_spec.daemon_id
-        host_ip = self.mgr.inventory.get_addr(daemon_spec.host)
-        map_addr = spec.addr_map.get(daemon_spec.host) if spec.addr_map else None
-        map_discovery_addr = spec.discovery_addr_map.get(daemon_spec.host) if spec.discovery_addr_map else None
         keyring = self.get_keyring_with_caps(self.get_auth_entity(nvmeof_gw_id),
                                              ['mon', 'profile rbd',
                                               'mgr', 'allow command "service dump"',
@@ -139,13 +154,10 @@ class NvmeofService(CephService):
         name = f'{utils.name_to_config_section(self.TYPE)}.{nvmeof_gw_id}'
         rados_id = name[len('client.'):] if name.startswith('client.') else name
 
-        # The address is first searched in the per node address map,
-        # then in the spec address configuration.
-        # If neither is defined, the host IP is used as a fallback.
-        addr = map_addr or spec.addr or host_ip
-        self.mgr.log.info(f"gateway address: {addr} from {map_addr=} {spec.addr=} {host_ip=}")
-        discovery_addr = map_discovery_addr or spec.discovery_addr or host_ip
-        self.mgr.log.info(f"discovery address: {discovery_addr} from {map_discovery_addr=} {spec.discovery_addr=} {host_ip=}")
+        addr = self.bind_addr('gateway', daemon_spec.host, daemon_spec.ip,
+                              spec.addr_map, spec.addr)
+        discovery_addr = self.bind_addr('discovery', daemon_spec.host, daemon_spec.ip,
+                                        spec.discovery_addr_map, spec.discovery_addr)
         context = {
             'spec': spec,
             'name': name,

--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -247,7 +247,16 @@ class NvmeofService(CephService):
                     logger.warning(f'No ServiceSpec found for {service_name}')
                     continue
 
-                ip = utils.resolve_ip(self.mgr.inventory.get_addr(dd.hostname))
+                # Register where the gateway listens, not where cephadm reaches
+                # the host, or the mgr dials an address nothing is bound to.
+                ip = utils.resolve_ip(
+                    self.bind_addr('gateway', dd.hostname, dd.ip,
+                                   spec.addr_map, spec.addr))
+                if ip_address(ip).is_unspecified:
+                    # a wildcard listener takes in every interface and so names
+                    # none of them. The host address is one it answers on, and
+                    # the mgr already reaches the host there.
+                    ip = utils.resolve_ip(self.mgr.inventory.get_addr(dd.hostname))
                 if type(ip_address(ip)) is IPv6Address:
                     ip = f'[{ip}]'
                 service_url = '{}:{}'.format(ip, spec.port or '5500')

--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -1,11 +1,11 @@
 import errno
 import logging
 import json
-from typing import Dict, List, cast, Optional, NamedTuple
+from typing import Dict, List, cast, Optional, NamedTuple, TYPE_CHECKING
 from ipaddress import ip_address, IPv6Address
 
 from mgr_module import HandleCommandResult
-from ceph.deployment.service_spec import NvmeofServiceSpec, CertificateSource
+from ceph.deployment.service_spec import NvmeofServiceSpec, CertificateSource, ServiceSpec
 
 from orchestrator import (
     OrchestratorError,
@@ -16,6 +16,9 @@ from orchestrator import (
 from .cephadmservice import CephadmDaemonDeploySpec, CephService
 from .service_registry import register_cephadm_service
 from .. import utils
+
+if TYPE_CHECKING:
+    from ..module import CephadmOrchestrator
 
 logger = logging.getLogger(__name__)
 NVMEOF_CLIENT_CERT_LABEL = 'client'
@@ -133,6 +136,36 @@ class NvmeofService(CephService):
         self.mgr.log.info(f'{listener} address on {host}: {chosen}, from '
                           f'{mapped_addr=} {addr=} {placement_addr=} {host_addr=}')
         return chosen
+
+    @classmethod
+    def get_dependencies(cls, mgr: "CephadmOrchestrator",
+                         spec: Optional[ServiceSpec] = None,
+                         daemon_type: Optional[str] = None) -> List[str]:
+        deps: List[str] = []
+        if spec:
+            nvmeof_spec = cast(NvmeofServiceSpec, spec)
+            # The declarations bind_addr reads. A gateway keeps the address it
+            # was deployed with, so moving one has to reach the daemon as a
+            # reconfig. `networks` is not here: the address it resolves to
+            # lands on the placement, which the scheduler already compares
+            # against the daemon it deployed.
+            #
+            # Only what is set, so a spec that declares no address at all
+            # carries the deps it carried before and upgrading to this does
+            # not reconfigure it. A map renders in insertion order, which a
+            # reload of the spec need not repeat, so sort it: deps that differ
+            # from one pass to the next reconfigure on every pass.
+            if nvmeof_spec.addr:
+                deps.append(f'addr: {nvmeof_spec.addr}')
+            if nvmeof_spec.addr_map:
+                deps.append(f'addr_map: {sorted(nvmeof_spec.addr_map.items())}')
+            if nvmeof_spec.discovery_addr:
+                deps.append(f'discovery_addr: {nvmeof_spec.discovery_addr}')
+            if nvmeof_spec.discovery_addr_map:
+                deps.append(
+                    f'discovery_addr_map: {sorted(nvmeof_spec.discovery_addr_map.items())}')
+        parent_deps = super().get_dependencies(mgr, spec, daemon_type)
+        return sorted(deps + parent_deps)
 
     def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type

--- a/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
@@ -1,7 +1,8 @@
+import contextlib
 import json
 import pytest
-from unittest.mock import MagicMock, patch
-from typing import Dict, List, cast
+from unittest.mock import ANY, MagicMock, patch
+from typing import Any, Dict, List, cast
 from ceph.utils import datetime_now
 
 from cephadm.services.nvmeof import NvmeofService, NVMEOF_CLIENT_CERT_LABEL
@@ -311,6 +312,33 @@ timeout = 1.0\n"""
             placement=PlacementSpec(hosts=['host1']), networks=['10.0.0.0/24'],
             addr_map={'host1': '10.0.0.8'}))
         assert 'addr = 10.0.0.8\n' in conf
+
+    def test_nvmeof_addr_dependencies(self, cephadm_module: CephadmOrchestrator):
+        def deps(**kwargs: Any) -> List[str]:
+            spec = NvmeofServiceSpec(service_id='testpool.groupa', group='groupa',
+                                     pool='testpool', **kwargs)
+            return NvmeofService.get_dependencies(cephadm_module, spec, 'nvmeof')
+
+        # A spec that names no address carries what it carried before these
+        # were tracked, so upgrading to them reconfigures nothing.
+        assert deps() == []
+
+        # Each declaration bind_addr reads is one the daemon has to be told
+        # about, having been deployed with the address it resolved to.
+        assert deps(addr='10.0.0.7') != deps()
+        assert deps(addr_map={'host1': '10.0.0.7'}) != deps()
+        assert deps(discovery_addr='10.0.0.7') != deps()
+        assert deps(discovery_addr_map={'host1': '10.0.0.7'}) != deps()
+        assert deps(addr_map={'host1': '10.0.0.7'}) != deps(addr_map={'host1': '10.0.0.8'})
+
+        # The same map written in another order is the same map. Deps that
+        # differ from one pass to the next reconfigure on every pass.
+        assert (deps(addr_map={'host1': '10.0.0.7', 'host2': '10.0.0.8'})
+                == deps(addr_map={'host2': '10.0.0.8', 'host1': '10.0.0.7'}))
+
+        # `networks` is left to the placement, which the scheduler already
+        # compares against the daemon it deployed.
+        assert deps(networks=['10.0.0.0/24']) == []
 
     @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     def test_validate_no_group_duplicate_on_apply(self, cephadm_module: CephadmOrchestrator):
@@ -1132,3 +1160,19 @@ class TestNvmeofTLSBundle:
         assert bundle.client_cert == ''
         assert bundle.client_key == ''
         assert bundle.ca_cert == ''
+
+
+def test_nvmeof_choose_next_action_on_addr_change(cephadm_module, mock_cephadm):
+    spec = NvmeofServiceSpec(service_id='testpool.groupa', group='groupa',
+                             pool='testpool', placement=PlacementSpec(hosts=['test']))
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(with_host(cephadm_module, 'test'))
+        stack.enter_context(with_service(cephadm_module, spec))
+        mock_cephadm._daemon_action.reset_mock()
+        # Moving the gateway has to reach the gateway. While the address was
+        # not a dependency the spec moved under a daemon that went on
+        # listening where it was, and only the dashboard registry followed.
+        spec.addr_map = {'test': '10.0.0.7'}
+        cephadm_module.apply([spec])
+        mock_cephadm.serve(cephadm_module)._check_daemons()
+        mock_cephadm._daemon_action.assert_called_with(ANY, action='reconfig')

--- a/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
@@ -10,7 +10,7 @@ from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 from cephadm.module import CephadmOrchestrator
 from ceph.deployment.service_spec import NvmeofServiceSpec, PlacementSpec
 from cephadm.tests.fixtures import with_host, with_service, wait, _run_cephadm, async_side_effect
-from orchestrator import OrchestratorError
+from orchestrator import OrchestratorError, DaemonDescription
 from cephadm.tlsobject_types import TLSCredentials
 
 cephadm_root_ca = """-----BEGIN CERTIFICATE-----\nMIIE7DCCAtSgAwIBAgIUE8b2zZ64geu2ns3Zfn3/4L+Cf6MwDQYJKoZIhvcNAQEL\nBQAwFzEVMBMGA1UEAwwMY2VwaGFkbS1yb290MB4XDTI0MDYyNjE0NDA1M1oXDTM0\nMDYyNzE0NDA1M1owFzEVMBMGA1UEAwwMY2VwaGFkbS1yb290MIICIjANBgkqhkiG\n9w0BAQEFAAOCAg8AMIICCgKCAgEAsZRJsdtTr9GLG1lWFql5SGc46ldFanNJd1Gl\nqXq5vgZVKRDTmNgAb/XFuNEEmbDAXYIRZolZeYKMHfn0pouPRSel0OsC6/02ZUOW\nIuN89Wgo3IYleCFpkVIumD8URP3hwdu85plRxYZTtlruBaTRH38lssyCqxaOdEt7\nAUhvYhcMPJThB17eOSQ73mb8JEC83vB47fosI7IhZuvXvRSuZwUW30rJanWNhyZq\neS2B8qw2RSO0+77H6gA4ftBnitfsE1Y8/F9Z/f92JOZuSMQXUB07msznPbRJia3f\nueO8gOc32vxd1A1/Qzp14uX34yEGY9ko2lW226cZO29IVUtXOX+LueQttwtdlpz8\ne6Npm09pXhXAHxV/OW3M28MdXmobIqT/m9MfkeAErt5guUeC5y8doz6/3VQRjFEn\nRpN0WkblgnNAQ3DONPc+Qd9Fi/wZV2X7bXoYpNdoWDsEOiE/eLmhG1A2GqU/mneP\nzQ6u79nbdwTYpwqHpa+PvusXeLfKauzI8lLUJotdXy9EK8iHUofibB61OljYye6B\nG3b8C4QfGsw8cDb4APZd/6AZYyMx/V3cGZ+GcOV7WvsC8k7yx5Uqasm/kiGQ3EZo\nuNenNEYoGYrjb8D/8QzqNUTwlEh27/ps80tO7l2GGTvWVZL0PRZbmLDvO77amtOf\nOiRXMoUCAwEAAaMwMC4wGwYDVR0RBBQwEocQAAAAAAAAAAAAAAAAAAAAATAPBgNV\nHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQAxwzX5AhYEWhTV4VUwUj5+\nqPdl4Q2tIxRokqyE+cDxoSd+6JfGUefUbNyBxDt0HaBq8obDqqrbcytxnn7mpnDu\nhtiauY+I4Amt7hqFOiFA4cCLi2mfok6g2vL53tvhd9IrsfflAU2wy7hL76Ejm5El\nA+nXlkJwps01Whl9pBkUvIbOn3pXX50LT4hb5zN0PSu957rjd2xb4HdfuySm6nW4\n4GxtVWfmGA6zbC4XMEwvkuhZ7kD2qjkAguGDF01uMglkrkCJT3OROlNBuSTSBGqt\ntntp5VytHvb7KTF7GttM3ha8/EU2KYaHM6WImQQTrOfiImAktOk4B3lzUZX3HYIx\n+sByO4P4dCvAoGz1nlWYB2AvCOGbKf0Tgrh4t4jkiF8FHTXGdfvWmjgi1pddCNAy\nn65WOCmVmLZPERAHOk1oBwqyReSvgoCFo8FxbZcNxJdlhM0Z6hzKggm3O3Dl88Xl\n5euqJjh2STkBW8Xuowkg1TOs5XyWvKoDFAUzyzeLOL8YSG+gXV22gPTUaPSVAqdb\nwd0Fx2kjConuC5bgTzQHs8XWA930U3XWZraj21Vaa8UxlBLH4fUro8H5lMSYlZNE\nJHRNW8BkznAClaFSDG3dybLsrzrBFAu/Qb5zVkT1xyq0YkepGB7leXwq6vjWA5Pw\nmZbKSphWfh0qipoqxqhfkw==\n-----END CERTIFICATE-----\n"""
@@ -80,9 +80,38 @@ class TestNVMEOFService:
     def test_nvmeof_client_caps(self):
         pass
 
-    @patch('cephadm.utils.resolve_ip')
-    def test_nvmeof_dashboard_config(self, mock_resolve_ip):
-        pass
+    @pytest.mark.parametrize(
+        "addr,addr_map,daemon_ip,expected",
+        [
+            # Nothing declared: the address cephadm reaches the host at.
+            (None, None, None, '1.2.3.4:5500'),
+            # Declared per host: that one. Registering the host address instead
+            # is what leaves the gateway unreachable.
+            (None, {'testhost1': '10.0.0.7'}, None, '10.0.0.7:5500'),
+            # Resolved for the placement, which is how a `networks` CIDR arrives.
+            (None, None, '10.0.0.9', '10.0.0.9:5500'),
+            # A wildcard listener is not something to dial. The host address is
+            # among the ones it answers on, so register that instead.
+            ('0.0.0.0', None, None, '1.2.3.4:5500'),
+            ('::', None, None, '1.2.3.4:5500'),
+            # A v6 address is bracketed before the port is appended.
+            ('fd00::7', None, None, '[fd00::7]:5500'),
+        ])
+    @patch('cephadm.utils.resolve_ip', lambda addr: addr)
+    def test_nvmeof_dashboard_config(self, addr, addr_map, daemon_ip, expected):
+        spec = NvmeofServiceSpec(service_type='nvmeof', service_id='a',
+                                 addr=addr, addr_map=addr_map)
+        dd = DaemonDescription(daemon_type='nvmeof', hostname='testhost1',
+                               daemon_id='a', ip=daemon_ip)
+        with patch.object(self.mgr, 'check_mon_command') as check_mon_command, \
+                patch.object(self.mgr.spec_store.all_specs, 'get', return_value=spec):
+            check_mon_command.return_value = (0, '{"gateways": {}}', '')
+            self.nvmeof_service.config_dashboard([dd])
+            adds = [c.args for c in check_mon_command.mock_calls
+                    if c.args and c.args[0].get('prefix') == 'dashboard nvmeof-gateway-add']
+        # _check_and_set_dashboard pops 'inbuf' and passes it as the second
+        # positional argument, so the registered URL is args[1].
+        assert [a[1] for a in adds] == [expected]
 
     @patch("cephadm.inventory.Inventory.get_addr", lambda _, __: '192.168.100.100')
     @patch("cephadm.serve.CephadmServe._run_cephadm")

--- a/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
@@ -1,13 +1,15 @@
 import json
 import pytest
 from unittest.mock import MagicMock, patch
-from typing import Dict, List
+from typing import Dict, List, cast
 from ceph.utils import datetime_now
 
 from cephadm.services.nvmeof import NvmeofService, NVMEOF_CLIENT_CERT_LABEL
+from cephadm.services.service_registry import service_registry
+from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 from cephadm.module import CephadmOrchestrator
-from ceph.deployment.service_spec import NvmeofServiceSpec
-from cephadm.tests.fixtures import with_host, with_service, _run_cephadm, async_side_effect
+from ceph.deployment.service_spec import NvmeofServiceSpec, PlacementSpec
+from cephadm.tests.fixtures import with_host, with_service, wait, _run_cephadm, async_side_effect
 from orchestrator import OrchestratorError
 from cephadm.tlsobject_types import TLSCredentials
 
@@ -247,6 +249,39 @@ timeout = 1.0\n"""
                     error_ok=True,
                     use_current_daemon_image=False,
                 )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_nvmeof_config_bind_addr(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        def gateway_conf(spec: NvmeofServiceSpec) -> str:
+            # prepare_create is what fills final_config, and it is also where the
+            # address is chosen, so the rendered conf is what to assert on.
+            with with_host(cephadm_module, 'host1', addr='1.2.3.7'):
+                cephadm_module.cache.update_host_networks('host1', {
+                    '1.2.3.0/24': {'if0': ['1.2.3.7']},
+                    '10.0.0.0/24': {'if1': ['10.0.0.7', '10.0.0.8']},
+                })
+                with with_service(cephadm_module, spec, status_running=True):
+                    dd = wait(cephadm_module, cephadm_module.list_daemons())[0]
+                    daemon_spec = service_registry.get_service('nvmeof').prepare_create(
+                        CephadmDaemonDeploySpec.from_daemon_description(dd))
+                    return cast(str, daemon_spec.final_config['files']['ceph-nvmeof.conf'])
+
+        # Gateway and discovery listener both take the address the scheduler
+        # resolved from `networks`, not the one cephadm reaches the host at.
+        conf = gateway_conf(NvmeofServiceSpec(
+            service_id='testpool.groupa', group='groupa', pool='testpool',
+            placement=PlacementSpec(hosts=['host1']), networks=['10.0.0.0/24']))
+        assert conf.count('addr = 10.0.0.7\n') == 2
+        assert 'addr = 1.2.3.7\n' not in conf
+
+        # An explicit per-host address still wins over the resolved one.
+        conf = gateway_conf(NvmeofServiceSpec(
+            service_id='testpool.groupb', group='groupb', pool='testpool',
+            placement=PlacementSpec(hosts=['host1']), networks=['10.0.0.0/24'],
+            addr_map={'host1': '10.0.0.8'}))
+        assert 'addr = 10.0.0.8\n' in conf
 
     @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     def test_validate_no_group_duplicate_on_apply(self, cephadm_module: CephadmOrchestrator):


### PR DESCRIPTION


An NVMe-oF gateway asked to bind anything but the interface cephadm manages the host through serves I/O fine while every ceph nvmeof command fails with "failed to connect to all addresses". Cephadm answers 

> where does this gateway live?

 in three places, and the answers had drifted apart: HostAssignment resolves the spec's networks onto the placement, prepare_create picks from `addr_map` and `spec.addr` and ignores that, and `config_dashboard` takes the inventory host address and reads neither of the other two. The last one is why no spec can be written around this: addr_map and networks arrive by different fields and the dashboard registration sees neither.

These two commits collapse the three answers into one `bind_addr`, called by the gateway listener, the discovery listener and the dashboard registration, so what gets registered is what gets bound. No new spec fields and no change in precedence. Backport is tentacle only, since squid binds the host address unconditionally and its registration is already right. The unit tests now cover all three address sources; the failure came off a live cluster but the fix has not run on one.

Fixes: https://tracker.ceph.com/issues/79272

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
