### PR TITLE
test/rgw: link unittest_rgw_posix_driver against rgw_libs

### DIFF
--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -471,7 +471,7 @@ target_include_directories(unittest_rgw_posix_driver
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw/driver/posix")
 target_link_libraries(unittest_rgw_posix_driver
   ${UNITTEST_LIBS}
-  rgw_a_standalone
+  ${rgw_libs}
   ${LMDB_LIBRARIES})
 endif(WITH_RADOSGW_POSIX)
 


### PR DESCRIPTION
rgw_a_standalone only exists under WITH_RADOSGW_STANDALONE, but the test
is built whenever WITH_RADOSGW_POSIX is on. With POSIX=ON and
STANDALONE=OFF cmake takes the unknown target for a plain library name
and passes -lrgw_a_standalone, so the test loses rgw's include
directories and fails to compile:

    rgw_iam_policy.h:28:10: fatal error: rapidjson/error/error.h: No such
    file or directory

The posix driver sources go into rgw_common either way, and the
neighbouring unittest_posix_bucket_cache already links rgw_libs.

A CI failure on this: https://github.com/sunyuechi/ceph-ci/actions/runs/31381833079/job/93433514754

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests