### PR TITLE
mgr/cephadm: Foreground start agents and release listener port

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -10,6 +10,7 @@ import os
 import random
 import shlex
 import shutil
+import signal
 import socket
 import string
 import subprocess
@@ -1474,10 +1475,14 @@ class MgrListener(Thread):
     def __init__(self, agent: 'CephadmAgent') -> None:
         self.agent = agent
         self.stop = False
+        self._listen_socket: Optional[ssl.SSLSocket] = None
         super(MgrListener, self).__init__(target=self.run)
 
     def run(self) -> None:
         listenSocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        # Allow rebinding after restart while the prior socket is in TIME_WAIT.
+        # Does not allow stealing a port from a live LISTEN socket.
+        listenSocket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         listenSocket.bind(('0.0.0.0', int(self.agent.listener_port)))
         listenSocket.settimeout(60)
         listenSocket.listen(1)
@@ -1486,12 +1491,18 @@ class MgrListener(Thread):
         ssl_ctx.load_cert_chain(self.agent.listener_cert_path, self.agent.listener_key_path)
         ssl_ctx.load_verify_locations(self.agent.ca_path)
         secureListenSocket = ssl_ctx.wrap_socket(listenSocket, server_side=True)
+        self._listen_socket = secureListenSocket
         while not self.stop:
             try:
                 try:
                     conn, _ = secureListenSocket.accept()
                 except socket.timeout:
                     continue
+                except OSError:
+                    # Expected when shutdown() closes the listen socket.
+                    if self.stop:
+                        break
+                    raise
                 try:
                     length: int = int(conn.recv(10).decode())
                 except Exception as e:
@@ -1519,10 +1530,18 @@ class MgrListener(Thread):
                             self.agent.volume_gatherer.wakeup()
                             logger.debug(f'Got mgr message {data}')
             except Exception as e:
+                if self.stop:
+                    break
                 logger.error(f'Mgr Listener encountered exception: {e}')
 
     def shutdown(self) -> None:
         self.stop = True
+        if self._listen_socket is not None:
+            try:
+                self._listen_socket.close()
+            except Exception:
+                pass
+            self._listen_socket = None
 
     def handle_json_payload(self, data: Dict[Any, Any]) -> None:
         if 'counter' in data:
@@ -1647,7 +1666,18 @@ class CephadmAgent(DaemonForm):
     def unit_run(self) -> str:
         py3 = shutil.which('python3')
         binary_path = os.path.realpath(sys.argv[0])
-        return ('set -e\n' + f'{py3} {binary_path} agent --fsid {self.fsid} --daemon-id {self.daemon_id} &\n')
+        # Run the agent in the foreground under Type=simple with no trailing '&'
+        # so systemd's MainPID is the agent itself and stop/restart wait for it
+        # to exit
+        # - exec ensures that the agent is PID 1 of the service and receives
+        #   SIGTERM directly
+        # - TimeoutStopSec=30 in agent.service.j2 ensures that a SIGKILL is sent
+        #   if the agent does not exit within 30 seconds. This is a safegaurd
+        #   to ensure that the agent is stopped if it gets stuck.
+        return (
+            'set -e\n'
+            f'exec {py3} {binary_path} agent --fsid {self.fsid} --daemon-id {self.daemon_id}\n'
+        )
 
     def unit_file(self) -> str:
         return templating.render(
@@ -1662,6 +1692,12 @@ class CephadmAgent(DaemonForm):
             self.ls_gatherer.shutdown()
         if self.volume_gatherer.is_alive():
             self.volume_gatherer.shutdown()
+        self.wakeup()
+
+    def join_threads(self, timeout: float = 2.0) -> None:
+        for t in (self.mgr_listener, self.ls_gatherer, self.volume_gatherer):
+            if t.is_alive():
+                t.join(timeout=timeout)
 
     def wakeup(self) -> None:
         self.event.set()
@@ -1954,6 +1990,7 @@ class AgentGatherer(Thread):
 
     def shutdown(self) -> None:
         self.stop = True
+        self.wakeup()
 
     def wakeup(self) -> None:
         self.event.set()
@@ -1968,7 +2005,16 @@ def command_agent(ctx: CephadmContext) -> None:
     if not os.path.isdir(agent.daemon_dir):
         raise Error(f'Agent daemon directory {agent.daemon_dir} does not exist. Perhaps agent was never deployed?')
 
-    agent.run()
+    def _handle_sigterm(signum: int, frame: object) -> None:
+        logger.info('Agent received SIGTERM, shutting down gracefully')
+        agent.shutdown()
+
+    signal.signal(signal.SIGTERM, _handle_sigterm)
+    try:
+        agent.run()
+    finally:
+        agent.shutdown()
+        agent.join_threads()
 
 
 ##################################

--- a/src/cephadm/cephadmlib/templates/agent.service.j2
+++ b/src/cephadm/cephadmlib/templates/agent.service.j2
@@ -6,7 +6,9 @@ PartOf=ceph-{{agent.fsid}}.target
 Before=ceph-{{agent.fsid}}.target
 
 [Service]
-Type=forking
+Type=simple
+KillMode=control-group
+TimeoutStopSec=30
 ExecStart=/bin/bash {{agent.daemon_dir}}/unit.run
 Restart=on-failure
 RestartSec=10s

--- a/src/cephadm/tests/test_agent.py
+++ b/src/cephadm/tests/test_agent.py
@@ -212,11 +212,25 @@ def test_agent_shutdown(_is_alive):
         assert agent.mgr_listener.stop == False
         assert agent.ls_gatherer.stop == False
         assert agent.volume_gatherer.stop == False
+        assert agent.event.is_set() == False
         agent.shutdown()
         assert agent.stop == True
         assert agent.mgr_listener.stop == True
         assert agent.ls_gatherer.stop == True
         assert agent.volume_gatherer.stop == True
+        assert agent.event.is_set() == True
+
+
+def test_agent_unit_is_type_simple():
+    with with_cephadm_ctx([]) as ctx:
+        agent = _cephadm.CephadmAgent(ctx, FSID, AGENT_ID)
+        unit = agent.unit_file()
+        assert 'Type=simple' in unit
+        assert 'Type=forking' not in unit
+        assert 'KillMode=control-group' in unit
+        unit_run = agent.unit_run()
+        assert 'exec ' in unit_run
+        assert not unit_run.rstrip().endswith('&')
 
 
 def test_agent_wakeup():
@@ -727,6 +741,9 @@ def test_mgr_listener_run(_load_cert_chain, _load_verify_locations, _handle_json
                 self.family = family
                 self.type = type
 
+            def setsockopt(*args, **kwargs):
+                return
+
             def bind(*args, **kwargs):
                 return
 
@@ -734,6 +751,9 @@ def test_mgr_listener_run(_load_cert_chain, _load_verify_locations, _handle_json
                 return
 
             def listen(*args, **kwargs):
+                return
+
+            def close(*args, **kwargs):
                 return
 
         class FakeSecureSocket:


### PR DESCRIPTION
Agent unit started with Type=simple and TimeoutStopSec=30 in foreground exec (no &) to retain MainPID as the agent.

Primary code changes
- Type=simple replaces Type=forking so stop targets the real agent PID
- Agent shutdown closes listen socket as a part of SIGTERM handler
- systemd sends SIGKILL/ABORT if agents don't gracefully stop before TimeoutStopSec=30
- 30 sec configured to be under refresh_rate × down_multiplier, typically 60s
- Use SO_REUSEADDR for bind even if it still has connections in TIME_WAIT (does not take the port from a live LISTEN)

Fixes: https://tracker.ceph.com/issues/79461
Signed-off-by: Ashwin M. Joshi <ashjosh1@in.ibm.com>




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
