### PR TITLE
mgr/prometheus: add native tls support for metrics endpoint

### DIFF
--- a/doc/mgr/prometheus.rst
+++ b/doc/mgr/prometheus.rst
@@ -66,6 +66,10 @@ Configuration
 .. confval:: standby_error_status_code
 .. confval:: exclude_perf_counters
 .. confval:: healthcheck_history_max_entries
+.. confval:: ssl
+.. confval:: ssl_server_port
+.. confval:: crt_file
+.. confval:: key_file
 
 By default the module will accept HTTP requests on port ``9283`` on all IPv4
 and IPv6 addresses on the host.  The port and listen address are
@@ -75,9 +79,75 @@ is registered with Prometheus's `registry
 <https://github.com/prometheus/prometheus/wiki/Default-port-allocations>`_.
 
 .. prompt:: bash #
-   
+
    ceph config set mgr mgr/prometheus/server_addr 0.0.0.0
    ceph config set mgr mgr/prometheus/server_port 9283
+
+SSL/TLS Support
+^^^^^^^^^^^^^^^
+
+.. note::
+
+   For cephadm deployments, TLS for the monitoring stack is managed by
+   cephadm itself. Use the ``secure_monitoring_stack`` option instead of
+   the manual configuration described below. See
+   :ref:`cephadm-monitoring-stack-security` for details.
+
+The Prometheus module can be configured to serve metrics over HTTPS
+(HTTP secured with TLS). This is intended for non-cephadm deployments
+(e.g., Rook or standalone). TLS is disabled by default. To enable it,
+provide a certificate and key, then set the ``ssl`` option to ``true``:
+
+.. prompt:: bash #
+
+   ceph prometheus set-ssl-certificate -i /path/to/cert.pem
+   ceph prometheus set-ssl-certificate-key -i /path/to/key.pem
+   ceph config set mgr mgr/prometheus/ssl true
+
+When TLS is enabled, the module will listen on port ``9284`` by default instead
+of ``9283``. The TLS port is configurable:
+
+.. prompt:: bash #
+
+   ceph config set mgr mgr/prometheus/ssl_server_port 9284
+
+Alternatively, instead of injecting certificates via the CLI, you can point
+to certificate files on disk:
+
+.. prompt:: bash #
+
+   ceph config set mgr mgr/prometheus/crt_file /path/to/cert.pem
+   ceph config set mgr mgr/prometheus/key_file /path/to/key.pem
+   ceph config set mgr mgr/prometheus/ssl true
+
+To set a certificate for a specific manager daemon (e.g., ``mgr.a``),
+pass the manager ID:
+
+.. prompt:: bash #
+
+   ceph prometheus set-ssl-certificate mgr.a -i /path/to/cert.pem
+   ceph prometheus set-ssl-certificate-key mgr.a -i /path/to/key.pem
+
+To disable TLS and revert to HTTP:
+
+.. prompt:: bash #
+
+   ceph config set mgr mgr/prometheus/ssl false
+
+.. note::
+
+   The module must be restarted after changing TLS settings:
+
+   .. prompt:: bash #
+
+      ceph mgr module disable prometheus
+      ceph mgr module enable prometheus
+
+.. note::
+
+   When TLS is enabled, the module listens on a different port (``9284``
+   by default). Update your Prometheus scrape configuration to use
+   ``https`` and the new port.
 
 .. warning::
 

--- a/doc/mgr/prometheus.rst
+++ b/doc/mgr/prometheus.rst
@@ -120,6 +120,17 @@ to certificate files on disk:
    ceph config set mgr mgr/prometheus/key_file /path/to/key.pem
    ceph config set mgr mgr/prometheus/ssl true
 
+.. note::
+
+   Certificates configured with ``ceph prometheus set-ssl-certificate`` and
+   ``ceph prometheus set-ssl-certificate-key`` take precedence over
+   ``crt_file`` and ``key_file``. To switch to file-based certificates, clear
+   the stored certificate and key first:
+
+   .. prompt:: bash #
+
+      ceph prometheus clear-ssl-certificate
+
 To set a certificate for a specific manager daemon (e.g., ``mgr.a``),
 pass the manager ID:
 

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -2331,6 +2331,16 @@ class Module(MgrModule, OrchestratorClientMixin):
             self.set_store('key', inbuf)
         return 0, 'SSL certificate key updated', ''
 
+    @PrometheusCLICommand.Write('prometheus clear-ssl-certificate')
+    def clear_ssl_certificate(self, mgr_id: Optional[str] = None) -> Tuple[int, str, str]:
+        if mgr_id is not None:
+            self.set_store(_get_localized_key(mgr_id, 'crt'), None)
+            self.set_store(_get_localized_key(mgr_id, 'key'), None)
+        else:
+            self.set_store('crt', None)
+            self.set_store('key', None)
+        return 0, 'SSL certificate and key cleared', ''
+
     def self_test(self) -> None:
         self.collect()
         self.get_file_sd_config()
@@ -2377,22 +2387,33 @@ class Module(MgrModule, OrchestratorClientMixin):
 
     def setup_direct_tls_config(self) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, Any], str]:
         cert = self.get_localized_store("crt")
+        pkey = self.get_localized_store("key")
+        crt_file = cast(str, self.get_localized_module_option('crt_file'))
+        key_file = cast(str, self.get_localized_module_option('key_file'))
+
+        if (cert is not None or pkey is not None) and (crt_file or key_file):
+            self.log.warning(
+                'Prometheus TLS certificate/key stored with the '
+                '`prometheus set-ssl-certificate` commands take precedence '
+                'over crt_file/key_file. Run `ceph prometheus '
+                'clear-ssl-certificate` before using file-based TLS configuration.'
+            )
+
         if cert is not None:
             self.cert_tmp = NamedTemporaryFile()
             self.cert_tmp.write(cert.encode('utf-8'))
             self.cert_tmp.flush()
             cert_fname = self.cert_tmp.name
         else:
-            cert_fname = cast(str, self.get_localized_module_option('crt_file'))
+            cert_fname = crt_file
 
-        pkey = self.get_localized_store("key")
         if pkey is not None:
             self.pkey_tmp = NamedTemporaryFile()
             self.pkey_tmp.write(pkey.encode('utf-8'))
             self.pkey_tmp.flush()
             pkey_fname = self.pkey_tmp.name
         else:
-            pkey_fname = cast(str, self.get_localized_module_option('key_file'))
+            pkey_fname = key_file
 
         verify_tls_files(cert_fname, pkey_fname)
 
@@ -2674,22 +2695,33 @@ class StandbyModule(MgrStandbyModule):
         ssl_info = None
         if use_ssl:
             cert = self.get_localized_store("crt")
+            pkey = self.get_localized_store("key")
+            crt_file = cast(str, self.get_localized_module_option('crt_file'))
+            key_file = cast(str, self.get_localized_module_option('key_file'))
+
+            if (cert is not None or pkey is not None) and (crt_file or key_file):
+                self.log.warning(
+                    'Prometheus TLS certificate/key stored with the '
+                    '`prometheus set-ssl-certificate` commands take precedence '
+                    'over crt_file/key_file. Run `ceph prometheus '
+                    'clear-ssl-certificate` before using file-based TLS configuration.'
+                )
+
             if cert is not None:
                 self.cert_tmp = NamedTemporaryFile()
                 self.cert_tmp.write(cert.encode('utf-8'))
                 self.cert_tmp.flush()
                 cert_fname = self.cert_tmp.name
             else:
-                cert_fname = cast(str, self.get_localized_module_option('crt_file'))
+                cert_fname = crt_file
 
-            pkey = self.get_localized_store("key")
             if pkey is not None:
                 self.pkey_tmp = NamedTemporaryFile()
                 self.pkey_tmp.write(pkey.encode('utf-8'))
                 self.pkey_tmp.flush()
                 pkey_fname = self.pkey_tmp.name
             else:
-                pkey_fname = cast(str, self.get_localized_module_option('key_file'))
+                pkey_fname = key_file
 
             verify_tls_files(cert_fname, pkey_fname)
 

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -7,6 +7,7 @@ import re
 import threading
 import time
 import errno
+import ssl
 import enum
 from collections import namedtuple
 from collections import OrderedDict
@@ -16,8 +17,8 @@ from cherrypy import _cptree
 
 from .cli import PrometheusCLICommand
 
-from mgr_module import MgrModule, MgrStandbyModule, PG_STATES, Option, ServiceInfoT, HandleCommandResult
-from mgr_util import get_default_addr, profile_method, build_url, test_port_allocation, PortAlreadyInUse
+from mgr_module import MgrModule, MgrStandbyModule, PG_STATES, Option, ServiceInfoT, HandleCommandResult, _get_localized_key
+from mgr_util import get_default_addr, profile_method, build_url, test_port_allocation, PortAlreadyInUse, verify_tls_files
 from orchestrator import OrchestratorClientMixin, raise_if_exception, OrchestratorError
 from rbd import RBD
 
@@ -31,6 +32,7 @@ MetricValue = Dict[LabelValues, Number]
 # for Prometheus exporter port registry
 
 DEFAULT_PORT = 9283
+DEFAULT_SSL_PORT = 9284
 
 # to access things in class Module from subclass Root.  Because
 # it's a dict, the writer doesn't need to declare 'global' for access
@@ -750,6 +752,26 @@ class Module(MgrModule, OrchestratorClientMixin):
             desc='Maximum number of health check history entries to keep',
             runtime=True
         ),
+        Option(
+            name='ssl',
+            type='bool',
+            default=False,
+            desc='Enable SSL/TLS for the metrics endpoint'),
+        Option(
+            name='ssl_server_port',
+            type='int',
+            default=DEFAULT_SSL_PORT,
+            desc='Port for HTTPS when ssl is enabled'),
+        Option(
+            name='crt_file',
+            type='str',
+            default='',
+            desc='Path to SSL certificate file'),
+        Option(
+            name='key_file',
+            type='str',
+            default='',
+            desc='Path to SSL key file'),
     ]
 
     STALE_CACHE_FAIL = 'fail'
@@ -2275,7 +2297,11 @@ class Module(MgrModule, OrchestratorClientMixin):
                 if service['type'] != 'mgr':
                     continue
                 id_ = service['id']
-                port = self._get_module_option('server_port', DEFAULT_PORT, id_)
+                use_ssl = self._get_module_option('ssl', False, id_)
+                if use_ssl:
+                    port = self._get_module_option('ssl_server_port', DEFAULT_SSL_PORT, id_)
+                else:
+                    port = self._get_module_option('server_port', DEFAULT_PORT, id_)
                 targets.append(f'{hostname}:{port}')
         ret = [
             {
@@ -2284,6 +2310,26 @@ class Module(MgrModule, OrchestratorClientMixin):
             }
         ]
         return 0, json.dumps(ret), ""
+
+    @PrometheusCLICommand.Write('prometheus set-ssl-certificate')
+    def set_ssl_certificate(self, mgr_id: Optional[str] = None, inbuf: Optional[str] = None) -> Tuple[int, str, str]:
+        if inbuf is None:
+            return -errno.EINVAL, '', 'Please specify the certificate with "-i" option'
+        if mgr_id is not None:
+            self.set_store(_get_localized_key(mgr_id, 'crt'), inbuf)
+        else:
+            self.set_store('crt', inbuf)
+        return 0, 'SSL certificate updated', ''
+
+    @PrometheusCLICommand.Write('prometheus set-ssl-certificate-key')
+    def set_ssl_certificate_key(self, mgr_id: Optional[str] = None, inbuf: Optional[str] = None) -> Tuple[int, str, str]:
+        if inbuf is None:
+            return -errno.EINVAL, '', 'Please specify the certificate key with "-i" option'
+        if mgr_id is not None:
+            self.set_store(_get_localized_key(mgr_id, 'key'), inbuf)
+        else:
+            self.set_store('key', inbuf)
+        return 0, 'SSL certificate key updated', ''
 
     def self_test(self) -> None:
         self.collect()
@@ -2305,7 +2351,10 @@ class Module(MgrModule, OrchestratorClientMixin):
                     e
                 )
 
-        # In any error fallback to plain http mode
+        use_ssl = self.get_localized_module_option('ssl', False)
+        if use_ssl:
+            return self.setup_direct_tls_config()
+
         return self.setup_default_config()
 
     def get_cherrypy_config(self) -> Dict[str, Dict[str, Any]]:
@@ -2325,6 +2374,38 @@ class Module(MgrModule, OrchestratorClientMixin):
 
     def setup_default_config(self) -> Tuple[Dict[str, Dict[str, Any]], None, str]:
         return self.get_cherrypy_config(), None, 'http'
+
+    def setup_direct_tls_config(self) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, Any], str]:
+        cert = self.get_localized_store("crt")
+        if cert is not None:
+            self.cert_tmp = NamedTemporaryFile()
+            self.cert_tmp.write(cert.encode('utf-8'))
+            self.cert_tmp.flush()
+            cert_fname = self.cert_tmp.name
+        else:
+            cert_fname = cast(str, self.get_localized_module_option('crt_file'))
+
+        pkey = self.get_localized_store("key")
+        if pkey is not None:
+            self.pkey_tmp = NamedTemporaryFile()
+            self.pkey_tmp.write(pkey.encode('utf-8'))
+            self.pkey_tmp.flush()
+            pkey_fname = self.pkey_tmp.name
+        else:
+            pkey_fname = cast(str, self.get_localized_module_option('key_file'))
+
+        verify_tls_files(cert_fname, pkey_fname)
+
+        context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        context.load_cert_chain(cert_fname, pkey_fname)
+        context.minimum_version = ssl.TLSVersion.TLSv1_3
+
+        ssl_info = {
+            'cert': cert_fname,
+            'key': pkey_fname,
+            'context': context
+        }
+        return self.get_cherrypy_config(), ssl_info, 'https'
 
     def setup_tls_config(self) -> Tuple[Dict[str, Dict[str, Any]], Optional[Dict[str, Any]], str]:
         # Temporarily disabling the verify function due to issues.
@@ -2449,7 +2530,11 @@ class Module(MgrModule, OrchestratorClientMixin):
 
         def start_server() -> cherrypy.process.servers.ServerAdapter:
             server_addr = cast(str, self.get_localized_module_option('server_addr', get_default_addr()))
-            server_port = cast(int, self.get_localized_module_option('server_port', DEFAULT_PORT))
+            use_ssl = self.get_localized_module_option('ssl', False)
+            if use_ssl:
+                server_port = cast(int, self.get_localized_module_option('ssl_server_port', DEFAULT_SSL_PORT))
+            else:
+                server_port = cast(int, self.get_localized_module_option('server_port', DEFAULT_PORT))
 
             config, ssl_info, scheme = self.configure()
             tree = _cptree.Tree()
@@ -2576,10 +2661,42 @@ class StandbyModule(MgrStandbyModule):
     def serve(self) -> None:
         server_addr = cast(str, self.get_localized_module_option(
             'server_addr', get_default_addr()))
-        server_port = cast(int, self.get_localized_module_option(
-            'server_port', DEFAULT_PORT))
+        use_ssl = self.get_localized_module_option('ssl', False)
+        if use_ssl:
+            server_port = cast(int, self.get_localized_module_option(
+                'ssl_server_port', DEFAULT_SSL_PORT))
+        else:
+            server_port = cast(int, self.get_localized_module_option(
+                'server_port', DEFAULT_PORT))
         self.log.info("server_addr: %s server_port: %s" %
                       (server_addr, server_port))
