### PR TITLE
librados: honor rados_mon_op_timeout in wait_for_latest_osdmap

### DIFF
--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -18,6 +18,7 @@
 #include <fcntl.h>
 
 #include <iostream>
+#include <optional>
 #include <string>
 #include <sstream>
 #include <pthread.h>
@@ -596,8 +597,13 @@ int librados::RadosClient::wait_for_osdmap()
 
 int librados::RadosClient::wait_for_latest_osdmap()
 {
+  std::optional<ceph::mono_time> deadline;
+  if (rados_mon_op_timeout.count() > 0) {
+    deadline = ceph::mono_clock::now() + rados_mon_op_timeout;
+  }
+
   bs::error_code ec;
-  objecter->wait_for_latest_osdmap(ca::use_blocked[ec]);
+  objecter->wait_for_latest_osdmap(deadline, ca::use_blocked[ec]);
   return ceph::from_error_code(ec);
 }
 

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -545,12 +545,11 @@ void MonClient::shutdown()
   monc_lock.lock();
   stopping = true;
   while (!version_requests.empty()) {
+    auto tid = version_requests.begin()->first;
     ldout(cct, 20) << __func__ << " canceling and discarding version request "
-		   << version_requests.begin()->first << dendl;
-    asio::post(service.get_executor(),
-               asio::append(std::move(version_requests.begin()->second),
-                            make_error_code(monc_errc::shutting_down), 0, 0));
-    version_requests.erase(version_requests.begin());
+		   << tid << dendl;
+    _finish_version_request(
+      tid, make_error_code(monc_errc::shutting_down));
   }
   while (!mon_commands.empty()) {
     auto tid = mon_commands.begin()->first;
@@ -778,12 +777,11 @@ void MonClient::_reopen_session(int rank)
 
   // throw out version check requests
   while (!version_requests.empty()) {
+    auto tid = version_requests.begin()->first;
     ldout(cct, 20) << __func__ << " canceling and discarding version request "
-		   << version_requests.begin()->first << dendl;
-    asio::post(service.get_executor(),
-               asio::append(std::move(version_requests.begin()->second),
-                            make_error_code(monc_errc::session_reset), 0, 0));
-    version_requests.erase(version_requests.begin());
+		   << tid << dendl;
+    _finish_version_request(
+      tid, make_error_code(monc_errc::session_reset));
   }
 
   for (auto& c : pending_cons) {
@@ -1492,6 +1490,57 @@ void MonClient::_finish_command(MonCommand *r, bs::error_code ret,
 
 // ---------
 
+bool MonClient::_arm_version_request_timeout(
+  ceph_tid_t tid, std::optional<ceph::mono_time> deadline)
+{
+  ceph_assert(ceph_mutex_is_locked(monc_lock));
+  if (!deadline) {
+    return true;
+  }
+  if (*deadline <= ceph::mono_clock::now()) {
+    _finish_version_request(tid, make_error_code(monc_errc::timed_out));
+    return false;
+  }
+
+  auto iter = version_requests.find(tid);
+  ceph_assert(iter != version_requests.end());
+  iter->second.timeout_event = timer.add_event_at(
+    *deadline,
+    make_lambda_context(
+      [this, tid](int) { _handle_version_request_timeout(tid); }));
+  return true;
+}
+
+void MonClient::_finish_version_request(
+  ceph_tid_t tid, bs::error_code ec, version_t newest, version_t oldest)
+{
+  ceph_assert(ceph_mutex_is_locked(monc_lock));
+  auto iter = version_requests.find(tid);
+  if (iter == version_requests.end()) {
+    return;
+  }
+
+  if (iter->second.timeout_event) {
+    timer.cancel_event(iter->second.timeout_event);
+  }
+  auto onfinish = std::move(iter->second.onfinish);
+  version_requests.erase(iter);
+  asio::post(service.get_executor(),
+	     asio::append(std::move(onfinish), ec, newest, oldest));
+}
+
+void MonClient::_handle_version_request_timeout(ceph_tid_t tid)
+{
+  ceph_assert(ceph_mutex_is_locked(monc_lock));
+  auto iter = version_requests.find(tid);
+  if (iter == version_requests.end()) {
+    return;
+  }
+
+  iter->second.timeout_event = nullptr;
+  _finish_version_request(tid, make_error_code(monc_errc::timed_out));
+}
+
 void MonClient::handle_get_version_reply(MMonGetVersionReply* m)
 {
   ceph_assert(ceph_mutex_is_locked(monc_lock));
@@ -1500,13 +1549,10 @@ void MonClient::handle_get_version_reply(MMonGetVersionReply* m)
     ldout(cct, 0) << __func__ << " version request with handle " << m->handle
 		  << " not found" << dendl;
   } else {
-    auto req = std::move(iter->second);
     ldout(cct, 10) << __func__ << " finishing " << iter->first << " version "
 		   << m->version << dendl;
-    version_requests.erase(iter);
-    asio::post(service.get_executor(),
-	       asio::append(std::move(req), bs::error_code(),
-			    m->version, m->oldest_version));
+    _finish_version_request(
+      m->handle, bs::error_code(), m->version, m->oldest_version);
   }
   m->put();
 }

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -19,6 +19,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <vector>
@@ -712,18 +713,29 @@ public:
    */
   template<typename CompletionToken>
   auto get_version(std::string&& map, CompletionToken&& token) {
+    return get_version(std::move(map), std::nullopt,
+		       std::forward<CompletionToken>(token));
+  }
+
+  template<typename CompletionToken>
+  auto get_version(std::string&& map,
+		   std::optional<ceph::mono_time> deadline,
+		   CompletionToken&& token) {
     namespace asio = boost::asio;
     auto consigned = asio::consign(
       std::forward<CompletionToken>(token), asio::make_work_guard(
 	asio::get_associated_executor(token, service.get_executor())));
     return asio::async_initiate<decltype(consigned), VersionSig>(
-      [this, map = std::move(map)](auto handler) mutable {
+      [this, map = std::move(map), deadline](auto handler) mutable {
 	std::scoped_lock l(monc_lock);
 	auto m = ceph::make_message<MMonGetVersion>();
 	m->what = std::move(map);
 	m->handle = ++version_req_id;
-	version_requests.emplace(m->handle, std::move(handler));
-	_send_mon_message(m);
+	version_requests.emplace(
+	  m->handle, VersionRequest{std::move(handler)});
+	if (_arm_version_request_timeout(m->handle, deadline)) {
+	  _send_mon_message(m);
+	}
       }, consigned);
   }
 
@@ -745,9 +757,22 @@ public:
   md_config_t::config_callback get_config_callback();
 
 private:
+  friend class MonClientLatestOsdmapTimeoutTest;
 
-  std::map<ceph_tid_t, VersionCompletion> version_requests;
+
+  struct VersionRequest {
+    VersionCompletion onfinish;
+    Context* timeout_event = nullptr;
+  };
+
+  std::map<ceph_tid_t, VersionRequest> version_requests;
   ceph_tid_t version_req_id;
+  bool _arm_version_request_timeout(
+    ceph_tid_t tid, std::optional<ceph::mono_time> deadline);
+  void _finish_version_request(
+    ceph_tid_t tid, boost::system::error_code ec,
+    version_t newest = 0, version_t oldest = 0);
+  void _handle_version_request_timeout(ceph_tid_t tid);
   void handle_get_version_reply(MMonGetVersionReply* m);
   md_config_t::config_callback config_cb;
   std::function<void(void)> config_notify_cb;

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -453,6 +453,7 @@ void Objecter::start(const OSDMap* o)
 void Objecter::shutdown()
 {
   ceph_assert(initialized);
+  std::vector<OpCompletion> map_waiters_to_cancel;
 
   unique_lock wl(rwlock);
 
@@ -551,6 +552,16 @@ void Objecter::shutdown()
     op->put();
   }
 
+  for (auto& entry : waiting_for_map) {
+    for (auto& waiter : entry.second) {
+      if (waiter.timeout_event) {
+        timer.cancel_event(waiter.timeout_event);
+      }
+      map_waiters_to_cancel.push_back(std::move(waiter.onfinish));
+    }
+  }
+  waiting_for_map.clear();
+
   if (tick_event) {
     if (timer.cancel_event(tick_event)) {
       ldout(cct, 10) <<  " successfully canceled tick" << dendl;
@@ -564,8 +575,18 @@ void Objecter::shutdown()
     logger = NULL;
   }
 
-  // Let go of Objecter write lock so timer thread can shutdown
+  // Let go of Objecter write lock before joining the timer thread. A map
+  // timeout callback may already be running and waiting for rwlock.
   wl.unlock();
+  timer.suspend();
+  timer.cancel_all_events();
+
+  for (auto& onfinish : map_waiters_to_cancel) {
+    asio::post(
+      service.get_executor(),
+      asio::append(
+        std::move(onfinish), make_error_code(bs::errc::operation_canceled)));
+  }
 
   // Outside of lock to avoid cycle WRT calls to RequestStateHook
   // This is safe because we guarantee no concurrent calls to
@@ -1444,21 +1465,30 @@ void Objecter::handle_osd_map(MOSDMap *m)
 
   _dump_active();
 
-  // finish any Contexts that were waiting on a map update
-  auto p = waiting_for_map.begin();
-  while (p != waiting_for_map.end() &&
-	 p->first <= osdmap->get_epoch()) {
-    //go through the list and call the onfinish methods
-    for (auto& [c, ec] : p->second) {
-      asio::post(service.get_executor(), asio::append(std::move(c), ec));
-    }
-    p = waiting_for_map.erase(p);
-  }
+  // finish any Contexts that were waiting on this map update
+  _finish_map_waiters(osdmap->get_epoch());
 
   monc->sub_got("osdmap", osdmap->get_epoch());
 
   if (!waiting_for_map.empty()) {
     _maybe_request_map();
+  }
+}
+
+void Objecter::_finish_map_waiters(epoch_t epoch)
+{
+  // rwlock is locked unique
+  auto p = waiting_for_map.begin();
+  while (p != waiting_for_map.end() && p->first <= epoch) {
+    for (auto& waiter : p->second) {
+      if (waiter.timeout_event) {
+	timer.cancel_event(waiter.timeout_event);
+      }
+      asio::post(
+	service.get_executor(),
+	asio::append(std::move(waiter.onfinish), waiter.result));
+    }
+    p = waiting_for_map.erase(p);
   }
 }
 
@@ -2067,17 +2097,18 @@ void Objecter::wait_for_osd_map(epoch_t e)
   auto ex = boost::asio::prefer(
     service.get_executor(),
     boost::asio::execution::outstanding_work.tracked);
-  waiting_for_map[e].emplace_back(asio::bind_executor(
-				    service.get_executor(),
-				    w.ref()),
-				  bs::error_code{});
+  waiting_for_map[e].push_back(MapWaiter{
+    ++last_map_waiter_id,
+    asio::bind_executor(service.get_executor(), w.ref()),
+    bs::error_code{}});
   l.unlock();
   w.wait();
 }
 
-void Objecter::_get_latest_version(epoch_t oldest, epoch_t newest,
-				   OpCompletion fin,
-				   std::unique_lock<ceph::shared_mutex>&& l)
+void Objecter::_get_latest_version(
+  epoch_t oldest, epoch_t newest, OpCompletion fin,
+  std::optional<ceph::mono_time> deadline,
+  std::unique_lock<ceph::shared_mutex>&& l)
 {
   ceph_assert(fin);
   if (osdmap->get_epoch() >= newest) {
@@ -2087,7 +2118,8 @@ void Objecter::_get_latest_version(epoch_t oldest, epoch_t newest,
 		asio::append(std::move(fin), bs::error_code{}));
   } else {
     ldout(cct, 10) << __func__ << " latest " << newest << ", waiting" << dendl;
-    _wait_for_new_map(std::move(fin), newest, bs::error_code{});
+    _wait_for_new_map(
+      std::move(fin), newest, bs::error_code{}, deadline);
     l.unlock();
   }
 }
@@ -2119,12 +2151,59 @@ void Objecter::_maybe_request_map()
   }
 }
 
