### PR TITLE
umbrella: mgr/dashboard: Display pattern validation error for bad numeric inputs

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/ng-bootstrap-form-validation/cd-form-control.directive.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/ng-bootstrap-form-validation/cd-form-control.directive.spec.ts
@@ -25,13 +25,61 @@
  * Based on https://github.com/third774/ng-bootstrap-form-validation
  */
 
-import { NgForm } from '@angular/forms';
+import { ElementRef } from '@angular/core';
+import { NgForm, UntypedFormControl, Validators } from '@angular/forms';
 
 import { CdFormControlDirective } from './cd-form-control.directive';
 
 describe('CdFormControlDirective', () => {
+  let directive: CdFormControlDirective;
+  let mockControl: UntypedFormControl;
+  let mockElementRef: ElementRef;
+
+  beforeEach(() => {
+    mockControl = new UntypedFormControl('', [Validators.required]);
+    mockElementRef = {
+      nativeElement: {
+        validity: {
+          badInput: false
+        }
+      }
+    } as ElementRef;
+    directive = new CdFormControlDirective(new NgForm([], []), mockElementRef);
+    jest.spyOn(directive, 'control', 'get').mockReturnValue(mockControl);
+  });
+
   it('should create an instance', () => {
-    const directive = new CdFormControlDirective(new NgForm([], []));
     expect(directive).toBeTruthy();
+  });
+
+  it('should set pattern error and remove required error when badInput is true', () => {
+    mockControl.setErrors({ required: true });
+    (mockElementRef.nativeElement as any).validity.badInput = true;
+
+    directive.onInput();
+
+    expect(mockControl.hasError('pattern')).toBe(true);
+    expect(mockControl.hasError('required')).toBe(false);
+  });
+
+  it('should preserve other errors like min and remove required when badInput is true', () => {
+    mockControl.setErrors({ required: true, min: true });
+    (mockElementRef.nativeElement as any).validity.badInput = true;
+
+    directive.onInput();
+
+    expect(mockControl.hasError('pattern')).toBe(true);
+    expect(mockControl.hasError('min')).toBe(true);
+    expect(mockControl.hasError('required')).toBe(false);
+  });
+
+  it('should not modify errors when badInput is false', () => {
+    mockControl.setErrors({ required: true });
+    (mockElementRef.nativeElement as any).validity.badInput = false;
+
+    directive.onInput();
+
+    expect(mockControl.hasError('required')).toBe(true);
+    expect(mockControl.hasError('pattern')).toBe(false);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/ng-bootstrap-form-validation/cd-form-control.directive.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/ng-bootstrap-form-validation/cd-form-control.directive.ts
@@ -25,7 +25,16 @@
  * Based on https://github.com/third774/ng-bootstrap-form-validation
  */
 
-import { Directive, Host, HostBinding, Input, Optional, SkipSelf } from '@angular/core';
+import {
+  Directive,
+  ElementRef,
+  Host,
+  HostBinding,
+  HostListener,
+  Input,
+  Optional,
+  SkipSelf
+} from '@angular/core';
 import { ControlContainer, UntypedFormControl } from '@angular/forms';
 
 export function controlPath(name: string, parent: ControlContainer): string[] {
@@ -72,12 +81,27 @@ export class CdFormControlDirective {
     return this.parent ? this.parent.formDirective : null;
   }
 
+  @HostListener('input')
+  @HostListener('blur')
+  onInput() {
+    if (!this.control) {
+      return;
+    }
+    const nativeElement = this.elRef.nativeElement as HTMLInputElement;
+    if (nativeElement?.validity?.badInput) {
+      const errors: Record<string, any> = { ...this.control.errors, pattern: true };
+      delete errors['required'];
+      this.control.setErrors(errors);
+    }
+  }
+
   constructor(
     // this value might be null, but we union type it as such until
     // this issue is resolved: https://github.com/angular/angular/issues/25544
     @Optional()
     @Host()
     @SkipSelf()
-    private parent: ControlContainer
+    private parent: ControlContainer,
+    private elRef: ElementRef
   ) {}
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79291

---

backport of https://github.com/ceph/ceph/pull/70783
parent tracker: https://tracker.ceph.com/issues/78969

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh