### PR TITLE
doc: convert http links to https across user-facing docs

### DIFF
--- a/doc/cephadm/services/smb.rst
+++ b/doc/cephadm/services/smb.rst
@@ -16,8 +16,8 @@ SMB Service
 Deploying Samba Containers
 ==========================
 
-Cephadm deploys `Samba <http://www.samba.org>`_ servers using container images
-built by the `samba-container project <http://github.com/samba-in-kubernetes/samba-container>`_.
+Cephadm deploys `Samba <https://www.samba.org>`_ servers using container images
+built by the `samba-container project <https://github.com/samba-in-kubernetes/samba-container>`_.
 
 In order to host SMB shares with access to CephFS file systems, deploy
 Samba containers with the following command:

--- a/doc/cephfs/mantle.rst
+++ b/doc/cephfs/mantle.rst
@@ -27,7 +27,7 @@ following features from that paper:
 #. "Instantaneous CPU utilization" as a metric.
 
 [1] Supercomputing '15 Paper:
-http://sc15.supercomputing.org/schedule/event_detail-evid=pap168.html
+https://sc15.supercomputing.org/schedule/event_detail-evid=pap168.html
 
 Quickstart with vstart
 ----------------------

--- a/doc/cephfs/quota.rst
+++ b/doc/cephfs/quota.rst
@@ -135,4 +135,4 @@ Limitations
    See also: https://tracker.ceph.com/issues/55090
 
 #. *Snapshot file data which has since been deleted or changed does not count
-   towards the quota.* See also: http://tracker.ceph.com/issues/24284
+   towards the quota.* See also: https://tracker.ceph.com/issues/24284

--- a/doc/cephfs/troubleshooting.rst
+++ b/doc/cephfs/troubleshooting.rst
@@ -593,5 +593,5 @@ If you are satisfied that you have found a bug, please file it on `the bug
 tracker`. For more general queries, please write to the `ceph-users mailing
 list`.
 
-.. _the bug tracker: http://tracker.ceph.com
-.. _ceph-users mailing list:  http://lists.ceph.com/listinfo.cgi/ceph-users-ceph.com/
+.. _the bug tracker: https://tracker.ceph.com
+.. _ceph-users mailing list:  https://lists.ceph.io/hyperkitty/list/ceph-users@ceph.io/

--- a/doc/install/install-vm-cloud.rst
+++ b/doc/install/install-vm-cloud.rst
@@ -126,7 +126,7 @@ See `libvirt Installation`_ for details.
 
 
 
-.. _libvirt Installation: http://www.libvirt.org/compiling.html
-.. _AutoGen: http://www.gnu.org/software/autogen/
+.. _libvirt Installation: https://www.libvirt.org/compiling.html
+.. _AutoGen: https://www.gnu.org/software/autogen/
 .. _QEMU and Block Devices: ../../rbd/qemu-rbd
 .. _Using libvirt with Ceph Block Device: ../../rbd/libvirt

--- a/doc/install/mirrors.rst
+++ b/doc/install/mirrors.rst
@@ -16,15 +16,15 @@ Locations
 
 These mirrors are available on the following locations:
 
-- **EU: Netherlands**: http://eu.ceph.com/
-- **AU: Australia**: http://au.ceph.com/
+- **EU: Netherlands**: https://eu.ceph.com/
+- **AU: Australia**: https://au.ceph.com/
 - **SE: Sweden**: http://se.ceph.com/
 - **DE: Germany**: http://de.ceph.com/
 - **FR: France**: http://fr.ceph.com/
-- **UK: UK**: http://uk.ceph.com
-- **US-Mid-West: Chicago**: http://mirrors.gigenet.com/ceph/
+- **UK: UK**: https://uk.ceph.com
+- **US-Mid-West: Chicago**: https://mirrors.gigenet.com/ceph/
 - **US-West: US West Coast**: http://us-west.ceph.com/
-- **CN: China**: http://mirrors.ustc.edu.cn/ceph/
+- **CN: China**: https://mirrors.ustc.edu.cn/ceph/
 
 You can replace all ``download.ceph.com`` URLs with any of the mirrors,
 for example:

--- a/doc/mgr/modules.rst
+++ b/doc/mgr/modules.rst
@@ -456,7 +456,7 @@ be automatically processed. Example:
            raise ErrorResponse.wrap(err)
 
 
-.. _`Rule of Silence`: http://www.linfo.org/rule_of_silence.html
+.. _`Rule of Silence`: https://www.linfo.org/rule_of_silence.html
 
 .. _mgr module dev configuration options:
 

--- a/doc/rados/configuration/bluestore-config-ref.rst
+++ b/doc/rados/configuration/bluestore-config-ref.rst
@@ -385,7 +385,7 @@ SPDK Usage
 To use the SPDK driver for NVMe devices, you must first prepare your system.
 See `SPDK document`__.
 
-.. __: http://www.spdk.io/doc/getting_started.html#getting_started_examples
+.. __: https://www.spdk.io/doc/getting_started.html#getting_started_examples
 
 SPDK offers a script that will configure the device automatically. Run this
 script with root permissions:

--- a/doc/rados/operations/erasure-code-shec.rst
+++ b/doc/rados/operations/erasure-code-shec.rst
@@ -8,7 +8,7 @@ The SHEC plugin is deprecated. Support for this plugin will be removed in
 the Vampire release.
 
 The *shec* plugin encapsulates the `multiple SHEC
-<http://tracker.ceph.com/projects/ceph/wiki/Shingled_Erasure_Code_(SHEC)>`_
+<https://tracker.ceph.com/projects/ceph/wiki/Shingled_Erasure_Code_(SHEC)>`_
 library. It allows Ceph to recover data more efficiently than Reed-Solomon codes.
 
 Create an SHEC profile

--- a/doc/rados/operations/operating.rst
+++ b/doc/rados/operations/operating.rst
@@ -116,4 +116,4 @@ For example:
    sudo systemctl stop ceph-mds@ceph-server
 
 
-.. _Valgrind: http://www.valgrind.org/
+.. _Valgrind: https://www.valgrind.org/

--- a/doc/rados/troubleshooting/cpu-profiling.rst
+++ b/doc/rados/troubleshooting/cpu-profiling.rst
@@ -74,7 +74,7 @@ Run the following command to reset ``oprofile``:
    results from prior tests do not get mixed in with the results of the current
    test. 
 
-.. _oprofile: http://oprofile.sourceforge.net/about/
+.. _oprofile: https://oprofile.sourceforge.net/about/
 .. _Installing Oprofile: ../../../dev/cpu-profiler
 
 

--- a/doc/rados/troubleshooting/memory-profiling.rst
+++ b/doc/rados/troubleshooting/memory-profiling.rst
@@ -187,7 +187,7 @@ For example:
    ceph tell osd.0 heap stop_profiler
 
 .. _Logging and Debugging: ../log-and-debug
-.. _Google Heap Profiler: http://goog-perftools.sourceforge.net/doc/heap_profiler.html
+.. _Google Heap Profiler: https://goog-perftools.sourceforge.net/doc/heap_profiler.html
 
 Alternative Methods of  Memory Profiling
 ----------------------------------------

--- a/doc/rados/troubleshooting/troubleshooting-mon.rst
+++ b/doc/rados/troubleshooting/troubleshooting-mon.rst
@@ -717,7 +717,7 @@ Reaching Out for Help
 ---------------------
 
 You can find help on IRC in #ceph and #ceph-devel on OFTC (server
-irc.oftc.net), or at ``dev@ceph.io`` and ``ceph-users@lists.ceph.com``. Make
+irc.oftc.net), or at ``dev@ceph.io`` and ``ceph-users@ceph.io``. Make
 sure that you have prepared your logs and that you have them ready upon
 request.
 
@@ -830,7 +830,7 @@ logs based on that information.
 Contact the upstream Ceph community on the mailing lists or IRC or Slack, or by
 filing a new issue on the `Ceph bug tracker`_.
 
-.. _Ceph bug tracker: http://tracker.ceph.com/projects/ceph/issues/new
+.. _Ceph bug tracker: https://tracker.ceph.com/projects/ceph/issues/new
 
 .. |---|   unicode:: U+2014 .. EM DASH
    :trim:

--- a/doc/rados/troubleshooting/troubleshooting-osd.rst
+++ b/doc/rados/troubleshooting/troubleshooting-osd.rst
@@ -1014,7 +1014,7 @@ being marked ``out`` (regardless of the current value of
 
 .. _subscribe to the ceph-devel email list: mailto:majordomo@vger.kernel.org?body=subscribe+ceph-devel
 .. _unsubscribe from the ceph-devel email list: mailto:majordomo@vger.kernel.org?body=unsubscribe+ceph-devel
-.. _subscribe to the ceph-users email list: mailto:ceph-users-join@lists.ceph.com
-.. _unsubscribe from the ceph-users email list: mailto:ceph-users-leave@lists.ceph.com
+.. _subscribe to the ceph-users email list: mailto:ceph-users-join@ceph.io
+.. _unsubscribe from the ceph-users email list: mailto:ceph-users-leave@ceph.io
 .. _OS recommendations: ../../../start/os-recommendations
 .. _ceph-devel: ceph-devel@vger.kernel.org

--- a/doc/rados/troubleshooting/troubleshooting-pg.rst
+++ b/doc/rados/troubleshooting/troubleshooting-pg.rst
@@ -567,7 +567,7 @@ For example:
 If you receive ``active+clean+inconsistent`` states periodically due to
 clock skew, consider configuring the `NTP
 <https://en.wikipedia.org/wiki/Network_Time_Protocol>`_ daemons on your monitor
-hosts to act as peers. See `The Network Time Protocol <http://www.ntp.org>`_
+hosts to act as peers. See `The Network Time Protocol <https://www.ntp.org>`_
 and Ceph :ref:`Clock Settings <mon-config-ref-clock>` for more information.
 
 

--- a/doc/radosgw/barbican.rst
+++ b/doc/radosgw/barbican.rst
@@ -119,5 +119,5 @@ When using API version 3::
 .. _Barbican: https://wiki.openstack.org/wiki/Barbican
 .. _Manage projects, users, and roles: https://docs.openstack.org/admin-guide/cli-manage-projects-users-and-roles.html#create-a-user
 .. _How to Create a Secret: https://developer.openstack.org/api-guide/key-manager/secrets.html#how-to-create-a-secret
-.. _SSE-KMS: http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html
+.. _SSE-KMS: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html
 .. _How to Set/Replace ACL: https://developer.openstack.org/api-guide/key-manager/acls.html#how-to-set-replace-acl

--- a/doc/radosgw/encryption.rst
+++ b/doc/radosgw/encryption.rst
@@ -199,11 +199,11 @@ In addition the ``rgw`` collection has:
 
 .. _Linux Kernel Key Retention Service:  https://www.kernel.org/doc/html/latest/security/keys/core.html
 .. _Amazon SSE-C: https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html
-.. _Amazon SSE-KMS: http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html
+.. _Amazon SSE-KMS: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html
 .. _Amazon SSE-S3: https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html
 .. _Barbican: https://wiki.openstack.org/wiki/Barbican
 .. _Vault: https://www.vaultproject.io/docs/
-.. _KMIP: http://www.oasis-open.org/committees/kmip/
+.. _KMIP: https://www.oasis-open.org/committees/kmip/
 .. _PutBucketEncryption: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketEncryption.html
 .. _GetBucketEncryption: https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketEncryption.html
 .. _DeleteBucketEncryption: https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketEncryption.html

--- a/doc/radosgw/keystone.rst
+++ b/doc/radosgw/keystone.rst
@@ -139,7 +139,7 @@ OpenStack clients with a ``--insecure`` switch) by setting the value of the
 configurable ``rgw keystone verify ssl`` to false.
 
 
-.. _OpenStack Keystone documentation: http://docs.openstack.org/developer/keystone/configuringservices.html#setting-up-projects-users-and-roles
+.. _OpenStack Keystone documentation: https://docs.openstack.org/developer/keystone/configuringservices.html#setting-up-projects-users-and-roles
 
 Cross-Project (Tenant) Access
 -----------------------------

--- a/doc/radosgw/kmip.rst
+++ b/doc/radosgw/kmip.rst
@@ -209,6 +209,6 @@ radosgw would fetch the secret from::
 
   pykmip-mybucketkey
 
-.. _KMIP: http://www.oasis-open.org/committees/kmip/
+.. _KMIP: https://www.oasis-open.org/committees/kmip/
 .. _SKLM: https://www.ibm.com/products/ibm-security-key-lifecycle-manager
 .. _PyKMIP: https://pykmip.readthedocs.io/en/latest/

--- a/doc/radosgw/nfs.rst
+++ b/doc/radosgw/nfs.rst
@@ -369,4 +369,4 @@ in the RGW section(s) of the Ceph configuration file.
 References
 ==========
 
-.. [#] http://docs.aws.amazon.com/AmazonS3/latest/dev/ListingKeysHierarchy.html
+.. [#] https://docs.aws.amazon.com/AmazonS3/latest/dev/ListingKeysHierarchy.html

--- a/doc/radosgw/s3.rst
+++ b/doc/radosgw/s3.rst
@@ -105,4 +105,4 @@ The following common request header fields are not supported:
 | **x-amz-id-2**             | Response   |
 +----------------------------+------------+
 
-.. _Amazon S3 API: http://docs.aws.amazon.com/AmazonS3/latest/API/APIRest.html
+.. _Amazon S3 API: https://docs.aws.amazon.com/AmazonS3/latest/API/APIRest.html

--- a/doc/radosgw/s3/perl.rst
+++ b/doc/radosgw/s3/perl.rst
@@ -186,7 +186,7 @@ The output will look something like this::
    http://objects.dreamhost.com:80/my-bucket-name/secret_plans.txt?Signature=XXXXXXXXXXXXXXXXXXXXXXXXXXX&Expires=1316027075&AWSAccessKeyId=XXXXXXXXXXXXXXXXXXX
 
 
-.. _`Amazon::S3`: http://search.cpan.org/~tima/Amazon-S3-0.441/lib/Amazon/S3.pm
-.. _`Amazon::S3::Bucket`: http://search.cpan.org/~tima/Amazon-S3-0.441/lib/Amazon/S3/Bucket.pm
-.. _`Muck::FS::S3`: http://search.cpan.org/~mike/Muck-0.02/
+.. _`Amazon::S3`: https://search.cpan.org/~tima/Amazon-S3-0.441/lib/Amazon/S3.pm
+.. _`Amazon::S3::Bucket`: https://search.cpan.org/~tima/Amazon-S3-0.441/lib/Amazon/S3/Bucket.pm
+.. _`Muck::FS::S3`: https://search.cpan.org/~mike/Muck-0.02/
 

--- a/doc/radosgw/s3/ruby.rst
+++ b/doc/radosgw/s3/ruby.rst
@@ -184,7 +184,7 @@ The output of this will look something like::
    http://objects.dreamhost.com/my-bucket-name/hello.txt
    http://objects.dreamhost.com/my-bucket-name/secret_plans.txt?Signature=XXXXXXXXXXXXXXXXXXXXXXXXXXX&Expires=1316027075&AWSAccessKeyId=XXXXXXXXXXXXXXXXXXX
 
-.. _`AWS::SDK`: http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html
+.. _`AWS::SDK`: https://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html
 
 
 
@@ -359,6 +359,6 @@ The output of this will look something like::
    http://objects.dreamhost.com/my-bucket-name/hello.txt
    http://objects.dreamhost.com/my-bucket-name/secret_plans.txt?Signature=XXXXXXXXXXXXXXXXXXXXXXXXXXX&Expires=1316027075&AWSAccessKeyId=XXXXXXXXXXXXXXXXXXX
 
-.. _`AWS::S3`: http://amazon.rubyforge.org/
-.. _`AWS::S3::Bucket`: http://amazon.rubyforge.org/doc/
+.. _`AWS::S3`: https://rubygems.org/gems/aws-s3
+.. _`AWS::S3::Bucket`: https://www.rubydoc.info/gems/aws-s3
 

--- a/doc/rbd/libvirt.rst
+++ b/doc/rbd/libvirt.rst
@@ -307,14 +307,14 @@ If everything looks okay, you may begin using the Ceph block device
 within your VM.
 
 
-.. _libvirt Virtualization API: http://www.libvirt.org
+.. _libvirt Virtualization API: https://www.libvirt.org
 .. _Block Devices and OpenStack: ../rbd-openstack
 .. _Block Devices and OpenNebula: https://docs.opennebula.io/stable/open_cluster_deployment/storage_setup/ceph_ds.html#datastore-internals
 .. _Block Devices and CloudStack: ../rbd-cloudstack
 .. _create an image: ../qemu-rbd#creating-images-with-qemu
-.. _Virsh Command Reference: http://www.libvirt.org/virshcmdref.html
+.. _Virsh Command Reference: https://libvirt.org/manpages/virsh.html
 .. _KVM/VirtManager: https://help.ubuntu.com/community/KVM/VirtManager
-.. _Disks: http://www.libvirt.org/formatdomain.html#elementsDisks
+.. _Disks: https://www.libvirt.org/formatdomain.html#elementsDisks
 .. _rbd create: ../rados-rbd-cmds#creating-a-block-device-image
 .. _User Management - CLI: ../../rados/operations/user-management#command-line-usage
-.. _Virtio: http://www.linux-kvm.org/page/Virtio
+.. _Virtio: https://www.linux-kvm.org/page/Virtio

--- a/doc/rbd/qemu-rbd.rst
+++ b/doc/rbd/qemu-rbd.rst
@@ -211,8 +211,8 @@ are explicitly set in the Ceph configuration file).
    in the Ceph configuration file, your Ceph settings override the QEMU cache
    settings.
 
-.. _QEMU Open Source Processor Emulator: http://wiki.qemu.org/Main_Page
-.. _QEMU Manual: http://wiki.qemu.org/Manual
+.. _QEMU Open Source Processor Emulator: https://wiki.qemu.org/Main_Page
+.. _QEMU Manual: https://wiki.qemu.org/Manual
 .. _RBD Cache: ../rbd-config-ref/
 .. _Snapshots: ../rbd-snapshot/
 .. _Installation: ../../install

--- a/doc/rbd/rbd-cloudstack.rst
+++ b/doc/rbd/rbd-cloudstack.rst
@@ -151,7 +151,7 @@ Limitations
 .. _Placement Groups: ../../rados/operations/placement-groups
 .. _Install and Configure QEMU: ../qemu-rbd
 .. _Install and Configure libvirt: ../libvirt
-.. _KVM Hypervisor Host Installation: http://docs.cloudstack.apache.org/en/latest/installguide/hypervisor/kvm.html
-.. _Storage Tags: http://docs.cloudstack.apache.org/en/latest/adminguide/storage.html#storage-tags
-.. _Create a New Disk Offering: http://docs.cloudstack.apache.org/en/latest/adminguide/service_offerings.html#creating-a-new-disk-offering
+.. _KVM Hypervisor Host Installation: https://docs.cloudstack.apache.org/en/latest/installguide/hypervisor/kvm.html
+.. _Storage Tags: https://docs.cloudstack.apache.org/en/latest/adminguide/storage.html#storage-tags
+.. _Create a New Disk Offering: https://docs.cloudstack.apache.org/en/latest/adminguide/service_offerings.html#creating-a-new-disk-offering
 .. _User Management: ../../rados/operations/user-management

--- a/doc/rbd/rbd-openstack.rst
+++ b/doc/rbd/rbd-openstack.rst
@@ -211,7 +211,7 @@ Edit ``/etc/glance/glance-api.conf`` and add under the ``[glance_store]`` sectio
     rbd_store_ceph_conf = /etc/ceph/ceph.conf
     rbd_store_chunk_size = 8
 
-For more information about the configuration options available in Glance please refer to the OpenStack Configuration Reference: http://docs.openstack.org/.
+For more information about the configuration options available in Glance please refer to the OpenStack Configuration Reference: https://docs.openstack.org/.
 
 Enable copy-on-write cloning of images
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/rbd/rbd-windows.rst
+++ b/doc/rbd/rbd-windows.rst
@@ -91,7 +91,7 @@ The following sample imports an RBD image and boots a Hyper-V VM using it::
     # Feel free to use any other image. This one is convenient to use for
     # testing purposes because it's very small (~15MB) and the login prompt
     # prints the pre-configured password.
-    wget http://download.cirros-cloud.net/0.5.1/cirros-0.5.1-x86_64-disk.img `
+    wget https://download.cirros-cloud.net/0.5.1/cirros-0.5.1-x86_64-disk.img `
          -OutFile cirros-0.5.1-x86_64-disk.img
 
     # We'll need to make sure that the imported images are raw (so no qcow2 or vhdx).


### PR DESCRIPTION
Converted http:// links to https:// across the user-facing doc directories. Every converted URL was verified to respond over https before conversion. Dead links were retargeted: the ceph-users list to lists.ceph.io, the rubyforge AWS::S3 docs to rubygems/rubydoc, and the libvirt virsh reference to the current manpage. Deliberately unchanged: the de/fr/us-west ceph.com mirror entries (those hosts serve http only), se.ceph.com (host appears dead entirely, flagging for a separate decision on removal), the libvirt XML namespace URI (an identifier, not a link), and historical release notes.

Fixes: https://tracker.ceph.com/issues/77198

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
