### PR TITLE
doc/radosgw: improve keystone.rst

### DIFF
--- a/doc/radosgw/keystone.rst
+++ b/doc/radosgw/keystone.rst
@@ -13,47 +13,49 @@ token that Keystone validates will be considered as valid by the gateway.
 The following configuration options are available for Keystone integration::
 
 	[client.radosgw.gateway]
-        rgw keystone api version = {keystone api version}
-        rgw keystone url = {keystone server url:keystone server port}
-        rgw keystone accepted roles = {accepted user roles}
-        rgw keystone token cache size = {number of tokens to cache}
-        rgw keystone implicit tenants = {true for private tenant for each new user}
-        rgw keystone admin user = {keystone service user name}
-        rgw keystone admin password = {keystone service user password}
-        rgw keystone admin password path = {keystone service user password path} # preferred
-        rgw keystone admin domain = {keystone service user domain}
-        rgw keystone admin project = {keystone service project name}
+        rgw_keystone_api_version = {keystone api version}
+        rgw_keystone_url = {keystone server url:keystone server port}
+        rgw_keystone_accepted_roles = {accepted user roles}
+        rgw_keystone_token_cache_size = {number of tokens to cache}
+        rgw_keystone_implicit_tenants = {true for private tenant for each new user}
+        rgw_keystone_admin_user = {keystone service user name}
+        rgw_keystone_admin_password = {keystone service user password}
+        rgw_keystone_admin_password_path = {keystone service user password path} # preferred
+        rgw_keystone_admin_domain = {keystone service user domain}
+        rgw_keystone_admin_project = {keystone service project name}
 
 You need to configure credentials to use against the Keystone service. You need
-a project (tenant), username, and password credentials must be configured to use
+a project (tenant), username, and password credentials to be configured to use
 the Keystone v3 API.
 
-The service credentials needs to have the ``admin`` and ``service`` roles in Keystone to
-allow ``POST /v3/s3tokens`` and ``GET /v3/users/<user>/OS-EC2/<credential>`` requests. You
-can lock down the service credentials to only need the ``service`` role and avoid granting
-the ``admin`` role in Keystone by changing the changing the ``identity:ec2_get_credential``
-policy.
+The service credentials need to have the ``admin`` and ``service`` roles in
+Keystone to allow ``POST /v3/s3tokens`` and
+``GET /v3/users/<user>/OS-EC2/<credential>`` requests. You can lock down the
+service credentials to only need the ``service`` role and avoid granting the
+``admin`` role in Keystone by changing the changing the
+``identity:ec2_get_credential`` policy.
 
 A Ceph Object Gateway user is mapped to a Keystone ``project``. A Keystone
 user may have multiple roles asssigned, possibly for multiple projects.
 
-When the Ceph Object Gateway processes tokens retrieved from Keystone, it looks at the
-project, and the user roles that are assigned to that token, and accepts/rejects the
-request according to the ``rgw keystone accepted roles`` configurable.
+When the Ceph Object Gateway processes tokens retrieved from Keystone, it looks
+at the project, and the user roles that are assigned to that token, and
+accepts/rejects the request according to the
+:confval:`rgw_keystone_accepted_roles` configurable.
 
-For compatibility with previous versions of ceph, it is also
-possible to set ``rgw keystone implicit tenants`` to either
+For compatibility with previous versions of Ceph, it is also
+possible to set :confval:`rgw_keystone_implicit_tenants` to either
 ``s3`` or ``swift``.  This has the effect of splitting
 the identity space such that the indicated protocol will
 only use implicit tenants, and the other protocol will
-never use implicit tenants.  Some older versions of ceph
-only supported implicit tenants with swift.
+never use implicit tenants.  Some older versions of Ceph
+only supported implicit tenants with Swift.
 
-Configuring Keystone service and endpoints
+Configuring Keystone Service and Endpoints
 ------------------------------------------
 
-Keystone itself needs to be configured to point to the Ceph Object Gateway as an
-object-storage endpoint:
+Keystone itself needs to be configured to point to the Ceph Object Gateway as
+an object storage endpoint:
 
 .. prompt:: bash #
 
@@ -116,20 +118,20 @@ object-storage endpoint:
   | service_type | object-store                             |
   +--------------+------------------------------------------+
 
-.. note:: If your radosgw ``ceph.conf`` sets the configuration option
-	  ``rgw swift account in url = true``, your ``object-store``
+.. note:: If :ref:`ceph-conf-database` sets the configuration option
+	  ``rgw_swift_account_in_url = true``, your ``object-store``
 	  endpoint URLs must be set to include the suffix
 	  ``/v1/AUTH_%(tenant_id)s`` (instead of just ``/v1``).
 
 The Keystone URL is the Keystone admin RESTful API URL. The admin token is the
 token that is configured internally in Keystone for admin requests.
 
-OpenStack Keystone may be terminated with a self-signed SSL certificate, in
-order for radosgw to interact with Keystone in such a case, you could either
-install Keystone's SSL certificate in the node running radosgw. Alternatively
-radosgw could be made to not verify the SSL certificate at all (similar to
+OpenStack Keystone may be terminated with a self-signed SSL certificate. In
+order for Ceph Object Gateway to interact with Keystone in such a case, you could
+install Keystone's SSL certificate in the node running the Ceph Object Gateway instance. Alternatively,
+Ceph Object Gateway could be made to not verify the SSL certificate at all (similar to
 OpenStack clients with a ``--insecure`` switch) by setting the value of the
-configurable ``rgw keystone verify ssl`` to false.
+configurable :confval:`rgw_keystone_verify_ssl` to false.
 
 
 .. _OpenStack Keystone documentation: http://docs.openstack.org/developer/keystone/configuringservices.html#setting-up-projects-users-and-roles
@@ -137,11 +139,13 @@ configurable ``rgw keystone verify ssl`` to false.
 Cross-Project (Tenant) Access
 -----------------------------
 
-In order to let a project (earlier called a 'tenant') access buckets belonging to a different project, the following config option needs to be enabled::
+In order to let a project (earlier called a 'tenant') access buckets belonging
+to a different project, the following config option needs to be enabled::
 
-   rgw swift account in url = true
+   rgw_swift_account_in_url = true
 
-The Keystone object-store endpoint must accordingly be configured to include the ``AUTH_%(project_id)s`` suffix:
+The Keystone object store endpoint must accordingly be configured to include
+the ``AUTH_%(project_id)s`` suffix:
 
 .. prompt:: bash #
 
@@ -170,17 +174,17 @@ Keystone Integration with the S3 API
 ------------------------------------
 
 It is possible to use Keystone for authentication even when using the
-S3 API (with AWS-like access and secret keys), if the ``rgw s3 auth
-use keystone`` option is set. For details, see
+S3 API (with AWS-like access and secret keys) if the
+:confval:`rgw_s3_auth_use_keystone` option is set. For details, see
 :doc:`s3/authentication`.
 
 Requests authenticated via Keystone (Swift tokens or S3 with Keystone-managed
-credentials) expose the Keystone idenitity in the IAM policy environment
+credentials) expose the Keystone identity in the IAM policy environment
 as the condition keys: ``keystone:role`` (role names) and
 ``keystone:userid`` (user UUID). These conditions can be used in bucket
 policies and idenitity policies with ``StringEquals``, ``StringNotEquals`` etc.
 
-- **keystone:role** - Allow or deny by *role* (e.g only users with role
+- **keystone:role** - Allow or deny by *role* (e.g. only users with role
   ``reader`` get read access). Use for RBAC.
 - **keystone:userid** - Restrict to specific *user*. Use when policy
   depends on a specific user, not just their role.
@@ -190,18 +194,18 @@ See :doc:`bucketpolicy` for list of supported condition keys.
 Service Token Support
 ---------------------
 
-Service tokens can be enabled to support RadosGW Keystone integration
+Service tokens can be enabled to support Ceph Object Gateway Keystone integration
 to allow expired tokens when coupled with a valid service token in the request.
 
-Enable the support with ``rgw keystone service token enabled`` and use the
-``rgw keystone service token accepted roles`` option to specify which roles are considered
+Enable the support with :confval:`rgw_keystone_service_token_enabled` and use the
+:confval:`rgw_keystone_service_token_accepted_roles` option to specify which roles are considered
 service roles.
 
-The ``rgw keystone expired token cache expiration`` option can be used to tune the cache
-expiration for an expired token allowed with a service token, please note that this must
+The :confval:`rgw_keystone_expired_token_cache_expiration` option can be used to tune the cache
+expiration for an expired token allowed with a service token. Please note that this must
 be lower than the ``[token]/allow_expired_window`` option in the Keystone configuration.
 
 Enabling this will cause an expired token given in the ``X-Auth-Token`` header to be allowed
 if coupled with a ``X-Service-Token`` header that contains a valid token with the accepted
-roles. This can allow long running processes using a user token in ``X-Auth-Token`` to function
+roles. This can allow long-running processes using a user token in ``X-Auth-Token`` to function
 beyond the expiration of the token.


### PR DESCRIPTION
Use underscores instead of spaces in config keys and use `confval` markup.  
Improve language, punctuation, capitalization etc.  
Mention Monitor config db with a link instead of `ceph.conf`.  

- Original: https://docs.ceph.com/en/latest/radosgw/keystone/
- Rendered PR: https://ceph--71095.org.readthedocs.build/en/71095/radosgw/keystone/






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
