### PR TITLE
tentacle: mgr: don't record a crash dump for NotImplementedError from dispatch_remote

### DIFF
--- a/src/mgr/ActivePyModule.cc
+++ b/src/mgr/ActivePyModule.cc
@@ -189,8 +189,21 @@ std::optional<std::vector<std::byte>> ActivePyModule::dispatch_remote(
     // Because the caller is in a different context, we can't let this
     // exception bubble up, need to re-raise it from the caller's
     // context later.
+    //
+    // NotImplementedError is not a fault: it is how a module signals that
+    // it does not implement an optional method of an interface it inherits
+    // from. The orchestrator interface is built on exactly that - see
+    // Orchestrator.get_feature_set() in the orchestrator module, whose
+    // docstring tells callers to "ask for forgiveness" and catch
+    // NotImplementedError. Recording a crash dump for it turns a documented,
+    // expected signal into a health warning: on a Rook-managed cluster
+    // mgr/prometheus calls the cephadm-only node_proxy_fullreport() once per
+    // scrape, which pinned RECENT_MGR_MODULE_CRASH permanently and added
+    // ~5,760 crash records per day. The exception is still reported to the
+    // caller, it is just not treated as a crash.
+    const bool crash_dump = !PyErr_ExceptionMatches(PyExc_NotImplementedError);
     std::string caller = "ActivePyModule::dispatch_remote "s + method;
-    *err = handle_pyerror(true, get_name(), caller);
+    *err = handle_pyerror(crash_dump, get_name(), caller);
     return std::nullopt;
   }
   dout(20) << "Success calling '" << method << "'" << dendl;

--- a/src/mgr/ActivePyModule.cc
+++ b/src/mgr/ActivePyModule.cc
@@ -132,9 +132,13 @@ std::optional<std::vector<std::byte>> ActivePyModule::dispatch_remote(
     const std::string &method,
     std::span<std::byte const> pickled_args,
     std::span<std::byte const> pickled_kwargs,
-    std::string *err)
+    std::string *err,
+    bool *crash_dump)
 {
   ceph_assert(err != nullptr);
+  if (crash_dump != nullptr) {
+    *crash_dump = true;
+  }
 
   // deserialize arguments.
 
@@ -201,9 +205,12 @@ std::optional<std::vector<std::byte>> ActivePyModule::dispatch_remote(
     // scrape, which pinned RECENT_MGR_MODULE_CRASH permanently and added
     // ~5,760 crash records per day. The exception is still reported to the
     // caller, it is just not treated as a crash.
-    const bool crash_dump = !PyErr_ExceptionMatches(PyExc_NotImplementedError);
+    const bool do_crash_dump = !PyErr_ExceptionMatches(PyExc_NotImplementedError);
     std::string caller = "ActivePyModule::dispatch_remote "s + method;
-    *err = handle_pyerror(crash_dump, get_name(), caller);
+    *err = handle_pyerror(do_crash_dump, get_name(), caller);
+    if (crash_dump != nullptr) {
+      *crash_dump = do_crash_dump;
+    }
     return std::nullopt;
   }
   dout(20) << "Success calling '" << method << "'" << dendl;

--- a/src/mgr/ActivePyModule.h
+++ b/src/mgr/ActivePyModule.h
@@ -70,7 +70,8 @@ public:
       const std::string &method,
       std::span<std::byte const> pickled_args,
       std::span<std::byte const> pickled_kwargs,
-      std::string *err);
+      std::string *err,
+      bool *crash_dump = nullptr);
 
   int handle_command(
     const ModuleCommand& module_command,

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -641,13 +641,14 @@ std::optional<std::vector<std::byte>> ActivePyModules::dispatch_remote(
     const std::string &method,
     std::span<std::byte const> pickled_args,
     std::span<std::byte const> pickled_kwargs,
-    std::string *err)
+    std::string *err,
+    bool *crash_dump)
 {
   auto mod_iter = modules.find(other_module);
   ceph_assert(mod_iter != modules.end());
 
   return mod_iter->second->dispatch_remote(
-    method, pickled_args, pickled_kwargs, err);
+    method, pickled_args, pickled_kwargs, err, crash_dump);
 }
 
 

--- a/src/mgr/ActivePyModules.h
+++ b/src/mgr/ActivePyModules.h
@@ -245,7 +245,8 @@ public:
       const std::string &method,
       std::span<std::byte const> pickled_args,
       std::span<std::byte const> pickled_kwargs,
-      std::string *err);
+      std::string *err,
+      bool *crash_dump = nullptr);
 
   int init();
 

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -894,13 +894,15 @@ ceph_dispatch_remote(BaseMgrModule *self, PyObject *args)
   }
 
   std::string err;
+  bool crash_dump = true;
   std::optional<std::vector<std::byte>> maybe_pickled_ret =
     self->py_modules->dispatch_remote(
       other_module,
       method,
       pickled_args_span,
       pickled_kwargs_span,
-      &err);
+      &err,
+      &crash_dump);
 
   PyEval_RestoreThread(tstate);
 
@@ -913,7 +915,14 @@ ceph_dispatch_remote(BaseMgrModule *self, PyObject *args)
     std::stringstream ss;
     ss << "Remote method threw exception: " << err;
     PyErr_SetString(PyExc_RuntimeError, ss.str().c_str());
-    derr << ss.str() << dendl;
+    // NotImplementedError is the documented way for a module to signal
+    // that it doesn't implement an optional method (see dispatch_remote()
+    // in ActivePyModule.cc); it isn't a fault, so don't log it as one.
+    if (crash_dump) {
+      derr << ss.str() << dendl;
+    } else {
+      dout(10) << ss.str() << dendl;
+    }
     return nullptr;
   }
 

--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -108,7 +108,7 @@ std::string handle_pyerror(
   }
   formatted = str("").join(formatted_list);
 
-  if (!module.empty()) {
+  if (crash_dump && !module.empty()) {
     std::list<std::string> bt_strings;
     std::map<std::string, std::string> extra;
     

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1,6 +1,8 @@
 import enum
 import errno
 import json
+import os
+import shutil
 from typing import List, Set, Optional, Iterator, cast, Dict, Any, Union, Sequence, Mapping, Tuple
 import re
 import datetime
@@ -2531,6 +2533,76 @@ Usage:
             assert False
         except OrchestratorError as e:
             assert e.args == ('hello, world',)
+
+        self._self_test_no_crash_dump_for_not_implemented_error()
+
+    def _self_test_no_crash_dump_for_not_implemented_error(self) -> None:
+        """
+        Regression test for https://tracker.ceph.com/issues/79106:
+        dispatch_remote() must not generate a crash dump for
+        NotImplementedError, since that's the documented way a module
+        signals an optional method isn't implemented, not a fault. A
+        genuine exception (the RuntimeError control case below) must
+        still be recorded.
+        """
+        crash_dir = cast(str, self.get_ceph_option('crash_dir'))
+
+        def crash_dir_entries() -> Set[str]:
+            try:
+                return set(os.listdir(crash_dir))
+            except FileNotFoundError:
+                return set()
+
+        def new_entries_from_selftest(before: Set[str], method: str) -> Set[str]:
+            # self_test() runs live inside ceph-mgr alongside every other
+            # always-on module, so crash_dir is shared: don't assume every
+            # entry that showed up since 'before' is ours. Only count/clean
+            # up entries whose crash metadata actually names this call, so
+            # an unrelated module crashing elsewhere during this window is
+            # neither mistaken for a test failure nor swept up and deleted.
+            matches = set()
+            for name in crash_dir_entries() - before:
+                try:
+                    with open(os.path.join(crash_dir, name, 'meta')) as f:
+                        meta = json.load(f)
+                except (OSError, ValueError):
+                    continue
+                if (meta.get('mgr_module') == 'selftest'
+                        and method in meta.get('mgr_module_caller', '')):
+                    matches.add(name)
+            return matches
+
+        before = crash_dir_entries()
+
+        # self.remote() converts *any* exception raised by the callee into
+        # a RuntimeError (see MgrModule.remote()'s docstring), so the
+        # NotImplementedError doesn't survive as its own type here -- the
+        # signal we actually care about is whether it produced a crash dump.
+        try:
+            self.remote('selftest', 'remote_raise_not_implemented_error')
+            assert False, 'exception not raised'
+        except RuntimeError:
+            pass
+        not_implemented_dumps = new_entries_from_selftest(
+            before, 'remote_raise_not_implemented_error')
+        assert not not_implemented_dumps, (
+            f'NotImplementedError from dispatch_remote() generated a crash '
+            f'dump: {not_implemented_dumps}')
+
+        try:
+            self.remote('selftest', 'remote_raise_runtime_error')
+            assert False, 'exception not raised'
+        except RuntimeError:
+            pass
+        runtime_error_dumps = new_entries_from_selftest(
+            before, 'remote_raise_runtime_error')
+        assert runtime_error_dumps, (
+            'RuntimeError from dispatch_remote() unexpectedly did not '
+            'generate a crash dump (control case failed)')
+
+        # Don't leave synthetic crash dumps lying around.
+        for name in runtime_error_dumps:
+            shutil.rmtree(os.path.join(crash_dir, name), ignore_errors=True)
 
     @staticmethod
     def _upgrade_check_image_name(image: Optional[str], ceph_version: Optional[str]) -> None:

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -2168,6 +2168,23 @@ class Module(MgrModule, OrchestratorClientMixin):
         if not self.orch_is_available():
             return
 
+        # node-proxy is only implemented by the cephadm orchestrator backend.
+        # Other backends (e.g. rook) report available() as True but don't
+        # implement node_proxy_fullreport(), so calling it every scrape would
+        # raise NotImplementedError on every invocation for no reason.
+        #
+        # Read the backend name directly from config instead of asking the
+        # orchestrator module for it: orch_is_available() above already
+        # makes that exact remote() call internally (via available()), so
+        # a second self.remote() here would just repeat the same
+        # dispatch_remote() round trip for no benefit.
+        try:
+            if self.get_module_option_ex('orchestrator', 'orchestrator') != 'cephadm':
+                return
+        except Exception as e:
+            self.log.debug(f"Failed to determine orchestrator backend: {e}")
+            return
+
         try:
             report = raise_if_exception(self.node_proxy_fullreport())
         except Exception as e:

--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -446,6 +446,23 @@ class Module(MgrModule):
             return orchestrator.OrchResult(result=None, exception=ZeroDivisionError('hello, world'))
         assert False, repr(what)
 
+    def remote_raise_not_implemented_error(self) -> None:
+        """
+        Called via self.remote() to verify that dispatch_remote() does not
+        generate a crash dump for NotImplementedError: it is the documented
+        way a module signals that it doesn't implement an optional method,
+        not a fault. See https://tracker.ceph.com/issues/79106.
+        """
+        raise NotImplementedError('selftest: intentional NotImplementedError')
+
+    def remote_raise_runtime_error(self) -> None:
+        """
+        Called via self.remote() as a negative control for
+        remote_raise_not_implemented_error(): a genuine exception must
+        still generate a crash dump.
+        """
+        raise RuntimeError('selftest: intentional RuntimeError')
+
     def shutdown(self) -> None:
         self._workload = Workload.SHUTDOWN
         self._event.set()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79397

---

backport of https://github.com/ceph/ceph/pull/70967
parent tracker: https://tracker.ceph.com/issues/79106

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh