### PR TITLE
.github/workflows: revert bump actions for GitHub deprecations

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,406 +1,352 @@
 api-change:
-- changed-files:
-  - any-glob-to-any-file:
-    - src/pybind/mgr/dashboard/openapi.yaml
+  - src/pybind/mgr/dashboard/openapi.yaml
 
 build/ops:
-- changed-files:
-  - any-glob-to-any-file:
-    - "**/CMakeLists.txt"
-    - admin/**
-    - ceph.spec.in
-    - cmake/**
-    - container/**
-    - debian/**
-    - do_cmake.sh
-    - do_freebsd.sh
-    - install-deps.sh
-    - keys/**
-    - make-debs.sh
-    - make-dist
-    - make-srpm.sh
-    - run-make-check.sh
-    - win32_build.sh
-    - win32_deps_build.sh
+  - "**/CMakeLists.txt"
+  - admin/**
+  - ceph.spec.in
+  - cmake/**
+  - container/**
+  - debian/**
+  - do_cmake.sh
+  - do_freebsd.sh
+  - install-deps.sh
+  - keys/**
+  - make-debs.sh
+  - make-dist
+  - make-srpm.sh
+  - run-make-check.sh
+  - win32_build.sh
+  - win32_deps_build.sh
 
 documentation:
-- changed-files:
-  - any-glob-to-any-file:
-    - AUTHORS
-    - CONTRIBUTING.rst
-    - COPYING*
-    - CodingStyle
-    - PendingReleaseNotes
-    - README.*
-    - SubmittingPatches*
-    - doc/**
-    - doc_deps.deb.txt
-    - man/**
-    - "**/*.+(rst|md)"
+  - AUTHORS
+  - CONTRIBUTING.rst
+  - COPYING*
+  - CodingStyle
+  - PendingReleaseNotes
+  - README.*
+  - SubmittingPatches*
+  - doc/**
+  - doc_deps.deb.txt
+  - man/**
+  - "**/*.+(rst|md)"
 
 libcephsqlite:
-- changed-files:
-  - any-glob-to-any-file:
-    - doc/rados/api/libcephsqlite.rst
-    - qa/suites/rados/basic/tasks/libcephsqlite.yaml
-    - qa/workunits/rados/test_libcephsqlite.sh
-    - src/SimpleRADOSStriper.*
-    - src/include/libcephsqlite.h
-    - src/libcephsqlite.cc
-    - src/test/libcephsqlite/**
+  - doc/rados/api/libcephsqlite.rst
+  - qa/suites/rados/basic/tasks/libcephsqlite.yaml
+  - qa/workunits/rados/test_libcephsqlite.sh
+  - src/SimpleRADOSStriper.*
+  - src/include/libcephsqlite.h
+  - src/libcephsqlite.cc
+  - src/test/libcephsqlite/**
 
 mon:
-- changed-files:
-  - any-glob-to-any-file:
-    - doc/man/8/ceph-mon.rst
-    - doc/man/8/monmaptool.rst
-    - doc/mon/**
-    - qa/workunits/mon/**
-    - src/mon/**
-    - src/test/mon/**
+  - doc/man/8/ceph-mon.rst
+  - doc/man/8/monmaptool.rst
+  - doc/mon/**
+  - qa/workunits/mon/**
+  - src/mon/**
+  - src/test/mon/**
 
 mgr:
-- changed-files:
-  - any-glob-to-any-file:
-    - doc/mgr/**
-    - src/mgr/**
-    - src/pybind/mgr/ceph_module.pyi
-    - src/pybind/mgr/mgr_module.py
-    - src/pybind/mgr/mgr_util.py
-    - src/pybind/mgr/cherrypy_mgr.py
-    - src/pybind/mgr/object_format.py
-    - src/pybind/mgr/requirements.txt
-    - src/pybind/mgr/tox.ini
-    - src/test/mgr/**
+  - doc/mgr/**
+  - src/mgr/**
+  - src/pybind/mgr/ceph_module.pyi
+  - src/pybind/mgr/mgr_module.py
+  - src/pybind/mgr/mgr_util.py
+  - src/pybind/mgr/cherrypy_mgr.py
+  - src/pybind/mgr/object_format.py
+  - src/pybind/mgr/requirements.txt
+  - src/pybind/mgr/tox.ini
+  - src/test/mgr/**
 
 pybind:
-- changed-files:
-  - any-glob-to-any-file:
-    - src/pybind/cephfs/**
-    - src/pybind/mgr/**
-    - src/pybind/rados/**
-    - src/pybind/rbd/**
-    - src/pybind/rgw/**
-    - src/pybind/**
-    - src/python-common/**
+  - src/pybind/cephfs/**
+  - src/pybind/mgr/**
+  - src/pybind/rados/**
+  - src/pybind/rbd/**
+  - src/pybind/rgw/**
+  - src/pybind/**
+  - src/python-common/**
 
 common:
-- changed-files:
-  - any-glob-to-any-file:
-    - src/common/**
-    - src/global/**
-    - src/log/**
+  - src/common/**
+  - src/global/**
+  - src/log/**
 
 cephadm:
-- changed-files:
-  - any-glob-to-any-file:
-    - doc/cephadm/**
-    - doc/dev/cephadm/**
-    - doc/man/8/cephadm.rst
-    - qa/suites/orch/cephadm/**
-    - qa/tasks/cephadm.py
-    - qa/tasks/cephadm_cases
-    - qa/tasks/mgr/test_cephadm_orchestrator.py
-    - qa/tasks/mgr/test_orchestrator_cli.py
-    - qa/workunits/cephadm/**
-    - src/cephadm/**
-    - src/pybind/mgr/cephadm/**
-    - src/python-common/**
+  - doc/cephadm/**
+  - doc/dev/cephadm/**
+  - doc/man/8/cephadm.rst
+  - qa/suites/orch/cephadm/**
+  - qa/tasks/cephadm.py
+  - qa/tasks/cephadm_cases
+  - qa/tasks/mgr/test_cephadm_orchestrator.py
+  - qa/tasks/mgr/test_orchestrator_cli.py
+  - qa/workunits/cephadm/**
+  - src/cephadm/**
+  - src/pybind/mgr/cephadm/**
+  - src/python-common/**
     
 orchestrator:
-- changed-files:
-  - any-glob-to-any-file:
-    - doc/mgr/orchestrator.rst
-    - doc/mgr/orchestrator_modules.rst
-    - src/pybind/mgr/orchestrator/**
-    - src/pybind/mgr/rook/**
-    - src/pybind/mgr/test_orchestrator/**
-    - qa/tasks/mgr/test_orchestrator_cli.py
+  - doc/mgr/orchestrator.rst
+  - doc/mgr/orchestrator_modules.rst
+  - src/pybind/mgr/orchestrator/**
+  - src/pybind/mgr/rook/**
+  - src/pybind/mgr/test_orchestrator/**
+  - qa/tasks/mgr/test_orchestrator_cli.py
 
 rook:
-- changed-files:
-  - any-glob-to-any-file:
-    - doc/mgr/rook.rst
-    - src/pybind/mgr/rook/**
-    - qa/tasks/rook.py
-    - qa/suites/orch/rook/smoke/**
+  - doc/mgr/rook.rst
+  - src/pybind/mgr/rook/**
+  - qa/tasks/rook.py
+  - qa/suites/orch/rook/smoke/**
 
 bluestore:
-- changed-files:
-  - any-glob-to-any-file:
-    - src/os/bluestore/**
+  - src/os/bluestore/**
 
 core:
-- changed-files:
-  - any-glob-to-any-file:
-    - doc/man/8/ceph-authtool.rst
-    - doc/man/8/ceph-conf.rst
-    - doc/man/8/ceph-create-keys.rst
-    - doc/man/8/ceph-kvstore-tool.rst
-    - doc/man/8/ceph-mon.rst
-    - doc/man/8/ceph-objectstore-tool.rst
-    - doc/man/8/ceph-osd.rst
-    - doc/man/8/ceph.rst
-    - doc/man/8/crushtool.rst
-    - doc/man/8/monmaptool.rst
-    - doc/man/8/rados.rst
-    - doc/rados/**
-    - qa/standalone/**
-    - qa/suites/rados/**
-    - qa/workunits/erasure-code/**
-    - qa/workunits/mgr/**
-    - qa/workunits/mon/**
-    - qa/workunits/objectstore/**
-    - qa/workunits/rados/**
-    - src/ceph.in
-    - src/ceph_osd.cc
-    - src/ceph_mon.cc
-    - src/blk/**
-    - src/crush/*
-    - src/erasure-code/**
-    - src/kv/**
-    - src/librados/**
-    - src/mgr/**
-    - src/mon/**
-    - src/msg/**
-    - src/os/**
-    - src/osd/**
-    - src/tools/ceph_dedup_tool.cc
-    - src/tools/ceph_kvstore_tool.cc
-    - src/tools/ceph_monstore_tool.cc
-    - src/tools/ceph_objectstore_tool.*
-    - src/tools/crushtool.cc
-    - src/tools/kvstore_tool.*
-    - src/tools/monmaptool.cc
-    - src/tools/osdmaptool.cc
-    - src/tools/rados/**
-    - src/test/librados/**
-    - src/test/osd/**
+  - doc/man/8/ceph-authtool.rst
+  - doc/man/8/ceph-conf.rst
+  - doc/man/8/ceph-create-keys.rst
+  - doc/man/8/ceph-kvstore-tool.rst
+  - doc/man/8/ceph-mon.rst
+  - doc/man/8/ceph-objectstore-tool.rst
+  - doc/man/8/ceph-osd.rst
+  - doc/man/8/ceph.rst
+  - doc/man/8/crushtool.rst
+  - doc/man/8/monmaptool.rst
+  - doc/man/8/rados.rst
+  - doc/rados/**
+  - qa/standalone/**
+  - qa/suites/rados/**
+  - qa/workunits/erasure-code/**
+  - qa/workunits/mgr/**
+  - qa/workunits/mon/**
+  - qa/workunits/objectstore/**
+  - qa/workunits/rados/**
+  - src/ceph.in
+  - src/ceph_osd.cc
+  - src/ceph_mon.cc
+  - src/blk/**
+  - src/crush/*
+  - src/erasure-code/**
+  - src/kv/**
+  - src/librados/**
+  - src/mgr/**
+  - src/mon/**
+  - src/msg/**
+  - src/os/**
+  - src/osd/**
+  - src/tools/ceph_dedup_tool.cc
+  - src/tools/ceph_kvstore_tool.cc
+  - src/tools/ceph_monstore_tool.cc
+  - src/tools/ceph_objectstore_tool.*
+  - src/tools/crushtool.cc
+  - src/tools/kvstore_tool.*
+  - src/tools/monmaptool.cc
+  - src/tools/osdmaptool.cc
+  - src/tools/rados/**
+  - src/test/librados/**
+  - src/test/osd/**
 
 crimson:
-- changed-files:
-  - any-glob-to-any-file:
-    - doc/dev/crimson/**
-    - src/crimson/**
-    - src/test/crimson/**
-    - qa/suites/crimson-rados/**
-    - src/seastar/**
+  - doc/dev/crimson/**
+  - src/crimson/**
+  - src/test/crimson/**
+  - qa/suites/crimson-rados/**
+  - src/seastar/**
 
 dashboard:
-- changed-files:
-  - any-glob-to-any-file:
-    - src/pybind/mgr/dashboard/**
-    - qa/suites/rados/dashboard/**
-    - qa/tasks/mgr/test_dashboard.py
-    - qa/tasks/mgr/dashboard/**
-    - monitoring/**
-    - doc/mgr/dashboard.rst
-    - doc/dev/developer_guide/dash-devel.rst
+  - src/pybind/mgr/dashboard/**
+  - qa/suites/rados/dashboard/**
+  - qa/tasks/mgr/test_dashboard.py
+  - qa/tasks/mgr/dashboard/**
+  - monitoring/**
+  - doc/mgr/dashboard.rst
+  - doc/dev/developer_guide/dash-devel.rst
 
 cephfs:
-- changed-files:
-  - any-glob-to-any-file:
-    - doc/cephfs/**
-    - doc/man/8/ceph-fuse.rst
-    - doc/man/8/ceph-mds.rst
-    - doc/man/8/ceph-syn.rst
-    - doc/man/8/mount.ceph.rst
-    - doc/man/8/mount.fuse.ceph.rst
-    - qa/suites/fs/**
-    - qa/suites/multimds/**
-    - qa/tasks/ceph_fuse.py
-    - qa/tasks/cephfs/**
-    - qa/tasks/cephfs_test_runner.py
-    - qa/tasks/fs.py
-    - qa/tasks/kclient.py
-    - qa/tasks/mds_creation_failure.py
-    - qa/tasks/mds_thrash.py
-    - src/ceph_fuse.cc
-    - src/ceph_mds.cc
-    - src/ceph_syn.cc
-    - src/client/**
-    - src/include/ceph_fs.h
-    - src/include/ceph_fuse.h
-    - src/include/cephfs/**
-    - src/include/filepath.h
-    - src/include/frag.h
-    - src/include/fs_types.h
-    - src/libcephfs.cc
-    - src/mds/**
-    - src/mon/MDSMonitor.*
-    - src/mon/FSCommands.*
-    - src/pybind/cephfs/**
-    - src/pybind/mgr/mds_autoscaler/**
-    - src/pybind/mgr/status/**
-    - src/pybind/mgr/volumes/**
-    - src/test/fs/**
-    - src/test/libcephfs/**
-    - src/tools/cephfs/**
-    - src/tools/cephfs_mirror/**
+  - doc/cephfs/**
+  - doc/man/8/ceph-fuse.rst
+  - doc/man/8/ceph-mds.rst
+  - doc/man/8/ceph-syn.rst
+  - doc/man/8/mount.ceph.rst
+  - doc/man/8/mount.fuse.ceph.rst
+  - qa/suites/fs/**
+  - qa/suites/multimds/**
+  - qa/tasks/ceph_fuse.py
+  - qa/tasks/cephfs/**
+  - qa/tasks/cephfs_test_runner.py
+  - qa/tasks/fs.py
+  - qa/tasks/kclient.py
+  - qa/tasks/mds_creation_failure.py
+  - qa/tasks/mds_thrash.py
+  - src/ceph_fuse.cc
+  - src/ceph_mds.cc
+  - src/ceph_syn.cc
+  - src/client/**
+  - src/include/ceph_fs.h
+  - src/include/ceph_fuse.h
+  - src/include/cephfs/**
+  - src/include/filepath.h
+  - src/include/frag.h
+  - src/include/fs_types.h
+  - src/libcephfs.cc
+  - src/mds/**
+  - src/mon/MDSMonitor.*
+  - src/mon/FSCommands.*
+  - src/pybind/cephfs/**
+  - src/pybind/mgr/mds_autoscaler/**
+  - src/pybind/mgr/status/**
+  - src/pybind/mgr/volumes/**
+  - src/test/fs/**
+  - src/test/libcephfs/**
+  - src/tools/cephfs/**
+  - src/tools/cephfs_mirror/**
 
 CI:
-- changed-files:
-  - any-glob-to-any-file:
-    - .github/**
+  - .github/**
 
 rbd:
-- changed-files:
-  - any-glob-to-any-file:
-    - doc/dev/rbd*
-    - doc/man/8/ceph-rbdnamer.rst
-    - doc/man/8/rbd*
-    - doc/rbd/**
-    - doc/start/quick-rbd.rst
-    - examples/librbd/**
-    - examples/rbd-replay/**
-    - qa/rbd/**
-    - qa/run_xfstests*
-    - qa/suites/krbd/**
-    - qa/suites/rbd/**
-    - qa/tasks/ceph_iscsi_client.py
-    - qa/tasks/metadata.yaml
-    - qa/tasks/qemu.py
-    - qa/tasks/rbd*
-    - qa/tasks/userdata*
-    - qa/workunits/cls/test_cls_journal.sh
-    - qa/workunits/cls/test_cls_lock.sh
-    - qa/workunits/cls/test_cls_rbd.sh
-    - qa/workunits/rbd/**
-    - qa/workunits/windows/**
-    - src/ceph-rbdnamer
-    - src/cls/journal/**
-    - src/cls/lock/**
-    - src/cls/rbd/**
-    - src/common/options/rbd*
-    - src/etc-rbdmap
-    - src/include/krbd.h
-    - src/include/rbd*
-    - src/include/rbd/**
-    - src/journal/**
-    - src/krbd.cc
-    - src/librbd/**
-    - src/ocf/**
-    - src/pybind/mgr/rbd_support/**
-    - src/pybind/rbd/**
-    - src/rbd*
-    - src/rbd*/**
-    - src/test/cli/rbd/**
-    - src/test/cli-integration/rbd/**
-    - src/test/cls_journal/**
-    - src/test/cls_lock/**
-    - src/test/cls_rbd/**
-    - src/test/journal/**
-    - src/test/librbd/**
-    - src/test/pybind/test_rbd.py
-    - src/test/rbd*
-    - src/test/rbd*/**
-    - src/test/run-rbd*
-    - src/test/test_rbd*
-    - src/tools/rbd*/**
-    - systemd/ceph-rbd-mirror*
-    - systemd/rbdmap.service.in
-    - udev/50-rbd.rules
+  - doc/dev/rbd*
+  - doc/man/8/ceph-rbdnamer.rst
+  - doc/man/8/rbd*
+  - doc/rbd/**
+  - doc/start/quick-rbd.rst
+  - examples/librbd/**
+  - examples/rbd-replay/**
+  - qa/rbd/**
+  - qa/run_xfstests*
+  - qa/suites/krbd/**
+  - qa/suites/rbd/**
+  - qa/tasks/ceph_iscsi_client.py
+  - qa/tasks/metadata.yaml
+  - qa/tasks/qemu.py
+  - qa/tasks/rbd*
+  - qa/tasks/userdata*
+  - qa/workunits/cls/test_cls_journal.sh
+  - qa/workunits/cls/test_cls_lock.sh
+  - qa/workunits/cls/test_cls_rbd.sh
+  - qa/workunits/rbd/**
+  - qa/workunits/windows/**
+  - src/ceph-rbdnamer
+  - src/cls/journal/**
+  - src/cls/lock/**
+  - src/cls/rbd/**
+  - src/common/options/rbd*
+  - src/etc-rbdmap
+  - src/include/krbd.h
+  - src/include/rbd*
+  - src/include/rbd/**
+  - src/journal/**
+  - src/krbd.cc
+  - src/librbd/**
+  - src/ocf/**
+  - src/pybind/mgr/rbd_support/**
+  - src/pybind/rbd/**
+  - src/rbd*
+  - src/rbd*/**
+  - src/test/cli/rbd/**
+  - src/test/cli-integration/rbd/**
+  - src/test/cls_journal/**
+  - src/test/cls_lock/**
+  - src/test/cls_rbd/**
+  - src/test/journal/**
+  - src/test/librbd/**
+  - src/test/pybind/test_rbd.py
+  - src/test/rbd*
+  - src/test/rbd*/**
+  - src/test/run-rbd*
+  - src/test/test_rbd*
+  - src/tools/rbd*/**
+  - systemd/ceph-rbd-mirror*
+  - systemd/rbdmap.service.in
+  - udev/50-rbd.rules
 
 nvmeof:
-- changed-files:
-  - any-glob-to-any-file:
-    - qa/suites/nvmeof/**
-    - qa/tasks/nvmeof.py
-    - qa/workunits/nvmeof/**
-    - src/ceph_nvmeof_monitor_client.cc
-    - src/cephadm/cephadmlib/daemons/nvmeof.py
-    - src/messages/MNVMeofGw*
-    - src/mon/NVMeofGw*
-    - src/nvmeof/**
-    - src/pybind/mgr/cephadm/services/nvmeof.py
-    - src/pybind/mgr/cephadm/templates/services/nvmeof/**
-    - src/tools/ceph-dencoder/nvmeof*
+  - qa/suites/nvmeof/**
+  - qa/tasks/nvmeof.py
+  - qa/workunits/nvmeof/**
+  - src/ceph_nvmeof_monitor_client.cc
+  - src/cephadm/cephadmlib/daemons/nvmeof.py
+  - src/messages/MNVMeofGw*
+  - src/mon/NVMeofGw*
+  - src/nvmeof/**
+  - src/pybind/mgr/cephadm/services/nvmeof.py
+  - src/pybind/mgr/cephadm/templates/services/nvmeof/**
+  - src/tools/ceph-dencoder/nvmeof*
 
 rgw:
-- changed-files:
-  - any-glob-to-any-file:
-    - qa/suites/rgw/**
-    - qa/tasks/rgw*
-    - qa/tasks/s3*
-    - src/cls/cmpomap/**
-    - src/cls/fifo/**
-    - src/cls/otp/**
-    - src/cls/queue/**
-    - src/cls/rgw/**
-    - src/cls/rgw_gc/**
-    - src/cls/timeindex/**
-    - src/mrgw.sh
-    - src/mrun
-    - src/mstart.sh
-    - src/mstop.sh
-    - src/rgw/**
-    - src/test/cls_rgw/**
-    - src/test/librgw_*
-    - src/test/rgw/**
-    - src/test/test_rgw*
-    - doc/radosgw
+  - qa/suites/rgw/**
+  - qa/tasks/rgw*
+  - qa/tasks/s3*
+  - src/cls/cmpomap/**
+  - src/cls/fifo/**
+  - src/cls/otp/**
+  - src/cls/queue/**
+  - src/cls/rgw/**
+  - src/cls/rgw_gc/**
+  - src/cls/timeindex/**
+  - src/mrgw.sh
+  - src/mrun
+  - src/mstart.sh
+  - src/mstop.sh
+  - src/rgw/**
+  - src/test/cls_rgw/**
+  - src/test/librgw_*
+  - src/test/rgw/**
+  - src/test/test_rgw*
+  - doc/radosgw
 
 ceph-volume:
-- changed-files:
-  - any-glob-to-any-file:
-    - src/ceph-volume/**
-    - doc/ceph-volume/**
-    - src/python-common/ceph/deployment/drive_group.py
-    - src/python-common/ceph/deployment/drive_selection/**
+  - src/ceph-volume/**
+  - doc/ceph-volume/**
+  - src/python-common/ceph/deployment/drive_group.py
+  - src/python-common/ceph/deployment/drive_selection/**
 
 tests:
-- changed-files:
-  - any-glob-to-any-file:
-    - qa/**
-    - src/test/**
+  - qa/**
+  - src/test/**
 
 nfs:
-- changed-files:
-  - any-glob-to-any-file:
-    - src/pybind/mgr/nfs/**
-    - src/pybind/mgr/cephadm/services/nfs.py
-    - src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
-    - src/pybind/mgr/dashboard/controllers/nfs.py
-    - src/pybind/mgr/dashboard/tests/test_nfs.py
-    - qa/tasks/cephfs/test_nfs.py
-    - doc/mgr/nfs.rst
-    - doc/cephfs/nfs.rst
-    - doc/cephadm/nfs.rst
-    - doc/radosgw/nfs.rst
-    - doc/dev/vstart-ganesha.rst
+  - src/pybind/mgr/nfs/**
+  - src/pybind/mgr/cephadm/services/nfs.py
+  - src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
+  - src/pybind/mgr/dashboard/controllers/nfs.py
+  - src/pybind/mgr/dashboard/tests/test_nfs.py
+  - qa/tasks/cephfs/test_nfs.py
+  - doc/mgr/nfs.rst
+  - doc/cephfs/nfs.rst
+  - doc/cephadm/nfs.rst
+  - doc/radosgw/nfs.rst
+  - doc/dev/vstart-ganesha.rst
 
 monitoring:
-- changed-files:
-  - any-glob-to-any-file:
-    - doc/cephadm/monitoring.rst
-    - src/pybind/mgr/cephadm/services/monitoring.py
-    - src/pybind/mgr/cephadm/templates/services/alertmanager/**
-    - src/pybind/mgr/cephadm/templates/services/grafana/**
-    - src/pybind/mgr/cephadm/templates/services/prometheus/**
-    - src/pybind/mgr/dashboard/ci/check_grafana_dashboards.py
-    - src/pybind/mgr/prometheus/**
-    - monitoring/**  
+  - doc/cephadm/monitoring.rst
+  - src/pybind/mgr/cephadm/services/monitoring.py
+  - src/pybind/mgr/cephadm/templates/services/alertmanager/**
+  - src/pybind/mgr/cephadm/templates/services/grafana/**
+  - src/pybind/mgr/cephadm/templates/services/prometheus/**
+  - src/pybind/mgr/dashboard/ci/check_grafana_dashboards.py
+  - src/pybind/mgr/prometheus/**
+  - monitoring/**  
  
 telemetry:
-- changed-files:
-  - any-glob-to-any-file:
-    - doc/mgr/telemetry.rst
-    - qa/suites/upgrade/telemetry-upgrade/**
-    - qa/workunits/test_telemetry_pacific.sh
-    - qa/workunits/test_telemetry_pacific_x.sh
-    - qa/workunits/test_telemetry_quincy.sh
-    - qa/workunits/test_telemetry_quincy_x.sh
-    - src/pybind/mgr/telemetry/**
-    - src/telemetry/**
+  - doc/mgr/telemetry.rst
+  - qa/suites/upgrade/telemetry-upgrade/**
+  - qa/workunits/test_telemetry_pacific.sh
+  - qa/workunits/test_telemetry_pacific_x.sh
+  - qa/workunits/test_telemetry_quincy.sh
+  - qa/workunits/test_telemetry_quincy_x.sh
+  - src/pybind/mgr/telemetry/**
+  - src/telemetry/**
 
 script:
-- changed-files:
-  - any-glob-to-any-file:
-    - src/script/**
-    - admin/**
-    - doc/scripts/**
+  - src/script/**
+  - admin/**
+  - doc/scripts/**
 
 config-change:
-- changed-files:
-  - any-glob-to-any-file:
-    - src/common/options/**
+  - src/common/options/**

--- a/.github/workflows/create-backport-trackers.yml
+++ b/.github/workflows/create-backport-trackers.yml
@@ -44,7 +44,7 @@ jobs:
               src/script/backport-create-issue
               src/script/requirements.backport-create-issue.txt
           sparse-checkout-cone-mode: false
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '>=3.6 <3.12'
           cache: 'pip'

--- a/.github/workflows/diff-ceph-config.yml
+++ b/.github/workflows/diff-ceph-config.yml
@@ -59,7 +59,7 @@ jobs:
           echo "COMMON_ANCESTOR_SHA=$COMMON_ANCESTOR_SHA" >> "$GITHUB_ENV"
 
       - name: Setup Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.13'
 
@@ -96,7 +96,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Post output as a comment
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DIFF_JSON_OUTPUT: ${{ steps.diff_tool.outputs.DIFF_JSON }}

--- a/.github/workflows/needs-rebase.yml
+++ b/.github/workflows/needs-rebase.yml
@@ -7,11 +7,11 @@ jobs:
   needs-rebase:
     runs-on: ubuntu-latest
     steps:
-      # eps1lon/actions-label-merge-conflict@v3.1.0
+      # eps1lon/actions-label-merge-conflict@v2.0.1
       # (NOTE: pinning the action to a given commit is a security best-practice:
       # https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/security-hardening-for-github-actions)
       - name: Check if PR needs rebase
-        uses: eps1lon/actions-label-merge-conflict@0273be72a0bbd58fcd71d0d6c02c209b50d1e5e1
+        uses: eps1lon/actions-label-merge-conflict@b8bf8341285ec9a4567d4318ba474fee998a6919
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           dirtyLabel: "needs-rebase"

--- a/.github/workflows/pr-check-deps.yml
+++ b/.github/workflows/pr-check-deps.yml
@@ -5,6 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Check PR Dependencies
     steps:
-    - uses: gregsdennis/dependencies-action@a8cccab69814b9b985496cf97cbfe154c96c03c7 # v1.4.2
+    - uses: gregsdennis/dependencies-action@f98d55eee1f66e7aaea4a60e71892736ae2548c7
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -8,21 +8,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign labels based on modified files
-        # https://github.com/marketplace/actions/labeler?version=v7.0.0
-        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13
+        # https://github.com/marketplace/actions/labeler?version=v4.0.2
+        uses: actions/labeler@5c7539237e04b714afd8ad9b4aed733815b9fab4
         with:
-          sync-labels: false
+          sync-labels: ''
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Assign to Dashboard project
-        # https://github.com/marketplace/actions/add-to-github-projects?version=v2.0.0
-        uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd
+        # https://github.com/marketplace/actions/add-to-github-projects?version=v0.5.0
+        uses: actions/add-to-project@31b3f3ccdc584546fc445612dec3f38ff5edb41c
         with:
           project-url: https://github.com/orgs/ceph/projects/2
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: dashboard
       - name: Assign milestone based on target brach name
-        # https://github.com/marketplace/actions/pull-request-milestone?version=v1.4.0
-        uses: iyu/actions-milestone@d3a96497d18f333d0419641cc3fcfbd02939a2aa
+        # https://github.com/marketplace/actions/pull-request-milestone?version=v1.3.0
+        uses: iyu/actions-milestone@e93115c90ff7bcddee71086e9253f1b6a5f4b48a
         with:
           configuration-path: .github/milestone.yml
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/redmine-upkeep.yml
+++ b/.github/workflows/redmine-upkeep.yml
@@ -55,7 +55,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.9'
           cache: 'pip'


### PR DESCRIPTION
This reverts commit 7bb58be6f9e140ff277a73a99a0091c6c6af4cad.

#70992 broke third-party Actions because the new versions were not whitelisted on GitHub "enterprise policy".





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
