### PR TITLE
os/bluestore/BlueFS: fix envelope header alignment for non-4K page hosts

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -4263,7 +4263,12 @@ void BlueFS::append_try_flush(FileWriter *h, const char* buf, size_t len)/*_WF_L
       h->envelope_head_filler = h->append_hole(File::envelope_t::head_size());
       uint32_t pos1 = h->get_effective_write_pos() - File::envelope_t::head_size();
       uint32_t pos2 = reinterpret_cast<uintptr_t>(h->envelope_head_filler.c_str());
-      ceph_assert(p2aligned(pos1 ^ pos2, CEPH_PAGE_SIZE));
+      // Buffer memory must mirror the on-disk position, but only up to
+      // the smaller of the page size (alignment of fresh appender
+      // chunks) and the block size (padding granularity of envelope
+      // flushes) - the two can differ in either direction.
+      ceph_assert(p2aligned(pos1 ^ pos2,
+                            std::min<uint32_t>(CEPH_PAGE_SIZE, super.block_size)));
     }
     size_t max_size = 1ull << 30; // cap to 1GB
     while (len > 0) {

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -464,7 +464,12 @@ public:
       : file(std::move(f))
       , super_block_size(super_block_size)
       , buffer_appender(buffer.get_page_aligned_appender(
-        std::max<uint64_t>(g_conf()->bluefs_alloc_size, 2 * super_block_size) / CEPH_PAGE_SIZE))
+        // round up: when CEPH_PAGE_SIZE exceeds the wanted capacity this
+        // must not truncate to 0 pages, or refill() allocates nothing and
+        // append_hole() falls back to an unaligned buffer
+        p2roundup<uint64_t>(
+          std::max<uint64_t>(g_conf()->bluefs_alloc_size, 2 * super_block_size),
+          CEPH_PAGE_SIZE) / CEPH_PAGE_SIZE))
       , envelope_head_filler() {
       ++file->num_writers;
       iocv.fill(nullptr);

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 sts=2 expandtab
 
+#include <bit>
 #include <chrono>
 #include <stdio.h>
 #include <string.h>
@@ -16,6 +17,7 @@
 #include "common/debug.h"
 #include "global/global_init.h"
 #include "common/ceph_argparse.h"
+#include "include/page.h"
 #include "include/stringify.h"
 #include "include/scope_guard.h"
 #include "common/errno.h"
@@ -1223,6 +1225,70 @@ TEST_F(BlueFS_wal, wal_v2_check_split_header_small_alloc)
   many_small_reads("db.wal", "wal1.log", read_content, 4076 + 4077, 4076, 4077);
   ASSERT_EQ(content, read_content);
   fs.umount();
+}
+
+// Simulates a host whose VM page size differs from the 4K BlueFS
+// block size, as on 16K (Apple Silicon) or 64K aarch64 kernels.
+struct PageSizeOverride {
+  unsigned old_size = ceph::_page_size;
+  unsigned long old_mask = ceph::_page_mask;
+  unsigned old_shift = ceph::_page_shift;
+  explicit PageSizeOverride(unsigned size) {
+    ceph_assert(std::has_single_bit(size));
+    ceph::_page_size = size;
+    ceph::_page_mask = ~(unsigned long)(size - 1);
+    ceph::_page_shift = std::countr_zero(size);
+  }
+  ~PageSizeOverride() {
+    ceph::_page_size = old_size;
+    ceph::_page_mask = old_mask;
+    ceph::_page_shift = old_shift;
+  }
+};
+
+// Run the envelope-mode small-writes workload under a simulated 16K
+// page size. 256K of content crosses several appender refill
+// boundaries and buffer.clear() events.
+static void wal_v2_16k_page_size_case(BlueFS_wal& t, const char* alloc_size)
+{
+  PageSizeOverride page_size_override(16384);
+  ConfSaver conf(g_ceph_context->_conf);
+  conf.SetVal("bluefs_min_flush_size", "65536");
+  conf.SetVal("bluefs_wal_envelope_mode", "true");
+  conf.SetVal("bluefs_alloc_size", alloc_size);
+  conf.ApplyChanges();
+
+  t.Create(1048576 * 256, 1048576 * 128, 1048576 * 64);
+  ASSERT_EQ(0, t.fs.mount());
+
+  bufferlist content;
+  t.many_small_writes("db.wal", "wal1.log", content, 256 * 1024, 4076, 4077);
+  t.fs.umount();
+  t.fs.mount();
+  bufferlist read_content;
+  t.many_small_reads("db.wal", "wal1.log", read_content, 256 * 1024, 4076, 4077);
+  ASSERT_EQ(content, read_content);
+  t.fs.umount();
+}
+
+TEST_F(BlueFS_wal, wal_v2_16k_page_size)
+{
+  // Reproducer for https://tracker.ceph.com/issues/79141: on hosts
+  // whose page size exceeds the BlueFS block size, the envelope
+  // header alignment assert in append_try_flush() fired for write
+  // positions that are block-aligned but not page-aligned.
+  //
+  wal_v2_16k_page_size_case(*this, "65536");
+}
+
+TEST_F(BlueFS_wal, wal_v2_16k_page_size_small_alloc)
+{
+  // Same with bluefs_alloc_size below the simulated page size: the
+  // appender's min_pages computation must round up rather than
+  // truncate to 0 pages, or append_hole() falls back to an unaligned
+  // buffer and the alignment assert fires.
+  //
+  wal_v2_16k_page_size_case(*this, "4096");
 }
 
 TEST_F(BlueFS_wal, wal_v2_check_feature)


### PR DESCRIPTION
On hosts whose VM page size exceeds the BlueFS block size (16K Apple Silicon, 64K aarch64 kernels), every OSD with WAL v2 envelope mode enabled (the default) aborts at startup:

```
FAILED ceph_assert(p2aligned(pos1 ^ pos2, ceph::_page_size))
```

The assert (introduced in 4c03bbea4437, first released in v20.2.3) requires the envelope header's buffer address to mirror its file position modulo the runtime VM page size, but the write path only maintains that congruence modulo min(page size, block size): envelope flushes pad the on-disk stream to `super.block_size`, while fresh appender chunks are page-aligned allocations. Direct I/O itself only needs block-size memory alignment, so check the congruence the code actually maintains.

A second latent issue is fixed alongside: the FileWriter appender sizing integer-truncated to 0 pages when `bluefs_alloc_size` <= page size, making `append_hole()` fall back to an unaligned buffer.

The added tests override `ceph::_page_size` to reproduce the abort deterministically on any architecture; both fail before the fix and pass after. Full `ceph_test_bluefs` passes (48/48) on two x86 hosts, plus a live-OSD smoke on real NVMe: restart on existing data (exercising WAL replay + append at an inherited offset, the field crash path) and a 4K-write bench, ~10k envelope WAL flushes, no asserts.

The regression shipped in v20.2.3, so this needs a tentacle backport; squid is unaffected (no envelope mode there).

Fixes: https://tracker.ceph.com/issues/79141

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests
