### PR TITLE
mgr/prometheus: optimize get_pool_repaired_objects and memoize cluster maps

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -768,6 +768,7 @@ class Module(MgrModule, OrchestratorClientMixin):
         self.cache = True
         self.stale_cache_strategy: str = self.STALE_CACHE_FAIL
         self.collect_cache: Optional[str] = None
+        self._get_cache: Dict[str, Any] = {}
         self.rbd_stats = {
             'pools': {},
             'pools_refresh_time': 0,
@@ -790,6 +791,21 @@ class Module(MgrModule, OrchestratorClientMixin):
         _global_instance = self
         self.metrics_thread = MetricCollectionThread(_global_instance)
         self.health_history = HealthHistory(self)
+
+    def get_once(self, data_name: str) -> Any:
+        """self.get(), memoized for the duration of a single collect() call.
+
+        Only safe for collectors driven from collect(), which resets the
+        memo on entry and on exit. collect() is serialised: with the cache
+        enabled it only ever runs on MetricCollectionThread, and with the
+        cache disabled it only ever runs under collect_lock.
+        """
+        try:
+            return self._get_cache[data_name]
+        except KeyError:
+            value = self.get(data_name)
+            self._get_cache[data_name] = value
+            return value
 
     def _setup_static_metrics(self) -> Dict[str, Metric]:
         metrics = {}
@@ -1362,7 +1378,7 @@ class Module(MgrModule, OrchestratorClientMixin):
     @profile_method()
     def get_pg_status(self) -> None:
 
-        pg_summary = self.get('pg_summary')
+        pg_summary = self.get_once('pg_summary')
 
         for pool in pg_summary['by_pool']:
             num_by_state: DefaultDict[str, int] = defaultdict(int)
@@ -1403,7 +1419,7 @@ class Module(MgrModule, OrchestratorClientMixin):
 
     @profile_method()
     def get_metadata_and_osd_status(self) -> None:
-        osd_map = self.get('osd_map')
+        osd_map = self.get_once('osd_map')
 
         cluster_nearfull_ratio = osd_map.get('nearfull_ratio', None)
         cluster_full_ratio = osd_map.get('full_ratio', None)
@@ -1636,7 +1652,7 @@ class Module(MgrModule, OrchestratorClientMixin):
 
     @profile_method()
     def get_num_objects(self) -> None:
-        pg_sum = self.get('pg_summary')['pg_stats_sum']['stat_sum']
+        pg_sum = self.get_once('pg_summary')['pg_stats_sum']['stat_sum']
         for obj in NUM_OBJECTS:
             stat = 'num_objects_{}'.format(obj)
             self.metrics[stat].set(pg_sum[stat])
@@ -1662,7 +1678,7 @@ class Module(MgrModule, OrchestratorClientMixin):
         # '*' can be used to indicate all pools or namespaces
         pools_string = cast(str, self.get_localized_module_option('rbd_stats_pools'))
         pool_keys = set()
-        osd_map = self.get('osd_map')
+        osd_map = self.get_once('osd_map')
         rbd_pools = [pool['pool_name'] for pool in osd_map['pools']
                      if 'rbd' in pool.get('application_metadata', {})]
         for x in re.split(r'[\s,]+', pools_string):
@@ -2257,6 +2273,17 @@ class Module(MgrModule, OrchestratorClientMixin):
         for k in self.metrics.keys():
             self.metrics[k].clear()
 
+        # Memoize self.get() for the duration of this collection. Several
+        # collectors below need the same cluster structures, and every
+        # self.get() miss costs a full C++ dump of that structure into Python
+        # objects, performed with the GIL held (see
+        # ActivePyModules::get_python()). Fetching 'osd_map' or 'pg_summary'
+        # twice therefore stalls every other thread in ceph-mgr -- including
+        # the CherryPy thread trying to answer the scrape -- for twice as long
+        # as necessary. As a bonus, all collectors now observe one consistent
+        # snapshot rather than two maps fetched seconds apart.
+        self._get_cache = {}
+
         self.get_health()
         self.get_df()
         self.get_osd_blocklisted_entries()
@@ -2284,6 +2311,7 @@ class Module(MgrModule, OrchestratorClientMixin):
         _metrics = [m.str_expfmt() for m in self.metrics.values()]
         for k in self.metrics.keys():
             self.metrics[k].clear()
+        self._get_cache = {}
 
         return ''.join(_metrics) + '\n'
 

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1943,12 +1943,20 @@ class Module(MgrModule, OrchestratorClientMixin):
                 cast(MetricCounter, sum_metric).add(duration, (method_name,))
                 cast(MetricCounter, count_metric).add(1, (method_name,))
 
+    @profile_method()
     def get_pool_repaired_objects(self) -> None:
-        dump = self.get('pg_dump')
-        for stats in dump['pool_stats']:
+        # 'pool_stats' is PGMap::dump_pool_stats(), which is exactly the
+        # 'pool_stats' section that the far larger 'pg_dump' embeds -- see
+        # PGMap::dump(), which produces it by calling dump_pool_stats().
+        # Asking for 'pg_dump' here additionally dumped dump_basic(),
+        # dump_pg_stats() (every PG in the cluster) and dump_osd_stats()
+        # into Python objects under the GIL, all of it discarded, just to
+        # read one counter per pool.
+        stats = self.get('pool_stats')
+        for pool in stats['pool_stats']:
             path = 'pool_objects_repaired'
-            self.metrics[path].set(stats['stat_sum']['num_objects_repaired'],
-                                   labelvalues=(stats['poolid'],))
+            self.metrics[path].set(pool['stat_sum']['num_objects_repaired'],
+                                   labelvalues=(pool['poolid'],))
 
     def get_all_daemon_health_metrics(self) -> None:
         daemon_metrics = self.get_daemon_health_metrics()

--- a/src/pybind/mgr/prometheus/test_module.py
+++ b/src/pybind/mgr/prometheus/test_module.py
@@ -471,3 +471,42 @@ class HardwareMetricsTest(TestCase):
         self.module._process_processors(self.status, self.hostname)
         for labels in self.module.metrics['hardware_cpu_cores'].value:
             self.assertEqual(len(labels), 5)
+
+
+class PoolRepairedObjectsTest(TestCase):
+    """Tests for how get_pool_repaired_objects() sources its data.
+
+    Every self.get() miss costs a full C++ dump of the requested structure
+    into Python objects with the GIL held, so which key is asked for matters
+    as much as how the result is used.
+    """
+
+    def setUp(self):
+        from prometheus.module import Module
+        self.module = mock.MagicMock(spec=Module)
+        self.module.log = mock.MagicMock()
+        self.module.get_pool_repaired_objects = \
+            Module.get_pool_repaired_objects.__get__(self.module)
+        self.module.metrics = {
+            'pool_objects_repaired': Metric(
+                'counter', 'pool_objects_repaired', '', ('pool_id',)),
+        }
+
+    def test_uses_pool_stats_not_pg_dump(self):
+        """'pg_dump' embeds every PG in the cluster; 'pool_stats' does not."""
+        self.module.get.return_value = {'pool_stats': []}
+        self.module.get_pool_repaired_objects()
+        self.module.get.assert_called_once_with('pool_stats')
+
+    def test_reads_counter_per_pool(self):
+        self.module.get.return_value = {
+            'pool_stats': [
+                {'poolid': 1, 'stat_sum': {'num_objects_repaired': 7}},
+                {'poolid': 2, 'stat_sum': {'num_objects_repaired': 0}},
+            ],
+        }
+        self.module.get_pool_repaired_objects()
+        self.assertEqual(
+            self.module.metrics['pool_objects_repaired'].value,
+            {(1,): 7, (2,): 0},
+        )

--- a/src/pybind/mgr/prometheus/test_module.py
+++ b/src/pybind/mgr/prometheus/test_module.py
@@ -510,3 +510,33 @@ class PoolRepairedObjectsTest(TestCase):
             self.module.metrics['pool_objects_repaired'].value,
             {(1,): 7, (2,): 0},
         )
+
+
+class GetOnceTest(TestCase):
+    """Tests for the per-collection memo in front of self.get()."""
+
+    def setUp(self):
+        from prometheus.module import Module
+        self.module = mock.MagicMock(spec=Module)
+        self.module._get_cache = {}
+        self.module.get_once = Module.get_once.__get__(self.module)
+
+    def test_fetches_once_per_key(self):
+        self.module.get.return_value = {'epoch': 1}
+        first = self.module.get_once('osd_map')
+        second = self.module.get_once('osd_map')
+        self.module.get.assert_called_once_with('osd_map')
+        self.assertIs(first, second)
+
+    def test_distinguishes_keys(self):
+        self.module.get.side_effect = lambda what: {'key': what}
+        self.assertEqual(self.module.get_once('osd_map'), {'key': 'osd_map'})
+        self.assertEqual(self.module.get_once('pg_summary'), {'key': 'pg_summary'})
+        self.assertEqual(self.module.get.call_count, 2)
+
+    def test_caches_falsy_result(self):
+        """An empty dump must not be re-fetched on every call."""
+        self.module.get.return_value = {}
+        self.module.get_once('pg_summary')
+        self.module.get_once('pg_summary')
+        self.module.get.assert_called_once_with('pg_summary')


### PR DESCRIPTION
While debugging a prometheus performance / latency issue I found two places that can use some optimization. First, `get_pool_repaired_objects` only reads the `pool_stats`, so we can speed it up by not getting the entire pg_dump. Second, we can memoize the cluster maps so that we don't need to serialize them several times per `collect` tick.

Fixes: https://tracker.ceph.com/issues/79728

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests