### PR TITLE
smb: refactor results.py and users to be more consistent and reusable

### DIFF
--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -63,7 +63,7 @@ from .proto import (
     Simplified,
 )
 from .resources import SMBResource
-from .results import ErrorResult, Result, ResultGroup
+from .results import ErrorResult, ResourceResult, Result, ResultGroup
 from .rgw_auth import RGWAuthorizer
 from .staging import (
     Staging,
@@ -486,7 +486,7 @@ class ClusterConfigHandler:
         log.debug('staging resource: %r', resource)
         if create_only:
             if not staging.is_new(resource):
-                return Result(
+                return ResourceResult(
                     resource,
                     success=False,
                     msg='a resource with the same ID already exists',
@@ -506,7 +506,9 @@ class ClusterConfigHandler:
             log.debug('rejected resource: %r', resource)
             return err
         log.debug('checked resource: %r', resource)
-        result = Result(resource, success=True, status={'checked': True})
+        result = ResourceResult(
+            resource, success=True, status={'checked': True}
+        )
         return result
 
     def _choose_path_resolver(
@@ -629,7 +631,7 @@ class ClusterConfigHandler:
         chg_tls_ids: Set[str] = set()
         chg_rgw_cred_ids: Set[str] = set()
         chg_extc_ids: Set[str] = set()
-        for result in updated:
+        for result in updated.resources():
             state = (result.status or {}).get('state', None)
             if state in (State.PRESENT, State.NOT_PRESENT):
                 # these are the no-change states. we can ignore them

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -506,9 +506,7 @@ class ClusterConfigHandler:
             log.debug('rejected resource: %r', resource)
             return err
         log.debug('checked resource: %r', resource)
-        result = ResourceResult(
-            resource, success=True, status={'checked': True}
-        )
+        result = ResourceResult.checked(resource)
         return result
 
     def _choose_path_resolver(

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -486,9 +486,8 @@ class ClusterConfigHandler:
         log.debug('staging resource: %r', resource)
         if create_only:
             if not staging.is_new(resource):
-                return ResourceResult(
+                return ErrorResult(
                     resource,
-                    success=False,
                     msg='a resource with the same ID already exists',
                 )
         try:

--- a/src/pybind/mgr/smb/module.py
+++ b/src/pybind/mgr/smb/module.py
@@ -505,7 +505,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         successful_share_updates = []
         failed_share_updates = []
 
-        for result in result_group:
+        for result in result_group.resources():
             if result.success:
                 if isinstance(result.src, resources.Cluster):
                     cluster_updated = True
@@ -594,7 +594,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             successful_updates = []
             failed_updates = []
 
-            for result in result_group:
+            for result in result_group.resources():
                 if result.success and hasattr(result.src, 'share_id'):
                     successful_updates.append(result.src.share_id)
                 elif hasattr(result.src, 'share_id'):

--- a/src/pybind/mgr/smb/module.py
+++ b/src/pybind/mgr/smb/module.py
@@ -464,7 +464,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         self,
         client_compat: ClientSupportMode,
         cluster_id: str,
-    ) -> Simplified:
+    ) -> results.Result:
         """Update client compatibility mode for an SMB cluster and all its shares"""
         # Get the existing cluster
         clusters = self._handler.matching_resources(
@@ -499,34 +499,24 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
         # Apply the updates
         result_group = self._apply_res(resources_to_update)
-
-        # Process results
-        cluster_updated = False
-        successful_share_updates = []
-        failed_share_updates = []
-
-        for result in result_group.resources():
-            if result.success:
-                if isinstance(result.src, resources.Cluster):
-                    cluster_updated = True
-                elif hasattr(result.src, 'share_id'):
-                    successful_share_updates.append(result.src.share_id)
-            else:
-                if isinstance(result.src, resources.Share) and hasattr(
-                    result.src, 'share_id'
-                ):
-                    failed_share_updates.append(
-                        {"share_id": result.src.share_id, "error": result.msg}
-                    )
-
-        return {
-            "cluster_id": cluster_id,
-            "client_compat": client_compat.value,
-            "cluster_updated": cluster_updated,
-            "successful_share_updates": successful_share_updates,
-            "failed_share_updates": failed_share_updates,
-            "total_shares": len(active_shares),
-        }
+        try:
+            summary = results.ClusterShareSummary.from_result_group(
+                result_group
+            ).build_dict(
+                successful_shares_key='successful_share_updates',
+                failed_shares_key='failed_share_updates',
+                cluster_updated_key='cluster_updated',
+            )
+        except ValueError:
+            return result_group
+        return results.ClientCompatBatchResult.create(
+            {
+                'cluster_id': cluster_id,
+                'client_compat': client_compat.value,
+                'total_shares': len(active_shares),
+            }
+            | summary
+        )
 
     @SMBCLICommand('cluster update cephfs qos', perm='rw')
     def cluster_update_qos(
@@ -538,7 +528,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         write_bw_limit: Optional[str] = None,
         read_burst_mult: Optional[int] = None,
         write_burst_mult: Optional[int] = None,
-    ) -> Simplified:
+    ) -> results.Result:
         """Update QoS settings for all CephFS shares in a cluster"""
         try:
             shares = self._handler.matching_resources(
@@ -582,43 +572,36 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                     )
 
             if not shares_to_update:
-                return {
-                    "cluster_id": cluster_id,
-                    "message": "No shares required QoS updates",
-                    "unchanged_shares": unchanged_shares,
-                    "total_shares": len(active_shares),
-                }
+                return results.QoSBatchResult.unchanged(
+                    {
+                        "cluster_id": cluster_id,
+                        "message": "No shares required QoS updates",
+                        "unchanged_shares": unchanged_shares,
+                        "total_shares": len(active_shares),
+                    }
+                )
 
             result_group = self._apply_res(shares_to_update)
 
-            successful_updates = []
-            failed_updates = []
+            summary = results.ClusterShareSummary.from_result_group(
+                result_group
+            ).build_dict(
+                successful_shares_key='successful_updates',
+                failed_shares_key='failed_updates',
+            )
 
-            for result in result_group.resources():
-                if result.success and hasattr(result.src, 'share_id'):
-                    successful_updates.append(result.src.share_id)
-                elif hasattr(result.src, 'share_id'):
-                    failed_updates.append(
-                        {"share_id": result.src.share_id, "error": result.msg}
-                    )
-
-            return {
-                "cluster_id": cluster_id,
-                "successful_updates": successful_updates,
-                "failed_updates": failed_updates,
-                "unchanged_shares": unchanged_shares,
-                "total_shares": len(active_shares),
-                "success": len(failed_updates) == 0,
-            }
-
+            return results.QoSBatchResult.create(
+                {
+                    "cluster_id": cluster_id,
+                    "unchanged_shares": unchanged_shares,
+                    "total_shares": len(active_shares),
+                }
+                | summary
+            )
         except resources.InvalidResourceError as err:
-            return {
-                "success": False,
-                "error": str(err),
-                "resource": err.resource_data,
-            }
+            return results.InvalidResourceResult(err.resource_data, str(err))
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            return results.QoSBatchResult.unhandled_error(str(e))
 
     @SMBCLICommand('share ls', perm='r')
     def share_ls(self, cluster_id: str) -> List[str]:
@@ -713,7 +696,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     @SMBCLICommand('share rm', perm='rw')
     def share_rm(
         self, cluster_id: str, share_id: str, wildcard: bool = False
-    ) -> Union[results.Result, results.ResultGroup]:
+    ) -> results.Result:
         """Remove an smb share"""
         if wildcard:
             return self._share_wildcard_rm(cluster_id, share_id)

--- a/src/pybind/mgr/smb/module.py
+++ b/src/pybind/mgr/smb/module.py
@@ -2,11 +2,8 @@ from typing import (
     TYPE_CHECKING,
     Any,
     List,
-    Literal,
     Optional,
-    Union,
     cast,
-    overload,
 )
 
 import logging
@@ -359,26 +356,6 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             password_filter_out=password_filter_out,
         ).squash(cluster)
 
-    @overload
-    def cluster_rm(
-        self,
-        cluster_id: str,
-        wildcard: Literal[False] = False,
-        recursive: bool = False,
-        password_filter: PasswordFilter = PasswordFilter.NONE,
-    ) -> results.Result:
-        ...
-
-    @overload
-    def cluster_rm(
-        self,
-        cluster_id: str,
-        wildcard: Literal[True],
-        recursive: bool = False,
-        password_filter: PasswordFilter = PasswordFilter.NONE,
-    ) -> results.ResultGroup:
-        ...
-
     @SMBCLICommand('cluster rm', perm='rw')
     def cluster_rm(
         self,
@@ -386,7 +363,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         wildcard: bool = False,
         recursive: bool = False,
         password_filter: PasswordFilter = PasswordFilter.NONE,
-    ) -> Union[results.Result, results.ResultGroup]:
+    ) -> results.Result:
         """Remove an smb cluster"""
         if recursive or wildcard:
             return self._cluster_multi_rm(
@@ -680,18 +657,6 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             ),
         )
         return self._apply_res([share], create_only=True).one()
