### PR TITLE
mgr/dashboard: Fix duplicate "Role path Path" field label in RGW Account Create Role modal

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-form/rgw-account-role-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-form/rgw-account-role-form.component.html
@@ -75,7 +75,8 @@
             [invalidText]="roleNameError"
             helperText="Unique name used to identify this role within the account."
             i18n-helperText
-            >Role name
+          >
+            Role name
             <input
               cdsText
               cdValidate
@@ -143,7 +144,8 @@
             [invalidText]="pathError"
             helperText='Specifies the hierarchy or namespace for the role. Use "/" for the root path.'
             i18n-helperText
-            >Role path
+          >
+            Role path
             <input
               cdsText
               cdValidate
@@ -155,17 +157,6 @@
               placeholder="Enter path (/applications/)"
               [invalid]="rolePath.isInvalid"
               [invalidText]="pathError"
-            />Path
-            <input
-              cdsText
-              cdValidate
-              #rolePath="cdValidate"
-              type="text"
-              id="role_path"
-              name="role_path"
-              formControlName="role_path"
-              placeholder="Placeholder text"
-              [invalid]="rolePath.isInvalid"
             />
           </cds-text-label>
           <ng-template #pathError>
@@ -187,7 +178,8 @@
             [invalidText]="policyError"
             helperText="Defines which principals can assume this role. Enter a valid JSON policy document."
             i18n-helperText
-            >Trust policy
+          >
+            Trust policy
             <textarea
               cdsTextArea
               cdValidate
@@ -201,20 +193,6 @@
               [invalid]="policyDoc.isInvalid"
               [invalidText]="policyError"
               cdRequiredField="Trust Policy"
-            >
-Trust policy
-            <textarea
-              cdsTextArea
-              cdValidate
-              #policyDoc="cdValidate"
-              id="role_assume_policy_doc"
-              name="role_assume_policy_doc"
-              formControlName="role_assume_policy_doc"
-              placeholder="Placeholder text"
-              rows="8"
-              cols="200"
-              [invalid]="policyDoc.isInvalid"
-              [invalidText]="policyError"
             ></textarea>
           </cds-textarea-label>
           <ng-template #policyError>


### PR DESCRIPTION
mgr/dashboard: Fix duplicate "Role path Path" field label in RGW Account Create Role modal

Signed-off-by: Sagar Gopale sagar.gopale@ibm.com

Fixes: https://tracker.ceph.com/issues/79413

After : 
<img width="3814" height="2080" alt="image" src="https://github.com/user-attachments/assets/06a609f2-2537-4e7a-8657-da83ace51490" />

PR Description : 
- Fixed duplicate "Role path Path" label and redundant control elements in the RGW Account "Create Role" modal template.
- Removed duplicate string text nodes and duplicate input/textarea elements from `rgw-account-role-form.component.html`.
- Verified that the "Role path" and "Trust policy" form fields now render cleanly in the UI without duplicate labels.






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
