### PR TITLE
mds: safely defer old fragment cleanup to fix auth_pins assert

### DIFF
--- a/qa/tasks/cephfs/test_fragment.py
+++ b/qa/tasks/cephfs/test_fragment.py
@@ -409,6 +409,69 @@ class TestFragmentation(CephFSTestCase):
         self.assertEqual(self.get_merges(), 0)
         self.assertEqual(len(self.get_dir_ino("/splitdir")["dirfrags"]), 2)
 
+    def test_finish_old_fragment_auth_pin_race(self):
+        """
+        Reproduce the race condition between directory fragmentation (split/merge)
+        and concurrent client metadata operations generating auth_pins.
+        """
+        log.info("Testing auth_pin race condition during fragment split/merge...")
+
+        # Configure the MDS balancer for ultra-aggressive fragmentation
+        self._configure(
+            mds_bal_split_size=20,
+            mds_bal_merge_size=5,
+            mds_bal_interval=1,
+            mds_bal_fragment_interval=1
+        )
+
+        time.sleep(5)
+
+        test_dir = f"{self.mount_a.mountpoint}/frag_race_dir"
+        self.mount_a.run_shell(['mkdir', '-p', test_dir])
+
+        # Define the background workloads for the client
+        spawner_script = f"""
+        while true; do
+            touch {test_dir}/file_{{1..50}} > /dev/null 2>&1 || true
+            sleep 0.2
+            rm -f {test_dir}/file_{{1..50}} > /dev/null 2>&1 || true
+            sleep 0.2
+        done
+        """
+
+        pinner_script = f"""
+        while true; do
+            stat {test_dir}/file_* > /dev/null 2>&1 || true
+            chmod 777 {test_dir}/file_* > /dev/null 2>&1 || true
+        done
+        """
+
+        # Write and execute the workloads
+        self.mount_a.client_remote.write_file('/tmp/spawner.sh', spawner_script.encode('utf-8'))
+        self.mount_a.client_remote.write_file('/tmp/pinner.sh', pinner_script.encode('utf-8'))
+        self.mount_a.client_remote.run(args=['chmod', '+x', '/tmp/spawner.sh', '/tmp/pinner.sh'])
+
+        self.mount_a.run_shell(['bash', '/tmp/spawner.sh'], wait=False)
+        self.mount_a.run_shell(['bash', '/tmp/pinner.sh'], wait=False)
+
+        run_time = 120
+        sleep_interval = 5
+        try:
+            for i in range(run_time // sleep_interval):
+                # Actively verify the MDS ranks are still active.
+                # wait_for_daemons() returns instantly if the MDS is healthy, but will
+                # block and fail if a daemon crashes. Looping it here acts as a fail-fast
+                # heartbeat, ensuring we catch any assertion failures from the race
+                # condition immediately during the 120s window rather than waiting blindly.
+                self.fs.wait_for_daemons()
+                time.sleep(sleep_interval)
+        finally:
+            # Use pkill to terminate the infinite loops.
+            self.mount_a.client_remote.run(args=['pkill', '-f', 'spawner.sh'], check_status=False)
+            self.mount_a.client_remote.run(args=['pkill', '-f', 'pinner.sh'], check_status=False)
+            self.mount_a.client_remote.run(args=['rm', '-f', '/tmp/spawner.sh', '/tmp/pinner.sh'])
+            self.mount_a.run_shell(['rm', '-rf', test_dir])
+
     def _run_dir_frag(self, killpoint):
         self._test_oversize(killpoint=killpoint)
 

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1136,7 +1136,19 @@ void CDir::split(int bits, std::vector<CDir*>* subs, MDSContext::vec& waiters, b
     }
   }
 
-  finish_old_fragment(waiters, replay);
+  // During fragmentation, MDCache deliberately takes an auth_pin on a directory
+  // to protect it. We calculate this baseline to determine if there are any
+  // *additional* pins indicating active client operations. 'expected_auth_pins'
+  // indicates the auth_pin that the authoritative MDS holds.
+  int expected_auth_pins = (!replay && is_auth()) ? 1 : 0;
+  if (auth_pins > expected_auth_pins || dir_auth_pins > 0) {
+    dout(10) << __func__ << " deferring old fragment cleanup, auth_pins=" << auth_pins
+             << " dir_auth_pins=" << dir_auth_pins << dendl;
+    mdcache->queue_delayed_fragment_delete(this, replay);
+  } else {
+    finish_old_fragment(waiters, replay);
+  }
+
 }
 
 void CDir::merge(const std::vector<CDir*>& subs, MDSContext::vec& waiters, bool replay)
@@ -1195,7 +1207,14 @@ void CDir::merge(const std::vector<CDir*>& subs, MDSContext::vec& waiters, bool 
     // merge state
     state_set(dir->get_state() & MASK_STATE_FRAGMENT_KEPT);
 
-    dir->finish_old_fragment(waiters, replay);
+    int expected_auth_pins = (!replay && dir->is_auth()) ? 1 : 0;
+    if (dir->get_auth_pins() > expected_auth_pins || dir->get_dir_auth_pins() > 0) {
+      dout(10) << __func__ << " deferring old fragment cleanup, auth_pins=" << dir->get_auth_pins()
+               << " dir_auth_pins=" << dir->get_dir_auth_pins() << dendl;
+      mdcache->queue_delayed_fragment_delete(dir, replay);
+    } else {
+      dir->finish_old_fragment(waiters, replay);
+    }
     inode->close_dirfrag(dir->get_frag());
   }
 

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -121,6 +121,7 @@ public:
   static const int PIN_EXPORTBOUND = 10;
   static const int PIN_STICKY =      11;
   static const int PIN_SUBTREETEMP = 12;  // used by MDCache::trim_non_auth()
+  static const int PIN_DELAYEDDROP = 13;  // used by delayed fragment garbage collection
 
   // -- state --
   static const unsigned STATE_COMPLETE =      (1<< 0);  // the complete contents are in cache
@@ -221,6 +222,7 @@ public:
     case PIN_EXPORTBOUND: return "exportbound";
     case PIN_STICKY: return "sticky";
     case PIN_SUBTREETEMP: return "subtreetemp";
+    case PIN_DELAYEDDROP: return "delayeddrop";
     default: return generic_pin_name(p);
     }
   }

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -6976,6 +6976,8 @@ std::pair<bool, uint64_t> MDCache::trim(uint64_t count)
   // process delayed eval_stray()
   stray_manager.advance_delayed();
 
+  process_delayed_fragment_deletes();
+
   auto result = trim_lru(count, expiremap);
   auto& trimmed = result.second;
 
@@ -14805,4 +14807,33 @@ void MDCache::aggregate_snap_sets(const std::vector<std::unique_ptr<SnapSetConte
     block_diff->blocks = extents;
   }
   on_finish->complete(r);
+}
+
+void MDCache::queue_delayed_fragment_delete(CDir *dir, bool replay)
+{
+  dir->get(CDir::PIN_DELAYEDDROP);
+  delayed_fragment_deletes.push_back({dir, replay});
+}
+
+void MDCache::process_delayed_fragment_deletes()
+{
+  auto it = delayed_fragment_deletes.begin();
+  while (it != delayed_fragment_deletes.end()) {
+    CDir *dir = it->dir;
+    bool replay = it->replay;
+    int expected_auth_pins = (!replay && dir->is_auth()) ? 1 : 0;
+
+    if (dir->get_auth_pins() <= expected_auth_pins && dir->get_dir_auth_pins() == 0) {
+      dout(10) << __func__ << ": finishing deferred old fragment " << *dir << dendl;
+      dir->put(CDir::PIN_DELAYEDDROP);
+      MDSContext::vec waiters;
+      dir->finish_old_fragment(waiters, replay);
+      if (!waiters.empty()) {
+        mds->queue_waiters(waiters);
+      }
+      it = delayed_fragment_deletes.erase(it);
+    } else {
+      ++it;
+    }
+  }
 }

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1131,6 +1131,15 @@ private:
   void dump_resolve_status(Formatter *f) const;
   void dump_rejoin_status(Formatter *f) const;
 
+  // -- garbage collection for orphaned fragments --
+  struct delayed_fragment_t {
+    CDir *dir;
+    bool replay;
+  };
+  std::list<delayed_fragment_t> delayed_fragment_deletes;
+  void queue_delayed_fragment_delete(CDir *dir, bool replay);
+  void process_delayed_fragment_deletes();
+
   // == crap fns ==
   void show_cache();
   void show_subtrees(int dbl=10, bool force_print=false);


### PR DESCRIPTION
This PR addresses a race condition during directory fragmentation (splits/merges) where the MDS can crash with `FAILED ceph_assert(auth_pins == 0)` if it attempts to clean up an old directory fragment while concurrent client operations are still actively using it. This PR decouples the cleanup into a safe, deferred garbage collection queue.

1. **Defers Cleanup**: Modifies CDir::split and CDir::merge to check for active client contention (using expected_auth_pins and dir_auth_pins). If the fragment is still in use, cleanup is deferred.

2. **New GC Queue**: Introduces a `PIN_DELAYEDDROP` pin to safely protect these busy fragments and pushes them to a `MDCache::delayed_fragment_deletes` queue.

3. **Background Sweeping**: Hooks into the `MDCache::trim()` cycle to periodically check the queue. The MDS safely executes `finish_old_fragment` in the background only after all client locks have naturally drained.

4. **Adds QA Regression Test**: Adds a Teuthology stress test `test_finish_old_fragment_auth_pin_race` that aggressively forces fragmentation while running heavy concurrent client workloads to validate the fix.

Fixes: https://tracker.ceph.com/issues/61363


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
