### PR TITLE
squid: ceph-objectstore-tool: update `clear-snapset` command doc

### DIFF
--- a/qa/standalone/scrub/osd-scrub-snaps.sh
+++ b/qa/standalone/scrub/osd-scrub-snaps.sh
@@ -142,7 +142,7 @@ function create_scenario() {
     ceph-objectstore-tool --data-path $dir/${osd} "$JSON" set-bytes $TESTDATA || return 1
 
     JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj6)"
-    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" clear-snapset || return 1
+    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" clear-snapset clones || return 1
     JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj7)"
     ceph-objectstore-tool --data-path $dir/${osd} "$JSON" clear-snapset corrupt || return 1
     JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj8)"

--- a/qa/standalone/scrub/osd-scrub-snaps.sh
+++ b/qa/standalone/scrub/osd-scrub-snaps.sh
@@ -153,8 +153,6 @@ function create_scenario() {
     ceph-objectstore-tool --data-path $dir/${osd} "$JSON" clear-snapset clone_overlap || return 1
     JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj11)"
     ceph-objectstore-tool --data-path $dir/${osd} "$JSON" clear-snapset clones || return 1
-    JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj12)"
-    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" clear-snapset head || return 1
     JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj13)"
     ceph-objectstore-tool --data-path $dir/${osd} "$JSON" clear-snapset snaps || return 1
     JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj14)"

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -3497,6 +3497,9 @@ void usage(po::options_description &desc)
     cerr << "ceph-objectstore-tool ... <object> set-size" << std::endl;
     cerr << "ceph-objectstore-tool ... <object> clear-data-digest" << std::endl;
     cerr << "ceph-objectstore-tool ... <object> remove-clone-metadata <cloneid>" << std::endl;
+    cerr << "ceph-objectstore-tool ... <object> clear-snapset "
+            "[(corrupt|seq|snaps|clones|clone_size|clone_overlap|size)]"
+         << std::endl;
     cerr << std::endl;
     cerr << "<object> can be a JSON object description as displayed" << std::endl;
     cerr << "by --op list." << std::endl;
@@ -3507,6 +3510,19 @@ void usage(po::options_description &desc)
     cerr << std::endl;
     cerr << "The optional [file] argument will read stdin or write stdout" << std::endl;
     cerr << "if not specified or if '-' specified." << std::endl;
+    cerr << std::endl;
+    cerr << "clear-snapset options:" << std::endl;
+    cerr << "  clear-snapset               : by default, clear clones, "
+            "clone_size and clone_overlap"
+         << std::endl;
+    cerr << "  clear-snapset corrupt       : clear entire snapset" << std::endl;
+    cerr << "  clear-snapset seq           : clear snapset.seq" << std::endl;
+    cerr << "  clear-snapset clone_size    : clear clone_size" << std::endl;
+    cerr << "  clear-snapset clone_overlap : clear clone_overlap" << std::endl;
+    cerr << "  clear-snapset clones        : clear clones" << std::endl;
+    cerr << "  clear-snapset snaps         : clear clone_snaps" << std::endl;
+    cerr << "  clear-snapset size          : break all clone sizes by adding 1"
+         << std::endl;
 }
 
 bool ends_with(const string& check, const string& ending)
@@ -4571,9 +4587,22 @@ int main(int argc, char **argv)
         ret = clear_data_digest(fs.get(), coll, ghobj);
         goto out;
       } else if (objcmd == "clear-snapset") {
-        // UNDOCUMENTED: For testing zap SnapSet
-        // IGNORE extra args since not in usage anyway
-	if (!ghobj.hobj.has_snapset()) {
+        if (vm.count("arg1") == 0) {
+          usage(desc);
+          ret = 1;
+          goto out;
+        }
+
+        if (vm.count("arg2") != 0) {
+          if (arg2 != "corrupt" && arg2 != "seq" && arg2 != "snaps" &&
+              arg2 != "clones" && arg2 != "clone_size" &&
+              arg2 != "clone_overlap" && arg2 != "size") {
+            usage(desc);
+            ret = 1;
+            goto out;
+          }
+        }
+        if (!ghobj.hobj.has_snapset()) {
 	  cerr << "'" << objcmd << "' requires a head or snapdir object" << std::endl;
 	  ret = 1;
 	  goto out;


### PR DESCRIPTION
backport tracker: 
- https://tracker.ceph.com/issues/79494
- https://tracker.ceph.com/issues/79495

backport of two related PRs:
- https://github.com/ceph/ceph/pull/65099
- https://github.com/ceph/ceph/pull/66303

Closes:
https://tracker.ceph.com/issues/79494
https://tracker.ceph.com/issues/79495

---

backport of https://github.com/ceph/ceph/pull/65099
parent tracker: 
- https://tracker.ceph.com/issues/78807
- https://tracker.ceph.com/issues/73900

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh