### PR TITLE
squid: test/rgw/multisite: test_object_lock_sync() from secondary zones too

### DIFF
--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -4046,38 +4046,33 @@ def test_bucket_full_sync_when_the_bucket_is_deleted_in_the_meantime():
         raise
 
 def test_object_lock_sync():
-
-    zonegroup = realm.master_zonegroup()
-    zonegroup_conns = ZonegroupConns(zonegroup)
-    primary = zonegroup_conns.rw_zones[0]
-    secondary = zonegroup_conns.rw_zones[1]
-
-    bucket = primary.create_bucket(gen_bucket_name())
-    log.debug('created bucket=%s', bucket.name)
-
-    # enable versioning
-    primary.s3_client.put_bucket_versioning(
-        Bucket=bucket.name,
-        VersioningConfiguration={'Status': 'Enabled'})
-    zonegroup_meta_checkpoint(zonegroup)
-
     lock_config = {
-    'ObjectLockEnabled': 'Enabled',
-    'Rule': {
-        'DefaultRetention': {
-            'Mode': 'COMPLIANCE',
-            'Days': 1
+        'ObjectLockEnabled': 'Enabled',
+        'Rule': {
+            'DefaultRetention': {
+                'Mode': 'COMPLIANCE',
+                'Days': 1
             }
         }
     }
 
-    # enable object lock on bucket
-    primary.s3_client.put_object_lock_configuration(
-        Bucket=bucket.name,
-        ObjectLockConfiguration = lock_config)
+    buckets, zone_bucket = create_bucket_per_zone_in_realm()
+    for zone, bucket in zone_bucket:
+        # enable versioning
+        zone.s3_client.put_bucket_versioning(
+            Bucket=bucket.name,
+            VersioningConfiguration={'Status': 'Enabled'}
+        )
+        zone.s3_client.put_object_lock_configuration(
+            Bucket=bucket.name,
+            ObjectLockConfiguration=lock_config
+        )
 
-    zonegroup_meta_checkpoint(zonegroup)
-    zone_data_checkpoint(secondary.zone, primary.zone)
+    realm_meta_checkpoint(realm)
 
-    response = secondary.s3_client.get_object_lock_configuration(Bucket=bucket.name)
-    assert(response['ObjectLockConfiguration'] == lock_config)
+    for zone, bucket in zone_bucket:
+        # cross-zonegroup redirects don't work, so we only test zones in the bucket's zonegroup
+        for z in zone.zone.zonegroup.zones:
+            conn = z.get_conn(user.credentials)
+            response = conn.s3_client.get_object_lock_configuration(Bucket=bucket.name)
+            assert response['ObjectLockConfiguration'] == lock_config


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79490

---

backport of https://github.com/ceph/ceph/pull/71033
parent tracker: https://tracker.ceph.com/issues/68460

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh