### PR TITLE
mds: harden journal replay against corrupt journal data

### DIFF
--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -1580,7 +1580,19 @@ void MDLog::_replay_thread()
         return;
       }
       logger->inc(l_mdl_replayed);
-      le->replay(mds);
+      try {
+        le->replay(mds);
+      } catch (const buffer::error &e) {
+        // Events may lazily decode part of their payload during replay
+        // (e.g. EMetaBlob dentry bits).  The event envelope passed
+        // decode_event() but the payload is corrupt; mark the MDS damaged
+        // instead of crashing.
+        mds->clog->error() << "corrupt journal event " << std::string(le->get_type_str())
+                           << " at " << pos << "~" << bl.length() << " / "
+                           << journaler->get_write_pos() << ": " << e.what();
+        mds->damaged();
+        ceph_abort();  // Should be unreachable because damaged() calls respawn()
+      }
     }
 
     logger->set(l_mdl_rdpos, pos);

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -1259,6 +1259,14 @@ void EMetaBlob::replay(MDSRank *mds, LogSegmentRef const& logseg, int type, MDPe
   CDir *olddir = 0;
   if (renamed_dirino) {
     renamed_diri = mds->mdcache->get_inode(renamed_dirino);
+    if (renamed_diri && renamed_diri->ino() != renamed_dirino) {
+      // See the inode_map corruption check in the full dentry loop.
+      dout(0) << "EMetaBlob.replay inode_map corruption: renamed inode " << renamed_diri->ino()
+	      << " expected " << renamed_dirino << dendl;
+      mds->clog->error() << "failure replaying journal (EMetaBlob): corrupt inode_map entry";
+      mds->damaged();
+      ceph_abort();  // Should be unreachable because damaged() calls respawn()
+    }
     if (renamed_diri)
       dout(10) << "EMetaBlob.replay renamed inode is " << *renamed_diri << dendl;
     else
@@ -1285,7 +1293,18 @@ void EMetaBlob::replay(MDSRank *mds, LogSegmentRef const& logseg, int type, MDPe
     dout(10) << "EMetaBlob.replay dir " << lp << dendl;
     dirlump &lump = lump_map[lp];
 
-    // the dir 
+    if (!lump.fnode) {
+      // A dirlump always carries its fnode in the encoded event.  A null
+      // fnode means the event data is corrupt (e.g. lump_order and
+      // lump_map out of sync); mark the MDS damaged instead of crashing
+      // on the null dereference in update_projected_version().
+      dout(0) << "EMetaBlob.replay corrupt dirlump, missing fnode for " << lp << dendl;
+      mds->clog->error() << "failure replaying journal (EMetaBlob): missing fnode for dirfrag " << lp;
+      mds->damaged();
+      ceph_abort();  // Should be unreachable because damaged() calls respawn()
+    }
+
+    // the dir
     CDir *dir = mds->mdcache->get_force_dirfrag(lp, true);
     if (!dir) {
       // hmm.  do i have the inode?
@@ -1310,7 +1329,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegmentRef const& logseg, int type, MDPe
       if (MDS_INO_IS_BASE(lp.ino))
 	mds->mdcache->adjust_subtree_auth(dir, CDIR_AUTH_UNDEF);
 
-      dout(10) << "EMetaBlob.replay added dir " << *dir << dendl;  
+      dout(10) << "EMetaBlob.replay added dir " << *dir << dendl;
     }
     dir->reset_fnode(std::move(lump.fnode));
     dir->update_projected_version();
@@ -1355,6 +1374,13 @@ void EMetaBlob::replay(MDSRank *mds, LogSegmentRef const& logseg, int type, MDPe
 
     // full dentry+inode pairs
     for (auto& fb : lump._get_dfull()) {
+      if (fb.dnfirst > fb.dnlast) {
+	dout(0) << "EMetaBlob.replay corrupt dentry [" << fb.dnfirst << ","
+		<< fb.dnlast << "] " << fb.dn << " in " << dir->dirfrag() << dendl;
+	mds->clog->error() << "failure replaying journal (EMetaBlob): corrupt dentry version";
+	mds->damaged();
+	ceph_abort();  // Should be unreachable because damaged() calls respawn()
+      }
       CDentry *dn = dir->lookup_exact_snap(fb.dn, fb.dnlast);
       if (!dn) {
 	dn = dir->add_null_dentry(fb.dn, fb.dnfirst, fb.dnlast);
@@ -1394,6 +1420,19 @@ void EMetaBlob::replay(MDSRank *mds, LogSegmentRef const& logseg, int type, MDPe
 	dir->link_primary_inode(dn, in);
 	dout(10) << "EMetaBlob.replay added " << *in << dendl;
       } else {
+	if (in->ino() != fb.inode->ino) {
+	  // The inode_map/snap_inode_map entry for the journal's ino does not
+	  // match the inode's own number.  This happens when replay of an
+	  // earlier corrupt event left a stale (or overwritten) map entry;
+	  // using such an inode may dereference freed memory later (e.g. a
+	  // subsequent rename event's renamed_dirino).  Mark the MDS damaged
+	  // instead of continuing.
+	  dout(0) << "EMetaBlob.replay inode_map corruption: found inode " << in->ino()
+		  << " expected " << fb.inode->ino << " for dentry " << fb.dn << dendl;
+	  mds->clog->error() << "failure replaying journal (EMetaBlob): corrupt inode_map entry";
+	  mds->damaged();
+	  ceph_abort();  // Should be unreachable because damaged() calls respawn()
+	}
 	in->first = fb.dnfirst;
 	fb.update_inode(mds, in);
 	if (dn->get_linkage()->get_inode() != in && in->get_parent_dn()) {
@@ -1452,6 +1491,13 @@ void EMetaBlob::replay(MDSRank *mds, LogSegmentRef const& logseg, int type, MDPe
 
     // remote dentries
     for (const auto& rb : lump.get_dremote()) {
+      if (rb.dnfirst > rb.dnlast) {
+	dout(0) << "EMetaBlob.replay corrupt dentry [" << rb.dnfirst << ","
+		<< rb.dnlast << "] " << rb.dn << " in " << dir->dirfrag() << dendl;
+	mds->clog->error() << "failure replaying journal (EMetaBlob): corrupt dentry version";
+	mds->damaged();
+	ceph_abort();  // Should be unreachable because damaged() calls respawn()
+      }
       CDentry *dn = dir->lookup_exact_snap(rb.dn, rb.dnlast);
       if (!dn) {
 	dn = dir->add_remote_dentry(rb.dn, rb.ino, rb.d_type, mempool::mds_co::string(rb.alternate_name), rb.dnfirst, rb.dnlast);
@@ -1488,6 +1534,13 @@ void EMetaBlob::replay(MDSRank *mds, LogSegmentRef const& logseg, int type, MDPe
 
     // null dentries
     for (const auto& nb : lump.get_dnull()) {
+      if (nb.dnfirst > nb.dnlast) {
+	dout(0) << "EMetaBlob.replay corrupt dentry [" << nb.dnfirst << ","
+		<< nb.dnlast << "] " << nb.dn << " in " << dir->dirfrag() << dendl;
+	mds->clog->error() << "failure replaying journal (EMetaBlob): corrupt dentry version";
+	mds->damaged();
+	ceph_abort();  // Should be unreachable because damaged() calls respawn()
+      }
       CDentry *dn = dir->lookup_exact_snap(nb.dn, nb.dnlast);
       if (!dn) {
 	dn = dir->add_null_dentry(nb.dn, nb.dnfirst, nb.dnlast);
@@ -1536,6 +1589,14 @@ void EMetaBlob::replay(MDSRank *mds, LogSegmentRef const& logseg, int type, MDPe
       // we imported a diri we haven't seen before
       renamed_diri = mds->mdcache->get_inode(renamed_dirino);
       ceph_assert(renamed_diri);  // it was in the metablob
+      if (renamed_diri->ino() != renamed_dirino) {
+	// See the inode_map corruption check in the full dentry loop.
+	dout(0) << "EMetaBlob.replay inode_map corruption: renamed inode " << renamed_diri->ino()
+		<< " expected " << renamed_dirino << dendl;
+	mds->clog->error() << "failure replaying journal (EMetaBlob): corrupt inode_map entry";
+	mds->damaged();
+	ceph_abort();  // Should be unreachable because damaged() calls respawn()
+      }
     }
 
     if (olddir) {
@@ -1568,6 +1629,20 @@ void EMetaBlob::replay(MDSRank *mds, LogSegmentRef const& logseg, int type, MDPe
 	else
 	  mds->mdcache->try_trim_non_auth_subtree(root);
       }
+    }
+
+    // The trim above may have discarded the subtree we renamed out of; with
+    // corrupt journal data that decision can be wrong and free renamed_diri
+    // itself.  Detect that via the event's ino (a plain map lookup, no
+    // dereference of the possibly-freed pointer) instead of dereferencing
+    // freed memory in the check below.  On healthy data the renamed inode
+    // always survives the trim, so this cannot trigger spuriously.
+    if (mds->mdcache->get_inode(renamed_dirino) != renamed_diri) {
+      dout(0) << "EMetaBlob.replay renamed inode " << renamed_dirino
+              << " was freed during replay (corrupt journal?)" << dendl;
+      mds->clog->error() << "failure replaying journal (EMetaBlob): renamed inode was trimmed during replay";
+      mds->damaged();
+      ceph_abort();  // Should be unreachable because damaged() calls respawn()
     }
 
     // if we are the srci importer, we'll also have some dirfrags we have to open up...


### PR DESCRIPTION
An MDS joining a filesystem crashed deterministically in `EMetaBlob::replay()`
(reef 18.2.4): the `md_log_replay` thread segfaulted at
`EMetaBlob::replay+0x4010`, identified via disassembly as the
`renamed_diri->authority()` virtual call in the rename-replay path.  The
journal contained a rename event that decoded successfully but carried
corrupt payload data (cephfs-journal-tool reported corrupt dentries and the
filesystem recovered only after `event recover_dentries` + `journal reset`).

Root cause: replay of the corrupt event built an inconsistent cache state; the
subtree trim after `adjust_subtree_after_rename()` then freed `renamed_diri`
itself, and the immediately following `renamed_diri->authority()` check
dereferenced the freed object.  Journal events have no integrity protection
(sentinel+length envelope only), so the corruption was invisible until the
crash.

Changes:

- validate the decoded payload in `EMetaBlob::replay()` and mark the MDS
  damaged instead of crashing:
  - check `dnfirst <= dnlast` for full, remote and null dentry bits
  - check the dirlump `fnode` is present (lump_order/lump_map in sync)
  - check the inode found for a journal ino still carries that ino, and
    likewise for `renamed_dirino`'s inode
  - verify the renamed inode survived the subtree trim before using it
    again; the lookup uses the event's ino, so no freed-memory dereference
    is involved and the check cannot trigger on healthy data (the subsequent
    `authority()` call would have been a use-after-free already)
- catch `buffer::error` thrown by lazily-decoded payloads in
  `MDLog::_replay_thread()` and mark the MDS damaged instead of letting the
  exception terminate the replay thread

All checks are detection, not recovery: a freed object cannot be validated
in-band, but corrupt journal data now surfaces as a clean `damaged` state
with diagnostics instead of a deterministic segfault.

Link: https://tracker.ceph.com/issues/79524

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
