### PR TITLE
doc/radosgw: improve s3_objects_dedup.rst

### DIFF
--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -2929,7 +2929,7 @@ permission. ::
 
 	POST /{admin}/ratelimit?ratelimit-scope=anon&global=<True|False><[&max-read-bytes=<bytes>][&max-write-bytes=<bytes>][&max-read-ops=<ops>][&max-write-ops=<ops>][&max-list-ops=<ops>][&max-delete-ops=<ops>][&enabled=<True|False>]>
 
-
+.. _radosgw-adminops-dedup:
 
 Dedup
 =====

--- a/doc/radosgw/s3_objects_dedup.rst
+++ b/doc/radosgw/s3_objects_dedup.rst
@@ -7,7 +7,7 @@ Full RGW Object Dedup
 Full RGW object deduplication adds ``radosgw-admin`` commands to deduplicate
 RGW tail RADOS objects and to collect and report statistics.
 
-These operations are also available through the `Admin Ops API <../radosgw/adminops/#dedup>`_
+These operations are also available through the :ref:`Admin Ops API <radosgw-adminops-dedup>`
 under ``/{admin}/dedup``.
 
 
@@ -80,7 +80,7 @@ RGW processes within the same zone spreads the dedup work between them.
 This setting is evaluated at RGW startup. Changing it requires a daemon
 restart.
 
-When running RGW as an NFS-Ganesha gateway (librgw), the dedup thread is
+When running RGW as an NFS-Ganesha gateway (``librgw``), the dedup thread is
 disabled by default. To enable it in NFS mode, also set:
 
 .. confval:: rgw_nfs_run_dedup_threads
@@ -92,13 +92,13 @@ Skipped Objects
 The dedup estimate process skips the following RGW objects:
 
 - Objects smaller than :confval:`rgw_dedup_min_obj_size_for_dedup` (unless they
-  are multipart).
-- Objects with different placement rules.
-- Objects in different RADOS pools.
-- Objects with different RGW storage classes.
+  are multipart)
+- Objects with different placement rules
+- Objects in different RADOS pools
+- Objects with different RGW storage classes
 - On EC pools without ``allow_ec_overwrites``: non-multipart objects smaller
-  than ``rgw_max_chunk_size`` in the default storage class (these require
-  split-head which is unavailable on such pools).
+  than :confval:`rgw_max_chunk_size` in the default storage class (these require
+  split-head which is unavailable on such pools)
 
 The full dedup process skips all of the above and additionally skips
 **compressed** and **user-encrypted** objects.
@@ -123,8 +123,8 @@ daemons.
 
 The dedup estimate process does not access the object payload
 data, which means that processing time won't be significantly affected by the
-underlying media (SSD/HDD) storing the objects. Best practice places bucket index pools
-on fast storage: SSDs
+underlying media (SSD/HDD) storing the objects. Best practice places bucket
+index pools on fast storage: SSDs
 :ref:`are recommended <hardware-recommendations>` and they are cached heavily
 in memory.
 
@@ -147,8 +147,8 @@ Full Dedup Processing
 The full dedup process begins by constructing a dedup table from the bucket
 indexes in a fashion similar to the estimate process described above.
 
-This table is then scanned linearly to exclude RADOS objects without duplicates,
-leaving only dedup candidates.
+This table is then scanned linearly to exclude RADOS objects without
+duplicates, leaving only dedup candidates.
 
 Next, it iterates through these dedup candidate objects, reading their complete
 information from the object metadata, a per-object RADOS operation. During
@@ -164,7 +164,7 @@ matches. If they are, we proceed with deduplication:
 - Copy the manifest from the source to the target.
 - Remove all tail objects on the target.
 
-Split Head Mode
+Split-Head Mode
 ===============
 
 The dedup code can split a head object into two objects:
@@ -175,10 +175,9 @@ The dedup code can split a head object into two objects:
 The new tail object will be deduplicated, unlike head objects, which cannot
 be deduplicated.
 
-:confval:`rgw_dedup_split_obj_head` (default: true). Setting
-this option to ``false`` disables split-head entirely.
-
 .. confval:: rgw_dedup_split_obj_head
+
+   Setting this option to ``false`` disables split-head entirely.
 
 .. note::
    Split-head is automatically disabled on erasure-coded (EC) data pools


### PR DESCRIPTION
Use `ref` for a link.
Improve punctuation and line wrapping.
Combine a duplicate confval mention.

Fixes a broken link.

- Original: https://docs.ceph.com/en/latest/radosgw/s3_objects_dedup/
- Rendered PR: https://ceph--71089.org.readthedocs.build/en/71089/radosgw/s3_objects_dedup/






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
