### PR TITLE
mgr/dashboard: fix CephFS mirror last sync time display

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-mirror-paths/cephfs-mirroring-fs-mirror-paths.component.ts
@@ -34,6 +34,7 @@ import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { RelativeDatePipe } from '~/app/shared/pipes/relative-date.pipe';
+import { MirroringSyncUtils } from '../mirroring-sync-utils';
 
 type SnapshotReplicationStatus = 'in-progress' | 'replicated' | 'pending' | 'failed';
 type SyncStatus = 'syncing' | 'idle' | 'failed' | 'completed';
@@ -442,6 +443,9 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
 
     const syncStatus = (peerInfo.state ?? 'idle') as SyncStatus;
     const snapshots = this.buildSnapshotList(peerInfo, syncStatus);
+    const lastSyncedAt = MirroringSyncUtils.parseSyncTimeStamp(
+      peerInfo.last_synced_snap?.sync_time_stamp
+    );
 
     return {
       path,
@@ -453,11 +457,7 @@ export class CephfsMirroringFsMirrorPathsComponent implements OnInit, OnDestroy 
       currentSyncMode: currentSnap?.['sync-mode'],
       lastSyncedSnapshot: peerInfo.last_synced_snap?.name ?? '-',
       lastSyncedTime:
-        peerInfo.last_synced_snap?.sync_time_stamp != null
-          ? this.relativeDatePipe.transform(
-              parseFloat(String(peerInfo.last_synced_snap.sync_time_stamp))
-            )
-          : undefined,
+        lastSyncedAt != null ? this.relativeDatePipe.transform(lastSyncedAt) : undefined,
       snapshotCount: peerInfo.snaps_synced ?? 0,
       pendingSnapshotCount: snapshots.filter(
         (snapshot) => snapshot.status === 'in-progress' || snapshot.status === 'pending'

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-overview/cephfs-mirroring-fs-overview.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-fs-overview/cephfs-mirroring-fs-overview.component.spec.ts
@@ -64,9 +64,8 @@ describe('CephfsMirroringFsOverviewComponent', () => {
             last_synced_snap: {
               name: 'snap1',
               sync_bytes: '1.00 KiB',
-              sync_time_stamp: '1786358053.364396s'
-            },
-            metrics_updated_at: 1_700_000_000
+              sync_time_stamp: '2026-08-12T13:32:21.383628+0000'
+            }
           }
         }
       },
@@ -148,7 +147,7 @@ describe('CephfsMirroringFsOverviewComponent', () => {
     expect(fsData?.sync.bytesSynced).toBe('1 KiB');
     expect(fsData?.sync.path).toBe('/dir1');
     expect(fsData?.sync.snapName).toBe('snap1');
-    expect(fsData?.sync.syncedAt).toBe(1786358053.364396);
+    expect(fsData?.sync.syncedAt).toBe(1786541541.383);
   });
 
   it('should refresh overview data on interval tick', async () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mirroring-list/cephfs-mirroring-list.component.spec.ts
@@ -184,9 +184,8 @@ describe('CephfsMirroringListComponent', () => {
                 last_synced_snap: {
                   name: 'snap1',
                   sync_bytes: '1.00 MiB',
-                  sync_time_stamp: '1s'
-                },
-                metrics_updated_at: 1_700_000_000
+                  sync_time_stamp: '2026-08-12T13:32:21.383628+0000'
+                }
               }
             }
           }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/mirroring-sync-utils.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/mirroring-sync-utils.spec.ts
@@ -93,6 +93,48 @@ describe('MirroringSyncUtils', () => {
     expect(info.syncedAt).toBeNull();
   });
 
+  it('parseSyncTimeStamp handles ISO-8601 and epoch sync_time_stamp values', () => {
+    expect(MirroringSyncUtils.parseSyncTimeStamp('2026-08-12T13:32:21.383628+0000')).toBe(
+      1786541541.383
+    );
+    expect(MirroringSyncUtils.parseSyncTimeStamp('1786358053.364396s')).toBe(1786358053.364396);
+    expect(MirroringSyncUtils.parseSyncTimeStamp(1786443055.4675815)).toBe(1786443055.4675815);
+    expect(MirroringSyncUtils.parseSyncTimeStamp(undefined)).toBeNull();
+  });
+
+  it('extractLatestSync picks the latest snapshot from ISO sync_time_stamp values', () => {
+    const sync = MirroringSyncUtils.extractLatestSync({
+      metrics: {
+        '/old': {
+          peer: {
+            p1: {
+              state: 'idle',
+              last_synced_snap: {
+                name: 'old',
+                sync_time_stamp: '2026-08-12T13:00:00.000000+0000'
+              }
+            }
+          }
+        },
+        '/new': {
+          peer: {
+            p2: {
+              state: 'idle',
+              last_synced_snap: {
+                name: 'new',
+                sync_time_stamp: '2026-08-12T13:32:21.383628+0000'
+              }
+            }
+          }
+        }
+      }
+    });
+
+    expect(sync.info.snapName).toBe('new');
+    expect(sync.info.path).toBe('/new');
+    expect(sync.info.syncedAt).toBe(1786541541.383);
+  });
+
   it('parseSyncBytes handles numeric and human-readable values', () => {
     expect(MirroringSyncUtils.parseSyncBytes('1.00 MiB')).toBe(1048576);
     expect(MirroringSyncUtils.parseSyncBytes(2048)).toBe(2048);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/mirroring-sync-utils.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/mirroring-sync-utils.ts
@@ -39,9 +39,8 @@ export class MirroringSyncUtils {
           hasBytesSynced = true;
         }
 
-        // sync_time_stamp is a wall-clock Unix epoch (number or "<epoch>s" string).
-        const syncTime = parseFloat(String(snap.sync_time_stamp ?? ''));
-        if (syncTime >= latestSyncTime) {
+        const syncTime = MirroringSyncUtils.parseSyncTimeStamp(snap.sync_time_stamp);
+        if (syncTime !== null && syncTime >= latestSyncTime) {
           latestSyncTime = syncTime;
           latestSnapName = snap.name ?? '';
           latestSyncPath = dirPath;
@@ -58,6 +57,31 @@ export class MirroringSyncUtils {
         syncedAt: latestSyncTime || null
       }
     };
+  }
+
+  static parseSyncTimeStamp(value: number | string | undefined | null): number | null {
+    if (value === undefined || value === null || value === '') {
+      return null;
+    }
+    if (typeof value === 'number') {
+      return Number.isFinite(value) && value > 0 ? value : null;
+    }
+
+    const str = String(value).trim();
+    if (!str) {
+      return null;
+    }
+
+    if (str.includes('T')) {
+      const ms = Date.parse(str.replace(/([+-]\d{2})(\d{2})$/, '$1:$2'));
+      if (!Number.isFinite(ms)) {
+        return null;
+      }
+      return ms / 1000;
+    }
+
+    const epoch = parseFloat(str);
+    return Number.isFinite(epoch) && epoch > 0 ? epoch : null;
   }
 
   static parseSyncBytes(value: number | string | undefined | null): number | null {


### PR DESCRIPTION
The timestamp formatting was udpated from the backend (I was using wrong image on my latest testing) and this last sync values were coming wrong. Fixing it here to properly desplay the actual values fro last sync time

<img width="1890" height="643" alt="image" src="https://github.com/user-attachments/assets/90c455b8-aac4-46b5-a3b8-b9e72c7f2bc1" />





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
