### PR TITLE
common/LogClient: don't derive the unsent range from last_log

### DIFF
--- a/src/common/LogClient.cc
+++ b/src/common/LogClient.cc
@@ -21,6 +21,8 @@
 #include "mon/MonMap.h"
 #include "common/Graylog.h"
 
+#include <algorithm>
+#include <iterator>
 #include <sstream>
 
 #define dout_subsys ceph_subsys_monc
@@ -64,9 +66,16 @@ LogClient::LogClient(CephContext *cct, Messenger *m, MonMap *mm,
 
 void LogChannel::set_log_to_monitors(bool v)
 {
+  std::lock_guard l(channel_lock);
+  _set_log_to_monitors(v);
+}
+
+void LogChannel::_set_log_to_monitors(bool v)
+{
+  ceph_assert(ceph_mutex_is_locked(channel_lock));
   if (log_to_monitors != v) {
-    parent->reset();
     log_to_monitors = v;
+    parent->reset();
   }
 }
 
@@ -78,12 +87,17 @@ void LogChannel::update_config(const clog_targets_conf_t& conf_strings)
 		 << " log_prios " << conf_strings.log_prios
 		 << dendl;
 
+  // hold channel_lock so that a concurrent do_log() cannot decide to
+  // queue an entry for the monitors based on the old log_to_monitors
+  // and then queue it after we have reset the queue.
+  std::lock_guard l(channel_lock);
+
   bool to_monitors = (conf_strings.log_to_monitors == "true");
   bool to_syslog = (conf_strings.log_to_syslog == "true");
   bool to_graylog = (conf_strings.log_to_graylog == "true");
   auto graylog_port = atoi(conf_strings.log_to_graylog_port.c_str());
 
-  set_log_to_monitors(to_monitors);
+  _set_log_to_monitors(to_monitors);
   set_log_to_syslog(to_syslog);
   set_syslog_facility(conf_strings.log_channels);
   set_log_prio(conf_strings.log_prios);
@@ -213,7 +227,7 @@ ceph::ref_t<Message> LogClient::get_mon_log_message(bool flush)
 bool LogClient::are_pending()
 {
   std::lock_guard l(log_lock);
-  return last_log > last_log_sent;
+  return !log_queue.empty() && log_queue.back().seq > last_log_sent;
 }
 
 ceph::ref_t<Message> LogClient::_get_mon_log_message()
@@ -229,8 +243,21 @@ ceph::ref_t<Message> LogClient::_get_mon_log_message()
   if (last_log_sent == last_log)
     return {};
 
+  // last_log is bumped for *every* log entry, including those that are
+  // not queued for the monitors (see LogChannel::do_log()), and any
+  // channel sharing this LogClient may empty the queue via reset().
+  // last_log - last_log_sent is therefore not a count of queued entries
+  // that we have yet to send: find the first unsent entry -- if any --
+  // by walking the (seq-ordered) queue instead.
+  auto p = std::find_if(log_queue.begin(), log_queue.end(),
+			[this](const LogEntry& e) {
+			  return e.seq > last_log_sent;
+			});
+  if (p == log_queue.end())
+    return {};
+
   // limit entries per message
-  unsigned num_unsent = last_log - last_log_sent;
+  unsigned num_unsent = (unsigned)std::distance(p, log_queue.end());
   unsigned num_send;
   if (cct->_conf->mon_client_max_log_entries_per_message > 0)
     num_send = std::min(num_unsent, (unsigned)cct->_conf->mon_client_max_log_entries_per_message);
@@ -241,13 +268,7 @@ ceph::ref_t<Message> LogClient::_get_mon_log_message()
 		<< " num " << log_queue.size()
 		<< " unsent " << num_unsent
 		<< " sending " << num_send << dendl;
-  ceph_assert(num_unsent <= log_queue.size());
-  std::deque<LogEntry>::iterator p = log_queue.begin();
   std::deque<LogEntry> o;
-  while (p->seq <= last_log_sent) {
-    ++p;
-    ceph_assert(p != log_queue.end());
-  }
   while (num_send--) {
     ceph_assert(p != log_queue.end());
     o.push_back(*p);

--- a/src/common/LogClient.h
+++ b/src/common/LogClient.h
@@ -187,6 +187,9 @@ private:
    */
   void update_config(const clog_targets_conf_t& conf_strings);
 
+  /// set log_to_monitors with channel_lock already held
+  void _set_log_to_monitors(bool v);
+
   clog_targets_conf_t parse_log_client_options(CephContext* conf_cct);
 };
 

--- a/src/crimson/common/logclient.cc
+++ b/src/crimson/common/logclient.cc
@@ -1,4 +1,6 @@
 #include "crimson/common/logclient.h"
+#include <algorithm>
+#include <iterator>
 #include <fmt/ranges.h>
 #include "include/str_map.h"
 #include "messages/MLog.h"
@@ -247,7 +249,7 @@ MessageURef LogClient::get_mon_log_message(log_flushing_t flush_flag)
 
 bool LogClient::are_pending() const
 {
-  return last_log > last_log_sent;
+  return !log_queue.empty() && log_queue.back().seq > last_log_sent;
 }
 
 MessageURef LogClient::_get_mon_log_message()
@@ -264,8 +266,22 @@ MessageURef LogClient::_get_mon_log_message()
     return {};
   }
 
+  // last_log is bumped for *every* log entry, including those that are
+  // not queued for the monitors (see LogChannel::do_log()), and any
+  // channel sharing this LogClient may empty the queue via reset().
+  // last_log - last_log_sent is therefore not a count of queued entries
+  // that we have yet to send: find the first unsent entry -- if any --
+  // by walking the (seq-ordered) queue instead.
+  auto log_iter = std::find_if(log_queue.begin(), log_queue.end(),
+			       [this](const LogEntry& e) {
+				 return e.seq > last_log_sent;
+			       });
+  if (log_iter == log_queue.end()) {
+    return {};
+  }
+
   // limit entries per message
-  const int64_t num_unsent = last_log - last_log_sent;
+  const int64_t num_unsent = std::distance(log_iter, log_queue.end());
   int64_t num_to_send;
   if (local_conf()->mon_client_max_log_entries_per_message > 0) {
     num_to_send = std::min(num_unsent,
@@ -277,13 +293,7 @@ MessageURef LogClient::_get_mon_log_message()
   logger().debug("log_queue is {} last_log {} sent {} num {} unsent {}"
 		" sending {}", log_queue.size(), last_log,
 		last_log_sent, log_queue.size(), num_unsent, num_to_send);
-  ceph_assert((unsigned)num_unsent <= log_queue.size());
-  auto log_iter = log_queue.begin();
   std::deque<LogEntry> out_log_queue; /* will send the logs contained here */
-  while (log_iter->seq <= last_log_sent) {
-    ++log_iter;
-    ceph_assert(log_iter != log_queue.end());
-  }
   while (num_to_send--) {
     ceph_assert(log_iter != log_queue.end());
     out_log_queue.push_back(*log_iter);


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/79444


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
