### PR TITLE
doc/dev: document the cve-pipeline private-fork build/test flow

### DIFF
--- a/doc/dev/developer_guide/cve.rst
+++ b/doc/dev/developer_guide/cve.rst
@@ -6,27 +6,54 @@ Building and Testing a CVE Fix
 Fixes for CVEs (Common Vulnerabilities and Exposures) must be developed under
 embargo. This means the fix cannot be pushed to the public ``ceph/ceph``
 repository, built using the public build infrastructure, or discussed in
-public channels until the embargo is lifted. Instead, each CVE has its own
-private fork of ``ceph/ceph`` (for example,
-``ceph/ceph-ghsa-xrjv-7fcr-h485``) where the fix is developed. Builds and
-tests use internal infrastructure in the `Sepia lab
-<https://wiki.sepia.ceph.com/doku.php>`_.
+public channels until the embargo is lifted. Instead, the fix is developed,
+built, and tested against a private repository. Builds and tests use internal
+infrastructure in the `Sepia lab <https://wiki.sepia.ceph.com/doku.php>`_.
+
+Three git repositories are involved. This document refers to them by the
+remote names below:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Repository
+     - Remote
+     - Purpose
+   * - ``ceph/ceph`` (public)
+     - ``origin``
+     - Clone from here and branch off its target branch. **Never** push the
+       fix here until the embargo is lifted.
+   * - `ceph-private <https://github.com/ceph/ceph-private>`_ (shared)
+     - ``private``
+     - Default repo to develop, build (via cve-pipeline), and test the fix
+       under embargo.
+   * - a per-CVE GitHub Security Advisory fork (for example,
+       ``ceph/ceph-ghsa-xrjv-7fcr-h485``)
+     - ``advisory``
+     - Used instead of ``private``, for higher-sensitivity fixes only, to
+       develop/build/test under embargo. Open a pull request here when done,
+       but **do not merge** it — also push the finished branch to
+       ``private`` (see "Merging the fix") so the Release Manager can build
+       the security release from it.
 
 Prerequisites
 -------------
 
-Access to a private fork is limited to Ceph GitHub organization admins and
-the collaborators added to its security advisory. If you cannot view the
-private fork for the CVE you are working on, ask Sage McTaggart or
-Gabriella Roman to add you as a collaborator to the parent advisory
-(not the fork itself).
+Access to ``private`` (``ceph-private``) is limited to Ceph GitHub
+organization admins. Access to an ``advisory`` fork is limited to
+organization admins plus the collaborators added to its security advisory.
+If you cannot view the private repo for the CVE you are working on, ask Sage
+McTaggart or Gabriella Roman to add you as a collaborator to the parent
+advisory (not the fork itself).
 
-Private CVE forks can be built using the `cve-pipeline
-<https://jenkins.ceph.com/job/cve-pipeline>`_ (404s unless logged in and authorized)
-Jenkins job. Access to the this job is limited to Ceph GitHub organization
-admins and members of the `ceph/security <https://github.com/orgs/ceph/teams/security>`_
-GitHub Team. Again, if you do not have access to see the cve-pipeline
-job, ask Sage or Gabriella for access.
+Builds go through the `cve-pipeline
+<https://jenkins.ceph.com/job/cve-pipeline>`_ (404s unless logged in and
+authorized) Jenkins job. Access to this job is limited to Ceph GitHub
+organization admins and members of the `ceph/security
+<https://github.com/orgs/ceph/teams/security>`_ GitHub Team. Again, if you
+do not have access to see the cve-pipeline job, ask Sage or Gabriella for
+access.
 
 Developing the Fix
 ------------------
@@ -37,23 +64,27 @@ Developing the Fix
 
       git clone https://github.com/ceph/ceph.git
 
-#. Add the CVE's private fork as a remote by adding the following to
-   ``.git/config`` in your local working copy, substituting the fork for your
-   CVE:
+#. Add a remote for whichever repo you'll develop in — ``private`` for most
+   CVEs:
 
-   .. code-block:: ini
+   .. prompt:: bash $
 
-      [remote "private"]
-              url = git@github.com:ceph/ceph-ghsa-xrjv-7fcr-h485.git
-              fetch = +refs/heads/*:refs/remotes/private/*
+      git remote add private git@github.com:ceph/ceph-private.git
+
+   or, for higher-sensitivity CVEs, ``advisory`` instead, substituting the
+   fork for your CVE:
+
+   .. prompt:: bash $
+
+      git remote add advisory git@github.com:ceph/ceph-ghsa-xrjv-7fcr-h485.git
 
 #. Create a branch and develop the fix as you would for any other bug. See
    :ref:`basic workflow dev guide` for the general development workflow.
 
 .. note::
 
-   A branch just needs to be pushed to the private fork in order to start a
-   package and container build.
+   Pushing a branch does not by itself trigger a build — the cve-pipeline
+   Jenkins job must be triggered manually (see "Building the Fix" below).
 
 .. warning::
 
@@ -66,7 +97,8 @@ Developing the Fix
 Building the Fix
 ----------------
 
-When the fix is ready to be built, push the branch to the private fork:
+When the fix is ready to be built, push the branch to whichever remote you
+set up above:
 
 .. prompt:: bash $
 
@@ -74,7 +106,21 @@ When the fix is ready to be built, push the branch to the private fork:
 
 Then manually trigger the `cve-pipeline
 <https://jenkins.ceph.com/job/cve-pipeline>`_
-Jenkins job.
+Jenkins job. Key parameters:
+
+* ``CEPH_REPO`` — SSH URL of the repo to build (defaults to your ``private``
+  remote's URL; use your ``advisory`` remote's URL instead if that's where
+  the fix lives).
+* ``BRANCH`` — the branch on ``CEPH_REPO`` to build.
+* ``SHA1`` — leave blank; this is intentional.
+* ``DISTROS`` / ``ARCHS`` — which distros/architectures to build.
+* ``THROWAWAY`` — must stay ``false``. Setting it ``true`` silently
+  overrides ``PULP_UPLOAD`` to ``false`` regardless of its own value, so
+  nothing gets published and a subsequent teuthology run has nothing to
+  fetch.
+* ``PULP_UPLOAD`` — ``true`` (the default) to actually publish packages.
+* ``CI_CONTAINER`` / ``CONTAINER_REPO_HOSTNAME`` /
+  ``CONTAINER_REPO_ORGANIZATION`` — control the container build.
 
 Unlike regular builds, the resulting artifacts are not published to the public
 chacra or quay repositories:
@@ -82,7 +128,8 @@ chacra or quay repositories:
 * Packages are pushed to an internal Pulp instance at
   ``pulp.front.sepia.ceph.com``.
 * Containers are pushed to an internal Quay instance at
-  ``quay-int.front.sepia.ceph.com``.
+  ``quay-int.front.sepia.ceph.com`` (``ceph-ci`` org), not the public
+  ``quay.ceph.io``.
 
 Testing the Fix
 ---------------
@@ -107,6 +154,13 @@ Chacra/Shaman. The Pulp API credentials are supplied by the lab-wide
 teuthology configuration on the teuthology hosts. Do **not** put credentials
 in the fragment; job configurations are archived publicly.
 
+.. warning::
+
+   This file is per-host, not synced between scheduling hosts. If you
+   normally schedule from more than one teuthology host, create it on each
+   one — a run from a second host fails with an "override file not found"
+   error until it exists there too.
+
 Schedule the run with the fragment appended to the ``teuthology-suite``
 command:
 
@@ -124,12 +178,18 @@ command:
 
 Note the following:
 
-* ``--ceph $BRANCH_NAME`` must match the private fork branch name.
+* ``--ceph $BRANCH_NAME`` must match the branch name that was built.
 * ``-S $SHA1`` must be the full 40-character sha1 of the commit that was built.
 * ``--validate-sha1 false`` is required because the teuthology hosts do not
-  (and should not) have access to ``ceph-private.git``. The build is located
-  in Pulp by its sha1 label instead, so no git access to the private
+  (and should not) have access to ``private`` or ``advisory``. The build is
+  located in Pulp by its sha1 label instead, so no git access to either
   repository is needed anywhere in the test pipeline.
+* ``--suite-repo``/``--suite-branch`` must point at the **public** repo
+  (``origin``) and the real release branch (e.g. ``tentacle``), *not* the
+  private branch name — the teuthology hosts have no network access to
+  ``private``/``advisory``, and the suite YAML doesn't exist there. Mixing
+  this up (leaving ``--suite-branch`` set to the private branch name) fails
+  the suite-YAML fetch.
 
 Remember that the warning about branch names applies to test runs as well:
 scheduled jobs and their results are publicly visible in paddles and Pulpito.
@@ -148,6 +208,16 @@ that was built:
 Merging the fix
 ---------------
 
-Once you have tested your changes and are happy with the fix, create a pull
-request in the private fork. It will eventually get merged into the ceph.git
-repo via the parent advisory.
+Once you have tested your changes and are happy with the fix, open a pull
+request in the repo you developed in (``private`` or ``advisory``) — but
+**do not merge it**. If you developed in ``advisory``, also push the
+finished branch to ``private`` so the Release Manager can build the security
+release from it:
+
+.. prompt:: bash $
+
+   git push private $BRANCH_NAME
+
+Then notify the Release Manager, who will proceed with the `Security Release
+Process Deviation
+<https://docs.ceph.com/en/latest/dev/release-process/#security-release-process-deviation>`_.

--- a/doc/dev/release-process.rst
+++ b/doc/dev/release-process.rst
@@ -80,6 +80,10 @@ A security/CVE release is similar to a hotfix release with two differences:
     git push origin v19.2.3
     # Now create a Pull Request of squid-release targeting squid to merge the version commit and security fixes back into the squid branch
 
+For the pre-merge phase of an embargoed CVE fix — developing, building, and
+testing against a private fork via the ``cve-pipeline`` Jenkins job, before
+it ever reaches the process above — see :ref:`build and test cve`.
+
 1. Preparing the release branch
 ===============================
 


### PR DESCRIPTION
## Summary

`docs.ceph.com/en/latest/dev/release-process/` currently documents the
Hotfix and Security Release Process Deviations, both of which start
from "cherry-pick onto a release branch, push, notify Build Lead." It
doesn't cover the pre-merge phase that comes before that for embargoed
CVE fixes: developing, building, and testing against a private fork
via the `cve-pipeline` Jenkins job. This adds that missing section.

## What's added

A new "CVE-Pipeline Private-Fork Flow (pre-merge dev/build/test)"
section, placed after "Security Release Process Deviation", covering:

- Where the fix lives (`ceph-private` vs. a per-CVE GHSA private fork)
  and the opsec rule against putting the CVE ID/description in branch
  names
- The `cve-pipeline` Jenkins job's key parameters (`CEPH_REPO`,
  `BRANCH`, `SHA1`, `THROWAWAY`/`PULP_UPLOAD` interaction, container
  publish target) — internal Pulp/quay-int only, never public infra
  at this stage
- The `--suite-repo`/`--suite-branch` gotcha hit live during a
  squid+tentacle dry run (must point at the public repo + real release
  branch, not the private-fork branch name), and the per-host
  `~/pulp.yaml` config-override requirement

Scope is explicit: this phase stops at "merged into `ceph.git` via the
parent advisory" — from there, the existing Security Release Process
Deviation section applies unchanged.

## References

Reconciled against djgalloway/ceph's cve-docs reference branch:
https://github.com/djgalloway/ceph/blob/cve-docs/doc/dev/developer_guide/cve.rst
Adopted its `advisory`/`private` remote naming and its "open PR,
don't merge, push to ceph-private, notify Release Manager" merge
flow; kept this PR's more detailed Jenkins-parameter and teuthology
gotcha content that the reference branch doesn't have.

## Type of change

- [x] Documentation only.
