### PR TITLE
mds: expose multiversion hardlink inode changes in snapdiff

### DIFF
--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -2222,6 +2222,216 @@ class TestMirroring(CephFSTestCase):
 
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
 
+    def test_cephfs_mirror_hardlink_snapdiff_visibility(self):
+        """Verify snapdiff reports every path of a multiversion hardlink.
+
+        The shared inode is multiversion because nlink is greater than one.
+        Updating it COWs the inode without necessarily COWing either
+        hardlink dentry. Snapdiff must therefore report both paths by
+        considering the inode version as well as the dentry version. Keep
+        blockdiff disabled so this test isolates dentry visibility from
+        changed-block calculation.
+        """
+        self.setup_mount_b(mds_perm='rw')
+        self.config_set(
+            'client.mirror',
+            'cephfs_mirror_blockdiff_min_file_size', 134217728)
+        peer_spec = "client.mirror_remote@ceph"
+        dir_name = 'd0'
+        file_names = ('file', 'link')
+
+        def snapshot_file_state(mount, snap_name, file_name):
+            path = f'{dir_name}/.snap/{snap_name}/{file_name}'
+            stat = mount.run_shell(
+                ['stat', '-c', '%F:%s:%i:%h', path]
+            ).stdout.getvalue().strip()
+            file_type, size, inode, nlink = stat.rsplit(':', 3)
+            digest = mount.run_shell(
+                ['sha256sum', path]
+            ).stdout.getvalue().split()[0]
+            return file_type, int(size), digest, int(inode), int(nlink)
+
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        self.peer_add(self.primary_fs_name, self.primary_fs_id,
+                      peer_spec, self.secondary_fs_name)
+        self.mount_a.run_shell(['mkdir', dir_name])
+        self.mount_a.run_shell([
+            'dd', 'if=/dev/zero', f'of={dir_name}/{file_names[0]}',
+            'bs=1M', 'count=64', 'conv=fsync'
+        ])
+        self.mount_a.run_shell([
+            'ln', f'{dir_name}/{file_names[0]}',
+            f'{dir_name}/{file_names[1]}'
+        ])
+        self.mount_a.run_shell([
+            'touch', '-m', '-d', '2020-01-01 00:00:00 UTC',
+            f'{dir_name}/{file_names[0]}'
+        ])
+        self.add_directory(self.primary_fs_name, self.primary_fs_id,
+                           f'/{dir_name}')
+
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/snap_a'])
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, f'/{dir_name}', 'snap_a', 1)
+        self.verify_snapshot(dir_name, 'snap_a')
+        initial_states = {
+            name: snapshot_file_state(self.mount_a, 'snap_a', name)
+            for name in file_names
+        }
+        self.assertEqual(initial_states['file'][3],
+                         initial_states['link'][3])
+        self.assertEqual(2, initial_states['file'][4])
+
+        self.mount_a.run_shell([
+            'dd', 'if=/dev/urandom', f'of={dir_name}/{file_names[0]}',
+            'bs=1M', 'count=1', 'seek=32', 'conv=notrunc,fsync'
+        ])
+        # Pin distinct mtimes so this test isolates the unchanged-hardlink
+        # dentry bug rather than the separate pending-snapflush/mtime issue.
+        self.mount_a.run_shell([
+            'touch', '-m', '-d', '2020-01-01 00:00:02 UTC',
+            f'{dir_name}/{file_names[0]}'
+        ])
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/snap_b'])
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, f'/{dir_name}', 'snap_b', 2)
+        self.assertIn('snap_b', self.mount_b.ls(path=f'{dir_name}/.snap'))
+
+        source_states = {
+            name: snapshot_file_state(self.mount_a, 'snap_b', name)
+            for name in file_names
+        }
+        destination_states = {
+            name: snapshot_file_state(self.mount_b, 'snap_b', name)
+            for name in file_names
+        }
+        log.info('hardlink snapdiff visibility: source=%s destination=%s',
+                 source_states, destination_states)
+
+        self.remove_directory(self.primary_fs_name, self.primary_fs_id,
+                              f'/{dir_name}')
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+        self.assertNotEqual(initial_states['file'][2],
+                            source_states['file'][2])
+        self.assertEqual(source_states['file'][:3],
+                         source_states['link'][:3])
+        self.assertEqual(source_states['file'][3],
+                         source_states['link'][3])
+        self.assertEqual(2, source_states['file'][4])
+        for name in file_names:
+            self.assertEqual(source_states[name][:3],
+                             destination_states[name][:3])
+
+    def test_cephfs_mirror_hardlink_snapdiff_replica_inode(self):
+        """Verify snapdiff reports a hardlink through an inode replica.
+
+        Pin the hardlink's primary dentry and remote dentry to different
+        active MDS ranks. The rank serving the remote dentry has only an
+        inode replica, whose snap range is not authoritative. Snapdiff must
+        report the remote dentry conservatively even if the replica's
+        ``first`` value appears to span both snapshots.
+        """
+        self.setup_mount_b(mds_perm='rw')
+        self.fs.set_max_mds(2)
+        status = self.fs.wait_for_daemons()
+        self.config_set(
+            'client.mirror',
+            'cephfs_mirror_blockdiff_min_file_size', 134217728)
+        peer_spec = "client.mirror_remote@ceph"
+        dir_name = 'd0'
+        file_paths = ('file', 'replica/link')
+
+        def snapshot_file_state(mount, snap_name, file_path):
+            path = f'{dir_name}/.snap/{snap_name}/{file_path}'
+            stat = mount.run_shell(
+                ['stat', '-c', '%F:%s:%i:%h', path]
+            ).stdout.getvalue().strip()
+            file_type, size, inode, nlink = stat.rsplit(':', 3)
+            digest = mount.run_shell(
+                ['sha256sum', path]
+            ).stdout.getvalue().split()[0]
+            return file_type, int(size), digest, int(inode), int(nlink)
+
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        self.peer_add(self.primary_fs_name, self.primary_fs_id,
+                      peer_spec, self.secondary_fs_name)
+        self.mount_a.run_shell(['mkdir', '-p', f'{dir_name}/replica/empty'])
+        self.mount_a.setfattr(dir_name, 'ceph.dir.pin', '0')
+        self.mount_a.setfattr(f'{dir_name}/replica', 'ceph.dir.pin', '1')
+        self._wait_subtrees(
+            [(f'/{dir_name}', 0), (f'/{dir_name}/replica', 1)],
+            rank='all', status=status, path=f'/{dir_name}')
+
+        self.mount_a.run_shell([
+            'dd', 'if=/dev/zero', f'of={dir_name}/{file_paths[0]}',
+            'bs=1M', 'count=64', 'conv=fsync'
+        ])
+        self.mount_a.run_shell([
+            'ln', f'{dir_name}/{file_paths[0]}',
+            f'{dir_name}/{file_paths[1]}'
+        ])
+        self.mount_a.run_shell([
+            'touch', '-m', '-d', '2020-01-01 00:00:00 UTC',
+            f'{dir_name}/{file_paths[0]}'
+        ])
+        # Populate rank 1's remote-dentry linkage and inode replica before
+        # the first snapshot.
+        self.mount_a.run_shell(['stat', f'{dir_name}/{file_paths[1]}'])
+        self.add_directory(self.primary_fs_name, self.primary_fs_id,
+                           f'/{dir_name}')
+
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/snap_a'])
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, f'/{dir_name}', 'snap_a', 1)
+        self.verify_snapshot(dir_name, 'snap_a')
+        initial_states = {
+            path: snapshot_file_state(self.mount_a, 'snap_a', path)
+            for path in file_paths
+        }
+        self.assertEqual(initial_states[file_paths[0]][3],
+                         initial_states[file_paths[1]][3])
+        self.assertEqual(2, initial_states[file_paths[0]][4])
+
+        self.mount_a.run_shell([
+            'dd', 'if=/dev/urandom', f'of={dir_name}/{file_paths[0]}',
+            'bs=1M', 'count=1', 'seek=32', 'conv=notrunc,fsync'
+        ])
+        self.mount_a.run_shell([
+            'touch', '-m', '-d', '2020-01-01 00:00:02 UTC',
+            f'{dir_name}/{file_paths[0]}'
+        ])
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/snap_b'])
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               peer_spec, f'/{dir_name}', 'snap_b', 2)
+        self.assertIn('snap_b', self.mount_b.ls(path=f'{dir_name}/.snap'))
+
+        source_states = {
+            path: snapshot_file_state(self.mount_a, 'snap_b', path)
+            for path in file_paths
+        }
+        destination_states = {
+            path: snapshot_file_state(self.mount_b, 'snap_b', path)
+            for path in file_paths
+        }
+        log.info('replica inode hardlink snapdiff: source=%s destination=%s',
+                 source_states, destination_states)
+
+        self.remove_directory(self.primary_fs_name, self.primary_fs_id,
+                              f'/{dir_name}')
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+        self.assertNotEqual(initial_states[file_paths[0]][2],
+                            source_states[file_paths[0]][2])
+        self.assertEqual(source_states[file_paths[0]][:3],
+                         source_states[file_paths[1]][:3])
+        self.assertEqual(source_states[file_paths[0]][3],
+                         source_states[file_paths[1]][3])
+        self.assertEqual(2, source_states[file_paths[0]][4])
+        for path in file_paths:
+            self.assertEqual(source_states[path][:3],
+                             destination_states[path][:3])
+
     def test_cephfs_mirror_incremental_sync_with_type_mixup(self):
         """ Test incremental snapshot synchronization with file type changes.
 

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -12464,34 +12464,40 @@ bool Server::build_snap_diff(
     bool valid() const {
       return in != nullptr && dn != nullptr;
     }
-    bool meta_differs(const CInode* _in, unsigned mask, unsigned& res_mask) const {
-      ceph_assert(in);
-      ceph_assert(_in);
 
-      auto my = in->get_inode();
-      auto oth = _in->get_inode();
-      ceph_assert(my);
-      ceph_assert(oth);
+    static bool meta_differs(const CInode::mempool_inode& my,
+                             const CInode::mempool_inode& oth,
+                             unsigned mask,
+                             unsigned& res_mask) {
       res_mask = 0;
-      if ((mask & CEPH_SNAPDIFF_MODE) && (my->mode != oth->mode))
+      if ((mask & CEPH_SNAPDIFF_MODE) && (my.mode != oth.mode))
 	res_mask |= CEPH_SNAPDIFF_MODE;
-      if ((mask & CEPH_SNAPDIFF_UID) && (my->uid != oth->uid))
+      if ((mask & CEPH_SNAPDIFF_UID) && (my.uid != oth.uid))
 	res_mask |= CEPH_SNAPDIFF_UID;
-      if ((mask & CEPH_SNAPDIFF_GID) && (my->gid != oth->gid))
+      if ((mask & CEPH_SNAPDIFF_GID) && (my.gid != oth.gid))
 	res_mask |= CEPH_SNAPDIFF_GID;
-      if ((mask & CEPH_SNAPDIFF_SIZE) && (my->size != oth->size))
+      if ((mask & CEPH_SNAPDIFF_SIZE) && (my.size != oth.size))
 	res_mask |= CEPH_SNAPDIFF_SIZE;
-      if ((mask & CEPH_SNAPDIFF_NLINK) && (my->nlink != oth->nlink))
+      if ((mask & CEPH_SNAPDIFF_NLINK) && (my.nlink != oth.nlink))
 	res_mask |= CEPH_SNAPDIFF_NLINK;
-      if ((mask & CEPH_SNAPDIFF_MTIME) && (my->mtime != oth->mtime))
+      if ((mask & CEPH_SNAPDIFF_MTIME) && (my.mtime != oth.mtime))
 	res_mask |= CEPH_SNAPDIFF_MTIME;
-      if ((mask & CEPH_SNAPDIFF_ATIME) && (my->atime != oth->atime))
+      if ((mask & CEPH_SNAPDIFF_ATIME) && (my.atime != oth.atime))
 	res_mask |= CEPH_SNAPDIFF_ATIME;
-      if ((mask & CEPH_SNAPDIFF_CTIME) && (my->ctime != oth->ctime))
+      if ((mask & CEPH_SNAPDIFF_CTIME) && (my.ctime != oth.ctime))
 	res_mask |= CEPH_SNAPDIFF_CTIME;
-      if ((mask & CEPH_SNAPDIFF_BTIME) && (my->btime != oth->btime))
+      if ((mask & CEPH_SNAPDIFF_BTIME) && (my.btime != oth.btime))
 	res_mask |= CEPH_SNAPDIFF_BTIME;
       return res_mask != 0;
+    }
+
+    bool meta_differs(const CInode* _in,
+                      unsigned mask,
+                      unsigned& res_mask) const {
+      ceph_assert(in);
+      ceph_assert(_in);
+      return meta_differs(*in->get_inode(), *_in->get_inode(),
+                          mask, res_mask);
     }
   } before;
 
@@ -12503,6 +12509,27 @@ bool Server::build_snap_diff(
     return r;
   };
   client_t client = mdr->client_request->get_source().num();
+
+  // Return the inode metadata visible at @snapid. Multiversion inodes keep
+  // their historical versions in old_inodes, keyed by the version's last
+  // snapshot.
+  auto inode_at_snap = [](const CInode* head, snapid_t snapid)
+      -> const CInode::mempool_inode* {
+    ceph_assert(head->is_head());
+
+    if (snapid >= head->first)
+      return head->get_inode().get();
+
+    snapid_t old_last = head->pick_old_inode(snapid);
+    if (!old_last)
+      return nullptr;
+
+    const auto& old_inodes = head->get_old_inodes();
+    ceph_assert(old_inodes);
+    auto it = old_inodes->find(old_last);
+    ceph_assert(it != old_inodes->end());
+    return &it->second.inode;
+  };
 
   auto it = !skip_key ? dir->begin() : dir->upper_bound(*skip_key);
 
@@ -12590,9 +12617,69 @@ bool Server::build_snap_diff(
       }
     } else {
       if (snapid_prev >= dn->first && snapid <= dn->last) {
-	dout(20) << __func__ << " skipping unchanged " << dn->get_name() << " "
-	  << dn->first << "/" << dn->last << dendl;
-	continue;
+        // A multiversion inode can be COWed without COWing its dentry.
+        // Do not infer that the inode is unchanged solely because this
+        // dentry spans both snapshots.
+        CInode* head = in->is_head() ? in : mdcache->get_inode(in->ino());
+        // A replica's first can lag the inode auth MDS, so only use the
+        // range as a fast path when it is authoritative.
+        const bool inode_state_authoritative = head && head->is_auth();
+        bool inode_spans_both =
+          inode_state_authoritative &&
+          snapid_prev >= in->first && snapid <= in->last;
+        if (inode_spans_both) {
+	  dout(20) << __func__ << " skipping unchanged " << dn->get_name() << " "
+	    << dn->first << "/" << dn->last << dendl;
+	  continue;
+        }
+
+        unsigned res_mask = 0;
+        bool attrs_known = false;
+        bool attrs_changed = true;
+
+        // old_inodes is authoritative only on the inode auth MDS. If this
+        // rank has only a replica, report the entry conservatively rather
+        // than silently losing an update.
+        if (inode_state_authoritative) {
+          const auto* prev_inode = inode_at_snap(head, snapid_prev);
+          const auto* snap_inode = inode_at_snap(head, snapid);
+          if (prev_inode && snap_inode) {
+            attrs_known = true;
+            attrs_changed = EntryInfo::meta_differs(
+              *prev_inode, *snap_inode, diff_mask, res_mask);
+          }
+        }
+
+        if (attrs_known && !attrs_changed) {
+          dout(20) << __func__
+            << " skipping unchanged hardlink inode attrs "
+            << dn->get_name() << " " << dn->first << "/" << dn->last
+            << dendl;
+          continue;
+        }
+
+        // Preserve hash/name ordering if a deleted entry is pending.
+        if (before.valid() && !insert_deleted(before))
+          break;
+
+        if (attrs_known) {
+          dout(20) << __func__
+            << " inode attrs changed behind unchanged hardlink dentry "
+            << dn->get_name() << " dn " << dn->first << "/" << dn->last
+            << " inode " << in->first << "/" << in->last
+            << " result mask: 0x" << std::hex << res_mask << std::dec
+            << dendl;
+        } else {
+          dout(10) << __func__
+            << " reporting unchanged-span hardlink conservatively "
+            << dn->get_name() << " dn " << dn->first << "/" << dn->last
+            << " inode " << in->first << "/" << in->last
+            << dendl;
+        }
+
+        if (!add_result_cb(dn, in, true))
+          break;
+        continue;
       } else if (snapid_prev < dn->first && snapid > dn->last) {
 	dout(20) << __func__ << " skipping inner modification " << dn->get_name() << " "
 	  << dn->first << "/" << dn->last << dendl;

--- a/src/test/libcephfs/snapdiff.cc
+++ b/src/test/libcephfs/snapdiff.cc
@@ -38,9 +38,11 @@
 #include <dirent.h>
 #include <optional>
 #include <random>
+#include <sstream>
 #include <string.h>
 
 using namespace std;
+
 class TestMount {
   ceph_mount_info* cmount = nullptr;
   char dir_path[64];
@@ -74,7 +76,9 @@ public:
     return ceph_conf_get(cmount, option, buf, len);
   }
 
-  json_spirit::mValue tell_rank0(const std::string& prefix, cmdmap_t&& cmdmap = {}) {
+  json_spirit::mValue tell_rank(const std::string& rank,
+                               const std::string& prefix,
+                               cmdmap_t&& cmdmap = {}) {
     cmdmap["prefix"] = prefix;
     cmdmap["format"] = std::string("json");
 
@@ -88,23 +92,54 @@ public:
 
     const char *cmdv[] = {oss.begin()};
 
-    char *outb, *outs;
-    size_t outb_len, outs_len;
-    int status = ceph_mds_command(cmount, "0", cmdv, sizeof(cmdv)/sizeof(cmdv[0]), nullptr, 0, &outb, &outb_len, &outs, &outs_len);
+    char *outb = nullptr, *outs = nullptr;
+    size_t outb_len = 0, outs_len = 0;
+    int status = ceph_mds_command(cmount, rank.c_str(), cmdv,
+                                  sizeof(cmdv)/sizeof(cmdv[0]), nullptr, 0,
+                                  &outb, &outb_len, &outs, &outs_len);
+    std::string output(outb ? outb : "", outb ? outb_len : 0);
+    std::string error(outs ? outs : "", outs ? outs_len : 0);
+    if (outb) {
+      ceph_buffer_free(outb);
+    }
+    if (outs) {
+      ceph_buffer_free(outs);
+    }
     if (status < 0)
     {
-      outs[outs_len] = 0;
-      std::cout << "couldn't tell rank 0 '" << oss.begin() << "'\n" << strerror(-status) << ": " << outs << std::endl;
+      std::cout << "couldn't tell rank " << rank << " '" << oss.begin()
+                << "'\n" << strerror(-status) << ": " << error << std::endl;
       return json_spirit::mValue::null;
     }
 
     json_spirit::mValue dump;
-    if (!json_spirit::read(outb, dump))
+    if (!json_spirit::read(output, dump))
     {
       std::cout << "couldn't parse '" << prefix << "'response json" << std::endl;
       return json_spirit::mValue::null;
     }
     return dump;
+  }
+
+  json_spirit::mValue tell_rank0(const std::string& prefix,
+                                cmdmap_t&& cmdmap = {}) {
+    return tell_rank("0", prefix, std::move(cmdmap));
+  }
+
+  bool wait_for_subtree_on_rank(const char* relpath, const char* rank) {
+    const auto path = make_file_path(relpath);
+    for (unsigned attempt = 0; attempt < 30; ++attempt) {
+      auto subtrees = tell_rank(rank, "get subtrees");
+      if (!subtrees.is_null()) {
+        std::ostringstream oss;
+        json_spirit::write(subtrees, oss);
+        if (oss.str().find(path) != std::string::npos) {
+          return true;
+        }
+      }
+      sleep(1);
+    }
+    return false;
   }
 
   bool tell_rank0_config(const std::string &var, const std::optional<const std::string> val = {}) {
@@ -244,6 +279,17 @@ public:
     auto src_path = make_file_path(relpath);
     auto target_path = make_file_path(target);
     return ceph_symlink(cmount, target_path.c_str(), src_path.c_str());
+  }
+  int link(const char* existing, const char* newname)
+  {
+    auto existing_path = make_file_path(existing);
+    auto new_path = make_file_path(newname);
+    return ceph_link(cmount, existing_path.c_str(), new_path.c_str());
+  }
+  int setxattr(const char* relpath, const char* name, const char* value)
+  {
+    auto path = make_file_path(relpath);
+    return ceph_setxattr(cmount, path.c_str(), name, value, strlen(value), 0);
   }
   int chmod(const char* relpath, int mode)
   {
@@ -2072,6 +2118,72 @@ TEST(LibCephFS, HugeSnapDiffLargeDelta)
   }
 
   std::cout << "------------- closing -------------" << std::endl;
+  ASSERT_EQ(0, test_mount.purge_dir(""));
+  ASSERT_EQ(0, test_mount.rmsnap("snap1"));
+  ASSERT_EQ(0, test_mount.rmsnap("snap2"));
+}
+
+TEST(LibCephFS, SnapDiffHardlinkReplicaInode)
+{
+  TestMount test_mount("snapdiff_hardlink_replica", CEPH_SNAPDIFF_MODE);
+
+  if (test_mount.tell_rank("1", "status").is_null()) {
+    GTEST_SKIP() << "requires two active MDS ranks";
+  }
+
+  ASSERT_EQ(0, test_mount.mkdir("primary"));
+  ASSERT_EQ(0, test_mount.mkdir("replica"));
+  ASSERT_EQ(0, test_mount.mkdir("replica/empty"));
+  ASSERT_EQ(0, test_mount.setxattr("", "ceph.dir.pin", "0"));
+  ASSERT_EQ(0, test_mount.setxattr("primary", "ceph.dir.pin", "0"));
+  ASSERT_EQ(0, test_mount.setxattr("replica", "ceph.dir.pin", "1"));
+  ASSERT_TRUE(test_mount.wait_for_subtree_on_rank("replica", "1"));
+
+  ASSERT_LE(0, test_mount.write_full("primary/file", "before"));
+  ASSERT_EQ(0, test_mount.link("primary/file", "replica/link"));
+
+  struct ceph_statx primary_stx;
+  struct ceph_statx replica_stx;
+  ASSERT_EQ(0, test_mount.statx("primary/file", &primary_stx,
+                                CEPH_STATX_BASIC_STATS, 0));
+  ASSERT_EQ(0, test_mount.statx("replica/link", &replica_stx,
+                                CEPH_STATX_BASIC_STATS, 0));
+  ASSERT_EQ(primary_stx.stx_ino, replica_stx.stx_ino);
+  ASSERT_EQ(2U, primary_stx.stx_nlink);
+
+  ASSERT_EQ(0, test_mount.mksnap("snap1"));
+  ASSERT_EQ(0, test_mount.chmod("primary/file", 0600));
+  ASSERT_EQ(0, test_mount.sync());
+  ASSERT_EQ(0, test_mount.mksnap("snap2"));
+
+  uint64_t snapid1;
+  uint64_t snapid2;
+  ASSERT_EQ(0, test_mount.get_snapid("snap1", &snapid1));
+  ASSERT_EQ(0, test_mount.get_snapid("snap2", &snapid2));
+  ASSERT_LT(snapid1, snapid2);
+
+  vector<pair<string, uint64_t>> primary_diff;
+  ASSERT_EQ(0, test_mount.for_each_readdir_snapdiff(
+    "primary", "snap1", "snap2",
+    [&](const dirent* dire, uint64_t snapid) {
+      primary_diff.emplace_back(dire->d_name, snapid);
+      return true;
+    }));
+  EXPECT_NE(primary_diff.end(),
+            std::find(primary_diff.begin(), primary_diff.end(),
+                      std::make_pair(std::string("file"), snapid2)));
+
+  vector<pair<string, uint64_t>> replica_diff;
+  ASSERT_EQ(0, test_mount.for_each_readdir_snapdiff(
+    "replica", "snap1", "snap2",
+    [&](const dirent* dire, uint64_t snapid) {
+      replica_diff.emplace_back(dire->d_name, snapid);
+      return true;
+    }));
+  EXPECT_NE(replica_diff.end(),
+            std::find(replica_diff.begin(), replica_diff.end(),
+                      std::make_pair(std::string("link"), snapid2)));
+
   ASSERT_EQ(0, test_mount.purge_dir(""));
   ASSERT_EQ(0, test_mount.rmsnap("snap1"));
   ASSERT_EQ(0, test_mount.rmsnap("snap2"));


### PR DESCRIPTION
## Summary

CephFS snapdiff treats a non-directory dentry whose snapshot range spans both operands as unchanged. That is incorrect for multiversion hardlinks: inode COW can create a new inode version without COWing either dentry, so cephfs-mirror can report a successful sync while the destination snapshot retains stale file contents.

Compare the authoritative inode metadata visible at each snapshot before skipping an unchanged-span dentry. Because a replica's inode range and historical inode metadata are not authoritative, report the entry conservatively on replica ranks instead of risking a false negative. Add focused libcephfs and cephfs-mirror coverage, including a hardlink split across auth and replica MDS ranks.

Fixes: https://tracker.ceph.com/issues/79275

Tested with:

- `ceph_test_libcephfs_snapdiff --gtest_filter=LibCephFS.SnapDiffHardlinkReplicaInode`
- `test_cephfs_mirror_hardlink_snapdiff_visibility`
- `test_cephfs_mirror_hardlink_snapdiff_replica_inode`

## Checklist

- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests
