### PR TITLE
rgw: suspend account-owned buckets (root user and account)

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -57,6 +57,30 @@ as follows:
 :command:`user list`
   List all users.
 
+:command:`account create`
+  Create a new account.
+
+:command:`account modify`
+  Modify an existing account.
+
+:command:`account get`
+  Get account info.
+
+:command:`account stats`
+  Dump account storage stats.
+
+:command:`account rm`
+  Remove an account.
+
+:command:`account list`
+  List all account ids.
+
+:command:`account suspend`
+  Suspend an account and its owned buckets.
+
+:command:`account enable`
+  Re-enable an account after suspension.
+
 :command:`caps add`
   Add user capabilities.
 

--- a/doc/radosgw/account.rst
+++ b/doc/radosgw/account.rst
@@ -163,6 +163,18 @@ To enable a bucket quota for the account::
     radosgw-admin quota set --quota-scope=bucket --account-id={accountid} --max-objects=1000000
     radosgw-admin quota enable --quota-scope=bucket --account-id={accountid}
 
+Account Suspend
+---------------
+
+To suspend an account (block its users and roles, and mark account-owned
+buckets as suspended)::
+
+    radosgw-admin account suspend --account-id={accountid}
+
+To re-enable the account::
+
+    radosgw-admin account enable --account-id={accountid}
+
 Migrate an Existing User into an Account
 ----------------------------------------
 

--- a/doc/radosgw/admin.rst
+++ b/doc/radosgw/admin.rst
@@ -191,6 +191,16 @@ form:
 
    radosgw-admin user suspend --uid=johndoe
 
+Suspending a user also marks that user's buckets as suspended
+(``BUCKET_SUSPENDED``), which blocks access for anyone using those buckets.
+
+For :ref:`RGW accounts <radosgw-account>`, bucket ownership belongs to the
+account. Use ``account suspend`` / ``account enable`` to freeze or restore
+an entire account (sets the ``ACCOUNT_SUSPENDED`` flag and marks account-owned
+buckets as suspended). Suspending a user in an account---including the account
+root---only disables that identity; account-owned buckets remain accessible to
+other users and roles unless the account itself is suspended.
+
 User Enable
 -----------
 To re-enable a suspended user, provide ``user enable`` and specify the user ID

--- a/qa/suites/rgw/singleton/all/radosgw-admin.yaml
+++ b/qa/suites/rgw/singleton/all/radosgw-admin.yaml
@@ -24,5 +24,6 @@ tasks:
     clients:
       client.0:
         - rgw/test_account_migration.sh
+        - rgw/test_account_root_suspend.sh
 - radosgw-admin:
 - radosgw-admin-rest:

--- a/qa/workunits/rgw/test_account_root_suspend.sh
+++ b/qa/workunits/rgw/test_account_root_suspend.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+#
+# Verify that suspending an account root user also suspends account-owned
+# buckets (BUCKET_SUSPENDED), while suspending a non-root account user does not.
+#
+# To run with vstart:
+#   PATH=~/ceph/build/bin/:$PATH AWS_ENDPOINT_URL=http://localhost:8000 \
+#     ~/ceph/qa/workunits/rgw/test_account_root_suspend.sh
+#
+
+set -ex
+
+if [ -z ${AWS_ENDPOINT_URL} ]
+then
+	url=$(cat ${TESTDIR}/url_file)
+	export AWS_ENDPOINT_URL=$url
+fi
+
+BUCKET_SUSPENDED=1
+
+python3 -m venv account-root-suspend-virtualenv
+source account-root-suspend-virtualenv/bin/activate
+pip install --upgrade pip awscli
+
+# create a user, bucket, then migrate as account root
+userinfo=$(radosgw-admin user create --uid test-account-root-suspend \
+	--display-name "AccountRootSuspend" \
+	--email accountrootsuspend@example.com)
+export AWS_ACCESS_KEY_ID=$(echo $userinfo | jq -r .keys[0].access_key)
+export AWS_SECRET_ACCESS_KEY=$(echo $userinfo | jq -r .keys[0].secret_key)
+
+aws s3 mb s3://test-account-root-suspend
+aws s3api put-object --bucket test-account-root-suspend --key obj
+
+accountid=$(radosgw-admin account create | jq -r .id)
+radosgw-admin user modify --uid test-account-root-suspend \
+	--account-root --account-id=$accountid
+
+# second (non-root) user in the same account with S3 access
+iaminfo=$(radosgw-admin user create --uid test-account-member-suspend \
+	--display-name "AccountMemberSuspend" \
+	--account-id=$accountid --gen-secret --gen-access-key)
+IAM_ACCESS_KEY=$(echo $iaminfo | jq -r .keys[0].access_key)
+IAM_SECRET_KEY=$(echo $iaminfo | jq -r .keys[0].secret_key)
+aws iam attach-user-policy --region us-east-1 --user-name AccountMemberSuspend \
+	--policy-arn arn:aws:iam::aws:policy/AmazonS3FullAccess
+
+flags=$(radosgw-admin bucket stats --bucket test-account-root-suspend | jq -r .flags)
+test $((flags & BUCKET_SUSPENDED)) -eq 0
+
+# suspending account root must suspend account-owned buckets
+radosgw-admin user suspend --uid test-account-root-suspend
+flags=$(radosgw-admin bucket stats --bucket test-account-root-suspend | jq -r .flags)
+test $((flags & BUCKET_SUSPENDED)) -eq $BUCKET_SUSPENDED
+
+# non-root member is also blocked via BUCKET_SUSPENDED
+set +e
+AWS_ACCESS_KEY_ID=$IAM_ACCESS_KEY AWS_SECRET_ACCESS_KEY=$IAM_SECRET_KEY \
+	aws s3api head-object --bucket test-account-root-suspend --key obj
+rc=$?
+set -e
+test $rc -ne 0
+
+# re-enable account root restores buckets
+radosgw-admin user enable --uid test-account-root-suspend
+flags=$(radosgw-admin bucket stats --bucket test-account-root-suspend | jq -r .flags)
+test $((flags & BUCKET_SUSPENDED)) -eq 0
+AWS_ACCESS_KEY_ID=$IAM_ACCESS_KEY AWS_SECRET_ACCESS_KEY=$IAM_SECRET_KEY \
+	aws s3api head-object --bucket test-account-root-suspend --key obj
+
+# suspending a non-root account member must not suspend account buckets
+radosgw-admin user suspend --uid test-account-member-suspend
+flags=$(radosgw-admin bucket stats --bucket test-account-root-suspend | jq -r .flags)
+test $((flags & BUCKET_SUSPENDED)) -eq 0
+# root can still access
+aws s3api head-object --bucket test-account-root-suspend --key obj
+
+radosgw-admin user enable --uid test-account-member-suspend
+
+# account suspend freezes account-owned buckets and blocks members
+radosgw-admin account suspend --account-id=$accountid
+suspended=$(radosgw-admin account get --account-id=$accountid | jq -r '.AccountInfo.suspended // .suspended')
+test "$suspended" = "1"
+flags=$(radosgw-admin bucket stats --bucket test-account-root-suspend | jq -r .flags)
+test $((flags & BUCKET_SUSPENDED)) -eq $BUCKET_SUSPENDED
+set +e
+aws s3api head-object --bucket test-account-root-suspend --key obj
+rc=$?
+set -e
+test $rc -ne 0
+
+radosgw-admin account enable --account-id=$accountid
+suspended=$(radosgw-admin account get --account-id=$accountid | jq -r '.AccountInfo.suspended // .suspended')
+test "$suspended" = "0"
+flags=$(radosgw-admin bucket stats --bucket test-account-root-suspend | jq -r .flags)
+test $((flags & BUCKET_SUSPENDED)) -eq 0
+aws s3api head-object --bucket test-account-root-suspend --key obj
+
+# clean up
+radosgw-admin bucket rm --bucket test-account-root-suspend --purge-objects
+radosgw-admin user rm --uid test-account-member-suspend
+radosgw-admin user rm --uid test-account-root-suspend
+radosgw-admin account rm --account-id=$accountid
+deactivate
+rm -rf account-root-suspend-virtualenv
+
+exit 0

--- a/src/rgw/driver/rados/rgw_user.cc
+++ b/src/rgw/driver/rados/rgw_user.cc
@@ -1689,6 +1689,50 @@ static int adopt_user_buckets(const DoutPrefixProvider* dpp, optional_yield y,
   return 0;
 }
 
