### PR TITLE
osd: add option osd_numa_auto_affinity_policy

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -14,8 +14,36 @@ options:
 - name: osd_numa_auto_affinity
   type: bool
   level: advanced
-  desc: automatically set affinity to numa node when storage and network match
+  desc: automatically set affinity to numa node based on osd_numa_auto_affinity_policy
   default: true
+  see_also:
+  - osd_numa_auto_affinity_policy
+  flags:
+  - startup
+- name: osd_numa_auto_affinity_policy
+  type: str
+  level: advanced
+  desc: policy for automatically setting numa node affinity
+  long_desc: This specifies the policy for automatically setting the OSD's NUMA node affinity
+    when osd_numa_auto_affinity is enabled.
+  fmt_desc:
+    This specifies the policy for automatically setting the OSD's NUMA node affinity when
+    ``osd_numa_auto_affinity`` is enabled. The ``storage`` setting uses the NUMA node
+    shared by all storage devices used by the OSD. The ``public_network`` and ``cluster_network``
+    settings use the NUMA node of the corresponding network interface. The ``network`` setting
+    sets NUMA affinity only when the public and cluster network interfaces are associated with
+    the same NUMA node. The ``all`` setting sets NUMA affinity only when all storage devices
+    and both network interfaces are associated with the same NUMA node.
+    If the NUMA node cannot be determined, or if the required NUMA nodes do not match, no NUMA affinity is set.
+  default: storage
+  see_also:
+  - osd_numa_auto_affinity
+  enum_values:
+  - all
+  - storage
+  - network
+  - public_network
+  - cluster_network
   flags:
   - startup
 - name: osd_numa_node

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2581,84 +2581,133 @@ int OSD::pre_init()
   return 0;
 }
 
