### PR TITLE
rgw/notify: report topic queue ownership in topic stats

### DIFF
--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -130,6 +130,10 @@ the following command:
 
    radosgw-admin topic stats --topic={topic-name} [--tenant={tenant}]
 
+The command also reports, for each queue shard of the topic, the radosgw that
+currently owns it and the time at which that ownership expires. A shard that is
+not owned by any radosgw is reported without an owner.
+
 Dump (in JSON format) all pending bucket notifications of a persistent topic
 by running the following command:
 

--- a/src/rgw/driver/rados/rgw_notify.cc
+++ b/src/rgw/driver/rados/rgw_notify.cc
@@ -90,6 +90,8 @@ class Manager : public DoutPrefixProvider {
   CephContext* const cct;
   static constexpr auto COOKIE_LEN = 16;
   const std::string lock_cookie;
+  // stored in the lock so that the owner of a queue can be identified
+  const std::string lock_description;
   boost::asio::io_context io_context;
   boost::asio::executor_work_guard<Executor> work_guard;
   std::thread worker;
@@ -718,7 +720,7 @@ private:
               ClsLockType::EXCLUSIVE,
               lock_cookie,
               "" /*no tag*/,
-              "" /*no description*/,
+              lock_description,
               failover_time,
               LOCK_FLAG_MAY_RENEW);
 
@@ -835,6 +837,7 @@ public:
   Manager(CephContext* _cct, rgw::sal::RadosStore* store, const SiteConfig& site) :
     cct(_cct),
     lock_cookie(gen_rand_alphanumeric(cct, COOKIE_LEN)),
+    lock_description(cct->_conf->name.to_str()),
     work_guard(boost::asio::make_work_guard(io_context)),
     site(site),
     rados_store(store)
