### PR TITLE
mgr/cephadm-The ganesha-rados-grace command

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -556,6 +556,15 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                  'When enabled, cephadm and bash commands are validated and executed via '
                  'the secure invoker wrapper.'
         ),
+        Option(
+            'nfs_rados_command_timeout',
+            type='secs',
+            default=30,
+            desc='Timeout (in seconds) for rados and ganesha-rados-grace commands '
+                 'issued by the NFS service (e.g. add/remove from the grace table, '
+                 'create/remove the rados config object). Increase this value if '
+                 'your cluster is under heavy load and these operations time out.',
+        ),
     ]
     for image in DefaultImages:
         MODULE_OPTIONS.append(Option(image.key, default=image.image_ref, desc=image.desc))
@@ -659,6 +668,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.inventory_list_all = False
             self.cgroups_split = True
             self.log_refresh_metadata = False
+            self.nfs_rados_command_timeout = 30
             self.default_cephadm_command_timeout = 0
             self.cephadm_log_destination = ''
             self.oob_default_addr = ''

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -379,10 +379,16 @@ class NFSService(CephService):
             '-p', POOL_NAME,
             '--namespace', cast(str, spec.service_id),
         ]
+        rados_timeout = self.mgr.nfs_rados_command_timeout
+        if rados_timeout < 5:
+            self.mgr.log.info(
+                f'nfs_rados_command_timeout set to {rados_timeout}, using minimum of 5 seconds.'
+            )
+            rados_timeout = 5
         result = subprocess.run(
             cmd + ['get', objname, '-'],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-            timeout=10)
+            timeout=rados_timeout)
         if not result.returncode and not clobber:
             logger.info('Rados config object exists: %s' % objname)
             config_file_data = result.stdout
@@ -391,7 +397,7 @@ class NFSService(CephService):
             result = subprocess.run(
                 cmd + ['put', objname, '-'],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                timeout=10)
+                timeout=rados_timeout)
             if result.returncode:
                 self.mgr.log.warning(
                     f'Unable to create rados config object {objname}: {result.stderr.decode("utf-8")}'
@@ -469,8 +475,14 @@ class NFSService(CephService):
                 action, nodeid,
             ]
             self.mgr.log.debug(cmd)
+            grace_timeout = self.mgr.nfs_rados_command_timeout
+            if grace_timeout < 5:
+                self.mgr.log.info(
+                    f'nfs_rados_command_timeout set to {grace_timeout}, using minimum of 5 seconds.'
+                )
+                grace_timeout = 5
             result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                    timeout=10)
+                                    timeout=grace_timeout)
             if result.returncode:
                 stderr = result.stderr.decode("utf-8")
                 self.mgr.log.warning(
@@ -540,12 +552,18 @@ class NFSService(CephService):
             '--namespace', cast(str, spec.service_id),
             'rm', 'grace',
         ]
+        purge_timeout = self.mgr.nfs_rados_command_timeout
+        if purge_timeout < 5:
+            self.mgr.log.info(
+                f'nfs_rados_command_timeout set to {purge_timeout}, using minimum of 5 seconds.'
+            )
+            purge_timeout = 5
         try:
             result = subprocess.run(
                 cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                timeout=10
+                timeout=purge_timeout
             )
         except Exception as e:
             err_msg = f'Got unexpected exception trying to remove ganesha grace file for nfs.{spec.service_id} service: {str(e)}'

--- a/src/pybind/mgr/cephadm/tests/services/test_nfs.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nfs.py
@@ -958,3 +958,190 @@ def test_nfs_choose_next_action_detects_explicit_value_change():
         last_deps=['tls_ktls: False'],
     )
     assert step.action is utils.Action.REDEPLOY
+
+
+# ---------------------------------------------------------------------------
+# Tests for configurable nfs_rados_command_timeout (IBMCEPH-14352)
+# ---------------------------------------------------------------------------
+
+class TestNFSRadosCommandTimeout:
+    """Verify that ganesha-rados-grace and rados subprocess calls use the
+    nfs_rados_command_timeout module option instead of a hardcoded value."""
+
+    def _make_nfs_service(self, module_options=None):
+        """Return an NFSService instance backed by a freshly constructed
+        CephadmOrchestrator module so that get_module_option() works."""
+        from cephadm.tests.fixtures import with_cephadm_module
+        from cephadm.services.service_registry import service_registry
+        # with_cephadm_module is a context manager; keep it alive via return
+        ctx = with_cephadm_module(module_options or {})
+        mgr = ctx.__enter__()
+        return ctx, service_registry.get_service('nfs')
+
+    # ------------------------------------------------------------------
+    # run_grace_tool: default timeout (30 s)
+    # ------------------------------------------------------------------
+    def test_run_grace_tool_uses_default_timeout(self):
+        import subprocess
+        from unittest.mock import patch, MagicMock
+        from cephadm.tests.fixtures import with_cephadm_module
+        from cephadm.services.service_registry import service_registry
+        from ceph.deployment.service_spec import NFSServiceSpec
+
+        with with_cephadm_module({}) as mgr:
+            assert mgr.nfs_rados_command_timeout == 30
+
+            nfs_svc = service_registry.get_service('nfs')
+            spec = NFSServiceSpec(service_id='mytest')
+
+            completed = MagicMock()
+            completed.returncode = 0
+            completed.stdout = b''
+
+            captured_timeout = []
+
+            def fake_run(cmd, stdout, stderr, timeout):
+                captured_timeout.append(timeout)
+                return completed
+
+            with patch.object(subprocess, 'run', side_effect=fake_run), \
+                 patch.object(nfs_svc, 'get_keyring_with_caps', return_value='[client.mgr.nfs.grace.nfs.mytest]\n\tkey = AQ==\n'), \
+                 patch.object(mgr, 'get_minimal_ceph_conf', return_value='[global]\n'), \
+                 patch.object(mgr, 'check_mon_command', return_value=None):
+                nfs_svc.run_grace_tool(spec, 'add', '0')
+
+            assert len(captured_timeout) == 1
+            assert captured_timeout[0] == 30
+
+    # ------------------------------------------------------------------
+    # run_grace_tool: custom configured timeout (60 s)
+    # ------------------------------------------------------------------
+    def test_run_grace_tool_uses_custom_timeout(self):
+        import subprocess
+        from unittest.mock import patch, MagicMock
+        from cephadm.tests.fixtures import with_cephadm_module
+        from cephadm.services.service_registry import service_registry
+        from ceph.deployment.service_spec import NFSServiceSpec
+
+        with with_cephadm_module({'nfs_rados_command_timeout': '60'}) as mgr:
+            assert mgr.nfs_rados_command_timeout == 60
+
+            nfs_svc = service_registry.get_service('nfs')
+            spec = NFSServiceSpec(service_id='mytest')
+
+            completed = MagicMock()
+            completed.returncode = 0
+            completed.stdout = b''
+
+            captured_timeout = []
+
+            def fake_run(cmd, stdout, stderr, timeout):
+                captured_timeout.append(timeout)
+                return completed
+
+            with patch.object(subprocess, 'run', side_effect=fake_run), \
+                 patch.object(nfs_svc, 'get_keyring_with_caps', return_value='[client.mgr.nfs.grace.nfs.mytest]\n\tkey = AQ==\n'), \
+                 patch.object(mgr, 'get_minimal_ceph_conf', return_value='[global]\n'), \
+                 patch.object(mgr, 'check_mon_command', return_value=None):
+                nfs_svc.run_grace_tool(spec, 'add', '0')
+
+            assert len(captured_timeout) == 1
+            assert captured_timeout[0] == 60
+
+    # ------------------------------------------------------------------
+    # create_rados_config_obj: both subprocess.run calls use the timeout
+    # ------------------------------------------------------------------
+    def test_create_rados_config_obj_uses_configurable_timeout(self):
+        import subprocess
+        from unittest.mock import patch, MagicMock
+        from cephadm.tests.fixtures import with_cephadm_module
+        from cephadm.services.service_registry import service_registry
+        from ceph.deployment.service_spec import NFSServiceSpec
+
+        with with_cephadm_module({'nfs_rados_command_timeout': '45'}) as mgr:
+            nfs_svc = service_registry.get_service('nfs')
+            spec = NFSServiceSpec(service_id='mytest')
+
+            captured_timeouts = []
+            call_count = [0]
+
+            def fake_run(cmd, stdout, stderr, timeout):
+                captured_timeouts.append(timeout)
+                r = MagicMock()
+                if call_count[0] == 0:
+                    # first call: "get" returns non-zero to trigger "put"
+                    r.returncode = 1
+                    r.stdout = b''
+                else:
+                    r.returncode = 0
+                    r.stdout = b''
+                call_count[0] += 1
+                return r
+
+            with patch.object(subprocess, 'run', side_effect=fake_run), \
+                 patch.object(mgr, 'get_ceph_option', return_value='/tmp/fake-keyring'), \
+                 patch.object(mgr, 'get_mgr_id', return_value='mgr.a'):
+                nfs_svc.create_rados_config_obj(spec)
+
+            # Both the "get" and the "put" calls must use the configured timeout
+            assert all(t == 45 for t in captured_timeouts), \
+                f"Expected all timeouts=45, got {captured_timeouts}"
+            assert len(captured_timeouts) == 2
+
+    # ------------------------------------------------------------------
+    # purge: rados rm uses the configurable timeout
+    # ------------------------------------------------------------------
+    def test_purge_uses_configurable_timeout(self):
+        import subprocess
+        from unittest.mock import patch, MagicMock
+        from cephadm.tests.fixtures import with_cephadm_module
+        from cephadm.services.service_registry import service_registry
+        from ceph.deployment.service_spec import NFSServiceSpec
+
+        with with_cephadm_module({'nfs_rados_command_timeout': '50'}) as mgr:
+            nfs_svc = service_registry.get_service('nfs')
+            spec = NFSServiceSpec(service_id='mytest')
+            mgr.spec_store._specs['nfs.mytest'] = MagicMock(spec=spec, spec_lock=MagicMock())
+            mgr.spec_store._specs['nfs.mytest'].spec = spec
+            mgr.spec_store.spec_created['nfs.mytest'] = datetime_now()
+
+            captured_timeouts = []
+
+            def fake_run(cmd, stdout, stderr, timeout):
+                captured_timeouts.append(timeout)
+                r = MagicMock()
+                r.returncode = 0
+                r.stderr = b''
+                return r
+
+            with patch.object(subprocess, 'run', side_effect=fake_run), \
+                 patch.object(mgr, 'get_ceph_option', return_value='/tmp/fake-keyring'), \
+                 patch.object(mgr, 'get_mgr_id', return_value='mgr.a'):
+                nfs_svc.purge('nfs.mytest')
+
+            assert len(captured_timeouts) == 1
+            assert captured_timeouts[0] == 50
+
+    # ------------------------------------------------------------------
+    # Option presence and defaults in MODULE_OPTIONS
+    # ------------------------------------------------------------------
+    def test_nfs_rados_command_timeout_option_registered(self):
+        from cephadm.module import CephadmOrchestrator
+        names = [o['name'] for o in CephadmOrchestrator.MODULE_OPTIONS]
+        assert 'nfs_rados_command_timeout' in names
+
+    def test_nfs_rados_command_timeout_default_is_30(self):
+        from cephadm.module import CephadmOrchestrator
+        opt = next(
+            o for o in CephadmOrchestrator.MODULE_OPTIONS
+            if o['name'] == 'nfs_rados_command_timeout'
+        )
+        assert opt['default'] == 30
+
+    def test_nfs_rados_command_timeout_type_is_secs(self):
+        from cephadm.module import CephadmOrchestrator
+        opt = next(
+            o for o in CephadmOrchestrator.MODULE_OPTIONS
+            if o['name'] == 'nfs_rados_command_timeout'
+        )
+        assert opt['type'] == 'secs'


