### PR TITLE
qa: Add Cross-namespace copy test (nvmeof)

### DIFF
--- a/qa/suites/nvmeof/basic/workloads/nvmeof_namespaces.yaml
+++ b/qa/suites/nvmeof/basic/workloads/nvmeof_namespaces.yaml
@@ -33,6 +33,7 @@ tasks:
       client.1:
         - nvmeof/basic_tests.sh
         - nvmeof/namespace_test.sh
+        - nvmeof/cross_namespace_copy_test.sh
     env:
       RBD_POOL: mypool
       IOSTAT_INTERVAL: '10'

--- a/qa/workunits/nvmeof/cross_namespace_copy_test.sh
+++ b/qa/workunits/nvmeof/cross_namespace_copy_test.sh
@@ -1,0 +1,78 @@
+#!/bin/bash -ex
+
+# Cross-namespace copy test using the NVMe Simple Copy command (TP 4065).
+#
+# The test connects to the NVMe-oF gateway, discovers a second NVMe device
+# (sorted by namespace index), then issues an `nvme copy` command that copies
+# one LBA range from a source namespace into that device at the destination
+# LBA offset.
+#
+# Expected outcome: the nvme-cli reports "NVMe Copy: success".
+
+source /etc/ceph/nvmeof.env
+
+SPDK_CONTROLLER="Ceph bdev Controller"
+DISCOVERY_PORT="8009"
+
+# Ensure we are connected to all subsystems so that nvme list sees all devices.
+# basic_tests.sh (which runs before this script on client.1) leaves a
+# connect-all session open, but namespace_test.sh may have changed device
+# counts.  Re-running connect-all is idempotent.
+sudo nvme connect-all --traddr="$NVMEOF_DEFAULT_GATEWAY_IP_ADDRESS" --transport=tcp -l 3600
+sleep 5
+
+# Pick the second SPDK device sorted by namespace number.
+# nvmeof_namespaces.yaml connects all namespaces so there are many devices
+# available; we just need any valid second one for the copy destination.
+target_device=$(sudo nvme list --output-format=json |
+    jq -r '[.Devices[] | select(.ModelNumber == "'"$SPDK_CONTROLLER"'")] | sort_by(.NameSpace) | .[1] | .DevicePath')
+
+if [ -z "$target_device" ] || [ "$target_device" = "null" ]; then
+    echo "[nvmeof.copy] ERROR: could not find a second NVMe device to use as copy destination"
+    sudo nvme list
+    exit 1
+fi
+
+echo "[nvmeof.copy] Using target device: $target_device"
+
+copy_test() {
+    # nvme-cli flag names differ by version:
+    #   2.13: --slba, --nlb, --snsid  (singular)
+    #   2.16+: --slbs, --blocks, --snsids  (plural, comma-separated list)
+    # Detect by checking which flag the installed binary accepts.
+    local nvme_ver
+    nvme_ver=$(nvme version 2>/dev/null | head -n1 | awk '{print $3}')
+    local major minor
+    major=$(echo "$nvme_ver" | cut -d. -f1)
+    minor=$(echo "$nvme_ver" | cut -d. -f2)
+
+    if [ "$major" -gt 2 ] || { [ "$major" -eq 2 ] && [ "$minor" -ge 16 ]; }; then
+        # nvme-cli >= 2.16: plural list flags
+        # Format 2 is required for cross-namespace copy (NVMe TP4065);
+        # formats 0 and 1 are same-namespace only and nvme-cli 2.16 enforces this.
+        output=$(sudo nvme copy "$target_device" \
+            --sdlba=1000 \
+            --slbs=5000 \
+            --blocks=99 \
+            --snsids=1 \
+            --format=2 2>&1)
+    else
+        # nvme-cli < 2.16 (e.g. 2.13): singular flags
+        output=$(sudo nvme copy "$target_device" \
+            --sdlba=1000 \
+            --slba=5000 \
+            --nlb=99 \
+            --snsid=1 \
+            --format=2 2>&1)
+    fi
+    echo "$output"
+    if ! echo "$output" | grep -q "NVMe Copy: success"; then
+        echo "[nvmeof.copy] copy_test FAILED — expected 'NVMe Copy: success' in output"
+        sudo dmesg -T > "$TESTDIR/archive/dmesg-copy_test.log" 2>/dev/null || true
+        return 1
+    fi
+}
+
+echo "[nvmeof.copy] Running NVMe copy test..."
+copy_test
+echo "[nvmeof.copy] NVMe copy test passed!"


### PR DESCRIPTION
Added test coverage for NVMe-oF Cross Namespace Copy (CNC) enabling efficient data copying between namespaces without host memory transfers.

**pulpito run**: https://pulpito.ceph.com/bdavidov-2026-08-10_19:26:04-nvmeof-wip-nvmeof-cross-namespace-copy-test-distro-default-trial/
**Fixes**: https://tracker.ceph.com/issues/79359





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
