### PR TITLE
mgr: don't record a crash dump for NotImplementedError from dispatch_remote

### DIFF
--- a/src/mgr/ActivePyModule.cc
+++ b/src/mgr/ActivePyModule.cc
@@ -145,9 +145,13 @@ std::optional<std::vector<std::byte>> ActivePyModule::dispatch_remote(
     const std::string &method,
     std::span<std::byte const> pickled_args,
     std::span<std::byte const> pickled_kwargs,
-    std::string *err)
+    std::string *err,
+    bool *crash_dump)
 {
   ceph_assert(err != nullptr);
+  if (crash_dump != nullptr) {
+    *crash_dump = true;
+  }
 
   // deserialize arguments.
 
@@ -206,9 +210,12 @@ std::optional<std::vector<std::byte>> ActivePyModule::dispatch_remote(
     // scrape, which pinned RECENT_MGR_MODULE_CRASH permanently and added
     // ~5,760 crash records per day. The exception is still reported to the
     // caller, it is just not treated as a crash.
-    const bool crash_dump = !PyErr_ExceptionMatches(PyExc_NotImplementedError);
+    const bool do_crash_dump = !PyErr_ExceptionMatches(PyExc_NotImplementedError);
     std::string caller = "ActivePyModule::dispatch_remote "s + method;
-    *err = handle_pyerror(crash_dump, get_name(), caller);
+    *err = handle_pyerror(do_crash_dump, get_name(), caller);
+    if (crash_dump != nullptr) {
+      *crash_dump = do_crash_dump;
+    }
     return std::nullopt;
   }
   dout(20) << "Success calling '" << method << "'" << dendl;

--- a/src/mgr/ActivePyModule.cc
+++ b/src/mgr/ActivePyModule.cc
@@ -194,8 +194,21 @@ std::optional<std::vector<std::byte>> ActivePyModule::dispatch_remote(
     // Because the caller is in a different context, we can't let this
     // exception bubble up, need to re-raise it from the caller's
     // context later.
+    //
+    // NotImplementedError is not a fault: it is how a module signals that
+    // it does not implement an optional method of an interface it inherits
+    // from. The orchestrator interface is built on exactly that - see
+    // Orchestrator.get_feature_set() in the orchestrator module, whose
+    // docstring tells callers to "ask for forgiveness" and catch
+    // NotImplementedError. Recording a crash dump for it turns a documented,
+    // expected signal into a health warning: on a Rook-managed cluster
+    // mgr/prometheus calls the cephadm-only node_proxy_fullreport() once per
+    // scrape, which pinned RECENT_MGR_MODULE_CRASH permanently and added
+    // ~5,760 crash records per day. The exception is still reported to the
+    // caller, it is just not treated as a crash.
+    const bool crash_dump = !PyErr_ExceptionMatches(PyExc_NotImplementedError);
     std::string caller = "ActivePyModule::dispatch_remote "s + method;
-    *err = handle_pyerror(true, get_name(), caller);
+    *err = handle_pyerror(crash_dump, get_name(), caller);
     return std::nullopt;
   }
   dout(20) << "Success calling '" << method << "'" << dendl;

--- a/src/mgr/ActivePyModule.h
+++ b/src/mgr/ActivePyModule.h
@@ -72,7 +72,8 @@ public:
       const std::string &method,
       std::span<std::byte const> pickled_args,
       std::span<std::byte const> pickled_kwargs,
-      std::string *err);
+      std::string *err,
+      bool *crash_dump = nullptr);
 
   int handle_command(
     const ModuleCommand& module_command,

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -675,13 +675,14 @@ std::optional<std::vector<std::byte>> ActivePyModules::dispatch_remote(
     const std::string &method,
     std::span<std::byte const> pickled_args,
     std::span<std::byte const> pickled_kwargs,
-    std::string *err)
+    std::string *err,
+    bool *crash_dump)
 {
   auto mod_iter = modules.find(other_module);
   ceph_assert(mod_iter != modules.end());
 
   return mod_iter->second->dispatch_remote(
-    method, pickled_args, pickled_kwargs, err);
+    method, pickled_args, pickled_kwargs, err, crash_dump);
 }
 
 

--- a/src/mgr/ActivePyModules.h
+++ b/src/mgr/ActivePyModules.h
@@ -253,7 +253,8 @@ public:
       const std::string &method,
       std::span<std::byte const> pickled_args,
       std::span<std::byte const> pickled_kwargs,
-      std::string *err);
+      std::string *err,
+      bool *crash_dump = nullptr);
 
   int init();
 

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -908,13 +908,15 @@ ceph_dispatch_remote(BaseMgrModule *self, PyObject *args)
   }
 
   std::string err;
+  bool crash_dump = true;
   std::optional<std::vector<std::byte>> maybe_pickled_ret =
     self->py_modules->dispatch_remote(
       other_module,
       method,
       pickled_args_span,
       pickled_kwargs_span,
-      &err);
+      &err,
+      &crash_dump);
 
   PyEval_RestoreThread(tstate);
 
@@ -927,7 +929,14 @@ ceph_dispatch_remote(BaseMgrModule *self, PyObject *args)
     std::stringstream ss;
     ss << "Remote method threw exception: " << err;
     PyErr_SetString(PyExc_RuntimeError, ss.str().c_str());
-    derr << ss.str() << dendl;
+    // NotImplementedError is the documented way for a module to signal
+    // that it doesn't implement an optional method (see dispatch_remote()
+    // in ActivePyModule.cc); it isn't a fault, so don't log it as one.
+    if (crash_dump) {
+      derr << ss.str() << dendl;
+    } else {
+      dout(10) << ss.str() << dendl;
+    }
     return nullptr;
   }
 

--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -110,7 +110,7 @@ std::string handle_pyerror(
   }
   formatted = str("").join(formatted_list);
 
-  if (!module.empty()) {
+  if (crash_dump && !module.empty()) {
     std::list<std::string> bt_strings;
     std::map<std::string, std::string> extra;
     

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1,6 +1,8 @@
 import enum
 import errno
 import json
+import os
+import shutil
 from typing import List, Set, Optional, Iterator, cast, Dict, Any, Union, Sequence, Mapping, Tuple
 import re
 import datetime
@@ -2606,6 +2608,76 @@ Usage:
             assert False
         except OrchestratorError as e:
             assert e.args == ('hello, world',)
+
+        self._self_test_no_crash_dump_for_not_implemented_error()
+
+    def _self_test_no_crash_dump_for_not_implemented_error(self) -> None:
+        """
+        Regression test for https://tracker.ceph.com/issues/79106:
+        dispatch_remote() must not generate a crash dump for
+        NotImplementedError, since that's the documented way a module
+        signals an optional method isn't implemented, not a fault. A
+        genuine exception (the RuntimeError control case below) must
+        still be recorded.
+        """
+        crash_dir = cast(str, self.get_ceph_option('crash_dir'))
+
+        def crash_dir_entries() -> Set[str]:
+            try:
+                return set(os.listdir(crash_dir))
+            except FileNotFoundError:
+                return set()
+
+        def new_entries_from_selftest(before: Set[str], method: str) -> Set[str]:
+            # self_test() runs live inside ceph-mgr alongside every other
+            # always-on module, so crash_dir is shared: don't assume every
+            # entry that showed up since 'before' is ours. Only count/clean
+            # up entries whose crash metadata actually names this call, so
+            # an unrelated module crashing elsewhere during this window is
+            # neither mistaken for a test failure nor swept up and deleted.
+            matches = set()
+            for name in crash_dir_entries() - before:
+                try:
+                    with open(os.path.join(crash_dir, name, 'meta')) as f:
+                        meta = json.load(f)
+                except (OSError, ValueError):
+                    continue
+                if (meta.get('mgr_module') == 'selftest'
+                        and method in meta.get('mgr_module_caller', '')):
+                    matches.add(name)
+            return matches
+
+        before = crash_dir_entries()
+
+        # self.remote() converts *any* exception raised by the callee into
+        # a RuntimeError (see MgrModule.remote()'s docstring), so the
+        # NotImplementedError doesn't survive as its own type here -- the
+        # signal we actually care about is whether it produced a crash dump.
+        try:
+            self.remote('selftest', 'remote_raise_not_implemented_error')
+            assert False, 'exception not raised'
+        except RuntimeError:
+            pass
+        not_implemented_dumps = new_entries_from_selftest(
+            before, 'remote_raise_not_implemented_error')
+        assert not not_implemented_dumps, (
+            f'NotImplementedError from dispatch_remote() generated a crash '
+            f'dump: {not_implemented_dumps}')
+
+        try:
+            self.remote('selftest', 'remote_raise_runtime_error')
+            assert False, 'exception not raised'
+        except RuntimeError:
+            pass
+        runtime_error_dumps = new_entries_from_selftest(
+            before, 'remote_raise_runtime_error')
+        assert runtime_error_dumps, (
+            'RuntimeError from dispatch_remote() unexpectedly did not '
+            'generate a crash dump (control case failed)')
+
+        # Don't leave synthetic crash dumps lying around.
+        for name in runtime_error_dumps:
+            shutil.rmtree(os.path.join(crash_dir, name), ignore_errors=True)
 
     @staticmethod
     def _upgrade_check_image_name(image: Optional[str], ceph_version: Optional[str]) -> None:

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -2211,6 +2211,23 @@ class Module(MgrModule, OrchestratorClientMixin):
         if not self.orch_is_available():
             return
 
+        # node-proxy is only implemented by the cephadm orchestrator backend.
+        # Other backends (e.g. rook) report available() as True but don't
+        # implement node_proxy_fullreport(), so calling it every scrape would
+        # raise NotImplementedError on every invocation for no reason.
+        #
+        # Read the backend name directly from config instead of asking the
+        # orchestrator module for it: orch_is_available() above already
+        # makes that exact remote() call internally (via available()), so
+        # a second self.remote() here would just repeat the same
+        # dispatch_remote() round trip for no benefit.
+        try:
+            if self.get_module_option_ex('orchestrator', 'orchestrator') != 'cephadm':
+                return
+        except Exception as e:
+            self.log.debug(f"Failed to determine orchestrator backend: {e}")
+            return
+
         try:
             report = raise_if_exception(self.node_proxy_fullreport())
         except Exception as e:

--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -446,6 +446,23 @@ class Module(MgrModule):
             return orchestrator.OrchResult(result=None, exception=ZeroDivisionError('hello, world'))
         assert False, repr(what)
 
+    def remote_raise_not_implemented_error(self) -> None:
+        """
+        Called via self.remote() to verify that dispatch_remote() does not
+        generate a crash dump for NotImplementedError: it is the documented
+        way a module signals that it doesn't implement an optional method,
+        not a fault. See https://tracker.ceph.com/issues/79106.
+        """
+        raise NotImplementedError('selftest: intentional NotImplementedError')
+
+    def remote_raise_runtime_error(self) -> None:
+        """
+        Called via self.remote() as a negative control for
+        remote_raise_not_implemented_error(): a genuine exception must
+        still generate a crash dump.
+        """
+        raise RuntimeError('selftest: intentional RuntimeError')
+
     def shutdown(self) -> None:
         self._workload = Workload.SHUTDOWN
         self._event.set()


### PR DESCRIPTION
NotImplementedError is how an orchestrator module signals it doesn't
implement an optional method not a fault. But dispatch_remote() asked
for a crash dump on any exception the callee raised, so following that
convention still produced a crash record.

On a Rook-managed cluster this bit hard: mgr/prometheus calls the
cephadm-only node_proxy_fullreport() every scrape, Rook doesn't
implement it, and each scrape left a crash record behind about 5,760
a day. RECENT_MGR_MODULE_CRASH gets raised within minutes and never
clears, so HEALTH_OK becomes unreachable.

Skip the crash dump for NotImplementedError; the exception itself is
still raised and returned to the caller as before. handle_pyerror()
already took a crash_dump parameter for this but never honored it
now it does, with no effect on any other caller.

Fixes: https://tracker.ceph.com/issues/79106
Signed-off-by: Sebastian Marschke <sebastian@marschke.org>
Signed-off-by: Nitzan Mordechai <nmordech@ibm.com>
Commit message assisted by: IBM Bob



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
