### PR TITLE
doc/install: fix empty Upgrade toctree and tab indentation

### DIFF
--- a/doc/install/index_manual.rst
+++ b/doc/install/index_manual.rst
@@ -19,12 +19,12 @@ repository and build Ceph yourself.
 .. toctree::
    :maxdepth: 1
 
-	Get Packages <get-packages>
-	Get Tarballs <get-tarballs>
-	Clone Source <clone-source>
-	Build Ceph <build-ceph>
-    	Ceph Mirrors <mirrors>
-	Ceph Containers <containers>
+   Get Packages <get-packages>
+   Get Tarballs <get-tarballs>
+   Clone Source <clone-source>
+   Build Ceph <build-ceph>
+   Ceph Mirrors <mirrors>
+   Ceph Containers <containers>
 
 
 Install Software
@@ -39,8 +39,8 @@ QEMU.
 .. toctree::
    :maxdepth: 1
 
-	Install Ceph Storage Cluster <install-storage-cluster>
-	Install Virtualization for Block <install-vm-cloud>
+   Install Ceph Storage Cluster <install-storage-cluster>
+   Install Virtualization for Block <install-vm-cloud>
 
 
 Deploy a Cluster Manually
@@ -52,17 +52,16 @@ deployment scripts with Chef, Juju, Puppet, etc.
 
 .. toctree::
 
-	Manual Deployment <manual-deployment>
-	Manual Deployment on FreeBSD <manual-freebsd-deployment>
+   Manual Deployment <manual-deployment>
+   Manual Deployment on FreeBSD <manual-freebsd-deployment>
 
 Upgrade Software
 ================
 
-As new versions of Ceph become available, you may upgrade your cluster to take
-advantage of new functionality. Read the upgrade documentation before you
-upgrade your cluster. Sometimes upgrading Ceph requires you to follow an upgrade
-sequence.
-
-.. toctree::
-   :maxdepth: 2
+As new versions of Ceph become available, you may upgrade your cluster to
+take advantage of new functionality. Read the release notes of the new
+version before you upgrade your cluster: they document the required
+upgrade sequence and any release-specific steps. See the :ref:`releases
+index <ceph-releases-general>` for the release notes, and
+:doc:`/cephadm/upgrade` if your cluster is managed by cephadm.
 

--- a/doc/install/index_manual.rst
+++ b/doc/install/index_manual.rst
@@ -59,7 +59,8 @@ Upgrade Software
 ================
 
 As new versions of Ceph become available, you may upgrade your cluster to
-take advantage of new functionality. Read the release notes of the new
+take advantage of new functionality, as well as bug fixes and performance
+and security enhancements. Read the release notes of the new
 version before you upgrade your cluster: they document the required
 upgrade sequence and any release-specific steps. See the :ref:`releases
 index <ceph-releases-general>` for the release notes, and


### PR DESCRIPTION
The Upgrade Software section in install/index_manual.rst ended with an empty toctree that rendered nothing. Point at the release notes and the cephadm upgrade guide instead, and normalize the tab-indented toctree entries to spaces.

Fixes: https://tracker.ceph.com/issues/79042

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
