### PR TITLE
python-common/drive_group: preserve crush_device_class and actuators in to_json

### DIFF
--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -124,8 +124,14 @@ class DeviceSelection(object):
     def to_json(self):
         # type: () -> Dict[str, Any]
         ret: Dict[str, Any] = {}
+        if self.actuators:
+            ret['actuators'] = self.actuators
         if self.paths:
-            ret['paths'] = [p.path for p in self.paths]
+            ret['paths'] = [
+                {'path': p.path, 'crush_device_class': p.crush_device_class}
+                if p.crush_device_class else p.path
+                for p in self.paths
+            ]
         if self.model:
             ret['model'] = self.model
         if self.vendor:

--- a/src/python-common/ceph/tests/test_drive_group.py
+++ b/src/python-common/ceph/tests/test_drive_group.py
@@ -721,3 +721,46 @@ def test_drive_group_osd_type_crimson_roundtrip():
     assert spec2.osd_type == 'crimson'
     j2 = spec2.to_json()
     assert j2['spec']['osd_type'] == 'crimson'
+
+
+def test_DeviceSelection_to_json_preserves_per_path_crush_device_class():
+    """
+    A spec is persisted via to_json() and reloaded via from_json() on every mgr
+    restart and by `ceph orch ls --export`, so the round trip must be lossless.
+    """
+    spec = DriveGroupSpec.from_json({
+        'service_type': 'osd',
+        'service_id': 'osd_using_paths',
+        'placement': {'hosts': ['node01']},
+        'crush_device_class': 'ssd',
+        'spec': {
+            'data_devices': {'paths': [
+                {'path': '/dev/sdb', 'crush_device_class': 'ssd'},
+                {'path': '/dev/sdc', 'crush_device_class': 'nvme'},
+            ]},
+            'db_devices': {'paths': ['/dev/sdd']},
+        },
+    })
+
+    reloaded = DriveGroupSpec.from_json(spec.to_json())
+
+    assert [(d.path, d.crush_device_class) for d in reloaded.data_devices.paths] == [
+        ('/dev/sdb', 'ssd'),
+        ('/dev/sdc', 'nvme'),
+    ]
+    # a path with no per-device class still serializes as a plain string
+    assert reloaded.db_devices.to_json()['paths'] == ['/dev/sdd']
+
+
+def test_DeviceSelection_to_json_preserves_actuators():
+    spec = DriveGroupSpec.from_json({
+        'service_type': 'osd',
+        'service_id': 'osd_actuators',
+        'placement': {'hosts': ['node01']},
+        'spec': {'data_devices': {'actuators': 2, 'rotational': 1}},
+    })
+
+    reloaded = DriveGroupSpec.from_json(spec.to_json())
+
+    assert reloaded.data_devices.actuators == 2
+    assert reloaded.data_devices.rotational == 1


### PR DESCRIPTION
`DeviceSelection.__init__` accepts a per-path `crush_device_class` and an `actuators`
filter, but `to_json` emits neither: paths are flattened to bare strings, dropping the
class, and `actuators` has no branch at all.

That serialization is on the persistence path. `SpecStore._save` stores `spec.to_json()`
in the mon config-key store and `SpecStore.load` rebuilds the spec with `from_json` on
mgr start, so both settings are lost across a mgr restart or failover. The same `to_json`
backs `ceph orch ls --export`, which the docs recommend for backing up and re-applying
specs.

Consequences:

- `crush_device_class` is silently dropped, so OSDs are reclassified and CRUSH rules,
  which select by device class, place data on a different tier than the operator asked for.
- `actuators` is dropped rather than narrowed, so devices the operator excluded can be
  selected and consumed.
- An `actuators`-only `data_devices` serializes to `{}` and fails to reload at all.

The fix emits `actuators`, and emits each path as a mapping when it carries a
`crush_device_class`. `__init__` already accepts both the string and the mapping form, so
previously persisted specs still load, and a path with no class is still written as a
plain string. The per-path syntax is documented in `doc/cephadm/services/osd.rst`, so no
documentation change is needed.

Tests are in `src/python-common/ceph/tests/test_drive_group.py` and include a round-trip
reproducer that fails on `main` and passes here. Verified with `pytest` against
`src/python-common` — 43 tests pass. This is a pure `python-common` change with no
compiled dependency, so no local Ceph build was required.

I used Claude Code while investigating this and preparing the patch. I read the source and
ran the tests myself; the analysis above reflects what I verified rather than unrun output.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
