### PR TITLE
doc: harmonize docs on CephX

### DIFF
--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -365,14 +365,14 @@ between the client and the daemon.
 
 This authentication protects only the connections between Ceph clients and Ceph
 daemons. The authentication is not extended beyond the Ceph client. If a user
-accesses the Ceph client from a remote host, cephx authentication will not be
+accesses the Ceph client from a remote host, CephX authentication will not be
 applied to the connection between the user's host and the client host.
 
 See :ref:`rados-cephx-config-ref` for more on configuration details.
 
 See :ref:`user-management` for more on user management.
 
-See :ref:`A Detailed Description of the Cephx Authentication Protocol
+See :ref:`A Detailed Description of the CephX Authentication Protocol
 <cephx_2012_peter>` for more on the distinction between authorization and
 authentication and for a step-by-step explanation of the setup of ``cephx``
 tickets and session keys.

--- a/doc/cephadm/services/smb.rst
+++ b/doc/cephadm/services/smb.rst
@@ -215,8 +215,8 @@ bind_addrs
         For example, ``192.168.7.0/24``.
 
 include_ceph_users
-    A list of cephx user (aka entity) names that the Samba containers may use.
-    The cephx keys for each user in the list will automatically be added to
+    A list of CephX user (aka entity) names that the Samba containers may use.
+    The CephX keys for each user in the list will automatically be added to
     the keyring in the container.
 
 cluster_meta_uri
@@ -302,8 +302,8 @@ named ``.smb``. Within the pool there should be a namespace named after the
 constructed like ``rados://.smb/<cluster_id>/<object_name>``. Example:
 ``rados://.smb/tango/config.json``.
 
-The containers are automatically deployed with cephx keys allowing access to
-resources in these pools and namespaces. As long as this scheme is used
+The containers are automatically deployed with CephX keys allowing access to
+resources in these pools and namespaces. As long as this scheme is used,
 no additional configuration to read the object is needed.
 
 To copy a configuration file to a RADOS pool, use the ``rados`` command line
@@ -324,9 +324,9 @@ identify this configuration constructed like
 ``rados:mon-config-key:smb/config/<cluster_id>/<name>``.
 Example: ``rados:mon-config-key:smb/config/tango/config.json``.
 
-The containers are automatically deployed with cephx keys allowing access to
+The containers are automatically deployed with CephX keys allowing access to
 resources with the key-prefix ``smb/config/<cluster_id>/``. As long as this
-scheme is used no additional configuration to read the value is needed.
+scheme is used, no additional configuration to read the value is needed.
 
 To copy a configuration file into the Key/Value store use the ``ceph config-key
 put ...`` tool. For example:

--- a/doc/cephfs/file-layouts.rst
+++ b/doc/cephfs/file-layouts.rst
@@ -271,7 +271,7 @@ Before you can use a pool with CephFS you have to add it to the Metadata Servers
     $ ceph fs ls  # Pool should now show up
     .... data pools: [cephfs_data cephfs_data_ssd ]
 
-Make sure that your cephx keys allows the client to access this new pool.
+Make sure that your CephX key allows the client to access this new pool.
 
 You can then update the layout on a directory in CephFS to use the pool you added:
 

--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -31,7 +31,7 @@ Requirements
 
 * Nautilus (14.2.x) or later Ceph release
 
-* Cephx client user (see :doc:`/rados/operations/user-management`) with
+* CephX client user (see :doc:`/rados/operations/user-management`) with
   at least the following capabilities::
 
     mon 'allow r'

--- a/doc/install/manual-deployment.rst
+++ b/doc/install/manual-deployment.rst
@@ -367,7 +367,7 @@ OSDs with the long form procedure, execute the following steps for each OSD.
 
      UUID=$(uuidgen)
 
-#. Generate a cephx key for the OSD. ::
+#. Generate a CephX key for the OSD. ::
 
      OSD_SECRET=$(ceph-authtool --gen-print-key)
 

--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -764,10 +764,10 @@ Usage::
 
 Subcommand ``new`` can be used to create a new OSD or to recreate a previously
 destroyed OSD with a specific *id*. The new OSD will have the specified *uuid*,
-and the command expects a JSON file containing the base64 cephx key for auth
-entity *client.osd.<id>*, as well as optional base64 cephx key for dm-crypt
-lockbox access and a dm-crypt key. Specifying a dm-crypt requires specifying
-the accompanying lockbox cephx key.
+and the command expects a JSON file containing the base64 CephX key for auth
+entity *client.osd.<id>*, as well as optional base64 CephX key for dm-crypt
+lockbox access and a dm-crypt key. Specifying a dm-crypt key requires specifying
+the accompanying lockbox CephX key.
 
 Usage::
 
@@ -1361,7 +1361,7 @@ Usage::
 
     ceph osd rm <ids> [<ids>...]
 
-Subcommand ``destroy`` marks OSD *id* as *destroyed*, removing its cephx
+Subcommand ``destroy`` marks OSD *id* as *destroyed*, removing its CephX
 entity's keys and all of its dm-crypt and daemon-private config key
 entries.
 

--- a/doc/man/8/rados.rst
+++ b/doc/man/8/rados.rst
@@ -210,7 +210,7 @@ Generic options
 
 .. option:: -n TYPE.ID, --name TYPE.ID
 
-   Set cephx user name.
+   Set CephX user name.
 
 .. option:: --cluster NAME
 

--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -978,7 +978,7 @@ To delete a snapshot::
 
        rbd snap rm mypool/myimage@mysnap
 
-To map an image via the kernel with cephx enabled::
+To map an image via the kernel with CephX enabled::
 
        rbd device map mypool/myimage --id admin --keyfile secretfile
 

--- a/doc/mgr/administrator.rst
+++ b/doc/mgr/administrator.rst
@@ -84,8 +84,8 @@ The manager is a new daemon which requires new CephX capabilities. If you
 upgrade a cluster from an old version of Ceph, or use the default
 install/deploy tools, your admin client should get this capability
 automatically. If you use tooling from elsewhere, you may get EACCES errors
-when invoking certain ceph cluster commands.  To fix that, add a ``mgr allow
-\*`` stanza to your client's cephx capabilities by `Modifying User
+when invoking certain Ceph cluster commands.  To fix that, add a ``mgr allow
+\*`` stanza to your client's CephX capabilities by `Modifying User
 Capabilities`_.
 
 High availability

--- a/doc/rados/api/librados-intro.rst
+++ b/doc/rados/api/librados-intro.rst
@@ -222,23 +222,23 @@ The Ceph Storage Cluster handle encapsulates the client configuration, including
 - The `user ID`_ for ``rados_create()`` or user name for ``rados_create2()`` 
   (preferred).
 - The :term:`cephx` authentication key
-- The monitor ID and IP address
+- The Monitor ID and IP address
 - Logging levels
 - Debugging levels
 
 Thus, the first steps in using the cluster from your app are to 1) create
 a cluster handle that your app will use to connect to the storage cluster,
 and then 2) use that handle to connect. To connect to the cluster, the
-app must supply a monitor address, a username and an authentication key
-(cephx is enabled by default).
+app must supply a Monitor address, a username and an authentication key
+(CephX is enabled by default).
 
 .. tip:: Talking to different Ceph Storage Clusters – or to the same cluster 
    with different users – requires different cluster handles.
 
 RADOS provides a number of ways for you to set the required values. For
-the monitor and encryption key settings, an easy way to handle them is to ensure
+the Monitor and encryption key settings, an easy way to handle them is to ensure
 that your Ceph configuration file contains a ``keyring`` path to a keyring file
-and at least one monitor address (e.g., ``mon_host``). For example::
+and at least one Monitor address (e.g., ``mon_host``). For example::
 
 	[global]
 	mon_host = 192.168.1.1

--- a/doc/rados/configuration/msgr2.rst
+++ b/doc/rados/configuration/msgr2.rst
@@ -98,7 +98,7 @@ The v2 protocol supports two connection modes:
 * *crc* mode provides:
 
   - a strong initial authentication when the connection is established
-    (with cephx, mutual authentication of both parties with protection
+    (with CephX, mutual authentication of both parties with protection
     from a man-in-the-middle or eavesdropper), and
   - a crc32c integrity check to protect against bit flips due to flaky
     hardware or cosmic rays
@@ -114,7 +114,7 @@ The v2 protocol supports two connection modes:
 * *secure* mode provides:
 
   - a strong initial authentication when the connection is established
-    (with cephx, mutual authentication of both parties with protection
+    (with CephX, mutual authentication of both parties with protection
     from a man-in-the-middle or eavesdropper), and
   - full encryption of all post-authentication traffic, including a
     cryptographic integrity check.

--- a/doc/rados/operations/user-management.rst
+++ b/doc/rados/operations/user-management.rst
@@ -49,7 +49,7 @@ Alternatively, you may use the ``CEPH_ARGS`` environment variable to avoid
 re-entry of the user name and secret.
 
 For details on configuring the Ceph Storage Cluster to use authentication, see
-:ref:`rados-cephx-config-ref`. For details on the architecture of Cephx, see
+:ref:`rados-cephx-config-ref`. For details on the architecture of CephX, see
 :ref:`arch_high_availability_authentication`.
 
 Background
@@ -75,7 +75,7 @@ Ceph has the concept of a ``type`` of user. For purposes of user management,
 the type will always be ``client``. Ceph identifies users in a "period-delimited
 form" that consists of the user type and the user ID: for example,
 ``TYPE.ID``, ``client.admin``, or ``client.user1``. The reason for user typing
-is that the Cephx protocol is used not only by clients but also non-clients,
+is that the CephX protocol is used not only by clients but also non-clients,
 such as Ceph Monitors, OSDs, and Metadata Servers. Distinguishing the user type
 helps to distinguish between client users and other users. This distinction
 streamlines access control, user monitoring, and traceability.

--- a/doc/rados/troubleshooting/troubleshooting-mon.rst
+++ b/doc/rados/troubleshooting/troubleshooting-mon.rst
@@ -650,7 +650,7 @@ to recover the Monitors:
   done
 
   # rebuild the monitor store from the collected map, if the cluster does not
-  # use cephx authentication, we can skip the following steps to update the
+  # use CephX authentication, we can skip the following steps to update the
   # keyring with the caps, and there is no need to pass the "--keyring" option.
   # i.e. just use "ceph-monstore-tool $ms rebuild" instead
   ceph-authtool /path/to/admin.keyring -n mon. \

--- a/doc/rbd/libvirt.rst
+++ b/doc/rbd/libvirt.rst
@@ -111,7 +111,7 @@ To configure Ceph for use with ``libvirt``, perform the following steps:
 	log file = /var/log/ceph/qemu-guest-$pid.log
 	admin socket = /var/run/ceph/$cluster-$type.$id.$pid.$cctid.asok
 
-   The ``client.libvirt`` section name should match the cephx user you created
+   The ``client.libvirt`` section name should match the CephX user you created
    above.
    If SELinux or AppArmor is enabled, note that this could prevent the client
    process (qemu via libvirt) from doing some operations, such as writing logs

--- a/doc/rbd/rbd-ko.rst
+++ b/doc/rbd/rbd-ko.rst
@@ -26,7 +26,7 @@ For example::
 
   sudo rbd device map rbd/myimage --id admin
  
-If you use `cephx`_ authentication, you must also specify a secret.  It may come
+If you use :ref:`CephX <user-management>` authentication, you must also specify a secret.  It may come
 from a keyring or a file containing the secret. ::
 
   sudo rbd device map rbd/myimage --id admin --keyring /path/to/keyring
@@ -55,5 +55,3 @@ For example::
 
 	sudo rbd device unmap /dev/rbd/rbd/foo
 
-
-.. _cephx: ../../rados/operations/user-management/

--- a/doc/rbd/rbd-kubernetes.rst
+++ b/doc/rbd/rbd-kubernetes.rst
@@ -14,7 +14,7 @@ platforms has moved to its own chapter:
 - :ref:`csi-deployment` covers deployment, including the recommended
   Ceph-CSI-Operator.
 - :ref:`csi-rbd` covers the Ceph-side preparation for RBD volumes:
-  pools, cephx users, and StorageClass essentials.
+  pools, CephX users, and StorageClass essentials.
 
 CephFS, NFS, and NVMe-oF backends are covered in the same chapter.
 

--- a/doc/rbd/rbd-nomad.rst
+++ b/doc/rbd/rbd-nomad.rst
@@ -347,9 +347,9 @@ Using Ceph Block Devices
 Create rbd image
 ----------------
 
-``ceph-csi`` requires the cephx credentials for communicating with the Ceph
+``ceph-csi`` requires the CephX credentials for communicating with the Ceph
 cluster. Generate a ``ceph-volume.hcl`` file similar to the example below,
-using the newly created nomad user id and cephx key::
+using the newly created nomad user ID and CephX key::
 
     id = "ceph-mysql"
     name = "ceph-mysql"

--- a/doc/rbd/rbd-openstack.rst
+++ b/doc/rbd/rbd-openstack.rst
@@ -130,7 +130,7 @@ use both the Python bindings and the client command line tools::
 Setup Ceph Client Authentication
 --------------------------------
 
-If you have `cephx authentication`_ enabled, create a new user for Nova/Cinder
+If you have `CephX authentication`_ enabled, create a new user for Nova/Cinder
 and Glance. Execute the following::
 
     ceph auth get-or-create client.glance mon 'profile rbd' osd 'profile rbd pool=images' mgr 'profile rbd pool=images'
@@ -179,13 +179,13 @@ temporary copy of the key::
   Secret 457eb676-33da-42ec-9a8c-9293d545c337 created
   sudo virsh secret-set-value --secret 457eb676-33da-42ec-9a8c-9293d545c337 --base64 $(cat client.cinder.key) && rm client.cinder.key secret.xml
 
-Save the uuid of the secret for configuring ``nova-compute`` later.
+Save the UUID of the secret for configuring ``nova-compute`` later.
 
 .. important:: You don't necessarily need the UUID on all the compute nodes.
    However from a platform consistency perspective, it's better to keep the
    same UUID.
 
-.. _cephx authentication: ../../rados/configuration/auth-config-ref/#enabling-disabling-cephx
+.. _CephX authentication: ../../rados/configuration/auth-config-ref/#enabling-disabling-cephx
 
 
 Configure OpenStack to use Ceph
@@ -268,7 +268,7 @@ specify the pool name for the block device. On your OpenStack node, edit
     rbd_store_chunk_size = 4
     rados_connect_timeout = -1
 
-If you are using `cephx authentication`_, also configure the user and uuid of
+If you are using `CephX authentication`_, also configure the user and UUID of
 the secret you added to ``libvirt`` as documented earlier::
 
     [ceph]

--- a/doc/rbd/rbd-snapshot.rst
+++ b/doc/rbd/rbd-snapshot.rst
@@ -39,10 +39,10 @@ the ``rbd`` command and several higher-level interfaces, including `QEMU`_,
            +------------+         +-------------+
 
 
-Cephx Notes
+CephX Notes
 ===========
 
-When :ref:`cephx <rados-cephx-config-ref>` authentication is enabled (it is by default), you must specify a
+When :ref:`CephX <rados-cephx-config-ref>` authentication is enabled (it is by default), you must specify a
 user name or ID and a path to the keyring containing the corresponding key. See
 :ref:`User Management <user-management>` for details.
 


### PR DESCRIPTION
Stylize always as CephX.  
Use `ref` for a link where a label for the destination already exists.  
Fix various other capitalization.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
