### PR TITLE
libfdb: add result-reporting transactor mode

### DIFF
--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -61,6 +61,20 @@ if (!lfdb::commit(txn)) {
 }
 ```
 
+```cpp
+// Ask commit() to report whether the transaction should be replayed:
+auto txn = lfdb::make_transaction(dbh);
+
+lfdb::set(txn, "person/frances-allen/name", "Frances Allen");
+
+const auto result = lfdb::commit(lfdb::with_result, txn);
+
+if (not result.committed and 0 != result.replay_error) {
+  // A non-zero replay_error means FoundationDB prepared txn for replay.
+  retry_transaction_body(txn, result.replay_error);
+}
+```
+
 ## Version Stamps
 
 ```cpp
@@ -164,7 +178,7 @@ if (lfdb::get(dbh, "person/konrad-zuse/name", name)) {
 ```
 
 ```cpp
-// Use a callback when the raw serialized bytes must be copied or decoded
+// Use a void callback when the raw serialized bytes must be copied or decoded
 // immediately. The span is only valid during the callback.
 lfdb::get(dbh, "person/konrad-zuse/name",
           [](std::span<const std::uint8_t> bytes) {
@@ -943,6 +957,27 @@ txr([](auto& txn) {
 });
 ```
 
+### Reporting replay results
+
+Use `with_result` when application code needs to stop, resume, or report retry
+progress instead of treating retry exhaustion as an exception. The returned
+`transaction_result` describes the transaction machinery, not the user
+operation's value. `last_error == 0` means there was no FoundationDB replay
+error to report. Use an ordinary transactor when the transaction body should
+return an application value.
+
+```cpp
+auto txr = lfdb::make_transactor(dbh);
+
+auto result = txr(lfdb::with_result, [](auto& txn, std::string_view key, std::string_view title) {
+  lfdb::set(txn, key, title);
+}, "person/murasaki-shikibu/title", "Novelist");
+
+if (!result.committed) {
+  record_retry_exhaustion(result.attempts, result.replay_count, result.last_error);
+}
+```
+
 ### Transactor options
 
 ```cpp
@@ -1202,8 +1237,9 @@ watch_thread.request_stop();
 ```
 
 `watched_loop()` is a gadget for repeated watch handling. Its callback takes
-the watched key as a `std::string_view`. The helper blocks; applications should
-own any thread, executor, shutdown, or callback error policy around it:
+the watched key as a `std::string_view` and returns `void`. The helper blocks;
+applications should own any thread, executor, shutdown, or callback error
+policy around it:
 
 ```cpp
 std::jthread watch_thread {

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -75,8 +75,10 @@ struct interval;
 } // namespace query
 
 using select = query::interval;
+struct with_result_t;
 struct versionstamp;
 struct watch_handle;
+struct commit_result;
 
 class database;
 class transaction;
@@ -135,7 +137,8 @@ namespace ceph::libfdb::concepts {
 // Note that "stringlikes" are not all "stringview-likes", such as when they can be
 // written to:
 template <typename StringViewLikeT>
-concept stringview_convertible = std::convertible_to<StringViewLikeT, std::string_view>;
+concept stringview_convertible =
+ std::convertible_to<std::remove_reference_t<StringViewLikeT> const&, std::string_view>;
 
 template <typename KeyViewT>
 concept libfdb_key_view = std::same_as<std::remove_cvref_t<KeyViewT>, std::string_view>;
@@ -199,32 +202,31 @@ concept string_pair_output_range =
 template <typename RangeT>
 concept materializable_string_pair_output_range =
  string_pair_output_range<RangeT> and
- std::default_initializable<std::remove_cvref_t<RangeT>>;
+ std::default_initializable<std::remove_cvref_t<RangeT>> and
+ std::move_constructible<std::remove_cvref_t<RangeT>>;
 
-template <typename ContainerT>
-concept has_merge =
- requires(ContainerT& out, ContainerT& in) {
-  out.merge(in);
- };
+template <typename FnT>
+concept value_invocable =
+ std::invocable<FnT&, std::span<const std::uint8_t>>;
 
 template <typename FnT>
 concept value_callback =
- std::invocable<FnT&, std::span<const std::uint8_t>>;
+ value_invocable<FnT> &&
+ std::is_void_v<std::invoke_result_t<FnT&, std::span<const std::uint8_t>>>;
 
 template <typename T>
 concept decoded_value_sink =
- not value_callback<std::remove_reference_t<T>> and
+ not value_invocable<std::remove_reference_t<T>> and
  std::is_lvalue_reference_v<T> and
  not std::is_const_v<std::remove_reference_t<T>> and
  std::is_object_v<std::remove_reference_t<T>>;
 
 template <typename T>
-concept storable_invocation_result =
- not std::is_void_v<T> and not std::is_reference_v<T>;
-
-template <typename T>
 concept supported_invocation_result =
- not std::is_reference_v<T>;
+ std::is_void_v<T> or
+ (not std::is_reference_v<T> and
+  std::constructible_from<std::remove_cvref_t<T>, T> and
+  std::move_constructible<std::remove_cvref_t<T>>);
 
 } // namespace ceph::libfdb::concepts
 
@@ -925,6 +927,7 @@ class transaction final
                                const commit_after_op commit_after);
 
  friend inline bool commit(transaction_handle& txn);
+ friend inline commit_result commit(with_result_t, transaction_handle& txn);
  friend inline bool commit(transaction_handle& txn, const versionstamp& stamp);
  friend inline watch_handle make_watch(transaction_handle txn, std::string_view key);
  friend inline fdb_error_t ceph::libfdb::detail::do_commit(transaction_handle& txn);

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -17,7 +17,30 @@
 #include "base.h"
 #include "conversion.h"
 
+#include <tuple>
+
 namespace ceph::libfdb {
+
+// Overload tag for transactors that should report replay/commit metadata:
+struct with_result_t final {};
+inline constexpr with_result_t with_result;
+
+// Describes replay/commit work performed by result-reporting transactors.
+struct transaction_result final {
+ bool committed = false;
+ std::size_t attempts = 0;
+
+ // Replays prepared after retryable failures; excludes a final exhausted attempt:
+ std::size_t replay_count = 0;
+
+ fdb_error_t last_error = 0;
+};
+
+// Describes a commit attempt when the caller owns transaction replay.
+struct commit_result final {
+ bool committed = false;
+ fdb_error_t replay_error = 0;
+};
 
 /* This should be called when the application is all done with FoundationDB: */
 inline void shutdown_libfdb()
@@ -62,6 +85,10 @@ inline database_handle create_database(const std::filesystem::path dbfile,
 
 inline transaction_handle make_transaction(database_handle dbh)
 {
+ if (!dbh) {
+  throw std::invalid_argument("make_transaction() requires database handle");
+ }
+
  return std::make_shared<transaction>(dbh);
 }
 
@@ -76,8 +103,13 @@ inline transaction_handle make_transaction(database_handle dbh, const transactio
 // On false, the client should retry the transaction:
 [[nodiscard]] inline bool commit(transaction_handle& txn)
 {
- return txn->commit(); 
+ return txn->commit();
 }
+
+// Prepare a transaction to replay after a retryable operation-body error:
+void prepare_replay(transaction_handle& txn, fdb_error_t error);
+
+[[nodiscard]] commit_result commit(with_result_t, transaction_handle& txn);
 
 [[nodiscard]] inline bool commit(transaction_handle& txn,
                                  const versionstamp& stamp)
@@ -96,19 +128,34 @@ inline transaction_handle make_transaction(database_handle dbh, const transactio
 namespace ceph::libfdb::detail {
 
 // Forward declarations:
-template <typename FnT>
+template <typename FnT, typename ...ArgTs>
 using transaction_invocation_result_t =
- std::invoke_result_t<FnT&, transaction_handle&>;
+ std::invoke_result_t<FnT&, transaction_handle&, ArgTs&...>;
 
-template <typename FnT>
-concept supported_transaction_invocation =
- concepts::supported_invocation_result<transaction_invocation_result_t<FnT>>;
+template <typename FnT, typename ...ArgTs>
+concept transaction_op =
+ std::invocable<FnT&, transaction_handle&, ArgTs&...> &&
+ concepts::supported_invocation_result<transaction_invocation_result_t<FnT, ArgTs...>>;
+
+template <typename FnT, typename ...ArgTs>
+concept result_reporting_transaction_op =
+ transaction_op<FnT, ArgTs...> &&
+ std::is_void_v<transaction_invocation_result_t<FnT, ArgTs...>>;
+
+template <typename FnT, typename ...ArgTs>
+concept bound_transaction_op =
+ std::constructible_from<std::decay_t<FnT>, FnT> &&
+ (std::constructible_from<std::decay_t<ArgTs>, ArgTs> && ...) &&
+ transaction_op<std::decay_t<FnT>, std::decay_t<ArgTs>...>;
 
 template <typename FnT>
 using operation_result_t =
  std::conditional_t<std::is_void_v<transaction_invocation_result_t<FnT>>,
                     void,
                     std::remove_cvref_t<transaction_invocation_result_t<FnT>>>;
+
+template <result_reporting_transaction_op FnT>
+transaction_result maybe_retry_with_result(transaction_handle txn, FnT&& fn);
 
 template <typename OutValuesT>
 struct value_collector_t final
@@ -121,14 +168,28 @@ struct value_collector_t final
 template <typename OutValuesT>
 auto value_collector(OutValuesT& out_values) -> value_collector_t<OutValuesT>;
 
-template <supported_transaction_invocation FnT>
+template <typename OutputTargetOrFnT>
+requires concepts::value_callback<std::remove_reference_t<OutputTargetOrFnT>>
+decltype(auto) get_output_for(OutputTargetOrFnT&& output_target_or_fn)
+{
+ return std::forward<OutputTargetOrFnT>(output_target_or_fn);
+}
+
+template <typename OutputTargetOrFnT>
+requires (not concepts::value_callback<std::remove_reference_t<OutputTargetOrFnT>>)
+auto get_output_for(OutputTargetOrFnT&& output_target_or_fn)
+{
+ return value_collector(output_target_or_fn);
+}
+
+template <transaction_op FnT>
 auto maybe_retry(transaction_handle txn, FnT&& fn) -> operation_result_t<FnT>;
 
-template <supported_transaction_invocation FnT>
+template <transaction_op FnT>
 auto commit_noreplay(transaction_handle txn, const commit_after_op commit_after, FnT&& fn)
  -> operation_result_t<FnT>;
 
-template <supported_transaction_invocation FnT>
+template <transaction_op FnT>
 auto in_transaction(database_handle dbh, FnT&& fn)
  -> operation_result_t<FnT>;
 
@@ -145,7 +206,12 @@ namespace ceph::libfdb {
 }
 
 template <typename FnT>
-requires std::invocable<FnT&, std::string_view>
+concept watch_callback =
+ std::invocable<FnT&, std::string_view> &&
+ std::is_void_v<std::invoke_result_t<FnT&, std::string_view>>;
+
+template <typename FnT>
+requires watch_callback<FnT>
 void watched_loop(database_handle dbh, std::string_view key, std::stop_token stop_token, FnT&& fn)
 {
  std::string watched_key(key);
@@ -160,7 +226,7 @@ void watched_loop(database_handle dbh, std::string_view key, std::stop_token sto
  * For more complex stop behavior, see make_watch(), ready(), cancel(), and
  * wait_for_event(): */
 template <typename FnT>
-requires std::invocable<FnT&, std::string_view>
+requires watch_callback<FnT>
 void watched_loop(database_handle dbh, std::string_view key, FnT&& fn)
 {
  return watched_loop(dbh, key, std::stop_token{}, std::forward<FnT>(fn));
@@ -426,11 +492,6 @@ inline select select_from_initializer_list(std::initializer_list<std::string_vie
 }
 
 template <typename OutT>
-concept string_pair_output =
- concepts::string_pair_output_iterator<OutT> ||
- concepts::string_pair_output_range<OutT>;
-
-template <typename OutT>
 struct materialized_string_pair_output final
 {
  OutT values;
@@ -455,7 +516,7 @@ inline void publish_string_pair_results(ContainerT& out, ContainerT&& tmp)
   }
  }
 
- if constexpr (concepts::has_merge<ContainerT>) {
+ if constexpr (requires { out.merge(tmp); }) {
   out.merge(tmp);
   return;
  }
@@ -463,7 +524,9 @@ inline void publish_string_pair_results(ContainerT& out, ContainerT&& tmp)
  ceph::util::append_range(out, move_range(tmp));
 }
 
-template <query::expression SelectionT, string_pair_output OutT>
+template <query::expression SelectionT, typename OutT>
+requires concepts::string_pair_output_iterator<OutT> ||
+         concepts::string_pair_output_range<OutT>
 inline std::size_t get_value_selection_from_transaction(transaction& txn,
                                                         const SelectionT& selection,
                                                         OutT& out)
@@ -595,12 +658,8 @@ inline bool get(ceph::libfdb::transaction_handle txn,
 {
  return detail::commit_noreplay(txn, commit_after,
           [key = detail::as_fdb_span(key), &output_target_or_fn](const transaction_handle& active_txn) {
-            if constexpr (concepts::value_callback<std::remove_reference_t<OutputTargetOrFnT>>) {
-              return active_txn->get(key, output_target_or_fn);
-            } else {
-              return active_txn->get(key,
-                              detail::value_collector(output_target_or_fn));
-            }
+            return active_txn->get(key,
+                                   detail::get_output_for(output_target_or_fn));
           });
 }
 
@@ -661,7 +720,7 @@ namespace ceph::libfdb {
 
 /* A "transactor" is a function-like wrapper for running replayable transactions.
  * It defers transaction creation until called, commits after the user function
- * returns, retries when FoundationDB requests replay, and throws when recovery
+ * returns, replays when FoundationDB requests replay, and throws when recovery
  * fails or retry attempts are exhausted. Plus, the name is pretty cool. */
 class transactor final
 {
@@ -679,15 +738,58 @@ class transactor final
     opts(opts_)
  {}
 
+ // Bind the callable and arguments once so replays see stable state:
+ template <typename FnT, typename ...ArgTs>
+ static auto bind_invocation(FnT&& fn, ArgTs&& ...args)
+ {
+  return [frame = std::tuple<std::decay_t<FnT>, std::decay_t<ArgTs>...> {
+            std::forward<FnT>(fn), std::forward<ArgTs>(args)...
+          }](transaction_handle& txn) mutable -> decltype(auto) {
+    return std::apply([&txn](auto& active_fn, auto& ...active_args) -> decltype(auto) {
+      return std::invoke(active_fn, txn, active_args...);
+    }, frame);
+  };
+ }
+
+ transaction_handle make_transaction_for_call() const
+ {
+  return opts ? make_transaction(dbh, *opts) : make_transaction(dbh);
+ }
+
  public:
  template <typename FnT>
- requires std::invocable<FnT&, transaction_handle&>
+ requires detail::transaction_op<FnT>
  decltype(auto) operator()(FnT&& fn) const
  {
-  auto txn = opts ? make_transaction(dbh, *opts)
-                  : make_transaction(dbh);
+  return detail::maybe_retry(make_transaction_for_call(), std::forward<FnT>(fn));
+ }
 
-  return detail::maybe_retry(txn, std::forward<FnT>(fn));
+ template <typename FnT, typename ...ArgTs>
+ requires (sizeof...(ArgTs) > 0 && detail::bound_transaction_op<FnT, ArgTs...>)
+ decltype(auto) operator()(FnT&& fn, ArgTs&& ...args) const
+ {
+  auto bound = bind_invocation(std::forward<FnT>(fn), std::forward<ArgTs>(args)...);
+
+  return (*this)(bound);
+ }
+
+ template <typename FnT>
+ requires detail::result_reporting_transaction_op<FnT>
+ transaction_result operator()(with_result_t, FnT&& fn) const
+ {
+  return detail::maybe_retry_with_result(make_transaction_for_call(), std::forward<FnT>(fn));
+ }
+
+ template <typename FnT, typename ...ArgTs>
+ requires (sizeof...(ArgTs) > 0 &&
+           detail::bound_transaction_op<FnT, ArgTs...> &&
+           detail::result_reporting_transaction_op<
+             std::decay_t<FnT>, std::decay_t<ArgTs>...>)
+ transaction_result operator()(with_result_t, FnT&& fn, ArgTs&& ...args) const
+ {
+  auto bound = bind_invocation(std::forward<FnT>(fn), std::forward<ArgTs>(args)...);
+
+  return (*this)(with_result, bound);
  }
 
  private:
@@ -826,9 +928,9 @@ auto blocks_selector(ceph::libfdb::database_handle dbh, ceph::libfdb::select sel
 
  auto read_blocks = [txr = make_transactor(dbh)](this auto& self, ceph::libfdb::select range, const int iteration)
  -> std::generator<AssocT> {
-  auto read_result = txr([range, iteration](auto& txn) {
-   return detail::materialize_query_window<ValueT, AssocT>(*txn, range, iteration);
-  });
+  auto read_result = txr([](auto& txn, ceph::libfdb::select range, const int iteration) {
+   return detail::materialize_query_window<ValueT, AssocT>(*txn, std::move(range), iteration);
+  }, std::move(range), iteration);
 
   auto next_range = std::move(read_result.next_range);
 
@@ -924,6 +1026,32 @@ inline bool commit_or_throw(transaction_handle& txn)
  return true;
 }
 
+} // namespace ceph::libfdb::detail
+
+namespace ceph::libfdb {
+
+inline void prepare_replay(transaction_handle& txn, const fdb_error_t error)
+{
+ if (not detail::retry_after_error(txn, error)) {
+  throw libfdb_exception(error);
+ }
+}
+
+[[nodiscard]] inline commit_result commit(with_result_t, transaction_handle& txn)
+{
+ fdb_error_t replay_error = 0;
+ const auto committed = txn->commit(&replay_error);
+
+ return {
+  .committed = committed,
+  .replay_error = replay_error,
+ };
+}
+
+} // namespace ceph::libfdb
+
+namespace ceph::libfdb::detail {
+
 template <typename OutValuesT>
 void value_collector_t<OutValuesT>::operator()(std::span<const std::uint8_t> out_data) const
 {
@@ -940,40 +1068,72 @@ enum struct invocation_failure_policy { no_retry, retry };
 
 struct no_invocation_result final {};
 
-template <typename ResultT>
-using stored_invocation_result_t =
- std::conditional_t<std::is_void_v<ResultT>,
-                    no_invocation_result,
-                    std::remove_cvref_t<ResultT>>;
+// Keep the existing transactor retry behavior in one place.
+constexpr std::size_t transaction_retry_attempts = 10;
 
-template <typename ResultT, typename FnT>
-requires concepts::supported_invocation_result<ResultT>
-auto store_invocation_result(transaction_handle& txn, FnT&& fn)
- -> stored_invocation_result_t<ResultT>
+inline void record_transaction_replay(transaction_result& result,
+                                      const fdb_error_t r,
+                                      const bool can_replay)
 {
- if constexpr (std::is_void_v<ResultT>) {
-  return (std::invoke(fn, txn), stored_invocation_result_t<ResultT>{});
- } else {
-  return std::invoke(fn, txn);
+ result.last_error = r;
+
+ if (can_replay) {
+  ++result.replay_count;
  }
 }
 
-template <typename ResultT, typename StoredT>
-requires std::is_void_v<ResultT> || concepts::storable_invocation_result<ResultT>
-auto invocation_value_from_result(std::optional<StoredT>&& result)
-{
- if constexpr (std::is_void_v<ResultT>) {
-  return;
- } else {
+template <typename ResultT>
+struct invocation_result_traits final {
+ using stored_t = std::remove_cvref_t<ResultT>;
+
+ template <typename FnT>
+ static stored_t store(transaction_handle& txn, FnT&& fn)
+ {
+  return std::invoke(std::forward<FnT>(fn), txn);
+ }
+
+ static stored_t take(std::optional<stored_t>&& result)
+ {
   return *std::move(result);
  }
+};
+
+template <>
+struct invocation_result_traits<void> final {
+ using stored_t = no_invocation_result;
+
+ template <typename FnT>
+ static stored_t store(transaction_handle& txn, FnT&& fn)
+ {
+  std::invoke(std::forward<FnT>(fn), txn);
+
+  return {};
+ }
+
+ static void take(std::optional<stored_t>&&)
+ {}
+};
+
+template <typename ResultT>
+using stored_invocation_result_t = typename invocation_result_traits<ResultT>::stored_t;
+
+template <typename ResultT, typename FnT>
+auto store_invocation_result(transaction_handle& txn, FnT&& fn)
+ -> stored_invocation_result_t<ResultT>
+{
+ return invocation_result_traits<ResultT>::store(txn, std::forward<FnT>(fn));
+}
+
+template <typename ResultT, typename StoredT>
+decltype(auto) invocation_value_from_result(std::optional<StoredT>&& result)
+{
+ return invocation_result_traits<ResultT>::take(std::move(result));
 }
 
 template <invocation_failure_policy FailurePolicy,
           typename FnT,
           typename CommitFnT,
           typename ResultT = std::invoke_result_t<FnT&, transaction_handle&>>
-requires concepts::supported_invocation_result<ResultT>
 auto attempt_invocation(transaction_handle& txn, FnT&& fn, CommitFnT&& commit_fn)
  -> std::optional<stored_invocation_result_t<ResultT>>
 {
@@ -982,21 +1142,21 @@ auto attempt_invocation(transaction_handle& txn, FnT&& fn, CommitFnT&& commit_fn
  std::optional<stored_result_t> result;
 
  try {
-     result.emplace(store_invocation_result<ResultT>(txn, fn));
+  result.emplace(store_invocation_result<ResultT>(txn, fn));
  }
  catch (const libfdb_exception& e) {
-     // Figure out how to recover from invocation failure:
+  // Figure out how to recover from invocation failure:
 
-     if constexpr (invocation_failure_policy::no_retry == FailurePolicy) {
-      throw;
-     }
+  if constexpr (invocation_failure_policy::no_retry == FailurePolicy) {
+   throw;
+  }
 
-     if (not e.retryable()) {
-      throw;
-     }
+  if (not e.retryable()) {
+   throw;
+  }
 
-     retry_after_error(txn, e.fdb_error_value);
-     return std::nullopt;
+  prepare_replay(txn, e.fdb_error_value);
+  return std::nullopt;
  }
 
  if (!std::invoke(commit_fn, txn)) {
@@ -1010,10 +1170,9 @@ template <invocation_failure_policy FailurePolicy,
           typename FnT,
           typename CommitFnT,
           typename ResultT = std::invoke_result_t<FnT&, transaction_handle&>>
-requires concepts::supported_invocation_result<ResultT>
 decltype(auto) invoke_with_retry(transaction_handle& txn, FnT&& fn, CommitFnT&& commit_fn)
 {
- for (auto tries = 10; tries; --tries) {
+ for (auto tries = transaction_retry_attempts; tries; --tries) {
   if (auto result = attempt_invocation<FailurePolicy>(txn, fn, commit_fn)) {
    return invocation_value_from_result<ResultT>(std::move(result));
   }
@@ -1022,7 +1181,7 @@ decltype(auto) invoke_with_retry(transaction_handle& txn, FnT&& fn, CommitFnT&& 
  throw libfdb_exception("transaction retry limit exceeded");
 }
 
-template <supported_transaction_invocation FnT>
+template <transaction_op FnT>
 auto maybe_retry(transaction_handle txn, FnT&& fn) -> operation_result_t<FnT>
 {
  return invoke_with_retry<invocation_failure_policy::retry>(
@@ -1032,7 +1191,46 @@ auto maybe_retry(transaction_handle txn, FnT&& fn) -> operation_result_t<FnT>
           });
 }
 
-template <supported_transaction_invocation FnT>
+template <result_reporting_transaction_op FnT>
+transaction_result maybe_retry_with_result(transaction_handle txn, FnT&& fn)
+{
+ transaction_result result;
+
+ for (auto attempts_left = transaction_retry_attempts; attempts_left; --attempts_left) {
+  ++result.attempts;
+
+  try {
+   std::invoke(fn, txn);
+  } catch (const libfdb_exception& e) {
+   if (not e.retryable()) {
+    throw;
+   }
+
+   prepare_replay(txn, e.fdb_error_value);
+   record_transaction_replay(result, e.fdb_error_value, 1 < attempts_left);
+
+   continue;
+  }
+
+  const auto commit_state = commit(with_result, txn);
+  if (not commit_state.committed and 0 == commit_state.replay_error) {
+   throw libfdb_exception("transactor commit did not start");
+  }
+
+  if (not commit_state.committed) {
+   record_transaction_replay(result, commit_state.replay_error, 1 < attempts_left);
+
+   continue;
+  }
+
+  result.committed = true;
+  return result;
+ }
+
+ return result;
+}
+
+template <transaction_op FnT>
 auto in_transaction(database_handle dbh, FnT&& fn)
  -> operation_result_t<FnT>
 {
@@ -1040,7 +1238,7 @@ auto in_transaction(database_handle dbh, FnT&& fn)
 }
 
 // Commit only once; the caller is responsible for transaction replay:
-template <supported_transaction_invocation FnT>
+template <transaction_op FnT>
 auto commit_noreplay(transaction_handle txn, const commit_after_op commit_after, FnT&& fn)
  -> operation_result_t<FnT>
 {

--- a/src/rgw/fdb/interval.h
+++ b/src/rgw/fdb/interval.h
@@ -489,16 +489,6 @@ class static_interval_set final
 
 namespace detail {
 
-template <typename T>
-concept has_explicit_empty =
- requires(const std::remove_cvref_t<T>& x) {
-  { x.explicitly_empty() } -> std::same_as<bool>;
- };
-
-template <typename BoundT, typename DomainT>
-concept interval_boundary_for =
- ::ceph::libfdb::interval::boundary_view_for<BoundT, DomainT>;
-
 template <typename BoundT>
 using boundary_storage =
  std::conditional_t<std::is_lvalue_reference_v<BoundT>,
@@ -508,7 +498,7 @@ using boundary_storage =
 template <typename T>
 constexpr bool explicitly_empty(const T& x)
 {
- if constexpr (has_explicit_empty<T>) {
+ if constexpr (requires { { x.explicitly_empty() } -> std::same_as<bool>; }) {
   return x.explicitly_empty();
  }
 
@@ -556,9 +546,9 @@ concept interval_view =
   typename std::remove_cvref_t<T>::domain_type;
   requires ordered_domain<typename std::remove_cvref_t<T>::domain_type>;
   { x.lower() } ->
-   detail::interval_boundary_for<typename std::remove_cvref_t<T>::domain_type>;
+   boundary_view_for<typename std::remove_cvref_t<T>::domain_type>;
   { x.upper() } ->
-   detail::interval_boundary_for<typename std::remove_cvref_t<T>::domain_type>;
+   boundary_view_for<typename std::remove_cvref_t<T>::domain_type>;
  };
 
 template <typename T>
@@ -569,19 +559,17 @@ concept canonical_interval =
 
 template <typename T>
 concept expression =
- std::derived_from<std::remove_cvref_t<T>, detail::expression_tag> ||
- interval_view<T>;
-
-template <typename T>
-concept domain_expression =
- expression<T> && requires {
+ requires {
   typename std::remove_cvref_t<T>::domain_type;
- };
+  requires ordered_domain<typename std::remove_cvref_t<T>::domain_type>;
+ } &&
+ (std::derived_from<std::remove_cvref_t<T>, detail::expression_tag> ||
+  interval_view<T>);
 
 template <typename LhsT, typename RhsT>
 concept same_expression_domain =
- domain_expression<LhsT> &&
- domain_expression<RhsT> &&
+ expression<LhsT> &&
+ expression<RhsT> &&
  std::same_as<typename std::remove_cvref_t<LhsT>::domain_type,
               typename std::remove_cvref_t<RhsT>::domain_type>;
 
@@ -1316,7 +1304,6 @@ constexpr bool includes_endpoint(const endpoint_inclusion inclusion) noexcept
 
 template <typename DomainT, typename ValueT>
 concept domain_value_source =
- ordered_domain<DomainT> &&
  std::constructible_from<typename DomainT::value_type, ValueT>;
 
 template <ordered_domain DomainT, typename ValueT>
@@ -1338,12 +1325,6 @@ constexpr auto boundary_for(const typename DomainT::value_type& value,
 
  return boundary_type::open(value);
 }
-
-template <typename T>
-concept detects_empty_prefix =
- requires(const typename T::value_type& value) {
-  { T::empty_prefix(value) } -> std::same_as<bool>;
- };
 
 template <typename EndpointT, ordered_domain DomainT, typename ValueT>
 requires domain_value_source<DomainT, ValueT>
@@ -1514,7 +1495,9 @@ constexpr auto prefix(ValueT&& value)
 {
  auto prefix_value = detail::value_for<DomainT>(std::forward<ValueT>(value));
 
- if constexpr (detail::detects_empty_prefix<DomainT>) {
+ if constexpr (requires {
+                { DomainT::empty_prefix(prefix_value) } -> std::same_as<bool>;
+               }) {
   if (DomainT::empty_prefix(prefix_value)) {
    return query<DomainT>::universal();
   }

--- a/src/rgw/fdb/query.h
+++ b/src/rgw/fdb/query.h
@@ -283,17 +283,22 @@ concept query_interval =
 
 template <typename T>
 concept byte_interval_expression =
- core::domain_expression<T> &&
+ core::expression<T> &&
  std::same_as<core::expression_domain_t<T>, byte_string_domain>;
 
 template <typename T>
 concept configured_expression =
- requires {
+ requires(const std::remove_cvref_t<T>& configured) {
   typename std::remove_cvref_t<T>::interval_expression_type;
   typename std::remove_cvref_t<T>::domain_type;
- } &&
- byte_interval_expression<typename std::remove_cvref_t<T>::interval_expression_type> &&
- std::same_as<typename std::remove_cvref_t<T>::domain_type, byte_string_domain>;
+  requires byte_interval_expression<
+             typename std::remove_cvref_t<T>::interval_expression_type>;
+  requires std::same_as<typename std::remove_cvref_t<T>::domain_type,
+                        byte_string_domain>;
+  { configured.expression } ->
+   std::same_as<const typename std::remove_cvref_t<T>::interval_expression_type&>;
+  { configured.options } -> std::same_as<const query_options&>;
+ };
 
 template <byte_interval_expression ExprT>
 struct configured final

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -84,6 +84,56 @@ struct pair_identity final
  }
 };
 
+struct rvalue_string_view_only final
+{
+ operator std::string_view() && { return {}; }
+};
+
+struct move_only_invocation_result final
+{
+ move_only_invocation_result() = default;
+ move_only_invocation_result(move_only_invocation_result&&) = default;
+ move_only_invocation_result(const move_only_invocation_result&) = delete;
+};
+
+struct immovable_invocation_result final
+{
+ immovable_invocation_result() = default;
+ immovable_invocation_result(immovable_invocation_result&&) = delete;
+ immovable_invocation_result(const immovable_invocation_result&) = delete;
+};
+
+struct move_only_transaction_argument final
+{
+ move_only_transaction_argument() = default;
+ move_only_transaction_argument(move_only_transaction_argument&&) = default;
+ move_only_transaction_argument(const move_only_transaction_argument&) = delete;
+};
+
+struct transaction_with_move_only_argument final
+{
+ void operator()(lfdb::transaction_handle&, move_only_transaction_argument&) const {}
+};
+
+struct reference_returning_transaction final
+{
+ int& operator()(lfdb::transaction_handle&) const;
+};
+
+struct immovable_string_pair_output final
+{
+ std::vector<string_pair> values;
+
+ immovable_string_pair_output() = default;
+ immovable_string_pair_output(immovable_string_pair_output&&) = delete;
+ immovable_string_pair_output(const immovable_string_pair_output&) = delete;
+
+ auto begin() { return std::begin(values); }
+ auto end() { return std::end(values); }
+
+ void push_back(string_pair value) { values.push_back(std::move(value)); }
+};
+
 TEST_CASE("libfdb concepts describe supported API shapes", "[fdb][concepts]")
 {
  using string_pair_vector = std::vector<string_pair>;
@@ -99,11 +149,44 @@ TEST_CASE("libfdb concepts describe supported API shapes", "[fdb][concepts]")
 
  STATIC_REQUIRE(lfdb::concepts::string_pair_output_range<string_pair_vector>);
  STATIC_REQUIRE(lfdb::concepts::string_pair_output_range<std::map<std::string, std::string>>);
+ STATIC_REQUIRE(lfdb::concepts::string_pair_output_range<immovable_string_pair_output>);
+ STATIC_REQUIRE_FALSE(
+  lfdb::concepts::materializable_string_pair_output_range<immovable_string_pair_output>);
+
+ STATIC_REQUIRE(lfdb::concepts::stringview_convertible<std::string>);
+ STATIC_REQUIRE(lfdb::concepts::stringview_convertible<const char[4]>);
+ STATIC_REQUIRE_FALSE(lfdb::concepts::stringview_convertible<rvalue_string_view_only>);
 
  STATIC_REQUIRE(lfdb::concepts::decoded_value_sink<std::string&>);
  STATIC_REQUIRE(lfdb::concepts::decoded_value_sink<char(&)[9]>);
  STATIC_REQUIRE_FALSE(lfdb::concepts::decoded_value_sink<const std::string&>);
  STATIC_REQUIRE_FALSE(lfdb::concepts::decoded_value_sink<std::string>);
+ STATIC_REQUIRE(lfdb::concepts::value_callback<decltype([](std::span<const std::uint8_t>) {})>);
+ STATIC_REQUIRE_FALSE(lfdb::concepts::value_callback<decltype([](std::span<const std::uint8_t>) {
+  return true;
+ })>);
+ STATIC_REQUIRE_FALSE(lfdb::concepts::decoded_value_sink<decltype([](std::span<const std::uint8_t>) {
+  return true;
+ })&>);
+
+ using void_transaction = decltype([](lfdb::transaction_handle&) {});
+ using value_transaction = decltype([](lfdb::transaction_handle&) {
+  return move_only_invocation_result {};
+ });
+ using immovable_transaction = decltype([](lfdb::transaction_handle&) {
+  return immovable_invocation_result {};
+ });
+
+ STATIC_REQUIRE(lfdb::detail::transaction_op<void_transaction>);
+ STATIC_REQUIRE(lfdb::detail::transaction_op<value_transaction>);
+ STATIC_REQUIRE_FALSE(lfdb::detail::transaction_op<immovable_transaction>);
+ STATIC_REQUIRE_FALSE(lfdb::detail::transaction_op<reference_returning_transaction>);
+ STATIC_REQUIRE((lfdb::detail::bound_transaction_op<
+                 transaction_with_move_only_argument,
+                 move_only_transaction_argument>));
+ STATIC_REQUIRE_FALSE((lfdb::detail::bound_transaction_op<
+                       transaction_with_move_only_argument,
+                       move_only_transaction_argument&>));
 }
 
 TEST_CASE("query prefix handles byte-string keyspace edges", "[fdb][query]")
@@ -551,6 +634,11 @@ bool trigger_watch_until(lfdb::database_handle dbh,
 
 TEST_CASE("transaction watches", "[rgw][fdb]") {
  janitor dbh;
+
+ static_assert(lfdb::watch_callback<decltype([](std::string_view) {})>);
+ static_assert(!lfdb::watch_callback<decltype([](std::string_view) {
+  return true;
+ })>);
 
  SECTION("watch fires after committed key change") {
   auto txn = lfdb::make_transaction(dbh);
@@ -1767,6 +1855,11 @@ SCENARIO("transactor", "[fdb]")
 {
  janitor j;
 
+ static_assert(lfdb::detail::result_reporting_transaction_op<decltype([](auto) {})>);
+ static_assert(!lfdb::detail::result_reporting_transaction_op<decltype([](auto) {
+  return 7;
+ })>);
+
  SECTION("transaction function returns nothing") {
   auto txr = lfdb::make_transactor(j);
   const auto key = test_key("key");
@@ -1839,12 +1932,163 @@ SCENARIO("transactor", "[fdb]")
   CHECK("final" == out);
  }
 
+ SECTION("direct commit can report success") {
+  const auto key = test_key("direct-result-key");
+
+  auto txn = lfdb::make_transaction(j);
+  lfdb::set(txn, key, "value");
+
+  const auto result = lfdb::commit(lfdb::with_result, txn);
+  CHECK(result.committed);
+  CHECK(0 == result.replay_error);
+
+  std::string out;
+  CHECK(lfdb::get(j, key, out));
+  CHECK("value" == out);
+ }
+
+ SECTION("direct commit can report replay") {
+  const auto key = test_key("direct-result-conflict-key");
+
+  lfdb::set(j, key, "initial");
+
+  auto txn = lfdb::make_transaction(j);
+
+  std::string out;
+  REQUIRE(lfdb::get(txn, key, out));
+  CHECK("initial" == out);
+
+  lfdb::set(j, key, "conflict");
+  lfdb::set(txn, key, "final");
+
+  auto result = lfdb::commit(lfdb::with_result, txn);
+  CHECK_FALSE(result.committed);
+  CHECK(0 != result.replay_error);
+
+  REQUIRE(lfdb::get(txn, key, out));
+  CHECK("conflict" == out);
+
+  lfdb::set(txn, key, "final");
+
+  result = lfdb::commit(lfdb::with_result, txn);
+  CHECK(result.committed);
+  CHECK(0 == result.replay_error);
+
+  CHECK(lfdb::get(j, key, out));
+  CHECK("final" == out);
+ }
+
+ SECTION("transactor can report transaction results") {
+  auto txr = lfdb::make_transactor(j);
+  const auto key = test_key("result-key");
+
+  auto result = txr(lfdb::with_result, [&key](auto txn) {
+    lfdb::set(txn, key, "value");
+  });
+
+  std::string out;
+  CHECK(lfdb::get(j, key, out));
+  CHECK("value" == out);
+
+  CHECK(result.committed);
+  CHECK(result.attempts == 1);
+  CHECK(result.replay_count == 0);
+  CHECK(0 == result.last_error);
+ }
+
+ SECTION("transactor accepts stable invocation arguments") {
+  auto txr = lfdb::make_transactor(j);
+  const auto key = test_key("argument-key");
+  const std::string value = "argument-value";
+
+  txr([](auto txn, const std::string& key, const std::string& value) {
+    lfdb::set(txn, key, value);
+  }, key, value);
+
+  std::string out;
+  CHECK(lfdb::get(j, key, out));
+  CHECK(value == out);
+ }
+
+ SECTION("result-reporting transactor replays after conflict") {
+  auto txr = lfdb::make_transactor(j);
+  const auto key = test_key("result-conflict-key");
+
+  lfdb::set(j, key, "initial");
+
+  auto result = txr(lfdb::with_result, [&j, &key](auto txn) {
+    std::string out;
+    if (not lfdb::get(txn, key, out)) {
+     throw std::runtime_error("expected key does not exist");
+    }
+
+    // Force a conflict, making the transactor replay the body:
+    if ("initial" == out) {
+     lfdb::set(j, key, "conflict");
+    }
+
+    lfdb::set(txn, key, "final");
+  });
+
+  std::string out;
+  CHECK(lfdb::get(j, key, out));
+  CHECK("final" == out);
+
+  CHECK(result.committed);
+  CHECK(result.attempts == 2);
+  CHECK(result.replay_count == 1);
+  CHECK(0 != result.last_error);
+ }
+
+ SECTION("result-reporting transactor reports retry exhaustion") {
+  auto txr = lfdb::make_transactor(j);
+  const auto key = test_key("result-retry-limit-key");
+
+  lfdb::set(j, key, "initial");
+
+  auto result = txr(lfdb::with_result, [&j, &key](auto txn) {
+    std::string out;
+    if (not lfdb::get(txn, key, out)) {
+     throw std::runtime_error("expected key does not exist");
+    }
+
+    // Force every commit attempt to conflict:
+    lfdb::set(j, key, "conflict");
+    lfdb::set(txn, key, "final");
+  });
+
+  std::string out;
+  CHECK(lfdb::get(j, key, out));
+  CHECK("conflict" == out);
+
+  CHECK_FALSE(result.committed);
+  CHECK(result.attempts == 10);
+  CHECK(result.replay_count == 9);
+  CHECK(0 != result.last_error);
+ }
+
+ SECTION("result-reporting transactor rejects invalid database handles") {
+  lfdb::database_handle dbh;
+  auto txr = lfdb::make_transactor(dbh);
+
+  CHECK_THROWS_WITH(txr(lfdb::with_result, [](auto) {}),
+                    "make_transaction() requires database handle");
+ }
+
  SECTION("transactor propagates transaction body exceptions") {
   auto txr = lfdb::make_transactor(j);
 
   CHECK_THROWS_WITH(txr([](auto) {
     throw std::runtime_error("transaction body failed");
   }), "transaction body failed");
+ }
+
+ SECTION("result-reporting transactor propagates transaction body exceptions") {
+  auto txr = lfdb::make_transactor(j);
+
+  CHECK_THROWS_AS(txr(lfdb::with_result, [](auto) {
+    throw std::runtime_error("transaction body failed");
+  }), std::runtime_error);
  }
 }
 

--- a/src/test/rgw/test_fdb_query.cc
+++ b/src/test/rgw/test_fdb_query.cc
@@ -261,6 +261,19 @@ lfdb::select revision_rank_query(const std::string_view collection_id,
  return lq::between(begin_prefix, lq::successor(end_prefix));
 }
 
+struct malformed_interval_expression final : li::detail::expression_tag
+{};
+
+struct incomplete_configured_expression final
+{
+ using interval_expression_type = lq::interval;
+ using domain_type = lq::byte_string_domain;
+};
+
+using configured_difference =
+ decltype(lq::with_options(lq::difference(lq::empty(), lq::universal()),
+                           lq::query_options {}));
+
 static_assert(lq::expression<lq::interval>);
 static_assert(lq::expression<decltype(lq::difference(lq::empty(), lq::universal()))>);
 static_assert(lq::expression<decltype(lq::set_union(lq::empty(), lq::universal()))>);
@@ -270,9 +283,12 @@ static_assert(lq::expression<decltype(lq::without(lq::universal(), "m"))>);
 static_assert(lq::non_interval_expression<decltype(lq::difference(lq::empty(), lq::universal()))>);
 static_assert(not lq::expression<lq::interval_bound>);
 static_assert(not lq::non_interval_expression<lq::interval>);
+static_assert(lq::configured_expression<configured_difference>);
+static_assert(not lq::configured_expression<incomplete_configured_expression>);
 static_assert(li::expression<li::query<int_domain>>);
 static_assert(li::expression<decltype(li::difference(li::query<int_domain>::empty(),
                                                      li::query<int_domain>::universal()))>);
+static_assert(not li::expression<malformed_interval_expression>);
 
 using composite_intersection_query =
  decltype(lq::intersection(lq::difference(lq::empty(), lq::universal()),


### PR DESCRIPTION
libfdb: replay results, transaction versions, conflict ranges, atomic mutations

Extends libfdb with structured transaction results, more explicit
control over transaction replaying, access to transaction versions
(FoundationDB feature), FoundationDB conflict ranges, and the entire
family of atomic operations (server-side).

in special cases. Expose prepare_replay() for retryable operation-body errors,
reuse the same machinery in result-reporting transactors.

Rejects ambiguous transactor states, validates DB handles before
transaction constructions, and improves naming. Constrains
result reports and callbacks to void-returning callables.

See EXAMPLES.md for new examples; test coverage significantly updated.

Assisted-by: Codex:GPT-5

Signed-off-by: Jesse F. Williamson <jfw@ibm.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
