### PR TITLE
umbrella: mgr: rate-limit repetitive CherryPy access logs 

### DIFF
--- a/src/pybind/mgr/cherrypy_mgr.py
+++ b/src/pybind/mgr/cherrypy_mgr.py
@@ -33,6 +33,9 @@ Usage:
 """
 import logging
 import cherrypy
+import re
+import threading
+import time
 from cherrypy.process.servers import ServerAdapter
 from cheroot.wsgi import Server as WSGIServer
 from cheroot.ssl.builtin import BuiltinSSLAdapter
@@ -40,6 +43,42 @@ from cherrypy._cptree import Tree
 from typing import Any, Tuple, Optional, Dict
 
 logger = logging.getLogger(__name__)
+
+
+class CherryPyAccessFilter(logging.Filter):
+    """Rate-limits access log to one entry per endpoint per 300 s.
+    Non-200 responses always pass through."""
+    _PATH_RE = re.compile(r'"[A-Z]+\s+(/[^\s]*)')
+
+    def __init__(self, interval: float = 300.0) -> None:
+        super().__init__()
+        self.interval = interval
+        self._last: Dict[str, float] = {}
+        self._calls = 0
+        self._lock = threading.Lock()
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if not record.name.startswith('cherrypy.access'):
+            return True
+        msg = record.getMessage()
+        if '" 200 ' not in msg:
+            return True
+        m = self._PATH_RE.search(msg)
+        key = m.group(1) if m else msg
+        now = time.monotonic()
+        with self._lock:
+            self._calls += 1
+            if self._calls % 500 == 0:
+                cutoff = now - self.interval
+                self._last = {
+                    path: ts for path, ts in self._last.items()
+                    if ts >= cutoff
+                }
+            last = self._last.get(key)
+            if last is not None and now - last < self.interval:
+                return False
+            self._last[key] = now
+        return True
 
 
 class CherryPyErrorFilter(logging.Filter):
@@ -128,7 +167,7 @@ class CherryPyMgr:
 
     @staticmethod
     def configure_logging() -> None:
-        cherrypy.log.access_log.propagate = False
+        cherrypy.log.access_log.propagate = True
         cherrypy.log.error_log.propagate = False
 
         error_log = logging.getLogger('cherrypy.error')
@@ -137,6 +176,14 @@ class CherryPyMgr:
         has_filter = any(isinstance(f, CherryPyErrorFilter) for f in error_log.filters)
         if not has_filter:
             error_log.addFilter(CherryPyErrorFilter())
+
+        access_filter = CherryPyAccessFilter()
+
+        root_log = logging.getLogger()
+
+        for handler in root_log.handlers:
+            if not any(isinstance(f, CherryPyAccessFilter) for f in handler.filters):
+                handler.addFilter(access_filter)
 
     @staticmethod
     def create_adapter(

--- a/src/pybind/mgr/tests/test_cherrypy_mgr.py
+++ b/src/pybind/mgr/tests/test_cherrypy_mgr.py
@@ -2,8 +2,73 @@ import unittest
 from unittest import mock
 import cherrypy
 import cherrypy_mgr
+import logging
 
-from cherrypy_mgr import CherryPyMgr
+from cherrypy_mgr import CherryPyMgr, CherryPyAccessFilter
+
+
+class TestCherryPyAccessFilter(unittest.TestCase):
+    def setUp(self):
+        self.filter = CherryPyAccessFilter(interval=300.0)
+        self.monotonic_patcher = mock.patch('cherrypy_mgr.time.monotonic', return_value=100.0)
+        self.mock_monotonic = self.monotonic_patcher.start()
+
+    def tearDown(self):
+        self.monotonic_patcher.stop()
+
+    def _record(self, name: str, message: str) -> logging.LogRecord:
+        return logging.LogRecord(name, logging.INFO, __file__, 0, message, (), None)
+
+    def test_rate_limits_200_within_interval(self):
+        record = self._record(
+            'cherrypy.access.123',
+            '127.0.0.1 - - [time] "GET /metrics HTTP/1.1" 200 1 "" "Prometheus/3.6.0"'
+        )
+
+        self.assertTrue(self.filter.filter(record))
+        self.assertFalse(self.filter.filter(record))
+
+    def test_non_200_always_passes(self):
+        record = self._record(
+            'cherrypy.access.123',
+            '127.0.0.1 - - [time] "GET /metrics HTTP/1.1" 500 1 "" "Prometheus/3.6.0"'
+        )
+
+        self.assertTrue(self.filter.filter(record))
+        self.assertTrue(self.filter.filter(record))
+        self.assertEqual(self.filter._last, {})
+
+    def test_regex_key_extraction_without_query_params(self):
+        record = self._record(
+            'cherrypy.access.123',
+            '127.0.0.1 - - [time] "GET /metrics HTTP/1.1" 200 1 "" "Prometheus/3.6.0"'
+        )
+
+        self.assertTrue(self.filter.filter(record))
+        self.assertEqual(self.filter._last, {'/metrics': 100.0})
+
+    def test_regex_key_extraction_with_query_params(self):
+        record = self._record(
+            'cherrypy.access.123',
+            '127.0.0.1 - - [time] "GET /sd/prometheus/sd-config?service=ceph HTTP/1.1" 200 1 "" "Prometheus/3.6.0"'
+        )
+
+        self.assertTrue(self.filter.filter(record))
+        self.assertEqual(
+            self.filter._last,
+            {'/sd/prometheus/sd-config?service=ceph': 100.0}
+        )
+
+    def test_fallback_when_regex_does_not_match(self):
+        message = 'raw" 200 message without an HTTP request pattern'
+        record = self._record('cherrypy.access.123', message)
+
+        self.assertTrue(self.filter.filter(record))
+        self.assertEqual(
+            self.filter._last,
+            {'raw" 200 message without an HTTP request pattern': 100.0}
+        )
+
 
 class TestCherryPyMgr(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79285

---

backport of https://github.com/ceph/ceph/pull/70639
parent tracker: https://tracker.ceph.com/issues/77814

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh