### PR TITLE
Split FSEnt into it's own files

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -290,6 +290,7 @@ list(APPEND librgw_daos_srcs
 )
 list(APPEND librgw_posix_srcs
   driver/posix/rgw_sal_posix.cc
+  driver/posix/fsent.cc
   driver/posix/lmdb-safe.cc
   driver/posix/posixDB.cc
   driver/posix/notify.cpp

--- a/src/rgw/driver/posix/bucket_cache.h
+++ b/src/rgw/driver/posix/bucket_cache.h
@@ -205,7 +205,7 @@ public:
   typedef cohort::lru::TreeX<BucketCacheEntry, bucket_avl_t, BucketCacheEntryLT, BucketCacheEntryEQ, std::string,
 			     std::mutex> bucket_avl_cache;
 
-  bool reclaim(const cohort::lru::ObjectFactory* newobj_fac) {
+  bool reclaim(const cohort::lru::ObjectFactory* newobj_fac) override {
     auto factory = dynamic_cast<const BucketCacheEntry<D, B>::Factory*>(newobj_fac);
     if (factory == nullptr) {
         return false;

--- a/src/rgw/driver/posix/fsent.cc
+++ b/src/rgw/driver/posix/fsent.cc
@@ -1,0 +1,1809 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "fsent.h"
+#include <dirent.h>
+#include "include/random.h"
+
+namespace rgw { namespace sal {
+
+const std::string ATTR_PREFIX = "user.X-RGW-";
+const std::string mp_ns = "multipart";
+const std::string MP_OBJ_PART_PFX = "part-";
+const std::string MP_OBJ_HEAD_NAME = MP_OBJ_PART_PFX + "00000";
+const int64_t READ_SIZE = 128 * 1024;
+
+namespace posix {
+
+/*
+ * Object ownership is stored in RGW_ATTR_ACL (the standard ACL policy
+ * attribute written by the generic RGW layer), matching the rados driver.
+ * Earlier code maintained a separate "POSIX-Owner" xattr with a
+ * POSIXOwner struct that only held rgw_user — this could not represent
+ * account-owned objects (STS role sessions, account root users) and
+ * crashed with std::bad_variant_access.  Removed in favour of the
+ * generic ACLOwner which carries the full rgw_owner variant.
+ */
+
+
+/* RAII guard for OFD (Open File Description) locks.  OFD locks are
+ * per-open-file-description rather than per-process, so they work
+ * correctly across threads that open independent fds to the same
+ * inode.  Used to serialise xattr writes against concurrent readers
+ * on the same directory or file. */
+struct OFDLockGuard {
+  int fd;
+  OFDLockGuard(int _fd, short type) : fd(_fd) {
+    struct flock fl{};
+    fl.l_type = type;
+    fl.l_whence = SEEK_SET;
+    fcntl(fd, F_OFD_SETLKW, &fl);
+  }
+  ~OFDLockGuard() {
+    struct flock fl{};
+    fl.l_type = F_UNLCK;
+    fl.l_whence = SEEK_SET;
+    fcntl(fd, F_OFD_SETLK, &fl);
+  }
+};
+
+static int get_x_attrs(optional_yield y, const DoutPrefixProvider* dpp, int fd,
+		       Attrs& attrs, const std::string& display)
+{
+  char namebuf[64 * 1024]; // Max list size supported on linux
+  ssize_t buflen;
+  int ret;
+
+  buflen = flistxattr(fd, namebuf, sizeof(namebuf));
+  if (buflen < 0) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not list attributes for " << display << ": "
+      << cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+
+  char *keyptr = namebuf;
+  while (buflen > 0) {
+    std::string value;
+    ssize_t vallen, keylen;
+    char* vp;
+
+    keylen = strlen(keyptr) + 1;
+    std::string key(keyptr);
+    std::string::size_type prefixloc = key.find(ATTR_PREFIX);
+
+    if (prefixloc == std::string::npos) {
+      /* Not one of our attributes */
+      buflen -= keylen;
+      keyptr += keylen;
+      continue;
+    }
+
+    /* Make a key that has just the attribute name */
+    key.erase(prefixloc, ATTR_PREFIX.length());
+
+    vallen = fgetxattr(fd, keyptr, nullptr, 0);
+    if (vallen < 0) {
+      ret = errno;
+      ldpp_dout(dpp, 0) << "ERROR: could not get attribute " << keyptr << " for " << display << ": " << cpp_strerror(ret) << dendl;
+      return -ret;
+    } else if (vallen == 0) {
+      attrs.emplace(std::move(key), bufferlist{});
+      buflen -= keylen;
+      keyptr += keylen;
+      continue;
+    }
+
+    value.reserve(vallen + 1);
+    vp = &value[0];
+
+    vallen = fgetxattr(fd, keyptr, vp, vallen);
+    if (vallen < 0) {
+      ret = errno;
+      ldpp_dout(dpp, 0) << "ERROR: could not get attribute " << keyptr << " for " << display << ": " << cpp_strerror(ret) << dendl;
+      return -ret;
+    }
+
+    bufferlist bl;
+    bl.append(vp, vallen);
+    attrs.emplace(std::move(key), std::move(bl)); /* key and bl are r-value refs */
+
+    buflen -= keylen;
+    keyptr += keylen;
+  }
+
+  return 0;
+}
+
+static int write_x_attr(const DoutPrefixProvider* dpp, optional_yield y, int fd,
+			const std::string& key, bufferlist& value,
+			const std::string& display)
+{
+  int ret;
+  std::string attrname;
+
+  attrname = ATTR_PREFIX + key;
+
+  ret = fsetxattr(fd, attrname.c_str(), value.c_str(), value.length(), 0);
+  if (ret < 0) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not write attribute " << attrname << " for " << display << ": " << cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+
+  return 0;
+}
+
+static int delete_directory(int parent_fd, const char* dname, bool delete_children,
+		     const DoutPrefixProvider* dpp)
+{
+  int ret;
+  int dir_fd = -1;
+  DIR *dir;
+  struct dirent *entry;
+
+  dir_fd = openat(parent_fd, dname, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+  if (dir_fd < 0) {
+    dir_fd = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not open subdir " << dname << ": "
+                      << cpp_strerror(dir_fd) << dendl;
+    return -dir_fd;
+  }
+
+  dir = fdopendir(dir_fd);
+  if (dir == NULL) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not open bucket " << dname
+                      << " for listing: " << cpp_strerror(ret) << dendl;
+    ::close(dir_fd);
+    return -ret;
+  }
+
+  errno = 0;
+  while ((entry = readdir(dir)) != NULL) {
+    struct statx stx;
+
+    if ((entry->d_name[0] == '.' && entry->d_name[1] == '\0') ||
+        (entry->d_name[0] == '.' && entry->d_name[1] == '.' &&
+         entry->d_name[2] == '\0')) {
+      /* Skip . and .. */
+      errno = 0;
+      continue;
+    }
+
+    std::string_view d_name = entry->d_name;
+    bool is_mp = d_name.starts_with("." + mp_ns);
+    if (!is_mp && !delete_children) {
+      closedir(dir);
+      return -ENOTEMPTY;
+    }
+
+    ret = statx(dir_fd, entry->d_name, AT_SYMLINK_NOFOLLOW, STATX_ALL, &stx);
+    if (ret < 0) {
+      ret = errno;
+      ldpp_dout(dpp, 0) << "ERROR: could not stat object " << entry->d_name
+                        << ": " << cpp_strerror(ret) << dendl;
+      closedir(dir);
+      return -ret;
+    }
+
+    if (S_ISDIR(stx.stx_mode)) {
+      /* Recurse */
+      ret = delete_directory(dir_fd, entry->d_name, true, dpp);
+      if (ret < 0) {
+        closedir(dir);
+        return ret;
+      }
+
+      continue;
+    }
+
+    /* Otherwise, unlink */
+    ret = unlinkat(dir_fd, entry->d_name, 0);
+    if (ret < 0) {
+      ret = errno;
+      ldpp_dout(dpp, 0) << "ERROR: could not remove file " << entry->d_name
+                        << ": " << cpp_strerror(ret) << dendl;
+      closedir(dir);
+      return -ret;
+    }
+  }
+  closedir(dir);
+
+  ret = unlinkat(parent_fd, dname, AT_REMOVEDIR);
+  if (ret < 0) {
+    ret = errno;
+    if (errno != ENOENT) {
+      ldpp_dout(dpp, 0) << "ERROR: could not remove bucket " << dname << ": "
+	<< cpp_strerror(ret) << dendl;
+      return -ret;
+    }
+  }
+
+  return 0;
+}
+
+int FSEnt::stat(const DoutPrefixProvider* dpp, bool force)
+{
+  if (force) {
+    stat_done = false;
+  }
+
+  if (stat_done) {
+    return 0;
+  }
+
+  int ret = statx(parent->get_fd(), fname.c_str(), AT_SYMLINK_NOFOLLOW,
+		  STATX_ALL, &stx);
+  if (ret < 0) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not stat " << get_name() << ": "
+                  << cpp_strerror(ret) << dendl;
+    exist = false;
+    return -ret;
+  }
+
+  exist = true;
+  stat_done = true;
+  return 0;
+}
+
+int FSEnt::write_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs, Attrs* extra_attrs)
+{
+  int ret = open(dpp);
+  if (ret < 0) {
+    return ret;
+  }
+
+  OFDLockGuard lock(fd, F_WRLCK);
+  need_fsync = true;
+
+  /* Set the type */
+  bufferlist type_bl;
+  ObjectType type{get_type()};
+  type.encode(type_bl);
+  attrs[RGW_POSIX_ATTR_OBJECT_TYPE] = type_bl;
+
+  /* Snapshot old xattrs so we can remove genuinely stale ones after
+   * writing — covered by the OFD write lock above. */
+  Attrs old_attrs;
+  int old_ret = get_x_attrs(y, dpp, fd, old_attrs, get_name());
+
+  /* Write new values first — fsetxattr overwrites in place, so
+   * readers always see either the old or the new value, never
+   * ENODATA for an attr that is being updated. */
+  if (extra_attrs) {
+    for (auto &it : *extra_attrs) {
+      ret = write_x_attr(dpp, y, fd, it.first, it.second, get_name());
+      if (ret < 0) {
+        return ret;
+      }
+    }
+  }
+
+  for (auto& it : attrs) {
+    ret = write_x_attr(dpp, y, fd, it.first, it.second, get_name());
+    if (ret < 0) {
+      return ret;
+    }
+  }
+
+  /* Now remove xattrs that are on disk but genuinely gone from the
+   * new attrs (not just about to be rewritten). */
+  if (old_ret >= 0) {
+    for (auto& it : old_attrs) {
+      if (attrs.find(it.first) == attrs.end() &&
+          (!extra_attrs || extra_attrs->find(it.first) == extra_attrs->end())) {
+        remove_x_attr(dpp, y, fd, it.first, get_name());
+      }
+    }
+  }
+
+  return 0;
+}
+
+int FSEnt::read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs)
+{
+  int ret = open(dpp);
+  if (ret < 0) {
+    return ret;
+  }
+
+  OFDLockGuard lock(get_fd(), F_RDLCK);
+  return get_x_attrs(y, dpp, get_fd(), attrs, get_name());
+}
+
+int FSEnt::fill_cache(const DoutPrefixProvider *dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags)
+{
+  rgw_bucket_dir_entry bde{};
+
+  rgw_obj_key key = decode_obj_key(get_name());
+  if (parent->get_type() == ObjectType::MULTIPART) {
+    key.ns = mp_ns;
+  }
+  key.get_index_key(&bde.key);
+  bde.ver.pool = 1;
+  bde.ver.epoch = 1;
+
+  switch (parent->get_type().type) {
+    case ObjectType::VERSIONED:
+      bde.flags = rgw_bucket_dir_entry::FLAG_VER;
+      bde.exists = true;
+      if (flags & FSEnt::FLAG_CURRENT) {
+	  bde.flags |= rgw_bucket_dir_entry::FLAG_CURRENT;
+      }
+      if (flags & FSEnt::FLAG_DELETE_MARKER) {
+        bde.flags |= rgw_bucket_dir_entry::FLAG_DELETE_MARKER;
+      }
+      break;
+    case ObjectType::MULTIPART:
+    case ObjectType::DIRECTORY:
+      bde.exists = true;
+      break;
+    case ObjectType::UNKNOWN:
+    case ObjectType::FILE:
+    case ObjectType::SYMLINK:
+      return -EINVAL;
+  }
+
+  Attrs attrs;
+  int ret = open(dpp);
+  if (ret < 0)
+    return ret;
+
+  ret = get_x_attrs(y, dpp, get_fd(), attrs, get_name());
+  if (ret < 0)
+    return ret;
+
+  ACLOwner acl_owner;
+  ret = decode_acl_owner(attrs, acl_owner);
+  if (ret < 0) {
+    bde.meta.owner = "unknown";
+    bde.meta.owner_display_name = "unknown";
+  } else {
+    bde.meta.owner = to_string(acl_owner.id);
+    bde.meta.owner_display_name = acl_owner.display_name;
+  }
+  bde.meta.category = RGWObjCategory::Main;
+  bde.meta.size = stx.stx_size;
+  bde.meta.accounted_size = stx.stx_size;
+  bde.meta.mtime = from_statx_timestamp(stx.stx_mtime);
+  bde.meta.storage_class = RGW_STORAGE_CLASS_STANDARD;
+  bde.meta.appendable = true;
+  bufferlist etag_bl;
+  if (get_attr(attrs, RGW_ATTR_ETAG, etag_bl)) {
+    bde.meta.etag = etag_bl.to_str();
+  }
+
+  return cb(dpp, bde);
+}
+
+int File::create(const DoutPrefixProvider *dpp, bool* existed, bool temp_file)
+{
+  int flags, ret;
+  std::string path;
+  if(temp_file) {
+    flags = O_TMPFILE | O_RDWR;
+    path = ".";
+  } else {
+    flags = O_CREAT | O_RDWR;
+    path = get_name();
+  }
+
+  ret = openat(parent->get_fd(), path.c_str(), flags | O_NOFOLLOW, S_IRWXU);
+  if (ret < 0) {
+    ret = errno;
+    if (ret == EEXIST) {
+      return 0;
+    }
+    ldpp_dout(dpp, 0) << "ERROR: could not open object " << get_name() << ": "
+                      << cpp_strerror(ret) << dendl;
+    return -ret;
+    }
+
+  fd = ret;
+  need_fsync = true;
+
+  return 0;
+}
+
+int File::open(const DoutPrefixProvider* dpp)
+{
+  if (fd >= 0) {
+    return 0;
+  }
+
+  int ret = openat(parent->get_fd(), fname.c_str(), O_RDWR, S_IRWXU);
+  if (ret < 0) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not open object " << get_name() << ": "
+                      << cpp_strerror(ret) << dendl;
+    return -ret;
+    }
+
+  fd = ret;
+
+  return 0;
+}
+
+int File::close()
+{
+  if (fd < 0) {
+    return 0;
+  }
+
+  if (need_fsync) {
+    int ret = ::fsync(fd);
+    if (ret < 0) {
+      return ret;
+    }
+    need_fsync = false;
+  }
+
+  int ret = ::close(fd);
+  if(ret < 0) {
+    return ret;
+  }
+  fd = -1;
+
+  return 0;
+}
+
+
+int File::stat(const DoutPrefixProvider* dpp, bool force)
+{
+  int ret = FSEnt::stat(dpp, force);
+  if (ret < 0) {
+    return ret;
+  }
+
+  if (!S_ISREG(stx.stx_mode)) {
+    /* Not a file */
+    ldpp_dout(dpp, 0) << "ERROR: " << get_name() << " is not a file" << dendl;
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+int File::write(int64_t ofs, bufferlist& bl, const DoutPrefixProvider* dpp,
+		       optional_yield y)
+{
+  need_fsync = true;
+  int64_t left = bl.length();
+  char* curp = bl.c_str();
+  ssize_t ret;
+
+  ret = fchmod(fd, S_IRUSR|S_IWUSR);
+  if(ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not change permissions on object " << get_name() << ": "
+                  << cpp_strerror(ret) << dendl;
+    return ret;
+  }
+
+
+  ret = lseek(fd, ofs, SEEK_SET);
+  if (ret < 0) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not seek object " << get_name() << " to "
+      << ofs << " :" << cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+
+  while (left > 0) {
+    ret = ::write(fd, curp, left);
+    if (ret < 0) {
+      ret = errno;
+      ldpp_dout(dpp, 0) << "ERROR: could not write object " << get_name() << ": "
+	<< cpp_strerror(ret) << dendl;
+      return -ret;
+    }
+
+    curp += ret;
+    left -= ret;
+  }
+
+  return 0;
+}
+
+int File::read(int64_t ofs, int64_t left, bufferlist& bl,
+		      const DoutPrefixProvider* dpp, optional_yield y)
+{
+  int64_t len = std::min(left, READ_SIZE);
+  ssize_t ret;
+
+  ret = lseek(fd, ofs, SEEK_SET);
+  if (ret < 0) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not seek object " << get_name() << " to "
+                      << ofs << " :" << cpp_strerror(ret) << dendl;
+    return -ret;
+    }
+
+    char read_buf[READ_SIZE];
+    ret = ::read(fd, read_buf, len);
+    if (ret < 0) {
+      ret = errno;
+      ldpp_dout(dpp, 0) << "ERROR: could not read object " << get_name() << ": "
+	<< cpp_strerror(ret) << dendl;
+      return -ret;
+    }
+
+    bl.append(read_buf, ret);
+
+    return ret;
+}
+
+int File::copy(const DoutPrefixProvider *dpp, optional_yield y,
+                      Directory* dst_dir, const std::string& dst_name)
+{
+  off64_t scount = 0, dcount = 0;
+
+  int ret = stat(dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not stat source file " << get_name()
+                      << dendl;
+    return ret;
+  }
+
+  ret = open(dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not open source file " << get_name()
+                      << dendl;
+    return ret;
+  }
+
+  // Delete the target
+  {
+    std::unique_ptr<FSEnt> del;
+    ret = dst_dir->get_ent(dpp, y, dst_name, std::string(), del);
+    if (ret >= 0) {
+      ret = del->remove(dpp, y, /*delete_children=*/true, nullptr);
+      if (ret < 0) {
+        ldpp_dout(dpp, 0) << "ERROR: could not remove dest " << dst_name
+                          << dendl;
+        return ret;
+      }
+    }
+  }
+
+  std::unique_ptr<File> dest = clone();
+  dest->parent = dst_dir;
+  dest->fname = dst_name;
+
+  ret = dest->create(dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not create dest file "
+                      << dest->get_name() << dendl;
+    return ret;
+  }
+  ret = dest->open(dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not open dest file "
+                      << dest->get_name() << dendl;
+    return ret;
+  }
+
+  ret = copy_file_range(fd, &scount, dest->get_fd(), &dcount, get_size(), 0);
+  if (ret < 0) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not copy object " << dest->get_name()
+                      << ": " << cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+
+  return 0;
+}
+
+int File::remove(const DoutPrefixProvider* dpp, optional_yield y, bool delete_children, DeleteResult* result)
+{
+  if (!exists()) {
+    return 0;
+  }
+
+  int ret = unlinkat(parent->get_fd(), fname.c_str(), 0);
+  if (ret < 0) {
+    ret = errno;
+    if (errno != ENOENT) {
+      ldpp_dout(dpp, 0) << "ERROR: could not remove object " << get_name()
+                        << ": " << cpp_strerror(ret) << dendl;
+      return -ret;
+    }
+  }
+
+  return 0;
+}
+
+int File::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y, std::string temp_fname)
+{
+  if (fd < 0) {
+    return 0;
+  }
+
+  char temp_file_path[PATH_MAX];
+  // Only works on Linux - Non-portable
+  snprintf(temp_file_path, PATH_MAX,  "/proc/self/fd/%d", fd);
+
+  int ret = linkat(AT_FDCWD, temp_file_path, parent->get_fd(), temp_fname.c_str(), AT_SYMLINK_FOLLOW);
+  if(ret < 0) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: linkat for temp file could not finish: "
+	<< cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+
+  ret = renameat(parent->get_fd(), temp_fname.c_str(), parent->get_fd(), get_name().c_str());
+  if(ret < 0) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: renameat for object could not finish: "
+	<< cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+
+  /* note that open() and stat() return already sign-reversed result codes */
+  ret = open(dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 20) << "ERROR: POSIXAtomicWriter failed opening file" << dendl;
+    return ret;
+  }
+
+  ret = stat(dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 20) << "ERROR: POSIXAtomicWriter failed closing file" << dendl;
+    return ret;
+  }
+
+  return 0;
+}
+
+bool Directory::file_exists(std::string& name)
+{
+  struct statx nstx;
+  int ret = statx(fd, name.c_str(), AT_SYMLINK_NOFOLLOW, STATX_ALL, &nstx);
+
+  return (ret >= 0);
+}
+
+int Directory::create(const DoutPrefixProvider* dpp, bool* existed, bool temp_file)
+{
+  if (temp_file) {
+    ldpp_dout(dpp, 0) << "ERROR: cannot create directory with temp_file " << get_name() << dendl;
+    return -EINVAL;
+  }
+
+  int ret = mkdirat(parent->get_fd(), fname.c_str(), S_IRWXU);
+  if (ret < 0) {
+    ret = errno;
+    if (ret != EEXIST) {
+      if (dpp)
+	ldpp_dout(dpp, 0) << "ERROR: could not create bucket " << get_name() << ": "
+	  << cpp_strerror(ret) << dendl;
+      return -ret;
+    } else if (existed != nullptr) {
+      *existed = true;
+    }
+  }
+
+  return 0;
+}
+
+int Directory::open(const DoutPrefixProvider* dpp)
+{
+  if (fd >= 0) {
+    return 0;
+  }
+
+  int pfd{AT_FDCWD};
+  if (parent)
+    pfd = parent->get_fd();
+
+  int ret = openat(pfd, fname.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+  if (ret < 0) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not open dir " << get_name() << ": "
+                  << cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+
+  fd = ret;
+
+  return 0;
+}
+
+int Directory::close()
+{
+  if (fd < 0) {
+    return 0;
+  }
+
+  ::close(fd);
+  fd = -1;
+
+  return 0;
+}
+
+int Directory::stat(const DoutPrefixProvider* dpp, bool force)
+{
+  int ret = FSEnt::stat(dpp, force);
+  if (ret < 0) {
+    return ret;
+  }
+
+  if (!S_ISDIR(stx.stx_mode)) {
+    /* Not a directory */
+    ldpp_dout(dpp, 0) << "ERROR: " << get_name() << " is not a directory" << dendl;
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+int Directory::remove(const DoutPrefixProvider* dpp, optional_yield y, bool delete_children, DeleteResult* result)
+{
+  return delete_directory(parent->get_fd(), fname.c_str(), delete_children, dpp);
+}
+
+int Directory::write(int64_t ofs, bufferlist& bl, const DoutPrefixProvider* dpp,
+		     optional_yield y)
+{
+  return -EINVAL;
+}
+
+int Directory::read(int64_t ofs, int64_t left, bufferlist &bl,
+                    const DoutPrefixProvider *dpp, optional_yield y)
+{
+  return -EINVAL;
+}
+
+int Directory::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y,
+                              std::string temp_fname)
+{
+  return -EINVAL;
+}
+
+int Directory::rename(const DoutPrefixProvider* dpp, optional_yield y, Directory* dst_dir, std::string dst_name)
+{
+  int flags = 0;
+  int ret;
+  std::string src_name = fname;
+  int parent_fd = parent->get_fd();
+
+  if (dst_dir->file_exists(dst_name)) {
+    flags = RENAME_EXCHANGE;
+  }
+  // swap
+  ret = renameat2(parent_fd, src_name.c_str(), dst_dir->get_fd(), dst_name.c_str(), flags);
+  if(ret < 0) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: renameat2 for shadow object could not finish: "
+	<< cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+
+  /* Parent of this dir is now dest dir */
+  parent = dst_dir;
+  /* Name has changed */
+  fname = dst_name;
+
+  // Delete old one (could be file or directory)
+  struct statx stx;
+  ret = statx(parent_fd, src_name.c_str(), AT_SYMLINK_NOFOLLOW,
+		  STATX_ALL, &stx);
+  if (ret < 0) {
+    ret = errno;
+    if (ret == ENOENT) {
+      return 0;
+    }
+    ldpp_dout(dpp, 0) << "ERROR: could not stat object " << get_name() << ": "
+                  << cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+
+  if (S_ISREG(stx.stx_mode)) {
+    ret = unlinkat(parent_fd, src_name.c_str(), 0);
+  } else if (S_ISDIR(stx.stx_mode)) {
+    ret = delete_directory(parent_fd, src_name.c_str(), true, dpp);
+  }
+  if (ret < 0) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not remove old file " << get_name()
+                      << ": " << cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+
+  return 0;
+}
+
+int Directory::copy(const DoutPrefixProvider *dpp, optional_yield y,
+                      Directory* dst_dir, const std::string& dst_name)
+{
+  int ret;
+
+  // Delete the target
+  {
+    std::unique_ptr<FSEnt> del;
+    ret = dst_dir->get_ent(dpp, y, dst_name, std::string(), del);
+    if (ret >= 0) {
+      ret = del->remove(dpp, y, /*delete_children=*/true, nullptr);
+      if (ret < 0) {
+        ldpp_dout(dpp, 0) << "ERROR: could not remove dest " << dst_name
+                          << dendl;
+        return ret;
+      }
+    }
+  }
+
+  ret = dst_dir->open(dpp);
+  std::unique_ptr<Directory> dest = clone_dir();
+  dest->parent = dst_dir;
+  dest->fname = dst_name;
+
+  ret = dest->create(dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not create dest " << dest->get_name() << dendl;
+    return ret;
+  }
+
+  Attrs attrs;
+  ret = read_attrs(dpp, y, attrs);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not read attrs from " << get_name() << dendl;
+    return ret;
+  }
+  ret = dest->write_attrs(dpp, y, attrs, nullptr);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not write attrs to " << dest->get_name() << dendl;
+    return ret;
+  }
+
+  ret = for_each(dpp, [this, &dest, &dpp, &y](const char* name) {
+    std::unique_ptr<FSEnt> sobj;
+
+    if (name[0] == '.') {
+      /* Skip dotfiles */
+      return 0;
+    }
+
+    int r = this->get_ent(dpp, y, name, std::string(), sobj);
+    if (r < 0)
+      return r;
+    return sobj->copy(dpp, y, dest.get(), name);
+  });
+
+  return ret;
+}
+
+int Directory::get_ent(const DoutPrefixProvider *dpp, optional_yield y, const std::string &name, const std::string& instance, std::unique_ptr<FSEnt>& ent)
+{
+  struct statx nstx;
+  std::unique_ptr<FSEnt> nent;
+
+  int ret = open(dpp);
+  if (ret < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: could not open directory " << name << dendl;
+      return ret;
+  }
+
+  ret = statx(get_fd(), name.c_str(),
+                  AT_SYMLINK_NOFOLLOW, STATX_ALL, &nstx);
+  if (ret < 0) {
+      ret = errno;
+      ldpp_dout(dpp, 0) << "ERROR: could not stat object " << name << " in dir "
+                        << get_name() << " : " << cpp_strerror(ret) << dendl;
+      return -ret;
+  }
+  if (S_ISREG(nstx.stx_mode)) {
+    nent = std::make_unique<File>(name, this, nstx, ctx);
+  } else if (S_ISDIR(nstx.stx_mode)) {
+    ObjectType type{ObjectType::MULTIPART};
+    int tmpfd;
+    Attrs attrs;
+
+    tmpfd = openat(get_fd(), name.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+    if (tmpfd >= 0) {
+      ret = get_x_attrs(y, dpp, tmpfd, attrs, name);
+      if (ret >= 0) {
+        decode_attr(attrs, RGW_POSIX_ATTR_OBJECT_TYPE, type);
+      }
+      ::close(tmpfd);
+    }
+    switch (type.type) {
+    case ObjectType::VERSIONED:
+      nent = std::make_unique<VersionedDirectory>(name, this, instance, nstx, ctx);
+      break;
+    case ObjectType::MULTIPART:
+      nent = std::make_unique<MPDirectory>(name, this, nstx, ctx);
+      break;
+    case ObjectType::DIRECTORY:
+      nent = std::make_unique<Directory>(name, this, nstx, ctx);
+      break;
+    default:
+      ldpp_dout(dpp, 0) << "ERROR: invalid type " << type << dendl;
+      return -EINVAL;
+    }
+  } else if (S_ISLNK(nstx.stx_mode)) {
+    nent = std::make_unique<Symlink>(name, this, nstx, ctx);
+  } else {
+    return -EINVAL;
+  }
+
+  ent.swap(nent);
+  return 0;
+}
+
+int Directory::fill_cache(const DoutPrefixProvider *dpp, optional_yield y,
+                          fill_cache_cb_t &cb, uint32_t flags)
+{
+  int ret = for_each(dpp, [this, &cb, &dpp, &y](const char *name) {
+    std::unique_ptr<FSEnt> ent;
+
+    if (name[0] == '.') {
+      /* Skip dotfiles */
+      return 0;
+    }
+
+    int ret = get_ent(dpp, y, name, std::string(), ent);
+    if (ret < 0)
+      return ret;
+
+    ent->stat(dpp); // Stat the object to get the type
+
+    ret = ent->fill_cache(dpp, y, cb, FSEnt::FLAG_NONE);
+    if (ret < 0)
+      return ret;
+    return 0;
+  });
+
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not list directory " << get_name() << ": "
+      << cpp_strerror(ret) << dendl;
+    return ret;
+  }
+
+  return 0;
+}
+
+int Symlink::create(const DoutPrefixProvider* dpp, bool* existed, bool temp_file)
+{
+  if (temp_file) {
+    ldpp_dout(dpp, 0) << "ERROR: cannot create symlink with temp_file " << get_name() << dendl;
+    return -EINVAL;
+  }
+
+  int ret = symlinkat(target->get_name().c_str(), parent->get_fd(), fname.c_str());
+  if (ret < 0) {
+    ret = errno;
+    if (ret == EEXIST && existed != nullptr) {
+      *existed = true;
+    }
+    ldpp_dout(dpp, 0) << "ERROR: could not create bucket " << get_name() << ": "
+                      << cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+
+  return 0;
+}
+
+int Symlink::fill_target(const DoutPrefixProvider *dpp, Directory* parent, std::string sname, std::string tname, std::unique_ptr<FSEnt>& ent, CephContext* _ctx)
+{
+  int ret;
+
+  if (!tname.empty()) {
+      ret = parent->get_ent(dpp, null_yield, tname, std::string(), ent);
+      if (ret < 0) {
+	ent = std::make_unique<File>(tname, parent, _ctx);
+      }
+      return 0;
+  }
+
+  char link[PATH_MAX];
+  memset(link, 0, sizeof(link));
+  ret = readlinkat(parent->get_fd(), sname.c_str(), link, sizeof(link));
+  if (ret < 0) {
+    ret = errno;
+    return -ret;
+  }
+  ret = parent->get_ent(dpp, null_yield, link, std::string(), ent);
+  if (ret < 0) {
+    ent = std::make_unique<File>(link, parent, _ctx);
+  }
+  return 0;
+}
+
+int Symlink::stat(const DoutPrefixProvider* dpp, bool force)
+{
+  int ret = FSEnt::stat(dpp, force);
+  if (ret < 0) {
+    return ret;
+  }
+
+  if (!S_ISLNK(stx.stx_mode)) {
+    /* Not a symlink */
+    ldpp_dout(dpp, 0) << "ERROR: " << get_name() << " is not a symlink" << dendl;
+    return -EINVAL;
+  }
+
+  struct statx sstx;
+  ret = statx(parent->get_fd(), fname.c_str(), 0, STATX_BASIC_STATS, &sstx);
+  if (ret >= 0) {
+    stx.stx_size = sstx.stx_size;
+  }
+
+  exist = true;
+  return fill_target(dpp, parent, get_name(), std::string(), target, ctx);
+}
+
+int Symlink::read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs)
+{
+  if (target)
+    return target->read_attrs(dpp, y, attrs);
+
+  return FSEnt::read_attrs(dpp, y, attrs);
+}
+
+int Symlink::copy(const DoutPrefixProvider *dpp, optional_yield y,
+                      Directory* dst_dir, const std::string& dst_name)
+{
+  int ret = stat(dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not stat source file " << get_name()
+                      << dendl;
+    return ret;
+  }
+  rgw_obj_key skey = decode_obj_key(target->get_name());
+  rgw_obj_key dkey = decode_obj_key(dst_name);
+  dkey.instance = skey.instance;
+  std::string tgtname = get_key_fname(dkey, /*use_version=*/true);
+
+  ret = symlinkat(tgtname.c_str(), dst_dir->get_fd(), dst_name.c_str());
+
+  return 0;
+}
+
+int MPDirectory::create(const DoutPrefixProvider* dpp, bool* existed, bool temp_file)
+{
+  std::string path;
+
+  if(temp_file) {
+    tmpname = path = "._tmpname_" +
+           std::to_string(ceph::util::generate_random_number<uint64_t>());
+  } else {
+    path = get_name();
+  }
+
+  int ret = mkdirat(parent->get_fd(), path.c_str(), S_IRWXU);
+  if (ret < 0) {
+    ret = errno;
+    if (ret != EEXIST) {
+      if (dpp)
+	ldpp_dout(dpp, 0) << "ERROR: could not create bucket " << get_name() << ": "
+	  << cpp_strerror(ret) << dendl;
+      return -ret;
+    } else if (existed != nullptr) {
+      *existed = true;
+    }
+  }
+
+  return 0;
+}
+
+int MPDirectory::read(int64_t ofs, int64_t left, bufferlist &bl,
+                    const DoutPrefixProvider *dpp, optional_yield y)
+{
+  std::string pname;
+  for (auto part : parts) {
+    if (ofs < part.second) {
+      pname = part.first;
+      break;
+    }
+
+    ofs -= part.second;
+  }
+
+  if (pname.empty()) {
+    // ofs is past the end
+    return 0;
+  }
+
+  if (!cur_read_part || cur_read_part->get_name() != pname) {
+    cur_read_part = std::make_unique<File>(pname, this, ctx);
+  }
+  int ret = cur_read_part->open(dpp);
+  if (ret < 0) {
+    return ret;
+  }
+
+  return cur_read_part->read(ofs, left, bl, dpp, y);
+}
+
+int MPDirectory::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y,
+                                std::string temp_fname)
+{
+  if (tmpname.empty()) {
+    return 0;
+  }
+
+  /* Temporarily change name to tmpname, so we can reuse rename() */
+  std::string savename = fname;
+  fname = tmpname;
+  tmpname.clear();
+
+  return rename(dpp, y, parent, savename);
+}
+
+int MPDirectory::remove(const DoutPrefixProvider* dpp, optional_yield y, bool delete_children, DeleteResult* result)
+{
+  return Directory::remove(dpp, y, /*delete_children=*/true, result);
+}
+
+int MPDirectory::stat(const DoutPrefixProvider* dpp, bool force)
+{
+  int ret = Directory::stat(dpp, force);
+  if (ret < 0) {
+    return ret;
+  }
+
+  uint64_t total_size{0};
+  for_each(dpp, [this, &total_size, &dpp](const char *name) {
+    int ret;
+    struct statx stx;
+    std::string sname = name;
+
+    if (sname.rfind(MP_OBJ_PART_PFX, 0) != 0) {
+      /* Skip non-parts */
+      return 0;
+    }
+
+    ret = statx(fd, name, AT_SYMLINK_NOFOLLOW, STATX_ALL, &stx);
+    if (ret < 0) {
+      ret = errno;
+      ldpp_dout(dpp, 0) << "ERROR: could not stat object " << name << ": "
+                        << cpp_strerror(ret) << dendl;
+      return -ret;
+    }
+
+    if (!S_ISREG(stx.stx_mode)) {
+      /* Skip non-files */
+      return 0;
+    }
+
+    parts[name] = stx.stx_size;
+    total_size += stx.stx_size;
+    return 0;
+  });
+
+  stx.stx_size = total_size;
+
+  return 0;
+}
+
+
+std::unique_ptr<File> MPDirectory::get_part_file(int partnum)
+{
+  std::string partname = MP_OBJ_PART_PFX + fmt::format("{:0>5}", partnum);
+  rgw_obj_key part_key(partname);
+
+  return std::make_unique<File>(partname, this, ctx);
+}
+
+int MPDirectory::fill_cache(const DoutPrefixProvider *dpp, optional_yield y,
+                            fill_cache_cb_t &cb, uint32_t flags)
+{
+  int ret = FSEnt::fill_cache(dpp, y, cb, FSEnt::FLAG_NONE);
+  if (ret < 0)
+    return ret;
+
+  return Directory::fill_cache(dpp, y, cb, FSEnt::FLAG_NONE);
+}
+
+int VersionedDirectory::open(const DoutPrefixProvider* dpp)
+{
+  if (fd > 0) {
+    return 0;
+  }
+  int ret = Directory::open(dpp);
+  if (ret < 0) {
+    return ret;
+  }
+
+  if (!instance_id.empty()) {
+    rgw_obj_key key = decode_obj_key(get_name());
+    key.instance = instance_id;
+    get_ent(dpp, null_yield, get_key_fname(key, /*use_version=*/true), std::string(), cur_version);
+  }
+
+  if (!cur_version) {
+    /* Can't open File, probably doesn't exist yet */
+    return 0;
+  }
+
+  return cur_version->open(dpp);
+}
+
+int VersionedDirectory::create(const DoutPrefixProvider* dpp, bool* existed, bool temp_file)
+{
+  int ret = mkdirat(parent->get_fd(), fname.c_str(), S_IRWXU);
+  if (ret < 0) {
+    ret = errno;
+    if (ret != EEXIST) {
+      if (dpp)
+	ldpp_dout(dpp, 0) << "ERROR: could not create versioned directory " << get_name() << ": "
+	  << cpp_strerror(ret) << dendl;
+      return -ret;
+    }
+  }
+
+  ret = open(dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not open versioned directory " << get_name()
+                      << dendl;
+    return ret;
+  }
+
+  /* Need type attribute written */
+  Attrs attrs;
+  ret = write_attrs(dpp, null_yield, attrs, nullptr);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not write attrs for versioned directory " << get_name()
+                      << dendl;
+    return ret;
+  }
+
+  if (temp_file) {
+    /* Want to create an actual versioned object */
+    rgw_obj_key key = decode_obj_key(get_name());
+    key.instance = instance_id;
+    std::unique_ptr<FSEnt> file =
+        std::make_unique<File>(get_key_fname(key, /*use_version=*/true), this, ctx);
+    ret = add_file(dpp, std::move(file), existed, temp_file);
+    if (ret < 0) {
+      return ret;
+    }
+  }
+
+  return 0;
+}
+
+std::string VersionedDirectory::get_new_instance()
+{
+  return gen_rand_instance_name();
+}
+
+int VersionedDirectory::add_file(const DoutPrefixProvider* dpp, std::unique_ptr<FSEnt>&& file, bool* existed, bool temp_file)
+{
+  int ret = open(dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not open versioned directory " << get_name()
+                      << dendl;
+    return ret;
+  }
+
+  ret = file->create(dpp, existed, temp_file);
+  if (ret < 0) {
+    return ret;
+  }
+
+  if (!temp_file) {
+    return set_cur_version_ent(dpp, file.get());
+  }
+
+  cur_version = std::move(file);
+  return 0;
+}
+
+int VersionedDirectory::set_cur_version_ent(const DoutPrefixProvider* dpp, FSEnt* file)
+{
+  /* Delete current version symlink */
+  std::unique_ptr<FSEnt> del;
+  int ret = get_ent(dpp, null_yield, get_name(), std::string(), del);
+  if (ret >= 0) {
+    ret = del->remove(dpp, null_yield, /*delete_children=*/true, nullptr);
+    if (ret < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: could not remove cur_version " << get_name()
+                        << dendl;
+      return ret;
+    }
+  }
+
+  /* Create new current version symlink */
+  std::unique_ptr<Symlink> sl =
+      std::make_unique<Symlink>(get_name(), this, file->get_name(), ctx);
+  ret = sl->create(dpp, /*existed=*/nullptr, /*temp_file=*/false);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not create cur_version symlink "
+                      << get_name() << dendl;
+    return ret;
+  }
+
+  return 0;
+}
+
+int VersionedDirectory::stat(const DoutPrefixProvider* dpp, bool force)
+{
+  int ret = Directory::stat(dpp, force);
+  if (ret < 0) {
+    return ret;
+  }
+
+  ret = open(dpp);
+  if (ret < 0)
+    return ret;
+
+  if (cur_version) {
+    /* Already have a File for the current version, use it */
+    ret = cur_version->stat(dpp);
+    if (ret < 0)
+      return ret;
+    stx.stx_size = cur_version->get_stx().stx_size;
+
+    return 0;
+  }
+
+  /* Try to read the symlink */
+  std::unique_ptr<Symlink> sl = std::make_unique<Symlink>(get_name(), this, ctx);
+  ret = sl->stat(dpp);
+  if (ret < 0) {
+    if (ret == -ENOENT)
+      return 0;
+    return ret;
+  }
+
+  if (!sl->exists()) {
+    stx.stx_size = 0;
+    return 0;
+  }
+
+  cur_version = sl->get_target()->clone_base();
+  ret = cur_version->open(dpp);
+  if (ret < 0) {
+    return 0;
+  }
+  ret = cur_version->stat(dpp);
+  if (ret < 0)
+    return ret;
+  stx.stx_size = cur_version->get_stx().stx_size;
+
+  if (cur_version->get_stx().stx_size == 0) {
+    //Possibly a delete marker
+    Attrs attrs;
+    ret = cur_version->read_attrs(dpp, null_yield, attrs);
+    if (ret < 0) {
+      return ret;
+    }
+    bufferlist bl;
+    if (get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
+      uint16_t flags = 0;
+      ceph::decode(flags, bl);
+      if (flags & rgw_bucket_dir_entry::FLAG_DELETE_MARKER) {
+        ldpp_dout(dpp, 0) << "ERROR: a delete marker, returning ENOENT "
+                          << get_name() << dendl;
+        cur_version.reset();
+        return -ENOENT;
+      }
+    }
+  }
+
+  return 0;
+}
+
+int VersionedDirectory::read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs)
+{
+  if (!cur_version)
+    return FSEnt::read_attrs(dpp, y, attrs);
+
+  int ret = cur_version->read_attrs(dpp, y, attrs);
+  if (ret < 0) {
+    return ret;
+  }
+
+  /* Override type, it should be VERSIONED */
+  bufferlist type_bl;
+  ObjectType type{get_type()};
+  type.encode(type_bl);
+  attrs[RGW_POSIX_ATTR_OBJECT_TYPE] = type_bl;
+
+  return 0;
+}
+
+int VersionedDirectory::write_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs, Attrs* extra_attrs)
+{
+  if (cur_version) {
+    int ret = cur_version->write_attrs(dpp, y, attrs, extra_attrs);
+    if (ret < 0)
+      return ret;
+  }
+
+  return FSEnt::write_attrs(dpp, y, attrs, extra_attrs);
+}
+
+int VersionedDirectory::write(int64_t ofs, bufferlist &bl,
+                              const DoutPrefixProvider *dpp, optional_yield y)
+{
+  if (!cur_version)
+    return 0;
+  return cur_version->write(ofs, bl, dpp, y);
+}
+
+int VersionedDirectory::read(int64_t ofs, int64_t left, bufferlist &bl,
+                    const DoutPrefixProvider *dpp, optional_yield y)
+{
+  if (!cur_version)
+    return 0;
+  return cur_version->read(ofs, left, bl, dpp, y);
+}
+
+int VersionedDirectory::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y,
+                              std::string temp_fname)
+{
+  if (!cur_version)
+    return -EINVAL;
+  int ret = cur_version->link_temp_file(dpp, y, temp_fname);
+  if (ret < 0)
+    return ret;
+
+  return set_cur_version_ent(dpp, cur_version.get());
+}
+
+int VersionedDirectory::copy(const DoutPrefixProvider *dpp, optional_yield y,
+                      Directory* dst_dir, const std::string& dst_name)
+{
+  int ret;
+  rgw_obj_key dest_key = decode_obj_key(dst_name);
+  std::string basename = get_key_fname(dest_key, /*use_version=*/false);
+
+  // Delete the target
+  {
+    std::unique_ptr<FSEnt> del;
+    ret = dst_dir->get_ent(dpp, y, basename, std::string(), del);
+    if (ret >= 0) {
+      ret = del->remove(dpp, y, /*delete_children=*/true, nullptr);
+      if (ret < 0) {
+        ldpp_dout(dpp, 0) << "ERROR: could not remove dest " << basename
+                          << dendl;
+        return ret;
+      }
+    }
+  }
+
+  ret = dst_dir->open(dpp);
+  std::unique_ptr<VersionedDirectory> dest = clone();
+  dest->parent = dst_dir;
+  dest->fname = basename;
+
+  ret = dest->create(dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not create dest " << dest->get_name() << dendl;
+    return ret;
+  }
+
+  Attrs attrs;
+  ret = read_attrs(dpp, y, attrs);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not read attrs from " << get_name() << dendl;
+    return ret;
+  }
+  ret = dest->write_attrs(dpp, y, attrs, nullptr);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not write attrs to " << dest->get_name() << dendl;
+    return ret;
+  }
+
+  std::string tgtname;
+  ret = for_each(dpp, [this, &dest, &dest_key, &tgtname, &dpp, &y](const char* name) {
+    std::unique_ptr<FSEnt> sobj;
+
+    if (name[0] == '.') {
+      /* Skip dotfiles */
+      return 0;
+    }
+    rgw_obj_key key = decode_obj_key(name);
+    if (!dest_key.instance.empty() && dest_key.instance != key.instance) {
+      /* Were asked to copy a single version, and this is not it */
+      return 0;
+    }
+
+    int r = this->get_ent(dpp, y, name, std::string(), sobj);
+    if (r < 0)
+      return r;
+    key.name = dest_key.name;
+    tgtname = get_key_fname(key, /*use_version=*/true);
+    return sobj->copy(dpp, y, dest.get(), tgtname);
+  });
+
+  if (!dest_key.instance.empty()) {
+    /* We didn't copy the symlink, make a new one */
+    std::unique_ptr<Symlink> sl = std::make_unique<Symlink>(basename, dest.get(), tgtname, ctx);
+    ret = sl->create(dpp, /*existed=*/nullptr, /*temp_file=*/false);
+  }
+
+  return ret;
+}
+
+int VersionedDirectory::add_delete_marker(const DoutPrefixProvider* dpp,
+                                          optional_yield y,
+                                          std::unique_ptr<File>& marker,
+                                          const std::string &name)
+{
+  // Create as temporary file first
+  int ret = marker->create(dpp, /*existed=*/nullptr, /*temp_file=*/true);
+  if (ret < 0) {
+    return ret;
+  }
+
+  // XXX: Hack to set the owner on the delete marker
+  Attrs v_attrs;
+  Attrs attrs;
+
+  ret = get_x_attrs(y, dpp, get_fd(), v_attrs, get_name());
+  if (ret < 0) {
+    // removing the temporary files before returning failure
+    marker->remove(dpp, y, /*delete_children=*/false, nullptr);
+    return ret;
+  }
+
+  bufferlist owner_bl;
+  if (get_attr(v_attrs, RGW_ATTR_ACL, owner_bl)) {
+    attrs[RGW_ATTR_ACL] = std::move(owner_bl);
+  }
+
+  buffer::list bl;
+  uint16_t flags = 0;
+  flags |= rgw_bucket_dir_entry::FLAG_DELETE_MARKER;
+  ceph::encode(flags, bl);
+  attrs[RGW_POSIX_ATTR_VERSION] = std::move(bl);
+
+  // Write attributes before linking
+  ret = marker->write_attrs(dpp, y, attrs, nullptr);
+  if (ret < 0) {
+    // removing the temporary files before returning failure
+    marker->remove(dpp, y, /*delete_children=*/false, nullptr);
+    return ret;
+  }
+
+  // Link temp file to final name atomically
+  ret = marker->link_temp_file(dpp, y, name);
+  if (ret < 0) {
+    // removing the temporary files before returning failure
+    marker->remove(dpp, y, /*delete_children=*/false, nullptr);
+    return ret;
+  }
+
+  return 0;
+}
+
+int VersionedDirectory::remove(const DoutPrefixProvider* dpp, optional_yield y,
+                               bool delete_children, DeleteResult* result)
+{
+  std::string tgtname;
+  bool newlink = false;
+
+  int ret = open(dpp);
+  if (ret < 0)
+    return ret;
+
+  if (instance_id.empty()) {
+    /* Check if directory is empty */
+    ret = for_each(dpp, [](const char *n) {
+      return -ENOENT;
+    });
+
+    if (ret == 0) {
+      /* We're empty, nuke us */
+      return Directory::remove(dpp, y, /*delete_children=*/true, result);
+    }
+
+    /* Add a delete marker */
+    std::unique_ptr<File> f;
+    rgw_obj_key key = decode_obj_key(get_name());
+    key.instance = gen_rand_instance_name();
+    tgtname = get_key_fname(key, /*use_version=*/true);
+
+    result->delete_marker = true;
+    result->version_id = key.instance;
+
+    f = std::make_unique<File>(tgtname, this, ctx);
+    ret = add_delete_marker(dpp, y, f, tgtname);
+    if (ret < 0) {
+      return ret;
+    }
+
+    newlink = true;
+    ret = set_cur_version_ent(dpp, f.get());
+    if (ret < 0) {
+      return ret;
+    }
+    cur_version = std::move(f);
+    return 0;
+  } else {
+    /* Delete specific version */
+    rgw_obj_key key = decode_obj_key(get_name());
+    key.instance = instance_id;
+    std::string name = get_key_fname(key, /*use_version=*/true);
+
+    std::unique_ptr<FSEnt> f;
+    ret = get_ent(dpp, y, name, std::string(), f);
+    if (ret == 0) {
+      ret = f->stat(dpp);
+      if (ret < 0)
+        return ret;
+      Attrs attrs;
+      ret = f->read_attrs(dpp, y, attrs);
+      if (ret < 0) {
+        return ret;
+      }
+      bufferlist bl;
+      if (get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
+       result->delete_marker = true;
+      }
+      ret = f->remove(dpp, y, /*delete_children=*/true, result);
+      if (ret < 0)
+       return ret;
+      result->version_id = instance_id;
+    } else {
+      return ret;
+    }
+    /* Possibly move symlink */
+    ret = remove_symlink(dpp, y, name);
+    if (ret < 0) {
+      if (ret == -ENOKEY) {
+        return 0;
+      }
+      return ret;
+    }
+    newlink = true;
+    /* Create new current version symlink */
+    ret = for_each(dpp, [&tgtname](const char *n) {
+      if (n[0] == '.') {
+        /* Skip dotfiles */
+        return 0;
+      }
+
+      tgtname = n;
+      return 0;
+    });
+
+    if (tgtname.empty()) {
+      /* We're empty, nuke us */
+      exist = false;
+      return Directory::remove(dpp, y, /*delete_children=*/true, result);
+    }
+  }
+  if (newlink) {
+    exist = true;
+    std::unique_ptr<FSEnt> f;
+    ret = get_ent(dpp, y, tgtname, std::string(), f);
+    if (ret < 0) {
+      return ret;
+    }
+    ret = set_cur_version_ent(dpp, f.get());
+    if (ret < 0) {
+      return ret;
+    }
+    cur_version = std::move(f);
+  }
+
+  return 0;
+}
+
+int VersionedDirectory::fill_cache(const DoutPrefixProvider *dpp, optional_yield y,
+                                   fill_cache_cb_t &cb, uint32_t flags)
+{
+  /* Fill cur_version — stat() may reset cur_version to null if the
+   * current version is a delete marker, so also resolve the symlink
+   * target name for the FLAG_CURRENT comparison below */
+  stat(dpp, /*force=*/false);
+
+  std::string cur_version_name;
+  if (cur_version) {
+    cur_version_name = cur_version->get_name();
+  } else {
+    /* cur_version is null — likely a delete marker; read the symlink
+     * to determine which entry is current */
+    std::unique_ptr<Symlink> sl = std::make_unique<Symlink>(get_name(), this, ctx);
+    if (sl->stat(dpp) >= 0 && sl->exists()) {
+      cur_version_name = sl->get_target()->get_name();
+    }
+  }
+
+  int ret = for_each(dpp, [this, &cb, &dpp, &y, &cur_version_name](const char *name) {
+    std::unique_ptr<FSEnt> ent;
+
+    if (name[0] == '.') {
+      /* Skip dotfiles */
+      return 0;
+    }
+
+    int ret = get_ent(dpp, y, name, std::string(), ent);
+    if (ret < 0)
+      return ret;
+
+    ent->stat(dpp); // Stat the object to get the type
+
+    if (ent->get_type() != ObjectType::SYMLINK) {
+      uint32_t fill_flags =
+          (!cur_version_name.empty() &&
+           (ent->get_name() == cur_version_name)) ?
+        FSEnt::FLAG_CURRENT :
+        FSEnt::FLAG_NONE;
+
+      // Delete markers are zero byte files
+      if (ent->get_stx().stx_size == 0) {
+        Attrs attrs;
+        bufferlist bl;
+        ret = ent->read_attrs(dpp, y, attrs);
+        if (ret < 0) {
+          return ret;
+        }
+        if (get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
+          fill_flags |= FSEnt::FLAG_DELETE_MARKER;
+        }
+      }
+
+      ret = ent->fill_cache(dpp, y, cb, fill_flags);
+      if (ret < 0)
+        return ret;
+    }
+    return 0;
+  });
+
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not list directory " << get_name() << ": "
+      << cpp_strerror(ret) << dendl;
+    return ret;
+  }
+
+  return 0;
+}
+
+std::string VersionedDirectory::get_cur_version()
+{
+  if (!cur_version)
+    return "";
+
+  rgw_obj_key key = decode_obj_key(cur_version->get_name());
+
+  return key.instance;
+}
+
+int VersionedDirectory::remove_symlink(const DoutPrefixProvider *dpp, optional_yield y, std::string match)
+{
+  int ret;
+
+  std::unique_ptr<Symlink> sl =
+      std::make_unique<Symlink>(get_name(), this, ctx);
+  ret = sl->stat(dpp);
+  if (ret < 0) {
+    /* Doesn't exist, nothing to do */
+    if (ret == -ENOENT)
+      return 0;
+    return ret;
+  }
+
+  if (!match.empty()) {
+    if (match != sl->get_target()->get_name())
+      return -ENOKEY;
+  }
+
+  ret = sl->remove(dpp, y, /*delete_children=*/false, nullptr);
+  if (ret < 0) {
+    return ret;
+  }
+
+  return 0;
+}
+
+} // namespace posix
+
+} } // namespace rgw::sal

--- a/src/rgw/driver/posix/fsent.cc
+++ b/src/rgw/driver/posix/fsent.cc
@@ -1500,32 +1500,48 @@ int VersionedDirectory::copy(const DoutPrefixProvider *dpp, optional_yield y,
     return ret;
   }
 
-  std::string tgtname;
-  ret = for_each(dpp, [this, &dest, &dest_key, &tgtname, &dpp, &y](const char* name) {
-    std::unique_ptr<FSEnt> sobj;
-
-    if (name[0] == '.') {
-      /* Skip dotfiles */
-      return 0;
+  if (instance_id.empty()) {
+    /* We were asked to copy the current version */
+    if (!cur_version) {
+      stat(dpp, /*force=*/false);
     }
-    rgw_obj_key key = decode_obj_key(name);
-    if (!dest_key.instance.empty() && dest_key.instance != key.instance) {
-      /* Were asked to copy a single version, and this is not it */
-      return 0;
+    if (!cur_version) {
+      /* Delete marker */
+      return -ENOENT;
     }
+    ret = cur_version->copy(dpp, y, dest.get(), dst_name);
+  } else {
+    /* Copy specific version */
+    ret = for_each(dpp, [this, &dest, &dst_name, &dpp, &y](const char* name) {
+      std::unique_ptr<FSEnt> sobj;
 
-    int r = this->get_ent(dpp, y, name, std::string(), sobj);
-    if (r < 0)
-      return r;
-    key.name = dest_key.name;
-    tgtname = get_key_fname(key, /*use_version=*/true);
-    return sobj->copy(dpp, y, dest.get(), tgtname);
-  });
+      if (name[0] == '.') {
+        /* Skip dotfiles */
+        return 0;
+      }
+      rgw_obj_key key = decode_obj_key(name);
+      if (instance_id != key.instance) {
+        return 0;
+      }
 
-  if (!dest_key.instance.empty()) {
-    /* We didn't copy the symlink, make a new one */
-    std::unique_ptr<Symlink> sl = std::make_unique<Symlink>(basename, dest.get(), tgtname, ctx);
-    ret = sl->create(dpp, /*existed=*/nullptr, /*temp_file=*/false);
+      int r = this->get_ent(dpp, y, name, std::string(), sobj);
+      if (r < 0)
+        return r;
+      return sobj->copy(dpp, y, dest.get(), dst_name);
+    });
+  }
+  if (ret < 0) {
+    return ret;
+  }
+
+  {
+    /* Set current version symlink for new object */
+    std::unique_ptr<FSEnt> dobj;
+    ret = dest->get_ent(dpp, y, dst_name, std::string(), dobj);
+    if (ret < 0)
+      return ret;
+
+    ret = dest->set_cur_version_ent(dpp, dobj.get());
   }
 
   return ret;

--- a/src/rgw/driver/posix/fsent.h
+++ b/src/rgw/driver/posix/fsent.h
@@ -1,0 +1,540 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; ind
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+#include "rgw_sal.h"
+#include "bucket_cache.h"
+#include "common/errno.h"
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/xattr.h>
+#include <unistd.h>
+
+
+namespace rgw { namespace sal {
+
+class POSIXDriver;
+class POSIXBucket;
+class POSIXObject;
+
+using DeleteResult = rgw::sal::Object::DeleteOp::Result;
+
+extern const std::string ATTR_PREFIX;
+#define RGW_POSIX_ATTR_BUCKET_INFO "POSIX-Bucket-Info"
+#define RGW_POSIX_ATTR_MPUPLOAD "POSIX-Multipart-Upload"
+#define RGW_POSIX_ATTR_OBJECT_TYPE "POSIX-Object-Type"
+#define RGW_POSIX_ATTR_VERSION "POSIX-version"
+#define RGW_POSIX_ATTR_MULTIPART_PART_COUNT "POSIX-Multipart-Part-Count"
+#define RGW_POSIX_ATTR_MULTIPART_TOTAL_SIZE "POSIX-Multipart-Total-Size"
+extern const std::string mp_ns;
+extern const std::string MP_OBJ_PART_PFX;
+extern const std::string MP_OBJ_HEAD_NAME;
+
+/* integration w/bucket listing cache */
+using fill_cache_cb_t = file::listing::fill_cache_cb_t;
+
+static inline ceph::real_time from_statx_timestamp(const struct statx_timestamp& xts)
+{
+  struct timespec ts{xts.tv_sec, xts.tv_nsec};
+  return ceph::real_clock::from_timespec(ts);
+}
+
+static inline std::string gen_rand_instance_name()
+{
+  enum { OBJ_INSTANCE_LEN = 32 };
+  char buf[OBJ_INSTANCE_LEN + 1];
+
+#if 0
+  gen_rand_alphanumeric_no_underscore(driver->ctx(), buf, OBJ_INSTANCE_LEN);
+#else
+  static std::atomic<uint64_t> last_id{UINT64_MAX};
+  snprintf(buf, OBJ_INSTANCE_LEN, "%lx", last_id.fetch_sub(1));
+#endif
+
+  return buf;
+}
+
+namespace posix {
+
+using BucketCache = file::listing::BucketCache<POSIXDriver, POSIXBucket>;
+
+static inline bool get_attr(Attrs& attrs, const char* name, bufferlist& bl)
+{
+  auto iter = attrs.find(name);
+  if (iter == attrs.end()) {
+    return false;
+  }
+
+  bl = iter->second;
+  return true;
+}
+
+template <typename F>
+static bool decode_attr(Attrs &attrs, const char *name, F &f) {
+  bufferlist bl;
+  if (!get_attr(attrs, name, bl)) {
+    return false;
+  }
+  try {
+    auto bufit = bl.cbegin();
+    decode(f, bufit);
+  } catch (buffer::error &err) {
+    return false;
+  }
+
+  return true;
+}
+
+static inline rgw_obj_key decode_obj_key(const char* fname)
+{
+  std::string dname, oname, ns; // XXX ns is unused?
+  dname = url_decode(fname);
+  rgw_obj_key key;
+  rgw_obj_key::parse_raw_oid(dname, &key);
+  return key;
+}
+
+static inline rgw_obj_key decode_obj_key(const std::string& fname)
+{
+  return decode_obj_key(fname.c_str());
+}
+
+/* Extract object owner from the standard RGW_ATTR_ACL attribute */
+static inline int decode_acl_owner(Attrs& attrs, ACLOwner& owner)
+{
+  auto i = attrs.find(RGW_ATTR_ACL);
+  if (i == attrs.end()) {
+    return -EINVAL;
+  }
+  RGWAccessControlPolicy policy;
+  try {
+    auto bp = i->second.cbegin();
+    policy.decode(bp);
+  } catch (const buffer::error&) {
+    return -EIO;
+  }
+  owner = policy.get_owner();
+  return 0;
+}
+
+static inline std::string get_key_fname(rgw_obj_key& key, bool use_version)
+{
+  std::string oid;
+  if (use_version) {
+    oid = key.get_oid();
+  } else {
+    oid = key.get_index_key_name();
+  }
+  std::string fname = url_encode(oid, true);
+
+  if (!key.get_ns().empty()) {
+    /* Namespaced objects are hidden */
+    fname.insert(0, 1, '.');
+  }
+
+  return fname;
+}
+
+static inline int remove_x_attr(const DoutPrefixProvider *dpp, optional_yield y,
+                         int fd, const std::string &key,
+                         const std::string &display)
+{
+  int ret;
+  std::string attrname{ATTR_PREFIX + key};
+
+  ret = fremovexattr(fd, attrname.c_str());
+  if (ret < 0) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not remove attribute " << attrname << " for " << display << ": " << cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+
+  return 0;
+}
+
+struct ObjectType {
+  enum Type {
+    UNKNOWN = 0,
+    FILE = 1,
+    DIRECTORY = 2,
+    VERSIONED = 3,
+    MULTIPART = 4,
+    SYMLINK = 5,
+  };
+  uint32_t type{UNKNOWN};
+
+  ObjectType &operator=(ObjectType::Type &&_t) {
+    type = _t;
+    return *this;
+  };
+
+  ObjectType() {}
+  ObjectType(Type _t) : type(_t){}
+
+  bool operator==(const ObjectType &t) const { return (type == t.type); }
+  bool operator==(const ObjectType::Type &t) const { return (type == t); }
+
+  void encode(bufferlist &bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(type, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator &bl) {
+    DECODE_START(1, bl);
+    ceph::decode(type, bl);
+    DECODE_FINISH(bl);
+  }
+  friend inline std::ostream &operator<<(std::ostream &out,
+                                         const ObjectType &t) {
+    switch (t.type) {
+    case UNKNOWN:
+      out << "UNKNOWN";
+      break;
+    case FILE:
+      out << "FILE";
+      break;
+    case DIRECTORY:
+      out << "DIRECTORY";
+      break;
+    case VERSIONED:
+      out << "VERSIONED";
+      break;
+    case MULTIPART:
+      out << "MULTIPART";
+      break;
+    case SYMLINK:
+      out << "SYMLINK";
+      break;
+    }
+    return out;
+  }
+};
+WRITE_CLASS_ENCODER(ObjectType);
+
+class Directory;
+
+class FSEnt {
+protected:
+  std::string fname;
+  Directory* parent;
+  int fd{-1};
+  bool need_fsync{false};
+  bool exist{false};
+  struct statx stx;
+  bool stat_done{false};
+  CephContext* ctx;
+
+public:
+  static constexpr uint32_t FLAG_NONE =      0x0;
+  static constexpr uint32_t FLAG_CURRENT =   0x2;
+  static constexpr uint32_t FLAG_DELETE_MARKER =   0x4;
+
+  FSEnt(std::string _name, Directory* _parent, CephContext* _ctx) : fname(_name), parent(_parent), ctx(_ctx) {}
+  FSEnt(std::string _name, Directory* _parent, struct statx& _stx, CephContext* _ctx) : fname(_name), parent(_parent), exist(true), stx(_stx), stat_done(true), ctx(_ctx) {}
+  FSEnt(const FSEnt& _e) :
+    fname(_e.fname),
+    parent(_e.parent),
+    exist(_e.exist),
+    stx(_e.stx),
+    stat_done(_e.stat_done),
+    ctx(_e.ctx)
+  { }
+
+  virtual ~FSEnt() { }
+
+  int get_fd() { return fd; };
+  std::string& get_name() { return fname; }
+  Directory* get_parent() { return parent; }
+  bool exists() { return exist; }
+  struct statx& get_stx() { return stx; }
+  virtual ObjectType get_type() { return ObjectType::UNKNOWN; };
+
+  virtual int create(const DoutPrefixProvider *dpp, bool* existed = nullptr, bool temp_file = false) = 0;
+  virtual int open(const DoutPrefixProvider *dpp) = 0;
+  virtual int close() = 0;
+  virtual int stat(const DoutPrefixProvider *dpp, bool force = false);
+  virtual int remove(const DoutPrefixProvider* dpp, optional_yield y, bool delete_children, DeleteResult* result) = 0;
+  virtual int write(int64_t ofs, bufferlist& bl, const DoutPrefixProvider* dpp, optional_yield y) = 0;
+  virtual int read(int64_t ofs, int64_t end, bufferlist& bl, const DoutPrefixProvider* dpp, optional_yield y) = 0;
+  virtual int write_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs, Attrs* extra_attrs);
+  virtual int read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs);
+  virtual int copy(const DoutPrefixProvider *dpp, optional_yield y, Directory* dst_dir, const std::string& name) = 0;
+  virtual int link_temp_file(const DoutPrefixProvider* dpp, optional_yield y, std::string target_fname) = 0;
+  virtual std::unique_ptr<FSEnt> clone_base() = 0;
+  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags);
+  virtual std::string get_cur_version() { return ""; };
+};
+
+class File : public FSEnt {
+protected:
+
+public:
+  File(std::string _name, Directory* _parent, CephContext* _ctx) : FSEnt(_name, _parent, _ctx)
+    {}
+  File(std::string _name, Directory* _parent, struct statx& _stx, CephContext* _ctx) : FSEnt(_name, _parent, _stx, _ctx)
+    {}
+  File(const File& _f) : FSEnt(_f) {}
+  virtual ~File() { close(); }
+
+  virtual uint64_t get_size() { return stx.stx_size; }
+  virtual ObjectType get_type() override { return ObjectType::FILE; };
+
+
+  virtual int create(const DoutPrefixProvider *dpp, bool* existed = nullptr, bool temp_file = false) override;
+  virtual int open(const DoutPrefixProvider *dpp) override;
+  virtual int close() override;
+  virtual int stat(const DoutPrefixProvider *dpp, bool force = false) override;
+  virtual int remove(const DoutPrefixProvider* dpp, optional_yield y, bool delete_children, DeleteResult* result) override;
+  virtual int write(int64_t ofs, bufferlist& bl, const DoutPrefixProvider* dpp, optional_yield y) override;
+  virtual int read(int64_t ofs, int64_t end, bufferlist& bl, const DoutPrefixProvider* dpp, optional_yield y) override;
+  virtual int copy(const DoutPrefixProvider *dpp, optional_yield y, Directory* dst_dir, const std::string& name) override;
+  virtual int link_temp_file(const DoutPrefixProvider* dpp, optional_yield y, std::string target_fname) override;
+  virtual std::unique_ptr<FSEnt> clone_base() override {
+    return std::make_unique<File>(*this);
+  }
+  std::unique_ptr<File> clone() {
+    return std::make_unique<File>(*this);
+  }
+};
+
+class Directory : public FSEnt {
+protected:
+
+public:
+  Directory(std::string _name, Directory* _parent, CephContext* _ctx) : FSEnt(_name, _parent, _ctx)
+    {}
+  Directory(std::string _name, Directory* _parent, struct statx& _stx, CephContext* _ctx) : FSEnt(_name, _parent, _stx, _ctx)
+    {}
+  Directory(const Directory& _d) : FSEnt(_d) {}
+  virtual ~Directory() { close(); }
+
+  virtual ObjectType get_type() override { return ObjectType::DIRECTORY; };
+
+  virtual bool file_exists(std::string& name);
+
+  virtual int create(const DoutPrefixProvider *dpp, bool* existed = nullptr, bool temp_file = false) override;
+  virtual int open(const DoutPrefixProvider *dpp) override;
+  virtual int close() override;
+  virtual int stat(const DoutPrefixProvider *dpp, bool force = false) override;
+  virtual int remove(const DoutPrefixProvider* dpp, optional_yield y, bool delete_children, DeleteResult* result) override;
+  template <typename F>
+    int for_each(const DoutPrefixProvider* dpp, const F& func);
+  virtual int rename(const DoutPrefixProvider* dpp, optional_yield y, Directory* dst_dir, std::string dst_name);
+  virtual int write(int64_t ofs, bufferlist& bl, const DoutPrefixProvider* dpp, optional_yield y) override;
+  virtual int read(int64_t ofs, int64_t end, bufferlist& bl, const DoutPrefixProvider* dpp, optional_yield y) override;
+  virtual std::unique_ptr<FSEnt> clone_base() override {
+    return std::make_unique<Directory>(*this);
+  }
+  virtual std::unique_ptr<Directory> clone_dir() {
+    return std::make_unique<Directory>(*this);
+  }
+  std::unique_ptr<Directory> clone() {
+    return std::make_unique<Directory>(*this);
+  }
+  virtual int copy(const DoutPrefixProvider *dpp, optional_yield y, Directory* dst_dir, const std::string& name) override;
+  virtual int link_temp_file(const DoutPrefixProvider* dpp, optional_yield y, std::string target_fname) override;
+  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags) override;
+
+  int get_ent(const DoutPrefixProvider *dpp, optional_yield y, const std::string& name, const std::string& version, std::unique_ptr<FSEnt>& ent);
+};
+
+template <typename F>
+int Directory::for_each(const DoutPrefixProvider* dpp, const F& func)
+{
+  DIR* dir;
+  struct dirent* entry;
+  int ret;
+
+  ret = open(dpp);
+  if (ret < 0) {
+    return ret;
+  }
+
+  dir = fdopendir(fd);
+  if (dir == NULL) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not open dir " << get_name() << " for listing: "
+      << cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+
+  rewinddir(dir);
+
+  ret = 0;
+  while ((entry = readdir(dir)) != NULL) {
+    std::string_view vname(entry->d_name);
+
+    if (vname == "." || vname == "..")
+      continue;
+
+    int r = func(entry->d_name);
+    if (r < 0) {
+      ret = r;
+      break;
+    }
+  }
+
+  if (ret == -EAGAIN) {
+    /* Limit reached */
+    ret = 0;
+  }
+
+  closedir(dir);
+  // closedir() closes the fd, so we need to invalidate it
+  fd = -1;
+  // closedir() closes fd, but succeeding calls might assume that fd is still valid.
+  // so let's reopen it.
+  open(dpp);
+  return ret;
+}
+
+class Symlink: public File {
+  std::unique_ptr<FSEnt> target;
+public:
+  Symlink(std::string _name, Directory* _parent, std::string _tgt, CephContext* _ctx) :
+    File(_name, _parent, _ctx)
+    { fill_target(nullptr, parent, fname,_tgt, target, _ctx); }
+  Symlink(std::string _name, Directory* _parent, CephContext* _ctx) :
+    File(_name, _parent, _ctx)
+    {}
+  Symlink(std::string _name, Directory* _parent, struct statx& _stx, std::string _tgt, CephContext* _ctx) :
+    File(_name, _parent, _stx, _ctx)
+    { fill_target(nullptr, parent, fname,_tgt, target, _ctx); }
+  Symlink(std::string _name, Directory* _parent, struct statx& _stx, CephContext* _ctx) :
+    File(_name, _parent, _stx, _ctx)
+    {}
+  Symlink(const Symlink& _s) : File(_s) {}
+  virtual ~Symlink() { close(); }
+
+  static int fill_target(const DoutPrefixProvider *dpp, Directory* parent, std::string sname, std::string tname, std::unique_ptr<FSEnt>& ent, CephContext* _ctx);
+
+  virtual ObjectType get_type() override { return ObjectType::SYMLINK; };
+  virtual int create(const DoutPrefixProvider *dpp, bool* existed = nullptr, bool temp_file = false) override;
+  virtual int stat(const DoutPrefixProvider *dpp, bool force = false) override;
+  virtual int read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs) override;
+  FSEnt* get_target() { return target.get(); }
+  virtual std::unique_ptr<FSEnt> clone_base() override {
+    return std::make_unique<Symlink>(*this);
+  }
+  std::unique_ptr<Symlink> clone() {
+    return std::make_unique<Symlink>(*this);
+  }
+  virtual int copy(const DoutPrefixProvider *dpp, optional_yield y, Directory* dst_dir, const std::string& name) override;
+};
+
+class MPDirectory : public Directory {
+  std::string tmpname;
+protected:
+  std::map<std::string, int64_t> parts;
+  std::unique_ptr<FSEnt> cur_read_part;
+
+public:
+  MPDirectory(std::string _name, Directory* _parent, CephContext* _ctx) : Directory(_name, _parent, _ctx)
+    {}
+  MPDirectory(std::string _name, Directory* _parent, struct statx& _stx, CephContext* _ctx) : Directory(_name, _parent, _stx, _ctx)
+    {}
+  MPDirectory(const MPDirectory& _d) :
+    Directory(_d),
+    parts(_d.parts)
+    { if (_d.cur_read_part) cur_read_part = _d.cur_read_part->clone_base(); }
+  virtual ~MPDirectory() { close(); }
+
+  virtual ObjectType get_type() override { return ObjectType::MULTIPART; };
+  virtual int create(const DoutPrefixProvider *dpp, bool* existed = nullptr, bool temp_file = false) override;
+  virtual int read(int64_t ofs, int64_t end, bufferlist& bl, const DoutPrefixProvider* dpp, optional_yield y) override;
+  virtual int link_temp_file(const DoutPrefixProvider* dpp, optional_yield y, std::string target_fname) override;
+  virtual int remove(const DoutPrefixProvider* dpp, optional_yield y, bool delete_children, DeleteResult* result) override;
+  virtual int stat(const DoutPrefixProvider *dpp, bool force = false) override;
+  std::unique_ptr<File> get_part_file(int partnum);
+  const std::map<std::string, int64_t>& get_parts() const { return parts; }
+  virtual std::unique_ptr<FSEnt> clone_base() override {
+    return std::make_unique<MPDirectory>(*this);
+  }
+  virtual std::unique_ptr<Directory> clone_dir() override {
+    return std::make_unique<MPDirectory>(*this);
+  }
+  std::unique_ptr<MPDirectory> clone() {
+    return std::make_unique<MPDirectory>(*this);
+  }
+  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags) override;
+};
+
+class VersionedDirectory : public Directory {
+protected:
+  std::string instance_id;
+  std::unique_ptr<FSEnt> cur_version;
+
+public:
+  VersionedDirectory(std::string _name, Directory* _parent, CephContext* _ctx) : Directory(_name, _parent, _ctx)
+    {}
+  VersionedDirectory(std::string _name, Directory* _parent, std::string _instance_id, CephContext* _ctx) :
+    Directory(_name, _parent, _ctx),
+    instance_id(_instance_id)
+    {}
+  VersionedDirectory(std::string _name, Directory* _parent, std::unique_ptr<FSEnt>&& _cur, CephContext* _ctx) :
+    Directory(_name, _parent, _ctx),
+    cur_version(std::move(_cur))
+    {}
+  VersionedDirectory(std::string _name, Directory* _parent, struct statx& _stx, CephContext* _ctx) : Directory(_name, _parent, _stx, _ctx)
+    {}
+  VersionedDirectory(std::string _name, Directory* _parent, std::string _instance_id, struct statx& _stx, CephContext* _ctx) :
+    Directory(_name, _parent, _stx, _ctx),
+    instance_id(_instance_id)
+    {}
+  VersionedDirectory(const VersionedDirectory& _d) :
+    Directory(_d),
+    instance_id(_d.instance_id),
+    cur_version(_d.cur_version ? _d.cur_version->clone_base() : nullptr)
+    { }
+  VersionedDirectory(const Directory& _d) :
+    Directory(_d)
+    { }
+  virtual ~VersionedDirectory() { close(); }
+
+  virtual ObjectType get_type() override { return ObjectType::VERSIONED; };
+  virtual int create(const DoutPrefixProvider *dpp, bool* existed = nullptr, bool temp_file = false) override;
+  virtual int open(const DoutPrefixProvider *dpp) override;
+  virtual int stat(const DoutPrefixProvider *dpp, bool force = false) override;
+  virtual int read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs) override;
+  virtual int write_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs, Attrs* extra_attrs) override;
+  virtual int write(int64_t ofs, bufferlist& bl, const DoutPrefixProvider* dpp, optional_yield y) override;
+  virtual int read(int64_t ofs, int64_t end, bufferlist& bl, const DoutPrefixProvider* dpp, optional_yield y) override;
+  virtual int link_temp_file(const DoutPrefixProvider* dpp, optional_yield y, std::string target_fname) override;
+  virtual int remove(const DoutPrefixProvider* dpp, optional_yield y, bool delete_children, DeleteResult* result) override;
+  virtual std::string get_cur_version() override;
+  std::string get_new_instance();
+  int remove_symlink(const DoutPrefixProvider *dpp, optional_yield y, std::string match = "");
+  int add_file(const DoutPrefixProvider *dpp, std::unique_ptr<FSEnt>&& file, bool* existed = nullptr, bool temp_file = false);
+  int add_delete_marker(const DoutPrefixProvider* dpp, optional_yield y, std::unique_ptr<File>& marker, const std::string &name);
+  FSEnt* get_cur_version_ent() { return cur_version.get(); };
+  int set_cur_version_ent(const DoutPrefixProvider *dpp, FSEnt* file);
+  virtual std::unique_ptr<FSEnt> clone_base() override {
+    return std::make_unique<VersionedDirectory>(*this);
+  }
+  virtual std::unique_ptr<Directory> clone_dir() override {
+    return std::make_unique<VersionedDirectory>(*this);
+  }
+  std::unique_ptr<VersionedDirectory> clone() {
+    return std::make_unique<VersionedDirectory>(*this);
+  }
+  virtual int copy(const DoutPrefixProvider *dpp, optional_yield y, Directory* dst_dir, const std::string& name) override;
+  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags) override;
+};
+
+std::string get_key_fname(rgw_obj_key& key, bool use_version);
+
+} // namespace posix
+} } // namespace rgw::sal

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -18,11 +18,6 @@
 #include "rgw_pubsub_push.h"
 #include "rgw_pubsub.h"
 #include "rgw_s3_filter.h"
-#include <dirent.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <sys/xattr.h>
-#include <unistd.h>
 #include <cstdint>
 #include "rgw_multi.h"
 #include "include/scope_guard.h"
@@ -58,67 +53,6 @@ static void encode_attr(rgw::sal::Attrs& attrs, const char* name, const T& val) 
 
 namespace rgw { namespace sal {
 
-using namespace posix;
-
-const int64_t READ_SIZE = 128 * 1024;
-const std::string ATTR_PREFIX = "user.X-RGW-";
-#define RGW_POSIX_ATTR_BUCKET_INFO "POSIX-Bucket-Info"
-#define RGW_POSIX_ATTR_MPUPLOAD "POSIX-Multipart-Upload"
-#define RGW_POSIX_ATTR_OBJECT_TYPE "POSIX-Object-Type"
-#define RGW_POSIX_ATTR_VERSION "POSIX-version"
-#define RGW_POSIX_ATTR_MULTIPART_PART_COUNT "POSIX-Multipart-Part-Count"
-#define RGW_POSIX_ATTR_MULTIPART_TOTAL_SIZE "POSIX-Multipart-Total-Size"
-const std::string mp_ns = "multipart";
-const std::string MP_OBJ_PART_PFX = "part-";
-const std::string MP_OBJ_HEAD_NAME = MP_OBJ_PART_PFX + "00000";
-
-/*
- * Object ownership is stored in RGW_ATTR_ACL (the standard ACL policy
- * attribute written by the generic RGW layer), matching the rados driver.
- * Earlier code maintained a separate "POSIX-Owner" xattr with a
- * POSIXOwner struct that only held rgw_user — this could not represent
- * account-owned objects (STS role sessions, account root users) and
- * crashed with std::bad_variant_access.  Removed in favour of the
- * generic ACLOwner which carries the full rgw_owner variant.
- */
-
-namespace posix {
-
-std::string get_key_fname(rgw_obj_key& key, bool use_version)
-{
-  std::string oid;
-  if (use_version) {
-    oid = key.get_oid();
-  } else {
-    oid = key.get_index_key_name();
-  }
-  std::string fname = url_encode(oid, true);
-
-  if (!key.get_ns().empty()) {
-    /* Namespaced objects are hidden */
-    fname.insert(0, 1, '.');
-  }
-
-  return fname;
-}
-
-} // namespace posix
-
-static inline std::string gen_rand_instance_name()
-{
-  enum { OBJ_INSTANCE_LEN = 32 };
-  char buf[OBJ_INSTANCE_LEN + 1];
-
-#if 0
-  gen_rand_alphanumeric_no_underscore(driver->ctx(), buf, OBJ_INSTANCE_LEN);
-#else
-  static std::atomic<uint64_t> last_id{UINT64_MAX};
-  snprintf(buf, OBJ_INSTANCE_LEN, "%lx", last_id.fetch_sub(1));
-#endif
-
-  return buf;
-}
-
 static inline std::string bucket_fname(std::string name, std::optional<std::string>& ns)
 {
   std::string bname;
@@ -131,1913 +65,10 @@ static inline std::string bucket_fname(std::string name, std::optional<std::stri
   return bname;
 }
 
-static inline bool get_attr(Attrs& attrs, const char* name, bufferlist& bl)
-{
-  auto iter = attrs.find(name);
-  if (iter == attrs.end()) {
-    return false;
-  }
-
-  bl = iter->second;
-  return true;
-}
-
-template <typename F>
-static bool decode_attr(Attrs &attrs, const char *name, F &f) {
-  bufferlist bl;
-  if (!get_attr(attrs, name, bl)) {
-    return false;
-  }
-  try {
-    auto bufit = bl.cbegin();
-    decode(f, bufit);
-  } catch (buffer::error &err) {
-    return false;
-  }
-
-  return true;
-}
-
-
-static inline rgw_obj_key decode_obj_key(const char* fname)
-{
-  std::string dname, oname, ns; // XXX ns is unused?
-  dname = url_decode(fname);
-  rgw_obj_key key;
-  rgw_obj_key::parse_raw_oid(dname, &key);
-  return key;
-}
-
-static inline rgw_obj_key decode_obj_key(const std::string& fname)
-{
-  return decode_obj_key(fname.c_str());
-}
-
-/* Extract object owner from the standard RGW_ATTR_ACL attribute */
-static int decode_acl_owner(Attrs& attrs, ACLOwner& owner)
-{
-  auto i = attrs.find(RGW_ATTR_ACL);
-  if (i == attrs.end()) {
-    return -EINVAL;
-  }
-  RGWAccessControlPolicy policy;
-  try {
-    auto bp = i->second.cbegin();
-    policy.decode(bp);
-  } catch (const buffer::error&) {
-    return -EIO;
-  }
-  owner = policy.get_owner();
-  return 0;
-}
-
-static inline ceph::real_time from_statx_timestamp(const struct statx_timestamp& xts)
-{
-  struct timespec ts{xts.tv_sec, xts.tv_nsec};
-  return ceph::real_clock::from_timespec(ts);
-}
-
 static inline int copy_dir_fd(int old_fd)
 {
   return openat(old_fd, ".", O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
 }
-
-/* RAII guard for OFD (Open File Description) locks.  OFD locks are
- * per-open-file-description rather than per-process, so they work
- * correctly across threads that open independent fds to the same
- * inode.  Used to serialise xattr writes against concurrent readers
- * on the same directory or file. */
-struct OFDLockGuard {
-  int fd;
-  OFDLockGuard(int _fd, short type) : fd(_fd) {
-    struct flock fl{};
-    fl.l_type = type;
-    fl.l_whence = SEEK_SET;
-    fcntl(fd, F_OFD_SETLKW, &fl);
-  }
-  ~OFDLockGuard() {
-    struct flock fl{};
-    fl.l_type = F_UNLCK;
-    fl.l_whence = SEEK_SET;
-    fcntl(fd, F_OFD_SETLK, &fl);
-  }
-};
-
-static int get_x_attrs(optional_yield y, const DoutPrefixProvider* dpp, int fd,
-		       Attrs& attrs, const std::string& display)
-{
-  char namebuf[64 * 1024]; // Max list size supported on linux
-  ssize_t buflen;
-  int ret;
-
-  buflen = flistxattr(fd, namebuf, sizeof(namebuf));
-  if (buflen < 0) {
-    ret = errno;
-    ldpp_dout(dpp, 0) << "ERROR: could not list attributes for " << display << ": "
-      << cpp_strerror(ret) << dendl;
-    return -ret;
-  }
-
-  char *keyptr = namebuf;
-  while (buflen > 0) {
-    std::string value;
-    ssize_t vallen, keylen;
-    char* vp;
-
-    keylen = strlen(keyptr) + 1;
-    std::string key(keyptr);
-    std::string::size_type prefixloc = key.find(ATTR_PREFIX);
-
-    if (prefixloc == std::string::npos) {
-      /* Not one of our attributes */
-      buflen -= keylen;
-      keyptr += keylen;
-      continue;
-    }
-
-    /* Make a key that has just the attribute name */
-    key.erase(prefixloc, ATTR_PREFIX.length());
-
-    vallen = fgetxattr(fd, keyptr, nullptr, 0);
-    if (vallen < 0) {
-      ret = errno;
-      ldpp_dout(dpp, 0) << "ERROR: could not get attribute " << keyptr << " for " << display << ": " << cpp_strerror(ret) << dendl;
-      return -ret;
-    } else if (vallen == 0) {
-      attrs.emplace(std::move(key), bufferlist{});
-      buflen -= keylen;
-      keyptr += keylen;
-      continue;
-    }
-
-    value.reserve(vallen + 1);
-    vp = &value[0];
-
-    vallen = fgetxattr(fd, keyptr, vp, vallen);
-    if (vallen < 0) {
-      ret = errno;
-      ldpp_dout(dpp, 0) << "ERROR: could not get attribute " << keyptr << " for " << display << ": " << cpp_strerror(ret) << dendl;
-      return -ret;
-    }
-
-    bufferlist bl;
-    bl.append(vp, vallen);
-    attrs.emplace(std::move(key), std::move(bl)); /* key and bl are r-value refs */
-
-    buflen -= keylen;
-    keyptr += keylen;
-  }
-
-  return 0;
-}
-
-static int write_x_attr(const DoutPrefixProvider* dpp, optional_yield y, int fd,
-			const std::string& key, bufferlist& value,
-			const std::string& display)
-{
-  int ret;
-  std::string attrname;
-
-  attrname = ATTR_PREFIX + key;
-
-  ret = fsetxattr(fd, attrname.c_str(), value.c_str(), value.length(), 0);
-  if (ret < 0) {
-    ret = errno;
-    ldpp_dout(dpp, 0) << "ERROR: could not write attribute " << attrname << " for " << display << ": " << cpp_strerror(ret) << dendl;
-    return -ret;
-  }
-
-  return 0;
-}
-
-static int remove_x_attr(const DoutPrefixProvider *dpp, optional_yield y,
-                         int fd, const std::string &key,
-                         const std::string &display)
-{
-  int ret;
-  std::string attrname{ATTR_PREFIX + key};
-
-  ret = fremovexattr(fd, attrname.c_str());
-  if (ret < 0) {
-    ret = errno;
-    ldpp_dout(dpp, 0) << "ERROR: could not remove attribute " << attrname << " for " << display << ": " << cpp_strerror(ret) << dendl;
-    return -ret;
-  }
-
-  return 0;
-}
-
-static int delete_directory(int parent_fd, const char* dname, bool delete_children,
-		     const DoutPrefixProvider* dpp)
-{
-  int ret;
-  int dir_fd = -1;
-  DIR *dir;
-  struct dirent *entry;
-
-  dir_fd = openat(parent_fd, dname, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
-  if (dir_fd < 0) {
-    dir_fd = errno;
-    ldpp_dout(dpp, 0) << "ERROR: could not open subdir " << dname << ": "
-                      << cpp_strerror(dir_fd) << dendl;
-    return -dir_fd;
-  }
-
-  dir = fdopendir(dir_fd);
-  if (dir == NULL) {
-    ret = errno;
-    ldpp_dout(dpp, 0) << "ERROR: could not open bucket " << dname
-                      << " for listing: " << cpp_strerror(ret) << dendl;
-    ::close(dir_fd);
-    return -ret;
-  }
-
-  errno = 0;
-  while ((entry = readdir(dir)) != NULL) {
-    struct statx stx;
-
-    if ((entry->d_name[0] == '.' && entry->d_name[1] == '\0') ||
-        (entry->d_name[0] == '.' && entry->d_name[1] == '.' &&
-         entry->d_name[2] == '\0')) {
-      /* Skip . and .. */
-      errno = 0;
-      continue;
-    }
-
-    std::string_view d_name = entry->d_name;
-    bool is_mp = d_name.starts_with("." + mp_ns);
-    if (!is_mp && !delete_children) {
-      closedir(dir);
-      return -ENOTEMPTY;
-    }
-
-    ret = statx(dir_fd, entry->d_name, AT_SYMLINK_NOFOLLOW, STATX_ALL, &stx);
-    if (ret < 0) {
-      ret = errno;
-      ldpp_dout(dpp, 0) << "ERROR: could not stat object " << entry->d_name
-                        << ": " << cpp_strerror(ret) << dendl;
-      closedir(dir);
-      return -ret;
-    }
-
-    if (S_ISDIR(stx.stx_mode)) {
-      /* Recurse */
-      ret = delete_directory(dir_fd, entry->d_name, true, dpp);
-      if (ret < 0) {
-        closedir(dir);
-        return ret;
-      }
-
-      continue;
-    }
-
-    /* Otherwise, unlink */
-    ret = unlinkat(dir_fd, entry->d_name, 0);
-    if (ret < 0) {
-      ret = errno;
-      ldpp_dout(dpp, 0) << "ERROR: could not remove file " << entry->d_name
-                        << ": " << cpp_strerror(ret) << dendl;
-      closedir(dir);
-      return -ret;
-    }
-  }
-  closedir(dir);
-
-  ret = unlinkat(parent_fd, dname, AT_REMOVEDIR);
-  if (ret < 0) {
-    ret = errno;
-    if (errno != ENOENT) {
-      ldpp_dout(dpp, 0) << "ERROR: could not remove bucket " << dname << ": "
-	<< cpp_strerror(ret) << dendl;
-      return -ret;
-    }
-  }
-
-  return 0;
-}
-
-namespace posix {
-
-int FSEnt::stat(const DoutPrefixProvider* dpp, bool force)
-{
-  if (force) {
-    stat_done = false;
-  }
-
-  if (stat_done) {
-    return 0;
-  }
-
-  int ret = statx(parent->get_fd(), fname.c_str(), AT_SYMLINK_NOFOLLOW,
-		  STATX_ALL, &stx);
-  if (ret < 0) {
-    ret = errno;
-    ldpp_dout(dpp, 0) << "ERROR: could not stat " << get_name() << ": "
-                  << cpp_strerror(ret) << dendl;
-    exist = false;
-    return -ret;
-  }
-
-  exist = true;
-  stat_done = true;
-  return 0;
-}
-
-int FSEnt::write_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs, Attrs* extra_attrs)
-{
-  int ret = open(dpp);
-  if (ret < 0) {
-    return ret;
-  }
-
-  OFDLockGuard lock(fd, F_WRLCK);
-  need_fsync = true;
-
-  /* Set the type */
-  bufferlist type_bl;
-  ObjectType type{get_type()};
-  type.encode(type_bl);
-  attrs[RGW_POSIX_ATTR_OBJECT_TYPE] = type_bl;
-
-  /* Snapshot old xattrs so we can remove genuinely stale ones after
-   * writing — covered by the OFD write lock above. */
-  Attrs old_attrs;
-  int old_ret = get_x_attrs(y, dpp, fd, old_attrs, get_name());
-
-  /* Write new values first — fsetxattr overwrites in place, so
-   * readers always see either the old or the new value, never
-   * ENODATA for an attr that is being updated. */
-  if (extra_attrs) {
-    for (auto &it : *extra_attrs) {
-      ret = write_x_attr(dpp, y, fd, it.first, it.second, get_name());
-      if (ret < 0) {
-        return ret;
-      }
-    }
-  }
-
-  for (auto& it : attrs) {
-    ret = write_x_attr(dpp, y, fd, it.first, it.second, get_name());
-    if (ret < 0) {
-      return ret;
-    }
-  }
-
-  /* Now remove xattrs that are on disk but genuinely gone from the
-   * new attrs (not just about to be rewritten). */
-  if (old_ret >= 0) {
-    for (auto& it : old_attrs) {
-      if (attrs.find(it.first) == attrs.end() &&
-          (!extra_attrs || extra_attrs->find(it.first) == extra_attrs->end())) {
-        remove_x_attr(dpp, y, fd, it.first, get_name());
-      }
-    }
-  }
-
-  return 0;
-}
-
-int FSEnt::read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs)
-{
-  int ret = open(dpp);
-  if (ret < 0) {
-    return ret;
-  }
-
-  OFDLockGuard lock(get_fd(), F_RDLCK);
-  return get_x_attrs(y, dpp, get_fd(), attrs, get_name());
-}
-
-int FSEnt::fill_cache(const DoutPrefixProvider *dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags)
-{
-  rgw_bucket_dir_entry bde{};
-
-  rgw_obj_key key = decode_obj_key(get_name());
-  if (parent->get_type() == ObjectType::MULTIPART) {
-    key.ns = mp_ns;
-  }
-  key.get_index_key(&bde.key);
-  bde.ver.pool = 1;
-  bde.ver.epoch = 1;
-
-  switch (parent->get_type().type) {
-    case ObjectType::VERSIONED:
-      bde.flags = rgw_bucket_dir_entry::FLAG_VER;
-      bde.exists = true;
-      if (flags & FSEnt::FLAG_CURRENT) {
-	  bde.flags |= rgw_bucket_dir_entry::FLAG_CURRENT;
-      }
-      if (flags & FSEnt::FLAG_DELETE_MARKER) {
-        bde.flags |= rgw_bucket_dir_entry::FLAG_DELETE_MARKER;
-      }
-      break;
-    case ObjectType::MULTIPART:
-    case ObjectType::DIRECTORY:
-      bde.exists = true;
-      break;
-    case ObjectType::UNKNOWN:
-    case ObjectType::FILE:
-    case ObjectType::SYMLINK:
-      return -EINVAL;
-  }
-
-  Attrs attrs;
-  int ret = open(dpp);
-  if (ret < 0)
-    return ret;
-
-  ret = get_x_attrs(y, dpp, get_fd(), attrs, get_name());
-  if (ret < 0)
-    return ret;
-
-  ACLOwner acl_owner;
-  ret = decode_acl_owner(attrs, acl_owner);
-  if (ret < 0) {
-    bde.meta.owner = "unknown";
-    bde.meta.owner_display_name = "unknown";
-  } else {
-    bde.meta.owner = to_string(acl_owner.id);
-    bde.meta.owner_display_name = acl_owner.display_name;
-  }
-  bde.meta.category = RGWObjCategory::Main;
-  bde.meta.size = stx.stx_size;
-  bde.meta.accounted_size = stx.stx_size;
-  bde.meta.mtime = from_statx_timestamp(stx.stx_mtime);
-  bde.meta.storage_class = RGW_STORAGE_CLASS_STANDARD;
-  bde.meta.appendable = true;
-  bufferlist etag_bl;
-  if (rgw::sal::get_attr(attrs, RGW_ATTR_ETAG, etag_bl)) {
-    bde.meta.etag = etag_bl.to_str();
-  }
-
-  return cb(dpp, bde);
-}
-
-int File::create(const DoutPrefixProvider *dpp, bool* existed, bool temp_file)
-{
-  int flags, ret;
-  std::string path;
-  if(temp_file) {
-    flags = O_TMPFILE | O_RDWR;
-    path = ".";
-  } else {
-    flags = O_CREAT | O_RDWR;
-    path = get_name();
-  }
-
-  ret = openat(parent->get_fd(), path.c_str(), flags | O_NOFOLLOW, S_IRWXU);
-  if (ret < 0) {
-    ret = errno;
-    if (ret == EEXIST) {
-      return 0;
-    }
-    ldpp_dout(dpp, 0) << "ERROR: could not open object " << get_name() << ": "
-                      << cpp_strerror(ret) << dendl;
-    return -ret;
-    }
-
-  fd = ret;
-  need_fsync = true;
-
-  return 0;
-}
-
-int File::open(const DoutPrefixProvider* dpp)
-{
-  if (fd >= 0) {
-    return 0;
-  }
-
-  int ret = openat(parent->get_fd(), fname.c_str(), O_RDWR, S_IRWXU);
-  if (ret < 0) {
-    ret = errno;
-    ldpp_dout(dpp, 0) << "ERROR: could not open object " << get_name() << ": "
-                      << cpp_strerror(ret) << dendl;
-    return -ret;
-    }
-
-  fd = ret;
-
-  return 0;
-}
-
-int File::close()
-{
-  if (fd < 0) {
-    return 0;
-  }
-
-  if (need_fsync) {
-    int ret = ::fsync(fd);
-    if (ret < 0) {
-      return ret;
-    }
-    need_fsync = false;
-  }
-
-  int ret = ::close(fd);
-  if(ret < 0) {
-    return ret;
-  }
-  fd = -1;
-
-  return 0;
-}
-
-
-int File::stat(const DoutPrefixProvider* dpp, bool force)
-{
-  int ret = FSEnt::stat(dpp, force);
-  if (ret < 0) {
-    return ret;
-  }
-
-  if (!S_ISREG(stx.stx_mode)) {
-    /* Not a file */
-    ldpp_dout(dpp, 0) << "ERROR: " << get_name() << " is not a file" << dendl;
-    return -EINVAL;
-  }
-
-  return 0;
-}
-
-int File::write(int64_t ofs, bufferlist& bl, const DoutPrefixProvider* dpp,
-		       optional_yield y)
-{
-  need_fsync = true;
-  int64_t left = bl.length();
-  char* curp = bl.c_str();
-  ssize_t ret;
-
-  ret = fchmod(fd, S_IRUSR|S_IWUSR);
-  if(ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: could not change permissions on object " << get_name() << ": "
-                  << cpp_strerror(ret) << dendl;
-    return ret;
-  }
-
-
-  ret = lseek(fd, ofs, SEEK_SET);
-  if (ret < 0) {
-    ret = errno;
-    ldpp_dout(dpp, 0) << "ERROR: could not seek object " << get_name() << " to "
-      << ofs << " :" << cpp_strerror(ret) << dendl;
-    return -ret;
-  }
-
-  while (left > 0) {
-    ret = ::write(fd, curp, left);
-    if (ret < 0) {
-      ret = errno;
-      ldpp_dout(dpp, 0) << "ERROR: could not write object " << get_name() << ": "
-	<< cpp_strerror(ret) << dendl;
-      return -ret;
-    }
-
-    curp += ret;
-    left -= ret;
-  }
-
-  return 0;
-}
-
-int File::read(int64_t ofs, int64_t left, bufferlist& bl,
-		      const DoutPrefixProvider* dpp, optional_yield y)
-{
-  int64_t len = std::min(left, READ_SIZE);
-  ssize_t ret;
-
-  ret = lseek(fd, ofs, SEEK_SET);
-  if (ret < 0) {
-    ret = errno;
-    ldpp_dout(dpp, 0) << "ERROR: could not seek object " << get_name() << " to "
-                      << ofs << " :" << cpp_strerror(ret) << dendl;
-    return -ret;
-    }
-
-    char read_buf[READ_SIZE];
-    ret = ::read(fd, read_buf, len);
-    if (ret < 0) {
-      ret = errno;
-      ldpp_dout(dpp, 0) << "ERROR: could not read object " << get_name() << ": "
-	<< cpp_strerror(ret) << dendl;
-      return -ret;
-    }
-
-    bl.append(read_buf, ret);
-
-    return ret;
-}
-
-int File::copy(const DoutPrefixProvider *dpp, optional_yield y,
-                      Directory* dst_dir, const std::string& dst_name)
-{
-  off64_t scount = 0, dcount = 0;
-
-  int ret = stat(dpp);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: could not stat source file " << get_name()
-                      << dendl;
-    return ret;
-  }
-
-  ret = open(dpp);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: could not open source file " << get_name()
-                      << dendl;
-    return ret;
-  }
-
-  // Delete the target
-  {
-    std::unique_ptr<FSEnt> del;
-    ret = dst_dir->get_ent(dpp, y, dst_name, std::string(), del);
-    if (ret >= 0) {
-      ret = del->remove(dpp, y, /*delete_children=*/true, nullptr);
-      if (ret < 0) {
-        ldpp_dout(dpp, 0) << "ERROR: could not remove dest " << dst_name
-                          << dendl;
-        return ret;
-      }
-    }
-  }
-
-  std::unique_ptr<File> dest = clone();
-  dest->parent = dst_dir;
-  dest->fname = dst_name;
-
-  ret = dest->create(dpp);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: could not create dest file "
-                      << dest->get_name() << dendl;
-    return ret;
-  }
-  ret = dest->open(dpp);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: could not open dest file "
-                      << dest->get_name() << dendl;
-    return ret;
-  }
-
-  ret = copy_file_range(fd, &scount, dest->get_fd(), &dcount, get_size(), 0);
-  if (ret < 0) {
-    ret = errno;
-    ldpp_dout(dpp, 0) << "ERROR: could not copy object " << dest->get_name()
-                      << ": " << cpp_strerror(ret) << dendl;
-    return -ret;
-  }
-
-  return 0;
-}
-
-int File::remove(const DoutPrefixProvider* dpp, optional_yield y, bool delete_children, DeleteResult* result)
-{
-  if (!exists()) {
-    return 0;
-  }
-
-  int ret = unlinkat(parent->get_fd(), fname.c_str(), 0);
-  if (ret < 0) {
-    ret = errno;
-    if (errno != ENOENT) {
-      ldpp_dout(dpp, 0) << "ERROR: could not remove object " << get_name()
-                        << ": " << cpp_strerror(ret) << dendl;
-      return -ret;
-    }
-  }
-
-  return 0;
-}
-
-int File::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y, std::string temp_fname)
-{
-  if (fd < 0) {
-    return 0;
-  }
-
-  char temp_file_path[PATH_MAX];
-  // Only works on Linux - Non-portable
-  snprintf(temp_file_path, PATH_MAX,  "/proc/self/fd/%d", fd);
-
-  int ret = linkat(AT_FDCWD, temp_file_path, parent->get_fd(), temp_fname.c_str(), AT_SYMLINK_FOLLOW);
-  if(ret < 0) {
-    ret = errno;
-    ldpp_dout(dpp, 0) << "ERROR: linkat for temp file could not finish: "
-	<< cpp_strerror(ret) << dendl;
-    return -ret;
-  }
-
-  ret = renameat(parent->get_fd(), temp_fname.c_str(), parent->get_fd(), get_name().c_str());
-  if(ret < 0) {
-    ret = errno;
-    ldpp_dout(dpp, 0) << "ERROR: renameat for object could not finish: "
-	<< cpp_strerror(ret) << dendl;
-    return -ret;
-  }
-
-  /* note that open() and stat() return already sign-reversed result codes */
-  ret = open(dpp);
-  if (ret < 0) {
-    ldpp_dout(dpp, 20) << "ERROR: POSIXAtomicWriter failed opening file" << dendl;
-    return ret;
-  }
-
-  ret = stat(dpp);
-  if (ret < 0) {
-    ldpp_dout(dpp, 20) << "ERROR: POSIXAtomicWriter failed closing file" << dendl;
-    return ret;
-  }
-
-  return 0;
-}
-
-bool Directory::file_exists(std::string& name)
-{
-  struct statx nstx;
-  int ret = statx(fd, name.c_str(), AT_SYMLINK_NOFOLLOW, STATX_ALL, &nstx);
-
-  return (ret >= 0);
-}
-
-int Directory::create(const DoutPrefixProvider* dpp, bool* existed, bool temp_file)
-{
-  if (temp_file) {
-    ldpp_dout(dpp, 0) << "ERROR: cannot create directory with temp_file " << get_name() << dendl;
-    return -EINVAL;
-  }
-
-  int ret = mkdirat(parent->get_fd(), fname.c_str(), S_IRWXU);
-  if (ret < 0) {
-    ret = errno;
-    if (ret != EEXIST) {
-      if (dpp)
-	ldpp_dout(dpp, 0) << "ERROR: could not create bucket " << get_name() << ": "
-	  << cpp_strerror(ret) << dendl;
-      return -ret;
-    } else if (existed != nullptr) {
-      *existed = true;
-    }
-  }
-
-  return 0;
-}
-
-int Directory::open(const DoutPrefixProvider* dpp)
-{
-  if (fd >= 0) {
-    return 0;
-  }
-
-  int pfd{AT_FDCWD};
-  if (parent)
-    pfd = parent->get_fd();
-
-  int ret = openat(pfd, fname.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
-  if (ret < 0) {
-    ret = errno;
-    ldpp_dout(dpp, 0) << "ERROR: could not open dir " << get_name() << ": "
-                  << cpp_strerror(ret) << dendl;
-    return -ret;
-  }
-
-  fd = ret;
-
-  return 0;
-}
-
-int Directory::close()
-{
-  if (fd < 0) {
-    return 0;
-  }
-
-  ::close(fd);
-  fd = -1;
-
-  return 0;
-}
-
-int Directory::stat(const DoutPrefixProvider* dpp, bool force)
-{
-  int ret = FSEnt::stat(dpp, force);
-  if (ret < 0) {
-    return ret;
-  }
-
-  if (!S_ISDIR(stx.stx_mode)) {
-    /* Not a directory */
-    ldpp_dout(dpp, 0) << "ERROR: " << get_name() << " is not a directory" << dendl;
-    return -EINVAL;
-  }
-
-  return 0;
-}
-
-int Directory::remove(const DoutPrefixProvider* dpp, optional_yield y, bool delete_children, DeleteResult* result)
-{
-  return delete_directory(parent->get_fd(), fname.c_str(), delete_children, dpp);
-}
-
-int Directory::write(int64_t ofs, bufferlist& bl, const DoutPrefixProvider* dpp,
-		     optional_yield y)
-{
-  return -EINVAL;
-}
-
-int Directory::read(int64_t ofs, int64_t left, bufferlist &bl,
-                    const DoutPrefixProvider *dpp, optional_yield y)
-{
-  return -EINVAL;
-}
-
-int Directory::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y,
-                              std::string temp_fname)
-{
-  return -EINVAL;
-}
-
-template <typename F>
-int Directory::for_each(const DoutPrefixProvider* dpp, const F& func)
-{
-  DIR* dir;
-  struct dirent* entry;
-  int ret;
-
-  ret = open(dpp);
-  if (ret < 0) {
-    return ret;
-  }
-
-  dir = fdopendir(fd);
-  if (dir == NULL) {
-    ret = errno;
-    ldpp_dout(dpp, 0) << "ERROR: could not open dir " << get_name() << " for listing: "
-      << cpp_strerror(ret) << dendl;
-    return -ret;
-  }
-
-  rewinddir(dir);
-
-  ret = 0;
-  while ((entry = readdir(dir)) != NULL) {
-    std::string_view vname(entry->d_name);
-
-    if (vname == "." || vname == "..")
-      continue;
-
-    int r = func(entry->d_name);
-    if (r < 0) {
-      ret = r;
-      break;
-    }
-  }
-
-  if (ret == -EAGAIN) {
-    /* Limit reached */
-    ret = 0;
-  }
-
-  closedir(dir);
-  // closedir() closes the fd, so we need to invalidate it
-  fd = -1;
-  // closedir() closes fd, but succeeding calls might assume that fd is still valid.
-  // so let's reopen it.
-  open(dpp);
-  return ret;
-}
-
-int Directory::rename(const DoutPrefixProvider* dpp, optional_yield y, Directory* dst_dir, std::string dst_name)
-{
-  int flags = 0;
-  int ret;
-  std::string src_name = fname;
-  int parent_fd = parent->get_fd();
-
-  if (dst_dir->file_exists(dst_name)) {
-    flags = RENAME_EXCHANGE;
-  }
-  // swap
-  ret = renameat2(parent_fd, src_name.c_str(), dst_dir->get_fd(), dst_name.c_str(), flags);
-  if(ret < 0) {
-    ret = errno;
-    ldpp_dout(dpp, 0) << "ERROR: renameat2 for shadow object could not finish: "
-	<< cpp_strerror(ret) << dendl;
-    return -ret;
-  }
-
-  /* Parent of this dir is now dest dir */
-  parent = dst_dir;
-  /* Name has changed */
-  fname = dst_name;
-
-  // Delete old one (could be file or directory)
-  struct statx stx;
-  ret = statx(parent_fd, src_name.c_str(), AT_SYMLINK_NOFOLLOW,
-		  STATX_ALL, &stx);
-  if (ret < 0) {
-    ret = errno;
-    if (ret == ENOENT) {
-      return 0;
-    }
-    ldpp_dout(dpp, 0) << "ERROR: could not stat object " << get_name() << ": "
-                  << cpp_strerror(ret) << dendl;
-    return -ret;
-  }
-
-  if (S_ISREG(stx.stx_mode)) {
-    ret = unlinkat(parent_fd, src_name.c_str(), 0);
-  } else if (S_ISDIR(stx.stx_mode)) {
-    ret = delete_directory(parent_fd, src_name.c_str(), true, dpp);
-  }
-  if (ret < 0) {
-    ret = errno;
-    ldpp_dout(dpp, 0) << "ERROR: could not remove old file " << get_name()
-                      << ": " << cpp_strerror(ret) << dendl;
-    return -ret;
-  }
-
-  return 0;
-}
-
-int Directory::copy(const DoutPrefixProvider *dpp, optional_yield y,
-                      Directory* dst_dir, const std::string& dst_name)
-{
-  int ret;
-
-  // Delete the target
-  {
-    std::unique_ptr<FSEnt> del;
-    ret = dst_dir->get_ent(dpp, y, dst_name, std::string(), del);
-    if (ret >= 0) {
-      ret = del->remove(dpp, y, /*delete_children=*/true, nullptr);
-      if (ret < 0) {
-        ldpp_dout(dpp, 0) << "ERROR: could not remove dest " << dst_name
-                          << dendl;
-        return ret;
-      }
-    }
-  }
-
-  ret = dst_dir->open(dpp);
-  std::unique_ptr<Directory> dest = clone_dir();
-  dest->parent = dst_dir;
-  dest->fname = dst_name;
-
-  ret = dest->create(dpp);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: could not create dest " << dest->get_name() << dendl;
-    return ret;
-  }
-
-  Attrs attrs;
-  ret = read_attrs(dpp, y, attrs);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: could not read attrs from " << get_name() << dendl;
-    return ret;
-  }
-  ret = dest->write_attrs(dpp, y, attrs, nullptr);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: could not write attrs to " << dest->get_name() << dendl;
-    return ret;
-  }
-
-  ret = for_each(dpp, [this, &dest, &dpp, &y](const char* name) {
-    std::unique_ptr<FSEnt> sobj;
-
-    if (name[0] == '.') {
-      /* Skip dotfiles */
-      return 0;
-    }
-
-    int r = this->get_ent(dpp, y, name, std::string(), sobj);
-    if (r < 0)
-      return r;
-    return sobj->copy(dpp, y, dest.get(), name);
-  });
-
-  return ret;
-}
-
-int Directory::get_ent(const DoutPrefixProvider *dpp, optional_yield y, const std::string &name, const std::string& instance, std::unique_ptr<FSEnt>& ent)
-{
-  struct statx nstx;
-  std::unique_ptr<FSEnt> nent;
-
-  int ret = open(dpp);
-  if (ret < 0) {
-      ldpp_dout(dpp, 0) << "ERROR: could not open directory " << name << dendl;
-      return ret;
-  }
-
-  ret = statx(get_fd(), name.c_str(),
-                  AT_SYMLINK_NOFOLLOW, STATX_ALL, &nstx);
-  if (ret < 0) {
-      ret = errno;
-      ldpp_dout(dpp, 0) << "ERROR: could not stat object " << name << " in dir "
-                        << get_name() << " : " << cpp_strerror(ret) << dendl;
-      return -ret;
-  }
-  if (S_ISREG(nstx.stx_mode)) {
-    nent = std::make_unique<File>(name, this, nstx, ctx);
-  } else if (S_ISDIR(nstx.stx_mode)) {
-    ObjectType type{ObjectType::MULTIPART};
-    int tmpfd;
-    Attrs attrs;
-
-    tmpfd = openat(get_fd(), name.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
-    if (tmpfd >= 0) {
-      ret = get_x_attrs(y, dpp, tmpfd, attrs, name);
-      if (ret >= 0) {
-        decode_attr(attrs, RGW_POSIX_ATTR_OBJECT_TYPE, type);
-      }
-      ::close(tmpfd);
-    }
-    switch (type.type) {
-    case ObjectType::VERSIONED:
-      nent = std::make_unique<VersionedDirectory>(name, this, instance, nstx, ctx);
-      break;
-    case ObjectType::MULTIPART:
-      nent = std::make_unique<MPDirectory>(name, this, nstx, ctx);
-      break;
-    case ObjectType::DIRECTORY:
-      nent = std::make_unique<Directory>(name, this, nstx, ctx);
-      break;
-    default:
-      ldpp_dout(dpp, 0) << "ERROR: invalid type " << type << dendl;
-      return -EINVAL;
-    }
-  } else if (S_ISLNK(nstx.stx_mode)) {
-    nent = std::make_unique<Symlink>(name, this, nstx, ctx);
-  } else {
-    return -EINVAL;
-  }
-
-  ent.swap(nent);
-  return 0;
-}
-
-int Directory::fill_cache(const DoutPrefixProvider *dpp, optional_yield y,
-                          fill_cache_cb_t &cb, uint32_t flags)
-{
-  int ret = for_each(dpp, [this, &cb, &dpp, &y](const char *name) {
-    std::unique_ptr<FSEnt> ent;
-
-    if (name[0] == '.') {
-      /* Skip dotfiles */
-      return 0;
-    }
-
-    int ret = get_ent(dpp, y, name, std::string(), ent);
-    if (ret < 0)
-      return ret;
-
-    ent->stat(dpp); // Stat the object to get the type
-
-    ret = ent->fill_cache(dpp, y, cb, FSEnt::FLAG_NONE);
-    if (ret < 0)
-      return ret;
-    return 0;
-  });
-
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: could not list directory " << get_name() << ": "
-      << cpp_strerror(ret) << dendl;
-    return ret;
-  }
-
-  return 0;
-}
-
-int Symlink::create(const DoutPrefixProvider* dpp, bool* existed, bool temp_file)
-{
-  if (temp_file) {
-    ldpp_dout(dpp, 0) << "ERROR: cannot create symlink with temp_file " << get_name() << dendl;
-    return -EINVAL;
-  }
-
-  int ret = symlinkat(target->get_name().c_str(), parent->get_fd(), fname.c_str());
-  if (ret < 0) {
-    ret = errno;
-    if (ret == EEXIST && existed != nullptr) {
-      *existed = true;
-    }
-    ldpp_dout(dpp, 0) << "ERROR: could not create bucket " << get_name() << ": "
-                      << cpp_strerror(ret) << dendl;
-    return -ret;
-  }
-
-  return 0;
-}
-
-int Symlink::fill_target(const DoutPrefixProvider *dpp, Directory* parent, std::string sname, std::string tname, std::unique_ptr<FSEnt>& ent, CephContext* _ctx)
-{
-  int ret;
-
-  if (!tname.empty()) {
-      ret = parent->get_ent(dpp, null_yield, tname, std::string(), ent);
-      if (ret < 0) {
-	ent = std::make_unique<File>(tname, parent, _ctx);
-      }
-      return 0;
-  }
-
-  char link[PATH_MAX];
-  memset(link, 0, sizeof(link));
-  ret = readlinkat(parent->get_fd(), sname.c_str(), link, sizeof(link));
-  if (ret < 0) {
-    ret = errno;
-    return -ret;
-  }
-  ret = parent->get_ent(dpp, null_yield, link, std::string(), ent);
-  if (ret < 0) {
-    ent = std::make_unique<File>(link, parent, _ctx);
-  }
-  return 0;
-}
-
-int Symlink::stat(const DoutPrefixProvider* dpp, bool force)
-{
-  int ret = FSEnt::stat(dpp, force);
-  if (ret < 0) {
-    return ret;
-  }
-
-  if (!S_ISLNK(stx.stx_mode)) {
-    /* Not a symlink */
-    ldpp_dout(dpp, 0) << "ERROR: " << get_name() << " is not a symlink" << dendl;
-    return -EINVAL;
-  }
-
-  struct statx sstx;
-  ret = statx(parent->get_fd(), fname.c_str(), 0, STATX_BASIC_STATS, &sstx);
-  if (ret >= 0) {
-    stx.stx_size = sstx.stx_size;
-  }
-
-  exist = true;
-  return fill_target(dpp, parent, get_name(), std::string(), target, ctx);
-}
-
-int Symlink::read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs)
-{
-  if (target)
-    return target->read_attrs(dpp, y, attrs);
-
-  return FSEnt::read_attrs(dpp, y, attrs);
-}
-
-int Symlink::copy(const DoutPrefixProvider *dpp, optional_yield y,
-                      Directory* dst_dir, const std::string& dst_name)
-{
-  int ret = stat(dpp);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: could not stat source file " << get_name()
-                      << dendl;
-    return ret;
-  }
-  rgw_obj_key skey = decode_obj_key(target->get_name());
-  rgw_obj_key dkey = decode_obj_key(dst_name);
-  dkey.instance = skey.instance;
-  std::string tgtname = get_key_fname(dkey, /*use_version=*/true);
-
-  ret = symlinkat(tgtname.c_str(), dst_dir->get_fd(), dst_name.c_str());
-
-  return 0;
-}
-
-int MPDirectory::create(const DoutPrefixProvider* dpp, bool* existed, bool temp_file)
-{
-  std::string path;
-
-  if(temp_file) {
-    tmpname = path = "._tmpname_" +
-           std::to_string(ceph::util::generate_random_number<uint64_t>());
-  } else {
-    path = get_name();
-  }
-
-  int ret = mkdirat(parent->get_fd(), path.c_str(), S_IRWXU);
-  if (ret < 0) {
-    ret = errno;
-    if (ret != EEXIST) {
-      if (dpp)
-	ldpp_dout(dpp, 0) << "ERROR: could not create bucket " << get_name() << ": "
-	  << cpp_strerror(ret) << dendl;
-      return -ret;
-    } else if (existed != nullptr) {
-      *existed = true;
-    }
-  }
-
-  return 0;
-}
-
-int MPDirectory::read(int64_t ofs, int64_t left, bufferlist &bl,
-                    const DoutPrefixProvider *dpp, optional_yield y)
-{
-  std::string pname;
-  for (auto part : parts) {
-    if (ofs < part.second) {
-      pname = part.first;
-      break;
-    }
-
-    ofs -= part.second;
-  }
-
-  if (pname.empty()) {
-    // ofs is past the end
-    return 0;
-  }
-
-  if (!cur_read_part || cur_read_part->get_name() != pname) {
-    cur_read_part = std::make_unique<File>(pname, this, ctx);
-  }
-  int ret = cur_read_part->open(dpp);
-  if (ret < 0) {
-    return ret;
-  }
-
-  return cur_read_part->read(ofs, left, bl, dpp, y);
-}
-
-int MPDirectory::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y,
-                                std::string temp_fname)
-{
-  if (tmpname.empty()) {
-    return 0;
-  }
-
-  /* Temporarily change name to tmpname, so we can reuse rename() */
-  std::string savename = fname;
-  fname = tmpname;
-  tmpname.clear();
-
-  return rename(dpp, y, parent, savename);
-}
-
-int MPDirectory::remove(const DoutPrefixProvider* dpp, optional_yield y, bool delete_children, DeleteResult* result)
-{
-  return Directory::remove(dpp, y, /*delete_children=*/true, result);
-}
-
-int MPDirectory::stat(const DoutPrefixProvider* dpp, bool force)
-{
-  int ret = Directory::stat(dpp, force);
-  if (ret < 0) {
-    return ret;
-  }
-
-  uint64_t total_size{0};
-  for_each(dpp, [this, &total_size, &dpp](const char *name) {
-    int ret;
-    struct statx stx;
-    std::string sname = name;
-
-    if (sname.rfind(MP_OBJ_PART_PFX, 0) != 0) {
-      /* Skip non-parts */
-      return 0;
-    }
-
-    ret = statx(fd, name, AT_SYMLINK_NOFOLLOW, STATX_ALL, &stx);
-    if (ret < 0) {
-      ret = errno;
-      ldpp_dout(dpp, 0) << "ERROR: could not stat object " << name << ": "
-                        << cpp_strerror(ret) << dendl;
-      return -ret;
-    }
-
-    if (!S_ISREG(stx.stx_mode)) {
-      /* Skip non-files */
-      return 0;
-    }
-
-    parts[name] = stx.stx_size;
-    total_size += stx.stx_size;
-    return 0;
-  });
-
-  stx.stx_size = total_size;
-
-  return 0;
-}
-
-
-std::unique_ptr<File> MPDirectory::get_part_file(int partnum)
-{
-  std::string partname = MP_OBJ_PART_PFX + fmt::format("{:0>5}", partnum);
-  rgw_obj_key part_key(partname);
-
-  return std::make_unique<File>(partname, this, ctx);
-}
-
-int MPDirectory::fill_cache(const DoutPrefixProvider *dpp, optional_yield y,
-                            fill_cache_cb_t &cb, uint32_t flags)
-{
-  int ret = FSEnt::fill_cache(dpp, y, cb, FSEnt::FLAG_NONE);
-  if (ret < 0)
-    return ret;
-
-  return Directory::fill_cache(dpp, y, cb, FSEnt::FLAG_NONE);
-}
-
-int VersionedDirectory::open(const DoutPrefixProvider* dpp)
-{
-  if (fd > 0) {
-    return 0;
-  }
-  int ret = Directory::open(dpp);
-  if (ret < 0) {
-    return ret;
-  }
-
-  if (!instance_id.empty()) {
-    rgw_obj_key key = decode_obj_key(get_name());
-    key.instance = instance_id;
-    get_ent(dpp, null_yield, get_key_fname(key, /*use_version=*/true), std::string(), cur_version);
-  }
-
-  if (!cur_version) {
-    /* Can't open File, probably doesn't exist yet */
-    return 0;
-  }
-
-  return cur_version->open(dpp);
-}
-
-int VersionedDirectory::create(const DoutPrefixProvider* dpp, bool* existed, bool temp_file)
-{
-  int ret = mkdirat(parent->get_fd(), fname.c_str(), S_IRWXU);
-  if (ret < 0) {
-    ret = errno;
-    if (ret != EEXIST) {
-      if (dpp)
-	ldpp_dout(dpp, 0) << "ERROR: could not create versioned directory " << get_name() << ": "
-	  << cpp_strerror(ret) << dendl;
-      return -ret;
-    }
-  }
-
-  ret = open(dpp);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: could not open versioned directory " << get_name()
-                      << dendl;
-    return ret;
-  }
-
-  /* Need type attribute written */
-  Attrs attrs;
-  ret = write_attrs(dpp, null_yield, attrs, nullptr);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: could not write attrs for versioned directory " << get_name()
-                      << dendl;
-    return ret;
-  }
-
-  if (temp_file) {
-    /* Want to create an actual versioned object */
-    rgw_obj_key key = decode_obj_key(get_name());
-    key.instance = instance_id;
-    std::unique_ptr<FSEnt> file =
-        std::make_unique<File>(get_key_fname(key, /*use_version=*/true), this, ctx);
-    ret = add_file(dpp, std::move(file), existed, temp_file);
-    if (ret < 0) {
-      return ret;
-    }
-  }
-
-  return 0;
-}
-
-std::string VersionedDirectory::get_new_instance()
-{
-  return gen_rand_instance_name();
-}
-
-int VersionedDirectory::add_file(const DoutPrefixProvider* dpp, std::unique_ptr<FSEnt>&& file, bool* existed, bool temp_file)
-{
-  int ret = open(dpp);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: could not open versioned directory " << get_name()
-                      << dendl;
-    return ret;
-  }
-
-  ret = file->create(dpp, existed, temp_file);
-  if (ret < 0) {
-    return ret;
-  }
-
-  if (!temp_file) {
-    return set_cur_version_ent(dpp, file.get());
-  }
-
-  cur_version = std::move(file);
-  return 0;
-}
-
-int VersionedDirectory::set_cur_version_ent(const DoutPrefixProvider* dpp, FSEnt* file)
-{
-  /* Delete current version symlink */
-  std::unique_ptr<FSEnt> del;
-  int ret = get_ent(dpp, null_yield, get_name(), std::string(), del);
-  if (ret >= 0) {
-    ret = del->remove(dpp, null_yield, /*delete_children=*/true, nullptr);
-    if (ret < 0) {
-      ldpp_dout(dpp, 0) << "ERROR: could not remove cur_version " << get_name()
-                        << dendl;
-      return ret;
-    }
-  }
-
-  /* Create new current version symlink */
-  std::unique_ptr<Symlink> sl =
-      std::make_unique<Symlink>(get_name(), this, file->get_name(), ctx);
-  ret = sl->create(dpp, /*existed=*/nullptr, /*temp_file=*/false);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: could not create cur_version symlink "
-                      << get_name() << dendl;
-    return ret;
-  }
-
-  return 0;
-}
-
-int VersionedDirectory::stat(const DoutPrefixProvider* dpp, bool force)
-{
-  int ret = Directory::stat(dpp, force);
-  if (ret < 0) {
-    return ret;
-  }
-
-  ret = open(dpp);
-  if (ret < 0)
-    return ret;
-
-  if (cur_version) {
-    /* Already have a File for the current version, use it */
-    ret = cur_version->stat(dpp);
-    if (ret < 0)
-      return ret;
-    stx.stx_size = cur_version->get_stx().stx_size;
-
-    return 0;
-  }
-
-  /* Try to read the symlink */
-  std::unique_ptr<Symlink> sl = std::make_unique<Symlink>(get_name(), this, ctx);
-  ret = sl->stat(dpp);
-  if (ret < 0) {
-    if (ret == -ENOENT)
-      return 0;
-    return ret;
-  }
-
-  if (!sl->exists()) {
-    stx.stx_size = 0;
-    return 0;
-  }
-
-  cur_version = sl->get_target()->clone_base();
-  ret = cur_version->open(dpp);
-  if (ret < 0) {
-    return 0;
-  }
-  ret = cur_version->stat(dpp);
-  if (ret < 0)
-    return ret;
-  stx.stx_size = cur_version->get_stx().stx_size;
-
-  if (cur_version->get_stx().stx_size == 0) {
-    //Possibly a delete marker
-    Attrs attrs;
-    ret = cur_version->read_attrs(dpp, null_yield, attrs);
-    if (ret < 0) {
-      return ret;
-    }
-    bufferlist bl;
-    if (rgw::sal::get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
-      uint16_t flags = 0;
-      ceph::decode(flags, bl);
-      if (flags & rgw_bucket_dir_entry::FLAG_DELETE_MARKER) {
-        ldpp_dout(dpp, 0) << "ERROR: a delete marker, returning ENOENT "
-                          << get_name() << dendl;
-        cur_version.reset();
-        return -ENOENT;
-      }
-    }
-  }
-
-  return 0;
-}
-
-int VersionedDirectory::read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs)
-{
-  if (!cur_version)
-    return FSEnt::read_attrs(dpp, y, attrs);
-
-  int ret = cur_version->read_attrs(dpp, y, attrs);
-  if (ret < 0) {
-    return ret;
-  }
-
-  /* Override type, it should be VERSIONED */
-  bufferlist type_bl;
-  ObjectType type{get_type()};
-  type.encode(type_bl);
-  attrs[RGW_POSIX_ATTR_OBJECT_TYPE] = type_bl;
-
-  return 0;
-}
-
-int VersionedDirectory::write_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs, Attrs* extra_attrs)
-{
-  if (cur_version) {
-    int ret = cur_version->write_attrs(dpp, y, attrs, extra_attrs);
-    if (ret < 0)
-      return ret;
-  }
-
-  return FSEnt::write_attrs(dpp, y, attrs, extra_attrs);
-}
-
-int VersionedDirectory::write(int64_t ofs, bufferlist &bl,
-                              const DoutPrefixProvider *dpp, optional_yield y)
-{
-  if (!cur_version)
-    return 0;
-  return cur_version->write(ofs, bl, dpp, y);
-}
-
-int VersionedDirectory::read(int64_t ofs, int64_t left, bufferlist &bl,
-                    const DoutPrefixProvider *dpp, optional_yield y)
-{
-  if (!cur_version)
-    return 0;
-  return cur_version->read(ofs, left, bl, dpp, y);
-}
-
-int VersionedDirectory::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y,
-                              std::string temp_fname)
-{
-  if (!cur_version)
-    return -EINVAL;
-  int ret = cur_version->link_temp_file(dpp, y, temp_fname);
-  if (ret < 0)
-    return ret;
-
-  return set_cur_version_ent(dpp, cur_version.get());
-}
-
-int VersionedDirectory::copy(const DoutPrefixProvider *dpp, optional_yield y,
-                      Directory* dst_dir, const std::string& dst_name)
-{
-  int ret;
-  rgw_obj_key dest_key = decode_obj_key(dst_name);
-  std::string basename = get_key_fname(dest_key, /*use_version=*/false);
-
-  // Delete the target
-  {
-    std::unique_ptr<FSEnt> del;
-    ret = dst_dir->get_ent(dpp, y, basename, std::string(), del);
-    if (ret >= 0) {
-      ret = del->remove(dpp, y, /*delete_children=*/true, nullptr);
-      if (ret < 0) {
-        ldpp_dout(dpp, 0) << "ERROR: could not remove dest " << basename
-                          << dendl;
-        return ret;
-      }
-    }
-  }
-
-  ret = dst_dir->open(dpp);
-  std::unique_ptr<VersionedDirectory> dest = clone();
-  dest->parent = dst_dir;
-  dest->fname = basename;
-
-  ret = dest->create(dpp);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: could not create dest " << dest->get_name() << dendl;
-    return ret;
-  }
-
-  Attrs attrs;
-  ret = read_attrs(dpp, y, attrs);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: could not read attrs from " << get_name() << dendl;
-    return ret;
-  }
-  ret = dest->write_attrs(dpp, y, attrs, nullptr);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: could not write attrs to " << dest->get_name() << dendl;
-    return ret;
-  }
-
-  std::string tgtname;
-  ret = for_each(dpp, [this, &dest, &dest_key, &tgtname, &dpp, &y](const char* name) {
-    std::unique_ptr<FSEnt> sobj;
-
-    if (name[0] == '.') {
-      /* Skip dotfiles */
-      return 0;
-    }
-    rgw_obj_key key = decode_obj_key(name);
-    if (!dest_key.instance.empty() && dest_key.instance != key.instance) {
-      /* Were asked to copy a single version, and this is not it */
-      return 0;
-    }
-
-    int r = this->get_ent(dpp, y, name, std::string(), sobj);
-    if (r < 0)
-      return r;
-    key.name = dest_key.name;
-    tgtname = get_key_fname(key, /*use_version=*/true);
-    return sobj->copy(dpp, y, dest.get(), tgtname);
-  });
-
-  if (!dest_key.instance.empty()) {
-    /* We didn't copy the symlink, make a new one */
-    std::unique_ptr<Symlink> sl = std::make_unique<Symlink>(basename, dest.get(), tgtname, ctx);
-    ret = sl->create(dpp, /*existed=*/nullptr, /*temp_file=*/false);
-  }
-
-  return ret;
-}
-
-int VersionedDirectory::add_delete_marker(const DoutPrefixProvider* dpp,
-                                          optional_yield y,
-                                          std::unique_ptr<File>& marker,
-                                          const std::string &name)
-{
-  // Create as temporary file first
-  int ret = marker->create(dpp, /*existed=*/nullptr, /*temp_file=*/true);
-  if (ret < 0) {
-    return ret;
-  }
-
-  // XXX: Hack to set the owner on the delete marker
-  Attrs v_attrs;
-  Attrs attrs;
-
-  ret = get_x_attrs(y, dpp, get_fd(), v_attrs, get_name());
-  if (ret < 0) {
-    // removing the temporary files before returning failure
-    marker->remove(dpp, y, /*delete_children=*/false, nullptr);
-    return ret;
-  }
-
-  bufferlist owner_bl;
-  if (rgw::sal::get_attr(v_attrs, RGW_ATTR_ACL, owner_bl)) {
-    attrs[RGW_ATTR_ACL] = std::move(owner_bl);
-  }
-
-  buffer::list bl;
-  uint16_t flags = 0;
-  flags |= rgw_bucket_dir_entry::FLAG_DELETE_MARKER;
-  ceph::encode(flags, bl);
-  attrs[RGW_POSIX_ATTR_VERSION] = std::move(bl);
-
-  // Write attributes before linking
-  ret = marker->write_attrs(dpp, y, attrs, nullptr);
-  if (ret < 0) {
-    // removing the temporary files before returning failure
-    marker->remove(dpp, y, /*delete_children=*/false, nullptr);
-    return ret;
-  }
-
-  // Link temp file to final name atomically
-  ret = marker->link_temp_file(dpp, y, name);
-  if (ret < 0) {
-    // removing the temporary files before returning failure
-    marker->remove(dpp, y, /*delete_children=*/false, nullptr);
-    return ret;
-  }
-
-  return 0;
-}
-
-int VersionedDirectory::remove(const DoutPrefixProvider* dpp, optional_yield y,
-                               bool delete_children, DeleteResult* result)
-{
-  std::string tgtname;
-  bool newlink = false;
-
-  int ret = open(dpp);
-  if (ret < 0)
-    return ret;
-
-  if (instance_id.empty()) {
-    /* Check if directory is empty */
-    ret = for_each(dpp, [](const char *n) {
-      return -ENOENT;
-    });
-
-    if (ret == 0) {
-      /* We're empty, nuke us */
-      return Directory::remove(dpp, y, /*delete_children=*/true, result);
-    }
-
-    /* Add a delete marker */
-    std::unique_ptr<File> f;
-    rgw_obj_key key = decode_obj_key(get_name());
-    key.instance = gen_rand_instance_name();
-    tgtname = get_key_fname(key, /*use_version=*/true);
-
-    result->delete_marker = true;
-    result->version_id = key.instance;
-
-    f = std::make_unique<File>(tgtname, this, ctx);
-    ret = add_delete_marker(dpp, y, f, tgtname);
-    if (ret < 0) {
-      return ret;
-    }
-
-    newlink = true;
-    ret = set_cur_version_ent(dpp, f.get());
-    if (ret < 0) {
-      return ret;
-    }
-    cur_version = std::move(f);
-    return 0;
-  } else {
-    /* Delete specific version */
-    rgw_obj_key key = decode_obj_key(get_name());
-    key.instance = instance_id;
-    std::string name = get_key_fname(key, /*use_version=*/true);
-
-    std::unique_ptr<FSEnt> f;
-    ret = get_ent(dpp, y, name, std::string(), f);
-    if (ret == 0) {
-      ret = f->stat(dpp);
-      if (ret < 0)
-        return ret;
-      Attrs attrs;
-      ret = f->read_attrs(dpp, y, attrs);
-      if (ret < 0) {
-        return ret;
-      }
-      bufferlist bl;
-      if (get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
-       result->delete_marker = true;
-      }
-      ret = f->remove(dpp, y, /*delete_children=*/true, result);
-      if (ret < 0)
-       return ret;
-      result->version_id = instance_id;
-    } else {
-      return ret;
-    }
-    /* Possibly move symlink */
-    ret = remove_symlink(dpp, y, name);
-    if (ret < 0) {
-      if (ret == -ENOKEY) {
-        return 0;
-      }
-      return ret;
-    }
-    newlink = true;
-    /* Create new current version symlink */
-    ret = for_each(dpp, [&tgtname](const char *n) {
-      if (n[0] == '.') {
-        /* Skip dotfiles */
-        return 0;
-      }
-
-      tgtname = n;
-      return 0;
-    });
-
-    if (tgtname.empty()) {
-      /* We're empty, nuke us */
-      exist = false;
-      return Directory::remove(dpp, y, /*delete_children=*/true, result);
-    }
-  }
-  if (newlink) {
-    exist = true;
-    std::unique_ptr<FSEnt> f;
-    ret = get_ent(dpp, y, tgtname, std::string(), f);
-    if (ret < 0) {
-      return ret;
-    }
-    ret = set_cur_version_ent(dpp, f.get());
-    if (ret < 0) {
-      return ret;
-    }
-    cur_version = std::move(f);
-  }
-
-  return 0;
-}
-
-int VersionedDirectory::fill_cache(const DoutPrefixProvider *dpp, optional_yield y,
-                                   fill_cache_cb_t &cb, uint32_t flags)
-{
-  /* Fill cur_version — stat() may reset cur_version to null if the
-   * current version is a delete marker, so also resolve the symlink
-   * target name for the FLAG_CURRENT comparison below */
-  stat(dpp, /*force=*/false);
-
-  std::string cur_version_name;
-  if (cur_version) {
-    cur_version_name = cur_version->get_name();
-  } else {
-    /* cur_version is null — likely a delete marker; read the symlink
-     * to determine which entry is current */
-    std::unique_ptr<Symlink> sl = std::make_unique<Symlink>(get_name(), this, ctx);
-    if (sl->stat(dpp) >= 0 && sl->exists()) {
-      cur_version_name = sl->get_target()->get_name();
-    }
-  }
-
-  int ret = for_each(dpp, [this, &cb, &dpp, &y, &cur_version_name](const char *name) {
-    std::unique_ptr<FSEnt> ent;
-
-    if (name[0] == '.') {
-      /* Skip dotfiles */
-      return 0;
-    }
-
-    int ret = get_ent(dpp, y, name, std::string(), ent);
-    if (ret < 0)
-      return ret;
-
-    ent->stat(dpp); // Stat the object to get the type
-
-    if (ent->get_type() != ObjectType::SYMLINK) {
-      uint32_t fill_flags =
-          (!cur_version_name.empty() &&
-           (ent->get_name() == cur_version_name)) ?
-        FSEnt::FLAG_CURRENT :
-        FSEnt::FLAG_NONE;
-
-      // Delete markers are zero byte files
-      if (ent->get_stx().stx_size == 0) {
-        Attrs attrs;
-        bufferlist bl;
-        ret = ent->read_attrs(dpp, y, attrs);
-        if (ret < 0) {
-          return ret;
-        }
-        if (get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
-          fill_flags |= FSEnt::FLAG_DELETE_MARKER;
-        }
-      }
-
-      ret = ent->fill_cache(dpp, y, cb, fill_flags);
-      if (ret < 0)
-        return ret;
-    }
-    return 0;
-  });
-
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: could not list directory " << get_name() << ": "
-      << cpp_strerror(ret) << dendl;
-    return ret;
-  }
-
-  return 0;
-}
-
-std::string VersionedDirectory::get_cur_version()
-{
-  if (!cur_version)
-    return "";
-
-  rgw_obj_key key = decode_obj_key(cur_version->get_name());
-
-  return key.instance;
-}
-
-int VersionedDirectory::remove_symlink(const DoutPrefixProvider *dpp, optional_yield y, std::string match)
-{
-  int ret;
-
-  std::unique_ptr<Symlink> sl =
-      std::make_unique<Symlink>(get_name(), this, ctx);
-  ret = sl->stat(dpp);
-  if (ret < 0) {
-    /* Doesn't exist, nothing to do */
-    if (ret == -ENOENT)
-      return 0;
-    return ret;
-  }
-
-  if (!match.empty()) {
-    if (match != sl->get_target()->get_name())
-      return -ENOKEY;
-  }
-
-  ret = sl->remove(dpp, y, /*delete_children=*/false, nullptr);
-  if (ret < 0) {
-    return ret;
-  }
-
-  return 0;
-}
-
-} // namespace posix
 
 bool POSIXZoneGroup::placement_target_exists(std::string& target) const {
   return !!group->placement_targets.count(target);
@@ -2143,7 +174,7 @@ int POSIXDriver::initialize(CephContext *cct, const DoutPrefixProvider *dpp)
 
   /* ordered listing cache */
   bucket_cache.reset(
-    new BucketCache(
+    new posix::BucketCache(
       this, base_path,
       g_conf().get_val<std::string>("rgw_posix_database_root"),
       g_conf().get_val<int64_t>("rgw_posix_cache_max_buckets"),
@@ -2155,7 +186,7 @@ int POSIXDriver::initialize(CephContext *cct, const DoutPrefixProvider *dpp)
   /* user info cache */
   user_cache.set_max_size(dpp, g_conf().get_val<uint64_t>("rgw_posix_cache_max_users"));
 
-  root_dir = std::make_unique<Directory>(base_path, nullptr, ctx());
+  root_dir = std::make_unique<posix::Directory>(base_path, nullptr, ctx());
   ret = root_dir->open(dpp);
   if (ret < 0) {
     if (ret == -ENOTDIR) {
@@ -2753,7 +784,7 @@ std::unique_ptr<Object> POSIXBucket::get_object(const rgw_obj_key& k)
 
 int POSIXObject::fill_cache(const DoutPrefixProvider *dpp, optional_yield y, fill_cache_cb_t& cb)
 {
-  return ent->fill_cache(dpp, y, cb, FSEnt::FLAG_NONE);
+  return ent->fill_cache(dpp, y, cb, posix::FSEnt::FLAG_NONE);
 }
 
 int POSIXDriver::mint_listing_entry(const std::string &bname,
@@ -2768,7 +799,7 @@ int POSIXDriver::mint_listing_entry(const std::string &bname,
     if (ret < 0)
       return ret;
 
-    obj = b->get_object(decode_obj_key(bde.key.name));
+    obj = b->get_object(posix::decode_obj_key(bde.key.name));
     pobj = static_cast<POSIXObject *>(obj.get());
 
     if (!pobj->check_exists(nullptr)) {
@@ -3397,7 +1428,7 @@ void POSIXDriver::meta_list_keys_complete(void* handle)
 int POSIXBucket::fill_cache(const DoutPrefixProvider* dpp, optional_yield y,
                             fill_cache_cb_t& cb)
 {
-  return dir->fill_cache(dpp, y, cb, FSEnt::FLAG_NONE);
+  return dir->fill_cache(dpp, y, cb, posix::FSEnt::FLAG_NONE);
 }
 
 int POSIXBucket::list(const DoutPrefixProvider* dpp, ListParams& params,
@@ -3640,7 +1671,7 @@ int POSIXBucket::load_bucket(const DoutPrefixProvider* dpp, optional_yield y)
   }
 
   RGWBucketInfo bak_info = info;;
-  ret = decode_attr(attrs, RGW_POSIX_ATTR_BUCKET_INFO, info);
+  ret = posix::decode_attr(attrs, RGW_POSIX_ATTR_BUCKET_INFO, info);
   if (ret < 0) {
     // TODO dang: fake info up (UID to owner conversion?)
     info = bak_info;
@@ -3682,7 +1713,7 @@ int POSIXBucket::read_stats(const DoutPrefixProvider *dpp, optional_yield y,
       return 0;
     }
 
-    std::unique_ptr<FSEnt> dent;
+    std::unique_ptr<posix::FSEnt> dent;
     int ret = dir->get_ent(dpp, y, name, std::string(), dent);
     if (ret < 0) {
       ret = errno;
@@ -3936,7 +1967,7 @@ std::string POSIXBucket::get_fname()
 int POSIXBucket::rename(const DoutPrefixProvider* dpp, optional_yield y, Object* target_obj)
 {
   int ret;
-  Directory* dst_dir = dir->get_parent();
+  posix::Directory* dst_dir = dir->get_parent();
 
   info.bucket.name = target_obj->get_key().get_oid();
   ns.reset();
@@ -3949,7 +1980,7 @@ int POSIXBucket::rename(const DoutPrefixProvider* dpp, optional_yield y, Object*
       ldpp_dout(dpp, 0) << "ERROR: could not open target obj " << to->get_name() << dendl;
       return ret;
     }
-    dst_dir = static_cast<Directory *>(to->get_fsent());
+    dst_dir = static_cast<posix::Directory *>(to->get_fsent());
   }
 
   return dir->rename(dpp, y, dst_dir, get_fname());
@@ -3992,20 +2023,20 @@ int POSIXObject::delete_object(const DoutPrefixProvider* dpp,
    * changed — if the symlink now points to a delete marker, update
    * its cache entry to add FLAG_CURRENT so the LC can expire it */
   if (!get_key().instance.empty() && ent->get_parent()) {
-    auto* vdir = dynamic_cast<VersionedDirectory*>(ent->get_parent());
+    auto* vdir = dynamic_cast<posix::VersionedDirectory*>(ent->get_parent());
     if (vdir) {
-      std::unique_ptr<Symlink> sl =
-	std::make_unique<Symlink>(vdir->get_name(), vdir, driver->ctx());
+      std::unique_ptr<posix::Symlink> sl =
+	std::make_unique<posix::Symlink>(vdir->get_name(), vdir, driver->ctx());
       if (sl->stat(dpp) >= 0 && sl->exists()) {
 	auto* target = sl->get_target();
 	std::string cur_name = target->get_name();
 	if (!cur_name.empty()) {
-	  std::unique_ptr<FSEnt> cur_ent;
+	  std::unique_ptr<posix::FSEnt> cur_ent;
 	  ret = vdir->get_ent(dpp, y, cur_name, std::string(), cur_ent);
 	  if (ret == 0) {
 	    cur_ent->stat(dpp);
 	    rgw_bucket_dir_entry bde{};
-	    rgw_obj_key cur_key = decode_obj_key(cur_name);
+	    rgw_obj_key cur_key = posix::decode_obj_key(cur_name);
 	    cur_key.get_index_key(&bde.key);
 	    bde.flags = rgw_bucket_dir_entry::FLAG_VER
 	      | rgw_bucket_dir_entry::FLAG_CURRENT;
@@ -4019,7 +2050,7 @@ int POSIXObject::delete_object(const DoutPrefixProvider* dpp,
 	      Attrs attrs;
 	      bufferlist bl;
 	      if (cur_ent->read_attrs(dpp, y, attrs) >= 0 &&
-		  ::rgw::sal::get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
+		  posix::get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
 		bde.flags |= rgw_bucket_dir_entry::FLAG_DELETE_MARKER;
 	      }
 	    }
@@ -4155,7 +2186,7 @@ int POSIXObject::copy_object(const ACLOwner& owner,
       attrs[RGW_ATTR_ETAG] = src_attrs[RGW_ATTR_ETAG];
     }
     if (!attrs[RGW_ATTR_TAIL_TAG].length() &&
-	rgw::sal::get_attr(src_attrs, RGW_ATTR_TAIL_TAG, tt)) {
+	posix::get_attr(src_attrs, RGW_ATTR_TAIL_TAG, tt)) {
       attrs[RGW_ATTR_TAIL_TAG] = tt;
     }
     break;
@@ -4181,15 +2212,15 @@ int POSIXObject::copy_object(const ACLOwner& owner,
 
   /* Some attrs always come from the source */
   bufferlist com;
-  if (rgw::sal::get_attr(src_attrs, RGW_ATTR_COMPRESSION, com)) {
+  if (posix::get_attr(src_attrs, RGW_ATTR_COMPRESSION, com)) {
     attrs[RGW_ATTR_COMPRESSION] = com;
   }
   bufferlist mpu;
-  if (rgw::sal::get_attr(src_attrs, RGW_POSIX_ATTR_MPUPLOAD, mpu)) {
+  if (posix::get_attr(src_attrs, RGW_POSIX_ATTR_MPUPLOAD, mpu)) {
     attrs[RGW_POSIX_ATTR_MPUPLOAD] = mpu;
   }
   bufferlist pot;
-  if (rgw::sal::get_attr(src_attrs, RGW_POSIX_ATTR_OBJECT_TYPE, pot)) {
+  if (posix::get_attr(src_attrs, RGW_POSIX_ATTR_OBJECT_TYPE, pot)) {
     attrs[RGW_POSIX_ATTR_OBJECT_TYPE] = pot;
   }
   return dobj->set_obj_attrs(dpp, &attrs, nullptr, y, rgw::sal::FLAG_LOG_OP);
@@ -4200,7 +2231,7 @@ int POSIXObject::list_parts(const DoutPrefixProvider* dpp, CephContext* cct,
 			    bool* truncated, list_parts_each_t&& each_func,
 			    optional_yield y)
 {
-  if (ent->get_type() != ObjectType::MULTIPART) {
+  if (ent->get_type() != posix::ObjectType::MULTIPART) {
     return 0;
   }
 
@@ -4334,7 +2365,7 @@ int POSIXObject::delete_obj_attrs(const DoutPrefixProvider* dpp, const char* att
     return ret;
   }
 
-  ret = remove_x_attr(dpp, y, ent->get_fd(), attr_name, get_name());
+  ret = posix::remove_x_attr(dpp, y, ent->get_fd(), attr_name, get_name());
   if (ret < 0) {
     ret = errno;
     ldpp_dout(dpp, 0) << "ERROR: could not remover attribute " << attr_name << " for " << get_name() << ": " << cpp_strerror(ret) << dendl;
@@ -4347,7 +2378,7 @@ int POSIXObject::delete_obj_attrs(const DoutPrefixProvider* dpp, const char* att
 bool POSIXObject::is_expired()
 {
   utime_t delete_at;
-  if (!decode_attr(state.attrset, RGW_ATTR_DELETE_AT, delete_at)) {
+  if (!posix::decode_attr(state.attrset, RGW_ATTR_DELETE_AT, delete_at)) {
     ldout(driver->ctx(), 0)
         << "ERROR: " << __func__
         << ": failed to decode " RGW_ATTR_DELETE_AT " attr" << dendl;
@@ -4378,7 +2409,7 @@ int MPPOSIXSerializer::try_lock(const DoutPrefixProvider *dpp, ceph::timespan du
   }
 
   POSIXBucket* b = static_cast<POSIXBucket*>(obj->get_bucket());
-  if (b->get_dir()->get_type() == ObjectType::MULTIPART && b->get_dir_fd(dpp) > 0) {
+  if (b->get_dir()->get_type() == posix::ObjectType::MULTIPART && b->get_dir_fd(dpp) > 0) {
     locked = true;
     return 0;
   }
@@ -4499,11 +2530,11 @@ int POSIXObject::set_cur_version(const DoutPrefixProvider *dpp)
       return ret;
     }
   }
-  if (ent->get_type() != ObjectType::VERSIONED) {
+  if (ent->get_type() != posix::ObjectType::VERSIONED) {
     return -EINVAL;
   }
-  VersionedDirectory* vdir = static_cast<VersionedDirectory*>(ent.get());
-  std::unique_ptr<FSEnt> child;
+  posix::VersionedDirectory* vdir = static_cast<posix::VersionedDirectory*>(ent.get());
+  std::unique_ptr<posix::FSEnt> child;
   int ret = vdir->get_ent(dpp, null_yield, get_fname(true), std::string(), child);
   if (ret < 0) {
     return ret;
@@ -4547,32 +2578,32 @@ int POSIXObject::stat(const DoutPrefixProvider* dpp)
   return 0;
 }
 
-int POSIXObject::make_ent(ObjectType type)
+int POSIXObject::make_ent(posix::ObjectType type)
 {
   if (ent)
     return 0;
 
   switch (type.type) {
-    case ObjectType::UNKNOWN:
+    case posix::ObjectType::UNKNOWN:
       return -EINVAL;
-    case ObjectType::FILE:
-      ent = std::make_unique<File>(
+    case posix::ObjectType::FILE:
+      ent = std::make_unique<posix::File>(
           get_fname(/*use_version=*/true), static_cast<POSIXBucket *>(bucket)->get_dir(), driver->ctx());
       break;
-    case ObjectType::DIRECTORY:
-      ent = std::make_unique<Directory>(
+    case posix::ObjectType::DIRECTORY:
+      ent = std::make_unique<posix::Directory>(
           get_fname(/*use_version=*/true), static_cast<POSIXBucket *>(bucket)->get_dir(), driver->ctx());
       break;
-    case ObjectType::SYMLINK:
-      ent = std::make_unique<Symlink>(
+    case posix::ObjectType::SYMLINK:
+      ent = std::make_unique<posix::Symlink>(
           get_fname(/*use_version=*/true), static_cast<POSIXBucket *>(bucket)->get_dir(), driver->ctx());
       break;
-    case ObjectType::MULTIPART:
-      ent = std::make_unique<MPDirectory>(
+    case posix::ObjectType::MULTIPART:
+      ent = std::make_unique<posix::MPDirectory>(
           get_fname(/*use_version=*/true), static_cast<POSIXBucket *>(bucket)->get_dir(), driver->ctx());
       break;
-    case ObjectType::VERSIONED:
-      ent = std::make_unique<VersionedDirectory>(
+    case posix::ObjectType::VERSIONED:
+      ent = std::make_unique<posix::VersionedDirectory>(
           get_fname(/*use_version=*/false), static_cast<POSIXBucket *>(bucket)->get_dir(), get_instance(), driver->ctx());
       break;
   }
@@ -4583,7 +2614,7 @@ int POSIXObject::make_ent(ObjectType type)
 int POSIXObject::get_owner(const DoutPrefixProvider *dpp, optional_yield y, std::unique_ptr<User> *owner)
 {
   ACLOwner acl_owner;
-  int ret = decode_acl_owner(get_attrs(), acl_owner);
+  int ret = posix::decode_acl_owner(get_attrs(), acl_owner);
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: " << __func__
         << ": No " RGW_ATTR_ACL " attr" << dendl;
@@ -4620,9 +2651,9 @@ int POSIXObject::open(const DoutPrefixProvider* dpp, bool create, bool temp_file
 	return ret;
       }
       if (versioned()) {
-        ret = make_ent(ObjectType::VERSIONED);
+        ret = make_ent(posix::ObjectType::VERSIONED);
       } else {
-        ret = make_ent(ObjectType::FILE);
+        ret = make_ent(posix::ObjectType::FILE);
       }
     }
   }
@@ -4738,7 +2769,7 @@ int POSIXObject::POSIXReadOp::prepare(optional_yield y, const DoutPrefixProvider
 
   if (params.part_num) {
     int pn = *params.part_num;
-    if (source->ent->get_type() != ObjectType::MULTIPART) {
+    if (source->ent->get_type() != posix::ObjectType::MULTIPART) {
       if (pn == 1) {
         params.parts_count = 1;
       } else {
@@ -4889,7 +2920,7 @@ int POSIXObject::generate_etag(const DoutPrefixProvider* dpp, optional_yield y)
 
 const std::string POSIXObject::get_fname(bool use_version)
 {
-  return get_key_fname(state.obj.key, use_version);
+  return posix::get_key_fname(state.obj.key, use_version);
 }
 
 std::string POSIXObject::gen_temp_fname()
@@ -5021,7 +3052,7 @@ int POSIXObject::copy(const DoutPrefixProvider *dpp, optional_yield y,
   if (!get_key().instance.empty())
     dst_key.instance = get_key().instance;
 
-  return ent->copy(dpp, y, db->get_dir(), get_key_fname(dst_key, /*use_version=*/true));
+  return ent->copy(dpp, y, db->get_dir(), posix::get_key_fname(dst_key, /*use_version=*/true));
 }
 
 void POSIXMPObj::init_gen(POSIXDriver* driver, const std::string& _oid, ACLOwner& _owner)
@@ -5043,7 +3074,7 @@ int POSIXMultipartPart::load(const DoutPrefixProvider* dpp, optional_yield y,
     return 0;
   }
 
-  part_file = std::make_unique<File>(get_key_fname(key, false), upload->get_shadow()->get_dir(), driver->ctx());
+  part_file = std::make_unique<posix::File>(posix::get_key_fname(key, false), upload->get_shadow()->get_dir(), driver->ctx());
 
   // Stat the part_file object to get things like size
   int ret = part_file->stat(dpp, y);
@@ -5057,7 +3088,7 @@ int POSIXMultipartPart::load(const DoutPrefixProvider* dpp, optional_yield y,
     return ret;
   }
 
-  ret = decode_attr(attrs, RGW_POSIX_ATTR_MPUPLOAD, info);
+  ret = posix::decode_attr(attrs, RGW_POSIX_ATTR_MPUPLOAD, info);
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: " << __func__ << ": failed to decode part info: " << key << dendl;
     return ret;
@@ -5073,7 +3104,7 @@ int POSIXMultipartUpload::load(const DoutPrefixProvider *dpp, bool create)
     POSIXBucket* pb = static_cast<POSIXBucket*>(bucket);
     std::optional<std::string> ns{mp_ns};
 
-    std::unique_ptr<Directory> mpdir = std::make_unique<MPDirectory>(bucket_fname(get_meta(), ns), pb->get_dir(), driver->ctx());
+    std::unique_ptr<posix::Directory> mpdir = std::make_unique<posix::MPDirectory>(bucket_fname(get_meta(), ns), pb->get_dir(), driver->ctx());
 
     shadow = std::make_unique<POSIXBucket>(driver, std::move(mpdir), rgw_bucket(std::string(), get_meta()), mp_ns);
 
@@ -5291,7 +3322,7 @@ int POSIXMultipartUpload::complete(const DoutPrefixProvider *dpp,
     }
 
     for (auto obj_iter = parts.begin(); etags_iter != part_etags.end() && obj_iter != parts.end(); ++etags_iter, ++obj_iter, ++handled_parts) {
-      POSIXMultipartPart* part = static_cast<rgw::sal::POSIXMultipartPart*>(obj_iter->second.get());
+      POSIXMultipartPart* part = static_cast<POSIXMultipartPart*>(obj_iter->second.get());
       uint64_t part_size = part->get_size();
       if (handled_parts < (int)part_etags.size() - 1 &&
           part_size < min_part_size) {
@@ -5402,7 +3433,7 @@ int POSIXMultipartUpload::complete(const DoutPrefixProvider *dpp,
           return -ENOENT;
         }
         bufferlist bl;
-        if (!get_attr(tobj->get_attrs(), RGW_ATTR_ETAG, bl)) {
+        if (!posix::get_attr(tobj->get_attrs(), RGW_ATTR_ETAG, bl)) {
           return -ERR_PRECONDITION_FAILED;
         }
         std::string if_match_str = rgw_string_unquote(if_match);
@@ -5418,7 +3449,7 @@ int POSIXMultipartUpload::complete(const DoutPrefixProvider *dpp,
         }
       } else if (target_exists) {
         bufferlist bl;
-        if (get_attr(tobj->get_attrs(), RGW_ATTR_ETAG, bl)) {
+        if (posix::get_attr(tobj->get_attrs(), RGW_ATTR_ETAG, bl)) {
           std::string if_nomatch_str = rgw_string_unquote(if_nomatch);
           if (if_nomatch_str == bl.to_str()) {
             return -ERR_PRECONDITION_FAILED;
@@ -5495,7 +3526,7 @@ int POSIXMultipartUpload::get_info(const DoutPrefixProvider *dpp, optional_yield
                           << get_key() << dendl;
         return ret;
       }
-      ret = decode_attr(meta_obj->get_attrs(), RGW_POSIX_ATTR_MPUPLOAD, mp_obj);
+      ret = posix::decode_attr(meta_obj->get_attrs(), RGW_POSIX_ATTR_MPUPLOAD, mp_obj);
       if (ret < 0) {
 	ldpp_dout(dpp, 0) << " ERROR: could not get meta object attrs for mp upload "
 	  << get_key() << dendl;
@@ -5591,7 +3622,7 @@ int POSIXMultipartWriter::complete(
       if (ret < 0) {
         return -ERR_PRECONDITION_FAILED;
       }
-      if (!get_attr(attrs, RGW_ATTR_ETAG, bl)) {
+      if (!posix::get_attr(attrs, RGW_ATTR_ETAG, bl)) {
         return -ERR_PRECONDITION_FAILED;
       }
       if (strncmp(if_match, bl.c_str(), bl.length()) != 0) {
@@ -5630,9 +3661,9 @@ int POSIXAtomicWriter::prepare(optional_yield y)
   int ret;
 
   if (obj->versioned()) {
-    ret = obj->make_ent(ObjectType::VERSIONED);
+    ret = obj->make_ent(posix::ObjectType::VERSIONED);
   } else {
-    ret = obj->make_ent(ObjectType::FILE);
+    ret = obj->make_ent(posix::ObjectType::FILE);
   }
   if (ret < 0) {
     return ret;
@@ -5675,7 +3706,7 @@ int POSIXAtomicWriter::complete(size_t accounted_size, const std::string& etag,
 	return -ENOENT;
       }
       bufferlist bl;
-      if (!get_attr(obj->get_attrs(), RGW_ATTR_ETAG, bl)) {
+      if (!posix::get_attr(obj->get_attrs(), RGW_ATTR_ETAG, bl)) {
         return -ERR_PRECONDITION_FAILED;
       }
       std::string if_match_str = rgw_string_unquote(if_match);
@@ -5692,7 +3723,7 @@ int POSIXAtomicWriter::complete(size_t accounted_size, const std::string& etag,
       }
     } else {
       bufferlist bl;
-      if (get_attr(obj->get_attrs(), RGW_ATTR_ETAG, bl)) {
+      if (posix::get_attr(obj->get_attrs(), RGW_ATTR_ETAG, bl)) {
         std::string if_nomatch_str = rgw_string_unquote(if_nomatch);
         if (if_nomatch_str.compare(0, bl.length(), bl.c_str(), bl.length()) == 0) {
           return -ERR_PRECONDITION_FAILED;

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -1,4 +1,4 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// -*- mode:C++; tab-width:8; c-basic-offset:2; ind
 // vim: ts=8 sw=2 sts=2 expandtab ft=cpp
 
 /*
@@ -15,357 +15,19 @@
 
 #pragma once
 
-#include "rgw_sal_filter.h"
 #include "rgw_sal_store.h"
+#include "fsent.h"
 #include "rgw_quota.h"
 #include "include/encoding.h"
 #include <cstdint>
 #include <memory>
 #include "common/dout.h"
-#include "bucket_cache.h"
 #include "user_cache.h"
 #include "posixDB.h"
 
 class RGWLC;
 
 namespace rgw { namespace sal {
-
-class POSIXDriver;
-class POSIXBucket;
-class POSIXObject;
-
-using DeleteResult = rgw::sal::Object::DeleteOp::Result;
-
-namespace posix {
-
-using BucketCache = file::listing::BucketCache<POSIXDriver, POSIXBucket>;
-
-/* integration w/bucket listing cache */
-using fill_cache_cb_t = file::listing::fill_cache_cb_t;
-
-struct ObjectType {
-  enum Type {
-    UNKNOWN = 0,
-    FILE = 1,
-    DIRECTORY = 2,
-    VERSIONED = 3,
-    MULTIPART = 4,
-    SYMLINK = 5,
-  };
-  uint32_t type{UNKNOWN};
-
-  ObjectType &operator=(ObjectType::Type &&_t) {
-    type = _t;
-    return *this;
-  };
-
-  ObjectType() {}
-  ObjectType(Type _t) : type(_t){}
-
-  bool operator==(const ObjectType &t) const { return (type == t.type); }
-  bool operator==(const ObjectType::Type &t) const { return (type == t); }
-
-  void encode(bufferlist &bl) const {
-    ENCODE_START(1, 1, bl);
-    encode(type, bl);
-    ENCODE_FINISH(bl);
-  }
-
-  void decode(bufferlist::const_iterator &bl) {
-    DECODE_START(1, bl);
-    ceph::decode(type, bl);
-    DECODE_FINISH(bl);
-  }
-  friend inline std::ostream &operator<<(std::ostream &out,
-                                         const ObjectType &t) {
-    switch (t.type) {
-    case UNKNOWN:
-      out << "UNKNOWN";
-      break;
-    case FILE:
-      out << "FILE";
-      break;
-    case DIRECTORY:
-      out << "DIRECTORY";
-      break;
-    case VERSIONED:
-      out << "VERSIONED";
-      break;
-    case MULTIPART:
-      out << "MULTIPART";
-      break;
-    case SYMLINK:
-      out << "SYMLINK";
-      break;
-    }
-    return out;
-  }
-};
-WRITE_CLASS_ENCODER(ObjectType);
-
-class Directory;
-
-class FSEnt {
-protected:
-  std::string fname;
-  Directory* parent;
-  int fd{-1};
-  bool need_fsync{false};
-  bool exist{false};
-  struct statx stx;
-  bool stat_done{false};
-  CephContext* ctx;
-
-public:
-  static constexpr uint32_t FLAG_NONE =      0x0;
-  static constexpr uint32_t FLAG_CURRENT =   0x2;
-  static constexpr uint32_t FLAG_DELETE_MARKER =   0x4;
-
-  FSEnt(std::string _name, Directory* _parent, CephContext* _ctx) : fname(_name), parent(_parent), ctx(_ctx) {}
-  FSEnt(std::string _name, Directory* _parent, struct statx& _stx, CephContext* _ctx) : fname(_name), parent(_parent), exist(true), stx(_stx), stat_done(true), ctx(_ctx) {}
-  FSEnt(const FSEnt& _e) :
-    fname(_e.fname),
-    parent(_e.parent),
-    exist(_e.exist),
-    stx(_e.stx),
-    stat_done(_e.stat_done),
-    ctx(_e.ctx)
-  { }
-
-  virtual ~FSEnt() { }
-
-  int get_fd() { return fd; };
-  std::string& get_name() { return fname; }
-  Directory* get_parent() { return parent; }
-  bool exists() { return exist; }
-  struct statx& get_stx() { return stx; }
-  virtual ObjectType get_type() { return ObjectType::UNKNOWN; };
-
-  virtual int create(const DoutPrefixProvider *dpp, bool* existed = nullptr, bool temp_file = false) = 0;
-  virtual int open(const DoutPrefixProvider *dpp) = 0;
-  virtual int close() = 0;
-  virtual int stat(const DoutPrefixProvider *dpp, bool force = false);
-  virtual int remove(const DoutPrefixProvider* dpp, optional_yield y, bool delete_children, DeleteResult* result) = 0;
-  virtual int write(int64_t ofs, bufferlist& bl, const DoutPrefixProvider* dpp, optional_yield y) = 0;
-  virtual int read(int64_t ofs, int64_t end, bufferlist& bl, const DoutPrefixProvider* dpp, optional_yield y) = 0;
-  virtual int write_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs, Attrs* extra_attrs);
-  virtual int read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs);
-  virtual int copy(const DoutPrefixProvider *dpp, optional_yield y, Directory* dst_dir, const std::string& name) = 0;
-  virtual int link_temp_file(const DoutPrefixProvider* dpp, optional_yield y, std::string target_fname) = 0;
-  virtual std::unique_ptr<FSEnt> clone_base() = 0;
-  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags);
-  virtual std::string get_cur_version() { return ""; };
-};
-
-class File : public FSEnt {
-protected:
-
-public:
-  File(std::string _name, Directory* _parent, CephContext* _ctx) : FSEnt(_name, _parent, _ctx)
-    {}
-  File(std::string _name, Directory* _parent, struct statx& _stx, CephContext* _ctx) : FSEnt(_name, _parent, _stx, _ctx)
-    {}
-  File(const File& _f) : FSEnt(_f) {}
-  virtual ~File() { close(); }
-
-  virtual uint64_t get_size() { return stx.stx_size; }
-  virtual ObjectType get_type() override { return ObjectType::FILE; };
-
-
-  virtual int create(const DoutPrefixProvider *dpp, bool* existed = nullptr, bool temp_file = false) override;
-  virtual int open(const DoutPrefixProvider *dpp) override;
-  virtual int close() override;
-  virtual int stat(const DoutPrefixProvider *dpp, bool force = false) override;
-  virtual int remove(const DoutPrefixProvider* dpp, optional_yield y, bool delete_children, DeleteResult* result) override;
-  virtual int write(int64_t ofs, bufferlist& bl, const DoutPrefixProvider* dpp, optional_yield y) override;
-  virtual int read(int64_t ofs, int64_t end, bufferlist& bl, const DoutPrefixProvider* dpp, optional_yield y) override;
-  virtual int copy(const DoutPrefixProvider *dpp, optional_yield y, Directory* dst_dir, const std::string& name) override;
-  virtual int link_temp_file(const DoutPrefixProvider* dpp, optional_yield y, std::string target_fname) override;
-  virtual std::unique_ptr<FSEnt> clone_base() override {
-    return std::make_unique<File>(*this);
-  }
-  std::unique_ptr<File> clone() {
-    return std::make_unique<File>(*this);
-  }
-};
-
-class Directory : public FSEnt {
-protected:
-
-public:
-  Directory(std::string _name, Directory* _parent, CephContext* _ctx) : FSEnt(_name, _parent, _ctx)
-    {}
-  Directory(std::string _name, Directory* _parent, struct statx& _stx, CephContext* _ctx) : FSEnt(_name, _parent, _stx, _ctx)
-    {}
-  Directory(const Directory& _d) : FSEnt(_d) {}
-  virtual ~Directory() { close(); }
-
-  virtual ObjectType get_type() override { return ObjectType::DIRECTORY; };
-
-  virtual bool file_exists(std::string& name);
-
-  virtual int create(const DoutPrefixProvider *dpp, bool* existed = nullptr, bool temp_file = false) override;
-  virtual int open(const DoutPrefixProvider *dpp) override;
-  virtual int close() override;
-  virtual int stat(const DoutPrefixProvider *dpp, bool force = false) override;
-  virtual int remove(const DoutPrefixProvider* dpp, optional_yield y, bool delete_children, DeleteResult* result) override;
-  template <typename F>
-    int for_each(const DoutPrefixProvider* dpp, const F& func);
-  virtual int rename(const DoutPrefixProvider* dpp, optional_yield y, Directory* dst_dir, std::string dst_name);
-  virtual int write(int64_t ofs, bufferlist& bl, const DoutPrefixProvider* dpp, optional_yield y) override;
-  virtual int read(int64_t ofs, int64_t end, bufferlist& bl, const DoutPrefixProvider* dpp, optional_yield y) override;
-  virtual std::unique_ptr<FSEnt> clone_base() override {
-    return std::make_unique<Directory>(*this);
-  }
-  virtual std::unique_ptr<Directory> clone_dir() {
-    return std::make_unique<Directory>(*this);
-  }
-  std::unique_ptr<Directory> clone() {
-    return std::make_unique<Directory>(*this);
-  }
-  virtual int copy(const DoutPrefixProvider *dpp, optional_yield y, Directory* dst_dir, const std::string& name) override;
-  virtual int link_temp_file(const DoutPrefixProvider* dpp, optional_yield y, std::string target_fname) override;
-  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags) override;
-
-  int get_ent(const DoutPrefixProvider *dpp, optional_yield y, const std::string& name, const std::string& version, std::unique_ptr<FSEnt>& ent);
-};
-
-class Symlink: public File {
-  std::unique_ptr<FSEnt> target;
-public:
-  Symlink(std::string _name, Directory* _parent, std::string _tgt, CephContext* _ctx) :
-    File(_name, _parent, _ctx)
-    { fill_target(nullptr, parent, fname,_tgt, target, _ctx); }
-  Symlink(std::string _name, Directory* _parent, CephContext* _ctx) :
-    File(_name, _parent, _ctx)
-    {}
-  Symlink(std::string _name, Directory* _parent, struct statx& _stx, std::string _tgt, CephContext* _ctx) :
-    File(_name, _parent, _stx, _ctx)
-    { fill_target(nullptr, parent, fname,_tgt, target, _ctx); }
-  Symlink(std::string _name, Directory* _parent, struct statx& _stx, CephContext* _ctx) :
-    File(_name, _parent, _stx, _ctx)
-    {}
-  Symlink(const Symlink& _s) : File(_s) {}
-  virtual ~Symlink() { close(); }
-
-  static int fill_target(const DoutPrefixProvider *dpp, Directory* parent, std::string sname, std::string tname, std::unique_ptr<FSEnt>& ent, CephContext* _ctx);
-
-  virtual ObjectType get_type() override { return ObjectType::SYMLINK; };
-  virtual int create(const DoutPrefixProvider *dpp, bool* existed = nullptr, bool temp_file = false) override;
-  virtual int stat(const DoutPrefixProvider *dpp, bool force = false) override;
-  virtual int read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs) override;
-  FSEnt* get_target() { return target.get(); }
-  virtual std::unique_ptr<FSEnt> clone_base() override {
-    return std::make_unique<Symlink>(*this);
-  }
-  std::unique_ptr<Symlink> clone() {
-    return std::make_unique<Symlink>(*this);
-  }
-  virtual int copy(const DoutPrefixProvider *dpp, optional_yield y, Directory* dst_dir, const std::string& name) override;
-};
-
-class MPDirectory : public Directory {
-  std::string tmpname;
-protected:
-  std::map<std::string, int64_t> parts;
-  std::unique_ptr<FSEnt> cur_read_part;
-
-public:
-  MPDirectory(std::string _name, Directory* _parent, CephContext* _ctx) : Directory(_name, _parent, _ctx)
-    {}
-  MPDirectory(std::string _name, Directory* _parent, struct statx& _stx, CephContext* _ctx) : Directory(_name, _parent, _stx, _ctx)
-    {}
-  MPDirectory(const MPDirectory& _d) :
-    Directory(_d),
-    parts(_d.parts)
-    { if (_d.cur_read_part) cur_read_part = _d.cur_read_part->clone_base(); }
-  virtual ~MPDirectory() { close(); }
-
-  virtual ObjectType get_type() override { return ObjectType::MULTIPART; };
-  virtual int create(const DoutPrefixProvider *dpp, bool* existed = nullptr, bool temp_file = false) override;
-  virtual int read(int64_t ofs, int64_t end, bufferlist& bl, const DoutPrefixProvider* dpp, optional_yield y) override;
-  virtual int link_temp_file(const DoutPrefixProvider* dpp, optional_yield y, std::string target_fname) override;
-  virtual int remove(const DoutPrefixProvider* dpp, optional_yield y, bool delete_children, DeleteResult* result) override;
-  virtual int stat(const DoutPrefixProvider *dpp, bool force = false) override;
-  std::unique_ptr<File> get_part_file(int partnum);
-  const std::map<std::string, int64_t>& get_parts() const { return parts; }
-  virtual std::unique_ptr<FSEnt> clone_base() override {
-    return std::make_unique<MPDirectory>(*this);
-  }
-  virtual std::unique_ptr<Directory> clone_dir() override {
-    return std::make_unique<MPDirectory>(*this);
-  }
-  std::unique_ptr<MPDirectory> clone() {
-    return std::make_unique<MPDirectory>(*this);
-  }
-  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags) override;
-};
-
-class VersionedDirectory : public Directory {
-protected:
-  std::string instance_id;
-  std::unique_ptr<FSEnt> cur_version;
-
-public:
-  VersionedDirectory(std::string _name, Directory* _parent, CephContext* _ctx) : Directory(_name, _parent, _ctx)
-    {}
-  VersionedDirectory(std::string _name, Directory* _parent, std::string _instance_id, CephContext* _ctx) :
-    Directory(_name, _parent, _ctx),
-    instance_id(_instance_id)
-    {}
-  VersionedDirectory(std::string _name, Directory* _parent, std::unique_ptr<FSEnt>&& _cur, CephContext* _ctx) :
-    Directory(_name, _parent, _ctx),
-    cur_version(std::move(_cur))
-    {}
-  VersionedDirectory(std::string _name, Directory* _parent, struct statx& _stx, CephContext* _ctx) : Directory(_name, _parent, _stx, _ctx)
-    {}
-  VersionedDirectory(std::string _name, Directory* _parent, std::string _instance_id, struct statx& _stx, CephContext* _ctx) :
-    Directory(_name, _parent, _stx, _ctx),
-    instance_id(_instance_id)
-    {}
-  VersionedDirectory(const VersionedDirectory& _d) :
-    Directory(_d),
-    instance_id(_d.instance_id),
-    cur_version(_d.cur_version ? _d.cur_version->clone_base() : nullptr)
-    { }
-  VersionedDirectory(const Directory& _d) :
-    Directory(_d)
-    { }
-  virtual ~VersionedDirectory() { close(); }
-
-  virtual ObjectType get_type() override { return ObjectType::VERSIONED; };
-  virtual int create(const DoutPrefixProvider *dpp, bool* existed = nullptr, bool temp_file = false) override;
-  virtual int open(const DoutPrefixProvider *dpp) override;
-  virtual int stat(const DoutPrefixProvider *dpp, bool force = false) override;
-  virtual int read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs) override;
-  virtual int write_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs& attrs, Attrs* extra_attrs) override;
-  virtual int write(int64_t ofs, bufferlist& bl, const DoutPrefixProvider* dpp, optional_yield y) override;
-  virtual int read(int64_t ofs, int64_t end, bufferlist& bl, const DoutPrefixProvider* dpp, optional_yield y) override;
-  virtual int link_temp_file(const DoutPrefixProvider* dpp, optional_yield y, std::string target_fname) override;
-  virtual int remove(const DoutPrefixProvider* dpp, optional_yield y, bool delete_children, DeleteResult* result) override;
-  virtual std::string get_cur_version() override;
-  std::string get_new_instance();
-  int remove_symlink(const DoutPrefixProvider *dpp, optional_yield y, std::string match = "");
-  int add_file(const DoutPrefixProvider *dpp, std::unique_ptr<FSEnt>&& file, bool* existed = nullptr, bool temp_file = false);
-  int add_delete_marker(const DoutPrefixProvider* dpp, optional_yield y, std::unique_ptr<File>& marker, const std::string &name);
-  FSEnt* get_cur_version_ent() { return cur_version.get(); };
-  int set_cur_version_ent(const DoutPrefixProvider *dpp, FSEnt* file);
-  virtual std::unique_ptr<FSEnt> clone_base() override {
-    return std::make_unique<VersionedDirectory>(*this);
-  }
-  virtual std::unique_ptr<Directory> clone_dir() override {
-    return std::make_unique<VersionedDirectory>(*this);
-  }
-  std::unique_ptr<VersionedDirectory> clone() {
-    return std::make_unique<VersionedDirectory>(*this);
-  }
-  virtual int copy(const DoutPrefixProvider *dpp, optional_yield y, Directory* dst_dir, const std::string& name) override;
-  virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags) override;
-};
-
-std::string get_key_fname(rgw_obj_key& key, bool use_version);
-
-} // namespace posix
 
 class POSIXZoneGroup : public StoreZoneGroup {
   POSIXDriver* store;
@@ -402,7 +64,7 @@ public:
     return 1;
   }
   virtual int get_placement_tier(const rgw_placement_rule& rule,
-				 std::unique_ptr<PlacementTier>* tier) {
+				 std::unique_ptr<PlacementTier>* tier) override {
     return -1;
   }
   virtual int get_zone_by_id(const std::string& id, std::unique_ptr<Zone>* zone) override {
@@ -522,7 +184,7 @@ public:
     return *this;
   }
 
-  virtual int initialize(CephContext *cct, const DoutPrefixProvider *dpp);
+  virtual int initialize(CephContext *cct, const DoutPrefixProvider *dpp) override;
   virtual const std::string get_name() const override { return "posix"; }
   virtual std::string get_cluster_id(const DoutPrefixProvider* dpp,  optional_yield y) override { return "PLACEHOLDER"; };
   virtual std::unique_ptr<User> get_user(const rgw_user& u) override;
@@ -675,7 +337,7 @@ public:
   virtual int list_all_zones(const DoutPrefixProvider* dpp, std::list<std::string>& zone_ids) override;
   virtual int cluster_stat(RGWClusterStat& stats) override;
   virtual std::unique_ptr<Lifecycle> get_lifecycle(void) override;
-  virtual std::unique_ptr<Restore> get_restore(void) { return nullptr; }
+  virtual std::unique_ptr<Restore> get_restore(void) override { return nullptr; }
   virtual bool process_expired_objects(const DoutPrefixProvider *dpp, optional_yield y) override { return 0; }
 
   virtual std::unique_ptr<Notification> get_notification(rgw::sal::Object* obj, rgw::sal::Object* src_obj, req_state* s,
@@ -734,7 +396,7 @@ public:
 				      const std::string& topic_queue) override { return -ENOTSUP; }
 
   virtual RGWLC* get_rgwlc(void) override { return lc; }
-  virtual rgw::restore::Restore* get_rgwrestore(void) { return nullptr; }
+  virtual rgw::restore::Restore* get_rgwrestore(void) override { return nullptr; }
   virtual RGWCoroutinesManagerRegistry* get_cr_registry() override { return NULL; }
 
   virtual int log_usage(const DoutPrefixProvider *dpp, std::map<rgw_user_bucket, RGWUsageBatch>& usage_info, optional_yield y) override { return 0; }
@@ -1044,7 +706,7 @@ public:
   int rename(const DoutPrefixProvider* dpp, optional_yield y, Object* target_obj);
 
   /* enumerate all entries by callback, in any order */
-  int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, posix::fill_cache_cb_t& cb);
+  int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb);
 
   static MDB_cmp_func* lmdb_cmp() { return nullptr; }
 
@@ -1214,7 +876,7 @@ public:
   int get_owner(const DoutPrefixProvider *dpp, optional_yield y, std::unique_ptr<User> *owner);
   int copy(const DoutPrefixProvider *dpp, optional_yield y, POSIXBucket *sb,
            POSIXBucket *db, POSIXObject *dobj);
-  int fill_cache(const DoutPrefixProvider *dpp, optional_yield y, posix::fill_cache_cb_t& cb);
+  int fill_cache(const DoutPrefixProvider *dpp, optional_yield y, fill_cache_cb_t& cb);
   int set_cur_version(const DoutPrefixProvider *dpp);
   int stat(const DoutPrefixProvider *dpp);
   int make_ent(posix::ObjectType type);

--- a/src/test/rgw/test_rgw_posix_driver.cc
+++ b/src/test/rgw/test_rgw_posix_driver.cc
@@ -21,7 +21,6 @@
 #include "global/global_init.h"
 
 using namespace rgw::sal;
-using namespace posix;
 
 const std::string ATTR1{"attr1"};
 const std::string ATTR2{"attr2"};
@@ -31,8 +30,9 @@ const std::string ATTR_OBJECT_TYPE{"POSIX-Object-Type"};
 namespace sf = std::filesystem;
 class Environment* env;
 sf::path base_path{"posixtest"};
-std::unique_ptr<Directory> root;
+std::unique_ptr<posix::Directory> root;
 std::vector<const char*> args;
+uint64_t curver = UINT64_MAX - 1;
 
 class Environment : public ::testing::Environment {
 public:
@@ -59,7 +59,7 @@ public:
     dpp = nullptr;
     //dpp = new NoDoutPrefix(cct.get(), 1);
 
-    root = std::make_unique<Directory>(base_path, nullptr, cct.get());
+    root = std::make_unique<posix::Directory>(base_path, nullptr, cct.get());
     ASSERT_EQ(root->open(dpp), 0);
   }
 
@@ -77,51 +77,22 @@ static inline void add_attr(Attrs& attrs, const std::string& name, const std::st
   attrs[name] = bl;
 }
 
-static inline bool get_attr(Attrs& attrs, const char* name, bufferlist& bl)
-{
-  auto iter = attrs.find(name);
-  if (iter == attrs.end()) {
-    return false;
-  }
-
-  bl = iter->second;
-  return true;
-}
-
-template <typename F>
-static bool decode_attr(Attrs &attrs, const char *name, F &f) {
-  bufferlist bl;
-  if (!get_attr(attrs, name, bl)) {
-    return false;
-  }
-  F tmpf;
-  try {
-    auto bufit = bl.cbegin();
-    decode(tmpf, bufit);
-  } catch (buffer::error &err) {
-    return false;
-  }
-
-  f = tmpf;
-  return true;
-}
-
-class TestDirectory : public Directory {
+class TestDirectory : public posix::Directory {
 public:
-  TestDirectory(std::string _name, Directory* _parent, CephContext* _ctx) : Directory(_name, _parent, _ctx)
+  TestDirectory(std::string _name, posix::Directory* _parent, CephContext* _ctx) : posix::Directory(_name, _parent, _ctx)
     {}
-  TestDirectory(std::string _name, Directory* _parent, struct statx& _stx, CephContext* _ctx) : Directory(_name, _parent, _stx, _ctx)
+  TestDirectory(std::string _name, posix::Directory* _parent, struct statx& _stx, CephContext* _ctx) : posix::Directory(_name, _parent, _stx, _ctx)
     {}
   virtual ~TestDirectory() { close(); }
 
   bool get_stat_done() { return stat_done; }
 };
 
-class TestFile : public File {
+class TestFile : public posix::File {
 public:
-  TestFile(std::string _name, Directory* _parent, CephContext* _ctx) : File(_name, _parent, _ctx)
+  TestFile(std::string _name, posix::Directory* _parent, CephContext* _ctx) : posix::File(_name, _parent, _ctx)
     {}
-  TestFile(std::string _name, Directory* _parent, struct statx& _stx, CephContext* _ctx) : File(_name, _parent, _stx, _ctx)
+  TestFile(std::string _name, posix::Directory* _parent, struct statx& _stx, CephContext* _ctx) : posix::File(_name, _parent, _stx, _ctx)
     {}
   virtual ~TestFile() { close(); }
 
@@ -138,14 +109,30 @@ std::string get_test_name()
   return suitename + testname;
 }
 
+template <typename F>
+static bool test_decode_attr(Attrs &attrs, const char *name, F &f) {
+  bufferlist bl;
+  if (!posix::get_attr(attrs, name, bl)) {
+    return false;
+  }
+  try {
+    auto bufit = bl.cbegin();
+    decode(f, bufit);
+  } catch (buffer::error &err) {
+    return false;
+  }
 
-// Directory
+  return true;
+}
+
+
+// posix::Directory
 
 TEST(FSEnt, DirCreate)
 {
   std::string dirname = get_test_name();
   sf::path tp{base_path / dirname};
-  std::unique_ptr<Directory> testdir = std::make_unique<Directory>(dirname, root.get(), env->cct.get());
+  std::unique_ptr<posix::Directory> testdir = std::make_unique<posix::Directory>(dirname, root.get(), env->cct.get());
 
   EXPECT_FALSE(sf::exists(tp));
 
@@ -178,7 +165,7 @@ TEST(FSEnt, DirBase)
   EXPECT_EQ(testdir->get_name(), dirname);
   EXPECT_EQ(testdir->get_parent(), root.get());
   EXPECT_FALSE(testdir->exists());
-  EXPECT_EQ(testdir->get_type(), ObjectType::DIRECTORY);
+  EXPECT_EQ(testdir->get_type(), posix::ObjectType::DIRECTORY);
   EXPECT_FALSE(testdir->get_stat_done());
 
   ret = testdir->open(env->dpp);
@@ -204,19 +191,19 @@ TEST(FSEnt, DirBase)
   EXPECT_EQ(ret, 0);
   EXPECT_EQ(attrs.size(), 4);
   std::string val;
-  bool success = decode_attr(attrs, ATTR1.c_str(), val);
+  bool success = test_decode_attr(attrs, ATTR1.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR1);
-  success = decode_attr(attrs, ATTR2.c_str(), val);
+  success = test_decode_attr(attrs, ATTR2.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR2);
-  success = decode_attr(attrs, ATTR3.c_str(), val);
+  success = test_decode_attr(attrs, ATTR3.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR3);
-  ObjectType type;
-  success = decode_attr(attrs, ATTR_OBJECT_TYPE.c_str(), type);
+  posix::ObjectType type;
+  success = posix::decode_attr(attrs, ATTR_OBJECT_TYPE.c_str(), type);
   EXPECT_TRUE(success);
-  EXPECT_EQ(type.type, ObjectType::DIRECTORY);
+  EXPECT_EQ(type.type, posix::ObjectType::DIRECTORY);
 
   ret = testdir->close();
   EXPECT_EQ(ret, 0);
@@ -255,13 +242,13 @@ TEST(FSEnt, DirBase)
   ret = copydir->read_attrs(env->dpp, null_yield, attrs);
   EXPECT_EQ(ret, 0);
   EXPECT_EQ(attrs.size(), 4);
-  success = decode_attr(attrs, ATTR1.c_str(), val);
+  success = test_decode_attr(attrs, ATTR1.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR1);
-  success = decode_attr(attrs, ATTR2.c_str(), val);
+  success = test_decode_attr(attrs, ATTR2.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR2);
-  success = decode_attr(attrs, ATTR3.c_str(), val);
+  success = test_decode_attr(attrs, ATTR3.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR3);
 
@@ -269,10 +256,10 @@ TEST(FSEnt, DirBase)
   EXPECT_EQ(ret, 0);
   EXPECT_EQ(copydir->get_fd(), -1);
 
-  std::unique_ptr<FSEnt> ent;
+  std::unique_ptr<posix::FSEnt> ent;
   ret = root->get_ent(env->dpp, null_yield, dirname, std::string(), ent);
   EXPECT_EQ(ret, 0);
-  EXPECT_EQ(ent->get_type(), ObjectType::DIRECTORY);
+  EXPECT_EQ(ent->get_type(), posix::ObjectType::DIRECTORY);
 
   ret = testdir->remove(env->dpp, null_yield, false, nullptr);
   EXPECT_EQ(ret, 0);
@@ -284,7 +271,7 @@ TEST(FSEnt, DirAddDir)
   bool existed{false};
   std::string dirname = get_test_name();
   sf::path tp{base_path / dirname};
-  std::unique_ptr<Directory> testdir = std::make_unique<Directory>(dirname, root.get(), env->cct.get());
+  std::unique_ptr<posix::Directory> testdir = std::make_unique<posix::Directory>(dirname, root.get(), env->cct.get());
   int ret = testdir->create(env->dpp, &existed);
   EXPECT_EQ(ret, 0);
 
@@ -293,7 +280,7 @@ TEST(FSEnt, DirAddDir)
 
   std::string subdirname{"SubDir"};
   sf::path sp{base_path / dirname / subdirname};
-  std::unique_ptr<Directory> subdir = std::make_unique<Directory>(subdirname, testdir.get(), env->cct.get());
+  std::unique_ptr<posix::Directory> subdir = std::make_unique<posix::Directory>(subdirname, testdir.get(), env->cct.get());
   ret = subdir->create(env->dpp, &existed);
   EXPECT_EQ(ret, 0);
   EXPECT_FALSE(existed);
@@ -305,7 +292,7 @@ TEST(FSEnt, DirAddDir)
 
   std::string subsubdirname{"SubSubDir"};
   sf::path ssp{base_path / dirname / subdirname / subsubdirname };
-  std::unique_ptr<Directory> subsubdir = std::make_unique<Directory>(subsubdirname, subdir.get(), env->cct.get());
+  std::unique_ptr<posix::Directory> subsubdir = std::make_unique<posix::Directory>(subsubdirname, subdir.get(), env->cct.get());
   ret = subsubdir->create(env->dpp, &existed);
   EXPECT_EQ(ret, 0);
   EXPECT_FALSE(existed);
@@ -318,7 +305,7 @@ TEST(FSEnt, DirRename)
   bool existed{false};
   std::string dirname = get_test_name();
   sf::path tp{base_path / dirname};
-  std::unique_ptr<Directory> testdir = std::make_unique<Directory>(dirname, root.get(), env->cct.get());
+  std::unique_ptr<posix::Directory> testdir = std::make_unique<posix::Directory>(dirname, root.get(), env->cct.get());
   int ret = testdir->create(env->dpp, &existed);
   EXPECT_EQ(ret, 0);
 
@@ -327,7 +314,7 @@ TEST(FSEnt, DirRename)
 
   std::string subdirname{"SubDir"};
   sf::path sp{base_path / dirname / subdirname};
-  std::unique_ptr<Directory> subdir = std::make_unique<Directory>(subdirname, testdir.get(), env->cct.get());
+  std::unique_ptr<posix::Directory> subdir = std::make_unique<posix::Directory>(subdirname, testdir.get(), env->cct.get());
   ret = subdir->create(env->dpp, &existed);
   EXPECT_EQ(ret, 0);
   EXPECT_FALSE(existed);
@@ -348,7 +335,7 @@ TEST(FSEnt, DirRename)
 }
 
 
-// File
+// posix::File
 
 TEST(FSEnt, FileCreateReal)
 {
@@ -410,7 +397,7 @@ TEST(FSEnt, FileBase)
   EXPECT_EQ(testfile->get_name(), fname);
   EXPECT_EQ(testfile->get_parent(), root.get());
   EXPECT_FALSE(testfile->exists());
-  EXPECT_EQ(testfile->get_type(), ObjectType::FILE);
+  EXPECT_EQ(testfile->get_type(), posix::ObjectType::FILE);
   EXPECT_FALSE(testfile->get_stat_done());
 
   ret = testfile->open(env->dpp);
@@ -436,19 +423,19 @@ TEST(FSEnt, FileBase)
   EXPECT_EQ(ret, 0);
   EXPECT_EQ(attrs.size(), 4);
   std::string val;
-  bool success = decode_attr(attrs, ATTR1.c_str(), val);
+  bool success = test_decode_attr(attrs, ATTR1.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR1);
-  success = decode_attr(attrs, ATTR2.c_str(), val);
+  success = test_decode_attr(attrs, ATTR2.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR2);
-  success = decode_attr(attrs, ATTR3.c_str(), val);
+  success = test_decode_attr(attrs, ATTR3.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR3);
-  ObjectType type;
-  success = decode_attr(attrs, ATTR_OBJECT_TYPE.c_str(), type);
+  posix::ObjectType type;
+  success = posix::decode_attr(attrs, ATTR_OBJECT_TYPE.c_str(), type);
   EXPECT_TRUE(success);
-  EXPECT_EQ(type.type, ObjectType::FILE);
+  EXPECT_EQ(type.type, posix::ObjectType::FILE);
 
   ret = testfile->close();
   EXPECT_EQ(ret, 0);
@@ -481,10 +468,10 @@ TEST(FSEnt, FileBase)
   EXPECT_EQ(ret, 0);
   EXPECT_EQ(copyfile->get_fd(), -1);
 
-  std::unique_ptr<FSEnt> ent;
+  std::unique_ptr<posix::FSEnt> ent;
   ret = root->get_ent(env->dpp, null_yield, fname, std::string(), ent);
   EXPECT_EQ(ret, 0);
-  EXPECT_EQ(ent->get_type(), ObjectType::FILE);
+  EXPECT_EQ(ent->get_type(), posix::ObjectType::FILE);
 
   ret = testfile->remove(env->dpp, null_yield, false, nullptr);
   EXPECT_EQ(ret, 0);
@@ -495,7 +482,7 @@ TEST(FSEnt, FileReadWrite)
 {
   std::string fname = get_test_name();
   sf::path tp{base_path / fname};
-  std::unique_ptr<File> testfile{std::make_unique<File>(fname, root.get(), env->cct.get())};
+  std::unique_ptr<posix::File> testfile{std::make_unique<posix::File>(fname, root.get(), env->cct.get())};
 
   int ret = testfile->create(env->dpp);
   EXPECT_EQ(ret, 0);
@@ -527,7 +514,7 @@ TEST(FSEnt, SymlinkBase)
   std::string fname = get_test_name();
   sf::path tp{base_path / fname};
   std::string target{"symlinktarget"};
-  std::unique_ptr<Symlink> testlink = std::make_unique<Symlink>(fname, root.get(), target, env->cct.get());
+  std::unique_ptr<posix::Symlink> testlink = std::make_unique<posix::Symlink>(fname, root.get(), target, env->cct.get());
 
   EXPECT_FALSE(sf::exists(tp));
 
@@ -542,12 +529,12 @@ TEST(FSEnt, SymlinkBase)
   EXPECT_EQ(testlink->get_name(), fname);
   EXPECT_EQ(testlink->get_parent(), root.get());
   EXPECT_FALSE(testlink->exists());
-  EXPECT_EQ(testlink->get_type(), ObjectType::SYMLINK);
+  EXPECT_EQ(testlink->get_type(), posix::ObjectType::SYMLINK);
 
-  std::unique_ptr<FSEnt> ent;
+  std::unique_ptr<posix::FSEnt> ent;
   ret = root->get_ent(env->dpp, null_yield, fname, std::string(), ent);
   EXPECT_EQ(ret, 0);
-  EXPECT_EQ(ent->get_type(), ObjectType::SYMLINK);
+  EXPECT_EQ(ent->get_type(), posix::ObjectType::SYMLINK);
 
 
   ret = testlink->remove(env->dpp, null_yield, false, nullptr);
@@ -559,7 +546,7 @@ TEST(FSEnt, MPDirBase)
 {
   std::string dirname = get_test_name();
   sf::path tp{base_path / dirname};
-  std::unique_ptr<MPDirectory> testdir = std::make_unique<MPDirectory>(dirname, root.get(), env->cct.get());
+  std::unique_ptr<posix::MPDirectory> testdir = std::make_unique<posix::MPDirectory>(dirname, root.get(), env->cct.get());
 
   EXPECT_FALSE(sf::exists(tp));
 
@@ -575,7 +562,7 @@ TEST(FSEnt, MPDirBase)
   EXPECT_EQ(testdir->get_name(), dirname);
   EXPECT_EQ(testdir->get_parent(), root.get());
   EXPECT_FALSE(testdir->exists());
-  EXPECT_EQ(testdir->get_type(), ObjectType::MULTIPART);
+  EXPECT_EQ(testdir->get_type(), posix::ObjectType::MULTIPART);
 
   ret = testdir->open(env->dpp);
   EXPECT_EQ(ret, 0);
@@ -599,19 +586,19 @@ TEST(FSEnt, MPDirBase)
   EXPECT_EQ(ret, 0);
   EXPECT_EQ(attrs.size(), 4);
   std::string val;
-  bool success = decode_attr(attrs, ATTR1.c_str(), val);
+  bool success = test_decode_attr(attrs, ATTR1.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR1);
-  success = decode_attr(attrs, ATTR2.c_str(), val);
+  success = test_decode_attr(attrs, ATTR2.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR2);
-  success = decode_attr(attrs, ATTR3.c_str(), val);
+  success = test_decode_attr(attrs, ATTR3.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR3);
-  ObjectType type;
-  success = decode_attr(attrs, ATTR_OBJECT_TYPE.c_str(), type);
+  posix::ObjectType type;
+  success = posix::decode_attr(attrs, ATTR_OBJECT_TYPE.c_str(), type);
   EXPECT_TRUE(success);
-  EXPECT_EQ(type.type, ObjectType::MULTIPART);
+  EXPECT_EQ(type.type, posix::ObjectType::MULTIPART);
 
   ret = testdir->close();
   EXPECT_EQ(ret, 0);
@@ -636,7 +623,7 @@ TEST(FSEnt, MPDirBase)
   EXPECT_TRUE(sf::exists(cp));
   EXPECT_TRUE(sf::is_directory(tp));
 
-  std::unique_ptr<MPDirectory> copydir = std::make_unique<MPDirectory>(copyname, root.get(), env->cct.get());
+  std::unique_ptr<posix::MPDirectory> copydir = std::make_unique<posix::MPDirectory>(copyname, root.get(), env->cct.get());
   ret = copydir->open(env->dpp);
   EXPECT_EQ(ret, 0);
   EXPECT_GT(copydir->get_fd(), 0);
@@ -649,13 +636,13 @@ TEST(FSEnt, MPDirBase)
   ret = copydir->read_attrs(env->dpp, null_yield, attrs);
   EXPECT_EQ(ret, 0);
   EXPECT_EQ(attrs.size(), 4);
-  success = decode_attr(attrs, ATTR1.c_str(), val);
+  success = test_decode_attr(attrs, ATTR1.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR1);
-  success = decode_attr(attrs, ATTR2.c_str(), val);
+  success = test_decode_attr(attrs, ATTR2.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR2);
-  success = decode_attr(attrs, ATTR3.c_str(), val);
+  success = test_decode_attr(attrs, ATTR3.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR3);
 
@@ -663,10 +650,10 @@ TEST(FSEnt, MPDirBase)
   EXPECT_EQ(ret, 0);
   EXPECT_EQ(copydir->get_fd(), -1);
 
-  std::unique_ptr<FSEnt> ent;
+  std::unique_ptr<posix::FSEnt> ent;
   ret = root->get_ent(env->dpp, null_yield, dirname, std::string(), ent);
   EXPECT_EQ(ret, 0);
-  EXPECT_EQ(ent->get_type(), ObjectType::MULTIPART);
+  EXPECT_EQ(ent->get_type(), posix::ObjectType::MULTIPART);
 
   ret = testdir->remove(env->dpp, null_yield, false, nullptr);
   EXPECT_EQ(ret, 0);
@@ -677,7 +664,7 @@ TEST(FSEnt, MPDirTemp)
 {
   std::string dirname = get_test_name();
   sf::path tp{base_path / dirname};
-  std::unique_ptr<MPDirectory> testdir = std::make_unique<MPDirectory>(dirname, root.get(), env->cct.get());
+  std::unique_ptr<posix::MPDirectory> testdir = std::make_unique<posix::MPDirectory>(dirname, root.get(), env->cct.get());
 
   EXPECT_FALSE(sf::exists(tp));
 
@@ -696,14 +683,14 @@ TEST(FSEnt, MPDirTemp)
 
   EXPECT_EQ(testdir->get_name(), dirname);
   EXPECT_EQ(testdir->get_parent(), root.get());
-  EXPECT_EQ(testdir->get_type(), ObjectType::MULTIPART);
+  EXPECT_EQ(testdir->get_type(), posix::ObjectType::MULTIPART);
 }
 
 TEST(FSEnt, MPDirReadWrite)
 {
   std::string dirname = get_test_name();
   sf::path tp{base_path / dirname};
-  std::unique_ptr<MPDirectory> testdir = std::make_unique<MPDirectory>(dirname, root.get(), env->cct.get());
+  std::unique_ptr<posix::MPDirectory> testdir = std::make_unique<posix::MPDirectory>(dirname, root.get(), env->cct.get());
   int ret = testdir->create(env->dpp, nullptr);
   EXPECT_EQ(ret, 0);
   EXPECT_TRUE(sf::exists(tp));
@@ -715,7 +702,7 @@ TEST(FSEnt, MPDirReadWrite)
   bufferlist write_bl;
   int total_len{0};
   for (int part_num = 0; part_num < 4; ++part_num) {
-    std::unique_ptr<File> testfile = testdir->get_part_file(part_num);
+    std::unique_ptr<posix::File> testfile = testdir->get_part_file(part_num);
     sf::path pp{tp / testfile->get_name()};
 
     ret = testfile->create(env->dpp, /*existed=*/nullptr, /*temp_file=*/false);
@@ -768,7 +755,7 @@ TEST(FSEnt, VerDirBase)
 {
   std::string dirname = get_test_name();
   sf::path tp{base_path / dirname};
-  std::unique_ptr<VersionedDirectory> testdir = std::make_unique<VersionedDirectory>(dirname, root.get(), env->cct.get());
+  std::unique_ptr<posix::VersionedDirectory> testdir = std::make_unique<posix::VersionedDirectory>(dirname, root.get(), env->cct.get());
 
   EXPECT_FALSE(sf::exists(tp));
 
@@ -785,7 +772,7 @@ TEST(FSEnt, VerDirBase)
   EXPECT_EQ(testdir->get_name(), dirname);
   EXPECT_EQ(testdir->get_parent(), root.get());
   EXPECT_FALSE(testdir->exists());
-  EXPECT_EQ(testdir->get_type(), ObjectType::VERSIONED);
+  EXPECT_EQ(testdir->get_type(), posix::ObjectType::VERSIONED);
 
   ret = testdir->open(env->dpp);
   EXPECT_EQ(ret, 0);
@@ -809,19 +796,19 @@ TEST(FSEnt, VerDirBase)
   EXPECT_EQ(ret, 0);
   EXPECT_EQ(attrs.size(), 4);
   std::string val;
-  bool success = decode_attr(attrs, ATTR1.c_str(), val);
+  bool success = test_decode_attr(attrs, ATTR1.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR1);
-  success = decode_attr(attrs, ATTR2.c_str(), val);
+  success = test_decode_attr(attrs, ATTR2.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR2);
-  success = decode_attr(attrs, ATTR3.c_str(), val);
+  success = test_decode_attr(attrs, ATTR3.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR3);
-  ObjectType type;
-  success = decode_attr(attrs, ATTR_OBJECT_TYPE.c_str(), type);
+  posix::ObjectType type;
+  success = test_decode_attr(attrs, ATTR_OBJECT_TYPE.c_str(), type);
   EXPECT_TRUE(success);
-  EXPECT_EQ(type.type, ObjectType::VERSIONED);
+  EXPECT_EQ(type.type, posix::ObjectType::VERSIONED);
 
   ret = testdir->close();
   EXPECT_EQ(ret, 0);
@@ -837,46 +824,12 @@ TEST(FSEnt, VerDirBase)
   ret = testdir->link_temp_file(env->dpp, null_yield, dirname);
   EXPECT_EQ(ret, -EINVAL);
 
-  std::string copyname{dirname + "-copy"};
-  sf::path cp{base_path / copyname};
-  sf::remove_all(cp);
-  EXPECT_FALSE(sf::exists(cp));
-  ret = testdir->copy(env->dpp, null_yield, root.get(), copyname);
-  EXPECT_EQ(ret, 0);
-  EXPECT_TRUE(sf::exists(cp));
-  EXPECT_TRUE(sf::is_directory(tp));
+  /* Can't test copy, there's no data in the object */
 
-  std::unique_ptr<VersionedDirectory> copydir = std::make_unique<VersionedDirectory>(copyname, root.get(), env->cct.get());
-  ret = copydir->open(env->dpp);
-  EXPECT_EQ(ret, 0);
-  EXPECT_GT(copydir->get_fd(), 0);
-
-  ret = copydir->stat(env->dpp, false);
-  EXPECT_EQ(ret, 0);
-  EXPECT_TRUE(S_ISDIR(copydir->get_stx().stx_mode));
-
-  attrs.clear();
-  ret = copydir->read_attrs(env->dpp, null_yield, attrs);
-  EXPECT_EQ(ret, 0);
-  EXPECT_EQ(attrs.size(), 4);
-  success = decode_attr(attrs, ATTR1.c_str(), val);
-  EXPECT_TRUE(success);
-  EXPECT_EQ(val, ATTR1);
-  success = decode_attr(attrs, ATTR2.c_str(), val);
-  EXPECT_TRUE(success);
-  EXPECT_EQ(val, ATTR2);
-  success = decode_attr(attrs, ATTR3.c_str(), val);
-  EXPECT_TRUE(success);
-  EXPECT_EQ(val, ATTR3);
-
-  ret = copydir->close();
-  EXPECT_EQ(ret, 0);
-  EXPECT_EQ(copydir->get_fd(), -1);
-
-  std::unique_ptr<FSEnt> ent;
+  std::unique_ptr<posix::FSEnt> ent;
   ret = root->get_ent(env->dpp, null_yield, dirname, std::string(), ent);
   EXPECT_EQ(ret, 0);
-  EXPECT_EQ(ent->get_type(), ObjectType::VERSIONED);
+  EXPECT_EQ(ent->get_type(), posix::ObjectType::VERSIONED);
 
   ret = testdir->remove(env->dpp, null_yield, false, nullptr);
   EXPECT_EQ(ret, 0);
@@ -886,8 +839,8 @@ TEST(FSEnt, VerDirBase)
 TEST(FSEnt, VerDirReadWrite)
 {
   std::string fname = get_test_name();
-  std::unique_ptr<VersionedDirectory> verdir{
-      std::make_unique<VersionedDirectory>(fname, root.get(), env->cct.get())};
+  std::unique_ptr<posix::VersionedDirectory> verdir{
+      std::make_unique<posix::VersionedDirectory>(fname, root.get(), env->cct.get())};
   std::string instance_id{verdir->get_new_instance()};
   std::string vfname{"_%3A" + instance_id + "_" + fname};
   sf::path tp{base_path / fname};
@@ -897,7 +850,7 @@ TEST(FSEnt, VerDirReadWrite)
   int ret = verdir->create(env->dpp, /*existed=*/nullptr, /*temp_file=*/false);
   EXPECT_EQ(ret, 0);
 
-  std::unique_ptr<File> testfile{std::make_unique<File>(vfname, verdir.get(), env->cct.get())};
+  std::unique_ptr<posix::File> testfile{std::make_unique<posix::File>(vfname, verdir.get(), env->cct.get())};
   ret = verdir->add_file(env->dpp, std::move(testfile), /*existed=*/nullptr, /*temp_file=*/true);
   EXPECT_EQ(ret, 0);
 
@@ -944,44 +897,44 @@ TEST(FSEnt, VerDirReadWrite)
   EXPECT_EQ(ret, 0);
   EXPECT_EQ(attrs.size(), 4);
   std::string val;
-  bool success = decode_attr(attrs, ATTR1.c_str(), val);
+  bool success = test_decode_attr(attrs, ATTR1.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR1);
-  success = decode_attr(attrs, ATTR2.c_str(), val);
+  success = test_decode_attr(attrs, ATTR2.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR2);
-  success = decode_attr(attrs, ATTR3.c_str(), val);
+  success = test_decode_attr(attrs, ATTR3.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR3);
-  ObjectType type;
-  success = decode_attr(attrs, ATTR_OBJECT_TYPE.c_str(), type);
+  posix::ObjectType type;
+  success = posix::decode_attr(attrs, ATTR_OBJECT_TYPE.c_str(), type);
   EXPECT_TRUE(success);
-  EXPECT_EQ(type.type, ObjectType::VERSIONED);
+  EXPECT_EQ(type.type, posix::ObjectType::VERSIONED);
 
-  FSEnt* ent = verdir->get_cur_version_ent();
+  posix::FSEnt* ent = verdir->get_cur_version_ent();
   attrs.clear();
   ret = ent->read_attrs(env->dpp, null_yield, attrs);
   EXPECT_EQ(ret, 0);
   EXPECT_EQ(attrs.size(), 4);
-  success = decode_attr(attrs, ATTR1.c_str(), val);
+  success = test_decode_attr(attrs, ATTR1.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR1);
-  success = decode_attr(attrs, ATTR2.c_str(), val);
+  success = test_decode_attr(attrs, ATTR2.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR2);
-  success = decode_attr(attrs, ATTR3.c_str(), val);
+  success = test_decode_attr(attrs, ATTR3.c_str(), val);
   EXPECT_TRUE(success);
   EXPECT_EQ(val, ATTR3);
-  success = decode_attr(attrs, ATTR_OBJECT_TYPE.c_str(), type);
+  success = posix::decode_attr(attrs, ATTR_OBJECT_TYPE.c_str(), type);
   EXPECT_TRUE(success);
-  EXPECT_EQ(type.type, ObjectType::FILE);
+  EXPECT_EQ(type.type, posix::ObjectType::FILE);
 }
 
 TEST(FSEnt, MPVerDirReadWrite)
 {
   std::string testname = get_test_name();
-  std::unique_ptr<VersionedDirectory> verdir{
-      std::make_unique<VersionedDirectory>(testname, root.get(), env->cct.get())};
+  std::unique_ptr<posix::VersionedDirectory> verdir{
+      std::make_unique<posix::VersionedDirectory>(testname, root.get(), env->cct.get())};
   std::string instance_id{verdir->get_new_instance()};
   std::string vfname{"_%3A" + instance_id + "_" + testname};
   sf::path vp{base_path / testname};
@@ -991,7 +944,7 @@ TEST(FSEnt, MPVerDirReadWrite)
   int ret = verdir->create(env->dpp, /*existed=*/nullptr, /*temp_file=*/false);
   EXPECT_EQ(ret, 0);
 
-  std::unique_ptr<MPDirectory> mpdir{std::make_unique<MPDirectory>(vfname, verdir.get(), env->cct.get())};
+  std::unique_ptr<posix::MPDirectory> mpdir{std::make_unique<posix::MPDirectory>(vfname, verdir.get(), env->cct.get())};
   ret = verdir->add_file(env->dpp, std::move(mpdir), /*existed=*/nullptr, /*temp_file=*/true);
   EXPECT_EQ(ret, 0);
 
@@ -1008,7 +961,7 @@ TEST(FSEnt, MPVerDirReadWrite)
   ret = verdir->open(env->dpp);
   EXPECT_EQ(ret, 0);
 
-  MPDirectory* mpp = static_cast<MPDirectory*>(verdir->get_cur_version_ent());
+  posix::MPDirectory* mpp = static_cast<posix::MPDirectory*>(verdir->get_cur_version_ent());
   EXPECT_NE(mpp, nullptr);
 
   ret = mpp->open(env->dpp);
@@ -1017,7 +970,7 @@ TEST(FSEnt, MPVerDirReadWrite)
   bufferlist write_bl;
   int total_len{0};
   for (int part_num = 0; part_num < 4; ++part_num) {
-    std::unique_ptr<File> testfile = mpp->get_part_file(part_num);
+    std::unique_ptr<posix::File> testfile = mpp->get_part_file(part_num);
     sf::path pp{mp / testfile->get_name()};
 
     ret = testfile->create(env->dpp, /*existed=*/nullptr, /*temp_file=*/false);
@@ -1083,7 +1036,7 @@ public:
     std::string cache_base = driver_base + "/cache";
     base_path = driver_base + "/root";
 
-    root_dir = std::make_unique<Directory>(base_path, nullptr, env->cct.get());
+    root_dir = std::make_unique<posix::Directory>(base_path, nullptr, env->cct.get());
     int ret = root_dir->open(env->dpp);
     if (ret < 0) {
       if (ret == -ENOTDIR) {
@@ -1102,7 +1055,7 @@ public:
     }
     quota_handler = RGWQuotaHandler::generate_handler(env->dpp, this, false);
     /* ordered listing cache */
-    bucket_cache.reset(new BucketCache(
+    bucket_cache.reset(new posix::BucketCache(
         this, base_path, cache_base, 100, 3, 3, 3));
 
     ldpp_dout(env->dpp, 20) << "SUCCESS" << dendl;
@@ -1241,7 +1194,7 @@ TEST_F(POSIXDriverTest, BucketCreate)
   EXPECT_EQ(bucket->get_name(), testname);
   EXPECT_EQ(bucket->get_key().name, testname);
   EXPECT_EQ(bucket->get_key().tenant, "");
-  EXPECT_EQ(bucket->get_key().bucket_id, "");
+  EXPECT_TRUE(bucket->get_key().bucket_id.starts_with(testname));
   EXPECT_FALSE(bucket_exists);
 
   sf::path tp{bp / "root" / testname};
@@ -1528,8 +1481,8 @@ TEST_F(POSIXObjectTest, ObjectCopy)
 	   placement,
 	   &mtime,
 	   &mtime,
-	   &mtime,
-	   &mtime,
+	   nullptr,
+	   nullptr,
 	   false,
 	   nullptr,
 	   nullptr,
@@ -1561,10 +1514,9 @@ TEST_F(POSIXObjectTest, ObjectAttrs)
   bufferlist origbl;
   encode(ATTR1, origbl);
 
-  // POSIXDriver adds attributes ("POSIX-Owner", and "POSIX-Object-Type")
-  EXPECT_EQ(object->get_attrs().size(), 3);
+  // POSIXDriver adds attributes ("POSIX-Object-Type")
+  EXPECT_EQ(object->get_attrs().size(), 2);
   EXPECT_EQ(object->get_attrs()[ATTR1], origbl);
-  EXPECT_TRUE(object->get_attrs().contains("POSIX-Owner"));
   EXPECT_TRUE(object->get_attrs().contains(ATTR_OBJECT_TYPE));
 
   std::string addattr{"AddAttrO"};
@@ -1574,17 +1526,15 @@ TEST_F(POSIXObjectTest, ObjectAttrs)
   ret = object->modify_obj_attrs(addattr.c_str(), addbl, null_yield, env->dpp);
   EXPECT_EQ(ret, 0);
 
-  EXPECT_EQ(object->get_attrs().size(), 4);
+  EXPECT_EQ(object->get_attrs().size(), 3);
   EXPECT_EQ(object->get_attrs()[ATTR1], origbl);
   EXPECT_EQ(object->get_attrs()[addattr], addbl);
-  EXPECT_TRUE(object->get_attrs().contains("POSIX-Owner"));
   EXPECT_TRUE(object->get_attrs().contains(ATTR_OBJECT_TYPE));
 
   ret = object->delete_obj_attrs(env->dpp, ATTR1.c_str(), null_yield);
   EXPECT_EQ(ret, 0);
-  EXPECT_EQ(object->get_attrs().size(), 3);
+  EXPECT_EQ(object->get_attrs().size(), 2);
   EXPECT_EQ(object->get_attrs()[addattr], addbl);
-  EXPECT_TRUE(object->get_attrs().contains("POSIX-Owner"));
   EXPECT_TRUE(object->get_attrs().contains(ATTR_OBJECT_TYPE));
 }
 
@@ -1837,8 +1787,8 @@ TEST_F(POSIXMPObjectTest, MPUploadCopy)
 	   placement,
 	   &mtime,
 	   &mtime,
-	   &mtime,
-	   &mtime,
+	   nullptr,
+	   nullptr,
 	   false,
 	   nullptr,
 	   nullptr,
@@ -2288,8 +2238,8 @@ TEST_F(POSIXVerObjectTest, ObjectCopy)
 	   placement,
 	   &mtime,
 	   &mtime,
-	   &mtime,
-	   &mtime,
+	   nullptr,
+	   nullptr,
 	   false,
 	   nullptr,
 	   nullptr,
@@ -2311,18 +2261,14 @@ TEST_F(POSIXVerObjectTest, ObjectCopy)
   EXPECT_TRUE(sf::exists(sp));
   EXPECT_TRUE(sf::exists(dp));
 
-  std::string vfname1{"_%3A" + obj1v1_inst + "_" + dstname};
+  std::string vfname1{"_%3A" + dstobj->get_instance() + "_" + dstname};
   sf::path op1{dp / vfname1};
   EXPECT_TRUE(sf::exists(op1));
   EXPECT_TRUE(sf::is_regular_file(op1));
-  std::string vfname2{"_%3A" + obj1v2_inst + "_" + dstname};
-  sf::path op2{dp / vfname2};
-  EXPECT_TRUE(sf::exists(op2));
-  EXPECT_TRUE(sf::is_regular_file(op2));
   sf::path ops{dp / dstname};
   EXPECT_TRUE(sf::exists(ops));
   EXPECT_TRUE(sf::is_symlink(ops));
-  EXPECT_EQ(sf::read_symlink(ops), vfname2);
+  EXPECT_EQ(sf::read_symlink(ops), vfname1);
 }
 
 TEST_F(POSIXVerObjectTest, CopyVersion)
@@ -2366,8 +2312,8 @@ TEST_F(POSIXVerObjectTest, CopyVersion)
 	   placement,
 	   &mtime,
 	   &mtime,
-	   &mtime,
-	   &mtime,
+	   nullptr,
+	   nullptr,
 	   false,
 	   nullptr,
 	   nullptr,
@@ -2523,9 +2469,9 @@ public:
     std::string getver = object->get_instance();
     EXPECT_EQ(inst_id, getver);
 
-    ObjectType type{ObjectType::VERSIONED};
-    ret = decode_attr(object->get_attrs(), ATTR_OBJECT_TYPE.c_str(), type);
-    EXPECT_EQ(type.type, ObjectType::VERSIONED);
+    posix::ObjectType type{posix::ObjectType::VERSIONED};
+    ret = posix::decode_attr(object->get_attrs(), ATTR_OBJECT_TYPE.c_str(), type);
+    EXPECT_EQ(type.type, posix::ObjectType::VERSIONED);
 
     std::unique_ptr<Object> vobj = bucket->get_object(rgw_obj_key(objname, inst_id));
     std::unique_ptr<rgw::sal::Object::ReadOp> vread_op(vobj->get_read_op());
@@ -2533,8 +2479,8 @@ public:
     ret = vread_op->prepare(null_yield, env->dpp);
     EXPECT_EQ(ret, 0);
 
-    ret = decode_attr(vobj->get_attrs(), ATTR_OBJECT_TYPE.c_str(), type);
-    EXPECT_EQ(type.type, ObjectType::VERSIONED);
+    ret = posix::decode_attr(vobj->get_attrs(), ATTR_OBJECT_TYPE.c_str(), type);
+    EXPECT_EQ(type.type, posix::ObjectType::VERSIONED);
 
     sf::path ops{bp / "root" / testname / objname / objname};
     EXPECT_TRUE(sf::exists(ops));


### PR DESCRIPTION
- Split FSEnt into it's own files, and fix resulting build errors.
- Fix POSIX driver test to work with this split
- Fix other accumulated brokenness in POSIX driver test

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
