### PR TITLE
rgw/dedup: Bug fix for listing all bucket.instance

### DIFF
--- a/src/rgw/driver/rados/rgw_dedup.cc
+++ b/src/rgw/driver/rados/rgw_dedup.cc
@@ -2692,13 +2692,13 @@ namespace rgw::dedup {
             goto err;
           }
         }
-        driver->meta_list_keys_complete(handle);
       }
       else {
         ldpp_dout(dpp, 1) << __func__ << "::ERR: failed driver->meta_list_keys_next()" << dendl;
         goto err;
       }
     }
+    driver->meta_list_keys_complete(handle);
     ldpp_dout(dpp, 10) <<__func__
                        << "::all_buckets_obj_count=" << d_all_buckets_obj_count
                        << "::all_buckets_obj_size=" << d_all_buckets_obj_size
@@ -2773,7 +2773,6 @@ namespace rgw::dedup {
             continue;
           }
         }
-        driver->meta_list_keys_complete(handle);
       }
       else {
         ldpp_dout(dpp, 1) << __func__ << "::failed driver->meta_list_keys_next()" << dendl;
@@ -2782,6 +2781,7 @@ namespace rgw::dedup {
         break;
       }
     }
+    driver->meta_list_keys_complete(handle);
     ldpp_dout(dpp, 20) <<__func__ << "::flush_output_buffers() worker_id="
                        << worker_id << dendl;
     disk_arr.flush_output_buffers(dpp, d_dedup_cluster_ioctx);

--- a/src/rgw/driver/rados/rgw_dedup.cc
+++ b/src/rgw/driver/rados/rgw_dedup.cc
@@ -76,6 +76,7 @@ using namespace rgw::dedup;
 #include "rgw_dedup_epoch.h"
 #include "rgw_perf_counters.h"
 #include "include/ceph_assert.h"
+#include "include/scope_guard.h"
 
 static constexpr auto dout_subsys = ceph_subsys_rgw_dedup;
 
@@ -2649,6 +2650,15 @@ namespace rgw::dedup {
   }
 
   //---------------------------------------------------------------------------
+  static inline void reset_bucket_counters(uint64_t *p_all_buckets_obj_count,
+                                           uint64_t *p_all_buckets_obj_size)
+  {
+    // reset counters to mark that we don't have the info
+    *p_all_buckets_obj_count = 0;
+    *p_all_buckets_obj_size  = 0;
+  }
+
+  //---------------------------------------------------------------------------
   int Background::collect_all_buckets_stats()
   {
     int ret = 0;
@@ -2661,6 +2671,9 @@ namespace rgw::dedup {
                         << cpp_strerror(-ret) << dendl;
       return ret;
     }
+
+    auto keys_guard = make_scope_guard(
+      [this, handle] { driver->meta_list_keys_complete(handle); });
 
     d_all_buckets_obj_count = 0;
     d_all_buckets_obj_size  = 0;
@@ -2678,7 +2691,8 @@ namespace rgw::dedup {
           if (unlikely(ret < 0)) {
             ldpp_dout(dpp, 1) << __func__ << "::ERR: Failed rgw_bucket_parse_bucket_key: "
                               << cpp_strerror(-ret) << dendl;
-            goto err;
+            reset_bucket_counters(&d_all_buckets_obj_count, &d_all_buckets_obj_size);
+            return ret;
           }
           ldpp_dout(dpp, 20) <<__func__ << "::bucket=" << bucket << dendl;
           if (!d_filter.allow_bucket(bucket.name)) {
@@ -2689,31 +2703,23 @@ namespace rgw::dedup {
           ret = read_bucket_stats(bucket, &d_all_buckets_obj_count,
                                   &d_all_buckets_obj_size);
           if (unlikely(ret != 0)) {
-            goto err;
+            reset_bucket_counters(&d_all_buckets_obj_count, &d_all_buckets_obj_size);
+            return ret;
           }
         }
       }
       else {
         ldpp_dout(dpp, 1) << __func__ << "::ERR: failed driver->meta_list_keys_next()" << dendl;
-        goto err;
+        reset_bucket_counters(&d_all_buckets_obj_count, &d_all_buckets_obj_size);
+        return ret;
       }
     }
-    driver->meta_list_keys_complete(handle);
+
     ldpp_dout(dpp, 10) <<__func__
                        << "::all_buckets_obj_count=" << d_all_buckets_obj_count
                        << "::all_buckets_obj_size=" << d_all_buckets_obj_size
                        << dendl;
     return 0;
-
-  err:
-    ldpp_dout(dpp, 1) << __func__ << "::error handler" << dendl;
-    // reset counters to mark that we don't have the info
-    d_all_buckets_obj_count = 0;
-    d_all_buckets_obj_size  = 0;
-    if (handle) {
-      driver->meta_list_keys_complete(handle);
-    }
-    return ret;
   }
 
   //---------------------------------------------------------------------------
@@ -2734,6 +2740,9 @@ namespace rgw::dedup {
                         << cpp_strerror(-ret) << dendl;
       return ret;
     }
+    auto keys_guard = make_scope_guard(
+      [this, handle] { driver->meta_list_keys_complete(handle); });
+
     disk_block_array_t disk_arr(dpp, raw_mem, raw_mem_size, worker_id,
                                 p_worker_stats, num_md5_shards);
     bool has_more = true;
@@ -2765,7 +2774,6 @@ namespace rgw::dedup {
                                                     num_work_shards, p_worker_stats);
           if (unlikely(ret != 0)) {
             if (d_ctl.should_stop()) {
-              driver->meta_list_keys_complete(handle);
               return -ECANCELED;
             }
             ldpp_dout(dpp, 1) << __func__ << "::Failed ingress_bucket_objects_single_shard()" << dendl;
@@ -2776,12 +2784,10 @@ namespace rgw::dedup {
       }
       else {
         ldpp_dout(dpp, 1) << __func__ << "::failed driver->meta_list_keys_next()" << dendl;
-        driver->meta_list_keys_complete(handle);
         // TBD: what can we do here?
         break;
       }
     }
-    driver->meta_list_keys_complete(handle);
     ldpp_dout(dpp, 20) <<__func__ << "::flush_output_buffers() worker_id="
                        << worker_id << dendl;
     disk_arr.flush_output_buffers(dpp, d_dedup_cluster_ioctx);

--- a/src/test/rgw/dedup/test_dedup.py
+++ b/src/test/rgw/dedup/test_dedup.py
@@ -4289,3 +4289,87 @@ def test_dedup_filter_bucket_exec():
 
     log.info("dedup_filter_bucket_exec: filter_mode_allow")
     dedup_filter_allow_deny_bucket_common(dry_run, filter_mode_allow=True)
+
+#-------------------------------------------------------------------------------
+@pytest.mark.basic_test
+def test_dedup_many_buckets():
+    """Regression: dedup must not crash on multi-page listing of buckets.
+    The default page size for meta_list_keys_next() is 1000.
+    Make sure dedup can handle more than a single page
+    """
+
+    num_test_buckets = 1500
+    bucket_names = []
+
+    # raise per-user bucket limit (default is 1000) to allow 1500 buckets
+    access_key = get_access_key()
+    result = admin(['user', 'info', '--access-key', access_key])
+    assert result[1] == 0
+    info = json.loads(result[0])
+    uid = info['user_id']
+    tenant = info.get('tenant', '')
+    if tenant:
+        uid = tenant + '$' + uid
+
+    orig_max_buckets = info['max_buckets']
+    log.info("orig_max_buckets=%d, setting unlimited max-buckets", orig_max_buckets)
+    result = admin(['user', 'modify', '--uid', uid, '--max-buckets', '0'])
+    assert result[1] == 0, "failed to set unlimited max-buckets"
+    try:
+        conn = get_single_connection()
+        log.info("creating %d empty buckets to trigger multi-page listing",
+                 num_test_buckets)
+        start_time = time.perf_counter()
+        for i in range(num_test_buckets):
+            name = gen_bucket_name()
+            log.debug("conn.create_bucket(%s)", name)
+            conn.create_bucket(Bucket=name)
+            bucket_names.append(name)
+
+        log.info("mb total time=%d(sec) for %d buckets",
+                 time.perf_counter() - start_time, len(bucket_names))
+        result = dedup_admin('estimate')
+        assert result[1] == 0
+
+        max_time = 5 * 60
+        elapsed = 0
+        while elapsed < max_time:
+            time.sleep(3)
+            elapsed += 3
+            result = dedup_admin('stats')
+            assert result[1] == 0, "RGW crashed or became unresponsive (segfault in collect_all_buckets_stats?)"
+            jstats = json.loads(result[0])
+            if jstats['completed']:
+                log.info("dedup estimate completed in %d seconds", elapsed)
+                break
+        else:
+            assert False, "dedup estimate did not complete within %d seconds" % max_time
+
+        # verify RGW is still alive after estimate (would fail if process segfaulted)
+        response = conn.list_buckets()
+        assert 'Buckets' in response, "RGW not responding after estimate — possible crash"
+        log.info("RGW is alive after multi-page bucket estimate, listed %d buckets",
+                 len(response['Buckets']))
+
+        # verify dedup_bg thread is still running (segfault kills the thread)
+        pgrep_out, rc = bash(['pgrep', '-x', 'radosgw'])
+        assert rc == 0, "radosgw process not found — likely crashed"
+        for pid in pgrep_out.strip().split('\n'):
+            ps_out, _ = bash(['ps', '-T', '-p', pid])
+            assert 'dedup_bg' in ps_out, \
+                "dedup_bg thread not found in radosgw pid %s — thread died (segfault?)" % pid
+
+        log.info("dedup_bg thread is alive in all radosgw processes")
+    finally:
+        log.info("calling conn.delete_bucket() for %d buckets (can be slow)",
+                 len(bucket_names))
+        start_time = time.perf_counter()
+        for name in bucket_names:
+            conn.delete_bucket(Bucket=name)
+
+        log.info("delete_bucket() total time=%d(sec) for %d buckets",
+                 time.perf_counter() - start_time, len(bucket_names))
+
+        log.info("restore orig_max_buckets=%d", orig_max_buckets)
+        admin(['user', 'modify', '--uid', uid,
+               '--max-buckets', str(orig_max_buckets)])


### PR DESCRIPTION
meta_list_keys_complete(handle) is now called only after scanning all buckets and not after the first page was returned

Tracker: https://tracker.ceph.com/issues/79442



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
