### PR TITLE
rgw/notify: make persistent topic ownership timeout configurable

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1098,3 +1098,13 @@ Relevant tracker: https://tracker.ceph.com/issues/71677
   until they complete or abort.
 
   Relevant tracker: https://tracker.ceph.com/issues/77509
+
+* RGW: The new ``rgw_topic_ownership_update_period`` option sets how often a
+  radosgw refreshes the persistent topic queue list. The ownership (failover)
+  timeout of a persistent topic queue is three times this value, so lowering it
+  speeds up failover of persistent topics between gateways. Setting it too low
+  may cause false-positive failures. Changing it affects the ownership of an
+  existing persistent topic queue only on its next renewal. It defaults to 30
+  seconds, which matches the previously hardcoded behaviour.
+
+  Relevant tracker: https://tracker.ceph.com/issues/78727

--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -88,6 +88,7 @@ which tells the client that it may retry later.
 Persistent bucket notifications are managed by the following central configuration options:
 
 .. confval:: rgw_bucket_persistent_notif_num_shards
+.. confval:: rgw_topic_ownership_update_period
 
 .. note:: When a topic is created during a Ceph upgrade, per-key reordering of notifications may
    happen on any bucket mapped to that topic.

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -4684,6 +4684,19 @@ options:
   flags:
   - startup
   with_legacy: true
+- name: rgw_topic_ownership_update_period
+  type: uint
+  level: advanced
+  desc: Number of seconds between refreshes of the persistent topic queue list.
+    The ownership (failover) timeout of a persistent topic queue is three times
+    this value. Setting this value too low may cause false-positive failures.
+    Changing this value affects the ownership of an existing persistent topic
+    queue only on its next renewal
+  default: 30
+  services:
+  - rgw
+  min: 1
+  max: 3600
 - name: rgw_relaxed_topic_names
   type: bool
   level: advanced

--- a/src/rgw/driver/rados/rgw_notify.cc
+++ b/src/rgw/driver/rados/rgw_notify.cc
@@ -85,10 +85,8 @@ void publish_commit_completion(rados_completion_t completion, void* arg) {
 class Manager : public DoutPrefixProvider {
   using Executor = boost::asio::io_context::executor_type;
   bool shutdown = false;
-  static constexpr auto queues_update_period = std::chrono::milliseconds(30000); // 30s
   static constexpr auto queues_update_retry = std::chrono::milliseconds(1000); // 1s
   static constexpr auto queue_idle_sleep = std::chrono::milliseconds(100); // 100ms
-  const utime_t failover_time = utime_t(queues_update_period*3); // 90s
   CephContext* const cct;
   static constexpr auto COOKIE_LEN = 16;
   const std::string lock_cookie;
@@ -683,6 +681,12 @@ private:
     auto& rados_ioctx = rados_store->getRados()->get_notif_pool_ctx();
     auto next_check_time = ceph::coarse_real_clock::zero();
     while (!shutdown) {
+      // both the refresh period and the ownership timeout are derived from the
+      // same read, so the renewal cadence always stays shorter than the lock
+      // duration, even if the option is changed at runtime
+      const auto queues_update_period = std::chrono::seconds(
+          cct->_conf.get_val<uint64_t>("rgw_topic_ownership_update_period"));
+      const utime_t failover_time = utime_t(queues_update_period*3);
       // check if queue list needs to be refreshed
       if (ceph::coarse_real_clock::now() > next_check_time) {
         next_check_time = ceph::coarse_real_clock::now() + queues_update_period;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/78727

## Problem

In `rgw_notify.cc` the queue list refresh period was a hardcoded 30s constant, and the ownership timeout of a persistent topic queue was derived from it as `30 * 3 = 90s`. Neither could be changed, so failover of a persistent topic between gateways always took up to ~90s, and there was no way to shorten it for testing.

## Fix

Expose the period as a new config option, `rgw_topic_ownership_update_period`, and keep the ownership timeout at three times that value. Per the tracker discussion this is option (a): a single option, with the other value computed as before.

The option is read **once per iteration of the ownership loop** rather than at startup, so `next_check_time` and the lock duration always come from the same read. That keeps the renewal cadence shorter than the lock duration regardless of what the option does between iterations.

On the concern about lowering the value moving ownership unnecessarily:

- **A challenger cannot steal early.** `cls_lock.cc:85` trims lockers by comparing the *stored* expiration against the OSD clock; the caller's duration is only used to compute a new expiration. An RGW that computes `9*3=27` simply gets `EBUSY` until the stored expiry passes.
- **The owner cannot shorten an interval already in flight.** `next_check_time` is only recomputed in the branch that does the work, so the owner keeps its longer expiry until its next scheduled check and then writes both new values together. The tradeoff is that a lowered value takes effect after up to one old period.

`max` is 3600 because the value is multiplied by three into a `std::chrono::seconds`, so an unbounded option would overflow `int64`.

## Testing

Manual test on vstart with 2 RGWs and one persistent topic (11 queue shards):

| Case | Result |
| --- | --- |
| default, option unset | refresh stayed at 30s, no behaviour change |
| set to 5 at runtime | cadence became 5s, no gateway restart needed |
| lowered while one gateway owned all queues | **0** ownership takeovers by the other gateway |
| `kill -9` of the owning gateway | other gateway took all 11 queues in **13s**, inside the 15s lock duration (about 90s at the default) |
| `0`, `3601` | both rejected by the config layer |

Added `test_persistent_topic_ownership_period_change_http`, which lowers the option at runtime and checks that delivery on an already-owned queue is not interrupted. It runs with a single gateway, so it covers the config change and not failover itself.

The automated failover test is left for a separate PR as agreed on the tracker. `test_persistent_gateways_recovery` and `test_persistent_multiple_gateways` are currently `not_implemented` stubs and are where it belongs.

## Open for review

- `min` is 1, which allows a 3s lock duration against a 1s poll interval, so a higher floor may be safer.
- `max: 3600` and the option name are both suggestions.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins test ceph-volume all`
- `jenkins test windows`
- `jenkins test rook e2e`

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
