### PR TITLE
qa/tasks/cbt: stop hardcoding the pdsh version for el10

### DIFF
--- a/qa/tasks/cbt.py
+++ b/qa/tasks/cbt.py
@@ -69,17 +69,23 @@ class CBT(Task):
             install_cmd = ['sudo', 'yum', '-y', 'install']
             cbt_depends = ['librbd-devel', 'perf']
 
-            # pdsh is not available in the repos for el10, use el9 version which works fine
+            # pdsh is not available in the repos for el10, use el9 version which works fine.
+            # Pull it straight from the epel9 repo rather than hardcoding an rpm URL, since
+            # epel rebuilds/bumps pdsh and any pinned version eventually 404s. The repo is
+            # limited to the pdsh packages so nothing else gets resolved against el9.
             os_version = misc.get_distro_version(self.ctx)
             os_major_version = int(os_version.split('.')[0])
             if os_major_version >= 10:
                 self.log.info('Installing pdsh from el9 repo into el10 system')
-                pdsh_base = 'https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/p'
+                pdsh_packages = ['pdsh', 'pdsh-rcmd-ssh']
+                epel9_baseurl = 'https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/'
                 self.first_mon.run(args=[
-                    'sudo', 'yum', '-y', 'install',
-                    f'{pdsh_base}/pdsh-2.34-7.el9.x86_64.rpm',
-                    f'{pdsh_base}/pdsh-rcmd-ssh-2.34-7.el9.x86_64.rpm',
-                ])
+                    'sudo', 'yum', '-y',
+                    '--repofrompath', f'epel9-pdsh,{epel9_baseurl}',
+                    f'--setopt=epel9-pdsh.includepkgs={",".join(pdsh_packages)}',
+                    '--nogpgcheck',
+                    'install',
+                ] + pdsh_packages)
             else:
                 cbt_depends += ['pdsh', 'pdsh-rcmd-ssh']
 


### PR DESCRIPTION
## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

The el10 branch of `CBT.install_dependencies()` installed pdsh by pinned rpm URL out of the epel9 `Packages/p` tree:

```
https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/p/pdsh-2.34-7.el9.x86_64.rpm
https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/p/pdsh-rcmd-ssh-2.34-7.el9.x86_64.rpm
```

epel recently bumped pdsh, which removed those exact files, so the download 404s and every cbt job on el10 dies during dependency installation.

This replaces the pinned URLs with an on-the-fly repo definition so dnf resolves whatever version epel9 currently publishes:

```
sudo yum -y \
  --repofrompath 'epel9-pdsh,https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/' \
  --setopt=epel9-pdsh.includepkgs=pdsh,pdsh-rcmd-ssh \
  --nogpgcheck \
  install pdsh pdsh-rcmd-ssh
```

Reviewer notes:
- `includepkgs` scopes the temporary repo to just the two pdsh packages, so no other part of the transaction can get resolved against el9 content on an el10 box.
- `--nogpgcheck` is required because the ad-hoc repo has no gpgkey configured. This is the same trust level as before — installing rpms directly by URL did not verify against an imported epel9 key either.
- `--repofrompath` and `--setopt=<repoid>.<opt>` are both supported by dnf5, which is what el10 ships.
- The pre-el10 path is unchanged (plain `pdsh` / `pdsh-rcmd-ssh` from the distro repos).
- I verified the file compiles but have not run this against a live el10 node — a cbt smoke test on el10 before merge would be worthwhile.

## Checklist
- Tracker (select at least one)
  - [x] Very recent bug; references commit where it was introduced
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] No tests
