### PR TITLE
mgr/dashboard: Use existing "Save Changes" label constant for Edit Host button

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/users.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/users.po.ts
@@ -41,7 +41,7 @@ export class UsersPageHelper extends PageHelper {
   edit(name: string, newCaps: string, isMultiselect = false) {
     this.navigateEdit(name, false, true, null, isMultiselect);
     cy.get('#formly_5_string_cap_1').clear().type(newCaps);
-    cy.get("[aria-label='Edit User']").should('exist').click();
+    cy.get("[aria-label='Save changes']").should('exist').click();
     cy.get('cd-crud-table').should('exist');
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
@@ -22,7 +22,9 @@ import { TableActionsComponent } from '~/app/shared/datatable/table-actions/tabl
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import { OrchestratorFeature } from '~/app/shared/models/orchestrator.enum';
 import { Permissions } from '~/app/shared/models/permissions';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
+import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { ModalService } from '~/app/shared/services/modal.service';
 import {
   configureTestBed,
@@ -130,6 +132,21 @@ describe('OsdListComponent', () => {
   it('should create', () => {
     fixture.detectChanges();
     expect(component).toBeTruthy();
+  });
+
+  it('should set OSD edit modal submit label to Save changes', () => {
+    const modalService = TestBed.inject(ModalCdsService);
+    const actionLabels = TestBed.inject(ActionLabelsI18n);
+    const showSpy = spyOn(modalService, 'show').and.stub();
+
+    setFakeSelection();
+    component.editAction();
+
+    expect(showSpy).toHaveBeenCalled();
+    const modalConfig = showSpy.calls.mostRecent().args[1];
+    expect(modalConfig.submitButtonText).toBe('Save changes');
+    expect(modalConfig.submitButtonText).toBe(actionLabels.SAVE_CHANGES);
+    expect(modalConfig.titleText).toContain('Edit OSD');
   });
 
   it('should have columns that are sortable', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
@@ -483,7 +483,7 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
           required: true
         }
       ],
-      submitButtonText: $localize`Edit OSD`,
+      submitButtonText: this.actionLabels.SAVE_CHANGES,
       onSubmit: (values: any) => {
         this.osdService.update(selectedOsd.id, values.deviceClass).subscribe(() => {
           this.notificationService.show(

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/crud-form/crud-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/crud-form/crud-form.component.html
@@ -26,7 +26,7 @@
         <cd-form-button-panel
           (submitActionEvent)="submit(model, formUISchema.taskInfo)"
           [form]="formDir"
-          [submitText]="formUISchema.title"
+          [submitText]="submitAction"
           [disabled]="!form.valid"
           wrappingClass="text-right"
         ></cd-form-button-panel>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/crud-form/crud-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/crud-form/crud-form.component.spec.ts
@@ -1,31 +1,85 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { configureTestBed } from '~/testing/unit-test-helper';
-import { CdDatePipe } from '~/app/shared/pipes/cd-date.pipe';
-import { CrudFormComponent } from './crud-form.component';
+import { ActivatedRoute, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { configureTestBed } from '~/testing/unit-test-helper';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
+import { CdDatePipe } from '~/app/shared/pipes/cd-date.pipe';
+import { DataGatewayService } from '~/app/shared/services/data-gateway.service';
+import { CrudFormComponent } from './crud-form.component';
 
 describe('CrudFormComponent', () => {
   let component: CrudFormComponent;
   let fixture: ComponentFixture<CrudFormComponent>;
+  let dataGatewayService: DataGatewayService;
+  let actionLabels: ActionLabelsI18n;
+
+  const formSchema = {
+    title: 'Edit User',
+    methodType: 'PUT',
+    model: {},
+    controlSchema: [],
+    uiSchema: {},
+    taskInfo: { metadataFields: [], message: '' }
+  };
 
   configureTestBed({
     imports: [RouterTestingModule, HttpClientTestingModule],
-    providers: [{ provide: CdDatePipe, useValue: { transform: (d: any) => d } }]
-  });
-
-  configureTestBed({
-    declarations: [CrudFormComponent]
+    declarations: [CrudFormComponent],
+    providers: [
+      { provide: CdDatePipe, useValue: { transform: (d: any) => d } },
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          queryParamMap: of(new Map()),
+          data: of({ resource: 'cluster/user' }),
+          snapshot: { url: [{ path: 'cluster' }, { path: 'user' }, { path: 'edit' }] }
+        }
+      },
+      {
+        provide: Router,
+        useValue: { url: '/cluster/user/edit' }
+      },
+      {
+        provide: DataGatewayService,
+        useValue: {
+          form: jasmine.createSpy('form').and.returnValue(of(formSchema))
+        }
+      }
+    ]
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CrudFormComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    dataGatewayService = TestBed.inject(DataGatewayService);
+    actionLabels = TestBed.inject(ActionLabelsI18n);
   });
 
   it('should create', () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
+  });
+
+  it('should set submit label to Save changes in edit mode', () => {
+    fixture.detectChanges();
+
+    expect(dataGatewayService.form).toHaveBeenCalled();
+    expect(component.submitAction).toBe('Save changes');
+    expect(component.submitAction).toBe(actionLabels.SAVE_CHANGES);
+  });
+
+  it('should keep schema title as submit label in create mode', () => {
+    const router = TestBed.inject(Router) as any;
+    router.url = '/cluster/user/create';
+    (dataGatewayService.form as jasmine.Spy).and.returnValue(
+      of({ ...formSchema, title: 'Create User', methodType: 'POST' })
+    );
+
+    fixture.detectChanges();
+
+    expect(component.submitAction).toBe('Create User');
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/crud-form/crud-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/crud-form/crud-form.component.ts
@@ -9,6 +9,7 @@ import { mergeMap } from 'rxjs/operators';
 import { CrudTaskInfo, JsonFormUISchema } from './crud-form.model';
 import { Observable } from 'rxjs';
 import _ from 'lodash';
+import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { CdTableSelection } from '../../models/cd-table-selection';
 
 @Component({
@@ -24,7 +25,8 @@ export class CrudFormComponent implements OnInit {
   form = new UntypedFormGroup({});
   formUISchema$: Observable<JsonFormUISchema>;
   methodType: string;
-  urlFormName: string;
+  urlFormAction: string;
+  submitAction: string;
   key: string = '';
   selected: CdTableSelection;
 
@@ -33,11 +35,19 @@ export class CrudFormComponent implements OnInit {
     private activatedRoute: ActivatedRoute,
     private taskWrapper: TaskWrapperService,
     private location: Location,
-    private router: Router
+    private router: Router,
+    private actionLabels: ActionLabelsI18n
   ) {}
 
   ngOnInit(): void {
     this.activatedRoute.queryParamMap.subscribe((paramMap) => {
+      this.urlFormAction = this.router.url.split('/').pop();
+      // remove optional arguments
+      const paramIndex = this.urlFormAction.indexOf('?');
+      if (paramIndex > 0) {
+        this.urlFormAction = this.urlFormAction.substring(0, paramIndex);
+      }
+
       this.formUISchema$ = this.activatedRoute.data.pipe(
         mergeMap((data: any) => {
           this.resource = data.resource || this.resource;
@@ -49,13 +59,9 @@ export class CrudFormComponent implements OnInit {
       this.formUISchema$.subscribe((data: any) => {
         this.methodType = data.methodType;
         this.model = data.model;
+        this.submitAction =
+          this.urlFormAction === URLVerbs.EDIT ? this.actionLabels.SAVE_CHANGES : data.title;
       });
-      this.urlFormName = this.router.url.split('/').pop();
-      // remove optional arguments
-      const paramIndex = this.urlFormName.indexOf('?');
-      if (paramIndex > 0) {
-        this.urlFormName = this.urlFormName.substring(0, paramIndex);
-      }
     });
   }
 
@@ -92,7 +98,7 @@ export class CrudFormComponent implements OnInit {
       await this.preSubmit(data);
       this.taskWrapper
         .wrapTaskAroundCall({
-          task: new FinishedTask(`crud-component/${this.urlFormName}`, taskMetadata),
+          task: new FinishedTask(`crud-component/${this.urlFormAction}`, taskMetadata),
           call: this.dataGatewayService.submit(this.resource, data, this.methodType)
         })
         .subscribe({

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/host-action.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/host-action.service.spec.ts
@@ -4,6 +4,7 @@ import { of, throwError } from 'rxjs';
 
 import { HostActionService } from './host-action.service';
 import { HostService } from '~/app/shared/api/host.service';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
@@ -18,6 +19,7 @@ describe('HostActionService', () => {
   let notificationService: NotificationService;
   let cdsModalService: ModalCdsService;
   let taskWrapper: TaskWrapperService;
+  let actionLabels: ActionLabelsI18n;
 
   const mockHost: Host = {
     hostname: 'test-host',
@@ -66,6 +68,7 @@ describe('HostActionService', () => {
     notificationService = TestBed.inject(NotificationService);
     cdsModalService = TestBed.inject(ModalCdsService);
     taskWrapper = TestBed.inject(TaskWrapperService);
+    actionLabels = TestBed.inject(ActionLabelsI18n);
   });
 
   afterEach(() => {
@@ -96,6 +99,7 @@ describe('HostActionService', () => {
         // Simulate form submission
         const showCall = (cdsModalService.show as jasmine.Spy).calls.mostRecent();
         const modalConfig = showCall.args[1];
+        expect(modalConfig.submitButtonText).toBe(actionLabels.SAVE_CHANGES);
         modalConfig.onSubmit({ labels: updatedLabels });
 
         setTimeout(() => {
@@ -107,6 +111,18 @@ describe('HostActionService', () => {
           );
           done();
         }, 100);
+      }, 100);
+    });
+
+    it('should set submit button label to Save changes (not Edit Host)', (done) => {
+      service.openEditModal(mockHost, () => undefined);
+
+      setTimeout(() => {
+        const modalConfig = (cdsModalService.show as jasmine.Spy).calls.mostRecent().args[1];
+        expect(modalConfig.submitButtonText).toBe('Save changes');
+        expect(modalConfig.submitButtonText).toBe(actionLabels.SAVE_CHANGES);
+        expect(modalConfig.titleText).toContain('Edit Host');
+        done();
       }, 100);
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/host-action.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/host-action.service.ts
@@ -6,6 +6,7 @@ import { ConfirmationModalComponent } from '~/app/shared/components/confirmation
 import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
 import { FormModalComponent } from '~/app/shared/components/form-modal/form-modal.component';
 import { SelectMessages } from '~/app/shared/components/select/select-messages.model';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { HostService, HostModalRef } from '~/app/shared/api/host.service';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { NotificationService } from '~/app/shared/services/notification.service';
@@ -29,7 +30,8 @@ export class HostActionService {
     private hostService: HostService,
     private notificationService: NotificationService,
     private cdsModalService: ModalCdsService,
-    private taskWrapper: TaskWrapperService
+    private taskWrapper: TaskWrapperService,
+    private actionLabels: ActionLabelsI18n
   ) {}
 
   /**
@@ -44,7 +46,7 @@ export class HostActionService {
       this.cdsModalService.show(FormModalComponent, {
         titleText: $localize`Edit Host: ${host.hostname}`,
         fields: [labelsField],
-        submitButtonText: $localize`Save changes`,
+        submitButtonText: this.actionLabels.SAVE_CHANGES,
         onSubmit: (values: { labels: string[] }) => {
           this.submitHostLabelUpdate(host.hostname, values.labels, onSuccess);
         }


### PR DESCRIPTION



https://github.com/user-attachments/assets/90c96c1c-8c13-4ea2-bd56-bcdd865761e6



Fixes: https://tracker.ceph.com/issues/79299

Signed-off-by: pujaoshahu <pshahu@redhat.com>

Regression of : https://tracker.ceph.com/issues/76507

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