-int OSD::set_numa_affinity()
+int OSD::set_numa_node(int node)
 {
-  // storage numa node
-  int store_node = -1;
-  store->get_numa_node(&store_node, nullptr, nullptr);
-  if (store_node >= 0) {
-    dout(1) << __func__ << " storage numa node " << store_node << dendl;
+  int r = get_numa_node_cpu_set(node, &numa_cpu_set_size, &numa_cpu_set);
+  if (r < 0) {
+    dout(1) << __func__ << " unable to determine numa node " << node
+	    << " CPUs" << dendl;
+    return r;
   }
 
-  // check network numa node(s)
-  int front_node = -1, back_node = -1;
-  string front_iface = pick_iface(
-    cct,
-    client_messenger->get_myaddrs().front().get_sockaddr_storage());
-  string back_iface = pick_iface(
-    cct,
-    cluster_messenger->get_myaddrs().front().get_sockaddr_storage());
-  int r = get_iface_numa_node(front_iface, &front_node);
-  if (r >= 0 && front_node >= 0) {
-    dout(1) << __func__ << " public network " << front_iface << " numa node "
-            << front_node << dendl;
-    r = get_iface_numa_node(back_iface, &back_node);
-    if (r >= 0 && back_node >= 0) {
+  dout(1) << __func__ << " setting numa affinity to node " << node << " cpus "
+	  << cpu_set_to_str_list(numa_cpu_set_size, &numa_cpu_set) << dendl;
+
+  r = set_cpu_affinity_all_threads(numa_cpu_set_size, &numa_cpu_set);
+  if (r < 0) {
+    derr << __func__ << " failed to set numa affinity: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  numa_node = node;
+
+  return 0;
+}
+
+int OSD::set_numa_affinity()
+{
+  if (int node = g_conf().get_val<int64_t>("osd_numa_node"); node >= 0) {
+    // this takes precedence over the automagic logic
+    return set_numa_node(node);
+  }
+
+  if (!g_conf().get_val<bool>("osd_numa_auto_affinity")) {
+    return 0;
+  }
+
+  string affinity_policy = g_conf().get_val<string>("osd_numa_auto_affinity_policy");
+  dout(1) << __func__ << " numa auto affinity policy is " << affinity_policy << dendl;
+
+  // storage numa node
+  int store_node = -1;
+  if (affinity_policy == "storage" || affinity_policy == "all") {
+    set<int> nodes;
+    store->get_numa_node(&store_node, &nodes, nullptr);
+    if (store_node >= 0) {
+      dout(1) << __func__ << " storage numa node " << store_node << dendl;
+      if (affinity_policy == "storage") {
+	return set_numa_node(store_node);
+      }
+    } else {
+      if (nodes.size() > 0) {
+	dout(1) << __func__ << " storage numa nodes do not match" << dendl;
+      } else {
+	dout(1) << __func__ << " unable to identify storage numa node" << dendl;
+      }
+      dout(1) << __func__ << " not setting numa affinity" << dendl;
+      return 0;
+    }
+  }
+
+  // public network numa node
+  int front_node = -1;
+  if (affinity_policy == "public_network" || affinity_policy == "network" || affinity_policy == "all") {
+    string front_iface = pick_iface(cct,
+      client_messenger->get_myaddrs().front().get_sockaddr_storage());
+    if (int r = get_iface_numa_node(front_iface, &front_node); r >= 0 && front_node >= 0) {
+      dout(1) << __func__ << " public network " << front_iface << " numa node "
+	      << front_node << dendl;
+      if (affinity_policy == "public_network") {
+	return set_numa_node(front_node);
+      }
+    } else {
+      if (front_node == -2) {
+	dout(1) << __func__ << " public network " << front_iface
+		<< " ports numa nodes do not match" << dendl;
+      } else {
+	dout(1) << __func__ << " unable to identify public interface '" << front_iface
+		<< "' numa node: " << cpp_strerror(r) << dendl;
+      }
+      dout(1) << __func__ << " not setting numa affinity" << dendl;
+      return 0;
+    }
+  }
+
+  // cluster network numa node
+  int back_node = -1;
+  if (affinity_policy == "cluster_network" || affinity_policy == "network" || affinity_policy == "all") {
+    string back_iface = pick_iface(cct,
+      cluster_messenger->get_myaddrs().front().get_sockaddr_storage());
+    if (int r = get_iface_numa_node(back_iface, &back_node); r >= 0 && back_node >= 0) {
       dout(1) << __func__ << " cluster network " << back_iface << " numa node "
 	      << back_node << dendl;
-      if (front_node == back_node &&
-	  front_node == store_node) {
-	dout(1) << " objectstore and network numa nodes all match" << dendl;
-	if (g_conf().get_val<bool>("osd_numa_auto_affinity")) {
-	  numa_node = front_node;
-	}
-      } else if (front_node != back_node) {
-        dout(1) << __func__ << " public and cluster network numa nodes do not match"
-                << dendl;
+      if (affinity_policy == "cluster_network") {
+	return set_numa_node(back_node);
+      }
+    } else {
+      if (back_node == -2) {
+	dout(1) << __func__ << " cluster network " << back_iface
+		<< " ports numa nodes do not match" << dendl;
       } else {
-	dout(1) << __func__ << " objectstore and network numa nodes do not match"
-		<< dendl;
+	dout(1) << __func__ << " unable to identify cluster interface '" << back_iface
+		<< "' numa node: " << cpp_strerror(r) << dendl;
       }
-    } else if (back_node == -2) {
-      dout(1) << __func__ << " cluster network " << back_iface
-              << " ports numa nodes do not match" << dendl;
-    } else {
-      derr << __func__ << " unable to identify cluster interface '" << back_iface
-           << "' numa node: " << cpp_strerror(r) << dendl;
+      dout(1) << __func__ << " not setting numa affinity" << dendl;
+      return 0;
     }
-  } else if (front_node == -2) {
-    dout(1) << __func__ << " public network " << front_iface
-            << " ports numa nodes do not match" << dendl;
-  } else {
-    derr << __func__ << " unable to identify public interface '" << front_iface
-	 << "' numa node: " << cpp_strerror(r) << dendl;
   }
-  if (int node = g_conf().get_val<int64_t>("osd_numa_node"); node >= 0) {
-    // this takes precedence over the automagic logic above
-    numa_node = node;
-  }
-  if (numa_node >= 0) {
-    int r = get_numa_node_cpu_set(numa_node, &numa_cpu_set_size, &numa_cpu_set);
-    if (r < 0) {
-      dout(1) << __func__ << " unable to determine numa node " << numa_node
-	      << " CPUs" << dendl;
-      numa_node = -1;
-    } else {
-      dout(1) << __func__ << " setting numa affinity to node " << numa_node
-	      << " cpus "
-	      << cpu_set_to_str_list(numa_cpu_set_size, &numa_cpu_set)
-	      << dendl;
-      r = set_cpu_affinity_all_threads(numa_cpu_set_size, &numa_cpu_set);
-      if (r < 0) {
-	r = -errno;
-	derr << __func__ << " failed to set numa affinity: " << cpp_strerror(r)
-	     << dendl;
-	numa_node = -1;
-      }
+
+  ceph_assert(affinity_policy == "network" || affinity_policy == "all");
+
+  ceph_assert(front_node >= 0);
+  ceph_assert(back_node >= 0);
+  if (affinity_policy == "network") {
+    if (front_node == back_node) {
+      dout(1) << __func__ << " network numa nodes match" << dendl;
+      return set_numa_node(front_node);
     }
-  } else {
-    dout(1) << __func__ << " not setting numa affinity" << dendl;
+    dout(1) << __func__ << " not setting numa affinity, network numa nodes do not match: public_network="
+	    << front_node << " cluster_network=" << back_node << dendl;
+    return 0;
   }
+
+  ceph_assert(store_node >= 0);
+  if (store_node == front_node && front_node == back_node) {
+    dout(1) << __func__ << " storage and network numa nodes all match" << dendl;
+    return set_numa_node(store_node);
+  }
+  dout(1) << __func__ << " not setting numa affinity, numa nodes do not match: storage=" << store_node
+	  << " public_network=" << front_node << " cluster_network=" << back_node << dendl;
   return 0;
 }
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2254,6 +2254,7 @@ public:
   void final_init();
 
   int enable_disable_fuse(bool stop);
+  int set_numa_node(int node);
   int set_numa_affinity();
 
   void suicide(int exitcode);


### PR DESCRIPTION
This option specifies the policy for automatically setting the OSD's NUMA node affinity.

Signed-off-by: Zhansong Gao zhsgao@hotmail.com


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
