### PR TITLE
rgw: guard RADOS-only code paths for the no-RADOS standalone build

### DIFF
--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -3,6 +3,7 @@
 
 #include "common/Clock.h" // for ceph_clock_now()
 #include "common/JSONFormatter.h"
+#include "common/errno.h"
 #include "include/function2.hpp"
 #include "rgw_acl_s3.h"
 #include "rgw_tag_s3.h"
@@ -28,7 +29,9 @@
 
 #include "cls/user/cls_user_types.h"
 
+#ifdef WITH_RADOSGW_RADOS
 #include "rgw_sal_rados.h"
+#endif
 
 #define dout_subsys ceph_subsys_rgw
 

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -68,11 +68,15 @@ extern "C" {
 #include "rgw_log.h"
 #include "rgw_formats.h"
 #include "rgw_usage.h"
+#ifdef WITH_RADOSGW_RADOS
 #include "rgw_sync.h"
+#endif
 #include "rgw_trim_bilog.h"
 #include "rgw_trim_datalog.h"
 #include "rgw_trim_mdlog.h"
+#ifdef WITH_RADOSGW_RADOS
 #include "rgw_data_sync.h"
+#endif
 #include "rgw_rest_conn.h"
 #include "rgw_realm_watcher.h"
 #include "rgw_role.h"
@@ -2019,6 +2023,7 @@ int do_check_object_locator(const string& tenant_name, const string& bucket_name
 }
 #endif
 
+#ifdef WITH_RADOSGW_RADOS
 /// search for a matching zone/zonegroup id and return a connection if found
 static boost::optional<RGWRESTConn> get_remote_conn(rgw::sal::RadosStore* driver,
                                                     const RGWZoneGroup& zonegroup,
@@ -2053,6 +2058,7 @@ static boost::optional<RGWRESTConn> get_remote_conn(rgw::sal::RadosStore* driver
   }
   return conn;
 }
+#endif // WITH_RADOSGW_RADOS
 
 // we expect a very small response
 static constexpr size_t MAX_REST_RESPONSE = 128 * 1024;
@@ -2171,6 +2177,7 @@ static int commit_period(rgw::sal::ConfigStore* cfgstore,
   boost::optional<RGWRESTConn> conn;
   RGWRESTConn *remote_conn = nullptr;
   if (!remote.empty()) {
+#ifdef WITH_RADOSGW_RADOS
     conn = get_remote_conn(static_cast<rgw::sal::RadosStore*>(driver), period.get_map(), remote);
     if (!conn) {
       cerr << "failed to find a zone or zonegroup for remote "
@@ -2178,6 +2185,11 @@ static int commit_period(rgw::sal::ConfigStore* cfgstore,
       return -ENOENT;
     }
     remote_conn = &*conn;
+#else
+    cerr << "ERROR: sending the period to a remote zone by id (--remote) "
+        "requires the RADOS backend; use --url instead" << std::endl;
+    return -ENOTSUP;
+#endif
   }
 
   // push period to the master with an empty period id
@@ -3402,10 +3414,12 @@ int check_reshard_bucket_params(rgw::sal::Driver* driver,
     return -EINVAL;
   }
 
+#ifdef WITH_RADOSGW_RADOS
   if (num_shards > (int)static_cast<rgw::sal::RadosStore*>(driver)->getRados()->get_max_bucket_shards()) {
     cerr << "ERROR: num_shards too high, max value: " << static_cast<rgw::sal::RadosStore*>(driver)->getRados()->get_max_bucket_shards() << std::endl;
     return -EINVAL;
   }
+#endif
 
   if (num_shards < 0) {
     cerr << "ERROR: num_shards must be non-negative integer" << std::endl;
@@ -5800,6 +5814,7 @@ int main(int argc, const char **argv)
         // validate --tier-type if specified
         const string *ptier_type = (tier_type_specified ? &tier_type : nullptr);
         if (ptier_type) {
+#ifdef WITH_RADOSGW_RADOS
           auto sync_mgr = static_cast<rgw::sal::RadosStore*>(driver)->svc()->sync_modules->get_manager();
           if (!sync_mgr->get_module(*ptier_type, nullptr)) {
             ldpp_dout(dpp(), -1) << "ERROR: could not find sync module: "
@@ -5807,6 +5822,10 @@ int main(int argc, const char **argv)
                 << sync_mgr->get_registered_module_names() << dendl;
             return EINVAL;
           }
+#else
+          ldpp_dout(dpp(), -1) << "ERROR: --tier-type requires the RADOS backend" << dendl;
+          return EINVAL;
+#endif
         }
 
         if (enable_features.empty()) { // enable all features by default
@@ -6473,6 +6492,7 @@ int main(int argc, const char **argv)
           // validate --tier-type if specified
           const string *ptier_type = (tier_type_specified ? &tier_type : nullptr);
           if (ptier_type) {
+#ifdef WITH_RADOSGW_RADOS
             auto sync_mgr = static_cast<rgw::sal::RadosStore*>(driver)->svc()->sync_modules->get_manager();
             if (!sync_mgr->get_module(*ptier_type, nullptr)) {
               ldpp_dout(dpp(), -1) << "ERROR: could not find sync module: "
@@ -6480,6 +6500,10 @@ int main(int argc, const char **argv)
                   << sync_mgr->get_registered_module_names() << dendl;
               return EINVAL;
             }
+#else
+            ldpp_dout(dpp(), -1) << "ERROR: --tier-type requires the RADOS backend" << dendl;
+            return EINVAL;
+#endif
           }
 
           if (enable_features.empty()) { // enable all features by default
@@ -6753,6 +6777,7 @@ int main(int argc, const char **argv)
         // validate --tier-type if specified
         const string *ptier_type = (tier_type_specified ? &tier_type : nullptr);
         if (ptier_type) {
+#ifdef WITH_RADOSGW_RADOS
           auto sync_mgr = static_cast<rgw::sal::RadosStore*>(driver)->svc()->sync_modules->get_manager();
           if (!sync_mgr->get_module(*ptier_type, nullptr)) {
             ldpp_dout(dpp(), -1) << "ERROR: could not find sync module: "
@@ -6760,6 +6785,10 @@ int main(int argc, const char **argv)
                 << sync_mgr->get_registered_module_names() << dendl;
             return EINVAL;
           }
+#else
+          ldpp_dout(dpp(), -1) << "ERROR: --tier-type requires the RADOS backend" << dendl;
+          return EINVAL;
+#endif
         }
 
         if (enable_features.empty()) { // enable all features by default

--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -46,7 +46,9 @@
 #include "rgw_rest_account.h"
 #include "rgw_rest_bucket.h"
 #include "rgw_rest_metadata.h"
+#ifdef WITH_RADOSGW_RADOS
 #include "rgw_rest_log.h"
+#endif
 #include "rgw_rest_config.h"
 #include "rgw_rest_realm.h"
 #include "rgw_rest_ratelimit.h"

--- a/src/rgw/rgw_frontend.h
+++ b/src/rgw/rgw_frontend.h
@@ -15,7 +15,9 @@
 #include "rgw_realm_reloader.h"
 
 #include "rgw_auth_registry.h"
+#ifdef WITH_RADOSGW_RADOS
 #include "rgw_sal_rados.h"
+#endif
 
 #define dout_context g_ceph_context
 

--- a/src/rgw/rgw_main.h
+++ b/src/rgw/rgw_main.h
@@ -161,6 +161,7 @@ static inline RGWRESTMgr *set_logging(RGWRESTMgr* mgr)
   return mgr;
 }
 
+#ifdef WITH_RADOSGW_RADOS
 static inline RGWRESTMgr *rest_filter(rgw::sal::Driver* driver, int dialect, RGWRESTMgr* orig)
 {
   RGWSyncModuleInstanceRef sync_module = driver->get_sync_module();
@@ -170,4 +171,13 @@ static inline RGWRESTMgr *rest_filter(rgw::sal::Driver* driver, int dialect, RGW
     return orig;
   }
 }
+#else
+// sync modules (and their REST filters) are a RADOS-only feature; the
+// complete RGWSyncModuleInstance type lives in the rados driver, so avoid
+// referring to it in no-RADOS builds
+static inline RGWRESTMgr *rest_filter(rgw::sal::Driver*, int, RGWRESTMgr* orig)
+{
+  return orig;
+}
+#endif
 

--- a/src/rgw/rgw_realm_reloader.cc
+++ b/src/rgw/rgw_realm_reloader.cc
@@ -10,7 +10,9 @@
 #include "driver/rados/rgw_user.h"
 #include "rgw_process_env.h"
 #include "rgw_sal.h"
+#ifdef WITH_RADOSGW_RADOS
 #include "rgw_sal_rados.h"
+#endif
 
 #include "services/svc_zone.h"
 
@@ -193,6 +195,7 @@ void RGWRealmReloader::reload()
   if (env.lua.manager.get()) {
     env.lua.manager = env.driver->get_lua_manager(
         env.lua.manager->luarocks_path());
+#ifdef WITH_RADOSGW_RADOS
     if (env.driver->get_name() == "rados") {
       static_cast<rgw::sal::RadosLuaManager*>(env.lua.manager.get())->watch_reload(&dp);
       if (env.lua.background) {
@@ -200,6 +203,7 @@ void RGWRealmReloader::reload()
         env.lua.manager.get()->set_lua_background(env.lua.background);
       }
     }
+#endif
   }
 
   ldpp_dout(&dp, 1) << "Resuming frontends with new realm configuration." << dendl;

--- a/src/rgw/rgw_rest_config.cc
+++ b/src/rgw/rgw_rest_config.cc
@@ -20,7 +20,9 @@
 #include "rgw_rest_s3.h"
 #include "rgw_rest_config.h"
 #include "rgw_client_io.h"
+#ifdef WITH_RADOSGW_RADOS
 #include "driver/rados/rgw_sal_rados.h"
+#endif
 #include "common/errno.h"
 #include "include/ceph_assert.h"
 
@@ -32,6 +34,7 @@
 using namespace std;
 
 void RGWOp_ZoneConfig_Get::send_response() {
+#ifdef WITH_RADOSGW_RADOS
   const RGWZoneParams& zone_params = static_cast<rgw::sal::RadosStore*>(driver)->svc()->zone->get_zone_params();
 
   set_req_state_err(s, op_ret);
@@ -43,6 +46,12 @@ void RGWOp_ZoneConfig_Get::send_response() {
 
   encode_json("zone_params", zone_params, s->formatter);
   flusher.flush();
+#else
+  // zone params live in the RADOS zone service; not available standalone
+  set_req_state_err(s, -ENOTSUP);
+  dump_errno(s);
+  end_header(s);
+#endif
 }
 
 RGWOp* RGWHandler_Config::op_get() {

--- a/src/rgw/rgw_rest_metadata.cc
+++ b/src/rgw/rgw_rest_metadata.cc
@@ -21,7 +21,9 @@
 #include "rgw_rest_metadata.h"
 #include "rgw_client_io.h"
 #include "rgw_mdlog_types.h"
+#ifdef WITH_RADOSGW_RADOS
 #include "driver/rados/rgw_sal_rados.h"
+#endif
 #include "common/errno.h"
 #include "common/strtol.h"
 #include "rgw/rgw_b64.h"
@@ -56,6 +58,7 @@ void RGWOp_Metadata_Get::execute(optional_yield y) {
 
   frame_metadata_key(s, metadata_key);
 
+#ifdef WITH_RADOSGW_RADOS
   auto meta_mgr = static_cast<rgw::sal::RadosStore*>(driver)->ctl()->meta.mgr;
 
   /* Get keys */
@@ -66,6 +69,10 @@ void RGWOp_Metadata_Get::execute(optional_yield y) {
   }
 
   op_ret = 0;
+#else
+  // the metadata manager is a RADOS-only facility
+  op_ret = -ENOTSUP;
+#endif
 }
 
 void RGWOp_Metadata_Get_Myself::execute(optional_yield y) {
@@ -260,8 +267,13 @@ void RGWOp_Metadata_Put::execute(optional_yield y) {
     }
   }
 
+#ifdef WITH_RADOSGW_RADOS
   op_ret = static_cast<rgw::sal::RadosStore*>(driver)->ctl()->meta.mgr->put(metadata_key, bl, s->yield, s, sync_type,
 				       false, &ondisk_version);
+#else
+  // the metadata manager is a RADOS-only facility
+  op_ret = -ENOTSUP;
+#endif
   if (op_ret < 0) {
     ldpp_dout(s, 5) << "ERROR: can't put key: " << cpp_strerror(op_ret) << dendl;
     return;
@@ -291,7 +303,12 @@ void RGWOp_Metadata_Delete::execute(optional_yield y) {
   string metadata_key;
 
   frame_metadata_key(s, metadata_key);
+#ifdef WITH_RADOSGW_RADOS
   op_ret = static_cast<rgw::sal::RadosStore*>(driver)->ctl()->meta.mgr->remove(metadata_key, s->yield, s);
+#else
+  // the metadata manager is a RADOS-only facility
+  op_ret = -ENOTSUP;
+#endif
   if (op_ret < 0) {
     ldpp_dout(s, 5) << "ERROR: can't remove key: " << cpp_strerror(op_ret) << dendl;
     return;


### PR DESCRIPTION
Since the rgw-standalone-admin target landed (pr#68291, commit #77f6a3b4), the default build (WITH_RADOSGW_POSIX=ON implies WITH_RADOSGW_STANDALONE=ON) fails to link:

  * undefined reference to `vtable for rgw::sal::RadosZone'
  * undefined reference to `vtable for rgw::sal::RadosZoneGroup'

Build command used is the one with all the defaults turned ON, e.g. `cmake ../../ceph -GNinja -DCMAKE_BUILD_TYPE=Release && ninja`

```
$ cat CMakeCache.txt | grep RADOSGW
WITH_RADOSGW:BOOL=ON
WITH_RADOSGW_AMQP_ENDPOINT:BOOL=ON
WITH_RADOSGW_ARROW_FLIGHT:BOOL=OFF
WITH_RADOSGW_BACKTRACE_LOGGING:BOOL=OFF
WITH_RADOSGW_BEAST_OPENSSL:BOOL=ON
WITH_RADOSGW_D4N:BOOL=ON
WITH_RADOSGW_DAOS:BOOL=OFF
WITH_RADOSGW_DBSTORE:BOOL=ON
WITH_RADOSGW_FDB:BOOL=OFF
WITH_RADOSGW_KAFKA_ENDPOINT:BOOL=ON
WITH_RADOSGW_LUA_PACKAGES:BOOL=ON
WITH_RADOSGW_MOTR:BOOL=OFF
WITH_RADOSGW_POSIX:BOOL=ON
WITH_RADOSGW_RADOS:BOOL=ON
WITH_RADOSGW_SELECT_PARQUET:BOOL=ON
WITH_RADOSGW_STANDALONE:BOOL=ON
```

Re-running the build at `git checkout 77f6a3b4~1` yields a successful build. Debug builds aren't affected but optimized only.

radosgw-admin.cc (and several sources in rgw_a_standalone) use the concrete rgw::sal::RadosStore outside WITH_RADOSGW_RADOS guards. These uses only compile in the -UWITH_RADOSGW_RADOS configuration because rgw_sal_rados.h leaks in transitively (rgw_sync.h, rgw_data_sync.h, rgw_frontend.h). The link then fails because the RADOS driver objects that emit the vtables and out-of-line key functions for RadosZone / RadosZoneGroup are deliberately not part of the standalone libraries.

Fix both sides of the problem:

* guard the concrete-RADOS uses in radosgw-admin.cc: get_remote_conn(), the remote period commit lookup (which now returns -ENOTSUP with a hint to use --url), the reshard max-shards check (its callers were already guarded) and the sync-module tier-type validation (--tier-type now returns EINVAL without the RADOS backend)
* guard the transitive routes to rgw_sal_rados.h: the rgw_sync.h / rgw_data_sync.h includes in radosgw-admin.cc, the rgw_sal_rados.h include in rgw_frontend.h (an over-include: the header uses no RADOS type), and the rgw_rest_log.h include in rgw_appmain.cc (unused)
* provide a no-RADOS fallback for rest_filter() in rgw_main.h: sync modules (and the complete RGWSyncModuleInstance type) are RADOS-only, and the non-RADOS stores return a null sync module anyway
* guard the RADOS-only bodies of the metadata and zone-config admin REST ops (-ENOTSUP). These handlers are only registered by RadosStore::register_admin_apis(), so they are unreachable in the standalone daemon; the guards are defensive
* guard the RadosLuaManager reload block in rgw_realm_reloader.cc; it was already unreachable at runtime behind get_name() == "rados"
* include common/errno.h directly in driver/rados/rgw_bucket.cc, which previously received cpp_strerror() transitively via rgw_sal_rados.h

All guards evaluate true when WITH_RADOSGW_RADOS is defined, so the regular RADOS build preprocesses to identical code.

Note that before this change, the unguarded static_cast<RadosStore*> paths would have been undefined behavior at runtime if reached with a non-RADOS driver; they now fail cleanly with an error message.

Fixes: https://tracker.ceph.com/issues/XXXXX
Signed-off-by: Jusufadis Bakamovic <jusufadis.bakamovic@clyso.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
