### PR TITLE
crimson/os/seastore: Simplify device/backend terminology

### DIFF
--- a/doc/dev/crimson/index.rst
+++ b/doc/dev/crimson/index.rst
@@ -84,7 +84,7 @@ The following options can be used with ``vstart.sh``.
     Optional.  Specify the type of secondary devices.  When the secondary
     device is slower than main device passed to ``--seastore-devs``, cold
     data on the faster device will be migrated to the slower devices over time.
-    Valid types include ``HDD``, ``SSD``(default), ``ZNS``, and ``RANDOM_BLOCK_SSD``
+    Valid types include ``HDD``, ``SSD``(default) and ``ZBD``.
     Note secondary devices should not be faster than the main device.
 
 To start a cluster with a single Crimson node, run::
@@ -101,7 +101,7 @@ run::
   $ MDS=0 MON=1 OSD=1 MGR=1 taskset -ac '0-95' /ceph/src/vstart.sh --new -x \
   --localhost --without-dashboard --redirect-output --seastore --osd-args \
   "--seastore_max_concurrent_transactions=128 --seastore_cachepin_type=LRU \
-  --seastore_hot_device_type=RANDOM_BLOCK_SSD" --seastore-devs  /dev/nvme0n1 \
+  --seastore_primary_backend_type=RANDOM_BLOCK" --seastore-devs  /dev/nvme0n1 \
   --crimson  --crimson-smp 1 --no-restart
 
 Another SeaStore example::

--- a/doc/dev/crimson/seastore.rst
+++ b/doc/dev/crimson/seastore.rst
@@ -291,7 +291,8 @@ separated into **Segmented** and **RBM** backend types as follows:
 
   Used for:
 
-  * ``device_type_t::RANDOM_BLOCK_SSD``
+  * ``device_type_t::SSD``
+  * ``device_type_t::HDD``
 
   Preferred for fast NVMe devices where overwrites are efficient enough
   that log structured updates aren't worth the overhead.
@@ -302,25 +303,28 @@ separated into **Segmented** and **RBM** backend types as follows:
 Device Hardware
 ---------------
 
-The following table maps each device_type_t enum value to
-the physical hardware it represents and the backend implementation it uses.
+``backend_type_t`` and ``device_type_t`` are independent. The backend is
+configured directly and picks the interface; the device type describes the
+hardware and picks the driver within that backend.
 
 
 +------------------------------------------+---------------------------+------------------------+
-| Device Type                              | Physical Hardware         | Backend                |
+| Device Type                              | Physical Hardware         | Driver                 |
 +==========================================+===========================+========================+
-| ``HDD``                                  | Spinning disk             | **Segmented**          |
+| ``HDD``                                  | Spinning disk             | ``BlockSegmentManager``|
+|                                          |                           | / ``RotationalDevice`` |
 +------------------------------------------+---------------------------+------------------------+
-| ``SSD``                                  | Conventional SSD / NVMe   | **Segmented**          |
+| ``SSD``                                  | Conventional SSD / NVMe   | ``BlockSegmentManager``|
+|                                          |                           | / ``NVMeBlockDevice``  |
 +------------------------------------------+---------------------------+------------------------+
-| ``ZBD``                                  | ZNS SSD or SMR HDD        | **Segmented**          |
+| ``ZBD``                                  | ZNS SSD or SMR HDD        | ``ZBDSegmentManager``  |
 +------------------------------------------+---------------------------+------------------------+
-| ``RANDOM_BLOCK_SSD``                     | NVMe                      | **Random Block (RBM)** |
+| ``EPHEMERAL_COLD`` / ``EPHEMERAL_MAIN``  | In-memory (test)          | ephemeral              |
 +------------------------------------------+---------------------------+------------------------+
-| ``EPHEMERAL_COLD`` / ``EPHEMERAL_MAIN``  | In-memory (test)          | **Segmented**          |
-+------------------------------------------+---------------------------+------------------------+
-| ``RANDOM_BLOCK_EPHEMERAL``               | In-memory (test)          | **Random Block (RBM)** |
-+------------------------------------------+---------------------------+------------------------+
+
+Where two drivers are listed, the first is used under
+``backend_type_t::SEGMENTED`` and the second under
+``backend_type_t::RANDOM_BLOCK``.
 
 
 .. _journal:

--- a/qa/config/crimson_logical_bucket_cache.yaml
+++ b/qa/config/crimson_logical_bucket_cache.yaml
@@ -2,4 +2,4 @@ overrides:
   ceph:
     conf:
       osd:
-        seastore logical bucket cache test stress: true
+        seastore lbc test stress: true

--- a/qa/objectstore_crimson/seastore/rbm$/crimson_seastore_rbm.yaml
+++ b/qa/objectstore_crimson/seastore/rbm$/crimson_seastore_rbm.yaml
@@ -4,9 +4,9 @@ overrides:
       osd:
         # crimson's osd objectstore option
         osd objectstore: seastore
-        seastore primary device type: RANDOM_BLOCK_SSD
+        seastore primary device type: SSD
         seastore primary backend type: RANDOM_BLOCK
-        seastore secondary device type: RANDOM_BLOCK_HDD
+        seastore secondary device type: HDD
         seastore secondary backend type: RANDOM_BLOCK
         debug seastore: 20
         debug seastore onode: 20

--- a/qa/objectstore_crimson/seastore/rbm$/crimson_seastore_rbm.yaml
+++ b/qa/objectstore_crimson/seastore/rbm$/crimson_seastore_rbm.yaml
@@ -4,8 +4,8 @@ overrides:
       osd:
         # crimson's osd objectstore option
         osd objectstore: seastore
-        seastore hot device type: RANDOM_BLOCK_SSD
-        seastore hot backend type: RANDOM_BLOCK
+        seastore primary device type: RANDOM_BLOCK_SSD
+        seastore primary backend type: RANDOM_BLOCK
         seastore cold device type: RANDOM_BLOCK_HDD
         seastore cold backend type: RANDOM_BLOCK
         debug seastore: 20

--- a/qa/objectstore_crimson/seastore/rbm$/crimson_seastore_rbm.yaml
+++ b/qa/objectstore_crimson/seastore/rbm$/crimson_seastore_rbm.yaml
@@ -6,8 +6,8 @@ overrides:
         osd objectstore: seastore
         seastore primary device type: RANDOM_BLOCK_SSD
         seastore primary backend type: RANDOM_BLOCK
-        seastore cold device type: RANDOM_BLOCK_HDD
-        seastore cold backend type: RANDOM_BLOCK
+        seastore secondary device type: RANDOM_BLOCK_HDD
+        seastore secondary backend type: RANDOM_BLOCK
         debug seastore: 20
         debug seastore onode: 20
         debug seastore odata: 20

--- a/qa/objectstore_crimson/seastore/rbm$/crimson_seastore_rbm_2q.yaml
+++ b/qa/objectstore_crimson/seastore/rbm$/crimson_seastore_rbm_2q.yaml
@@ -5,8 +5,8 @@ overrides:
         # crimson's osd objectstore option
         osd objectstore: seastore
         seastore cachepin type: 2Q
-        seastore hot device type: RANDOM_BLOCK_SSD
-        seastore hot backend type: RANDOM_BLOCK
+        seastore primary device type: RANDOM_BLOCK_SSD
+        seastore primary backend type: RANDOM_BLOCK
         seastore cold device type: RANDOM_BLOCK_HDD
         seastore cold backend type: RANDOM_BLOCK
         debug seastore: 20

--- a/qa/objectstore_crimson/seastore/rbm$/crimson_seastore_rbm_2q.yaml
+++ b/qa/objectstore_crimson/seastore/rbm$/crimson_seastore_rbm_2q.yaml
@@ -5,9 +5,9 @@ overrides:
         # crimson's osd objectstore option
         osd objectstore: seastore
         seastore cachepin type: 2Q
-        seastore primary device type: RANDOM_BLOCK_SSD
+        seastore primary device type: SSD
         seastore primary backend type: RANDOM_BLOCK
-        seastore secondary device type: RANDOM_BLOCK_HDD
+        seastore secondary device type: HDD
         seastore secondary backend type: RANDOM_BLOCK
         debug seastore: 20
         debug seastore onode: 20

--- a/qa/objectstore_crimson/seastore/rbm$/crimson_seastore_rbm_2q.yaml
+++ b/qa/objectstore_crimson/seastore/rbm$/crimson_seastore_rbm_2q.yaml
@@ -7,8 +7,8 @@ overrides:
         seastore cachepin type: 2Q
         seastore primary device type: RANDOM_BLOCK_SSD
         seastore primary backend type: RANDOM_BLOCK
-        seastore cold device type: RANDOM_BLOCK_HDD
-        seastore cold backend type: RANDOM_BLOCK
+        seastore secondary device type: RANDOM_BLOCK_HDD
+        seastore secondary backend type: RANDOM_BLOCK
         debug seastore: 20
         debug seastore onode: 20
         debug seastore odata: 20

--- a/qa/objectstore_crimson/seastore/segmented$/crimson_seastore_segmented.yaml
+++ b/qa/objectstore_crimson/seastore/segmented$/crimson_seastore_segmented.yaml
@@ -4,8 +4,8 @@ overrides:
       osd:
         # crimson's osd objectstore option
         osd objectstore: seastore
-        seastore cold device type: RANDOM_BLOCK_HDD
-        seastore cold backend type: RANDOM_BLOCK
+        seastore secondary device type: RANDOM_BLOCK_HDD
+        seastore secondary backend type: RANDOM_BLOCK
         debug seastore: 20
         debug seastore onode: 20
         debug seastore odata: 20

--- a/qa/objectstore_crimson/seastore/segmented$/crimson_seastore_segmented.yaml
+++ b/qa/objectstore_crimson/seastore/segmented$/crimson_seastore_segmented.yaml
@@ -4,7 +4,7 @@ overrides:
       osd:
         # crimson's osd objectstore option
         osd objectstore: seastore
-        seastore secondary device type: RANDOM_BLOCK_HDD
+        seastore secondary device type: HDD
         seastore secondary backend type: RANDOM_BLOCK
         debug seastore: 20
         debug seastore onode: 20

--- a/qa/objectstore_crimson/seastore/segmented$/crimson_seastore_segmented_2q.yaml
+++ b/qa/objectstore_crimson/seastore/segmented$/crimson_seastore_segmented_2q.yaml
@@ -5,7 +5,7 @@ overrides:
         # crimson's osd objectstore option
         osd objectstore: seastore
         seastore cachepin type: 2Q
-        seastore secondary device type: RANDOM_BLOCK_HDD
+        seastore secondary device type: HDD
         seastore secondary backend type: RANDOM_BLOCK
         debug seastore: 20
         debug seastore onode: 20

--- a/qa/objectstore_crimson/seastore/segmented$/crimson_seastore_segmented_2q.yaml
+++ b/qa/objectstore_crimson/seastore/segmented$/crimson_seastore_segmented_2q.yaml
@@ -5,8 +5,8 @@ overrides:
         # crimson's osd objectstore option
         osd objectstore: seastore
         seastore cachepin type: 2Q
-        seastore cold device type: RANDOM_BLOCK_HDD
-        seastore cold backend type: RANDOM_BLOCK
+        seastore secondary device type: RANDOM_BLOCK_HDD
+        seastore secondary backend type: RANDOM_BLOCK
         debug seastore: 20
         debug seastore onode: 20
         debug seastore odata: 20

--- a/qa/suites/crimson-rados/basic/deploy/ceph.yaml
+++ b/qa/suites/crimson-rados/basic/deploy/ceph.yaml
@@ -15,4 +15,4 @@ overrides:
   ceph:
     conf:
       osd:
-        seastore logical bucket cache test stress: true
+        seastore lbc test stress: true

--- a/qa/tasks/ceph_objectstore_tool.py
+++ b/qa/tasks/ceph_objectstore_tool.py
@@ -209,8 +209,8 @@ def task(ctx, config):
     manager.raw_cluster_cmd('osd', 'set', 'nodown')
 
     if CRIMSON:
-        CRIMSON_DEVICE_TYPE = manager.get_config('osd', 0, 'seastore_hot_device_type')
-        log.info('seastore_hot_device_type is {}...'.format(CRIMSON_DEVICE_TYPE))
+        CRIMSON_DEVICE_TYPE = manager.get_config('osd', 0, 'seastore_primary_device_type')
+        log.info('seastore_primary_device_type is {}...'.format(CRIMSON_DEVICE_TYPE))
 
     PGNUM = config.get('pgnum', 12)
     log.info("pgnum: {num}".format(num=PGNUM))

--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -252,20 +252,21 @@ options:
   level: advanced
   desc: maximum concurrent transactions that seastore allows (per reactor)
   default: 128
-- name: seastore_hot_device_type
+- name: seastore_primary_device_type
   type: str
   level: dev
-  desc: The type of the devices in the hot (or only) tier, valid values are HDD, SSD, RANDOM_BLOCK_SSD and RANDOM_BLOCK_HDD
+  desc: Device type of the primary device, valid values are HDD, SSD, RANDOM_BLOCK_SSD and RANDOM_BLOCK_HDD.
+        The primary device holds the journal, the root and the metadata trees.
   default: SSD
-- name: seastore_hot_backend_type
+- name: seastore_primary_backend_type
   type: str
   level: dev
-  desc: The back end used by the devices in the hot (or only) tier, valid values are SEGMENTED and RANDOM_BLOCK
+  desc: Backend used by the primary device, valid values are SEGMENTED and RANDOM_BLOCK
   default: SEGMENTED
-- name: seastore_hot_backend_bw_throttle
+- name: seastore_primary_bw_throttle
   type: size
   level: advanced
-  desc: Size in bytes per second written to the hot devices, 0 indicates no limit
+  desc: Size in bytes per second written to the primary device, 0 indicates no limit
   default: 0
 - name: seastore_cold_devices_count
   type: uint
@@ -291,7 +292,7 @@ options:
 - name: seastore_cbjournal_size
   type: size
   level: dev
-  desc: Total size to use for CircularBoundedJournal if created, it is valid only if seastore_hot_device_type is RANDOM_BLOCK
+  desc: Total size to use for CircularBoundedJournal if created, it is valid only if seastore_primary_backend_type is RANDOM_BLOCK
   default: 5_G
 - name: seastore_multiple_tiers_stop_evict_ratio
   type: float

--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -293,20 +293,20 @@ options:
   level: dev
   desc: Total size to use for CircularBoundedJournal if created, it is valid only if seastore_primary_backend_type is RANDOM_BLOCK
   default: 5_G
-- name: seastore_multiple_tiers_stop_evict_ratio
+- name: seastore_cold_evict_stop_ratio
   type: float
   level: advanced
-  desc: When the used ratio of main tier is less than this value, then stop evict cold data to the cold tier.
+  desc: Stop evicting to the cold tier when the used ratio of the hot tier drops below this value.
   default: 0.5
-- name: seastore_multiple_tiers_default_evict_ratio
+- name: seastore_cold_evict_start_ratio
   type: float
   level: advanced
-  desc: Begin evicting cold data to the cold tier when the used ratio of the main tier reaches this value.
+  desc: Start evicting to the cold tier when the used ratio of the hot tier reaches this value.
   default: 0.6
-- name: seastore_multiple_tiers_fast_evict_ratio
+- name: seastore_cold_evict_fast_ratio
   type: float
   level: advanced
-  desc: Begin fast eviction when the used ratio of the main tier reaches this value.
+  desc: Start fast eviction when the used ratio of the hot tier reaches this value.
   default: 0.7
 - name: seastore_hot_tier_generations
   type: uint

--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -255,8 +255,10 @@ options:
 - name: seastore_primary_device_type
   type: str
   level: dev
-  desc: Device type of the primary device, valid values are HDD, SSD, RANDOM_BLOCK_SSD and RANDOM_BLOCK_HDD.
-        The primary device holds the journal, the root and the metadata trees.
+  desc: Device type of the primary device, only SSD is supported. It selects the
+        driver within the configured backend, the backend itself is
+        seastore_primary_backend_type. The primary device holds the journal,
+        the root and the metadata trees.
   default: SSD
 - name: seastore_primary_backend_type
   type: str
@@ -276,8 +278,9 @@ options:
 - name: seastore_secondary_device_type
   type: str
   level: dev
-  desc: Device type of the secondary devices, valid values are RANDOM_BLOCK_SSD, RANDOM_BLOCK_HDD, SSD and HDD
-  default: RANDOM_BLOCK_HDD
+  desc: Device type of the secondary devices, valid values are HDD, SSD and ZBD.
+        It selects the driver within seastore_secondary_backend_type.
+  default: HDD
 - name: seastore_secondary_backend_type
   type: str
   level: dev

--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -154,7 +154,7 @@ options:
   desc: CPU cores on which POSIX threads alienized to seastar will run in cpuset(7) format
   flags:
   - startup
-- name: seastore_logical_bucket_cache_test_stress
+- name: seastore_lbc_test_stress
   type: bool
   level: dev
   desc: Enable SeaStore Logical Bucket Cache stress mode. When enabled, SeaStore exercises cold-tier
@@ -380,37 +380,37 @@ options:
   desc: disable osd shards changes upon restart.
   flags:
   - startup
-- name: seastore_cache_promotion_size
+- name: seastore_lbc_promote_size
   type: size
   level: advanced
-  desc: Size in bytes of extents to be promoted from cold devices, set 0 to disable promotion
+  desc: Size in bytes of extents to be promoted from the cold tier, set 0 to disable promotion
   default: 2_M
-- name: seastore_logical_bucket_capacity
+- name: seastore_lbc_index_memory
   type: size
   level: advanced
-  desc: Size in bytes of memory used by logical bucket
+  desc: Size in bytes of memory used by the logical bucket cache index
   default: 200_M
-- name: seastore_logical_bucket_proceed_size_per_cycle
+- name: seastore_lbc_demote_size_per_cycle
   type: size
   level: advanced
-  desc: Size in bytes of extents to be demoted from logical bucket
+  desc: Size in bytes of extents to be demoted to the cold tier per cycle
   default: 2_M
-- name: seastore_write_through_size
+- name: seastore_lbc_write_through_size
   type: size
   level: dev
-  desc: Select write through policy when data length is greater than this value.
+  desc: Write data directly to the cold tier when its length is greater than this value.
   default: 512_K
-- name: seastore_test_workload_write_through_probability
+- name: seastore_lbc_test_write_through_probability
   type: float
   level: dev
-  desc: The percentage of writes that are applied directly to slow devices
+  desc: The percentage of writes that are applied directly to the cold tier
   default: 0.5
-- name: seastore_test_workload_2Q_promote_probability
+- name: seastore_lbc_test_2q_promote_probability
   type: float
   level: dev
-  desc: The probability of promoting the extents evicted from the warm_in queue to faster devices
+  desc: The probability of promoting the extents evicted from the warm_in queue to the hot tier
   default: 0.5
-- name: seastore_test_workload_force_process_background_tasks_period
+- name: seastore_lbc_test_force_background_period
   type: uint
   level: dev
   desc: Seconds of the period to force process background tasks

--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -268,26 +268,25 @@ options:
   level: advanced
   desc: Size in bytes per second written to the primary device, 0 indicates no limit
   default: 0
-- name: seastore_cold_devices_count
+- name: seastore_secondary_devices_count
   type: uint
   level: dev
-  desc: create cold devices during mkfs
+  desc: Number of secondary devices to create during mkfs. Secondary devices form the cold tier.
   default: 0
-- name: seastore_cold_device_type
+- name: seastore_secondary_device_type
   type: str
   level: dev
-  desc: The cold device type SeaStore uses, valid values are RANDOM_BLOCK_SSD, RANDOM_BLOCK_HDD, SSD and HDD.
-        This is only effective when there are two tiers, a hot one and a cold one.
+  desc: Device type of the secondary devices, valid values are RANDOM_BLOCK_SSD, RANDOM_BLOCK_HDD, SSD and HDD
   default: RANDOM_BLOCK_HDD
-- name: seastore_cold_backend_type
+- name: seastore_secondary_backend_type
   type: str
   level: dev
-  desc: The backend used by cold devices (SEGMENTED or RANDOM_BLOCK)
+  desc: Backend used by the secondary devices, valid values are SEGMENTED and RANDOM_BLOCK
   default: RANDOM_BLOCK
-- name: seastore_cold_backend_bw_throttle
+- name: seastore_secondary_bw_throttle
   type: size
   level: advanced
-  desc: Size in bytes per second written to cold devices, 0 indicates no limit
+  desc: Size in bytes per second written to the secondary devices, 0 indicates no limit
   default: 100_M
 - name: seastore_cbjournal_size
   type: size

--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -264,6 +264,14 @@ public:
 
   virtual seastar::future<std::string> get_default_device_class() = 0;
 
+  virtual seastar::future<std::string> get_primary_backend_type_name() {
+    return seastar::make_ready_future<std::string>();
+  }
+
+  virtual seastar::future<std::string> get_secondary_backend_type_name() {
+    return seastar::make_ready_future<std::string>();
+  }
+
   /// Run garbage collection on all shards until space ratios are acceptable.
   /// Default implementation is a no-op (for stores that don't need GC).
   virtual seastar::future<> do_gc() { return seastar::now(); }

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -37,7 +37,7 @@ Cache::Cache(
       crimson::common::get_conf<Option::size_t>(
         "seastore_data_delta_based_overwrite") > 0),
     force_backref(crimson::common::get_conf<bool>(
-        "seastore_logical_bucket_cache_test_stress")),
+        "seastore_lbc_test_stress")),
     pinboard(create_extent_pinboard(
       crimson::common::get_conf<Option::size_t>(
        "seastore_cachepin_size_pershard"),

--- a/src/crimson/os/seastore/device.cc
+++ b/src/crimson/os/seastore/device.cc
@@ -109,7 +109,7 @@ void device_superblock_t::validate() const
                   shard_infos[i].size % block_size == 0);
       ceph_assert_always(shard_infos[i].size <= DEVICE_OFF_MAX);
       ceph_assert((journal_size > 0 && journal_size % block_size == 0) ||
-                   config.spec.dtype == device_type_t::RANDOM_BLOCK_HDD);
+                   config.spec.dtype == device_type_t::HDD);
       ceph_assert(shard_infos[i].start_offset < total_size &&
                   shard_infos[i].start_offset % block_size == 0);
     }

--- a/src/crimson/os/seastore/extent_pinboard.cc
+++ b/src/crimson/os/seastore/extent_pinboard.cc
@@ -275,7 +275,7 @@ public:
     : promotion_size(promotion_size),
       epm(epm),
       test_workload(crimson::common::get_conf<bool>(
-        "seastore_logical_bucket_cache_test_stress"))
+        "seastore_lbc_test_stress"))
   {}
 
   ~ExtentPromoter() {
@@ -743,9 +743,9 @@ public:
 	hot(hot_capacity),
 	promoter(promotion_size, epm),
         test_workload(crimson::common::get_conf<bool>(
-          "seastore_logical_bucket_cache_test_stress")),
+          "seastore_lbc_test_stress")),
         TwoQ_promote_probability(crimson::common::get_conf<double>(
-          "seastore_test_workload_2Q_promote_probability"))
+          "seastore_lbc_test_2q_promote_probability"))
   {
     LOG_PREFIX(ExtentPinboardTwoQ::ExtentPinboardTwoQ);
     INFO("created, warm_in_capacity=0x{:x}B, warm_out_capacity=0x{:x}B, "
@@ -1180,7 +1180,7 @@ void ExtentPinboardTwoQ::register_metrics(store_index_t store_index) {
 
 ExtentPinboardRef create_extent_pinboard(std::size_t capacity, ExtentPlacementManager *epm) {
   using crimson::common::get_conf;
-  size_t promotion_size = get_conf<Option::size_t>("seastore_cache_promotion_size");
+  size_t promotion_size = get_conf<Option::size_t>("seastore_lbc_promote_size");
   auto algorithm = get_conf<std::string>("seastore_cachepin_type");
   if (algorithm == "LRU") {
     return std::make_unique<ExtentPinboardLRU>(capacity, promotion_size, *epm);

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -228,7 +228,7 @@ void ExtentPlacementManager::init(
   auto primary_bw_limit = crimson::common::get_conf<
     Option::size_t>("seastore_primary_bw_throttle");
   auto secondary_bw_limit = crimson::common::get_conf<
-    Option::size_t>("seastore_cold_backend_bw_throttle");
+    Option::size_t>("seastore_secondary_bw_throttle");
 
   token_buckets.emplace_back(std::make_unique<TokenBucket>(primary_bw_limit));
   token_buckets.back()->start();

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -225,12 +225,12 @@ void ExtentPlacementManager::init(
         cold_tier_generations);
   ceph_assert(dynamic_max_rewrite_generation > MIN_REWRITE_GENERATION);
 
-  auto main_bw_limit = crimson::common::get_conf<
-    Option::size_t>("seastore_hot_backend_bw_throttle");
+  auto primary_bw_limit = crimson::common::get_conf<
+    Option::size_t>("seastore_primary_bw_throttle");
   auto secondary_bw_limit = crimson::common::get_conf<
     Option::size_t>("seastore_cold_backend_bw_throttle");
 
-  token_buckets.emplace_back(std::make_unique<TokenBucket>(main_bw_limit));
+  token_buckets.emplace_back(std::make_unique<TokenBucket>(primary_bw_limit));
   token_buckets.back()->start();
 
   if (trimmer->get_backend_type() == backend_type_t::SEGMENTED) {

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -915,11 +915,11 @@ private:
         using crimson::common::get_conf;
         eviction_state.init(
           crimson::common::get_conf<double>(
-            "seastore_multiple_tiers_stop_evict_ratio"),
+            "seastore_cold_evict_stop_ratio"),
           crimson::common::get_conf<double>(
-            "seastore_multiple_tiers_default_evict_ratio"),
+            "seastore_cold_evict_start_ratio"),
           crimson::common::get_conf<double>(
-            "seastore_multiple_tiers_fast_evict_ratio"),
+            "seastore_cold_evict_fast_ratio"),
           hot_tier_generations);
 
         pinboard = _pinboard;

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -375,11 +375,11 @@ public:
       max_data_allocation_size(crimson::common::get_conf<Option::size_t>(
 	  "seastore_max_data_allocation_size")),
       write_through_size(crimson::common::get_conf<Option::size_t>(
-	  "seastore_write_through_size")),
+	  "seastore_lbc_write_through_size")),
       test_workload(crimson::common::get_conf<bool>(
-          "seastore_logical_bucket_cache_test_stress")),
+          "seastore_lbc_test_stress")),
       write_through_probability(crimson::common::get_conf<double>(
-          "seastore_test_workload_write_through_probability"))
+          "seastore_lbc_test_write_through_probability"))
   {
     LOG_PREFIX(ExtentPlacementManager::ExtentPlacementManager);
     devices_by_id.resize(DEVICE_ID_MAX, nullptr);
@@ -927,20 +927,20 @@ private:
         pinboard->set_background_callback(this);
 
         logical_bucket_demote_size_per_cycle =
-          get_conf<Option::size_t>("seastore_logical_bucket_proceed_size_per_cycle");
+          get_conf<Option::size_t>("seastore_lbc_demote_size_per_cycle");
         logical_bucket = create_logical_bucket(
-          get_conf<Option::size_t>("seastore_logical_bucket_capacity"),
+          get_conf<Option::size_t>("seastore_lbc_index_memory"),
           logical_bucket_demote_size_per_cycle);
         logical_bucket->set_background_callback(this);
       }
       LOG_PREFIX(BackgroundProcess::init);
       test_workload = crimson::common::get_conf<bool>(
-        "seastore_logical_bucket_cache_test_stress");
+        "seastore_lbc_test_stress");
       force_process_half_life = crimson::common::get_conf<uint64_t>(
-        "seastore_test_workload_force_process_background_tasks_period");
+        "seastore_lbc_test_force_background_period");
       force_background_timer.set_callback([this] { wake_half_life(); });
       write_through_probability = crimson::common::get_conf<double>(
-        "seastore_test_workload_write_through_probability");
+        "seastore_lbc_test_write_through_probability");
       SUBINFO(seastore_epm, "crimson test workload supported, enabled: {}", test_workload);
       if (test_workload) {
         set_next_force_process();

--- a/src/crimson/os/seastore/random_block_manager.cc
+++ b/src/crimson/os/seastore/random_block_manager.cc
@@ -13,7 +13,7 @@ seastar::future<random_block_device::RBMDeviceRef>
 get_rb_device(
   const std::string &device, device_type_t dtype)
 {
-  if (dtype == device_type_t::RANDOM_BLOCK_HDD) {
+  if (dtype == device_type_t::HDD) {
     return seastar::make_ready_future<random_block_device::RBMDeviceRef>(
       std::make_unique<
         random_block_device::RotationalDevice

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
@@ -21,7 +21,7 @@ device_config_t get_rbm_ephemeral_device_config(
 {
   assert(num_devices > index);
   magic_t magic = 0xfffa;
-  auto type = device_type_t::RANDOM_BLOCK_EPHEMERAL;
+  auto type = device_type_t::EPHEMERAL_MAIN;
   bool is_major_device;
   secondary_device_set_t secondary_devices;
   if (index == 0) {

--- a/src/crimson/os/seastore/random_block_manager/hdd_device.h
+++ b/src/crimson/os/seastore/random_block_manager/hdd_device.h
@@ -34,7 +34,7 @@ public:
   mount_ret mount() final;
 
   device_type_t get_device_type() const final {
-    return device_type_t::RANDOM_BLOCK_HDD;
+    return device_type_t::HDD;
   }
 
   close_ertr::future<> close() final {

--- a/src/crimson/os/seastore/random_block_manager/rbm_device.cc
+++ b/src/crimson/os/seastore/random_block_manager/rbm_device.cc
@@ -47,7 +47,7 @@ RBMDevice::mkfs_ret RBMDevice::do_primary_mkfs(device_config_t config,
   const size_t cur_block_size = (*st).block_size;
   const size_t cur_total_size = (*st).size;
   ceph_assert_always(journal_size > 0 ||
-                     config.spec.dtype == device_type_t::RANDOM_BLOCK_HDD);
+                     config.spec.dtype == device_type_t::HDD);
   ceph_assert_always(cur_total_size >= journal_size);
   ceph_assert_always(shard_num > 0);
 

--- a/src/crimson/os/seastore/random_block_manager/rbm_device.h
+++ b/src/crimson/os/seastore/random_block_manager/rbm_device.h
@@ -112,7 +112,7 @@ public:
   }
 
   virtual device_type_t get_device_type() const {
-    return device_type_t::RANDOM_BLOCK_SSD;
+    return device_type_t::SSD;
   }
 
   backend_type_t get_backend_type() const final {

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -3050,6 +3050,24 @@ seastar::future<std::string> SeaStore::get_default_device_class()
   return seastar::make_ready_future<std::string>(type);
 }
 
+seastar::future<std::string> SeaStore::get_primary_backend_type_name()
+{
+  ceph_assert(seastar::this_shard_id() == primary_core);
+  ceph_assert(device);
+  return seastar::make_ready_future<std::string>(
+    fmt::format("{}", device->get_backend_type()));
+}
+
+seastar::future<std::string> SeaStore::get_secondary_backend_type_name()
+{
+  ceph_assert(seastar::this_shard_id() == primary_core);
+  if (secondaries.empty()) {
+    return seastar::make_ready_future<std::string>();
+  }
+  return seastar::make_ready_future<std::string>(
+    fmt::format("{}", secondaries.front()->get_backend_type()));
+}
+
 uuid_d SeaStore::Shard::get_fsid() const
 {
   return device->get_meta().seastore_id;

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -388,14 +388,14 @@ seastar::future<uint32_t> SeaStore::start()
   bool is_test = false;
 #endif
   using crimson::common::get_conf;
-  std::string type = get_conf<std::string>("seastore_hot_device_type");
+  std::string type = get_conf<std::string>("seastore_primary_device_type");
   device_type_t d_type = string_to_device_type(type);
   assert(d_type == device_type_t::SSD ||
          d_type == device_type_t::RANDOM_BLOCK_SSD);
 
-  type = get_conf<std::string>("seastore_hot_backend_type");
+  type = get_conf<std::string>("seastore_primary_backend_type");
   auto b_type = string_to_backend_type(type);
-  INFO("main device type: {}, main backend type: {}", d_type, b_type);
+  INFO("primary device type: {}, primary backend type: {}", d_type, b_type);
   ceph_assert(root != "");
   DeviceRef device_obj = co_await Device::make_device(root, d_type, b_type);
   device = std::move(device_obj);
@@ -3046,7 +3046,7 @@ SeaStore::read_meta(const std::string& key)
 seastar::future<std::string> SeaStore::get_default_device_class()
 {
   using crimson::common::get_conf;
-  std::string type = get_conf<std::string>("seastore_hot_device_type");
+  std::string type = get_conf<std::string>("seastore_primary_device_type");
   return seastar::make_ready_future<std::string>(type);
 }
 

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -729,7 +729,7 @@ Device::access_ertr::future<> SeaStore::_mkfs(uuid_d new_osd_fsid)
   }
 
   if (sds.empty() && crimson::common::get_conf<bool>(
-        "seastore_logical_bucket_cache_test_stress")) {
+        "seastore_lbc_test_stress")) {
     // lbc test workload enabled while no secondary devices indicated, create one
     std::string path = fmt::format("{}/block.1", root);
     co_await seastar::make_directory(path);

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -471,7 +471,7 @@ Device::access_ertr::future<> SeaStore::_mount()
     [[maybe_unused]] magic_t magic = device_entry.second.magic;
     device_type_t dtype = device_entry.second.dtype;
     backend_type_t btype = device_entry.second.btype;
-    auto btype_conf_str = get_conf<std::string>("seastore_cold_backend_type");
+    auto btype_conf_str = get_conf<std::string>("seastore_secondary_backend_type");
     ceph_assert(string_to_backend_type(btype_conf_str) == btype);
     std::string path = fmt::format("{}/block.{}", root, std::to_string(id));
     DeviceRef sec_dev = co_await Device::make_device(path, dtype, btype);
@@ -693,9 +693,9 @@ Device::access_ertr::future<> SeaStore::_mkfs(uuid_d new_osd_fsid)
     co_return;
   }
   DEBUG("mkfs_done does not exist, starting mkfs");
-  auto dtype_str = get_conf<std::string>("seastore_cold_device_type");
+  auto dtype_str = get_conf<std::string>("seastore_secondary_device_type");
   auto dtype = string_to_device_type(dtype_str);
-  auto btype_str = get_conf<std::string>("seastore_cold_backend_type");
+  auto btype_str = get_conf<std::string>("seastore_secondary_backend_type");
   auto btype = string_to_backend_type(btype_str);
   ceph_assert(!root.empty());
   INFO("secondary device type: {}, secondary backend type: {}", dtype, btype);

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -390,8 +390,7 @@ seastar::future<uint32_t> SeaStore::start()
   using crimson::common::get_conf;
   std::string type = get_conf<std::string>("seastore_primary_device_type");
   device_type_t d_type = string_to_device_type(type);
-  assert(d_type == device_type_t::SSD ||
-         d_type == device_type_t::RANDOM_BLOCK_SSD);
+  assert(d_type == device_type_t::SSD);
 
   type = get_conf<std::string>("seastore_primary_backend_type");
   auto b_type = string_to_backend_type(type);
@@ -748,10 +747,9 @@ Device::access_ertr::future<> SeaStore::_mkfs(uuid_d new_osd_fsid)
   device_id_t id = 0;
   device_type_t d_type = device->get_device_type();
   backend_type_t b_type = device->get_backend_type();
-  assert(d_type == device_type_t::SSD ||
-      d_type == device_type_t::RANDOM_BLOCK_SSD);
+  assert(d_type == device_type_t::SSD);
   assert(b_type != backend_type_t::NONE);
-  if (d_type == device_type_t::RANDOM_BLOCK_SSD) {
+  if (b_type == backend_type_t::RANDOM_BLOCK) {
       id = static_cast<device_id_t>(DEVICE_ID_RANDOM_BLOCK_MIN);
   }
   DEBUG("creating primary device");

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -737,6 +737,10 @@ public:
 
   seastar::future<std::string> get_default_device_class() final;
 
+  seastar::future<std::string> get_primary_backend_type_name() final;
+
+  seastar::future<std::string> get_secondary_backend_type_name() final;
+
   seastar::future<> do_gc() override;
 
   BackendStore get_backend_store(store_index_t store_index) override {

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -1250,12 +1250,6 @@ device_type_t string_to_device_type(std::string type) {
   if (type == "ZBD") {
     return device_type_t::ZBD;
   }
-  if (type == "RANDOM_BLOCK_SSD") {
-    return device_type_t::RANDOM_BLOCK_SSD;
-  }
-  if (type == "RANDOM_BLOCK_HDD") {
-    return device_type_t::RANDOM_BLOCK_HDD;
-  }
   return device_type_t::NONE;
 }
 
@@ -1274,12 +1268,6 @@ std::ostream& operator<<(std::ostream& out, device_type_t t)
     return out << "EPHEMERAL_COLD";
   case device_type_t::EPHEMERAL_MAIN:
     return out << "EPHEMERAL_MAIN";
-  case device_type_t::RANDOM_BLOCK_SSD:
-    return out << "RANDOM_BLOCK_SSD";
-  case device_type_t::RANDOM_BLOCK_EPHEMERAL:
-    return out << "RANDOM_BLOCK_EPHEMERAL";
-  case device_type_t::RANDOM_BLOCK_HDD:
-    return out << "RANDOM_BLOCK_HDD";
   default:
     return out << "INVALID_DEVICE_TYPE!";
   }

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -964,9 +964,6 @@ enum class device_type_t : uint8_t {
   ZBD,            // ZNS SSD or SMR HDD
   EPHEMERAL_COLD,
   EPHEMERAL_MAIN,
-  RANDOM_BLOCK_SSD,
-  RANDOM_BLOCK_EPHEMERAL,
-  RANDOM_BLOCK_HDD,
   NUM_TYPES
 };
 
@@ -977,8 +974,8 @@ device_type_t string_to_device_type(std::string type);
 
 enum class backend_type_t : uint8_t {
   NONE,
-  SEGMENTED,    // SegmentManager: SSD, ZBD, HDD
-  RANDOM_BLOCK  // RBMDevice:      RANDOM_BLOCK_SSD
+  SEGMENTED,    // SegmentManager: BlockSegmentManager, ZBDSegmentManager
+  RANDOM_BLOCK  // RBMDevice:      NVMeBlockDevice, RotationalDevice
 };
 
 std::ostream& operator<<(std::ostream& out, backend_type_t);

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -1486,7 +1486,7 @@ TransactionManager::promote_extents_from_disk(
     co_await promote_extent(t, extent);
     size += length;
     if (size >= crimson::common::get_conf<
-        Option::size_t>("seastore_cache_promotion_size")) {
+        Option::size_t>("seastore_lbc_promote_size")) {
       co_return seastar::stop_iteration::yes;
     } else {
       co_return seastar::stop_iteration::no;
@@ -1838,7 +1838,7 @@ TransactionManagerRef make_transaction_manager(
       backend_type, roll_start, roll_size,
       !pure_rbm_backend
         || crimson::common::get_conf<bool>(
-            "seastore_logical_bucket_cache_test_stress")
+            "seastore_lbc_test_stress")
     );
 
   AsyncCleanerRef cleaner;

--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -264,7 +264,7 @@ int main(int argc, const char* argv[])
               // use a random osd uuid if not specified
               osd_uuid.generate_random();
             }
-            if (auto c = local_conf().get_val<uint64_t>("seastore_cold_devices_count");
+            if (auto c = local_conf().get_val<uint64_t>("seastore_secondary_devices_count");
                 c != 0) {
               auto root = local_conf().get_val<std::string>("osd_data");
               for (size_t i = 1; i <= c; i++) {

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -714,6 +714,14 @@ seastar::future<> OSD::_send_boot()
   if (ret == 0) {
     m->metadata["osd_objectstore"] = type;
   }
+  auto primary_backend = co_await store.get_primary_backend_type_name();
+  if (!primary_backend.empty()) {
+    m->metadata["seastore_primary_backend"] = primary_backend;
+  }
+  auto secondary_backend = co_await store.get_secondary_backend_type_name();
+  if (!secondary_backend.empty()) {
+    m->metadata["seastore_secondary_backend"] = secondary_backend;
+  }
   co_await monc->send_message(std::move(m));
 }
 

--- a/src/test/crimson/seastore/nvmedevice/test_nvmedevice.cc
+++ b/src/test/crimson/seastore/nvmedevice/test_nvmedevice.cc
@@ -64,7 +64,7 @@ TEST_F(nvdev_test_t, write_and_verify_test)
 	true,
 	device_spec_t{
 	(magic_t)std::rand(),
-	device_type_t::RANDOM_BLOCK_SSD,
+	device_type_t::SSD,
 	backend_type_t::RANDOM_BLOCK,
 	static_cast<device_id_t>(DEVICE_ID_RANDOM_BLOCK_MIN)},
 	seastore_meta_t{uuid_d()},

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -229,8 +229,8 @@ declare -a bluestore_db_devs
 declare -a bluestore_wal_devs
 declare -a secondary_block_devs
 declare -a cpu_table
-seastore_hot_device_type="SSD"
-seastore_hot_backend_type="SEGMENTED"
+seastore_primary_device_type="SSD"
+seastore_primary_backend_type="SEGMENTED"
 seastore_cold_device_type="SSD"
 seastore_cold_backend_type="SEGMENTED"
 
@@ -302,8 +302,8 @@ options:
 	--seastore-device-size: set total size of seastore
 	--seastore-devs: comma-separated list of blockdevs to use for seastore
 	--seastore-secondary-devs: comma-separated list of secondary blockdevs to use for seastore
-	--seastore-main-device-type: device type of main blockdevs. (SSD or RANDOM_BLOCK_SSD)
-	--seastore-main-backend-type: the driver used by main blockdevs (SEGMENTED or RANDOM_BLOCK)
+	--seastore-primary-device-type: device type of the primary blockdev. (SSD or RANDOM_BLOCK_SSD)
+	--seastore-primary-backend-type: the backend used by the primary blockdev (SEGMENTED or RANDOM_BLOCK)
 	--seastore-secondary-device-type: device type of all secondary blockdevs. HDD, SSD(default), ZNS or RANDOM_BLOCK_SSD
 	--seastore-secondary-backend-type: the driver used by secondary blockdevs (SEGMENTED or RANDOM_BLOCK)
 	--crimson-smp: number of cores to use for crimson
@@ -640,12 +640,12 @@ case $1 in
         parse_block_devs --seastore-devs "$2"
         shift
         ;;
-    --seastore-main-device-type)
-        seastore_hot_device_type="$2"
+    --seastore-primary-device-type)
+        seastore_primary_device_type="$2"
         shift
         ;;
-    --seastore-main-backend-type)
-        seastore_hot_backend_type="$2"
+    --seastore-primary-backend-type)
+        seastore_primary_backend_type="$2"
         shift
         ;;
     --seastore-secondary-devs)
@@ -978,8 +978,8 @@ EOF
         seastore device size = $seastore_size"
       fi
       SEASTORE_OPTS+="
-        seastore_hot_device_type=$seastore_hot_device_type
-        seastore_hot_backend_type=$seastore_hot_backend_type
+        seastore_primary_device_type=$seastore_primary_device_type
+        seastore_primary_backend_type=$seastore_primary_backend_type
         seastore_cold_device_type=$seastore_cold_device_type
         seastore_cold_backend_type=$seastore_cold_backend_type"
     fi

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -302,9 +302,9 @@ options:
 	--seastore-device-size: set total size of seastore
 	--seastore-devs: comma-separated list of blockdevs to use for seastore
 	--seastore-secondary-devs: comma-separated list of secondary blockdevs to use for seastore
-	--seastore-primary-device-type: device type of the primary blockdev. (SSD or RANDOM_BLOCK_SSD)
+	--seastore-primary-device-type: device type of the primary blockdev. Only SSD(default) is supported
 	--seastore-primary-backend-type: the backend used by the primary blockdev (SEGMENTED or RANDOM_BLOCK)
-	--seastore-secondary-device-type: device type of all secondary blockdevs. HDD, SSD(default), ZNS or RANDOM_BLOCK_SSD
+	--seastore-secondary-device-type: device type of all secondary blockdevs. HDD, SSD(default) or ZBD
 	--seastore-secondary-backend-type: the backend used by secondary blockdevs (SEGMENTED or RANDOM_BLOCK)
 	--crimson-smp: number of cores to use for crimson
 	--crimson-alien-num-threads: number of alien-tp threads

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -231,8 +231,8 @@ declare -a secondary_block_devs
 declare -a cpu_table
 seastore_primary_device_type="SSD"
 seastore_primary_backend_type="SEGMENTED"
-seastore_cold_device_type="SSD"
-seastore_cold_backend_type="SEGMENTED"
+seastore_secondary_device_type="SSD"
+seastore_secondary_backend_type="SEGMENTED"
 
 VSTART_SEC="client.vstart.sh"
 
@@ -305,7 +305,7 @@ options:
 	--seastore-primary-device-type: device type of the primary blockdev. (SSD or RANDOM_BLOCK_SSD)
 	--seastore-primary-backend-type: the backend used by the primary blockdev (SEGMENTED or RANDOM_BLOCK)
 	--seastore-secondary-device-type: device type of all secondary blockdevs. HDD, SSD(default), ZNS or RANDOM_BLOCK_SSD
-	--seastore-secondary-backend-type: the driver used by secondary blockdevs (SEGMENTED or RANDOM_BLOCK)
+	--seastore-secondary-backend-type: the backend used by secondary blockdevs (SEGMENTED or RANDOM_BLOCK)
 	--crimson-smp: number of cores to use for crimson
 	--crimson-alien-num-threads: number of alien-tp threads
 	--crimson-reactor-physical-only: use only one cpu per physical core for seastar reactors
@@ -653,11 +653,11 @@ case $1 in
         shift
         ;;
     --seastore-secondary-device-type)
-        seastore_cold_device_type="$2"
+        seastore_secondary_device_type="$2"
         shift
         ;;
     --seastore-secondary-backend-type)
-        seastore_cold_backend_type="$2"
+        seastore_secondary_backend_type="$2"
         shift
         ;;
     --crimson-smp)
@@ -980,8 +980,8 @@ EOF
       SEASTORE_OPTS+="
         seastore_primary_device_type=$seastore_primary_device_type
         seastore_primary_backend_type=$seastore_primary_backend_type
-        seastore_cold_device_type=$seastore_cold_device_type
-        seastore_cold_backend_type=$seastore_cold_backend_type"
+        seastore_secondary_device_type=$seastore_secondary_device_type
+        seastore_secondary_backend_type=$seastore_secondary_backend_type"
     fi
 
     wconf <<EOF


### PR DESCRIPTION
This PR cleans up SeaStore backend terminology and options:

* Rename hot/cold devices to primary/secondary devices.
Hot and cold are really data placement tiers (for example used by GC and promotion/demotion) while primary and secondary describe the device roles.
This also unifies the previous mix of main/hot/primary terminology under "primary".

* `osd metadata` to now also out put backend (instead of relying on config):
```
  "osd_objectstore": "seastore",
  "seastore_primary_backend": "SEGMENTED",
  "seastore_secondary_backend": "RANDOM_BLOCK",
```

* Drop `RANDOM_BLOCK_*` device types.
Device type and backend type were separated recently. Keeping the backend (RANDOM_BLOCK) in the device type no longer makes sense.
Device types now describe the hardware (`SSD`, `HDD`, `ZBD`), while the backend is selected independently.

* Group Logical Bucket Cache options under a common `seastore_lbc_*` prefix.


TODO:
* Make `RANDOM_BLOCK` the default backend option.
* Update seastore.rst docs to match the new names



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
