### PR TITLE
crush/CrushWrapper: fix verify_upmap for multi-take rules with device classes

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -23,6 +23,10 @@
   a few times in random workloads.  ``mds_dir_prefetch_backend_max`` (default 1)
   limits the number of concurrent background fetches.  This reduces latency in
   large directories while retaining cache warmth for hot directories.
+* RADOS: ``pg-upmap-items`` entries and the upmap balancer now work on pools whose
+  CRUSH rule has more than one ``take`` step, such as hybrid rules that place some
+  replicas on one device class and the rest on another. Previously every upmap on
+  such a pool was rejected by the mon and the balancer could not optimize them.
 
 * CephFS: The ``client_force_lazyio`` configuration option is now correctly marked
   as not supporting runtime updates. Previously, the configuration schema indicated

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -952,6 +952,17 @@ int CrushWrapper::verify_upmap(CephContext *cct,
   int root_bucket = 0;
   int cursor = 0;
   std::map<int, int> type_stack;
+  // A rule may have multiple take..emit scopes (e.g. hybrid device-class
+  // rules), each mapping its own segment of `up`.  Checking a scope's
+  // choose/chooseleaf constraints against the whole vector miscounts other
+  // scopes' OSDs and per-class shadow buckets, so record the constraints
+  // and check them at EMIT, where the segment boundaries are known.
+  struct scope_check {
+    bool leaf;   // chooseleaf vs choose
+    int type;
+    int numrep;
+  };
+  std::vector<scope_check> scope_checks;
   for (unsigned step = 0; step < rule->len; ++step) {
     auto curstep = &rule->steps[step];
     ldout(cct, 10) << __func__ << " step " << step << dendl;
@@ -963,36 +974,6 @@ int CrushWrapper::verify_upmap(CephContext *cct,
       break;
     case CRUSH_RULE_CHOOSELEAF_FIRSTN:
     case CRUSH_RULE_CHOOSELEAF_INDEP:
-      {
-        int numrep = curstep->arg1;
-        int type = curstep->arg2;
-        if (numrep <= 0)
-          numrep += pool_size;
-        type_stack.emplace(type, numrep);
-        if (type == 0) // osd
-          break;
-        map<int, set<int>> osds_by_parent; // parent_of_desired_type -> osds
-        for (auto osd : up) {
-          auto parent = get_parent_of_type(osd, type, rule_id);
-          if (parent < 0) {
-            osds_by_parent[parent].insert(osd);
-          } else {
-            ldout(cct, 1) << __func__ << " unable to get parent of osd." << osd
-                          << ", skipping for now"
-                          << dendl;
-          }
-        }
-        for (auto i : osds_by_parent) {
-          if (i.second.size() > 1) {
-            lderr(cct) << __func__ << " multiple osds " << i.second
-                       << " come from same failure domain " << i.first
-                       << dendl;
-            return -EINVAL;
-          }
-        }
-      }
-      break;
-
     case CRUSH_RULE_CHOOSE_FIRSTN:
     case CRUSH_RULE_CHOOSE_INDEP:
       {
@@ -1003,23 +984,9 @@ int CrushWrapper::verify_upmap(CephContext *cct,
         type_stack.emplace(type, numrep);
         if (type == 0) // osd
           break;
-        set<int> parents_of_type;
-        for (auto osd : up) {
-          auto parent = get_parent_of_type(osd, type, rule_id);
-          if (parent < 0) {
-            parents_of_type.insert(parent);
-          } else {
-            ldout(cct, 1) << __func__ << " unable to get parent of osd." << osd
-                          << ", skipping for now"
-                          << dendl;
-          }
-        }
-        if ((int)parents_of_type.size() > numrep) {
-          lderr(cct) << __func__ << " number of buckets "
-                     << parents_of_type.size() << " exceeds desired " << numrep
-                     << dendl;
-          return -EINVAL;
-        }
+        bool leaf = curstep->op == CRUSH_RULE_CHOOSELEAF_FIRSTN ||
+                    curstep->op == CRUSH_RULE_CHOOSELEAF_INDEP;
+        scope_checks.push_back({leaf, type, numrep});
       }
       break;
 
@@ -1030,6 +997,7 @@ int CrushWrapper::verify_upmap(CephContext *cct,
           for (auto &item : type_stack) {
             num_osds *= item.second;
           }
+          int seg_begin = cursor;
           // validate the osd's in subtree
           for (int c = 0; cursor < (int)up.size() && c < num_osds; ++cursor, ++c) {
             int osd = up[cursor];
@@ -1038,8 +1006,51 @@ int CrushWrapper::verify_upmap(CephContext *cct,
               return -EINVAL;
             }
           }
+          // check the choose/chooseleaf constraints of this scope
+          // against this scope's segment of `up` only
+          for (auto& check : scope_checks) {
+            // parents of `check.type` within this scope's take subtree only
+            vector<int> candidates;
+            get_children_of_type(root_bucket, check.type, &candidates, false);
+            map<int, set<int>> osds_by_parent; // parent_of_desired_type -> osds
+            for (int c = seg_begin; c < cursor; ++c) {
+              int osd = up[c];
+              int parent = 0;
+              for (auto candidate : candidates) {
+                if (subtree_contains(candidate, osd)) {
+                  parent = candidate;
+                  break;
+                }
+              }
+              if (parent < 0) {
+                osds_by_parent[parent].insert(osd);
+              } else {
+                ldout(cct, 1) << __func__ << " unable to get parent of osd." << osd
+                              << ", skipping for now"
+                              << dendl;
+              }
+            }
+            if (check.leaf) {
+              for (auto& i : osds_by_parent) {
+                if (i.second.size() > 1) {
+                  lderr(cct) << __func__ << " multiple osds " << i.second
+                             << " come from same failure domain " << i.first
+                             << dendl;
+                  return -EINVAL;
+                }
+              }
+            } else {
+              if ((int)osds_by_parent.size() > check.numrep) {
+                lderr(cct) << __func__ << " number of buckets "
+                           << osds_by_parent.size() << " exceeds desired "
+                           << check.numrep << dendl;
+                return -EINVAL;
+              }
+            }
+          }
         }
         type_stack.clear();
+        scope_checks.clear();
         root_bucket = 0;
       }
       break;

--- a/src/test/crush/CrushWrapper.cc
+++ b/src/test/crush/CrushWrapper.cc
@@ -1193,6 +1193,104 @@ TEST_F(CrushWrapperTest, device_class_clone) {
 				 &other_clone_id, &cmap_item_weight), -EBADF);
 }
 
+TEST_F(CrushWrapperTest, verify_upmap_multi_take_device_class) {
+  CrushWrapper c;
+  c.create();
+  c.set_type_name(1, "host");
+  c.set_type_name(2, "zone");
+  c.set_type_name(3, "root");
+
+  int weight = 1;
+  auto add_osd = [&](int id, const string& host, const string& zone,
+                     const string& device_class) {
+    map<string,string> loc;
+    loc["host"] = host;
+    loc["zone"] = zone;
+    loc["root"] = "default";
+    ASSERT_EQ(0, c.insert_item(cct, id, weight, "osd." + stringify(id), loc));
+    ASSERT_EQ(0, c.set_item_class(id, device_class));
+  };
+  // zone dc1: hosts a1 (osd.0, osd.6 ssd), a2 (osd.2 hdd), a3 (osd.4 ssd)
+  // zone dc2: hosts b1 (osd.1 ssd), b2 (osd.3 hdd), b3 (osd.5 ssd)
+  add_osd(0, "a1", "dc1", "ssd");
+  add_osd(6, "a1", "dc1", "ssd");
+  add_osd(4, "a3", "dc1", "ssd");
+  add_osd(2, "a2", "dc1", "hdd");
+  add_osd(1, "b1", "dc2", "ssd");
+  add_osd(5, "b3", "dc2", "ssd");
+  add_osd(3, "b2", "dc2", "hdd");
+  c.reweight(cct);
+  int ssd_class = c.get_class_id("ssd");
+  int hdd_class = c.get_class_id("hdd");
+  ASSERT_LE(0, ssd_class);
+  ASSERT_LE(0, hdd_class);
+
+  map<int32_t, map<int32_t, int32_t>> old_class_bucket;
+  map<int,map<int,vector<int>>> cmap_item_weight; // cargs -> bno -> weights
+  set<int32_t> used_ids;
+  int root_id = c.get_item_id("default");
+  int ssd_root, hdd_root;
+  ASSERT_EQ(0, c.device_class_clone(root_id, ssd_class, old_class_bucket,
+                                    used_ids, &ssd_root, &cmap_item_weight));
+  ASSERT_EQ(0, c.device_class_clone(root_id, hdd_class, old_class_bucket,
+                                    used_ids, &hdd_root, &cmap_item_weight));
+
+  // hybrid rule: one ssd per zone, then one hdd per zone
+  int ruleno = c.add_rule(-1, 8, 1);
+  ASSERT_LE(0, ruleno);
+  int step = 0;
+  ASSERT_EQ(0, c.set_rule_step(ruleno, step++, CRUSH_RULE_TAKE, ssd_root, 0));
+  ASSERT_EQ(0, c.set_rule_step(ruleno, step++, CRUSH_RULE_CHOOSE_FIRSTN, 2, 2));
+  ASSERT_EQ(0, c.set_rule_step(ruleno, step++, CRUSH_RULE_CHOOSELEAF_FIRSTN, 1, 1));
+  ASSERT_EQ(0, c.set_rule_step(ruleno, step++, CRUSH_RULE_EMIT, 0, 0));
+  ASSERT_EQ(0, c.set_rule_step(ruleno, step++, CRUSH_RULE_TAKE, hdd_root, 0));
+  ASSERT_EQ(0, c.set_rule_step(ruleno, step++, CRUSH_RULE_CHOOSE_FIRSTN, 2, 2));
+  ASSERT_EQ(0, c.set_rule_step(ruleno, step++, CRUSH_RULE_CHOOSELEAF_FIRSTN, 1, 1));
+  ASSERT_EQ(0, c.set_rule_step(ruleno, step++, CRUSH_RULE_EMIT, 0, 0));
+
+  // a mapping matching the rule exactly: one ssd and one hdd per zone.
+  // this used to be falsely rejected: the same physical zone was counted
+  // once per device-class shadow bucket, so the checker saw 4 zones > 2.
+  ASSERT_EQ(0, c.verify_upmap(cct, ruleno, 4, {0, 1, 2, 3}));
+  // a legal upmap replacement within the ssd scope (osd.0 -> osd.4,
+  // a different dc1 host)
+  ASSERT_EQ(0, c.verify_upmap(cct, ruleno, 4, {4, 1, 2, 3}));
+  // two ssd replicas on the same host must still be rejected
+  ASSERT_EQ(-EINVAL, c.verify_upmap(cct, ruleno, 4, {0, 6, 2, 3}));
+  // an hdd osd in the ssd scope must still be rejected
+  ASSERT_EQ(-EINVAL, c.verify_upmap(cct, ruleno, 4, {2, 1, 0, 3}));
+
+  // regression guard: single-take rule behavior is unchanged
+  int ruleno2 = c.add_rule(-1, 4, 1);
+  ASSERT_LE(0, ruleno2);
+  step = 0;
+  ASSERT_EQ(0, c.set_rule_step(ruleno2, step++, CRUSH_RULE_TAKE, ssd_root, 0));
+  ASSERT_EQ(0, c.set_rule_step(ruleno2, step++, CRUSH_RULE_CHOOSE_FIRSTN, 2, 2));
+  ASSERT_EQ(0, c.set_rule_step(ruleno2, step++, CRUSH_RULE_CHOOSELEAF_FIRSTN, 1, 1));
+  ASSERT_EQ(0, c.set_rule_step(ruleno2, step++, CRUSH_RULE_EMIT, 0, 0));
+  ASSERT_EQ(0, c.verify_upmap(cct, ruleno2, 2, {0, 1}));
+  ASSERT_EQ(-EINVAL, c.verify_upmap(cct, ruleno2, 2, {0, 6}));
+
+  // multi-take rule reusing the same root (no device classes).  CRUSH
+  // provides no uniqueness across take..emit scopes for such rules, so
+  // a mapping placing replicas of different scopes on the same host is
+  // not a rule violation and must be accepted; a duplicate within one
+  // scope must still be rejected.
+  int ruleno3 = c.add_rule(-1, 6, 1);
+  ASSERT_LE(0, ruleno3);
+  step = 0;
+  ASSERT_EQ(0, c.set_rule_step(ruleno3, step++, CRUSH_RULE_TAKE, root_id, 0));
+  ASSERT_EQ(0, c.set_rule_step(ruleno3, step++, CRUSH_RULE_CHOOSELEAF_FIRSTN, 2, 1));
+  ASSERT_EQ(0, c.set_rule_step(ruleno3, step++, CRUSH_RULE_EMIT, 0, 0));
+  ASSERT_EQ(0, c.set_rule_step(ruleno3, step++, CRUSH_RULE_TAKE, root_id, 0));
+  ASSERT_EQ(0, c.set_rule_step(ruleno3, step++, CRUSH_RULE_CHOOSELEAF_FIRSTN, 2, 1));
+  ASSERT_EQ(0, c.set_rule_step(ruleno3, step++, CRUSH_RULE_EMIT, 0, 0));
+  // osd.0/osd.6 share host a1 but sit in different scopes: accepted
+  ASSERT_EQ(0, c.verify_upmap(cct, ruleno3, 4, {0, 2, 6, 3}));
+  // osd.0/osd.6 within the same scope: still rejected
+  ASSERT_EQ(-EINVAL, c.verify_upmap(cct, ruleno3, 4, {0, 6, 2, 3}));
+}
+
 TEST_F(CrushWrapperTest, split_id_class) {
   CrushWrapper c;
   c.create();


### PR DESCRIPTION
`verify_upmap()` checks each choose/chooseleaf step against the entire `up` vector.
For a rule with more than one take step - hybrid device-class rules, mainly - that
counts OSDs belonging to other take scopes against the current step's constraint. On
top of that, parents are resolved through the per-class shadow trees of all of the
rule's takes, so the same physical failure domain gets counted once per device class.

The result is that for the documented hybrid layout (one ssd and one hdd per zone,
ssd take first so the primary lands there) every upmap is rejected, including the
ones that match the rule exactly:

    verify_upmap number of buckets 4 exceeds desired 2

Two physical zones, seen as four buckets: dc1~ssd, dc2~ssd, dc1~hdd, dc2~hdd. The mon
cancels each pg-upmap-items entry right after it is set (check_pg_upmaps), and the
upmap balancer can never touch those pools either, since calc_pg_upmaps -> legal_swap
fails the same way. That leaves `osd reweight` as the only balancing tool. We hit this
in production when a node failure pushed one OSD to 90% (backfillfull) while its
same-zone peers sat at 25%, and there was no upmap we could apply to relieve it.

## Fix

Defer the choose/chooseleaf checks to EMIT, where the take scope's segment of `up` is
known - the EMIT handler already computes that segment length for its subtree
containment check. Check only the OSDs in the current segment, and resolve their
parents within the current take subtree, which also gets rid of the cross-take
shadow-bucket double count. Nothing changes for single-take rules: there the segment
is the whole `up` vector and the parent search space is the same single take root as
before.

This is orthogonal to #69151, which fixes a different false rejection in the same
function (nested choose steps within one take). I checked both directions: with
#69151 applied the hybrid reproducer above still fails, and with this patch applied
the rule shape from #51729 is still rejected exactly as before (same verdicts for the
exact shape and a set of permutations). So neither patch subsumes the other. Happy to
rebase on top of it either way.

## Offline reproducer

No cluster needed. Build a small map with a hybrid rule and let the balancer fill in
some upmaps, then ask osdmaptool to revalidate them:

    crushtool -c hybrid.txt -o hybrid.bin
    osdmaptool --createsimple 12 --with-default-pool om.bin --clobber \
        --osd-pool-default-size 4
    osdmaptool om.bin --import-crush hybrid.bin
    osdmaptool om.bin --mark-up-in --upmap up.txt --upmap-pool rbd \
        --upmap-max 20 --upmap-deviation 1 --save
    osdmaptool om.bin --mark-up-in --upmap-cleanup cleanup.txt

Before the patch the last command rejects all 20 entries:

    verify_upmap number of buckets 4 exceeds desired 2
    check_pg_upmaps verify_upmap of pg 1.2 returning -22
    ...
    $ grep -c rm-pg-upmap cleanup.txt
    20

After the patch it rejects none, and cleanup.txt is empty. The crush map used above
is the rule from the tracker ticket over two zones of three hosts, one ssd and one
hdd per host.

## Behavior change surface

The set of rejected mappings is a strict subset of what it was. The old code checked
every step against a superset of the OSDs (whole `up` instead of the scope's segment)
and resolved parents in a superset of the search space (all take roots via
find_takes_by_rule instead of the current root), and both comparisons are monotonic in
those inputs. Nothing that was accepted before can be rejected now, so stored upmaps
keep validating and no mass cancellation can happen on upgrade.

I checked that by brute force rather than by argument. Over the topology of the unit
test, every ordered mapping was fed to verify_upmap on both versions:

    rule                      mappings   still accepted   newly accepted   accept->reject
    hybrid (2 takes, classes)      840                0               36                0
    same-root, 2 takes             840              600              160                0
    single take                     42               40                0                0

Note the first row: the old code rejects all 840 mappings for a hybrid rule, so no
cluster can have a stored upmap on such a pool to begin with - there is no state to
regress. The same-root row is the intended semantic change: the newly accepted
mappings are the ones placing replicas of *different* take scopes on one host, which
CRUSH itself produces for those rules since the scopes are drawn independently.
Single-take rules are bit for bit unchanged.

Running osdmaptool --upmap-cleanup with both versions over a single-take pool with 30
stored upmap entries also gives identical output (nothing cancelled either way).

## Tests

`unittest_crush_wrapper --gtest_filter='*verify_upmap*'`:

* hybrid rule, two classes, two takes:
  * the exact shape the rule produces - was -EINVAL, now passes
  * a legal replacement within the ssd scope - was -EINVAL, now passes
  * two ssd replicas on one host - still rejected
  * an hdd OSD inside the ssd scope - still rejected
* single-take rule, accept and reject cases unchanged
* same-root multi-take rule, covering the behavior change described above

I have a standalone test for this as well (build a hybrid rule on a live cluster, set a
rule-compliant pg-upmap-items entry, check the mon still has it a few osdmap epochs
later) but I could not run it on my machine, so I left it out rather than send
something I have not exercised. Say the word and I will get it verified and add it.

Full CrushWrapper suite 25/25, unittest_osdmap 41/41 (including the BUG_40104 /
BUG_42485 / BUG_51842 upmap regression guards).

Fixes: https://tracker.ceph.com/issues/79493
Related: https://tracker.ceph.com/issues/51729

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests
