### PR TITLE
doc/cephadm: document the cephfs-proxy sidecar

### DIFF
--- a/doc/cephadm/services/smb.rst
+++ b/doc/cephadm/services/smb.rst
@@ -348,6 +348,41 @@ exercise for the reader.
    scheme has different performance and security characteristics.
 
 
+.. _smb-cephfs-proxy:
+
+The CephFS Proxy Sidecar
+========================
+
+When a cluster hosts CephFS-backed shares that use the default
+``samba-vfs/proxied`` provider (see the ``provider`` share field in
+:ref:`mgr-smb`), cephadm automatically runs a ``cephfs-proxy``
+container alongside each Samba instance. No operator action is needed
+to deploy it, and it is not a separate orchestrator service: it
+appears as a sidecar of the ``smb`` daemon rather than as its own
+entry.
+
+The sidecar runs the ``libcephfsd`` daemon from the regular Ceph
+container image. Without the proxy, every SMB client connection opens
+its own ``libcephfs`` instance with its own private cache, which can
+consume large amounts of memory on busy servers. The proxy daemon
+holds the real CephFS mounts and shares them among connections with
+identical configuration, allowing a much greater number of
+simultaneous client connections at some cost in performance.
+
+Points useful when troubleshooting:
+
+* The proxy listens on the UNIX socket ``/run/libcephfsd.sock``
+  inside the shared ``/run`` mount of the Samba pod.
+* The daemon binary is ``/usr/sbin/libcephfsd``; its container is
+  named as a ``proxy`` sub-daemon of the parent ``smb`` daemon.
+* The proxy is only deployed when at least one share uses the
+  proxied provider. Shares using ``samba-vfs/classic`` or
+  ``samba-vfs/new`` connect to CephFS directly from the Samba
+  container.
+
+For design details, see the developer documentation in
+``doc/dev/libcephfs_proxy.rst``.
+
 Limitations
 ===========
 

--- a/doc/cephadm/services/smb.rst
+++ b/doc/cephadm/services/smb.rst
@@ -348,44 +348,15 @@ exercise for the reader.
    scheme has different performance and security characteristics.
 
 
-.. _smb-cephfs-proxy:
-
 The CephFS Proxy Sidecar
 ========================
 
-When a cluster hosts CephFS-backed shares that use the default
-``samba-vfs/proxied`` provider (see the ``provider`` share field in
-:ref:`mgr-smb`), cephadm automatically runs a ``cephfs-proxy``
-sidecar container alongside each Samba instance. No operator action
-is needed to deploy it, and it is not a separate orchestrator
-service.
-
-The sidecar container runs the ``libcephfsd`` daemon. Unlike the
-Samba containers, which use images from the samba-container project,
-the sidecar uses the regular Ceph container image; the ``smb``
-service intentionally runs containers from both images. Without the
-proxy, every SMB client connection opens its own ``libcephfs``
-instance with its own private cache, which can consume large amounts
-of memory on busy servers. The proxy multiplexes the client
-connections over shared CephFS mounts for connections with identical
-configuration, serving a greater number of concurrent clients with
-fewer server-side resources. When the number of clients is very
-large, there may be some impact to individual client performance.
-
-Points useful when troubleshooting:
-
-* The proxy listens on the UNIX socket ``/run/libcephfsd.sock``
-  inside the ``/run`` mount that the ``smb`` daemon's containers
-  share.
-* The daemon binary is ``/usr/sbin/libcephfsd``; its container is
-  named as a ``proxy`` sub-daemon of the parent ``smb`` daemon.
-* The proxy is only deployed when at least one share uses the
-  proxied provider. Shares using ``samba-vfs/classic`` or
-  ``samba-vfs/new`` connect to CephFS directly from the Samba
-  container.
-
-For design details, see the developer documentation in
-``doc/dev/libcephfs_proxy.rst``.
+When at least one CephFS-backed share uses a proxied provider, the
+smb manager module includes the ``cephfs-proxy`` feature in the
+``features`` parameter of the smb service specification, and cephadm
+deploys a ``cephfs-proxy`` sidecar container alongside each Samba
+instance. See :ref:`smb-cephfs-proxy` for a description of the
+sidecar and troubleshooting pointers.
 
 Limitations
 ===========

--- a/doc/cephadm/services/smb.rst
+++ b/doc/cephadm/services/smb.rst
@@ -356,23 +356,27 @@ The CephFS Proxy Sidecar
 When a cluster hosts CephFS-backed shares that use the default
 ``samba-vfs/proxied`` provider (see the ``provider`` share field in
 :ref:`mgr-smb`), cephadm automatically runs a ``cephfs-proxy``
-container alongside each Samba instance. No operator action is needed
-to deploy it, and it is not a separate orchestrator service: it
-appears as a sidecar of the ``smb`` daemon rather than as its own
-entry.
+sidecar container alongside each Samba instance. No operator action
+is needed to deploy it, and it is not a separate orchestrator
+service.
 
-The sidecar runs the ``libcephfsd`` daemon from the regular Ceph
-container image. Without the proxy, every SMB client connection opens
-its own ``libcephfs`` instance with its own private cache, which can
-consume large amounts of memory on busy servers. The proxy daemon
-holds the real CephFS mounts and shares them among connections with
-identical configuration, allowing a much greater number of
-simultaneous client connections at some cost in performance.
+The sidecar container runs the ``libcephfsd`` daemon. Unlike the
+Samba containers, which use images from the samba-container project,
+the sidecar uses the regular Ceph container image; the ``smb``
+service intentionally runs containers from both images. Without the
+proxy, every SMB client connection opens its own ``libcephfs``
+instance with its own private cache, which can consume large amounts
+of memory on busy servers. The proxy multiplexes the client
+connections over shared CephFS mounts for connections with identical
+configuration, serving a greater number of concurrent clients with
+fewer server-side resources. When the number of clients is very
+large, there may be some impact to individual client performance.
 
 Points useful when troubleshooting:
 
 * The proxy listens on the UNIX socket ``/run/libcephfsd.sock``
-  inside the shared ``/run`` mount of the Samba pod.
+  inside the ``/run`` mount that the ``smb`` daemon's containers
+  share.
 * The daemon binary is ``/usr/sbin/libcephfsd``; its container is
   named as a ``proxy`` sub-daemon of the parent ``smb`` daemon.
 * The proxy is only deployed when at least one share uses the

--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -1172,7 +1172,9 @@ cephfs
         connect to CephFS. ``samba-vfs`` automatically selects the preferred VFS
         based implementation, currently ``samba-vfs/proxied``. This option is
         suitable for the majority of use cases and can be left unspecified for most
-        shares.
+        shares. When a proxied provider is in use, cephadm automatically
+        deploys a ``cephfs-proxy`` sidecar next to each Samba instance;
+        see :ref:`smb-cephfs-proxy`.
     qos
         Optional object. Quality of Service settings for the share. Fields:
         

--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -1844,6 +1844,49 @@ at the prompt. Refer to the `smbclient documentation`_ for more details.
 .. _smbclient documentation:
    https://www.samba.org/samba/docs/current/man-html/smbclient.1.html
 
+.. _smb-cephfs-proxy:
+
+The CephFS Proxy Sidecar
+========================
+
+When a cluster hosts CephFS-backed shares that use the default
+``samba-vfs/proxied`` provider (see the ``provider`` share field
+above), the smb module adds the ``cephfs-proxy`` feature to the smb
+service specification that it generates, and cephadm deploys a
+``cephfs-proxy`` sidecar container alongside each Samba instance. No
+operator action is needed, and the sidecar is not a separate
+orchestrator service. The sidecar always runs on the same host as
+its Samba instance and shares that instance's ``/run`` mount and
+namespaces.
+
+The sidecar container runs the ``libcephfsd`` daemon. Unlike the
+Samba containers, which use images from the samba-container project,
+the sidecar uses the Ceph container image; the ``smb`` service
+intentionally runs containers from both images. Without the proxy,
+every SMB client connection opens its own ``libcephfs`` instance
+with its own private cache, which can consume large amounts of
+memory on busy servers. The proxy multiplexes the client connections
+over shared CephFS mounts for connections with identical
+configuration, serving a greater number of concurrent clients with
+fewer server-side resources. When the number of clients is very
+large, there may be some impact to individual client performance.
+
+Points useful when troubleshooting:
+
+* The proxy listens on the UNIX socket ``/run/libcephfsd.sock``
+  inside the ``/run`` mount that the smb instance's containers
+  share.
+* The daemon binary is ``/usr/sbin/libcephfsd``. It runs as a
+  sidecar container in the ``smb`` service, with a ``proxy`` suffix
+  in the container name.
+* The proxy is only deployed when at least one share uses the
+  proxied provider. Shares using ``samba-vfs/classic`` or
+  ``samba-vfs/new`` connect to CephFS directly from the Samba
+  container.
+
+For design details, see the developer documentation in
+``doc/dev/libcephfs_proxy.rst``.
+
 .. _smb-remote-control:
 
 SMB Remote Control

--- a/doc/releases/tentacle.rst
+++ b/doc/releases/tentacle.rst
@@ -856,7 +856,7 @@ Integrated SMB support
   provided by the ``samba-container`` project. The Ceph dashboard can be used
   to configure SMB clusters and shares. A new ``cephfs-proxy`` daemon is
   automatically deployed to improve scalability and memory usage when connecting
-  Samba to CephFS.
+  Samba to CephFS; see :ref:`smb-cephfs-proxy`.
 
 MGR
 


### PR DESCRIPTION
The Tentacle release notes announce an automatically deployed cephfs-proxy daemon, but the only documentation was the developer design page. Added an operator-facing section to the cephadm SMB service docs (why it exists, when it deploys, troubleshooting pointers such as the libcephfsd binary and /run/libcephfsd.sock socket), linked from the smb module provider field and the release notes. Facts verified against src/libcephfs_proxy and the cephadm smb daemon code.

Fixes: https://tracker.ceph.com/issues/79041

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
