### PR TITLE
cephadm: deploy Ceph cluster inside container (CiC)

### DIFF
--- a/src/cephadm/Containerfile
+++ b/src/cephadm/Containerfile
@@ -1,0 +1,73 @@
+# syntax=docker/dockerfile:1
+ARG RHEL_MAJOR="10"
+ARG CEPH_RELEASE="20.2.2"
+ARG DNF="dnf"
+ARG DNF_OPTS="--setopt=install_weak_deps=False --nodocs"
+
+###
+FROM quay.io/fedora/fedora-minimal:44 AS ceph-cluster
+ARG RHEL_MAJOR
+ARG DNF
+ARG DNF_OPTS
+ARG CEPH_RELEASE
+
+ARG CEPH_REPO_KEY="https://download.ceph.com/keys/release.asc"
+ARG CEPH_REPO_RPM="https://download.ceph.com/rpm-${CEPH_RELEASE}/el${RHEL_MAJOR}/noarch/ceph-release-1-0.el${RHEL_MAJOR}.noarch.rpm"
+ARG BASE_RPMS="chrony curl fuse-overlayfs iproute jq logrotate podman"
+ARG SYSTEMD_UNITS="chronyd.service logrotate.timer"
+
+WORKDIR /root
+
+RUN ${DNF} install -y ${DNF_OPTS} ${BASE_RPMS} \
+ && ${DNF} clean all
+RUN systemctl enable ${SYSTEMD_UNITS}
+
+COPY <<'EOF' /etc/sysconfig/chronyd
+OPTIONS="-F 2 -x"
+EOF
+
+COPY <<'EOF' /etc/containers/containers.conf
+[containers]
+cgroups = "disabled"
+EOF
+
+COPY <<'EOF' /etc/containers/storage.conf
+[storage]
+driver="overlay"
+
+[storage.options.overlay]
+mount_program="/usr/bin/fuse-overlayfs"
+ignore_chown_errors = "true"
+EOF
+
+RUN rpm --import ${CEPH_REPO_KEY}
+RUN ${DNF} install -y ${DNF_OPTS} "${CEPH_REPO_RPM}" \
+ && ${DNF} install -y ${DNF_OPTS} cephadm \
+ && ${DNF} clean all
+
+RUN mkdir -p /run/udev
+
+COPY <<'EOF' /etc/systemd/system/ceph-bootstrap.service
+[Unit]
+Description=Bootstrap Ceph Cluster
+After=network-online.target chronyd.service
+Wants=network-online.target
+
+# Don't rerun if already bootstrapped
+ConditionPathExists=!/etc/ceph/ceph.conf
+
+[Service]
+Type=oneshot
+PassEnvironment=CEPHADM_BOOTSTRAP_OPTIONS
+ExecStart=/usr/sbin/cephadm bootstrap $CEPHADM_BOOTSTRAP_OPTIONS
+RemainAfterExit=yes
+StandardOutput=tty
+StandardError=tty
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+RUN systemctl enable ceph-bootstrap.service
+
+CMD [ "/sbin/init" ]

--- a/src/cephadm/docker-compose.yaml
+++ b/src/cephadm/docker-compose.yaml
@@ -1,0 +1,97 @@
+services:
+  ceph-cluster:
+    build:
+      context: .
+      dockerfile: Containerfile
+      target: ceph-cluster
+    image: ceph-cluster:latest
+    container_name: ceph-cluster
+    hostname: ceph-cluster
+
+    stop_signal: SIGTERM
+    stop_grace_period: 5s
+
+    tty: true
+    stdin_open: true
+
+    logging:
+      driver: json-file
+    environment:
+      CEPHADM_BOOTSTRAP_OPTIONS: >
+        --initial-dashboard-password admin
+        --dashboard-password-noupdate
+        --allow-fqdn-hostname
+        --single-host-defaults 
+        --no-cleanup-on-failure
+        --mon-ip 192.168.250.2
+
+    healthcheck:
+      test: systemctl is-active --quiet ceph-bootstrap.service
+      interval: 5s
+      timeout: 2s
+      start_period: 10s
+      retries: 60
+
+    cgroup: private
+
+    cap_add:
+      - SYS_ADMIN
+      - CAP_SYS_TIME
+    
+    security_opt:
+      - seccomp:unconfined
+      - label=disable
+
+    ports:
+      - 8443:8443
+      - 3000:3000
+
+    devices:
+      - /dev/fuse
+      - /dev/ublk-control
+
+    volumes:
+      - podman-storage:/var/lib/containers/storage
+
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+
+    networks:
+      ceph-internal:
+        ipv4_address: 192.168.250.2
+
+#    user: ceph
+#    working_dir: /ceph
+
+#    volumes:
+      # Ceph source tree
+#      - ../:/ceph:Z
+
+      # Persist generated configuration
+#      - ceph-data:/var/lib/ceph
+
+#    environment:
+#      CEPHADM_IMAGE: quay.io/ceph/ceph:main
+
+#    security_opt:
+#      - label=disable
+
+#    network_mode: bridge
+
+#    restart: "no"
+
+#volumes:
+#  ceph-data:
+
+volumes:
+  podman-storage:
+
+networks:
+  ceph-internal:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 192.168.250.0/24
+          gateway: 192.168.250.1


### PR DESCRIPTION
Goals:
- [x] Rootless containers
- [x] CoW internal storage (FUSE OverlayFS)
- [x] Cephadm logs as the container output
- [x] Fixed IP address (reproducible environments)
- [x] Cache pulled containers (via volume)
- [ ] Ideally no external scripts required
- [ ] No footprint in the host environment
- [ ] Userspace block devices  


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
