### PR TITLE
tentacle: cephfs_mirror: A few bug fix backports

### DIFF
--- a/doc/cephfs/cephfs-mirroring.rst
+++ b/doc/cephfs/cephfs-mirroring.rst
@@ -357,7 +357,7 @@ command parameter is of format ``filesystem-name@filesystem-id peer-uuid``::
             "id": 120,
             "name": "snap1",
             "sync_duration": 3,
-            "sync_time_stamp": "274900.558797s",
+            "sync_time_stamp": "2026-07-15T12:00:00.558797+0530",
             "sync_bytes": 52428800
         },
         "snaps_synced": 2,
@@ -391,7 +391,7 @@ When a directory is currently being synchronized, the mirror daemon marks it as 
             "id": 120,
             "name": "snap1",
             "sync_duration": 3,
-            "sync_time_stamp": "274900.558797s",
+            "sync_time_stamp": "2026-07-15T12:00:00.558797+0530",
             "sync_bytes": 52428800
         },
         "snaps_synced": 2,
@@ -420,7 +420,7 @@ E.g., adding a regular file for synchronization would result in failed status::
             "id": 121,
             "name": "snap2",
             "sync_duration": 5,
-            "sync_time_stamp": "500900.600797s",
+            "sync_time_stamp": "2026-07-15T12:05:33.600797+0530",
             "sync_bytes": 78643200
         },
         "snaps_synced": 3,
@@ -456,7 +456,7 @@ In the remote filesystem::
             "id": 120,
             "name": "snap1",
             "sync_duration": 3,
-            "sync_time_stamp": "274900.558797s"
+            "sync_time_stamp": "2026-07-15T12:00:00.558797+0530"
         },
         "snaps_synced": 2,
         "snaps_deleted": 0,

--- a/doc/dev/cephfs-mirroring.rst
+++ b/doc/dev/cephfs-mirroring.rst
@@ -396,7 +396,7 @@ status. Commands of this kind take the form ``filesystem-name@filesystem-id peer
             "id": 120,
             "name": "snap1",
             "sync_duration": 0.079997898999999997,
-            "sync_time_stamp": "274900.558797s"
+            "sync_time_stamp": "2026-07-15T12:00:00.558797+0530"
         },
         "snaps_synced": 2,
         "snaps_deleted": 0,
@@ -441,7 +441,7 @@ status:
             "id": 120,
             "name": "snap1",
             "sync_duration": 0.079997898999999997,
-            "sync_time_stamp": "274900.558797s"
+            "sync_time_stamp": "2026-07-15T12:00:00.558797+0530"
         },
         "snaps_synced": 2,
         "snaps_deleted": 0,

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -43,8 +43,8 @@ def retry_assert(timeout=60, interval=1):
                         attempt += 1
             # Final failure
             if last_exc is not None and hasattr(last_exc, "res"):
-              log.error("\n--- Last peer status (res) ---")
-              log.error(last_exc.res)
+                log.error("\n--- Last peer status (res) ---")
+                log.error(last_exc.res)
 
             raise AssertionError(
                 f"{func.__name__} did not succeed within {timeout}s "
@@ -53,6 +53,7 @@ def retry_assert(timeout=60, interval=1):
 
         return wrapper
     return decorator
+
 
 class TestMirroring(CephFSTestCase):
     MDSS_REQUIRED = 5
@@ -329,7 +330,6 @@ class TestMirroring(CephFSTestCase):
     def check_peer_snap_in_progress(self, fs_name, fs_id,
                                     peer_spec, dir_name, snap_name, timeout=60, interval=1):
         peer_uuid = self.get_peer_uuid(peer_spec)
-        deadline = time.time() + timeout
         try:
             res = self.mirror_daemon_command(f'peer status for fs: {fs_name}',
                                              'fs', 'mirror', 'peer', 'status',

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -4,6 +4,7 @@ import errno
 import logging
 import random
 import time
+import functools
 
 from io import StringIO
 from collections import deque
@@ -13,6 +14,45 @@ from teuthology.exceptions import CommandFailedError
 from teuthology.contextutil import safe_while
 
 log = logging.getLogger(__name__)
+
+
+# retry decorator
+def retry_assert(timeout=60, interval=1):
+    """
+    Retry a test helper until assertions inside it pass or timeout expires.
+    Prints retry count on each failure.
+    """
+    tries = int(timeout/interval)
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            last_exc = None
+            attempt = 1
+
+            with safe_while(sleep=interval, tries=tries, action=f"retry {func.__name__}") as proceed:
+                while proceed():
+                    try:
+                        return func(*args, **kwargs)
+                    except (AssertionError, KeyError, IndexError) as e:
+                        last_exc = e
+                        log.debug(
+                            f"[retry_assert] {func.__name__}: "
+                            f"attempt {attempt} failed ({type(e).__name__}), retrying..."
+                        )
+                        attempt += 1
+            # Final failure
+            if last_exc is not None and hasattr(last_exc, "res"):
+              log.error("\n--- Last peer status (res) ---")
+              log.error(last_exc.res)
+
+            raise AssertionError(
+                f"{func.__name__} did not succeed within {timeout}s "
+                f"after {attempt - 1} attempts"
+            ) from last_exc
+
+        return wrapper
+    return decorator
 
 class TestMirroring(CephFSTestCase):
     MDSS_REQUIRED = 5
@@ -194,53 +234,112 @@ class TestMirroring(CephFSTestCase):
 
         self.assertLess(vafter["counters"]["directory_count"], vbefore["counters"]["directory_count"])
 
+    @retry_assert(timeout=140, interval=2)
+    def check_mirror_status_after_failure(self):
+        status = self.get_mirror_daemon_status()
+        fs = status['filesystems'][0]
+        peer = fs['peers'][0]
+
+        self.assertEqual(fs['directory_count'], 1)
+        self.assertEqual(peer['stats']['failure_count'], 1)
+        self.assertEqual(peer['stats']['recovery_count'], 0)
+
+    @retry_assert(timeout=140, interval=2)
+    def check_mirror_status_after_failure_recovery(self):
+        status = self.get_mirror_daemon_status()
+        fs = status['filesystems'][0]
+        peer = fs['peers'][0]
+
+        self.assertEqual(fs['directory_count'], 1)
+        self.assertEqual(peer['stats']['failure_count'], 1)
+        self.assertEqual(peer['stats']['recovery_count'], 1)
+
+    @retry_assert(timeout=60, interval=3)
+    def check_peer_status_empty(self, fs_name, fs_id, peer_spec):
+        peer_uuid = self.get_peer_uuid(peer_spec)
+        res = self.mirror_daemon_command(f'peer status for fs: {fs_name}',
+                                         'fs', 'mirror', 'peer', 'status',
+                                         f'{fs_name}@{fs_id}', peer_uuid)
+        try:
+            self.assertFalse(res)
+        except (AssertionError, KeyError, IndexError) as e:
+            e.res = res
+            raise
+
+    @retry_assert(timeout=600, interval=10)
     def check_peer_status(self, fs_name, fs_id, peer_spec, dir_name, expected_snap_name,
                           expected_snap_count):
         peer_uuid = self.get_peer_uuid(peer_spec)
         res = self.mirror_daemon_command(f'peer status for fs: {fs_name}',
                                          'fs', 'mirror', 'peer', 'status',
                                          f'{fs_name}@{fs_id}', peer_uuid)
-        self.assertTrue(dir_name in res)
-        self.assertTrue(res[dir_name]['last_synced_snap']['name'] == expected_snap_name)
-        self.assertTrue(res[dir_name]['snaps_synced'] == expected_snap_count)
+        try:
+            self.assertTrue(dir_name in res)
+            self.assertTrue(res[dir_name]['last_synced_snap']['name'] == expected_snap_name)
+            self.assertTrue(res[dir_name]['snaps_synced'] == expected_snap_count)
+        except (AssertionError, KeyError, IndexError) as e:
+            e.res = res
+            raise
 
+    @retry_assert(timeout=60, interval=5)
     def check_peer_status_idle(self, fs_name, fs_id, peer_spec, dir_name, expected_snap_name,
                                expected_snap_count):
         peer_uuid = self.get_peer_uuid(peer_spec)
         res = self.mirror_daemon_command(f'peer status for fs: {fs_name}',
                                          'fs', 'mirror', 'peer', 'status',
                                          f'{fs_name}@{fs_id}', peer_uuid)
-        self.assertTrue(dir_name in res)
-        self.assertTrue('idle' == res[dir_name]['state'])
-        self.assertTrue(expected_snap_name == res[dir_name]['last_synced_snap']['name'])
-        self.assertTrue(expected_snap_count == res[dir_name]['snaps_synced'])
+        try:
+            self.assertTrue(dir_name in res)
+            self.assertTrue('idle' == res[dir_name]['state'])
+            self.assertTrue(expected_snap_name == res[dir_name]['last_synced_snap']['name'])
+            self.assertTrue(expected_snap_count == res[dir_name]['snaps_synced'])
+        except (AssertionError, KeyError, IndexError) as e:
+            e.res = res
+            raise
 
+    @retry_assert(timeout=60, interval=2)
     def check_peer_status_deleted_snap(self, fs_name, fs_id, peer_spec, dir_name,
                                       expected_delete_count):
         peer_uuid = self.get_peer_uuid(peer_spec)
         res = self.mirror_daemon_command(f'peer status for fs: {fs_name}',
                                          'fs', 'mirror', 'peer', 'status',
                                          f'{fs_name}@{fs_id}', peer_uuid)
-        self.assertTrue(dir_name in res)
-        self.assertTrue(res[dir_name]['snaps_deleted'] == expected_delete_count)
+        try:
+            self.assertTrue(dir_name in res)
+            self.assertTrue(res[dir_name]['snaps_deleted'] == expected_delete_count)
+        except (AssertionError, KeyError, IndexError) as e:
+            e.res = res
+            raise
 
+    @retry_assert(timeout=60, interval=2)
     def check_peer_status_renamed_snap(self, fs_name, fs_id, peer_spec, dir_name,
                                        expected_rename_count):
         peer_uuid = self.get_peer_uuid(peer_spec)
         res = self.mirror_daemon_command(f'peer status for fs: {fs_name}',
                                          'fs', 'mirror', 'peer', 'status',
                                          f'{fs_name}@{fs_id}', peer_uuid)
-        self.assertTrue(dir_name in res)
-        self.assertTrue(res[dir_name]['snaps_renamed'] == expected_rename_count)
+        try:
+            self.assertTrue(dir_name in res)
+            self.assertTrue(res[dir_name]['snaps_renamed'] == expected_rename_count)
+        except (AssertionError, KeyError, IndexError) as e:
+            e.res = res
+            raise
 
+    @retry_assert(timeout=60, interval=1)
     def check_peer_snap_in_progress(self, fs_name, fs_id,
-                                    peer_spec, dir_name, snap_name):
+                                    peer_spec, dir_name, snap_name, timeout=60, interval=1):
         peer_uuid = self.get_peer_uuid(peer_spec)
-        res = self.mirror_daemon_command(f'peer status for fs: {fs_name}',
-                                         'fs', 'mirror', 'peer', 'status',
-                                         f'{fs_name}@{fs_id}', peer_uuid)
-        self.assertTrue('syncing' == res[dir_name]['state'])
-        self.assertTrue(res[dir_name]['current_syncing_snap']['name'] == snap_name)
+        deadline = time.time() + timeout
+        try:
+            res = self.mirror_daemon_command(f'peer status for fs: {fs_name}',
+                                             'fs', 'mirror', 'peer', 'status',
+                                             f'{fs_name}@{fs_id}', peer_uuid)
+
+            self.assertTrue('syncing' == res[dir_name]['state'])
+            self.assertTrue(res[dir_name]['current_syncing_snap']['name'] == snap_name)
+        except (AssertionError, KeyError, IndexError) as e:
+            e.res = res
+            raise
 
     def verify_snapshot(self, dir_name, snap_name):
         snap_list = self.mount_b.ls(path=f'{dir_name}/.snap')
@@ -255,6 +354,7 @@ class TestMirroring(CephFSTestCase):
         log.debug(f'destination snapshot checksum {snap_name} {dest_res}')
         self.assertTrue(source_res == dest_res)
 
+    @retry_assert(timeout=150, interval=5)
     def verify_failed_directory(self, fs_name, fs_id, peer_spec, dir_name):
         peer_uuid = self.get_peer_uuid(peer_spec)
         res = self.mirror_daemon_command(f'peer status for fs: {fs_name}',
@@ -590,7 +690,6 @@ class TestMirroring(CephFSTestCase):
         for i in range(10):
             self.mount_a.write_n_mb(os.path.join('d0', f'file.{i}'), 100)
 
-        time.sleep(60)
         self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
         self.add_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
         self.peer_add(self.primary_fs_name, self.primary_fs_id, "client.mirror_remote@ceph", self.secondary_fs_name)
@@ -602,7 +701,6 @@ class TestMirroring(CephFSTestCase):
         # take a snapshot
         self.mount_a.run_shell(["mkdir", "d0/.snap/snap0"])
 
-        time.sleep(120)
         self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
                                "client.mirror_remote@ceph", '/d0', 'snap0', 1)
         self.verify_snapshot('d0', 'snap0')
@@ -620,12 +718,9 @@ class TestMirroring(CephFSTestCase):
         for i in range(15):
             self.mount_a.write_n_mb(os.path.join('d0', f'more_file.{i}'), 100)
 
-        time.sleep(60)
-
         # take another snapshot
         self.mount_a.run_shell(["mkdir", "d0/.snap/snap1"])
 
-        time.sleep(240)
         self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
                                "client.mirror_remote@ceph", '/d0', 'snap1', 2)
         self.verify_snapshot('d0', 'snap1')
@@ -642,11 +737,11 @@ class TestMirroring(CephFSTestCase):
         # delete a snapshot
         self.mount_a.run_shell(["rmdir", "d0/.snap/snap0"])
 
-        time.sleep(10)
-        snap_list = self.mount_b.ls(path='d0/.snap')
-        self.assertTrue('snap0' not in snap_list)
         self.check_peer_status_deleted_snap(self.primary_fs_name, self.primary_fs_id,
                                             "client.mirror_remote@ceph", '/d0', 1)
+        snap_list = self.mount_b.ls(path='d0/.snap')
+        self.assertTrue('snap0' not in snap_list)
+
         # check snaps_deleted
         res = self.mirror_daemon_command(f'counter dump for fs: {self.primary_fs_name}', 'counter', 'dump')
         fourth = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_PEER][0]
@@ -655,12 +750,11 @@ class TestMirroring(CephFSTestCase):
         # rename a snapshot
         self.mount_a.run_shell(["mv", "d0/.snap/snap1", "d0/.snap/snap2"])
 
-        time.sleep(10)
+        self.check_peer_status_renamed_snap(self.primary_fs_name, self.primary_fs_id,
+                                            "client.mirror_remote@ceph", '/d0', 1)
         snap_list = self.mount_b.ls(path='d0/.snap')
         self.assertTrue('snap1' not in snap_list)
         self.assertTrue('snap2' in snap_list)
-        self.check_peer_status_renamed_snap(self.primary_fs_name, self.primary_fs_id,
-                                            "client.mirror_remote@ceph", '/d0', 1)
         # check snaps_renamed
         res = self.mirror_daemon_command(f'counter dump for fs: {self.primary_fs_name}', 'counter', 'dump')
         fifth = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_PEER][0]
@@ -684,7 +778,6 @@ class TestMirroring(CephFSTestCase):
         # take a snapshot
         self.mount_a.run_shell(["mkdir", "d0/.snap/snap0"])
 
-        time.sleep(10)
         self.check_peer_snap_in_progress(self.primary_fs_name, self.primary_fs_id,
                                          "client.mirror_remote@ceph", '/d0', 'snap0')
 
@@ -722,7 +815,6 @@ class TestMirroring(CephFSTestCase):
         # take a snapshot
         self.mount_a.run_shell(["mkdir", "d0/.snap/snap0"])
 
-        time.sleep(10)
         self.check_peer_snap_in_progress(self.primary_fs_name, self.primary_fs_id,
                                          "client.mirror_remote@ceph", '/d0', 'snap0')
 
@@ -743,7 +835,6 @@ class TestMirroring(CephFSTestCase):
         # check if the rados addr is blocklisted
         self.assertTrue(self.mds_cluster.is_addr_blocklisted(rados_inst))
 
-        time.sleep(500)
         self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
                                "client.mirror_remote@ceph", '/d0', 'snap0', expected_snap_count=1)
         self.verify_snapshot('d0', 'snap0')
@@ -767,7 +858,6 @@ class TestMirroring(CephFSTestCase):
         self.add_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
 
         # wait for mirror daemon to mark it the directory as failed
-        time.sleep(120)
         self.verify_failed_directory(self.primary_fs_name, self.primary_fs_id,
                                      "client.mirror_remote@ceph", '/d0')
 
@@ -776,7 +866,6 @@ class TestMirroring(CephFSTestCase):
         self.mount_a.run_shell(["mkdir", "d0/.snap/snap0"])
 
         # wait for correction
-        time.sleep(120)
         self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
                                "client.mirror_remote@ceph", '/d0', 'snap0', 1)
         # check snaps_synced
@@ -805,25 +894,12 @@ class TestMirroring(CephFSTestCase):
         # in daemon stats
         self.add_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
 
-        time.sleep(120)
-        status = self.get_mirror_daemon_status()
-        # we added one
-        peer = status['filesystems'][0]['peers'][0]
-        self.assertEqual(status['filesystems'][0]['directory_count'], 1)
-        # failure count should be reflected
-        self.assertEqual(peer['stats']['failure_count'], 1)
-        self.assertEqual(peer['stats']['recovery_count'], 0)
+        self.check_mirror_status_after_failure()
 
         # create the directory, mirror daemon would recover
         self.mount_a.run_shell(["mkdir", "d0"])
 
-        time.sleep(120)
-        status = self.get_mirror_daemon_status()
-        peer = status['filesystems'][0]['peers'][0]
-        self.assertEqual(status['filesystems'][0]['directory_count'], 1)
-        # failure and recovery count should be reflected
-        self.assertEqual(peer['stats']['failure_count'], 1)
-        self.assertEqual(peer['stats']['recovery_count'], 1)
+        self.check_mirror_status_after_failure_recovery()
 
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
 
@@ -959,7 +1035,6 @@ class TestMirroring(CephFSTestCase):
         # take a snapshot
         self.mount_a.run_shell(["mkdir", "d0/.snap/snap0"])
 
-        time.sleep(30)
         self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
                                "client.mirror_remote@ceph", '/d0', 'snap0', 1)
         self.verify_snapshot('d0', 'snap0')
@@ -986,7 +1061,6 @@ class TestMirroring(CephFSTestCase):
         # take a snapshot
         self.mount_a.run_shell(["mkdir", "d0/d1/d2/d3/.snap/snap0"])
 
-        time.sleep(30)
         self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
                                "client.mirror_remote@ceph", '/d0/d1/d2/d3', 'snap0', 1)
         # check snaps_synced
@@ -1001,7 +1075,6 @@ class TestMirroring(CephFSTestCase):
 
         # try syncing more snapshots
         self.mount_a.run_shell(["mkdir", "d0/d1/d2/d3/.snap/snap1"])
-        time.sleep(30)
         self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
                                "client.mirror_remote@ceph", '/d0/d1/d2/d3', 'snap1', 2)
         # check snaps_synced
@@ -1011,7 +1084,6 @@ class TestMirroring(CephFSTestCase):
 
         self.mount_a.run_shell(["rmdir", "d0/d1/d2/d3/.snap/snap0"])
         self.mount_a.run_shell(["rmdir", "d0/d1/d2/d3/.snap/snap1"])
-        time.sleep(15)
         self.check_peer_status_deleted_snap(self.primary_fs_name, self.primary_fs_id,
                                             "client.mirror_remote@ceph", '/d0/d1/d2/d3', 2)
         # check snaps_deleted
@@ -1116,7 +1188,6 @@ class TestMirroring(CephFSTestCase):
         self.mount_a.run_shell(['mkdir', f'{repo_path}/.snap/snap_a'])
 
         # full copy, takes time
-        time.sleep(500)
         self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
                                "client.mirror_remote@ceph", f'/{repo_path}', 'snap_a', 1)
         self.verify_snapshot(repo_path, 'snap_a')
@@ -1124,21 +1195,23 @@ class TestMirroring(CephFSTestCase):
         res = self.mirror_daemon_command(f'counter dump for fs: {self.primary_fs_name}', 'counter', 'dump')
         vsecond = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_PEER][0]
         self.assertGreater(vsecond["counters"]["snaps_synced"], vfirst["counters"]["snaps_synced"])
+        full_sync_duration = vsecond["counters"]["last_synced_duration"]
 
         # create some diff
-        num = random.randint(5, 20)
+        num = random.randint(5, 10)
         log.debug(f'resetting to HEAD~{num}')
         exec_git_cmd(["reset", "--hard", f'HEAD~{num}'])
 
         self.mount_a.run_shell(['mkdir', f'{repo_path}/.snap/snap_b'])
         # incremental copy, should be fast
-        time.sleep(180)
         self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
                                "client.mirror_remote@ceph", f'/{repo_path}', 'snap_b', 2)
         self.verify_snapshot(repo_path, 'snap_b')
         res = self.mirror_daemon_command(f'counter dump for fs: {self.primary_fs_name}', 'counter', 'dump')
         vthird = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_PEER][0]
         self.assertGreater(vthird["counters"]["snaps_synced"], vsecond["counters"]["snaps_synced"])
+        inc_sync_duration1 = vthird["counters"]["last_synced_duration"]
+        self.assertGreaterEqual(float(full_sync_duration), float(inc_sync_duration1))
 
         # diff again, this time back to HEAD
         log.debug('resetting to HEAD')
@@ -1146,13 +1219,14 @@ class TestMirroring(CephFSTestCase):
 
         self.mount_a.run_shell(['mkdir', f'{repo_path}/.snap/snap_c'])
         # incremental copy, should be fast
-        time.sleep(180)
         self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
                                "client.mirror_remote@ceph", f'/{repo_path}', 'snap_c', 3)
         self.verify_snapshot(repo_path, 'snap_c')
         res = self.mirror_daemon_command(f'counter dump for fs: {self.primary_fs_name}', 'counter', 'dump')
         vfourth = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_PEER][0]
         self.assertGreater(vfourth["counters"]["snaps_synced"], vthird["counters"]["snaps_synced"])
+        inc_sync_duration2 = vfourth["counters"]["last_synced_duration"]
+        self.assertGreaterEqual(float(full_sync_duration), float(inc_sync_duration2))
 
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
 
@@ -1216,7 +1290,6 @@ class TestMirroring(CephFSTestCase):
             res = self.mirror_daemon_command(f'counter dump for fs: {self.primary_fs_name}', 'counter', 'dump')
             vbefore = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_PEER][0]
             self.mount_a.run_shell(['mkdir', f'd0/.snap/{snapname}'])
-            time.sleep(30)
             self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
                                    "client.mirror_remote@ceph", '/d0', snapname, turns+1)
             verify_types('d0', fnames, snapname)
@@ -1264,7 +1337,6 @@ class TestMirroring(CephFSTestCase):
         self.mount_a.run_shell(['mkdir', f'{repo_path}/.snap/snap_a'])
 
         # full copy, takes time
-        time.sleep(500)
         self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
                                "client.mirror_remote@ceph", f'/{repo_path}', 'snap_a', 1)
         self.verify_snapshot(repo_path, 'snap_a')
@@ -1283,7 +1355,6 @@ class TestMirroring(CephFSTestCase):
         self.mount_a.run_shell(['rmdir', f'{repo_path}/.snap/snap_a'])
 
         # incremental copy but based on remote dir_root
-        time.sleep(300)
         self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
                                "client.mirror_remote@ceph", f'/{repo_path}', 'snap_b', 2)
         self.verify_snapshot(repo_path, 'snap_b')
@@ -1367,7 +1438,7 @@ class TestMirroring(CephFSTestCase):
         self.remove_directory(self.primary_fs_name, self.primary_fs_id, '/d2')
 
         # Wait a while for the sync backoff
-        time.sleep(500)
+        self.check_peer_status_empty(self.primary_fs_name, self.primary_fs_id, "client.mirror_remote@ceph")
 
         log.debug('removing snapshots')
         self.mount_a.run_shell(["rmdir", f"d0/.snap/{snap_name}"])
@@ -1397,8 +1468,6 @@ class TestMirroring(CephFSTestCase):
         self.mount_a.run_shell(["mkdir", f"d2/.snap/{snap_name}"])
 
         # Wait for the threads to finish
-        time.sleep(500)
-
         self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
                                "client.mirror_remote@ceph", '/d0', f'{snap_name}', 1)
         self.verify_snapshot('d0', f'{snap_name}')
@@ -1426,7 +1495,6 @@ class TestMirroring(CephFSTestCase):
         self.add_directory(self.primary_fs_name, self.primary_fs_id, '/l1')
         self.peer_add(self.primary_fs_name, self.primary_fs_id, "client.mirror_remote@ceph", self.secondary_fs_name)
 
-        time.sleep(60)
         self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
                                "client.mirror_remote@ceph", '/l1', 'snap0', 1)
         # dump perf counters
@@ -1475,7 +1543,6 @@ class TestMirroring(CephFSTestCase):
         expected_snap_count = 1
         self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/{snap_name}'])
 
-        time.sleep(30)
         # confirm snapshot synced and status 'idle'
         self.check_peer_status_idle(self.primary_fs_name, self.primary_fs_id,
                                     peer_spec, f'/{dir_name}', snap_name, expected_snap_count)
@@ -1538,8 +1605,6 @@ class TestMirroring(CephFSTestCase):
 
         # add the directory for mirroring
         self.add_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
-
-        time.sleep(60)
 
         # confirm snapshot synced and status 'idle'
         expected_snap_count = 2

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -16,6 +16,8 @@ from teuthology.contextutil import safe_while
 log = logging.getLogger(__name__)
 
 
+# Exceptions to retry in test assertions
+RETRY_EXCEPTIONS = (AssertionError, KeyError, IndexError, CommandFailedError)
 # retry decorator
 def retry_assert(timeout=60, interval=1):
     """
@@ -34,7 +36,7 @@ def retry_assert(timeout=60, interval=1):
                 while proceed():
                     try:
                         return func(*args, **kwargs)
-                    except (AssertionError, KeyError, IndexError) as e:
+                    except RETRY_EXCEPTIONS as e:
                         last_exc = e
                         log.debug(
                             f"[retry_assert] {func.__name__}: "
@@ -263,7 +265,7 @@ class TestMirroring(CephFSTestCase):
                                          f'{fs_name}@{fs_id}', peer_uuid)
         try:
             self.assertFalse(res)
-        except (AssertionError, KeyError, IndexError) as e:
+        except RETRY_EXCEPTIONS as e:
             e.res = res
             raise
 
@@ -278,7 +280,7 @@ class TestMirroring(CephFSTestCase):
             self.assertTrue(dir_name in res)
             self.assertTrue(res[dir_name]['last_synced_snap']['name'] == expected_snap_name)
             self.assertTrue(res[dir_name]['snaps_synced'] == expected_snap_count)
-        except (AssertionError, KeyError, IndexError) as e:
+        except RETRY_EXCEPTIONS as e:
             e.res = res
             raise
 
@@ -294,7 +296,7 @@ class TestMirroring(CephFSTestCase):
             self.assertTrue('idle' == res[dir_name]['state'])
             self.assertTrue(expected_snap_name == res[dir_name]['last_synced_snap']['name'])
             self.assertTrue(expected_snap_count == res[dir_name]['snaps_synced'])
-        except (AssertionError, KeyError, IndexError) as e:
+        except RETRY_EXCEPTIONS as e:
             e.res = res
             raise
 
@@ -308,7 +310,7 @@ class TestMirroring(CephFSTestCase):
         try:
             self.assertTrue(dir_name in res)
             self.assertTrue(res[dir_name]['snaps_deleted'] == expected_delete_count)
-        except (AssertionError, KeyError, IndexError) as e:
+        except RETRY_EXCEPTIONS as e:
             e.res = res
             raise
 
@@ -322,7 +324,7 @@ class TestMirroring(CephFSTestCase):
         try:
             self.assertTrue(dir_name in res)
             self.assertTrue(res[dir_name]['snaps_renamed'] == expected_rename_count)
-        except (AssertionError, KeyError, IndexError) as e:
+        except RETRY_EXCEPTIONS as e:
             e.res = res
             raise
 
@@ -337,7 +339,7 @@ class TestMirroring(CephFSTestCase):
 
             self.assertTrue('syncing' == res[dir_name]['state'])
             self.assertTrue(res[dir_name]['current_syncing_snap']['name'] == snap_name)
-        except (AssertionError, KeyError, IndexError) as e:
+        except RETRY_EXCEPTIONS as e:
             e.res = res
             raise
 

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -313,6 +313,17 @@ class TestMirroring(CephFSTestCase):
         log.debug(f'status: {status}')
         return status
 
+    def setup_mount_b(self, mds_perm):
+        log.debug('reconfigure client auth caps')
+        self.get_ceph_cmd_result(
+            'auth', 'caps', f"client.{self.mount_b.client_id}",
+            'mds', f'allow {mds_perm}',
+            'mon', 'allow r',
+            'osd', f"allow rw pool={self.backup_fs.get_data_pool_name()}")
+        self.mount_b.umount_wait()
+        log.debug(f'mounting filesystem {self.secondary_fs_name}')
+        self.mount_b.mount_wait(cephfs_name=self.secondary_fs_name)
+
     def test_basic_mirror_commands(self):
         self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
@@ -573,19 +584,7 @@ class TestMirroring(CephFSTestCase):
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
 
     def test_cephfs_mirror_stats(self):
-        log.debug('reconfigure client auth caps')
-        self.get_ceph_cmd_result(
-            'auth', 'caps', "client.{0}".format(self.mount_b.client_id),
-                'mds', 'allow rw',
-                'mon', 'allow r',
-                'osd', 'allow rw pool={0}, allow rw pool={1}'.format(
-                    self.backup_fs.get_data_pool_name(),
-                    self.backup_fs.get_data_pool_name()))
-
-        log.debug(f'mounting filesystem {self.secondary_fs_name}')
-        self.mount_b.umount_wait()
-        self.mount_b.mount_wait(cephfs_name=self.secondary_fs_name)
-
+        self.setup_mount_b(mds_perm='rw')
         # create a bunch of files in a directory to snap
         self.mount_a.run_shell(["mkdir", "d0"])
         for i in range(10):
@@ -671,19 +670,7 @@ class TestMirroring(CephFSTestCase):
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
 
     def test_cephfs_mirror_cancel_sync(self):
-        log.debug('reconfigure client auth caps')
-        self.get_ceph_cmd_result(
-            'auth', 'caps', "client.{0}".format(self.mount_b.client_id),
-                'mds', 'allow rw',
-                'mon', 'allow r',
-                'osd', 'allow rw pool={0}, allow rw pool={1}'.format(
-                    self.backup_fs.get_data_pool_name(),
-                    self.backup_fs.get_data_pool_name()))
-
-        log.debug(f'mounting filesystem {self.secondary_fs_name}')
-        self.mount_b.umount_wait()
-        self.mount_b.mount_wait(cephfs_name=self.secondary_fs_name)
-
+        self.setup_mount_b(mds_perm='rw')
         # create a bunch of files in a directory to snap
         self.mount_a.run_shell(["mkdir", "d0"])
         for i in range(100):
@@ -714,19 +701,7 @@ class TestMirroring(CephFSTestCase):
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
 
     def test_cephfs_mirror_restart_sync_on_blocklist(self):
-        log.debug('reconfigure client auth caps')
-        self.get_ceph_cmd_result(
-            'auth', 'caps', "client.{0}".format(self.mount_b.client_id),
-                'mds', 'allow rw',
-                'mon', 'allow r',
-                'osd', 'allow rw pool={0}, allow rw pool={1}'.format(
-                    self.backup_fs.get_data_pool_name(),
-                    self.backup_fs.get_data_pool_name()))
-
-        log.debug(f'mounting filesystem {self.secondary_fs_name}')
-        self.mount_b.umount_wait()
-        self.mount_b.mount_wait(cephfs_name=self.secondary_fs_name)
-
+        self.setup_mount_b(mds_perm='rw')
         # create a bunch of files in a directory to snap
         self.mount_a.run_shell(["mkdir", "d0"])
         for i in range(8):
@@ -965,19 +940,7 @@ class TestMirroring(CephFSTestCase):
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
 
     def test_cephfs_mirror_symlink_sync(self):
-        log.debug('reconfigure client auth caps')
-        self.get_ceph_cmd_result(
-            'auth', 'caps', "client.{0}".format(self.mount_b.client_id),
-                'mds', 'allow rw',
-                'mon', 'allow r',
-                'osd', 'allow rw pool={0}, allow rw pool={1}'.format(
-                    self.backup_fs.get_data_pool_name(),
-                    self.backup_fs.get_data_pool_name()))
-
-        log.debug(f'mounting filesystem {self.secondary_fs_name}')
-        self.mount_b.umount_wait()
-        self.mount_b.mount_wait(cephfs_name=self.secondary_fs_name)
-
+        self.setup_mount_b(mds_perm='rw')
         # create a bunch of files w/ symbolic links in a directory to snap
         self.mount_a.run_shell(["mkdir", "d0"])
         self.mount_a.create_n_files('d0/file', 10, sync=True)
@@ -1127,18 +1090,7 @@ class TestMirroring(CephFSTestCase):
 
     def test_cephfs_mirror_incremental_sync(self):
         """ Test incremental snapshot synchronization (based on mtime differences)."""
-        log.debug('reconfigure client auth caps')
-        self.get_ceph_cmd_result(
-            'auth', 'caps', "client.{0}".format(self.mount_b.client_id),
-            'mds', 'allow rw',
-            'mon', 'allow r',
-            'osd', 'allow rw pool={0}, allow rw pool={1}'.format(
-                self.backup_fs.get_data_pool_name(),
-                self.backup_fs.get_data_pool_name()))
-        log.debug(f'mounting filesystem {self.secondary_fs_name}')
-        self.mount_b.umount_wait()
-        self.mount_b.mount_wait(cephfs_name=self.secondary_fs_name)
-
+        self.setup_mount_b(mds_perm='rw')
         repo = 'ceph-qa-suite'
         repo_dir = 'ceph_repo'
         repo_path = f'{repo_dir}/{repo}'
@@ -1219,18 +1171,7 @@ class TestMirroring(CephFSTestCase):
                |
         file_z |   sym          dir         reg         sym
         """
-        log.debug('reconfigure client auth caps')
-        self.get_ceph_cmd_result(
-            'auth', 'caps', "client.{0}".format(self.mount_b.client_id),
-                'mds', 'allow rw',
-                'mon', 'allow r',
-                'osd', 'allow rw pool={0}, allow rw pool={1}'.format(
-                    self.backup_fs.get_data_pool_name(),
-                    self.backup_fs.get_data_pool_name()))
-        log.debug(f'mounting filesystem {self.secondary_fs_name}')
-        self.mount_b.umount_wait()
-        self.mount_b.mount_wait(cephfs_name=self.secondary_fs_name)
-
+        self.setup_mount_b(mds_perm='rw')
         typs = deque(['reg', 'dir', 'sym'])
         def cleanup_and_create_with_type(dirname, fnames):
             self.mount_a.run_shell_payload(f"rm -rf {dirname}/*")
@@ -1297,19 +1238,7 @@ class TestMirroring(CephFSTestCase):
         mirror daemon should identify the purge and switch to using remote
         comparison to sync the snapshot (in the next iteration of course).
         """
-
-        log.debug('reconfigure client auth caps')
-        self.get_ceph_cmd_result(
-            'auth', 'caps', "client.{0}".format(self.mount_b.client_id),
-            'mds', 'allow rw',
-            'mon', 'allow r',
-            'osd', 'allow rw pool={0}, allow rw pool={1}'.format(
-                self.backup_fs.get_data_pool_name(),
-                self.backup_fs.get_data_pool_name()))
-        log.debug(f'mounting filesystem {self.secondary_fs_name}')
-        self.mount_b.umount_wait()
-        self.mount_b.mount_wait(cephfs_name=self.secondary_fs_name)
-
+        self.setup_mount_b(mds_perm='rw')
         repo = 'ceph-qa-suite'
         repo_dir = 'ceph_repo'
         repo_path = f'{repo_dir}/{repo}'
@@ -1388,19 +1317,7 @@ class TestMirroring(CephFSTestCase):
         as expected. Note that we schedule three (3) directories for mirroring to ensure
         that all replayer threads (3 by default) in the mirror daemon are busy.
         """
-        log.debug('reconfigure client auth caps')
-        self.get_ceph_cmd_result(
-            'auth', 'caps', "client.{0}".format(self.mount_b.client_id),
-                'mds', 'allow rw',
-                'mon', 'allow r',
-                'osd', 'allow rw pool={0}, allow rw pool={1}'.format(
-                    self.backup_fs.get_data_pool_name(),
-                    self.backup_fs.get_data_pool_name()))
-
-        log.debug(f'mounting filesystem {self.secondary_fs_name}')
-        self.mount_b.umount_wait()
-        self.mount_b.mount_wait(cephfs_name=self.secondary_fs_name)
-
+        self.setup_mount_b(mds_perm='rw')
         # create some large files in 3 directories to snap
         self.mount_a.run_shell(["mkdir", "d0"])
         self.mount_a.run_shell(["mkdir", "d1"])
@@ -1500,19 +1417,7 @@ class TestMirroring(CephFSTestCase):
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
 
     def test_local_and_remote_dir_root_mode(self):
-        log.debug('reconfigure client auth caps')
-        cid = self.mount_b.client_id
-        data_pool = self.backup_fs.get_data_pool_name()
-        self.get_ceph_cmd_result(
-            'auth', 'caps', f"client.{cid}",
-            'mds', 'allow rw',
-            'mon', 'allow r',
-            'osd', f"allow rw pool={data_pool}, allow rw pool={data_pool}")
-
-        log.debug(f'mounting filesystem {self.secondary_fs_name}')
-        self.mount_b.umount_wait()
-        self.mount_b.mount_wait(cephfs_name=self.secondary_fs_name)
-
+        self.setup_mount_b(mds_perm='rw')
         self.mount_a.run_shell(["mkdir", "l1"])
         self.mount_a.run_shell(["mkdir", "l1/.snap/snap0"])
         self.mount_a.run_shell(["chmod", "go-rwx", "l1"])
@@ -1543,17 +1448,7 @@ class TestMirroring(CephFSTestCase):
         """
         That get/set ceph.mirror.dirty_snap_id attribute succeeds in a remote filesystem.
         """
-        log.debug('reconfigure client auth caps')
-        self.get_ceph_cmd_result(
-            'auth', 'caps', "client.{0}".format(self.mount_b.client_id),
-                'mds', 'allow rw',
-                'mon', 'allow r',
-                'osd', 'allow rw pool={0}, allow rw pool={1}'.format(
-                    self.backup_fs.get_data_pool_name(),
-                    self.backup_fs.get_data_pool_name()))
-        log.debug(f'mounting filesystem {self.secondary_fs_name}')
-        self.mount_b.umount_wait()
-        self.mount_b.mount_wait(cephfs_name=self.secondary_fs_name)
+        self.setup_mount_b(mds_perm='rw')
         log.debug('setting ceph.mirror.dirty_snap_id attribute')
         self.mount_b.run_shell(["mkdir", "-p", "d1/d2/d3"])
         attr = str(random.randint(1, 10))
