### PR TITLE
osd/PeeringState: avoid dereferencing olog end() in proc_master_log

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -3435,11 +3435,11 @@ void PeeringState::proc_master_log(
 	} else {
 	  consider_adjusting_pwlc(pg_log.get_tail());
 	}
-      } else if (op->version == p->version) {
+      } else if (std::prev(op)->version == p->version) {
 	// Normal case - both logs have this entry
 	consider_adjusting_pwlc(p->version);
 	++p;
-      } else if (op->version < p->version) {
+      } else if (std::prev(op)->version < p->version) {
 	// Last entry in other log is before this entry
 	consider_adjusting_pwlc(pg_log.get_tail());
       } else {


### PR DESCRIPTION
`auto op = olog.log.end()` is never moved, so `op->version` dereferences
the end iterator (UB). Compare the last log entry via `std::prev(op)`
instead.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests