### PR TITLE
crimson/os/seastore: replace Transaction block lists with PMR vectors

### DIFF
--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -538,14 +538,14 @@ ExtentPlacementManager::dispatch_delayed_extents(Transaction &t)
   res.delayed_extents = t.get_delayed_alloc_list();
 
   // init projected usage
-  for (auto &extent : t.get_inline_block_list()) {
+  for (auto& extent : t.get_inline_block_list()) {
     if (extent->is_valid()) {
       res.usage.inline_usage += extent->get_length();
       res.usage.cleaner_usage.main_usage += extent->get_length();
     }
   }
 
-  for (auto &extent : res.delayed_extents) {
+  for (auto& extent : res.delayed_extents) {
     if (dispatch_delayed_extent(extent)) {
       res.usage.inline_usage += extent->get_length();
       res.usage.cleaner_usage.main_usage += extent->get_length();
@@ -590,8 +590,8 @@ ExtentPlacementManager::write_delayed_ool_extents(
 
 ExtentPlacementManager::alloc_paddr_iertr::future<>
 ExtentPlacementManager::write_preallocated_ool_extents(
-    Transaction &t,
-    std::list<CachedExtentRef> &extents)
+    Transaction& t,
+    std::vector<CachedExtentRef>& extents)
 {
   LOG_PREFIX(ExtentPlacementManager::write_preallocated_ool_extents);
   DEBUGT("start with {} allocated extents",
@@ -1287,7 +1287,8 @@ RandomBlockOolWriter::alloc_write_ool_extents(
         token_bucket.get(size));
       seastar::lw_shared_ptr<rbm_pending_ool_t> ptr =
           seastar::make_lw_shared<rbm_pending_ool_t>();
-      ptr->pending_extents = t.get_pre_alloc_list();
+      auto& pal = t.get_pre_alloc_list();
+      ptr->pending_extents.assign(pal.begin(), pal.end());
       assert(!t.is_conflicted());
       t.set_pending_ool(ptr);
       co_await do_write(t, extents

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -619,7 +619,7 @@ public:
     std::map<ExtentOolWriter*, std::list<CachedExtentRef>>;
   struct dispatch_result_t {
     extents_by_writer_t alloc_map;
-    std::list<CachedExtentRef> delayed_extents;
+    std::vector<CachedExtentRef> delayed_extents;
     io_usage_t usage;
   };
 
@@ -648,7 +648,7 @@ public:
    */
   alloc_paddr_iertr::future<> write_preallocated_ool_extents(
     Transaction &t,
-    std::list<CachedExtentRef> &extents);
+    std::vector<CachedExtentRef>& extents);
 
   seastar::future<> stop_background() {
     return background_process.stop_background();

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -5,6 +5,7 @@
 
 #include <chrono>
 #include <iostream>
+#include <memory_resource>
 
 #include <boost/intrusive/list.hpp>
 
@@ -101,7 +102,7 @@ struct btree_cursor_stats_t {
 
 struct rbm_pending_ool_t {
   bool is_conflicted = false;
-  std::list<CachedExtentRef> pending_extents;
+  std::vector<CachedExtentRef> pending_extents;
 };
 
 /**
@@ -313,8 +314,9 @@ public:
     }
   }
 
-  auto get_delayed_alloc_list() {
-    std::list<CachedExtentRef> ret;
+  std::vector<CachedExtentRef> get_delayed_alloc_list() {
+    std::vector<CachedExtentRef> ret;
+    ret.reserve(delayed_alloc_list.size());
     for (auto& extent : delayed_alloc_list) {
       // delayed extents may be invalidated
       if (extent->is_valid()) {
@@ -327,8 +329,9 @@ public:
     return ret;
   }
 
-  auto get_valid_pre_alloc_list() {
-    std::list<CachedExtentRef> ret;
+  std::vector<CachedExtentRef> get_valid_pre_alloc_list() {
+    std::vector<CachedExtentRef> ret;
+    ret.reserve(pre_alloc_list.size() + pre_inplace_rewrite_list.size());
     assert(num_allocated_invalid_extents == 0);
     for (auto& extent : pre_alloc_list) {
       if (extent->is_valid()) {
@@ -340,7 +343,7 @@ public:
     for (auto& extent : pre_inplace_rewrite_list) {
       if (extent->is_valid()) {
 	ret.push_back(extent);
-      } 
+      }
     }
     return ret;
   }
@@ -942,33 +945,47 @@ private:
 
   /**
    * lists of fresh blocks, holds refcounts, subset of write_set
+   *
+   * Backed by a small inline arena so that typical transactions
+   * (fewer than ~200 total entries across all lists) never touch
+   * the heap for list storage.  The monotonic_buffer_resource falls
+   * back to upstream (new/delete) for very large transactions.
    */
   io_stat_t fresh_block_stats;
   uint64_t num_delayed_invalid_extents = 0;
   uint64_t num_allocated_invalid_extents = 0;
+
+  static constexpr std::size_t BLOCK_LIST_ARENA_BYTES = 4096;
+  alignas(std::max_align_t)
+    std::byte block_list_arena_[BLOCK_LIST_ARENA_BYTES];
+  std::pmr::monotonic_buffer_resource block_list_mr_{
+    block_list_arena_, BLOCK_LIST_ARENA_BYTES};
+
   /// fresh blocks with delayed allocation,
   /// may become inline_block_list or ool_block_list below
-  std::list<CachedExtentRef> delayed_alloc_list;
+  std::pmr::vector<CachedExtentRef> delayed_alloc_list{&block_list_mr_};
   /// fresh blocks with pre-allocated addresses with RBM,
   /// should be released upon conflicts,
   /// will be added to ool_block_list below
-  std::list<CachedExtentRef> pre_alloc_list;
+  std::pmr::vector<CachedExtentRef> pre_alloc_list{&block_list_mr_};
   /// dirty blocks for inplace rewrite with RBM,
   /// will be added to inplace inplace_ool_block_list below
-  std::list<LogicalCachedExtentRef> pre_inplace_rewrite_list;
+  std::pmr::vector<LogicalCachedExtentRef>
+    pre_inplace_rewrite_list{&block_list_mr_};
 
   /// fresh blocks that will be committed with inline journal record
-  std::list<CachedExtentRef> inline_block_list;
+  std::pmr::vector<CachedExtentRef> inline_block_list{&block_list_mr_};
   /// fresh blocks that will be committed with out-of-line record
-  std::list<CachedExtentRef> ool_block_list;
+  std::pmr::vector<CachedExtentRef> ool_block_list{&block_list_mr_};
   /// dirty blocks that will be committed out-of-line with inplace rewrite
-  std::list<LogicalCachedExtentRef> inplace_ool_block_list;
+  std::pmr::vector<LogicalCachedExtentRef>
+    inplace_ool_block_list{&block_list_mr_};
 
   /// list of mutated blocks, holds refcounts, subset of write_set
-  std::list<CachedExtentRef> mutated_block_list;
+  std::pmr::vector<CachedExtentRef> mutated_block_list{&block_list_mr_};
 
   /// partial blocks of extents on disk, with data and refcounts
-  std::list<CachedExtentRef> existing_block_list;
+  std::pmr::vector<CachedExtentRef> existing_block_list{&block_list_mr_};
   existing_block_stats_t existing_block_stats;
 
   std::list<view_ref> views;

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -680,7 +680,7 @@ TransactionManager::submit_transaction_direct(
 TransactionManager::update_lba_mappings_ret
 TransactionManager::update_lba_mappings(
   Transaction &t,
-  std::list<CachedExtentRef> &pre_allocated_extents)
+  std::vector<CachedExtentRef> &pre_allocated_extents)
 {
   LOG_PREFIX(TransactionManager::update_lba_mappings);
   SUBTRACET(seastore_t, "update extent lba mappings", t);

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -1824,7 +1824,7 @@ private:
   using update_lba_mappings_ret = LBAManager::update_mappings_ret;
   update_lba_mappings_ret update_lba_mappings(
     Transaction &t,
-    std::list<CachedExtentRef> &pre_allocated_extents);
+    std::vector<CachedExtentRef> &pre_allocated_extents);
 
   /**
    * pin_to_extent


### PR DESCRIPTION
Replace the eight std::list block-extent members in Transaction with std::pmr::vector backed by a 4 KiB inline arena (monotonic_buffer_resource). Typical transactions (< ~200 entries) avoid the heap entirely.

Downstream signatures (dispatch_result_t::delayed_extents, write_preallocated_ool_extents, update_lba_mappings, rbm_pending_ool_t) are updated to std::vector accordingly.  The std::list<view_ref> views member is unchanged (stable-reference requirement).


