### PR TITLE
umbrella: Mon: Prevent pool creation if it will exceed mon_max_pg_per_osd

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1145,6 +1145,7 @@ COMMAND("osd pool create "
 	"name=bulk,type=CephBool,req=false "
 	"name=target_size_bytes,type=CephInt,range=0,req=false "
 	"name=target_size_ratio,type=CephFloat,range=0.0,req=false "\
+	"name=force_pg_limit,type=CephBool,req=false"
 	"name=yes_i_really_mean_it,type=CephBool,req=false"
 	"name=crimson,type=CephBool,req=false",
 	"create pool", "osd", "rw")

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7528,12 +7528,14 @@ int OSDMonitor::prepare_new_pool(MonOpRequestRef op)
   stringstream ss;
   string rule_name;
   bool bulk = false;
+  bool force_create = false;
   int ret = 0;
   ret = prepare_new_pool(m->name, m->crush_rule, rule_name,
 			 0, 0, 0, 0, 0, 0, 0.0,
 			 erasure_code_profile,
 			 pg_pool_t::TYPE_REPLICATED, 0, FAST_READ_OFF, {}, bulk,
 			 cct->_conf.get_val<bool>("osd_pool_default_crimson"),
+       force_create,
 			 &ss);
 
   if (ret < 0) {
@@ -8133,7 +8135,16 @@ int OSDMonitor::check_pg_num(int64_t pool,
   // assume min cluster size 3
   osd_num_by_crush = std::max(osd_num_by_crush, 3u);
   auto projected_pgs_per_osd = projected / osd_num_by_crush;
-
+  uint64_t pg_limit = max_pgs_per_osd * osd_num_by_crush;
+  if (projected > pg_limit) {
+      *ss << " pg_num " << pg_num
+      << " size " << size
+      << " for this pool would result in "
+      << projected
+      << " cumulative PGs which exceeds the limit of "
+      << "value of " << max_pgs_per_osd;
+    return -ERANGE;
+  }
   if (projected_pgs_per_osd > max_pgs_per_osd) {
     if (pool >= 0) {
       *ss << "pool id " << pool;
@@ -8188,6 +8199,7 @@ int OSDMonitor::prepare_new_pool(string& name,
 				 string pg_autoscale_mode,
 				 bool bulk,
 				 bool crimson,
+         bool force_create,
 				 ostream *ss)
 {
   if (crimson && pg_autoscale_mode.empty()) {
@@ -8201,15 +8213,7 @@ int OSDMonitor::prepare_new_pool(string& name,
     return -EINVAL;
 
   if (pg_num == 0) {
-    auto pg_num_from_mode =
-      [pg_num=g_conf().get_val<uint64_t>("osd_pool_default_pg_num")]
-      (const string& mode) {
-      return mode == "on" ? 1 : pg_num;
-    };
-    pg_num = pg_num_from_mode(
-      pg_autoscale_mode.empty() ?
-      g_conf().get_val<string>("osd_pool_default_pg_autoscale_mode") :
-      pg_autoscale_mode);
+    pg_num = g_conf().get_val<uint64_t>("osd_pool_default_pg_num");
   }
   if (pgp_num == 0)
     pgp_num = g_conf().get_val<uint64_t>("osd_pool_default_pgp_num");
@@ -8282,7 +8286,7 @@ int OSDMonitor::prepare_new_pool(string& name,
              << duration << dendl;
   }
   r = check_pg_num(-1, pg_num, size, crush_rule, ss);
-  if (r) {
+  if (r && !force_create) {
     dout(10) << "check_pg_num returns " << r << dendl;
     return r;
   }
@@ -8298,7 +8302,6 @@ int OSDMonitor::prepare_new_pool(string& name,
     dout(10) << "prepare_pool_stripe_width returns " << r << dendl;
     return r;
   }
-  
   bool fread = false;
   if (pool_type == pg_pool_t::TYPE_ERASURE) {
     switch (fast_read) {
@@ -14015,7 +14018,8 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 
     bool crimson = cmd_getval_or<bool>(cmdmap, "crimson", false) ||
       cct->_conf.get_val<bool>("osd_pool_default_crimson");
-
+    bool force_create = false;
+    cmd_getval(cmdmap, "force_pg_limit", force_create);
     err = prepare_new_pool(poolstr,
 			   -1, // default crush rule
 			   rule_name,
@@ -14027,6 +14031,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 			   pg_autoscale_mode,
 			   bulk,
 			   crimson,
+         force_create,
 			   &ss);
     if (err < 0) {
       switch(err) {

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -555,6 +555,7 @@ private:
 		       std::string pg_autoscale_mode,
 		       bool bulk,
 		       bool crimson,
+           bool force_create,
 		       std::ostream *ss);
   int prepare_new_pool(MonOpRequestRef op);
 

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -25,8 +25,6 @@ Some terminology is made up for the purposes of this module:
 
 INTERVAL = 5
 
-PG_NUM_MIN = 32  # unless specified on a per-pool basis
-
 if TYPE_CHECKING:
     import sys
     if sys.version_info >= (3, 8):
@@ -193,6 +191,7 @@ class PgAutoscaler(MgrModule):
     NATIVE_OPTIONS = [
         'mon_target_pg_per_osd',
         'mon_max_pg_per_osd',
+        'osd_pool_default_pg_num'
     ]
 
     MODULE_OPTIONS = [
@@ -223,6 +222,7 @@ class PgAutoscaler(MgrModule):
             self.sleep_interval = 60
             self.mon_target_pg_per_osd = 0
             self.threshold = 3.0
+            self.osd_pool_default_pg_num = 32
 
     def config_notify(self) -> None:
         for opt in self.NATIVE_OPTIONS:
@@ -535,7 +535,7 @@ class PgAutoscaler(MgrModule):
         """
         for i, group in enumerate(pool_groups):
             for pool_name, p in group.pools.items():
-                min_pg = p.get('options', {}).get('pg_num_min', PG_NUM_MIN)
+                min_pg = p.get('options', {}).get('pg_num_min', self.osd_pool_default_pg_num)
                 max_pg = p.get('options', {}).get('pg_num_max')
                 pool_pg_target = int(group.pg_target_total / group.size())
                 final_pool_pg_target_total = backtrack[i].current_pg_sum - backtrack[i].prev_pg_sum + group.rd_down_total

--- a/src/pybind/mgr/pg_autoscaler/tests/test_calculate_final_pool_pg_target.py
+++ b/src/pybind/mgr/pg_autoscaler/tests/test_calculate_final_pool_pg_target.py
@@ -23,7 +23,7 @@ class TestPgAutoscaler(object):
     def setup_method(self):
         # a bunch of attributes for testing.
         self.autoscaler = module.PgAutoscaler('module_name', 0, 0)
-
+        self.autoscaler.osd_pool_default_pg_num = 32
     def create_group(self,
         pools: Dict[str, Any],
         root_map: Dict[int, RootMapItem],


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79328

---

backport of https://github.com/ceph/ceph/pull/67985
parent tracker: https://tracker.ceph.com/issues/75423

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh