### PR TITLE
umbrella: rgw: skip writing ObjectCache when incoming obj_version is stale

### DIFF
--- a/src/rgw/rgw_cache.cc
+++ b/src/rgw/rgw_cache.cc
@@ -152,6 +152,17 @@ void ObjectCache::put(const DoutPrefixProvider *dpp, const string& name, ObjectC
 
   auto [iter, inserted] = cache_map.emplace(name, ObjectCacheEntry{});
   ObjectCacheEntry& entry = iter->second;
+  if (!inserted &&
+      (info.flags & CACHE_FLAG_OBJV) &&
+      (entry.info.flags & CACHE_FLAG_OBJV) &&
+      (entry.info.version.tag == info.version.tag) &&
+      (entry.info.version.ver > info.version.ver)) {
+    ldpp_dout(dpp, 10) << "cache put: name=" << name
+                   << " skipping stale ver=" << info.version.ver
+                   << " (cached ver=" << entry.info.version.ver << ")" << dendl;
+    return;
+  }
+
   entry.info.time_added = ceph::coarse_mono_clock::now();
   if (inserted) {
     entry.lru_iter = lru.end();

--- a/src/rgw/services/svc_sys_obj_cache.cc
+++ b/src/rgw/services/svc_sys_obj_cache.cc
@@ -1,6 +1,9 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 sts=2 expandtab ft=cpp
 
+#include <chrono>
+#include <thread>
+
 #include "common/admin_socket.h"
 
 #include "svc_sys_obj_cache.h"
@@ -455,6 +458,18 @@ int RGWSI_SysObj_Cache::distribute_cache(const DoutPrefixProvider *dpp,
                                          ObjectCacheInfo& obj_info, int op,
                                          optional_yield y)
 {
+  // for testing: hold the cache notification in-flight to reproduce
+  // timing-sensitive races
+  if (cct->_conf->rgw_inject_delay_sec > 0) {
+    if (std::string_view(cct->_conf->rgw_inject_delay_pattern) ==
+        "delay_distribute_cache") {
+      const double delay_sec = cct->_conf->rgw_inject_delay_sec;
+      ldpp_dout(dpp, 0) << "distribute_cache: injecting delay of " << delay_sec
+          << "s before notify for " << obj << dendl;
+      std::this_thread::sleep_for(std::chrono::duration<double>(delay_sec));
+    }
+  }
+
   RGWCacheNotifyInfo info;
   info.op = op;
   info.obj_info = obj_info;

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -127,6 +127,13 @@ add_executable(unittest_rgw_compression
 add_ceph_unittest(unittest_rgw_compression)
 target_link_libraries(unittest_rgw_compression ${rgw_libs})
 
+# unittest_rgw_cache
+add_executable(unittest_rgw_cache
+  test_rgw_cache.cc
+  $<TARGET_OBJECTS:unit-main>)
+add_ceph_unittest(unittest_rgw_cache)
+target_link_libraries(unittest_rgw_cache ${rgw_libs})
+
 # unittest_http_manager
 add_executable(unittest_http_manager test_http_manager.cc)
 add_ceph_unittest(unittest_http_manager)

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -6977,3 +6977,91 @@ def test_bucket_full_sync_when_the_bucket_is_deleted_in_the_meantime():
         except:
             pass
         raise
+
+def test_stale_bucket_owner_after_concurrent_chown():
+    """ Integration test for https://tracker.ceph.com/issues/77731 """
+    zonegroup = realm.master_zonegroup()
+    zonegroup_conns = ZonegroupConns(zonegroup)
+    if len(zonegroup_conns.rw_zones) < 2:
+        raise SkipTest('test_stale_bucket_owner_after_concurrent_chown requires at least 2 read-write zones')
+
+    master = zonegroup_conns.master_zone
+    secondary = next(z for z in zonegroup_conns.rw_zones if z != master)
+
+    uid_a = run_prefix + '-chown-a'
+    uid_b1 = run_prefix + '-chown-b1'
+    uid_b2 = run_prefix + '-chown-b2'
+    ak_a, sk_a = uid_a + 'AK', uid_a + 'SK'
+    ak_b1, sk_b1 = uid_b1 + 'AK', uid_b1 + 'SK'
+    ak_b2, sk_b2 = uid_b2 + 'AK', uid_b2 + 'SK'
+
+    for uid, ak, sk in ((uid_a, ak_a, sk_a), (uid_b1, ak_b1, sk_b1), (uid_b2, ak_b2, sk_b2)):
+        master.zone.cluster.admin(['user', 'create',
+                                   '--uid', uid, '--display-name', uid,
+                                   '--access-key', ak, '--secret-key', sk])
+
+    zonegroup_meta_checkpoint(zonegroup)
+    bucket_name = gen_bucket_name()
+
+    try:
+        region = zonegroup.name
+        owner_a_conn = get_gateway_connection(master.zone.gateways[0], Credentials(ak_a, sk_a), region)
+        owner_a_conn.create_bucket(Bucket=bucket_name)
+        owner_a_conn.head_bucket(Bucket=bucket_name)
+
+        zonegroup_meta_checkpoint(zonegroup)
+
+        instance_list_json, _ = master.zone.cluster.admin(
+            ['metadata', 'list', 'bucket.instance'] + master.zone.zone_args(),
+            read_only=True)
+        instance_key = next(k for k in json.loads(instance_list_json)
+                            if k.startswith(bucket_name + ':'))
+
+        errors = []
+
+        def link_b2():
+            try:
+                master.zone.cluster.admin(['bucket', 'link',
+                                           '--bucket', bucket_name, '--uid', uid_b2,
+                                           '--rgw-inject-delay-sec=1',
+                                           '--rgw-inject-delay-pattern=delay_distribute_cache'])
+            except Exception as e:
+                errors.append(e)
+
+        def link_b1():
+            try:
+                time.sleep(0.2)
+                master.zone.cluster.admin(['bucket', 'link',
+                                           '--bucket', bucket_name, '--uid', uid_b1])
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=link_b1)
+        t2 = threading.Thread(target=link_b2)
+        t2.start()
+        t1.start()
+        t1.join()
+        t2.join()
+
+        assert not errors, 'bucket link failed: %s' % errors
+
+        zonegroup_meta_checkpoint(zonegroup)
+
+        def get_owner(zone_conn, key):
+            meta_json, _ = zone_conn.zone.cluster.admin(
+                ['metadata', 'get', 'bucket.instance:' + key] + zone_conn.zone.zone_args(),
+                read_only=True)
+            return json.loads(meta_json)['data']['bucket_info']['owner']
+
+        master_owner = get_owner(master, instance_key)
+        second_owner = get_owner(secondary, instance_key)
+
+        log.info('master owner=%s secondary owner=%s', master_owner, second_owner)
+        assert master_owner == uid_b1, \
+            'master has stale owner %r, expected %r' % (master_owner, uid_b1)
+        assert second_owner == uid_b1, \
+            'secondary has stale owner %r, expected %r' % (second_owner, uid_b1)
+    finally:
+        for uid in (uid_a, uid_b1, uid_b2):
+            master.zone.cluster.admin(['user', 'rm', '--uid', uid, '--purge-data'],
+                                      check_retcode=False)

--- a/src/test/rgw/test_rgw_cache.cc
+++ b/src/test/rgw/test_rgw_cache.cc
@@ -1,0 +1,134 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2026 Hetzner Cloud GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#include <gtest/gtest.h>
+#include "common/dout.h"
+#include "global/global_context.h"
+#include "rgw_cache.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+static ObjectCacheInfo make_versioned(uint64_t ver, const std::string& tag,
+                                      const std::string& payload = "") {
+  ObjectCacheInfo info;
+  info.status = 0;
+  info.flags = CACHE_FLAG_OBJV | CACHE_FLAG_DATA;
+  info.version.ver = ver;
+  info.version.tag = tag;
+  bufferlist bl;
+  bl.append(payload);
+  info.data = bl;
+  return info;
+}
+
+class ObjectCacheTest : public ::testing::Test {
+protected:
+  ObjectCache cache;
+  NoDoutPrefix dpp;
+
+  ObjectCacheTest() : dpp(g_ceph_context, dout_subsys) {
+    cache.set_ctx(g_ceph_context);
+    cache.set_enabled(true);
+  }
+};
+
+// A stale put (same tag, lower ver) must not overwrite a newer cached entry.
+TEST_F(ObjectCacheTest, StaleVersionRejected)
+{
+  auto info3 = make_versioned(3, "tagA", "v3-data");
+  cache.put(&dpp, "key1", info3, nullptr);
+
+  auto info2 = make_versioned(2, "tagA", "v2-data");
+  cache.put(&dpp, "key1", info2, nullptr);
+
+  ObjectCacheInfo got;
+  ASSERT_EQ(0, cache.get(&dpp, "key1", got, CACHE_FLAG_OBJV | CACHE_FLAG_DATA, nullptr));
+  EXPECT_EQ(3u, got.version.ver);
+  EXPECT_EQ("tagA", got.version.tag);
+}
+
+// A newer put (same tag, higher ver) must overwrite the cached entry.
+TEST_F(ObjectCacheTest, NewerVersionAccepted)
+{
+  auto info2 = make_versioned(2, "tagA", "v2-data");
+  cache.put(&dpp, "key2", info2, nullptr);
+
+  auto info4 = make_versioned(4, "tagA", "v4-data");
+  cache.put(&dpp, "key2", info4, nullptr);
+
+  ObjectCacheInfo got;
+  ASSERT_EQ(0, cache.get(&dpp, "key2", got, CACHE_FLAG_OBJV | CACHE_FLAG_DATA, nullptr));
+  EXPECT_EQ(4u, got.version.ver);
+}
+
+// A put with a different tag always wins (object was recreated under the same key).
+TEST_F(ObjectCacheTest, DifferentTagAlwaysAccepted)
+{
+  auto infoA = make_versioned(5, "tagA", "v5-data");
+  cache.put(&dpp, "key3", infoA, nullptr);
+
+  auto infoB = make_versioned(1, "tagB", "v1-data");
+  cache.put(&dpp, "key3", infoB, nullptr);
+
+  ObjectCacheInfo got;
+  ASSERT_EQ(0, cache.get(&dpp, "key3", got, CACHE_FLAG_OBJV | CACHE_FLAG_DATA, nullptr));
+  EXPECT_EQ(1u, got.version.ver);
+  EXPECT_EQ("tagB", got.version.tag);
+}
+
+// The first put for a key always succeeds (no prior entry to compare against).
+TEST_F(ObjectCacheTest, NoExistingEntryAlwaysAccepted)
+{
+  auto info = make_versioned(2, "tagA", "data");
+  cache.put(&dpp, "key4", info, nullptr);
+
+  ObjectCacheInfo got;
+  ASSERT_EQ(0, cache.get(&dpp, "key4", got, CACHE_FLAG_OBJV | CACHE_FLAG_DATA, nullptr));
+  EXPECT_EQ(2u, got.version.ver);
+}
+
+// A put without CACHE_FLAG_OBJV bypasses the version guard and always overwrites.
+TEST_F(ObjectCacheTest, NoObjvFlagSkipsGuard)
+{
+  auto info3 = make_versioned(3, "tagA", "v3-data");
+  cache.put(&dpp, "key5", info3, nullptr);
+
+  ObjectCacheInfo info_no_v;
+  info_no_v.status = 0;
+  info_no_v.flags = CACHE_FLAG_DATA;
+  bufferlist bl;
+  bl.append("no-objv-data");
+  info_no_v.data = bl;
+  cache.put(&dpp, "key5", info_no_v, nullptr);
+
+  // The entry was overwritten: CACHE_FLAG_OBJV is now absent (type miss).
+  ObjectCacheInfo got;
+  EXPECT_EQ(-ENOENT, cache.get(&dpp, "key5", got, CACHE_FLAG_OBJV, nullptr));
+  // But CACHE_FLAG_DATA alone still hits.
+  EXPECT_EQ(0, cache.get(&dpp, "key5", got, CACHE_FLAG_DATA, nullptr));
+}
+
+// Equal versions are not considered stale; the put goes through.
+TEST_F(ObjectCacheTest, EqualVersionAccepted)
+{
+  auto info3a = make_versioned(3, "tagA", "first");
+  cache.put(&dpp, "key6", info3a, nullptr);
+
+  auto info3b = make_versioned(3, "tagA", "second");
+  cache.put(&dpp, "key6", info3b, nullptr);
+
+  ObjectCacheInfo got;
+  ASSERT_EQ(0, cache.get(&dpp, "key6", got, CACHE_FLAG_OBJV | CACHE_FLAG_DATA, nullptr));
+  EXPECT_EQ(3u, got.version.ver);
+}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79146

---

backport of https://github.com/ceph/ceph/pull/69748
parent tracker: https://tracker.ceph.com/issues/77554

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh