### PR TITLE
common/options: fix typos and improve language

### DIFF
--- a/src/common/options/ceph-exporter.yaml.in
+++ b/src/common/options/ceph-exporter.yaml.in
@@ -5,7 +5,7 @@ options:
 - name: exporter_sock_dir
   type: str
   level: advanced
-  desc: The path to ceph daemons socket files dir
+  desc: The path to Ceph daemons socket files dir
   default: /var/run/ceph/
   services:
   - ceph-exporter
@@ -14,7 +14,7 @@ options:
 - name: exporter_addr
   type: str
   level: advanced
-  desc: Host ip address where exporter is deployed
+  desc: Host IP address where exporter is deployed
   default: 0.0.0.0
   services:
   - ceph-exporter
@@ -35,7 +35,7 @@ options:
 - name: exporter_key_file
   type: str
   level: advanced
-  desc: Key certificate file for TLS.
+  desc: Certificate private key file for TLS.
   default:
   services:
   - ceph-exporter
@@ -60,7 +60,7 @@ options:
 - name: exporter_sort_metrics
   type: bool
   level: advanced
-  desc: If true it will sort the metrics and group them.
+  desc: If true, sort and group the metrics.
   default: true
   services:
   - ceph-exporter

--- a/src/common/options/cephfs-mirror.yaml.in
+++ b/src/common/options/cephfs-mirror.yaml.in
@@ -6,9 +6,9 @@ options:
   type: uint
   level: advanced
   desc: maximum number of concurrent snapshot synchronization crawler threads
-  long_desc: maximum number of directory snapshots that can be crawled concurrently
+  long_desc: Maximum number of directory snapshots that can be crawled concurrently
     by cephfs-mirror daemon. Controls the number of synchronization crawler threads.
-    Note that the crawler threads also does entry operations like directory creations,
+    Note that the crawler threads also do entry operations like directory creations,
     file deletes and snapshot deletes/renames.
   default: 3
   services:
@@ -18,7 +18,7 @@ options:
   type: uint
   level: advanced
   desc: maximum number of concurrent snapshot data synchronization threads
-  long_desc: specifies the maximum number of worker threads in the CephFS mirror
+  long_desc: Specifies the maximum number of worker threads in the CephFS mirror
     data synchronization thread pool. These threads process file synchronization tasks
     produced by crawler threads for mirrored directory snapshots.
   default: 6
@@ -28,8 +28,8 @@ options:
 - name: cephfs_mirror_distribute_datasync_threads
   type: bool
   level: advanced
-  desc: distribute data synchronization threads evenly across multiple snapshots.
-  long_desc: controls how datasync worker threads are scheduled when multiple snapshots are
+  desc: distribute data synchronization threads evenly across multiple snapshots
+  long_desc: Controls how datasync worker threads are scheduled when multiple snapshots are
     queued for synchronization. When enabled, worker threads are distributed fairly across
     active snapshots, preventing a single large snapshot from monopolizing all available
     threads and causing other snapshots to starve. When disabled, datasync threads process
@@ -43,8 +43,8 @@ options:
 - name: cephfs_mirror_datasync_files_per_batch
   type: uint
   level: advanced
-  desc: maximum number of files processed by datasync threads per scheduling cycle before yielding.
-  long_desc: defines the maximum number of files a data synchronization thread will process for a
+  desc: maximum number of files processed by datasync threads per scheduling cycle before yielding
+  long_desc: Defines the maximum number of files a data synchronization thread will process for a
     specific snapshot before yielding the thread to re-check scheduling logic. This is applicable
     only when cephfs_mirror_distribute_datasync_threads is enabled. This batch size determines the
     granularity of thread distribution; smaller batches allow threads to rotate between snapshots
@@ -57,9 +57,9 @@ options:
 - name: cephfs_mirror_blockdiff_min_file_size
   type: size
   level: advanced
-  desc: minimum file size threshold in bytes above which block-level diff is used during CephFS mirroring.
-  long_desc: defines the minimum file size, in bytes, required for CephFS mirroring to use block-level
-    delta synchronization instead of performing a full file copy. When a file’s size is greater than to
+  desc: minimum file size threshold in bytes above which block-level diff is used during CephFS mirroring
+  long_desc: Defines the minimum file size, in bytes, required for CephFS mirroring to use block-level
+    delta synchronization instead of performing a full file copy. When a file's size is greater than
     this threshold, the mirroring engine attempts to synchronize only the modified block extents between
     snapshots. For files smaller than or equal to this value, a full file copy is performed instead, as
     block-level diff may not provide meaningful performance benefits for small files.
@@ -89,7 +89,7 @@ options:
   type: uint
   level: advanced
   desc: number of snapshots to mirror in one cycle
-  long_desc: maximum number of snapshots to mirror when a directory is picked up for
+  long_desc: Maximum number of snapshots to mirror when a directory is picked up for
     mirroring by worker threads.
   default: 3
   services:
@@ -99,7 +99,7 @@ options:
   type: uint
   level: advanced
   desc: interval to scan directories to mirror snapshots
-  long_desc: interval in seconds to scan configured directories for snapshot mirroring.
+  long_desc: Interval in seconds to scan configured directories for snapshot mirroring.
   default: 10
   services:
   - cephfs-mirror
@@ -108,7 +108,7 @@ options:
   type: secs
   level: advanced
   desc: interval for the per-peer mirroring tick thread
-  long_desc: interval in seconds for the per-peer tick thread that runs periodic
+  long_desc: Interval in seconds for the per-peer tick thread that runs periodic
     mirroring work. The value is re-read each iteration so configuration changes
     take effect without restarting the daemon.
   default: 5
@@ -120,8 +120,8 @@ options:
   level: advanced
   desc: consecutive failed directory synchronization attempts before marking a directory
     as "failed"
-  long_desc: number of consecutive snapshot synchronization failures to mark a directory
-    as "failed". failed directories are retried for synchronization less frequently.
+  long_desc: Number of consecutive snapshot synchronization failures to mark a directory
+    as "failed". Failed directories are retried for synchronization less frequently.
   default: 10
   services:
   - cephfs-mirror
@@ -130,7 +130,7 @@ options:
   type: uint
   level: advanced
   desc: failed directory retry interval for synchronization
-  long_desc: interval in seconds to retry synchronization for failed directories.
+  long_desc: Interval in seconds to retry synchronization for failed directories.
   default: 60
   services:
   - cephfs-mirror
@@ -148,8 +148,8 @@ options:
 - name: cephfs_mirror_mount_timeout
   type: secs
   level: advanced
-  desc: timeout for mounting primary/secondary ceph file system
-  long_desc: Timeout in seconds for mounting primary or secondary (remote) ceph file system
+  desc: timeout for mounting primary/secondary Ceph file system
+  long_desc: Timeout in seconds for mounting primary or secondary (remote) Ceph file system
     by the cephfs-mirror daemon. Setting this to a higher value could result in the mirror
     daemon getting stalled when mounting a file system if the cluster is not reachable. This
     option is used to override the usual client_mount_timeout.

--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -8,10 +8,10 @@ options:
 - name: crimson_cpu_set
   type: str
   level: advanced
-  desc: CPU cores on which seastar reactor threads will run in cpuset(7) format per OSD with pinning.
-  long_desc: CPU cores on which seastar reactor threads will run in cpuset(7) format per OSD with pinning.
-             overrides crimson_cpu_num.
-             smp::count is deduced from this option
+  desc: CPU cores on which Seastar reactor threads will run in cpuset(7) format per OSD with pinning.
+  long_desc: CPU cores on which Seastar reactor threads will run in cpuset(7) format per OSD with pinning.
+             Overrides crimson_cpu_num.
+             smp::count is deduced from this option.
   flags:
   - startup
 
@@ -19,9 +19,9 @@ options:
   type: uint
   level: advanced
   default: 0
-  desc: The number of CPUs to use for serving seastar reactors per OSD without CPU pinning.
-  long_desc: The number of CPUs to use for serving seastar reactors per OSD without CPU pinning.
-             overridden if crimson_cpu_set is set.
+  desc: The number of CPUs to use for serving Seastar reactors per OSD without CPU pinning.
+  long_desc: The number of CPUs to use for serving Seastar reactors per OSD without CPU pinning.
+             Overridden if crimson_cpu_set is set.
              smp::count is deduced from this option.
   flags:
   - startup
@@ -31,9 +31,9 @@ options:
   type: size
   level: advanced
   default: 0
-  desc: Total memory to use for the seastar allocator per OSD.
-  long_desc: Total memory to use for the seastar allocator per OSD.
-             Maps to seastar's --memory flag. 0 means use seastar's default
+  desc: Total memory to use for the Seastar allocator per OSD.
+  long_desc: Total memory to use for the Seastar allocator per OSD.
+             Maps to Seastar's --memory flag. 0 means use Seastar's default
              (all available memory minus a reserve).
   flags:
   - startup
@@ -48,11 +48,11 @@ options:
   - io_uring
   - linux-aio
   - epoll
-  desc: Select which Seastar's internal reactor implementation
+  desc: Select which Seastar's internal reactor implementation to use
   long_desc: Controls which asynchronous I/O engine the Seastar reactor will use
              during OSD startup. Different backends have different
              performance characteristics and require different kernel capabilities.
-             Note, If none is non is selected, let seastar choose.
+             Note, if none is selected, let Seastar choose.
 
   flags:
   - startup
@@ -63,7 +63,7 @@ options:
   default: 0.5
   desc: The maximum time (ms) Seastar reactors will wait between polls.
   long_desc: The maximum time (ms) Seastar reactors will wait between polls.
-             Shorter time between pools will result in larger CPU utilization.
+             Shorter time between polls will result in larger CPU utilization.
   flags:
   - startup
 
@@ -82,7 +82,7 @@ options:
   level: advanced
   default: 0
   desc: The maximum time (ms) Seastar's reactor I/O operations must take.
-        If not set(0 mean not set), defaults to 1.5 * crimson_reactor_task_quota_ms
+        If not set (0 means not set), defaults to 1.5 * crimson_reactor_task_quota_ms
   long_desc: The maximum time (ms) Seastar's reactor I/O operations must take.
              If not set, defaults to 1.5 * crimson_reactor_task_quota_ms.
              Increasing this value will allow more I/O requests to be dispatched concurrently.
@@ -99,7 +99,7 @@ options:
 - name: crimson_osd_scheduler_concurrency
   type: uint
   level: advanced
-  desc: The maximum number concurrent I/O operations, 0 for unlimited
+  desc: The maximum number of concurrent I/O operations, 0 for unlimited
   default: 0
 
 - name: crimson_osd_stat_interval
@@ -112,7 +112,7 @@ options:
   type: bool
   level: advanced
   default: false
-  desc: Let the seastar reactor poll continuously without sleeping at the expense of 100% cpu usage.
+  desc: Let the Seastar reactor poll continuously without sleeping at the expense of 100% CPU usage.
   flags:
   - startup
 
@@ -123,9 +123,9 @@ options:
   min: 1
   max: 65535
   desc: Maximum buffer fragments to batch in a single outgoing network write
-  long_desc: Limits how many buffer::ptr entries are batched into one seastar
+  long_desc: Limits how many buffer::ptr entries are batched into one Seastar
              packet during the outgoing message sweep. Prevents overflow of the
-             seastar packet fragment counter (uint16_t).
+             Seastar packet fragment counter (uint16_t).
 
 - name: crimson_allow_pg_split
   type: bool
@@ -143,7 +143,7 @@ options:
 - name: crimson_bluestore_num_threads
   type: uint
   level: advanced
-  desc: The number of POSIX threads alienized to seastar for serving Bluestore
+  desc: The number of POSIX threads alienized to Seastar for serving BlueStore
   default: 6
   flags:
   - startup
@@ -151,7 +151,7 @@ options:
 - name: crimson_bluestore_cpu_set
   type: str
   level: advanced
-  desc: CPU cores on which POSIX threads alienized to seastar will run in cpuset(7) format
+  desc: CPU cores on which POSIX threads alienized to Seastar will run in cpuset(7) format
   flags:
   - startup
 - name: seastore_logical_bucket_cache_test_stress
@@ -204,13 +204,13 @@ options:
 - name: seastore_default_max_object_size
   type: uint
   level: dev
-  desc: default logical address space reservation for seastore objects' data
+  desc: default logical address space reservation for SeaStore objects' data
   default: 16777216
 # TODO: implement sub-extent checksum and deprecate this configuration.
 - name: seastore_full_integrity_check
   type: bool
   level: dev
-  desc: Whether seastore need to fully check the integrity of each extent,
+  desc: Whether SeaStore needs to fully check the integrity of each extent,
         non-full integrity check means the integrity check might be skipped
         during extent remapping for better performance, disable with caution
   default: false
@@ -229,7 +229,7 @@ options:
 - name: seastore_cachepin_type
   type: str
   level: dev
-  desc: The cache replacement algorithm used by extent pinboard in seastore. (LRU/2Q)
+  desc: The cache replacement algorithm used by extent pinboard in SeaStore. (LRU/2Q)
   default: LRU
   enum_values:
   - LRU
@@ -250,7 +250,7 @@ options:
 - name: seastore_max_concurrent_transactions
   type: uint
   level: advanced
-  desc: maximum concurrent transactions that seastore allows (per reactor)
+  desc: maximum concurrent transactions that SeaStore allows (per reactor)
   default: 128
 - name: seastore_hot_device_type
   type: str
@@ -296,7 +296,7 @@ options:
 - name: seastore_multiple_tiers_stop_evict_ratio
   type: float
   level: advanced
-  desc: When the used ratio of main tier is less than this value, then stop evict cold data to the cold tier.
+  desc: When the used ratio of main tier is less than this value, then stop evicting cold data to the cold tier.
   default: 0.5
 - name: seastore_multiple_tiers_default_evict_ratio
   type: float
@@ -356,7 +356,7 @@ options:
   long_desc: Higher is more conservative (override fires less often, the
              configured formula's age weighting is preserved more
              aggressively). Lower is more aggressive (override fires more
-             often, behaviour converges toward pure greedy). The default
+             often, behavior converges toward pure greedy). The default
              (2.0) captures the random-write failure regime while staying
              clear of normal-operation fluctuations.
   default: 2.0
@@ -364,13 +364,15 @@ options:
 - name: seastore_data_delta_based_overwrite
   type: size
   level: dev
-  desc: overwrite the existing data block based on delta if the overwrite size is equal to or less than the value, otherwise do overwrite based on remapping, set to 0 to enforce the remap-based overwrite.
+  desc: Overwrite the existing data block based on delta if the overwrite size
+        is equal to or less than the value, otherwise do overwrite based on
+        remapping, set to 0 to enforce the remap-based overwrite.
   default: 0
-- name: seastore_disable_end_to_end_data_protection 
+- name: seastore_disable_end_to_end_data_protection
   type: bool
   level: dev
-  desc: When false, upon mkfs, try to discover whether the nvme device supports
-        internal checksum feature without using sever CPU then enable if available,
+  desc: When false, upon mkfs, try to discover whether the NVMe device supports
+        internal checksum feature without using server CPU and enable if available,
         set to true to disable unconditionally.
   default: true
 - name: seastore_require_partition_count_match_reactor_count

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -182,8 +182,8 @@ options:
 - name: mon_dns_srv_name
   type: str
   level: advanced
-  desc: Name of DNS SRV record to check for monitor addresses
-  fmt_desc: The service name used querying the DNS for Monitor hosts / addresses
+  desc: Name of the DNS SRV record to check for Monitor addresses
+  fmt_desc: The service name used for querying the DNS for Monitor hosts / addresses
   default: ceph-mon
   tags:
   - network
@@ -418,8 +418,8 @@ options:
 - name: fatal_signal_handlers
   type: bool
   level: advanced
-  desc: Whether to register signal handlers for SIGABRT etc that dump a stack trace
-  long_desc: This is normally true for daemons and values for libraries.
+  desc: Whether to register signal handlers for SIGABRT etc. that dump a stack trace
+  long_desc: This is normally true for daemons and false for libraries.
   fmt_desc: If set, we will install signal handlers for SEGV, ABRT, BUS, ILL,
     FPE, XCPU, XFSZ, SYS signals to generate a useful log message
   default: true
@@ -799,12 +799,12 @@ options:
 - name: qat_compressor_session_max_number
   type: uint
   level: advanced
-  desc: Set the maximum number of session within Qatzip when using QAT compressor
+  desc: Set the maximum number of sessions within Qatzip when using QAT compressor
   default: 256
 - name: qat_compressor_busy_polling
   type: bool
   level: advanced
-  desc: Set QAT busy bolling to reduce latency at the cost of potentially increasing CPU usage
+  desc: Set QAT busy polling to reduce latency at the cost of potentially increasing CPU usage
   default: false
 - name: uadk_compressor_enabled
   type: bool
@@ -1069,9 +1069,9 @@ options:
   type: str
   level: advanced
   desc: Compression algorithm to use in Messenger when communicating with OSD
-  long_desc: Compression algorithm for connections with OSD in order of preference 
-    Although the default value is set to snappy, a list
-    (like snappy zlib zstd etc.) is acceptable as well. 
+  long_desc: Compression algorithm for connections with OSD in order of preference.
+    Although the default value is set to snappy, a space-delimited list
+    (for example, 'snappy zlib zstd') is acceptable as well.
   default: snappy
   services:
   - osd
@@ -1082,13 +1082,13 @@ options:
 - name: ms_compress_secure
   type: bool
   level: advanced
-  desc: Allowing compression when on-wire encryption is enabled
+  desc: Allow compression when on-wire encryption is enabled
   long_desc: Combining encryption with compression reduces the level of security of
-    messages between peers. In case both encryption and compression are enabled, 
-    compression setting will be ignored and message will not be compressed. 
-    This behaviour can be override using this setting. 
+    messages between peers. In case both encryption and compression are enabled,
+    compression setting will be ignored and message will not be compressed.
+    This behavior can be overridden using this setting.
   default: false
-  see_also: 
+  see_also:
   - ms_osd_compress_mode
   flags:
   - runtime
@@ -1526,9 +1526,9 @@ options:
 - name: ms_dpdk_devs_allowlist
   type: str
   level: advanced
-  desc: NIC's PCIe address are allowed to use
-  long_desc: for a single NIC use ms_dpdk_devs_allowlist=-a 0000:7d:010 or --allow=0000:7d:010;
-    for a bond nics use ms_dpdk_devs_allowlist=--allow=0000:7d:01.0 --allow=0000:7d:02.6
+  desc: PCIe addresses of NICs allowed for use
+  long_desc: For a single NIC use ms_dpdk_devs_allowlist=-a 0000:7d:010 or --allow=0000:7d:010;
+    for bonded NICs use ms_dpdk_devs_allowlist=--allow=0000:7d:01.0 --allow=0000:7d:02.6
     --vdev=net_bonding0,mode=2,slave=0000:7d:01.0,slave=0000:7d:02.6.
 - name: ms_dpdk_host_ipv4_addr
   type: str
@@ -1582,12 +1582,12 @@ options:
 - name: mon_initial_members
   type: str
   level: advanced
-  fmt_desc: The IDs of initial monitors in a cluster during startup. If 
-    specified, Ceph requires an odd number of monitors to form an 
+  fmt_desc: The IDs of initial Monitors in a cluster during startup. If
+    specified, Ceph requires an odd number of Monitors to form an
     initial quorum (e.g., 3).
-  note: A *majority* of monitors in your cluster must be able to reach 
-    each other in order to establish a quorum. You can decrease the initial 
-    number of monitors to establish a quorum with this setting.
+  note: A *majority* of Monitors in your cluster must be able to reach
+    each other in order to establish a quorum. You can decrease the initial
+    number of Monitors to establish a quorum with this setting.
   services:
   - mon
   flags:
@@ -2213,7 +2213,7 @@ options:
 - name: cephx_require_version
   type: int
   level: advanced
-  desc: Cephx version required (1 = pre-mimic, 2 = mimic+)
+  desc: CephX version required (1 = pre-mimic, 2 = mimic+)
   default: 2
   with_legacy: true
 - name: cephx_cluster_require_signatures
@@ -2226,7 +2226,7 @@ options:
 - name: cephx_cluster_require_version
   type: int
   level: advanced
-  desc: Cephx version required by the cluster from clients (1 = pre-mimic, 2 = mimic+)
+  desc: CephX version required by the cluster from clients (1 = pre-mimic, 2 = mimic+)
   default: 2
   with_legacy: true
 - name: cephx_service_require_signatures
@@ -2239,7 +2239,7 @@ options:
 - name: cephx_service_require_version
   type: int
   level: advanced
-  desc: Cephx version required from ceph services (1 = pre-mimic, 2 = mimic+)
+  desc: CephX version required from Ceph services (1 = pre-mimic, 2 = mimic+)
   default: 2
   with_legacy: true
 # Default to signing session messages if supported
@@ -2561,9 +2561,9 @@ options:
 - name: osd_pool_default_min_size
   type: uint
   level: advanced
-  desc: The minimal number of copies allowed to write to a degraded pool for new replicated
+  desc: The minimum number of copies allowed to write to a degraded pool for new replicated
     pools
-  long_desc: 0 means no specific default; ceph will use size-size/2
+  long_desc: 0 means no specific default; Ceph will use size-size/2
   fmt_desc: Sets the minimum number of written replicas for objects in the
     pool in order to acknowledge an I/O operation to the client.  If
     minimum is not met, Ceph will not acknowledge the I/O to the
@@ -2586,13 +2586,13 @@ options:
   desc: number of PGs for new pools
   fmt_desc: The default number of placement groups for a pool. The default
     value is the same as ``pg_num`` with ``mkpool``.
-  long_desc: With default value of `osd_pool_default_pg_autoscale_mode` being 
-    `on` the number of PGs for new pools will start out with 1 pg, unless the 
+  long_desc: With default value of `osd_pool_default_pg_autoscale_mode` being
+    `on` the number of PGs for new pools will start out with 1 PG, unless the
     user specifies the pg_num.
   default: 32
   services:
   - mon
-  see_also: 
+  see_also:
   - osd_pool_default_pg_autoscale_mode
   flags:
   - runtime
@@ -2769,7 +2769,7 @@ options:
   type: str
   level: advanced
   desc: Default PG autoscaling behavior for new pools
-  long_desc: When 'on', the autoscaler assigns 1 pg to new pools unless the user
+  long_desc: When 'on', the autoscaler assigns 1 PG to new pools unless the user
     specifies a value.
   default: 'on'
   enum_values:
@@ -2945,7 +2945,7 @@ options:
 - name: osd_heartbeat_min_size
   type: size
   level: advanced
-  desc: Minimum heartbeat packet size in bytes. Will padd if the heartbeat
+  desc: Minimum heartbeat packet size in bytes. Will pad if the heartbeat
     packet is smaller than this. This helps identify host and switch
     MTU configuration issues when jumbo frames are in use.
   default: 2000
@@ -3124,7 +3124,7 @@ options:
   type: uint
   level: dev
   desc: How many versions back to track in order to detect duplicate ops; this is
-    combined with both the regular pg log entries and additional minimal dup detection
+    combined with both the regular PG log entries and additional minimal dup detection
     entries
   default: 3000
   services:
@@ -3561,7 +3561,7 @@ options:
 - name: rocksdb_delete_range_threshold
   type: uint
   level: advanced
-  desc: The number of keys required to invoke DeleteRange when deleting muliple keys.
+  desc: The number of keys required to invoke DeleteRange when deleting multiple keys.
   default: 1_M
 - name: rocksdb_bloom_bits_per_key
   type: uint
@@ -4236,10 +4236,10 @@ options:
 - name: bluefs_failed_shared_alloc_cooldown
   type: float
   level: advanced
-  desc: duration(in seconds) untill the next attempt to use
+  desc: duration (in seconds) until the next attempt to use
    'bluefs_shared_alloc_size' after facing ENOSPC failure.
-  long_desc: Cooldown period(in seconds) when BlueFS uses shared/slow device
-   allocation size instead of "bluefs_shared_alloc_size' one after facing
+  long_desc: Cooldown period (in seconds) when BlueFS uses shared/slow device
+   allocation size instead of 'bluefs_shared_alloc_size' one after facing
    recoverable (via fallback to smaller chunk size) ENOSPC failure. Intended
    primarily to avoid repetitive unsuccessful allocations which might be
    expensive.
@@ -4726,11 +4726,11 @@ options:
   flags:
   - startup
   with_legacy: true
-- name: bluestore_use_optimal_io_size_for_min_alloc_size 
+- name: bluestore_use_optimal_io_size_for_min_alloc_size
   type: bool
   level: advanced
   desc: Discover media optimal I/O size and use for min_alloc_size. This is useful
-    when OSDs are created on coarse-IU QLC SSDs or other novel types of underlyinng
+    when OSDs are created on coarse-IU QLC SSDs or other novel types of underlying
     block device. It is a no-op for conventional media.
   default: false
   see_also:
@@ -4807,7 +4807,7 @@ options:
   level: advanced
   desc: Default compression algorithm to use when writing object data
   long_desc: This controls the default compressor to use (if any) if the per-pool
-    property is not set.  Note that zstd is *not* recommended for bluestore due to
+    property is not set.  Note that zstd is *not* recommended for BlueStore due to
     high CPU overhead when compressing small amounts of data.
   fmt_desc: The default compressor to use (if any) if the per-pool property
     ``compression_algorithm`` is not set. Note that ``zstd`` is *not*
@@ -4969,7 +4969,7 @@ options:
     from one or more RADOS objects.  Blobs can be compressed, typically have checksum data,
     may be overwritten, may be shared (with an extent ref map), or split.  This setting
     controls the maximum size a blob is allowed to be. A value of 0 indicates that no
-    limiit is to be enforced.
+    limit is to be enforced.
   default: 0
   flags:
   - runtime
@@ -5051,7 +5051,7 @@ options:
 - name: bluestore_cache_trim_interval
   type: float
   level: advanced
-  desc: How frequently we trim the bluestore cache
+  desc: How frequently we trim the BlueStore cache
   default: 0.05
   with_legacy: true
 - name: bluestore_cache_trim_max_skip_pinned
@@ -5185,7 +5185,7 @@ options:
   level: dev
   desc: The duration (in seconds) represented by a single cache age bin.
   fmt_desc: |
-    The caches used by bluestore will assign cache entries to an 'age bin'
+    The caches used by BlueStore will assign cache entries to an 'age bin'
     that represents a period of time during which that cache entry was most
     recently updated.  By binning the caches in this way, Ceph's priority
     cache balancing code can make better decisions about which caches should
@@ -6084,7 +6084,7 @@ options:
 - name: filestore_wbthrottle_btrfs_bytes_start_flusher
   type: size
   level: advanced
-  desc: Start flushing (fsyncing) when this many bytes are written (btrfs, deprecated)  
+  desc: Start flushing (fsyncing) when this many bytes are written (btrfs, deprecated)
   default: 40_M
   with_legacy: true
 - name: filestore_wbthrottle_btrfs_bytes_hard_limit
@@ -6096,7 +6096,7 @@ options:
 - name: filestore_wbthrottle_btrfs_ios_start_flusher
   type: uint
   level: advanced
-  desc: Start flushing (fsyncing) when this many I/Os are written (brtrfs, deprecated)
+  desc: Start flushing (fsyncing) when this many I/Os are written (btrfs, deprecated)
   default: 500
   with_legacy: true
 - name: filestore_wbthrottle_btrfs_ios_hard_limit
@@ -7112,12 +7112,12 @@ options:
   type: str
   level: advanced
   desc: Unique string to be returned in PerfCounters
-  fmt_desc: A unique id to be created by orchestration software or the
+  fmt_desc: A unique ID to be created by orchestration software or the
     administrator upon initial setup of a service. Enforcing uniqueness
     is entirely the responsibility of the process used to create and
-    manage the cluster. A unique id will be unique within the scope of
+    manage the cluster. A unique ID will be unique within the scope of
     the entire cluster across all services if they are chosen to be so.
-  note: If this is empty no uniquifier is provided.
+  note: If this is empty, no uniquifier is provided.
   tags:
   - service
   services:

--- a/src/common/options/mds-client.yaml.in
+++ b/src/common/options/mds-client.yaml.in
@@ -105,7 +105,7 @@ options:
   type: str
   level: advanced
   desc: Default mountpoint
-  fmt_desc: Directory on which to mount a the CephFS file system. An alternative to the
+  fmt_desc: Directory on which to mount the CephFS file system. An alternative to the
     ``-r`` option of the ``ceph-fuse`` command.
   default: /
   services:
@@ -230,7 +230,7 @@ options:
 - name: client_debug_getattr_caps
   type: bool
   level: dev
-  desc: Should the client check MDS replies for wanted capabiliites?
+  desc: Should the client check MDS replies for wanted capabilities?
   default: false
   services:
   - mds_client
@@ -365,7 +365,7 @@ options:
 - name: fuse_default_permissions
   type: bool
   level: advanced
-  desc: Pass default_permisions to FUSE on mount
+  desc: Pass default_permissions to FUSE on mount
   fmt_desc: When set to ``false``, ``ceph-fuse`` utility checks does its own
     permissions checking, instead of relying on the permissions enforcement in
     FUSE. Set to ``false`` together with the ``client acl type=posix_acl``
@@ -577,7 +577,7 @@ options:
   type: bool
   level: advanced
   desc: Whether to enable and force collecting and sending the global metrics to MDS
-  long_desc: To be careful for this, when connecting to some old ceph clusters
+  long_desc: Warning, when connecting to some old Ceph clusters
     it may crash the MDS daemons while upgrading.
   default: false
   tags:

--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -356,7 +356,7 @@ options:
   long_desc: This determines how long a session needs to be quiescent before the MDS
     begins preemptively recalling capabilities. The default of 5 minutes will cause
     10 halvings of the decay counter after 1 hour, or 1/1024. The default magnitude
-    of 10 (1^10 or 1024) is chosen so that the MDS considers a previously chatty session
+    of 10 (2^10 or 1024) is chosen so that the MDS considers a previously chatty session
     (approximately) to be quiescent after 1 hour.
   default: 5_min
   services:
@@ -521,7 +521,7 @@ options:
 - name: mds_replay_unsafe_with_closed_session
   type: bool
   level: advanced
-  desc: complete all the replay request when mds is restarted, no matter the session
+  desc: complete all replay requests when MDS is restarted, no matter the session
     is closed or not
   default: false
   services:
@@ -1564,8 +1564,8 @@ options:
 - name: mds_task_status_update_interval
   type: float
   level: dev
-  desc: task status update interval to manager
-  long_desc: interval (in seconds) for sending mds task status to ceph manager
+  desc: task status update interval to the Manager
+  long_desc: interval (in seconds) for sending MDS task status to the Manager
   default: 2
   services:
   - mds
@@ -1587,7 +1587,7 @@ options:
   default: true
   services:
   - mds
-  fmt_desc: MDS will use the global snaprealm's seq to cow old inodes
+  fmt_desc: MDS will use the global snaprealm's seq to CoW old inodes
     for the directory. If the option is disabled, MDS will use the
     respective snaprealm seq number for the subvolume snapshot directory
     i.e., the directory marked with the 'ceph.dir.subvolume'. This is
@@ -1596,9 +1596,9 @@ options:
     above subvolume, it will use the global snaprealm's seq only if there
     is at least one snapshot of the directory above the subvolume.
     If the option is enabled, which is the default, it uses the global
-    snaprealm's seq to cow old inodes across the filesystem. Hence,
-    disabling this option is only suitalbe for the cephfs volumes used
-    purely for subvolume usecase where there are no snapshots in the
+    snaprealm's seq to CoW old inodes across the filesystem. Hence,
+    disabling this option is only suitable for the CephFS volumes used
+    purely for subvolume use case where there are no snapshots in the
     filesystem apart from the subvolume snapshots. So it's a great
     optimization for subvolumes.
   flags:

--- a/src/common/options/mgr.yaml.in
+++ b/src/common/options/mgr.yaml.in
@@ -6,7 +6,7 @@ options:
   type: str
   level: advanced
   desc: Filesystem path to the Manager's data directory, which contains
-    keyrings and other data 
+    keyrings and other data
   fmt_desc: Path to load daemon data (such as keyring)
   default: /var/lib/ceph/mgr/$cluster-$id
   services:
@@ -25,10 +25,10 @@ options:
 - name: mgr_stats_period
   type: int
   level: basic
-  desc: Period in seconds of OSD/MDS stats reports to manager
+  desc: Period in seconds of OSD/MDS stats reports to the Manager
   long_desc: Use this setting to control the granularity of time series data collection
-    from daemons.  Adjust upwards if the manager CPU load is too high, or if you simply
-    do not require the most up to date performance counter data.
+    from daemons.  Adjust upwards if the Manager CPU load is too high, or if you simply
+    do not require the most up-to-date performance counter data.
   default: 5
   services:
   - mgr
@@ -130,7 +130,7 @@ options:
   type: float
   level: advanced
   desc: Period in seconds from last beacon to manager dropping state about a monitored
-    service (RGW, rbd-mirror etc)
+    service (RGW, rbd-mirror etc.)
   default: 1_min
   services:
   - mgr
@@ -152,7 +152,7 @@ options:
 - name: mgr_max_pg_creating
   type: uint
   level: advanced
-  desc: bound on max creating pgs when acting to create more pgs
+  desc: bound on max creating PGs when acting to create more PGs
   default: 1024
   services:
   - mgr
@@ -178,7 +178,7 @@ options:
 - name: mgr_disabled_modules
   type: str
   level: advanced
-  desc: List of manager modules never get loaded
+  desc: List of Manager modules that never get loaded
   long_desc: A comma delimited list of module names. This list is read by manager
     when it starts. By default, manager loads all modules found in specified 'mgr_module_path',
     and it starts the enabled ones as instructed. The modules in this list will not
@@ -315,7 +315,7 @@ options:
 - name: mon_pg_check_down_all_threshold
   type: float
   level: advanced
-  desc: threshold of down osds after which we check all pgs
+  desc: threshold of down OSDs after which we check all PGs
   fmt_desc: Percentage threshold of ``down`` OSDs above which we check all PGs
     for stale ones.
   default: 0.5
@@ -325,8 +325,8 @@ options:
 - name: mon_pg_stuck_threshold
   type: int
   level: advanced
-  desc: number of seconds after which pgs can be considered stuck inactive, unclean,
-    etc
+  desc: number of seconds after which PGs can be considered stuck inactive, unclean,
+    etc.
   long_desc: see doc/control.rst under dump_stuck for more info
   fmt_desc: Number of seconds after which PGs can be considered as
     being stuck.
@@ -336,7 +336,7 @@ options:
 - name: mon_pg_warn_min_per_osd
   type: uint
   level: advanced
-  desc: minimal number PGs per (in) osd before we warn the admin
+  desc: minimal number of PGs per (in) OSD before we warn the admin
   fmt_desc: Raise ``HEALTH_WARN`` if the average number
     of PGs per ``in`` OSD is under this number. A non-positive number
     disables this.
@@ -346,7 +346,7 @@ options:
 - name: mon_pg_warn_max_object_skew
   type: float
   level: advanced
-  desc: max skew few average in objects per pg
+  desc: max skew from average object count per PG
   fmt_desc: Raise ``HEALTH_WARN`` if the average RADOS object count per PG
     of any pool is greater than ``mon_pg_warn_max_object_skew`` times
     the average RADOS object count per PG of all pools. Zero or a non-positive
@@ -357,7 +357,7 @@ options:
 - name: mon_pg_warn_min_objects
   type: int
   level: advanced
-  desc: 'do not warn below this object #'
+  desc: do not warn below this object count
   fmt_desc: Do not warn if the total number of RADOS objects in cluster is below
     this number
   default: 10000
@@ -366,7 +366,7 @@ options:
 - name: mon_pg_warn_min_pool_objects
   type: int
   level: advanced
-  desc: 'do not warn on pools below this object #'
+  desc: do not warn on pools below this object count
   fmt_desc: Do not warn on pools whose RADOS object count is below this number
   default: 1000
   services:
@@ -475,7 +475,7 @@ options:
 - name: mon_osd_err_op_age_ratio
   type: float
   level: advanced
-  desc: issue REQUEST_STUCK health error if OSD ops are slower than is age (seconds)
+  desc: issue REQUEST_STUCK health error if OSD ops are slower than this age (seconds)
   default: 128
   services:
   - mgr

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -18,16 +18,16 @@ options:
   level: advanced
   desc: the amount of data (in bytes) in a data chunk, per stripe
   fmt_desc: Sets the default size, in bytes, of a chunk of an object
-    stripe for erasure coded pools. Every object of size S
+    stripe for erasure-coded pools. Every object of size S
     will be stored as N stripes, with each data chunk
-    receiving ``stripe unit`` bytes. Each stripe of ``N *
-    stripe unit`` bytes will be encoded/decoded individually. 
+    receiving ``stripe_unit`` bytes. Each stripe of ``N *
+    stripe_unit`` bytes will be encoded/decoded individually.
     A value of 0 causes the code to select either a 4KB or 16KB
-    stripe_unit depending on whether ``allow_ec_optimizations`` 
-    is enabled.  If enabled, ``stripe unit`` is set to 16KB, otherwise it 
+    stripe_unit depending on whether ``allow_ec_optimizations``
+    is enabled.  If enabled, ``stripe_unit`` is set to 16KB, otherwise it
     is set to 4KB. This option can be overridden by the ``stripe_unit``
     setting in an erasure code profile.
-  long_desc: A value of 0 causes the code to select either a 4KB or 16KB stripe_unit 
+  long_desc: A value of 0 causes the code to select either a 4KB or 16KB stripe_unit
     depending on whether allow_ec_optimizations is enabled.
   default: 0
   services:
@@ -37,7 +37,7 @@ options:
   level: advanced
   desc: Create pools by default with FLAG_CRIMSON
   default: false
-  services :
+  services:
   - mon
   flags:
   - runtime
@@ -91,7 +91,7 @@ options:
 - name: mon_nvmeofgw_beacon_grace
   type: secs
   level: advanced
-  desc: Period in seconds from last beacon to monitor marking a  NVMeoF gateway as
+  desc: Period in seconds from last beacon to monitor marking a NVMeoF gateway as
     failed
   default: 7
   services:
@@ -99,15 +99,15 @@ options:
 - name: mon_nvmeofgw_skip_failovers_interval
   type: secs
   level: advanced
-  desc: Period in seconds in which no failovers are performed in GW's pool-group
-    this is equal to max GW redeploy interval
+  desc: Period in seconds in which no failovers are performed in GW's pool-group.
+    This is equal to max GW redeploy interval.
   default: 16
   services:
   - mon
 - name: mon_nvmeofgw_set_group_id_retry
   type: uint
   level: advanced
-  desc: Retry wait time in microsecond for set group id between the monitor client
+  desc: Retry wait time in microseconds for set group ID between the monitor client
     and gateway
   long_desc: The monitor server determines the gateway's group ID. If the monitor client
     receives a monitor group ID assignment before the gateway is fully up during
@@ -123,7 +123,7 @@ options:
 - name: mon_nvmeofgw_delete_grace
   type: secs
   level: advanced
-  desc: Issue NVMEOF_GATEWAY_DELETING health warning after this amount of time has elapsed 
+  desc: Issue NVMEOF_GATEWAY_DELETING health warning after this amount of time has elapsed
   default: 15_min
   services:
   - mon
@@ -405,7 +405,7 @@ options:
   desc: issue MON_DISK_LOW health warning when mon available space below this percentage
   fmt_desc: Raise ``HEALTH_WARN`` status when the filesystem that houses a
     monitor's data store reports that its available capacity is
-    less than or equal to this percentage .
+    less than or equal to this percentage.
   default: 30
   services:
   - mon
@@ -514,7 +514,7 @@ options:
 - name: mon_elector_ping_divisor
   type: uint
   level: advanced
-  desc: We will send a ping up to this many times per timeout per
+  desc: We will send a ping up to this many times per timeout
   default: 2
   services:
   - mon
@@ -625,7 +625,7 @@ options:
 - name: mon_crush_min_required_version
   type: str
   level: advanced
-  desc: minimum ceph release to use for mon_warn_on_legacy_crush_tunables
+  desc: minimum Ceph release to use for mon_warn_on_legacy_crush_tunables
   fmt_desc: The minimum tunable profile required by the cluster. See
     :ref:`CRUSH map tunables <crush-map-tunables>` for details.
   default: hammer
@@ -742,7 +742,7 @@ options:
   services:
   - mon
   fmt_desc: How often (in commits) to stash a full copy of the PaxosService state.
-    Current this setting only affects ``mds``, ``mon``, ``auth`` and ``mgr``
+    Currently this setting only affects ``mds``, ``mon``, ``auth``, and ``mgr``
     PaxosServices.
   with_legacy: true
 # max paxos iterations before we must first sync the monitor stores
@@ -826,7 +826,7 @@ options:
   type: uint
   level: advanced
   desc: factor by which paxos_service_trim_max will be multiplied to get a new upper
-    bound when trim sizes are high  (0 disables it)
+    bound when trim sizes are high (0 disables it)
   default: 20
   services:
   - mon
@@ -967,7 +967,7 @@ options:
     to model this situation to increase the heartbeat grace period for this OSD so
     that it isn't marked down again.  laggy_probability is an estimated probability
     that the given OSD is down because it is laggy (not actually down), and laggy_interval
-    is an estiate on how long it stays down when it is laggy.
+    is an estimate on how long it stays down when it is laggy.
   fmt_desc: If set to ``true``, Ceph will scale based on laggy estimations.
   default: true
   services:
@@ -981,7 +981,8 @@ options:
   type: bool
   level: advanced
   desc: increase the mon_osd_down_out_interval if an OSD appears to be laggy
-  fmt_desc: If set to ``true``, Ceph will scaled based on laggy estimations.
+  fmt_desc: If set to ``true``, Ceph will scale ``mon_osd_down_out_interval``
+    based on laggy estimations.
   default: true
   services:
   - mon