### PR DESCRIPTION

mgr/cephadm: The ganesha-rados-grace command (and the rados get/put/rm calls used during NFS service deployment) were using a hardcoded 10-second timeout. Under cluster load this causes subprocess.TimeoutExpired, which propagates as a CEPHADM_APPLY_SPEC_FAIL health warning.

Introduce a new module option
nfs_rados_command_timeout (type secs,
default 30) and replace every hardcoded timeout=10 in NFSService with this configurable value. The affected call sites are:

NFSService.run_grace_tool() -- ganesha-rados-grace add/remove
NFSService.create_rados_config_obj() -- rados get + rados put
NFSService.purge() -- rados rm grace
The option is stored in the monitor config store and is picked up by config_notify(), so it takes effect immediately after ceph config set mgr mgr/cephadm/nfs_rados_command_timeout without requiring a MGR restart.

Operators on slow or heavily loaded clusters can raise the value:

ceph config set mgr mgr/cephadm/nfs_rados_command_timeout 60

The default of 30 s is a safe increase over the previous 10 s and preserves backward-compatible behaviour for all existing NFS deployments.

Fixes: https://tracker.ceph.com/issues/77107
Signed-off-by: swatithombe-blip [swati.thombe@gmail.com](mailto:swati.thombe@gmail.com)

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