@@ -1567,18 +1462,7 @@ class TestMirroring(CephFSTestCase):
         That making manual changes to the remote .snap directory shows 'peer status' state: "failed"
         for a synced snapshot and then restores to "idle" when those changes are reverted.
         """
-        log.debug('reconfigure client auth caps')
-        self.get_ceph_cmd_result(
-            'auth', 'caps', "client.{0}".format(self.mount_b.client_id),
-            'mds', 'allow rwps',
-            'mon', 'allow r',
-            'osd', 'allow rw pool={0}, allow rw pool={1}'.format(
-                self.backup_fs.get_data_pool_name(),
-                self.backup_fs.get_data_pool_name()))
-        log.debug(f'mounting filesystem {self.secondary_fs_name}')
-        self.mount_b.umount_wait()
-        self.mount_b.mount_wait(cephfs_name=self.secondary_fs_name)
-
+        self.setup_mount_b(mds_perm='rwps')
         self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
         peer_spec = "client.mirror_remote@ceph"
         self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec, self.secondary_fs_name)
@@ -1631,19 +1515,7 @@ class TestMirroring(CephFSTestCase):
         """
         That mirroring syncs the already existing snapshot correctly.
         """
-        log.debug('reconfigure client auth caps')
-        self.get_ceph_cmd_result(
-            'auth', 'caps', "client.{0}".format(self.mount_b.client_id),
-                'mds', 'allow rw',
-                'mon', 'allow r',
-                'osd', 'allow rw pool={0}, allow rw pool={1}'.format(
-                    self.backup_fs.get_data_pool_name(),
-                    self.backup_fs.get_data_pool_name()))
-
-        log.debug(f'mounting filesystem {self.secondary_fs_name}')
-        self.mount_b.umount_wait()
-        self.mount_b.mount_wait(cephfs_name=self.secondary_fs_name)
-
+        self.setup_mount_b(mds_perm='rw')
         self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
         peer_spec = "client.mirror_remote@ceph"
         self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec, self.secondary_fs_name)

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -86,6 +86,37 @@ class TestMirroring(CephFSTestCase):
     def disable_mirroring_module(self):
         self.run_ceph_cmd("mgr", "module", "disable", TestMirroring.MODULE_NAME)
 
+    def is_mirroring_module_enabled(self):
+        modules = json.loads(
+            self.get_ceph_cmd_stdout('mgr', 'module', 'ls', '--format', 'json'))
+        return self.MODULE_NAME in modules.get('enabled_modules', [])
+
+    def wait_mirroring_module_disabled(self):
+        with safe_while(sleep=1, tries=30,
+                        action='wait for mirroring module disable') as proceed:
+            while proceed():
+                if not self.is_mirroring_module_enabled():
+                    return
+
+    def wait_mirroring_module_reload(self, fs_name, dir_name):
+        """Wait for mirroring module enable and directory re-acquire after reload."""
+        with safe_while(sleep=2, tries=60,
+                        action='wait for mirroring module reload') as proceed:
+            while proceed():
+                if not self.is_mirroring_module_enabled():
+                    continue
+                dirmap = self.mirror_dirmap(fs_name, dir_name)
+                if dirmap.get('state') == 'mapped':
+                    return
+
+    def wait_directory_mapped(self, fs_name, dir_name):
+        with safe_while(sleep=2, tries=30,
+                        action='wait for directory to be mapped') as proceed:
+            while proceed():
+                dirmap = self.mirror_dirmap(fs_name, dir_name)
+                if dirmap.get('state') == 'mapped':
+                    return
+
     def enable_mirroring(self, fs_name, fs_id):
         res = self.mirror_daemon_command(f'counter dump for fs: {fs_name}', 'counter', 'dump')
         vbefore = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR][0]
@@ -355,6 +386,19 @@ class TestMirroring(CephFSTestCase):
                                              follow_symlinks=True)
         log.debug(f'destination snapshot checksum {snap_name} {dest_res}')
         self.assertTrue(source_res == dest_res)
+
+    def mirror_dirmap(self, fs_name, dir_name):
+        return json.loads(self.get_ceph_cmd_stdout(
+            'fs', 'snapshot', 'mirror', 'dirmap', fs_name, dir_name))
+
+    @retry_assert(timeout=60, interval=5)
+    def assert_snapshot_not_synced(self, dir_name, snap_name):
+        """Assert a snapshot on the primary has not appeared on the secondary."""
+        try:
+            snap_list = self.mount_b.ls(path=f'{dir_name}/.snap')
+        except CommandFailedError:
+            return
+        self.assertNotIn(snap_name, snap_list)
 
     @retry_assert(timeout=150, interval=5)
     def verify_failed_directory(self, fs_name, fs_id, peer_spec, dir_name):
@@ -1620,4 +1664,41 @@ class TestMirroring(CephFSTestCase):
                                     peer_spec, f'/{dir_name}', snap_b, expected_snap_count)
         self.verify_snapshot(dir_name, snap_a)
         self.verify_snapshot(dir_name, snap_b)
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_cephfs_mirror_duplicate_acquire_notify(self):
+        """Duplicate acquire notifies must not leave a ghost replayer directory.
+
+        Disabling and re-enabling the mirroring module reloads FSPolicy from omap
+        and re-sends acquire for mapped directories. Without an idempotent
+        PeerReplayer::add_directory(), a duplicate vector entry survives
+        remove_directory() (only one list entry is erased) and the replayer
+        keeps syncing after the directory is removed from mirroring.
+
+        Without the fix, a ghost entry may also crash the replayer thread when
+        pick_directory() calls m_snap_sync_stats.at() after remove erased the map
+        entry; this test catches spurious sync when that path still runs.
+        """
+        self.setup_mount_b(mds_perm='rw')
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        peer_spec = "client.mirror_remote@ceph"
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec,
+                      self.secondary_fs_name)
+
+        dir_name = 'dup_acquire_dir'
+        self.mount_a.run_shell(['mkdir', dir_name])
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+
+        self.wait_directory_mapped(self.primary_fs_name, f'/{dir_name}')
+
+        self.disable_mirroring_module()
+        self.wait_mirroring_module_disabled()
+        self.enable_mirroring_module()
+        self.wait_mirroring_module_reload(self.primary_fs_name, f'/{dir_name}')
+
+        self.remove_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+
+        snap_name = 'snap_after_remove'
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/{snap_name}'])
+        self.assert_snapshot_not_synced(dir_name, snap_name)
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -614,7 +614,7 @@ class TestMirroring(CephFSTestCase):
         self.assertGreater(second["counters"]["last_synced_start"], first["counters"]["last_synced_start"])
         self.assertGreaterEqual(second["counters"]["last_synced_end"], second["counters"]["last_synced_start"])
         self.assertGreater(second["counters"]["last_synced_duration"], 0)
-        self.assertEquals(second["counters"]["last_synced_bytes"], 1048576000) # last_synced_bytes = 10 files of 100MB size each
+        self.assertEqual(second["counters"]["last_synced_bytes"], 1048576000) # last_synced_bytes = 10 files of 100MB size each
 
         # some more IO
         for i in range(15):
@@ -637,7 +637,7 @@ class TestMirroring(CephFSTestCase):
         self.assertGreater(third["counters"]["last_synced_start"], second["counters"]["last_synced_end"])
         self.assertGreaterEqual(third["counters"]["last_synced_end"], third["counters"]["last_synced_start"])
         self.assertGreater(third["counters"]["last_synced_duration"], 0)
-        self.assertEquals(third["counters"]["last_synced_bytes"], 1572864000) # last_synced_bytes = 15 files of 100MB size each
+        self.assertEqual(third["counters"]["last_synced_bytes"], 1572864000) # last_synced_bytes = 15 files of 100MB size each
 
         # delete a snapshot
         self.mount_a.run_shell(["rmdir", "d0/.snap/snap0"])
@@ -797,9 +797,9 @@ class TestMirroring(CephFSTestCase):
 
         # we have not added any directories
         peer = status['filesystems'][0]['peers'][0]
-        self.assertEquals(status['filesystems'][0]['directory_count'], 0)
-        self.assertEquals(peer['stats']['failure_count'], 0)
-        self.assertEquals(peer['stats']['recovery_count'], 0)
+        self.assertEqual(status['filesystems'][0]['directory_count'], 0)
+        self.assertEqual(peer['stats']['failure_count'], 0)
+        self.assertEqual(peer['stats']['recovery_count'], 0)
 
         # add a non-existent directory for synchronization -- check if its reported
         # in daemon stats
@@ -809,10 +809,10 @@ class TestMirroring(CephFSTestCase):
         status = self.get_mirror_daemon_status()
         # we added one
         peer = status['filesystems'][0]['peers'][0]
-        self.assertEquals(status['filesystems'][0]['directory_count'], 1)
+        self.assertEqual(status['filesystems'][0]['directory_count'], 1)
         # failure count should be reflected
-        self.assertEquals(peer['stats']['failure_count'], 1)
-        self.assertEquals(peer['stats']['recovery_count'], 0)
+        self.assertEqual(peer['stats']['failure_count'], 1)
+        self.assertEqual(peer['stats']['recovery_count'], 0)
 
         # create the directory, mirror daemon would recover
         self.mount_a.run_shell(["mkdir", "d0"])
@@ -820,10 +820,10 @@ class TestMirroring(CephFSTestCase):
         time.sleep(120)
         status = self.get_mirror_daemon_status()
         peer = status['filesystems'][0]['peers'][0]
-        self.assertEquals(status['filesystems'][0]['directory_count'], 1)
+        self.assertEqual(status['filesystems'][0]['directory_count'], 1)
         # failure and recovery count should be reflected
-        self.assertEquals(peer['stats']['failure_count'], 1)
-        self.assertEquals(peer['stats']['recovery_count'], 1)
+        self.assertEqual(peer['stats']['failure_count'], 1)
+        self.assertEqual(peer['stats']['recovery_count'], 1)
 
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
 
@@ -831,7 +831,7 @@ class TestMirroring(CephFSTestCase):
         """Test mirror daemon init failure"""
 
         # disable mgr mirroring plugin as it would try to load dir map on
-        # on mirroring enabled for a filesystem (an throw up erorrs in
+        # on mirroring enabled for a filesystem (an throw up errors in
         # the logs)
         self.disable_mirroring_module()
 
@@ -867,7 +867,7 @@ class TestMirroring(CephFSTestCase):
         """Test if the mirror daemon can recover from a init failure"""
 
         # disable mgr mirroring plugin as it would try to load dir map on
-        # on mirroring enabled for a filesystem (an throw up erorrs in
+        # on mirroring enabled for a filesystem (an throw up errors in
         # the logs)
         self.disable_mirroring_module()
 
@@ -1194,11 +1194,11 @@ class TestMirroring(CephFSTestCase):
             for fname in fnames:
                 t = self.mount_b.run_shell_payload(f"stat -c %F {dirname}/.snap/{snap_name}/{fname}").stdout.getvalue().strip()
                 if typs[tidx] == 'reg':
-                    self.assertEquals('regular file', t)
+                    self.assertEqual('regular file', t)
                 elif typs[tidx] == 'dir':
-                    self.assertEquals('directory', t)
+                    self.assertEqual('directory', t)
                 elif typs[tidx] == 'sym':
-                    self.assertEquals('symbolic link', t)
+                    self.assertEqual('symbolic link', t)
                 tidx += 1
 
         self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
@@ -1234,7 +1234,7 @@ class TestMirroring(CephFSTestCase):
         """Test snapshot synchronization in midst of snapshot deletes.
 
         Deleted the previous snapshot when the mirror daemon is figuring out
-        incremental differences between current and previous snaphot. The
+        incremental differences between current and previous snapshot. The
         mirror daemon should identify the purge and switch to using remote
         comparison to sync the snapshot (in the next iteration of course).
         """

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -1164,6 +1164,9 @@ class TestMirroring(CephFSTestCase):
 
     def test_cephfs_mirror_incremental_sync(self):
         """ Test incremental snapshot synchronization (based on mtime differences)."""
+
+        self.skipTest("temporarily disable test: snapdiff bug - see https://tracker.ceph.com/issues/74984")
+
         self.setup_mount_b(mds_perm='rw')
         repo = 'ceph-qa-suite'
         repo_dir = 'ceph_repo'
@@ -1313,6 +1316,9 @@ class TestMirroring(CephFSTestCase):
         mirror daemon should identify the purge and switch to using remote
         comparison to sync the snapshot (in the next iteration of course).
         """
+
+        self.skipTest("temporarily disable test: snapdiff bug - see https://tracker.ceph.com/issues/74984")
+
         self.setup_mount_b(mds_perm='rw')
         repo = 'ceph-qa-suite'
         repo_dir = 'ceph_repo'

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -1557,7 +1557,7 @@ class TestMirroring(CephFSTestCase):
         # create a directory in the remote fs and check status 'failed'
         self.mount_b.run_shell(['sudo', 'mkdir', remote_snap_path], omit_sudo=False)
         peer_uuid = self.get_peer_uuid(peer_spec)
-        with safe_while(sleep=1, tries=60, action=f'wait for failed status: {peer_spec}') as proceed:
+        with safe_while(sleep=2, tries=100, action=f'wait for failed status: {peer_spec}') as proceed:
             while proceed():
                 res = self.mirror_daemon_command(f'peer status for fs: {self.primary_fs_name}',
                                                  'fs', 'mirror', 'peer', 'status',
@@ -1569,7 +1569,7 @@ class TestMirroring(CephFSTestCase):
                     break
         # remove the directory in the remote fs and check status restores to 'idle'
         self.mount_b.run_shell(['sudo', 'rmdir', remote_snap_path], omit_sudo=False)
-        with safe_while(sleep=1, tries=60, action=f'wait for idle status: {peer_spec}') as proceed:
+        with safe_while(sleep=2, tries=100, action=f'wait for idle status: {peer_spec}') as proceed:
             while proceed():
                 res = self.mirror_daemon_command(f'peer status for fs: {self.primary_fs_name}',
                                                  'fs', 'mirror', 'peer', 'status',

--- a/qa/tasks/mgr/test_cache.py
+++ b/qa/tasks/mgr/test_cache.py
@@ -34,7 +34,7 @@ class TestCache(MgrTestCase):
     def test_init_cache(self):
         get_ttl = "config get mgr mgr_ttl_cache_expire_seconds"
         res = self.cluster_cmd(get_ttl)
-        self.assertEquals(int(res), 10)
+        self.assertEqual(int(res), 10)
 
     def test_health_not_cached(self):
         get_health = "mgr api get health"
@@ -43,8 +43,8 @@ class TestCache(MgrTestCase):
         self.cluster_cmd(get_health)
         h, m = self.get_hit_miss_ratio()
 
-        self.assertEquals(h, h_start)
-        self.assertEquals(m, m_start)
+        self.assertEqual(h, h_start)
+        self.assertEqual(m, m_start)
 
     def test_osdmap(self):
         get_osdmap = "mgr api get osd_map"
@@ -73,11 +73,11 @@ class TestCache(MgrTestCase):
         # Miss, add osd_map to cache
         self.wait_until_true(wait_miss, self.ttl + 5)
         h, m = self.get_hit_miss_ratio()
-        self.assertEquals(h, hit_start)
-        self.assertEquals(m, miss_start+1)
+        self.assertEqual(h, hit_start)
+        self.assertEqual(m, miss_start+1)
 
         # Hit, get osd_map from cache
         self.cluster_cmd(get_osdmap)
         h, m = self.get_hit_miss_ratio()
-        self.assertEquals(h, hit_start+1)
-        self.assertEquals(m, miss_start+1)
+        self.assertEqual(h, hit_start+1)
+        self.assertEqual(m, miss_start+1)

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -2118,19 +2118,23 @@ void PeerReplayer::peer_status(Formatter *f) {
   f->open_object_section("stats");
   for (auto &[dir_root, sync_stat] : m_snap_sync_stats) {
     f->open_object_section(dir_root);
-    if (sync_stat.failed) {
+    switch (get_dir_sync_state(sync_stat)) {
+    case DirSyncState::Failed:
       f->dump_string("state", "failed");
       if (sync_stat.last_failed_reason) {
 	f->dump_string("failure_reason", *sync_stat.last_failed_reason);
       }
-    } else if (!sync_stat.current_syncing_snap) {
+      break;
+    case DirSyncState::Idle:
       f->dump_string("state", "idle");
-    } else {
+      break;
+    case DirSyncState::Syncing:
       f->dump_string("state", "syncing");
       f->open_object_section("current_syncing_snap");
       f->dump_unsigned("id", (*sync_stat.current_syncing_snap).first);
       f->dump_string("name", (*sync_stat.current_syncing_snap).second);
       f->close_section();
+      break;
     }
     if (sync_stat.last_synced_snap) {
       f->open_object_section("last_synced_snap");

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -323,10 +323,16 @@ void PeerReplayer::shutdown() {
 
 void PeerReplayer::add_directory(string_view dir_root) {
   dout(20) << ": dir_root=" << dir_root << dendl;
+  auto _dir_root = std::string(dir_root);
 
   std::scoped_lock locker(m_lock);
-  m_directories.emplace_back(dir_root);
-  m_snap_sync_stats.emplace(dir_root, SnapSyncStat());
+  if (std::find(m_directories.begin(), m_directories.end(), _dir_root) !=
+      m_directories.end()) {
+    dout(10) << ": dir_root=" << _dir_root << " already in replay list" << dendl;
+    return;
+  }
+  m_directories.emplace_back(_dir_root);
+  m_snap_sync_stats.emplace(_dir_root, SnapSyncStat());
   m_cond.notify_all();
 }
 

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -2142,7 +2142,10 @@ void PeerReplayer::peer_status(Formatter *f) {
       f->dump_string("name", (*sync_stat.last_synced_snap).second);
       if (sync_stat.last_sync_duration) {
         f->dump_float("sync_duration", *sync_stat.last_sync_duration);
-        f->dump_stream("sync_time_stamp") << sync_stat.last_synced;
+      }
+      if (!sync_stat.last_synced.is_zero()) {
+        // ISO-8601 local time with offset (matches utime_t::localtime)
+        f->dump_string("sync_time_stamp", stringify(sync_stat.last_synced));
       }
       if (sync_stat.last_sync_bytes) {
 	f->dump_unsigned("sync_bytes", *sync_stat.last_sync_bytes);

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -1324,7 +1324,7 @@ int PeerReplayer::SnapDiffSync::init_sync() {
   int r = ceph_fstatx(m_local, m_fh->c_fd, &tstx,
                       CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
                       CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                      AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+                      AT_SYMLINK_NOFOLLOW);
   if (r < 0) {
     derr << ": failed to stat snap=" << m_current.first << ": " << cpp_strerror(r)
          << dendl;
@@ -1505,7 +1505,7 @@ int PeerReplayer::SnapDiffSync::get_entry(std::string *epath, struct ceph_statx 
     r = ceph_statxat(m_local, m_fh->c_fd, _epath.c_str(), &estx,
                      CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
                      CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                     AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+                     AT_SYMLINK_NOFOLLOW);
     if (r < 0) {
       derr << ": failed to stat epath=" << epath << ", r=" << r << dendl;
       return r;
@@ -1622,7 +1622,7 @@ int PeerReplayer::RemoteSync::init_sync() {
   int r = ceph_fstatx(m_local, m_fh->c_fd, &tstx,
                       CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
                       CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                      AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+                      AT_SYMLINK_NOFOLLOW);
   if (r < 0) {
     derr << ": failed to stat snap=" << m_current.first << ": " << cpp_strerror(r)
          << dendl;
@@ -1709,7 +1709,7 @@ int PeerReplayer::RemoteSync::get_entry(std::string *epath, struct ceph_statx *s
     r = ceph_statxat(m_local, m_fh->c_fd, _epath.c_str(), &cstx,
                      CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
                      CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                     AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+                     AT_SYMLINK_NOFOLLOW);
     if (r < 0) {
       derr << ": failed to stat epath=" << _epath << ": " << cpp_strerror(r)
            << dendl;

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -257,6 +257,22 @@ private:
     uint64_t sync_bytes = 0; //sync bytes counter, independently for each directory sync.
   };
 
+  enum class DirSyncState {
+    Idle,
+    Syncing,
+    Failed,
+  };
+
+  static DirSyncState get_dir_sync_state(const SnapSyncStat &sync_stat) {
+    if (sync_stat.current_syncing_snap) {
+      return DirSyncState::Syncing;
+    }
+    if (sync_stat.failed) {
+      return DirSyncState::Failed;
+    }
+    return DirSyncState::Idle;
+  }
+
   void _inc_failed_count(const std::string &dir_root) {
     auto max_failures = g_ceph_context->_conf.get_val<uint64_t>(
     "cephfs_mirror_max_consecutive_failures_per_directory");

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -4,8 +4,10 @@
 #ifndef CEPHFS_MIRROR_PEER_REPLAYER_H
 #define CEPHFS_MIRROR_PEER_REPLAYER_H
 
+#include "common/Clock.h"
 #include "common/Formatter.h"
 #include "common/Thread.h"
+#include "include/utime.h"
 #include "mds/FSMap.h"
 #include "ServiceDaemon.h"
 #include "Types.h"
@@ -251,7 +253,7 @@ private:
     uint64_t synced_snap_count = 0;
     uint64_t deleted_snap_count = 0;
     uint64_t renamed_snap_count = 0;
-    monotime last_synced = clock::zero();
+    utime_t last_synced;
     boost::optional<double> last_sync_duration;
     boost::optional<uint64_t> last_sync_bytes; //last sync bytes for display in status
     uint64_t sync_bytes = 0; //sync bytes counter, independently for each directory sync.
@@ -339,7 +341,7 @@ private:
     std::scoped_lock locker(m_lock);
     _set_last_synced_snap(dir_root, snap_id, snap_name);
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
-    sync_stat.last_synced = clock::now();
+    sync_stat.last_synced = ceph_clock_now();
     sync_stat.last_sync_duration = duration;
     sync_stat.last_sync_bytes = sync_stat.sync_bytes;
     ++sync_stat.synced_snap_count;


### PR DESCRIPTION
Contains multiple mirroring PR back ports as there were dependent

The following qa commits were required as a prerequisite
1. 133cdb7798f8409d417b36e49aa11861567360d2
2. bbdc2e2a533e67dd04bdfe4bf7ed61ecd533b6cc
3. c1e827247bd20e8a1851bc2d7a9861c12d033ef0
4. c34da69f762ca88b0790726a1075145c37ed1a58
5. ef83f0451e0f8b78730600ece21bc72e6ad077a7
6. f2f535e114b2d5a08ad0046dedc5d43699aeb1b0
7. 825fa3af8db51efc98777a1c46815bcf74832fea

---------------------------
1.
backport tracker: https://tracker.ceph.com/issues/77425

backport of https://github.com/ceph/ceph/pull/69467
parent tracker: https://tracker.ceph.com/issues/77398

-----------------
2.
backport tracker: https://tracker.ceph.com/issues/78283

backport of https://github.com/ceph/ceph/pull/69466
parent tracker: https://tracker.ceph.com/issues/77393

-----------------
3.
backport tracker: https://tracker.ceph.com/issues/78286

backport of https://github.com/ceph/ceph/pull/68924
parent tracker:  https://tracker.ceph.com/issues/76616

-----------------

4.
backport tracker: https://tracker.ceph.com/issues/78913

backport of https://github.com/ceph/ceph/pull/70212/commits
parent tracker: https://tracker.ceph.com/issues/76506

NOTE:  Among 4 commits, only 2 commits are required because mirroring metrics
  feature is not back ported to tentacle
  a. 0bb27c7de12e2f2aaac33215b733779b9bfd0362
  b. 10e008aaca509b5f84e215fe99c41f6d12bb1f08
  
-------------------



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
