### PR TITLE
umbrella: rgw: bind gcm object keys to the bucket marker

### DIFF
--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -2125,7 +2125,7 @@ int rgw_s3_prepare_encrypt(req_state* s, optional_yield y,
           if (!gcm->derive_object_key(
                   reinterpret_cast<const uint8_t*>(key_bin.c_str()),
                   AES_256_KEYSIZE,
-                  s->bucket->get_info().bucket.bucket_id,
+                  s->bucket->get_marker(),
                   s->object->get_name(),
                   part_number)) {
             ldpp_dout(s, 5) << "ERROR: SSE-C-AES256-GCM key derivation failed for "
@@ -2249,7 +2249,7 @@ int rgw_s3_prepare_encrypt(req_state* s, optional_yield y,
             if (!gcm || !gcm->derive_object_key(
                     reinterpret_cast<const uint8_t*>(actual_key.c_str()),
                     AES_256_KEYSIZE,
-                    s->bucket->get_info().bucket.bucket_id,
+                    s->bucket->get_marker(),
                     s->object->get_name(),
                     part_number,
                     "SSE-KMS-GCM")) {
@@ -2347,7 +2347,7 @@ int rgw_s3_prepare_encrypt(req_state* s, optional_yield y,
           if (!gcm || !gcm->derive_object_key(
                   reinterpret_cast<const uint8_t*>(actual_key.c_str()),
                   AES_256_KEYSIZE,
-                  s->bucket->get_info().bucket.bucket_id,
+                  s->bucket->get_marker(),
                   s->object->get_name(),
                   part_number,
                   "AES256-GCM")) {
@@ -2416,7 +2416,7 @@ int rgw_s3_prepare_encrypt(req_state* s, optional_yield y,
           if (!gcm->derive_object_key(
                   reinterpret_cast<const uint8_t*>(master_encryption_key.c_str()),
                   AES_256_KEYSIZE,
-                  s->bucket->get_info().bucket.bucket_id,
+                  s->bucket->get_marker(),
                   s->object->get_name(),
                   part_number,
                   "RGW-AUTO-GCM")) {
@@ -2470,12 +2470,12 @@ static void pick_gcm_identity(req_state* s,
       return;
     }
     if (s->src_object && s->src_object->get_bucket()) {
-      bucket_id = s->src_object->get_bucket()->get_info().bucket.bucket_id;
+      bucket_id = s->src_object->get_bucket()->get_marker();
       object_name = s->src_object->get_name();
       return;
     }
   }
-  bucket_id = s->bucket->get_info().bucket.bucket_id;
+  bucket_id = s->bucket->get_marker();
   object_name = s->object->get_name();
 }
 

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3100,7 +3100,7 @@ int RGWPutObj_ObjStore_S3::get_decrypt_filter(
     bufferlist* manifest_bl)
 {
   static constexpr bool copy_source = true;
-  rgw_crypt_src_identity src_identity{copy_source_bucket_info.bucket.bucket_id, copy_source_bucket_name, copy_source_object_name};
+  rgw_crypt_src_identity src_identity{copy_source_bucket_info.bucket.marker, copy_source_bucket_name, copy_source_object_name};
   // part_num=0 for copy source (full object read)
   return ::get_decrypt_filter(filter, cb, s, attrs, manifest_bl, nullptr, copy_source,
                               0, 0, &src_identity);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79471

---

backport of https://github.com/ceph/ceph/pull/70914
parent tracker: https://tracker.ceph.com/issues/79161

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh