### PR TITLE
cephadm: add firewall debugging for monitoring service port handling

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1221,7 +1221,15 @@ def deploy_daemon(
     with write_new(data_dir + '/unit.configured', owner=(uid, gid)) as f:
         f.write('mtime is time we were last configured\n')
 
+    logger.warning(
+        'FIREWALL DEBUG deploy_daemon(): daemon_type=%s endpoints=%s skip_firewalld=%s',
+        daemon_type,
+        [e.port for e in endpoints],
+        getattr(ctx, 'skip_firewalld', None),
+    )
+
     update_firewalld(ctx, daemon_form_create(ctx, ident))
+    logger.warning('FIREWALL DEBUG deploy_daemon(): update_firewalld() completed')
 
     # Open ports explicitly required for the daemon
     if not ('skip_firewalld' in ctx and ctx.skip_firewalld):

--- a/src/cephadm/cephadmlib/firewalld.py
+++ b/src/cephadm/cephadmlib/firewalld.py
@@ -33,18 +33,20 @@ class Firewalld(object):
     def check(self):
         # type: () -> bool
         self.cmd = find_executable('firewall-cmd')
+        logger.warning('FIREWALL DEBUG check(): firewall-cmd=%s', self.cmd)
         if not self.cmd:
-            logger.debug('firewalld does not appear to be present')
+            logger.warning('FIREWALL DEBUG check(): firewalld does not appear to be present')
             return False
         (enabled, state, _) = check_unit(self.ctx, 'firewalld.service')
+        logger.warning('FIREWALL DEBUG check(): enabled=%s state=%s', enabled, state)
         if not enabled:
-            logger.debug('firewalld.service is not enabled')
+            logger.warning('FIREWALL DEBUG check(): firewalld.service is not enabled')
             return False
         if state != 'running':
-            logger.debug('firewalld.service is not running')
+            logger.warning('FIREWALL DEBUG check(): firewalld.service is not running')
             return False
 
-        logger.info('firewalld ready')
+        logger.warning('FIREWALL DEBUG check(): firewalld ready, returning True')
         return True
 
     def enable_service_for(self, svc: str) -> None:
@@ -83,9 +85,10 @@ class Firewalld(object):
 
     def open_ports(self, fw_ports):
         # type: (List[int]) -> None
+        logger.warning('FIREWALL DEBUG open_ports(): available=%s ports=%s', self.available, fw_ports)
         if not self.available:
-            logger.debug(
-                'Not possible to open ports <%s>. firewalld.service is not available'
+            logger.warning(
+                'FIREWALL DEBUG open_ports(): NOT available, skipping ports <%s>'
                 % fw_ports
             )
             return
@@ -101,8 +104,9 @@ class Firewalld(object):
                 verbosity=CallVerbosity.DEBUG,
             )
             if ret:
-                logger.info(
-                    'Enabling firewalld port %s in current zone...' % tcp_port
+                logger.warning(
+                    'FIREWALL DEBUG open_ports(): running: %s --permanent --add-port %s',
+                    self.cmd, tcp_port,
                 )
                 out, err, ret = call(
                     self.ctx,
@@ -114,8 +118,8 @@ class Firewalld(object):
                         % (tcp_port, err)
                     )
             else:
-                logger.debug(
-                    'firewalld port %s is enabled in current zone' % tcp_port
+                logger.warning(
+                    'FIREWALL DEBUG open_ports(): port %s already open in current zone' % tcp_port
                 )
 
     def close_ports(self, fw_ports):
@@ -156,19 +160,29 @@ class Firewalld(object):
     def apply_rules(self):
         # type: () -> None
         if not self.available:
+            logger.warning('FIREWALL DEBUG apply_rules(): NOT available, skipping reload')
             return
 
         if not self.cmd:
             raise RuntimeError('command not defined')
 
+        logger.warning('FIREWALL DEBUG apply_rules(): reloading firewalld')
         call_throws(self.ctx, [self.cmd, '--reload'])
 
 
 def update_firewalld(ctx: CephadmContext, daemon: DaemonForm) -> None:
+    logger.warning(
+        'FIREWALL DEBUG update_firewalld(): daemon=%s firewalled=%s service=%s skip_firewalld=%s',
+        getattr(daemon, 'identity', None),
+        isinstance(daemon, FirewalledServiceDaemonForm),
+        getattr(daemon, 'firewall_service_name', lambda: None)() if isinstance(daemon, FirewalledServiceDaemonForm) else None,
+        getattr(ctx, 'skip_firewalld', 'NOT SET'),
+    )
     if not ('skip_firewalld' in ctx and ctx.skip_firewalld) and isinstance(
         daemon, FirewalledServiceDaemonForm
     ):
         svc = daemon.firewall_service_name()
+        logger.warning('FIREWALL DEBUG update_firewalld(): enabling service=%s', svc)
         if not svc:
             return
         firewall = Firewalld(ctx)


### PR DESCRIPTION
**Summary**

Add temporary debug instrumentation around cephadm firewalld handling to aid investigation of monitoring stack connectivity issues.

The additional logging records:

- firewalld detection status
- service enablement decisions
- port opening operations
- firewall reload activity
- daemon firewall configuration flow

This instrumentation is intended to help determine why monitoring service ports are not being opened when firewalld is enabled.

Fixes: https://tracker.ceph.com/issues/79302
Resolves: IBMCEPH-17334
Signed-off-by: Shubha Jain [SHUBHA.JAIN1@ibm.com]

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
