### PR TITLE
librbd: don't let a scheduled dispatch outlive the simple scheduler

### DIFF
--- a/src/librbd/io/SimpleSchedulerObjectDispatch.cc
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.cc
@@ -215,8 +215,30 @@ void SimpleSchedulerObjectDispatch<I>::shut_down(Context* on_finish) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 5) << dendl;
 
+  {
+    std::lock_guard locker{m_lock};
+
+    // dispatch anything still being delayed -- otherwise the associated
+    // completion contexts would be leaked
+    dispatch_all_delayed_requests();
+
+    // ensure a scheduled task cannot fire (and post a dispatch to the asio
+    // engine) after the dispatcher has deleted us
+    std::lock_guard timer_locker{*m_timer_lock};
+    if (m_timer_task != nullptr) {
+      ldout(cct, 20) << "canceling task " << m_timer_task << dendl;
+
+      bool canceled = m_timer->cancel_event(m_timer_task);
+      ceph_assert(canceled);
+      m_timer_task = nullptr;
+    }
+  }
+
   m_flush_tracker->shut_down();
-  on_finish->complete(0);
+
+  // a task that already expired may have posted a dispatch to the asio engine
+  // -- wait for it to complete before we are deleted
+  m_async_op_tracker.wait_for_ops(on_finish);
 }
 
 template <typename I>
@@ -547,10 +569,18 @@ void SimpleSchedulerObjectDispatch<I>::schedule_dispatch_delayed_requests() {
       ldout(cct, 20) << "running timer task " << m_timer_task << dendl;
 
       m_timer_task = nullptr;
+
+      // the dispatch is deferred to the asio engine -- track it so that
+      // shut_down cannot complete (and the dispatcher delete us) while it
+      // is still pending
+      m_async_op_tracker.start_op();
       m_image_ctx->asio_engine->post(
         [this, object_no]() {
-          std::lock_guard locker{m_lock};
-          dispatch_delayed_requests(object_no);
+          {
+            std::lock_guard locker{m_lock};
+            dispatch_delayed_requests(object_no);
+          }
+          m_async_op_tracker.finish_op();
         });
     });
 

--- a/src/librbd/io/SimpleSchedulerObjectDispatch.h
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_LIBRBD_IO_SIMPLE_SCHEDULER_OBJECT_DISPATCH_H
 #define CEPH_LIBRBD_IO_SIMPLE_SCHEDULER_OBJECT_DISPATCH_H
 
+#include "common/AsyncOpTracker.h"
 #include "common/ceph_mutex.h"
 #include "include/interval_set.h"
 #include "include/utime.h"
@@ -203,6 +204,10 @@ private:
   std::list<ObjectRequestsRef> m_dispatch_queue;
   Context *m_timer_task = nullptr;
   std::unique_ptr<LatencyStats> m_latency_stats;
+
+  // tracks dispatches posted to the asio engine by an expired timer task so
+  // that shut_down can wait for them before we are deleted
+  AsyncOpTracker m_async_op_tracker;
 
   bool try_delay_write(uint64_t object_no, uint64_t object_off,
                        ceph::bufferlist&& data, IOContext io_context,

--- a/src/test/librbd/io/test_mock_SimpleSchedulerObjectDispatch.cc
+++ b/src/test/librbd/io/test_mock_SimpleSchedulerObjectDispatch.cc
@@ -819,5 +819,115 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Timer) {
   ASSERT_EQ(0, cond2.wait());
 }
 
+TEST_F(TestMockIoSimpleSchedulerObjectDispatch, ShutDownCancelsTimerTask) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+  MockSimpleSchedulerObjectDispatch
+      mock_simple_scheduler_object_dispatch(&mock_image_ctx);
+
+  expect_get_object_name(mock_image_ctx, 0);
+
+  InSequence seq;
+
+  ceph::bufferlist data;
+  data.append("X");
+  int object_dispatch_flags = 0;
+  C_SaferCond cond1;
+  Context *on_finish1 = &cond1;
+  ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
+      0, 0, std::move(data), mock_image_ctx.get_data_io_context(), 0, 0,
+      std::nullopt, {}, &object_dispatch_flags, nullptr, nullptr, &on_finish1,
+      nullptr));
+  ASSERT_NE(on_finish1, &cond1);
+
+  Context *timer_task = nullptr;
+  expect_schedule_dispatch_delayed_requests(nullptr, &timer_task);
+
+  io::DispatchResult dispatch_result;
+  C_SaferCond cond2;
+  Context *on_finish2 = &cond2;
+  C_SaferCond on_dispatched;
+  ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
+      0, 0, std::move(data), mock_image_ctx.get_data_io_context(), 0, 0,
+      std::nullopt, {}, &object_dispatch_flags, nullptr, &dispatch_result,
+      &on_finish2, &on_dispatched));
+  ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
+  ASSERT_NE(on_finish2, &cond2);
+  ASSERT_NE(timer_task, nullptr);
+
+  // shut down must dispatch the delayed requests and cancel the scheduled
+  // task -- otherwise it would fire after the dispatcher deleted us
+  expect_dispatch_delayed_requests(mock_image_ctx, 0);
+  expect_cancel_timer_task(timer_task);
+
+  C_SaferCond on_shut_down;
+  mock_simple_scheduler_object_dispatch.shut_down(&on_shut_down);
+  ASSERT_EQ(0, on_shut_down.wait());
+  ASSERT_EQ(0, on_dispatched.wait());
+
+  on_finish1->complete(0);
+  ASSERT_EQ(0, cond1.wait());
+  on_finish2->complete(0);
+  ASSERT_EQ(0, cond2.wait());
+}
+
+TEST_F(TestMockIoSimpleSchedulerObjectDispatch,
+       ShutDownWaitsForExpiredTimerTask) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+  MockSimpleSchedulerObjectDispatch
+      mock_simple_scheduler_object_dispatch(&mock_image_ctx);
+
+  expect_get_object_name(mock_image_ctx, 0);
+
+  InSequence seq;
+
+  ceph::bufferlist data;
+  data.append("X");
+  int object_dispatch_flags = 0;
+  C_SaferCond cond1;
+  Context *on_finish1 = &cond1;
+  ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
+      0, 0, std::move(data), mock_image_ctx.get_data_io_context(), 0, 0,
+      std::nullopt, {}, &object_dispatch_flags, nullptr, nullptr, &on_finish1,
+      nullptr));
+  ASSERT_NE(on_finish1, &cond1);
+
+  Context *timer_task = nullptr;
+  expect_schedule_dispatch_delayed_requests(nullptr, &timer_task);
+
+  io::DispatchResult dispatch_result;
+  C_SaferCond cond2;
+  Context *on_finish2 = &cond2;
+  C_SaferCond on_dispatched;
+  ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
+      0, 0, std::move(data), mock_image_ctx.get_data_io_context(), 0, 0,
+      std::nullopt, {}, &object_dispatch_flags, nullptr, &dispatch_result,
+      &on_finish2, &on_dispatched));
+  ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
+  ASSERT_NE(on_finish2, &cond2);
+  ASSERT_NE(timer_task, nullptr);
+
+  expect_dispatch_delayed_requests(mock_image_ctx, 0);
+
+  // the expired task posts the dispatch to the asio engine -- shut down must
+  // not complete until that dispatch has run
+  run_timer_task(timer_task);
+
+  C_SaferCond on_shut_down;
+  mock_simple_scheduler_object_dispatch.shut_down(&on_shut_down);
+  ASSERT_EQ(0, on_shut_down.wait());
+  ASSERT_EQ(0, on_dispatched.wait());
+
+  on_finish1->complete(0);
+  ASSERT_EQ(0, cond1.wait());
+  on_finish2->complete(0);
+  ASSERT_EQ(0, cond2.wait());
+}
+
 } // namespace io
 } // namespace librbd


### PR DESCRIPTION
`SimpleSchedulerObjectDispatch::shut_down()` completed as soon as the flush
tracker was shut down, leaving any scheduled timer task armed.
`Dispatcher::shut_down_dispatch()` deletes the dispatch object the moment
`shut_down()` completes, so an expiring task -- and the dispatch it defers to
the asio engine -- could run against freed memory:

```
/ceph/src/common/mutex_debug.h: 139: FAILED ceph_assert(r == 0)
 7: std::lock_guard<ceph::mutex_debug_detail::mutex_debug_impl<false> >::~lock_guard()
 8: librbd::io::SimpleSchedulerObjectDispatch<librbd::ImageCtx>::schedule_dispatch_delayed_requests()::{lambda(int)#1}::operator()(int) const::{lambda()#1}::operator()() const
 ...
 14: boost::asio::io_context::run()
```

Caught as an unrelated failure in `unittest_librbd` with `RBD_FEATURES=0` on
aarch64:
https://jenkins.ceph.com/job/ceph-pull-requests-arm64/101784/consoleFull

`75ff8fd14dc` ("librbd: flush all queued object IO from simple scheduler")
added the flush tracker so that shut down waits for IO the scheduler has
already dispatched. Nothing accounted for a task that has not expired yet, nor
for the window between a task expiring and the dispatch it hands to the asio
engine actually running -- that deferral predates `bb149938738`, which only
switched it from `op_work_queue` to an asio post.

Shut down now dispatches whatever is still delayed and cancels the scheduled
task under the timer lock (preserving the existing `m_lock` -> `m_timer_lock`
ordering), then gates completion on an `AsyncOpTracker` covering the post.

Note on test coverage: `ShutDownCancelsTimerTask` blocks without the fix and
passes with it, so it guards the dispatch-and-cancel half. It does not
deterministically reproduce the use-after-free itself, which needs shut down to
land inside the asio window; `ShutDownWaitsForExpiredTimerTask` exercises that
path but passes either way.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
