### PR TITLE
mgr/nfs: Added warning on ceph orch rm nfs.<cluster> command for nfs and fix RADOS cleanup

### DIFF
--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -337,6 +337,15 @@ class NFSCluster:
                 orchestrator.raise_if_exception(completion)
                 self.delete_config_obj(cluster_id)
                 return
+            # The NFS service may have already been removed via 'ceph orch rm'.
+            # Check if orphaned RADOS config objects remain and clean them up.
+            if self._rados(cluster_id).has_objects():
+                log.warning(
+                    f"NFS cluster '{cluster_id}' not found in orchestrator but RADOS objects "
+                    f"still exist. Cleaning up orphaned objects."
+                )
+                self.delete_config_obj(cluster_id)
+                return
             raise NonFatalError("Cluster does not exist")
         except Exception as e:
             log.exception(f"Failed to delete NFS Cluster {cluster_id}")

--- a/src/pybind/mgr/nfs/rados_utils.py
+++ b/src/pybind/mgr/nfs/rados_utils.py
@@ -87,6 +87,11 @@ class NFSRados:
             for obj in ioctx.list_objects():
                 obj.remove()
 
+    def has_objects(self) -> bool:
+        with self.rados.open_ioctx(self.pool) as ioctx:
+            ioctx.set_namespace(self.namespace)
+            return next(ioctx.list_objects(), None) is not None
+
     def check_config(self, config: str = USER_CONF_PREFIX) -> bool:
         with self.rados.open_ioctx(self.pool) as ioctx:
             ioctx.set_namespace(self.namespace)

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1896,7 +1896,15 @@ Usage:
             force_delete_data=force_delete_data,
         )
         raise_if_exception(completion)
-        return HandleCommandResult(stdout=completion.result_str())
+        result = completion.result_str()
+        if service_name.startswith('nfs.'):
+            cluster_id = service_name[len('nfs.'):]
+            result += (
+                f"\n\nWARNING: 'ceph orch rm {service_name}' only removes the NFS service daemon.\n"
+                f"Associated resources (RADOS config objects, exports, ingress service) will NOT be cleaned up.\n"
+                f"Use 'ceph nfs cluster rm {cluster_id}' for full resource cleanup."
+            )
+        return HandleCommandResult(stdout=result)
 
     @OrchestratorCLICommand.Write('orch apply')
     def apply_misc(self,


### PR DESCRIPTION
mgr/nfs: Added warning on ceph orch rm nfs.<cluster> command for nfs and fix RADOS cleanup

> Signed-off-by: Pooja Dwivedi pooja.dwivedi@ibm.com
> Fixes: https://tracker.ceph.com/issues/79535


### Description
Description of problem - Provide a detailed description of the issue encountered, including logs/command-output snippets and screenshots if the issue:

When an NFS-Ganesha cluster is removed via ceph orch rm nfs.<cluster_name>, the orchestrator successfully tears down the NFS daemon/service but does not remove the corresponding RADOS objects stored in the .nfs pool under the cluster's namespace. 

To address this issue, this PR  does two things

1. A warning: when a user runs ceph orch rm nfs.<cluster>, they get a warning message which states that only the daemon was removed and the user should run ceph nfs cluster rm <cluster> for full cleanup.

2. A recovery path: previously, if someone ran ceph orch rm nfs.<cluster> by mistake, ceph nfs cluster rm would fail with "Cluster does not exist," and there was no way to clean up the orphaned RADOS objects. Now ceph nfs cluster rm checks the RADOS pool directly and can clean up those objects even after the daemon is already gone.

### Testing Logs

Create NFS service

```
[ceph: root@ceph-node-0 /]# ceph orch apply nfs mynfs3 --placement="ceph-node-0"
Scheduled nfs.mynfs3 update..

[ceph: root@ceph-node-0 /]# ceph orch ps --daemon_type nfs
NAME                               HOST         PORTS              STATUS        REFRESHED  AGE  MEM USE  MEM LIM  VERSION  IMAGE ID      CONTAINER ID  
nfs.mynfs3.0.0.ceph-node-0.nebduj  ceph-node-0  *:2049,9587,31311  running (4s)     2s ago  16s    11.3M        -  9.16     d16453ddb70f  e74d9fd937b4  

[ceph: root@ceph-node-0 /]# ceph fs volume create mfs

[ceph: root@ceph-node-0 /]# ceph nfs export create cephfs mynfs3 /mfs mfs --path=/
{
  "bind": "/mfs",
  "cluster": "mynfs3",
  "fs": "mfs",
  "mode": "RW",
  "path": "/"
}
[ceph: root@ceph-node-0 /]# rados ls -N mynfs3 -p ".nfs"
grace
conf-nfs.mynfs3
export-1
rec-0000000000000002:node0
[ceph: root@ceph-node-0 /]# ceph orch ls
NAME                       PORTS              RUNNING  REFRESHED  AGE   PLACEMENT    
crash                                             3/3  81s ago    7m    *            
mds.mfs                                           2/2  81s ago    113s  count:2      
mgr                                               2/2  81s ago    7m    count:2      
mon                                               3/5  81s ago    7m    count:5      
nfs.mynfs3                 ?:2049,9587,31311      0/1  81s ago    4m    ceph-node-0  
osd.all-available-devices         

[ceph: root@ceph-node-0 /]# ceph orch rm nfs.mynfs3
Removed service nfs.mynfs3
WARNING: 'ceph orch rm nfs.mynfs3' only removes the NFS service daemon.
Associated resources (RADOS config objects, exports, ingress service) will NOT be cleaned up.
Use 'ceph nfs cluster rm mynfs3' for full resource cleanup.

[ceph: root@ceph-node-0 /]# rados ls -N mynfs3 -p ".nfs"
conf-nfs.mynfs3
export-1
rec-0000000000000002:node0

[ceph: root@ceph-node-0 /]# ceph nfs cluster rm mynfs3
[ceph: root@ceph-node-0 /]# rados ls -N mynfs3 -p ".nfs"

```




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
