### PR TITLE
squid: mgr: erase daemon_connections ref on reset for all peer types

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -316,21 +316,27 @@ void DaemonServer::ms_handle_accept(Connection* con)
 
 bool DaemonServer::ms_handle_reset(Connection *con)
 {
+  std::lock_guard l(lock);
   if (con->get_peer_type() == CEPH_ENTITY_TYPE_OSD) {
     auto priv = con->get_priv();
     auto session = static_cast<MgrSession*>(priv.get());
-    if (!session) {
-      return false;
+    if (session) {
+      dout(10) << "unregistering osd." << session->osd_id
+               << "  session " << session << " con " << con << dendl;
+      osd_cons[session->osd_id].erase(con);
     }
-    std::lock_guard l(lock);
-    dout(10) << "unregistering osd." << session->osd_id
-	     << "  session " << session << " con " << con << dendl;
-    osd_cons[session->osd_id].erase(con);
+  }
 
-    auto iter = daemon_connections.find(con);
-    if (iter != daemon_connections.end()) {
-      daemon_connections.erase(iter);
-    }
+  auto iter = daemon_connections.find(con);
+  if (iter != daemon_connections.end()) {
+    dout(10) << "removing daemon connection " << con
+             << " peer " << con->get_peer_addr()
+             << dendl;
+    daemon_connections.erase(iter);
+  } else {
+    dout(10) << "reset for untracked daemon connection " << con
+             << " peer " << con->get_peer_addr()
+             << dendl;
   }
   return false;
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79420

---

backport of https://github.com/ceph/ceph/pull/70367
parent tracker: https://tracker.ceph.com/issues/78408

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh