### PR TITLE
nvmeofgw: fix sending dummy maps

### DIFF
--- a/src/mon/NVMeofGwMap.cc
+++ b/src/mon/NVMeofGwMap.cc
@@ -399,18 +399,20 @@ bool NVMeofGwMap::get_location_in_disaster_cleanup(const NvmeGroupKey& group_key
   return false;
 }
 
-void NVMeofGwMap::disaster_map_remove_location(const NvmeGroupKey& group_key,
+bool NVMeofGwMap::disaster_map_remove_location(const NvmeGroupKey& group_key,
            NvmeLocation& location) {
   // this function called when GW with last location removed from the group
   //or when removed location from the disaster_location map
   auto grp_it = disaster_locations.find(group_key);
   if (grp_it != disaster_locations.end()) {
     auto& locs = grp_it->second;
-    locs.erase(location);
+    const bool erased = locs.erase(location) != 0;
     if (locs.empty()) {
       disaster_locations.erase(grp_it);
     }
+    return erased;
   }
+  return false;
 }
 
 int NVMeofGwMap::cfg_location_disaster_set(
@@ -872,13 +874,16 @@ void NVMeofGwMap::check_relocate_ana_groups(const NvmeGroupKey& group_key,
           }
         }
       }
-      if (num_gw_in_location == num_active_ana_in_location) {// All ana groups of disaster location are in Active
-        disaster_map_remove_location(group_key, location);
-        dout(4) <<  "the location entry is erased "<< location
-            << " from disaster-locations num_ana_groups in location "
-            << num_gw_in_location
-            << " from the failbacks-in-progress of group " << group_key <<dendl;
-        propose = true;
+      if (disaster && (num_gw_in_location == num_active_ana_in_location))
+      { // All ana groups of disaster location are in Active state
+        bool removed_loc = disaster_map_remove_location(group_key, location);
+        if (removed_loc) {
+          dout(4) <<  "the location entry is erased "<< location
+                  << " from disaster-locations num_ana_groups in location "
+                  << num_gw_in_location
+                  << " from the failbacks-in-progress of group " << group_key <<dendl;
+          propose = true;
+        }
         return;
       }
     // for all ana groups in the list do relocate
@@ -1121,7 +1126,7 @@ void  NVMeofGwMap::find_failover_candidate(
   const NvmeGwId &gw_id, const NvmeGroupKey& group_key,
   NvmeAnaGrpId grpid, bool &propose_pending)
 {
-  dout(10) << __func__<< " " << gw_id << dendl;
+  dout(10) << __func__<< " for " << gw_id << " Ana-grp " << grpid << dendl;
   std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
   NvmeGwId min_loaded_gw_id = ILLEGAL_GW_ID;
   auto& gws_states = created_gws[group_key];

--- a/src/mon/NVMeofGwMap.h
+++ b/src/mon/NVMeofGwMap.h
@@ -193,7 +193,7 @@ private:
     NvmeGwId& min_loaded_gw_id, bool ignore_locations);
   bool get_location_in_disaster_cleanup(const NvmeGroupKey& group_key,
              NvmeLocation& returned_location);
-  void disaster_map_remove_location(const NvmeGroupKey& group_key,
+  bool disaster_map_remove_location(const NvmeGroupKey& group_key,
              NvmeLocation& location);
   bool validate_number_locations(int num_gws, int num_locations);
   void check_relocate_ana_groups(const NvmeGroupKey& group_key,


### PR DESCRIPTION
fixed: https://tracker.ceph.com/issues/78947





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
