### PR TITLE
rbd-mirror: fix deadlocks in journal Replayer and ImageDeleter

### DIFF
--- a/src/tools/rbd_mirror/ImageDeleter.cc
+++ b/src/tools/rbd_mirror/ImageDeleter.cc
@@ -265,7 +265,6 @@ void ImageDeleter<I>::enqueue_failed_delete(DeleteInfoRef* delete_info,
                                             double retry_delay) {
   dout(20) << "info=" << *delete_info << ", r=" << error_code << dendl;
   if (error_code == -EBLOCKLISTED) {
-    std::lock_guard locker{m_lock};
     derr << "blocklisted while deleting local image" << dendl;
     complete_active_delete(delete_info, error_code);
     return;

--- a/src/tools/rbd_mirror/image_replayer/journal/Replayer.cc
+++ b/src/tools/rbd_mirror/image_replayer/journal/Replayer.cc
@@ -25,6 +25,7 @@
 #include "tools/rbd_mirror/image_replayer/journal/ReplayStatusFormatter.h"
 #include "tools/rbd_mirror/image_replayer/journal/StateBuilder.h"
 
+#include <functional> // for std::function
 #include <shared_mutex> // for std::shared_lock
 
 #define dout_context g_ceph_context
@@ -128,16 +129,35 @@ struct Replayer<I>::LocalJournalListener
   LocalJournalListener(Replayer* replayer) : replayer(replayer) {
   }
 
+  // notifications cannot take m_lock (remove_listener() waits for
+  // them) nor capture the listener (deleted right after removal)
+  void schedule_notification(std::function<void(Replayer*)>&& notification) {
+    auto replayer = this->replayer;
+    auto ctx = new C_TrackedOp(
+      replayer->m_in_flight_op_tracker,
+      new LambdaContext(
+        [replayer, notification=std::move(notification)](int r) {
+          notification(replayer);
+        }));
+    replayer->m_threads->work_queue->queue(ctx, 0);
+  }
+
   void handle_close() override {
-    replayer->handle_replay_complete(0, "");
+    schedule_notification([](Replayer* replayer) {
+        replayer->handle_replay_complete(0, "");
+      });
   }
 
   void handle_promoted() override {
-    replayer->handle_replay_complete(0, "force promoted");
+    schedule_notification([](Replayer* replayer) {
+        replayer->handle_replay_complete(0, "force promoted");
+      });
   }
 
   void handle_resync() override {
-    replayer->handle_resync_image();
+    schedule_notification([](Replayer* replayer) {
+        replayer->handle_resync_image();
+      });
   }
 };
 


### PR DESCRIPTION
- **avoid deadlock removing local journal listener** : `close_local_image()`
  and `handle_replay_flush_shut_down()` call `remove_listener()` with
  `m_lock` held. `remove_listener()` waits for in-flight listener
  callbacks, which acquire `m_lock`, so a concurrent notification
  deadlocks the replayer. Defer the callbacks to the work queue, as
  `RemoteJournalerListener` already does.

- **fix self-deadlock in ImageDeleter on blocklist** :
  `enqueue_failed_delete()`'s `-EBLOCKLISTED` branch held `m_lock` and
  then called `complete_active_delete()`, which re-locks the
  non-recursive `m_lock`, deadlocking the work queue thread.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
