### PR TITLE
qa/suites/orch/cephadm/smb: retry CTDB healthy check in clustering_ips

### DIFF
--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_clustering_ips.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_clustering_ips.yaml
@@ -66,16 +66,12 @@ tasks:
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U user1%t3stP4ss1 //{{'host.a'|role_to_remote|attr('ip_address')}}/share2 -c ls"
 
 # verify CTDB is healthy, cluster well formed
-- template.exec:
-    host.a:
-      - "{{ctx.cephadm}} ls --no-detail  | {{ctx.cephadm}} shell jq -r 'map(select(.name | startswith(\"smb.modusr1\")))[-1].name' > /tmp/svcname"
-      - "{{ctx.cephadm}} enter -n $(cat /tmp/svcname) ctdb status > /tmp/ctdb_status"
-      - cat /tmp/ctdb_status
-      - grep 'pnn:0 .*OK' /tmp/ctdb_status
-      - grep 'pnn:1 .*OK' /tmp/ctdb_status
-      - grep 'pnn:2 .*OK' /tmp/ctdb_status
-      - grep 'Number of nodes:3' /tmp/ctdb_status
-      - rm -rf /tmp/svcname /tmp/ctdb_status
+- smb.workunit:
+    admin_node: host.a
+    timeout: 15m
+    clients:
+      client.0:
+        - [ctdb_healthy]
 
 # Test the assigned VIP
 - template.exec:

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_basic.yaml
@@ -95,16 +95,12 @@ tasks:
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U user2%t3stP4ss2 //{{'host.a'|role_to_remote|attr('ip_address')}}/share2 -c ls"
 
 # verify CTDB is healthy, cluster well formed
-- template.exec:
-    host.a:
-      - "{{ctx.cephadm}} ls --no-detail  | {{ctx.cephadm}} shell jq -r 'map(select(.name | startswith(\"smb.uctdb1\")))[-1].name' > /tmp/svcname"
-      - "{{ctx.cephadm}} enter -n $(cat /tmp/svcname) ctdb status > /tmp/ctdb_status"
-      - cat /tmp/ctdb_status
-      - grep 'pnn:0 .*OK' /tmp/ctdb_status
-      - grep 'pnn:1 .*OK' /tmp/ctdb_status
-      - grep 'pnn:2 .*OK' /tmp/ctdb_status
-      - grep 'Number of nodes:3' /tmp/ctdb_status
-      - rm -rf /tmp/svcname /tmp/ctdb_status
+- smb.workunit:
+    admin_node: host.a
+    timeout: 15m
+    clients:
+      client.0:
+        - [ctdb_healthy]
 
 # Test a different host in the cluster
 - template.exec:

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_dom.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_dom.yaml
@@ -98,16 +98,12 @@ tasks:
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share2 -c ls"
 
 # verify CTDB is healthy, cluster well formed
-- template.exec:
-    host.a:
-      - "{{ctx.cephadm}} ls --no-detail  | {{ctx.cephadm}} shell jq -r 'map(select(.name | startswith(\"smb.adctdb1\")))[-1].name' > /tmp/svcname"
-      - "{{ctx.cephadm}} enter -n $(cat /tmp/svcname) ctdb status > /tmp/ctdb_status"
-      - cat /tmp/ctdb_status
-      - grep 'pnn:0 .*OK' /tmp/ctdb_status
-      - grep 'pnn:1 .*OK' /tmp/ctdb_status
-      - grep 'pnn:2 .*OK' /tmp/ctdb_status
-      - grep 'Number of nodes:3' /tmp/ctdb_status
-      - rm -rf /tmp/svcname /tmp/ctdb_status
+- smb.workunit:
+    admin_node: host.a
+    timeout: 15m
+    clients:
+      client.0:
+        - [ctdb_healthy]
 
 # Test a different host in the cluster
 - template.exec:

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_ips.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_ips.yaml
@@ -103,16 +103,12 @@ tasks:
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share2 -c ls"
 
 # verify CTDB is healthy, cluster well formed
-- template.exec:
-    host.a:
-      - "{{ctx.cephadm}} ls --no-detail  | {{ctx.cephadm}} shell jq -r 'map(select(.name | startswith(\"smb.adipctdb\")))[-1].name' > /tmp/svcname"
-      - "{{ctx.cephadm}} enter -n $(cat /tmp/svcname) ctdb status > /tmp/ctdb_status"
-      - cat /tmp/ctdb_status
-      - grep 'pnn:0 .*OK' /tmp/ctdb_status
-      - grep 'pnn:1 .*OK' /tmp/ctdb_status
-      - grep 'pnn:2 .*OK' /tmp/ctdb_status
-      - grep 'Number of nodes:3' /tmp/ctdb_status
-      - rm -rf /tmp/svcname /tmp/ctdb_status
+- smb.workunit:
+    admin_node: host.a
+    timeout: 15m
+    clients:
+      client.0:
+        - [ctdb_healthy]
 
 # Test the two assigned VIPs
 - template.exec:

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_ports2c.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_ports2c.yaml
@@ -136,28 +136,13 @@ tasks:
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share2 -c ls"
       - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -p4455 -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/s1ac2 -c ls"
 
-# verify CTDB is healthy, cluster 1 is well formed
-- template.exec:
-    host.a:
-      - "{{ctx.cephadm}} ls --no-detail  | {{ctx.cephadm}} shell jq -r 'map(select(.name | startswith(\"smb.ac1\")))[-1].name' > /tmp/svcname"
-      - "{{ctx.cephadm}} enter -n $(cat /tmp/svcname) ctdb status > /tmp/ctdb_status"
-      - cat /tmp/ctdb_status
-      - grep 'pnn:0 .*OK' /tmp/ctdb_status
-      - grep 'pnn:1 .*OK' /tmp/ctdb_status
-      - grep 'pnn:2 .*OK' /tmp/ctdb_status
-      - grep 'Number of nodes:3' /tmp/ctdb_status
-      - rm -rf /tmp/svcname /tmp/ctdb_status
-# verify CTDB is healthy, cluster 2 is well formed
-- template.exec:
-    host.a:
-      - "{{ctx.cephadm}} ls --no-detail  | {{ctx.cephadm}} shell jq -r 'map(select(.name | startswith(\"smb.ac2\")))[-1].name' > /tmp/svcname"
-      - "{{ctx.cephadm}} enter -n $(cat /tmp/svcname) ctdb status > /tmp/ctdb_status"
-      - cat /tmp/ctdb_status
-      - grep 'pnn:0 .*OK' /tmp/ctdb_status
-      - grep 'pnn:1 .*OK' /tmp/ctdb_status
-      - grep 'pnn:2 .*OK' /tmp/ctdb_status
-      - grep 'Number of nodes:3' /tmp/ctdb_status
-      - rm -rf /tmp/svcname /tmp/ctdb_status
+# verify CTDB is healthy, both clusters well formed
+- smb.workunit:
+    admin_node: host.a
+    timeout: 15m
+    clients:
+      client.0:
+        - [ctdb_healthy]
 
 # Test the two assigned VIPs on cluster 1
 - template.exec:

--- a/qa/workunits/smb/tests/test_ctdb_clustering.py
+++ b/qa/workunits/smb/tests/test_ctdb_clustering.py
@@ -49,21 +49,27 @@ def _wait_for_ctdb_status(
 
 @pytest.mark.ctdb_healthy
 def test_ctdb_cluster_healthy(smb_cfg):
-    """After deploy with placement count:3, CTDB reports three OK nodes."""
-    cluster_id = _cluster_id(smb_cfg)
-    _wait_for_ctdb_status(
-        smb_cfg,
-        cluster_id,
-        [
-            re.compile(r'pnn:0 .*OK'),
-            re.compile(r'pnn:1 .*OK'),
-            re.compile(r'pnn:2 .*OK'),
-            re.compile(r'Number of nodes:3'),
-        ],
-        # allow CTDB a bit of time after orch reports the service running
-        attempts=12,
-        sleep_s=10,
-    )
+    """After deploy with placement count:3, CTDB reports three OK nodes.
+
+    Checks every unique cluster_id present in shares so multi-cluster
+    deploys (e.g. ports2c) wait for each CTDB cluster, not only the first.
+    """
+    cluster_ids = sorted({s['cluster_id'] for s in smbutil.get_shares(smb_cfg)})
+    matchers = [
+        re.compile(r'pnn:0 .*OK'),
+        re.compile(r'pnn:1 .*OK'),
+        re.compile(r'pnn:2 .*OK'),
+        re.compile(r'Number of nodes:3'),
+    ]
+    for cluster_id in cluster_ids:
+        _wait_for_ctdb_status(
+            smb_cfg,
+            cluster_id,
+            matchers,
+            # allow CTDB a bit of time after orch reports the service running
+            attempts=12,
+            sleep_s=10,
+        )
 
 
 @pytest.mark.ctdb_node_gone


### PR DESCRIPTION
Replace one-shot ctdb status greps with smb.workunit ctdb_healthy so the test waits for all three nodes OK after orch reports running.

cephadm.wait_for_service only waits until orch reports the smb daemons running. CTDB can still lag, so a single grep 'pnn:2 .*OK' can fail even though the cluster becomes healthy shortly after. Reuse the existing retry helper so the test waits until all three nodes are OK (or times out).

Fixes: https://tracker.ceph.com/issues/79326

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