@@ -1497,7 +1498,7 @@ options:
 - name: nvmeof_mon_client_disconnect_panic
   type: secs
   level: advanced
-  desc: The duration, expressed in seconds, after which the nvmeof gateway
+  desc: The duration, expressed in seconds, after which the NVMeoF gateway
     should trigger a panic if it loses connection to the monitor
   default: 100
   services:
@@ -1505,24 +1506,24 @@ options:
 - name: nvmeof_mon_client_tick_period
   type: secs
   level: advanced
-  desc: Period in seconds of nvmeof gateway beacon messages to monitor
+  desc: Period in seconds of NVMeoF gateway beacon messages to monitor
   default: 1
   services:
   - mon
 - name: enable_availability_tracking
   type: bool
   level: advanced
-  desc: Calculate and store availablity score for each pool in the 
+  desc: Calculate and store availability score for each pool in the
     cluster at regular intervals
   default: false
-  services :
+  services:
   - mon
   flags:
   - runtime
 - name: nvmeof_mon_client_connect_panic
   type: secs
   level: advanced
-  desc: The duration, expressed in seconds, after which the nvmeof gateway
+  desc: The duration, expressed in seconds, after which the NVMeoF gateway
     should trigger a panic if it does not receive the initial map from the monitor
   default: 30
   services:
@@ -1532,15 +1533,15 @@ options:
   desc: Time (in seconds) to wait before emitting a MON_NETSPLIT
     health warning.
   default: 9
-  services :
+  services:
   - mon
 - name: pool_availability_update_interval
   type: float
   level: advanced
-  desc: Update data availability score at this interval. By default the interval 
-    is same as paxos_propose_interval configuration.  
+  desc: Update data availability score at this interval. By default the interval
+    is the same as paxos_propose_interval.
   default: 1
-  services :
+  services:
   - mon
   flags:
   - runtime

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -5,7 +5,7 @@ options:
 - name: osd_numa_prefer_iface
   type: bool
   level: advanced
-  desc: prefer IP on network interface on same numa node as storage
+  desc: prefer IP on network interface on same NUMA node as storage
   default: true
   see_also:
   - osd_numa_auto_affinity
@@ -14,14 +14,14 @@ options:
 - name: osd_numa_auto_affinity
   type: bool
   level: advanced
-  desc: automatically set affinity to numa node when storage and network match
+  desc: automatically set affinity to NUMA node when storage and network match
   default: true
   flags:
   - startup
 - name: osd_numa_node
   type: int
   level: advanced
-  desc: set affinity to a numa node (-1 for none)
+  desc: set affinity to a NUMA node (-1 for none)
   default: -1
   see_also:
   - osd_numa_auto_affinity
@@ -31,9 +31,9 @@ options:
   type: bool
   level: advanced
   desc: set the keepcaps flag before changing UID, preserving the permitted capability set
-  long_desc: When ceph switches from root to the ceph uid, all capabilities in all sets are eraseed. If
-    a component that is capability aware needs a specific capability, the keepcaps flag maintains
-     the permitted capability set, allowing the capabilities in the effective set to be activated as needed.
+  long_desc: When Ceph switches from root to the ceph UID, all capabilities in all sets are erased. If
+    a component that is capability-aware needs a specific capability, the keepcaps flag maintains
+    the permitted capability set, allowing the capabilities in the effective set to be activated as needed.
   default: false
   flags:
   - startup
@@ -155,7 +155,7 @@ options:
   type: float
   level: advanced
   desc: Time in seconds to sleep before next recovery or backfill op for HDDs
-    when PGs is degraded.
+    when PGs are degraded.
   fmt_desc: Time in seconds to sleep before next recovery or backfill op
     for HDDs when PGs are degraded.
   default: 0.1
@@ -340,7 +340,7 @@ options:
   type: float
   level: advanced
   desc: The desired interval between scrubs of a specific PG. Note that this option
-    must be set at ``global`` scope, or for both ``mgr`` and``osd``.
+    must be set at the ``global`` scope, or for both ``mgr`` and ``osd``.
   fmt_desc: The desired interval in seconds between scrubs of a specific PG.
   default: 1_day
   see_also:
@@ -350,7 +350,7 @@ options:
   type: float
   level: advanced
   desc: Scrub each PG no less often than this interval. Note that this option
-    must be set at ``global`` scope, or for both ``mgr`` and``osd``.
+    must be set at the ``global`` scope, or for both ``mgr`` and ``osd``.
   fmt_desc: The maximum interval in seconds for scrubbing each PG.
   default: 7_day
   see_also:
@@ -492,7 +492,7 @@ options:
   type: float
   level: advanced
   desc: Deep scrub each PG (i.e., verify data checksums) at least this often. Note that this option
-    must be set at ``global`` scope, or for both ``mgr`` and``osd``.
+    must be set at the ``global`` scope, or for both ``mgr`` and ``osd``.
   fmt_desc: The interval for "deep" scrubbing (fully reading all data).
   default: 7_day
   with_legacy: true
@@ -505,12 +505,12 @@ options:
     Technically ``osd_deep_scrub_interval_cv`` is the coefficient of variation for
     the deep scrub interval.
   fmt_desc: The coefficient of variation for the deep scrub interval, specified as a
-    ratio. On average, the next deep scrub for a PG is scheduled osd_deep_scrub_interval
-    after the last deep scrub . The actual time is randomized to a normal distribution
-    with a standard deviation of osd_deep_scrub_interval * osd_deep_scrub_interval_cv
+    ratio. On average, the next deep scrub for a PG is scheduled ``osd_deep_scrub_interval``
+    after the last deep scrub. The actual time is randomized to a normal distribution
+    with a standard deviation of ``osd_deep_scrub_interval`` * ``osd_deep_scrub_interval_cv``
     (clamped to within 2 standard deviations).
     The default value guarantees that 95% of deep scrubs will be scheduled in the range
-    [0.8 * osd_deep_scrub_interval, 1.2 * osd_deep_scrub_interval].
+    [0.8 * ``osd_deep_scrub_interval``, 1.2 * ``osd_deep_scrub_interval``].
   min: 0
   max: 0.4
   default: 0.2
@@ -656,8 +656,8 @@ options:
   type: bool
   level: advanced
   desc: Disable queuing of scrub reservations
-  long_desc: When set - scrub replica reservations are responded to immediately, with
-    either success or failure (the pre-Squid version behaviour). This configuration
+  long_desc: If set to true, scrub replica reservations are responded to immediately, with
+    either success or failure (the pre-Squid version behavior). This configuration
     option is introduced to support mixed-version clusters and debugging, and will
     be removed in the next release.
   default: false
@@ -893,7 +893,7 @@ options:
 - name: osd_pg_epoch_max_lag_factor
   type: float
   level: advanced
-  desc: Max multiple of the map cache that PGs can lag before we throttle map injest
+  desc: Max multiple of the map cache that PGs can lag before we throttle map ingest
   default: 2
   see_also:
   - osd_map_cache_size
@@ -907,7 +907,7 @@ options:
   level: dev
   default: false
   with_legacy: true
-# shutdown the OSD if stuatus flipping more than max_markdown_count times in recent max_markdown_period seconds
+# shutdown the OSD if status flipping more than max_markdown_count times in recent max_markdown_period seconds
 - name: osd_max_markdown_period
   type: int
   level: advanced
@@ -958,8 +958,8 @@ options:
   type: bool
   level: advanced
   desc: Allow OSD daemon to send an aggregated slow ops to the cluster log
-  fmt_desc: If set to ``true``, the OSD daemon will send slow ops information in 
-    an aggregated format to the cluster log else sends every slow op to the
+  fmt_desc: If set to ``true``, the OSD daemon will send slow ops information in
+    an aggregated format to the cluster log; otherwise, it sends every slow op to the
     cluster log.
   default: true
   with_legacy: true
@@ -1028,7 +1028,7 @@ options:
 - name: osd_skip_data_digest
   type: bool
   level: dev
-  desc: Do not store full-object checksums if the backend (bluestore) does its own
+  desc: Do not store full-object checksums if the backend (BlueStore) does its own
     checksums.  Only usable with all BlueStore OSDs.
   default: false
 # Weighted Priority Queue (wpq), mClock Scheduler (mclock_scheduler: default)

--- a/src/common/options/rbd.yaml.in
+++ b/src/common/options/rbd.yaml.in
@@ -359,7 +359,7 @@ options:
 - name: rbd_read_from_replica_policy
   type: str
   level: basic
-  desc: Read replica policy send to the OSDS during reads
+  desc: Read replica policy send to the OSDs during reads
   fmt_desc: |
     Policy for determining which OSD will receive read operations.
     If set to ``default``, each PG's primary OSD will always be used
@@ -817,7 +817,7 @@ options:
 - name: rbd_io_scheduler_simple_max_delay
   type: uint
   level: advanced
-  desc: maximum I/O delay (in milliseconds) for simple I/O scheduler (if set to 0 dalay
+  desc: maximum I/O delay (in milliseconds) for simple I/O scheduler (if set to 0, delay
     is calculated based on latency stats)
   default: 0
   services:

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -42,7 +42,7 @@ options:
   services:
   - rgw
   with_legacy: true
-# According to AWS S3, An website routing config can have up to 50 rules.
+# According to AWS S3, a website routing config can have up to 50 rules.
 - name: rgw_website_routing_rules_max_num
   type: int
   level: advanced
@@ -54,7 +54,7 @@ options:
 - name: rgw_disable_s3select
   type: bool
   level: advanced
-  desc: disable the s3select operation; RGW will report an error and will return ERR_INVALID_REQUEST.
+  desc: Disable the s3select operation; RGW will report an error and will return ERR_INVALID_REQUEST.
   default: false
   services:
   - rgw
@@ -62,7 +62,7 @@ options:
 - name: rgw_parquet_buffer_size
   type: size
   level: advanced
-  desc: the Maximum parquet buffer size, a limit to memory consumption for parquet reading operations.
+  desc: The maximum parquet buffer size, a limit to memory consumption for parquet reading operations.
   default: 16_M
   services:
   - rgw
@@ -325,7 +325,7 @@ options:
   type: str
   level: advanced
   desc: Alternative location for RGW configuration.
-  long_desc: If this is set, the different Ceph system configurables (such as the keyring file will be located in the path that is specified here.
+  long_desc: If this is set, the different Ceph system configurables (such as the keyring file) will be located in the path that is specified here.
   fmt_desc: Sets the location of the data files for Ceph RADOS Gateway.
   default: /var/lib/ceph/radosgw/$cluster-$id
   services:
@@ -337,13 +337,9 @@ options:
   type: str
   level: advanced
   desc: A list of RESTful APIs for RGW to enable
-  fmt_desc: |
-    Enables the specified APIs.
-
-      .. note:: Enabling the ``S3`` API is a requirement for
-                any ``radosgw`` instance that is meant to
-                participate in a `multi-site <../multisite>`_
-                configuration.
+  note: Enabling the ``s3`` API is a requirement for
+    any ``radosgw`` instance that is meant to
+    participate in a :ref:`multisite` configuration.
   default: s3, s3control, s3website, swift, swift_auth, admin, sts, iam, notifications
   services:
   - rgw
@@ -465,8 +461,8 @@ options:
   type: int
   level: advanced
   desc: Number of LCWorker tasks that will be run in parallel
-  long_desc: Number of LCWorker tasks that will run in parallel--used to permit >1
-    bucket/index shards to be processed simultaneously
+  long_desc: Number of LCWorker tasks that will run in parallel. Used to permit >1
+    bucket/index shards to be processed simultaneously.
   fmt_desc: This option specifies the number of lifecycle worker threads
     to run in parallel, thereby processing bucket and index
     shards simultaneously.
@@ -478,8 +474,8 @@ options:
   type: int
   level: advanced
   desc: Number of workpool coroutines per LCWorker
-  long_desc: Number of coroutines in per-LCWorker workpools--used to accelerate per-bucket
-    processing
+  long_desc: Number of coroutines in per-LCWorker workpools. Used to accelerate per-bucket
+    processing.
   fmt_desc: This option specifies the number of coroutines in each lifecycle
     workers work pool. This option can help accelerate processing each bucket.
   default: 128
@@ -509,10 +505,10 @@ options:
 - name: rgw_lc_debug_interval
   type: int
   level: dev
-  desc: The number of seconds that simulate one "day" in order to debug RGW LifeCycle.
+  desc: The number of seconds that simulate one "day" in order to debug RGW lifecycle.
     Do *not* modify for a production cluster.
-  long_desc: For debugging RGW LifeCycle, the number of seconds that are equivalent to
-    one simulated "day". Values less than 1 are ignored and do not change LifeCycle behavior.
+  long_desc: For debugging RGW lifecycle, the number of seconds that are equivalent to
+    one simulated "day". Values less than 1 are ignored and do not change lifecycle behavior.
     For example, during debugging if one wanted every 10 minutes to be equivalent to one day,
     then this would be set to 600, the number of seconds in 10 minutes.
   default: -1
@@ -534,7 +530,7 @@ options:
 - name: rgw_lc_list_cnt
   type: uint
   level: dev
-  desc: The count of number of objects in per listing of lc processing from each bucket.
+  desc: The maximum number of objects per bucket listing for lifecycle processing.
   long_desc: Number of objects that will be requested when performing a listing request
     of a bucket for lifecycle processing.
   default: 1000
@@ -658,7 +654,7 @@ options:
   level: advanced
   desc: Restore cycle run time
   long_desc: The amount of time between the start of consecutive runs of the restore
-    processing threads. If the thread runs takes more than this period, it will
+    processing threads. If the thread runs more than this period, it will
     not wait before running again.
   fmt_desc: The cycle time for restore state processing.
   default: 15_min
@@ -1732,7 +1728,7 @@ options:
   level: advanced
   desc: Should RGW log operations on bucket that does not exist
   long_desc: This config option applies to the ops log. When this option is set, the
-    ops log will log operations that are sent to non existing buckets. These operations
+    ops log will log operations that are sent to nonexistent buckets. These operations
     inherently fail, and do not correspond to a specific user.
   fmt_desc: Enables Ceph Object Gateway to log a request for a non-existent
     bucket.
@@ -1903,7 +1899,7 @@ options:
   long_desc: This is the max number of entries that will be held in the usage log,
     before it will be flushed to the backend. Note that the usage log is periodically
     flushed, even if number of entries does not reach this threshold. A usage log
-    entry corresponds to one or more operations on a single bucket.i
+    entry corresponds to one or more operations on a single bucket.
   fmt_desc: The number of dirty merged entries in the usage log before
     flushing synchronously.
   default: 1024
@@ -3230,7 +3226,7 @@ options:
 - name: rgw_crypt_s3_kms_cache_transient_error_ttl
   type: uint
   level: advanced
-  desc: Time in seconds after which the KMS cache evicts entries representing transient errors (timeouts, temporary outages, misconfiguration, etc).
+  desc: Time in seconds after which the KMS cache evicts entries representing transient errors (timeouts, temporary outages, misconfiguration, etc.).
   services:
   - rgw
   with_legacy: true
@@ -4166,7 +4162,7 @@ options:
     write and read object data. This is the default cache backend chosen by the D4N filter.
     Only the SSD cache backend uses this path for object data storage since the RedisDriver
     uses a Redis server instead and there are no additional cache backend implementations
-    available at the moment. 
+    available at the moment.
   default: /tmp/rgw_d4n_datacache/
   services:
   - rgw
@@ -4175,7 +4171,7 @@ options:
   type: size
   level: advanced
   desc: amount of disk space to keep free for datacache
-  long_desc: The local SSD cache uses this option to determine how much disk space to 
+  long_desc: The local SSD cache uses this option to determine how much disk space to
     reserve. The cache can grow until disk usage reaches (total disk space - reserved space).
   default: 1_G
   services:
@@ -4186,8 +4182,8 @@ options:
   level: advanced
   desc: clear the contents of the persistent datacache on start
   long_desc: The local SSD cache uses this option to clear the contents of the path supplied
-    by the rgw_d4n_l1_datacache_persistent_path config option on start. If false, the path's 
-    contents will be retained. 
+    by the rgw_d4n_l1_datacache_persistent_path config option on start. If false, the path's
+    contents will be retained.
   default: true
   services:
   - rgw
@@ -4222,7 +4218,7 @@ options:
   level: advanced
   desc: specifies the maximum number of worker threads that may be used by libaio
   long_desc: This option is used by the SSD cache backend during initialization to set the maximum
-    number of worker threads libaio may use. It does not apply to the Redis cache backend. 
+    number of worker threads libaio may use. It does not apply to the Redis cache backend.
   default: 20
   services:
   - rgw
@@ -4235,7 +4231,7 @@ options:
   desc: specifies the maximum number of simultaneous I/O requests that libaio expects to enqueue
   long_desc: This option is used by the SSD cache backend during initialization to set the maximum
     number of simultaneous I/O requests that libaio can expect to enqueue. It
-    does not apply to the Redis cache backend. 
+    does not apply to the Redis cache backend.
   default: 64
   services:
   - rgw
@@ -4338,13 +4334,13 @@ options:
 - name: rgw_lfuda_sync_frequency
   type: int
   level: advanced
-  desc: LFUDA variables' sync frequency in seconds 
-  long_desc: By default, the D4N cache uses the Least Frequently Used with Dynamic Aging (LFUDA) 
-    cache replacement policy. This class globally stores values that are used by the policy's 
+  desc: LFUDA variables' sync frequency in seconds
+  long_desc: By default, the D4N cache uses the Least Frequently Used with Dynamic Aging (LFUDA)
+    cache replacement policy. This class globally stores values that are used by the policy's
     algorithm. However, strong consistency for these values is not necessary and adds additional
     overhead to support. As a result, a thread periodically retrieves these global values and posts
     updates when certain conditions are satisfied. This Redis thread completes this logic in a loop
-    that is called once every interval, with the interval being set by this option.  
+    that is called once every interval, with the interval being set by this option.
   default: 60
   services:
   - rgw
@@ -4356,7 +4352,7 @@ options:
   level: advanced
   desc: The d4n write cache
   default: false
-  services: 
+  services:
   - rgw
   flags:
   - startup
@@ -4540,7 +4536,7 @@ options:
 - name: rgw_luarocks_location
   type: str
   level: advanced
-  desc: Directory where luarocks install packages from allowlist
+  desc: Directory where LuaRocks installs packages from allowlist
   default: /tmp/rgw_luarocks/$name
   services:
   - rgw
@@ -4587,12 +4583,12 @@ options:
 - name: rgw_allow_notification_secrets_in_cleartext
   type: bool
   level: advanced
-  desc: Allows sending secrets (e.g. passwords) over non encrypted HTTP messages.
+  desc: Allows sending secrets (e.g. passwords) over non-encrypted HTTP messages.
   long_desc: When bucket notification endpoint require secrets (e.g. passwords),
-    we allow the topic creation only over HTTPS messages. 
+    we allow the topic creation only over HTTPS messages.
     This parameter can be set to "true" to bypass this check.
-    Use this only if radosgw is on a trusted private network, and the message 
-    broker cannot be configured without password authentication. Otherwise, this will 
+    Use this only if radosgw is on a trusted private network, and the message
+    broker cannot be configured without password authentication. Otherwise, this will
     leak the credentials of your message broker and compromise its security.
   default: false
   services:
@@ -4623,10 +4619,10 @@ options:
   desc: address for the D4N Redis connection
   long_desc: The current D4N implementation supports one Redis node
     which the D4N directory, policy, and overall filter communicate
-    with. This default value is also the address that a Redis server 
+    with. This default value is also the address that a Redis server
     with no additional configuration will use.
   default: 127.0.0.1:6379
-  services: 
+  services:
   - rgw
   flags:
   - startup
@@ -4636,7 +4632,7 @@ options:
   level: advanced
   desc: This is the interval in seconds for invoking write cache cleaning process
   default: 1000
-  services: 
+  services:
   - rgw
   flags:
   - startup
@@ -4711,10 +4707,10 @@ options:
 - name: rgw_lua_max_memory_per_state
   type: uint
   level: advanced
-  desc: Max size of memory used by a single lua state
-  long_desc: This is the maximum size in bytes that a lua state can allocate for its own use.
-    Note that this does not include any memory that can be accessed from lua, but managed by the RGW.
-    If not set, it would use a default of 128K. If set to zero, the amount of memory would 
+  desc: Max size of memory used by a single Lua state
+  long_desc: This is the maximum size in bytes that a Lua state can allocate for its own use.
+    Note that this does not include any memory that can be accessed from Lua, but managed by the RGW.
+    If not set, it would use a default of 128K. If set to zero, the amount of memory would
     only be limited by the system.
   default: 128000
   services:
@@ -4790,9 +4786,9 @@ options:
   - rgw
   with_legacy: true
 - name: rgw_kafka_connection_idle
-  type: uint 
+  type: uint
   level: advanced
-  desc: Time in seconds to delete idle kafka connections
+  desc: Time in seconds to delete idle Kafka connections
   long_desc: A connection will be considered "idle" if no messages
     are sent to it for more than the time defined.
     Note that the connection will not be considered idle, even if it is down,
@@ -4802,19 +4798,19 @@ options:
   - rgw
   with_legacy: true
 - name: rgw_kafka_sleep_timeout
-  type: uint 
+  type: uint
   level: advanced
-  desc: Time in milliseconds to sleep while polling for kafka replies
-  long_desc: This will be used to prevent busy waiting for the kafka replies
+  desc: Time in milliseconds to sleep while polling for Kafka replies
+  long_desc: This will be used to prevent busy waiting for the Kafka replies
     As well as for the cases where the broker is down and we try to reconnect.
     The same values times 3 will be used to sleep if there were no messages
-    sent or received across all kafka connections
+    sent or received across all Kafka connections
   default: 10
   services:
   - rgw
   with_legacy: true
 - name: rgw_kafka_message_timeout
-  type: uint 
+  type: uint
   level: advanced
   desc: This is the maximum time in milliseconds to deliver a message (including retries)
   long_desc: Delivery error occurs when the message timeout is exceeded.
@@ -4826,8 +4822,8 @@ options:
 - name: rgw_kafka_max_batch_size
   type: uint
   level: advanced
-  desc: This is the maximum size in bytes of a batch of messages sent to kafka
-  long_desc: This is the maximum size in bytes of a batch of messages sent to kafka. Messages will be sent
+  desc: This is the maximum size in bytes of a batch of messages sent to Kafka
+  long_desc: This is the maximum size in bytes of a batch of messages sent to Kafka. Messages will be sent
     in batches to improve performance, and this option sets the maximum size of those batches.
     If set to zero, the value is not set and the default batch size will be used.
   default: 0
@@ -4873,9 +4869,9 @@ options:
 - name: rgw_d4n_local_rgw_address
   type: str
   level: advanced
-  desc: local RGW address 
+  desc: local RGW address
   long_desc: This is the address used to represent the local RGW in a distributed D4N
-    system that involves remote RGWs. 
+    system that involves remote RGWs.
   default: 127.0.0.1:8000
   services:
   - rgw
@@ -4885,9 +4881,9 @@ options:
 - name: rgw_d4n_l1_datacache_address
   type: str
   level: advanced
-  desc: local Redis cache address 
+  desc: local Redis cache address
   long_desc: This is the address used to configure the Redis cache backend connection. The default
-    value is the same address used by Redis without any additional configuration. The SSD cache 
+    value is the same address used by Redis without any additional configuration. The SSD cache
     does not use this option.
   default: 127.0.0.1:6379
   services:
@@ -4896,7 +4892,7 @@ options:
   - startup
   with_legacy: true
 - name: rgw_bucket_logging_obj_roll_time
-  type: uint 
+  type: uint
   level: advanced
   desc: Default time in seconds for the bucket logging object to roll
   long_desc: Object roll time can be provided in the bucket logging configuration.
@@ -4919,7 +4915,7 @@ options:
 - name: rgw_lua_enable
   type: bool
   level: advanced
-  desc: Enable lua scripting.
+  desc: Enable Lua scripting.
   default: true
   services:
   - rgw
@@ -4930,9 +4926,9 @@ options:
 - name: rgw_d4n_backend_address
   type: str
   level: advanced
-  desc: The backend address used by D4N cache 
+  desc: The backend address used by D4N cache
   default: 127.0.0.1:6379
-  services: 
+  services:
   - rgw
   flags:
   - startup
@@ -4977,10 +4973,10 @@ options:
   type: uint
   level: advanced
   desc: Number of shards for a persistent topic.
-  long_desc: Number of shards of persistent topics. The notifications will be sharded by a combination of 
-    the bucket and key name. Changing the number effect only new topics and does not change exiting ones.
+  long_desc: Number of shards of persistent topics. The notifications will be sharded by a combination of
+    the bucket and key name. Changing the number affects only new topics and does not change existing ones.
   default: 11
-  services: 
+  services:
     - rgw
 
 - name: rgw_usage_log_key_transition


### PR DESCRIPTION
Fix typos, improve capitalization, grammar and language.  
Use the `note` attribute for generating an admonition in docs.ceph.com instead of `fmt_desc` and markup.  
Remove all trailing and stray spaces.

Leave mon/monitor/Monitor etc. harmonization for another PR.  
Leave most comments as-is.

GitHub Copilot was used to only find about half of the changes. All changes by the author.

Assisted-by: Copilot/Claude Sonnet 4.6





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
