### PR TITLE
cmake: rebuild bundled RocksDB when its sources change

### DIFF
--- a/cmake/modules/BuildRocksDB.cmake
+++ b/cmake/modules/BuildRocksDB.cmake
@@ -89,6 +89,13 @@ function(build_rocksdb)
     CMAKE_ARGS ${rocksdb_CMAKE_ARGS}
     BINARY_DIR "${rocksdb_BINARY_DIR}"
     BUILD_COMMAND "${make_cmd}"
+    # always re-enter the RocksDB build: ExternalProject's stamp files do not
+    # track the source tree, so without this a submodule bump (or a rebase
+    # across one) silently keeps linking the previously built librocksdb.a
+    # while the rest of the tree compiles against the updated headers in
+    # ${rocksdb_SOURCE_DIR}/include, producing ABI-mismatched binaries. the
+    # inner build is incremental, so the steady-state cost is a no-op check.
+    BUILD_ALWAYS ON
     BUILD_BYPRODUCTS "${rocksdb_LIBRARY}"
     INSTALL_COMMAND ""
     LIST_SEPARATOR !)


### PR DESCRIPTION
ExternalProject_Add() only tracks its own stamp files, not the source tree, so once the bundled RocksDB has been built, ninja/make never re-enter its build again. After a src/rocksdb submodule bump (or a rebase across one), the rest of the tree recompiles against the updated headers via RocksDB::RocksDB's INTERFACE_INCLUDE_DIRECTORIES, which point into the live source tree, while still linking the stale librocksdb.a frozen in the build directory. The resulting mixed-version binaries fail at runtime in arbitrary ways; observed as std::bad_alloc from garbage string lengths in
rocksdb::BlockBasedTableFactory::GetPrintableOptions() during ceph-mon --mkfs, after the build directory straddled the v7.9.2 to v7.10.2 submodule bump.

For example, vstart.sh would fail in non-obvious way with something like:

```
 ceph version 21.3.0-1956-g566dbe7df5a (566dbe7df5a4a2b0a252417682f10b8cd763a99b) umbrella (dev - Release)                                                                                                                                                                                                                   
 1: /lib64/libc.so.6(+0x40fd0) [0x7ff9c1a4efd0]                                                                                                                                                                                                                                                                              
 2: /lib64/libc.so.6(+0x9a034) [0x7ff9c1aa8034]                                                                                                                                                                                                                                                                              
 3: gsignal()                                                                                                                                                                                                                                                                                                                
 4: abort()                                                                                                                                                                                                                                                                                                                  
 5: /lib64/libstdc++.so.6(+0xa5da9) [0x7ff9c1ca5da9]                                                                                                                                                                                                                                                                         
 6: /lib64/libstdc++.so.6(+0xb7c4c) [0x7ff9c1cb7c4c]                                                                                                                                                                                                                                                                         
 7: (std::unexpected()+0) [0x7ff9c1ca5951]                                                                                                                                                                                                                                                                                   
 8: /lib64/libstdc++.so.6(+0xb7ed8) [0x7ff9c1cb7ed8]                                                                                                                                                                                                                                                                         
 9: /lib64/libtcmalloc.so.4(+0x15112) [0x7ff9c2615112]                                                                                                                                                                                                                                                                       
 10: (tcmalloc::allocate_full_cpp_throw_oom(unsigned long)+0xf6) [0x7ff9c2638a86]                                                                                                                                                                                                                                            
 11: (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_mutate(unsigned long, unsigned long, char const*, unsigned long)+0xa3) [0x55be357d81e3]                                                                                                                                            
 12: (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_append(char const*, unsigned long)+0x70) [0x7ff9c1d5c170]                                                                                                                                                                          
 13: (rocksdb::BlockBasedTableFactory::GetPrintableOptions[abi:cxx11]() const+0x44f) [0x55be35e3d89f]                                                                                                                                                                                                                        
 14: (rocksdb::ColumnFamilyOptions::Dump(rocksdb::Logger*) const+0x196) [0x55be35e18e86]                                                                                                                                                                                                                                     
 15: (rocksdb::ColumnFamilyData::ColumnFamilyData(unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rocksdb::Version*, rocksdb::Cache*, rocksdb::WriteBufferManager*, rocksdb::ColumnFamilyOptions const&, rocksdb::ImmutableDBOptions const&, rocksdb::FileOptions const
*, rocksdb::ColumnFamilySet*, rocksdb::BlockCacheTracer*, std::shared_ptr<rocksdb::IOTracer> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)+0xc04) [0x55be35f92fc4]                 
 16: (rocksdb::ColumnFamilySet::CreateColumnFamily(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned int, rocksdb::Version*, rocksdb::ColumnFamilyOptions const&)+0x7b) [0x55be35f93acb]                                                                                      
 17: (rocksdb::VersionSet::CreateColumnFamily(rocksdb::ColumnFamilyOptions const&, rocksdb::VersionEdit const*)+0x4a6) [0x55be35d5f616]                                                                                                                                                                                      
 18: (rocksdb::VersionEditHandler::CreateCfAndInit(rocksdb::ColumnFamilyOptions const&, rocksdb::VersionEdit const&)+0x24) [0x55be3600cf74]                                                                                                                                                                                  
 19: (rocksdb::VersionEditHandler::Initialize()+0xcb1) [0x55be3600e6e1]                                                                                                                                                                                                                                                      
 20: (rocksdb::VersionEditHandlerBase::Iterate(rocksdb::log::Reader&, rocksdb::Status*)+0x7b) [0x55be3600b4eb]                                                                                                                                                                                                               
 21: (rocksdb::VersionSet::Recover(std::vector<rocksdb::ColumnFamilyDescriptor, std::allocator<rocksdb::ColumnFamilyDescriptor> > const&, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, bool)+0x4b8) [0x55be35d64d78]                                                              
 22: (rocksdb::DBImpl::Recover(std::vector<rocksdb::ColumnFamilyDescriptor, std::allocator<rocksdb::ColumnFamilyDescriptor> > const&, bool, bool, bool, unsigned long*, rocksdb::DBImpl::RecoveryContext*)+0x2ac) [0x55be35c69a9c]                                                                                           
 23: (rocksdb::DBImpl::Open(rocksdb::DBOptions const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<rocksdb::ColumnFamilyDescriptor, std::allocator<rocksdb::ColumnFamilyDescriptor> > const&, std::vector<rocksdb::ColumnFamilyHandle*, std::allocator<rocksdb::Colum
nFamilyHandle*> >*, rocksdb::DB**, bool, bool)+0x849) [0x55be35c614c9]                                                                                                                                                                                                                                                       
 24: (rocksdb::DB::Open(rocksdb::DBOptions const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<rocksdb::ColumnFamilyDescriptor, std::allocator<rocksdb::ColumnFamilyDescriptor> > const&, std::vector<rocksdb::ColumnFamilyHandle*, std::allocator<rocksdb::ColumnFam
ilyHandle*> >*, rocksdb::DB**)+0x15) [0x55be35c63a65]                                                                                                                                                                                                                                                                        
 25: (rocksdb::DB::Open(rocksdb::Options const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rocksdb::DB**)+0xbbf) [0x55be35c6462f]                                                                                                                                              
 26: (RocksDBStore::do_open(std::ostream&, bool, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)+0x1df) [0x55be35ba323f]                                                                                                                                                       
 27: (MonitorDBStore::create_and_open(std::ostream&)+0x36c) [0x55be357e165c]                                                                                                                                                                                                                                                 
 28: main()                                                                                                                                                                                                                                                                                                                  
 29: /lib64/libc.so.6(+0x2a088) [0x7ff9c1a38088]                                                                                                                                                                                                                                                                             
 30: __libc_start_main()                                                                                                                                                                                                                                                                                                     
 31: _start()                                                                                                                                                                                                                                                                                                                
 NOTE: a copy of the executable, or `objdump -rdS <executable>` is needed to interpret this.                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                             
../../ceph/src/vstart.sh: line 35: 141573 Aborted                 (core dumped) PATH=$CEPH_BIN:$PATH "$@" 
```

Set BUILD_ALWAYS so every build re-enters the RocksDB build step. The inner build is itself an incremental cmake build, so when nothing changed this is a sub-second no-op scan; when the submodule moved it rebuilds exactly what is needed.

Signed-off-by: Jusufadis Bakamovic <jusufadis.bakamovic@clyso.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