+/* Enable or disable buckets owned by this user id. Account-owned buckets are
+ * not listed under a root user's uid after adopt_user_buckets; freeze those
+ * with account suspend, not user suspend. */
+static int set_user_bucket_suspended(const DoutPrefixProvider* dpp,
+                                     optional_yield y,
+                                     rgw::sal::Driver* driver,
+                                     const RGWUserInfo& user_info,
+                                     bool suspended,
+                                     std::string* err_msg)
+{
+  if (user_info.user_id.empty()) {
+    set_err_msg(err_msg, "empty user id passed...aborting");
+    return -EINVAL;
+  }
+
+  const rgw_owner owner = user_info.user_id;
+
+  const size_t max_buckets = dpp->get_cct()->_conf->rgw_list_buckets_max_chunk;
+  rgw::sal::BucketList listing;
+  do {
+    int ret = driver->list_buckets(dpp, owner, user_info.user_id.tenant,
+                                   listing.next_marker, string(),
+                                   max_buckets, false, listing, y);
+    if (ret < 0) {
+      set_err_msg(err_msg, "could not get buckets for owner: " +
+                  to_string(owner));
+      return ret;
+    }
+
+    std::vector<rgw_bucket> bucket_names;
+    for (auto& ent : listing.buckets) {
+      bucket_names.push_back(std::move(ent.bucket));
+    }
+
+    ret = driver->set_buckets_enabled(dpp, bucket_names, !suspended, y);
+    if (ret < 0) {
+      set_err_msg(err_msg, "failed to modify bucket");
+      return ret;
+    }
+  } while (!listing.next_marker.empty());
+
+  return 0;
+}
+
 int RGWUser::execute_add(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_state, std::string *err_msg,
 			 optional_yield y)
 {
@@ -2044,40 +2088,7 @@ int RGWUser::execute_modify(const DoutPrefixProvider *dpp, RGWUserAdminOpState& 
     user_info.quota.user_quota = op_state.get_user_quota();
 
   if (op_state.has_suspension_op()) {
-    __u8 suspended = op_state.get_suspension_status();
-    user_info.suspended = suspended;
-
-
-    if (user_id.empty()) {
-      set_err_msg(err_msg, "empty user id passed...aborting");
-      return -EINVAL;
-    }
-    std::unique_ptr<rgw::sal::User> user = driver->get_user(user_id);
-
-    size_t max_buckets = dpp->get_cct()->_conf->rgw_list_buckets_max_chunk;
-
-    rgw::sal::BucketList listing;
-    do {
-      ret = driver->list_buckets(dpp, user->get_id(), user->get_tenant(),
-                                 listing.next_marker, string(),
-                                 max_buckets, false, listing, y);
-      if (ret < 0) {
-        set_err_msg(err_msg, "could not get buckets for uid:  " + user_id.to_str());
-        return ret;
-      }
-
-      std::vector<rgw_bucket> bucket_names;
-      for (auto& ent : listing.buckets) {
-        bucket_names.push_back(std::move(ent.bucket));
-      }
-
-      ret = driver->set_buckets_enabled(dpp, bucket_names, !suspended, y);
-      if (ret < 0) {
-        set_err_msg(err_msg, "failed to modify bucket");
-        return ret;
-      }
-
-    } while (!listing.next_marker.empty());
+    user_info.suspended = op_state.get_suspension_status();
   }
 
   if (op_state.mfa_ids_specified) {
@@ -2138,6 +2149,16 @@ int RGWUser::execute_modify(const DoutPrefixProvider *dpp, RGWUserAdminOpState& 
       return -EINVAL;
     }
     user_info.type = op_state.account_root ? TYPE_ROOT : TYPE_RGW;
+  }
+
+  /* Apply per-user bucket suspension after account_id is resolved. Do not
+   * freeze account-owned buckets here; that is account suspend. */
+  if (op_state.has_suspension_op()) {
+    ret = set_user_bucket_suspended(dpp, y, driver, user_info,
+                                    user_info.suspended, err_msg);
+    if (ret < 0) {
+      return ret;
+    }
   }
 
   if (!user_info.account_id.empty()) {

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -188,6 +188,8 @@ void usage()
   cout << "  account stats                    dump account storage stats\n";
   cout << "  account rm                       remove an account\n";
   cout << "  account list                     list all account ids\n";
+  cout << "  account suspend                  suspend an account\n";
+  cout << "  account enable                   re-enable account after suspension\n";
   cout << "  bucket list                      list buckets (specify --allow-unordered for faster, unsorted listing)\n";
   cout << "  bucket limit check               show bucket sharding stats\n";
   cout << "  bucket link                      link bucket to specified user\n";
@@ -1018,6 +1020,8 @@ enum class OPT {
   ACCOUNT_STATS,
   ACCOUNT_RM,
   ACCOUNT_LIST,
+  ACCOUNT_SUSPEND,
+  ACCOUNT_ENABLE,
   RESTORE_STATUS,
   RESTORE_LIST,
   GLOBAL_CORS_GET,
@@ -1328,6 +1332,8 @@ static SimpleCmd::Commands all_cmds = {
   { "account stats", OPT::ACCOUNT_STATS },
   { "account rm", OPT::ACCOUNT_RM },
   { "account list", OPT::ACCOUNT_LIST },
+  { "account suspend", OPT::ACCOUNT_SUSPEND },
+  { "account enable", OPT::ACCOUNT_ENABLE },
   { "restore status", OPT::RESTORE_STATUS },
   { "restore list", OPT::RESTORE_LIST },
   { "global-cors get", OPT::GLOBAL_CORS_GET},
@@ -5055,7 +5061,9 @@ int main(int argc, const char **argv)
                           && opt_cmd != OPT::ACCOUNT_GET
                           && opt_cmd != OPT::ACCOUNT_STATS
                           && opt_cmd != OPT::ACCOUNT_RM
-                          && opt_cmd != OPT::ACCOUNT_LIST) {
+                          && opt_cmd != OPT::ACCOUNT_LIST
+                          && opt_cmd != OPT::ACCOUNT_SUSPEND
+                          && opt_cmd != OPT::ACCOUNT_ENABLE) {
         cerr << "ERROR: --tenant is set, but there's no user ID" << std::endl;
         return EINVAL;
       }
@@ -7093,6 +7101,7 @@ int main(int argc, const char **argv)
   bool non_master_cmd = (!driver->is_meta_master() && !yes_i_really_mean_it);
   std::set<OPT> non_master_ops_list = {OPT::ACCOUNT_CREATE,
                                         OPT::ACCOUNT_MODIFY, OPT::ACCOUNT_RM,
+                                        OPT::ACCOUNT_SUSPEND, OPT::ACCOUNT_ENABLE,
                                         OPT::USER_CREATE, OPT::USER_RM,
                                         OPT::USER_MODIFY, OPT::USER_ENABLE,
                                         OPT::USER_SUSPEND, OPT::SUBUSER_CREATE,
@@ -13063,6 +13072,27 @@ next:
             << ": " << err_msg << std::endl;
         return -ret;
       }
+    }
+  }
+
+  if (opt_cmd == OPT::ACCOUNT_SUSPEND ||
+      opt_cmd == OPT::ACCOUNT_ENABLE) {
+    auto op_state = rgw::account::AdminOpState{
+      .account_id = account_id,
+      .tenant = tenant,
+      .account_name = account_name,
+      .email = user_email,
+      .suspended = (opt_cmd == OPT::ACCOUNT_SUSPEND),
+    };
+    std::string err_msg;
+    ret = rgw::account::modify(dpp(), driver, op_state, err_msg,
+                               stream_flusher, null_yield);
+    if (ret < 0) {
+      cerr << "ERROR: failed to "
+           << (opt_cmd == OPT::ACCOUNT_SUSPEND ? "suspend" : "enable")
+           << " account with " << cpp_strerror(-ret)
+           << ": " << err_msg << std::endl;
+      return -ret;
     }
   }
   if (opt_cmd == OPT::RESTORE_STATUS ||

--- a/src/rgw/rgw_account.cc
+++ b/src/rgw/rgw_account.cc
@@ -257,11 +257,45 @@ int modify(const DoutPrefixProvider* dpp,
     }
   }
 
+  const bool suspension_changed =
+    op_state.suspended && *op_state.suspended != info.suspended();
+  if (op_state.suspended) {
+    if (*op_state.suspended) {
+      info.flags |= ACCOUNT_SUSPENDED;
+    } else {
+      info.flags &= ~ACCOUNT_SUSPENDED;
+    }
+  }
+
   constexpr bool exclusive = false;
 
   ret = driver->store_account(dpp, y, exclusive, info, &old_info, attrs, objv);
   if (ret < 0) {
     return ret;
+  }
+
+  if (suspension_changed) {
+    const size_t max_buckets =
+      dpp->get_cct()->_conf->rgw_list_buckets_max_chunk;
+    rgw::sal::BucketList listing;
+    do {
+      ret = driver->list_buckets(dpp, info.id, info.tenant,
+                                 listing.next_marker, "",
+                                 max_buckets, false, listing, y);
+      if (ret < 0) {
+        err_msg = "could not list account buckets to update suspension";
+        return ret;
+      }
+      std::vector<rgw_bucket> buckets;
+      for (auto& ent : listing.buckets) {
+        buckets.push_back(std::move(ent.bucket));
+      }
+      ret = driver->set_buckets_enabled(dpp, buckets, !info.suspended(), y);
+      if (ret < 0) {
+        err_msg = "failed to modify account bucket suspension";
+        return ret;
+      }
+    } while (!listing.next_marker.empty());
   }
 
   flusher.start(0);

--- a/src/rgw/rgw_account.h
+++ b/src/rgw/rgw_account.h
@@ -58,6 +58,7 @@ struct AdminOpState {
   std::optional<int64_t> quota_max_size;
   std::optional<int64_t> quota_max_objects;
   std::optional<bool> quota_enabled;
+  std::optional<bool> suspended;
   bool purge_data = false;
 };
 

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -3071,6 +3071,7 @@ void RGWAccountInfo::dump(Formatter * const f) const
   encode_json("max_groups", max_groups, f);
   encode_json("max_buckets", max_buckets, f);
   encode_json("max_access_keys", max_access_keys, f);
+  encode_json("flags", flags, f);
 }
 
 void RGWAccountInfo::decode_json(JSONObj* obj)
@@ -3086,6 +3087,7 @@ void RGWAccountInfo::decode_json(JSONObj* obj)
   JSONDecoder::decode_json("max_groups", max_groups, obj);
   JSONDecoder::decode_json("max_buckets", max_buckets, obj);
   JSONDecoder::decode_json("max_access_keys", max_access_keys, obj);
+  JSONDecoder::decode_json("flags", flags, obj);
 }
 
 std::list<RGWAccountInfo> RGWAccountInfo::generate_test_instances()

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -835,6 +835,10 @@ struct RGWUserInfo
 };
 WRITE_CLASS_ENCODER(RGWUserInfo)
 
+enum RGWAccountFlags {
+  ACCOUNT_SUSPENDED = 0x1,
+};
+
 // user account metadata
 struct RGWAccountInfo {
   rgw_account_id id;
@@ -859,8 +863,14 @@ struct RGWAccountInfo {
   static constexpr int32_t DEFAULT_ACCESS_KEY_LIMIT = 4;
   int32_t max_access_keys = DEFAULT_ACCESS_KEY_LIMIT;
 
+  uint32_t flags{0};
+
+  bool suspended() const {
+    return (flags & ACCOUNT_SUSPENDED) != 0;
+  }
+
   void encode(bufferlist& bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 1, bl);
     encode(id, bl);
     encode(tenant, bl);
     encode(name, bl);
@@ -872,11 +882,12 @@ struct RGWAccountInfo {
     encode(max_buckets, bl);
     encode(max_access_keys, bl);
     encode(bucket_quota, bl);
+    encode(flags, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(2, bl);
+    DECODE_START(3, bl);
     decode(id, bl);
     decode(tenant, bl);
     decode(name, bl);
@@ -889,6 +900,9 @@ struct RGWAccountInfo {
     decode(max_access_keys, bl);
     if (struct_v >= 2) {
       decode(bucket_quota, bl);
+    }
+    if (struct_v >= 3) {
+      decode(flags, bl);
     }
     DECODE_FINISH(bl);
   }

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -420,6 +420,12 @@ int process_request(const RGWProcessEnv& penv,
       abort_early(s, op, -ERR_USER_SUSPENDED, handler, yield);
       goto done;
     }
+    if (const auto& account = s->auth.identity->get_account();
+        account && account->suspended()) {
+      dout(10) << "account is suspended, account_id=" << account->id << dendl;
+      abort_early(s, op, -ERR_USER_SUSPENDED, handler, yield);
+      goto done;
+    }
 
   is_health_request = (op->get_type() == RGW_OP_GET_HEALTH_CHECK);
   {

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -34,6 +34,8 @@
     account stats                    dump account storage stats
     account rm                       remove an account
     account list                     list all account ids
+    account suspend                  suspend an account
+    account enable                   re-enable account after suspension
     bucket list                      list buckets (specify --allow-unordered for faster, unsorted listing)
     bucket limit check               show bucket sharding stats
     bucket link                      link bucket to specified user


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Summary

Account-owned buckets are not listed under individual uids after users are
adopted into an RGW account. This series addresses suspension of those
resources in two complementary ways:

1. **Account root user suspend** — `user suspend` on a `TYPE_ROOT` user
   lists/enables buckets by `account_id` (tracker #79320).
2. **Account suspend/enable** — new `radosgw-admin account suspend|enable`
   sets `RGWAccountInfo.suspended`, marks account buckets
   `BUCKET_SUSPENDED`, and rejects requests from users/roles in that
   account at auth time (tracker #79322).

Non-root account IAM users still only get `user.suspended` and do not
freeze the whole account.

## Testing

- `ninja radosgw` and `ninja radosgw-admin` on gcc 12 / Release (exit 0).
- Workunit `qa/workunits/rgw/test_account_root_suspend.sh` covers root
  suspend/enable, non-root suspend, and account suspend/enable.
- Suggest after ok to test: `jenkins test rgw:singleton`

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>