### PR TITLE
mgr/smb: fix sqlite3.InternalError crash on lost RADOS lock

### DIFF
--- a/qa/tasks/thrashosds-health.yaml
+++ b/qa/tasks/thrashosds-health.yaml
@@ -4,7 +4,13 @@ overrides:
       osd:
         osd max markdown count: 1000
         osd blocked scrub grace period: 3600
+      mgr:
+        cephsqlite inject stat error probability: 0.005
     log-ignorelist:
+      - "Caught fatal database error: disk I/O error"
+      - "Unhandled exception from module .*: disk I/O error"
+      - "Module .* has failed: disk I/O error"
+      - db not ready
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)
       - \(OSD_

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -6985,6 +6985,14 @@ options:
   default: true
   tags:
   - client
+- name: cephsqlite_inject_stat_error_probability
+  type: float
+  level: dev
+  desc: Probability that the libcephsqlite VFS fails a stat() with a fake I/O
+    error, for testing
+  default: 0
+  tags:
+  - client
 - name: bdev_type
   type: str
   level: advanced

--- a/src/libcephsqlite.cc
+++ b/src/libcephsqlite.cc
@@ -438,6 +438,12 @@ static int Sync(sqlite3_file *file, int flags)
 }
 
 
+static bool should_inject_stat_error(CephContext* cct)
+{
+  auto p = cct->_conf.get_val<double>("cephsqlite_inject_stat_error_probability");
+  return p && rand() % 10000 < p * 10000.0;
+}
+
 static int FileSize(sqlite3_file *file, sqlite_int64 *osize)
 {
   auto f = (cephsqlite_file*)file;
@@ -445,12 +451,14 @@ static int FileSize(sqlite3_file *file, sqlite_int64 *osize)
   df(5) << dendl;
 
   uint64_t size = 0;
-  if (int rc = f->io.rs->stat(&size); rc < 0) {
+  int rc = should_inject_stat_error(f->io.cct.get()) ? -EIO : f->io.rs->stat(&size);
+  if (rc < 0) {
     df(5) << "stat failed: " << cpp_strerror(rc) << dendl;
     if (rc == -EBLOCKLISTED) {
       getdata(f->vfs).maybe_reconnect(f->io.cluster);
+      return SQLITE_IOERR_LOCK;
     }
-    return SQLITE_NOTFOUND;
+    return SQLITE_IOERR_FSTAT;
   }
 
   *osize = (sqlite_int64)size;
@@ -727,9 +735,15 @@ static int Access(sqlite3_vfs* vfs, const char* path, int flags, int* result)
   }
 
   uint64_t size = 0;
-  if (int rc = io.rs->stat(&size); rc < 0) {
+  int access_rc = SQLITE_OK;
+  if (int rc = should_inject_stat_error(cct.get()) ? -EIO : io.rs->stat(&size); rc < 0) {
     dv(5) << "= " << rc << " (" << cpp_strerror(rc) << ")" << dendl;
-    *result = 0;
+    if (rc == -EBLOCKLISTED) {
+      getdata(vfs).maybe_reconnect(cluster);
+      access_rc = SQLITE_IOERR_LOCK;
+    } else {
+      access_rc = SQLITE_IOERR_FSTAT;
+    }
   } else {
     dv(5) << "= 0" << dendl;
     *result = 1;
@@ -737,7 +751,7 @@ static int Access(sqlite3_vfs* vfs, const char* path, int flags, int* result)
 
   auto end = ceph::coarse_mono_clock::now();
   getdata(vfs).logger->tinc(P_OP_ACCESS, end-start);
-  return SQLITE_OK;
+  return access_rc;
 }
 
 /* This method is only called once for each database. It provides a chance to

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -612,7 +612,7 @@ MAX_DBCLEANUP_RETRIES = 3
 
 def MgrModuleRecoverDB(func: Callable) -> Callable:
     @functools.wraps(func)
-    def check(self: MgrModule, *args: Any, **kwargs: Any) -> Any:
+    def check(self: 'MgrModule', *args: Any, **kwargs: Any) -> Any:
         retries = 0
         while True:
             try:
@@ -1315,6 +1315,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
 
         db.execute(SQL, (version,))
 
+    @MgrModuleRecoverDB
     def set_kv(self, key: str, value: Any) -> None:
         SQL = "INSERT OR REPLACE INTO MgrModuleKV (key, value) VALUES (?, ?);"
 
@@ -1326,6 +1327,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
             self.db.execute(SQL, (key, value))
 
     @API.expose
+    @MgrModuleRecoverDB
     def get_kv(self, key: str) -> Any:
         SQL = "SELECT value FROM MgrModuleKV WHERE key = ?;"
 
@@ -1425,6 +1427,9 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
             try:
                 return self.db is not None
             except MgrDBNotReady:
+                return False
+            except sqlite3.DatabaseError as e:
+                self.log.warning(f"db not ready: {e}")
                 return False
 
     @property

--- a/src/test/libcephsqlite/main.cc
+++ b/src/test/libcephsqlite/main.cc
@@ -1080,6 +1080,21 @@ out:
   ASSERT_EQ(0, rc);
 }
 
+TEST_F(CephSQLiteTest, FileSizeStatError) {
+  EXPECT_EQ(0, cct->_conf.set_val("cephsqlite_inject_stat_error_probability", "1.0"));
+  cct->_conf.apply_changes(nullptr);
+
+  sqlite3_extended_result_codes(db, 1);
+  int rc = sqlite3_exec(db, "CREATE TABLE IF NOT EXISTS stat_error (a INT);", NULL, NULL, NULL);
+  std::string errmsg = sqlite3_errmsg(db);
+
+  cct->_conf.set_val("cephsqlite_inject_stat_error_probability", "0");
+  cct->_conf.apply_changes(nullptr);
+
+  ASSERT_EQ(SQLITE_IOERR, rc & 0xff)
+    << "sqlite3 error: " << rc << " `" << sqlite3_errstr(rc) << "': " << errmsg;
+}
+
 
 int main(int argc, char **argv) {
   auto args = argv_to_vec(argc, argv);


### PR DESCRIPTION
FileSize() returned SQLITE_NOTFOUND instead of SQLITE_IOERR_FSTAT on a failed stat(), which Python's sqlite3 module can't map and surfaces as an unhandled sqlite3.InternalError, crashing the calling mgr module. Also harden db_ready() to catch sqlite3.DatabaseError, and add a probability-based fault injector plus thrash-suite coverage for it.

Fixes: https://tracker.ceph.com/issues/79526


Assisted-by: IBM-Bob:ClaudeSonnet





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
