### PR TITLE
rgw: redirect to the endpoint of the bucket's zonegroup

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -621,12 +621,21 @@ int rgw_build_bucket_policies(const DoutPrefixProvider *dpp, rgw::sal::Driver* d
     s->bucket_owner = s->bucket_acl.get_owner();
     acct_acl_user = &s->bucket_owner;
 
-    s->zonegroup_endpoint = rgw::get_zonegroup_endpoint(zonegroup);
-    s->zonegroup_name = zonegroup.get_name();
+    const std::string& bucket_zonegroup_id = s->bucket->get_info().zonegroup;
 
-    if (!zonegroup.equals(s->bucket->get_info().zonegroup)) {
+    /* the zonegroup that holds the bucket, which is where any redirect has to
+     * point. using the local zonegroup here would send the client back to the
+     * endpoint it just used, and clients that follow redirects would loop */
+    const RGWZoneGroup* bucket_zonegroup = rgw::find_zonegroup_by_id(
+        zonegroup, s->penv.site->get_period(), bucket_zonegroup_id);
+    if (bucket_zonegroup) {
+      s->zonegroup_endpoint = rgw::get_zonegroup_endpoint(*bucket_zonegroup);
+      s->zonegroup_name = bucket_zonegroup->get_name();
+    }
+
+    if (!zonegroup.equals(bucket_zonegroup_id)) {
       ldpp_dout(dpp, 0) << "NOTICE: request for data in a different zonegroup ("
-          << s->bucket->get_info().zonegroup << " != "
+          << bucket_zonegroup_id << " != "
           << zonegroup.get_id() << ")" << dendl;
       /* we now need to make sure that the operation actually requires copy source, that is
        * it's a copy operation
@@ -638,6 +647,11 @@ int rgw_build_bucket_policies(const DoutPrefixProvider *dpp, rgw::sal::Driver* d
       } else if (!s->local_source ||
           (s->op != OP_PUT && s->op != OP_COPY) ||
           rgw::sal::Object::empty(s->object.get())) {
+        if (s->zonegroup_endpoint.empty()) {
+          ldpp_dout(dpp, 0) << "NOTICE: no endpoint found for zonegroup "
+              << bucket_zonegroup_id << ", responding without a redirect "
+              "location" << dendl;
+        }
         return -ERR_PERMANENT_REDIRECT;
       }
     }

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -941,6 +941,24 @@ std::string get_zonegroup_endpoint(const RGWZoneGroup& info)
   return "";
 }
 
+const RGWZoneGroup* find_zonegroup_by_id(const RGWZoneGroup& local_zonegroup,
+                                         const std::optional<RGWPeriod>& period,
+                                         const std::string& zonegroup_id)
+{
+  if (local_zonegroup.equals(zonegroup_id)) {
+    return &local_zonegroup;
+  }
+  if (!period) {
+    return nullptr;
+  }
+  const auto& zonegroups = period->period_map.zonegroups;
+  auto z = zonegroups.find(zonegroup_id);
+  if (z == zonegroups.end()) {
+    return nullptr;
+  }
+  return &z->second;
+}
+
 int add_zone_to_group(const DoutPrefixProvider* dpp, RGWZoneGroup& zonegroup,
                       const RGWZoneParams& zone_params,
                       const bool *pis_master, const bool *pread_only,

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -801,6 +801,13 @@ int set_default_zonegroup(const DoutPrefixProvider* dpp, optional_yield y,
 /// Return an endpoint from the zonegroup or its master zone.
 std::string get_zonegroup_endpoint(const RGWZoneGroup& info);
 
+/// Return the zonegroup with the given id, which may be the local zonegroup or
+/// any other zonegroup of the given period. Returns null if the id matches
+/// neither.
+const RGWZoneGroup* find_zonegroup_by_id(const RGWZoneGroup& local_zonegroup,
+                                         const std::optional<RGWPeriod>& period,
+                                         const std::string& zonegroup_id);
+
 /// Add a zone to the zonegroup, or update an existing zone entry.
 int add_zone_to_group(const DoutPrefixProvider* dpp,
                       RGWZoneGroup& zonegroup,

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -139,6 +139,11 @@ add_executable(unittest_rgw_period_history test_rgw_period_history.cc)
 add_ceph_unittest(unittest_rgw_period_history)
 target_link_libraries(unittest_rgw_period_history ${rgw_libs})
 
+# unittest_rgw_zone
+add_executable(unittest_rgw_zone test_rgw_zone.cc)
+add_ceph_unittest(unittest_rgw_zone)
+target_link_libraries(unittest_rgw_zone ${rgw_libs})
+
 # unittest_rgw_compression
 add_executable(unittest_rgw_compression
   test_rgw_compression.cc

--- a/src/test/rgw/test_rgw_zone.cc
+++ b/src/test/rgw/test_rgw_zone.cc
@@ -1,0 +1,143 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "rgw_zone.h"
+
+#include <list>
+#include <optional>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+const std::string local_id = "74506436-cfb6-4105-8a8c-edd0c62632b7";
+const std::string remote_id = "70271812-eb5c-472a-9050-16e289e78941";
+
+RGWZoneGroup make_zonegroup(const std::string& id, const std::string& name,
+                            std::list<std::string> endpoints)
+{
+  RGWZoneGroup zonegroup{id, name};
+  zonegroup.endpoints = std::move(endpoints);
+  return zonegroup;
+}
+
+void add_master_zone(RGWZoneGroup& zonegroup, const std::string& zone_id,
+                     std::list<std::string> endpoints)
+{
+  zonegroup.master_zone = zone_id;
+  RGWZone& zone = zonegroup.zones[zone_id];
+  zone.id = zone_id;
+  zone.endpoints = std::move(endpoints);
+}
+
+RGWPeriod make_period(std::initializer_list<RGWZoneGroup> zonegroups)
+{
+  RGWPeriod period{"period-id"};
+  for (const auto& zonegroup : zonegroups) {
+    period.period_map.zonegroups[zonegroup.id] = zonegroup;
+  }
+  return period;
+}
+
+} // anonymous namespace
+
+TEST(ZonegroupEndpoint, PrefersZonegroupEndpoint)
+{
+  auto zonegroup = make_zonegroup(local_id, "local", {"http://zg:80"});
+  add_master_zone(zonegroup, "zone-id", {"http://zone:80"});
+
+  EXPECT_EQ("http://zg:80", rgw::get_zonegroup_endpoint(zonegroup));
+}
+
+TEST(ZonegroupEndpoint, FallsBackToMasterZoneEndpoint)
+{
+  auto zonegroup = make_zonegroup(local_id, "local", {});
+  add_master_zone(zonegroup, "zone-id", {"http://zone:80"});
+
+  EXPECT_EQ("http://zone:80", rgw::get_zonegroup_endpoint(zonegroup));
+}
+
+TEST(ZonegroupEndpoint, EmptyWithoutAnyEndpoint)
+{
+  auto zonegroup = make_zonegroup(local_id, "local", {});
+  add_master_zone(zonegroup, "zone-id", {});
+
+  EXPECT_EQ("", rgw::get_zonegroup_endpoint(zonegroup));
+}
+
+TEST(FindZonegroupById, ReturnsLocalZonegroup)
+{
+  const auto local = make_zonegroup(local_id, "local", {"http://local:80"});
+  const std::optional<RGWPeriod> no_period;
+
+  EXPECT_EQ(&local, rgw::find_zonegroup_by_id(local, no_period, local_id));
+}
+
+TEST(FindZonegroupById, ReturnsLocalZonegroupForEmptyIdOnMaster)
+{
+  // buckets created before zonegroups existed have no zonegroup id, and
+  // RGWZoneGroup::equals() treats those as local on the master zonegroup
+  auto local = make_zonegroup(local_id, "local", {"http://local:80"});
+  local.is_master = true;
+  const std::optional<RGWPeriod> no_period;
+
+  EXPECT_EQ(&local, rgw::find_zonegroup_by_id(local, no_period, ""));
+}
+
+TEST(FindZonegroupById, ReturnsNullWithoutPeriod)
+{
+  const auto local = make_zonegroup(local_id, "local", {"http://local:80"});
+  const std::optional<RGWPeriod> no_period;
+
+  EXPECT_EQ(nullptr, rgw::find_zonegroup_by_id(local, no_period, remote_id));
+}
+
+TEST(FindZonegroupById, ReturnsNullForUnknownId)
+{
+  const auto local = make_zonegroup(local_id, "local", {"http://local:80"});
+  const std::optional<RGWPeriod> period = make_period({local});
+
+  EXPECT_EQ(nullptr, rgw::find_zonegroup_by_id(local, period, remote_id));
+}
+
+TEST(FindZonegroupById, ReturnsRemoteZonegroupFromPeriod)
+{
+  const auto local = make_zonegroup(local_id, "local", {"http://local:80"});
+  const auto remote = make_zonegroup(remote_id, "remote", {"http://remote:80"});
+  const std::optional<RGWPeriod> period = make_period({local, remote});
+
+  const RGWZoneGroup* found =
+      rgw::find_zonegroup_by_id(local, period, remote_id);
+  ASSERT_NE(nullptr, found);
+  EXPECT_EQ(remote_id, found->id);
+  EXPECT_EQ("remote", found->name);
+}
+
+// a request for a bucket in another zonegroup has to be redirected to that
+// zonegroup's endpoint. redirecting to the local endpoint sends the client
+// back to the gateway it just used, which loops forever
+TEST(FindZonegroupById, RedirectTargetIsNotTheLocalEndpoint)
+{
+  const auto local = make_zonegroup(local_id, "local", {"http://local:80"});
+  const auto remote = make_zonegroup(remote_id, "remote", {"http://remote:80"});
+  const std::optional<RGWPeriod> period = make_period({local, remote});
+
+  const RGWZoneGroup* bucket_zonegroup =
+      rgw::find_zonegroup_by_id(local, period, remote_id);
+  ASSERT_NE(nullptr, bucket_zonegroup);
+
+  const std::string endpoint = rgw::get_zonegroup_endpoint(*bucket_zonegroup);
+  EXPECT_EQ("http://remote:80", endpoint);
+  EXPECT_NE(rgw::get_zonegroup_endpoint(local), endpoint);
+}


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Problem

When a request for a bucket that lives in another zonegroup reaches a gateway,
`rgw_build_bucket_policies()` correctly returns `ERR_PERMANENT_REDIRECT`, but
`s->zonegroup_endpoint` was read from the **local** zonegroup:

```
s->zonegroup_endpoint = rgw::get_zonegroup_endpoint(zonegroup);  // local zonegroup
s->zonegroup_name = zonegroup.get_name();

if (!zonegroup.equals(s->bucket->get_info().zonegroup)) {
  ...
  return -ERR_PERMANENT_REDIRECT;
```

`abort_early()` then builds the `Location` header from that endpoint, so the
`301` points at the gateway the client just used. Clients that follow redirects
resend the same request in a tight loop.

Example from a two-zonegroup cluster:

```
s3:stat_bucket NOTICE: request for data in a different zonegroup
    (70271812-eb5c-472a-9050-16e289e78941 != 74506436-cfb6-4105-8a8c-edd0c62632b7)
s3:stat_bucket init_permissions on :xxx[...] failed, ret=-2024
```

...with a `Location` header naming the local zonegroup's first endpoint.

This is the loop reported in http://tracker.ceph.com/issues/64983, where
two-zonegroup teuthology jobs spent hours redirecting to the same endpoint
until the requests failed with `RequestTimeTooSkewed`.

## Fix

Add `rgw::find_zonegroup_by_id()`, which resolves a zonegroup id against the
local zonegroup or the current period, and use it to take the endpoint and name
from the zonegroup that actually holds the bucket.

When the bucket's zonegroup is not part of the period, the endpoint is left
empty and the reason is logged, so the response carries no `Location` rather
than pointing the client back at itself.

Single-zonegroup deployments are unaffected: the lookup returns the local
zonegroup, exactly as before.

This also restores `Request.ZoneGroup.Name` and `Request.ZoneGroup.Endpoint` in
lua scripts to the bucket's zonegroup, which is what they reported before
e2eb66a36175 dropped the per-bucket zonegroup lookup.

## Testing

Built and ran locally (gcc 12, Release):

```
$ ninja unittest_rgw_zone
[189/189] Linking CXX executable bin/unittest_rgw_zone

$ ./bin/unittest_rgw_zone
[==========] Running 9 tests from 2 test suites.
...
[  PASSED  ] 9 tests.
```

The cross-zonegroup redirect path itself is exercised by the `rgw/multisite`
suite with `realms/two-zonegroup.yaml`; I have not run teuthology for this
change.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
