### PR TITLE
doc: update CVE developer guide and security release process

### DIFF
--- a/doc/dev/developer_guide/cve.rst
+++ b/doc/dev/developer_guide/cve.rst
@@ -8,7 +8,7 @@ embargo. This means the fix cannot be pushed to the public ``ceph/ceph``
 repository, built using the public build infrastructure, or discussed in
 public channels until the embargo is lifted. Instead, each CVE has its own
 private fork of ``ceph/ceph`` (for example,
-``ceph/ceph-ghsa-xrjv-7fcr-h485``) where the fix is developed. Builds and
+``ceph/ceph-ghsa-abcd-1234-beef``) where the fix is developed. Builds and
 tests use internal infrastructure in the `Sepia lab
 <https://wiki.sepia.ceph.com/doku.php>`_.
 
@@ -23,10 +23,39 @@ Gabriella Roman to add you as a collaborator to the parent advisory
 
 Private CVE forks can be built using the `cve-pipeline
 <https://jenkins.ceph.com/job/cve-pipeline>`_ (404s unless logged in and authorized)
-Jenkins job. Access to the this job is limited to Ceph GitHub organization
+Jenkins job. Access to this job is limited to Ceph GitHub organization
 admins and members of the `ceph/security <https://github.com/orgs/ceph/teams/security>`_
 GitHub Team. Again, if you do not have access to see the cve-pipeline
 job, ask Sage or Gabriella for access.
+
+A note about terminology
+------------------------
+
+Three separate git repositories will be used when developing a CVE fix.
+
+In this document, "private fork" and "ceph-private" will be referenced.
+
+For clarity,
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Repository
+     - Git remote
+     - Purpose
+   * - ``ceph/ceph`` (the public repository)
+     - ``origin``
+     - Clone from here and base the fix on its target branch. **Never** push
+       the fix here until the embargo is lifted.
+   * - ``ceph/ceph-ghsa-*`` (the "advisory fork" or "private fork")
+     - ``advisory``
+     - Develop, build (via cve-pipeline), and test the fix under embargo. Open a
+       pull request here, but **do not merge** it.
+   * - ``ceph/ceph-private``
+     - ``private``
+     - Push the finished branch here so the Release Manager can build the
+       security release from it.
 
 Developing the Fix
 ------------------
@@ -37,31 +66,34 @@ Developing the Fix
 
       git clone https://github.com/ceph/ceph.git
 
