### PR TITLE
mgr/cephadm: populate RGW port_ips for explicit placement IPs

### DIFF
--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1597,7 +1597,11 @@ class RgwService(CephService):
             assert daemon_spec.host is not None
             ip_to_bind_to = self.mgr.get_first_matching_network_ip(daemon_spec.host, spec) or ''
             if ip_to_bind_to:
-                daemon_spec.port_ips = {str(port): ip_to_bind_to}
+                # Tell the host-side port-in-use precheck (fetch_endpoints /
+                # port_in_use) to probe this IP. Without port_ips it falls
+                # back to 0.0.0.0 and can false-conflict with listeners on
+                # other addresses.
+                daemon_spec.port_ips.update({str(port): ip_to_bind_to})
             else:
                 logger.warning(
                     f'Failed to find ip in {spec.networks} for host {daemon_spec.host}. '
@@ -1605,6 +1609,9 @@ class RgwService(CephService):
                 )
         elif daemon_spec.ip:
             ip_to_bind_to = daemon_spec.ip
+            # Same as only_bind_port_on_networks: keep precheck in sync with
+            # the narrow endpoint=<ip>:<port> / port=<ip>:<port> bind below.
+            daemon_spec.port_ips.update({str(port): ip_to_bind_to})
 
         if ftype == 'beast':
             if spec.ssl:

--- a/src/pybind/mgr/cephadm/tests/services/test_rgw.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_rgw.py
@@ -3,8 +3,9 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from cephadm.services.service_registry import service_registry
+from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 from cephadm.module import CephadmOrchestrator
-from ceph.deployment.service_spec import RGWSpec, CertificateSource
+from ceph.deployment.service_spec import RGWSpec, CertificateSource, PlacementSpec
 from cephadm.tests.fixtures import with_host, with_service, _run_cephadm
 from cephadm.tlsobject_types import TLSCredentials
 
@@ -50,6 +51,40 @@ class TestRGWService:
                     'key': 'rgw_frontends',
                 })
                 assert f == expected
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_rgw_port_ips_with_explicit_ip(self, cephadm_module: CephadmOrchestrator):
+        """Explicit placement IP must populate port_ips for the host-side precheck.
+
+        Without this, fetch_endpoints() defaults to 0.0.0.0 and port_in_use()
+        falsely conflicts with unrelated listeners on other addresses.
+        """
+        ip = '1.2.3.4'
+        port = 7480
+        with with_host(cephadm_module, 'host1'):
+            s = RGWSpec(
+                service_id='foo',
+                placement=PlacementSpec(hosts=['host1']),
+                rgw_frontend_type='beast',
+                rgw_frontend_port=port,
+            )
+            with with_service(cephadm_module, s) as _:
+                daemon_spec = service_registry.get_service('rgw').prepare_create(
+                    CephadmDaemonDeploySpec(
+                        host='host1',
+                        daemon_type='rgw',
+                        daemon_id='foo.host1.0',
+                        service_name=s.service_name(),
+                        ports=[port],
+                        ip=ip,
+                    ))
+                assert daemon_spec.port_ips == {str(port): ip}
+                _, f, _ = cephadm_module.check_mon_command({
+                    'prefix': 'config get',
+                    'who': f'client.{daemon_spec.name()}',
+                    'key': 'rgw_frontends',
+                })
+                assert f == f'beast endpoint={ip}:{port}'
 
     @pytest.mark.parametrize(
         "disable_sync_traffic",


### PR DESCRIPTION
When RGW binds to daemon_spec.ip, also set port_ips so the host-side port-in-use precheck tests that address instead of 0.0.0.0. Without this, redeploy/upgrade fails if another process holds the same port on a different address (e.g. external HAProxy on a VIP).

Fixes: https://tracker.ceph.com/issues/78018


Verification steps with the fix

1. installed a cluster with 3 kcli VM's with ceph cluster
2. ceph status
[ceph: root@ceph-node-0 /]# ceph -s
  cluster:
    id:     fa11ead0-97f8-11f1-a959-52540070d228
    health: HEALTH_OK
 
  services:
    mon: 3 daemons, quorum ceph-node-0,ceph-node-1,ceph-node-2 (age 18m) [leader: ceph-node-0]
    mgr: ceph-node-0.evneok(active, since 23m), standbys: ceph-node-1.fejnwy
    osd: 3 osds: 3 up (since 19m), 3 in (since 19m)
 
  data:
    pools:   5 pools, 129 pgs
    objects: 230 objects, 459 KiB
    usage:   137 MiB used, 30 GiB / 30 GiB avail
    pgs:     129 active+clean


2. using cephadm console create a daemon  of rgw

ceph orch apply -i - <<'EOF'
service_type: rgw
service_id: verify78018
placement:
  hosts:
    - ceph-node-0
networks:
  - 192.168.100.0/24
rgw_frontend_port: 7480
rgw_frontend_type: beast
EOF

3. checking that rgw is running
[ceph: root@ceph-node-0 /]# ceph orch ls
NAME                       PORTS   RUNNING  REFRESHED  AGE  PLACEMENT    
crash                                  3/3  7m ago     24m  *            
mgr                                    2/2  6m ago     24m  count:2      
mon                                    3/5  7m ago     24m  count:5      
osd.all-available-devices                3  7m ago     23m  *            
rgw.verify78018            ?:7480      1/1  9s ago     16s  ceph-node-0 

[ceph: root@ceph-node-0 /]# ceph orch ps --daemon-type rgw
NAME                                HOST         PORTS                 STATUS         REFRESHED  AGE  MEM USE  MEM LIM  VERSION                IMAGE ID      CONTAINER ID  
rgw.verify78018.ceph-node-0.rjvury  ceph-node-0  192.168.100.100:7480  running (58s)    51s ago  58s    68.1M        -  21.3.0-1899-g1b5f6d5e  62bbc288bacd  86f40449f78c

4. validating bind on port
[ceph: root@ceph-node-0 /]# ceph config get client.rgw.verify78018.ceph-node-0.* rgw_frontends
beast port=7480

5. Listen on the secondary IP with socat application
[root@ceph-node-0 ~]# socat TCP-LISTEN:7480,bind=192.168.100.110,fork,reuseaddr -

6. on another windows lets redeploy the rgw
first verify listenning
[root@ceph-node-0 ~]# ss -lntp | grep 7480
LISTEN 0      4096   192.168.100.100:7480      0.0.0.0:*    users:(("radosgw",pid=23253,fd=61))      
LISTEN 0      5      192.168.100.110:7480      0.0.0.0:*    users:(("socat",pid=24575,fd=5))  

then 
[ceph: root@ceph-node-0 /]# ceph orch daemon redeploy rgw.verify78018.ceph-node-0.rjvury
Scheduled to redeploy rgw.verify78018.ceph-node-0.rjvury on host 'ceph-node-0'

7. validate success
[ceph: root@ceph-node-0 /]# ceph orch ps --daemon-type rgw
NAME                                HOST         PORTS                 STATUS         REFRESHED  AGE  MEM USE  MEM LIM  VERSION                IMAGE ID      CONTAINER ID  
rgw.verify78018.ceph-node-0.rjvury  ceph-node-0  192.168.100.100:7480  running (47s)    43s ago   8m    68.1M        -  21.3.0-1899-g1b5f6d5e  62bbc288bacd  fe3a39834108  

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
