### PR TITLE
tools/cephfs_mirror: optimize decoding/reading snap metadata from PeerReplayer::build_snap_map

### DIFF
--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -1306,7 +1306,9 @@ void PeerReplayer::unlock_directory(const std::string &dir_root, const DirRegist
 }
 
 int PeerReplayer::build_snap_map(const std::string &dir_root,
-                                 std::map<uint64_t, std::string> *snap_map, bool is_remote) {
+                                 std::map<uint64_t, std::string> *snap_map,
+                                 bool is_remote,
+                                 SnapMetadataMap *snap_metadata_map) {
   auto snap_dir = snapshot_dir_path(m_cct, dir_root);
   dout(20) << ": dir_root=" << dir_root << ", snap_dir=" << snap_dir
            << ", is_remote=" << is_remote << dendl;
@@ -1349,15 +1351,22 @@ int PeerReplayer::build_snap_map(const std::string &dir_root,
       break;
     }
 
+    std::map<std::string, std::string> metadata;
+    if (info.nr_snap_metadata) {
+      if (is_remote || snap_metadata_map) {
+        metadata = decode_snap_metadata(info.snap_metadata, info.nr_snap_metadata);
+      }
+      ceph_free_snap_info_buffer(&info);
+    }
+
     uint64_t snap_id;
     if (is_remote) {
-      if (!info.nr_snap_metadata) {
+      if (metadata.empty()) {
         std::string failed_reason = "snapshot '" + snap  + "' has invalid metadata";
         derr << ": " << failed_reason << dendl;
         m_snap_sync_stats.at(dir_root).last_failed_reason = failed_reason;
         rv = -EINVAL;
       } else {
-        auto metadata = decode_snap_metadata(info.snap_metadata, info.nr_snap_metadata);
         dout(20) << ": snap_path=" << snap_path << ", metadata=" << metadata << dendl;
         auto it = metadata.find(PRIMARY_SNAP_ID_KEY);
         if (it == metadata.end()) {
@@ -1367,7 +1376,6 @@ int PeerReplayer::build_snap_map(const std::string &dir_root,
         } else {
           snap_id = std::stoull(it->second);
         }
-        ceph_free_snap_info_buffer(&info);
       }
     } else {
       snap_id = info.id;
@@ -1377,6 +1385,9 @@ int PeerReplayer::build_snap_map(const std::string &dir_root,
       break;
     }
     snap_map->emplace(snap_id, snap);
+    if (snap_metadata_map) {
+      snap_metadata_map->emplace(snap_id, std::move(metadata));
+    }
   }
 
   r = ceph_closedir(mnt, dirp);
@@ -1442,7 +1453,9 @@ void PeerReplayer::initialize_checkpoints(const std::string &dir_root) {
 
   // Build local snapshot map
   std::map<uint64_t, std::string> local_snap_map;
-  int r = build_snap_map(dir_root, &local_snap_map, false);
+  SnapMetadataMap local_snap_metadata_map;
+  int r = build_snap_map(dir_root, &local_snap_map, false,
+                         &local_snap_metadata_map);
   if (r < 0) {
     derr << ": failed to build local snap map for dir_root=" << dir_root
          << ": " << cpp_strerror(r) << dendl;
@@ -1475,15 +1488,14 @@ void PeerReplayer::initialize_checkpoints(const std::string &dir_root) {
   // if their snap_id is <= remote_highest_snap_id
   for (const auto &[snap_id, snap_name] : local_snap_map) {
     // Read snapshot metadata
-    auto snap_path = snapshot_path(m_cct, dir_root, snap_name);
-    std::map<std::string, std::string> snap_metadata;
-    r = read_snap_metadata(m_local_mount, snap_path, &snap_metadata);
-    if (r < 0) {
+    auto it = local_snap_metadata_map.find(snap_id);
+    if (it == local_snap_metadata_map.end()) {
       derr << ": failed to read snap metadata for snap_id=" << snap_id
-           << " snap_name=" << snap_name << ": " << cpp_strerror(r) << dendl;
+           << " snap_name=" << snap_name << dendl;
       continue;
     }
 
+    const auto& snap_metadata = it->second;
     if (!has_checkpoint(snap_metadata)) {
       continue;
     }

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -787,7 +787,7 @@ private:
 
 
   int build_snap_map(const std::string &dir_root, std::map<uint64_t, std::string> *snap_map,
-                     bool is_remote=false);
+                     bool is_remote=false, SnapMetadataMap *snap_metadata_map = nullptr);
 
   void initialize_checkpoints(const std::string &dir_root);
   void checkpoint_sync_complete(const std::string &dir_root, uint64_t synced_snap_id,

--- a/src/tools/cephfs_mirror/Types.h
+++ b/src/tools/cephfs_mirror/Types.h
@@ -87,6 +87,9 @@ typedef ceph_mount_info *MountRef;
 
 using clock = ceph::coarse_mono_clock;
 using monotime = ceph::coarse_mono_time;
+
+using SnapMetadata = std::map<std::string, std::string>;
+using SnapMetadataMap = std::map<uint64_t, SnapMetadata>;
 } // namespace mirror
 } // namespace cephfs
 


### PR DESCRIPTION
specifically PeerReplayer::initialize_checkpoints which builds
the local snap map then a block down the line it also decodes the
metadata per snap path but we can achieve this from a single call.

Fixes: https://tracker.ceph.com/issues/79460





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
