### PR TITLE
squid: rgw: read user usage log in S3 GetUsage

### DIFF
--- a/doc/radosgw/s3/serviceops.rst
+++ b/doc/radosgw/s3/serviceops.rst
@@ -42,7 +42,25 @@ Response Entities
 Get Usage Stats
 ---------------
 
-Gets usage stats per user, similar to the admin command :ref:`rgw_user_usage_stats`.
+Gets usage statistics for the authenticated user, similar to the admin
+command :ref:`rgw_user_usage_stats`.
+
+The response combines three kinds of data:
+
+- **Storage** — current bytes and object counts (``Summary``, ``CapacityUsed``)
+- **Operations** — per-category ops and bandwidth (``Entries``), only when
+  usage logging is enabled on the cluster
+
+Usage Logging
+~~~~~~~~~~~~~
+
+Operation statistics in ``Entries`` require the following setting in the
+appropriate ``ceph.conf`` section, followed by an ``radosgw`` restart::
+
+  rgw enable usage log = true
+
+Without this setting, ``Entries`` is empty but ``CapacityUsed`` and storage
+fields in ``Summary`` are still returned.
 
 Syntax
 ~~~~~~
@@ -53,17 +71,48 @@ Syntax
 
 	Authorization: AWS {access-key}:{hash-of-header-and-secret}
 
+Parameters
+~~~~~~~~~~
+
++--------------+----------------------------------------------------------+---------------+------------+
+| Name         | Description                                              | Example       | Required   |
++==============+==========================================================+===============+============+
+| ``start-date`` | Start of the usage log time range (inclusive).         | ``2024-01-01``| No         |
++--------------+----------------------------------------------------------+---------------+------------+
+| ``end-date``   | End of the usage log time range.                       | ``2025-01-01``| No         |
++--------------+----------------------------------------------------------+---------------+------------+
+
 Response Entities
 ~~~~~~~~~~~~~~~~~
 
 +----------------------------+-------------+-----------------------------------------------------------------+
 | Name                       | Type        | Description                                                     |
 +============================+=============+=================================================================+
-| ``Summary``                | Container   | Summary of total stats by user.                                 |
+| ``Entries``                | Container   | Usage log entries (ops and bandwidth per bucket, per time       |
+|                            |             | window). Empty when usage logging is disabled.                  |
 +----------------------------+-------------+-----------------------------------------------------------------+
-| ``TotalBytes``             | Integer     | Bytes used by user                                              |
+| ``Summary``                | Container   | Aggregated quota settings and total storage for the user.       |
 +----------------------------+-------------+-----------------------------------------------------------------+
-| ``TotalBytesRounded``      | Integer     | Bytes rounded to the nearest 4k boundary                        |
+| ``CapacityUsed``           | Container   | Current storage usage broken down per bucket.                   |
 +----------------------------+-------------+-----------------------------------------------------------------+
-| ``TotalEntries``           | Integer     | Total object entries                                            |
+| ``TotalBytes``             | Integer     | Total bytes used by the user across all buckets.                |
++----------------------------+-------------+-----------------------------------------------------------------+
+| ``TotalBytesRounded``      | Integer     | Total bytes rounded to the nearest 4 KiB boundary.              |
++----------------------------+-------------+-----------------------------------------------------------------+
+| ``TotalEntries``           | Integer     | Total number of object entries for the user.                    |
++----------------------------+-------------+-----------------------------------------------------------------+
+| ``Bucket``                 | String      | Bucket name (inside ``CapacityUsed``).                          |
++----------------------------+-------------+-----------------------------------------------------------------+
+| ``Bytes``                  | Integer     | Raw bytes stored in the bucket.                                 |
++----------------------------+-------------+-----------------------------------------------------------------+
+| ``Bytes_Rounded``          | Integer     | Bytes stored, rounded to the nearest 4 KiB boundary.            |
++----------------------------+-------------+-----------------------------------------------------------------+
+| ``Category``               | String      | Operation category (for example ``put_obj``, ``get_obj``,       |
+|                            |             | ``delete_obj``) inside ``Entries``.                             |
++----------------------------+-------------+-----------------------------------------------------------------+
+| ``Ops``                    | Integer     | Number of operations in the category.                           |
++----------------------------+-------------+-----------------------------------------------------------------+
+| ``BytesSent``              | Integer     | Bytes sent in response to operations.                           |
++----------------------------+-------------+-----------------------------------------------------------------+
+| ``BytesReceived``          | Integer     | Bytes received in request bodies.                               |
 +----------------------------+-------------+-----------------------------------------------------------------+

--- a/examples/rgw/boto3/get_usage_stats.py
+++ b/examples/rgw/boto3/get_usage_stats.py
@@ -12,6 +12,7 @@ secret_key='h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q=='
 client = boto3.client('s3',
         endpoint_url=endpoint,
         aws_access_key_id=access_key,
-        aws_secret_access_key=secret_key)
+        aws_secret_access_key=secret_key,
+        region_name='us-east-1')
 
 print(json.dumps(client.get_usage_stats(), indent=2))

