### PR TITLE
mds: fix MDS crash in blockdiff on striped files

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -14608,6 +14608,23 @@ void MDCache::upkeep_main(void)
   }
 }
 
+// In a multi-object layout where each object spans multiple stripe units,
+// a contiguous object range can map to disjoint file ranges.
+static void add_file_extents(const file_layout_t& layout, uint64_t objectno,
+			     const interval_set<uint64_t>& object_extent,
+			     interval_set<uint64_t> *file_extents)
+{
+  file_layout_t l = layout; // extent_to_file() wants a non-const layout
+  std::vector<std::pair<uint64_t, uint64_t>> mapped;
+  for (const auto& [off, len] : object_extent) {
+    mapped.clear();
+    Striper::extent_to_file(g_ceph_context, &l, objectno, off, len, mapped);
+    for (const auto& [file_off, file_len] : mapped) {
+      file_extents->union_insert(file_off, file_len);
+    }
+  }
+}
+
 struct C_ListSnapsAggregator : public MDSIOContext {
   C_ListSnapsAggregator(MDSRank *mds, CInode *in1, CInode *in2, BlockDiff *block_diff,
 			Context *on_finish)
@@ -14761,9 +14778,9 @@ void MDCache::aggregate_snap_sets(const std::vector<std::unique_ptr<SnapSetConte
 	continue;
       }
 
-      interval_set<uint64_t> extent;
-      uint64_t offset = Striper::get_file_offset(g_ceph_context, &(in2->get_inode()->layout),
-						 snap_set->objectid, 0);
+      const auto& layout = in2->get_inode()->layout;
+      // both in object coordinates, like clone_info_t::size and ::overlap
+      interval_set<uint64_t> object_extent, unchanged;
 
       for (auto hops = std::distance(it1, it2); hops > 0; --hops) {
 	dout(20) << __func__ << ": [cloneid: " << it1->cloneid << " snaps: " << it1->snaps
@@ -14777,21 +14794,23 @@ void MDCache::aggregate_snap_sets(const std::vector<std::unique_ptr<SnapSetConte
 	  // TODO: report holes in blockdiff strucuter. that way,
 	  // caller can optimize and punch holes rather than writing
 	  // zeros.
-	  dout(10) << __func__ << ": hole: [" << offset << "~" << it1->size << "]" << dendl;
+	  dout(10) << __func__ << ": hole: object " << snap_set->objectid
+		   << " [0~" << it1->size << "]" << dendl;
 	  dout(10) << __func__ << ": adding whole extent - reader will read zeros" << dendl;
 	  sz = it1->size;
 	}
 
-	extent.clear();
-	extent.union_insert(offset, sz);
+	object_extent.clear();
+	object_extent.union_insert(0, sz);
+	unchanged.clear();
 	for (auto &overlap_region : it1->overlap) {
-	  uint64_t overlap_offset = Striper::get_file_offset(g_ceph_context, &(in2->get_inode()->layout),
-							     snap_set->objectid, overlap_region.first);
-	  extent.erase(overlap_offset, overlap_region.second);
+	  unchanged.union_insert(overlap_region.first, overlap_region.second);
 	}
+	unchanged.intersection_of(object_extent);
+	object_extent.subtract(unchanged);
 
-	dout(20) << __func__ << ": (non overlapping) extent=" << extent << dendl;
-	extents.union_of(extent);
+	dout(20) << __func__ << ": (non overlapping) object extent=" << object_extent << dendl;
+	add_file_extents(layout, snap_set->objectid, object_extent, &extents);
 	dout(20) << __func__ << ": (modified) extents=" << extents << dendl;
 	++it1;
       }

--- a/src/test/libcephfs/snapdiff.cc
+++ b/src/test/libcephfs/snapdiff.cc
@@ -527,6 +527,11 @@ public:
   void prepareBlockDiffChangedBlockWithChangedHead(interval_set<uint64_t> *expected);
   void prepareBlockDiffChangedBlockWithTruncatedBlock(interval_set<uint64_t> *expected);
   void prepareBlockDiffChangedBlockWithCustomObjectSize(interval_set<uint64_t> *expected);
+  void prepareBlockDiffChangedBlockWithStripedLayout(interval_set<uint64_t> *expected);
+  void prepareBlockDiffStripedSpanningWrite(interval_set<uint64_t> *expected);
+  void prepareBlockDiffStripedManyRowsPerObject(interval_set<uint64_t> *expected);
+  void set_striped_layout(const char* relpath, uint64_t stripe_unit,
+                          uint64_t stripe_count, uint64_t object_size);
   void prepareHugeSnapDiff(const std::string& name_prefix_start,
                            const std::string& name_prefix_bulk,
                            const std::string& name_prefix_end,
@@ -688,6 +693,105 @@ void TestMount::prepareBlockDiffChangedBlockWithCustomObjectSize(interval_set<ui
 
   std::vector<std::tuple<int64_t,uint64_t,bool>> changes{
     std::make_tuple(0, 40 * BLOCK_SIZE_FACTOR, false),
+  };
+  write_blocks(changes, expected);
+  ASSERT_EQ(0, mksnap("snap2"));
+}
+
+void TestMount::set_striped_layout(const char* relpath, uint64_t stripe_unit,
+				   uint64_t stripe_count, uint64_t object_size)
+{
+  auto file_path = make_file_path(relpath);
+  ASSERT_EQ(0, ceph_mknod(cmount, file_path.c_str(), 0666, 0));
+  std::string val = "stripe_unit=" + std::to_string(stripe_unit) +
+    " stripe_count=" + std::to_string(stripe_count) +
+    " object_size=" + std::to_string(object_size);
+  ASSERT_EQ(0, ceph_setxattr(cmount, file_path.c_str(), "ceph.file.layout", val.c_str(),
+			     val.size(), 0));
+
+  // read it back: the tests prove nothing if the striping is not in effect
+  char buf[256];
+  std::string expected = val + " pool=";
+  int len = ceph_getxattr(cmount, file_path.c_str(), "ceph.file.layout",
+			  buf, sizeof(buf));
+  ASSERT_LE((int)expected.size(), len);
+  ASSERT_EQ(expected, std::string(buf, expected.size()));
+}
+
+void TestMount::prepareBlockDiffChangedBlockWithStripedLayout(interval_set<uint64_t> *expected)
+{
+  // a striped layout: each object holds object_size/stripe_unit stripe units
+  // that are interleaved with those of the other objects in its object set,
+  // so an object does not back a contiguous run of the file.
+  const uint64_t stripe_unit = BLOCK_SIZE_FACTOR;
+  const uint64_t stripe_count = 4;
+  const uint64_t object_size = 4 * BLOCK_SIZE_FACTOR;
+  const uint64_t write_size = 4096;
+
+  //************ snap1 *************
+  set_striped_layout("fileA", stripe_unit, stripe_count, object_size);
+
+  ASSERT_LE(0, write_random("fileA", 8, object_size));
+  ASSERT_EQ(0, mksnap("snap1"));
+
+  //************ snap2 *************
+  // Straddle a stripe unit boundary, a complete stripe cycle boundary and the
+  // point where every object of the stripe set has consumed object_size. Each
+  // write lands in two different objects, and in the latter two cases at a
+  // non-zero offset within them.
+  std::vector<std::tuple<int64_t,uint64_t,bool>> changes{
+    std::make_tuple(stripe_unit - write_size / 2, write_size, false),
+    std::make_tuple(stripe_unit * stripe_count - write_size / 2, write_size, false),
+    std::make_tuple(object_size * stripe_count - write_size / 2, write_size, false),
+  };
+  write_blocks(changes, expected);
+  ASSERT_EQ(0, mksnap("snap2"));
+}
+
+void TestMount::prepareBlockDiffStripedSpanningWrite(interval_set<uint64_t> *expected)
+{
+  const uint64_t stripe_unit = BLOCK_SIZE_FACTOR;
+  const uint64_t stripe_count = 4;
+  const uint64_t object_size = 4 * BLOCK_SIZE_FACTOR;
+
+  //************ snap1 *************
+  set_striped_layout("fileA", stripe_unit, stripe_count, object_size);
+  ASSERT_LE(0, write_random("fileA", 8, object_size));
+  ASSERT_EQ(0, mksnap("snap1"));
+
+  //************ snap2 *************
+  // The write covers the last two stripe units of one row and all four
+  // units of the next row. Objects 2 and 3 therefore contribute two
+  // disjoint file extents, while objects 0 and 1 contribute one each.
+  std::vector<std::tuple<int64_t,uint64_t,bool>> changes{
+    std::make_tuple(2 * stripe_unit, 6 * stripe_unit, false),
+  };
+  write_blocks(changes, expected);
+  ASSERT_EQ(0, mksnap("snap2"));
+}
+
+void TestMount::prepareBlockDiffStripedManyRowsPerObject(interval_set<uint64_t> *expected)
+{
+  const uint64_t stripe_unit = BLOCK_SIZE_FACTOR / 4;
+  const uint64_t stripe_count = 2;
+  const uint64_t object_size = 4 * BLOCK_SIZE_FACTOR;
+  const uint64_t row = stripe_unit * stripe_count;
+  const uint64_t write_size = 4096;
+
+  //************ snap1 *************
+  // object_size/stripe_unit is 16 here, so one object spans sixteen stripe
+  // rows and its bytes are spread far apart in the file.
+  set_striped_layout("fileA", stripe_unit, stripe_count, object_size);
+  ASSERT_LE(0, write_random("fileA", 4, object_size));
+  ASSERT_EQ(0, mksnap("snap1"));
+
+  //************ snap2 *************
+  // three rows of the first object plus one row of the second
+  std::vector<std::tuple<int64_t,uint64_t,bool>> changes{
+    std::make_tuple(0, write_size, false),
+    std::make_tuple(3 * row, write_size, false),
+    std::make_tuple(7 * row, write_size, false),
+    std::make_tuple(5 * row + stripe_unit, write_size, false),
   };
   write_blocks(changes, expected);
   ASSERT_EQ(0, mksnap("snap2"));
@@ -2159,6 +2263,57 @@ TEST(LibCephFS, SnapDiffChangedBlockWithCustomObjectSize)
   test_mount.prepareBlockDiffChangedBlockWithCustomObjectSize(&expected);
   std::cout << "expected=" << expected << std::endl;
   test_mount.for_each_file_blockdiff("fileA", "snap1", "snap2", &expected);
+  ASSERT_TRUE(expected.empty());
+
+  std::cout << "------------- closing -------------" << std::endl;
+  ASSERT_EQ(0, test_mount.purge_dir(""));
+  ASSERT_EQ(0, test_mount.rmsnap("snap1"));
+  ASSERT_EQ(0, test_mount.rmsnap("snap2"));
+}
+
+TEST(LibCephFS, SnapDiffStripedSpanningWrite)
+{
+  TestMount test_mount;
+
+  interval_set<uint64_t> expected;
+  test_mount.prepareBlockDiffStripedSpanningWrite(&expected);
+  std::cout << "expected=" << expected << std::endl;
+  ASSERT_EQ(0, test_mount.for_each_file_blockdiff("fileA", "snap1", "snap2",
+						  &expected));
+  ASSERT_TRUE(expected.empty());
+
+  std::cout << "------------- closing -------------" << std::endl;
+  ASSERT_EQ(0, test_mount.purge_dir(""));
+  ASSERT_EQ(0, test_mount.rmsnap("snap1"));
+  ASSERT_EQ(0, test_mount.rmsnap("snap2"));
+}
+
+TEST(LibCephFS, SnapDiffStripedManyRowsPerObject)
+{
+  TestMount test_mount;
+
+  interval_set<uint64_t> expected;
+  test_mount.prepareBlockDiffStripedManyRowsPerObject(&expected);
+  std::cout << "expected=" << expected << std::endl;
+  ASSERT_EQ(0, test_mount.for_each_file_blockdiff("fileA", "snap1", "snap2",
+						  &expected));
+  ASSERT_TRUE(expected.empty());
+
+  std::cout << "------------- closing -------------" << std::endl;
+  ASSERT_EQ(0, test_mount.purge_dir(""));
+  ASSERT_EQ(0, test_mount.rmsnap("snap1"));
+  ASSERT_EQ(0, test_mount.rmsnap("snap2"));
+}
+
+TEST(LibCephFS, SnapDiffChangedBlockWithStripedLayout)
+{
+  TestMount test_mount;
+
+  interval_set<uint64_t> expected;
+  test_mount.prepareBlockDiffChangedBlockWithStripedLayout(&expected);
+  std::cout << "expected=" << expected << std::endl;
+  ASSERT_EQ(0, test_mount.for_each_file_blockdiff("fileA", "snap1", "snap2",
+						  &expected));
   ASSERT_TRUE(expected.empty());
 
   std::cout << "------------- closing -------------" << std::endl;


### PR DESCRIPTION
`MDCache::aggregate_snap_sets()` previously mixed two coordinate systems. `librados::clone_info_t::size` and `::overlap` are expressed as offsets within a RADOS object, while `BlockDiff::blocks` stores CephFS logical file intervals. The previous implementation converted only the start of each object interval with `Striper::get_file_offset()` and then treated its object-local length as a contiguous file length.

This works when an object maps contiguously into the file, but not when `stripe_count > 1` and an object spans multiple stripe units. In that layout, a contiguous object interval can map to several disjoint file intervals. The incorrectly translated overlap can therefore fall outside the interval being modified, causing strict `interval_set::erase()` to assert. Since the blockdiff request is retried after an MDS failover, each newly active MDS can hit the same assertion, potentially leaving the filesystem without an active MDS.

Keep the size and overlap calculations in object coordinates: construct the candidate object interval, intersect and subtract the clone overlap in that coordinate space, and then reverse-map each remaining interval with `Striper::extent_to_file()`. This splits the result at stripe-unit boundaries and returns the corresponding CephFS logical file intervals.

Add libcephfs regression coverage for:

* writes crossing stripe-unit, stripe-row, and object-set boundaries;
* a changed range spanning multiple stripe rows;
* multiple disjoint changes across many rows of the same object.

Fixes: https://tracker.ceph.com/issues/79459

## Checklist

- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
