### PR TITLE
crimson/osd/pg_backend: truncate to 0 when EC pool in _writefull

### DIFF
--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -489,7 +489,9 @@ PGBackend::write_iertr::future<> PGBackend::_writefull(
   unsigned flags)
 {
   const bool existing = maybe_create_new_object(os, txn, delta_stats);
-  if (existing && bl.length() < os.oi.size) {
+  if (existing && is_erasure()) {
+    txn.truncate(coll->get_cid(), ghobject_t{os.oi.soid}, 0);
+  } else if (existing && bl.length() < os.oi.size) {
 
     txn.truncate(coll->get_cid(), ghobject_t{os.oi.soid}, bl.length());
     truncate_update_size_and_usage(delta_stats, os.oi, truncate_size);
@@ -502,15 +504,15 @@ PGBackend::write_iertr::future<> PGBackend::_writefull(
     txn.write(
       coll->get_cid(), ghobject_t{os.oi.soid}, 0, bl.length(),
       bl, flags);
-    update_size_and_usage(
-      delta_stats,
-      osd_op_params.modified_ranges,
-      os.oi, 0,
-      bl.length(), true);
-    osd_op_params.clean_regions.mark_data_region_dirty(
-      0,
-      std::max((uint64_t)bl.length(), os.oi.size));
   }
+  osd_op_params.clean_regions.mark_data_region_dirty(
+    0,
+    std::max((uint64_t)bl.length(), os.oi.size));
+  update_size_and_usage(
+    delta_stats,
+    osd_op_params.modified_ranges,
+    os.oi, 0,
+    bl.length(), true); 
   return seastar::now();
 }
 


### PR DESCRIPTION
## Issue 

When running rados_api_tests with crimson OSDs and seatore backend, we were observing slowops. 

## Investigation 
Inspecting logs we see: 
```
WARN 2026-08-13 06:14:37,107 [shard 0:main] osd - OSD::get_health_metrics: slow request m=[osd_op(client.4224.0:2 38.6s0 38:602f83fe:::foo:head [writefull 0~64 in=64b] snapc 0=[] ondisk+write+known_if_redirected+supports_pool_eio e233)] initiated 2026-08-13T06:14:07.106160+0000
ERROR 2026-08-13 06:14:37,107 [shard 0:main] osd - OSD::get_health_metrics: get_health_metrics reporting 1 slow ops, oldest is m=[osd_op(client.4224.0:2 38.6s0 38:602f83fe:::foo:head [writefull 0~64 in=64b] snapc 0=[] ondisk+write+known_if_redirected+supports_pool_eio e233)]
WARN 2026-08-13 06:14:37,107 [shard 0:main] osd - OSD::get_health_metrics: slow requests (most affected pool [ 'RoundTripWriteFull/0_sockeni05.front.sepia.ceph.com-912231-37' : 1 ])
```
We see its a `writefull` operation on the client `client.4224.0:2`, failing on the pool corresponding to the test `RoundTripWriteFull/0`. Inspecting the logs of the op, we see the transaction was translated into: 

```
DEBUG 2026-08-13 06:14:07,107 [shard 0:main] osd - ECBackend::translate_transaction decoded op=12 ghobj=#38:602f83fe:::foo:head# dest_ghobj=#38:602f83fe:::foo:head#
DEBUG 2026-08-13 06:14:07,107 [shard 0:main] osd - ECBackend::translate_transaction decoded op=10 ghobj=#38:602f83fe:::foo:head# dest_ghobj=#38:602f83fe:::foo:head#
DEBUG 2026-08-13 06:14:07,107 [shard 0:main] osd - ECBackend::translate_transaction decoded op=14 ghobj=#38:602f83fe:::foo:head# dest_ghobj=#38:602f83fe:::foo:head#
DEBUG 2026-08-13 06:14:07,107 [shard 0:main] osd - ECBackend::translate_transaction decoded op=14 ghobj=#38:602f83fe:::foo:head# dest_ghobj=#38:602f83fe:::foo:head#
```
where op code 12 is `OP_TRUNCATE`, 10 is `OP_WRITE` and 14 is `OP_SETATTR`. Looking at logs further, we see the truncate is for 64, the new size of the object, not a complete delete that truncate(0) would have done: 
```
DEBUG 2026-08-13 06:14:07,108 [shard 0:main] osd -  pg_epoch 234 pg[38.6s0( v 234'1 (0'0,234'1] local-lis/les=233/234 n=1 ec=233/233 lis/c=233/233 les/c/f=234/234/0 sis=233) [0,2,1]p0(0) r=0 lpr=233 pct=0'0 crt=234'1 lcod 0'0 mlcod 0'0 active+clean  generate_transactions: oid: 38:602f83fe:::foo:head truncate_erase shard_extent_map: ({0~64}, maps={0:{0~64(64)}})
```
This means, our original write op now has been translated to truncate(64) + writing the object. Since, we are not deleting but only truncating the object, we now need to have a clone ready incase of rollback. The logs show this:  

```
DEBUG 2026-08-13 06:14:07,108 [shard 0:main] osd -  pg_epoch 234 pg[38.6s0( v 234'1 (0'0,234'1] local-lis/les=233/234 n=1 ec=233/233 lis/c=233/233 les/c/f=234/234/0 sis=233) [0,2,1]p0(0) r=0 lpr=233 pct=0'0 crt=234'1 lcod 0'0 mlcod 0'0 active+clean cache_ready Transaction for osd.0 shard 0 contents {"ops":[{"op_num":0,"op_name":"touch","collection":"38.6s0_head","oid":"0#38:602f83fe:::foo:head#2"},{"op_num":1,"op_name":"clonerange2","collection":"38.6s0_head","src_oid":"0#38:602f83fe:::foo:head#","dst_oid":"0#38:602f83fe:::foo:head#2","src_offset":0,"len":4096,"dst_offset":0},{"op_num":2,"op_name":"truncate","collection":"38.6s0_head","oid":"0#38:602f83fe:::foo:head#","offset":64},{"op_num":3,"op_name":"truncate","collection":"38.6s0_head","oid":"0#38:602f83fe:::foo:head#","offset":4096},{"op_num":4,"op_name":"touch","collection":"38.6s0_head","oid":"0#38:602f83fe:::foo:head#2"},{"op_num":5,"op_name":"clonerange2","collection":"38.6s0_head","src_oid":"0#38:602f83fe:::foo:head#","dst_oid":"0#38:602f83fe:::foo:head#2","src_offset":0,"len":4096,"dst_offset":0},{"op_num":6,"op_name":"write","collection":"38.6s0_head","oid":"0#38:602f83fe:::foo:head#","length":4096,"offset":0,"bufferlist length":4096},{"op_num":7,"op_name":"setattrs","collection":"38.6s0_head","oid":"0#38:602f83fe:::foo:head#","attr_lens":{"_":262,"snapset":35}}]}
DEBUG 2026-08-13 06:14:07,108 [shard 0:main] osd -  pg_epoch 234 pg[38.6s0( v 234'1 (0'0,234'1] local-lis/les=233/234 n=1 ec=233/233 lis/c=233/233 les/c/f=234/234/0 sis=233) [0,2,1]p0(0) r=0 lpr=233 pct=0'0 crt=234'1 lcod 0'0 mlcod 0'0 active+clean cache_ready Transaction for osd.1 shard 2 contents {"ops":[{"op_num":0,"op_name":"touch","collection":"38.6s2_head","oid":"2#38:602f83fe:::foo:head#2"},{"op_num":1,"op_name":"clonerange2","collection":"38.6s2_head","src_oid":"2#38:602f83fe:::foo:head#","dst_oid":"2#38:602f83fe:::foo:head#2","src_offset":0,"len":4096,"dst_offset":0},{"op_num":2,"op_name":"truncate","collection":"38.6s2_head","oid":"2#38:602f83fe:::foo:head#","offset":64},{"op_num":3,"op_name":"truncate","collection":"38.6s2_head","oid":"2#38:602f83fe:::foo:head#","offset":4096},{"op_num":4,"op_name":"touch","collection":"38.6s2_head","oid":"2#38:602f83fe:::foo:head#2"},{"op_num":5,"op_name":"clonerange2","collection":"38.6s2_head","src_oid":"2#38:602f83fe:::foo:head#","dst_oid":"2#38:602f83fe:::foo:head#2","src_offset":0,"len":4096,"dst_offset":0},{"op_num":6,"op_name":"write","collection":"38.6s2_head","oid":"2#38:602f83fe:::foo:head#","length":4096,"offset":0,"bufferlist length":4096},{"op_num":7,"op_name":"setattrs","collection":"38.6s2_head","oid":"2#38:602f83fe:::foo:head#","attr_lens":{"_":262,"snapset":35}}]}
DEBUG 2026-08-13 06:14:07,108 [shard 0:main] osd -  pg_epoch 234 pg[38.6s0( v 234'1 (0'0,234'1] local-lis/les=233/234 n=1 ec=233/233 lis/c=233/233 les/c/f=234/234/0 sis=233) [0,2,1]p0(0) r=0 lpr=233 pct=0'0 crt=234'1 lcod 0'0 mlcod 0'0 active+clean cache_ready Transaction for osd.2 shard 1 contents {"ops":[{"op_num":0,"op_name":"setattr","collection":"38.6s1_head","oid":"1#38:602f83fe:::foo:head#","name":"_","length":262}]}
```

The above shows per shard the list of operations to be executed. Shard 1 only has attribute updates as it doesn't contain a chunk of the concerning object as the object is 128 bytes, smaller than one 4096-byte chunk, so it lives entirely in shard 0; shard 2 is parity. Shards 0 and 2 have 8 operations each. Listing the ops for shard 0: 

|Op Number|Op Name|What does it do|
|-----------|-------|-----------|
|0|`touch`|creates the object where the clone will be copied into `0#38:602f83fe:::foo:head#2`|
|1|`clonerange2`|copies the original object[0:4096] into the clone destination created above `0#38:602f83fe:::foo:head#2`|
|2|`truncate`|truncates the original object `0#38:602f83fe:::foo:head#` till 64 bytes|
|3|`truncate`|truncates the original object `0#38:602f83fe:::foo:head#` back to 4096 bytes|
|4|`touch`|same things as op 0|
|5|`clonerange2`|same thing as op 1, but this time it overwrites the correct data with truncated contents of the original object|
|6|`write`|writes the new object|
|7|`setattrs`|updates attributes|
 
From the logs we see that the operation hangs on op 5, when the `clonerange2` is duplicated again. Seastore returns op 1 but hangs on op 5. 

```
DEBUG 2026-08-13 06:14:07,109 [shard 0:main] seastore - 0x50000043d000 trans.3883 SeaStoreS::_do_transaction_step: op 9, get_or_create oid=0#38:602f83fe:::foo:head#2 ...
DEBUG 2026-08-13 06:14:07,109 [shard 0:main] seastore_onode - 0x50000043d000 trans.3883 FLTreeOnodeManager::get_or_create_onode: created onode for entry for 0#38:602f83fe:::foo:head#2
DEBUG 2026-08-13 06:14:07,109 [shard 0:main] seastore - 0x50000043d000 trans.3883 SeaStoreS::_do_transaction_step: op TOUCH, oid=0#38:602f83fe:::foo:head#2 ...
DEBUG 2026-08-13 06:14:07,110 [shard 0:main] seastore - 0x50000043d000 trans.3883 SeaStoreS::_do_transaction_step: op 30, get oid=0#38:602f83fe:::foo:head# ...
DEBUG 2026-08-13 06:14:07,110 [shard 0:main] seastore - 0x50000043d000 trans.3883 SeaStore::_clone_range: src_onode=Onode(hobj=38:602f83fe:::foo:head, size=0x1000), dst_onode=Onode(hobj=38:602f83fe:::foo:head, size=0x0), src 0~4096, dst 0
DEBUG 2026-08-13 06:14:07,110 [shard 0:main] seastore_odata - 0x50000043d000 trans.3883 ObjectDataHandler::clone_range: 38:602f83fe:::foo:head->38:602f83fe:::foo:head, 0~4096
DEBUG 2026-08-13 06:14:07,110 [shard 0:main] seastore - 0x50000043d000 trans.3883 SeaStoreS::_do_transaction_step: op TRUNCATE, oid=0#38:602f83fe:::foo:head#, 0x40 ...
DEBUG 2026-08-13 06:14:07,111 [shard 0:main] seastore - 0x50000043d000 trans.3883 SeaStoreS::_do_transaction_step: op TRUNCATE, oid=0#38:602f83fe:::foo:head#, 0x1000 ...
DEBUG 2026-08-13 06:14:07,112 [shard 0:main] seastore - 0x50000043d000 trans.3883 SeaStoreS::_do_transaction_step: op TOUCH, oid=0#38:602f83fe:::foo:head#2 ...
DEBUG 2026-08-13 06:14:07,112 [shard 0:main] seastore - 0x50000043d000 trans.3883 SeaStore::_clone_range: src_onode=Onode(hobj=38:602f83fe:::foo:head, size=0x1000), dst_onode=Onode(hobj=38:602f83fe:::foo:head, size=0x1000), src 0~4096, dst 0
DEBUG 2026-08-13 06:14:07,112 [shard 0:main] seastore_odata - 0x50000043d000 trans.3883 ObjectDataHandler::clone_range: 38:602f83fe:::foo:head->38:602f83fe:::foo:head, 0~4096
DEBUG 2026-08-13 06:14:07,114 [shard 0:main] osd -  pg_epoch 234 pg[38.6s0( v 234'2 (0'0,234'2] local-lis/les=233/234 n=1 ec=233/233 lis/c=233/233 les/c/f=234/234/0 sis=233) [0,2,1]p0(0) r=0 lpr=233 pct=0'0 crt=234'2 lcod 0'0 mlcod 0'0 active+clean  ECBackend::handle_rep_write_reply: tid=24 hoid=38:602f83fe:::foo:head from=2(1) pending_commits=3
```
We see that op 1 returns and starts executing op 2 (truncating 64 bytes), but op 5, `_clone_range` does not return, otherwise we would have gotten a `WRITE` log. 

The above points to 3 issues: 

1. Seastore hangs for some reason when `clone_range` is being called twice on the same source range and destination range. https://tracker.ceph.com/issues/79530
2. We are duplicating clone writes when the new object is smaller than the existing one. Op 1 copies the original contents into a clone, before truncating. Op 5 copies the truncated+zero extended contents into same clone, overwriting the actual clone of the original content. In the event of a rollback, we will have wrong data. https://tracker.ceph.com/issues/79531 
3. We are issuing a in-place read-modify-write for a writefull in an EC pool. This is divergence from classic code which truncates to 0 (ie delete) the original object before writing the new one. Classic reference: https://github.com/ceph/ceph/blob/main/src/osd/PrimaryLogPG.cc#L7027-L7045

## Fix

In this PR, we are first fixing the issue 3. We are adding the EC branch in the code such that we simply truncate the old object (delete) before writing the new one. This way we avoid the faulty clone logic above. The rest of the issues will be fixed in a separate PR. 

## Testing 

Verified the fix on a vstart cluster by running the rados_api_tests. The cluster does not hang on `RoundTripWriteFull/0` test anymore. 

Fixes: https://tracker.ceph.com/issues/79453

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [X] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