@@ -1366,6 +1369,7 @@ int get_persistent_queue_stats(const DoutPrefixProvider *dpp, librados::IoCtx &r
   stats.queue_reservations = 0; 
   stats.queue_size = 0; 
   stats.queue_entries = 0; 
+  stats.shard_owners.clear();
   for(const auto& shard_name: shards){
     auto ret = cls_2pc_queue_list_reservations(rados_ioctx, shard_name, reservations);
     if (ret < 0) {
@@ -1382,6 +1386,29 @@ int get_persistent_queue_stats(const DoutPrefixProvider *dpp, librados::IoCtx &r
       ldpp_dout(dpp, 1) << "ERROR: failed to get the size or number of entries for queue shard: " << shard_name << ret << dendl;
       return ret;
     }
+
+    // the owner of the shard is the holder of its lock. a shard which is not
+    // owned by any gateway has no locker, and is reported without an owner
+    rgw_topic_shard_owner owner;
+    owner.shard_name = shard_name;
+    std::map<rados::cls::lock::locker_id_t, rados::cls::lock::locker_info_t> lockers;
+    ClsLockType lock_type = ClsLockType::NONE;
+    std::string tag;
+    ret = rados::cls::lock::get_lock_info(&rados_ioctx, shard_name,
+                                          shard_name + "_lock", &lockers,
+                                          &lock_type, &tag);
+    if (ret < 0) {
+      ldpp_dout(dpp, 1) << "ERROR: failed to get lock info for queue shard: " << shard_name << ". error: " << ret << dendl;
+      return ret;
+    }
+    if (!lockers.empty()) {
+      // the lock is exclusive, so there is at most one locker
+      const auto& info = lockers.begin()->second;
+      owner.lock = rgw_topic_shard_lock{info.description,
+                                        info.addr.get_legacy_str(),
+                                        info.expiration};
+    }
+    stats.shard_owners.push_back(std::move(owner));
   }
   return 0;
 }
@@ -1434,6 +1461,18 @@ void rgw_topic_stats::dump(Formatter *f) const {
   f->dump_int("Reservations", queue_reservations);
   f->dump_int("Size", queue_size);
   f->dump_int("Entries", queue_entries);
+  f->open_array_section("Shards");
+  for (const auto& shard : shard_owners) {
+    f->open_object_section("Shard");
+    f->dump_string("Name", shard.shard_name);
+    if (shard.lock) {
+      f->dump_string("Owner", shard.lock->owner);
+      f->dump_string("Owner Address", shard.lock->owner_addr);
+      f->dump_stream("Ownership Expiration") << shard.lock->expiration;
+    }
+    f->close_section();
+  }
+  f->close_section();
   f->close_section();
 }
 

--- a/src/rgw/driver/rados/rgw_notify.h
+++ b/src/rgw/driver/rados/rgw_notify.h
@@ -3,8 +3,11 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
+#include <vector>
 #include "common/ceph_time.h"
+#include "include/utime.h"
 #include "include/common_fwd.h"
 #include "rgw_notify_event_type.h"
 #include "common/async/yield_context.h"
@@ -106,10 +109,26 @@ struct reservation_t {
 
 
 
+// the gateway holding a queue shard's lock
+struct rgw_topic_shard_lock {
+  std::string owner;      // the daemon name kept in the lock. empty if the
+                          // lock is held by a gateway old enough not to store
+                          // it, which can happen while an upgrade is ongoing
+  std::string owner_addr;
+  utime_t expiration;
+};
+
+// ownership of a single queue shard, taken from the shard's lock
+struct rgw_topic_shard_owner {
+  std::string shard_name;
+  std::optional<rgw_topic_shard_lock> lock; // unset if no gateway owns it
+};
+
 struct rgw_topic_stats {
   std::size_t queue_reservations; // number of reservations
   uint64_t queue_size;            // in bytes
   uint32_t queue_entries;         // number of entries
+  std::vector<rgw_topic_shard_owner> shard_owners;
 
   void dump(Formatter *f) const;
 };

--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -3419,6 +3419,79 @@ def test_persistent_topic_stats_http():
     persistent_topic_stats(conn, 'http')
 
 
+def wait_for_shard_owner(topic_name, retries=30):
+    """ wait for at least one queue shard to be owned by a gateway """
+    for _ in range(retries):
+        stats = get_stats_persistent_topic(topic_name)
+        shards = stats['Topic Stats']['Shards']
+        if any('Owner Address' in shard for shard in shards):
+            return shards
+        time.sleep(1)
+    return get_stats_persistent_topic(topic_name)['Topic Stats']['Shards']
+
+
+@pytest.mark.http_test
+def test_persistent_topic_stats_shard_owner():
+    """ test that topic stats report which gateway owns each queue shard """
+    conn = connection()
+    zonegroup = get_config_zonegroup()
+
+    # create bucket
+    bucket_name = gen_bucket_name()
+    bucket = conn.create_bucket(bucket_name)
+    topic_name = bucket_name + TOPIC_SUFFIX
+
+    # create random port for the http server
+    host = get_ip()
+    port = random.randint(10000, 20000)
+    receiver = HTTPServerWithEvents((host, port))
+    endpoint_address = 'http://'+host+':'+str(port)
+    endpoint_args = 'push-endpoint='+endpoint_address+'&persistent=true'
+
+    # create topic and notification
+    topic_conf = PSTopicS3(conn, topic_name, zonegroup, endpoint_args=endpoint_args)
+    topic_arn = topic_conf.set_config()
+    notification_name = bucket_name + NOTIFICATION_SUFFIX
+    topic_conf_list = [{'Id': notification_name, 'TopicArn': topic_arn,
+                        'Events': []
+                        }]
+    s3_notification_conf = PSNotificationS3(conn, bucket_name, topic_conf_list)
+    _, status = s3_notification_conf.set_config()
+    assert status/100 == 2
+
+    try:
+        # write an object so that the queue is processed and its shards locked
+        key = bucket.new_key('foo')
+        key.set_contents_from_string('bar')
+        wait_for_queue_to_drain(topic_name, http_port=port)
+
+        shards = wait_for_shard_owner(topic_name)
+        # every shard of the queue is reported, owned or not
+        assert len(shards) > 0
+        for shard in shards:
+            assert 'Name' in shard
+            # ownership is reported as a whole: a shard that has an owner has
+            # all of the lock's details, one without an owner has none of them
+            owner_keys = {'Owner', 'Owner Address', 'Ownership Expiration'}
+            present = owner_keys.intersection(shard.keys())
+            assert present == owner_keys or not present, \
+                'partial ownership reported for shard: %s' % shard
+
+        owned = [shard for shard in shards if 'Owner Address' in shard]
+        assert len(owned) > 0, 'no shard is owned while the queue is processed'
+        # all gateways here are new enough to record their name in the lock
+        for shard in owned:
+            assert shard['Owner'] != ''
+            assert shard['Owner Address'] != ''
+    finally:
+        s3_notification_conf.del_config()
+        topic_conf.del_config()
+        for key in bucket.list():
+            key.delete()
+        conn.delete_bucket(bucket_name)
+        receiver.close()
+
+
 @pytest.mark.kafka_test
 def test_persistent_topic_stats_kafka():
     """ test persistent topic stats, kafka endpoint """


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/78693

## Problem

There was no way to tell which radosgw is processing a persistent topic, or until when it holds it. `radosgw-admin topic stats` reported only reservations, size and entries.

## Fix

The information is already in the queue's `cls_lock`, so report it from `topic stats`. Per the tracker discussion:

- **Owner per shard.** Each queue shard has its own lock, and in a cluster with several gateways the shards of one topic may be owned by different ones, so every shard is reported separately even when the owner is the same.
- **The daemon name is now stored in the lock description.** `rgw_notify` previously passed an empty description. Neither of the fields `cls_lock` already stored identifies a gateway usefully: the entity name is `client.<global_id>` assigned by the monitor at connect time, and the address is the librados client address, whose port is an ephemeral messenger port rather than the S3 frontend. Locks taken before this change carry an empty description until their next renewal.
- **No cookie.** It is random per daemon and cannot be correlated with a gateway.
- **Expiration only**, not a derived next-renewal time.
- A shard that no gateway owns is reported without owner fields.

## Testing

vstart, 2 radosgws, one persistent topic (11 shards):

```
"Shards": [
    {
        "Name": ":owner-test",
        "Owner": "client.rgw.8000",
        "Owner Address": "172.20.10.5:0/1630196608",
        "Ownership Expiration": "2026-08-17T12:08:46.841268+0530"
    },
    ...
]
```

All 11 shards reported `client.rgw.8000`. Killing that gateway with `kill -9` at 12:07:40 moved every shard to `client.rgw.8001` by 12:08:53, inside the 90s ownership timeout, so the reported owner follows the actual one.

No automated test: verifying this needs two gateways and a failover, which the bucket notification tests cannot currently set up.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
