### PR TITLE
tentacle: osd/PeeringState: don't clear PG rebuild latch on same-primary interval restart

### DIFF
--- a/qa/standalone/osd/osd-recovery-stats.sh
+++ b/qa/standalone/osd/osd-recovery-stats.sh
@@ -506,20 +506,35 @@ function TEST_recovery_multi() {
 }
 
 # Verify that the rebuild perf counters on the primary OSD increment after a
-# real EC shard recovery.  Kill one non-primary OSD so the PG goes degraded,
-# then let recovery run to completion.  After the PG is clean again:
-#   - pg_rebuild_duration.avgcount must be >= 1
-#   - pg_rebuild_duration.sum must be > 0 (real time elapsed)
+# real EC shard recovery, AND that a same-primary peering-interval restart
+# occurring mid-rebuild does not truncate or drop the recorded duration.
+#
+# Sequence:
+#  1. Kill one non-primary OSD so the PG goes degraded (1st interval restart)
+#  2. Grep primary's log for rebuild latch firing, hold a deliberate gap before
+#     the second restart to unambiguously distinguish the duration.
+#  3. Mark the non-primary OSD out which results in the 4th OSD added to the
+#     acting set and becomes a backfill target (2nd interval restart).
+#  4. Assert that "latched failure start" line appears only once in the logs.
+#     This confirms that the second restart does not reset the counters.
+#  5. Let recovery run to completion. Assert exactly one "recorded rebuild"
+#     line, and that the recorded duration covers at least the deliberate gap
+#     from step 2 -- proving the full window survived.
 function TEST_rebuild_perf_ec_increments() {
     local dir=$1
     local OSDS=4
     local ecpoolname=ectest
+    # Deliberate gap between the latch firing and the second interval
+    # restart, long enough to be unambiguous against scheduling jitter.
+    local gap_secs=5
 
     run_mon $dir a || return 1
     run_mgr $dir x || return 1
     for osd in $(seq 0 $(expr $OSDS - 1))
     do
-      run_osd $dir $osd --osd-mclock-skip-benchmark=true || return 1
+      # debug-osd=15 so the "rebuild-stats: latched/recorded" lines emitted
+      # by prepare_stats_for_publish() are captured in the OSD log.
+      run_osd $dir $osd --osd-mclock-skip-benchmark=true --debug-osd=15 || return 1
     done
 
     ceph osd erasure-code-profile set ecprofile \
@@ -538,17 +553,76 @@ function TEST_rebuild_perf_ec_increments() {
 
     local primary
     primary=$(get_primary $ecpoolname obj1)
+    local PG
+    PG=$(get_pg $ecpoolname obj1)
+    # Derive the primary's actual shard for a given object (obj1)
+    local primary_shard
+    primary_shard=$(ceph --format json osd map $ecpoolname obj1 2>/dev/null | \
+      jq ".acting | index($primary)")
+    local PG_SPG="${PG}s${primary_shard}"
     local replica
     replica=$(get_not_primary $ecpoolname obj1)
+    local log=$dir/osd.${primary}.log
 
     # Pause recovery so the PG stays degraded long enough for the latch to
     # fire inside prepare_stats_for_publish before recovery completes.
     ceph osd set norecover || return 1
 
     # Kill one non-primary OSD so the PG becomes degraded.
+    # ---1st interval restart---
     kill $(cat $dir/osd.${replica}.pid)
     ceph osd down osd.${replica} || return 1
+
+    if [ "$(get_primary $ecpoolname obj1)" != "$primary" ]; then
+      echo "FAIL: primary changed after killing a non-primary OSD;" \
+           "test topology assumption broken"
+      return 1
+    fi
+
+    # Wait for the latch to fire.
+    local latched=0
+    for i in $(seq 1 30)
+    do
+      flush_pg_stats || return 1
+      if grep -q "rebuild-stats: latched failure start for ${PG_SPG} " $log
+      then
+        latched=1
+        break
+      fi
+      sleep 1
+    done
+    test "$latched" = 1 || {
+      echo "FAIL: rebuild latch never fired after opening the acting-set hole"
+      return 1
+    }
+
+    # Deliberate gap before the second restart. A duration truncated by a
+    # re-latch after that restart would come out well under this.
+    sleep $gap_secs
+
+    # --- 2nd interval restart: mark the OSD out to force a remap of a spare
+    # OSD into the acting set as a backfill target. Primary is unaffected.
     ceph osd out osd.${replica} || return 1
+
+    if [ "$(get_primary $ecpoolname obj1)" != "$primary" ]; then
+      echo "FAIL: primary changed after marking the OSD out;" \
+           "test topology assumption broken"
+      return 1
+    fi
+
+    # Let the new interval settle and force another stats publish so a
+    # pre-fix reset-and-relatch would already be visible in the log here.
+    sleep 2
+    flush_pg_stats || return 1
+
+    local latch_count
+    latch_count=$(grep -c "rebuild-stats: latched failure start for ${PG_SPG} " $log)
+    test "$latch_count" = 1 || {
+      echo "FAIL: expected exactly 1 'latched failure start' for ${PG_SPG}," \
+           "got $latch_count -- the same-primary interval restart reset" \
+           "the in-progress latch"
+      return 1
+    }
 
     # Release the hold and wait for full recovery.
     ceph osd unset norecover || return 1
@@ -561,6 +635,7 @@ function TEST_rebuild_perf_ec_increments() {
     # The primary may be the same OSD we started with (we only killed a
     # replica), but re-query in case CRUSH remapped the primary shard.
     primary=$(get_primary $ecpoolname obj1)
+    log=$dir/osd.${primary}.log
 
     local dump
     dump=$(CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${primary}) \
@@ -574,11 +649,32 @@ function TEST_rebuild_perf_ec_increments() {
       return 1
     }
 
+    local rebuild_sum
+    rebuild_sum=$(jq '.recoverystate_perf.pg_rebuild_duration.sum' <<< "$dump")
     echo "$dump" | \
       jq -e '.recoverystate_perf.pg_rebuild_duration.sum > 0' > /dev/null || {
-      local rebuild_sum
-      rebuild_sum=$(jq '.recoverystate_perf.pg_rebuild_duration.sum' <<< "$dump")
       echo "FAIL: expected pg_rebuild_duration.sum>0, got $rebuild_sum"
+      return 1
+    }
+
+    # Exactly one full rebuild event must have been recorded.
+    local record_count
+    record_count=$(grep -c "rebuild-stats: recorded rebuild for ${PG_SPG} " $log)
+    test "$record_count" = 1 || {
+      echo "FAIL: expected exactly 1 'recorded rebuild' for ${PG_SPG}," \
+           "got $record_count"
+      return 1
+    }
+
+    # The recorded duration must cover at least the deliberate gap held
+    # before the second restart i.e., $gap_secs. pg_rebuild_duration.sum is
+    # reported in fractional seconds.
+    echo "$dump" | \
+      jq -e ".recoverystate_perf.pg_rebuild_duration.sum >= ${gap_secs}" \
+      > /dev/null || {
+      echo "FAIL: expected pg_rebuild_duration.sum >= ${gap_secs}s" \
+           "(the ${gap_secs}s gap held before the second interval restart)," \
+           "got ${rebuild_sum}s -- duration looks truncated"
       return 1
     }
 

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -823,6 +823,18 @@ void PeeringState::start_peering_interval(
   } else if (was_old_nonprimary || is_nonprimary()) {
     pl->clear_want_pg_temp();
   }
+
+  // Only reset the rebuild-time latch when the primary role actually
+  // changes across this interval transition. Routine peering restarts
+  // (e.g. acting-set churn from backfill peers being added/removed)
+  // that leave this OSD as primary throughout must not wipe an
+  // in-progress rebuild's start time.
+  if (!(was_old_primary && is_primary())) {
+    rebuild_start_time = utime_t();
+    rebuild_base_recovered = 0;
+    rebuild_had_redundancy_loss = false;
+  }
+
   clear_primary_state();
 
   pl->on_change(t);
@@ -1046,10 +1058,6 @@ void PeeringState::clear_primary_state()
   pg_log.reset_recovery_pointers();
 
   clear_recovery_state();
-
-  rebuild_start_time = utime_t();
-  rebuild_base_recovered = 0;
-  rebuild_had_redundancy_loss = false;
 
   pg_committed_to = eversion_t();
   missing_loc.clear();
@@ -4440,6 +4448,18 @@ std::optional<pg_stat_t> PeeringState::prepare_stats_for_publish(
      *     num_objects_recovered > 0 or the PG had confirmed redundancy loss
      *     at latch time, filtering out spurious state transitions. The latch
      *     is cleared after each recorded event.
+     *  4. The "recovered" (record) branch additionally requires the live
+     *     PG_STATE_ACTIVE bit, not just an empty degraded/misplaced count.
+     *     Right after a peering-interval restart, clear_primary_state()
+     *     wipes acting_recovery_backfill/missing_loc before peering has
+     *     repopulated them for the new interval; a publish landing in that
+     *     narrow mid-peering window sees num_objects_degraded == 0 and no
+     *     DEGRADED/UNDERSIZED bit set, which looks identical to a genuine
+     *     recovery completion even though the PG is still mid-transition
+     *     and about to go degraded again. Requiring PG_STATE_ACTIVE (never
+     *     set while PEERING) filters out that transient situation so it can't
+     *     prematurely record a truncated duration and reset the latch out
+     *     from under an in-progress rebuild.
      *
      * last_degraded is intentionally not used in the interim solution to
      * retain compatibility with older Ceph releases where this field doesn't
@@ -4474,8 +4494,12 @@ std::optional<pg_stat_t> PeeringState::prepare_stats_for_publish(
                        << info.pgid << " at " << rebuild_start_time << dendl;
           }
         }
-      } else if (rebuild_start_time != utime_t()) {
+      } else if (rebuild_start_time != utime_t() && (state & PG_STATE_ACTIVE)) {
         // PG recovered — record rebuild time if this was a genuine event.
+        // The PG_STATE_ACTIVE check excludes the transient mid-peering
+        // window (see point 4 above) where the degraded/misplaced counts
+        // can momentarily read as zero before peering has finished
+        // repopulating them for the new interval.
         const int64_t delta_recovered = num_recovered - rebuild_base_recovered;
         const utime_t rebuild_dur  = now - rebuild_start_time;
 

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -4430,10 +4430,8 @@ std::optional<pg_stat_t> PeeringState::prepare_stats_for_publish(
      *  - num_objects_degraded, num_objects_misplaced, num_objects_recovered
      *
      * The PG rebuild stats are aggregated into the following recoverystate
-     * perf counters:
+     * perf counter:
      *  - rs_pg_rebuild_duration: rebuild duration LONGRUNAVG time counter
-     *  - rs_pg_rebuild_max_secs: maximum rebuild duration (secs)
-     *  - rs_pg_rebuild_min_secs: minimum rebuild duration (secs)
      *
      * Workflow:
      *  1. Only the acting primary OSD of the PG executes the logic to
@@ -4505,17 +4503,7 @@ std::optional<pg_stat_t> PeeringState::prepare_stats_for_publish(
 
         if (rebuild_dur.to_msec() > 0 &&
             (delta_recovered > 0 || rebuild_had_redundancy_loss)) {
-          PerfCounters &perf = pl->get_peering_perf();
-          perf.tinc(rs_pg_rebuild_duration, rebuild_dur);
-
-          const uint64_t rebuild_secs = (uint64_t)rebuild_dur.sec();
-          if (rebuild_secs > perf.get(rs_pg_rebuild_max_secs)) {
-            perf.set(rs_pg_rebuild_max_secs, rebuild_secs);
-          }
-          const uint64_t cur_min = perf.get(rs_pg_rebuild_min_secs);
-          if (cur_min == 0 || rebuild_secs < cur_min) {
-            perf.set(rs_pg_rebuild_min_secs, rebuild_secs);
-          }
+          pl->get_peering_perf().tinc(rs_pg_rebuild_duration, rebuild_dur);
           psdout(15) << "rebuild-stats: recorded rebuild for " << info.pgid
                      << " duration=" << rebuild_dur
                      << " delta_recovered=" << delta_recovered << dendl;

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -1582,9 +1582,13 @@ public:
   /**
    * Per-PG latch state for rebuild time tracking. Cleared after each
    * completed rebuild event is recorded in the perf counters.
-   * The state is also cleared in clear_primary_state() so that an interval
-   * change or role transition (primary -> replica) does not carry a stale
-   * start time or baseline recovered count into a future interval.
+   * The state is also cleared in start_peering_interval() when the
+   * primary role actually changes across the transition, so that a
+   * role change (primary -> replica, or vice versa) does not carry a
+   * stale start time or baseline recovered count into a future primary
+   * stint. Peering-interval restarts that leave this OSD as primary
+   * throughout preserve the latch so an in-progress rebuild keeps
+   * accruing across them.
    */
   utime_t rebuild_start_time;
   int64_t rebuild_base_recovered = 0;

--- a/src/osd/osd_perf_counters.cc
+++ b/src/osd/osd_perf_counters.cc
@@ -534,12 +534,6 @@ PerfCounters *build_recoverystate_perf(CephContext *cct) {
   rs_perf.add_time_avg(rs_pg_rebuild_duration, "pg_rebuild_duration",
     "Average PG rebuild duration on this OSD (primary role only)",
     NULL, PerfCountersBuilder::PRIO_USEFUL);
-  rs_perf.add_u64(rs_pg_rebuild_max_secs, "pg_rebuild_max_secs",
-    "Max PG rebuild duration seen on this OSD in seconds (primary role only)",
-    NULL, PerfCountersBuilder::PRIO_USEFUL);
-  rs_perf.add_u64(rs_pg_rebuild_min_secs, "pg_rebuild_min_secs",
-    "Min PG rebuild duration seen on this OSD in seconds (primary role only)",
-    NULL, PerfCountersBuilder::PRIO_USEFUL);
 
   return rs_perf.create_perf_counters();
 }

--- a/src/osd/osd_perf_counters.h
+++ b/src/osd/osd_perf_counters.h
@@ -257,8 +257,6 @@ enum {
   rs_notrecovering_latency,
   rs_stats_invalidated,
   rs_pg_rebuild_duration,
-  rs_pg_rebuild_max_secs,
-  rs_pg_rebuild_min_secs,
   rs_last,
 };
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79400

---

backport of https://github.com/ceph/ceph/pull/70835
parent tracker: https://tracker.ceph.com/issues/79028

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh