### PR TITLE
common/crypto: cache EVP_MD_fetch() result for non-FIPS MD5

### DIFF
--- a/src/common/ceph_crypto.cc
+++ b/src/common/ceph_crypto.cc
@@ -90,7 +90,16 @@ void ssl::OpenSSLDigest::Restart() {
 void ssl::OpenSSLDigest::SetFlags(int flags) {
   if (flags == EVP_MD_CTX_FLAG_NON_FIPS_ALLOW && OpenSSL_version_num() >= 0x30000000L && mpType == EVP_md5() && !mpType_FIPS) {
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-    mpType_FIPS = EVP_MD_fetch(NULL, "MD5", "fips=no");
+    // EVP_MD_fetch() is expensive on OpenSSL 3 (provider store lookup under
+    // a global lock), and this path runs once per digest instance, i.e. per
+    // rgw request for MD5 etags. Fetch once per process and share the result;
+    // EVP_MD objects are reference-counted and safe to share across threads,
+    // so take a reference for this instance to keep the EVP_MD_free() in the
+    // destructor balanced.
+    static EVP_MD* const md5_non_fips = EVP_MD_fetch(NULL, "MD5", "fips=no");
+    if (md5_non_fips && EVP_MD_up_ref(md5_non_fips)) {
+      mpType_FIPS = md5_non_fips;
+    }
 #endif  // OPENSSL_VERSION_NUMBER >= 0x30000000L
   } else {
     EVP_MD_CTX_set_flags(mpContext, flags);


### PR DESCRIPTION
On OpenSSL 3, OpenSSLDigest::SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW) calls EVP_MD_fetch(NULL, "MD5", "fips=no") every time it runs. rgw constructs an MD5 digest and calls SetFlags() once per object write to compute the etag (RGWPutObj::execute and friends), so under small object workloads this performs a provider-store fetch per request. EVP_MD_fetch() takes the provider store lock and evaluates the property query, and OpenSSL documents the intended usage as fetch once, use many times.

Fetch the algorithm once per process instead and hand each digest instance its own reference via EVP_MD_up_ref(), keeping the EVP_MD_free() in the destructor balanced. EVP_MD objects are reference-counted and safe to share across threads.

Note that using the legacy static EVP_md5() instead would not avoid the cost: on OpenSSL 3 initializing a digest context from a legacy static EVP_MD performs an implicit fetch on every EVP_DigestInit_ex(), which benchmarks the same as the explicit per-instance fetch (see "implicit" below). Caching the fetched EVP_MD is the only variant that avoids the per-request provider-store traffic. The other ceph_crypto digests (SHA1/SHA256/SHA512, used per-request by e.g. rgw's SigV4 code via the implicit-fetch path) could benefit from the same treatment as a follow-up.

Microbenchmark (source in the PR description): each iteration performs one complete etag-style digest, exactly as rgw does per PUT: allocate an EVP_MD_CTX, obtain the MD5 EVP_MD, EVP_DigestInit_ex(), hash a 4KB payload, EVP_DigestFinal_ex(), free the context. The three modes differ only in how the EVP_MD is obtained:

- "fetch": EVP_MD_fetch(NULL, "MD5", "fips=no") per iteration, EVP_MD_free() afterwards -- the current behavior, where every digest instance performs its own provider-store fetch;
- "cached": EVP_MD_fetch() once into a function-local static, then EVP_MD_up_ref() per iteration -- the behavior with this change;
- "implicit": the legacy static EVP_md5() -- no explicit fetch, but on OpenSSL 3 EVP_DigestInit_ex() performs an implicit fetch internally on every init.

N threads run the loop concurrently and share no state beyond what libcrypto itself shares. Numbers are wall-clock ns per digest operation (lower is better), 200K iterations per thread, libcrypto 3.2.4, shown as fetch -> cached:

| CPU | 1 thread | 8 threads | 32 threads |
|--------|--------|--------|--------|
| Ryzen 9 9955HX 16C/32T | 3819 -> 3724  | 567 -> 500 | 311 -> 197 |
| Xeon Gold 6152 22C/44T | 6506 -> 6344 | 1131 -> 990  | 686 -> 583 |

Reading the numbers: at 1 thread the variants differ by only ~2.5%, i.e. the uncontended fetch is cheap. The gap widens with concurrency: +13%/+14% ops/s at 8 threads, +58%/+18% ops/s at 32 threads. That pattern is the provider store lock serializing concurrent fetches: the cost is contention rather than per-call latency, so it grows with exactly the parameter (concurrent requests per daemon) that loaded radosgw deployments maximize. The "implicit" mode benchmarks the same as "fetch" on both machines (Ryzen 32T: 314 vs 311 ns/op), confirming that switching to the legacy EVP_md5() static would not avoid the contention; caching the fetched EVP_MD is what removes it.

End-to-end behavior is unchanged: s3-tests boto3 functional smoke passes against a vstart cluster with this change (every PUT's etag is an MD5 that clients verify). Profiling radosgw under a small vstart PUT workload shows no measurable throughput difference, as expected: such a setup is IO-bound and rgw CPU is not the bottleneck there. The change targets CPU-saturated, many-threaded radosgw deployments.

Signed-off-by: Jusufadis Bakamovic [jusufadis.bakamovic@clyso.com](mailto:jusufadis.bakamovic@clyso.com)

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
