### PR TITLE
common/options: use an absolute libdir for osd_class_dir

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -666,7 +666,7 @@ options:
 - name: osd_class_dir
   type: str
   level: advanced
-  default: @CMAKE_INSTALL_LIBDIR@/rados-classes
+  default: @CMAKE_INSTALL_FULL_LIBDIR@/rados-classes
   fmt_desc: The class path for RADOS class plug-ins.
   with_legacy: true
 - name: osd_open_classes_on_start


### PR DESCRIPTION
`osd_class_dir` defaults to `@CMAKE_INSTALL_LIBDIR@`, which GNUInstallDirs
leaves relative (`lib64`). The OSD then looks for rados classes below its own
cwd, loads none, and every class-backed operation fails :

```
_load_class could not stat class lib64/rados-classes/libcls_lock.so:
    (2) No such file or directory
```

ceph.spec.in hides this by passing an absolute `-DCMAKE_INSTALL_LIBDIR`.
Use `@CMAKE_INSTALL_FULL_LIBDIR@` instead, as the tree already does for other
paths baked into the binaries.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
