### PR TITLE
rgw: don't pull the rados sal into the standalone radosgw-admin build

### DIFF
--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -68,11 +68,15 @@ extern "C" {
 #include "rgw_log.h"
 #include "rgw_formats.h"
 #include "rgw_usage.h"
+#ifdef WITH_RADOSGW_RADOS
+// these pull in driver/rados/rgw_sal_rados.h, whose vtables only exist in
+// rgw_sal_rados.cc -- a TU that is not part of the standalone build
 #include "rgw_sync.h"
+#include "rgw_data_sync.h"
+#endif
 #include "rgw_trim_bilog.h"
 #include "rgw_trim_datalog.h"
 #include "rgw_trim_mdlog.h"
-#include "rgw_data_sync.h"
 #include "rgw_rest_conn.h"
 #include "rgw_realm_watcher.h"
 #include "rgw_role.h"

--- a/src/rgw/rgw_http_client_curl.h
+++ b/src/rgw/rgw_http_client_curl.h
@@ -16,8 +16,10 @@
 #pragma once
 
 #include <map>
+#include <string>
 #include <boost/optional.hpp>
-#include "rgw_frontend.h"
+
+class RGWFrontendConfig;
 
 namespace rgw {
 namespace curl {


### PR DESCRIPTION
The Debian bookworm deb build fails at 98% linking `bin/rgw-standalone-admin`:

```
/usr/bin/ld: CMakeFiles/rgw-standalone-admin.dir/radosgw-admin/radosgw-admin.cc.o:
  in function `rgw::sal::RadosZone::~RadosZone()':
rgw_sal_rados.h:105: undefined reference to `vtable for rgw::sal::RadosZone'
rgw_sal_rados.h:60:  undefined reference to `vtable for rgw::sal::RadosZoneGroup'
collect2: error: ld returned 1 exit status
```

(https://jenkins.ceph.com/job/ceph-dev-pipeline/8190/)

### Cause

`rgw-standalone-admin` compiles `radosgw-admin.cc` a second time with
`-UWITH_RADOSGW_RADOS` and links it against `rgw_a_standalone`, which
deliberately excludes `rgw_sal_rados.cc` — the TU that emits the
`RadosZone` / `RadosZoneGroup` vtables (their key functions live there).

`radosgw-admin.cc` nevertheless reached `rgw_sal_rados.h` unconditionally, by
two routes:

* `-I src/rgw/driver/rados` is on the include path, so the unguarded
  `#include "rgw_sync.h"` and `#include "rgw_data_sync.h"` resolve to
  `driver/rados/rgw_sync.h` and `driver/rados/rgw_data_sync.h`, both of which
  include `rgw_sal_rados.h`.
* `rgw_http_client_curl.h` included the whole of `rgw_frontend.h` — which also
  includes `rgw_sal_rados.h` — only to name `RGWFrontendConfig` in a typedef.

gcc then emits the inline `~RadosZone()` / `~RadosZoneGroup()` bodies into
`radosgw-admin.cc.o`, and they reference vtables that aren't in the link.

### Why only Debian

Ubuntu (`dpkg-buildflags`) and Fedora/RHEL (`redhat-rpm-config`) both compile
with `-flto=auto -ffat-lto-objects` by default, and LTO discards the dead
destructors before the final link. Debian does not enable LTO, so the deb12
build is the only one that trips over it. Compiler version is not the
difference — jammy is gcc 12.3.0, bookworm 12.2.0.

Comparing the compile line for that exact object across distros in
[#8178](https://jenkins.ceph.com/job/ceph-dev-pipeline/8178/) (passing) vs
[#8190](https://jenkins.ceph.com/job/ceph-dev-pipeline/8190/) (failing):

| distro | flags |
| --- | --- |
| centos9 / rocky10 | `-O2 -flto=auto -ffat-lto-objects` |
| jammy / noble | `-O2 -flto=auto -ffat-lto-objects` |
| **bookworm** | `-O2` |

### Fix

Guard the two sync includes — every use of the types they declare is already
inside `WITH_RADOSGW_RADOS` — and forward declare `RGWFrontendConfig` instead of
including `rgw_frontend.h`. No unguarded include path from `radosgw-admin.cc`
reaches `rgw_sal_rados.h` afterwards.

`rgw_appmain.cc`, the only other consumer of `rgw::curl::setup_curl()` and the
only caller that passes a real `fe_map_t`, includes `rgw_frontend.h` directly.

### Testing

Built on bookworm via ceph-ci branch `wip-djgalloway-rgw-standalone-bookworm`.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes [bug reproducer](https://docs.ceph.com/en/latest/dev/developer_guide/tests-integration-tests/#bug-reproducer-tests)
  - [x] No tests
