### PR TITLE
mgr/dashboard: cephfs-mirroring-dashboard Delete snapshot schedule is failing with unknown task.

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.spec.ts
@@ -868,22 +868,42 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
         snapshotScheduleService.delete.mockReturnValue(of({}));
         snapshotScheduleService.getSnapshotSchedule.mockReturnValue(of([]));
         component.fsName = 'test-fs';
+        component.selectedPath = { path: '/mirror/path1' } as any;
+        component.schedulePolicies = [
+          {
+            path: '/volumes/group/subvol/uuid/..',
+            schedule: '1h',
+            removeId: '/volumes/group/subvol/uuid/..@1h'
+          } as any
+        ];
 
         const policy = {
-          path: '/path1',
+          path: '/volumes/group/subvol/uuid/..',
           schedule: '1h',
           start: '2024-01-01T00:00:00Z',
-          fs: 'test-fs'
+          fs: 'test-fs',
+          subvol: 'subvol',
+          group: 'group',
+          removeId: '/volumes/group/subvol/uuid/..@1h'
         };
 
         component.removeSchedulePolicy(policy as any);
 
         expect(snapshotScheduleService.delete).toHaveBeenCalledWith({
-          path: '/path1',
+          path: '/volumes/group/subvol/uuid/..',
           schedule: '1h',
           start: '2024-01-01T00:00:00Z',
-          fs: 'test-fs'
+          fs: 'test-fs',
+          retentionPolicy: undefined,
+          subvol: 'subvol',
+          group: 'group'
         });
+        expect(snapshotScheduleService.getSnapshotSchedule).toHaveBeenCalledWith(
+          '/mirror/path1',
+          'test-fs',
+          false
+        );
+        expect(component.schedulePolicies).toEqual([]);
         expect(component.removingSchedule).toBe('');
       });
 
@@ -1164,6 +1184,23 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
       });
     });
 
+    describe('buildRetentionPolicyString', () => {
+      it('should build retention policy string for API delete calls', () => {
+        const result = component['buildRetentionPolicyString']({ h: 24, d: 7 });
+
+        expect(result).toBe('24-h|7-d');
+      });
+
+      it('should return undefined for string retention values', () => {
+        expect(component['buildRetentionPolicyString']('-')).toBeUndefined();
+      });
+
+      it('should return undefined for empty retention', () => {
+        expect(component['buildRetentionPolicyString'](undefined)).toBeUndefined();
+        expect(component['buildRetentionPolicyString']({})).toBeUndefined();
+      });
+    });
+
     describe('buildRetentionCopy', () => {
       it('should build retention copy for hourly retention', () => {
         const retention = { h: 24 };
@@ -1286,6 +1323,42 @@ describe('CephfsMirroringFsMirrorPathsComponent', () => {
           actionDescription: 'remove'
         })
       );
+    });
+
+    it('should delete snapshot schedules before removing the mirror path', () => {
+      const modalService = TestBed.inject(ModalCdsService) as any;
+      const snapshotScheduleService = TestBed.inject(CephfsSnapshotScheduleService) as any;
+      snapshotScheduleService.getSnapshotSchedule.mockReturnValue(
+        of([
+          {
+            path: '/volumes/group/subvol/uuid/..',
+            rel_path: '/path1',
+            schedule: '1h',
+            start: '2024-01-01T00:00:00Z',
+            fs: 'test-fs',
+            subvol: 'subvol',
+            group: 'group'
+          }
+        ])
+      );
+      snapshotScheduleService.delete.mockReturnValue(of({}));
+      cephfsService.removeMirrorDirectory.mockReturnValue(of({}));
+      component.selection = new CdTableSelection([{ path: '/path1' }]);
+      component.fsName = 'test-fs';
+
+      component.removePathModal();
+      modalService.show.mock.calls[0][1].submitActionObservable().subscribe();
+
+      expect(snapshotScheduleService.delete).toHaveBeenCalledWith({
+        path: '/volumes/group/subvol/uuid/..',
+        schedule: '1h',
+        start: '2024-01-01T00:00:00Z',
+        fs: 'test-fs',
+        retentionPolicy: undefined,
+        subvol: 'subvol',
+        group: 'group'
+      });
+      expect(cephfsService.removeMirrorDirectory).toHaveBeenCalledWith('test-fs', '/path1');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.ts
@@ -8,7 +8,7 @@ import {
   inject
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { BehaviorSubject, of, Subscription } from 'rxjs';
+import { BehaviorSubject, forkJoin, Observable, of, Subscription } from 'rxjs';
 import { catchError, map, shareReplay, startWith, switchMap, tap } from 'rxjs/operators';
 import { CephfsService } from '~/app/shared/api/cephfs.service';
 import { CephfsSnapshotScheduleService } from '~/app/shared/api/cephfs-snapshot-schedule.service';
@@ -300,7 +300,8 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
             fsName: this.fsName,
             path
           }),
-          call: this.cephfsService.removeMirrorDirectory(this.fsName, path).pipe(
+          call: this.deleteSnapshotSchedulesForPath(path).pipe(
+            switchMap(() => this.cephfsService.removeMirrorDirectory(this.fsName, path)),
             tap(() => {
               if (this.selectedPath?.path === path) {
                 this.closeSidePanel();
@@ -867,12 +868,7 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
       return;
     }
 
-    const retentionPolicy = policy.retention
-      ? Object.entries(policy.retention)
-          .filter(([, interval]) => interval !== null && interval !== undefined)
-          .map(([frequency, interval]) => `${interval}-${frequency}`)
-          .join('|')
-      : undefined;
+    const retentionPolicy = this.buildRetentionPolicyString(policy.retention);
 
     this.removingSchedule = `${policy.path}@${policy.schedule}`;
     this.subscriptions.add(
@@ -882,12 +878,19 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
           schedule: policy.schedule,
           start: policy.start,
           fs: policy.fs || this.fsName,
-          retentionPolicy
+          retentionPolicy,
+          subvol: policy.subvol,
+          group: policy.group
         })
         .subscribe(
           () => {
             this.removingSchedule = '';
-            this.loadSchedulePolicies(policy.path);
+            this.schedulePolicies = this.schedulePolicies.filter(
+              (entry) => entry.removeId !== policy.removeId
+            );
+            if (this.selectedPath?.path) {
+              this.loadSchedulePolicies(this.selectedPath.path);
+            }
           },
           () => {
             this.removingSchedule = '';
@@ -927,6 +930,21 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
 
   private formatRetentionCopy(retentionCopy?: string[]): string {
     return retentionCopy?.length ? retentionCopy.join(', ') : '-';
+  }
+
+  private buildRetentionPolicyString(
+    retention?: Record<string, number> | string
+  ): string | undefined {
+    if (!retention || typeof retention === 'string') {
+      return undefined;
+    }
+
+    const retentionPolicy = Object.entries(retention)
+      .filter(([, interval]) => interval !== null && interval !== undefined)
+      .map(([frequency, interval]) => `${interval}-${frequency}`)
+      .join('|');
+
+    return retentionPolicy || undefined;
   }
 
   private buildRetentionCopy(retention?: Record<string, number>): string[] {
@@ -1007,6 +1025,41 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
     }
 
     return nextSync.toLocaleString();
+  }
+
+  private deleteSnapshotSchedulesForPath(path: string): Observable<void> {
+    return this.snapshotScheduleService.getSnapshotSchedule(path, this.fsName, false).pipe(
+      catchError(() => of([])),
+      switchMap((policies) => {
+        const normalizedPath = this.normalizePath(path);
+        const schedules = policies.filter(
+          (policy) =>
+            this.normalizePath(policy.path) === normalizedPath ||
+            this.normalizePath(policy.rel_path) === normalizedPath
+        );
+        if (!schedules.length) {
+          return of(undefined);
+        }
+
+        return forkJoin(
+          schedules.map((policy) => {
+            const retentionPolicy = this.buildRetentionPolicyString(policy.retention);
+
+            return this.snapshotScheduleService
+              .delete({
+                path: policy.path,
+                schedule: policy.schedule,
+                start: policy.start,
+                fs: policy.fs || this.fsName,
+                retentionPolicy,
+                subvol: policy.subvol,
+                group: policy.group
+              })
+              .pipe(catchError(() => of(undefined)));
+          })
+        ).pipe(map(() => undefined));
+      })
+    );
   }
 
   private normalizePath(path?: string): string {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/snapshot-schedule.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/snapshot-schedule.ts
@@ -4,6 +4,7 @@ import { ICON_TYPE } from '~/app/shared/enum/icons.enum';
 export interface SnapshotSchedule {
   fs?: string;
   subvol?: string;
+  group?: string;
   path: string;
   rel_path?: string;
   schedule: string;


### PR DESCRIPTION

Signed-off-by: Dnyaneshwari Talwekar dtalweka@redhat.com

Fixes: https://tracker.ceph.com/issues/79287


**Issue:**
When a user attempted to remove a schedule, the schedule was successfully removed from the backend, but the entry was still visible in the UI.

**Solution:**
An additional API call is triggered after removing the schedule to refresh the data, ensuring that the removed schedule entry is also cleared from the UI.

Before:-

https://github.com/user-attachments/assets/f20b8935-3610-4f48-a268-f04821d1a83f



After: -

https://github.com/user-attachments/assets/8354a8eb-8090-4500-a2c9-3559f5335a91


https://github.com/user-attachments/assets/b7234b08-bd09-4f04-9d6c-454ead2e4efd





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
