### PR TITLE
rgw/test: Add unit tests for sal_wrapper APIs and LanceDB ObjectStore

### DIFF
--- a/qa/suites/rgw/verify/tasks/sal-wrapper.yaml
+++ b/qa/suites/rgw/verify/tasks/sal-wrapper.yaml
@@ -1,0 +1,6 @@
+tasks:
+- workunit:
+    clients:
+      client.0:
+        - rgw/test_rgw_sal_wrapper.sh
+        - rgw/test_rgw_lancedb_object_store.sh

--- a/qa/workunits/rgw/test_rgw_lancedb_object_store.sh
+++ b/qa/workunits/rgw/test_rgw_lancedb_object_store.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+ceph_test_rgw_lancedb_object_store
+
+exit 0

--- a/qa/workunits/rgw/test_rgw_sal_wrapper.sh
+++ b/qa/workunits/rgw/test_rgw_sal_wrapper.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+ceph_test_rgw_sal_wrapper
+
+exit 0

--- a/src/rgw/Cargo.lock
+++ b/src/rgw/Cargo.lock
@@ -4570,6 +4570,7 @@ dependencies = [
  "log",
  "object_store",
  "pkg-config",
+ "tokio",
  "tokio-test",
  "url",
 ]

--- a/src/rgw/lancedb-rgw-store/Cargo.toml
+++ b/src/rgw/lancedb-rgw-store/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["staticlib", "rlib"]
 # Cargo.lock — versions are unified automatically.  No pins needed.
 lance-io = { version = "7.0", default-features = false }
 lance-core = { version = "7.0", default-features = false }
-object_store = "0.13"
+object_store = { version = "0.13", features = ["integration"] }
 bytes = "1"
 async-trait = "0.1"
 futures = "0.3"
@@ -34,3 +34,8 @@ pkg-config = "0.3"
 [dev-dependencies]
 tokio-test = "0.4"
 lazy_static = "1.4"
+# tests/object_store.rs drives the async ObjectStore trait with #[tokio::test];
+# the arrow-rs conformance suite (stream_get) needs a real runtime that
+# futures::executor cannot provide.  dev-dependency only, so the staticlib
+# linked into radosgw stays tokio-free.
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/src/rgw/lancedb-rgw-store/README.md
+++ b/src/rgw/lancedb-rgw-store/README.md
@@ -10,7 +10,10 @@ This crate implements the `object_store::ObjectStore` trait from Apache Arrow, r
 
 ### During Ceph Build
 
-The crate is built automatically as part of the Ceph build process when `WITH_RADOSGW_LANCEDB` is enabled:
+The crate is built automatically as part of the Ceph build process when
+`WITH_RADOSGW_LANCEDB` is enabled. It is compiled through the `rgw-lancedb`
+umbrella crate (which combines `lancedb-c` and `lancedb-rgw-store` into a
+single `librgw_lancedb.a` static library linked into `rgw_common`).
 
 ```bash
 cd ceph/build
@@ -36,14 +39,33 @@ After rebuilding, restart the RGW daemon to pick up the changes.
 
 ## Testing
 
-### Unit Tests
+### C++ SAL Wrapper Tests
 
-Unit tests run within the Ceph build system (via `ninja`). Standalone `cargo test`
-requires Ceph libraries to resolve FFI symbols at link time.
+Tests the C wrapper API directly against a live SAL driver:
 
-### Integration Tests
+```bash
+cd ceph/build
+ninja ceph_test_rgw_sal_wrapper
+./bin/ceph_test_rgw_sal_wrapper -c ./ceph.conf
+```
 
-Integration tests require a running Ceph cluster with RGW. See `src/test/rgw/s3vectors/` for the test suite.
+The backend (rados, dbstore, posix) is read from ceph.conf.
+
+### LanceDB ObjectStore Integration Tests
+
+Tests the `ObjectStore` trait implementation end-to-end through the
+real FFI boundary:
+
+```bash
+cd ceph/build
+# Force Rust rebuild if sources changed
+ninja ceph_test_rgw_lancedb_object_store
+./bin/ceph_test_rgw_lancedb_object_store -c ./ceph.conf
+```
+
+### S3 Vector Integration Tests
+
+Full end-to-end tests via S3 protocol. See `src/test/rgw/s3vectors/`.
 
 ## Architecture
 

--- a/src/rgw/lancedb-rgw-store/build.rs
+++ b/src/rgw/lancedb-rgw-store/build.rs
@@ -19,4 +19,28 @@ fn main() {
     println!("cargo:rerun-if-env-changed=CEPH_BUILD_DIR");
     println!("cargo:rerun-if-env-changed=CEPH_SRC_DIR");
     println!("cargo:rerun-if-changed=build.rs");
+
+    // A `cargo test` binary is a real link (unlike the staticlib above), so the
+    // rgw_sal_wrapper symbols the FFI calls have to resolve here. The ceph
+    // build sets RGW_SAL_TEST_ENV_DIR to the directory holding
+    // libceph_rgw_sal_test_env.so, which exports both that API and the test
+    // environment setup entry points (rgw_test_env_*).  It is unset for an
+    // ordinary build, which therefore links exactly as before.
+    println!("cargo:rerun-if-env-changed=RGW_SAL_TEST_ENV_DIR");
+    println!("cargo:rerun-if-env-changed=RGW_SAL_TEST_ENV_RPATH");
+    if let Ok(dir) = std::env::var("RGW_SAL_TEST_ENV_DIR") {
+        println!("cargo:rustc-link-search=native={dir}");
+        println!("cargo:rustc-link-lib=dylib=ceph_rgw_sal_test_env");
+        // Use rustc-link-arg (not -tests): it covers the crate's own
+        // #[cfg(test)] unit-test binary as well as the tests/ integration
+        // binary.  It never reaches the staticlib radosgw links, both because
+        // staticlibs are not a target kind rustc-link-arg applies to and
+        // because RGW_SAL_TEST_ENV_DIR is only set for cargo test.
+        println!("cargo:rustc-link-arg=-Wl,-rpath,{dir}");
+        if let Ok(extra) = std::env::var("RGW_SAL_TEST_ENV_RPATH") {
+            for path in extra.split(':').filter(|p| !p.is_empty()) {
+                println!("cargo:rustc-link-arg=-Wl,-rpath,{path}");
+            }
+        }
+    }
 }

--- a/src/rgw/lancedb-rgw-store/src/ffi.rs
+++ b/src/rgw/lancedb-rgw-store/src/ffi.rs
@@ -190,6 +190,7 @@ extern "C" {
         bucket: *const CRgwBucket,
         obj: *const CRgwObject,
         buffer: *const CRgwBuffer,
+        etag_out: *mut *mut c_char,
     ) -> c_int;
 
     /// Write an object with conditional preconditions
@@ -203,6 +204,7 @@ extern "C" {
         if_match: *const c_char,
         if_nomatch: *const c_char,
         canceled: *mut c_int,
+        etag_out: *mut *mut c_char,
     ) -> c_int;
 
     /// Read an object from RGW storage
@@ -214,6 +216,24 @@ extern "C" {
         obj: *const CRgwObject,
         offset: u64,
         length: u64,
+        buffer: *mut CRgwBuffer,
+    ) -> c_int;
+
+    /// Read an object with conditional checks (if-match, if-modified-since, etc.).
+    /// This is not used by Lance as it reads immutable files, but is added only
+    /// for object-store conformance tests.
+    pub fn rgw_get_object_conditional(
+        driver: *mut CRgwDriver,
+        dpp: *const CRgwDoutPrefix,
+        yield_ctx: *mut CRgwYieldContext,
+        bucket: *const CRgwBucket,
+        obj: *const CRgwObject,
+        offset: u64,
+        length: u64,
+        if_match: *const c_char,
+        if_nomatch: *const c_char,
+        if_modified_since: *const i64,
+        if_unmodified_since: *const i64,
         buffer: *mut CRgwBuffer,
     ) -> c_int;
 

--- a/src/rgw/lancedb-rgw-store/src/store.rs
+++ b/src/rgw/lancedb-rgw-store/src/store.rs
@@ -12,8 +12,8 @@
 //! routing all I/O operations through Ceph's RGW SAL C API.
 
 use crate::ffi::{
-    self, CRgwBucket, CRgwDoutPrefix, CRgwDriver, CRgwObject, OwnedRGWBuffer,
-    OwnedRGWListResult, OwnedRGWObjectMeta,
+    self, CRgwBucket, CRgwDoutPrefix, CRgwDriver, CRgwObject, OwnedRGWBuffer, OwnedRGWListResult,
+    OwnedRGWObjectMeta,
 };
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -68,6 +68,19 @@ impl SendConstPtr {
 }
 
 const DEFAULT_CHUNK_SIZE: u64 = 4 * 1024 * 1024;
+
+/// Extract etag string from a C pointer returned by rgw_put_object, then free it.
+///
+/// # Safety
+/// `ptr` must be null or a valid pointer from `strdup()` (freeable with `libc::free`).
+unsafe fn etag_from_ptr(ptr: *mut c_char) -> Option<String> {
+    if ptr.is_null() {
+        return None;
+    }
+    let s = CStr::from_ptr(ptr).to_string_lossy().into_owned();
+    libc::free(ptr as *mut std::ffi::c_void);
+    Some(s)
+}
 
 /// Convert a string to CString, returning an ObjectStore error on failure.
 fn str_to_cstring(s: &str) -> ObjectStoreResult<CString> {
@@ -151,7 +164,7 @@ impl RGWObjectStore {
 
     /// Convert path to C string key
     fn path_to_cstr(&self, path: &Path) -> ObjectStoreResult<CString> {
-        str_to_cstring(&path.to_string())
+        str_to_cstring(path.as_ref())
     }
 
     fn make_obj(key: &CString) -> CRgwObject {
@@ -175,8 +188,10 @@ impl RGWObjectStore {
         } else {
             Some(CStr::from_ptr(entry.etag).to_string_lossy().into_owned())
         };
+        // Keys written through this store are already percent-encoded
+        let location = Path::parse(&key).unwrap_or_else(|_| Path::from(key));
         ObjectMeta {
-            location: Path::from(key),
+            location,
             last_modified: Self::timestamp(entry.last_modified, entry.last_modified_ns),
             size: entry.size,
             e_tag,
@@ -245,6 +260,16 @@ impl RGWObjectStore {
                 // ENOTSUP
                 source: format!("{} not supported by RGW backend", op).into(),
             },
+            -2015 => object_store::Error::Precondition {
+                // ERR_PRECONDITION_FAILED
+                path: path.to_string(),
+                source: format!("{} failed: precondition failed", op).into(),
+            },
+            -2016 => object_store::Error::NotModified {
+                // ERR_NOT_MODIFIED
+                path: path.to_string(),
+                source: format!("{} failed: not modified", op).into(),
+            },
             _ => object_store::Error::Generic {
                 store: "rgw",
                 source: format!("{} failed with errno {}", op, errno).into(),
@@ -304,6 +329,7 @@ impl ObjectStore for RGWObjectStore {
                     data: bytes.as_ptr() as *mut u8,
                     len: bytes.len(),
                 };
+                let mut etag_ptr: *mut c_char = std::ptr::null_mut();
                 let result = unsafe {
                     ffi::rgw_put_object(
                         self.driver,
@@ -312,17 +338,18 @@ impl ObjectStore for RGWObjectStore {
                         &rgw_bucket,
                         &obj,
                         &buf,
+                        &mut etag_ptr,
                     )
                 };
 
-                if result == 0 {
-                    Ok(PutResult {
-                        e_tag: None,
-                        version: None,
-                    })
-                } else {
-                    Err(Self::errno_to_error(result, location, "put"))
+                if result != 0 {
+                    return Err(Self::errno_to_error(result, location, "put"));
                 }
+                let e_tag = unsafe { etag_from_ptr(etag_ptr) };
+                Ok(PutResult {
+                    e_tag,
+                    version: None,
+                })
             }
             PutMode::Create => {
                 let if_nomatch = str_to_cstring("*")?;
@@ -331,6 +358,7 @@ impl ObjectStore for RGWObjectStore {
                     data: bytes.as_ptr() as *mut u8,
                     len: bytes.len(),
                 };
+                let mut etag_ptr: *mut c_char = std::ptr::null_mut();
 
                 let result = unsafe {
                     ffi::rgw_put_object_conditional(
@@ -343,6 +371,7 @@ impl ObjectStore for RGWObjectStore {
                         std::ptr::null(),
                         if_nomatch.as_ptr(),
                         &mut canceled,
+                        &mut etag_ptr,
                     )
                 };
 
@@ -355,8 +384,9 @@ impl ObjectStore for RGWObjectStore {
                         source: "object already exists (conditional create failed)".into(),
                     });
                 }
+                let e_tag = unsafe { etag_from_ptr(etag_ptr) };
                 Ok(PutResult {
-                    e_tag: None,
+                    e_tag,
                     version: None,
                 })
             }
@@ -375,6 +405,7 @@ impl ObjectStore for RGWObjectStore {
                     data: bytes.as_ptr() as *mut u8,
                     len: bytes.len(),
                 };
+                let mut etag_ptr: *mut c_char = std::ptr::null_mut();
 
                 let result = unsafe {
                     ffi::rgw_put_object_conditional(
@@ -387,6 +418,7 @@ impl ObjectStore for RGWObjectStore {
                         if_match.as_ptr(),
                         std::ptr::null(),
                         &mut canceled,
+                        &mut etag_ptr,
                     )
                 };
 
@@ -396,11 +428,13 @@ impl ObjectStore for RGWObjectStore {
                 if canceled != 0 {
                     return Err(ObjectStoreError::Precondition {
                         path: location.to_string(),
-                        source: "object ETag does not match (conditional update failed)".into(),
+                        source: "conditional update failed (etag mismatch or object not found)"
+                            .into(),
                     });
                 }
+                let e_tag = unsafe { etag_from_ptr(etag_ptr) };
                 Ok(PutResult {
-                    e_tag: None,
+                    e_tag,
                     version: None,
                 })
             }
@@ -428,12 +462,50 @@ impl ObjectStore for RGWObjectStore {
             });
         }
 
+        let has_conditionals = opts.if_match.is_some()
+            || opts.if_none_match.is_some()
+            || opts.if_modified_since.is_some()
+            || opts.if_unmodified_since.is_some();
+
+        let if_match_c = opts
+            .if_match
+            .as_deref()
+            .map(str_to_cstring)
+            .transpose()?;
+        let if_nomatch_c = opts
+            .if_none_match
+            .as_deref()
+            .map(str_to_cstring)
+            .transpose()?;
+        let if_mod_since = opts.if_modified_since.map(|t| t.timestamp());
+        let if_unmod_since = opts.if_unmodified_since.map(|t| t.timestamp());
+
         let obj_size = meta.size;
 
         // Resolve the byte range to read
         let (range_start, range_end) = match &opts.range {
-            Some(GetRange::Bounded(range)) => (range.start, range.end.min(obj_size)),
-            Some(GetRange::Offset(start)) => (*start, obj_size),
+            Some(GetRange::Bounded(range)) => {
+                if range.start >= obj_size {
+                    return Err(ObjectStoreError::Generic {
+                        store: "rgw",
+                        source: format!(
+                            "range start {} exceeds object size {}",
+                            range.start, obj_size
+                        )
+                        .into(),
+                    });
+                }
+                (range.start, range.end.min(obj_size))
+            }
+            Some(GetRange::Offset(start)) => {
+                if *start >= obj_size {
+                    return Err(ObjectStoreError::Generic {
+                        store: "rgw",
+                        source: format!("offset {} exceeds object size {}", start, obj_size).into(),
+                    });
+                }
+                (*start, obj_size)
+            }
             Some(GetRange::Suffix(len)) => {
                 let start = obj_size.saturating_sub(*len);
                 (start, obj_size)
@@ -441,7 +513,7 @@ impl ObjectStore for RGWObjectStore {
             None => (0, obj_size),
         };
 
-        let total_len = range_end.saturating_sub(range_start);
+        let total_len = range_end - range_start;
 
         if total_len == 0 {
             return Ok(GetResult {
@@ -462,17 +534,42 @@ impl ObjectStore for RGWObjectStore {
 
             let bytes = {
                 let mut buffer = ffi::CRgwBuffer::default();
-                let result = unsafe {
-                    ffi::rgw_get_object(
-                        self.driver,
-                        self.dpp,
-                        std::ptr::null_mut(),
-                        &rgw_bucket,
-                        &obj,
-                        range_start,
-                        total_len,
-                        &mut buffer,
-                    )
+                let result = if has_conditionals {
+                    unsafe {
+                        ffi::rgw_get_object_conditional(
+                            self.driver,
+                            self.dpp,
+                            std::ptr::null_mut(),
+                            &rgw_bucket,
+                            &obj,
+                            range_start,
+                            total_len,
+                            if_match_c.as_ref().map_or(std::ptr::null(), |c| c.as_ptr()),
+                            if_nomatch_c
+                                .as_ref()
+                                .map_or(std::ptr::null(), |c| c.as_ptr()),
+                            if_mod_since
+                                .as_ref()
+                                .map_or(std::ptr::null(), |v| v as *const i64),
+                            if_unmod_since
+                                .as_ref()
+                                .map_or(std::ptr::null(), |v| v as *const i64),
+                            &mut buffer,
+                        )
+                    }
+                } else {
+                    unsafe {
+                        ffi::rgw_get_object(
+                            self.driver,
+                            self.dpp,
+                            std::ptr::null_mut(),
+                            &rgw_bucket,
+                            &obj,
+                            range_start,
+                            total_len,
+                            &mut buffer,
+                        )
+                    }
                 };
                 if result != 0 {
                     return Err(Self::errno_to_error(result, location, "get"));
@@ -492,7 +589,7 @@ impl ObjectStore for RGWObjectStore {
         // Uses SendPtr/SendConstPtr because the stream is 'static (outlives &self).
         let bucket_name = self.bucket.clone();
         let tenant_name = self.tenant.clone();
-        let key_str = location.to_string();
+        let key_str: String = location.as_ref().to_string();
         let driver = SendPtr::new(self.driver);
         let dpp = SendConstPtr::new(self.dpp);
         let chunk_size = self.chunk_size;
@@ -626,7 +723,7 @@ impl ObjectStore for RGWObjectStore {
                     let bucket_c = str_to_cstring(&bucket)?;
                     let tenant_c = str_to_cstring(&tenant)?;
                     let rgw_bucket = Self::make_bucket(&bucket_c, &tenant_c);
-                    let key_c = str_to_cstring(&location.to_string())?;
+                    let key_c = str_to_cstring(location.as_ref())?;
                     let obj = CRgwObject::from_key(key_c.as_ptr());
 
                     let result = unsafe {
@@ -659,7 +756,16 @@ impl ObjectStore for RGWObjectStore {
     /// The returned stream owns all its data (see `delete_stream`).
     /// Each page fetches up to 1000 entries via `rgw_list_objects`.
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, ObjectStoreResult<ObjectMeta>> {
-        let prefix_str = prefix.map(|p| p.to_string()).unwrap_or_default();
+        let prefix_str = prefix
+            .map(|p| {
+                let s = p.to_string();
+                if s.is_empty() || s.ends_with('/') {
+                    s
+                } else {
+                    format!("{}/", s)
+                }
+            })
+            .unwrap_or_default();
         let bucket = self.bucket.clone();
         let tenant = self.tenant.clone();
         let driver = SendPtr::new(self.driver);
@@ -760,7 +866,7 @@ impl ObjectStore for RGWObjectStore {
                 Some((entries, (next_marker, is_done)))
             }
         })
-        .flat_map(|results| stream::iter(results))
+        .flat_map(stream::iter)
         .boxed()
     }
 
@@ -773,9 +879,7 @@ impl ObjectStore for RGWObjectStore {
         let prefix_str = match prefix {
             Some(p) => {
                 let s = p.to_string();
-                if s.is_empty() {
-                    s
-                } else if s.ends_with('/') {
+                if s.is_empty() || s.ends_with('/') {
                     s
                 } else {
                     format!("{}/", s)
@@ -833,7 +937,10 @@ impl ObjectStore for RGWObjectStore {
                         if key.ends_with('/') {
                             let prefix_path = key.trim_end_matches('/');
                             if !prefix_path.is_empty() {
-                                common_prefixes.push(Path::from(prefix_path));
+                                common_prefixes.push(
+                                    Path::parse(prefix_path)
+                                        .unwrap_or_else(|_| Path::from(prefix_path)),
+                                );
                             }
                         } else if !key.is_empty() {
                             objects.push(Self::entry_meta(e));
@@ -981,7 +1088,7 @@ impl ObjectStore for RGWObjectStore {
             dpp: self.dpp,
             bucket: self.bucket.clone(),
             tenant: self.tenant.clone(),
-            key: location.to_string(),
+            key: location.as_ref().to_string(),
             upload_id: upload_id_str,
             parts: Arc::new(Mutex::new(Vec::new())),
         }))

--- a/src/rgw/lancedb-rgw-store/tests/object_store.rs
+++ b/src/rgw/lancedb-rgw-store/tests/object_store.rs
@@ -1,0 +1,308 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright 2026 IBM
+ *
+ * See file COPYING for licensing information.
+ */
+
+//! Integration tests for [`RGWObjectStore`], exercising the ObjectStore trait
+//! through the real FFI boundary against a live SAL driver.
+//!
+//! libtest owns main() -- so that happens in C++ behind the `rgw_test_env_*` API declared
+//! below and implemented in src/test/rgw/rgw_sal_test_env.cc.  The ceph build
+//! links the two into bin/ceph_test_rgw_lancedb_object_store;  see
+//! src/test/rgw/cargo_test_binary.cmake.
+//!
+//! Configuration comes from the environment, since libtest owns argv:
+//!
+//! ```text
+//! CEPH_CONF=build/ceph.conf ./bin/ceph_test_rgw_lancedb_object_store
+//! ```
+//!
+//! Each test gets its own bucket, which is what the arrow-rs conformance suite
+//! assumes and what keeps libtest's thread-parallel execution safe.
+
+use bytes::Bytes;
+use futures::StreamExt;
+use lancedb_rgw_store::ffi::{CRgwDoutPrefix, CRgwDriver};
+use lancedb_rgw_store::RGWObjectStore;
+use object_store::integration;
+use object_store::path::Path;
+use object_store::{MultipartUpload, ObjectStore, ObjectStoreExt, PutPayload};
+use std::ffi::CString;
+use std::os::raw::{c_char, c_int};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
+
+// The C test-environment API, provided by libceph_rgw_sal_test_env.so.
+extern "C" {
+    fn rgw_test_env_init() -> c_int;
+    fn rgw_test_env_driver() -> *mut CRgwDriver;
+    fn rgw_test_env_dpp() -> *const CRgwDoutPrefix;
+    fn rgw_test_env_backend() -> *const c_char;
+    fn rgw_test_env_create_bucket(name: *const c_char, tenant: *const c_char) -> c_int;
+    fn rgw_test_env_remove_bucket(name: *const c_char, tenant: *const c_char) -> c_int;
+}
+
+/// Process-wide SAL driver handles, initialized once and shared by every test.
+struct SalEnv {
+    driver: *mut CRgwDriver,
+    dpp: *const CRgwDoutPrefix,
+    #[allow(dead_code)]
+    backend: String,
+}
+
+// Safety: the driver and DoutPrefixProvider are shared across RGW request
+// threads in production, and rgw_test_env_init() hands the same pair to every
+// caller.  This matches the reasoning behind the RGWObjectStore Send/Sync impls
+// in store.rs.
+unsafe impl Send for SalEnv {}
+unsafe impl Sync for SalEnv {}
+
+/// Bring the SAL driver up once, then hand the same handles to every test.
+///
+/// libtest has no global setup hook, so the first test to run pays for
+/// initialization while the rest wait on the OnceLock.
+fn sal_env() -> &'static SalEnv {
+    static ENV: OnceLock<SalEnv> = OnceLock::new();
+    ENV.get_or_init(|| {
+        let ret = unsafe { rgw_test_env_init() };
+        assert_eq!(
+            ret, 0,
+            "rgw_test_env_init() failed ({ret}); is a cluster running and is \
+             $CEPH_CONF pointing at it?"
+        );
+        let backend = unsafe { rgw_test_env_backend() };
+        assert!(!backend.is_null(), "rgw_test_env_backend() returned null");
+        SalEnv {
+            driver: unsafe { rgw_test_env_driver() },
+            dpp: unsafe { rgw_test_env_dpp() },
+            backend: unsafe { std::ffi::CStr::from_ptr(backend) }
+                .to_string_lossy()
+                .into_owned(),
+        }
+    })
+}
+
+/// A bucket owned by a single test and removed when the test finishes.
+struct TestBucket {
+    name: CString,
+    store: RGWObjectStore,
+}
+
+impl TestBucket {
+    fn new(tag: &str) -> Self {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let env = sal_env();
+
+        // bucket names allow only lowercase alphanumerics and dashes, so the
+        // test tag (which may contain other characters) is sanitized
+        let tag: String = tag
+            .chars()
+            .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+            .collect();
+        let name = CString::new(format!(
+            "lancedb-test-{}-{}-{tag}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed),
+        ))
+        .unwrap();
+
+        let ret = unsafe { rgw_test_env_create_bucket(name.as_ptr(), std::ptr::null()) };
+        assert_eq!(
+            ret,
+            0,
+            "failed to create bucket {}: {ret}",
+            name.to_string_lossy()
+        );
+
+        // Safety: the driver outlives every test -- it is torn down from the
+        // atexit() handler registered by rgw_test_env_init().
+        let store = unsafe {
+            RGWObjectStore::new(
+                env.driver,
+                env.dpp,
+                name.to_str().unwrap(),
+                "", // tenant
+                "", // prefix
+            )
+        };
+        Self { name, store }
+    }
+
+    fn store(&self) -> &RGWObjectStore {
+        &self.store
+    }
+}
+
+impl Drop for TestBucket {
+    fn drop(&mut self) {
+        // Best effort: a bucket left behind by a panicking test is instead
+        // removed by the atexit() handler.
+        unsafe { rgw_test_env_remove_bucket(self.name.as_ptr(), std::ptr::null()) };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// arrow-rs object-store conformance suite
+//
+// The formal conformance tests for a custom ObjectStore implementation:
+// https://github.com/apache/arrow-rs-object-store/blob/main/src/integration.rs
+//
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn aros_put_get_delete_list() {
+    let b = TestBucket::new("put-get-delete-list");
+    integration::put_get_delete_list(b.store()).await;
+}
+
+#[tokio::test]
+async fn aros_get_nonexistent_object() {
+    let b = TestBucket::new("get-nonexistent");
+    let _ = integration::get_nonexistent_object(b.store(), None).await;
+}
+
+#[tokio::test]
+async fn aros_list_uses_directories_correctly() {
+    let b = TestBucket::new("list-uses-directories");
+    integration::list_uses_directories_correctly(b.store()).await;
+}
+
+#[tokio::test]
+async fn aros_list_with_delimiter() {
+    let b = TestBucket::new("list-with-delimiter");
+    integration::list_with_delimiter(b.store()).await;
+}
+
+#[tokio::test]
+async fn aros_rename_and_copy() {
+    let b = TestBucket::new("rename-and-copy");
+    integration::rename_and_copy(b.store()).await;
+}
+
+#[tokio::test]
+async fn aros_copy_if_not_exists() {
+    let b = TestBucket::new("copy-if-not-exists");
+    integration::copy_if_not_exists(b.store()).await;
+}
+
+#[tokio::test]
+async fn aros_copy_rename_nonexistent_object() {
+    let b = TestBucket::new("copy-rename-nonexistent");
+    integration::copy_rename_nonexistent_object(b.store()).await;
+}
+
+#[tokio::test]
+async fn aros_get_opts() {
+    let b = TestBucket::new("get-opts");
+    integration::get_opts(b.store()).await;
+}
+
+#[tokio::test]
+async fn aros_put_opts() {
+    let b = TestBucket::new("put-opts");
+    integration::put_opts(b.store(), true).await;
+}
+
+#[tokio::test]
+async fn aros_stream_get() {
+    let b = TestBucket::new("stream-get");
+    integration::stream_get(b.store()).await;
+}
+
+// ----------------------------------------
+// Coverage beyond the conformance suite
+// ----------------------------------------
+
+#[tokio::test]
+async fn put_get_binary() {
+    let b = TestBucket::new("put-get-binary");
+    let key = Path::from("binary");
+    let data: Vec<u8> = (0..=255u8).collect();
+
+    b.store()
+        .put(&key, PutPayload::from(Bytes::from(data.clone())))
+        .await
+        .unwrap();
+
+    let got = b.store().get(&key).await.unwrap().bytes().await.unwrap();
+    assert_eq!(got.as_ref(), data.as_slice());
+}
+
+#[tokio::test]
+async fn delete_non_existent() {
+    let b = TestBucket::new("delete-non-existent");
+    b.store().delete(&Path::from("already-gone")).await.unwrap();
+}
+
+#[tokio::test]
+async fn delete_then_put() {
+    let b = TestBucket::new("delete-then-put");
+    let key = Path::from("del-reput");
+
+    b.store().put(&key, "original".into()).await.unwrap();
+    b.store().delete(&key).await.unwrap();
+    b.store().put(&key, "recreated".into()).await.unwrap();
+
+    let got = b.store().get(&key).await.unwrap().bytes().await.unwrap();
+    assert_eq!(got.as_ref(), b"recreated");
+}
+
+#[tokio::test]
+async fn list_pagination() {
+    let b = TestBucket::new("list-pagination");
+    let prefix = Path::from("paginate");
+    for i in 0..15 {
+        b.store()
+            .put(&prefix.clone().join(format!("obj-{i:02}")), "d".into())
+            .await
+            .unwrap();
+    }
+
+    let listed = b.store().list(Some(&prefix)).collect::<Vec<_>>().await;
+    assert_eq!(listed.into_iter().filter(|r| r.is_ok()).count(), 15);
+}
+
+#[tokio::test]
+async fn multipart_basic() {
+    let b = TestBucket::new("multipart-basic");
+    let key = Path::from("multipart");
+    let mut upload = b.store().put_multipart(&key).await.unwrap();
+
+    // S3 requires every part except the last to be at least 5MB
+    let part1 = vec![0xAAu8; 5 * 1024 * 1024];
+    let part2 = vec![0xBBu8; 1024];
+    upload
+        .put_part(PutPayload::from(Bytes::from(part1.clone())))
+        .await
+        .unwrap();
+    upload
+        .put_part(PutPayload::from(Bytes::from(part2.clone())))
+        .await
+        .unwrap();
+    upload.complete().await.unwrap();
+
+    let meta = b.store().head(&key).await.unwrap();
+    assert_eq!(meta.size, (part1.len() + part2.len()) as u64);
+}
+
+#[tokio::test]
+async fn multipart_abort() {
+    let b = TestBucket::new("multipart-abort");
+    let key = Path::from("multipart-abort");
+    let mut upload = b.store().put_multipart(&key).await.unwrap();
+
+    upload
+        .put_part(PutPayload::from(Bytes::from(vec![0xCCu8; 1024])))
+        .await
+        .unwrap();
+    upload.abort().await.unwrap();
+
+    match b.store().head(&key).await {
+        Err(object_store::Error::NotFound { .. }) => {}
+        Err(e) => panic!("expected NotFound, got: {e}"),
+        Ok(_) => panic!("object exists after abort"),
+    }
+}

--- a/src/rgw/rgw_sal_wrapper.cc
+++ b/src/rgw/rgw_sal_wrapper.cc
@@ -107,10 +107,12 @@ extern "C" {
 
 int rgw_put_object( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_ptr,
       CRgwYieldContext* yield_ctx, const CRgwBucket* bucket_id, const CRgwObject* obj_id,
-      const CRgwBuffer* buffer) {
+      const CRgwBuffer* buffer, char** etag_out) {
   auto* driver = get_driver(driver_ptr);
   auto* dpp = get_dpp(dpp_ptr);
   auto y = get_yield(yield_ctx);
+
+  if (etag_out) *etag_out = nullptr;
 
   const uint8_t* data = buffer ? buffer->data : nullptr;
   size_t len = buffer ? buffer->len : 0;
@@ -198,16 +200,22 @@ int rgw_put_object( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_ptr,
                           nullptr,          /* canceled */
                           rctx, 0);
 
+  if (ret == 0 && etag_out) {
+    *etag_out = strdup(etag.c_str());
+  }
+
   return ret;
 }
 
 int rgw_put_object_conditional( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_ptr,
       CRgwYieldContext* yield_ctx, const CRgwBucket* bucket_id, const CRgwObject* obj_id,
       const CRgwBuffer* buffer,
-      const char* if_match, const char* if_nomatch, int* canceled) {
+      const char* if_match, const char* if_nomatch, int* canceled, char** etag_out) {
   auto* driver = get_driver(driver_ptr);
   auto* dpp = get_dpp(dpp_ptr);
   auto y = get_yield(yield_ctx);
+
+  if (etag_out) *etag_out = nullptr;
 
   const uint8_t* data = buffer ? buffer->data : nullptr;
   size_t len = buffer ? buffer->len : 0;
@@ -297,13 +305,27 @@ int rgw_put_object_conditional( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dp
                             &was_canceled,    /* canceled */
                             rctx, 0);
 
+  // Backend returns ERR_PRECONDITION_FAILED when if_match/if_nomatch fails;
+  // set canceled=1.
+  //
+  // when if_match etag is used the backend reports a missing object as
+  // ENOENT rather than ERR_PRECONDITION_FAILED
+  if (ret == -ERR_PRECONDITION_FAILED || (ret == -ENOENT && if_match)) {
+    if (canceled) *canceled = 1;
+    return 0;
+  }
+
   if (canceled) *canceled = was_canceled ? 1 : 0;
+
+  if (ret == 0 && !was_canceled && etag_out) {
+    *etag_out = strdup(etag.c_str());
+  }
+
   return ret;
 }
 
 // Callers issue ranged reads (offset/length) for large objects.
 // Read length is clamped to min(requested, obj_size - offset).
-// If offset >= obj_size, returns 0 with empty buffer (not an error).
 // TODO: explore streaming reads via callback-based Rust FFI.
 int rgw_get_object( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_ptr,
       CRgwYieldContext* yield_ctx, const CRgwBucket* bucket_id, const CRgwObject* obj_id,
@@ -347,7 +369,9 @@ int rgw_get_object( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_ptr,
   uint64_t obj_size = obj->get_size();
 
   if (offset >= obj_size) {
-    return 0;
+    ldpp_dout(dpp, 5) << "sal_wrapper: rgw_get_object: offset "
+        << offset << " >= object size " << obj_size << dendl;
+    return -ERANGE;
   }
 
   uint64_t read_len = length;
@@ -366,6 +390,113 @@ int rgw_get_object( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_ptr,
   }
 
   std::unique_ptr<rgw::sal::Object::ReadOp> read_op = obj->get_read_op();
+
+  ret = read_op->prepare(y, dpp);
+  if (ret < 0) {
+    free(buffer->data);
+    buffer->data = nullptr;
+    return ret;
+  }
+
+  bufferlist bl;
+  int64_t end_ofs = offset + read_len - 1;
+  ret = read_op->read(offset, end_ofs, bl, y, dpp);
+  if (ret < 0) {
+    free(buffer->data);
+    buffer->data = nullptr;
+    return ret;
+  }
+
+  size_t actual_len = bl.length();
+  if (actual_len > read_len) {
+    actual_len = read_len;
+  }
+  if (actual_len > 0) {
+    memcpy(buffer->data, bl.c_str(), actual_len);
+  }
+  buffer->len = actual_len;
+
+  return 0;
+}
+
+int rgw_get_object_conditional( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_ptr,
+      CRgwYieldContext* yield_ctx, const CRgwBucket* bucket_id, const CRgwObject* obj_id,
+      uint64_t offset, uint64_t length,
+      const char* if_match, const char* if_nomatch,
+      const int64_t* if_modified_since, const int64_t* if_unmodified_since,
+      CRgwBuffer* buffer) {
+  auto* driver = get_driver(driver_ptr);
+  auto* dpp = get_dpp(dpp_ptr);
+  auto y = get_yield(yield_ctx);
+
+  if (!driver || !bucket_id || !obj_id || !obj_id->key || !buffer) {
+    ldpp_dout(dpp, 1) << "ERROR: sal_wrapper: rgw_get_object_conditional: invalid args" << dendl;
+    return -EINVAL;
+  }
+
+  buffer->data = nullptr;
+  buffer->len = 0;
+
+  std::unique_ptr<rgw::sal::Bucket> bucket;
+  int ret = load_bucket(driver, dpp, bucket_id, bucket, y);
+  if (ret < 0) {
+    return ret;
+  }
+
+  std::unique_ptr<rgw::sal::Object> obj = bucket->get_object(make_obj_key(obj_id));
+  if (!obj) {
+    return -ENOMEM;
+  }
+
+  ret = obj->load_obj_state(dpp, y);
+  if (ret < 0) {
+    return ret;
+  }
+
+  if (!obj->exists()) {
+    return -ENOENT;
+  }
+
+  uint64_t obj_size = obj->get_size();
+
+  if (offset >= obj_size) {
+    ldpp_dout(dpp, 5) << "sal_wrapper: rgw_get_object_conditional: offset "
+        << offset << " >= object size " << obj_size << dendl;
+    return -ERANGE;
+  }
+
+  uint64_t read_len = length;
+  if (length == UINT64_MAX || length > obj_size - offset) {
+    read_len = obj_size - offset;
+  }
+
+  if (read_len == 0) {
+    return 0;
+  }
+
+  buffer->data = static_cast<uint8_t*>(malloc(read_len));
+  if (!buffer->data) {
+    return -ENOMEM;
+  }
+
+  std::unique_ptr<rgw::sal::Object::ReadOp> read_op = obj->get_read_op();
+
+  // Set conditional parameters
+  ceph::real_time mod_time, unmod_time;
+  if (if_match) {
+    read_op->params.if_match = if_match;
+  }
+  if (if_nomatch) {
+    read_op->params.if_nomatch = if_nomatch;
+  }
+  if (if_modified_since) {
+    mod_time = ceph::real_clock::from_time_t(static_cast<time_t>(*if_modified_since));
+    read_op->params.mod_ptr = &mod_time;
+  }
+  if (if_unmodified_since) {
+    unmod_time = ceph::real_clock::from_time_t(static_cast<time_t>(*if_unmodified_since));
+    read_op->params.unmod_ptr = &unmod_time;
+  }
 
   ret = read_op->prepare(y, dpp);
   if (ret < 0) {
@@ -651,6 +782,10 @@ int rgw_copy_object( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_ptr,
     return -ENOMEM;
   }
 
+  ret = src_obj->load_obj_state(dpp, y);
+  if (ret < 0) return ret;
+  if (!src_obj->exists()) return -ENOENT;
+
   std::unique_ptr<rgw::sal::Object> dst_obj =
     dst_bucket->get_object(make_obj_key(dst_obj_id));
   if (!dst_obj) {
@@ -716,9 +851,31 @@ int rgw_copy_object_conditional( CRgwDriver* driver_ptr, const CRgwDoutPrefix* d
                      << " dst_bucket=" << dst_bucket_id->name
                      << " dst_obj=" << dst_obj_id->key << dendl;
 
+  // Check source exists before checking destination conditions
+  std::unique_ptr<rgw::sal::Bucket> src_bucket;
+  int ret = load_bucket(driver, dpp, src_bucket_id, src_bucket, y);
+  if (ret < 0) return ret;
+
+  std::unique_ptr<rgw::sal::Object> src_obj =
+    src_bucket->get_object(make_obj_key(src_obj_id));
+  if (!src_obj) {
+    ldpp_dout(dpp, 1) << "ERROR: sal_wrapper: rgw_copy_object_conditional: allocation failed" << dendl;
+    return -ENOMEM;
+  }
+
+  ret = src_obj->load_obj_state(dpp, y);
+  if (ret < 0) return ret;
+  if (!src_obj->exists()) return -ENOENT;
+
+  // XXX: this check-then-copy is not atomic. Another writer could
+  // create the destination between our existence check and the copy_object
+  // call below. RGW's copy_object API only supports source-side preconditions
+  // (if_match/if_nomatch check the source etag), not destination-side
+  // preconditions, so we cannot make this atomic without changes to the
+  // SAL copy_object interface.
   if (if_nomatch && std::string(if_nomatch) == "*") {
     std::unique_ptr<rgw::sal::Bucket> check_bucket;
-    int ret = load_bucket(driver, dpp, dst_bucket_id, check_bucket, y);
+    ret = load_bucket(driver, dpp, dst_bucket_id, check_bucket, y);
     if (ret < 0) return ret;
 
     std::unique_ptr<rgw::sal::Object> check_obj =
@@ -731,20 +888,9 @@ int rgw_copy_object_conditional( CRgwDriver* driver_ptr, const CRgwDoutPrefix* d
     }
   }
 
-  std::unique_ptr<rgw::sal::Bucket> src_bucket;
-  int ret = load_bucket(driver, dpp, src_bucket_id, src_bucket, y);
-  if (ret < 0) return ret;
-
   std::unique_ptr<rgw::sal::Bucket> dst_bucket;
   ret = load_bucket(driver, dpp, dst_bucket_id, dst_bucket, y);
   if (ret < 0) return ret;
-
-  std::unique_ptr<rgw::sal::Object> src_obj =
-    src_bucket->get_object(make_obj_key(src_obj_id));
-  if (!src_obj) {
-    ldpp_dout(dpp, 1) << "ERROR: sal_wrapper: rgw_copy_object_conditional: allocation failed" << dendl;
-    return -ENOMEM;
-  }
 
   std::unique_ptr<rgw::sal::Object> dst_obj =
     dst_bucket->get_object(make_obj_key(dst_obj_id));
@@ -883,8 +1029,9 @@ int rgw_init_multipart( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_ptr,
     return ret;
   }
 
+  std::string initial_upload_id;
   std::unique_ptr<rgw::sal::MultipartUpload> upload =
-    bucket->get_multipart_upload(obj_id->key);
+    bucket->get_multipart_upload(obj_id->key, initial_upload_id);
   if (!upload) {
     ldpp_dout(dpp, 1) << "ERROR: sal_wrapper: rgw_init_multipart: allocation failed" << dendl;
     return -ENOMEM;
@@ -941,10 +1088,16 @@ int rgw_multipart_put_part( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_pt
     return -ENOMEM;
   }
 
+  std::unique_ptr<rgw::sal::Object> obj = bucket->get_object(make_obj_key(obj_id));
+  if (!obj) {
+    ldpp_dout(dpp, 1) << "ERROR: sal_wrapper: rgw_multipart_put_part: failed to allocate object" << dendl;
+    return -ENOMEM;
+  }
+
   ACLOwner owner = bucket->get_acl().get_owner();
   const rgw_placement_rule& placement_rule = bucket->get_placement_rule();
   std::unique_ptr<rgw::sal::Writer> writer = upload->get_writer(
-    dpp, y, nullptr, owner, &placement_rule, part_num,
+    dpp, y, obj.get(), owner, &placement_rule, part_num,
     std::to_string(part_num));
 
   if (!writer) {
@@ -970,13 +1123,28 @@ int rgw_multipart_put_part( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_pt
     return ret;
   }
 
+  // compute etag before complete() so the backend stores the correct value
+  unsigned char md5_digest[CEPH_CRYPTO_MD5_DIGESTSIZE];
+  ceph::crypto::MD5 md5_hash;
+  md5_hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+  md5_hash.Update(data, len);
+  md5_hash.Final(md5_digest);
+
+  std::string md5_hex;
+  md5_hex.reserve(CEPH_CRYPTO_MD5_DIGESTSIZE * 2);
+  buf_to_hex(md5_digest, std::back_inserter(md5_hex));
+
   rgw::sal::Attrs attrs;
+  bufferlist etag_bl;
+  etag_bl.append(md5_hex);
+  attrs[RGW_ATTR_ETAG] = std::move(etag_bl);
+
   ceph::real_time mtime = ceph::real_clock::now();
   req_context rctx{dpp, y, nullptr};
 
   ret = writer->complete(
                             len,              /* accounted_size */
-                            "",               /* etag (part etag computed separately below) */
+                            md5_hex,          /* etag */
                             &mtime,           /* mtime (output) */
                             mtime,            /* set_mtime */
                             attrs,            /* attrs */
@@ -992,16 +1160,6 @@ int rgw_multipart_put_part( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_pt
   if (ret < 0) {
     return ret;
   }
-
-  unsigned char md5_digest[CEPH_CRYPTO_MD5_DIGESTSIZE];
-  ceph::crypto::MD5 md5_hash;
-  md5_hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
-  md5_hash.Update(data, len);
-  md5_hash.Final(md5_digest);
-
-  std::string md5_hex;
-  md5_hex.reserve(CEPH_CRYPTO_MD5_DIGESTSIZE * 2);
-  buf_to_hex(md5_digest, std::back_inserter(md5_hex));
 
   *etag = strndup(md5_hex.c_str(), MAX_ETAG_LEN);
   if (!*etag) {
@@ -1048,7 +1206,7 @@ int rgw_multipart_complete( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_pt
     }
   }
 
-  std::list<rgw_obj_index_key> remove_objs;
+  std::list<rgw_obj_index_key> remove_objs; /* objects to be removed from index listing */
   uint64_t accounted_size = 0;
   bool compressed = false;
   RGWCompressionInfo cs_info;
@@ -1058,11 +1216,68 @@ int rgw_multipart_complete( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_pt
   rgw::sal::MultipartUpload::prefix_map_t processed_prefixes;
 
   std::unique_ptr<rgw::sal::Object> target_obj = bucket->get_object(make_obj_key(obj_id));
+  
+  std::unique_ptr<rgw::sal::Object> meta_obj = upload->get_meta_obj();
+  meta_obj->set_in_extra_data(true);
+  meta_obj->set_hash_source(target_obj->get_name());
+  
 
+  /* XXX: Do we need cls lock here for racing completions? like done in 
+   * frontend RGWCompleteMultipart::execute().
+   */
+   
   ret = upload->complete(
     dpp, y, g_ceph_context, part_etags, remove_objs,
     accounted_size, compressed, cs_info, ofs, tag, owner,
     0, target_obj.get(), processed_prefixes, nullptr, nullptr);
+
+  if (ret < 0) {
+    return ret;
+  }
+
+  RGWObjVersionTracker objv_tracker = meta_obj->get_version_tracker();
+  remove_objs.clear();
+  
+  // use cls_version_check() when deleting the meta object to detect part uploads that raced
+  // with upload->complete(). any parts that finish after that won't be part of the final
+  // upload, so they need to be gc'd and removed from the bucket index before retrying
+  // deletion of the multipart meta object
+  static constexpr auto MAX_DELETE_RETRIES = 15u;
+  for (auto i = 0u; i < MAX_DELETE_RETRIES; i++) {
+    // remove the upload meta object ; the meta object is not versioned
+    // when the bucket is, as that would add an unneeded delete marker
+    int del_ret = meta_obj->delete_object(dpp, y, rgw::sal::FLAG_PREVENT_VERSIONING, 
+                                          &remove_objs, &objv_tracker);
+    if (del_ret != -ECANCELED || i == MAX_DELETE_RETRIES - 1) {
+      if (del_ret < 0 && del_ret != -ENOENT) {
+        ldpp_dout(dpp, 1) << "WARNING: failed to remove multipart metadata object " << meta_obj << " ret: " << del_ret << dendl;
+        // Don't fail the complete operation if metadata deletion fails
+        // The metadata will be cleaned up during bucket deletion
+      }
+      break;
+    }
+    
+    ldpp_dout(dpp, 20) << "deleting meta_obj is cancelled due to mismatch cls_version: " 
+                       << objv_tracker << dendl;
+    del_ret = meta_obj->get_obj_attrs(y, dpp);
+    if (del_ret < 0) {
+      ldpp_dout(dpp, 1) << "ERROR: failed to get obj attrs, obj=" << meta_obj
+			 << " del_ret=" << ret << dendl;
+
+      if (del_ret != -ENOENT) {
+	ldpp_dout(dpp, 0) << "ERROR: failed to remove object " << meta_obj << dendl;
+      }
+      break;
+    }
+
+    del_ret = upload->cleanup_orphaned_parts(dpp, driver->ctx(), y, meta_obj->get_obj(), remove_objs, processed_prefixes);
+    if (del_ret < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: failed to cleanup orphaned parts. del_ret=" << del_ret << dendl;
+    }
+
+    objv_tracker.clear();
+    remove_objs.clear();
+  }
 
   return ret;
 }

--- a/src/rgw/rgw_sal_wrapper.h
+++ b/src/rgw/rgw_sal_wrapper.h
@@ -126,10 +126,13 @@ typedef struct CRgwListResult {
  *
  * Creates the object if it doesn't exist, or replaces it if it does.
  *
+ * @param etag_out  [out] If non-NULL, receives the computed ETag (caller must free())
+ *
  * @return 0 on success, negative errno on failure
  */
 int rgw_put_object( CRgwDriver* driver, const CRgwDoutPrefix* dpp, CRgwYieldContext* yield_ctx,
-  const CRgwBucket* bucket, const CRgwObject* obj, const CRgwBuffer* buffer);
+  const CRgwBucket* bucket, const CRgwObject* obj, const CRgwBuffer* buffer,
+  char** etag_out);
 
 /**
  * Write an object with conditional preconditions.
@@ -137,11 +140,13 @@ int rgw_put_object( CRgwDriver* driver, const CRgwDoutPrefix* dpp, CRgwYieldCont
  * Atomically writes data only if the specified precondition is met.
  * Exactly one of if_match/if_nomatch should be non-NULL.
  *
+ * @param etag_out  [out] If non-NULL, receives the computed ETag (caller must free())
+ *
  * @return 0 on success (check *canceled for precondition result), negative errno on failure
  */
 int rgw_put_object_conditional( CRgwDriver* driver, const CRgwDoutPrefix* dpp, CRgwYieldContext* yield_ctx,
   const CRgwBucket* bucket, const CRgwObject* obj, const CRgwBuffer* buffer,
-  const char* if_match, const char* if_nomatch, int* canceled);
+  const char* if_match, const char* if_nomatch, int* canceled, char** etag_out);
 
 /**
  * Read an object (or a byte range) from storage.
@@ -153,6 +158,24 @@ int rgw_put_object_conditional( CRgwDriver* driver, const CRgwDoutPrefix* dpp, C
 int rgw_get_object( CRgwDriver* driver, const CRgwDoutPrefix* dpp, CRgwYieldContext* yield_ctx,
   const CRgwBucket* bucket, const CRgwObject* obj, uint64_t offset, uint64_t length,
   CRgwBuffer* buffer);
+
+/**
+ * Read an object (or byte range) with conditional checks.
+ *
+ * Like rgw_get_object but supports If-Match, If-None-Match,
+ * If-Modified-Since, and If-Unmodified-Since preconditions.
+ * Pass NULL for any condition to skip it.
+ *
+ * @param buffer   [out] Receives allocated data; caller must free with rgw_free_buffer()
+ *
+ * @return 0 on success, -ERR_PRECONDITION_FAILED if if_match/if_unmodified_since fails,
+ *         -ERR_NOT_MODIFIED if if_nomatch/if_modified_since fails,
+ *         -ENOENT if object not found, negative errno on failure
+ */
+int rgw_get_object_conditional( CRgwDriver* driver, const CRgwDoutPrefix* dpp,
+  CRgwYieldContext* yield_ctx, const CRgwBucket* bucket, const CRgwObject* obj,
+  uint64_t offset, uint64_t length, const char* if_match, const char* if_nomatch,
+  const int64_t* if_modified_since, const int64_t* if_unmodified_since, CRgwBuffer* buffer);
 
 /**
  * Delete a single object from storage.

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -536,4 +536,43 @@ if(WITH_SYSTEM_ARROW)
 else()
   target_include_directories(unittest_rgw_s3vector PRIVATE ${CMAKE_BINARY_DIR}/src/arrow/include)
 endif()
+
+add_executable(ceph_test_rgw_sal_wrapper test_rgw_sal_wrapper.cc)
+target_link_libraries(ceph_test_rgw_sal_wrapper
+  rgw_common
+  ${rgw_libs}
+  ${UNITTEST_LIBS})
+install(TARGETS ceph_test_rgw_sal_wrapper DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# libtest (used by the LanceDB ObjectStore cargo tests) owns main(), so the
+# ceph context and SAL driver are brought up in this shared library instead.
+# Linking rgw_common also makes it re-export the rgw_sal_wrapper API, so the
+# cargo test binary links this one .so rather than the full RGW link line.
+add_library(ceph_rgw_sal_test_env SHARED rgw_sal_test_env.cc)
+target_link_libraries(ceph_rgw_sal_test_env
+  rgw_common
+  ${rgw_libs})
+target_include_directories(ceph_rgw_sal_test_env PRIVATE
+  ${CMAKE_SOURCE_DIR}/src/rgw)
+install(TARGETS ceph_rgw_sal_test_env DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+# The LanceDB ObjectStore tests are Rust `cargo test` functions
+# (lancedb-rgw-store/tests/object_store.rs).  They link against
+# libceph_rgw_sal_test_env.so for driver bring-up and the rgw_sal_wrapper API.
+include(${CMAKE_CURRENT_SOURCE_DIR}/cargo_test_binary.cmake)
+add_rgw_cargo_test_binary(
+  NAME    ceph_test_rgw_lancedb_object_store
+  PACKAGE lancedb-rgw-store
+  TEST    object_store
+  DEPENDS ceph_rgw_sal_test_env)
+
+# The crate's own #[cfg(test)] unit tests (errno mapping in store.rs, FFI struct
+# defaults in ffi.rs).  They need no cluster, so they run under `make check`
+# rather than being installed.  They still link libceph_rgw_sal_test_env.so,
+# since the FFI reaches through it to rgw_sal_wrapper_version().
+add_rgw_cargo_test_binary(
+  NAME      unittest_rgw_lancedb_store
+  PACKAGE   lancedb-rgw-store
+  UNIT_TEST
+  DEPENDS   ceph_rgw_sal_test_env)
 endif()

--- a/src/test/rgw/cargo_test_binary.cmake
+++ b/src/test/rgw/cargo_test_binary.cmake
@@ -1,0 +1,181 @@
+# Build a Rust `cargo test` binary and expose it as a ceph test executable.
+#
+# libtest owns main(), so tests that need a ceph context / SAL driver get it from
+# libceph_rgw_sal_test_env.so, which the test binary links against (see
+# lancedb-rgw-store/build.rs, keyed on RGW_SAL_TEST_ENV_DIR).
+#
+# This one file plays two roles:
+#
+#   * include()d from CMakeLists.txt  -> defines add_rgw_cargo_test_binary().
+#   * run via `cmake -P` (build time) -> does the actual `cargo test --no-run`
+#     and copies the hash-suffixed output to a stable path.  The build-time work
+#     has to happen in a script (add_custom_command runs commands, not cmake
+#     code), and CMAKE_SCRIPT_MODE_FILE is set only in that `-P` invocation, so
+#     we branch on it below.  No Python helper required.
+#
+# Two flavours, selected by TEST vs UNIT_TEST:
+#
+#   TEST <name>  a tests/<name>.rs integration test.  Built as part of ALL and
+#                installed under bin/ so it runs on teuthology nodes with neither
+#                a source tree nor a rust toolchain.
+#   UNIT_TEST    the crate's own #[cfg(test)] unit tests (cargo's --lib binary).
+#                Registered with add_ceph_test so it runs under `make check`; not
+#                built by ALL and not installed, since it needs no cluster.
+#
+# add_rgw_cargo_test_binary(
+#   NAME      <output binary name>
+#   PACKAGE   <cargo package that owns the test>
+#   TEST      <integration test name (tests/<TEST>.rs)>  # omit with UNIT_TEST
+#   UNIT_TEST                                             # build --lib instead
+#   DEPENDS   <cmake targets that must build first, e.g. the test-env .so>)
+
+if(CMAKE_SCRIPT_MODE_FILE)
+  # ---- build-time runner (invoked as `cmake -D... -P cargo_test_binary.cmake`) ----
+  #
+  # libtest names its output target/<profile>/deps/<name>-<hash>, where <hash>
+  # changes across builds, so cmake cannot depend on a fixed path.  We ask cargo
+  # for the artifact path via the JSON message stream and copy the reported
+  # executable to OUTPUT.  The link-steering env vars (RGW_SAL_TEST_ENV_DIR,
+  # RGW_SAL_TEST_ENV_RPATH, CARGO_TARGET_DIR) are read by build.rs from the
+  # inherited environment; the caller sets them via `cmake -E env`.
+  #
+  # Required -D variables: CARGO MANIFEST PACKAGE MODE OUTPUT
+  #   MODE = "lib" (crate #[cfg(test)] unit tests) or "test" (integration test)
+  # Required when MODE=test: TEST_NAME (tests/<TEST_NAME>.rs)
+  # Optional: PROFILE_FLAG (e.g. --release, to match the ceph build type)
+
+  foreach(_required CARGO MANIFEST PACKAGE MODE OUTPUT)
+    if(NOT ${_required})
+      message(FATAL_ERROR "cargo_test_binary.cmake: ${_required} is not set")
+    endif()
+  endforeach()
+
+  set(_flags)
+  if(PROFILE_FLAG)
+    list(APPEND _flags ${PROFILE_FLAG})
+  endif()
+  if(MODE STREQUAL "lib")
+    list(APPEND _flags --lib)
+  elseif(MODE STREQUAL "test")
+    if(NOT TEST_NAME)
+      message(FATAL_ERROR "cargo_test_binary.cmake: TEST_NAME is required when MODE=test")
+    endif()
+    list(APPEND _flags --test ${TEST_NAME})
+  else()
+    message(FATAL_ERROR "cargo_test_binary.cmake: MODE must be 'lib' or 'test', got '${MODE}'")
+  endif()
+
+  # json-render-diagnostics keeps stdout pure JSON (the artifact stream we parse)
+  # while cargo renders rustc diagnostics to stderr, so a compile error stays
+  # readable in the build log.
+  set(_json "${OUTPUT}.cargo-artifacts.json")
+  execute_process(
+    COMMAND ${CARGO} test --no-run
+            --message-format=json-render-diagnostics
+            --manifest-path ${MANIFEST}
+            -p ${PACKAGE}
+            ${_flags}
+    OUTPUT_FILE ${_json}
+    RESULT_VARIABLE _rc
+    COMMAND_ECHO STDERR)
+  if(NOT _rc EQUAL 0)
+    message(FATAL_ERROR "cargo test --no-run failed with status ${_rc}")
+  endif()
+
+  # Only a target compiled as a test harness reports a non-null "executable"; the
+  # plain library and build-script artifacts report null.  --lib / --test each
+  # restrict the build to a single such target, so the last match is the binary
+  # we want (works regardless of crate-type, which here is staticlib/rlib).
+  file(READ ${_json} _artifacts)
+  string(REGEX MATCHALL "\"executable\":\"[^\"]+\"" _matches "${_artifacts}")
+  if(NOT _matches)
+    message(FATAL_ERROR
+      "cargo produced no test executable for '${MODE} ${TEST_NAME}'; see ${_json}")
+  endif()
+  list(GET _matches -1 _match)
+  string(REGEX REPLACE "^\"executable\":\"(.*)\"$" "\\1" _executable "${_match}")
+
+  file(COPY_FILE "${_executable}" "${OUTPUT}" ONLY_IF_DIFFERENT)
+  return()
+endif()
+
+# ---- configure-time: define the function ----
+
+function(add_rgw_cargo_test_binary)
+  cmake_parse_arguments(CT "UNIT_TEST" "NAME;PACKAGE;TEST" "DEPENDS" ${ARGN})
+
+  if(CT_UNIT_TEST AND CT_TEST)
+    message(FATAL_ERROR "add_rgw_cargo_test_binary: TEST and UNIT_TEST are mutually exclusive")
+  elseif(NOT CT_UNIT_TEST AND NOT CT_TEST)
+    message(FATAL_ERROR "add_rgw_cargo_test_binary: one of TEST or UNIT_TEST is required")
+  endif()
+
+  set(_output "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CT_NAME}")
+  set(_manifest "${CMAKE_SOURCE_DIR}/src/rgw/${CT_PACKAGE}/Cargo.toml")
+
+  # --lib for the crate unit tests, --test <name> for an integration target.
+  if(CT_UNIT_TEST)
+    set(_mode lib)
+  else()
+    set(_mode test)
+  endif()
+
+  # A target dir dedicated to the test build.  It must NOT be shared with the
+  # umbrella rgw-lancedb build: build.rs gates its extra link args on
+  # RGW_SAL_TEST_ENV_DIR (set here, unset there), so a shared dir would rerun
+  # build.rs and recompile on every switch between the two.  The integration and
+  # unit-test builds do share it -- they set identical env, so there is no such
+  # churn, and cargo's own target-dir lock serializes the two cargo runs.
+  set(_target_dir "${CMAKE_CURRENT_BINARY_DIR}/cargo-test-target")
+
+  # Same profile rule as src/rgw/CMakeLists.txt: release unless a Debug build.
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(_release_flag "")
+  else()
+    set(_release_flag "--release")
+  endif()
+
+  # Rebuild when any crate or test source changes; cargo is incremental so a
+  # no-op run is cheap, but this keeps the dependency graph honest for cmake.
+  file(GLOB _srcs CONFIGURE_DEPENDS
+    "${CMAKE_SOURCE_DIR}/src/rgw/${CT_PACKAGE}/src/*.rs"
+    "${CMAKE_SOURCE_DIR}/src/rgw/${CT_PACKAGE}/tests/*.rs")
+
+  # This same file, re-invoked in script mode to do the build-time work.
+  set(_runner "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/cargo_test_binary.cmake")
+
+  add_custom_command(
+    OUTPUT ${_output}
+    COMMAND ${CMAKE_COMMAND} -E env
+      CARGO_TARGET_DIR=${_target_dir}
+      RGW_SAL_TEST_ENV_DIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+      RGW_SAL_TEST_ENV_RPATH=${CMAKE_INSTALL_FULL_LIBDIR}
+      ${CMAKE_COMMAND}
+        -DCARGO=${CARGO_EXECUTABLE}
+        -DMANIFEST=${_manifest}
+        -DPACKAGE=${CT_PACKAGE}
+        -DMODE=${_mode}
+        -DTEST_NAME=${CT_TEST}
+        -DPROFILE_FLAG=${_release_flag}
+        -DOUTPUT=${_output}
+        -P ${_runner}
+    DEPENDS ${_srcs} ${_runner}
+    COMMENT "Building cargo test binary ${CT_NAME}"
+    VERBATIM)
+
+  if(CT_UNIT_TEST)
+    # Not part of ALL; add_ceph_test hangs it off the `tests` target and runs it
+    # under `make check`/ctest.  The build tree's lib dir is on LD_LIBRARY_PATH
+    # there (and baked into the binary's rpath by build.rs), so the .so resolves
+    # without an install.
+    add_custom_target(${CT_NAME} DEPENDS ${_output})
+    add_ceph_test(${CT_NAME} ${_output})
+  else()
+    add_custom_target(${CT_NAME} ALL DEPENDS ${_output})
+    install(PROGRAMS ${_output} DESTINATION ${CMAKE_INSTALL_BINDIR})
+  endif()
+
+  if(CT_DEPENDS)
+    add_dependencies(${CT_NAME} ${CT_DEPENDS})
+  endif()
+endfunction()

--- a/src/test/rgw/rgw_sal_test_env.cc
+++ b/src/test/rgw/rgw_sal_test_env.cc
@@ -1,0 +1,251 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright 2026 IBM
+ *
+ * See file COPYING for licensing information.
+ */
+
+#include "rgw_sal_test_env.h"
+
+#include "rgw/rgw_sal.h"
+#include "rgw/rgw_sal_config.h"
+#include "rgw/rgw_bucket.h"
+#include "rgw/rgw_zone.h"
+#include "common/ceph_argparse.h"
+#include "common/dout.h"
+#include "common/async/context_pool.h"
+#include "global/global_init.h"
+#include "global/global_context.h"
+#include "common/async/yield_context.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#define dout_subsys ceph_subsys_rgw
+
+namespace {
+
+// Everything the driver bring-up in our old test_rgw_lancedb_object_store.cc
+// kept on the stack now has to outlive the individual tests, so it lives here.
+struct TestEnv {
+  boost::intrusive_ptr<CephContext> cct;
+  std::unique_ptr<DoutPrefix> dpp;
+  std::unique_ptr<ceph::async::io_context_pool> context_pool;
+  std::unique_ptr<rgw::sal::ConfigStore> cfgstore;
+  rgw::SiteConfig site;
+  rgw::sal::Driver* driver = nullptr;
+  std::string backend;
+
+  // buckets created via rgw_test_env_create_bucket() and not yet removed,
+  // dropped at exit so a failing test never leaks storage
+  std::mutex buckets_lock;
+  std::set<std::pair<std::string, std::string>> buckets;
+};
+
+TestEnv g_env;
+std::once_flag g_init_once;
+int g_init_ret = -EINVAL;
+
+void env_teardown();
+
+// Runs exactly once, guarded by g_init_once.  This is the same sequence the
+// old C++ harness ran in main(), minus the single hard-coded bucket.
+void env_init()
+{
+  // libtest owns argv, so there is nothing to parse; rgw_global_init() still
+  // reads $CEPH_CONF / $CEPH_ARGS from the environment.
+  std::vector<const char*> args;
+
+  g_env.cct = rgw_global_init(nullptr, args, CEPH_ENTITY_TYPE_CLIENT,
+                              CODE_ENVIRONMENT_UTILITY, 0);
+
+  if (!g_conf()->rgw_region.empty() && g_conf()->rgw_zonegroup.empty()) {
+    g_conf().set_val_or_die("rgw_zonegroup", g_conf()->rgw_region.c_str());
+  }
+
+  common_init_finish(g_ceph_context);
+
+  g_env.dpp = std::make_unique<DoutPrefix>(g_ceph_context, ceph_subsys_rgw,
+                                           "lancedb-object-store-test: ");
+
+  g_env.context_pool = std::make_unique<ceph::async::io_context_pool>(
+      g_env.cct->_conf->rgw_thread_pool_size);
+
+  DriverManager::Config cfg = DriverManager::get_config(true, g_ceph_context);
+  g_env.backend = cfg.store_name;
+  std::cerr << "INFO: using backend '" << cfg.store_name << "'" << std::endl;
+
+  auto config_store_type = g_conf().get_val<std::string>("rgw_config_store");
+  g_env.cfgstore = DriverManager::create_config_store(g_env.dpp.get(),
+                                                      config_store_type);
+  if (!g_env.cfgstore) {
+    std::cerr << "ERROR: failed to create config store" << std::endl;
+    g_init_ret = -EIO;
+    return;
+  }
+
+  int r = g_env.site.load(g_env.dpp.get(), null_yield, g_env.cfgstore.get());
+  if (r < 0) {
+    std::cerr << "ERROR: failed to load site config (r=" << r << ")" << std::endl;
+    g_init_ret = r;
+    return;
+  }
+
+  // all background threads off -- the tests drive the driver synchronously
+  g_env.driver = DriverManager::get_storage(g_env.dpp.get(),
+                                            g_ceph_context,
+                                            cfg,
+                                            *g_env.context_pool,
+                                            g_env.site,
+                                            false, false, false, false,
+                                            false, false, false, false,
+                                            false,
+                                            null_yield,
+                                            g_env.cfgstore.get(),
+                                            false);
+  if (!g_env.driver) {
+    std::cerr << "ERROR: failed to initialize SAL driver" << std::endl;
+    g_init_ret = -EIO;
+    return;
+  }
+
+  // libtest has no global teardown, so run cleanup from atexit().  It is
+  // registered after all static ctors, so it fires before their dtors -- the
+  // driver is shut down while ceph is still alive.
+  std::atexit(env_teardown);
+
+  g_init_ret = 0;
+}
+
+void env_teardown()
+{
+  if (!g_env.driver) {
+    return;
+  }
+
+  decltype(g_env.buckets) leftovers;
+  {
+    std::lock_guard l{g_env.buckets_lock};
+    leftovers.swap(g_env.buckets);
+  }
+  for (const auto& [name, tenant] : leftovers) {
+    rgw_bucket b;
+    b.name = name;
+    b.tenant = tenant;
+    std::unique_ptr<rgw::sal::Bucket> bucket;
+    if (g_env.driver->load_bucket(g_env.dpp.get(), b, &bucket, null_yield) == 0
+        && bucket) {
+      bucket->remove(g_env.dpp.get(), true, null_yield);
+    }
+  }
+
+  g_env.driver->shutdown();
+  DriverManager::close_storage(g_env.driver);
+  g_env.driver = nullptr;
+}
+
+} // namespace
+
+int rgw_test_env_init(void)
+{
+  std::call_once(g_init_once, env_init);
+  return g_init_ret;
+}
+
+CRgwDriver* rgw_test_env_driver(void)
+{
+  return reinterpret_cast<CRgwDriver*>(g_env.driver);
+}
+
+const CRgwDoutPrefix* rgw_test_env_dpp(void)
+{
+  if (!g_env.driver) {
+    return nullptr;
+  }
+  // cast through DoutPrefixProvider so the pointer refers to the right base
+  // subobject, matching what the rgw_sal_wrapper functions expect.
+  return reinterpret_cast<const CRgwDoutPrefix*>(
+      static_cast<const DoutPrefixProvider*>(g_env.dpp.get()));
+}
+
+const char* rgw_test_env_backend(void)
+{
+  return g_env.driver ? g_env.backend.c_str() : nullptr;
+}
+
+int rgw_test_env_create_bucket(const char* name, const char* tenant)
+{
+  if (!g_env.driver || !name) {
+    return -EINVAL;
+  }
+  const std::string tenant_str = tenant ? tenant : "";
+
+  // same creation path our old harness used for its single bucket, now
+  // parameterized on name/tenant
+  rgw_bucket b;
+  b.name = name;
+  b.tenant = tenant_str;
+
+  std::unique_ptr<rgw::sal::Bucket> bucket;
+  int r = g_env.driver->load_bucket(g_env.dpp.get(), b, &bucket, null_yield);
+  if (!bucket) {
+    std::cerr << "ERROR: load_bucket returned no bucket object (r=" << r << ")"
+              << std::endl;
+    return r < 0 ? r : -EIO;
+  }
+
+  rgw::sal::Bucket::CreateParams params;
+  params.owner = rgw_user{tenant_str, "lancedb-object-store-test-user"};
+  params.zonegroup_id = g_env.site.get_zonegroup().get_id();
+  params.placement_rule = g_env.site.get_zonegroup().default_placement;
+  params.zone_placement = rgw::find_zone_placement(
+      g_env.dpp.get(), g_env.site.get_zone_params(), params.placement_rule);
+
+  r = bucket->create(g_env.dpp.get(), params, null_yield);
+  if (r < 0 && r != -EEXIST) {
+    std::cerr << "ERROR: failed to create bucket '" << name << "' (r=" << r
+              << ")" << std::endl;
+    return r;
+  }
+
+  std::lock_guard l{g_env.buckets_lock};
+  g_env.buckets.emplace(name, tenant_str);
+  return 0;
+}
+
+int rgw_test_env_remove_bucket(const char* name, const char* tenant)
+{
+  if (!g_env.driver || !name) {
+    return -EINVAL;
+  }
+  const std::string tenant_str = tenant ? tenant : "";
+
+  rgw_bucket b;
+  b.name = name;
+  b.tenant = tenant_str;
+
+  std::unique_ptr<rgw::sal::Bucket> bucket;
+  int r = g_env.driver->load_bucket(g_env.dpp.get(), b, &bucket, null_yield);
+  if (r < 0 || !bucket) {
+    return r < 0 ? r : -ENOENT;
+  }
+
+  r = bucket->remove(g_env.dpp.get(), true, null_yield);
+  if (r < 0) {
+    return r;
+  }
+
+  std::lock_guard l{g_env.buckets_lock};
+  g_env.buckets.erase({name, tenant_str});
+  return 0;
+}

--- a/src/test/rgw/rgw_sal_test_env.h
+++ b/src/test/rgw/rgw_sal_test_env.h
@@ -1,0 +1,77 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright 2026 IBM
+ *
+ * See file COPYING for licensing information.
+ */
+
+/*
+ * Shared test environment for the LanceDB ObjectStore integration tests.
+ *
+ * The ObjectStore tests are Rust `cargo test` functions, and libtest owns
+ * main() -- so the ceph context and SAL driver cannot be brought up from the
+ * test itself the way our old C++ harness (test_rgw_lancedb_object_store.cc)
+ * did.  Instead the same bring-up lives here behind a small extern "C" API and
+ * is compiled into libceph_rgw_sal_test_env.so, which the cargo test binary
+ * links against.  Because that library links rgw_common it also satisfies the
+ * rgw_sal_wrapper symbols the Rust FFI needs, so the test binary links a single
+ * .so rather than the whole RGW C++ link line.
+ *
+ * Consumer: src/rgw/lancedb-rgw-store/tests/object_store.rs
+ */
+
+#pragma once
+
+#include "rgw/rgw_sal_wrapper.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Initialize the ceph context and SAL driver.  Safe to call from any number
+ * of threads: the first call performs the work, the rest wait for it and see
+ * the same result.  libtest has no global setup hook, so every test calls this
+ * and only the first one pays for it.
+ *
+ * Configuration comes from the environment ($CEPH_CONF, $CEPH_ARGS) since there
+ * is no argv to parse.  An atexit() handler is registered to drop any buckets
+ * still tracked and shut the driver down.
+ *
+ * Returns 0 on success, negative errno otherwise.
+ */
+int rgw_test_env_init(void);
+
+/* SAL driver handle, or NULL before a successful rgw_test_env_init(). */
+CRgwDriver* rgw_test_env_driver(void);
+
+/* DoutPrefixProvider handle, or NULL before a successful rgw_test_env_init(). */
+const CRgwDoutPrefix* rgw_test_env_dpp(void);
+
+/* Backend name ("rados", "dbstore", "posix", ...), or NULL if uninitialized. */
+const char* rgw_test_env_backend(void);
+
+/*
+ * Create a bucket and remember it for teardown.  Succeeds if it already
+ * exists.  Each test uses its own bucket so libtest can run them in parallel.
+ * tenant may be NULL for the default tenant.
+ *
+ * Returns 0 on success, negative errno otherwise.
+ */
+int rgw_test_env_create_bucket(const char* name, const char* tenant);
+
+/*
+ * Remove a bucket (and its contents) and stop tracking it.  Any bucket left
+ * behind by a failing test is cleaned up at exit instead.
+ *
+ * Returns 0 on success, negative errno otherwise.
+ */
+int rgw_test_env_remove_bucket(const char* name, const char* tenant);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/test/rgw/test_rgw_sal_wrapper.cc
+++ b/src/test/rgw/test_rgw_sal_wrapper.cc
@@ -1,0 +1,1180 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include "gtest/gtest.h"
+
+#include "rgw/rgw_sal_wrapper.h"
+#include "rgw/rgw_sal.h"
+#include "rgw/rgw_sal_config.h"
+#include "rgw/rgw_bucket.h"
+#include "rgw/rgw_zone.h"
+#include "common/ceph_argparse.h"
+#include "common/dout.h"
+#include "common/async/context_pool.h"
+#include "global/global_init.h"
+#include "global/global_context.h"
+#include "common/async/yield_context.h"
+
+#include <boost/asio/io_context.hpp>
+#include <cstddef>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#define dout_subsys ceph_subsys_rgw
+
+// ------------------
+// Global test state
+// ------------------
+namespace {
+
+struct TestEnv {
+  rgw::sal::Driver* driver = nullptr;
+  const DoutPrefixProvider* dpp = nullptr;
+  std::unique_ptr<rgw::sal::ConfigStore> cfgstore;
+  std::string bucket_name;
+  std::string backend;  // "rados", "dbstore", "posix", etc.
+};
+
+TestEnv* g_env = nullptr;
+
+}
+
+// ============
+// Null safety
+// ============
+
+TEST(NullSafety, NullDriverReturnsError) {
+  CRgwBucket b{"bucket", nullptr};
+  CRgwObject o{"key", nullptr};
+  CRgwBuffer buf{nullptr, 0};
+  CRgwObjectMeta meta{};
+  CRgwListResult result{};
+
+  // core ops
+  EXPECT_LT(rgw_put_object(nullptr, nullptr, nullptr, &b, &o, &buf, nullptr), 0);
+  EXPECT_LT(rgw_get_object(nullptr, nullptr, nullptr, &b, &o, 0, 0, &buf), 0);
+  EXPECT_LT(rgw_delete_object(nullptr, nullptr, nullptr, &b, &o), 0);
+  EXPECT_LT(rgw_head_object(nullptr, nullptr, nullptr, &b, &o, &meta), 0);
+  EXPECT_LT(rgw_list_objects(nullptr, nullptr, nullptr, &b,
+             nullptr, nullptr, nullptr, 100, &result), 0);
+
+  // conditional put
+  int canceled = 0;
+  EXPECT_LT(rgw_put_object_conditional(nullptr, nullptr, nullptr,
+             &b, &o, &buf, nullptr, nullptr, &canceled, nullptr), 0);
+
+  // copy
+  CRgwBucket db{"dst", nullptr};
+  CRgwObject d_o{"dkey", nullptr};
+  EXPECT_LT(rgw_copy_object(nullptr, nullptr, nullptr, &b, &o, &db, &d_o), 0);
+  EXPECT_LT(rgw_copy_object_conditional(nullptr, nullptr, nullptr,
+             &b, &o, &db, &d_o, nullptr, nullptr), 0);
+
+  // bulk delete
+  const char* keys[] = {"k1"};
+  EXPECT_LT(rgw_delete_objects(nullptr, nullptr, nullptr, &b, keys, 1), 0);
+
+  // multipart
+  char* upload_id = nullptr;
+  EXPECT_LT(rgw_init_multipart(nullptr, nullptr, nullptr, &b, &o, &upload_id), 0);
+
+  char* etag = nullptr;
+  uint8_t data[] = {0};
+  EXPECT_LT(rgw_multipart_put_part(nullptr, nullptr, nullptr,
+             &b, &o, "fake-id", 1, data, 1, &etag), 0);
+
+  const char* etags[] = {"etag1"};
+  EXPECT_LT(rgw_multipart_complete(nullptr, nullptr, nullptr,
+             &b, &o, "fake-id", etags, 1), 0);
+
+  EXPECT_LT(rgw_multipart_abort(nullptr, nullptr, nullptr,
+             &b, &o, "fake-id"), 0);
+}
+
+TEST(NullSafety, NullBucketAndKeyReturnsError) {
+  auto* driver = reinterpret_cast<CRgwDriver*>(0x1234);
+  CRgwBucket b{"bucket", nullptr};
+  CRgwObject o{"key", nullptr};
+  CRgwBuffer buf{nullptr, 0};
+
+  // null bucket
+  EXPECT_LT(rgw_put_object(driver, nullptr, nullptr, nullptr, &o, &buf, nullptr), 0);
+  EXPECT_LT(rgw_get_object(driver, nullptr, nullptr, nullptr, &o, 0, 0, &buf), 0);
+  EXPECT_LT(rgw_delete_object(driver, nullptr, nullptr, nullptr, &o), 0);
+  EXPECT_LT(rgw_head_object(driver, nullptr, nullptr, nullptr, &o, nullptr), 0);
+
+  // null object key
+  EXPECT_LT(rgw_put_object(driver, nullptr, nullptr, &b, nullptr, &buf, nullptr), 0);
+  EXPECT_LT(rgw_get_object(driver, nullptr, nullptr, &b, nullptr, 0, 0, &buf), 0);
+  EXPECT_LT(rgw_delete_object(driver, nullptr, nullptr, &b, nullptr), 0);
+
+  // null output pointers
+  EXPECT_LT(rgw_get_object(driver, nullptr, nullptr, &b, &o, 0, 0, nullptr), 0);
+  EXPECT_LT(rgw_head_object(driver, nullptr, nullptr, &b, &o, nullptr), 0);
+  EXPECT_LT(rgw_list_objects(driver, nullptr, nullptr, &b,
+             nullptr, nullptr, nullptr, 100, nullptr), 0);
+
+  // multipart null output
+  EXPECT_LT(rgw_init_multipart(driver, nullptr, nullptr, &b, &o, nullptr), 0);
+  EXPECT_LT(rgw_multipart_put_part(driver, nullptr, nullptr,
+             &b, &o, "id", 1, nullptr, 0, nullptr), 0);
+}
+
+
+
+TEST(NullSafety, FreeNullPointers) {
+  // free functions should handle null gracefully
+  rgw_free_buffer(nullptr);
+  rgw_free_object_meta(nullptr);
+  rgw_free_list_result(nullptr);
+}
+
+TEST(Utility, WrapperVersion) {
+  const char* ver = rgw_sal_wrapper_version();
+  ASSERT_NE(ver, nullptr);
+  EXPECT_GT(strlen(ver), 0u);
+
+  // verify the runtime version matches the header defines
+  std::string expected = std::to_string(RGW_SAL_WRAPPER_VERSION_MAJOR) + "."
+                       + std::to_string(RGW_SAL_WRAPPER_VERSION_MINOR);
+  EXPECT_EQ(expected, std::string(ver))
+      << "sal_wrapper version mismatch: header says " << expected
+      << " but runtime returns " << ver;
+}
+
+// ===========================================================================
+// Functional tests — require live driver + bucket
+// ===========================================================================
+
+class SALWrapperTest : public ::testing::Test {
+protected:
+  CRgwDriver* driver() {
+    return reinterpret_cast<CRgwDriver*>(g_env->driver);
+  }
+  const CRgwDoutPrefix* dpp() {
+    return reinterpret_cast<const CRgwDoutPrefix*>(g_env->dpp);
+  }
+
+  void SetUp() override {
+    if (!g_env || !g_env->driver) {
+      GTEST_SKIP() << "SAL driver not initialized";
+    }
+    bucket_ = {g_env->bucket_name.c_str(), nullptr};
+  }
+
+  int put(const char* key, const uint8_t* data, size_t len) {
+    CRgwObject obj{key, nullptr};
+    CRgwBuffer buf{const_cast<uint8_t*>(data), len};
+    return rgw_put_object(driver(), dpp(), nullptr, &bucket_, &obj, &buf, nullptr);
+  }
+
+  int put_str(const char* key, const std::string& data) {
+    return put(key, reinterpret_cast<const uint8_t*>(data.data()), data.size());
+  }
+
+  int get(const char* key, CRgwBuffer* buf,
+          uint64_t offset = 0, uint64_t length = UINT64_MAX) {
+    CRgwObject obj{key, nullptr};
+    return rgw_get_object(driver(), dpp(), nullptr, &bucket_, &obj,
+                          offset, length, buf);
+  }
+
+  int del(const char* key) {
+    CRgwObject obj{key, nullptr};
+    return rgw_delete_object(driver(), dpp(), nullptr, &bucket_, &obj);
+  }
+
+  int head(const char* key, CRgwObjectMeta* meta) {
+    CRgwObject obj{key, nullptr};
+    return rgw_head_object(driver(), dpp(), nullptr, &bucket_, &obj, meta);
+  }
+
+  CRgwBucket bucket_{};
+  std::vector<std::string> created_keys_;
+
+  void TearDown() override {
+    if (!g_env || !g_env->driver) return;
+    for (auto& k : created_keys_) {
+      del(k.c_str());
+    }
+  }
+
+  int put_tracked(const char* key, const uint8_t* data, size_t len) {
+    int ret = put(key, data, len);
+    if (ret == 0) created_keys_.emplace_back(key);
+    return ret;
+  }
+  int put_str_tracked(const char* key, const std::string& data) {
+    return put_tracked(key,
+                       reinterpret_cast<const uint8_t*>(data.data()),
+                       data.size());
+  }
+};
+
+// --------------- Null buffer ---------------
+
+TEST_F(SALWrapperTest, OutputBufferUntouchedOnFailure) {
+  CRgwBuffer buf{nullptr, 0};
+  CRgwObject obj{"test/no-such-key-ever", nullptr};
+  EXPECT_EQ(-ENOENT, rgw_get_object(driver(), dpp(), nullptr,
+             &bucket_, &obj, 0, 0, &buf));
+  EXPECT_EQ(buf.data, nullptr);
+  EXPECT_EQ(buf.len, 0u);
+}
+
+TEST_F(SALWrapperTest, NullBufferPut) {
+  CRgwObject obj{"test/null-buf", nullptr};
+
+  // null buffer pointer is treated as a zero-byte put (valid)
+  EXPECT_EQ(0, rgw_put_object(driver(), dpp(), nullptr, &bucket_, &obj, nullptr, nullptr));
+  created_keys_.emplace_back("test/null-buf");
+
+  // buffer with null data but non-zero length is invalid
+  CRgwBuffer bad_buf{nullptr, 100};
+  EXPECT_LT(rgw_put_object(driver(), dpp(), nullptr, &bucket_, &obj, &bad_buf, nullptr), 0);
+}
+
+// --------------- Put / Get ---------------
+
+TEST_F(SALWrapperTest, PutGetRoundTrip) {
+  std::string data = "hello, SAL wrapper!";
+  ASSERT_EQ(0, put_str_tracked("test/put-get", data));
+
+  CRgwBuffer buf{};
+  ASSERT_EQ(0, get("test/put-get", &buf));
+  ASSERT_EQ(data.size(), buf.len);
+  EXPECT_EQ(0, memcmp(data.data(), buf.data, buf.len));
+  rgw_free_buffer(&buf);
+}
+
+TEST_F(SALWrapperTest, PutGetBinaryData) {
+  std::vector<uint8_t> data(256);
+  std::iota(data.begin(), data.end(), 0);
+  ASSERT_EQ(0, put_tracked("test/binary", data.data(), data.size()));
+
+  CRgwBuffer buf{};
+  ASSERT_EQ(0, get("test/binary", &buf));
+  ASSERT_EQ(data.size(), buf.len);
+  EXPECT_EQ(0, memcmp(data.data(), buf.data, buf.len));
+  rgw_free_buffer(&buf);
+}
+
+// known fail: dbstore, posix — backend does not support multi-chunk reads
+TEST_F(SALWrapperTest, PutGetLargeObject) {
+  size_t test_size = 1024 * 1024;
+  std::vector<uint8_t> data(test_size);
+  std::iota(data.begin(), data.end(), 0);
+  ASSERT_EQ(0, put_tracked("test/large-obj", data.data(), data.size()));
+
+  CRgwBuffer buf{};
+  ASSERT_EQ(0, get("test/large-obj", &buf));
+  ASSERT_EQ(data.size(), buf.len);
+  EXPECT_EQ(0, memcmp(data.data(), buf.data, buf.len));
+  rgw_free_buffer(&buf);
+}
+
+TEST_F(SALWrapperTest, PutZeroLength) {
+  ASSERT_EQ(0, put_tracked("test/empty-obj", nullptr, 0));
+
+  CRgwObjectMeta meta{};
+  ASSERT_EQ(0, head("test/empty-obj", &meta));
+  EXPECT_EQ(0u, meta.size);
+  rgw_free_object_meta(&meta);
+}
+
+TEST_F(SALWrapperTest, PutOverwrite) {
+  std::string data1 = "first version";
+  std::string data2 = "second version, different length";
+  ASSERT_EQ(0, put_str_tracked("test/overwrite", data1));
+  ASSERT_EQ(0, put_str("test/overwrite", data2));
+
+  CRgwBuffer buf{};
+  ASSERT_EQ(0, get("test/overwrite", &buf));
+  ASSERT_EQ(data2.size(), buf.len);
+  EXPECT_EQ(0, memcmp(data2.data(), buf.data, buf.len));
+  rgw_free_buffer(&buf);
+}
+
+TEST_F(SALWrapperTest, PutGetMultipleObjects) {
+  const int count = 10;
+  for (int i = 0; i < count; i++) {
+    std::string key = "test/multi/obj-" + std::to_string(i);
+    std::string val = "value-" + std::to_string(i);
+    ASSERT_EQ(0, put_str_tracked(key.c_str(), val));
+  }
+
+  for (int i = 0; i < count; i++) {
+    std::string key = "test/multi/obj-" + std::to_string(i);
+    std::string expected = "value-" + std::to_string(i);
+    CRgwBuffer buf{};
+    ASSERT_EQ(0, get(key.c_str(), &buf));
+    ASSERT_EQ(expected.size(), buf.len);
+    EXPECT_EQ(0, memcmp(expected.data(), buf.data, buf.len));
+    rgw_free_buffer(&buf);
+  }
+}
+
+// --------------- Get edge cases ---------------
+
+TEST_F(SALWrapperTest, GetNonExistent) {
+  CRgwBuffer buf{};
+  EXPECT_EQ(-ENOENT, get("test/no-such-key-ever", &buf));
+}
+
+TEST_F(SALWrapperTest, RangeRead) {
+  std::vector<uint8_t> data(512);
+  std::iota(data.begin(), data.end(), 0);
+  ASSERT_EQ(0, put_tracked("test/range-read", data.data(), data.size()));
+
+  CRgwBuffer buf{};
+  ASSERT_EQ(0, get("test/range-read", &buf, 100, 200));
+  ASSERT_EQ(200u, buf.len);
+  EXPECT_EQ(0, memcmp(data.data() + 100, buf.data, buf.len));
+  rgw_free_buffer(&buf);
+}
+
+TEST_F(SALWrapperTest, RangeReadFromStart) {
+  std::string data = "range-read-from-start-test-data";
+  ASSERT_EQ(0, put_str_tracked("test/range-start", data));
+
+  CRgwBuffer buf{};
+  ASSERT_EQ(0, get("test/range-start", &buf, 0, 10));
+  ASSERT_EQ(10u, buf.len);
+  EXPECT_EQ(0, memcmp(data.data(), buf.data, 10));
+  rgw_free_buffer(&buf);
+}
+
+TEST_F(SALWrapperTest, RangeReadToEnd) {
+  std::string data = "read-to-end-data-here";
+  ASSERT_EQ(0, put_str_tracked("test/range-end", data));
+
+  CRgwBuffer buf{};
+  ASSERT_EQ(0, get("test/range-end", &buf, 5, UINT64_MAX));
+  ASSERT_EQ(data.size() - 5, buf.len);
+  EXPECT_EQ(0, memcmp(data.data() + 5, buf.data, buf.len));
+  rgw_free_buffer(&buf);
+}
+
+TEST_F(SALWrapperTest, RangeReadBeyondObjectSize) {
+  std::string data = "short-data";
+  ASSERT_EQ(0, put_str_tracked("test/range-beyond", data));
+
+  CRgwBuffer buf{};
+  EXPECT_EQ(-ERANGE, get("test/range-beyond", &buf, data.size(), 10));
+  EXPECT_EQ(nullptr, buf.data);
+  EXPECT_EQ(0u, buf.len);
+
+  EXPECT_EQ(-ERANGE, get("test/range-beyond", &buf, data.size() + 100, 10));
+  EXPECT_EQ(nullptr, buf.data);
+  EXPECT_EQ(0u, buf.len);
+}
+
+// --------------- Conditional get ---------------
+
+TEST_F(SALWrapperTest, ConditionalGetIfMatch) {
+  std::string data = "conditional get data";
+  ASSERT_EQ(0, put_str_tracked("test/cond-get", data));
+
+  CRgwObjectMeta meta{};
+  ASSERT_EQ(0, head("test/cond-get", &meta));
+  ASSERT_NE(meta.etag, nullptr);
+  std::string etag = meta.etag;
+  rgw_free_object_meta(&meta);
+
+  // if_match with correct etag — should succeed
+  CRgwBuffer buf{};
+  CRgwObject obj{"test/cond-get", nullptr};
+  ASSERT_EQ(0, rgw_get_object_conditional(driver(), dpp(), nullptr,
+             &bucket_, &obj, 0, UINT64_MAX,
+             etag.c_str(), nullptr, nullptr, nullptr, &buf));
+  ASSERT_EQ(data.size(), buf.len);
+  EXPECT_EQ(0, memcmp(data.data(), buf.data, buf.len));
+  rgw_free_buffer(&buf);
+
+  // if_match with wrong etag — should fail with precondition
+  CRgwBuffer buf2{};
+  EXPECT_EQ(-ERR_PRECONDITION_FAILED,
+            rgw_get_object_conditional(driver(), dpp(), nullptr,
+             &bucket_, &obj, 0, UINT64_MAX,
+             "wrong-etag", nullptr, nullptr, nullptr, &buf2));
+}
+
+TEST_F(SALWrapperTest, ConditionalGetIfNoneMatch) {
+  std::string data = "none-match data";
+  ASSERT_EQ(0, put_str_tracked("test/cond-get-nm", data));
+
+  CRgwObjectMeta meta{};
+  ASSERT_EQ(0, head("test/cond-get-nm", &meta));
+  ASSERT_NE(meta.etag, nullptr);
+  std::string etag = meta.etag;
+  rgw_free_object_meta(&meta);
+
+  CRgwObject obj{"test/cond-get-nm", nullptr};
+
+  // if_nomatch with matching etag — should fail with not modified
+  CRgwBuffer buf{};
+  EXPECT_EQ(-ERR_NOT_MODIFIED,
+            rgw_get_object_conditional(driver(), dpp(), nullptr,
+             &bucket_, &obj, 0, UINT64_MAX,
+             nullptr, etag.c_str(), nullptr, nullptr, &buf));
+
+  // if_nomatch with different etag — should succeed
+  CRgwBuffer buf2{};
+  ASSERT_EQ(0, rgw_get_object_conditional(driver(), dpp(), nullptr,
+             &bucket_, &obj, 0, UINT64_MAX,
+             nullptr, "different-etag", nullptr, nullptr, &buf2));
+  ASSERT_EQ(data.size(), buf2.len);
+  rgw_free_buffer(&buf2);
+}
+
+TEST_F(SALWrapperTest, ConditionalGetIfModifiedSince) {
+  std::string data = "modified since data";
+  ASSERT_EQ(0, put_str_tracked("test/cond-get-mod", data));
+
+  CRgwObjectMeta meta{};
+  ASSERT_EQ(0, head("test/cond-get-mod", &meta));
+  int64_t mtime = meta.last_modified;
+  rgw_free_object_meta(&meta);
+  ASSERT_GT(mtime, 0);
+
+  CRgwObject obj{"test/cond-get-mod", nullptr};
+
+  // if_modified_since far in the past — object is newer, should succeed
+  int64_t past = mtime - 3600;
+  CRgwBuffer buf{};
+  ASSERT_EQ(0, rgw_get_object_conditional(driver(), dpp(), nullptr,
+             &bucket_, &obj, 0, UINT64_MAX,
+             nullptr, nullptr, &past, nullptr, &buf));
+  ASSERT_EQ(data.size(), buf.len);
+  rgw_free_buffer(&buf);
+
+  // if_modified_since in the future — object is older, should fail
+  int64_t future = mtime + 3600;
+  CRgwBuffer buf2{};
+  EXPECT_EQ(-ERR_NOT_MODIFIED,
+            rgw_get_object_conditional(driver(), dpp(), nullptr,
+             &bucket_, &obj, 0, UINT64_MAX,
+             nullptr, nullptr, &future, nullptr, &buf2));
+}
+
+TEST_F(SALWrapperTest, ConditionalGetIfUnmodifiedSince) {
+  std::string data = "unmodified since data";
+  ASSERT_EQ(0, put_str_tracked("test/cond-get-unmod", data));
+
+  CRgwObjectMeta meta{};
+  ASSERT_EQ(0, head("test/cond-get-unmod", &meta));
+  int64_t mtime = meta.last_modified;
+  rgw_free_object_meta(&meta);
+  ASSERT_GT(mtime, 0);
+
+  CRgwObject obj{"test/cond-get-unmod", nullptr};
+
+  // if_unmodified_since in the future — object is older, should succeed
+  int64_t future = mtime + 3600;
+  CRgwBuffer buf{};
+  ASSERT_EQ(0, rgw_get_object_conditional(driver(), dpp(), nullptr,
+             &bucket_, &obj, 0, UINT64_MAX,
+             nullptr, nullptr, nullptr, &future, &buf));
+  ASSERT_EQ(data.size(), buf.len);
+  rgw_free_buffer(&buf);
+
+  // if_unmodified_since far in the past — object is newer, should fail
+  int64_t past = mtime - 3600;
+  CRgwBuffer buf2{};
+  EXPECT_EQ(-ERR_PRECONDITION_FAILED,
+            rgw_get_object_conditional(driver(), dpp(), nullptr,
+             &bucket_, &obj, 0, UINT64_MAX,
+             nullptr, nullptr, nullptr, &past, &buf2));
+}
+
+// --------------- Head / Metadata ---------------
+
+TEST_F(SALWrapperTest, HeadObject) {
+  std::string data = "metadata test data";
+  ASSERT_EQ(0, put_str_tracked("test/head-obj", data));
+
+  CRgwObjectMeta meta{};
+  ASSERT_EQ(0, head("test/head-obj", &meta));
+  EXPECT_EQ(data.size(), meta.size);
+  EXPECT_NE(meta.etag, nullptr);
+  if (meta.etag) {
+    EXPECT_GT(strlen(meta.etag), 0u);
+  }
+  EXPECT_GT(meta.last_modified, 0);
+  rgw_free_object_meta(&meta);
+}
+
+TEST_F(SALWrapperTest, HeadNonExistent) {
+  CRgwObjectMeta meta{};
+  EXPECT_EQ(-ENOENT, head("test/head-nonexistent", &meta));
+  rgw_free_object_meta(&meta);
+}
+
+TEST_F(SALWrapperTest, EtagChangesOnOverwrite) {
+  ASSERT_EQ(0, put_str_tracked("test/etag-change", "version1"));
+
+  CRgwObjectMeta meta1{};
+  ASSERT_EQ(0, head("test/etag-change", &meta1));
+
+  ASSERT_EQ(0, put_str("test/etag-change", "version2-different"));
+
+  CRgwObjectMeta meta2{};
+  ASSERT_EQ(0, head("test/etag-change", &meta2));
+
+  ASSERT_NE(meta1.etag, nullptr);
+  ASSERT_NE(meta2.etag, nullptr);
+  EXPECT_STRNE(meta1.etag, meta2.etag);
+
+  rgw_free_object_meta(&meta1);
+  rgw_free_object_meta(&meta2);
+}
+
+TEST_F(SALWrapperTest, HeadReflectsCorrectSize) {
+  std::vector<size_t> sizes = {1, 100, 512, 999};
+  for (size_t sz : sizes) {
+    std::string key = "test/size-" + std::to_string(sz);
+    std::vector<uint8_t> data(sz, 'x');
+    ASSERT_EQ(0, put_tracked(key.c_str(), data.data(), data.size()));
+
+    CRgwObjectMeta meta{};
+    ASSERT_EQ(0, head(key.c_str(), &meta));
+    EXPECT_EQ(sz, meta.size) << "size mismatch for " << key;
+    rgw_free_object_meta(&meta);
+  }
+}
+
+// --------------- Delete ---------------
+
+TEST_F(SALWrapperTest, DeleteObject) {
+  std::string data = "to-be-deleted";
+  ASSERT_EQ(0, put_str("test/delete-me", data));
+
+  ASSERT_EQ(0, del("test/delete-me"));
+
+  CRgwObjectMeta meta{};
+  EXPECT_EQ(-ENOENT, head("test/delete-me", &meta));
+  rgw_free_object_meta(&meta);
+}
+
+TEST_F(SALWrapperTest, DeleteNonExistent) {
+  EXPECT_EQ(0, del("test/already-gone"));
+}
+
+TEST_F(SALWrapperTest, DeleteThenPut) {
+  std::string data1 = "original";
+  ASSERT_EQ(0, put_str("test/delete-reput", data1));
+  ASSERT_EQ(0, del("test/delete-reput"));
+
+  std::string data2 = "rewritten after delete";
+  ASSERT_EQ(0, put_str_tracked("test/delete-reput", data2));
+
+  CRgwBuffer buf{};
+  ASSERT_EQ(0, get("test/delete-reput", &buf));
+  ASSERT_EQ(data2.size(), buf.len);
+  EXPECT_EQ(0, memcmp(data2.data(), buf.data, buf.len));
+  rgw_free_buffer(&buf);
+}
+
+TEST_F(SALWrapperTest, BulkDelete) {
+  const int count = 5;
+  std::vector<std::string> keys;
+  std::vector<const char*> key_ptrs;
+  for (int i = 0; i < count; i++) {
+    keys.push_back("test/bulk-del/obj-" + std::to_string(i));
+    ASSERT_EQ(0, put_str(keys.back().c_str(), "data"));
+  }
+  for (auto& k : keys) key_ptrs.push_back(k.c_str());
+
+  ASSERT_EQ(0, rgw_delete_objects(driver(), dpp(), nullptr, &bucket_,
+             key_ptrs.data(), key_ptrs.size()));
+
+  for (auto& k : keys) {
+    CRgwObjectMeta meta{};
+    EXPECT_EQ(-ENOENT, head(k.c_str(), &meta));
+    rgw_free_object_meta(&meta);
+  }
+}
+
+// --------------- List ---------------
+
+TEST_F(SALWrapperTest, ListObjects) {
+  // write each object with a distinct size so the size reported by list is
+  // meaningful to verify (not all identical).
+  std::map<std::string, uint64_t> expected;  // key -> size
+  for (int i = 0; i < 5; i++) {
+    std::string key = "test/list/obj-" + std::to_string(i);
+    std::string data(i + 1, 'x');
+    ASSERT_EQ(0, put_str_tracked(key.c_str(), data));
+    expected[key] = data.size();
+  }
+
+  CRgwListResult result{};
+  ASSERT_EQ(0, rgw_list_objects(driver(), dpp(), nullptr, &bucket_,
+             "test/list/", nullptr, nullptr, 100, &result));
+  EXPECT_GE(result.count, 5u);
+
+  size_t matched = 0;
+  for (size_t i = 0; i < result.count; i++) {
+    ASSERT_NE(result.entries[i].key, nullptr);
+    EXPECT_GT(strlen(result.entries[i].key), 0u);
+
+    auto it = expected.find(result.entries[i].key);
+    if (it == expected.end()) continue;  // ignore entries from other tests
+    matched++;
+
+    // size must match exactly what we wrote
+    EXPECT_EQ(it->second, result.entries[i].size)
+        << "size mismatch for " << result.entries[i].key;
+
+    // mtime must be populated with a plausible (non-zero) value
+    EXPECT_GT(result.entries[i].last_modified, 0)
+        << "missing mtime for " << result.entries[i].key;
+
+    // The list entry carries no etag, so cross-check via head that the object
+    // has a valid, non-empty etag and that head agrees with the list on
+    // size and mtime.
+    CRgwObjectMeta meta{};
+    ASSERT_EQ(0, head(result.entries[i].key, &meta));
+    EXPECT_EQ(it->second, meta.size);
+    EXPECT_EQ(result.entries[i].size, meta.size);
+    EXPECT_EQ(result.entries[i].last_modified, meta.last_modified);
+    ASSERT_NE(meta.etag, nullptr);
+    EXPECT_GT(strlen(meta.etag), 0u);
+    rgw_free_object_meta(&meta);
+  }
+  // every object we created must appear in the listing
+  EXPECT_EQ(expected.size(), matched);
+
+  rgw_free_list_result(&result);
+}
+
+TEST_F(SALWrapperTest, ListWithDelimiter) {
+  ASSERT_EQ(0, put_str_tracked("test/delim/a/1", "d"));
+  ASSERT_EQ(0, put_str_tracked("test/delim/a/2", "d"));
+  ASSERT_EQ(0, put_str_tracked("test/delim/b/1", "d"));
+
+  CRgwListResult result{};
+  ASSERT_EQ(0, rgw_list_objects(driver(), dpp(), nullptr, &bucket_,
+             "test/delim/", "/", nullptr, 100, &result));
+  EXPECT_GE(result.count, 2u);
+  rgw_free_list_result(&result);
+}
+
+TEST_F(SALWrapperTest, ListPagination) {
+  for (int i = 0; i < 10; i++) {
+    std::string key = "test/page/obj-" + std::to_string(i);
+    ASSERT_EQ(0, put_str_tracked(key.c_str(), "data"));
+  }
+
+  size_t total = 0;
+  std::string marker_str;
+  bool truncated = true;
+  int pages = 0;
+
+  while (truncated && pages < 20) {
+    CRgwListResult result{};
+    ASSERT_EQ(0, rgw_list_objects(driver(), dpp(), nullptr, &bucket_,
+               "test/page/", nullptr,
+               marker_str.empty() ? nullptr : marker_str.c_str(),
+               3, &result));
+    total += result.count;
+    truncated = result.is_truncated != 0;
+    if (result.next_marker) {
+      marker_str = result.next_marker;
+    }
+    rgw_free_list_result(&result);
+    pages++;
+  }
+  EXPECT_GE(total, 10u);
+  EXPECT_FALSE(truncated);
+}
+
+TEST_F(SALWrapperTest, ListEmpty) {
+  CRgwListResult result{};
+  ASSERT_EQ(0, rgw_list_objects(driver(), dpp(), nullptr, &bucket_,
+             "no-such-prefix-xyz/", nullptr, nullptr, 100, &result));
+  EXPECT_EQ(0u, result.count);
+  EXPECT_EQ(0, result.is_truncated);
+  rgw_free_list_result(&result);
+}
+
+TEST_F(SALWrapperTest, ListReflectsDeletedObjects) {
+  for (int i = 0; i < 3; i++) {
+    std::string key = "test/list-del/obj-" + std::to_string(i);
+    ASSERT_EQ(0, put_str(key.c_str(), "data"));
+  }
+
+  ASSERT_EQ(0, del("test/list-del/obj-1"));
+
+  CRgwListResult result{};
+  ASSERT_EQ(0, rgw_list_objects(driver(), dpp(), nullptr, &bucket_,
+             "test/list-del/", nullptr, nullptr, 100, &result));
+
+  bool found_0 = false, found_1 = false, found_2 = false;
+  for (size_t i = 0; i < result.count; i++) {
+    std::string k = result.entries[i].key;
+    if (k == "test/list-del/obj-0") found_0 = true;
+    if (k == "test/list-del/obj-1") found_1 = true;
+    if (k == "test/list-del/obj-2") found_2 = true;
+  }
+  EXPECT_TRUE(found_0);
+  EXPECT_FALSE(found_1);
+  EXPECT_TRUE(found_2);
+
+  rgw_free_list_result(&result);
+  del("test/list-del/obj-0");
+  del("test/list-del/obj-2");
+}
+
+// --------------- Copy ---------------
+
+// known fail: dbstore — copy_object is a no-op stub
+TEST_F(SALWrapperTest, CopyObject) {
+  std::string data = "copy me";
+  ASSERT_EQ(0, put_str_tracked("test/copy-src", data));
+
+  CRgwObject src{"test/copy-src", nullptr};
+  CRgwObject dst{"test/copy-dst", nullptr};
+  ASSERT_EQ(0, rgw_copy_object(driver(), dpp(), nullptr,
+                                &bucket_, &src, &bucket_, &dst));
+  created_keys_.emplace_back("test/copy-dst");
+
+  CRgwBuffer buf{};
+  ASSERT_EQ(0, get("test/copy-dst", &buf));
+  ASSERT_EQ(data.size(), buf.len);
+  EXPECT_EQ(0, memcmp(data.data(), buf.data, buf.len));
+  rgw_free_buffer(&buf);
+}
+
+// known fail: dbstore — copy_object is a no-op stub
+TEST_F(SALWrapperTest, CopyPreservesData) {
+  std::vector<uint8_t> data(512);
+  std::iota(data.begin(), data.end(), 0);
+  ASSERT_EQ(0, put_tracked("test/copy-bin-src", data.data(), data.size()));
+
+  CRgwObject src{"test/copy-bin-src", nullptr};
+  CRgwObject dst{"test/copy-bin-dst", nullptr};
+  ASSERT_EQ(0, rgw_copy_object(driver(), dpp(), nullptr,
+                                &bucket_, &src, &bucket_, &dst));
+  created_keys_.emplace_back("test/copy-bin-dst");
+
+  CRgwBuffer buf{};
+  ASSERT_EQ(0, get("test/copy-bin-dst", &buf));
+  ASSERT_EQ(data.size(), buf.len);
+  EXPECT_EQ(0, memcmp(data.data(), buf.data, buf.len));
+  rgw_free_buffer(&buf);
+}
+
+// known fail: dbstore — copy_object is a no-op stub
+TEST_F(SALWrapperTest, CopyNonExistent) {
+  CRgwObject src{"test/no-such-copy-src", nullptr};
+  CRgwObject dst{"test/copy-dst-fail", nullptr};
+  EXPECT_LT(rgw_copy_object(driver(), dpp(), nullptr,
+                              &bucket_, &src, &bucket_, &dst), 0);
+}
+
+// --------------- Conditional put ---------------
+
+// known fail: dbstore — ignores conditionals; posix — inverted if_nomatch logic
+TEST_F(SALWrapperTest, ConditionalPutIfNomatch) {
+  std::string data = "conditional data";
+  ASSERT_EQ(0, put_str_tracked("test/cond-put", data));
+
+  // put with if_nomatch="*" should be canceled since object already exists
+  std::string new_data = "should not overwrite";
+  CRgwObject obj{"test/cond-put", nullptr};
+  CRgwBuffer buf{reinterpret_cast<uint8_t*>(new_data.data()),
+                 new_data.size()};
+  int canceled = 0;
+  int ret = rgw_put_object_conditional(driver(), dpp(), nullptr,
+                                       &bucket_, &obj, &buf,
+                                       nullptr, "*", &canceled, nullptr);
+  ASSERT_EQ(0, ret);
+  EXPECT_EQ(1, canceled);
+
+  // original data should be preserved
+  CRgwBuffer get_buf{};
+  ASSERT_EQ(0, get("test/cond-put", &get_buf));
+  ASSERT_EQ(data.size(), get_buf.len);
+  EXPECT_EQ(0, memcmp(data.data(), get_buf.data, get_buf.len));
+  rgw_free_buffer(&get_buf);
+}
+
+// --------------- MaxChunkSize ---------------
+
+TEST_F(SALWrapperTest, MaxChunkSize) {
+  uint64_t chunk = rgw_get_max_chunk_size(driver());
+  EXPECT_GT(chunk, 0u);
+}
+
+// --------------- Key naming edge cases ---------------
+
+TEST_F(SALWrapperTest, SpecialCharacterKeys) {
+  std::string data = "special";
+  const char* keys[] = {
+    "test/special/key with spaces",
+    "test/special/key+plus",
+    "test/special/key=equals",
+    "test/special/deep/nested/path/obj",
+  };
+
+  for (auto key : keys) {
+    ASSERT_EQ(0, put_str_tracked(key, data)) << "put failed for: " << key;
+
+    CRgwBuffer buf{};
+    ASSERT_EQ(0, get(key, &buf)) << "get failed for: " << key;
+    ASSERT_EQ(data.size(), buf.len) << "size mismatch for: " << key;
+    EXPECT_EQ(0, memcmp(data.data(), buf.data, buf.len));
+    rgw_free_buffer(&buf);
+  }
+}
+
+// --------------- Conditional put — if_match ---------------
+
+// known fail: dbstore, posix — do not enforce conditional write preconditions
+TEST_F(SALWrapperTest, ConditionalPutIfMatchSucceeds) {
+  std::string data = "original";
+  ASSERT_EQ(0, put_str_tracked("test/cond-match", data));
+
+  CRgwObjectMeta meta{};
+  ASSERT_EQ(0, head("test/cond-match", &meta));
+  ASSERT_NE(meta.etag, nullptr);
+  std::string etag = meta.etag;
+  rgw_free_object_meta(&meta);
+
+  // put with if_match=current_etag should succeed (not canceled)
+  std::string new_data = "updated via if_match";
+  CRgwObject obj{"test/cond-match", nullptr};
+  CRgwBuffer buf{reinterpret_cast<uint8_t*>(new_data.data()), new_data.size()};
+  int canceled = 0;
+  ASSERT_EQ(0, rgw_put_object_conditional(driver(), dpp(), nullptr,
+                                          &bucket_, &obj, &buf,
+                                          etag.c_str(), nullptr, &canceled, nullptr));
+  EXPECT_EQ(0, canceled);
+
+  CRgwBuffer get_buf{};
+  ASSERT_EQ(0, get("test/cond-match", &get_buf));
+  ASSERT_EQ(new_data.size(), get_buf.len);
+  EXPECT_EQ(0, memcmp(new_data.data(), get_buf.data, get_buf.len));
+  rgw_free_buffer(&get_buf);
+}
+
+// known fail: dbstore, posix — do not enforce conditional write preconditions
+TEST_F(SALWrapperTest, ConditionalPutIfMatchWrongEtag) {
+  std::string data = "should stay";
+  ASSERT_EQ(0, put_str_tracked("test/cond-match-fail", data));
+
+  // put with if_match=wrong_etag should be canceled
+  std::string new_data = "should not appear";
+  CRgwObject obj{"test/cond-match-fail", nullptr};
+  CRgwBuffer buf{reinterpret_cast<uint8_t*>(new_data.data()), new_data.size()};
+  int canceled = 0;
+  ASSERT_EQ(0, rgw_put_object_conditional(driver(), dpp(), nullptr,
+                                          &bucket_, &obj, &buf,
+                                          "bogus-etag", nullptr, &canceled, nullptr));
+  EXPECT_EQ(1, canceled);
+
+  CRgwBuffer get_buf{};
+  ASSERT_EQ(0, get("test/cond-match-fail", &get_buf));
+  ASSERT_EQ(data.size(), get_buf.len);
+  EXPECT_EQ(0, memcmp(data.data(), get_buf.data, get_buf.len));
+  rgw_free_buffer(&get_buf);
+}
+
+// --------------- Conditional copy ---------------
+
+// known fail: dbstore — copy_object is a no-op stub
+TEST_F(SALWrapperTest, ConditionalCopyIfNomatch) {
+  std::string data = "conditional copy source";
+  ASSERT_EQ(0, put_str_tracked("test/ccopy-src", data));
+
+  // copy to a new destination with if_nomatch="*" — should succeed
+  CRgwObject src{"test/ccopy-src", nullptr};
+  CRgwObject dst{"test/ccopy-dst-new", nullptr};
+  ASSERT_EQ(0, rgw_copy_object_conditional(driver(), dpp(), nullptr,
+                                           &bucket_, &src, &bucket_, &dst,
+                                           nullptr, "*"));
+  created_keys_.emplace_back("test/ccopy-dst-new");
+
+  CRgwBuffer buf{};
+  ASSERT_EQ(0, get("test/ccopy-dst-new", &buf));
+  ASSERT_EQ(data.size(), buf.len);
+  EXPECT_EQ(0, memcmp(data.data(), buf.data, buf.len));
+  rgw_free_buffer(&buf);
+}
+
+// known fail: dbstore — copy_object is a no-op stub
+TEST_F(SALWrapperTest, ConditionalCopyIfNomatchExists) {
+  ASSERT_EQ(0, put_str_tracked("test/ccopy-src2", "source data"));
+  ASSERT_EQ(0, put_str_tracked("test/ccopy-dst-exists", "existing data"));
+
+  // copy with if_nomatch="*" to an existing destination — should fail
+  CRgwObject src{"test/ccopy-src2", nullptr};
+  CRgwObject dst{"test/ccopy-dst-exists", nullptr};
+  int ret = rgw_copy_object_conditional(driver(), dpp(), nullptr,
+                                        &bucket_, &src, &bucket_, &dst,
+                                        nullptr, "*");
+  EXPECT_LT(ret, 0);
+
+  // existing destination data should be unchanged
+  CRgwBuffer buf{};
+  ASSERT_EQ(0, get("test/ccopy-dst-exists", &buf));
+  std::string expected = "existing data";
+  ASSERT_EQ(expected.size(), buf.len);
+  EXPECT_EQ(0, memcmp(expected.data(), buf.data, buf.len));
+  rgw_free_buffer(&buf);
+}
+
+// --------------- Multipart upload ---------------
+
+// known fail: dbstore — does not support multi-chunk reads needed to verify multipart
+TEST_F(SALWrapperTest, MultipartBasic) {
+  CRgwObject obj{"test/multipart-obj", nullptr};
+  char* upload_id = nullptr;
+
+  int ret = rgw_init_multipart(driver(), dpp(), nullptr, &bucket_, &obj, &upload_id);
+  ASSERT_EQ(0, ret);
+  ASSERT_NE(upload_id, nullptr);
+  EXPECT_GT(strlen(upload_id), 0u);
+
+  // part 1: 5MB (minimum for non-last parts)
+  const size_t part_size = 5 * 1024 * 1024;
+  std::vector<uint8_t> part1_data(part_size, 'A');
+  // part 2: small last part (no minimum)
+  std::vector<uint8_t> part2_data(1024, 'B');
+
+  char* etag1 = nullptr;
+  ret = rgw_multipart_put_part(driver(), dpp(), nullptr, &bucket_, &obj,
+                               upload_id, 1,
+                               part1_data.data(), part1_data.size(), &etag1);
+  ASSERT_EQ(0, ret);
+  ASSERT_NE(etag1, nullptr);
+
+  char* etag2 = nullptr;
+  ret = rgw_multipart_put_part(driver(), dpp(), nullptr, &bucket_, &obj,
+                               upload_id, 2,
+                               part2_data.data(), part2_data.size(), &etag2);
+  ASSERT_EQ(0, ret);
+  ASSERT_NE(etag2, nullptr);
+
+  const char* etags[] = {etag1, etag2};
+  ret = rgw_multipart_complete(driver(), dpp(), nullptr, &bucket_, &obj,
+                               upload_id, etags, 2);
+  ASSERT_EQ(0, ret);
+  created_keys_.emplace_back("test/multipart-obj");
+
+  // verify the assembled object is readable and has correct total size
+  CRgwObjectMeta meta{};
+  ASSERT_EQ(0, head("test/multipart-obj", &meta));
+  EXPECT_EQ(part1_data.size() + part2_data.size(), meta.size);
+  rgw_free_object_meta(&meta);
+
+  free(upload_id);
+  free(etag1);
+  free(etag2);
+}
+
+TEST_F(SALWrapperTest, MultipartAbort) {
+  CRgwObject obj{"test/multipart-abort", nullptr};
+  char* upload_id = nullptr;
+
+  ASSERT_EQ(0, rgw_init_multipart(driver(), dpp(), nullptr,
+                                  &bucket_, &obj, &upload_id));
+  ASSERT_NE(upload_id, nullptr);
+
+  // upload one part
+  std::string part_data = "part that will be aborted";
+  char* etag = nullptr;
+  ASSERT_EQ(0, rgw_multipart_put_part(driver(), dpp(), nullptr, &bucket_, &obj,
+                                      upload_id, 1,
+                                      reinterpret_cast<const uint8_t*>(part_data.data()),
+                                      part_data.size(), &etag));
+
+  // abort the upload
+  ASSERT_EQ(0, rgw_multipart_abort(driver(), dpp(), nullptr,
+                                   &bucket_, &obj, upload_id));
+
+  // the final object should NOT exist
+  CRgwObjectMeta meta{};
+  EXPECT_EQ(-ENOENT, head("test/multipart-abort", &meta));
+  rgw_free_object_meta(&meta);
+
+  free(upload_id);
+  free(etag);
+}
+
+TEST_F(SALWrapperTest, MultipartInvalidUploadId) {
+  CRgwObject obj{"test/multipart-bad-id", nullptr};
+  std::string data = "data";
+  char* etag = nullptr;
+
+  int ret = rgw_multipart_put_part(driver(), dpp(), nullptr, &bucket_, &obj,
+                                   "nonexistent-upload-id", 1,
+                                   reinterpret_cast<const uint8_t*>(data.data()),
+                                   data.size(), &etag);
+  EXPECT_LT(ret, 0);
+
+  const char* etags[] = {"fake"};
+  ret = rgw_multipart_complete(driver(), dpp(), nullptr, &bucket_, &obj,
+                               "nonexistent-upload-id", etags, 1);
+  EXPECT_LT(ret, 0);
+}
+
+TEST_F(SALWrapperTest, MultipartSinglePart) {
+  CRgwObject obj{"test/multipart-single", nullptr};
+  char* upload_id = nullptr;
+
+  ASSERT_EQ(0, rgw_init_multipart(driver(), dpp(), nullptr,
+                                  &bucket_, &obj, &upload_id));
+  ASSERT_NE(upload_id, nullptr);
+
+  std::string data = "single part upload content";
+  char* etag = nullptr;
+  ASSERT_EQ(0, rgw_multipart_put_part(driver(), dpp(), nullptr, &bucket_, &obj,
+                                      upload_id, 1,
+                                      reinterpret_cast<const uint8_t*>(data.data()),
+                                      data.size(), &etag));
+  ASSERT_NE(etag, nullptr);
+
+  const char* etags[] = {etag};
+  ASSERT_EQ(0, rgw_multipart_complete(driver(), dpp(), nullptr, &bucket_, &obj,
+                                      upload_id, etags, 1));
+  created_keys_.emplace_back("test/multipart-single");
+
+  CRgwBuffer buf{};
+  ASSERT_EQ(0, get("test/multipart-single", &buf));
+  EXPECT_GT(buf.len, 0u);
+  rgw_free_buffer(&buf);
+
+  free(upload_id);
+  free(etag);
+}
+
+// ===========================================================================
+// main() — bootstrap SAL driver
+// ===========================================================================
+
+int main(int argc, char** argv) {
+  // ceph.conf is found via -c flag, $CEPH_CONF, or default paths.
+  // When running under teuthology, the default path is used.
+  auto args = argv_to_vec(argc, const_cast<const char**>(argv));
+
+  auto cct = rgw_global_init(nullptr, args, CEPH_ENTITY_TYPE_CLIENT,
+                             CODE_ENVIRONMENT_UTILITY, 0);
+
+  // region -> zonegroup conversion (must happen before common_init_finish)
+  if (!g_conf()->rgw_region.empty() && g_conf()->rgw_zonegroup.empty()) {
+    g_conf().set_val_or_die("rgw_zonegroup", g_conf()->rgw_region.c_str());
+  }
+
+  common_init_finish(g_ceph_context);
+
+  static TestEnv env;
+  g_env = &env;
+
+  static NoDoutPrefix nodpp(g_ceph_context, ceph_subsys_rgw);
+  env.dpp = &nodpp;
+
+  // io_context_pool provides worker threads needed by RADOS async ops
+  static ceph::async::io_context_pool context_pool{
+    cct->_conf->rgw_thread_pool_size};
+
+  // backend is read from ceph.conf via rgw_backend_store
+  DriverManager::Config cfg = DriverManager::get_config(true, g_ceph_context);
+  env.backend = cfg.store_name;
+  std::cerr << "INFO: using backend '" << cfg.store_name << "'" << std::endl;
+
+  // create config store
+  auto config_store_type = g_conf().get_val<std::string>("rgw_config_store");
+  env.cfgstore = DriverManager::create_config_store(env.dpp, config_store_type);
+  if (!env.cfgstore) {
+    std::cerr << "ERROR: failed to create config store" << std::endl;
+    return 1;
+  }
+
+  // load site config
+  rgw::SiteConfig site;
+  int r = site.load(env.dpp, null_yield, env.cfgstore.get());
+  if (r < 0) {
+    std::cerr << "ERROR: failed to load site config (r=" << r << ")" << std::endl;
+    return 1;
+  }
+
+  // initialize SAL driver with all background threads disabled
+  env.driver = DriverManager::get_storage(env.dpp,
+                                          g_ceph_context,
+                                          cfg,
+                                          context_pool,
+                                          site,
+                                          false,  // use_gc_thread
+                                          false,  // use_lc_thread
+                                          false,  // use_restore_thread
+                                          false,  // quota_threads
+                                          false,  // run_sync_thread
+                                          false,  // run_reshard_thread
+                                          false,  // run_notification_thread
+                                          false,  // run_bucket_logging_thread
+                                          false,  // background_tasks
+                                          null_yield,
+                                          env.cfgstore.get(),
+                                          false); // use_cache
+  if (!env.driver) {
+    std::cerr << "ERROR: failed to initialize SAL driver" << std::endl;
+    return 1;
+  }
+
+  // create test bucket via SAL API with proper zonegroup + placement
+  env.bucket_name = "sal-wrapper-test-" + std::to_string(getpid());
+  {
+    rgw_bucket b;
+    b.name = env.bucket_name;
+
+    std::unique_ptr<rgw::sal::Bucket> bucket;
+    r = env.driver->load_bucket(env.dpp, b, &bucket, null_yield);
+
+    if (bucket) {
+      rgw::sal::Bucket::CreateParams params;
+      rgw_user uid{"", "sal-wrapper-test-user"};
+      params.owner = uid;
+      params.zonegroup_id = site.get_zonegroup().get_id();
+      params.placement_rule = site.get_zonegroup().default_placement;
+      params.zone_placement = rgw::find_zone_placement(
+          env.dpp, site.get_zone_params(), params.placement_rule);
+
+      r = bucket->create(env.dpp, params, null_yield);
+      if (r < 0 && r != -EEXIST) {
+        std::cerr << "ERROR: failed to create test bucket (r=" << r << ")" << std::endl;
+        env.driver->shutdown();
+        DriverManager::close_storage(env.driver);
+        return 1;
+      }
+    } else {
+      std::cerr << "ERROR: load_bucket returned no bucket object" << std::endl;
+      env.driver->shutdown();
+      DriverManager::close_storage(env.driver);
+      return 1;
+    }
+  }
+
+  testing::InitGoogleTest(&argc, argv);
+  int ret = RUN_ALL_TESTS();
+
+  // cleanup: delete test bucket and all objects in it
+  if (env.driver) {
+    rgw_bucket b;
+    b.name = env.bucket_name;
+    std::unique_ptr<rgw::sal::Bucket> bucket;
+    if (env.driver->load_bucket(env.dpp, b, &bucket, null_yield) == 0 && bucket) {
+      bucket->remove(env.dpp, true, null_yield);
+    }
+    env.driver->shutdown();
+    DriverManager::close_storage(env.driver);
+    env.driver = nullptr;
+  }
+
+  return ret;
+}


### PR DESCRIPTION
This PR contains  unit tests for the rgw_sal_wrapper C FFI API and also integration tests for LanceDB ObjectStore both of which can be exercised against any backend and live cluster.

TODO:
* Include remaining tests from arrow-rs integration tests and mark them ignore/fail with comment
* the arrow suite has multipart tests, why are we testing them seperatly? cleanup the other tests which may be duplicate
* why do we take ownership over the pointer? (wrt etag_out ptr)
* Create list of failures for other backends posix/dbstore and raise trackers

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
