### PR TITLE
Increase max device size from 100TiB to 1PiB

### DIFF
--- a/src/crush/crush.h
+++ b/src/crush/crush.h
@@ -26,7 +26,7 @@
 #define CRUSH_MAX_DEPTH 10  /* max crush hierarchy depth */
 #define CRUSH_MAX_RULES (1<<8)  /* max crush rule id */
 
-#define CRUSH_MAX_DEVICE_WEIGHT (100u * 0x10000u)
+#define CRUSH_MAX_DEVICE_WEIGHT (1000u * 0x10000u)
 #define CRUSH_MAX_BUCKET_WEIGHT (65535u * 0x10000u)
 
 #define CRUSH_ITEM_UNDEF  0x7ffffffe  /* undefined result (internal use only) */

--- a/src/test/cli/crushtool/adjust-item-weight.t
+++ b/src/test/cli/crushtool/adjust-item-weight.t
@@ -15,3 +15,14 @@
   $ crushtool -i two --update-item 0 3.0 device0 --loc host host0 --loc cluster cluster0 -o three > /dev/null
   $ crushtool -d three -o final
   $ diff final "$TESTDIR/simple.template.adj.three"
+
+#
+# update the weight of device0 in host=host0 to a large value, and check that
+# it propagates up to cluster0.  note that --update-item does not go through
+# the crush compiler, so this does not exercise CRUSH_MAX_DEVICE_WEIGHT; see
+# large-device-weight.t for that.
+#
+
+  $ crushtool -i three --update-item 0 123.0 device0 --loc host host0 --loc cluster cluster0 -o four > /dev/null
+  $ crushtool -d four -o final
+  $ diff final "$TESTDIR/simple.template.adj.four"

--- a/src/test/cli/crushtool/large-device-weight.crushmap.txt
+++ b/src/test/cli/crushtool/large-device-weight.crushmap.txt
@@ -1,0 +1,34 @@
+# begin crush map
+
+# devices
+device 0 device0
+
+# types
+type 0 device
+type 1 host
+type 2 root
+
+# buckets
+host host0 {
+	id -1		# do not change unnecessarily
+	alg straw
+	hash 0	# rjenkins1
+	item device0 weight 123.00000
+}
+root root0 {
+	id -2		# do not change unnecessarily
+	alg straw
+	hash 0	# rjenkins1
+	item host0 weight 123.00000
+}
+
+# rules
+rule data {
+	id 0
+	type replicated
+	step take root0
+	step chooseleaf firstn 0 type host
+	step emit
+}
+
+# end crush map

--- a/src/test/cli/crushtool/large-device-weight.t
+++ b/src/test/cli/crushtool/large-device-weight.t
@@ -1,0 +1,33 @@
+#
+# CRUSH_MAX_DEVICE_WEIGHT is enforced by the crush compiler only, so it can
+# only be exercised via 'crushtool -c'.  The limit is 1000, raised from 100 to
+# accommodate devices larger than 100 TiB.
+#
+
+#
+# a device weight well above the old limit of 100 compiles, and survives a
+# compile / decompile round trip unchanged
+#
+
+  $ crushtool -c "$TESTDIR/large-device-weight.crushmap.txt" -o compiled
+  $ crushtool -d compiled | grep -c "item device0 weight 123.00000"
+  1
+  $ crushtool -d compiled -o decompiled
+  $ crushtool -c decompiled -o recompiled
+  $ cmp compiled recompiled
+
+#
+# a device weight exactly at the limit is accepted
+#
+
+  $ crushtool -c "$TESTDIR/max-device-weight.crushmap.txt" -o compiled-max
+  $ crushtool -d compiled-max | grep -c "item device0 weight 1000.00000"
+  1
+
+#
+# a device weight above the limit is rejected
+#
+
+  $ crushtool -c "$TESTDIR/too-large-device-weight.crushmap.txt" -o compiled-too-large
+  device weight limited to 1000
+  [1]

--- a/src/test/cli/crushtool/max-device-weight.crushmap.txt
+++ b/src/test/cli/crushtool/max-device-weight.crushmap.txt
@@ -1,0 +1,34 @@
+# begin crush map
+
+# devices
+device 0 device0
+
+# types
+type 0 device
+type 1 host
+type 2 root
+
+# buckets
+host host0 {
+	id -1		# do not change unnecessarily
+	alg straw
+	hash 0	# rjenkins1
+	item device0 weight 1000.00000
+}
+root root0 {
+	id -2		# do not change unnecessarily
+	alg straw
+	hash 0	# rjenkins1
+	item host0 weight 1000.00000
+}
+
+# rules
+rule data {
+	id 0
+	type replicated
+	step take root0
+	step chooseleaf firstn 0 type host
+	step emit
+}
+
+# end crush map

--- a/src/test/cli/crushtool/simple.template.adj.four
+++ b/src/test/cli/crushtool/simple.template.adj.four
@@ -1,0 +1,58 @@
+# begin crush map
+
+# devices
+device 0 device0
+
+# types
+type 0 device
+type 1 host
+type 2 cluster
+
+# buckets
+host host0 {
+	id -2		# do not change unnecessarily
+	# weight 123.00000
+	alg straw
+	hash 0	# rjenkins1
+	item device0 weight 123.00000
+}
+host fake {
+	id -3		# do not change unnecessarily
+	# weight 2.00000
+	alg straw
+	hash 0	# rjenkins1
+	item device0 weight 2.00000
+}
+cluster cluster0 {
+	id -1		# do not change unnecessarily
+	# weight 125.00000
+	alg straw
+	hash 0	# rjenkins1
+	item host0 weight 123.00000
+	item fake weight 2.00000
+}
+
+# rules
+rule data {
+	id 0
+	type replicated
+	step take cluster0
+	step chooseleaf firstn 0 type host
+	step emit
+}
+rule metadata {
+	id 1
+	type replicated
+	step take cluster0
+	step chooseleaf firstn 0 type host
+	step emit
+}
+rule rbd {
+	id 2
+	type replicated
+	step take cluster0
+	step chooseleaf firstn 0 type host
+	step emit
+}
+
+# end crush map

--- a/src/test/cli/crushtool/too-large-device-weight.crushmap.txt
+++ b/src/test/cli/crushtool/too-large-device-weight.crushmap.txt
@@ -1,0 +1,34 @@
+# begin crush map
+
+# devices
+device 0 device0
+
+# types
+type 0 device
+type 1 host
+type 2 root
+
+# buckets
+host host0 {
+	id -1		# do not change unnecessarily
+	alg straw
+	hash 0	# rjenkins1
+	item device0 weight 1001.00000
+}
+root root0 {
+	id -2		# do not change unnecessarily
+	alg straw
+	hash 0	# rjenkins1
+	item host0 weight 1001.00000
+}
+
+# rules
+rule data {
+	id 0
+	type replicated
+	step take root0
+	step chooseleaf firstn 0 type host
+	step emit
+}
+
+# end crush map


### PR DESCRIPTION
Replaces https://github.com/ceph/ceph/pull/64056. See some discussion/testing there.

This is a pretty simple fix which has a few tests to confirm that it's working. Large devices are on the market, so we need to support item crush weights above 100TiB.

Full future scalability will also require https://github.com/ceph/ceph/pull/70988, which should be merged *after* this one. #70988 will allow device sizes to scale with the new `weight_shift` proposed there.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
