### PR TITLE
mgr/cephadm: fix NodeProxyCache.save() not updating 'in memory' data

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -1839,7 +1839,11 @@ class NodeProxyCache:
 
     def save(self,
              host: str = '',
-             data: Dict[str, Any] = {}) -> None:
+             data: Optional[Dict[str, Any]] = None) -> None:
+        if data is None:
+            data = {}
+        host = normalize_hostname(host)
+        self.data[host] = data
         self.mgr.set_store(f'{NODE_PROXY_CACHE_PREFIX}/data/{host}', json.dumps(data))
 
     def update_oob(self, host: str, host_oob_info: Dict[str, str]) -> None:

--- a/src/pybind/mgr/cephadm/tests/test_node_proxy.py
+++ b/src/pybind/mgr/cephadm/tests/test_node_proxy.py
@@ -358,3 +358,44 @@ class TestNodeProxyEndpoint(helper.CPWebCase):
     def test_firmwares_legacy_endpoint(self):
         self.getPage("/host02/firmwares", method="GET")
         self.assertStatus('200 OK')
+
+
+class TestNodeProxyCacheSave:
+    def _make_cache(self) -> NodeProxyCache:
+        mgr = MagicMock()
+        mgr.get_store = MagicMock(return_value='{}')
+        mgr.set_store = MagicMock()
+        mgr.inventory = {}
+        cache = NodeProxyCache(mgr)
+        return cache
+
+    def test_save_updates_in_memory_data(self):
+        cache = self._make_cache()
+        data = {'status': {'storage': {}, 'fans': {}}, 'sn': 'ABC123'}
+        cache.save(host='host01', data=data)
+        assert cache.data['host01'] == data
+
+    def test_save_in_memory_data_includes_new_keys_after_upgrade(self):
+        cache = self._make_cache()
+        # Simulate what load() would have populated from the old KV store
+        cache.data['host01'] = {'status': {'storage': {}, 'fans': {}}, 'sn': 'ABC123'}
+        # Node-proxy POSTs new data with fcm after upgrade
+        new_data = {'status': {'storage': {}, 'fans': {}, 'fcm': {'local': {'nvme0n1': {}}}}, 'sn': 'ABC123'}
+        cache.save(host='host01', data=new_data)
+        assert 'fcm' in cache.data['host01']['status']
+
+    def test_save_normalizes_hostname(self):
+        cache = self._make_cache()
+        data = {'status': {}, 'sn': 'XYZ'}
+        cache.save(host='HOST01', data=data)
+        assert 'host01' in cache.data
+        assert 'HOST01' not in cache.data
+
+    def test_save_writes_to_kv_store(self):
+        cache = self._make_cache()
+        data = {'status': {}, 'sn': 'XYZ'}
+        cache.save(host='host01', data=data)
+        cache.mgr.set_store.assert_called_once()
+        key, value = cache.mgr.set_store.call_args[0]
+        assert 'host01' in key
+        assert json.loads(value) == data


### PR DESCRIPTION
NodeProxyCache.save() was writing the node-proxy data to the KV store but never updating self.data in memory. This could cause a KeyError when running `ceph orch hardware status --category fcm` on clusters upgraded from a version that did not support FCM: load() would populate self.data from the (old) KV store without the fcm key, and subsequent POSTs from the node-proxy would update the KV store correctly but leave self.data stale for the lifetime of the MGR process.


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