--- a/examples/rgw/boto3/service-2.sdk-extras.json
+++ b/examples/rgw/boto3/service-2.sdk-extras.json
@@ -266,17 +266,17 @@
         },
         "GetUsageStatsOutput":{
             "type":"structure",
-            "members":{
+            "members": {
                 "Entries":{
-                    "shape":"UsageStatsEntries",
+                    "shape": "UsageStatsEntries",
                     "documentation":"<p>Per-hour usage log entries (ops and bandwidth). Empty unless <code>rgw enable usage log = true</code>.</p>"
                 },
                 "Summary":{
-                    "shape":"UsageStatsSummary",
+                    "shape": "UsageStatsSummary",
                     "documentation":"<p>Aggregated quota and storage totals for the user.</p>"
                 },
                 "CapacityUsed":{
-                    "shape":"UsageStatsCapacityUsed",
+                    "shape": "UsageStatsCapacityUsed",
                     "documentation":"<p>Current storage usage per bucket.</p>"
                 }
             }
@@ -518,18 +518,18 @@
         },
         "GetUsageStatsRequest":{
             "type":"structure",
-            "members":{
+            "members": {
                 "StartDate":{
-                    "shape":"StartDate",
+                    "shape": "StartDate",
                     "documentation":"<p>Start of the usage log time range (inclusive).</p>",
                     "location":"querystring",
-                    "locationName":"start-date"
+                    "locationName": "start-date"
                 },
                 "EndDate":{
-                    "shape":"EndDate",
+                    "shape": "EndDate",
                     "documentation":"<p>End of the usage log time range.</p>",
                     "location":"querystring",
-                    "locationName":"end-date"
+                    "locationName": "end-date"
                 }
             }
         },
@@ -550,29 +550,17 @@
         },
         "UsageCategoryEntry":{
             "type":"structure",
-            "members":{
-                "Category":{
-                    "shape":"CategoryName"
-                },
-                "BytesSent":{
-                    "shape":"BytesSent"
-                },
-                "BytesReceived":{
-                    "shape":"BytesReceived"
-                },
-                "Ops":{
-                    "shape":"Ops"
-                },
-                "SuccessfulOps":{
-                    "shape":"SuccessfulOps"
-                }
+            "members": {
+                "Category":{"shape": "CategoryName"},
+                "BytesSent":{"shape": "BytesSent"},
+                "BytesReceived":{"shape": "BytesReceived"},
+                "Ops":{"shape": "Ops"},
+                "SuccessfulOps":{"shape": "SuccessfulOps"}
             }
         },
         "UsageCategoryEntryList":{
             "type":"list",
-            "member":{
-                "shape":"UsageCategoryEntry"
-            },
+            "member":{"shape": "UsageCategoryEntry"},
             "flattened":true
         },
         "UsageEpoch":{
@@ -580,191 +568,153 @@
         },
         "UsageStatsBucketEntry":{
             "type":"structure",
-            "members":{
-                "Time":{
-                    "shape":"UsageTime"
-                },
-                "Epoch":{
-                    "shape":"UsageEpoch"
-                },
+            "members": {
+                "Time":{"shape": "UsageTime"},
+                "Epoch":{"shape": "UsageEpoch"},
                 "Categories":{
-                    "shape":"UsageStatsCategories",
-                    "locationName":"categories"
+                    "shape": "UsageStatsCategories",
+                    "locationName": "categories"
                 },
                 "S3Select":{
-                    "shape":"UsageStatsS3Select",
-                    "locationName":"s3select"
+                    "shape": "UsageStatsS3Select",
+                    "locationName": "s3select"
                 },
                 "Bucket":{
-                    "shape":"UsageBucketName",
-                    "locationName":"Bucket"
+                    "shape": "UsageBucketName",
+                    "locationName": "Bucket"
                 }
             }
         },
         "UsageStatsCapacityBucketEntry":{
             "type":"structure",
-            "members":{
-                "Bytes":{
-                    "shape":"TotalBytes"
-                },
+            "members": {
+                "Bytes":{"shape": "TotalBytes"},
                 "BytesRounded":{
-                    "shape":"TotalBytesRounded",
-                    "locationName":"Bytes_Rounded"
+                    "shape": "TotalBytesRounded",
+                    "locationName": "Bytes_Rounded"
                 },
                 "Bucket":{
-                    "shape":"UsageBucketName",
-                    "locationName":"Bucket"
+                    "shape": "UsageBucketName",
+                    "locationName": "Bucket"
                 }
             }
         },
         "UsageStatsCapacityBucketItemList":{
             "type":"list",
-            "member":{
-                "shape":"UsageStatsCapacityBucketEntry"
-            },
+            "member":{"shape": "UsageStatsCapacityBucketEntry"},
             "flattened":true
         },
         "UsageStatsCapacityBuckets":{
             "type":"structure",
-            "members":{
+            "members": {
                 "Entry":{
-                    "shape":"UsageStatsCapacityBucketItemList",
-                    "locationName":"Entry"
+                    "shape": "UsageStatsCapacityBucketItemList",
+                    "locationName": "Entry"
                 }
             }
         },
         "UsageStatsCapacityUsed":{
             "type":"structure",
-            "members":{
+            "members": {
                 "User":{
-                    "shape":"UsageStatsCapacityUserList",
-                    "locationName":"User"
+                    "shape": "UsageStatsCapacityUserList",
+                    "locationName": "User"
                 }
             }
         },
         "UsageStatsCapacityUser":{
             "type":"structure",
-            "members":{
-                "Buckets":{
-                    "shape":"UsageStatsCapacityBuckets"
-                }
+            "members": {
+                "Buckets":{"shape": "UsageStatsCapacityBuckets"}
             }
         },
         "UsageStatsCapacityUserList":{
             "type":"list",
-            "member":{
-                "shape":"UsageStatsCapacityUser"
-            },
+            "member":{"shape": "UsageStatsCapacityUser"},
             "flattened":true
         },
         "UsageStatsCategories":{
             "type":"structure",
-            "members":{
+            "members": {
                 "Entry":{
-                    "shape":"UsageCategoryEntryList",
-                    "locationName":"Entry"
+                    "shape": "UsageCategoryEntryList",
+                    "locationName": "Entry"
                 }
             }
         },
         "UsageStatsEntries":{
             "type":"structure",
-            "members":{
+            "members": {
                 "User":{
-                    "shape":"UsageStatsEntryUserList",
-                    "locationName":"User"
+                    "shape": "UsageStatsEntryUserList",
+                    "locationName": "User"
                 }
             }
         },
         "UsageStatsEntryBucketItemList":{
             "type":"list",
-            "member":{
-                "shape":"UsageStatsBucketEntry"
-            },
+            "member":{"shape": "UsageStatsBucketEntry"},
             "flattened":true
         },
         "UsageStatsEntryBuckets":{
             "type":"structure",
-            "members":{
+            "members": {
                 "Bucket":{
-                    "shape":"UsageStatsEntryBucketItemList",
-                    "locationName":"Bucket"
+                    "shape": "UsageStatsEntryBucketItemList",
+                    "locationName": "Bucket"
                 }
             }
         },
         "UsageStatsEntryUser":{
             "type":"structure",
-            "members":{
-                "Owner":{
-                    "shape":"OwnerName"
-                },
-                "Buckets":{
-                    "shape":"UsageStatsEntryBuckets"
-                }
+            "members": {
+                "Owner":{"shape": "OwnerName"},
+                "Buckets":{"shape": "UsageStatsEntryBuckets"}
             }
         },
         "UsageStatsEntryUserList":{
             "type":"list",
-            "member":{
-                "shape":"UsageStatsEntryUser"
-            },
+            "member":{"shape": "UsageStatsEntryUser"},
             "flattened":true
         },
         "UsageStatsS3Select":{
             "type":"structure",
-            "members":{
-                "BytesProcessed":{
-                    "shape":"BytesProcessed"
-                },
-                "BytesReturned":{
-                    "shape":"BytesReturned"
-                }
+            "members": {
+                "BytesProcessed":{"shape": "BytesProcessed"},
+                "BytesReturned":{"shape": "BytesReturned"}
             }
         },
         "UsageStatsSummaryUser":{
             "type":"structure",
-            "members":{
+            "members": {
                 "User":{
-                    "shape":"OwnerName",
-                    "locationName":"User"
+                    "shape": "OwnerName",
+                    "locationName": "User"
                 },
                 "Categories":{
-                    "shape":"UsageStatsCategories",
-                    "locationName":"categories"
+                    "shape": "UsageStatsCategories",
+                    "locationName": "categories"
                 },
                 "Total":{
-                    "shape":"UsageStatsTotal",
-                    "locationName":"Total"
+                    "shape": "UsageStatsTotal",
+                    "locationName": "Total"
                 }
             }
         },
         "UsageStatsSummaryUserList":{
             "type":"list",
-            "member":{
-                "shape":"UsageStatsSummaryUser"
-            },
+            "member":{"shape": "UsageStatsSummaryUser"},
             "flattened":true
         },
         "UsageStatsTotal":{
             "type":"structure",
-            "members":{
-                "BytesSent":{
-                    "shape":"BytesSent"
-                },
-                "BytesReceived":{
-                    "shape":"BytesReceived"
-                },
-                "Ops":{
-                    "shape":"Ops"
-                },
-                "SuccessfulOps":{
-                    "shape":"SuccessfulOps"
-                },
-                "BytesProcessed":{
-                    "shape":"BytesProcessed"
-                },
-                "BytesReturned":{
-                    "shape":"BytesReturned"
-                }
+            "members": {
+                "BytesSent":{"shape": "BytesSent"},
+                "BytesReceived":{"shape": "BytesReceived"},
+                "Ops":{"shape": "Ops"},
+                "SuccessfulOps":{"shape": "SuccessfulOps"},
+                "BytesProcessed":{"shape": "BytesProcessed"},
+                "BytesReturned":{"shape": "BytesReturned"}
             }
         },
         "UsageTime":{

--- a/examples/rgw/boto3/service-2.sdk-extras.json
+++ b/examples/rgw/boto3/service-2.sdk-extras.json
@@ -1,225 +1,849 @@
 {
-"version": 1.0,
-"merge": {
-    "operations":{
-        "DeleteBucketNotificationConfiguration":{
-            "name":"DeleteBucketNotificationConfiguration",
-            "http":{
-                "method":"DELETE",
-                "requestUri":"/{Bucket}?notification",
-                "responseCode":204
-            },
-            "input":{"shape":"DeleteBucketNotificationConfigurationRequest"},
-            "documentationUrl":"https://docs.ceph.com/docs/master/radosgw/s3/bucketops/#delete-notification",
-            "documentation":"<p>Deletes the notification configuration from the bucket.</p>"
-        },
-        "GetUsageStats":{
-            "name":"GetUsageStats",
-            "http":{
-                "method":"GET",
-                "requestUri":"/?usage",
-                "responseCode":200
-            },
-            "output": {"shape": "GetUsageStatsOutput"},
-            "documentationUrl":"https://docs.ceph.com/docs/master/radosgw/s3/serviceops#get-usage-stats",
-            "documentation":"<p>Get usage stats for the user</p>"
-        }
-    },
-    "shapes": {
-        "ListObjectsRequest": {
-            "members": {
-                "AllowUnordered": {
-                    "shape":"AllowUnordered",
-                    "documentation":"<p>Allow the listing results to be returned in unsorted order. This may be faster when listing very large buckets.</p>",
-                    "location":"querystring",
-                    "locationName":"allow-unordered"
-                }
-            }
-        },
-        "ListObjectsV2Request": {
-            "members": {
-                "AllowUnordered": {
-                    "shape":"AllowUnordered",
-                    "documentation":"<p>Allow the listing results to be returned in unsorted order. This may be faster when listing very large buckets.</p>",
-                    "location":"querystring",
-                    "locationName":"allow-unordered"
-                }
-            }
-        },
-        "AllowUnordered":{"type":"boolean"},
-        "PutObjectRequest": {
-            "members": {
-                "AppendPosition": {
-                    "shape":"AppendPosition",
-                    "documentation": "<p>Position to allow appending</p>",
-                    "location": "querystring",
-                    "locationName": "position"
+    "version": 1.0,
+    "merge": {
+        "operations": {
+            "DeleteBucketNotificationConfiguration": {
+                "name": "DeleteBucketNotificationConfiguration",
+                "http": {
+                    "method": "DELETE",
+                    "requestUri": "/{Bucket}?notification",
+                    "responseCode": 204
                 },
-                "Append": {
-                    "shape":"Append",
-                    "documentation":"<p>Append Object</p>",
-                    "location": "querystring",
-                    "locationName": "append"
-                }
-            }
-        },
-        "Append": {"type":"boolean"},
-        "AppendPosition":{"type":"integer"},
-        "PutObjectOutput": {
-            "members": {
-                "AppendPosition": {
-                    "shape":"AppendPosition",
-                    "documentation": "<p>Position to allow appending</p>",
-                    "location": "header",
-                    "locationName": "x-rgw-next-append-position",
-                    "documentationUrl":"https://docs.ceph.com/docs/master/radosgw/s3/objectops/#append-object"
-                }
-            }
-        },
-        "GetBucketNotificationConfigurationRequest":{
-            "type":"structure",
-            "required":["Bucket"],
-            "members":{
-                "Bucket":{
-                    "shape":"BucketName",
-                    "documentation":"<p>Name of the bucket to get the notifications configuration for.</p>",
-                    "location":"uri",
-                    "locationName":"Bucket"
+                "input": {
+                    "shape": "DeleteBucketNotificationConfigurationRequest"
                 },
-                "Notification":{
-                    "shape":"NotificationId",
-                    "documentation":"<p>Id of the specific notification on the bucket for which the configuration should be retrieved.</p>",
-                    "location":"querystring",
-                    "locationName":"notification-id"
-                }
+                "documentationUrl": "https://docs.ceph.com/docs/master/radosgw/s3/bucketops/#delete-notification",
+                "documentation": "<p>Deletes the notification configuration from the bucket.</p>"
+            },
+            "PostBucketLogging": {
+                "name": "PostBucketLogging",
+                "http": {
+                    "method": "POST",
+                    "requestUri": "/{Bucket}?logging",
+                    "responseCode": 201
+                },
+                "input": {
+                    "shape": "PostBucketLoggingRequest"
+                },
+                "output": {
+                    "shape": "PostBucketLoggingOutput"
+                },
+                "documentationUrl": "https://docs.ceph.com/docs/master/radosgw/s3/bucketops/#post-bucket-logging",
+                "documentation": "<p>Flushes the logging objects of the buckets.</p>"
+            },
+            "PutBucketLogging": {
+                "name": "PutBucketLogging",
+                "http": {
+                    "method": "PUT",
+                    "requestUri": "/{Bucket}?logging"
+                },
+                "input": {
+                    "shape": "PutBucketLoggingRequest"
+                },
+                "output": {
+                    "shape": "PutBucketLoggingOutput"
+                },
+                "documentationUrl": "https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLogging.html",
+                "documentation": "<p>Put bucket logging configuration on source bucket.</p>"
+            },
+            "GetUsageStats": {
+                "name": "GetUsageStats",
+                "http": {
+                    "method": "GET",
+                    "requestUri": "/?usage",
+                    "responseCode": 200
+                },
+                "input": {
+                    "shape": "GetUsageStatsRequest"
+                },
+                "output": {
+                    "shape": "GetUsageStatsOutput",
+                    "resultWrapper": "Usage"
+                },
+                "documentationUrl": "https://docs.ceph.com/docs/master/radosgw/s3/serviceops#get-usage-stats",
+                "documentation": "<p>Get usage stats for the authenticated user. Returns storage totals, per-bucket capacity, and (when usage logging is enabled) per-operation statistics.</p>"
             }
         },
-        "DeleteBucketNotificationConfigurationRequest":{
-            "type":"structure",
-            "required":["Bucket"],
-            "members":{
-                "Bucket":{
-                    "shape":"BucketName",
-                    "documentation":"<p>Name of the bucket to delete the notifications configuration from.</p>",
-                    "location":"uri",
-                    "locationName":"Bucket"
-                },
-                "Notification":{
-                    "shape":"NotificationId",
-                    "documentation":"<p>Id of the specific notification on the bucket to be deleted.</p>",
-                    "location":"querystring",
-                    "locationName":"notification-id"
-                }
-            }
-        },
-        "FilterRule":{
-            "type":"structure",
-            "members":{
-                "Name":{
-                    "shape":"FilterRuleName",
-                    "documentation":"<p>The object key name prefix, suffix or regex identifying one or more objects to which the filtering rule applies. The maximum length is 1,024 characters. Overlapping prefixes and suffixes are supported.</p>"
-                },
-                "Value":{
-                    "shape":"FilterRuleValue",
-                    "documentation":"<p>The value that the filter searches for in object key names.</p>"
+        "shapes": {
+            "ListObjectsRequest": {
+                "members": {
+                    "AllowUnordered": {
+                        "shape": "AllowUnordered",
+                        "documentation": "<p>Allow the listing results to be returned in unsorted order. This may be faster when listing very large buckets.</p>",
+                        "location": "querystring",
+                        "locationName": "allow-unordered"
+                    }
                 }
             },
-            "documentation":"<p>Specifies the Amazon S3 object key name to filter on and whether to filter on the suffix, prefix or regex of the key name.</p>"
-        },
-        "FilterRuleName":{
-            "type":"string",
-            "enum":[
-                "prefix",
-                "suffix",
-                "regex"
-            ]
-        },
-        "NotificationConfigurationFilter":{
-            "type":"structure",
-            "members":{
-                "Key":{
-                    "shape":"S3KeyFilter",
-                    "documentation":"<p/>",
-                    "locationName":"S3Key"
+            "ListObjectsV2Request": {
+                "members": {
+                    "AllowUnordered": {
+                        "shape": "AllowUnordered",
+                        "documentation": "<p>Allow the listing results to be returned in unsorted order. This may be faster when listing very large buckets.</p>",
+                        "location": "querystring",
+                        "locationName": "allow-unordered"
+                    }
+                }
+            },
+            "ReplicationRule": {
+                "members": {
+                    "Source": {
+                        "shape": "S3RepSource",
+                        "documentation": "<p>A container for information about the replication source.<p>",
+                        "locationName": "Source"
+                    }
+                }
+            },
+            "S3RepSource": {
+                "type": "structure",
+                "members": {
+                    "Zones": {
+                        "shape": "ZoneList",
+                        "documentation": "<p>Array of replication source zone names.</p>",
+                        "locationName": "Zone"
+                    }
+                }
+            },
+            "Destination": {
+                "members": {
+                    "Zones": {
+                        "shape": "ZoneList",
+                        "documentation": "<p>Array of replication destination zone names.</p>",
+                        "locationName": "Zone"
+                    }
+                }
+            },
+            "ZoneList": {
+                "type": "list",
+                "member": {
+                    "shape": "Zone"
                 },
-                "Metadata":{
-                    "shape":"S3MetadataFilter",
-                    "documentation":"<p/>",
-                    "locationName":"S3Metadata"
+                "flattened": true
+            },
+            "Zone": {
+                "type": "string"
+            },
+            "AllowUnordered": {
+                "type": "boolean"
+            },
+            "PutObjectRequest": {
+                "members": {
+                    "AppendPosition": {
+                        "shape": "AppendPosition",
+                        "documentation": "<p>Position to allow appending</p>",
+                        "location": "querystring",
+                        "locationName": "position"
+                    },
+                    "Append": {
+                        "shape": "Append",
+                        "documentation": "<p>Append Object</p>",
+                        "location": "querystring",
+                        "locationName": "append"
+                    }
+                }
+            },
+            "Append": {
+                "type": "boolean"
+            },
+            "AppendPosition": {
+                "type": "integer"
+            },
+            "PutObjectOutput": {
+                "members": {
+                    "AppendPosition": {
+                        "shape": "AppendPosition",
+                        "documentation": "<p>Position to allow appending</p>",
+                        "location": "header",
+                        "locationName": "x-rgw-next-append-position",
+                        "documentationUrl": "https://docs.ceph.com/docs/master/radosgw/s3/objectops/#append-object"
+                    }
+                }
+            },
+            "GetBucketNotificationConfigurationRequest": {
+                "type": "structure",
+                "required": [
+                    "Bucket"
+                ],
+                "members": {
+                    "Bucket": {
+                        "shape": "BucketName",
+                        "documentation": "<p>Name of the bucket to get the notifications configuration for.</p>",
+                        "location": "uri",
+                        "locationName": "Bucket"
+                    },
+                    "Notification": {
+                        "shape": "NotificationId",
+                        "documentation": "<p>Id of the specific notification on the bucket for which the configuration should be retrieved.</p>",
+                        "location": "querystring",
+                        "locationName": "notification-id"
+                    }
+                }
+            },
+            "DeleteBucketNotificationConfigurationRequest": {
+                "type": "structure",
+                "required": [
+                    "Bucket"
+                ],
+                "members": {
+                    "Bucket": {
+                        "shape": "BucketName",
+                        "documentation": "<p>Name of the bucket to delete the notifications configuration from.</p>",
+                        "contextParam": {
+                            "name": "Bucket"
+                        },
+                        "location": "uri",
+                        "locationName": "Bucket"
+                    },
+                    "Notification": {
+                        "shape": "NotificationId",
+                        "documentation": "<p>Id of the specific notification on the bucket to be deleted.</p>",
+                        "location": "querystring",
+                        "locationName": "notification-id"
+                    }
+                }
+            },
+            "PostBucketLoggingRequest": {
+                "type": "structure",
+                "required": [
+                    "Bucket"
+                ],
+                "members": {
+                    "Bucket": {
+                        "shape": "BucketName",
+                        "documentation": "<p>Name of the bucket to flush its logging objects.</p>",
+                        "contextParam": {
+                            "name": "Bucket"
+                        },
+                        "location": "uri",
+                        "locationName": "Bucket"
+                    }
+                }
+            },
+            "FilterRule": {
+                "type": "structure",
+                "members": {
+                    "Name": {
+                        "shape": "FilterRuleName",
+                        "documentation": "<p>The object key name prefix, suffix or regex identifying one or more objects to which the filtering rule applies. The maximum length is 1,024 characters. Overlapping prefixes and suffixes are supported.</p>"
+                    },
+                    "Value": {
+                        "shape": "FilterRuleValue",
+                        "documentation": "<p>The value that the filter searches for in object key names.</p>"
+                    }
                 },
-                "Tags":{
-                    "shape":"S3TagsFilter",
-                    "documentation":"<p/>",
-                    "locationName":"S3Tags"
-                }
-
+                "documentation": "<p>Specifies the Amazon S3 object key name to filter on and whether to filter on the suffix, prefix or regex of the key name.</p>"
             },
-            "documentation":"<p>Specifies object key name filtering rules. For information about key name filtering, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html\">Configuring Event Notifications</a> in the <i>Amazon Simple Storage Service Developer Guide</i>.</p>"
-        },
-        "S3KeyFilter":{
-            "type":"structure",
-            "members":{
-                "FilterRules":{
-                    "shape":"FilterRuleList",
-                    "documentation":"<p/>",
-                    "locationName":"FilterRule"
+            "FilterRuleName": {
+                "type": "string",
+                "enum": [
+                    "prefix",
+                    "suffix",
+                    "regex"
+                ]
+            },
+            "NotificationConfigurationFilter": {
+                "type": "structure",
+                "members": {
+                    "Key": {
+                        "shape": "S3KeyFilter",
+                        "documentation": "<p/>",
+                        "locationName": "S3Key"
+                    },
+                    "Metadata": {
+                        "shape": "S3MetadataFilter",
+                        "documentation": "<p/>",
+                        "locationName": "S3Metadata"
+                    },
+                    "Tags": {
+                        "shape": "S3TagsFilter",
+                        "documentation": "<p/>",
+                        "locationName": "S3Tags"
+                    }
+                },
+                "documentation": "<p>Specifies object key name filtering rules. For information about key name filtering, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html\">Configuring Event Notifications</a> in the <i>Amazon Simple Storage Service Developer Guide</i>.</p>"
+            },
+            "S3KeyFilter": {
+                "type": "structure",
+                "members": {
+                    "FilterRules": {
+                        "shape": "FilterRuleList",
+                        "documentation": "<p/>",
+                        "locationName": "FilterRule"
+                    }
+                },
+                "documentation": "<p>A container for object key name prefix, suffix and regex filtering rules.</p>"
+            },
+            "S3MetadataFilter": {
+                "type": "structure",
+                "members": {
+                    "FilterRules": {
+                        "shape": "FilterRuleList",
+                        "documentation": "<p/>",
+                        "locationName": "FilterRule"
+                    }
+                },
+                "documentation": "<p>A container for metadata filtering rules.</p>"
+            },
+            "S3TagsFilter": {
+                "type": "structure",
+                "members": {
+                    "FilterRules": {
+                        "shape": "FilterRuleList",
+                        "documentation": "<p/>",
+                        "locationName": "FilterRule"
+                    }
+                },
+                "documentation": "<p>A container for object tags filtering rules.</p>"
+            },
+            "QuotaMaxBytes": {
+                "type": "integer"
+            },
+            "QuotaMaxBuckets": {
+                "type": "integer"
+            },
+            "QuotaMaxObjCount": {
+                "type": "integer"
+            },
+            "QuotaMaxBytesPerBucket": {
+                "type": "integer"
+            },
+            "QuotaMaxObjCountPerBucket": {
+                "type": "integer"
+            },
+            "TotalBytesRounded": {
+                "type": "integer"
+            },
+            "TotalBytes": {
+                "type": "integer"
+            },
+            "TotalEntries": {
+                "type": "integer"
+            },
+            "LoggingEnabled": {
+                "type": "structure",
+                "required": [
+                    "TargetBucket",
+                    "TargetPrefix"
+                ],
+                "members": {
+                    "TargetBucket": {
+                        "shape": "TargetBucket",
+                        "documentation": "<p>Specifies the bucket where you want to store server access logs. You can have your logs delivered to any bucket that you own. You can also configure multiple buckets to deliver their logs to the same target bucket. In this case, you should choose a different <code>TargetPrefix</code> for each source bucket so that the delivered log files can be distinguished by key.</p>"
+                    },
+                    "TargetGrants": {
+                        "shape": "TargetGrants",
+                        "documentation": "<p>Container for granting information.</p> <p>Should be used when the write permissions to the tagert bucket should eb different than the permissions of the user performing the operation thta needs to be logged. This is usually used in cased of batched logging. see: <code>RecordBatchSize</code>.</p>"
+                    },
+                    "TargetPrefix": {
+                        "shape": "TargetPrefix",
+                        "documentation": "<p>A prefix for all log object keys. If you store log files from multiple buckets in a single bucket, you can use a prefix to distinguish which log files came from which bucket.</p>"
+                    },
+                    "TargetObjectKeyFormat": {
+                        "shape": "TargetObjectKeyFormat",
+                        "documentation": "<p>key format for log objects.</p>"
+                    },
+                    "ObjectRollTime": {
+                        "shape": "ObjectRollTime",
+                        "documentation": "<p>time in seconds to move the log object to the target bucket and start another log object.</p>"
+                    },
+                    "LoggingType": {
+                        "shape": "LoggingType",
+                        "documentation": "<p>use Standard log type to log all bucket operations i nthe standard format. use Journal log type to log only creations and deletion of objects in more compact format.</p>"
+                    },
+                    "RecordsBatchSize": {
+                        "shape": "RecordsBatchSize",
+                        "documentation": "indicates how many records to batch in memory before writing to the object. if set to zero, records are written syncronously to the object. if <code>ObjectRollTime</code>e is reached, the batch of records will be written to the object regardless of the number of records. </p>"
+                    },
+                    "Filter": {
+                        "shape": "LoggingConfigurationFilter",
+                        "documentation": "<p>A filter for all log object. Filter for the object by its key (prefix, suffix and regex).</p>"
+                    }
+                },
+                "documentation": "<p>Describes where logs are stored the prefix assigned to all log object keys for a bucket, and their format. also, the level the delivery guarantee of the records.</p>"
+            },
+            "TargetObjectKeyFormat": {
+                "type": "structure",
+                "members": {
+                    "SimplePrefix": {
+                        "shape": "SimplePrefix",
+                        "documentation": "<p>To use the simple format for S3 keys for log objects. To specify SimplePrefix format, set SimplePrefix to {}.</p>",
+                        "locationName": "SimplePrefix"
+                    },
+                    "PartitionedPrefix": {
+                        "shape": "PartitionedPrefix",
+                        "documentation": "<p>Partitioned S3 key for log objects.</p>",
+                        "locationName": "PartitionedPrefix"
+                    }
+                },
+                "documentation": "<p>Key format for log objects. Only one format, PartitionedPrefix or SimplePrefix, is allowed.</p>"
+            },
+            "SimplePrefix": {
+                "type": "structure",
+                "members": {},
+                "documentation": "<p>To use simple format for S3 keys for log objects, set SimplePrefix to an empty object.</p> <p> <code>[DestinationPrefix][YYYY]-[MM]-[DD]-[hh]-[mm]-[ss]-[UniqueString]</code> </p>",
+                "locationName": "SimplePrefix"
+            },
+            "PartitionDateSource": {
+                "type": "string",
+                "enum": [
+                    "EventTime",
+                    "DeliveryTime"
+                ]
+            },
+            "PartitionedPrefix": {
+                "type": "structure",
+                "members": {
+                    "PartitionDateSource": {
+                        "shape": "PartitionDateSource",
+                        "documentation": "<p>Specifies the partition date source for the partitioned prefix. PartitionDateSource can be EventTime or DeliveryTime.</p>"
+                    }
+                },
+                "documentation": "<p>Amazon S3 keys for log objects are partitioned in the following format:</p> <p> <code>[DestinationPrefix][SourceAccountId]/[SourceRegion]/[SourceBucket]/[YYYY]/[MM]/[DD]/[YYYY]-[MM]-[DD]-[hh]-[mm]-[ss]-[UniqueString]</code> </p> <p>PartitionedPrefix defaults to EventTime delivery when server access logs are delivered.</p>",
+                "locationName": "PartitionedPrefix"
+            },
+            "ObjectRollTime": {
+                "type": "integer"
+            },
+            "RecordsBatchSize": {
+                "type": "integer"
+            },
+            "LoggingType": {
+                "type": "string",
+                "enum": [
+                    "Standard",
+                    "Journal"
+                ]
+            },
+            "LoggingConfigurationFilter": {
+                "type": "structure",
+                "members": {
+                    "Key": {
+                        "shape": "S3KeyFilter",
+                        "documentation": "<p/>",
+                        "locationName": "S3Key"
+                    }
+                },
+                "documentation": "<p>A filter for all log object. Filter for the object by its key (prefix, suffix and regex).</p>",
+                "locationName": "Filter"
+            },
+            "HeadBucketRequest": {
+                "members": {
+                    "ReadStats": {
+                        "shape": "ReadStats",
+                        "documentation": "<p>Read additional usage statistics for <code>ObjectCount</code> and <code>BytesUsed</code> in the response.</p> <note> <p>This request parameter is a Ceph RGW extension.</p> </note>",
+                        "location": "querystring",
+                        "locationName": "read-stats"
+                    }
                 }
             },
-            "documentation":"<p>A container for object key name prefix, suffix and regex filtering rules.</p>"
-        },
-        "S3MetadataFilter":{
-            "type":"structure",
-            "members":{
-                "FilterRules":{
-                    "shape":"FilterRuleList",
-                    "documentation":"<p/>",
-                    "locationName":"FilterRule"
+            "PostBucketLoggingOutput": {
+                "type": "structure",
+                "members": {
+                    "FlushedLoggingObject": {
+                        "shape": "FlushedLoggingObject",
+                        "documentation": "<p>Name of the pending logging object that was flushed.</p>"
+                    }
                 }
             },
-            "documentation":"<p>A container for metadata filtering rules.</p>"
-        },
-        "S3TagsFilter":{
-            "type":"structure",
-            "members":{
-                "FilterRules":{
-                    "shape":"FilterRuleList",
-                    "documentation":"<p/>",
-                    "locationName":"FilterRule"
+            "PutBucketLoggingOutput": {
+                "type": "structure",
+                "members": {
+                    "FlushedLoggingObject": {
+                        "shape": "FlushedLoggingObject",
+                        "documentation": "<p>Name of the pending logging object that was flushed.</p>"
+                    }
                 }
             },
-            "documentation":"<p>A container for object tags filtering rules.</p>"
-        },
-        "GetUsageStatsOutput": {
-            "type": "structure",
-            "members": {
-                "Summary": {
-                    "shape":"UsageStatsSummary",
-                    "documentation": "<p/>"
+            "FlushedLoggingObject": {
+                "type": "string"
+            },
+            "HeadBucketOutput": {
+                "type": "structure",
+                "members": {
+                    "ObjectCount": {
+                        "shape": "ObjectCount",
+                        "documentation": "<p>Total number of objects/versions in the bucket.</p>",
+                        "location": "header",
+                        "locationName": "x-rgw-object-count"
+                    },
+                    "BytesUsed": {
+                        "shape": "BytesUsed",
+                        "documentation": "<p>Total size in bytes of all objects/versions in the bucket.</p>",
+                        "location": "header",
+                        "locationName": "x-rgw-bytes-used"
+                    }
                 }
+            },
+            "ReadStats": {
+                "type": "boolean"
+            },
+            "ObjectCount": {
+                "type": "integer"
+            },
+            "BytesUsed": {
+                "type": "integer"
+            },
+            "CreateBucketConfiguration": {
+                "type": "structure",
+                "members": {
+                    "BucketIndex": {
+                        "shape": "BucketIndex",
+                        "documentation": "<p>Configuration to customize the bucket index layout.</p> <note> <p>This element is a Ceph RGW extension.</p> </note>"
+                    }
+                }
+            },
+            "BucketIndex": {
+                "type": "structure",
+                "required": [
+                    "Type"
+                ],
+                "members": {
+                    "Type": {
+                        "shape": "BucketIndexType",
+                        "documentation": "<p>Bucket index type: Normal or Indexless.</p>"
+                    },
+                    "NumShards": {
+                        "shape": "BucketIndexNumShards",
+                        "documentation": "<p>Number of initial bucket index shards. Only valid for the <code>Normal</code> index type.</p>"
+                    }
+                }
+            },
+            "BucketIndexType": {
+                "type": "string",
+                "enum": [
+                    "Normal",
+                    "Indexless"
+                ]
+            },
+            "BucketIndexNumShards": {
+                "type": "integer"
+            },
+            "GetUsageStatsRequest": {
+                "type": "structure",
+                "members": {
+                    "StartDate": {
+                        "shape": "StartDate",
+                        "documentation": "<p>Start of the usage log time range (inclusive).</p>",
+                        "location": "querystring",
+                        "locationName": "start-date"
+                    },
+                    "EndDate": {
+                        "shape": "EndDate",
+                        "documentation": "<p>End of the usage log time range.</p>",
+                        "location": "querystring",
+                        "locationName": "end-date"
+                    }
+                }
+            },
+            "StartDate": {
+                "type": "string"
+            },
+            "EndDate": {
+                "type": "string"
+            },
+            "GetUsageStatsOutput": {
+                "type": "structure",
+                "members": {
+                    "Entries": {
+                        "shape": "UsageStatsEntries",
+                        "documentation": "<p>Per-hour usage log entries (ops and bandwidth). Empty unless <code>rgw enable usage log = true</code>.</p>"
+                    },
+                    "Summary": {
+                        "shape": "UsageStatsSummary",
+                        "documentation": "<p>Aggregated quota and storage totals for the user.</p>"
+                    },
+                    "CapacityUsed": {
+                        "shape": "UsageStatsCapacityUsed",
+                        "documentation": "<p>Current storage usage per bucket.</p>"
+                    }
+                }
+            },
+            "UsageStatsEntries": {
+                "type": "structure",
+                "members": {
+                    "User": {
+                        "shape": "UsageStatsEntryUserList",
+                        "locationName": "User"
+                    }
+                }
+            },
+            "UsageStatsEntryUserList": {
+                "type": "list",
+                "member": {
+                    "shape": "UsageStatsEntryUser"
+                },
+                "flattened": true
+            },
+            "UsageStatsEntryUser": {
+                "type": "structure",
+                "members": {
+                    "Owner": {
+                        "shape": "OwnerName"
+                    },
+                    "Buckets": {
+                        "shape": "UsageStatsEntryBuckets"
+                    }
+                }
+            },
+            "UsageStatsEntryBuckets": {
+                "type": "structure",
+                "members": {
+                    "Bucket": {
+                        "shape": "UsageStatsEntryBucketItemList",
+                        "locationName": "Bucket"
+                    }
+                }
+            },
+            "UsageStatsEntryBucketItemList": {
+                "type": "list",
+                "member": {
+                    "shape": "UsageStatsBucketEntry"
+                },
+                "flattened": true
+            },
+            "UsageStatsBucketEntry": {
+                "type": "structure",
+                "members": {
+                    "Time": {
+                        "shape": "UsageTime"
+                    },
+                    "Epoch": {
+                        "shape": "UsageEpoch"
+                    },
+                    "Categories": {
+                        "shape": "UsageStatsCategories",
+                        "locationName": "categories"
+                    },
+                    "S3Select": {
+                        "shape": "UsageStatsS3Select",
+                        "locationName": "s3select"
+                    },
+                    "Bucket": {
+                        "shape": "UsageBucketName",
+                        "locationName": "Bucket"
+                    }
+                }
+            },
+            "UsageStatsCategories": {
+                "type": "structure",
+                "members": {
+                    "Entry": {
+                        "shape": "UsageCategoryEntryList",
+                        "locationName": "Entry"
+                    }
+                }
+            },
+            "UsageCategoryEntryList": {
+                "type": "list",
+                "member": {
+                    "shape": "UsageCategoryEntry"
+                },
+                "flattened": true
+            },
+            "UsageCategoryEntry": {
+                "type": "structure",
+                "members": {
+                    "Category": {
+                        "shape": "CategoryName"
+                    },
+                    "BytesSent": {
+                        "shape": "BytesSent"
+                    },
+                    "BytesReceived": {
+                        "shape": "BytesReceived"
+                    },
+                    "Ops": {
+                        "shape": "Ops"
+                    },
+                    "SuccessfulOps": {
+                        "shape": "SuccessfulOps"
+                    }
+                }
+            },
+            "UsageStatsS3Select": {
+                "type": "structure",
+                "members": {
+                    "BytesProcessed": {
+                        "shape": "BytesProcessed"
+                    },
+                    "BytesReturned": {
+                        "shape": "BytesReturned"
+                    }
+                }
+            },
+            "UsageStatsCapacityUsed": {
+                "type": "structure",
+                "members": {
+                    "User": {
+                        "shape": "UsageStatsCapacityUserList",
+                        "locationName": "User"
+                    }
+                }
+            },
+            "UsageStatsCapacityUserList": {
+                "type": "list",
+                "member": {
+                    "shape": "UsageStatsCapacityUser"
+                },
+                "flattened": true
+            },
+            "UsageStatsCapacityUser": {
+                "type": "structure",
+                "members": {
+                    "Buckets": {
+                        "shape": "UsageStatsCapacityBuckets"
+                    }
+                }
+            },
+            "UsageStatsCapacityBuckets": {
+                "type": "structure",
+                "members": {
+                    "Entry": {
+                        "shape": "UsageStatsCapacityBucketItemList",
+                        "locationName": "Entry"
+                    }
+                }
+            },
+            "UsageStatsCapacityBucketItemList": {
+                "type": "list",
+                "member": {
+                    "shape": "UsageStatsCapacityBucketEntry"
+                },
+                "flattened": true
+            },
+            "UsageStatsCapacityBucketEntry": {
+                "type": "structure",
+                "members": {
+                    "Bytes": {
+                        "shape": "TotalBytes"
+                    },
+                    "BytesRounded": {
+                        "shape": "TotalBytesRounded",
+                        "locationName": "Bytes_Rounded"
+                    },
+                    "Bucket": {
+                        "shape": "UsageBucketName",
+                        "locationName": "Bucket"
+                    }
+                }
+            },
+            "UsageStatsSummary": {
+                "type": "structure",
+                "members": {
+                    "User": {
+                        "shape": "UsageStatsSummaryUserList",
+                        "locationName": "User"
+                    },
+                    "QuotaMaxBytes": {
+                        "shape": "QuotaMaxBytes"
+                    },
+                    "QuotaMaxBuckets": {
+                        "shape": "QuotaMaxBuckets"
+                    },
+                    "QuotaMaxObjCount": {
+                        "shape": "QuotaMaxObjCount"
+                    },
+                    "QuotaMaxBytesPerBucket": {
+                        "shape": "QuotaMaxBytesPerBucket"
+                    },
+                    "QuotaMaxObjCountPerBucket": {
+                        "shape": "QuotaMaxObjCountPerBucket"
+                    },
+                    "TotalBytes": {
+                        "shape": "TotalBytes"
+                    },
+                    "TotalBytesRounded": {
+                        "shape": "TotalBytesRounded"
+                    },
+                    "TotalEntries": {
+                        "shape": "TotalEntries"
+                    }
+                }
+            },
+            "UsageStatsSummaryUserList": {
+                "type": "list",
+                "member": {
+                    "shape": "UsageStatsSummaryUser"
+                },
+                "flattened": true
+            },
+            "UsageStatsSummaryUser": {
+                "type": "structure",
+                "members": {
+                    "User": {
+                        "shape": "OwnerName",
+                        "locationName": "User"
+                    },
+                    "Categories": {
+                        "shape": "UsageStatsCategories",
+                        "locationName": "categories"
+                    },
+                    "Total": {
+                        "shape": "UsageStatsTotal",
+                        "locationName": "Total"
+                    }
+                }
+            },
+            "UsageStatsTotal": {
+                "type": "structure",
+                "members": {
+                    "BytesSent": {
+                        "shape": "BytesSent"
+                    },
+                    "BytesReceived": {
+                        "shape": "BytesReceived"
+                    },
+                    "Ops": {
+                        "shape": "Ops"
+                    },
+                    "SuccessfulOps": {
+                        "shape": "SuccessfulOps"
+                    },
+                    "BytesProcessed": {
+                        "shape": "BytesProcessed"
+                    },
+                    "BytesReturned": {
+                        "shape": "BytesReturned"
+                    }
+                }
+            },
+            "OwnerName": {
+                "type": "string"
+            },
+            "BucketName": {
+                "type": "string"
+            },
+            "UsageTime": {
+                "type": "string"
+            },
+            "UsageEpoch": {
+                "type": "integer"
+            },
+            "CategoryName": {
+                "type": "string"
+            },
+            "BytesSent": {
+                "type": "integer"
+            },
+            "BytesReceived": {
+                "type": "integer"
+            },
+            "Ops": {
+                "type": "integer"
+            },
+            "SuccessfulOps": {
+                "type": "integer"
+            },
+            "BytesProcessed": {
+                "type": "integer"
+            },
+            "BytesReturned": {
+                "type": "integer"
+            },
+            "UsageBucketName": {
+                "type": "string"
             }
         },
-        "UsageStatsSummary": {
-            "type": "structure",
-            "members": {
-		        "QuotaMaxBytes":{"shape":"QuotaMaxBytes"},
-		        "QuotaMaxBuckets":{"shape": "QuotaMaxBuckets"},
-		        "QuotaMaxObjCount":{"shape":"QuotaMaxObjCount"},
-		        "QuotaMaxBytesPerBucket":{"shape":"QuotaMaxBytesPerBucket"},
-                "QuotaMaxObjCountPerBucket":{"shape":"QuotaMaxObjCountPerBucket"},
-		        "TotalBytes":{"shape":"TotalBytes"},
-                "TotalBytesRounded":{"shape":"TotalBytesRounded"},
-                "TotalEntries":{"shape":"TotalEntries"}
-            }
-        },
-        "QuotaMaxBytes":{"type":"integer"},
-	    "QuotaMaxBuckets":{"type": "integer"},
-	    "QuotaMaxObjCount":{"type":"integer"},
-	    "QuotaMaxBytesPerBucket":{"type":"integer"},
-	    "QuotaMaxObjCountPerBucket":{"type":"integer"},
-	    "TotalBytesRounded":{"type":"integer"},
-        "TotalBytes":{"type":"integer"},
-        "TotalEntries":{"type":"integer"}
-    },
-    "documentation":"<p/>"
-}
+        "documentation": "<p/>"
+    }
 }

--- a/examples/rgw/boto3/service-2.sdk-extras.json
+++ b/examples/rgw/boto3/service-2.sdk-extras.json
@@ -37,21 +37,19 @@
           "documentation":"<p>Put bucket logging configuration on source bucket.</p>"
         },
         "GetUsageStats":{
-            "name": "GetUsageStats",
+            "name":"GetUsageStats",
             "http":{
-                "method": "GET",
-                "requestUri": "/?usage",
-                "responseCode": 200
+                "method":"GET",
+                "requestUri":"/?usage",
+                "responseCode":200
             },
-            "input":{
-                "shape": "GetUsageStatsRequest"
-            },
+            "input":{"shape":"GetUsageStatsRequest"},
             "output":{
-                "shape": "GetUsageStatsOutput",
-                "resultWrapper": "Usage"
+                "shape":"GetUsageStatsOutput",
+                "resultWrapper":"Usage"
             },
-            "documentationUrl": "https://docs.ceph.com/docs/master/radosgw/s3/serviceops#get-usage-stats",
-            "documentation": "<p>Get usage stats for the authenticated user. Returns storage totals, per-bucket capacity, and (when usage logging is enabled) per-operation statistics.</p>"
+            "documentationUrl":"https://docs.ceph.com/docs/master/radosgw/s3/serviceops#get-usage-stats",
+            "documentation":"<p>Get usage stats for the authenticated user. Returns storage totals, per-bucket capacity, and (when usage logging is enabled) per-operation statistics.</p>"
         }
     },
     "shapes": {
@@ -266,58 +264,42 @@
             },
             "documentation":"<p>A container for object tags filtering rules.</p>"
         },
-        "GetUsageStatsOutput":{
-            "type": "structure",
+        "GetUsageStatsOutput": {
+            "type":"structure",
             "members":{
                 "Entries":{
-                    "shape": "UsageStatsEntries",
-                    "documentation": "<p>Per-hour usage log entries (ops and bandwidth). Empty unless <code>rgw enable usage log = true</code>.</p>"
+                    "shape":"UsageStatsEntries",
+                    "documentation":"<p>Per-hour usage log entries (ops and bandwidth). Empty unless <code>rgw enable usage log = true</code>.</p>"
                 },
-                "Summary":{
-                    "shape": "UsageStatsSummary",
-                    "documentation": "<p>Aggregated quota and storage totals for the user.</p>"
+                "Summary": {
+                    "shape":"UsageStatsSummary",
+                    "documentation":"<p>Aggregated quota and storage totals for the user.</p>"
                 },
                 "CapacityUsed":{
-                    "shape": "UsageStatsCapacityUsed",
-                    "documentation": "<p>Current storage usage per bucket.</p>"
+                    "shape":"UsageStatsCapacityUsed",
+                    "documentation":"<p>Current storage usage per bucket.</p>"
                 }
             }
         },
-        "UsageStatsSummary":{
-            "type": "structure",
-            "members":{
+        "UsageStatsSummary": {
+            "type":"structure",
+            "members": {
                 "User":{
                     "shape": "UsageStatsSummaryUserList",
                     "locationName": "User"
                 },
-                "QuotaMaxBytes":{
-                    "shape": "QuotaMaxBytes"
-                },
-                "QuotaMaxBuckets":{
-                    "shape": "QuotaMaxBuckets"
-                },
-                "QuotaMaxObjCount":{
-                    "shape": "QuotaMaxObjCount"
-                },
-                "QuotaMaxBytesPerBucket":{
-                    "shape": "QuotaMaxBytesPerBucket"
-                },
-                "QuotaMaxObjCountPerBucket":{
-                    "shape": "QuotaMaxObjCountPerBucket"
-                },
-                "TotalBytes":{
-                    "shape": "TotalBytes"
-                },
-                "TotalBytesRounded":{
-                    "shape": "TotalBytesRounded"
-                },
-                "TotalEntries":{
-                    "shape": "TotalEntries"
-                }
+                "QuotaMaxBytes":{"shape": "QuotaMaxBytes"},
+                "QuotaMaxBuckets":{"shape": "QuotaMaxBuckets"},
+                "QuotaMaxObjCount":{"shape": "QuotaMaxObjCount"},
+                "QuotaMaxBytesPerBucket":{"shape": "QuotaMaxBytesPerBucket" },
+                "QuotaMaxObjCountPerBucket":{"shape": "QuotaMaxObjCountPerBucket"},
+                "TotalBytes":{"shape": "TotalBytes"},
+                "TotalBytesRounded":{"shape": "TotalBytesRounded"},
+                "TotalEntries":{"shape": "TotalEntries"}
             }
         },
         "QuotaMaxBytes":{"type":"integer"},
-        "QuotaMaxBuckets":{"type": "integer"},
+        "QuotaMaxBuckets":{"type":"integer"},
         "QuotaMaxObjCount":{"type":"integer"},
         "QuotaMaxBytesPerBucket":{"type":"integer"},
         "QuotaMaxObjCountPerBucket":{"type":"integer"},

--- a/examples/rgw/boto3/service-2.sdk-extras.json
+++ b/examples/rgw/boto3/service-2.sdk-extras.json
@@ -283,19 +283,19 @@
         },
         "UsageStatsSummary":{
             "type":"structure",
-            "members":{
+            "members": {
                 "User":{
-                    "shape":"UsageStatsSummaryUserList",
-                    "locationName":"User"
+                    "shape": "UsageStatsSummaryUserList",
+                    "locationName": "User"
                 },
-                "QuotaMaxBytes":{"shape":"QuotaMaxBytes"},
-                "QuotaMaxBuckets":{"shape":"QuotaMaxBuckets"},
-                "QuotaMaxObjCount":{"shape":"QuotaMaxObjCount"},
-                "QuotaMaxBytesPerBucket":{"shape":"QuotaMaxBytesPerBucket"},
-                "QuotaMaxObjCountPerBucket":{"shape":"QuotaMaxObjCountPerBucket"},
-                "TotalBytes":{"shape":"TotalBytes"},
-                "TotalBytesRounded":{"shape":"TotalBytesRounded"},
-                "TotalEntries":{"shape":"TotalEntries"}
+                "QuotaMaxBytes":{"shape": "QuotaMaxBytes"},
+                "QuotaMaxBuckets":{"shape": "QuotaMaxBuckets"},
+                "QuotaMaxObjCount":{"shape": "QuotaMaxObjCount"},
+                "QuotaMaxBytesPerBucket":{"shape": "QuotaMaxBytesPerBucket" },
+                "QuotaMaxObjCountPerBucket":{"shape": "QuotaMaxObjCountPerBucket"},
+                "TotalBytes":{"shape": "TotalBytes"},
+                "TotalBytesRounded":{"shape": "TotalBytesRounded"},
+                "TotalEntries":{"shape": "TotalEntries"}
             }
         },
         "QuotaMaxBytes":{"type":"integer"},

--- a/examples/rgw/boto3/service-2.sdk-extras.json
+++ b/examples/rgw/boto3/service-2.sdk-extras.json
@@ -264,14 +264,14 @@
             },
             "documentation":"<p>A container for object tags filtering rules.</p>"
         },
-        "GetUsageStatsOutput": {
+        "GetUsageStatsOutput":{
             "type":"structure",
             "members":{
                 "Entries":{
                     "shape":"UsageStatsEntries",
                     "documentation":"<p>Per-hour usage log entries (ops and bandwidth). Empty unless <code>rgw enable usage log = true</code>.</p>"
                 },
-                "Summary": {
+                "Summary":{
                     "shape":"UsageStatsSummary",
                     "documentation":"<p>Aggregated quota and storage totals for the user.</p>"
                 },
@@ -281,21 +281,21 @@
                 }
             }
         },
-        "UsageStatsSummary": {
+        "UsageStatsSummary":{
             "type":"structure",
-            "members": {
+            "members":{
                 "User":{
-                    "shape": "UsageStatsSummaryUserList",
-                    "locationName": "User"
+                    "shape":"UsageStatsSummaryUserList",
+                    "locationName":"User"
                 },
-                "QuotaMaxBytes":{"shape": "QuotaMaxBytes"},
-                "QuotaMaxBuckets":{"shape": "QuotaMaxBuckets"},
-                "QuotaMaxObjCount":{"shape": "QuotaMaxObjCount"},
-                "QuotaMaxBytesPerBucket":{"shape": "QuotaMaxBytesPerBucket" },
-                "QuotaMaxObjCountPerBucket":{"shape": "QuotaMaxObjCountPerBucket"},
-                "TotalBytes":{"shape": "TotalBytes"},
-                "TotalBytesRounded":{"shape": "TotalBytesRounded"},
-                "TotalEntries":{"shape": "TotalEntries"}
+                "QuotaMaxBytes":{"shape":"QuotaMaxBytes"},
+                "QuotaMaxBuckets":{"shape":"QuotaMaxBuckets"},
+                "QuotaMaxObjCount":{"shape":"QuotaMaxObjCount"},
+                "QuotaMaxBytesPerBucket":{"shape":"QuotaMaxBytesPerBucket"},
+                "QuotaMaxObjCountPerBucket":{"shape":"QuotaMaxObjCountPerBucket"},
+                "TotalBytes":{"shape":"TotalBytes"},
+                "TotalBytesRounded":{"shape":"TotalBytesRounded"},
+                "TotalEntries":{"shape":"TotalEntries"}
             }
         },
         "QuotaMaxBytes":{"type":"integer"},
@@ -496,279 +496,279 @@
         "BucketIndexNumShards":{"type":"integer"}
     ,
         "BucketName":{
-            "type": "string"
+            "type":"string"
         },
         "BytesProcessed":{
-            "type": "integer"
+            "type":"integer"
         },
         "BytesReceived":{
-            "type": "integer"
+            "type":"integer"
         },
         "BytesReturned":{
-            "type": "integer"
+            "type":"integer"
         },
         "BytesSent":{
-            "type": "integer"
+            "type":"integer"
         },
         "CategoryName":{
-            "type": "string"
+            "type":"string"
         },
         "EndDate":{
-            "type": "string"
+            "type":"string"
         },
         "GetUsageStatsRequest":{
-            "type": "structure",
+            "type":"structure",
             "members":{
                 "StartDate":{
-                    "shape": "StartDate",
-                    "documentation": "<p>Start of the usage log time range (inclusive).</p>",
-                    "location": "querystring",
-                    "locationName": "start-date"
+                    "shape":"StartDate",
+                    "documentation":"<p>Start of the usage log time range (inclusive).</p>",
+                    "location":"querystring",
+                    "locationName":"start-date"
                 },
                 "EndDate":{
-                    "shape": "EndDate",
-                    "documentation": "<p>End of the usage log time range.</p>",
-                    "location": "querystring",
-                    "locationName": "end-date"
+                    "shape":"EndDate",
+                    "documentation":"<p>End of the usage log time range.</p>",
+                    "location":"querystring",
+                    "locationName":"end-date"
                 }
             }
         },
         "Ops":{
-            "type": "integer"
+            "type":"integer"
         },
         "OwnerName":{
-            "type": "string"
+            "type":"string"
         },
         "StartDate":{
-            "type": "string"
+            "type":"string"
         },
         "SuccessfulOps":{
-            "type": "integer"
+            "type":"integer"
         },
         "UsageBucketName":{
-            "type": "string"
+            "type":"string"
         },
         "UsageCategoryEntry":{
-            "type": "structure",
+            "type":"structure",
             "members":{
                 "Category":{
-                    "shape": "CategoryName"
+                    "shape":"CategoryName"
                 },
                 "BytesSent":{
-                    "shape": "BytesSent"
+                    "shape":"BytesSent"
                 },
                 "BytesReceived":{
-                    "shape": "BytesReceived"
+                    "shape":"BytesReceived"
                 },
                 "Ops":{
-                    "shape": "Ops"
+                    "shape":"Ops"
                 },
                 "SuccessfulOps":{
-                    "shape": "SuccessfulOps"
+                    "shape":"SuccessfulOps"
                 }
             }
         },
         "UsageCategoryEntryList":{
-            "type": "list",
+            "type":"list",
             "member":{
-                "shape": "UsageCategoryEntry"
+                "shape":"UsageCategoryEntry"
             },
-            "flattened": true
+            "flattened":true
         },
         "UsageEpoch":{
-            "type": "integer"
+            "type":"integer"
         },
         "UsageStatsBucketEntry":{
-            "type": "structure",
+            "type":"structure",
             "members":{
                 "Time":{
-                    "shape": "UsageTime"
+                    "shape":"UsageTime"
                 },
                 "Epoch":{
-                    "shape": "UsageEpoch"
+                    "shape":"UsageEpoch"
                 },
                 "Categories":{
-                    "shape": "UsageStatsCategories",
-                    "locationName": "categories"
+                    "shape":"UsageStatsCategories",
+                    "locationName":"categories"
                 },
                 "S3Select":{
-                    "shape": "UsageStatsS3Select",
-                    "locationName": "s3select"
+                    "shape":"UsageStatsS3Select",
+                    "locationName":"s3select"
                 },
                 "Bucket":{
-                    "shape": "UsageBucketName",
-                    "locationName": "Bucket"
+                    "shape":"UsageBucketName",
+                    "locationName":"Bucket"
                 }
             }
         },
         "UsageStatsCapacityBucketEntry":{
-            "type": "structure",
+            "type":"structure",
             "members":{
                 "Bytes":{
-                    "shape": "TotalBytes"
+                    "shape":"TotalBytes"
                 },
                 "BytesRounded":{
-                    "shape": "TotalBytesRounded",
-                    "locationName": "Bytes_Rounded"
+                    "shape":"TotalBytesRounded",
+                    "locationName":"Bytes_Rounded"
                 },
                 "Bucket":{
-                    "shape": "UsageBucketName",
-                    "locationName": "Bucket"
+                    "shape":"UsageBucketName",
+                    "locationName":"Bucket"
                 }
             }
         },
         "UsageStatsCapacityBucketItemList":{
-            "type": "list",
+            "type":"list",
             "member":{
-                "shape": "UsageStatsCapacityBucketEntry"
+                "shape":"UsageStatsCapacityBucketEntry"
             },
-            "flattened": true
+            "flattened":true
         },
         "UsageStatsCapacityBuckets":{
-            "type": "structure",
+            "type":"structure",
             "members":{
                 "Entry":{
-                    "shape": "UsageStatsCapacityBucketItemList",
-                    "locationName": "Entry"
+                    "shape":"UsageStatsCapacityBucketItemList",
+                    "locationName":"Entry"
                 }
             }
         },
         "UsageStatsCapacityUsed":{
-            "type": "structure",
+            "type":"structure",
             "members":{
                 "User":{
-                    "shape": "UsageStatsCapacityUserList",
-                    "locationName": "User"
+                    "shape":"UsageStatsCapacityUserList",
+                    "locationName":"User"
                 }
             }
         },
         "UsageStatsCapacityUser":{
-            "type": "structure",
+            "type":"structure",
             "members":{
                 "Buckets":{
-                    "shape": "UsageStatsCapacityBuckets"
+                    "shape":"UsageStatsCapacityBuckets"
                 }
             }
         },
         "UsageStatsCapacityUserList":{
-            "type": "list",
+            "type":"list",
             "member":{
-                "shape": "UsageStatsCapacityUser"
+                "shape":"UsageStatsCapacityUser"
             },
-            "flattened": true
+            "flattened":true
         },
         "UsageStatsCategories":{
-            "type": "structure",
+            "type":"structure",
             "members":{
                 "Entry":{
-                    "shape": "UsageCategoryEntryList",
-                    "locationName": "Entry"
+                    "shape":"UsageCategoryEntryList",
+                    "locationName":"Entry"
                 }
             }
         },
         "UsageStatsEntries":{
-            "type": "structure",
+            "type":"structure",
             "members":{
                 "User":{
-                    "shape": "UsageStatsEntryUserList",
-                    "locationName": "User"
+                    "shape":"UsageStatsEntryUserList",
+                    "locationName":"User"
                 }
             }
         },
         "UsageStatsEntryBucketItemList":{
-            "type": "list",
+            "type":"list",
             "member":{
-                "shape": "UsageStatsBucketEntry"
+                "shape":"UsageStatsBucketEntry"
             },
-            "flattened": true
+            "flattened":true
         },
         "UsageStatsEntryBuckets":{
-            "type": "structure",
+            "type":"structure",
             "members":{
                 "Bucket":{
-                    "shape": "UsageStatsEntryBucketItemList",
-                    "locationName": "Bucket"
+                    "shape":"UsageStatsEntryBucketItemList",
+                    "locationName":"Bucket"
                 }
             }
         },
         "UsageStatsEntryUser":{
-            "type": "structure",
+            "type":"structure",
             "members":{
                 "Owner":{
-                    "shape": "OwnerName"
+                    "shape":"OwnerName"
                 },
                 "Buckets":{
-                    "shape": "UsageStatsEntryBuckets"
+                    "shape":"UsageStatsEntryBuckets"
                 }
             }
         },
         "UsageStatsEntryUserList":{
-            "type": "list",
+            "type":"list",
             "member":{
-                "shape": "UsageStatsEntryUser"
+                "shape":"UsageStatsEntryUser"
             },
-            "flattened": true
+            "flattened":true
         },
         "UsageStatsS3Select":{
-            "type": "structure",
+            "type":"structure",
             "members":{
                 "BytesProcessed":{
-                    "shape": "BytesProcessed"
+                    "shape":"BytesProcessed"
                 },
                 "BytesReturned":{
-                    "shape": "BytesReturned"
+                    "shape":"BytesReturned"
                 }
             }
         },
         "UsageStatsSummaryUser":{
-            "type": "structure",
+            "type":"structure",
             "members":{
                 "User":{
-                    "shape": "OwnerName",
-                    "locationName": "User"
+                    "shape":"OwnerName",
+                    "locationName":"User"
                 },
                 "Categories":{
-                    "shape": "UsageStatsCategories",
-                    "locationName": "categories"
+                    "shape":"UsageStatsCategories",
+                    "locationName":"categories"
                 },
                 "Total":{
-                    "shape": "UsageStatsTotal",
-                    "locationName": "Total"
+                    "shape":"UsageStatsTotal",
+                    "locationName":"Total"
                 }
             }
         },
         "UsageStatsSummaryUserList":{
-            "type": "list",
+            "type":"list",
             "member":{
-                "shape": "UsageStatsSummaryUser"
+                "shape":"UsageStatsSummaryUser"
             },
-            "flattened": true
+            "flattened":true
         },
         "UsageStatsTotal":{
-            "type": "structure",
+            "type":"structure",
             "members":{
                 "BytesSent":{
-                    "shape": "BytesSent"
+                    "shape":"BytesSent"
                 },
                 "BytesReceived":{
-                    "shape": "BytesReceived"
+                    "shape":"BytesReceived"
                 },
                 "Ops":{
-                    "shape": "Ops"
+                    "shape":"Ops"
                 },
                 "SuccessfulOps":{
-                    "shape": "SuccessfulOps"
+                    "shape":"SuccessfulOps"
                 },
                 "BytesProcessed":{
-                    "shape": "BytesProcessed"
+                    "shape":"BytesProcessed"
                 },
                 "BytesReturned":{
-                    "shape": "BytesReturned"
+                    "shape":"BytesReturned"
                 }
             }
         },
         "UsageTime":{
-            "type": "string"
+            "type":"string"
         }
 },
     "documentation":"<p/>"

--- a/examples/rgw/boto3/service-2.sdk-extras.json
+++ b/examples/rgw/boto3/service-2.sdk-extras.json
@@ -1,849 +1,794 @@
 {
-    "version": 1.0,
-    "merge": {
-        "operations": {
-            "DeleteBucketNotificationConfiguration": {
-                "name": "DeleteBucketNotificationConfiguration",
-                "http": {
-                    "method": "DELETE",
-                    "requestUri": "/{Bucket}?notification",
-                    "responseCode": 204
-                },
-                "input": {
-                    "shape": "DeleteBucketNotificationConfigurationRequest"
-                },
-                "documentationUrl": "https://docs.ceph.com/docs/master/radosgw/s3/bucketops/#delete-notification",
-                "documentation": "<p>Deletes the notification configuration from the bucket.</p>"
+"version": 1.0,
+"merge": {
+    "operations":{
+        "DeleteBucketNotificationConfiguration":{
+            "name":"DeleteBucketNotificationConfiguration",
+            "http":{
+                "method":"DELETE",
+                "requestUri":"/{Bucket}?notification",
+                "responseCode":204
             },
-            "PostBucketLogging": {
-                "name": "PostBucketLogging",
-                "http": {
-                    "method": "POST",
-                    "requestUri": "/{Bucket}?logging",
-                    "responseCode": 201
-                },
-                "input": {
-                    "shape": "PostBucketLoggingRequest"
-                },
-                "output": {
-                    "shape": "PostBucketLoggingOutput"
-                },
-                "documentationUrl": "https://docs.ceph.com/docs/master/radosgw/s3/bucketops/#post-bucket-logging",
-                "documentation": "<p>Flushes the logging objects of the buckets.</p>"
+            "input":{"shape":"DeleteBucketNotificationConfigurationRequest"},
+            "documentationUrl":"https://docs.ceph.com/docs/master/radosgw/s3/bucketops/#delete-notification",
+            "documentation":"<p>Deletes the notification configuration from the bucket.</p>"
+        },
+        "PostBucketLogging":{
+            "name":"PostBucketLogging",
+            "http":{
+                "method":"POST",
+                "requestUri":"/{Bucket}?logging",
+                "responseCode":201
             },
-            "PutBucketLogging": {
-                "name": "PutBucketLogging",
-                "http": {
-                    "method": "PUT",
-                    "requestUri": "/{Bucket}?logging"
-                },
-                "input": {
-                    "shape": "PutBucketLoggingRequest"
-                },
-                "output": {
-                    "shape": "PutBucketLoggingOutput"
-                },
-                "documentationUrl": "https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLogging.html",
-                "documentation": "<p>Put bucket logging configuration on source bucket.</p>"
+            "input":{"shape":"PostBucketLoggingRequest"},
+            "output": {"shape": "PostBucketLoggingOutput"},
+            "documentationUrl":"https://docs.ceph.com/docs/master/radosgw/s3/bucketops/#post-bucket-logging",
+            "documentation":"<p>Flushes the logging objects of the buckets.</p>"
+        },
+   			"PutBucketLogging":{
+      		"name":"PutBucketLogging",
+      		"http":{
+        		"method":"PUT",
+        		"requestUri":"/{Bucket}?logging"
+      		},
+      		"input":{"shape":"PutBucketLoggingRequest"},
+          "output": {"shape": "PutBucketLoggingOutput"},
+          "documentationUrl":"https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLogging.html",
+          "documentation":"<p>Put bucket logging configuration on source bucket.</p>"
+        },
+        "GetUsageStats":{
+            "name": "GetUsageStats",
+            "http":{
+                "method": "GET",
+                "requestUri": "/?usage",
+                "responseCode": 200
             },
-            "GetUsageStats": {
-                "name": "GetUsageStats",
-                "http": {
-                    "method": "GET",
-                    "requestUri": "/?usage",
-                    "responseCode": 200
-                },
-                "input": {
-                    "shape": "GetUsageStatsRequest"
-                },
-                "output": {
-                    "shape": "GetUsageStatsOutput",
-                    "resultWrapper": "Usage"
-                },
-                "documentationUrl": "https://docs.ceph.com/docs/master/radosgw/s3/serviceops#get-usage-stats",
-                "documentation": "<p>Get usage stats for the authenticated user. Returns storage totals, per-bucket capacity, and (when usage logging is enabled) per-operation statistics.</p>"
+            "input":{
+                "shape": "GetUsageStatsRequest"
+            },
+            "output":{
+                "shape": "GetUsageStatsOutput",
+                "resultWrapper": "Usage"
+            },
+            "documentationUrl": "https://docs.ceph.com/docs/master/radosgw/s3/serviceops#get-usage-stats",
+            "documentation": "<p>Get usage stats for the authenticated user. Returns storage totals, per-bucket capacity, and (when usage logging is enabled) per-operation statistics.</p>"
+        }
+    },
+    "shapes": {
+        "ListObjectsRequest": {
+            "members": {
+                "AllowUnordered": {
+                    "shape":"AllowUnordered",
+                    "documentation":"<p>Allow the listing results to be returned in unsorted order. This may be faster when listing very large buckets.</p>",
+                    "location":"querystring",
+                    "locationName":"allow-unordered"
+                }
             }
         },
-        "shapes": {
-            "ListObjectsRequest": {
-                "members": {
-                    "AllowUnordered": {
-                        "shape": "AllowUnordered",
-                        "documentation": "<p>Allow the listing results to be returned in unsorted order. This may be faster when listing very large buckets.</p>",
-                        "location": "querystring",
-                        "locationName": "allow-unordered"
-                    }
+        "ListObjectsV2Request": {
+            "members": {
+                "AllowUnordered": {
+                    "shape":"AllowUnordered",
+                    "documentation":"<p>Allow the listing results to be returned in unsorted order. This may be faster when listing very large buckets.</p>",
+                    "location":"querystring",
+                    "locationName":"allow-unordered"
                 }
-            },
-            "ListObjectsV2Request": {
-                "members": {
-                    "AllowUnordered": {
-                        "shape": "AllowUnordered",
-                        "documentation": "<p>Allow the listing results to be returned in unsorted order. This may be faster when listing very large buckets.</p>",
-                        "location": "querystring",
-                        "locationName": "allow-unordered"
-                    }
-                }
-            },
-            "ReplicationRule": {
-                "members": {
-                    "Source": {
-                        "shape": "S3RepSource",
-                        "documentation": "<p>A container for information about the replication source.<p>",
-                        "locationName": "Source"
-                    }
-                }
-            },
-            "S3RepSource": {
-                "type": "structure",
-                "members": {
-                    "Zones": {
-                        "shape": "ZoneList",
-                        "documentation": "<p>Array of replication source zone names.</p>",
-                        "locationName": "Zone"
-                    }
-                }
-            },
-            "Destination": {
-                "members": {
-                    "Zones": {
-                        "shape": "ZoneList",
-                        "documentation": "<p>Array of replication destination zone names.</p>",
-                        "locationName": "Zone"
-                    }
-                }
-            },
-            "ZoneList": {
-                "type": "list",
-                "member": {
-                    "shape": "Zone"
-                },
-                "flattened": true
-            },
-            "Zone": {
-                "type": "string"
-            },
-            "AllowUnordered": {
-                "type": "boolean"
-            },
-            "PutObjectRequest": {
-                "members": {
-                    "AppendPosition": {
-                        "shape": "AppendPosition",
-                        "documentation": "<p>Position to allow appending</p>",
-                        "location": "querystring",
-                        "locationName": "position"
-                    },
-                    "Append": {
-                        "shape": "Append",
-                        "documentation": "<p>Append Object</p>",
-                        "location": "querystring",
-                        "locationName": "append"
-                    }
-                }
-            },
-            "Append": {
-                "type": "boolean"
-            },
-            "AppendPosition": {
-                "type": "integer"
-            },
-            "PutObjectOutput": {
-                "members": {
-                    "AppendPosition": {
-                        "shape": "AppendPosition",
-                        "documentation": "<p>Position to allow appending</p>",
-                        "location": "header",
-                        "locationName": "x-rgw-next-append-position",
-                        "documentationUrl": "https://docs.ceph.com/docs/master/radosgw/s3/objectops/#append-object"
-                    }
-                }
-            },
-            "GetBucketNotificationConfigurationRequest": {
-                "type": "structure",
-                "required": [
-                    "Bucket"
-                ],
-                "members": {
-                    "Bucket": {
-                        "shape": "BucketName",
-                        "documentation": "<p>Name of the bucket to get the notifications configuration for.</p>",
-                        "location": "uri",
-                        "locationName": "Bucket"
-                    },
-                    "Notification": {
-                        "shape": "NotificationId",
-                        "documentation": "<p>Id of the specific notification on the bucket for which the configuration should be retrieved.</p>",
-                        "location": "querystring",
-                        "locationName": "notification-id"
-                    }
-                }
-            },
-            "DeleteBucketNotificationConfigurationRequest": {
-                "type": "structure",
-                "required": [
-                    "Bucket"
-                ],
-                "members": {
-                    "Bucket": {
-                        "shape": "BucketName",
-                        "documentation": "<p>Name of the bucket to delete the notifications configuration from.</p>",
-                        "contextParam": {
-                            "name": "Bucket"
-                        },
-                        "location": "uri",
-                        "locationName": "Bucket"
-                    },
-                    "Notification": {
-                        "shape": "NotificationId",
-                        "documentation": "<p>Id of the specific notification on the bucket to be deleted.</p>",
-                        "location": "querystring",
-                        "locationName": "notification-id"
-                    }
-                }
-            },
-            "PostBucketLoggingRequest": {
-                "type": "structure",
-                "required": [
-                    "Bucket"
-                ],
-                "members": {
-                    "Bucket": {
-                        "shape": "BucketName",
-                        "documentation": "<p>Name of the bucket to flush its logging objects.</p>",
-                        "contextParam": {
-                            "name": "Bucket"
-                        },
-                        "location": "uri",
-                        "locationName": "Bucket"
-                    }
-                }
-            },
-            "FilterRule": {
-                "type": "structure",
-                "members": {
-                    "Name": {
-                        "shape": "FilterRuleName",
-                        "documentation": "<p>The object key name prefix, suffix or regex identifying one or more objects to which the filtering rule applies. The maximum length is 1,024 characters. Overlapping prefixes and suffixes are supported.</p>"
-                    },
-                    "Value": {
-                        "shape": "FilterRuleValue",
-                        "documentation": "<p>The value that the filter searches for in object key names.</p>"
-                    }
-                },
-                "documentation": "<p>Specifies the Amazon S3 object key name to filter on and whether to filter on the suffix, prefix or regex of the key name.</p>"
-            },
-            "FilterRuleName": {
-                "type": "string",
-                "enum": [
-                    "prefix",
-                    "suffix",
-                    "regex"
-                ]
-            },
-            "NotificationConfigurationFilter": {
-                "type": "structure",
-                "members": {
-                    "Key": {
-                        "shape": "S3KeyFilter",
-                        "documentation": "<p/>",
-                        "locationName": "S3Key"
-                    },
-                    "Metadata": {
-                        "shape": "S3MetadataFilter",
-                        "documentation": "<p/>",
-                        "locationName": "S3Metadata"
-                    },
-                    "Tags": {
-                        "shape": "S3TagsFilter",
-                        "documentation": "<p/>",
-                        "locationName": "S3Tags"
-                    }
-                },
-                "documentation": "<p>Specifies object key name filtering rules. For information about key name filtering, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html\">Configuring Event Notifications</a> in the <i>Amazon Simple Storage Service Developer Guide</i>.</p>"
-            },
-            "S3KeyFilter": {
-                "type": "structure",
-                "members": {
-                    "FilterRules": {
-                        "shape": "FilterRuleList",
-                        "documentation": "<p/>",
-                        "locationName": "FilterRule"
-                    }
-                },
-                "documentation": "<p>A container for object key name prefix, suffix and regex filtering rules.</p>"
-            },
-            "S3MetadataFilter": {
-                "type": "structure",
-                "members": {
-                    "FilterRules": {
-                        "shape": "FilterRuleList",
-                        "documentation": "<p/>",
-                        "locationName": "FilterRule"
-                    }
-                },
-                "documentation": "<p>A container for metadata filtering rules.</p>"
-            },
-            "S3TagsFilter": {
-                "type": "structure",
-                "members": {
-                    "FilterRules": {
-                        "shape": "FilterRuleList",
-                        "documentation": "<p/>",
-                        "locationName": "FilterRule"
-                    }
-                },
-                "documentation": "<p>A container for object tags filtering rules.</p>"
-            },
-            "QuotaMaxBytes": {
-                "type": "integer"
-            },
-            "QuotaMaxBuckets": {
-                "type": "integer"
-            },
-            "QuotaMaxObjCount": {
-                "type": "integer"
-            },
-            "QuotaMaxBytesPerBucket": {
-                "type": "integer"
-            },
-            "QuotaMaxObjCountPerBucket": {
-                "type": "integer"
-            },
-            "TotalBytesRounded": {
-                "type": "integer"
-            },
-            "TotalBytes": {
-                "type": "integer"
-            },
-            "TotalEntries": {
-                "type": "integer"
-            },
-            "LoggingEnabled": {
-                "type": "structure",
-                "required": [
-                    "TargetBucket",
-                    "TargetPrefix"
-                ],
-                "members": {
-                    "TargetBucket": {
-                        "shape": "TargetBucket",
-                        "documentation": "<p>Specifies the bucket where you want to store server access logs. You can have your logs delivered to any bucket that you own. You can also configure multiple buckets to deliver their logs to the same target bucket. In this case, you should choose a different <code>TargetPrefix</code> for each source bucket so that the delivered log files can be distinguished by key.</p>"
-                    },
-                    "TargetGrants": {
-                        "shape": "TargetGrants",
-                        "documentation": "<p>Container for granting information.</p> <p>Should be used when the write permissions to the tagert bucket should eb different than the permissions of the user performing the operation thta needs to be logged. This is usually used in cased of batched logging. see: <code>RecordBatchSize</code>.</p>"
-                    },
-                    "TargetPrefix": {
-                        "shape": "TargetPrefix",
-                        "documentation": "<p>A prefix for all log object keys. If you store log files from multiple buckets in a single bucket, you can use a prefix to distinguish which log files came from which bucket.</p>"
-                    },
-                    "TargetObjectKeyFormat": {
-                        "shape": "TargetObjectKeyFormat",
-                        "documentation": "<p>key format for log objects.</p>"
-                    },
-                    "ObjectRollTime": {
-                        "shape": "ObjectRollTime",
-                        "documentation": "<p>time in seconds to move the log object to the target bucket and start another log object.</p>"
-                    },
-                    "LoggingType": {
-                        "shape": "LoggingType",
-                        "documentation": "<p>use Standard log type to log all bucket operations i nthe standard format. use Journal log type to log only creations and deletion of objects in more compact format.</p>"
-                    },
-                    "RecordsBatchSize": {
-                        "shape": "RecordsBatchSize",
-                        "documentation": "indicates how many records to batch in memory before writing to the object. if set to zero, records are written syncronously to the object. if <code>ObjectRollTime</code>e is reached, the batch of records will be written to the object regardless of the number of records. </p>"
-                    },
-                    "Filter": {
-                        "shape": "LoggingConfigurationFilter",
-                        "documentation": "<p>A filter for all log object. Filter for the object by its key (prefix, suffix and regex).</p>"
-                    }
-                },
-                "documentation": "<p>Describes where logs are stored the prefix assigned to all log object keys for a bucket, and their format. also, the level the delivery guarantee of the records.</p>"
-            },
-            "TargetObjectKeyFormat": {
-                "type": "structure",
-                "members": {
-                    "SimplePrefix": {
-                        "shape": "SimplePrefix",
-                        "documentation": "<p>To use the simple format for S3 keys for log objects. To specify SimplePrefix format, set SimplePrefix to {}.</p>",
-                        "locationName": "SimplePrefix"
-                    },
-                    "PartitionedPrefix": {
-                        "shape": "PartitionedPrefix",
-                        "documentation": "<p>Partitioned S3 key for log objects.</p>",
-                        "locationName": "PartitionedPrefix"
-                    }
-                },
-                "documentation": "<p>Key format for log objects. Only one format, PartitionedPrefix or SimplePrefix, is allowed.</p>"
-            },
-            "SimplePrefix": {
-                "type": "structure",
-                "members": {},
-                "documentation": "<p>To use simple format for S3 keys for log objects, set SimplePrefix to an empty object.</p> <p> <code>[DestinationPrefix][YYYY]-[MM]-[DD]-[hh]-[mm]-[ss]-[UniqueString]</code> </p>",
-                "locationName": "SimplePrefix"
-            },
-            "PartitionDateSource": {
-                "type": "string",
-                "enum": [
-                    "EventTime",
-                    "DeliveryTime"
-                ]
-            },
-            "PartitionedPrefix": {
-                "type": "structure",
-                "members": {
-                    "PartitionDateSource": {
-                        "shape": "PartitionDateSource",
-                        "documentation": "<p>Specifies the partition date source for the partitioned prefix. PartitionDateSource can be EventTime or DeliveryTime.</p>"
-                    }
-                },
-                "documentation": "<p>Amazon S3 keys for log objects are partitioned in the following format:</p> <p> <code>[DestinationPrefix][SourceAccountId]/[SourceRegion]/[SourceBucket]/[YYYY]/[MM]/[DD]/[YYYY]-[MM]-[DD]-[hh]-[mm]-[ss]-[UniqueString]</code> </p> <p>PartitionedPrefix defaults to EventTime delivery when server access logs are delivered.</p>",
-                "locationName": "PartitionedPrefix"
-            },
-            "ObjectRollTime": {
-                "type": "integer"
-            },
-            "RecordsBatchSize": {
-                "type": "integer"
-            },
-            "LoggingType": {
-                "type": "string",
-                "enum": [
-                    "Standard",
-                    "Journal"
-                ]
-            },
-            "LoggingConfigurationFilter": {
-                "type": "structure",
-                "members": {
-                    "Key": {
-                        "shape": "S3KeyFilter",
-                        "documentation": "<p/>",
-                        "locationName": "S3Key"
-                    }
-                },
-                "documentation": "<p>A filter for all log object. Filter for the object by its key (prefix, suffix and regex).</p>",
-                "locationName": "Filter"
-            },
-            "HeadBucketRequest": {
-                "members": {
-                    "ReadStats": {
-                        "shape": "ReadStats",
-                        "documentation": "<p>Read additional usage statistics for <code>ObjectCount</code> and <code>BytesUsed</code> in the response.</p> <note> <p>This request parameter is a Ceph RGW extension.</p> </note>",
-                        "location": "querystring",
-                        "locationName": "read-stats"
-                    }
-                }
-            },
-            "PostBucketLoggingOutput": {
-                "type": "structure",
-                "members": {
-                    "FlushedLoggingObject": {
-                        "shape": "FlushedLoggingObject",
-                        "documentation": "<p>Name of the pending logging object that was flushed.</p>"
-                    }
-                }
-            },
-            "PutBucketLoggingOutput": {
-                "type": "structure",
-                "members": {
-                    "FlushedLoggingObject": {
-                        "shape": "FlushedLoggingObject",
-                        "documentation": "<p>Name of the pending logging object that was flushed.</p>"
-                    }
-                }
-            },
-            "FlushedLoggingObject": {
-                "type": "string"
-            },
-            "HeadBucketOutput": {
-                "type": "structure",
-                "members": {
-                    "ObjectCount": {
-                        "shape": "ObjectCount",
-                        "documentation": "<p>Total number of objects/versions in the bucket.</p>",
-                        "location": "header",
-                        "locationName": "x-rgw-object-count"
-                    },
-                    "BytesUsed": {
-                        "shape": "BytesUsed",
-                        "documentation": "<p>Total size in bytes of all objects/versions in the bucket.</p>",
-                        "location": "header",
-                        "locationName": "x-rgw-bytes-used"
-                    }
-                }
-            },
-            "ReadStats": {
-                "type": "boolean"
-            },
-            "ObjectCount": {
-                "type": "integer"
-            },
-            "BytesUsed": {
-                "type": "integer"
-            },
-            "CreateBucketConfiguration": {
-                "type": "structure",
-                "members": {
-                    "BucketIndex": {
-                        "shape": "BucketIndex",
-                        "documentation": "<p>Configuration to customize the bucket index layout.</p> <note> <p>This element is a Ceph RGW extension.</p> </note>"
-                    }
-                }
-            },
-            "BucketIndex": {
-                "type": "structure",
-                "required": [
-                    "Type"
-                ],
-                "members": {
-                    "Type": {
-                        "shape": "BucketIndexType",
-                        "documentation": "<p>Bucket index type: Normal or Indexless.</p>"
-                    },
-                    "NumShards": {
-                        "shape": "BucketIndexNumShards",
-                        "documentation": "<p>Number of initial bucket index shards. Only valid for the <code>Normal</code> index type.</p>"
-                    }
-                }
-            },
-            "BucketIndexType": {
-                "type": "string",
-                "enum": [
-                    "Normal",
-                    "Indexless"
-                ]
-            },
-            "BucketIndexNumShards": {
-                "type": "integer"
-            },
-            "GetUsageStatsRequest": {
-                "type": "structure",
-                "members": {
-                    "StartDate": {
-                        "shape": "StartDate",
-                        "documentation": "<p>Start of the usage log time range (inclusive).</p>",
-                        "location": "querystring",
-                        "locationName": "start-date"
-                    },
-                    "EndDate": {
-                        "shape": "EndDate",
-                        "documentation": "<p>End of the usage log time range.</p>",
-                        "location": "querystring",
-                        "locationName": "end-date"
-                    }
-                }
-            },
-            "StartDate": {
-                "type": "string"
-            },
-            "EndDate": {
-                "type": "string"
-            },
-            "GetUsageStatsOutput": {
-                "type": "structure",
-                "members": {
-                    "Entries": {
-                        "shape": "UsageStatsEntries",
-                        "documentation": "<p>Per-hour usage log entries (ops and bandwidth). Empty unless <code>rgw enable usage log = true</code>.</p>"
-                    },
-                    "Summary": {
-                        "shape": "UsageStatsSummary",
-                        "documentation": "<p>Aggregated quota and storage totals for the user.</p>"
-                    },
-                    "CapacityUsed": {
-                        "shape": "UsageStatsCapacityUsed",
-                        "documentation": "<p>Current storage usage per bucket.</p>"
-                    }
-                }
-            },
-            "UsageStatsEntries": {
-                "type": "structure",
-                "members": {
-                    "User": {
-                        "shape": "UsageStatsEntryUserList",
-                        "locationName": "User"
-                    }
-                }
-            },
-            "UsageStatsEntryUserList": {
-                "type": "list",
-                "member": {
-                    "shape": "UsageStatsEntryUser"
-                },
-                "flattened": true
-            },
-            "UsageStatsEntryUser": {
-                "type": "structure",
-                "members": {
-                    "Owner": {
-                        "shape": "OwnerName"
-                    },
-                    "Buckets": {
-                        "shape": "UsageStatsEntryBuckets"
-                    }
-                }
-            },
-            "UsageStatsEntryBuckets": {
-                "type": "structure",
-                "members": {
-                    "Bucket": {
-                        "shape": "UsageStatsEntryBucketItemList",
-                        "locationName": "Bucket"
-                    }
-                }
-            },
-            "UsageStatsEntryBucketItemList": {
-                "type": "list",
-                "member": {
-                    "shape": "UsageStatsBucketEntry"
-                },
-                "flattened": true
-            },
-            "UsageStatsBucketEntry": {
-                "type": "structure",
-                "members": {
-                    "Time": {
-                        "shape": "UsageTime"
-                    },
-                    "Epoch": {
-                        "shape": "UsageEpoch"
-                    },
-                    "Categories": {
-                        "shape": "UsageStatsCategories",
-                        "locationName": "categories"
-                    },
-                    "S3Select": {
-                        "shape": "UsageStatsS3Select",
-                        "locationName": "s3select"
-                    },
-                    "Bucket": {
-                        "shape": "UsageBucketName",
-                        "locationName": "Bucket"
-                    }
-                }
-            },
-            "UsageStatsCategories": {
-                "type": "structure",
-                "members": {
-                    "Entry": {
-                        "shape": "UsageCategoryEntryList",
-                        "locationName": "Entry"
-                    }
-                }
-            },
-            "UsageCategoryEntryList": {
-                "type": "list",
-                "member": {
-                    "shape": "UsageCategoryEntry"
-                },
-                "flattened": true
-            },
-            "UsageCategoryEntry": {
-                "type": "structure",
-                "members": {
-                    "Category": {
-                        "shape": "CategoryName"
-                    },
-                    "BytesSent": {
-                        "shape": "BytesSent"
-                    },
-                    "BytesReceived": {
-                        "shape": "BytesReceived"
-                    },
-                    "Ops": {
-                        "shape": "Ops"
-                    },
-                    "SuccessfulOps": {
-                        "shape": "SuccessfulOps"
-                    }
-                }
-            },
-            "UsageStatsS3Select": {
-                "type": "structure",
-                "members": {
-                    "BytesProcessed": {
-                        "shape": "BytesProcessed"
-                    },
-                    "BytesReturned": {
-                        "shape": "BytesReturned"
-                    }
-                }
-            },
-            "UsageStatsCapacityUsed": {
-                "type": "structure",
-                "members": {
-                    "User": {
-                        "shape": "UsageStatsCapacityUserList",
-                        "locationName": "User"
-                    }
-                }
-            },
-            "UsageStatsCapacityUserList": {
-                "type": "list",
-                "member": {
-                    "shape": "UsageStatsCapacityUser"
-                },
-                "flattened": true
-            },
-            "UsageStatsCapacityUser": {
-                "type": "structure",
-                "members": {
-                    "Buckets": {
-                        "shape": "UsageStatsCapacityBuckets"
-                    }
-                }
-            },
-            "UsageStatsCapacityBuckets": {
-                "type": "structure",
-                "members": {
-                    "Entry": {
-                        "shape": "UsageStatsCapacityBucketItemList",
-                        "locationName": "Entry"
-                    }
-                }
-            },
-            "UsageStatsCapacityBucketItemList": {
-                "type": "list",
-                "member": {
-                    "shape": "UsageStatsCapacityBucketEntry"
-                },
-                "flattened": true
-            },
-            "UsageStatsCapacityBucketEntry": {
-                "type": "structure",
-                "members": {
-                    "Bytes": {
-                        "shape": "TotalBytes"
-                    },
-                    "BytesRounded": {
-                        "shape": "TotalBytesRounded",
-                        "locationName": "Bytes_Rounded"
-                    },
-                    "Bucket": {
-                        "shape": "UsageBucketName",
-                        "locationName": "Bucket"
-                    }
-                }
-            },
-            "UsageStatsSummary": {
-                "type": "structure",
-                "members": {
-                    "User": {
-                        "shape": "UsageStatsSummaryUserList",
-                        "locationName": "User"
-                    },
-                    "QuotaMaxBytes": {
-                        "shape": "QuotaMaxBytes"
-                    },
-                    "QuotaMaxBuckets": {
-                        "shape": "QuotaMaxBuckets"
-                    },
-                    "QuotaMaxObjCount": {
-                        "shape": "QuotaMaxObjCount"
-                    },
-                    "QuotaMaxBytesPerBucket": {
-                        "shape": "QuotaMaxBytesPerBucket"
-                    },
-                    "QuotaMaxObjCountPerBucket": {
-                        "shape": "QuotaMaxObjCountPerBucket"
-                    },
-                    "TotalBytes": {
-                        "shape": "TotalBytes"
-                    },
-                    "TotalBytesRounded": {
-                        "shape": "TotalBytesRounded"
-                    },
-                    "TotalEntries": {
-                        "shape": "TotalEntries"
-                    }
-                }
-            },
-            "UsageStatsSummaryUserList": {
-                "type": "list",
-                "member": {
-                    "shape": "UsageStatsSummaryUser"
-                },
-                "flattened": true
-            },
-            "UsageStatsSummaryUser": {
-                "type": "structure",
-                "members": {
-                    "User": {
-                        "shape": "OwnerName",
-                        "locationName": "User"
-                    },
-                    "Categories": {
-                        "shape": "UsageStatsCategories",
-                        "locationName": "categories"
-                    },
-                    "Total": {
-                        "shape": "UsageStatsTotal",
-                        "locationName": "Total"
-                    }
-                }
-            },
-            "UsageStatsTotal": {
-                "type": "structure",
-                "members": {
-                    "BytesSent": {
-                        "shape": "BytesSent"
-                    },
-                    "BytesReceived": {
-                        "shape": "BytesReceived"
-                    },
-                    "Ops": {
-                        "shape": "Ops"
-                    },
-                    "SuccessfulOps": {
-                        "shape": "SuccessfulOps"
-                    },
-                    "BytesProcessed": {
-                        "shape": "BytesProcessed"
-                    },
-                    "BytesReturned": {
-                        "shape": "BytesReturned"
-                    }
-                }
-            },
-            "OwnerName": {
-                "type": "string"
-            },
-            "BucketName": {
-                "type": "string"
-            },
-            "UsageTime": {
-                "type": "string"
-            },
-            "UsageEpoch": {
-                "type": "integer"
-            },
-            "CategoryName": {
-                "type": "string"
-            },
-            "BytesSent": {
-                "type": "integer"
-            },
-            "BytesReceived": {
-                "type": "integer"
-            },
-            "Ops": {
-                "type": "integer"
-            },
-            "SuccessfulOps": {
-                "type": "integer"
-            },
-            "BytesProcessed": {
-                "type": "integer"
-            },
-            "BytesReturned": {
-                "type": "integer"
-            },
-            "UsageBucketName": {
-                "type": "string"
             }
         },
-        "documentation": "<p/>"
-    }
+        "ReplicationRule":{
+            "members":{
+		"Source": {
+		    "shape":"S3RepSource",
+		    "documentation":"<p>A container for information about the replication source.<p>",
+		    "locationName":"Source"
+		}
+	    }
+	},
+	"S3RepSource": {
+	    "type": "structure",
+	    "members": {
+                "Zones": {
+                    "shape":"ZoneList",
+                    "documentation":"<p>Array of replication source zone names.</p>",
+		    "locationName":"Zone"
+                }
+            }
+        },
+	"Destination": {
+	    "members": {
+                "Zones": {
+                    "shape":"ZoneList",
+                    "documentation":"<p>Array of replication destination zone names.</p>",
+		    "locationName":"Zone"
+                }
+            }
+        },
+	"ZoneList": {
+	    "type":"list",
+	    "member":{"shape":"Zone"},
+	    "flattened":true
+	},
+        "Zone":{"type":"string"},
+        "AllowUnordered":{"type":"boolean"},
+        "PutObjectRequest": {
+            "members": {
+                "AppendPosition": {
+                    "shape":"AppendPosition",
+                    "documentation": "<p>Position to allow appending</p>",
+                    "location": "querystring",
+                    "locationName": "position"
+                },
+                "Append": {
+                    "shape":"Append",
+                    "documentation":"<p>Append Object</p>",
+                    "location": "querystring",
+                    "locationName": "append"
+                }
+            }
+        },
+        "Append": {"type":"boolean"},
+        "AppendPosition":{"type":"integer"},
+        "PutObjectOutput": {
+            "members": {
+                "AppendPosition": {
+                    "shape":"AppendPosition",
+                    "documentation": "<p>Position to allow appending</p>",
+                    "location": "header",
+                    "locationName": "x-rgw-next-append-position",
+                    "documentationUrl":"https://docs.ceph.com/docs/master/radosgw/s3/objectops/#append-object"
+                }
+            }
+        },
+        "GetBucketNotificationConfigurationRequest":{
+            "type":"structure",
+            "required":["Bucket"],
+            "members":{
+                "Bucket":{
+                    "shape":"BucketName",
+                    "documentation":"<p>Name of the bucket to get the notifications configuration for.</p>",
+                    "location":"uri",
+                    "locationName":"Bucket"
+                },
+                "Notification":{
+                    "shape":"NotificationId",
+                    "documentation":"<p>Id of the specific notification on the bucket for which the configuration should be retrieved.</p>",
+                    "location":"querystring",
+                    "locationName":"notification-id"
+                }
+            }
+        },
+        "DeleteBucketNotificationConfigurationRequest":{
+            "type":"structure",
+            "required":["Bucket"],
+            "members":{
+                "Bucket":{
+                    "shape":"BucketName",
+                    "documentation":"<p>Name of the bucket to delete the notifications configuration from.</p>",
+                    "contextParam":{"name":"Bucket"},
+                    "location":"uri",
+                    "locationName":"Bucket"
+                },
+                "Notification":{
+                    "shape":"NotificationId",
+                    "documentation":"<p>Id of the specific notification on the bucket to be deleted.</p>",
+                    "location":"querystring",
+                    "locationName":"notification-id"
+                }
+            }
+        },
+        "PostBucketLoggingRequest":{
+            "type":"structure",
+            "required":["Bucket"],
+            "members":{
+                "Bucket":{
+                    "shape":"BucketName",
+                    "documentation":"<p>Name of the bucket to flush its logging objects.</p>",
+                    "contextParam":{"name":"Bucket"},
+                    "location":"uri",
+                    "locationName":"Bucket"
+                }
+            }
+        },
+        "FilterRule":{
+            "type":"structure",
+            "members":{
+                "Name":{
+                    "shape":"FilterRuleName",
+                    "documentation":"<p>The object key name prefix, suffix or regex identifying one or more objects to which the filtering rule applies. The maximum length is 1,024 characters. Overlapping prefixes and suffixes are supported.</p>"
+                },
+                "Value":{
+                    "shape":"FilterRuleValue",
+                    "documentation":"<p>The value that the filter searches for in object key names.</p>"
+                }
+            },
+            "documentation":"<p>Specifies the Amazon S3 object key name to filter on and whether to filter on the suffix, prefix or regex of the key name.</p>"
+        },
+        "FilterRuleName":{
+            "type":"string",
+            "enum":[
+                "prefix",
+                "suffix",
+                "regex"
+            ]
+        },
+        "NotificationConfigurationFilter":{
+            "type":"structure",
+            "members":{
+                "Key":{
+                    "shape":"S3KeyFilter",
+                    "documentation":"<p/>",
+                    "locationName":"S3Key"
+                },
+                "Metadata":{
+                    "shape":"S3MetadataFilter",
+                    "documentation":"<p/>",
+                    "locationName":"S3Metadata"
+                },
+                "Tags":{
+                    "shape":"S3TagsFilter",
+                    "documentation":"<p/>",
+                    "locationName":"S3Tags"
+                }
+
+            },
+            "documentation":"<p>Specifies object key name filtering rules. For information about key name filtering, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html\">Configuring Event Notifications</a> in the <i>Amazon Simple Storage Service Developer Guide</i>.</p>"
+        },
+        "S3KeyFilter":{
+            "type":"structure",
+            "members":{
+                "FilterRules":{
+                    "shape":"FilterRuleList",
+                    "documentation":"<p/>",
+                    "locationName":"FilterRule"
+                }
+            },
+            "documentation":"<p>A container for object key name prefix, suffix and regex filtering rules.</p>"
+        },
+        "S3MetadataFilter":{
+            "type":"structure",
+            "members":{
+                "FilterRules":{
+                    "shape":"FilterRuleList",
+                    "documentation":"<p/>",
+                    "locationName":"FilterRule"
+                }
+            },
+            "documentation":"<p>A container for metadata filtering rules.</p>"
+        },
+        "S3TagsFilter":{
+            "type":"structure",
+            "members":{
+                "FilterRules":{
+                    "shape":"FilterRuleList",
+                    "documentation":"<p/>",
+                    "locationName":"FilterRule"
+                }
+            },
+            "documentation":"<p>A container for object tags filtering rules.</p>"
+        },
+        "GetUsageStatsOutput":{
+            "type": "structure",
+            "members":{
+                "Entries":{
+                    "shape": "UsageStatsEntries",
+                    "documentation": "<p>Per-hour usage log entries (ops and bandwidth). Empty unless <code>rgw enable usage log = true</code>.</p>"
+                },
+                "Summary":{
+                    "shape": "UsageStatsSummary",
+                    "documentation": "<p>Aggregated quota and storage totals for the user.</p>"
+                },
+                "CapacityUsed":{
+                    "shape": "UsageStatsCapacityUsed",
+                    "documentation": "<p>Current storage usage per bucket.</p>"
+                }
+            }
+        },
+        "UsageStatsSummary":{
+            "type": "structure",
+            "members":{
+                "User":{
+                    "shape": "UsageStatsSummaryUserList",
+                    "locationName": "User"
+                },
+                "QuotaMaxBytes":{
+                    "shape": "QuotaMaxBytes"
+                },
+                "QuotaMaxBuckets":{
+                    "shape": "QuotaMaxBuckets"
+                },
+                "QuotaMaxObjCount":{
+                    "shape": "QuotaMaxObjCount"
+                },
+                "QuotaMaxBytesPerBucket":{
+                    "shape": "QuotaMaxBytesPerBucket"
+                },
+                "QuotaMaxObjCountPerBucket":{
+                    "shape": "QuotaMaxObjCountPerBucket"
+                },
+                "TotalBytes":{
+                    "shape": "TotalBytes"
+                },
+                "TotalBytesRounded":{
+                    "shape": "TotalBytesRounded"
+                },
+                "TotalEntries":{
+                    "shape": "TotalEntries"
+                }
+            }
+        },
+        "QuotaMaxBytes":{"type":"integer"},
+        "QuotaMaxBuckets":{"type": "integer"},
+        "QuotaMaxObjCount":{"type":"integer"},
+        "QuotaMaxBytesPerBucket":{"type":"integer"},
+        "QuotaMaxObjCountPerBucket":{"type":"integer"},
+        "TotalBytesRounded":{"type":"integer"},
+        "TotalBytes":{"type":"integer"},
+        "TotalEntries":{"type":"integer"},
+        "LoggingEnabled":{
+            "type":"structure",
+            "required":[
+                "TargetBucket",
+                "TargetPrefix"
+            ],
+            "members":{
+                "TargetBucket":{
+                    "shape":"TargetBucket",
+                    "documentation":"<p>Specifies the bucket where you want to store server access logs. You can have your logs delivered to any bucket that you own. You can also configure multiple buckets to deliver their logs to the same target bucket. In this case, you should choose a different <code>TargetPrefix</code> for each source bucket so that the delivered log files can be distinguished by key.</p>"
+                },
+                "TargetGrants":{
+                    "shape":"TargetGrants",
+                    "documentation":"<p>Container for granting information.</p> <p>Should be used when the write permissions to the tagert bucket should eb different than the permissions of the user performing the operation thta needs to be logged. This is usually used in cased of batched logging. see: <code>RecordBatchSize</code>.</p>"
+                },
+                "TargetPrefix":{
+                    "shape":"TargetPrefix",
+                    "documentation":"<p>A prefix for all log object keys. If you store log files from multiple buckets in a single bucket, you can use a prefix to distinguish which log files came from which bucket.</p>"
+                },
+                "TargetObjectKeyFormat":{
+                    "shape":"TargetObjectKeyFormat",
+                    "documentation":"<p>key format for log objects.</p>"
+                },
+                "ObjectRollTime":{
+                    "shape":"ObjectRollTime",
+                    "documentation":"<p>time in seconds to move the log object to the target bucket and start another log object.</p>"
+                },
+                "LoggingType":{
+                    "shape":"LoggingType",
+                    "documentation":"<p>use Standard log type to log all bucket operations i nthe standard format. use Journal log type to log only creations and deletion of objects in more compact format.</p>"
+                },
+                "RecordsBatchSize":{
+                    "shape":"RecordsBatchSize",
+                    "documentation":"indicates how many records to batch in memory before writing to the object. if set to zero, records are written syncronously to the object. if <code>ObjectRollTime</code>e is reached, the batch of records will be written to the object regardless of the number of records. </p>"
+                },
+                "Filter":{
+                    "shape":"LoggingConfigurationFilter",
+                    "documentation":"<p>A filter for all log object. Filter for the object by its key (prefix, suffix and regex).</p>"
+                }
+            },
+            "documentation":"<p>Describes where logs are stored the prefix assigned to all log object keys for a bucket, and their format. also, the level the delivery guarantee of the records.</p>"
+        },
+        "TargetObjectKeyFormat":{
+      	    "type":"structure",
+            "members":{
+                "SimplePrefix":{
+                    "shape":"SimplePrefix",
+                    "documentation":"<p>To use the simple format for S3 keys for log objects. To specify SimplePrefix format, set SimplePrefix to {}.</p>",
+                    "locationName":"SimplePrefix"
+                },
+                "PartitionedPrefix":{
+                    "shape":"PartitionedPrefix",
+                    "documentation":"<p>Partitioned S3 key for log objects.</p>",
+                    "locationName":"PartitionedPrefix"
+                }
+            },
+            "documentation":"<p>Key format for log objects. Only one format, PartitionedPrefix or SimplePrefix, is allowed.</p>"
+        },
+        "SimplePrefix":{
+          "type":"structure",
+          "members":{
+          },
+          "documentation":"<p>To use simple format for S3 keys for log objects, set SimplePrefix to an empty object.</p> <p> <code>[DestinationPrefix][YYYY]-[MM]-[DD]-[hh]-[mm]-[ss]-[UniqueString]</code> </p>",
+          "locationName":"SimplePrefix"
+        },
+        "PartitionDateSource":{
+          "type":"string",
+          "enum":[
+            "EventTime",
+            "DeliveryTime"
+          ]
+        },
+        "PartitionedPrefix":{
+          "type":"structure",
+          "members":{
+            "PartitionDateSource":{
+              "shape":"PartitionDateSource",
+              "documentation":"<p>Specifies the partition date source for the partitioned prefix. PartitionDateSource can be EventTime or DeliveryTime.</p>"
+            }
+          },
+          "documentation":"<p>Amazon S3 keys for log objects are partitioned in the following format:</p> <p> <code>[DestinationPrefix][SourceAccountId]/[SourceRegion]/[SourceBucket]/[YYYY]/[MM]/[DD]/[YYYY]-[MM]-[DD]-[hh]-[mm]-[ss]-[UniqueString]</code> </p> <p>PartitionedPrefix defaults to EventTime delivery when server access logs are delivered.</p>",
+          "locationName":"PartitionedPrefix"
+        },
+        "ObjectRollTime":{"type":"integer"},
+        "RecordsBatchSize":{"type":"integer"},
+        "LoggingType":{
+            "type":"string",
+            "enum": [
+                "Standard",
+                "Journal"
+            ]
+        },
+        "LoggingConfigurationFilter":{
+            "type":"structure",
+            "members":{
+                "Key":{
+                    "shape":"S3KeyFilter",
+                    "documentation":"<p/>",
+                    "locationName":"S3Key"
+                }
+            },
+            "documentation":"<p>A filter for all log object. Filter for the object by its key (prefix, suffix and regex).</p>",
+            "locationName":"Filter"
+        },
+        "HeadBucketRequest": {
+            "members": {
+                "ReadStats":{
+                    "shape":"ReadStats",
+                    "documentation":"<p>Read additional usage statistics for <code>ObjectCount</code> and <code>BytesUsed</code> in the response.</p> <note> <p>This request parameter is a Ceph RGW extension.</p> </note>",
+                    "location":"querystring",
+                    "locationName":"read-stats"
+                }
+            }
+        },
+        "PostBucketLoggingOutput": {
+            "type":"structure",
+            "members":{
+              "FlushedLoggingObject": {
+                "shape":"FlushedLoggingObject",
+                "documentation":"<p>Name of the pending logging object that was flushed.</p>"
+              }
+            }
+        },
+        "PutBucketLoggingOutput": {
+            "type":"structure",
+            "members":{
+              "FlushedLoggingObject": {
+                "shape":"FlushedLoggingObject",
+                "documentation":"<p>Name of the pending logging object that was flushed.</p>"
+              }
+            }
+        },
+        "FlushedLoggingObject":{
+            "type":"string"
+        },
+        "HeadBucketOutput":{
+            "type":"structure",
+            "members":{
+                "ObjectCount":{
+                    "shape":"ObjectCount",
+                    "documentation": "<p>Total number of objects/versions in the bucket.</p>",
+                    "location": "header",
+                    "locationName": "x-rgw-object-count"
+                },
+                "BytesUsed":{
+                    "shape":"BytesUsed",
+                    "documentation": "<p>Total size in bytes of all objects/versions in the bucket.</p>",
+                    "location": "header",
+                    "locationName": "x-rgw-bytes-used"
+                }
+            }
+        },
+        "ReadStats":{"type":"boolean"},
+        "ObjectCount":{"type":"integer"},
+        "BytesUsed":{"type":"integer"},
+        "CreateBucketConfiguration":{
+            "type":"structure",
+            "members":{
+                "BucketIndex":{
+                    "shape":"BucketIndex",
+                    "documentation":"<p>Configuration to customize the bucket index layout.</p> <note> <p>This element is a Ceph RGW extension.</p> </note>"
+                }
+            }
+        },
+        "BucketIndex":{
+            "type":"structure",
+            "required":[
+                "Type"
+            ],
+            "members":{
+                "Type":{
+                    "shape":"BucketIndexType",
+                    "documentation":"<p>Bucket index type: Normal or Indexless.</p>"
+                },
+                "NumShards":{
+                    "shape":"BucketIndexNumShards",
+                    "documentation":"<p>Number of initial bucket index shards. Only valid for the <code>Normal</code> index type.</p>"
+                }
+            }
+        },
+        "BucketIndexType":{
+            "type":"string",
+            "enum":[
+                "Normal",
+                "Indexless"
+            ]
+        },
+        "BucketIndexNumShards":{"type":"integer"}
+    ,
+        "BucketName":{
+            "type": "string"
+        },
+        "BytesProcessed":{
+            "type": "integer"
+        },
+        "BytesReceived":{
+            "type": "integer"
+        },
+        "BytesReturned":{
+            "type": "integer"
+        },
+        "BytesSent":{
+            "type": "integer"
+        },
+        "CategoryName":{
+            "type": "string"
+        },
+        "EndDate":{
+            "type": "string"
+        },
+        "GetUsageStatsRequest":{
+            "type": "structure",
+            "members":{
+                "StartDate":{
+                    "shape": "StartDate",
+                    "documentation": "<p>Start of the usage log time range (inclusive).</p>",
+                    "location": "querystring",
+                    "locationName": "start-date"
+                },
+                "EndDate":{
+                    "shape": "EndDate",
+                    "documentation": "<p>End of the usage log time range.</p>",
+                    "location": "querystring",
+                    "locationName": "end-date"
+                }
+            }
+        },
+        "Ops":{
+            "type": "integer"
+        },
+        "OwnerName":{
+            "type": "string"
+        },
+        "StartDate":{
+            "type": "string"
+        },
+        "SuccessfulOps":{
+            "type": "integer"
+        },
+        "UsageBucketName":{
+            "type": "string"
+        },
+        "UsageCategoryEntry":{
+            "type": "structure",
+            "members":{
+                "Category":{
+                    "shape": "CategoryName"
+                },
+                "BytesSent":{
+                    "shape": "BytesSent"
+                },
+                "BytesReceived":{
+                    "shape": "BytesReceived"
+                },
+                "Ops":{
+                    "shape": "Ops"
+                },
+                "SuccessfulOps":{
+                    "shape": "SuccessfulOps"
+                }
+            }
+        },
+        "UsageCategoryEntryList":{
+            "type": "list",
+            "member":{
+                "shape": "UsageCategoryEntry"
+            },
+            "flattened": true
+        },
+        "UsageEpoch":{
+            "type": "integer"
+        },
+        "UsageStatsBucketEntry":{
+            "type": "structure",
+            "members":{
+                "Time":{
+                    "shape": "UsageTime"
+                },
+                "Epoch":{
+                    "shape": "UsageEpoch"
+                },
+                "Categories":{
+                    "shape": "UsageStatsCategories",
+                    "locationName": "categories"
+                },
+                "S3Select":{
+                    "shape": "UsageStatsS3Select",
+                    "locationName": "s3select"
+                },
+                "Bucket":{
+                    "shape": "UsageBucketName",
+                    "locationName": "Bucket"
+                }
+            }
+        },
+        "UsageStatsCapacityBucketEntry":{
+            "type": "structure",
+            "members":{
+                "Bytes":{
+                    "shape": "TotalBytes"
+                },
+                "BytesRounded":{
+                    "shape": "TotalBytesRounded",
+                    "locationName": "Bytes_Rounded"
+                },
+                "Bucket":{
+                    "shape": "UsageBucketName",
+                    "locationName": "Bucket"
+                }
+            }
+        },
+        "UsageStatsCapacityBucketItemList":{
+            "type": "list",
+            "member":{
+                "shape": "UsageStatsCapacityBucketEntry"
+            },
+            "flattened": true
+        },
+        "UsageStatsCapacityBuckets":{
+            "type": "structure",
+            "members":{
+                "Entry":{
+                    "shape": "UsageStatsCapacityBucketItemList",
+                    "locationName": "Entry"
+                }
+            }
+        },
+        "UsageStatsCapacityUsed":{
+            "type": "structure",
+            "members":{
+                "User":{
+                    "shape": "UsageStatsCapacityUserList",
+                    "locationName": "User"
+                }
+            }
+        },
+        "UsageStatsCapacityUser":{
+            "type": "structure",
+            "members":{
+                "Buckets":{
+                    "shape": "UsageStatsCapacityBuckets"
+                }
+            }
+        },
+        "UsageStatsCapacityUserList":{
+            "type": "list",
+            "member":{
+                "shape": "UsageStatsCapacityUser"
+            },
+            "flattened": true
+        },
+        "UsageStatsCategories":{
+            "type": "structure",
+            "members":{
+                "Entry":{
+                    "shape": "UsageCategoryEntryList",
+                    "locationName": "Entry"
+                }
+            }
+        },
+        "UsageStatsEntries":{
+            "type": "structure",
+            "members":{
+                "User":{
+                    "shape": "UsageStatsEntryUserList",
+                    "locationName": "User"
+                }
+            }
+        },
+        "UsageStatsEntryBucketItemList":{
+            "type": "list",
+            "member":{
+                "shape": "UsageStatsBucketEntry"
+            },
+            "flattened": true
+        },
+        "UsageStatsEntryBuckets":{
+            "type": "structure",
+            "members":{
+                "Bucket":{
+                    "shape": "UsageStatsEntryBucketItemList",
+                    "locationName": "Bucket"
+                }
+            }
+        },
+        "UsageStatsEntryUser":{
+            "type": "structure",
+            "members":{
+                "Owner":{
+                    "shape": "OwnerName"
+                },
+                "Buckets":{
+                    "shape": "UsageStatsEntryBuckets"
+                }
+            }
+        },
+        "UsageStatsEntryUserList":{
+            "type": "list",
+            "member":{
+                "shape": "UsageStatsEntryUser"
+            },
+            "flattened": true
+        },
+        "UsageStatsS3Select":{
+            "type": "structure",
+            "members":{
+                "BytesProcessed":{
+                    "shape": "BytesProcessed"
+                },
+                "BytesReturned":{
+                    "shape": "BytesReturned"
+                }
+            }
+        },
+        "UsageStatsSummaryUser":{
+            "type": "structure",
+            "members":{
+                "User":{
+                    "shape": "OwnerName",
+                    "locationName": "User"
+                },
+                "Categories":{
+                    "shape": "UsageStatsCategories",
+                    "locationName": "categories"
+                },
+                "Total":{
+                    "shape": "UsageStatsTotal",
+                    "locationName": "Total"
+                }
+            }
+        },
+        "UsageStatsSummaryUserList":{
+            "type": "list",
+            "member":{
+                "shape": "UsageStatsSummaryUser"
+            },
+            "flattened": true
+        },
+        "UsageStatsTotal":{
+            "type": "structure",
+            "members":{
+                "BytesSent":{
+                    "shape": "BytesSent"
+                },
+                "BytesReceived":{
+                    "shape": "BytesReceived"
+                },
+                "Ops":{
+                    "shape": "Ops"
+                },
+                "SuccessfulOps":{
+                    "shape": "SuccessfulOps"
+                },
+                "BytesProcessed":{
+                    "shape": "BytesProcessed"
+                },
+                "BytesReturned":{
+                    "shape": "BytesReturned"
+                }
+            }
+        },
+        "UsageTime":{
+            "type": "string"
+        }
+},
+    "documentation":"<p/>"
+}
 }

--- a/qa/tasks/radosgw_admin.py
+++ b/qa/tasks/radosgw_admin.py
@@ -30,6 +30,9 @@ import httplib2
 from tasks.rgw import RGWEndpoint
 from tasks.util.rgw import rgwadmin as tasks_util_rgw_rgwadmin
 from tasks.util.rgw import get_user_summary, get_user_successful_ops
+from tasks.util.rgw import (s3_get_usage, parse_s3_usage_xml,
+                            s3_usage_capacity_entries, s3_usage_log_users,
+                            s3_usage_total_ops)
 
 log = logging.getLogger(__name__)
 
@@ -856,6 +859,16 @@ def task(ctx, config):
 
     total = user_summary['total']
     assert total['successful_ops'] > 0
+
+    # TESTCASE 'usage-s3-getusage' 'usage' 's3-get' 'GET /?usage' 'returns capacity and log entries'
+    status, usage_xml = s3_get_usage(endpoint.url(), access_key, secret_key)
+    assert status == 200, usage_xml
+    usage_root = parse_s3_usage_xml(usage_xml)
+    capacity_entries = s3_usage_capacity_entries(usage_root)
+    assert len(capacity_entries) > 0
+    log_users = s3_usage_log_users(usage_root)
+    assert len(log_users) > 0
+    assert s3_usage_total_ops(usage_root) > 0
 
     # TESTCASE 'usage-show2' 'usage' 'show' 'user usage' 'succeeds'
     (err, out) = rgwadmin(ctx, client, ['usage', 'show', '--uid', user1],

--- a/qa/tasks/radosgw_admin.py
+++ b/qa/tasks/radosgw_admin.py
@@ -32,7 +32,8 @@ from tasks.util.rgw import rgwadmin as tasks_util_rgw_rgwadmin
 from tasks.util.rgw import get_user_summary, get_user_successful_ops
 from tasks.util.rgw import (s3_get_usage, parse_s3_usage_xml,
                             s3_usage_capacity_entries, s3_usage_log_users,
-                            s3_usage_total_ops)
+                            s3_usage_log_owners, s3_usage_total_ops,
+                            s3_usage_summary_successful_ops, s3_usage_total_bytes)
 
 log = logging.getLogger(__name__)
 
@@ -868,7 +869,12 @@ def task(ctx, config):
     assert len(capacity_entries) > 0
     log_users = s3_usage_log_users(usage_root)
     assert len(log_users) > 0
+    assert user1 in s3_usage_log_owners(usage_root)
     assert s3_usage_total_ops(usage_root) > 0
+    assert s3_usage_summary_successful_ops(usage_root) > 0
+    assert s3_usage_total_bytes(usage_root) > 0
+    # service-level GET /?usage must reflect the same user ops as usage show
+    assert s3_usage_summary_successful_ops(usage_root) >= total['successful_ops']
 
     # TESTCASE 'usage-show2' 'usage' 'show' 'user usage' 'succeeds'
     (err, out) = rgwadmin(ctx, client, ['usage', 'show', '--uid', user1],

--- a/qa/tasks/tests/test_util_rgw.py
+++ b/qa/tasks/tests/test_util_rgw.py
@@ -1,0 +1,78 @@
+from tasks.util.rgw import (parse_s3_usage_xml, s3_usage_capacity_entries,
+                            s3_usage_log_owners, s3_usage_log_users,
+                            s3_usage_summary_successful_ops, s3_usage_total_bytes,
+                            s3_usage_total_ops)
+
+SAMPLE_USAGE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<Usage>
+  <Entries>
+    <User>
+      <Owner>foo</Owner>
+      <Buckets>
+        <Bucket>
+          <Bucket>myfoo</Bucket>
+          <categories>
+            <Entry>
+              <Category>put_obj</Category>
+              <Ops>2</Ops>
+              <SuccessfulOps>2</SuccessfulOps>
+            </Entry>
+            <Entry>
+              <Category>delete_obj</Category>
+              <Ops>1</Ops>
+              <SuccessfulOps>1</SuccessfulOps>
+            </Entry>
+          </categories>
+        </Bucket>
+      </Buckets>
+    </User>
+  </Entries>
+  <Summary>
+    <User>
+      <User>foo</User>
+      <Total>
+        <Ops>3</Ops>
+        <SuccessfulOps>3</SuccessfulOps>
+      </Total>
+    </User>
+    <TotalBytes>4096</TotalBytes>
+    <TotalBytesRounded>4096</TotalBytesRounded>
+    <TotalEntries>2</TotalEntries>
+  </Summary>
+  <CapacityUsed>
+    <User>
+      <Buckets>
+        <Entry>
+          <Bucket>myfoo</Bucket>
+          <Bytes>4096</Bytes>
+          <Bytes_Rounded>4096</Bytes_Rounded>
+        </Entry>
+      </Buckets>
+    </User>
+  </CapacityUsed>
+</Usage>
+"""
+
+
+class TestS3UsageXml(object):
+
+    def setup(self):
+        self.root = parse_s3_usage_xml(SAMPLE_USAGE_XML)
+
+    def test_capacity_entries(self):
+        entries = s3_usage_capacity_entries(self.root)
+        assert len(entries) == 1
+        assert entries[0].find('Bucket').text == 'myfoo'
+
+    def test_log_users_and_owners(self):
+        assert len(s3_usage_log_users(self.root)) == 1
+        assert s3_usage_log_owners(self.root) == ['foo']
+
+    def test_total_ops(self):
+        assert s3_usage_total_ops(self.root) == 3
+
+    def test_summary_successful_ops(self):
+        assert s3_usage_summary_successful_ops(self.root) == 3
+
+    def test_total_bytes(self):
+        assert s3_usage_total_bytes(self.root) == 4096

--- a/qa/tasks/util/rgw.py
+++ b/qa/tasks/util/rgw.py
@@ -77,11 +77,16 @@ def get_user_successful_ops(out, user):
         return 0
     return get_user_summary(out, user)['total']['successful_ops']
 
-def s3_get_usage(endpoint_url, access_key, secret_key, region=''):
+def s3_get_usage(endpoint_url, access_key, secret_key, region='us-east-1'):
     """Issue a signed S3 GET /?usage request (Ceph RGW extension)."""
     creds = Credentials(access_key, secret_key)
-    url = endpoint_url.rstrip('/') + '/?usage'
-    request = AWSRequest(method='GET', url=url)
+    url = endpoint_url.rstrip('/') + '/'
+    request = AWSRequest(
+        method='GET',
+        url=url,
+        params={'usage': ''},
+        headers={'x-amz-content-sha256': 'UNSIGNED-PAYLOAD'},
+    )
     SigV4Auth(creds, 's3', region).add_auth(request)
     prepared = request.prepare()
     log.debug('s3_get_usage: url=%s', prepared.url)
@@ -100,6 +105,14 @@ def s3_usage_log_users(root):
     """Return usage log user sections from Entries."""
     return root.findall('.//Entries//User')
 
+def s3_usage_log_owners(root):
+    """Return Owner ids from usage log Entries."""
+    owners = []
+    for owner in root.findall('.//Entries//Owner'):
+        if owner.text:
+            owners.append(owner.text)
+    return owners
+
 def s3_usage_total_ops(root):
     """Sum Ops values from usage log categories in Entries."""
     total = 0
@@ -107,6 +120,21 @@ def s3_usage_total_ops(root):
         if ops.text:
             total += int(ops.text)
     return total
+
+def s3_usage_summary_successful_ops(root):
+    """Sum SuccessfulOps from Summary totals."""
+    total = 0
+    for ops in root.findall('.//Summary//Total//SuccessfulOps'):
+        if ops.text:
+            total += int(ops.text)
+    return total
+
+def s3_usage_total_bytes(root):
+    """Return TotalBytes from Summary (user storage)."""
+    el = root.find('.//Summary//TotalBytes')
+    if el is not None and el.text:
+        return int(el.text)
+    return 0
 
 def wait_for_radosgw(url, remote):
     """ poll the given url until it starts accepting connections

--- a/qa/tasks/util/rgw.py
+++ b/qa/tasks/util/rgw.py
@@ -1,8 +1,14 @@
 import logging
 import json
 import time
+import xml.etree.ElementTree as ET
 
 from io import StringIO
+
+import requests
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+from botocore.credentials import Credentials
 
 from teuthology import misc as teuthology
 
@@ -70,6 +76,37 @@ def get_user_successful_ops(out, user):
     if len(summary) == 0:
         return 0
     return get_user_summary(out, user)['total']['successful_ops']
+
+def s3_get_usage(endpoint_url, access_key, secret_key, region=''):
+    """Issue a signed S3 GET /?usage request (Ceph RGW extension)."""
+    creds = Credentials(access_key, secret_key)
+    url = endpoint_url.rstrip('/') + '/?usage'
+    request = AWSRequest(method='GET', url=url)
+    SigV4Auth(creds, 's3', region).add_auth(request)
+    prepared = request.prepare()
+    log.debug('s3_get_usage: url=%s', prepared.url)
+    result = requests.get(prepared.url, headers=prepared.headers)
+    return result.status_code, result.text
+
+def parse_s3_usage_xml(text):
+    """Parse the XML body of GET /?usage into an ElementTree root."""
+    return ET.fromstring(text)
+
+def s3_usage_capacity_entries(root):
+    """Return per-bucket storage entries from CapacityUsed."""
+    return root.findall('.//CapacityUsed//Entry')
+
+def s3_usage_log_users(root):
+    """Return usage log user sections from Entries."""
+    return root.findall('.//Entries//User')
+
+def s3_usage_total_ops(root):
+    """Sum Ops values from usage log categories in Entries."""
+    total = 0
+    for ops in root.findall('.//Entries//Ops'):
+        if ops.text:
+            total += int(ops.text)
+    return total
 
 def wait_for_radosgw(url, remote):
     """ poll the given url until it starts accepting connections

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2635,10 +2635,15 @@ void RGWGetUsage::execute(optional_yield y)
   bool is_truncated = true;
 
   RGWUsageIter usage_iter;
-  
-  while (s->bucket && is_truncated) {
-    op_ret = s->bucket->read_usage(this, start_epoch, end_epoch, max_entries, &is_truncated,
+
+  while (is_truncated) {
+    if (s->bucket) {
+      op_ret = s->bucket->read_usage(this, start_epoch, end_epoch, max_entries, &is_truncated,
+				     usage_iter, usage);
+    } else {
+      op_ret = s->user->read_usage(this, start_epoch, end_epoch, max_entries, &is_truncated,
 				   usage_iter, usage);
+    }
     if (op_ret == -ENOENT) {
       op_ret = 0;
       is_truncated = false;
@@ -2646,7 +2651,7 @@ void RGWGetUsage::execute(optional_yield y)
 
     if (op_ret < 0) {
       return;
-    }    
+    }
   }
 
   op_ret = rgw_sync_all_stats(this, y, driver, s->user->get_id(),


### PR DESCRIPTION
## Summary

Backport of https://github.com/ceph/ceph/pull/69459 to **squid**.

S3 GetUsage did not return per-user usage log entries that radosgw-admin usage show returns for the same user.

**Why squid:** the same issue/feature gap exists on squid; operators on this release need the fix landed on main.

**Minimal change:** cherry-pick of all commits from PR #69459 with `git cherry-pick -x`.
Conflict in `examples/rgw/boto3/service-2.sdk-extras.json`: took GetUsageStats shapes from main; later formatting commits polish those shapes.

Parent tracker: https://tracker.ceph.com/issues/79539
Official backport tracker: https://tracker.ceph.com/issues/79671
## Testing

- Includes unittest coverage and qa from main PR
- Not run locally on squid yet

## Checklist
- Tracker
  - [x] References tracker ticket
- Component impact
  - [x] No impact that needs to be tracked
- Documentation
  - [x] Updates relevant documentation
- Tests
  - [x] Includes unit test(s)

Fixes: https://tracker.ceph.com/issues/79542