### PR TITLE
.github/workflows: fix author permission check for external PRs

### DIFF
--- a/.github/workflows/author-ci-perms.yml
+++ b/.github/workflows/author-ci-perms.yml
@@ -36,7 +36,10 @@ jobs:
                 console.log(`Failed to fetch permissions for ${author}: ${error.message}`);
               }
             }
-            if (permission === 'none') {
+            // On a public repo every user has at least 'read', so checking for
+            // 'none' would never match a human author; require write or admin.
+            const hasWrite = ['admin', 'write'].includes(permission);
+            if (!hasWrite) {
               const currentLabels = pr.labels.map(label => label.name);
 
               // 1. Revoke approval on new pushes/updates by removing 'ci-approved'


### PR DESCRIPTION
## Problem

The `Check PR Author Permissions` workflow (`author-ci-perms.yml`) has never worked for human external contributors. Example: https://github.com/ceph/ceph/actions/runs/31390605327/job/93461183803?pr=70939 ran green on #70939 (an external contributor's PR) but posted no comment and applied no label.

## Cause

`getCollaboratorPermissionLevel` never returns `none` for a real user on a **public** repository — every GitHub user has at least `read` on ceph/ceph. So the `permission === 'none'` branch only ever fired for bot accounts, which 404 on the lookup and fall through to the `'none'` default. That's why the only PRs ever labeled `needs-ci-approval` are dependabot's (#70924, #70831).

## Fix

Require `write` or `admin` instead of checking for `none`. The API's `permission` field maps the `maintain` role to `write` and `triage` to `read`, so triage users (who cannot push) still correctly require CI approval.

## Heads-up for reviewers

Once this merges, the workflow's designed behavior kicks in for **all** external PRs for the first time:
- external PRs get `needs-ci-approval` and the notification comment on open
- `ci-approved` is **revoked on every push** (`synchronize`), requiring a Ceph member to re-apply it before Jenkins runs again

That label churn is the intended security model (approval shouldn't survive new commits under `pull_request_target`), not a new bug — but it will be new friction, so flagging it explicitly.