### PR TITLE
mds: safely defer old fragment cleanup to fix auth_pins assert

### DIFF
--- a/qa/tasks/cephfs/test_fragment.py
+++ b/qa/tasks/cephfs/test_fragment.py
@@ -409,6 +409,69 @@ class TestFragmentation(CephFSTestCase):
         self.assertEqual(self.get_merges(), 0)
         self.assertEqual(len(self.get_dir_ino("/splitdir")["dirfrags"]), 2)
 
+    def test_finish_old_fragment_auth_pin_race(self):
+        """
+        Reproduce the race condition between directory fragmentation (split/merge)
+        and concurrent client metadata operations generating auth_pins.
+        """
+        log.info("Testing auth_pin race condition during fragment split/merge...")
+
+        # Configure the MDS balancer for ultra-aggressive fragmentation
+        self._configure(
+            mds_bal_split_size=20,
+            mds_bal_merge_size=5,
+            mds_bal_interval=1,
+            mds_bal_fragment_interval=1
+        )
+
+        time.sleep(5)
+
+        test_dir = "frag_race_dir"
+        self.mount_a.run_shell(['mkdir', '-p', test_dir])
+
+        # Define the background workloads for the client
+        spawner_script = f"""
+        while true; do
+            touch {test_dir}/file_{{1..50}} > /dev/null 2>&1 || true
+            sleep 0.2
+            rm -f {test_dir}/file_{{1..50}} > /dev/null 2>&1 || true
+            sleep 0.2
+        done
+        """
+
+        pinner_script = f"""
+        while true; do
+            stat {test_dir}/file_* > /dev/null 2>&1 || true
+            chmod 777 {test_dir}/file_* > /dev/null 2>&1 || true
+        done
+        """
+
+        # Write and execute the workloads
+        self.mount_a.client_remote.write_file('/tmp/spawner.sh', spawner_script.encode('utf-8'))
+        self.mount_a.client_remote.write_file('/tmp/pinner.sh', pinner_script.encode('utf-8'))
+        self.mount_a.client_remote.run(args=['chmod', '+x', '/tmp/spawner.sh', '/tmp/pinner.sh'])
+
+        spawner_proc = self.mount_a.run_shell(['bash', '/tmp/spawner.sh'], wait=False)
+        pinner_proc = self.mount_a.run_shell(['bash', '/tmp/pinner.sh'], wait=False)
+
+        run_time = 120
+        sleep_interval = 5
+        try:
+            for i in range(run_time // sleep_interval):
+                # Actively verify the MDS ranks are still active.
+                # wait_for_daemons() returns instantly if the MDS is healthy, but will
+                # block and fail if a daemon crashes. Looping it here acts as a fail-fast
+                # heartbeat, ensuring we catch any assertion failures from the race
+                # condition immediately during the 120s window rather than waiting blindly.
+                self.fs.wait_for_daemons()
+                time.sleep(sleep_interval)
+        finally:
+            # Use pkill to terminate the infinite loops.
+            self.mount_a.client_remote.run(args=['pkill', '-f', 'spawner.sh'], check_status=False)
+            self.mount_a.client_remote.run(args=['pkill', '-f', 'pinner.sh'], check_status=False)
+            self.mount_a.client_remote.run(args=['rm', '-f', '/tmp/spawner.sh', '/tmp/pinner.sh'])
+            self.mount_a.run_shell(['rm', '-rf', test_dir])
+
     def _run_dir_frag(self, killpoint):
         self._test_oversize(killpoint=killpoint)
 

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -991,6 +991,16 @@ void CDir::finish_old_fragment(MDSContext::vec& waiters, bool replay)
     }
   }
 
+  // If concurrent operations still hold auth_pins on this old fragment,
+  // defer final object cleanup until the final auth_unpin() executes.
+  if (auth_pins > 0) {
+    dout(10) << __func__ << " deferred fragment cleanup, auth_pins=" << auth_pins
+             << " on " << *this << dendl;
+    return;
+  }
+
+  state_clear(STATE_FRAGMENTING);
+
   ceph_assert(dir_auth_pins == 0);
   ceph_assert(auth_pins == 0);
 
@@ -1009,9 +1019,6 @@ void CDir::finish_old_fragment(MDSContext::vec& waiters, bool replay)
     put(PIN_EXPORTBOUND);
   if (is_subtree_root())
     put(PIN_SUBTREE);
-
-  if (auth_pins > 0)
-    put(PIN_AUTHPIN);
 
   ceph_assert(get_num_ref() == (state_test(STATE_STICKY) ? 1:0));
 }
@@ -3184,8 +3191,6 @@ void CDir::auth_unpin(void *by)
     auth_pin_set.erase(it);
   }
 #endif
-  if (auth_pins == 0)
-    put(PIN_AUTHPIN);
 
   dout(10) << "auth_unpin by " << by << " on " << *this << " count now " << auth_pins << dendl;
   ceph_assert(auth_pins >= 0);
@@ -3194,6 +3199,19 @@ void CDir::auth_unpin(void *by)
     freeze_tree_state->auth_pins -= 1;
 
   maybe_finish_freeze();  // pending freeze?
+
+  // Drop the auth pin and trigger deferred cleanup
+  if (auth_pins == 0) {
+    put(PIN_AUTHPIN);
+
+    if (state_test(STATE_FRAGMENTING)) {
+      dout(10) << __func__
+               << " auth_pins reached 0, completing deferred fragment cleanup on "
+               << *this << dendl;
+      MDSContext::vec dummy_waiters;
+      finish_old_fragment(dummy_waiters, true); // pass replay=true to bypass re-unfreezing/re-unpinning
+    }
+  }
 }
 
 void CDir::adjust_nested_auth_pins(int dirinc, void *by)


### PR DESCRIPTION
This PR addresses a race condition during directory fragmentation (splits/merges) where the MDS can crash with `FAILED ceph_assert(auth_pins == 0)` if it attempts to clean up an old directory fragment while concurrent client operations are still actively using it. This PR decouples the cleanup into a safe, deferred garbage collection queue.

1. **Defers Cleanup**: Modifies CDir::split and CDir::merge to check for active client contention (using expected_auth_pins and dir_auth_pins). If the fragment is still in use, cleanup is deferred.

2. **New GC Queue**: Introduces a `PIN_DELAYEDDROP` pin to safely protect these busy fragments and pushes them to a `MDCache::delayed_fragment_deletes` queue.

3. **Background Sweeping**: Hooks into the `MDCache::trim()` cycle to periodically check the queue. The MDS safely executes `finish_old_fragment` in the background only after all client locks have naturally drained.

4. **Adds QA Regression Test**: Adds a Teuthology stress test `test_finish_old_fragment_auth_pin_race` that aggressively forces fragmentation while running heavy concurrent client workloads to validate the fix.

Fixes: https://tracker.ceph.com/issues/61363


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
