### PR TITLE
osd: fix misspelled inject ec-clear command names

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6573,9 +6573,9 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
         }
     } else {
         if ((command == "injectecreaderr") ||
-	    (command == "injecteclearreaderr") ||
+	    (command == "injectecclearreaderr") ||
 	    (command == "injectecwriteerr") ||
-	    (command == "injecteclearwriteerr") ||
+	    (command == "injectecclearwriteerr") ||
             (command == "injectparityread") ||
             (command == "injectclearparityread")) {
             ss << "Only supported on ec pool";


### PR DESCRIPTION
Read as "inject ec clear read/write err".

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests