### PR TITLE
mgr/dashboard : Dashboard allows disabling mTLS/Encryption without warning about security implications

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.html
@@ -126,14 +126,25 @@
             >
           </cds-checkbox>
 
-          @if (!groupForm.controls.enableEncryption.value) {
+          @if (!groupForm.controls.enableEncryption.value && !editing) {
             <cd-alert-panel
               type="warning"
               i18n
             >
-              <p class="cds--type-heading-01">
-                Encryption is required if you plan to use DH-CHAP or mTLS authentication.
-              </p>
+              <p class="cds--type-heading-01">Encryption is required if you plan to use DH-CHAP.</p>
+            </cd-alert-panel>
+          }
+
+          @if (showEncryptionDisableWarning) {
+            <cd-alert-panel
+              type="warning"
+              class="cds--type-heading-01"
+              alertTitle="Warning"
+              i18n-alertTitle
+              i18n
+            >
+              Disabling encryption will disable encryption for the gateway. The configured
+              encryption settings will no longer be used.
             </cd-alert-panel>
           }
 
@@ -192,13 +203,23 @@
             </p>
           </cds-checkbox>
 
-          @if (!groupForm.controls.enableMtls.value) {
+          @if (!groupForm.controls.enableMtls.value && !editing) {
             <cd-alert-panel
               type="warning"
               class="cds--type-heading-01"
               i18n
             >
               Disabling mTLS leaves gateway control and monitoring communication unencrypted.
+            </cd-alert-panel>
+          }
+
+          @if (showMtlsDisableWarning) {
+            <cd-alert-panel
+              type="warning"
+              class="cds--type-heading-01"
+              i18n
+            >
+              Disabling mTLS will disable mTLS. The configured mTLS settings will no longer be used.
             </cd-alert-panel>
           }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.spec.ts
@@ -447,6 +447,37 @@ describe('NvmeofGroupFormComponent', () => {
       expect(form.valid).toBe(true);
     });
 
+    it('should show encryption disable warning when unchecking encryption in edit mode', () => {
+      // Already editing with encryption enabled (loaded by beforeEach)
+      expect(component.showEncryptionDisableWarning).toBe(false);
+
+      form.controls.enableEncryption.setValue(false);
+      expect(component.showEncryptionDisableWarning).toBe(true);
+    });
+
+    it('should hide encryption disable warning when re-enabling encryption in edit mode', () => {
+      form.controls.enableEncryption.setValue(false);
+      expect(component.showEncryptionDisableWarning).toBe(true);
+
+      form.controls.enableEncryption.setValue(true);
+      expect(component.showEncryptionDisableWarning).toBe(false);
+    });
+
+    it('should show mTLS disable warning when unchecking mTLS in edit mode', () => {
+      expect(component.showMtlsDisableWarning).toBe(false);
+
+      form.controls.enableMtls.setValue(false);
+      expect(component.showMtlsDisableWarning).toBe(true);
+    });
+
+    it('should hide mTLS disable warning when re-enabling mTLS in edit mode', () => {
+      form.controls.enableMtls.setValue(false);
+      expect(component.showMtlsDisableWarning).toBe(true);
+
+      form.controls.enableMtls.setValue(true);
+      expect(component.showMtlsDisableWarning).toBe(false);
+    });
+
     it('should NOT set enableEncryption when ssl:true but encryption_key is absent (cephadm-internal ssl)', () => {
       // cephadm sets ssl:true internally for cert-managed services.
       // Without an explicit encryption_key the user did not enable the toggle.

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-group-form/nvmeof-group-form.component.ts
@@ -50,6 +50,8 @@ export class NvmeofGroupFormComponent extends CdForm implements OnInit {
   currentCertificate: CephServiceCertificate = null;
   currentSpecCertificateSource = '';
   showCertSourceChangeWarning = false;
+  showEncryptionDisableWarning = false;
+  showMtlsDisableWarning = false;
 
   constructor(
     private authStorageService: AuthStorageService,
@@ -131,22 +133,25 @@ export class NvmeofGroupFormComponent extends CdForm implements OnInit {
         encryptionConfigControl?.setValidators(null);
         encryptionKeyControl?.updateValueAndValidity({ emitEvent: false });
         encryptionConfigControl?.updateValueAndValidity({ emitEvent: false });
+        this.showEncryptionDisableWarning = this.editing;
         return;
       }
 
-      // Encryption enabled — the key is required (backend rejects empty encryption_key).
-      // Both fields mirror each other; only encryptionKey is surfaced in the template,
-      // so only that control needs the required validator on the user-visible form path.
+      this.showEncryptionDisableWarning = false;
+
       encryptionKeyControl?.setValidators([Validators.required]);
       encryptionKeyControl?.updateValueAndValidity({ emitEvent: false });
-      // Keep encryptionConfig in sync but do NOT add required to it;
-      // it is an internal mirror and never shown to the user.
+
       if (!encryptionKeyControl?.value && encryptionConfigControl?.value) {
         encryptionKeyControl.setValue(encryptionConfigControl.value, { emitEvent: false });
       }
       if (!encryptionConfigControl?.value && encryptionKeyControl?.value) {
         encryptionConfigControl.setValue(encryptionKeyControl.value, { emitEvent: false });
       }
+    });
+
+    this.groupForm.get('enableMtls')?.valueChanges.subscribe((enabled) => {
+      this.showMtlsDisableWarning = !enabled && this.editing;
     });
   }
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/607f803d-2eb1-464a-8ba6-a9aa97c4f250




Fixes: https://tracker.ceph.com/issues/79358
Signed-off-by: pujaoshahu <pshahu@redhat.com>

**Summary:** Implemented edit-specific warning alerts for Encryption and mTLS when switching from enabled to disabled, while preserving the existing alerts and behavior in the Create flow.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