-#. Add the CVE's private fork as a remote by adding the following to
-   ``.git/config`` in your local working copy, substituting the fork for your
-   CVE:
-
-   .. code-block:: ini
-
-      [remote "private"]
-              url = git@github.com:ceph/ceph-ghsa-xrjv-7fcr-h485.git
-              fetch = +refs/heads/*:refs/remotes/private/*
+#. Check out the target branch (probably ``main``)
 
 #. Create a branch and develop the fix as you would for any other bug. See
    :ref:`basic workflow dev guide` for the general development workflow.
 
+   .. prompt:: bash $
+
+      git checkout -b $BRANCH_NAME
+
+   .. warning::
+
+      Do **not** include any information pertaining to the CVE (for example, the
+      CVE ID or a description of the vulnerability) in the branch name. Branch
+      names are visible in public shaman build and repo metadata as well as in
+      teuthology job results in Paddles and Pulpito, even when the branch itself
+      is pushed only to the private repository.
+
+#. Add the CVE's private fork to your clone:
+
+   .. prompt:: bash $
+
+      git remote add advisory git@github.com:ceph/ceph-ghsa-abcd-1234-beef.git
+
 .. note::
 
-   A branch just needs to be pushed to the private fork in order to start a
-   package and container build.
-
-.. warning::
-
-   Do **not** include any information pertaining to the CVE (for example, the
-   CVE ID or a description of the vulnerability) in the branch name. Branch
-   names are visible in public shaman build and repo metadata as well as in
-   teuthology job results in paddles and Pulpito, even when the branch itself
-   is pushed only to the private repository.
+   Pushing a branch to the private fork or ceph-private.git will not
+   automatically trigger a build.  You must trigger the Jenkins job manually
+   below.
 
 Building the Fix
 ----------------
@@ -70,7 +102,7 @@ When the fix is ready to be built, push the branch to the private fork:
 
 .. prompt:: bash $
 
-   git push private $BRANCH_NAME
+   git push advisory $BRANCH_NAME
 
 Then manually trigger the `cve-pipeline
 <https://jenkins.ceph.com/job/cve-pipeline>`_
@@ -148,6 +180,18 @@ that was built:
 Merging the fix
 ---------------
 
-Once you have tested your changes and are happy with the fix, create a pull
-request in the private fork. It will eventually get merged into the ceph.git
-repo via the parent advisory.
+Once you have tested your changes and are happy with the fix,
+
+#. Open a pull request in the private fork but DO NOT MERGE it.
+
+#. Add the ceph-private repo to your remotes and push the same branch there:
+
+   .. prompt:: bash $
+
+      git remote add private git@github.com:ceph/ceph-private.git
+
+      git push private $BRANCH_NAME
+
+#. Notify the Release Manager. They will proceed with the Release process as
+   normal
+   https://docs.ceph.com/en/latest/dev/release-process/#security-release-process-deviation.

--- a/doc/dev/developer_guide/cve.rst
+++ b/doc/dev/developer_guide/cve.rst
@@ -104,7 +104,11 @@ When the fix is ready to be built, push the branch to the private fork:
 
    git push advisory $BRANCH_NAME
 
-Then manually trigger the `cve-pipeline
+At this point, you are encouraged to open a Pull Request in the private fork
+even if your changes aren't ready to be merged yet. This allows peer review to
+begin.
+
+Manually trigger the `cve-pipeline
 <https://jenkins.ceph.com/job/cve-pipeline>`_
 Jenkins job.
 
@@ -177,21 +181,85 @@ that was built:
 
    podman pull quay-int.front.sepia.ceph.com/ceph-ci/ceph:$BRANCH_NAME
 
-Merging the fix
----------------
+Preparing the fix for release
+-----------------------------
 
 Once you have tested your changes and are happy with the fix,
 
-#. Open a pull request in the private fork but DO NOT MERGE it.
+#. Comment in the pull request in the private fork that it's ready for review
+   but DO NOT MERGE it.
 
-#. Add the ceph-private repo to your remotes and push the same branch there:
+   .. note::
+
+      Merging the fix would disclose the CVE before the release is ready.
+      *Releasing* the fix is what requires pushing the branch to
+      ceph-private.git: official signed releases must be built from the
+      ceph-private.git repo because, for security reasons, the
+      ceph-release-pipeline job can only build from ceph.git or
+      ceph-private.git.
+
+#. Create a backport branch in the advisory for each Ceph release branch the
+   fix applies to. The backport is based on that release's most recent tag, not
+   on the release branch itself. For example, if the latest release of tentacle
+   was 20.2.3:
+
+   .. prompt:: bash $
+
+      git checkout -b ${BRANCH_NAME}-tentacle v20.2.3
+      git cherry-pick -x $SHA1_OF_YOUR_FIX_FROM_BRANCH_NAME
+      git push advisory ${BRANCH_NAME}-tentacle
+
+#. Repeat this and open a Pull Request in the advisory for each applicable
+   release branch.
+
+#. Add the ceph-private repo to your remotes:
 
    .. prompt:: bash $
 
       git remote add private git@github.com:ceph/ceph-private.git
 
-      git push private $BRANCH_NAME
+#. Push each of those backport branches to ceph-private.git, renamed to
+   ``$RELEASE-release``. The branch name matters: the release process builds
+   from ``$RELEASE-release`` branches regardless of release type, not just for
+   CVEs. Continuing the tentacle example, with ``${BRANCH_NAME}-tentacle``
+   checked out:
+
+   .. prompt:: bash $
+
+      git checkout -B tentacle-release
+      git push -f private tentacle-release
 
 #. Notify the Release Manager. They will proceed with the Release process as
    normal
    https://docs.ceph.com/en/latest/dev/release-process/#security-release-process-deviation.
+
+What Success Looks Like
+-----------------------
+
+In the end, you should have:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - What
+     - Where
+     - Contents
+   * - One **pull request** targeting ``main``
+     - advisory fork
+     - Your fix commit(s) on top of ``main``.
+   * - One **pull request** per affected release, targeting that release
+       branch
+     - advisory fork
+     - Your fix commit(s) cherry-picked from ``$BRANCH_NAME`` onto that
+       release's most recent tag.
+   * - One **branch** per affected release, named ``$RELEASE-release``
+       (for example ``tentacle-release``)
+     - ``ceph-private``
+     - That release's most recent tag (e.g., ``v20.2.3``) plus your
+       cherry-picked commits.
+
+Nothing is merged and nothing is pushed to ceph.git. The Release Manager builds
+the signed release from the ``$RELEASE-release`` branches in ceph-private.git,
+and the advisory pull requests are what eventually land in ceph.git once the
+embargo is lifted.

--- a/doc/dev/release-process.rst
+++ b/doc/dev/release-process.rst
@@ -54,31 +54,72 @@ A hotfix release has a couple differences.
 5. Notify the "Build Lead" to start the build.
 6. The "Build Lead" should set ``RELEASE_TYPE=HOTFIX`` instead of ``STABLE``.
 
+
 Security Release Process Deviation
 ----------------------------------
 
 A security/CVE release is similar to a hotfix release with two differences:
 
-    1. The fix should be pushed to the `ceph-private <https://github.com/ceph/ceph-private>`_ repo instead of ceph.git (requires GitHub Admin Role).
-    2. The tags (e.g., v19.2.3) must be manually pushed to ceph.git by the "Build Lead."
+#. The fix is pushed to the `ceph-private
+   <https://github.com/ceph/ceph-private>`_ repo instead of ceph.git (requires
+   GitHub Admin Role or membership in the `ceph/security
+   <https://github.com/orgs/ceph/teams/security>`_ GitHub team).
+#. The tags (e.g., v19.2.3) must be manually pushed to ceph.git by the "Build
+   Lead."
 
-1. Check out the most recent tag. For example, if we're releasing a security fix on top of 19.2.2, ``git checkout -f -B squid-release origin/v19.2.2``
-2. ``git cherry-pick -x`` the necessary security fix commits
-3. ``git remote add security git@github.com:ceph/ceph-private.git``
-4. ``git push -f security squid-release``
-5. Notify the "Build Lead" to start the build.
-6. The "Build Lead" should set ``RELEASE_TYPE=SECURITY`` instead of ``STABLE``.
-7. Finally, the `ceph-tag <https://github.com/ceph/ceph-build/blob/main/ansible/roles/ceph-release/tasks/push.yml>`_ steps need to be manually run by the "Build Lead" as close to the Announcement time as possible::
+The release must be built from the exact commits that were built and tested in
+the advisory fork (see :ref:`build and test cve`). Do **not** cherry-pick the
+fix commits onto a new branch; that rewrites their sha1s and the release would
+no longer match what was tested.
 
-    # Example using squid pretending 19.2.3 is the security release version
-    # Add the ceph-releases repo (also requires GitHub Admin Role). The `ceph-setup <https://jenkins.ceph.com/job/ceph-setup>`_ job will have already created and pushed the tag to ceph-releases.git.
-    git remote add releases git@github.com:ceph/ceph-releases.git
-    git fetch --all
-    # Check out the version commit
-    git checkout -f -B squid-release releases/squid-release
-    git push -f origin squid-release
-    git push origin v19.2.3
-    # Now create a Pull Request of squid-release targeting squid to merge the version commit and security fixes back into the squid branch
+#. Add the ceph-private repo to your remotes and fetch the security fix
+   branch that should already be pushed there by the developer(s)
+   working on the fix:
+
+   .. prompt:: bash $
+
+      git remote add private git@github.com:ceph/ceph-private.git
+
+      git fetch private
+
+#. Point the release branch at the security fix branch. For example, if we're
+   releasing a security fix on top of 19.2.2:
+
+   .. prompt:: bash $
+
+      git checkout -f -B squid-release private/$BRANCH_NAME
+
+#. Push the release branch to ceph-private:
+
+   .. prompt:: bash $
+
+      git push -f private squid-release
+
+#. Notify the "Build Lead" to start the build.
+
+#. The "Build Lead" should set ``RELEASE_TYPE=SECURITY`` instead of
+   ``STABLE``.
+
+#. Finally, the `ceph-tag
+   <https://github.com/ceph/ceph-build/blob/main/ansible/roles/ceph-release/tasks/push.yml>`_
+   steps need to be manually run by the "Build Lead" as close to the
+   Announcement time as possible. The `ceph-setup
+   <https://jenkins.ceph.com/job/ceph-setup>`_ job will have already created
+   and pushed the tag to ceph-releases.git. Example using squid, pretending
+   19.2.3 is the security release version:
+
+   .. prompt:: bash $
+
+      # Add the ceph-releases repo (also requires GitHub Admin Role)
+      git remote add releases git@github.com:ceph/ceph-releases.git
+      git fetch --all
+      # Check out the version commit
+      git checkout -f -B squid-release releases/squid-release
+      git push -f origin squid-release
+      git push origin v19.2.3
+
+   Now create a Pull Request of ``squid-release`` targeting ``squid`` to merge
+   the version commit and security fixes back into the ``squid`` branch.
 
 1. Preparing the release branch
 ===============================


### PR DESCRIPTION
Documentation updates covering the CVE/security workflow, from developing a fix under embargo through handing it off to the Release Manager.

## `doc/dev/developer_guide/cve.rst`

Partly an update to the guide added in #70144. That PR merged while a newer revision of the same commit was still sitting in my fork, so this brings the upstream copy up to date, and then adds the parts of the workflow that were missing.

**Repositories and remotes**

- Distinguishes the three repositories involved in a CVE fix (public `ceph/ceph`, the per-advisory `ceph/ceph-ghsa-*` fork, and `ceph/ceph-private`) with a table mapping each to its git remote and purpose.
- Renames the advisory fork's remote from `private` to `advisory`, so it is no longer confused with `ceph-private`, and switches from hand-editing `.git/config` to `git remote add`.
- Uses a placeholder GHSA name instead of a real advisory ID, plus a typo fix.

**Developing and building**

- Reorders the steps so the branch is created before the remote is added, and moves the "don't put CVE details in the branch name" warning next to the `git checkout -b` step where it applies.
- Notes that pushing a branch does **not** automatically trigger a build; the Jenkins job must be triggered manually.
- Encourages opening a pull request in the advisory fork as soon as the branch is pushed, so peer review can start before the fix is finished.

**Preparing the fix for release** (was "Merging the fix")

This is the part that was missing. Getting a security release built takes more than one branch, and the previous text only described pushing a single branch to `ceph-private`.

- Explains that the advisory pull requests are commented on but **not** merged, because official signed releases must be built from `ceph-private.git`; for security reasons the `ceph-release-pipeline` job can only build from `ceph.git` or `ceph-private.git`.
- Documents creating a backport branch per affected release, based on that release's most recent tag rather than on the release branch, and opening a pull request in the advisory for each.
- Documents pushing each of those branches to `ceph-private.git` renamed to `$RELEASE-release`, which is what the Release Manager actually builds from.
- Adds a "What Success Looks Like" table summarizing the expected end state, so it's possible to check your work before notifying the Release Manager.

## `doc/dev/release-process.rst`

Updates the "Security Release Process Deviation" section to match how we actually do security releases now (GitHub advisories and private forks):

- The release is built from the exact commits that were built and tested in the advisory fork. The old instructions had the Build Lead cherry-pick the fix onto a fresh branch, which rewrites the sha1s so the release no longer matches what was tested.
- Replaces the cherry-pick steps with fetching the developer's branch from `ceph-private` and pointing `$RELEASE-release` at it directly. This is the other half of the developer-side handoff described in `cve.rst`.
- Cross-references the CVE developer guide, and converts the section to numbered steps with `prompt` directives so it renders consistently with the rest of the page.

## Notes for reviewers

This branch was rebased onto current `main` after #70144 merged. The `cve.rst` conflict was resolved in favor of my fork's newer revision; the `sign-debs` changes from #68911 in `release-process.rst` are untouched and preserved.

Docs only, no code, no tests.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