+
+        ssl_info = None
+        if use_ssl:
+            cert = self.get_localized_store("crt")
+            if cert is not None:
+                self.cert_tmp = NamedTemporaryFile()
+                self.cert_tmp.write(cert.encode('utf-8'))
+                self.cert_tmp.flush()
+                cert_fname = self.cert_tmp.name
+            else:
+                cert_fname = cast(str, self.get_localized_module_option('crt_file'))
+
+            pkey = self.get_localized_store("key")
+            if pkey is not None:
+                self.pkey_tmp = NamedTemporaryFile()
+                self.pkey_tmp.write(pkey.encode('utf-8'))
+                self.pkey_tmp.flush()
+                pkey_fname = self.pkey_tmp.name
+            else:
+                pkey_fname = cast(str, self.get_localized_module_option('key_file'))
+
+            verify_tls_files(cert_fname, pkey_fname)
+
+            context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+            context.load_cert_chain(cert_fname, pkey_fname)
+            context.minimum_version = ssl.TLSVersion.TLSv1_3
+            ssl_info = {'cert': cert_fname, 'key': pkey_fname, 'context': context}
 
         module = self
 
@@ -2622,7 +2739,8 @@ class StandbyModule(MgrStandbyModule):
         self.server_adapter, _ = CherryPyMgr.mount(
             tree,
             'prometheus-standby',
-            (server_addr, int(server_port))
+            (server_addr, int(server_port)),
+            ssl_info=ssl_info
         )
         self.log.info('Engine started.')
 

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -71,6 +71,51 @@ def _wait_for_port_available(
     return False
 
 
+def _build_ssl_info(mod: Any) -> Dict[str, Any]:
+    """Resolve the Prometheus TLS cert/key and build an SSLContext.
+
+    The certificate/key stored via the `prometheus set-ssl-certificate`
+    commands (config-key store) take precedence over the crt_file/key_file
+    options; a warning is logged when both are set. Raises if the cert/key
+    are missing or invalid.
+    """
+    cert = mod.get_localized_store("crt")
+    pkey = mod.get_localized_store("key")
+    crt_file = cast(str, mod.get_localized_module_option('crt_file'))
+    key_file = cast(str, mod.get_localized_module_option('key_file'))
+
+    if (cert is not None or pkey is not None) and (crt_file or key_file):
+        mod.log.warning(
+            'Prometheus TLS certificate/key stored with the '
+            '`prometheus set-ssl-certificate` commands take precedence '
+            'over crt_file/key_file. Run `ceph prometheus '
+            'clear-ssl-certificate` before using file-based TLS configuration.'
+        )
+
+    if cert is not None:
+        mod.cert_tmp = NamedTemporaryFile()
+        mod.cert_tmp.write(cert.encode('utf-8'))
+        mod.cert_tmp.flush()
+        cert_fname = mod.cert_tmp.name
+    else:
+        cert_fname = crt_file
+
+    if pkey is not None:
+        mod.pkey_tmp = NamedTemporaryFile()
+        mod.pkey_tmp.write(pkey.encode('utf-8'))
+        mod.pkey_tmp.flush()
+        pkey_fname = mod.pkey_tmp.name
+    else:
+        pkey_fname = key_file
+
+    verify_tls_files(cert_fname, pkey_fname)
+
+    context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    context.load_cert_chain(cert_fname, pkey_fname)
+    context.minimum_version = ssl.TLSVersion.TLSv1_3
+    return {'cert': cert_fname, 'key': pkey_fname, 'context': context}
+
+
 def health_status_to_number(status: str) -> int:
     if status == 'HEALTH_OK':
         return 0
@@ -2386,46 +2431,7 @@ class Module(MgrModule, OrchestratorClientMixin):
         return self.get_cherrypy_config(), None, 'http'
 
     def setup_direct_tls_config(self) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, Any], str]:
