### PR TITLE
crimson/os/seastore: guard zero denominators in CBJ metric gauges

### DIFF
--- a/src/crimson/os/seastore/journal/circular_bounded_journal.cc
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.cc
@@ -432,15 +432,17 @@ void CircularBoundedJournal::register_metrics()
       sm::make_gauge(
 	"submit_record_latency_average",
 	[this] {
-	  return stats.submit_record_latency_total.count() /
-	    stats.submit_record_count;
+	  return stats.submit_record_count > 0 ?
+	    stats.submit_record_latency_total.count() /
+	    stats.submit_record_count : 0.0;
 	}
       ),
       sm::make_gauge(
 	"submit_record_size_average",
 	[this] {
-	  return stats.submit_record_size /
-	    stats.submit_record_count;
+	  return stats.submit_record_count > 0 ?
+	    stats.submit_record_size /
+	    stats.submit_record_count : 0;
 	}
       ),
       sm::make_gauge(
@@ -458,8 +460,9 @@ void CircularBoundedJournal::register_metrics()
       sm::make_gauge(
 	"submit_record_roll_latency_average",
 	[this] {
-	  return stats.submit_record_roll_latency_total.count() /
-	    stats.submit_record_roll_count;
+	  return stats.submit_record_roll_count > 0 ?
+	    stats.submit_record_roll_latency_total.count() /
+	    stats.submit_record_roll_count : 0.0;
 	}
       ),
       sm::make_gauge(
@@ -477,8 +480,9 @@ void CircularBoundedJournal::register_metrics()
       sm::make_gauge(
 	"submit_record_wait_latency_average",
 	[this] {
-	  return stats.submit_record_wait_latency_total.count() /
-	    stats.submit_record_wait_count;
+	  return stats.submit_record_wait_count > 0 ?
+	    stats.submit_record_wait_latency_total.count() /
+	    stats.submit_record_wait_count : 0.0;
 	}
       )
     }


### PR DESCRIPTION
## Issue 
Crimson OSDs crash with SIGFPE. Checking the backtrace, we see that this is due to `CircularBoundedJournal::register_metrics()::{lambda()#5}`.

Using gdb, we see: 

```
Program terminated with signal SIGFPE, Arithmetic exception.
#0  0x000055bded5d74f8 in std::_Function_handler<seastar::metrics::impl::metric_value (), seastar::metrics::impl::make_function<crimson::os::seastore::journal::CircularBoundedJournal::register_metrics()::{lambda()#5}>(crimson::os::seastore::journal::CircularBoundedJournal::register_metrics()::{lambda()#5}, seastar::metrics::impl::data_type)::{lambda()#1}>::_M_invoke(std::_Any_data const&) ()
[Current thread is 1 (LWP 5)]
#0  0x000055bded5d74f8 in std::_Function_handler<seastar::metrics::impl::metric_value (), seastar::metrics::impl::make_function<crimson::os::seastore::journal::CircularBoundedJournal::register_metrics()::{lambda()#5}>(crimson::os::seastore::journal::CircularBoundedJournal::register_metrics()::{lambda()#5}, seastar::metrics::impl::data_type)::{lambda()#1}>::_M_invoke(std::_Any_data const&) ()
```


## Root Cause
When an OSD starts, and PGs are just getting created, reactors have not yet sent any records. This means their `submit_record_count` is zero.

When we call `ceph tell osd.$ dump_metrics` just as an OSD is starting, calculating `submit_record_size_average` computes `0/0`. This leads to `SIGFPE`. 

A thing to note, `submit_record_latency_average` also computes `0/0`, but since its `double`, it silently fails. Its only with `submit_record_size_average` which is `uint64` where 0 division gets us into trouble.

This is only a cold start issue, made highly likely with `crimson_cpu_num 8`.

## Fix
Simply checking `submit_record_count` before calculating the average can save us from this issue.

Fixes: https://tracker.ceph.com/issues/79501

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
