### PR TITLE
mgr/mirroring: fix directory rebalance after mirror daemon restart

### DIFF
--- a/qa/suites/fs/mirror-ha/workloads/cephfs-mirror-ha-rebalance.yaml
+++ b/qa/suites/fs/mirror-ha/workloads/cephfs-mirror-ha-rebalance.yaml
@@ -1,0 +1,14 @@
+meta:
+- desc: test cephfs-mirror directory rebalance across HA daemons after restart
+
+overrides:
+  ceph:
+    conf:
+      mgr:
+        debug client: 10
+
+tasks:
+  - ceph-fuse: [client.0, client.1]
+  - cephfs_test_runner:
+      modules:
+        - tasks.cephfs.test_mirroring_rebalance.TestMirroringRebalance

--- a/qa/tasks/cephfs/test_mirroring_rebalance.py
+++ b/qa/tasks/cephfs/test_mirroring_rebalance.py
@@ -1,0 +1,206 @@
+import json
+import logging
+import time
+
+from tasks.cephfs.test_mirroring import TestMirroring, retry_assert
+
+log = logging.getLogger(__name__)
+
+
+class TestMirroringRebalance(TestMirroring):
+    """Directory assignment rebalance across multiple cephfs-mirror daemons.
+
+    Expects cephfs-mirror daemons client.mirror1/2/3 as in
+    qa/suites/fs/mirror-ha. Uses the default 300s shuffle throttle; deferred
+    rebalance after rejoin is asserted by waiting past that window.
+    """
+
+    MIRROR_CLIENTS = ('mirror1', 'mirror2', 'mirror3')
+    NUM_MIRROR_INSTANCES = len(MIRROR_CLIENTS)
+    # Policy.DIR_SHUFFLE_THROTTLE_INTERVAL — rejoin while throttled must still
+    # converge via deferred rebalance once this elapses.
+    SHUFFLE_THROTTLE_SECS = 300
+    # Extra slack after SHUFFLE_THROTTLE_SECS so the last-mapped directory
+    # (dirs are added sequentially) is shuffle-eligible and any deferred
+    # rebalance timer has time to fire.
+    SHUFFLE_THROTTLE_PAD_SECS = 60
+
+    def setUp(self):
+        super(TestMirroringRebalance, self).setUp()
+        for mid in self.MIRROR_CLIENTS:
+            self.config_set(f'client.{mid}', 'cephfs_mirror_directory_scan_interval', 1)
+            self.config_set(f'client.{mid}', 'cephfs_mirror_tick_interval',
+                            self.MIRROR_TICK_INTERVAL)
+
+    def get_daemon_admin_socket(self, mirror_client='mirror1'):
+        # Matches qa/suites/fs/mirror-ha/clients/mirror.yaml
+        return f'/var/run/ceph/cephfs-mirror{mirror_client[len("mirror"):]}.asok'
+
+    def get_mirror_daemon_pid(self, mirror_client='mirror1'):
+        pid_path = f'/var/run/ceph/cephfs-mirror{mirror_client[len("mirror"):]}.pid'
+        return self.mount_a.run_shell(['cat', pid_path]).stdout.getvalue().strip()
+
+    def get_mirror_daemon(self, mirror_client):
+        return self.ctx.daemons.get_daemon('cephfs-mirror', f'client.{mirror_client}')
+
+    def stop_mirror_daemon(self, mirror_client):
+        log.debug(f'stopping cephfs-mirror client.{mirror_client}')
+        self.get_mirror_daemon(mirror_client).stop()
+
+    def start_mirror_daemon(self, mirror_client):
+        log.debug(f'starting cephfs-mirror client.{mirror_client}')
+        self.get_mirror_daemon(mirror_client).restart()
+
+    def mirror_show_distribution(self, fs_name):
+        return json.loads(self.get_ceph_cmd_stdout(
+            'fs', 'snapshot', 'mirror', 'show', 'distribution', fs_name))
+
+    def distribution_counts(self, fs_name):
+        """Return {instance_id: dir_count} from show distribution."""
+        dist = self.mirror_show_distribution(fs_name)
+        counts = {}
+        for instance_id, label in dist.get('mapping', {}).items():
+            # label is e.g. "2 directories"
+            counts[str(instance_id)] = int(str(label).split()[0])
+        return counts
+
+    def max_min_dir_delta(self, counts):
+        if len(counts) <= 1:
+            return 0
+        vals = list(counts.values())
+        return max(vals) - min(vals)
+
+    @retry_assert(timeout=120, interval=2)
+    def wait_for_balanced_distribution(self, fs_name, expected_dirs,
+                                      min_instances=None):
+        """Wait until dirs are spread with max-min <= 1 across mirror instances.
+
+        min_instances: at least this many mirror instances must appear in the
+        distribution. Defaults to NUM_MIRROR_INSTANCES (all HA daemons).
+        """
+        if min_instances is None:
+            min_instances = self.NUM_MIRROR_INSTANCES
+        counts = self.distribution_counts(fs_name)
+        self.assertGreaterEqual(len(counts), min_instances)
+        self.assertEqual(sum(counts.values()), expected_dirs)
+        self.assertLessEqual(self.max_min_dir_delta(counts), 1,
+                             msg=f'uneven distribution: {counts}')
+
+    @retry_assert(timeout=90, interval=2)
+    def wait_for_failover_imbalance(self, fs_name, expected_dirs, max_instances):
+        """After failover, dirs concentrate on surviving instance(s).
+
+        max_instances: at most this many mirror instances may hold directories
+        (e.g. 2 when one of three daemons is down).
+        """
+        counts = self.distribution_counts(fs_name)
+        self.assertEqual(sum(counts.values()), expected_dirs)
+        nonzero = {i: c for i, c in counts.items() if c > 0}
+        self.assertLessEqual(len(nonzero), max_instances,
+                             msg=f'expected failover concentration: {counts}')
+        self.assertGreater(self.max_min_dir_delta(counts), 1,
+                           msg=f'expected imbalance after failover: {counts}')
+
+    @retry_assert(timeout=450, interval=5)
+    def wait_for_balanced_distribution_after_throttle(self, fs_name, expected_dirs,
+                                                      min_instances=None):
+        """Wait through the default 300s shuffle throttle for deferred rebalance.
+
+        min_instances: at least this many mirror instances must appear in the
+        distribution. Defaults to NUM_MIRROR_INSTANCES (all HA daemons).
+        """
+        if min_instances is None:
+            min_instances = self.NUM_MIRROR_INSTANCES
+        counts = self.distribution_counts(fs_name)
+        self.assertGreaterEqual(len(counts), min_instances)
+        self.assertEqual(sum(counts.values()), expected_dirs)
+        self.assertLessEqual(self.max_min_dir_delta(counts), 1,
+                             msg=f'uneven distribution: {counts}')
+
+    def wait_past_shuffle_throttle(self):
+        delay = self.SHUFFLE_THROTTLE_SECS + self.SHUFFLE_THROTTLE_PAD_SECS
+        log.info(f'waiting {delay}s for shuffle throttle to elapse')
+        time.sleep(delay)
+
+    def _setup_mirrored_dirs(self, n_dirs):
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        self.peer_add(self.primary_fs_name, self.primary_fs_id,
+                      'client.mirror_remote@ceph', self.secondary_fs_name,
+                      check_perf_counter=False)
+        dirs = []
+        for i in range(n_dirs):
+            name = f'rebal_dir_{i}'
+            self.mount_a.run_shell(['mkdir', '-p', name])
+            path = f'/{name}'
+            self.add_directory(self.primary_fs_name, self.primary_fs_id, path)
+            dirs.append(path)
+        return dirs
+
+    def test_initial_distribution_balanced(self):
+        """New dirs on multiple daemons end with max-min <= 1 (e.g. 2+1+1)."""
+        dirs = self._setup_mirrored_dirs(4)
+        for d in dirs:
+            self.wait_directory_mapped(self.primary_fs_name, d)
+        self.wait_for_balanced_distribution(self.primary_fs_name, 4)
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_failover_then_rejoin_rebalances(self):
+        """Stop one daemon (failover), restart it; deferred rebalance restores balance.
+
+        Rejoin happens while dirs are still inside the default 300s throttle
+        after failover remap. Immediate shuffle may select nothing; deferred
+        rebalance should converge once the throttle window elapses.
+        """
+        dirs = self._setup_mirrored_dirs(4)
+        for d in dirs:
+            self.wait_directory_mapped(self.primary_fs_name, d)
+        self.wait_for_balanced_distribution(self.primary_fs_name, 4)
+
+        before = self.distribution_counts(self.primary_fs_name)
+        log.info(f'distribution before failover: {before}')
+
+        victim = 'mirror2'
+        self.stop_mirror_daemon(victim)
+        # InstanceWatcher.INSTANCE_TIMEOUT is 30s
+        time.sleep(40)
+
+        self.wait_for_failover_imbalance(
+            self.primary_fs_name, 4, max_instances=2)
+        mid = self.distribution_counts(self.primary_fs_name)
+        log.info(f'distribution after failover: {mid}')
+        self.assertGreater(self.max_min_dir_delta(mid), 1)
+
+        self.start_mirror_daemon(victim)
+        # Default DIR_SHUFFLE_THROTTLE_INTERVAL (300s) + shuffle transitions
+        self.wait_for_balanced_distribution_after_throttle(
+            self.primary_fs_name, 4)
+        after = self.distribution_counts(self.primary_fs_name)
+        log.info(f'distribution after rejoin rebalance: {after}')
+        self.assertEqual(
+            len([c for c in after.values() if c > 0]),
+            self.NUM_MIRROR_INSTANCES,
+            msg=f'expected all mirror instances to hold dirs: {after}')
+
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_odd_dir_count_stable_balance(self):
+        """Odd dir counts (5) reach max-min <= 1 and the mapping stays fixed.
+
+        needs_rebalance() is internal (max-min > 1); we infer it from
+        ``show distribution``. Once balanced (e.g. 2+2+1), a wrongly true
+        needs_rebalance would still not shuffle until each dir's throttle
+        elapses, so we wait past DIR_SHUFFLE_THROTTLE_INTERVAL before
+        asserting the per-instance mapping is unchanged.
+        """
+        dirs = self._setup_mirrored_dirs(5)
+        for d in dirs:
+            self.wait_directory_mapped(self.primary_fs_name, d)
+        self.wait_for_balanced_distribution(self.primary_fs_name, 5)
+        first = self.distribution_counts(self.primary_fs_name)
+        log.info(f'distribution before throttle stability wait: {first}')
+        self.wait_past_shuffle_throttle()
+        second = self.distribution_counts(self.primary_fs_name)
+        log.info(f'distribution after throttle stability wait: {second}')
+        self.assertEqual(first, second,
+                         msg=f'distribution changed (possible ping-pong): {first} -> {second}')
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)

--- a/src/pybind/mgr/mirroring/fs/dir_map/policy.py
+++ b/src/pybind/mgr/mirroring/fs/dir_map/policy.py
@@ -53,13 +53,73 @@ class Policy:
         return self.is_state_scheduled(self.dir_states[dir_path], State.SHUFFLING)
 
     def can_shuffle_dir(self, dir_path):
-        """Right now, shuffle directories only based on idleness. Later, we
-        probably want to avoid shuffling images that were recently shuffled.
+        """Return True if dir_path may be reshuffled to another instance.
+
+        A directory is eligible only when:
+        - its state machine is idle (not mid ASSOCIATING/SHUFFLING/...), and
+        - either it has no mapped_time yet, or DIR_SHUFFLE_THROTTLE_INTERVAL
+          seconds have elapsed since it was last mapped.
+
+        The throttle avoids thrashing directory assignments when mirror
+        daemons flap. Dead-instance failover bypasses this via forced
+        SHUFFLING in _remove_instances().
         """
         log.debug(f'can_shuffle_dir: {dir_path}')
         dir_state = self.dir_states[dir_path]
-        return StateTransition.is_idle(dir_state.state) and \
-            (time.time() - dir_state['mapped_time']) > Policy.DIR_SHUFFLE_THROTTLE_INTERVAL
+        if not StateTransition.is_idle(dir_state.state):
+            return False
+        # Never mapped / just unmapped: nothing to throttle against.
+        if dir_state.mapped_time is None:
+            return True
+        return (time.time() - dir_state.mapped_time) > Policy.DIR_SHUFFLE_THROTTLE_INTERVAL
+
+    def _live_dir_counts(self):
+        """Per live instance directory counts (includes idle instances with 0)."""
+        counts = []
+        for instance_id, dir_paths in self.instance_to_dir_map.items():
+            if self.is_dead_instance(instance_id):
+                continue
+            counts.append(len(dir_paths))
+        return counts
+
+    def needs_rebalance(self):
+        """True if live instances differ by more than one directory.
+
+        Using max-min > 1 (rather than len > floor(n/k)) avoids perpetual
+        ping-pong when the directory count is not evenly divisible — e.g.
+        5 dirs on 2 daemons is balanced as 3+2, not a bug to keep "fixing".
+        """
+        with self.lock:
+            counts = self._live_dir_counts()
+            if len(counts) <= 1:
+                return False
+            return (max(counts) - min(counts)) > 1
+
+    def throttle_remaining(self):
+        """Seconds until the last throttled directory becomes shuffle-eligible.
+
+        Aligns deferred rebalance with each dir's mapped_time + throttle,
+        rather than always waiting a full DIR_SHUFFLE_THROTTLE_INTERVAL from
+        daemon join. Returns 0 if every directory is already eligible.
+        """
+        with self.lock:
+            now = time.time()
+            remaining = []
+            for dir_state in self.dir_states.values():
+                if dir_state.mapped_time is None:
+                    continue
+                left = Policy.DIR_SHUFFLE_THROTTLE_INTERVAL - (now - dir_state.mapped_time)
+                if left > 0:
+                    remaining.append(left)
+            return max(remaining) if remaining else 0
+
+    def rebalance(self):
+        """Retry directory shuffle with the current instance set.
+
+        Equivalent to add_instances([]) — used by deferred rebalance after
+        the throttle window. Does not abort in-flight SHUFFLING transitions.
+        """
+        return self.add_instances([]) or []
 
     def set_state(self, dir_state, state, ignore_current_state=False):
         if not ignore_current_state and dir_state.state == state:

--- a/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
+++ b/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
@@ -67,9 +67,78 @@ class FSPolicy:
         self.timer_task = RTimer(CEPHFS_IMAGE_POLICY_UPDATE_THROTTLE_INTERVAL,
                                  self.process_updates)
         self.timer_task.start()
+        # One-shot deferred rebalance. None means no retry is pending.
+        # Cancelling this timer does NOT abort in-flight directory SHUFFLING
+        # state machines — it only drops a future retry of policy.rebalance().
+        self.rebalance_timer = None
 
     def schedule_action(self, dir_paths):
         self.dir_paths.extend(dir_paths)
+
+    def _cancel_rebalance_timer(self):
+        """Drop a pending deferred rebalance retry only.
+
+        Active directory SHUFFLING transitions continue unaffected.
+        """
+        if self.rebalance_timer is not None:
+            self.rebalance_timer.cancel()
+            self.rebalance_timer = None
+
+    def _arm_rebalance_timer(self, delay):
+        """Start (or replace) a one-shot timer to retry rebalance after delay."""
+        self._cancel_rebalance_timer()
+        if self.stopping.is_set():
+            return
+        # Clamp so we never schedule a non-positive wait.
+        delay = max(float(delay), float(CEPHFS_IMAGE_POLICY_UPDATE_THROTTLE_INTERVAL))
+        log.info(f'scheduling deferred rebalance in {delay:.1f}s')
+        t = threading.Timer(delay, self._deferred_rebalance)
+        t.daemon = True
+        self.rebalance_timer = t
+        t.start()
+
+    def _deferred_rebalance(self):
+        # Always bounce onto the finisher so policy work stays serialized
+        # with other FSPolicy callbacks (never run under the Timer thread).
+        self.finisher.queue(self.handle_rebalance, [])
+
+    def _maybe_schedule_rebalance(self, just_shuffled=False):
+        """Arm deferred rebalance if the map is still uneven.
+
+        Re-arm rules (avoid infinite / tight loops):
+        - Balanced (max-min <= 1): do nothing.
+        - Still throttled: wait throttle_remaining() so we align with mapped_time.
+        - Just scheduled SHUFFLING dirs: counts stay uneven until UNMAP; recheck
+          shortly so we can stop once transitions finish.
+        - Idle, unthrottled, shuffle picked nothing: do NOT spin every 1s —
+          wait for the next instance add/remove.
+        """
+        if self.stopping.is_set() or not self.policy.needs_rebalance():
+            return
+        remaining = self.policy.throttle_remaining()
+        if remaining > 0:
+            self._arm_rebalance_timer(remaining)
+        elif just_shuffled:
+            # In-flight shuffle; poll soon, then stop once needs_rebalance is false.
+            self._arm_rebalance_timer(CEPHFS_IMAGE_POLICY_UPDATE_THROTTLE_INTERVAL)
+        else:
+            log.warning('directory map still uneven but no shuffle candidates '
+                        'and throttle elapsed; waiting for instance change')
+
+    def handle_rebalance(self):
+        """Deferred retry of directory shuffle after throttle allows."""
+        with self.lock:
+            if self.stopping.is_set():
+                return
+            self.rebalance_timer = None
+            if not self.policy.needs_rebalance():
+                log.debug('deferred rebalance: already balanced')
+                return
+            schedules = self.policy.rebalance()
+            if schedules:
+                log.info(f'deferred rebalance remapping: {schedules}')
+                self.schedule_action(schedules)
+            self._maybe_schedule_rebalance(just_shuffled=bool(schedules))
 
     def get_live_instance_ids(self):
         watcher = self.instance_watcher
@@ -92,6 +161,8 @@ class FSPolicy:
         with self.lock:
             log.debug('FSPolicy.shutdown')
             self.stopping.set()
+            log.debug('canceling deferred rebalance timer')
+            self._cancel_rebalance_timer()
             log.debug('canceling update timer task')
             self.timer_task.cancel()
             log.debug('update timer task canceled')
@@ -120,12 +191,25 @@ class FSPolicy:
                 if self.stopping.is_set():
                     log.debug(f'handle_update_instances: policy shutting down')
                     return
+                # Instance set changed: drop any stale deferred retry. This does
+                # not cancel in-flight SHUFFLING; remove_instances/add_instances
+                # below continue to own those transitions.
+                self._cancel_rebalance_timer()
+
                 schedules = []
                 if instances_removed:
+                    # Forced failover shuffle for dirs on the dead instance.
                     schedules.extend(self.policy.remove_instances(instances_removed))
                 if instances_added:
+                    # Least-load shuffle; may be empty if dirs are still throttled
+                    # after a recent failover remap.
                     schedules.extend(self.policy.add_instances(instances_added))
                 self.schedule_action(schedules)
+
+                # If still uneven (typical: daemon rejoins within the throttle
+                # window after failover), arm a one-shot retry aligned to
+                # mapped_time rather than leaving a permanent imbalance.
+                self._maybe_schedule_rebalance(just_shuffled=bool(schedules))
             finally:
                 self.op_tracker.finish_async_op()
 


### PR DESCRIPTION
can_shuffle_dir() incorrectly treated DirectoryState as a dict (dir_state['mapped_time']), so rejoin-time shuffle raised TypeError, was swallowed by the Finisher, and left dirs stuck on the surviving daemon. Failover still worked because dead-instance removal force-shuffles without can_shuffle_dir().

Use dir_state.mapped_time. Even with that fix, dirs remapped during failover get a fresh mapped_time and stay under the 300s shuffle throttle, so an immediate add_instances() on rejoin often selects nothing. Shuffle only ran on instance add/remove, so the imbalance could persist indefinitely.

After add/remove, if the map is still uneven, arm a one-shot deferred rebalance for throttle_remaining() - time until the most recently mapped dir clears the 300s window. When it fires, rebalance() retries add_instances([]). So after rejoin, reshuffle is either immediate (dirs already past throttle) or automatically once that window elapses.

Uneven means max(live dir counts) - min(live dir counts) > 1. For example 5 dirs on 2 daemons can never be "balanced" (always 3+2), so deferred rebalance would keep moving one dir back and forth every throttle period. Allowing a difference of one treats 3+2 as done.

Re-arm only while dirs are still throttled or SHUFFLING is in flight. If shuffle returns nothing and the throttle has already elapsed, do not arm a ~1s retry loop (a no-op spin that wakes forever without moving dirs); wait for the next instance change instead.

Fixes: https://tracker.ceph.com/issues/79010


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