-        cert = self.get_localized_store("crt")
-        pkey = self.get_localized_store("key")
-        crt_file = cast(str, self.get_localized_module_option('crt_file'))
-        key_file = cast(str, self.get_localized_module_option('key_file'))
-
-        if (cert is not None or pkey is not None) and (crt_file or key_file):
-            self.log.warning(
-                'Prometheus TLS certificate/key stored with the '
-                '`prometheus set-ssl-certificate` commands take precedence '
-                'over crt_file/key_file. Run `ceph prometheus '
-                'clear-ssl-certificate` before using file-based TLS configuration.'
-            )
-
-        if cert is not None:
-            self.cert_tmp = NamedTemporaryFile()
-            self.cert_tmp.write(cert.encode('utf-8'))
-            self.cert_tmp.flush()
-            cert_fname = self.cert_tmp.name
-        else:
-            cert_fname = crt_file
-
-        if pkey is not None:
-            self.pkey_tmp = NamedTemporaryFile()
-            self.pkey_tmp.write(pkey.encode('utf-8'))
-            self.pkey_tmp.flush()
-            pkey_fname = self.pkey_tmp.name
-        else:
-            pkey_fname = key_file
-
-        verify_tls_files(cert_fname, pkey_fname)
-
-        context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-        context.load_cert_chain(cert_fname, pkey_fname)
-        context.minimum_version = ssl.TLSVersion.TLSv1_3
-
-        ssl_info = {
-            'cert': cert_fname,
-            'key': pkey_fname,
-            'context': context
-        }
+        ssl_info = _build_ssl_info(self)
         return self.get_cherrypy_config(), ssl_info, 'https'
 
     def setup_tls_config(self) -> Tuple[Dict[str, Dict[str, Any]], Optional[Dict[str, Any]], str]:
@@ -2694,41 +2700,11 @@ class StandbyModule(MgrStandbyModule):
 
         ssl_info = None
         if use_ssl:
-            cert = self.get_localized_store("crt")
-            pkey = self.get_localized_store("key")
-            crt_file = cast(str, self.get_localized_module_option('crt_file'))
-            key_file = cast(str, self.get_localized_module_option('key_file'))
-
-            if (cert is not None or pkey is not None) and (crt_file or key_file):
-                self.log.warning(
-                    'Prometheus TLS certificate/key stored with the '
-                    '`prometheus set-ssl-certificate` commands take precedence '
-                    'over crt_file/key_file. Run `ceph prometheus '
-                    'clear-ssl-certificate` before using file-based TLS configuration.'
-                )
-
-            if cert is not None:
-                self.cert_tmp = NamedTemporaryFile()
-                self.cert_tmp.write(cert.encode('utf-8'))
-                self.cert_tmp.flush()
-                cert_fname = self.cert_tmp.name
-            else:
-                cert_fname = crt_file
-
-            if pkey is not None:
-                self.pkey_tmp = NamedTemporaryFile()
-                self.pkey_tmp.write(pkey.encode('utf-8'))
-                self.pkey_tmp.flush()
-                pkey_fname = self.pkey_tmp.name
-            else:
-                pkey_fname = key_file
-
-            verify_tls_files(cert_fname, pkey_fname)
-
-            context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-            context.load_cert_chain(cert_fname, pkey_fname)
-            context.minimum_version = ssl.TLSVersion.TLSv1_3
-            ssl_info = {'cert': cert_fname, 'key': pkey_fname, 'context': context}
+            try:
+                ssl_info = _build_ssl_info(self)
+            except Exception as e:
+                self.log.error(f'Failed to start Prometheus standby with TLS: {e}')
+                return
 
         module = self
 

--- a/src/pybind/mgr/prometheus/test_module.py
+++ b/src/pybind/mgr/prometheus/test_module.py
@@ -1,7 +1,8 @@
 from typing import Dict
 from unittest import TestCase, mock
+import errno
 
-from prometheus.module import Metric, LabelValues, Number, HealthHistory, ThreadSafeLRUCacheDict
+from prometheus.module import Metric, LabelValues, Number, HealthHistory, ThreadSafeLRUCacheDict, Module
 import threading
 
 
@@ -471,3 +472,110 @@ class HardwareMetricsTest(TestCase):
         self.module._process_processors(self.status, self.hostname)
         for labels in self.module.metrics['hardware_cpu_cores'].value:
             self.assertEqual(len(labels), 5)
+
+
+class TestSSLCertificateCLI(TestCase):
+    def setUp(self):
+        self.module = mock.MagicMock()
+        self.module.set_store = mock.MagicMock()
+
+    def test_set_ssl_certificate_no_inbuf(self):
+        ret, out, err = Module.set_ssl_certificate(self.module, inbuf=None)
+        self.assertEqual(ret, -errno.EINVAL)
+        self.assertIn('certificate', err)
+
+    def test_set_ssl_certificate_key_no_inbuf(self):
+        ret, out, err = Module.set_ssl_certificate_key(self.module, inbuf=None)
+        self.assertEqual(ret, -errno.EINVAL)
+        self.assertIn('certificate key', err)
+
+    def test_set_ssl_certificate_global(self):
+        ret, out, err = Module.set_ssl_certificate(self.module, inbuf='cert-data')
+        self.assertEqual(ret, 0)
+        self.module.set_store.assert_called_once_with('crt', 'cert-data')
+
+    def test_set_ssl_certificate_key_global(self):
+        ret, out, err = Module.set_ssl_certificate_key(self.module, inbuf='key-data')
+        self.assertEqual(ret, 0)
+        self.module.set_store.assert_called_once_with('key', 'key-data')
+
+    def test_set_ssl_certificate_per_mgr(self):
+        ret, out, err = Module.set_ssl_certificate(self.module, mgr_id='mgr.a', inbuf='cert-data')
+        self.assertEqual(ret, 0)
+        self.module.set_store.assert_called_once_with('mgr.a/crt', 'cert-data')
+
+    def test_set_ssl_certificate_key_per_mgr(self):
+        ret, out, err = Module.set_ssl_certificate_key(self.module, mgr_id='mgr.a', inbuf='key-data')
+        self.assertEqual(ret, 0)
+        self.module.set_store.assert_called_once_with('mgr.a/key', 'key-data')
+
+
+class TestConfigureSSL(TestCase):
+    def setUp(self):
+        self.module = mock.MagicMock(spec=Module)
+
+    def test_configure_calls_direct_tls_when_ssl_enabled(self):
+        self.module.mon_command = mock.MagicMock(return_value=(-22, None, ''))
+        self.module.get_localized_module_option = mock.MagicMock(return_value=True)
+        self.module.setup_direct_tls_config = mock.MagicMock(
+            return_value=({}, {'cert': '/tmp/c', 'key': '/tmp/k'}, 'https'))
+        Module.configure(self.module)
+        self.module.setup_direct_tls_config.assert_called_once()
+
+    def test_configure_prefers_orchestrator_over_direct_ssl(self):
+        self.module.mon_command = mock.MagicMock(
+            return_value=(0, '{"security_enabled": true}', ''))
+        self.module.get_localized_module_option = mock.MagicMock(return_value=True)
+        self.module.setup_tls_config = mock.MagicMock(
+            return_value=({}, {'cert': '/tmp/c', 'key': '/tmp/k'}, 'https'))
+        Module.configure(self.module)
+        self.module.setup_tls_config.assert_called_once()
+        self.module.setup_direct_tls_config.assert_not_called()
+
+    def test_configure_uses_direct_ssl_when_orchestrator_security_disabled(self):
+        self.module.mon_command = mock.MagicMock(
+            return_value=(0, '{"security_enabled": false}', ''))
+        self.module.get_localized_module_option = mock.MagicMock(return_value=True)
+        self.module.setup_direct_tls_config = mock.MagicMock(
+            return_value=({}, {'cert': '/tmp/c', 'key': '/tmp/k', 'context': mock.MagicMock()}, 'https'))
+        Module.configure(self.module)
+        self.module.setup_direct_tls_config.assert_called_once()
+        self.module.setup_tls_config.assert_not_called()
+
+    def test_configure_skips_direct_tls_when_ssl_disabled(self):
+        self.module.mon_command = mock.MagicMock(return_value=(0, None, ''))
+        self.module.get_localized_module_option = mock.MagicMock(return_value=False)
+        self.module.setup_default_config = mock.MagicMock(return_value=({}, None, 'http'))
+        Module.configure(self.module)
+        self.module.setup_direct_tls_config.assert_not_called()
+
+
+class TestFileSDConfig(TestCase):
+    def setUp(self):
+        self.module = mock.MagicMock(spec=Module)
+        self.module.list_servers = mock.MagicMock(return_value=[
+            {
+                'hostname': 'host1',
+                'services': [{'type': 'mgr', 'id': 'x'}]
+            }
+        ])
+
+    def test_file_sd_config_uses_default_port(self):
+        self.module._get_module_option = mock.MagicMock(
+            side_effect=lambda opt, default, id_: {
+                'ssl': False,
+                'server_port': 9283,
+            }.get(opt, default))
+        ret, out, err = Module.get_file_sd_config(self.module)
+        self.assertEqual(ret, 0)
+        self.assertIn('host1:9283', out)
+
+    def test_file_sd_config_uses_ssl_port(self):
+        self.module._get_module_option = mock.MagicMock(
+            side_effect=lambda opt, default, id_: {
+                'ssl': True,
+                'ssl_server_port': 9284,
+            }.get(opt, default))
+        ret, out, err = Module.get_file_sd_config(self.module)
+        self.assertEqual(ret, 0)
+        self.assertIn('host1:9284', out)

--- a/src/pybind/mgr/prometheus/test_module.py
+++ b/src/pybind/mgr/prometheus/test_module.py
@@ -579,3 +579,46 @@ class TestFileSDConfig(TestCase):
         ret, out, err = Module.get_file_sd_config(self.module)
         self.assertEqual(ret, 0)
         self.assertIn('host1:9284', out)
+
+
+class TestBuildSSLInfo(TestCase):
+    def setUp(self):
+        self.module = mock.MagicMock()
+        # By default no cert/key in the config-key store.
+        self.module.get_localized_store.return_value = None
+
+    def _set_options(self, **opts):
+        self.module.get_localized_module_option.side_effect = \
+            lambda opt: opts.get(opt)
+
+    def test_propagates_cert_error(self):
+        # A missing/invalid cert must raise so the caller can stay down
+        # instead of the module crashing with an unhandled exception.
+        from prometheus.module import _build_ssl_info
+        self._set_options(crt_file='/does/not/exist.pem',
+                          key_file='/does/not/exist.key')
+        with mock.patch('prometheus.module.verify_tls_files',
+                        side_effect=RuntimeError('Certificate does not exist')):
+            with self.assertRaises(RuntimeError):
+                _build_ssl_info(self.module)
+
+    def test_store_takes_precedence_and_warns(self):
+        # When both the config-key store and crt_file/key_file are set, the
+        # store wins and the user is warned about the precedence.
+        from prometheus.module import _build_ssl_info
+        self.module.get_localized_store.side_effect = \
+            lambda k: {'crt': 'CERT', 'key': 'KEY'}.get(k)
+        self._set_options(crt_file='/some/file.pem', key_file='/some/file.key')
+        with mock.patch('prometheus.module.verify_tls_files'), \
+                mock.patch('prometheus.module.ssl'):
+            _build_ssl_info(self.module)
+        self.module.log.warning.assert_called_once()
+
+    def test_no_warning_when_only_file_source(self):
+        # Only file-based config, no store values: no precedence conflict.
+        from prometheus.module import _build_ssl_info
+        self._set_options(crt_file='/some/file.pem', key_file='/some/file.key')
+        with mock.patch('prometheus.module.verify_tls_files'), \
+                mock.patch('prometheus.module.ssl'):
+            _build_ssl_info(self.module)
+        self.module.log.warning.assert_not_called()


### PR DESCRIPTION
Add SSL/TLS supprot for Prometheus MGR module, following the existing DAshbouard TLS pattern. This allows the metrics endpoint to serve over HTTPS.

Certifcates can be inject via CLI
 
```
 ceph prometheus set-ssl-certificate -i cert.pem
 ceph prometheus set-ssl-certificate-key -i key.pem
 ceph config set mgr mgr/prometheus/ssl true
```

or via file paths:
```
 ceph config set mgr mgr/prometheus/crt_file  /path/to/cert.pem
 ceph config set mgr mgr/prometheus/key_file  /path/to/key.pem
```

When SSL is enabled, the module listens on port 9284 (configuraable via ssl_server_port). TLS 1.3 is enforced as a minium version. Standby MGR also supports TLS.

Note: self signed cert, unlike Dashboard, is not implemented.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