-
-    @overload
-    def share_rm(
-        self, cluster_id: str, share_id: str, wildcard: Literal[False] = False
-    ) -> results.Result:
-        ...
-
-    @overload
-    def share_rm(
-        self, cluster_id: str, share_id: str, wildcard: Literal[True]
-    ) -> results.ResultGroup:
-        ...
 
     @SMBCLICommand('share rm', perm='rw')
     def share_rm(

--- a/src/pybind/mgr/smb/results.py
+++ b/src/pybind/mgr/smb/results.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Iterator, List, Optional
+from typing import Iterable, Iterator, List, Optional, Protocol
 
 import errno
 
@@ -9,7 +9,37 @@ from .utils import one
 _DOMAIN = 'domain'
 
 
-class Result:
+class Result(Protocol):
+    @property
+    def success(self) -> bool:
+        ...
+
+    def to_simplified(self) -> Simplified:
+        ...
+
+    def mgr_return_value(self) -> int:
+        ...
+
+    def mgr_status_value(self) -> str:
+        ...
+
+
+class BaseResult:
+    success = False
+
+    def to_simplified(self) -> Simplified:
+        return {'success': self.success}
+
+    def mgr_return_value(self) -> int:
+        return 0 if self.success else -errno.EAGAIN
+
+    def mgr_status_value(self) -> str:
+        if self.success:
+            return ""
+        return "resource failed to apply (see response data for details)"
+
+
+class ResourceResult(BaseResult):
     """Result of applying a single smb resource update to the system."""
 
     # Compatible with object formatter, thus suitable for being returned
@@ -36,14 +66,6 @@ class Result:
         ds['success'] = self.success
         return ds
 
-    def mgr_return_value(self) -> int:
-        return 0 if self.success else -errno.EAGAIN
-
-    def mgr_status_value(self) -> str:
-        if self.success:
-            return ""
-        return "resource failed to apply (see response data for details)"
-
     def replace_resource(self, resource: SMBResource) -> Self:
         return self.__class__(
             src=resource,
@@ -53,7 +75,7 @@ class Result:
         )
 
 
-class ErrorResult(Result, Exception):
+class ErrorResult(ResourceResult, Exception):
     """A Result subclass for wrapping an error condition."""
 
     def __init__(
@@ -65,7 +87,7 @@ class ErrorResult(Result, Exception):
         super().__init__(src, success=False, msg=msg, status=status)
 
 
-class InvalidResourceResult(Result):
+class InvalidResourceResult(BaseResult):
     def __init__(
         self,
         resource_data: Simplified,
@@ -108,11 +130,13 @@ class ResultGroup:
         match: Optional[Result] = None
         others: List[Result] = []
         for result in self._contents:
+            assert isinstance(result, ResourceResult)  # FIXME
             if result.src == target:
                 match = result
             else:
                 others.append(result)
         if match:
+            assert isinstance(match, ResourceResult)  # FIXME
             match.success = self.success
             match.status = {} if match.status is None else match.status
             match.status['additional_results'] = [
@@ -123,6 +147,20 @@ class ResultGroup:
 
     def __iter__(self) -> Iterator[Result]:
         return iter(self._contents)
+
+    def resources(self, check: bool = True) -> Iterator[ResourceResult]:
+        """Iterate over resource results in this result group.
+        If check is true (the default) raise an error if this is not
+        a successful result group.
+        """
+        for res in self._contents:
+            # check res.success to avoid iterating over contents twice
+            if check and not res.success:
+                raise ValueError(
+                    "getting resource results from failed result group"
+                )
+            if isinstance(res, ResourceResult):
+                yield res
 
     @property
     def success(self) -> bool:
@@ -150,7 +188,13 @@ class ResultGroup:
         """
         return self.__class__(
             initial_results=[
-                result.replace_resource(result.src.convert(operation))
+                _replace_resource(result, operation)
                 for result in self._contents
             ]
         )
+
+
+def _replace_resource(result: Result, operation: ConversionOp) -> Result:
+    if isinstance(result, ResourceResult):
+        return result.replace_resource(result.src.convert(operation))
+    return result

--- a/src/pybind/mgr/smb/results.py
+++ b/src/pybind/mgr/smb/results.py
@@ -1,4 +1,5 @@
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     Iterable,
@@ -16,6 +17,9 @@ import errno
 from .proto import Self, Simplified
 from .resources import ConversionOp, SMBResource
 from .utils import one
+
+if TYPE_CHECKING:
+    from .enums import State
 
 _DOMAIN = 'domain'
 
@@ -107,6 +111,20 @@ class ResourceResult(BaseResult):
             msg=self.msg,
             status=self.status,
         )
+
+    @classmethod
+    def processed(cls, src: SMBResource, state: 'State') -> Self:
+        """Return a new ResourceResult for a resource and the state in the
+        store afeter being processed by the mgr module.
+        """
+        return cls(src, success=True, status={'state': state})
+
+    @classmethod
+    def checked(cls, src: SMBResource) -> Self:
+        """Return a new ResourceResult with metadata indicating that the
+        resource has been checked for validity.
+        """
+        return cls(src, success=True, status={'checked': True})
 
 
 class ResourceErrorStatus(TypedDict, total=False):

--- a/src/pybind/mgr/smb/results.py
+++ b/src/pybind/mgr/smb/results.py
@@ -1,4 +1,12 @@
-from typing import Iterable, Iterator, List, Optional, Protocol
+from typing import (
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Protocol,
+    TypedDict,
+)
 
 import errno
 
@@ -198,3 +206,150 @@ def _replace_resource(result: Result, operation: ConversionOp) -> Result:
     if isinstance(result, ResourceResult):
         return result.replace_resource(result.src.convert(operation))
     return result
+
+
+class _DictValuesResult:
+    """Treat a generic dict as a result.
+    Special keys:
+        success -> success status
+        msg -> manager status
+        message -> manager status fallback
+
+    IMPORTANT - Try not to use this class in future code. This is added to
+    help support existing return values that were using loosely structured
+    dicts. Future code should be more consistent (across all return values
+    in the mgr module) and more structured & predictable.
+    """
+
+    def __init__(self, values: Dict) -> None:
+        self.values = values
+
+    @property
+    def success(self) -> bool:
+        return bool(self.values.get('success'))
+
+    def to_simplified(self) -> Simplified:
+        out = dict(self.values)
+        out['success'] = self.success  # ensure 'success' key
+        return out
+
+    def mgr_return_value(self) -> int:
+        return 0 if self.success else -errno.EAGAIN
+
+    def mgr_status_value(self) -> str:
+        if self.success:
+            return ''
+        msg = self.values.get('msg') or self.values.get('message')
+        return msg or 'unexpected error (see response data for details)'
+
+
+class _FailedCluster(TypedDict):
+    cluster_id: str
+    error: str
+
+
+class _FailedShare(TypedDict):
+    share_id: str
+    error: str
+
+
+class ClientCompatBatchResult(_DictValuesResult):
+    _required_keys = (
+        'cluster_id',
+        'client_compat',
+        'cluster_updated',
+        'successful_share_updates',
+        'failed_share_updates',
+        'total_shares',
+    )
+
+    @classmethod
+    def create(cls, values: Dict) -> Self:
+        for key in cls._required_keys:
+            if key not in values:
+                raise KeyError(f'missing required key: {key}')
+        return cls(values | {'success': not values['failed_share_updates']})
+
+
+class QoSBatchResult(_DictValuesResult):
+    _required_keys = (
+        'cluster_id',
+        'successful_updates',
+        'failed_updates',
+        'unchanged_shares',
+        'total_shares',
+    )
+    _unchanged_required_keys = (
+        'cluster_id',
+        'message',
+        'unchanged_shares',
+        'total_shares',
+    )
+
+    @classmethod
+    def create(cls, values: Dict) -> Self:
+        for key in cls._required_keys:
+            if key not in values:
+                raise KeyError(f'missing required key: {key}')
+        return cls(values | {'success': not values['failed_updates']})
+
+    @classmethod
+    def unchanged(cls, values: Dict) -> Self:
+        for key in cls._unchanged_required_keys:
+            if key not in values:
+                raise KeyError(f'missing required key: {key}')
+        return cls(values | {'success': True})
+
+    @classmethod
+    def unhandled_error(cls, msg: str) -> Self:
+        return cls({'success': False, 'msg': msg})
+
+
+class ClusterShareSummary:
+    def __init__(self) -> None:
+        self.successful_clusters: List[str] = []
+        self.successful_shares: List[str] = []
+        self.failed_clusters: List[_FailedCluster] = []
+        self.failed_shares: List[_FailedShare] = []
+
+    def build_dict(
+        self,
+        successful_shares_key: str = '',
+        failed_shares_key: str = '',
+        cluster_updated_key: str = '',
+        check_clusters_ok: bool = True,
+    ) -> Dict:
+        out: Dict = {}
+        if successful_shares_key:
+            out[successful_shares_key] = self.successful_shares
+        if failed_shares_key:
+            out[failed_shares_key] = self.failed_shares
+        if check_clusters_ok and self.failed_clusters:
+            raise ValueError('cluster failed to update')
+        if cluster_updated_key:
+            out[cluster_updated_key] = bool(self.successful_clusters)
+        return out
+
+    @classmethod
+    def from_result_group(cls, rg: ResultGroup) -> 'ClusterShareSummary':
+        cssum = cls()
+        for result in rg.resources(check=False):
+            cluster_id = str(getattr(result.src, 'cluster_id', ''))
+            share_id = str(getattr(result.src, 'share_id', ''))
+            if not cluster_id and not share_id:
+                continue
+            if cluster_id and not share_id:
+                if result.success:
+                    cssum.successful_clusters.append(cluster_id)
+                else:
+                    cssum.failed_clusters.append(
+                        {'cluster_id': cluster_id, 'error': result.msg}
+                    )
+            if cluster_id and share_id:
+                if result.success:
+                    cssum.successful_shares.append(share_id)
+                else:
+                    cssum.failed_shares.append(
+                        {'share_id': share_id, 'error': result.msg}
+                    )
+        return cssum

--- a/src/pybind/mgr/smb/results.py
+++ b/src/pybind/mgr/smb/results.py
@@ -135,16 +135,14 @@ class ResultGroup:
         return one(self._contents)
 
     def squash(self, target: SMBResource) -> Result:
-        match: Optional[Result] = None
+        match: Optional[ResourceResult] = None
         others: List[Result] = []
         for result in self._contents:
-            assert isinstance(result, ResourceResult)  # FIXME
-            if result.src == target:
+            if isinstance(result, ResourceResult) and result.src == target:
                 match = result
             else:
                 others.append(result)
         if match:
-            assert isinstance(match, ResourceResult)  # FIXME
             match.success = self.success
             match.status = {} if match.status is None else match.status
             match.status['additional_results'] = [

--- a/src/pybind/mgr/smb/results.py
+++ b/src/pybind/mgr/smb/results.py
@@ -160,12 +160,10 @@ class InvalidResourceResult(BaseResult):
         self,
         resource_data: Simplified,
         msg: str = '',
-        status: Optional[Simplified] = None,
     ) -> None:
         self.resource_data = resource_data
         self.success = False
         self.msg = msg
-        self.status = status
 
     def to_simplified(self) -> Simplified:
         ds: Simplified = {}
@@ -173,8 +171,6 @@ class InvalidResourceResult(BaseResult):
         ds['success'] = self.success
         if self.msg:
             ds['msg'] = self.msg
-        if self.status:
-            ds.update(self.status)
         return ds
 
 

--- a/src/pybind/mgr/smb/results.py
+++ b/src/pybind/mgr/smb/results.py
@@ -1,4 +1,5 @@
 from typing import (
+    Any,
     Dict,
     Iterable,
     Iterator,
@@ -6,6 +7,8 @@ from typing import (
     Optional,
     Protocol,
     TypedDict,
+    Union,
+    cast,
 )
 
 import errno
@@ -47,6 +50,14 @@ class BaseResult:
         return "resource failed to apply (see response data for details)"
 
 
+class ResourceStatus(TypedDict, total=False):
+    """Valid fields for updates to smb resources."""
+
+    checked: bool
+    state: str
+    additional_results: List[Simplified]
+
+
 class ResourceResult(BaseResult):
     """Result of applying a single smb resource update to the system."""
 
@@ -57,12 +68,27 @@ class ResourceResult(BaseResult):
         src: SMBResource,
         success: bool,
         msg: str = '',
-        status: Optional[Simplified] = None,
+        status: Union[ResourceStatus, Simplified, None] = None,
     ) -> None:
         self.src = src
         self.success = success
         self.msg = msg
         self.status = status
+        self._check_status()
+
+    _allowed_status: Any = ResourceStatus
+
+    def _check_status(self) -> None:
+        """Runtime check that only valid keys are passed via status."""
+        if not self.status:
+            return
+        other_keys = set(self.status) - set(
+            self._allowed_status.__optional_keys__
+        )
+        if other_keys:
+            raise KeyError(
+                f'unknown keys in status: {", ".join(sorted(other_keys))}'
+            )
 
     def to_simplified(self) -> Simplified:
         ds: Simplified = {}
@@ -83,6 +109,33 @@ class ResourceResult(BaseResult):
         )
 
 
+class ResourceErrorStatus(TypedDict, total=False):
+    """Valid fields for ErrorResult status metadata.
+
+    Use these fields to provide structured metadata about error conditions
+    modifying smb resources. We try to constrain the system to known
+    predictable fields so that tools have a chance at parsing results. Errors
+    can be a bit looser than non-error conditions. If error metadata doesn't
+    exist for your condition add it here but do try to reuse whenever possible.
+
+    The type hints are not enforced but you should try to match them to
+    avoid unexpected output.
+    """
+
+    cluster_id: str
+    clusters: List[str]
+    conflicting_share_id: str
+    credential_ref: str
+    existing_auth_mode: str
+    existing_domain_realm: str
+    hint: Dict[str, str]
+    invalid_scope: str
+    known_scopes: List[str]
+    other_cluster_id: str
+    shares: List[str]
+    unknown_id: str
+
+
 class ErrorResult(ResourceResult, Exception):
     """A Result subclass for wrapping an error condition."""
 
@@ -90,9 +143,16 @@ class ErrorResult(ResourceResult, Exception):
         self,
         src: SMBResource,
         msg: str = '',
-        status: Optional[Simplified] = None,
+        status: Union[ResourceErrorStatus, Simplified, None] = None,
     ) -> None:
-        super().__init__(src, success=False, msg=msg, status=status)
+        super().__init__(
+            src,
+            success=False,
+            msg=msg,
+            status=cast(Union[Dict, None], status),
+        )
+
+    _allowed_status: Any = ResourceErrorStatus
 
 
 class InvalidResourceResult(BaseResult):

--- a/src/pybind/mgr/smb/staging.py
+++ b/src/pybind/mgr/smb/staging.py
@@ -44,7 +44,7 @@ from .proto import (
     PathResolver,
 )
 from .resources import SMBResource
-from .results import ErrorResult, Result, ResultGroup
+from .results import ErrorResult, ResourceResult, ResultGroup
 from .utils import checked
 
 log = logging.getLogger(__name__)
@@ -148,7 +148,7 @@ class Staging:
             results.append(self._save(res))
         return results
 
-    def _save(self, resource: SMBResource) -> Result:
+    def _save(self, resource: SMBResource) -> ResourceResult:
         entry = resource_entry(self.destination_store, resource)
         if resource.intent == Intent.REMOVED:
             removed = entry.remove()
@@ -156,7 +156,9 @@ class Staging:
         else:
             state = entry.create_or_update(resource)
         log.debug('saved resource: %r; state: %s', resource, state)
-        result = Result(resource, success=True, status={'state': state})
+        result = ResourceResult(
+            resource, success=True, status={'state': state}
+        )
         return result
 
     def _prune(

--- a/src/pybind/mgr/smb/staging.py
+++ b/src/pybind/mgr/smb/staging.py
@@ -156,9 +156,7 @@ class Staging:
         else:
             state = entry.create_or_update(resource)
         log.debug('saved resource: %r; state: %s', resource, state)
-        result = ResourceResult(
-            resource, success=True, status={'state': state}
-        )
+        result = ResourceResult.processed(resource, state)
         return result
 
     def _prune(

--- a/src/pybind/mgr/smb/tests/test_handler.py
+++ b/src/pybind/mgr/smb/tests/test_handler.py
@@ -578,7 +578,7 @@ def test_error_result():
         ),
     )
     err = smb.handler.ErrorResult(share, msg='test error')
-    assert isinstance(err, smb.handler.Result)
+    assert isinstance(err, smb.handler.ResourceResult)
     assert isinstance(err, Exception)
 
     data = err.to_simplified()

--- a/src/pybind/mgr/smb/tests/test_results.py
+++ b/src/pybind/mgr/smb/tests/test_results.py
@@ -1,0 +1,979 @@
+import pytest
+
+import smb.enums
+import smb.resources
+import smb.results
+
+
+def test_resource_result_std():
+    share = smb.resources.Share(
+        cluster_id='foo',
+        share_id='bar',
+        name='Foo Bar',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/',
+        ),
+    )
+    rr = smb.results.ResourceResult(share, success=True)
+    assert rr.mgr_return_value() == 0
+    assert rr.mgr_status_value() == ''
+    dump = rr.to_simplified()
+    assert set(dump) == {'success', 'resource'}
+    assert dump['success'] is True
+    assert dump['resource'].get('resource_type') == 'ceph.smb.share'
+    assert dump['resource'].get('cluster_id') == 'foo'
+    assert dump['resource'].get('share_id') == 'bar'
+
+
+def test_resource_result_msg():
+    share = smb.resources.Share(
+        cluster_id='foo',
+        share_id='bar',
+        name='Foo Bar',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/',
+        ),
+    )
+    rr = smb.results.ResourceResult(share, success=True, msg='Robble robble')
+    assert rr.mgr_return_value() == 0
+    assert rr.mgr_status_value() == ''
+    dump = rr.to_simplified()
+    assert set(dump) == {'success', 'resource', 'msg'}
+    assert dump['success'] is True
+    assert dump['resource'].get('resource_type') == 'ceph.smb.share'
+    assert dump['resource'].get('cluster_id') == 'foo'
+    assert dump['resource'].get('share_id') == 'bar'
+    assert dump['msg'] == 'Robble robble'
+
+
+def test_resource_result_processed():
+    share = smb.resources.Share(
+        cluster_id='foo',
+        share_id='bar',
+        name='Foo Bar',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/',
+        ),
+    )
+    rr = smb.results.ResourceResult.processed(share, smb.enums.State.PRESENT)
+    assert rr.mgr_return_value() == 0
+    assert rr.mgr_status_value() == ''
+    dump = rr.to_simplified()
+    assert set(dump) == {'success', 'resource', 'state'}
+    assert dump['success'] is True
+    assert dump['resource'].get('resource_type') == 'ceph.smb.share'
+    assert dump['resource'].get('cluster_id') == 'foo'
+    assert dump['resource'].get('share_id') == 'bar'
+    assert dump['state'] == 'present'
+
+
+def test_resource_result_checked():
+    share = smb.resources.Share(
+        cluster_id='foo',
+        share_id='bar',
+        name='Foo Bar',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/',
+        ),
+    )
+    rr = smb.results.ResourceResult.checked(share)
+    assert rr.mgr_return_value() == 0
+    assert rr.mgr_status_value() == ''
+    dump = rr.to_simplified()
+    assert set(dump) == {'success', 'resource', 'checked'}
+    assert dump['success'] is True
+    assert dump['resource'].get('resource_type') == 'ceph.smb.share'
+    assert dump['resource'].get('cluster_id') == 'foo'
+    assert dump['resource'].get('share_id') == 'bar'
+    assert dump['checked'] is True
+
+
+def test_resource_result_bad_keys():
+    share = smb.resources.Share(
+        cluster_id='foo',
+        share_id='bar',
+        name='Foo Bar',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/',
+        ),
+    )
+    with pytest.raises(Exception, match='bloop, flurp'):
+        smb.results.ResourceResult(
+            share, success=True, status={'bloop': 'frungy', 'flurp': 'womble'}
+        )
+
+
+def test_resource_result_replace():
+    share = smb.resources.Share(
+        cluster_id='foo',
+        share_id='bar',
+        name='Foo Bar',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/',
+        ),
+    )
+    share2 = smb.resources.Share(
+        cluster_id='foo',
+        share_id='bar2',
+        name='Foo Bar 2',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/',
+        ),
+    )
+    rr = smb.results.ResourceResult(
+        share,
+        success=True,
+        msg='Swapme',
+        status={'state': smb.enums.State.UPDATED},
+    )
+    rr2 = rr.replace_resource(share2)
+
+    assert rr2.mgr_return_value() == 0
+    assert rr2.mgr_status_value() == ''
+    dump = rr2.to_simplified()
+    assert set(dump) == {'success', 'resource', 'msg', 'state'}
+    assert dump['success'] is True
+    assert dump['resource'].get('resource_type') == 'ceph.smb.share'
+    assert dump['resource'].get('cluster_id') == 'foo'
+    assert dump['resource'].get('share_id') == 'bar2'
+    assert dump['msg'] == 'Swapme'
+    assert dump['state'] == 'updated'
+
+
+def test_error_result_std():
+    share = smb.resources.Share(
+        cluster_id='foo',
+        share_id='bar',
+        name='Foo Bar',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/',
+        ),
+    )
+    er = smb.results.ErrorResult(share, msg='Whoops share fell down')
+    assert er.mgr_return_value() == -11
+    assert 'for details' in er.mgr_status_value()
+    dump = er.to_simplified()
+    assert set(dump) == {'success', 'resource', 'msg'}
+    assert dump['success'] is False
+    assert dump['resource'].get('resource_type') == 'ceph.smb.share'
+    assert dump['resource'].get('cluster_id') == 'foo'
+    assert dump['resource'].get('share_id') == 'bar'
+    assert dump['msg'] == 'Whoops share fell down'
+
+
+def test_error_result_bad_keys():
+    share = smb.resources.Share(
+        cluster_id='foo',
+        share_id='bar',
+        name='Foo Bar',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/',
+        ),
+    )
+    with pytest.raises(Exception, match='rumpled'):
+        smb.results.ErrorResult(share, status={'rumpled': 'very'})
+
+
+def test_error_result_good_keys():
+    share = smb.resources.Share(
+        cluster_id='foo',
+        share_id='bar',
+        name='Foo Bar',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/',
+        ),
+    )
+    er = smb.results.ErrorResult(
+        share,
+        msg='Scruffled by notha clusta',
+        status={'cluster_id': 'foo', 'other_cluster_id': 'oof'},
+    )
+    assert er.mgr_return_value() == -11
+    assert 'for details' in er.mgr_status_value()
+    dump = er.to_simplified()
+    assert set(dump) == {
+        'success',
+        'resource',
+        'msg',
+        'cluster_id',
+        'other_cluster_id',
+    }
+    assert dump['success'] is False
+    assert dump['resource'].get('resource_type') == 'ceph.smb.share'
+    assert dump['resource'].get('cluster_id') == 'foo'
+    assert dump['resource'].get('share_id') == 'bar'
+    assert dump['msg'] == 'Scruffled by notha clusta'
+
+
+def test_invalid_resource_result_std():
+    irr = smb.results.InvalidResourceResult(
+        resource_data={
+            'resource_type': 'ceph.smb.gnopf',
+            'gnopf_id': 'abc',
+            'power_level': '12',
+        },
+        msg='That aint a real thing',
+    )
+    assert irr.mgr_return_value() == -11
+    assert 'for details' in irr.mgr_status_value()
+    dump = irr.to_simplified()
+    assert dump['success'] is False
+    assert dump['resource'].get('resource_type') == 'ceph.smb.gnopf'
+    assert dump['resource'].get('gnopf_id') == 'abc'
+    assert dump['msg'] == 'That aint a real thing'
+
+
+def test_result_group_one():
+    share = smb.resources.Share(
+        cluster_id='foo',
+        share_id='bar',
+        name='Foo Bar',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/',
+        ),
+    )
+    rr = smb.results.ResourceResult(share, success=True)
+
+    rg = smb.results.ResultGroup(initial_results=[rr])
+    assert rg.mgr_return_value() == 0
+    assert rg.mgr_status_value() == ''
+    dump = rg.to_simplified()
+    assert set(dump) == {'success', 'results'}
+    assert dump['success'] is True
+    assert len(dump['results']) == 1
+    r0 = dump['results'][0]
+    assert set(r0) == {'success', 'resource'}
+    assert r0['success'] is True
+    assert r0['resource'].get('resource_type') == 'ceph.smb.share'
+    assert r0['resource'].get('cluster_id') == 'foo'
+    assert r0['resource'].get('share_id') == 'bar'
+
+    # assert the one function returns a ResourceResult with the orig share
+    rr1 = rg.one()
+    assert isinstance(rr1, smb.results.ResourceResult)
+    assert rr1.src is share
+
+
+def test_result_group_two():
+    share = smb.resources.Share(
+        cluster_id='foo',
+        share_id='bar',
+        name='Foo Bar',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/',
+        ),
+    )
+    share2 = smb.resources.Share(
+        cluster_id='foo',
+        share_id='bar2',
+        name='Foo Bar 2',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/',
+        ),
+    )
+
+    rr = smb.results.ResourceResult(share, success=True)
+
+    rg = smb.results.ResultGroup(initial_results=[rr])
+    rg.append(
+        smb.results.ResourceResult.processed(share2, smb.enums.State.UPDATED)
+    )
+
+    assert rg.mgr_return_value() == 0
+    assert rg.mgr_status_value() == ''
+    dump = rg.to_simplified()
+    assert set(dump) == {'success', 'results'}
+    assert dump['success'] is True
+    assert len(dump['results']) == 2
+
+    r0 = dump['results'][0]
+    assert set(r0) == {'success', 'resource'}
+    assert r0['success'] is True
+    assert r0['resource'].get('resource_type') == 'ceph.smb.share'
+    assert r0['resource'].get('cluster_id') == 'foo'
+    assert r0['resource'].get('share_id') == 'bar'
+
+    r1 = dump['results'][1]
+    assert set(r1) == {'success', 'resource', 'state'}
+    assert r1['success'] is True
+    assert r1['state'] == 'updated'
+    assert r1['resource'].get('resource_type') == 'ceph.smb.share'
+    assert r1['resource'].get('cluster_id') == 'foo'
+    assert r1['resource'].get('share_id') == 'bar2'
+
+    # assert the one function raises on a RG with >1 result
+    with pytest.raises(ValueError):
+        rg.one()
+
+
+def test_result_group_two_bad():
+    share = smb.resources.Share(
+        cluster_id='foo',
+        share_id='bar',
+        name='Foo Bar',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/',
+        ),
+    )
+    share2 = smb.resources.Share(
+        cluster_id='foo',
+        share_id='bar2',
+        name='Foo Bar 2',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/',
+        ),
+    )
+
+    rg = smb.results.ResultGroup(
+        initial_results=[
+            smb.results.ErrorResult(share, msg='Wonky circut'),
+            smb.results.ErrorResult(share2, msg='Damaged doodad'),
+        ]
+    )
+
+    assert rg.mgr_return_value() == -11
+    assert '2 resources' in rg.mgr_status_value()
+    dump = rg.to_simplified()
+    assert set(dump) == {'success', 'results'}
+    assert dump['success'] is False
+    assert len(dump['results']) == 2
+
+
+def test_result_group_iter_basic():
+    share = smb.resources.Share(
+        cluster_id='foo',
+        share_id='bar',
+        name='Foo Bar',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/',
+        ),
+    )
+    share2 = smb.resources.Share(
+        cluster_id='foo',
+        share_id='bar2',
+        name='Foo Bar 2',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/',
+        ),
+    )
+
+    rr = smb.results.ResourceResult(share, success=True)
+
+    rg = smb.results.ResultGroup(initial_results=[rr])
+    rg.append(
+        smb.results.ResourceResult.processed(share2, smb.enums.State.UPDATED)
+    )
+
+    # direct iter
+    lst = list(rg)
+    assert len(lst) == 2
+
+    # resource iter
+    lst2 = list(rg.resources())
+    assert len(lst2) == 2
+
+    # resource iter (no fail on non-rr)
+    lst2 = list(rg.resources(check=False))
+    assert len(lst2) == 2
+
+
+def test_result_group_iter_mixed():
+    share = smb.resources.Share(
+        cluster_id='foo',
+        share_id='bar',
+        name='Foo Bar',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/',
+        ),
+    )
+
+    rr = smb.results.ResourceResult(share, success=True)
+
+    rg = smb.results.ResultGroup(initial_results=[rr])
+    rg.append(
+        smb.results.InvalidResourceResult(
+            resource_data={
+                'resource_type': 'ceph.smb.gnopf',
+                'gnopf_id': 'abc',
+                'power_level': '12',
+            },
+            msg='That aint a real thing',
+        )
+    )
+
+    # direct iter
+    lst = list(rg)
+    assert len(lst) == 2
+
+    # resource iter
+    with pytest.raises(ValueError):
+        list(rg.resources())
+
+    # resource iter (no fail on non-rr)
+    lst2 = list(rg.resources(check=False))
+    assert len(lst2) == 1
+    assert lst2[0].src is share
+
+
+def test_result_group_squash():
+    ja = smb.resources.JoinAuth(
+        auth_id='join1',
+        auth=smb.resources.JoinAuthValues(
+            username='testadmin',
+            password='Passw0rd',
+        ),
+        linked_to_cluster='c1',
+    )
+    cluster = smb.resources.Cluster(
+        cluster_id='c1',
+        auth_mode=smb.enums.AuthMode.ACTIVE_DIRECTORY,
+        domain_settings=smb.resources.DomainSettings(
+            realm='MYDOMAIN.EXAMPLE.ORG',
+            join_sources=[
+                smb.resources.JoinSource(
+                    source_type=smb.enums.JoinSourceType.RESOURCE,
+                    ref='join1',
+                ),
+            ],
+        ),
+        custom_dns=['192.168.76.204'],
+    )
+
+    rg = smb.results.ResultGroup(
+        initial_results=[
+            smb.results.ResourceResult.processed(ja, smb.enums.State.CREATED),
+            smb.results.ResourceResult.processed(
+                cluster, smb.enums.State.CREATED
+            ),
+        ]
+    )
+
+    squashed = rg.squash(cluster)
+    assert squashed.mgr_return_value() == 0
+    assert squashed.mgr_status_value() == ''
+    dump = squashed.to_simplified()
+    assert set(dump) == {'success', 'resource', 'additional_results', 'state'}
+    assert dump['success'] is True
+    assert dump['resource'].get('resource_type') == 'ceph.smb.cluster'
+    assert dump['resource'].get('cluster_id') == 'c1'
+    assert dump['state'] == 'created'
+    assert len(dump['additional_results']) == 1
+    assert dump['additional_results'][0].get('success') is True
+    assert (
+        dump['additional_results'][0].get('resource').get('resource_type')
+        == 'ceph.smb.join.auth'
+    )
+
+
+def test_result_group_squash_fail():
+    ja = smb.resources.JoinAuth(
+        auth_id='join1',
+        auth=smb.resources.JoinAuthValues(
+            username='testadmin',
+            password='Passw0rd',
+        ),
+        linked_to_cluster='c1',
+    )
+    cluster = smb.resources.Cluster(
+        cluster_id='c1',
+        auth_mode=smb.enums.AuthMode.ACTIVE_DIRECTORY,
+        domain_settings=smb.resources.DomainSettings(
+            realm='MYDOMAIN.EXAMPLE.ORG',
+            join_sources=[
+                smb.resources.JoinSource(
+                    source_type=smb.enums.JoinSourceType.RESOURCE,
+                    ref='join1',
+                ),
+            ],
+        ),
+        custom_dns=['192.168.76.204'],
+    )
+
+    rg = smb.results.ResultGroup(
+        initial_results=[
+            smb.results.ResourceResult.processed(ja, smb.enums.State.CREATED),
+            smb.results.ResourceResult.processed(
+                cluster, smb.enums.State.CREATED
+            ),
+        ]
+    )
+
+    share = smb.resources.Share(
+        cluster_id='foo',
+        share_id='bar',
+        name='Foo Bar',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/',
+        ),
+    )
+    with pytest.raises(ValueError):
+        rg.squash(share)
+
+
+def test_result_group_convert():
+    ja = smb.resources.JoinAuth(
+        auth_id='join1',
+        auth=smb.resources.JoinAuthValues(
+            username='testadmin',
+            password='Passw0rd',
+        ),
+        linked_to_cluster='c1',
+    )
+    cluster = smb.resources.Cluster(
+        cluster_id='c1',
+        auth_mode=smb.enums.AuthMode.ACTIVE_DIRECTORY,
+        domain_settings=smb.resources.DomainSettings(
+            realm='MYDOMAIN.EXAMPLE.ORG',
+            join_sources=[
+                smb.resources.JoinSource(
+                    source_type=smb.enums.JoinSourceType.RESOURCE,
+                    ref='join1',
+                ),
+            ],
+        ),
+        custom_dns=['192.168.76.204'],
+    )
+
+    rg = smb.results.ResultGroup(
+        initial_results=[
+            smb.results.ResourceResult.processed(ja, smb.enums.State.CREATED),
+            smb.results.ResourceResult.processed(
+                cluster, smb.enums.State.CREATED
+            ),
+        ]
+    )
+
+    rg2 = rg.convert_results(
+        (smb.enums.PasswordFilter.NONE, smb.enums.PasswordFilter.BASE64)
+    )
+    assert rg.mgr_return_value() == 0
+    assert rg.mgr_status_value() == ''
+    dump = rg.to_simplified()
+    assert set(dump) == {'success', 'results'}
+    assert dump['success'] is True
+    assert len(dump['results']) == 2
+
+    ja_res = [
+        rr for rr in rg2 if getattr(rr.src, 'auth_id', None) == ja.auth_id
+    ][0]
+    assert ja_res.src.auth.password != 'Passw0rd'
+
+
+def test_result_group_convert_mixed_content():
+    ja = smb.resources.JoinAuth(
+        auth_id='join1',
+        auth=smb.resources.JoinAuthValues(
+            username='testadmin',
+            password='Passw0rd',
+        ),
+        linked_to_cluster='c1',
+    )
+    cluster = smb.resources.Cluster(
+        cluster_id='c1',
+        auth_mode=smb.enums.AuthMode.ACTIVE_DIRECTORY,
+        domain_settings=smb.resources.DomainSettings(
+            realm='MYDOMAIN.EXAMPLE.ORG',
+            join_sources=[
+                smb.resources.JoinSource(
+                    source_type=smb.enums.JoinSourceType.RESOURCE,
+                    ref='join1',
+                ),
+            ],
+        ),
+        custom_dns=['192.168.76.204'],
+    )
+
+    rg = smb.results.ResultGroup(
+        initial_results=[
+            smb.results.ResourceResult.processed(ja, smb.enums.State.CREATED),
+            smb.results.ResourceResult.processed(
+                cluster, smb.enums.State.CREATED
+            ),
+            smb.results.InvalidResourceResult(
+                resource_data={
+                    'resource_type': 'ceph.smb.gnopf',
+                    'gnopf_id': 'abc',
+                    'power_level': '12',
+                },
+                msg='That aint a real thing',
+            ),
+        ]
+    )
+
+    rg2 = rg.convert_results(
+        (smb.enums.PasswordFilter.NONE, smb.enums.PasswordFilter.BASE64)
+    )
+    assert rg.mgr_return_value() == -11
+    assert '1 resource' in rg.mgr_status_value()
+    dump = rg.to_simplified()
+    assert set(dump) == {'success', 'results'}
+    assert dump['success'] is False
+    assert len(dump['results']) == 3
+
+    ja_res = [
+        rr
+        for rr in rg2
+        if getattr(getattr(rr, 'src', None), 'auth_id', None) == ja.auth_id
+    ][0]
+    assert ja_res.src.auth.password != 'Passw0rd'
+
+
+@pytest.fixture()
+def cs2():
+    # quick and dirty fixture to avoid copy paste for summary tests
+    cluster = smb.resources.Cluster(
+        cluster_id='foo',
+        auth_mode=smb.enums.AuthMode.ACTIVE_DIRECTORY,
+        domain_settings=smb.resources.DomainSettings(
+            realm='MYDOMAIN.EXAMPLE.ORG',
+            join_sources=[
+                smb.resources.JoinSource(
+                    source_type=smb.enums.JoinSourceType.RESOURCE,
+                    ref='join1',
+                ),
+            ],
+        ),
+        custom_dns=['192.168.76.204'],
+    )
+    share = smb.resources.Share(
+        cluster_id='foo',
+        share_id='bar',
+        name='Foo Bar',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/',
+        ),
+    )
+    share2 = smb.resources.Share(
+        cluster_id='foo',
+        share_id='bar2',
+        name='Foo Bar 2',
+        cephfs=smb.resources.CephFSStorage(
+            volume='myvol',
+            path='/',
+        ),
+    )
+    return cluster, share, share2
+
+
+def test_cluster_share_summary(cs2):
+    cluster, share, share2 = cs2
+    rg = smb.results.ResultGroup(
+        initial_results=[
+            smb.results.ResourceResult.processed(
+                cluster, smb.enums.State.UPDATED
+            ),
+            smb.results.ResourceResult.processed(
+                share, smb.enums.State.UPDATED
+            ),
+            smb.results.ResourceResult.processed(
+                share2, smb.enums.State.UPDATED
+            ),
+        ]
+    )
+
+    summary = smb.results.ClusterShareSummary.from_result_group(rg)
+    assert len(summary.successful_clusters) == 1
+    assert len(summary.failed_clusters) == 0
+    assert len(summary.successful_shares) == 2
+    assert len(summary.failed_shares) == 0
+
+    dct = summary.build_dict(
+        successful_shares_key='good_shares',
+        failed_shares_key='bad_shares',
+        cluster_updated_key='cluster_updated',
+    )
+    assert set(dct) == {'good_shares', 'bad_shares', 'cluster_updated'}
+    assert len(dct['good_shares']) == 2
+    assert len(dct['bad_shares']) == 0
+    assert dct['cluster_updated'] is True
+
+
+def test_cluster_share_summary_failed(cs2):
+    cluster, share, share2 = cs2
+    rg = smb.results.ResultGroup(
+        initial_results=[
+            smb.results.ResourceResult.processed(
+                cluster, smb.enums.State.UPDATED
+            ),
+            smb.results.ResourceResult.processed(
+                share, smb.enums.State.UPDATED
+            ),
+            smb.results.ErrorResult(share2, msg='Blip'),
+        ]
+    )
+
+    summary = smb.results.ClusterShareSummary.from_result_group(rg)
+    assert len(summary.successful_clusters) == 1
+    assert len(summary.failed_clusters) == 0
+    assert len(summary.successful_shares) == 1
+    assert len(summary.failed_shares) == 1
+
+    dct = summary.build_dict(
+        successful_shares_key='good_shares',
+        failed_shares_key='bad_shares',
+        cluster_updated_key='cluster_updated',
+    )
+    assert set(dct) == {'good_shares', 'bad_shares', 'cluster_updated'}
+    assert len(dct['good_shares']) == 1
+    assert len(dct['bad_shares']) == 1
+    assert dct['cluster_updated'] is True
+
+
+def test_cluster_share_summary_failed2(cs2):
+    cluster, share, share2 = cs2
+    rg = smb.results.ResultGroup(
+        initial_results=[
+            smb.results.ErrorResult(cluster, msg='Blat'),
+            smb.results.ResourceResult.processed(
+                share, smb.enums.State.UPDATED
+            ),
+            smb.results.ErrorResult(share2, msg='Blip'),
+        ]
+    )
+
+    summary = smb.results.ClusterShareSummary.from_result_group(rg)
+    assert len(summary.successful_clusters) == 0
+    assert len(summary.failed_clusters) == 1
+    assert len(summary.successful_shares) == 1
+    assert len(summary.failed_shares) == 1
+
+    with pytest.raises(ValueError):
+        summary.build_dict(
+            successful_shares_key='shares',
+            failed_shares_key='failed_shares',
+        )
+
+
+def test_cluster_share_summary_invalid(cs2):
+    cluster, share, _ = cs2
+    rg = smb.results.ResultGroup(
+        initial_results=[
+            smb.results.ResourceResult.processed(
+                cluster, smb.enums.State.UPDATED
+            ),
+            smb.results.ResourceResult.processed(
+                share, smb.enums.State.UPDATED
+            ),
+            smb.results.InvalidResourceResult(
+                resource_data={
+                    'resource_type': 'ceph.smb.gnopf',
+                    'gnopf_id': 'abc',
+                    'power_level': '12',
+                },
+                msg='That aint a real thing',
+            ),
+        ]
+    )
+
+    summary = smb.results.ClusterShareSummary.from_result_group(rg)
+    assert len(summary.successful_clusters) == 1
+    assert len(summary.failed_clusters) == 0
+    assert len(summary.successful_shares) == 1
+    assert len(summary.failed_shares) == 0
+
+    dct = summary.build_dict(
+        successful_shares_key='shares',
+        failed_shares_key='failed_shares',
+    )
+    assert set(dct) == {'shares', 'failed_shares'}
+    assert len(dct['shares']) == 1
+    assert len(dct['failed_shares']) == 0
+
+
+def test_cluster_share_summary_other(cs2):
+    ja = smb.resources.JoinAuth(
+        auth_id='join1',
+        auth=smb.resources.JoinAuthValues(
+            username='testadmin',
+            password='Passw0rd',
+        ),
+        linked_to_cluster='c1',
+    )
+    cluster, share, share2 = cs2
+    rg = smb.results.ResultGroup(
+        initial_results=[
+            smb.results.ResourceResult.processed(
+                cluster, smb.enums.State.UPDATED
+            ),
+            smb.results.ResourceResult.processed(ja, smb.enums.State.UPDATED),
+            smb.results.ResourceResult.processed(
+                share, smb.enums.State.UPDATED
+            ),
+            smb.results.ResourceResult.processed(
+                share2, smb.enums.State.UPDATED
+            ),
+        ]
+    )
+
+    summary = smb.results.ClusterShareSummary.from_result_group(rg)
+    assert len(summary.successful_clusters) == 1
+    assert len(summary.failed_clusters) == 0
+    assert len(summary.successful_shares) == 2
+    assert len(summary.failed_shares) == 0
+
+    dct = summary.build_dict(
+        successful_shares_key='shares',
+        failed_shares_key='failed_shares',
+    )
+    assert set(dct) == {'shares', 'failed_shares'}
+    assert len(dct['shares']) == 2
+    assert len(dct['failed_shares']) == 0
+
+
+def test_client_compat_batch_result(cs2):
+    cluster, share, share2 = cs2
+    rg = smb.results.ResultGroup(
+        initial_results=[
+            smb.results.ResourceResult.processed(
+                cluster, smb.enums.State.UPDATED
+            ),
+            smb.results.ResourceResult.processed(
+                share, smb.enums.State.UPDATED
+            ),
+            smb.results.ResourceResult.processed(
+                share2, smb.enums.State.UPDATED
+            ),
+        ]
+    )
+
+    summary = smb.results.ClusterShareSummary.from_result_group(rg)
+    dct = summary.build_dict(
+        successful_shares_key='successful_share_updates',
+        failed_shares_key='failed_share_updates',
+        cluster_updated_key='cluster_updated',
+    )
+    ccbr = smb.results.ClientCompatBatchResult.create(
+        dct
+        | dict(
+            cluster_id=cluster.cluster_id,
+            client_compat='fred',
+            total_shares=3,
+        )
+    )
+
+    dump = ccbr.to_simplified()
+    assert dump['success'] is True
+    assert dump['successful_share_updates'] == ['bar', 'bar2']
+    assert dump['failed_share_updates'] == []
+    assert dump['cluster_updated'] is True
+
+
+def test_client_compat_batch_result_bad_key():
+    with pytest.raises(KeyError):
+        smb.results.ClientCompatBatchResult.create(
+            dict(
+                cluster_id='yuzpink',
+                client_compat='fred',
+                total_shares=3,
+            )
+        )
+
+
+def test_qos_batch_result(cs2):
+    cluster, share, share2 = cs2
+    rg = smb.results.ResultGroup(
+        initial_results=[
+            smb.results.ResourceResult.processed(
+                cluster, smb.enums.State.UPDATED
+            ),
+            smb.results.ResourceResult.processed(
+                share, smb.enums.State.UPDATED
+            ),
+            smb.results.ResourceResult.processed(
+                share2, smb.enums.State.UPDATED
+            ),
+        ]
+    )
+
+    summary = smb.results.ClusterShareSummary.from_result_group(rg)
+    dct = summary.build_dict(
+        successful_shares_key='successful_updates',
+        failed_shares_key='failed_updates',
+    )
+    qbr = smb.results.QoSBatchResult.create(
+        dct
+        | dict(
+            cluster_id=cluster.cluster_id,
+            total_shares=3,
+            unchanged_shares=['nop1', 'nop2'],
+        )
+    )
+
+    assert qbr.success is True
+    assert qbr.mgr_return_value() == 0
+    assert qbr.mgr_status_value() == ''
+    dump = qbr.to_simplified()
+    assert dump['success'] is True
+    assert dump['successful_updates'] == ['bar', 'bar2']
+    assert dump['failed_updates'] == []
+
+
+def test_qos_batch_result_bad_key():
+    with pytest.raises(KeyError):
+        smb.results.QoSBatchResult.create(
+            dict(
+                cluster_id='yuzpink',
+                total_shares=3,
+            )
+        )
+
+
+def test_qos_batch_result_unchanged():
+    qbr = smb.results.QoSBatchResult.unchanged(
+        dict(
+            cluster_id='wibble',
+            message='Nothing changed',
+            total_shares=3,
+            unchanged_shares=['nop1', 'nop2'],
+        )
+    )
+
+    assert qbr.success is True
+    assert qbr.mgr_return_value() == 0
+    assert qbr.mgr_status_value() == ''
+    dump = qbr.to_simplified()
+    assert dump['success'] is True
+    assert dump['message'] == 'Nothing changed'
+
+
+def test_qos_batch_result_unchanged_bad_key():
+    with pytest.raises(KeyError):
+        smb.results.QoSBatchResult.unchanged(
+            dict(
+                cluster_id='yuzpink',
+                total_shares=3,
+            )
+        )
+
+
+def test_qos_batch_result_unhandled():
+    qbr = smb.results.QoSBatchResult.unhandled_error(
+        'Something strange in the neighborhood'
+    )
+
+    assert qbr.success is False
+    assert qbr.mgr_return_value() == -11
+    assert 'Something strange' in qbr.mgr_status_value()
+    dump = qbr.to_simplified()
+    assert dump['success'] is False
+    assert dump['msg'] == 'Something strange in the neighborhood'

--- a/src/pybind/mgr/smb/tests/test_smb.py
+++ b/src/pybind/mgr/smb/tests/test_smb.py
@@ -1374,7 +1374,7 @@ def test_cluster_update_client_compat(tmodule):
     # Update to MACOS compatibility mode
     result = tmodule.cluster_update_client_compat(
         smb.enums.ClientSupportMode.MACOS, 'foo'
-    )
+    ).to_simplified()
     assert isinstance(result, dict)
     assert result['cluster_id'] == 'foo'
     assert result['client_compat'] == 'macos'
@@ -1399,7 +1399,7 @@ def test_cluster_update_client_compat(tmodule):
     # Update back to DEFAULT
     result = tmodule.cluster_update_client_compat(
         smb.enums.ClientSupportMode.DEFAULT, 'foo'
-    )
+    ).to_simplified()
     assert isinstance(result, dict)
     assert result['cluster_id'] == 'foo'
     assert result['client_compat'] == 'default'


### PR DESCRIPTION
Refactor Result to be a protocol class. Rename the existing class to
ResourceResult. With Result as a protocol what can be a result is contrained (by the interface) but flexible because we can add new types compatible with said protocol. For example ResultGroup itself now meets the Result protocol.

Clean up existing functions just returning unstructured dicts of "stuff". Use a helper class to do common stuff in a common way but these dicts diverge from each other as well as other previously Result returning funcs. Try to organize it a bit but keep compatibility with the outputs that are already being generated. However, this approach should not be followed again for any new code.

Adds unit tests.



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
