### PR TITLE
doc/dev/radosgw: draft design for s3express CreateSession

### DIFF
--- a/doc/dev/radosgw/s3express.md
+++ b/doc/dev/radosgw/s3express.md
@@ -1,0 +1,36 @@
+# s3express CreateSession
+
+a session-based scheme for streamlined authentication/authorization of s3 object operations. in aws, this is specific to directory buckets. we'd like to explore its use in rgw for normal buckets
+
+references:
+
+https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-create-session.html
+https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateSession.html
+
+## design
+
+s3express CreateSession api
+- authorize based on iam policy for `s3express:CreateSession` action and optional `s3express:SessionMode` condition key for as ReadOnly vs ReadWrite
+- encrypt a session token that includes:
+-- expiration datetime
+-- bucket name
+-- any information necessary to authorize subsequent requests
+-- encryption attributes if specified
+
+for subsequent requests with `x-amz-s3session-token`:
+- authenticate with sigv4 as normal, then
+- decrypt token
+- check expiration
+- verify that the token's bucket matches the requested bucket
+- for ReadOnly sessions, deny actions other than GetObject, HeadObject, ListObjectsV2, GetObjectAttributes, ListParts, and ListMultipartUploads
+- for ReadWrite sessions, only deny CopyObject/UploadPartCopy? normal credentials are required to authorize access to source bucket/object
+- teach rgw_s3_prepare_encrypt() to use encryption attrs from session token, not from x-amz-server-side-encryption-* request headers
+
+rgw buckets support bucket/object acls, but these session tokens would bypass acl enforcement. aws directory buckets never have acls enabled (see https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-overview.html#directory-buckets-access-management):
+> S3 Object Ownership is set to bucket owner enforced and access control lists (ACLs) are disabled. These settings can't be modified.
+
+should we reject CreateSession requests for buckets that aren't configured for BucketOwnerEnforced?
+
+## evaluation
+
+are there potential performance improvements here? i think the idea is that, by doing authorization up front during CreateSession, subsequent requests could avoid the overhead of reading/evaluating iam policies. this _might_ mean the requests could avoid reading/decoding the user/account metadata at all. however, we do expect the metadata cache to hide a lot of this overhead


### PR DESCRIPTION
a draft design for https://tracker.ceph.com/issues/79514, exploring the use of aws' s3express:CreateSession api

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
