### PR TITLE
fix rgw store concurrency

### DIFF
--- a/src/rgw/Cargo.lock
+++ b/src/rgw/Cargo.lock
@@ -4361,6 +4361,7 @@ dependencies = [
  "lance-io",
  "lazy_static",
  "libc",
+ "log",
  "object_store",
  "pkg-config",
  "tokio-test",

--- a/src/rgw/lancedb-rgw-store/Cargo.toml
+++ b/src/rgw/lancedb-rgw-store/Cargo.toml
@@ -24,6 +24,7 @@ futures = "0.3"
 url = "2"
 chrono = "0.4"
 libc = "0.2"
+log = "0.4"
 
 [build-dependencies]
 # For linking to Ceph libraries

--- a/src/rgw/lancedb-rgw-store/README.md
+++ b/src/rgw/lancedb-rgw-store/README.md
@@ -21,19 +21,15 @@ ninja radosgw
 
 When making changes to this crate during development:
 
+This crate is not built on its own: it is compiled into the `rgw-lancedb`
+umbrella crate, which is built by an ExternalProject of the same name, and
+produces the `librgw_lancedb.a` static library that the RGW is linked with.
+
 ```bash
-# Option 1: Use ninja to rebuild and copy the library
-rm ceph/src/rgw/lancedb-rgw-store
 cd ceph/build
-ninja lancedb-rgw-store
+rm -f src/rgw/rgw-lancedb-prefix/src/rgw-lancedb-stamp/rgw-lancedb-build
+ninja rgw-lancedb
 
-# Option 2: Build with cargo directly (faster iteration)
-cd ceph/src/rgw/lancedb-rgw-store
-cargo build --release
-
-# If using Option 2, ensure the build directory has a symlink to the target:
-# cd ceph/build/lib
-# ln -sf ../../src/lancedb-rgw-store/target/release/liblancedb_rgw_store.so .
 ```
 
 After rebuilding, restart the RGW daemon to pick up the changes.

--- a/src/rgw/lancedb-rgw-store/src/provider.rs
+++ b/src/rgw/lancedb-rgw-store/src/provider.rs
@@ -112,6 +112,14 @@ impl lance_io::object_store::ObjectStoreProvider for RGWStoreProvider {
             StorageOptions::new(params.storage_options().cloned().unwrap_or_default());
         let download_retry_count = storage_options.download_retry_count();
 
+        // whether listing is ordered is a property of the store, and not a
+        // choice of the caller, so a request for unordered listing is ignored.
+        if params.list_is_lexically_ordered == Some(false) {
+            log::debug!(
+                "ignoring the request for unordered listing: the listing of the RGW store is always ordered"
+            );
+        }
+
         Ok(ObjectStore::new(
             inner,
             base_path,
@@ -122,7 +130,7 @@ impl lance_io::object_store::ObjectStoreProvider for RGWStoreProvider {
             // to guarantee no duplicates or missing entries across pages.
             // RGW's unordered listing is cheaper but markers can skip/duplicate
             // entries across shard boundaries.
-            params.list_is_lexically_ordered.unwrap_or(true),
+            true,
             // Max concurrent I/O ops (64). Can be overridden via LANCE_IO_THREADS env var.
             DEFAULT_CLOUD_IO_PARALLELISM,
             download_retry_count,

--- a/src/rgw/lancedb-rgw-store/src/store.rs
+++ b/src/rgw/lancedb-rgw-store/src/store.rs
@@ -549,6 +549,21 @@ impl ObjectStore for RGWObjectStore {
                 }
 
                 let bytes = OwnedRGWBuffer(buffer).to_bytes();
+                if bytes.is_empty() {
+                    // the object was truncated after its size was read. the
+                    // offset would not advance,
+                    return Some((
+                        Err(object_store::Error::Generic {
+                            store: "rgw",
+                            source: format!(
+                                "read at offset {} returned no data, before the end of the range ({})",
+                                offset, range_end
+                            )
+                            .into(),
+                        }),
+                        range_end,
+                    ));
+                }
                 let next_offset = offset + bytes.len() as u64;
                 Some((Ok(bytes), next_offset))
             }

--- a/src/rgw/rgw_s3vector.cc
+++ b/src/rgw/rgw_s3vector.cc
@@ -84,7 +84,11 @@ namespace rgw::s3vector {
     return -EIO;
   }
 
-  static constexpr const char* RGW_PROVIDER_SCHEME = "rgw";
+  // the RGW provider is registered under the "s3" scheme, and not under one of
+  // its own. an unknown scheme is committed with the "unsafe" handler,
+  // which overwrites the manifest of a table without any precondition,
+  // so that concurrent writers lose each other's data.
+  static constexpr const char* RGW_PROVIDER_SCHEME = "s3";
 
   // Create a LanceDB session with RGW provider.
   // Returns a new session on success, nullptr on failure.

--- a/src/rgw/rgw_sal_wrapper.cc
+++ b/src/rgw/rgw_sal_wrapper.cc
@@ -24,6 +24,7 @@
 #include "rgw/rgw_compression_types.h"
 #include "common/dout.h"
 #include "common/errno.h"
+#include <fmt/format.h>
 #include "common/ceph_crypto.h"
 #include "global/global_context.h"
 #include "common/async/yield_context.h"
@@ -1110,15 +1111,10 @@ uint64_t rgw_get_max_chunk_size(CRgwDriver* driver_ptr) {
 }
 
 const char* rgw_sal_wrapper_version(void) {
-  static char version[16];
-  static bool initialized = false;
-  if (!initialized) {
-    snprintf(version, sizeof(version), "%d.%d",
-             RGW_SAL_WRAPPER_VERSION_MAJOR,
-             RGW_SAL_WRAPPER_VERSION_MINOR);
-    initialized = true;
-  }
-  return version;
+  static const std::string version = fmt::format("{}.{}",
+                                                 RGW_SAL_WRAPPER_VERSION_MAJOR,
+                                                 RGW_SAL_WRAPPER_VERSION_MINOR);
+  return version.c_str();
 }
 
 } // extern "C"

--- a/src/test/rgw/s3vectors/s3vector_test.py
+++ b/src/test/rgw/s3vectors/s3vector_test.py
@@ -1567,23 +1567,75 @@ def test_update_vectors():
 
 @pytest.mark.vector_test
 def test_update_vectors_single_index():
+    """
+    Vectors written concurrently to the same index must not be lost.
+    """
     conn = connection()
     bucket_name = gen_bucket_name()
     _ensure_s3_bucket_for_vector_bucket(bucket_name)
     result = conn.create_vector_bucket(vectorBucketName=bucket_name)
     assert result['ResponseMetadata']['HTTPStatusCode'] == 200
     num_threads = 10
+    rounds = 3
+    vectors_per_round = 5
     dimension = 128
-    threads = []
     index_name = 'test-index'
-    result = conn.create_index(vectorBucketName=bucket_name, indexName=index_name, dataType='float32', dimension=dimension, distanceMetric='euclidean')
+    result = conn.create_index(vectorBucketName=bucket_name, indexName=index_name,
+                               dataType='float32', dimension=dimension, distanceMetric='euclidean')
     assert result['ResponseMetadata']['HTTPStatusCode'] == 200
-    for i in range(num_threads):
-        t = threading.Thread(target=update_vectors_thread, args=(conn, bucket_name, index_name, dimension, True))
+
+    def vector_key(thread_id, round_id, i):
+        return f't{thread_id}-r{round_id}-vec-{i}'
+
+    # an assertion inside a thread does not fail the test, so the failures are
+    # collected and verified once the threads are done
+    errors = []
+
+    def put_vectors_thread(thread_id):
+        try:
+            # a connection is not shared between the threads
+            thread_conn = connection()
+            for round_id in range(rounds):
+                vectors = [{'key': vector_key(thread_id, round_id, i),
+                            'data': generate_data(dimension, i)}
+                           for i in range(vectors_per_round)]
+                res = thread_conn.put_vectors(vectorBucketName=bucket_name,
+                                              indexName=index_name, vectors=vectors)
+                status = res['ResponseMetadata']['HTTPStatusCode']
+                if status != 200:
+                    errors.append(f'thread {thread_id} round {round_id}: status {status}')
+        except Exception as e:
+            errors.append(f'thread {thread_id}: {e}')
+
+    threads = [threading.Thread(target=put_vectors_thread, args=(i,)) for i in range(num_threads)]
+    for t in threads:
         t.start()
-        threads.append(t)
     for t in threads:
         t.join()
+
+    assert not errors, 'concurrent put_vectors failed: ' + '; '.join(errors)
+
+    expected_keys = {vector_key(t, r, i)
+                     for t in range(num_threads)
+                     for r in range(rounds)
+                     for i in range(vectors_per_round)}
+    listed_keys = set()
+    next_token = None
+    while True:
+        kwargs = dict(vectorBucketName=bucket_name, indexName=index_name, maxResults=500)
+        if next_token:
+            kwargs['nextToken'] = next_token
+        result = conn.list_vectors(**kwargs)
+        assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+        listed_keys.update(v['key'] for v in result.get('vectors', []))
+        next_token = result.get('nextToken')
+        if not next_token:
+            break
+
+    missing = sorted(expected_keys - listed_keys)
+    assert not missing, \
+        f'{len(missing)} of {len(expected_keys)} vectors were lost by concurrent commits, ' \
+        f'first missing: {missing[:5]}'
 
     # cleanup
     _ = _delete_vector_bucket(conn, bucket_name)


### PR DESCRIPTION


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
