### PR TITLE
mgr/dashboard: fix cephfs mirror duplicate peers

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -88,7 +88,7 @@ MIRROR_LAST_SYNCED_SNAP_SCHEMA = {
     'crawl_duration': (str, 'Time taken to scan directory'),
     'datasync_queue_wait_duration': (str, 'Time in data sync queue'),
     'sync_duration': (str, 'Snapshot sync duration'),
-    'sync_time_stamp': (str, 'Time of the last sync'),
+    'sync_time_stamp': (str, 'Wall-clock time when the snapshot sync finished'),
     'sync_bytes': (str, 'Bytes synced for the snapshot'),
     'sync_files': (int, 'Number of files synced for the snapshot'),
 }
@@ -1648,7 +1648,7 @@ class CephFSMirror(RESTController):
 
     @EndpointDoc("Get mirror daemon and peers information",
                  responses={200: DAEMON_STATUS_SCHEMA})
-    @Endpoint('GET', path='/daemon-status')
+    @Endpoint('GET', path='/daemon/status')
     @ReadPermission
     def daemon_status(self):
         error_code, out, err = mgr.remote('mirroring', 'snapshot_mirror_daemon_status')

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.spec.ts
@@ -64,7 +64,7 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
             last_synced_snap: {
               id: 1,
               name: 'snap-last',
-              sync_time_stamp: '1583.101609s',
+              sync_time_stamp: '1786358053.364396s',
               sync_bytes: '150 MiB',
               sync_files: 5000
             },
@@ -316,7 +316,7 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
       expect(result[0].currentSyncEta).toBe('calculating...');
       expect(result[0].currentSyncMode).toBe('delta');
       expect(result[0].lastSyncedSnapshot).toBe('snap-last');
-      expect(result[0].lastSyncedTime).toBe('1583.101609s');
+      expect(result[0].lastSyncedTime).toBeTruthy();
       expect(result[0].snapshotCount).toBe(10);
       expect(result[0].pendingSnapshotCount).toBe(1);
       expect(result[0].syncStatusIcon).toBe('inProgress');

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.ts
@@ -33,6 +33,7 @@ import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
+import { RelativeDatePipe } from '~/app/shared/pipes/relative-date.pipe';
 
 type SnapshotReplicationStatus = 'in-progress' | 'replicated' | 'pending' | 'failed';
 type SyncStatus = 'syncing' | 'idle' | 'failed' | 'completed';
@@ -137,6 +138,7 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
   private cdsModalService = inject(ModalCdsService);
   private notificationService = inject(NotificationService);
   private taskWrapper = inject(TaskWrapperService);
+  private relativeDatePipe = inject(RelativeDatePipe);
 
   columns: CdTableColumn[] = [];
   mirrorPaths: MirrorPath[] = [];
@@ -452,7 +454,9 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
       lastSyncedSnapshot: peerInfo.last_synced_snap?.name ?? '-',
       lastSyncedTime:
         peerInfo.last_synced_snap?.sync_time_stamp != null
-          ? String(peerInfo.last_synced_snap.sync_time_stamp)
+          ? this.relativeDatePipe.transform(
+              parseFloat(String(peerInfo.last_synced_snap.sync_time_stamp))
+            )
           : undefined,
       snapshotCount: peerInfo.snaps_synced ?? 0,
       pendingSnapshotCount: snapshots.filter(

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-overview/cephfs-mirroring-fs-overview.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-overview/cephfs-mirroring-fs-overview.component.spec.ts
@@ -64,7 +64,7 @@ describe('CephfsMirroringFsOverviewComponent', () => {
             last_synced_snap: {
               name: 'snap1',
               sync_bytes: '1.00 KiB',
-              sync_time_stamp: '9000.000000s'
+              sync_time_stamp: '1786358053.364396s'
             },
             metrics_updated_at: 1_700_000_000
           }
@@ -145,10 +145,10 @@ describe('CephfsMirroringFsOverviewComponent', () => {
     expect(fsData?.destination.fsid).toBe('abc-123');
     expect(fsData?.destination.monitorEndpoint).toBe('10.0.0.1:6789');
     expect(fsData?.stats.syncingPaths).toBe(1);
-    expect(fsData?.sync.bytesSynced).toBe('1.00 KiB');
+    expect(fsData?.sync.bytesSynced).toBe('1 KiB');
     expect(fsData?.sync.path).toBe('/dir1');
     expect(fsData?.sync.snapName).toBe('snap1');
-    expect(fsData?.sync.syncedAt).toBe(1_700_000_000);
+    expect(fsData?.sync.syncedAt).toBe(1786358053.364396);
   });
 
   it('should refresh overview data on interval tick', async () => {
@@ -225,6 +225,50 @@ describe('CephfsMirroringFsOverviewComponent helpers', () => {
 
     expect(info.mirrorPaths).toBe(3);
     expect(info.failures).toBe(1);
+    expect(info.peerUuid).toBe('peer-1');
+    expect(info.siteName).toBe('remote');
+  });
+
+  it('getDaemonOverviewInfo aggregates counters across mirror daemons', () => {
+    const info = call<DaemonOverviewInfo>(
+      'getDaemonOverviewInfo',
+      [
+        {
+          filesystems: [
+            {
+              name: 'myfs',
+              directory_count: 3,
+              peers: [
+                {
+                  uuid: 'peer-1',
+                  remote: { cluster_name: 'remote', fs_name: 'dest', fsid: 'id', mon_host: 'mon' },
+                  stats: { failure_count: 1 }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          filesystems: [
+            {
+              name: 'myfs',
+              directory_count: 2,
+              peers: [
+                {
+                  uuid: 'peer-1',
+                  remote: { cluster_name: 'remote', fs_name: 'dest', fsid: 'id', mon_host: 'mon' },
+                  stats: { failure_count: 2 }
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      'myfs'
+    );
+
+    expect(info.mirrorPaths).toBe(5);
+    expect(info.failures).toBe(3);
     expect(info.peerUuid).toBe('peer-1');
     expect(info.siteName).toBe('remote');
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-overview/cephfs-mirroring-fs-overview.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-overview/cephfs-mirroring-fs-overview.component.ts
@@ -76,7 +76,7 @@ export class CephfsMirroringFsOverviewComponent {
   }
 
   private getDaemonOverviewInfo(daemons: Daemon[], fsName: string): DaemonOverviewInfo {
-    const empty: DaemonOverviewInfo = {
+    const info: DaemonOverviewInfo = {
       mirrorPaths: 0,
       failures: 0,
       siteName: '-',
@@ -91,19 +91,24 @@ export class CephfsMirroringFsOverviewComponent {
         continue;
       }
 
-      const peer = fs.peers?.[0];
-      return {
-        mirrorPaths: fs.directory_count ?? 0,
-        failures: (fs.peers ?? []).reduce((sum, item) => sum + (item.stats?.failure_count ?? 0), 0),
-        siteName: peer?.remote?.cluster_name ?? '-',
-        destinationFsName: peer?.remote?.fs_name ?? '-',
-        fsid: peer?.remote?.fsid ?? '-',
-        monitorEndpoint: peer?.remote?.mon_host ?? '-',
-        peerUuid: peer?.uuid
-      };
+      // Each cephfs-mirror daemon reports its own path/failure counters.
+      info.mirrorPaths += fs.directory_count ?? 0;
+      info.failures += (fs.peers ?? []).reduce(
+        (sum, item) => sum + (item.stats?.failure_count ?? 0),
+        0
+      );
+
+      if (!info.peerUuid) {
+        const peer = fs.peers?.[0];
+        info.siteName = peer?.remote?.cluster_name ?? '-';
+        info.destinationFsName = peer?.remote?.fs_name ?? '-';
+        info.fsid = peer?.remote?.fsid ?? '-';
+        info.monitorEndpoint = peer?.remote?.mon_host ?? '-';
+        info.peerUuid = peer?.uuid;
+      }
     }
 
-    return empty;
+    return info;
   }
 
   private buildMirroringFsOverviewData(

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.spec.ts
@@ -216,32 +216,58 @@ describe('CephfsMirroringListComponent', () => {
         sync_status: MirroringSyncStatus.SYNCING,
         sync_status_label: 'Syncing',
         id: '10-peer-uuid',
-        bytes_replicated: '1.00 MiB',
+        bytes_replicated: '1 MiB',
         last_sync: expect.any(String)
       })
     );
   });
 
-  it('should deduplicate mirror relationships across multiple daemons', () => {
-    const peer = {
-      remote: {
-        cluster_name: 'clusterA',
-        fs_name: 'fsA',
-        client_name: 'clientA'
-      },
-      uuid: 'peer-uuid',
-      stats: { failure_count: 0, recovery_count: 0 }
-    };
-    const filesystem = {
-      filesystem_id: 10,
-      name: 'fs1',
-      directory_count: 3,
-      peers: [peer],
-      id: ''
-    };
+  it('should aggregate per-daemon stats into one peer summary row', () => {
     const mockData: Daemon[] = [
-      { daemon_id: 14318, filesystems: [filesystem] },
-      { daemon_id: 24149, filesystems: [{ ...filesystem }] }
+      {
+        daemon_id: 14318,
+        filesystems: [
+          {
+            filesystem_id: 10,
+            name: 'fs1',
+            directory_count: 3,
+            peers: [
+              {
+                remote: {
+                  cluster_name: 'clusterA',
+                  fs_name: 'fsA',
+                  client_name: 'clientA'
+                },
+                uuid: 'peer-uuid',
+                stats: { failure_count: 1, recovery_count: 0 }
+              }
+            ],
+            id: ''
+          }
+        ]
+      },
+      {
+        daemon_id: 24149,
+        filesystems: [
+          {
+            filesystem_id: 10,
+            name: 'fs1',
+            directory_count: 2,
+            peers: [
+              {
+                remote: {
+                  cluster_name: 'clusterA',
+                  fs_name: 'fsA',
+                  client_name: 'clientA'
+                },
+                uuid: 'peer-uuid',
+                stats: { failure_count: 2, recovery_count: 1 }
+              }
+            ],
+            id: ''
+          }
+        ]
+      }
     ];
 
     cephfsServiceMock.listDaemonStatus.mockReturnValue(of(mockData));
@@ -249,9 +275,8 @@ describe('CephfsMirroringListComponent', () => {
 
     let emitted: MirroringRow[] = [];
 
-    component.ngOnInit();
     component.daemonStatus$.subscribe((v) => (emitted = v || []));
-    component.loadDaemonStatus();
+    component.ngOnInit();
 
     expect(emitted.length).toBe(1);
     expect(cephfsServiceMock.getMirrorStatus).toHaveBeenCalledTimes(1);
@@ -260,6 +285,11 @@ describe('CephfsMirroringListComponent', () => {
         local_fs_name: 'fs1',
         peer_uuid: 'peer-uuid',
         filesystem_id: 10,
+        directory_count: 5,
+        failure_count: 3,
+        recovery_count: 1,
+        sync_status: MirroringSyncStatus.ERROR,
+        sync_status_label: 'Error',
         id: '10-peer-uuid'
       })
     );

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.spec.ts
@@ -215,9 +215,52 @@ describe('CephfsMirroringListComponent', () => {
         recovery_count: 1,
         sync_status: MirroringSyncStatus.SYNCING,
         sync_status_label: 'Syncing',
-        id: '1-10',
+        id: '10-peer-uuid',
         bytes_replicated: '1.00 MiB',
         last_sync: expect.any(String)
+      })
+    );
+  });
+
+  it('should deduplicate mirror relationships across multiple daemons', () => {
+    const peer = {
+      remote: {
+        cluster_name: 'clusterA',
+        fs_name: 'fsA',
+        client_name: 'clientA'
+      },
+      uuid: 'peer-uuid',
+      stats: { failure_count: 0, recovery_count: 0 }
+    };
+    const filesystem = {
+      filesystem_id: 10,
+      name: 'fs1',
+      directory_count: 3,
+      peers: [peer],
+      id: ''
+    };
+    const mockData: Daemon[] = [
+      { daemon_id: 14318, filesystems: [filesystem] },
+      { daemon_id: 24149, filesystems: [{ ...filesystem }] }
+    ];
+
+    cephfsServiceMock.listDaemonStatus.mockReturnValue(of(mockData));
+    cephfsServiceMock.getMirrorStatus.mockReturnValue(of({} as any));
+
+    let emitted: MirroringRow[] = [];
+
+    component.ngOnInit();
+    component.daemonStatus$.subscribe((v) => (emitted = v || []));
+    component.loadDaemonStatus();
+
+    expect(emitted.length).toBe(1);
+    expect(cephfsServiceMock.getMirrorStatus).toHaveBeenCalledTimes(1);
+    expect(emitted[0]).toEqual(
+      expect.objectContaining({
+        local_fs_name: 'fs1',
+        peer_uuid: 'peer-uuid',
+        filesystem_id: 10,
+        id: '10-peer-uuid'
       })
     );
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
@@ -283,11 +283,11 @@ export class CephfsMirroringListComponent implements OnInit, OnDestroy {
   }
 
   private buildRows(daemons: Daemon[]): MirroringRow[] {
-    const rows: MirroringRow[] = [];
-    // Multiple cephfs-mirror daemons each report the same FS/peer topology
-    const rowsKeys = new Set<string>();
+    // Multiple cephfs-mirror daemons report the same FS/peer topology with
+    // per-daemon counters (directory_count, failure/recovery) that must be summed.
+    const rowsByKey = new Map<string, MirroringRow>();
     if (!daemons?.length) {
-      return rows;
+      return [];
     }
 
     for (const daemon of daemons) {
@@ -303,15 +303,16 @@ export class CephfsMirroringListComponent implements OnInit, OnDestroy {
             continue;
           }
           const key = `${fs.filesystem_id}-${peer.uuid}`;
-          if (rowsKeys.has(key)) {
-            continue;
+          const existing = rowsByKey.get(key);
+          if (existing) {
+            this.aggregatePeerStats(existing, fs, peer);
+          } else {
+            rowsByKey.set(key, this.peerToRow(fs, peer));
           }
-          rowsKeys.add(key);
-          rows.push(this.peerToRow(fs, peer));
         }
       }
     }
-    return rows;
+    return Array.from(rowsByKey.values());
   }
 
   private hasPeerInfo(peer: Peer): boolean {
@@ -319,11 +320,17 @@ export class CephfsMirroringListComponent implements OnInit, OnDestroy {
     return !!(remote?.cluster_name || remote?.fs_name || remote?.client_name);
   }
 
+  private aggregatePeerStats(row: MirroringRow, fs: Filesystem, peer: Peer): void {
+    row.directory_count += fs.directory_count ?? 0;
+    row.failure_count = (row.failure_count ?? 0) + (peer.stats?.failure_count ?? 0);
+    row.recovery_count = (row.recovery_count ?? 0) + (peer.stats?.recovery_count ?? 0);
+    this.applySyncStatus(row, row.failure_count);
+  }
+
   private peerToRow(fs: Filesystem, peer: Peer): MirroringRow {
     const failureCount = peer.stats?.failure_count ?? 0;
     const recoveryCount = peer.stats?.recovery_count ?? 0;
-
-    return {
+    const row: MirroringRow = {
       remote_site_name: peer.remote?.cluster_name ?? '-',
       local_fs_name: fs.name,
       fs_name: peer.remote?.fs_name ?? '-',
@@ -333,9 +340,14 @@ export class CephfsMirroringListComponent implements OnInit, OnDestroy {
       peer_uuid: peer.uuid,
       failure_count: failureCount,
       recovery_count: recoveryCount,
-      sync_status: failureCount > 0 ? MirroringSyncStatus.ERROR : MirroringSyncStatus.SYNCING,
-      sync_status_label: failureCount > 0 ? $localize`Error` : $localize`Syncing`,
       id: `${fs.filesystem_id}-${peer.uuid}`
     };
+    this.applySyncStatus(row, failureCount);
+    return row;
+  }
+
+  private applySyncStatus(row: MirroringRow, failureCount: number): void {
+    row.sync_status = failureCount > 0 ? MirroringSyncStatus.ERROR : MirroringSyncStatus.SYNCING;
+    row.sync_status_label = failureCount > 0 ? $localize`Error` : $localize`Syncing`;
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.ts
@@ -284,6 +284,8 @@ export class CephfsMirroringListComponent implements OnInit, OnDestroy {
 
   private buildRows(daemons: Daemon[]): MirroringRow[] {
     const rows: MirroringRow[] = [];
+    // Multiple cephfs-mirror daemons each report the same FS/peer topology
+    const rowsKeys = new Set<string>();
     if (!daemons?.length) {
       return rows;
     }
@@ -300,7 +302,12 @@ export class CephfsMirroringListComponent implements OnInit, OnDestroy {
           if (!this.hasPeerInfo(peer)) {
             continue;
           }
-          rows.push(this.peerToRow(daemon, fs, peer));
+          const key = `${fs.filesystem_id}-${peer.uuid}`;
+          if (rowsKeys.has(key)) {
+            continue;
+          }
+          rowsKeys.add(key);
+          rows.push(this.peerToRow(fs, peer));
         }
       }
     }
@@ -312,7 +319,7 @@ export class CephfsMirroringListComponent implements OnInit, OnDestroy {
     return !!(remote?.cluster_name || remote?.fs_name || remote?.client_name);
   }
 
-  private peerToRow(daemon: Daemon, fs: Filesystem, peer: Peer): MirroringRow {
+  private peerToRow(fs: Filesystem, peer: Peer): MirroringRow {
     const failureCount = peer.stats?.failure_count ?? 0;
     const recoveryCount = peer.stats?.recovery_count ?? 0;
 
@@ -328,7 +335,7 @@ export class CephfsMirroringListComponent implements OnInit, OnDestroy {
       recovery_count: recoveryCount,
       sync_status: failureCount > 0 ? MirroringSyncStatus.ERROR : MirroringSyncStatus.SYNCING,
       sync_status_label: failureCount > 0 ? $localize`Error` : $localize`Syncing`,
-      id: `${daemon.daemon_id}-${fs.filesystem_id}`
+      id: `${fs.filesystem_id}-${peer.uuid}`
     };
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/mirroring-sync-utils.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/mirroring-sync-utils.spec.ts
@@ -2,15 +2,18 @@ import { MirroringSyncUtils } from './mirroring-sync-utils';
 import { MirroringFsSyncInfo } from '~/app/shared/models/cephfs.model';
 
 describe('MirroringSyncUtils', () => {
-  it('extractLatestSync counts syncing paths and picks latest snapshot', () => {
+  it('extractLatestSync counts syncing paths and picks latest snapshot by sync_time_stamp', () => {
     const sync = MirroringSyncUtils.extractLatestSync({
       metrics: {
         '/old': {
           peer: {
             p1: {
               state: 'idle',
-              last_synced_snap: { name: 'old', sync_bytes: '1 B', sync_time_stamp: '1s' },
-              metrics_updated_at: 100
+              last_synced_snap: {
+                name: 'old',
+                sync_bytes: '1 B',
+                sync_time_stamp: '1786358053.364396s'
+              }
             }
           }
         },
@@ -18,8 +21,11 @@ describe('MirroringSyncUtils', () => {
           peer: {
             p2: {
               state: 'syncing',
-              last_synced_snap: { name: 'new', sync_bytes: '2 B', sync_time_stamp: '2s' },
-              metrics_updated_at: 200
+              last_synced_snap: {
+                name: 'new',
+                sync_bytes: '2 B',
+                sync_time_stamp: '1786362048.305584s'
+              }
             }
           }
         }
@@ -29,24 +35,67 @@ describe('MirroringSyncUtils', () => {
     expect(sync.syncingPaths).toBe(1);
     expect(sync.info.snapName).toBe('new');
     expect(sync.info.path).toBe('/new');
-    expect(sync.info.syncedAt).toBe(200);
+    expect(sync.info.bytesSynced).toBe('3 B');
+    expect(sync.info.syncedAt).toBe(1786362048.305584);
   });
 
-  it('isNewerMirrorSync prefers metrics_updated_at over sync timestamp', () => {
-    expect(MirroringSyncUtils.isNewerMirrorSync('1s', 300, '9s', 200)).toBe(true);
-    expect(MirroringSyncUtils.isNewerMirrorSync('9s', 100, '1s', 200)).toBe(false);
-  });
+  it('extractLatestSync sums sync_bytes across all mirror paths', () => {
+    const sync = MirroringSyncUtils.extractLatestSync({
+      metrics: {
+        '/dir1': {
+          peer: {
+            'peer-uuid': {
+              state: 'idle',
+              last_synced_snap: {
+                name: 'snap1',
+                sync_bytes: '1.00 MiB',
+                sync_time_stamp: '1786358053.364396s'
+              }
+            }
+          }
+        },
+        '/dir2': {
+          peer: {
+            'peer-uuid': {
+              state: 'idle',
+              last_synced_snap: {
+                name: 'snap2',
+                sync_bytes: '2.00 MiB',
+                sync_time_stamp: '1786362048.305584s'
+              }
+            }
+          }
+        },
+        '/dir3': {
+          peer: {
+            'peer-uuid': {
+              state: 'syncing',
+              last_synced_snap: {
+                name: 'snap3',
+                sync_bytes: 1048576,
+                sync_time_stamp: 1786443055.4675815
+              }
+            }
+          }
+        }
+      }
+    });
 
-  it('mirrorMetricsUpdatedAtToEpoch parses valid values and rejects invalid ones', () => {
-    expect(MirroringSyncUtils.mirrorMetricsUpdatedAtToEpoch(1_700_000_000.9)).toBe(1_700_000_000);
-    expect(MirroringSyncUtils.mirrorMetricsUpdatedAtToEpoch('1234.5')).toBe(1234);
-    expect(MirroringSyncUtils.mirrorMetricsUpdatedAtToEpoch('')).toBeNull();
-    expect(MirroringSyncUtils.mirrorMetricsUpdatedAtToEpoch(0)).toBeNull();
+    expect(sync.info.bytesSynced).toBe('4 MiB');
+    expect(sync.syncingPaths).toBe(1);
+    expect(sync.info.path).toBe('/dir3');
+    expect(sync.info.syncedAt).toBe(1786443055.4675815);
   });
 
   it('emptySyncInfo returns placeholder values', () => {
     const info: MirroringFsSyncInfo = MirroringSyncUtils.emptySyncInfo();
     expect(info.bytesSynced).toBe('-');
     expect(info.syncedAt).toBeNull();
+  });
+
+  it('parseSyncBytes handles numeric and human-readable values', () => {
+    expect(MirroringSyncUtils.parseSyncBytes('1.00 MiB')).toBe(1048576);
+    expect(MirroringSyncUtils.parseSyncBytes(2048)).toBe(2048);
+    expect(MirroringSyncUtils.parseSyncBytes(undefined)).toBeNull();
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/mirroring-sync-utils.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/mirroring-sync-utils.ts
@@ -1,4 +1,5 @@
 import { MirroringFsSyncInfo, MirrorStatusResponse } from '~/app/shared/models/cephfs.model';
+import { FormatterService } from '~/app/shared/services/formatter.service';
 
 export class MirroringSyncUtils {
   static emptySyncInfo(): MirroringFsSyncInfo {
@@ -15,11 +16,11 @@ export class MirroringSyncUtils {
     info: MirroringFsSyncInfo;
   } {
     let syncingPaths = 0;
-    let latestSyncTime = '';
-    let latestMetricsUpdatedAt: number | string | undefined;
+    let latestSyncTime = 0;
     let latestSnapName = '';
-    let latestBytes = '';
     let latestSyncPath = '';
+    let totalBytesSynced = 0;
+    let hasBytesSynced = false;
 
     for (const [dirPath, dirMetrics] of Object.entries(status.metrics ?? {})) {
       for (const dir of Object.values(dirMetrics.peer ?? {})) {
@@ -32,27 +33,18 @@ export class MirroringSyncUtils {
           continue;
         }
 
-        const syncTime = String(snap.sync_time_stamp ?? '');
-        const snapName = snap.name ?? '';
-        const metricsUpdatedAt = dir.metrics_updated_at;
-        if (
-          MirroringSyncUtils.isNewerMirrorSync(
-            syncTime,
-            metricsUpdatedAt,
-            latestSyncTime,
-            latestMetricsUpdatedAt
-          )
-        ) {
+        const parsedBytes = MirroringSyncUtils.parseSyncBytes(snap.sync_bytes);
+        if (parsedBytes !== null) {
+          totalBytesSynced += parsedBytes;
+          hasBytesSynced = true;
+        }
+
+        // sync_time_stamp is a wall-clock Unix epoch (number or "<epoch>s" string).
+        const syncTime = parseFloat(String(snap.sync_time_stamp ?? ''));
+        if (syncTime >= latestSyncTime) {
           latestSyncTime = syncTime;
-          latestMetricsUpdatedAt = metricsUpdatedAt;
-          latestSnapName = snapName;
-          latestBytes = String(snap.sync_bytes ?? '');
+          latestSnapName = snap.name ?? '';
           latestSyncPath = dirPath;
-        } else if (!latestSnapName && snapName) {
-          latestSnapName = snapName;
-          latestBytes = latestBytes || String(snap.sync_bytes ?? '');
-          latestSyncPath = dirPath;
-          latestMetricsUpdatedAt = latestMetricsUpdatedAt ?? metricsUpdatedAt;
         }
       }
     }
@@ -60,41 +52,25 @@ export class MirroringSyncUtils {
     return {
       syncingPaths,
       info: {
-        bytesSynced: latestBytes || '-',
+        bytesSynced: hasBytesSynced ? MirroringSyncUtils.formatSyncBytes(totalBytesSynced) : '-',
         path: latestSyncPath,
         snapName: latestSnapName,
-        syncedAt: MirroringSyncUtils.mirrorMetricsUpdatedAtToEpoch(latestMetricsUpdatedAt)
+        syncedAt: latestSyncTime || null
       }
     };
   }
 
-  static isNewerMirrorSync(
-    syncTime: string,
-    metricsUpdatedAt: number | string | undefined,
-    latestSyncTime: string,
-    latestMetricsUpdatedAt: number | string | undefined
-  ): boolean {
-    const newEpoch = MirroringSyncUtils.mirrorMetricsUpdatedAtToEpoch(metricsUpdatedAt);
-    const latestEpoch = MirroringSyncUtils.mirrorMetricsUpdatedAtToEpoch(latestMetricsUpdatedAt);
-    if (newEpoch !== null && latestEpoch !== null) {
-      return newEpoch >= latestEpoch;
+  static parseSyncBytes(value: number | string | undefined | null): number | null {
+    if (value === undefined || value === null || value === '') {
+      return null;
     }
-    return Boolean(syncTime && syncTime >= latestSyncTime);
+    if (typeof value === 'number') {
+      return Number.isFinite(value) ? value : null;
+    }
+    return new FormatterService().toBytes(String(value).replace(/\s+/g, ''), null);
   }
 
-  static mirrorMetricsUpdatedAtToEpoch(
-    metricsUpdatedAt: number | string | undefined
-  ): number | null {
-    if (metricsUpdatedAt === undefined || metricsUpdatedAt === null || metricsUpdatedAt === '') {
-      return null;
-    }
-    const epoch =
-      typeof metricsUpdatedAt === 'number'
-        ? metricsUpdatedAt
-        : parseFloat(String(metricsUpdatedAt));
-    if (!Number.isFinite(epoch) || epoch <= 0) {
-      return null;
-    }
-    return Math.floor(epoch);
+  static formatSyncBytes(bytes: number): string {
+    return new FormatterService().formatToBinary(bytes, false, 2);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
@@ -135,7 +135,7 @@ export class CephfsService {
   }
 
   listDaemonStatus(): Observable<Daemon[]> {
-    return this.http.get<Daemon[]>(`${this.baseURL}/mirror/daemon-status`);
+    return this.http.get<Daemon[]>(`${this.baseURL}/mirror/daemon/status`);
   }
 
   enableMirror(@cdEncodeNot fsName: string): Observable<any> {

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -3177,7 +3177,7 @@ paths:
       summary: Create bootstrap peer
       tags:
       - CephfsMirror
-  /api/cephfs/mirror/daemon-status:
+  /api/cephfs/mirror/daemon/status:
     get:
       parameters: []
       responses:
@@ -4125,7 +4125,8 @@ paths:
                                           snapshot
                                         type: integer
                                       sync_time_stamp:
-                                        description: Time of the last sync
+                                        description: Wall-clock time when the snapshot
+                                          sync finished
                                         type: string
                                     required: &id031
                                     - id
@@ -4301,7 +4302,8 @@ paths:
                                           snapshot
                                         type: integer
                                       sync_time_stamp:
-                                        description: Time of the last sync
+                                        description: Wall-clock time when the snapshot
+                                          sync finished
                                         type: string
                                     required: *id031
                                     type: object

--- a/src/pybind/mgr/dashboard/tests/test_cephfs.py
+++ b/src/pybind/mgr/dashboard/tests/test_cephfs.py
@@ -268,7 +268,7 @@ class CephFSMirrorTest(ControllerTestCase):  # pylint: disable=too-many-public-m
         mock_output = json.dumps(expected_status)
         mgr.remote = Mock(return_value=(0, mock_output, ''))
 
-        self._get('/api/cephfs/mirror/daemon-status')
+        self._get('/api/cephfs/mirror/daemon/status')
         self.assertStatus(200)
         self.assertJsonBody(expected_status)
         mgr.remote.assert_called_once_with('mirroring', 'snapshot_mirror_daemon_status')
@@ -277,7 +277,7 @@ class CephFSMirrorTest(ControllerTestCase):  # pylint: disable=too-many-public-m
         error_message = 'Daemon not available'
         mgr.remote = Mock(return_value=(1, '', error_message))
 
-        self._get('/api/cephfs/mirror/daemon-status')
+        self._get('/api/cephfs/mirror/daemon/status')
         self.assertStatus(400)
         response = self.json_body()
         self.assertIn('Failed to get Cephfs mirror daemon status', response.get('detail', ''))


### PR DESCRIPTION
**Before**

[screen-capture (35).webm](https://github.com/user-attachments/assets/4606e3f9-feb8-4db0-a9e8-c504e111b377)



**After**

Changes:

- Removes duplicate entries on multiple daemon setups
- Aggregate per-daemon peer stats across mirror daemons
- Sum sync_bytes across mirrored paths for total bytes
- Updates to use [newly updated ync_time_stamp epoch](https://github.com/ceph/ceph/pull/70212) for last sync display
- Rename daemon-status endpoint to mirror/daemon/status

[screen-capture (40).webm](https://github.com/user-attachments/assets/4704bf0c-f294-4e2d-be78-8a36c17b3610)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