-void Objecter::_wait_for_new_map(OpCompletion c, epoch_t epoch,
-				 bs::error_code ec)
+uint64_t Objecter::_wait_for_new_map(
+  OpCompletion c, epoch_t epoch, bs::error_code ec,
+  std::optional<ceph::mono_time> deadline)
 {
   // rwlock is locked unique
-  waiting_for_map[epoch].emplace_back(std::move(c), ec);
+  if (deadline && *deadline <= ceph::mono_clock::now()) {
+    asio::post(
+      service.get_executor(),
+      asio::append(std::move(c), make_error_code(bs::errc::timed_out)));
+    return 0;
+  }
+
+  auto waiter_id = ++last_map_waiter_id;
+  auto& waiter = waiting_for_map[epoch].emplace_back(
+    MapWaiter{waiter_id, std::move(c), ec});
+  if (deadline) {
+    waiter.timeout_event = timer.add_event(
+      *deadline - ceph::mono_clock::now(),
+      [this, epoch, waiter_id]() {
+	_timeout_map_waiter(epoch, waiter_id);
+      });
+  }
   _maybe_request_map();
+  return waiter_id;
+}
+
+void Objecter::_timeout_map_waiter(epoch_t epoch, uint64_t waiter_id)
+{
+  std::unique_lock l(rwlock);
+  auto p = waiting_for_map.find(epoch);
+  if (p == waiting_for_map.end()) {
+    return;
+  }
+
+  auto waiter = std::find_if(
+    p->second.begin(), p->second.end(),
+    [waiter_id](const MapWaiter& item) {
+      return item.id == waiter_id;
+    });
+  if (waiter == p->second.end()) {
+    return;
+  }
+
+  auto onfinish = std::move(waiter->onfinish);
+  p->second.erase(waiter);
+  if (p->second.empty()) {
+    waiting_for_map.erase(p);
+  }
+  l.unlock();
+  asio::post(
+    service.get_executor(),
+    asio::append(
+      std::move(onfinish), make_error_code(bs::errc::timed_out)));
 }
 
 

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2563,9 +2563,14 @@ public:
   std::map<ceph_tid_t, Op*> check_latest_map_ops;
   std::map<ceph_tid_t, CommandOp*> check_latest_map_commands;
 
-  std::map<epoch_t,
-	   std::vector<std::pair<OpCompletion,
-				 boost::system::error_code>>> waiting_for_map;
+  struct MapWaiter {
+    uint64_t id;
+    OpCompletion onfinish;
+    boost::system::error_code result;
+    uint64_t timeout_event = 0;
+  };
+  std::map<epoch_t, std::vector<MapWaiter>> waiting_for_map;
+  uint64_t last_map_waiter_id = 0;
 
   ceph::timespan mon_timeout;
   ceph::timespan osd_timeout;
@@ -2806,13 +2811,14 @@ private:
 	} else {
 	  auto e = boost::asio::get_associated_executor(
 	    handler, service.get_executor());
-	  waiting_for_map[0].emplace_back(
+	  waiting_for_map[0].push_back(MapWaiter{
+	    ++last_map_waiter_id,
 	    boost::asio::bind_executor(
 	      e, [c = std::move(handler)]
 	      (boost::system::error_code) mutable {
 		boost::asio::dispatch(std::move(c));
 	      }),
-	    boost::system::error_code{});
+	    boost::system::error_code{}});
 	  l.unlock();
 	}
       }, consigned);
@@ -2885,21 +2891,23 @@ public:
   struct CB_Objecter_GetVersion {
     Objecter *objecter;
     OpCompletion fin;
+    std::optional<ceph::mono_time> deadline;
 
-    CB_Objecter_GetVersion(Objecter *o, OpCompletion c)
-      : objecter(o), fin(std::move(c)) {}
+    CB_Objecter_GetVersion(
+      Objecter *o, OpCompletion c, std::optional<ceph::mono_time> d)
+      : objecter(o), fin(std::move(c)), deadline(d) {}
     void operator()(boost::system::error_code ec, version_t newest,
 		    version_t oldest) {
       if (ec == boost::system::errc::resource_unavailable_try_again) {
-	// try again as instructed
+	// try again as instructed, preserving the original deadline
 	objecter->_wait_for_latest_osdmap(std::move(*this));
       } else if (ec) {
 	boost::asio::post(objecter->service.get_executor(),
 			  boost::asio::append(std::move(fin), ec));
       } else {
 	auto l = std::unique_lock(objecter->rwlock);
-	objecter->_get_latest_version(oldest, newest, std::move(fin),
-				      std::move(l));
+	objecter->_get_latest_version(
+	  oldest, newest, std::move(fin), deadline, std::move(l));
       }
     }
   };
@@ -2919,31 +2927,43 @@ public:
 	} else {
 	  monc->get_version(
 	    "osdmap",
-	    CB_Objecter_GetVersion(this, std::move(handler)));
+	    CB_Objecter_GetVersion(this, std::move(handler), std::nullopt));
 	}
       }, consigned);
   }
-  void _wait_for_new_map(OpCompletion, epoch_t epoch,
-			 boost::system::error_code = {});
+  uint64_t _wait_for_new_map(
+    OpCompletion, epoch_t epoch, boost::system::error_code = {},
+    std::optional<ceph::mono_time> deadline = std::nullopt);
+  void _finish_map_waiters(epoch_t epoch);
+  void _timeout_map_waiter(epoch_t epoch, uint64_t waiter_id);
 
 private:
+  friend class ObjecterLatestOsdmapTimeoutTest;
+
   void _wait_for_latest_osdmap(CB_Objecter_GetVersion&& c) {
-    monc->get_version("osdmap", std::move(c));
+    auto deadline = c.deadline;
+    monc->get_version("osdmap", deadline, std::move(c));
   }
 
 public:
 
   template<typename CompletionToken>
   auto wait_for_latest_osdmap(CompletionToken&& token) {
+    return wait_for_latest_osdmap(
+      std::nullopt, std::forward<CompletionToken>(token));
+  }
+
+  template<typename CompletionToken>
+  auto wait_for_latest_osdmap(
+    std::optional<ceph::mono_time> deadline, CompletionToken&& token) {
     auto consigned = boost::asio::consign(
       std::forward<CompletionToken>(token), boost::asio::make_work_guard(
 	service.get_executor()));
     boost::asio::async_initiate<decltype(consigned), OpSignature>(
-      [this](auto handler) {
-	monc->get_version("osdmap",
-			  CB_Objecter_GetVersion(
-			    this,
-			    std::move(handler)));
+      [this, deadline](auto handler) {
+	monc->get_version(
+	  "osdmap", deadline,
+	  CB_Objecter_GetVersion(this, std::move(handler), deadline));
       }, consigned);
   }
 
@@ -2962,14 +2982,15 @@ public:
     return boost::asio::async_initiate<decltype(consigned), OpSignature>(
       [oldest, newest, this](auto handler) {
 	std::unique_lock wl(rwlock);
-	_get_latest_version(oldest, newest,
-			    std::move(handler), std::move(wl));
+	_get_latest_version(
+	  oldest, newest, std::move(handler), std::nullopt, std::move(wl));
       }, consigned);
   }
 
-  void _get_latest_version(epoch_t oldest, epoch_t neweset,
-			   OpCompletion fin,
-			   std::unique_lock<ceph::shared_mutex>&& ul);
+  void _get_latest_version(
+    epoch_t oldest, epoch_t neweset, OpCompletion fin,
+    std::optional<ceph::mono_time> deadline,
+    std::unique_lock<ceph::shared_mutex>&& ul);
 
   /** Get the current set of global op flags */
   int get_global_op_flags() const { return global_op_flags; }

--- a/src/test/osdc/CMakeLists.txt
+++ b/src/test/osdc/CMakeLists.txt
@@ -24,3 +24,8 @@ target_link_libraries(ceph_test_objectcacher_misc
   )
 install(TARGETS ceph_test_objectcacher_misc
   DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+add_executable(unittest_latest_osdmap_timeout
+  test_latest_osdmap_timeout.cc)
+add_ceph_unittest(unittest_latest_osdmap_timeout)
+target_link_libraries(unittest_latest_osdmap_timeout osdc global)

--- a/src/test/osdc/test_latest_osdmap_timeout.cc
+++ b/src/test/osdc/test_latest_osdmap_timeout.cc
@@ -1,0 +1,344 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <functional>
+#include <thread>
+
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/intrusive_ptr.hpp>
+#include <gtest/gtest.h>
+
+#include "common/ceph_context.h"
+#include "include/scope_guard.h"
+#include "mon/MonClient.h"
+#include "osdc/Objecter.h"
+
+namespace asio = boost::asio;
+namespace bs = boost::system;
+using namespace std::chrono_literals;
+
+class LatestOsdmapTimeoutTest : public testing::Test {
+ protected:
+  boost::intrusive_ptr<CephContext> cct{
+    new CephContext(CEPH_ENTITY_TYPE_CLIENT), false};
+  asio::io_context service;
+  asio::executor_work_guard<asio::io_context::executor_type> work{
+    service.get_executor()};
+  std::thread service_thread;
+
+  void SetUp() override {
+    service_thread = std::thread([this] { service.run(); });
+  }
+  void TearDown() override {
+    work.reset();
+    service.stop();
+    if (service_thread.joinable()) {
+      service_thread.join();
+    }
+  }
+};
+
+class MonClientLatestOsdmapTimeoutTest : public LatestOsdmapTimeoutTest {
+ protected:
+  static void start_timer(MonClient& monc) {
+    std::scoped_lock l(monc.monc_lock);
+    monc.timer.init();
+  }
+
+  static void stop_timer(MonClient& monc) {
+    std::scoped_lock l(monc.monc_lock);
+    monc.timer.shutdown();
+  }
+
+  static ceph_tid_t first_request(MonClient& monc) {
+    std::scoped_lock l(monc.monc_lock);
+    ceph_assert(!monc.version_requests.empty());
+    return monc.version_requests.begin()->first;
+  }
+
+  static size_t request_count(MonClient& monc) {
+    std::scoped_lock l(monc.monc_lock);
+    return monc.version_requests.size();
+  }
+
+  static void finish_request(
+    MonClient& monc, ceph_tid_t tid, bs::error_code ec,
+    version_t newest = 0, version_t oldest = 0) {
+    std::scoped_lock l(monc.monc_lock);
+    monc._finish_version_request(tid, ec, newest, oldest);
+  }
+};
+
+TEST_F(MonClientLatestOsdmapTimeoutTest, VersionRequestTimesOut)
+{
+  MonClient monc(cct.get(), service);
+  Objecter objecter(cct.get(), nullptr, &monc, service);
+  start_timer(monc);
+  auto stop = make_scope_guard([&] { stop_timer(monc); });
+
+  std::promise<bs::error_code> result;
+  auto future = result.get_future();
+  objecter.wait_for_latest_osdmap(
+    ceph::mono_clock::now() + 40ms,
+    [&result](bs::error_code ec) { result.set_value(ec); });
+
+  ASSERT_EQ(std::future_status::ready, future.wait_for(5s));
+  EXPECT_EQ(bs::errc::timed_out, future.get().default_error_condition());
+  EXPECT_EQ(0u, request_count(monc));
+}
+
+TEST_F(MonClientLatestOsdmapTimeoutTest, ZeroTimeoutRemainsUnlimited)
+{
+  MonClient monc(cct.get(), service);
+  Objecter objecter(cct.get(), nullptr, &monc, service);
+  start_timer(monc);
+  auto stop = make_scope_guard([&] { stop_timer(monc); });
+
+  std::promise<bs::error_code> result;
+  auto future = result.get_future();
+  objecter.wait_for_latest_osdmap(
+    [&result](bs::error_code ec) { result.set_value(ec); });
+
+  EXPECT_EQ(std::future_status::timeout, future.wait_for(80ms));
+  auto tid = first_request(monc);
+  finish_request(monc, tid, {}, 0, 0);
+
+  ASSERT_EQ(std::future_status::ready, future.wait_for(5s));
+  EXPECT_FALSE(future.get());
+  EXPECT_EQ(0u, request_count(monc));
+}
+
+TEST_F(MonClientLatestOsdmapTimeoutTest, SessionResetPreservesDeadline)
+{
+  work.reset();
+  service.stop();
+  service_thread.join();
+  service.restart();
+
+  MonClient monc(cct.get(), service);
+  Objecter objecter(cct.get(), nullptr, &monc, service);
+  start_timer(monc);
+  auto stop = make_scope_guard([&] { stop_timer(monc); });
+
+  std::promise<bs::error_code> result;
+  auto future = result.get_future();
+  const auto deadline = ceph::mono_clock::now() + 80ms;
+  objecter.wait_for_latest_osdmap(
+    deadline, [&result](bs::error_code ec) { result.set_value(ec); });
+
+  finish_request(
+    monc, first_request(monc),
+    make_error_code(monc_errc::session_reset));
+  std::this_thread::sleep_for(120ms);
+
+  service.run();
+  ASSERT_EQ(std::future_status::ready, future.wait_for(0s));
+  EXPECT_EQ(bs::errc::timed_out, future.get().default_error_condition());
+  EXPECT_EQ(0u, request_count(monc));
+}
+
+TEST_F(MonClientLatestOsdmapTimeoutTest, ReplyTimeoutRaceCompletesOnce)
+{
+  MonClient monc(cct.get(), service);
+  start_timer(monc);
+  auto stop = make_scope_guard([&] { stop_timer(monc); });
+
+  for (unsigned i = 0; i < 16; ++i) {
+    std::promise<void> done;
+    auto future = done.get_future();
+    std::atomic<unsigned> completions{0};
+    monc.get_version(
+      "osdmap", ceph::mono_clock::now() + 5ms,
+      [&done, &completions](bs::error_code, version_t, version_t) {
+        if (completions.fetch_add(1) == 0) {
+          done.set_value();
+        }
+      });
+    auto tid = first_request(monc);
+
+    std::thread reply([&monc, tid] {
+      std::this_thread::sleep_for(5ms);
+      finish_request(monc, tid, {}, 1, 1);
+    });
+
+    ASSERT_EQ(std::future_status::ready, future.wait_for(5s));
+    reply.join();
+    std::this_thread::sleep_for(10ms);
+    EXPECT_EQ(1u, completions.load());
+    EXPECT_EQ(0u, request_count(monc));
+  }
+}
+
+class ObjecterLatestOsdmapTimeoutTest : public LatestOsdmapTimeoutTest {
+ protected:
+  template <typename Handler>
+  static void wait_for_version(
+    Objecter& objecter, std::optional<ceph::mono_time> deadline,
+    Handler&& handler) {
+    std::unique_lock l(objecter.rwlock);
+    objecter._get_latest_version(
+      0, 1, Objecter::OpCompletion(std::forward<Handler>(handler)),
+      deadline, std::move(l));
+  }
+
+  static void finish_map_waiters(Objecter& objecter, epoch_t epoch) {
+    std::unique_lock l(objecter.rwlock);
+    objecter._finish_map_waiters(epoch);
+  }
+
+  template <typename Callable>
+  static void schedule_timer(Objecter& objecter, Callable&& callback) {
+    objecter.timer.add_event(0ms, std::forward<Callable>(callback));
+  }
+
+  static size_t waiter_count(Objecter& objecter) {
+    std::shared_lock l(objecter.rwlock);
+    size_t count = 0;
+    for (const auto& [epoch, waiters] : objecter.waiting_for_map) {
+      count += waiters.size();
+    }
+    return count;
+  }
+};
+
+TEST_F(ObjecterLatestOsdmapTimeoutTest, MapWaiterTimesOutAndIsRemoved)
+{
+  MonClient monc(cct.get(), service);
+  ASSERT_TRUE(monc.sub_want("osdmap", 0, CEPH_SUBSCRIBE_ONETIME));
+  Objecter objecter(cct.get(), nullptr, &monc, service);
+
+  std::promise<bs::error_code> result;
+  auto future = result.get_future();
+  wait_for_version(
+    objecter, ceph::mono_clock::now() + 40ms,
+    [&result](bs::error_code ec) { result.set_value(ec); });
+
+  ASSERT_EQ(std::future_status::ready, future.wait_for(5s));
+  EXPECT_EQ(bs::errc::timed_out, future.get().default_error_condition());
+  EXPECT_EQ(0u, waiter_count(objecter));
+}
+
+TEST_F(ObjecterLatestOsdmapTimeoutTest, ZeroTimeoutMapWaiterRemainsUnlimited)
+{
+  MonClient monc(cct.get(), service);
+  ASSERT_TRUE(monc.sub_want("osdmap", 0, CEPH_SUBSCRIBE_ONETIME));
+  Objecter objecter(cct.get(), nullptr, &monc, service);
+
+  std::promise<bs::error_code> result;
+  auto future = result.get_future();
+  wait_for_version(
+    objecter, std::nullopt,
+    [&result](bs::error_code ec) { result.set_value(ec); });
+
+  EXPECT_EQ(std::future_status::timeout, future.wait_for(80ms));
+  EXPECT_EQ(1u, waiter_count(objecter));
+  finish_map_waiters(objecter, 1);
+
+  ASSERT_EQ(std::future_status::ready, future.wait_for(5s));
+  EXPECT_FALSE(future.get());
+  EXPECT_EQ(0u, waiter_count(objecter));
+}
+
+TEST_F(ObjecterLatestOsdmapTimeoutTest, MapArrivalTimeoutRaceCompletesOnce)
+{
+  MonClient monc(cct.get(), service);
+  ASSERT_TRUE(monc.sub_want("osdmap", 0, CEPH_SUBSCRIBE_ONETIME));
+  Objecter objecter(cct.get(), nullptr, &monc, service);
+
+  for (unsigned i = 0; i < 16; ++i) {
+    std::promise<void> done;
+    auto future = done.get_future();
+    std::atomic<unsigned> completions{0};
+    wait_for_version(
+      objecter, ceph::mono_clock::now() + 5ms,
+      [&done, &completions](bs::error_code) {
+        if (completions.fetch_add(1) == 0) {
+          done.set_value();
+        }
+      });
+
+    std::thread map_arrival([&objecter] {
+      std::this_thread::sleep_for(5ms);
+      finish_map_waiters(objecter, 1);
+    });
+
+    ASSERT_EQ(std::future_status::ready, future.wait_for(5s));
+    map_arrival.join();
+    std::this_thread::sleep_for(10ms);
+    EXPECT_EQ(1u, completions.load());
+    EXPECT_EQ(0u, waiter_count(objecter));
+  }
+}
+
+TEST_F(ObjecterLatestOsdmapTimeoutTest, ShutdownCancelsMapWaiters)
+{
+  MonClient monc(cct.get(), service);
+  ASSERT_TRUE(monc.sub_want("osdmap", 0, CEPH_SUBSCRIBE_ONETIME));
+  Objecter objecter(cct.get(), nullptr, &monc, service);
+  objecter.init();
+
+  std::promise<bs::error_code> result;
+  auto future = result.get_future();
+  wait_for_version(
+    objecter, ceph::mono_clock::now() + 5s,
+    [&result](bs::error_code ec) { result.set_value(ec); });
+  EXPECT_EQ(1u, waiter_count(objecter));
+
+  objecter.shutdown();
+
+  ASSERT_EQ(std::future_status::ready, future.wait_for(5s));
+  EXPECT_EQ(
+    bs::errc::operation_canceled, future.get().default_error_condition());
+  EXPECT_EQ(0u, waiter_count(objecter));
+}
+
+TEST_F(ObjecterLatestOsdmapTimeoutTest, ShutdownJoinsRunningTimerCallback)
+{
+  MonClient monc(cct.get(), service);
+  Objecter objecter(cct.get(), nullptr, &monc, service);
+  objecter.init();
+
+  std::promise<void> started;
+  auto started_future = started.get_future();
+  std::promise<void> release;
+  auto release_future = release.get_future().share();
+  schedule_timer(objecter, [&started, release_future] {
+    started.set_value();
+    release_future.wait();
+  });
+
+  if (started_future.wait_for(5s) != std::future_status::ready) {
+    release.set_value();
+    objecter.shutdown();
+    FAIL() << "timer callback did not start";
+  }
+
+  auto shutdown = std::async(
+    std::launch::async, [&objecter] { objecter.shutdown(); });
+  EXPECT_EQ(std::future_status::timeout, shutdown.wait_for(40ms));
+
+  release.set_value();
+  ASSERT_EQ(std::future_status::ready, shutdown.wait_for(5s));
+  shutdown.get();
+}
+
+// Instantiates the wait_for_map(epoch, token) template so its
+// CB_Objecter_GetVersion construction stays compilable; Client.cc and the
+// MDS call it in builds this test's slim configuration does not cover.
+TEST_F(ObjecterLatestOsdmapTimeoutTest, WaitForMapWithCurrentEpoch)
+{
+  MonClient monc(cct.get(), service);
+  Objecter objecter(cct.get(), nullptr, &monc, service);
+
+  std::promise<bs::error_code> result;
+  auto future = result.get_future();
+  objecter.wait_for_map(
+    0, [&result](bs::error_code ec) { result.set_value(ec); });
+
+  ASSERT_EQ(std::future_status::ready, future.wait_for(5s));
+  EXPECT_FALSE(future.get());
+}


### PR DESCRIPTION
## Problem

`rados_wait_for_latest_osdmap()` can wait indefinitely even when `rados_mon_op_timeout` is configured. The wait has two asynchronous phases: a MON `get_version` request and an Objecter map waiter. Neither phase previously had a deadline.

## Change

- Derive one absolute deadline from the cached `rados_mon_op_timeout` value.
- Apply the same deadline to the MON version request and local map waiter.
- Preserve the deadline across session-reset retries.
- Remove timed-out requests and waiters before posting `-ETIMEDOUT`.
- Serialize reply/map-arrival/timeout races for exactly-once completion.
- Cancel map waiters and join the Objecter timer during shutdown.
- Preserve unlimited behavior when `rados_mon_op_timeout=0`.

## Compatibility

No public API or ABI changes. Existing behavior is unchanged with the default `rados_mon_op_timeout=0`.

## Tests

- Phase-1 request timeout and cleanup.
- Phase-2 map-waiter timeout and cleanup.
- Session-reset deadline preservation.
- Reply-versus-timeout and map-versus-timeout races.
- Zero-timeout compatibility.
- Objecter shutdown cancellation and running timer callback join.
- Legacy `wait_for_map(epoch, token)` template instantiation.

Verified after rebasing onto `ceph/ceph` main:

```text
ninja -C build -j16 unittest_latest_osdmap_timeout librados
./build/bin/unittest_latest_osdmap_timeout: 10/10 passed
--gtest_repeat=20: 20/20 iterations passed (200 test cases)
```

Not yet run: ASAN, TSAN, or real-cluster integration.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [x] Includes bug reproducer
  - [ ] No tests
