### PR TITLE
rgw: libfdb: remaining features and functional foundation

### DIFF
--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -134,6 +134,33 @@ Version stamps become readable and orderable only after commit resolution.
 Trying to read an unresolved stamp is a `std::invalid_argument`; trying to reuse a
 resolved stamp as a new commit output is a `std::invalid_argument`.
 
+## Transaction Versions
+
+Transaction versions let application code connect a successful write to a later
+consistent read. `committed_version()` is available after a successful commit,
+`set_read_version()` pins another transaction to that version, and
+`read_version()` reports the version an active transaction reads from. This is a
+consistency tool, not durable historical storage:
+
+```cpp
+auto write_txn = lfdb::make_transaction(dbh);
+
+lfdb::set(write_txn, "person/grace-hopper/name", "Grace Hopper");
+
+if (lfdb::commit(write_txn)) {
+  const auto version = lfdb::committed_version(write_txn);
+
+  auto read_txn = lfdb::make_transaction(dbh);
+  lfdb::set_read_version(read_txn, version);
+
+  std::string name;
+  if (lfdb::get(read_txn, "person/grace-hopper/name", name)) {
+    const auto observed_version = lfdb::read_version(read_txn);
+    record_observation(name, observed_version);
+  }
+}
+```
+
 ## Setup
 
 ```cpp

--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -223,6 +223,52 @@ if (lfdb::key_exists(dbh, "person/jose-capablanca/title")) {
 }
 ```
 
+## Atomic Mutations
+
+Atomic mutations tell FoundationDB to transform a value at commit time on the
+server side, without reading the current value back to the client. They are
+useful for frequently updated counters, flags, and other small raw-byte values.
+See the FoundationDB atomic operations guide:
+https://apple.github.io/foundationdb/developer-guide.html#atomic-operations
+
+```cpp
+// Increment a counter without a read-modify-write round trip:
+lfdb::atomic::add(dbh, "stats/person-count", std::uint64_t{1});
+```
+
+```cpp
+// Group atomic mutations with ordinary writes in the same transaction:
+auto txn = lfdb::make_transaction(dbh);
+
+lfdb::set(txn, "person/grace-hopper/name", "Grace Hopper");
+lfdb::atomic::add(txn, "stats/person-count", std::uint64_t{1});
+lfdb::atomic::bit_or(txn, "stats/person-flags", std::uint64_t{0x01});
+
+if (!lfdb::commit(txn)) {
+  retry_person_update();
+}
+```
+
+Numeric atomic mutations use FoundationDB's little-endian integer parameter
+encoding. The C++ integral type's width becomes the FoundationDB parameter
+width. They operate on raw FDB values, not zpp_bits object encoding:
+
+```cpp
+lfdb::atomic::max(dbh, "stats/high-watermark", std::uint64_t{128});
+lfdb::atomic::min(dbh, "stats/low-watermark", std::uint64_t{4});
+```
+
+Byte-wise atomic mutations operate on raw byte strings:
+
+```cpp
+const std::string_view zero_bytes("\0\0\0\0\0\0\0\0", 8);
+
+lfdb::atomic::byte_min(dbh, "stats/first-name", "Ada");
+lfdb::atomic::byte_max(dbh, "stats/last-name", "Zuse");
+lfdb::atomic::append_if_fits(dbh, "log/tail", "next-record\n");
+lfdb::atomic::compare_and_clear(dbh, "stats/person-count", zero_bytes);
+```
+
 ## Multi-Key Writes
 
 ```cpp
@@ -272,6 +318,7 @@ explicit open/closed boundaries.
 | Situation | Use | Result Shape | Why |
 | --- | --- | --- | --- |
 | Store one key/value pair | `lfdb::set(dbh, key, value)` | `void` | One logical write with automatic transaction handling. |
+| Apply a server-side value mutation | `lfdb::atomic::add(dbh, key, n)` | `void` | Updates counters or flags without a read-modify-write round trip. |
 | Store many key/value pairs already in a container | `lfdb::set(dbh, kvs)` | `void` | Writes the whole range in one managed transaction without spelling out iterators. |
 | Read one exact key | `lfdb::get(dbh, key, value)` | `bool` | Returns `true` only when the key exists and decodes into `value`. |
 | Read one exact key without adding a read conflict | `lfdb::get(dbh, key, value, lfdb::read_mode::snapshot)` | `bool` | Useful for advisory reads where the value is not part of the transaction's correctness condition. |

--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -1169,6 +1169,24 @@ if (!lfdb::commit(txn)) {
 }
 ```
 
+`approximate_commit_bytes()` asks FoundationDB to estimate the transaction's
+size as if it were committed now. Use it as a batching signal instead of trying
+to recreate FoundationDB's accounting for mutations, range clears, and conflict
+ranges.
+
+```cpp
+auto txn = lfdb::make_transaction(dbh);
+
+for (const auto& object : objects_to_index) {
+  lfdb::set(txn, object.index_key, object.index_record);
+
+  if (soft_limit < lfdb::approximate_commit_bytes(txn)) {
+    finish_batch(std::move(txn));
+    txn = lfdb::make_transaction(dbh);
+  }
+}
+```
+
 ## Manual Transactions With Options
 
 ```cpp

--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -855,8 +855,9 @@ auto people = lfdb::collect<person_record>(dbh, q::prefix("person/"));
 ```
 
 Use `for_each()` when the operation is naturally callback-shaped and you do not
-need a composable generator. Passing a transaction handle keeps the transaction
-boundary explicit:
+need a composable generator. The callback is a row consumer and must return
+`void`; use `transform()` when each row should produce a value. Passing a
+transaction handle keeps the transaction boundary explicit:
 
 ```cpp
 auto txn = lfdb::make_transaction(dbh);

--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -3,163 +3,22 @@
 "Take a thousand days of practice for forging, and ten thousand days of practice for refining."
     -- Miyamoto Musashi, Go Rin No Sho (~1645)
 
-Welcome, traveller! Grab your favorite walking stick, and let us journey into
-the realm of libfdb!
+Welcome, traveller. This is a cookbook-style tour of libfdb. It starts with
+ordinary key/value operations and then moves toward transactions, selectors,
+query algebra, content keys, watches, and system utilities.
 
-While this is not proper documentation, hopefully this "cookbook-style" set
-of mini-examples will help you on your libfdb path.
+Errata: Please report errata, or contact with examples you would like to see.
 
-Errata: Please report errata, or contact with examples you would like to see!
+See `examples/libfdb/` for small standalone programs.
 
-These examples use a short namespace alias for readability and also to save
-typing with one's poor fingers! Yoikes!
-
-See examples/libfdb/ for some working, compilable simple examples.
+The examples use aliases to keep the code readable:
 
 ```cpp
 namespace lfdb = ceph::libfdb;
 namespace q = lfdb::query;
+namespace fdbc = lfdb::layer::content;
 
 using namespace std::string_literals;
-```
-
-## Running Tests And Benchmarks
-
-From the build directory, run the libfdb tests with:
-
-```sh
-./bin/unittest_fdb
-./bin/unittest_fdb_ceph
-```
-
-Benchmarks are hidden from default test runs. Run all libfdb benchmarks with:
-
-```sh
-./bin/unittest_fdb_ceph "[benchmark]"
-```
-
-## General Recipes
-
-```cpp
-// Use a database_handle when you desire a single logical operation. Behind
-// the scenes, libfdb will create and complete its own transaction for you.
-// Database-handle operations may retry after recoverable FoundationDB errors,
-// so transaction callbacks may be activated more than once.
-lfdb::set(dbh, "person/barbara-moo/name", "Barbara Moo");
-```
-
-```cpp
-// Pass a transaction handle when several operations must be grouped in the
-// same transaction. Do not use the transaction after commit().
-auto txn = lfdb::make_transaction(dbh);
-
-lfdb::set(txn, "person/barbara-moo/name", "Barbara Moo");
-lfdb::set(txn, "person/barbara-moo/book", "Accelerated C++");
-
-if (!lfdb::commit(txn)) {
-  // Retry the transaction body with a fresh or recovered transaction.
-}
-```
-
-```cpp
-// Ask commit() to report whether the transaction should be replayed:
-auto txn = lfdb::make_transaction(dbh);
-
-lfdb::set(txn, "person/frances-allen/name", "Frances Allen");
-
-const auto result = lfdb::commit(lfdb::with_result, txn);
-
-if (not result.committed and 0 != result.replay_error) {
-  // A non-zero replay_error means FoundationDB prepared txn for replay.
-  retry_transaction_body(txn, result.replay_error);
-}
-```
-
-## Version Stamps
-
-```cpp
-// Store a value with a versioned key:
-lfdb::versionstamp stamp;
-
-lfdb::set(dbh,
-          lfdb::versioned("person/konrad-zuse/event/", "/created", stamp),
-          "created");
-```
-
-```cpp
-// Store a transaction-versioned value:
-lfdb::versionstamp stamp;
-
-lfdb::set(dbh,
-          "person/barbara-liskov/version",
-          lfdb::versioned("", stamp));
-```
-
-```cpp
-// Get a version stamp from a committed transaction:
-auto txn = lfdb::make_transaction(dbh);
-lfdb::versionstamp stamp;
-
-lfdb::set(txn, "person/alonzo-church/name", "Alonzo Church");
-
-if (lfdb::commit(txn, stamp)) {
-  const auto& version_stamp_bytes = stamp.resolved_bytes();
-}
-```
-
-```cpp
-// Use one version stamp for several operations in the same transaction:
-auto txn = lfdb::make_transaction(dbh);
-lfdb::versionstamp stamp;
-
-lfdb::set(txn,
-          lfdb::versioned("person/grace-hopper/event/", "/created", stamp),
-          "created");
-lfdb::set(txn,
-          lfdb::versioned("person/grace-hopper/event/", "/updated", stamp),
-          "updated");
-lfdb::set(txn,
-          "person/grace-hopper/version",
-          lfdb::versioned("", stamp));
-
-if (lfdb::commit(txn) && stamp.is_resolved()) {
-  const auto& version_stamp_bytes = stamp.resolved_bytes();
-}
-```
-
-Note that version stamping a key or a value is strictly an either/or proposition: there is no call
-to set a stamped key and value all at once.
-
-Version stamps become readable and orderable only after commit resolution.
-Trying to read an unresolved stamp is a `std::invalid_argument`; trying to reuse a
-resolved stamp as a new commit output is a `std::invalid_argument`.
-
-## Transaction Versions
-
-Transaction versions let application code connect a successful write to a later
-consistent read. `committed_version()` is available after a successful commit,
-`set_read_version()` pins another transaction to that version, and
-`read_version()` reports the version an active transaction reads from. This is a
-consistency tool, not durable historical storage. Set the read version before
-performing reads in that transaction:
-
-```cpp
-auto write_txn = lfdb::make_transaction(dbh);
-
-lfdb::set(write_txn, "person/grace-hopper/name", "Grace Hopper");
-
-if (lfdb::commit(write_txn)) {
-  const auto version = lfdb::committed_version(write_txn);
-
-  auto read_txn = lfdb::make_transaction(dbh);
-  lfdb::set_read_version(read_txn, version);
-
-  std::string name;
-  if (lfdb::get(read_txn, "person/grace-hopper/name", name)) {
-    const auto observed_version = lfdb::read_version(read_txn);
-    record_observation(name, observed_version);
-  }
-}
 ```
 
 ## Setup
@@ -181,11 +40,9 @@ and the C API database-opening documentation:
 <https://apple.github.io/foundationdb/api-c.html#database>.
 
 ```cpp
-// Open a database with explicit database and network options. Explicit database
-// options are used as passed. Flag-only options use
-// lfdb::option_flag because they have no value. Network options are applied
-// only during the first FoundationDB network initialization; later calls to
-// create_database() cannot change them.
+// Open a database with explicit database and network options. Flag-only options
+// use lfdb::option_flag because they have no value. Network options are applied
+// only during the first FoundationDB network initialization.
 lfdb::database_options dbopts{
   { FDB_DB_OPTION_TRANSACTION_TIMEOUT, std::int64_t{5000} },
 };
@@ -211,127 +68,48 @@ auto dbh = lfdb::create_database(
   lfdb::connection_source{"description:id@127.0.0.1:4500"});
 ```
 
-## API Namespace
+## Basic Operations
 
-`lfdb::api` reports facts about the FoundationDB client API available to this
-process. These calls do not require a database handle. See the FoundationDB C API
-documentation:
-<https://apple.github.io/foundationdb/api-c.html>.
+Use a `database_handle` when you want libfdb to create, commit, and retry a
+single logical operation:
 
 ```cpp
-const auto client = lfdb::api::client_version();
-const auto max_api = lfdb::api::max_version();
+lfdb::set(dbh, "person/barbara-moo/name", "Barbara Moo");
 ```
 
-## System Namespace
-
-`lfdb::system` contains FoundationDB system-level observations and operational
-surface. Read-only functions report live database/client state. Sharp
-operational functions belong here too, rather than in the core key/value API,
-but they should only be called by code that is explicitly managing a
-FoundationDB deployment. See the FoundationDB C API entries for these database
-functions:
-<https://apple.github.io/foundationdb/api-c.html#c.fdb_database_get_client_status>
-and
-<https://apple.github.io/foundationdb/api-c.html#c.fdb_database_get_main_thread_busyness>.
+Single-key `get()` returns whether the key was found:
 
 ```cpp
-const auto busyness = lfdb::system::main_thread_busyness(dbh);
-const auto protocol = lfdb::system::server_protocol(dbh);
-const auto status_json = lfdb::system::client_status_json(dbh);
-```
-
-The remaining functions are operational controls, not ordinary application data
-operations:
-
-```cpp
-lfdb::system::reboot_worker(dbh, "127.0.0.1:4500", false, 60);
-lfdb::system::force_recovery_with_data_loss(dbh, "dc1");
-lfdb::system::create_snapshot(dbh, "snapshot-id", "snapshot-command");
-```
-
-## Single-Key Operations
-
-Single-key `get()` returns whether the key was found.
-
-```cpp
-// Store and retrieve one value by key.
 lfdb::set(dbh, "person/konrad-zuse/name", "Konrad Zuse");
 
 std::string name;
 if (lfdb::get(dbh, "person/konrad-zuse/name", name)) {
-  // use name
+  use_name(name);
 }
 ```
 
+Use a void callback when the raw serialized bytes must be copied or decoded
+immediately. The span is only valid during the callback.
+
 ```cpp
-// Use a void callback when the raw serialized bytes must be copied or decoded
-// immediately. The span is only valid during the callback.
 lfdb::get(dbh, "person/konrad-zuse/name",
           [](std::span<const std::uint8_t> bytes) {
-            // copy or decode bytes here
+            copy_or_decode(bytes);
           });
 ```
 
-## Key Existence And Erase
+Check for a key and erase it if it exists:
 
 ```cpp
-// Check for a key and erase it if it exists.
 if (lfdb::key_exists(dbh, "person/jose-capablanca/title")) {
   lfdb::erase(dbh, "person/jose-capablanca/title");
 }
 ```
 
-## Atomic Mutations
-
-Atomic mutations tell FoundationDB to transform a value at commit time on the
-server side, without reading the current value back to the client. They are
-useful for frequently updated counters, flags, and other small raw-byte values.
-See the FoundationDB atomic operations guide:
-https://apple.github.io/foundationdb/developer-guide.html#atomic-operations
+Write key/value pairs from an STL associative container in one managed
+transaction:
 
 ```cpp
-// Increment a counter without a read-modify-write round trip:
-lfdb::atomic::add(dbh, "stats/person-count", std::uint64_t{1});
-```
-
-```cpp
-// Group atomic mutations with ordinary writes in the same transaction:
-auto txn = lfdb::make_transaction(dbh);
-
-lfdb::set(txn, "person/grace-hopper/name", "Grace Hopper");
-lfdb::atomic::add(txn, "stats/person-count", std::uint64_t{1});
-lfdb::atomic::bit_or(txn, "stats/person-flags", std::uint64_t{0x01});
-
-if (!lfdb::commit(txn)) {
-  retry_person_update();
-}
-```
-
-Numeric atomic mutations use FoundationDB's little-endian integer parameter
-encoding. The C++ integral type's width becomes the FoundationDB parameter
-width. They operate on raw FDB values, not zpp_bits object encoding:
-
-```cpp
-lfdb::atomic::max(dbh, "stats/high-watermark", std::uint64_t{128});
-lfdb::atomic::min(dbh, "stats/low-watermark", std::uint64_t{4});
-```
-
-Byte-wise atomic mutations operate on raw byte strings:
-
-```cpp
-const std::string_view zero_bytes("\0\0\0\0\0\0\0\0", 8);
-
-lfdb::atomic::byte_min(dbh, "stats/first-name", "Ada");
-lfdb::atomic::byte_max(dbh, "stats/last-name", "Zuse");
-lfdb::atomic::append_if_fits(dbh, "log/tail", "next-record\n");
-lfdb::atomic::compare_and_clear(dbh, "stats/person-count", zero_bytes);
-```
-
-## Multi-Key Writes
-
-```cpp
-// Write key/value pairs from an STL associative container in one transaction.
 std::map<std::string, std::string> people{
   { "person/saladin/name", "Saladin" },
   { "person/al-khwarizmi/name", "Al-Khwarizmi" },
@@ -341,38 +119,259 @@ std::map<std::string, std::string> people{
 lfdb::set(dbh, people);
 ```
 
-## Multi-Key Reads
-
 Selector and query-expression `get()` overloads return the number of key/value
-pairs emitted to the output container or iterator.
+pairs emitted to the output container or iterator:
 
 ```cpp
-// Read a key range into an STL associative container.
 std::map<std::string, std::string> people;
 
 const auto nread = lfdb::get(dbh, q::prefix("person/"), people);
 ```
 
-## Key Ordering
+## Values And Serialization
+
+libfdb stores C++ values as FoundationDB byte values. Built-in scalar/string
+cases are ordinary `set()`/`get()` calls. STL containers and user-defined types
+are serialized as one stored value.
 
 ```cpp
-// FoundationDB keys are ordered lexicographically by byte string. Choose key
-// formats so lexical order matches the scan order you want. Numeric suffixes
-// should usually be fixed-width and zero-padded.
+std::vector roles{ "compiler"s, "systems"s, "naval-officer"s };
+
+lfdb::set(dbh, "person/grace-hopper/roles", roles);
+
+std::vector<std::string> out_roles;
+lfdb::get(dbh, "person/grace-hopper/roles", out_roles);
+```
+
+```cpp
+std::map<std::string, std::string> profile{
+  { "name", "Maria Theresa" },
+  { "title", "Archduchess of Austria" },
+};
+
+lfdb::set(dbh, "person/maria-theresa/profile", profile);
+
+std::map<std::string, std::string> out_profile;
+lfdb::get(dbh, "person/maria-theresa/profile", out_profile);
+```
+
+User-defined types need to describe their serialized members:
+
+```cpp
+struct person_profile
+{
+  using serialize = zpp::bits::members<3>;
+
+  std::string name;
+  std::string field;
+  std::vector<std::string> tags;
+};
+
+auto profile = person_profile{
+  .name = "Edsger Dijkstra",
+  .field = "computer science",
+  .tags = std::vector{ "algorithms"s, "formal-methods"s },
+};
+
+lfdb::set(dbh, "person/edsger-dijkstra/profile", profile);
+
+person_profile out_profile;
+lfdb::get(dbh, "person/edsger-dijkstra/profile", out_profile);
+```
+
+## Transactions
+
+Pass a transaction handle when several operations must be grouped in the same
+transaction. Do not use the transaction after `commit()`.
+
+```cpp
+auto txn = lfdb::make_transaction(dbh);
+
+lfdb::set(txn, "person/barbara-moo/name", "Barbara Moo");
+lfdb::set(txn, "person/barbara-moo/book", "Accelerated C++");
+
+if (not lfdb::commit(txn)) {
+  retry_transaction_body();
+}
+```
+
+When the caller owns replay and needs the FoundationDB error that prepared it,
+use the result-reporting overload:
+
+```cpp
+auto txn = lfdb::make_transaction(dbh);
+
+lfdb::set(txn, "person/frances-allen/name", "Frances Allen");
+
+const auto result = lfdb::commit(lfdb::with_result, txn);
+
+if (not result.committed and 0 != result.replay_error) {
+  retry_transaction_body(result.replay_error);
+}
+```
+
+`committed_version()` is available after a successful commit. `set_read_version()`
+pins another transaction to that version, and `read_version()` reports the
+version an active transaction reads from. This is a consistency tool, not
+durable historical storage.
+
+```cpp
+auto write_txn = lfdb::make_transaction(dbh);
+
+lfdb::set(write_txn, "person/grace-hopper/name", "Grace Hopper");
+
+if (lfdb::commit(write_txn)) {
+  const auto version = lfdb::committed_version(write_txn);
+
+  auto read_txn = lfdb::make_transaction(dbh);
+  lfdb::set_read_version(read_txn, version);
+
+  std::string name;
+  if (lfdb::get(read_txn, "person/grace-hopper/name", name)) {
+    record_observation(name, lfdb::read_version(read_txn));
+  }
+}
+```
+
+`approximate_commit_bytes()` asks FoundationDB to estimate the transaction's
+size as if it were committed now. Use it as a batching signal instead of trying
+to recreate FoundationDB's accounting for mutations, range clears, and conflict
+ranges.
+
+```cpp
+auto txn = lfdb::make_transaction(dbh);
+
+for (const auto& object : objects_to_index) {
+  lfdb::set(txn, object.index_key, object.index_record);
+
+  if (soft_limit < lfdb::approximate_commit_bytes(txn)) {
+    finish_batch(std::move(txn));
+    txn = lfdb::make_transaction(dbh);
+  }
+}
+```
+
+Create an explicit transaction with transaction options:
+
+```cpp
+lfdb::transaction_options opts{
+  { FDB_TR_OPTION_READ_YOUR_WRITES_DISABLE, lfdb::option_flag },
+};
+
+auto txn = lfdb::make_transaction(dbh, opts);
+
+lfdb::set(txn, "person/hypatia/name", "Hypatia");
+
+if (not lfdb::commit(txn)) {
+  retry_transaction_body();
+}
+```
+
+`prepare_replay()` is the lower-level hook for application-managed replay. Most
+callers should use a transactor instead; use this when the application needs to
+keep its own progress marker before re-running part of a larger operation.
+`commit()` already prepares replay before returning `false`; call
+`prepare_replay()` only for retryable errors that escape before commit.
+
+```cpp
+auto txn = lfdb::make_transaction(dbh);
+
+try {
+  rebuild_cache_index(txn, marker);
+
+  if (not lfdb::commit(txn)) {
+    retry_from(marker);
+  }
+}
+catch (const lfdb::libfdb_exception& e) {
+  lfdb::prepare_replay(txn, e.fdb_error_value);
+  retry_from(marker);
+}
+```
+
+Transactors are function objects created with `make_transactor()`. Creating a
+transactor does not start a transaction; calling `operator()` creates the
+transaction, invokes the body, and commits it. The body may be called more than
+once after retryable FoundationDB errors. Keep it deterministic and free of
+non-idempotent external side effects.
+
+```cpp
+auto txr = lfdb::make_transactor(dbh);
+
+txr([](auto& txn) {
+  lfdb::set(txn, "person/eleanor-of-aquitaine/name", "Eleanor of Aquitaine");
+  lfdb::set(txn, "person/eleanor-of-aquitaine/title", "Duchess of Aquitaine");
+});
+```
+
+Use `with_result` when application code needs to report or resume after retry
+exhaustion. The transaction body must return `void` because the result describes
+transaction progress rather than an application value:
+
+```cpp
+const auto result = txr(lfdb::with_result, [](auto& txn) {
+  lfdb::set(txn, "person/murasaki-shikibu/title", "Novelist");
+});
+
+if (not result.committed) {
+  record_retry_exhaustion(result.attempts,
+                          result.replay_count,
+                          result.last_error);
+}
+```
+
+Options are applied to each transaction the transactor creates:
+
+```cpp
+lfdb::transaction_options opts{
+  { FDB_TR_OPTION_READ_YOUR_WRITES_DISABLE, lfdb::option_flag },
+};
+
+auto txr = lfdb::make_transactor(dbh, opts);
+
+txr([](auto& txn) {
+  lfdb::set(txn, "person/zenobia/name", "Zenobia");
+});
+```
+
+```cpp
+auto txr = lfdb::make_transactor(dbh);
+
+try {
+  txr([](auto& txn) {
+    validate_profile_update();
+
+    lfdb::set(txn, "person/jose-capablanca/title",
+              std::vector{ "Original Grandmaster"s, "World Chess Champion"s });
+  });
+}
+catch (const lfdb::libfdb_exception& e) {
+  handle_libfdb_error(e);
+}
+catch (const std::invalid_argument& e) {
+  handle_contract_error(e);
+}
+catch (const std::exception& e) {
+  handle_application_error(e);
+}
+```
+
+## Reads, Selectors, And Queries
+
+FoundationDB keys are byte strings ordered lexicographically. Choose key formats
+so lexical order matches the scan order you want; numeric suffixes should
+usually be fixed-width and zero-padded.
+
+```cpp
 lfdb::set(dbh, "person/000001/name", "Barbara Moo");
 lfdb::set(dbh, "person/000010/name", "Konrad Zuse");
 ```
 
-## Selectors And Queries
-
-FoundationDB keys are byte strings ordered lexicographically. Most libfdb range
-queries should start from that fact: build keys so related records share a
-prefix, then compose prefixes and bounds into the query you mean. `lfdb::select`
-is the simple interval form; `lfdb::query` adds a small interval algebra for
-prefixes, intersections, unions, differences, complements, singleton keys, and
-explicit open/closed boundaries.
-
-### What To Use When
+Most range queries should start from that ordering fact: build keys so related
+records share a prefix, then compose prefixes and bounds into the query you
+mean. `lfdb::select` is the simple interval form; `lfdb::query` adds a small
+interval algebra for prefixes, intersections, unions, differences, complements,
+singleton keys, and explicit open/closed boundaries.
 
 | Situation | Use | Result Shape | Why |
 | --- | --- | --- | --- |
@@ -395,25 +394,232 @@ explicit open/closed boundaries.
 | Add an explicit conflict check | `lfdb::mark_conflict_read(txn, query)` | `void` | Records transaction correctness dependencies that ordinary operations did not express. |
 | Run several dependent operations atomically | `lfdb::make_transactor(dbh)` | callable transaction runner | Replays retryable transactions while keeping user code explicit. |
 
-### Managed Range Reads
+### Key Selectors
 
-Managed range `get()` is for small, fully materialized reads. It gathers results
-inside the managed transaction and publishes them to the caller's output only
-after the read succeeds. Existing output is preserved and new results are
-appended.
+Key selectors navigate among keys that actually exist in FoundationDB. They do
+not compute byte-string successors or predecessors. See the FoundationDB
+[key selector guide](https://apple.github.io/foundationdb/developer-guide.html#key-selectors)
+for the underlying model.
+
+Assume the database contains these keys:
+
+`0 1 2 3 4`
+
+| Selector | Meaning | Result for anchor `2` | Result for anchor `2.5` |
+|---|---|---:|---:|
+| `lfdb::lower(key)` | greatest stored key `< key` | `1` | `2` |
+| `lfdb::floor(key)` | greatest stored key `<= key` | `2` | `2` |
+| `lfdb::ceiling(key)` | least stored key `>= key` | `2` | `3` |
+| `lfdb::higher(key)` | least stored key `> key` | `3` | `3` |
 
 ```cpp
-std::vector<std::pair<std::string, std::string>> people{
-  { "already/loaded", "kept" },
-};
+auto txn = lfdb::make_transaction(dbh);
 
-const auto nread = lfdb::get(dbh, q::prefix("person/"), people);
-// nread is the number of records read from FoundationDB; people now also
-// contains the newly-read records.
+auto previous = lfdb::get_key(txn, lfdb::lower("2"));
+auto current_or_previous = lfdb::get_key(txn, lfdb::floor("2"));
+auto current_or_next = lfdb::get_key(txn, lfdb::ceiling("2"));
+auto next = lfdb::get_key(txn, lfdb::higher("2"));
 ```
 
-For very large reads, prefer `lfdb::blocks()` so work stays block-at-a-time
-instead of collecting one large result before publishing it.
+### Prefixes And Explicit Ranges
+
+`q::prefix()` selects every key with a shared key prefix. This is the most
+common FoundationDB access pattern, because related records are usually grouped
+under prefixes such as `person/`, `bucket/index/`, or `object/metadata/`.
+
+```cpp
+auto people = q::prefix("person/");
+```
+
+Use `q::between()` when the selection is not a prefix. The default is the same
+half-open range shape FoundationDB normally expects: begin included, end
+excluded.
+
+```cpp
+auto medieval_people = q::between("person/charlemagne", "person/saladin/");
+```
+
+Use explicit interval notation when you need different endpoint inclusivity:
+
+```cpp
+auto medieval_people = q::between(
+  q::closed("person/al-khwarizmi"),
+  q::open("person/saladin/"));
+```
+
+Attach range options with `q::with_options()`:
+
+```cpp
+auto people = q::with_options(q::prefix("person/"),
+                              q::query_options{ .reverse_order = true });
+
+for (const auto& [key, value] : lfdb::scan(dbh, people)) {
+  process_reverse_result(key, value);
+}
+```
+
+### Query Algebra
+
+Underneath the friendly selection helpers, libfdb queries are a compiled
+interval algebra. A query expression emits zero or more canonical `lfdb::select`
+intervals, and the normal operations consume those expressions directly:
+`lfdb::get()`, `lfdb::erase()`, `lfdb::scan()`, `lfdb::blocks()`, and
+`lfdb::collect()`.
+
+In this context, an interval is a single contiguous span of lexicographic keys.
+A closed bound includes its endpoint; an open bound excludes it. `q::prefix(x)`
+is the interval from `x` up to, but not including, `q::successor(x)`.
+Intersection keeps only overlapping keys, union combines selected keys,
+difference subtracts one query from another, and complement means "everything
+outside this query".
+
+For deeper background, Allen's classic paper on interval reasoning is a useful
+reference, though libfdb uses a considerably smaller subset:
+[Maintaining Knowledge about Temporal Intervals](https://cse.unl.edu/~choueiry/Documents/Allen-CACM1983.pdf).
+
+Start with simple selectors, then compose when the problem demands it:
+
+```cpp
+for (const auto& [key, person] :
+     lfdb::scan<person_record>(dbh, q::prefix("person/"))) {
+  show(person);
+}
+```
+
+```cpp
+const auto visible_records =
+  q::difference(q::prefix("collection/records/"),
+                q::prefix("collection/records/.internal/"));
+
+for (const auto& [key, value] : lfdb::scan(dbh, visible_records)) {
+  process(key, value);
+}
+```
+
+Intersect composite queries with page windows or authorization windows without
+hand-editing byte ranges:
+
+```cpp
+const auto visible_objects =
+  q::difference(q::prefix("bucket/objects/"),
+                q::prefix("bucket/objects/.hidden/"));
+
+const auto page =
+  q::intersection(visible_objects,
+                  q::between("bucket/objects/a", "bucket/objects/z"));
+
+for (const auto& [key, object] : lfdb::scan<object_record>(dbh, page)) {
+  process(key, object);
+}
+```
+
+Use complement when the natural expression is "everything except this keyspace":
+
+```cpp
+const auto public_keys = q::complement(q::prefix("tenant/private/"));
+```
+
+Unbounded helpers are still bounded by FoundationDB's ordinary byte keyspace:
+
+```cpp
+// Reads keys from "tenant/public/" through the end of ordinary FDB keys.
+auto public_tail = q::from(q::lower_at_or_after("tenant/public/"));
+
+// Complement is relative to that same public keyspace, not mathematical infinity.
+auto non_private = q::complement(q::prefix("tenant/private/"));
+```
+
+Singleton queries are closed on both ends, so they remove one exact key cleanly:
+
+```cpp
+const auto without_tombstone =
+  q::difference(q::prefix("record/"),
+                q::singleton("record/tombstone"));
+```
+
+When you specifically need the emitted intervals, use `q::for_each_interval()`:
+
+```cpp
+q::for_each_interval(public_keys, [](const lfdb::select& interval) {
+  inspect(interval);
+});
+```
+
+### Prefix Cursors
+
+This is the common "list records under a prefix, optionally starting after a
+cursor" shape. The prefix query defines the valid record namespace; the cursor
+query is intersected with it, so cursors before the prefix clamp to the prefix
+and cursors past the prefix compile to an empty selection.
+
+```cpp
+auto record_subspace = [](std::string_view collection_id) {
+  return std::string(collection_id) + "/records/";
+};
+
+const auto base = record_subspace(collection_id);
+const auto prefix_key = base + std::string(prefix);
+
+auto read_records = [&](auto&& selection) {
+  return lfdb::get(dbh,
+                   std::forward<decltype(selection)>(selection),
+                   std::back_inserter(records));
+};
+
+const auto nread = [&] {
+  if (cursor.empty()) {
+    return read_records(q::prefix(prefix_key));
+  }
+
+  const auto cursor_key = base + std::string(cursor);
+  const auto lower = cursor_inclusive ? q::closed(cursor_key)
+                                      : q::open(cursor_key);
+
+  return read_records(
+    q::intersection(q::prefix(prefix_key),
+                    q::between(lower, q::open(q::successor(prefix_key)))));
+}();
+
+if (0 == nread) {
+  handle_empty_page();
+}
+```
+
+### Reverse And Ranked Subranges
+
+For a reverse revision list, build the same lexicographic interval and attach
+`reverse_order` with `q::with_options()`.
+
+```cpp
+auto revision_subspace = [](std::string_view collection_id,
+                            std::string_view record_id) {
+  return std::string(collection_id) + "#" + std::string(record_id) + "/revisions/";
+};
+
+auto revision_key = [&](std::string_view score, std::string_view revision) {
+  return revision_subspace(collection_id, record_id) +
+         std::string(score) + "/" + std::string(revision);
+};
+
+const auto revisions = q::with_options(
+  q::between(revision_subspace(collection_id, record_id),
+             revision_key(cursor_score, cursor_revision)),
+  q::query_options{ .reverse_order = true });
+
+auto revisions_out = lfdb::collect<revision_record>(dbh, revisions);
+```
+
+If encoded ranks sort lexicographically, a ranked query can select only the
+needed rank range instead of scanning the whole revision prefix and filtering
+client-side.
+
+```cpp
+const auto rank_base = revision_subspace(collection_id, record_id);
+const auto begin_prefix = rank_base + std::string(min_rank) + "/";
+const auto end_prefix = rank_base + std::string(max_rank) + "/";
+
+const auto rank_range = q::between(begin_prefix, q::successor(end_prefix));
+```
 
 ### Snapshot Reads
 
@@ -432,8 +638,7 @@ if (lfdb::get(dbh, "object/catalog/project-a/report.pdf", metadata,
 }
 ```
 
-The same mode works for range-shaped reads. This is useful when discovering
-best-effort cleanup candidates where stale discoveries are acceptable:
+The same mode works for range-shaped reads:
 
 ```cpp
 for (const auto& [key, metadata] :
@@ -480,351 +685,40 @@ lfdb::mark_conflict_read(txn, "object/index/a", "object/index/z");
 lfdb::mark_conflict_write(txn, q::prefix("object/cache/tenant-a/"));
 ```
 
-### Prefix Selection
+### Estimating Range Size
 
-`q::prefix()` selects every key with a shared key prefix. This is the most
-common FoundationDB access pattern, because related records are usually grouped
-under prefixes such as `person/`, `bucket/index/`, or `object/metadata/`.
-
-```cpp
-auto people = q::prefix("person/");
-```
-
-A prefix at the 0xFF boundary normalizes to an empty selection in the ordinary
-FDB keyspace; `q::successor()` still throws when no finite successor exists.
-
-### Selectively Selected Selectable Section
-
-The helpers in `lfdb::query` build FoundationDB key ranges without making
-callers hand-code byte bounds. Start with simple selectors: prefixes, bounded
-ranges, pagination, and options. When those are not enough, compose selectors
-with the query algebra.
-
-Read everything under one prefix:
+`approximate_range_size()` asks FoundationDB for an approximate byte size of a
+selection. FoundationDB calculates this from server-side sampling, so it is most
+useful for planning large ranges rather than measuring small ranges exactly. The
+C API documentation notes that estimates over roughly 3 MB can be considered
+accurate enough for many planning purposes:
+<https://apple.github.io/foundationdb/api-c.html#c.fdb_transaction_get_estimated_range_size_bytes>.
 
 ```cpp
-for (const auto& [key, person] :
-     lfdb::scan<person_record>(dbh, q::prefix("person/"))) {
-  show(person);
-}
-```
-
-Read the next page under a prefix, after the previous marker:
-
-```cpp
-const auto query =
-  q::prefix_starting_after("person/", "person/" + marker);
-
-auto page = lfdb::collect<person_record>(dbh, query);
-```
-
-Read an explicit half-open key range:
-
-```cpp
-const auto query =
-  q::between("person/name/ada", "person/name/grace");
-
-auto people = lfdb::collect<person_record>(dbh, query);
-```
-
-Read a limited page in reverse order:
-
-```cpp
-const auto query =
-  q::with_options(q::prefix("person/by-created/"),
-                  q::query_options{
-                    .result_limit = 100,
-                    .reverse_order = true,
-                  });
-
-auto people = lfdb::collect<person_record>(dbh, query);
-```
-
-Read public records while excluding an internal subspace:
-
-```cpp
-const auto query =
-  q::difference(q::prefix("person/"),
-                q::prefix("person/.internal/"));
-
-auto people = lfdb::collect<person_record>(dbh, query);
-```
-
-Page through that filtered result:
-
-```cpp
-const auto query =
-  q::starting_after(
-    q::difference(q::prefix("person/"),
-                  q::prefix("person/.internal/")),
-    page_marker);
-
-auto people = lfdb::collect<person_record>(dbh, query);
-```
-
-The same read APIs consume both simple selectors and composed query expressions,
-so the code that reads results does not have to change as the selection gets
-more precise.
-
-## Content Layer
-
-Raw FoundationDB keys are byte strings ordered lexicographically. That is powerful,
-but it also means an ad hoc key format can accidentally make common scans awkward
-or wrong. The Content layer is a small key compiler: compose domain segments, get
-one compiled byte key, and pass that key to the ordinary libfdb operations.
-
-Use a namespace alias for readability:
-
-```cpp
-namespace fdbc = ceph::libfdb::layer::content;
-```
-
-### Normal Interface: Operators
-
-The canonical way to build a keyspace is similar to writing a path:
-```cpp
-const std::string bucket_id = "bucket.8409.12";
-const std::string version = "v0000000000000017";
-const std::string object_name = "photos/2026/beach.jpg";
-
-const auto object_head =
-  fdbc::keyspace("object-cache") / "object" / bucket_id / version / object_name;
-
-lfdb::set(dbh, object_head, object_metadata);
-```
-
-...the result, in object_head above, is a compiled key that follows FoundationDB rules.
-
-Content keys are meant to flow into libfdb operations directly; callers should not
-need to extract bytes from them.
-
-Exact lookup uses the compiled key:
-
-```cpp
-std::string metadata;
-
-if (lfdb::get(dbh, object_head, metadata)) {
-  // cache hit
-}
-```
-
-Build deeper keys by adding more segments:
-
-```cpp
-const auto block_key =
-  object_head
-  / "block"
-  / fmt::format("{:020}", offset)
-  / fmt::format("{:020}", length);
-
-lfdb::set(dbh, block_key, block_data);
-```
-
-The fixed-width numeric strings are deliberate for now: Content layer string
-segments preserve bytewise ordering, so numeric values represented as strings
-must sort lexicographically the same way they sort numerically. A future typed
-numeric segment should make that mechanical.
-
-Here is the same idea applied to a block directory key. Ad hoc string keys often
-need delimiter escaping by hand; the Content layer treats bucket, object, block
-id, and size as separate key segments.
-
-```cpp
-fdbc::compiled_key block_index_key(const CacheBlock *block)
-{
-  return fdbc::keyspace("object-cache") / "block" / block->bucket_name /
-         block->object_name / fmt::format("{:020}", block->block_id) /
-         fmt::format("{:020}", block->size);
-}
-```
-
-Scan all cached blocks for one object by selecting the object-block prefix:
-
-```cpp
-const auto object_blocks =
-  fdbc::keyspace("object-cache") / "block" / bucket_id / object_name;
-
-for (const auto& [key, block] : lfdb::scan<CacheBlock>(dbh, fdbc::prefix(object_blocks))) {
-  // consume block
-}
-```
-
-### Normal Interface: Functions
-
-The function form is the same normal interface when a call expression is clearer
-than a chain:
-
-```cpp
-const auto object_head = fdbc::key("object-cache",
-                                   "object",
-                                   bucket_id,
-                                   version,
-                                   object_name);
-
-const auto block_key = fdbc::key("object-cache",
-                                 "object",
-                                 bucket_id,
-                                 version,
-                                 object_name,
-                                 "block",
-                                 fmt::format("{:020}", offset),
-                                 fmt::format("{:020}", length));
-```
-
-### Choosing `keyspace()` or `key()`
-
-The content key builder is effectively a small key compiler. Both `keyspace()`
-and `key()` target the same output type, `fdbc::compiled_key`, so their results
-can be used interchangeably by libfdb operations.
-
-You do not technically have to use `keyspace()`:
-
-```cpp
-auto k = fdbc::key("tenant", "bucket", "object");
-```
-
-This is equivalent to the path-style form:
-
-```cpp
-auto k = fdbc::keyspace("tenant") / "bucket" / "object";
-```
-
-`keyspace()` is mainly ergonomic. It makes the root segment visually clear and
-lets callers assemble keys piecewise:
-
-```cpp
-auto tenant = fdbc::keyspace("tenant");
-auto bucket = tenant / bucket_id;
-auto object = bucket / object_name;
-```
-
-This is not raw string concatenation. `/` is segment composition with escaping,
-so each segment remains unambiguous in the compiled key.
-
-For prefix scans, the compiled prefix can come from either spelling:
-
-```cpp
-fdbc::prefix(fdbc::keyspace("tenant") / bucket_id);
-fdbc::prefix(fdbc::key("tenant", bucket_id));
-```
-
-Separating key assembly from key use is also performance-oriented: once a key or
-key prefix is compiled, it can be reused without rebuilding those bytes each
-time.
-
-### Detailed Interface: Assembly
-
-`assemble()` is the explicit compiler entry point used under the nicer interfaces.
-Use it when you want the validation/lowering step to be visible, for example in
-tests, generated schemas, or other code that builds key layouts as data.
-
-```cpp
-const auto object_head = fdbc::assemble("object-cache",
-                                        "object",
-                                        bucket_id,
-                                        version,
-                                        object_name);
-```
-
-Invalid segment types are rejected at compile time, and invalid keyspace roots
-throw during assembly:
-
-```cpp
-static_assert(fdbc::key_segments<std::string_view, std::string_view>);
-static_assert(!fdbc::key_segments<int>);
-
-const auto object_records = fdbc::assemble("object-cache", "object");
-```
-
-Only the root segment has the non-empty and non-`0xFF` root restriction.
-Subsequent segments are encoded as data under that root, so empty strings or
-segments beginning with `0xFF` remain valid when the domain needs them.
-
-The lowering code is written to be constexpr-friendly, but the current compiled
-target owns a `std::string`. A future fixed-size/literal compiled target would
-let literal-only assembly produce a fully constexpr key.
-
-### Selecting Content Keys
-
-Use `fdbc::prefix()` for a full prefix range. It returns a normal `lfdb::select`,
-so it works with the ordinary range-read APIs:
-
-```cpp
-// All cached records for one object version.
 const auto object_records =
-  fdbc::keyspace("object-cache")
-  / "object"
-  / bucket_id
-  / version
-  / object_name;
+  fdbc::keyspace("object-cache") / "object" / bucket_id;
 
-std::vector<std::pair<std::string, std::string>> records;
+const auto bytes = lfdb::approximate_range_size(dbh, fdbc::prefix(object_records));
 
-const auto nread = lfdb::get(dbh, fdbc::prefix(object_records), records);
-```
-
-For a subrange, compose the lower and upper bounds and use the ordinary selector
-constructors:
-
-```cpp
-const auto first_block =
-  object_records / "block" / fmt::format("{:020}", first_offset);
-
-const auto last_block =
-  object_records / "block" / fmt::format("{:020}", last_offset);
-
-auto blocks = q::between(first_block, last_block);
-
-lfdb::get(dbh, blocks, records);
-```
-
-The explicit selector is half-open: the begin key is included and the end key is
-excluded. Use `lfdb::inclusive()` or `lfdb::exclusive()` when the boundary shape
-needs to be different.
-
-### Navigating Stored Keys
-
-Key selectors navigate among keys that actually exist in FoundationDB. They do
-not compute byte-string successors or predecessors. See the FoundationDB
-[key selector guide](https://apple.github.io/foundationdb/developer-guide.html#key-selectors)
-for the underlying model.
-
-Assume the database contains these keys:
-
-`0 1 2 3 4`
-
-| Selector | Meaning | Result for anchor `2` | Result for anchor `2.5` |
-|---|---|---:|---:|
-| `lfdb::lower(key)` | greatest stored key `< key` | `1` | `2` |
-| `lfdb::floor(key)` | greatest stored key `<= key` | `2` | `2` |
-| `lfdb::ceiling(key)` | least stored key `>= key` | `2` | `3` |
-| `lfdb::higher(key)` | least stored key `> key` | `3` | `3` |
-
-```cpp
-auto txn = lfdb::make_transaction(dbh);
-
-auto previous = lfdb::get_key(txn, lfdb::lower("2"));
-auto current_or_previous = lfdb::get_key(txn, lfdb::floor("2"));
-auto current_or_next = lfdb::get_key(txn, lfdb::ceiling("2"));
-auto next = lfdb::get_key(txn, lfdb::higher("2"));
-```
-
-Selectors compose with content keys because content keys compile to ordinary
-FoundationDB keys. The resolved key is still just a key, so use the query
-algebra when you need to test whether it belongs to a content prefix:
-
-```cpp
-const auto objects = fdbc::keyspace("object-cache") / "object" / bucket_id;
-const auto object_b = objects / "b";
-
-const auto candidate = lfdb::get_key(dbh, lfdb::ceiling(object_b));
-
-if (q::contains(fdbc::prefix(objects), candidate)) {
-  load_object(candidate);
+if (block_planning_threshold < bytes) {
+  for (const auto& block : lfdb::blocks<object_metadata>(
+         dbh, fdbc::prefix(object_records))) {
+    process_block(block);
+  }
 }
 ```
 
-### Scanning A Selection
+The helper accepts the same selection forms as `scan()` and `blocks()`:
+
+```cpp
+auto visible =
+  q::difference(q::prefix("object/"),
+                q::prefix("object/private/"));
+
+auto bytes = lfdb::approximate_range_size(dbh, visible);
+```
+
+## Scanning And Traversal
 
 `scan()` is the ordinary flat key/value traversal interface. With a transaction
 handle, it reads through the caller's transaction. Use this when the query is
@@ -856,8 +750,7 @@ auto people = lfdb::collect<person_record>(dbh, q::prefix("person/"));
 
 Use `for_each()` when the operation is naturally callback-shaped and you do not
 need a composable generator. The callback is a row consumer and must return
-`void`; use `transform()` when each row should produce a value. Passing a
-transaction handle keeps the transaction boundary explicit:
+`void`; use `transform()` when each row should produce a value.
 
 ```cpp
 auto txn = lfdb::make_transaction(dbh);
@@ -886,13 +779,12 @@ Use `transform()` when each input row produces one output value:
 auto txn = lfdb::make_transaction(dbh);
 std::vector<std::string> names;
 
-lfdb::transform<person_record>(
-  txn,
-  q::prefix("person/"),
-  [](auto&& row) {
-    return std::move(row.second.name);
-  },
-  std::back_inserter(names));
+lfdb::transform<person_record>(txn,
+                               q::prefix("person/"),
+                               [](auto&& row) {
+                                 return std::move(row.second.name);
+                               },
+                               std::back_inserter(names));
 ```
 
 When the transformed values should be materialized directly, let `transform()`
@@ -920,20 +812,18 @@ const auto removed = lfdb::erase_if<person_record>(
   });
 ```
 
-Selector-shaped scans can also ask for a bounded page. The returned page
-contains only rows the caller requested; the extra sentinel row used to detect
+Selector-shaped scans can ask for a bounded page. The returned page contains
+only rows the caller requested; the extra sentinel row used to detect
 continuation is not decoded or returned.
 
 ```cpp
-auto people = lfdb::select { "person/" };
+auto people = lfdb::select{ "person/" };
 const auto page = lfdb::scan<person_record>(dbh, people, lfdb::page{100});
 
 if (page.has_more) {
-  // Resume from the last returned row.
+  resume_after(page.rows.back().first);
 }
 ```
-
-### Block Traversal
 
 `blocks()` is for truly large scans. Given a database handle, libfdb internally
 plans the range work and manages transactions for each block/window. Use it
@@ -982,606 +872,340 @@ transaction behavior, and `std::views::chunk()` only changes the shape seen by
 the caller.
 
 ```cpp
-// Stream groups of 100:
 auto txn = lfdb::make_transaction(dbh);
 auto keys = lfdb::scan(txn, q::prefix("key_"));
 
 for (const auto& chunk : keys | std::views::chunk(100)) {
   for (const auto& [key, value] : chunk) {
-    // ...
+    process(key, value);
   }
 }
 ```
 
-### Estimating Range Size
+## Content Layer
 
-`approximate_range_size()` asks FoundationDB for an approximate byte size of a
-selection. FoundationDB calculates this from server-side sampling, so it is most
-useful for planning large ranges rather than measuring small ranges exactly. The
-C API documentation notes that estimates over roughly 3 MB can be considered
-accurate enough for many planning purposes:
-<https://apple.github.io/foundationdb/api-c.html#c.fdb_transaction_get_estimated_range_size_bytes>.
+Raw FoundationDB keys are byte strings ordered lexicographically. That is
+powerful, but it also means an ad hoc key format can accidentally make common
+scans awkward or wrong. The Content layer is a small key compiler: compose
+domain segments, get one compiled byte key, and pass that key to the ordinary
+libfdb operations.
+
+The canonical way to build a keyspace is similar to writing a path:
+
+```cpp
+const std::string bucket_id = "bucket.8409.12";
+const std::string version = "v0000000000000017";
+const std::string object_name = "photos/2026/beach.jpg";
+
+const auto object_head =
+  fdbc::keyspace("object-cache") / "object" / bucket_id / version / object_name;
+
+lfdb::set(dbh, object_head, object_metadata);
+```
+
+The result is a compiled key that follows FoundationDB rules. Content keys are
+meant to flow into libfdb operations directly; callers should not need to
+extract bytes from them.
+
+Exact lookup uses the compiled key:
+
+```cpp
+std::string metadata;
+
+if (lfdb::get(dbh, object_head, metadata)) {
+  record_cache_hit(metadata);
+}
+```
+
+Build deeper keys by adding more segments:
+
+```cpp
+const auto block_key =
+  object_head / "block" / fmt::format("{:020}", offset) / fmt::format("{:020}", length);
+
+lfdb::set(dbh, block_key, block_data);
+```
+
+The fixed-width numeric strings are deliberate for now: Content layer string
+segments preserve bytewise ordering, so numeric values represented as strings
+must sort lexicographically the same way they sort numerically. A future typed
+numeric segment should make that mechanical.
+
+Here is the same idea applied to a block directory key. Ad hoc string keys often
+need delimiter escaping by hand; the Content layer treats bucket, object, block
+id, and size as separate key segments.
+
+```cpp
+fdbc::compiled_key block_index_key(const CacheBlock *block)
+{
+  return fdbc::keyspace("object-cache") / "block" / block->bucket_name /
+         block->object_name / fmt::format("{:020}", block->block_id) /
+         fmt::format("{:020}", block->size);
+}
+```
+
+Scan all cached blocks for one object by selecting the object-block prefix:
+
+```cpp
+const auto object_blocks =
+  fdbc::keyspace("object-cache") / "block" / bucket_id / object_name;
+
+for (const auto& [key, block] : lfdb::scan<CacheBlock>(dbh, fdbc::prefix(object_blocks))) {
+  consume_block(key, block);
+}
+```
+
+The function form is the same normal interface when a call expression is clearer
+than a chain:
+
+```cpp
+const auto object_head = fdbc::key("object-cache",
+                                   "object",
+                                   bucket_id,
+                                   version,
+                                   object_name);
+
+const auto block_key = fdbc::key("object-cache",
+                                 "object",
+                                 bucket_id,
+                                 version,
+                                 object_name,
+                                 "block",
+                                 fmt::format("{:020}", offset),
+                                 fmt::format("{:020}", length));
+```
+
+The content key builder is effectively a small key compiler. Both `keyspace()`
+and `key()` target the same output type, `fdbc::compiled_key`, so their results
+can be used interchangeably by libfdb operations.
+
+```cpp
+auto k = fdbc::key("tenant", "bucket", "object");
+```
+
+This is equivalent to the path-style form:
+
+```cpp
+auto k = fdbc::keyspace("tenant") / "bucket" / "object";
+```
+
+`keyspace()` is mainly ergonomic. It makes the root segment visually clear and
+lets callers assemble keys piecewise:
+
+```cpp
+auto tenant = fdbc::keyspace("tenant");
+auto bucket = tenant / bucket_id;
+auto object = bucket / object_name;
+```
+
+This is not raw string concatenation. `/` is segment composition with escaping,
+so each segment remains unambiguous in the compiled key. Separating key assembly
+from key use is also performance-oriented: once a key or key prefix is compiled,
+it can be reused without rebuilding those bytes each time.
+
+For prefix scans, the compiled prefix can come from either spelling:
+
+```cpp
+fdbc::prefix(fdbc::keyspace("tenant") / bucket_id);
+fdbc::prefix(fdbc::key("tenant", bucket_id));
+```
+
+`assemble()` is the explicit compiler entry point used under the nicer
+interfaces. Use it when you want the validation/lowering step to be visible, for
+example in tests, generated schemas, or other code that builds key layouts as
+data.
+
+```cpp
+const auto object_head = fdbc::assemble("object-cache",
+                                        "object",
+                                        bucket_id,
+                                        version,
+                                        object_name);
+```
+
+Invalid segment types are rejected at compile time, and invalid keyspace roots
+throw during assembly:
+
+```cpp
+static_assert(fdbc::key_segments<std::string_view, std::string_view>);
+static_assert(!fdbc::key_segments<int>);
+
+const auto object_records = fdbc::assemble("object-cache", "object");
+```
+
+Only the root segment has the non-empty and non-`0xFF` root restriction.
+Subsequent segments are encoded as data under that root, so empty strings or
+segments beginning with `0xFF` remain valid when the domain needs them.
+
+The lowering code is written to be constexpr-friendly, but the current compiled
+target owns a `std::string`. A future fixed-size/literal compiled target would
+let literal-only assembly produce a fully constexpr key.
+
+Use `fdbc::prefix()` for a full prefix range. It returns a normal `lfdb::select`,
+so it works with the ordinary range-read APIs:
 
 ```cpp
 const auto object_records =
-  fdbc::keyspace("object-cache") / "object" / bucket_id;
+  fdbc::keyspace("object-cache") / "object" / bucket_id / version / object_name;
 
-const auto bytes = lfdb::approximate_range_size(dbh, fdbc::prefix(object_records));
+std::vector<std::pair<std::string, std::string>> records;
+const auto nread = lfdb::get(dbh, fdbc::prefix(object_records), records);
+```
 
-if (block_planning_threshold < bytes) {
-  for (const auto& block : lfdb::blocks<object_metadata>(
-         dbh, fdbc::prefix(object_records))) {
-    process_block(block);
-  }
+For a subrange, compose the lower and upper bounds and use the ordinary selector
+constructors:
+
+```cpp
+const auto first_block =
+  object_records / "block" / fmt::format("{:020}", first_offset);
+
+const auto last_block =
+  object_records / "block" / fmt::format("{:020}", last_offset);
+
+auto blocks = q::between(first_block, last_block);
+
+lfdb::get(dbh, blocks, records);
+```
+
+The explicit selector is half-open: the begin key is included and the end key is
+excluded. Use `lfdb::inclusive()` or `lfdb::exclusive()` when the boundary shape
+needs to be different.
+
+Selectors compose with content keys because content keys compile to ordinary
+FoundationDB keys. The resolved key is still just a key, so use the query
+algebra when you need to test whether it belongs to a content prefix:
+
+```cpp
+const auto objects = fdbc::keyspace("object-cache") / "object" / bucket_id;
+const auto object_b = objects / "b";
+
+const auto candidate = lfdb::get_key(dbh, lfdb::ceiling(object_b));
+
+if (q::contains(fdbc::prefix(objects), candidate)) {
+  load_object(candidate);
 }
 ```
 
-The helper accepts the same selection forms as `scan()` and `blocks()`, so query
-algebra composes normally:
+## Versioned Data
+
+Version stamps let FoundationDB write commit-versioned bytes into keys or
+values. They become readable and orderable only after commit resolution. Trying
+to read an unresolved stamp is a `std::invalid_argument`; trying to reuse a
+resolved stamp as a new commit output is also a `std::invalid_argument`.
 
 ```cpp
-auto visible =
-  q::difference(q::prefix("object/"),
-                q::prefix("object/private/"));
+lfdb::versionstamp stamp;
 
-auto bytes = lfdb::approximate_range_size(dbh, visible);
+lfdb::set(dbh,
+          lfdb::versioned("person/konrad-zuse/event/", "/created", stamp),
+          "created");
 ```
-
-### Explicit Key Ranges
-
-Use `q::between()` when the selection is not a prefix. The default is the same
-half-open range shape FoundationDB normally expects: begin included, end
-excluded.
 
 ```cpp
-auto medieval_people = q::between("person/charlemagne", "person/saladin/");
+lfdb::versionstamp stamp;
+
+lfdb::set(dbh,
+          "person/barbara-liskov/version",
+          lfdb::versioned("", stamp));
 ```
-
-Use explicit interval notation when you need different endpoint inclusivity:
-
-```cpp
-auto medieval_people = q::between(
-  q::closed("person/al-khwarizmi"),
-  q::open("person/saladin/"));
-```
-
-### Reverse Selection
-
-Attach range options with `q::with_options()`.
-
-```cpp
-auto people = q::with_options(q::prefix("person/"),
-                              q::query_options{ .reverse_order = true });
-
-auto txn = lfdb::make_transaction(dbh);
-
-for (const auto& [key, value] : lfdb::scan(txn, people)) {
-  // process results from high keys to low keys
-}
-```
-
-### Query Algebra
-
-Underneath the friendly selection helpers, libfdb queries are a compiled
-interval algebra. A query expression emits zero or more canonical `lfdb::select`
-intervals, and the normal operations consume those expressions directly:
-`lfdb::get()`, `lfdb::erase()`, `lfdb::scan()`, `lfdb::blocks()`, and
-`lfdb::collect()`.
-
-In this context, an interval is a single contiguous span of lexicographic keys.
-
-A closed bound includes its endpoint; an open bound excludes it. `q::prefix(x)`
-is the interval from `x` up to, but not including, `q::successor(x)`.
-Intersection keeps only overlapping keys, union combines selected keys,
-difference subtracts one query from another, and complement means "everything
-outside this query".
-
-For deeper background, Allen's classic paper on interval reasoning is a useful
-reference, though libfdb uses a considerably smaller subset:
-[Maintaining Knowledge about Temporal Intervals](https://cse.unl.edu/~choueiry/Documents/Allen-CACM1983.pdf).
-
-#### Prefix And Cursor Selection
-
-This is the common "list records under a prefix, optionally starting after a
-cursor" shape. The prefix query defines the valid record namespace; the cursor
-query is intersected with it, so cursors before the prefix "clamp" to the prefix
-and cursors past the prefix compile to an empty selection.
-
-```cpp
-auto record_subspace = [](std::string_view collection_id) {
-  return std::string(collection_id) + "/records/";
-};
-
-const auto base = record_subspace(collection_id);
-const auto prefix_key = base + std::string(prefix);
-auto query = q::prefix(prefix_key);
-
-if (!cursor.empty()) {
-  const auto cursor_key = base + std::string(cursor);
-  const auto lower = cursor_inclusive ? q::closed(cursor_key)
-                                      : q::open(cursor_key);
-
-  query = q::intersection(
-    query,
-    q::between(lower, q::open(q::successor(prefix_key))));
-}
-
-if (q::is_empty_expression(query)) {
-  return -ENOENT;
-}
-
-const auto nread = lfdb::get(dbh, query, std::back_inserter(records));
-
-if (0 == nread) {
-  return -ENOENT;
-}
-```
-
-#### Reverse Revision Selection
-
-For a reverse revision list, build the same lexicographic interval and attach
-`reverse_order` with `q::with_options()`.
-
-```cpp
-auto revision_subspace = [](std::string_view collection_id,
-                            std::string_view record_id) {
-  return std::string(collection_id) + "#" + std::string(record_id) + "/revisions/";
-};
-
-auto revision_key = [&](std::string_view score, std::string_view revision) {
-  return revision_subspace(collection_id, record_id) +
-         std::string(score) + "/" + std::string(revision);
-};
-
-const auto revisions = q::with_options(
-  q::between(revision_subspace(collection_id, record_id),
-             revision_key(cursor_score, cursor_revision)),
-  q::query_options{ .reverse_order = true });
-
-auto revisions_out = lfdb::collect<revision_record>(dbh, revisions);
-```
-
-#### Ranked Subranges
-
-If encoded ranks sort lexicographically, a ranked query can select only the
-needed rank range instead of scanning the whole revision prefix and filtering
-client-side.
-
-```cpp
-const auto rank_base = revision_subspace(collection_id, record_id);
-const auto begin_prefix = rank_base + std::string(min_rank) + "/";
-const auto end_prefix = rank_base + std::string(max_rank) + "/";
-
-const auto rank_range = q::between(begin_prefix, q::successor(end_prefix));
-```
-
-#### Combining Queries
-
-Scans accept query expressions directly. This is usually the most natural way
-to scan compound queries.
-
-```cpp
-const auto active_cache =
-  q::set_union(q::prefix("cache/hot/"),
-               q::prefix("cache/warm/"));
-
-for (const auto& [key, value] : lfdb::scan(dbh, active_cache)) {
-  process(key, value);
-}
-```
-
-The transaction-backed scan overload also accepts query expressions:
 
 ```cpp
 auto txn = lfdb::make_transaction(dbh);
+lfdb::versionstamp stamp;
 
-for (const auto& [key, value] : lfdb::scan(txn, active_cache)) {
-  process(key, value);
+lfdb::set(txn, "person/alonzo-church/name", "Alonzo Church");
+
+if (lfdb::commit(txn, stamp)) {
+  const auto& version_stamp_bytes = stamp.resolved_bytes();
 }
 ```
 
-Use difference to subtract a reserved subspace:
-
-```cpp
-const auto visible_records =
-  q::difference(q::prefix("collection/records/"),
-                q::prefix("collection/records/.internal/"));
-```
-
-Intersect composite queries with page windows or other bounds to narrow the
-result without hand-editing byte ranges. This is useful for prefix scans with
-markers, cursors, or authorization windows:
-
-```cpp
-const auto visible_objects =
-  q::difference(q::prefix("bucket/objects/"),
-                q::prefix("bucket/objects/.hidden/"));
-
-const auto page =
-  q::intersection(visible_objects,
-                  q::between("bucket/objects/a", "bucket/objects/z"));
-
-for (const auto& [key, object] : lfdb::scan<object_record>(dbh, page)) {
-  process(key, object);
-}
-```
-
-Use complement when the natural expression is "everything except this keyspace":
-
-```cpp
-const auto public_keys = q::complement(q::prefix("tenant/private/"));
-```
-
-Unbounded helpers are still bounded by FoundationDB's ordinary byte keyspace:
-
-```cpp
-// Reads keys from "tenant/public/" through the end of ordinary FDB keys.
-auto public_tail = q::from(q::lower_at_or_after("tenant/public/"));
-
-// Complement is relative to that same public keyspace, not mathematical infinity.
-auto non_private = q::complement(q::prefix("tenant/private/"));
-```
-
-Singleton queries are closed on both ends, so they remove one exact key cleanly:
-
-```cpp
-const auto without_tombstone =
-  q::difference(q::prefix("record/"),
-                q::singleton("record/tombstone"));
-```
-
-When you specifically need the emitted intervals, use `q::for_each_interval()`:
-
-```cpp
-q::for_each_interval(active_cache, [](const lfdb::select& interval) {
-  inspect(interval);
-});
-```
-
-## STL Containers As Values
-
-```cpp
-// Store an STL container as one serialized value.
-std::vector roles{ "compiler"s, "systems"s, "naval-officer"s };
-
-lfdb::set(dbh, "person/grace-hopper/roles", roles);
-
-std::vector<std::string> out_roles;
-lfdb::get(dbh, "person/grace-hopper/roles", out_roles);
-```
-
-## Associative Containers As Values
-
-```cpp
-// Store an associative container as one serialized value.
-std::map<std::string, std::string> profile{
-  { "name", "Maria Theresa" },
-  { "title", "Archduchess of Austria" },
-};
-
-lfdb::set(dbh, "person/maria-theresa/profile", profile);
-
-std::map<std::string, std::string> out_profile;
-lfdb::get(dbh, "person/maria-theresa/profile", out_profile);
-```
-
-## User Types As Values
-
-```cpp
-// Store a user-defined type as one serialized value.
-struct person_profile
-{
-  // User-defined types need to describe their serialized members.
-  using serialize = zpp::bits::members<3>;
-
-  std::string name;
-  std::string field;
-  std::vector<std::string> tags;
-};
-
-auto profile = person_profile{
-  .name = "Edsger Dijkstra",
-  .field = "computer science",
-  .tags = std::vector{ "algorithms"s, "formal-methods"s },
-};
-
-lfdb::set(dbh, "person/edsger-dijkstra/profile", profile);
-
-person_profile out_profile;
-lfdb::get(dbh, "person/edsger-dijkstra/profile", out_profile);
-```
-
-## Manual Transactions
-
-```cpp
-// Group multiple operations in one explicit transaction.
-auto txn = lfdb::make_transaction(dbh);
-
-lfdb::set(txn, "person/matilda-of-tuscany/name", "Matilda of Tuscany");
-lfdb::set(txn, "person/matilda-of-tuscany/title", "Margravine");
-
-if (!lfdb::commit(txn)) {
-  // Retry the transaction body.
-}
-```
-
-`approximate_commit_bytes()` asks FoundationDB to estimate the transaction's
-size as if it were committed now. Use it as a batching signal instead of trying
-to recreate FoundationDB's accounting for mutations, range clears, and conflict
-ranges.
+Use one versionstamp for several operations in the same transaction when those
+records should share the same commit order:
 
 ```cpp
 auto txn = lfdb::make_transaction(dbh);
+lfdb::versionstamp stamp;
 
-for (const auto& object : objects_to_index) {
-  lfdb::set(txn, object.index_key, object.index_record);
-
-  if (soft_limit < lfdb::approximate_commit_bytes(txn)) {
-    finish_batch(std::move(txn));
-    txn = lfdb::make_transaction(dbh);
-  }
-}
-```
-
-## Manual Transactions With Options
-
-```cpp
-// Create an explicit transaction with transaction options.
-lfdb::transaction_options opts{
-  { FDB_TR_OPTION_READ_YOUR_WRITES_DISABLE, lfdb::option_flag },
-};
-
-auto txn = lfdb::make_transaction(dbh, opts);
-
-lfdb::set(txn, "person/hypatia/name", "Hypatia");
-
-if (!lfdb::commit(txn)) {
-  // Retry the transaction body.
-}
-```
-
-`prepare_replay()` is the lower-level hook for application-managed replay. Most
-callers should use a transactor instead; use this when the application needs to
-keep its own progress marker before re-running part of a larger operation.
-`commit()` already prepares replay before returning `false`; call
-`prepare_replay()` only for retryable errors that escape before commit.
-
-```cpp
-auto txn = lfdb::make_transaction(dbh);
-
-try {
-  rebuild_cache_index(txn, marker);
-
-  if (!lfdb::commit(txn)) {
-    retry_from(marker);
-  }
-}
-catch (const lfdb::libfdb_exception& e) {
-  lfdb::prepare_replay(txn, e.fdb_error_value);
-  retry_from(marker);
-}
-```
-
-## Transactors: Replayable Transactions
-
-Transactors are function objects created with `make_transactor()`. Creating a
-transactor does not start a transaction; calling `operator()` creates the
-transaction, invokes the body, and commits it.
-
-The body may be called more than once after retryable FoundationDB errors. Keep
-it deterministic and free of non-idempotent external side effects. If recovery
-is not possible, or if user code throws, the exception escapes to the caller.
-
-```cpp
-// Use a transactor when the transaction body should be replayed after retryable
-// FoundationDB errors.
-auto txr = lfdb::make_transactor(dbh);
-
-txr([](auto& txn) {
-  lfdb::set(txn, "person/eleanor-of-aquitaine/name", "Eleanor of Aquitaine");
-  lfdb::set(txn, "person/eleanor-of-aquitaine/title", "Duchess of Aquitaine");
-});
-```
-
-### Reporting replay results
-
-Use `with_result` when application code needs to stop, resume, or report retry
-progress instead of treating retry exhaustion as an exception. The returned
-`transaction_result` describes the transaction machinery, not the user
-operation's value. `last_error == 0` means there was no FoundationDB replay
-error to report. Use an ordinary transactor when the transaction body should
-return an application value.
-
-```cpp
-auto txr = lfdb::make_transactor(dbh);
-
-auto result = txr(lfdb::with_result, [](auto& txn, std::string_view key, std::string_view title) {
-  lfdb::set(txn, key, title);
-}, "person/murasaki-shikibu/title", "Novelist");
-
-if (!result.committed) {
-  record_retry_exhaustion(result.attempts, result.replay_count, result.last_error);
-}
-```
-
-### Transactor options
-
-```cpp
-// Options are applied to each transaction the transactor creates.
-lfdb::transaction_options opts{
-  { FDB_TR_OPTION_READ_YOUR_WRITES_DISABLE, lfdb::option_flag },
-};
-
-auto txr = lfdb::make_transactor(dbh, opts);
-
-txr([](auto& txn) {
-  lfdb::set(txn, "person/zenobia/name", "Zenobia");
-});
-```
-
-```cpp
-/* Retryable FoundationDB errors may replay the transaction body. */
-auto txr = lfdb::make_transactor(dbh);
-
-try {
-  txr([](auto& txn) {
-    // User exceptions propagate; the body is not committed.
-    validate_profile_update();
-
-    lfdb::set(txn, "person/jose-capablanca/title",
-              std::vector{ "Original Grandmaster"s, "World Chess Champion"s });
-  });
-}
-catch (const lfdb::libfdb_exception& e) {
-  /* libfdb operation failure: FDB status failure, retry exhaustion, decode
-   * failure, or invalid data at the FoundationDB boundary. */
-}
-catch (const std::invalid_argument& e) {
-  /* The caller passed an argument that violates the libfdb API contract. */
-}
-catch (const std::exception& e) {
-  /* Application or other runtime error. */
-}
-```
-
-## Putting It All Together
-
-These examples assume the local libfdb feature stack is available: Content keys,
-query algebra, replayable transactors, and versionstamps. They are intentionally
-small, but the point is realistic composition: let each library feature remove
-one piece of hand-written database plumbing.
-
-### Write Object State And An Ordered Event
-
-```cpp
-struct cache_metadata
-{
-  std::string etag;
-  std::string storage_class;
-  std::uint64_t size = 0;
-};
-
-auto object_keyspace(std::string_view bucket_id, std::string_view object_name)
-{
-  return fdbc::keyspace("d4n") / "object" / bucket_id / object_name;
-}
-
-std::string object_event_prefix(std::string_view bucket_id)
-{
-  return fmt::format("d4n/event/{}/", bucket_id);
-}
-
-std::string object_event_suffix(std::string_view object_name,
-                                std::string_view event)
-{
-  return fmt::format("/{}/{}", object_name, event);
-}
-
-auto txn = lfdb::make_transaction(dbh);
-lfdb::versionstamp event_version;
-const auto object = object_keyspace(bucket_id, object_name);
-
-lfdb::set(txn, object / "head", metadata);
-lfdb::set(txn, object / "body" / fmt::format("{:020}", block_id), block);
 lfdb::set(txn,
-          lfdb::versioned(object_event_prefix(bucket_id),
-                          object_event_suffix(object_name, "put"),
-                          event_version),
-          "put");
+          lfdb::versioned("person/grace-hopper/event/", "/created", stamp),
+          "created");
+lfdb::set(txn,
+          lfdb::versioned("person/grace-hopper/event/", "/updated", stamp),
+          "updated");
+lfdb::set(txn,
+          "person/grace-hopper/version",
+          lfdb::versioned("", stamp));
 
-if (lfdb::commit(txn)) {
-  const auto& committed_order = event_version.resolved_bytes();
+if (lfdb::commit(txn) && stamp.is_resolved()) {
+  const auto& version_stamp_bytes = stamp.resolved_bytes();
 }
 ```
 
-Content keys keep the object records grouped. The explicit transaction keeps
-the state update and event append atomic. The versionstamped event key is commit
-ordered without an application sequence counter.
+Note that version stamping a key or a value is strictly an either/or
+proposition: there is no call to set a stamped key and value all at once.
 
-### Page A Prefix With A Marker
+## Atomic Mutations
+
+Atomic mutations tell FoundationDB to transform a value at commit time on the
+server side, without reading the current value back to the client. They are
+useful for frequently updated counters, flags, and other small raw-byte values.
+See the FoundationDB atomic operations guide:
+https://apple.github.io/foundationdb/developer-guide.html#atomic-operations
 
 ```cpp
-auto object_listing_prefix(std::string_view bucket_id,
-                           std::string_view prefix)
-{
-  return fmt::format("d4n/list/{}/{}", bucket_id, prefix);
-}
-
-auto object_listing_key(std::string_view bucket_id,
-                        std::string_view object_name)
-{
-  return fmt::format("d4n/list/{}/{}", bucket_id, object_name);
-}
-
-const auto listing_prefix = object_listing_prefix(bucket_id, prefix);
-const auto page_options =
-  q::query_options{ .result_limit = static_cast<int>(page_size + 1) };
-
-auto read_page = [&](auto query) {
-  return lfdb::collect<cache_metadata>(dbh,
-                                       q::with_options(std::move(query),
-                                                       page_options));
-};
-
-auto page = marker.empty()
-          ? read_page(q::prefix(listing_prefix))
-          : read_page(q::prefix_starting_after(
-              listing_prefix,
-              object_listing_key(bucket_id, marker)));
+// Increment a counter without a read-modify-write round trip:
+lfdb::atomic::add(dbh, "stats/person-count", std::uint64_t{1});
 ```
-
-The prefix helper gives the right upper bound, the marker helper gives the right
-exclusive lower bound, and the range limit stays attached to the query instead
-of being patched into a selector by hand.
-
-### Prune Visible Cache Records
 
 ```cpp
-const auto cache = fdbc::keyspace("d4n") / "cache" / bucket_id;
-const auto reserved = cache / ".internal";
-const auto tombstones = cache / ".tombstone";
-const auto cutoff_key = cache / fmt::format("{:020}", cutoff_epoch);
+auto txn = lfdb::make_transaction(dbh);
 
-const auto visible_cache =
-  q::difference(fdbc::prefix(cache),
-                q::set_union(fdbc::prefix(reserved),
-                             fdbc::prefix(tombstones)));
+lfdb::set(txn, "person/grace-hopper/name", "Grace Hopper");
+lfdb::atomic::add(txn, "stats/person-count", std::uint64_t{1});
+lfdb::atomic::bit_or(txn, "stats/person-flags", std::uint64_t{0x01});
 
-const auto old_visible_cache = q::ending_before(visible_cache, cutoff_key);
-
-auto txr = lfdb::make_transactor(dbh);
-txr([&](auto& txn) {
-  for (const auto& [key, value] : lfdb::scan<cache_metadata>(txn,
-                                                             old_visible_cache)) {
-    archive_cache_record(key, value);
-    lfdb::erase(txn, key);
-  }
-});
+if (not lfdb::commit(txn)) {
+  retry_person_update();
+}
 ```
 
-The query expression says exactly what should be touched: cache records, minus
-reserved subspaces, further trimmed by a cursor. The scan loop does work; it
-does not reimplement filtering.
+Numeric atomic mutations use FoundationDB's little-endian integer parameter
+encoding. The C++ integral type's width becomes the FoundationDB parameter
+width. They operate on raw FDB values, not zpp_bits object encoding:
 
-## Transaction Watches (Triggers)
+```cpp
+lfdb::atomic::max(dbh, "stats/high-watermark", std::uint64_t{128});
+lfdb::atomic::min(dbh, "stats/low-watermark", std::uint64_t{4});
+```
 
-Transaction watches (watches, triggers) ask FoundationDB to report a change
-to a key (relative to the transaction that created the watch). If watches are
-unsupported by the local FoundationDB configuration, or the transaction cannot
-create watches, waiting on the watch throws `lfdb::libfdb_exception`.
+Byte-wise atomic mutations operate on raw byte strings:
+
+```cpp
+const std::string_view zero_bytes("\0\0\0\0\0\0\0\0", 8);
+
+lfdb::atomic::byte_min(dbh, "stats/first-name", "Ada");
+lfdb::atomic::byte_max(dbh, "stats/last-name", "Zuse");
+lfdb::atomic::append_if_fits(dbh, "log/tail", "next-record\n");
+lfdb::atomic::compare_and_clear(dbh, "stats/person-count", zero_bytes);
+```
+
+## Watches / Triggers
+
+Transaction watches ask FoundationDB to report a change to a key relative to
+the transaction that created the watch. If watches are unsupported by the local
+FoundationDB configuration, or the transaction cannot create watches, waiting on
+the watch throws `lfdb::libfdb_exception`.
 
 Note that watches do not report the triggering value. If you need the value,
 read it in a separate transaction. For the underlying semantics, see the
-FoundationDB Developer Guide and the C API entry for ``fdb_transaction_watch()``.
+FoundationDB Developer Guide and the C API entry for `fdb_transaction_watch()`.
 
 See also:
 - https://apple.github.io/foundationdb/developer-guide.html#watches
 - https://apple.github.io/foundationdb/api-c.html#c.fdb_transaction_watch
 
-Here are some illustrative examples using transaction watches:
-
 ```cpp
-// Create a one-shot watch that becomes ready when the key changes:
 auto watch = lfdb::make_watch(dbh, "person/jose-capablanca/title");
 
 lfdb::set(dbh, "person/jose-capablanca/title", "World Chess Champion");
@@ -1591,9 +1215,10 @@ if (lfdb::watch_event::changed == watch.wait_for_event()) {
 }
 ```
 
+Create a watch inside a transaction when it must share that transaction's read
+version. Commit the transaction before waiting on the watch:
+
 ```cpp
-// Create a watch inside a transaction when it must share that transaction's
-// read version. Commit the transaction before waiting on the watch:
 auto txn = lfdb::make_transaction(dbh);
 auto watch = lfdb::make_watch(txn, "person/jose-capablanca/title");
 
@@ -1603,7 +1228,6 @@ if (lfdb::commit(txn)) {
 ```
 
 ```cpp
-// Cancel a watch that is no longer needed:
 auto watch = lfdb::make_watch(dbh, "person/jose-capablanca/title");
 
 watch.cancel();
@@ -1646,7 +1270,6 @@ if (lfdb::watch_event::changed == watch.wait_for_event()) {
 ```
 
 ```cpp
-// Let a jthread stop_token cancel a blocked transaction watch wait:
 std::jthread watch_thread {
   [dbh](std::stop_token stop_token) {
     auto watch = lfdb::make_watch(dbh, "person/jose-capablanca/title");
@@ -1681,7 +1304,6 @@ std::jthread watch_thread {
 Use a manual approach when you need direct control over each one-shot watch:
 
 ```cpp
-// Reset (re-arm) the transaction watch manually after each event:
 std::jthread watch_thread {
   [dbh](std::stop_token stop_token) {
     while (not stop_token.stop_requested()) {
@@ -1697,6 +1319,228 @@ std::jthread watch_thread {
 };
 ```
 
+## API And System Utilities
+
+`lfdb::api` reports facts about the FoundationDB client API available to this
+process. These calls do not require a database handle. See the FoundationDB C API
+documentation:
+<https://apple.github.io/foundationdb/api-c.html>.
+
+```cpp
+const auto client = lfdb::api::client_version();
+const auto max_api = lfdb::api::max_version();
+```
+
+`lfdb::system` contains FoundationDB system-level observations and operational
+surface. Read-only functions report live database/client state. Sharp
+operational functions belong here too, rather than in the core key/value API,
+but they should only be called by code that is explicitly managing a
+FoundationDB deployment. See the FoundationDB C API entries for these database
+functions:
+<https://apple.github.io/foundationdb/api-c.html#c.fdb_database_get_client_status>
+and
+<https://apple.github.io/foundationdb/api-c.html#c.fdb_database_get_main_thread_busyness>.
+
+```cpp
+const auto busyness = lfdb::system::main_thread_busyness(dbh);
+const auto protocol = lfdb::system::server_protocol(dbh);
+const auto status_json = lfdb::system::client_status_json(dbh);
+```
+
+The remaining functions are operational controls, not ordinary application data
+operations:
+
+```cpp
+lfdb::system::reboot_worker(dbh, "127.0.0.1:4500", false, 60);
+lfdb::system::force_recovery_with_data_loss(dbh, "dc1");
+lfdb::system::create_snapshot(dbh, "snapshot-id", "snapshot-command");
+```
+
+## Putting It All Together
+
+These examples assume the current libfdb feature stack is available: Content
+keys, query algebra, replayable transactors, versionstamps, snapshots, conflict
+ranges, and atomic mutations. They are intentionally compact; the point is to
+let library features remove hand-written database plumbing.
+
+### Content-Key Object Layout
+
+```cpp
+struct cache_metadata
+{
+  std::string etag;
+  std::string storage_class;
+  std::uint64_t size = 0;
+};
+
+struct object_block
+{
+  std::uint64_t offset = 0;
+  std::string bytes;
+};
+
+auto object_root = [](std::string_view bucket_id, std::string_view object_name) {
+  return fdbc::keyspace("d4n") / "object" / bucket_id / object_name;
+};
+
+const auto object = object_root(bucket_id, object_name);
+
+lfdb::set(dbh, object / "head", metadata);
+lfdb::set(dbh, object / "block" / fmt::format("{:020}", block.offset), block);
+```
+
+Content keys keep related records grouped without raw delimiter escaping. The
+same compiled prefix can be reused for lookup, range scan, pagination, or block
+planning.
+
+### Versioned Object Update
+
+```cpp
+auto txn = lfdb::make_transaction(dbh);
+lfdb::versionstamp event_version;
+const auto object = object_root(bucket_id, object_name);
+
+lfdb::set(txn, object / "head", metadata);
+lfdb::set(txn, object / "block" / fmt::format("{:020}", block.offset), block);
+lfdb::set(txn,
+          lfdb::versioned("d4n/event/" + std::string(bucket_id) + "/",
+                          "/" + std::string(object_name) + "/put",
+                          event_version),
+          "put");
+lfdb::atomic::add(txn, "d4n/stats/object-writes", std::uint64_t{1});
+
+if (lfdb::commit(txn) && event_version.is_resolved()) {
+  publish_ordered_event(event_version.resolved_bytes());
+}
+```
+
+The explicit transaction keeps the state update, event append, and counter
+mutation atomic. The versionstamped event key is commit ordered without an
+application sequence counter.
+
+### Prefix Page With Marker
+
+```cpp
+auto listing_key = [](std::string_view bucket_id, std::string_view object_name) {
+  return fdbc::keyspace("d4n") / "listing" / bucket_id / object_name;
+};
+
+const auto listing = fdbc::keyspace("d4n") / "listing" / bucket_id;
+
+auto read_page = [&](auto&& selection) {
+  auto rows = lfdb::scan<object_summary>(
+    dbh, std::forward<decltype(selection)>(selection));
+
+  return lfdb::collect(std::move(rows), lfdb::page{page_size});
+};
+
+const auto page = marker.empty()
+                ? read_page(fdbc::prefix(listing))
+                : read_page(q::starting_after(fdbc::prefix(listing),
+                                              listing_key(bucket_id, marker)));
+
+for (const auto& [key, summary] : page.rows) {
+  emit_object(summary);
+}
+
+if (page.has_more && not page.rows.empty()) {
+  remember_marker(page.rows.back().first);
+}
+```
+
+The selector expresses the listing subspace, the marker narrows it, and the page
+helper keeps the continuation check out of the application loop.
+
+### Snapshot Audit Read
+
+```cpp
+const auto objects = fdbc::keyspace("d4n") / "object" / bucket_id;
+
+auto txn = lfdb::make_transaction(dbh);
+
+for (const auto& [key, metadata] :
+     lfdb::scan<cache_metadata>(txn, fdbc::prefix(objects), lfdb::read_mode::snapshot)) {
+  if (metadata.expired(cutoff)) {
+    report_stale_object(key, metadata);
+  }
+}
+```
+
+Snapshot mode is useful for advisory scans where another transaction changing a
+read key should not by itself make this transaction fail.
+
+### Conflict-Protected Promotion
+
+```cpp
+auto txn = lfdb::make_transaction(dbh);
+const auto object = object_root(bucket_id, object_name);
+const auto head = object / "head";
+const auto versions = object / "versions";
+
+const auto previous = lfdb::collect<object_version>(txn,
+                                                   fdbc::prefix(versions),
+                                                   lfdb::read_mode::snapshot);
+
+lfdb::mark_conflict_read(txn, head);
+lfdb::set(txn, head, choose_new_head(previous));
+
+if (not lfdb::commit(txn)) {
+  retry_promotion();
+}
+```
+
+The snapshot scan avoids broad read conflicts, while the explicit conflict range
+keeps the narrow correctness dependency visible.
+
+### Maintenance Pass
+
+```cpp
+const auto cache = fdbc::keyspace("d4n") / "cache" / bucket_id;
+const auto reserved = cache / ".internal";
+const auto tombstones = cache / ".tombstone";
+
+const auto visible_cache =
+  q::difference(fdbc::prefix(cache),
+                q::set_union(fdbc::prefix(reserved),
+                             fdbc::prefix(tombstones)));
+
+const auto old_visible_cache = q::ending_before(
+  visible_cache,
+  cache / fmt::format("{:020}", cutoff_epoch));
+
+auto txr = lfdb::make_transactor(dbh);
+
+for (const auto& block : lfdb::blocks<cache_metadata>(dbh, old_visible_cache)) {
+  txr([&](auto& txn) {
+    for (const auto& [key, metadata] : block) {
+      lfdb::set(txn, "d4n/archive/" + key, metadata);
+      lfdb::erase(txn, key);
+    }
+  });
+}
+```
+
+The query expression says exactly what should be touched: cache records, minus
+reserved subspaces, further trimmed by a cursor. `blocks()` keeps discovery
+bounded, while the transactor keeps each mutation block replayable. The body
+only does transaction-local work, so replay does not repeat external side
+effects.
+
+## Running Tests And Benchmarks
+
+From the build directory, run the libfdb tests with:
+
+```sh
+./bin/unittest_fdb
+./bin/unittest_fdb_ceph
+```
+
+Benchmarks are hidden from default test runs. Run all libfdb benchmarks with:
+
+```sh
+./bin/unittest_fdb_ceph "[benchmark]"
+```
+
 ## Appendix: Exception Summary
 
 libfdb tries to keep its exception surface small. Ordinary library operation
@@ -1706,7 +1550,7 @@ violations use standard exceptions.
 The categories are intentionally coarse: they are meant to be useful to
 callers, not to divide every possible misuse into a separate exception type. For
 example, some versionstamp state violations are treated as `std::invalid_argument`
-to avoid a crazy taxonomy explosion.
+to avoid an overly fine-grained exception taxonomy.
 
 | Condition | Exception |
 | --- | --- |

--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -140,7 +140,8 @@ Transaction versions let application code connect a successful write to a later
 consistent read. `committed_version()` is available after a successful commit,
 `set_read_version()` pins another transaction to that version, and
 `read_version()` reports the version an active transaction reads from. This is a
-consistency tool, not durable historical storage:
+consistency tool, not durable historical storage. Set the read version before
+performing reads in that transaction:
 
 ```cpp
 auto write_txn = lfdb::make_transaction(dbh);
@@ -1430,4 +1431,4 @@ to avoid a crazy taxonomy explosion.
 | Invalid result at the FoundationDB boundary | `lfdb::libfdb_exception` |
 | Caller uses libfdb after shutdown | `lfdb::libfdb_exception` |
 | Caller passes an impossible selector prefix or invalid versionstamp bytes | `std::invalid_argument` |
-| Caller reads, compares, reuses, or overwrites a versionstamp in the wrong state | `std::invalid_argument` |
+| Caller reads, compares, reuses, or overwrites a versionstamp in the wrong state; or asks for a committed version before commit | `std::invalid_argument` |

--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -68,6 +68,10 @@ auto dbh = lfdb::create_database(
   lfdb::connection_source{"description:id@127.0.0.1:4500"});
 ```
 
+The source type makes the distinction explicit: a string is a FoundationDB
+connection string, while a cluster-file name must be passed as a
+`std::filesystem::path`.
+
 ## Basic Operations
 
 Use a `database_handle` when you want libfdb to create, commit, and retry a
@@ -267,11 +271,11 @@ if (not lfdb::commit(txn)) {
 }
 ```
 
-`prepare_replay()` is the lower-level hook for application-managed replay. Most
+`reset_for_replay()` is the lower-level hook for application-managed replay. Most
 callers should use a transactor instead; use this when the application needs to
 keep its own progress marker before re-running part of a larger operation.
-`commit()` already prepares replay before returning `false`; call
-`prepare_replay()` only for retryable errors that escape before commit.
+`commit()` already resets the transaction before returning `false`; call
+`reset_for_replay()` only for retryable errors that escape before commit.
 
 ```cpp
 auto txn = lfdb::make_transaction(dbh);
@@ -284,7 +288,7 @@ try {
   }
 }
 catch (const lfdb::libfdb_exception& e) {
-  lfdb::prepare_replay(txn, e.fdb_error_value);
+  lfdb::reset_for_replay(txn, e.fdb_error_value);
   retry_from(marker);
 }
 ```
@@ -1340,9 +1344,11 @@ functions:
 <https://apple.github.io/foundationdb/api-c.html#c.fdb_database_get_client_status>
 and
 <https://apple.github.io/foundationdb/api-c.html#c.fdb_database_get_main_thread_busyness>.
+`client_network_load()` reports load on FoundationDB's client network thread:
+zero is idle, while one or greater indicates saturation.
 
 ```cpp
-const auto busyness = lfdb::system::main_thread_busyness(dbh);
+const auto client_load = lfdb::system::client_network_load(dbh);
 const auto protocol = lfdb::system::server_protocol(dbh);
 const auto status_json = lfdb::system::client_status_json(dbh);
 ```

--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -933,6 +933,40 @@ for (const auto& chunk : keys | std::views::chunk(100)) {
 }
 ```
 
+### Estimating Range Size
+
+`approximate_range_size()` asks FoundationDB for an approximate byte size of a
+selection. FoundationDB calculates this from server-side sampling, so it is most
+useful for planning large ranges rather than measuring small ranges exactly. The
+C API documentation notes that estimates over roughly 3 MB can be considered
+accurate enough for many planning purposes:
+<https://apple.github.io/foundationdb/api-c.html#c.fdb_transaction_get_estimated_range_size_bytes>.
+
+```cpp
+const auto object_records =
+  fdbc::keyspace("object-cache") / "object" / bucket_id;
+
+const auto bytes = lfdb::approximate_range_size(dbh, fdbc::prefix(object_records));
+
+if (block_planning_threshold < bytes) {
+  for (const auto& block : lfdb::blocks<object_metadata>(
+         dbh, fdbc::prefix(object_records))) {
+    process_block(block);
+  }
+}
+```
+
+The helper accepts the same selection forms as `scan()` and `blocks()`, so query
+algebra composes normally:
+
+```cpp
+auto visible =
+  q::difference(q::prefix("object/"),
+                q::prefix("object/private/"));
+
+auto bytes = lfdb::approximate_range_size(dbh, visible);
+```
+
 ### Explicit Key Ranges
 
 Use `q::between()` when the selection is not a prefix. The default is the same

--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -610,15 +610,91 @@ Use `collect()` when a materialized container is exactly what the caller needs:
 auto people = lfdb::collect<person_record>(dbh, q::prefix("person/"));
 ```
 
-### Block Traversal
-
-`blocks()` is useful for reads that may become very large. Given a database
-handle, it internally manages transactions for each planned block/window. Use it
-for very large scans where a single transaction may get too old or block-at-a-time
-processing is preferable.
+Use `for_each()` when the operation is naturally callback-shaped and you do not
+need a composable generator. Passing a transaction handle keeps the transaction
+boundary explicit:
 
 ```cpp
-// Use blocks() when block-at-a-time processing is useful.
+auto txn = lfdb::make_transaction(dbh);
+
+lfdb::for_each(txn, q::prefix("person/"), [](auto&& row) {
+  const auto& [key, value] = row;
+  fmt::println("{}: {}", key, value);
+});
+```
+
+The database-handle overload is a convenience for bounded, retryable work that
+should run in one managed transaction. The callback may run again if the
+transaction is retried, so keep it replay-safe:
+
+```cpp
+lfdb::for_each<person_record>(dbh, q::prefix("person/"), [](auto&& row) {
+  if (row.second.name.empty()) {
+    throw std::runtime_error("stored person has no name");
+  }
+});
+```
+
+Use `transform()` when each input row produces one output value:
+
+```cpp
+auto txn = lfdb::make_transaction(dbh);
+std::vector<std::string> names;
+
+lfdb::transform<person_record>(
+  txn,
+  q::prefix("person/"),
+  [](auto&& row) {
+    return std::move(row.second.name);
+  },
+  std::back_inserter(names));
+```
+
+When the transformed values should be materialized directly, let `transform()`
+return the vector. The transform function is evaluated inside managed
+transaction work, so it should also be replay-safe:
+
+```cpp
+auto names = lfdb::transform<person_record>(
+  dbh,
+  q::prefix("person/"),
+  [](auto&& row) {
+    return std::move(row.second.name);
+  });
+```
+
+Use `erase_if()` when the delete decision depends on the decoded row. It returns
+the number of keys cleared; database-handle predicates are evaluated inside the
+managed transaction loop:
+
+```cpp
+const auto removed = lfdb::erase_if<person_record>(
+  dbh, q::prefix("person/"),
+  [](const auto& row) {
+    return row.second.disabled;
+  });
+```
+
+Selector-shaped scans can also ask for a bounded page. The returned page
+contains only rows the caller requested; the extra sentinel row used to detect
+continuation is not decoded or returned.
+
+```cpp
+auto people = lfdb::select { "person/" };
+const auto page = lfdb::scan<person_record>(dbh, people, lfdb::page{100});
+
+if (page.has_more) {
+  // Resume from the last returned row.
+}
+```
+
+### Block Traversal
+
+`blocks()` is for truly large scans. Given a database handle, it internally
+manages transactions for each planned block/window. Use it when a single
+transaction may get too old or block-at-a-time processing is preferable.
+
+```cpp
 for (const auto& block : lfdb::blocks(dbh, q::prefix("object/metadata/"))) {
   for (const auto& [key, value] : block) {
     fmt::println("{}: {}", key, value);

--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -833,9 +833,10 @@ if (page.has_more) {
 
 ### Block Traversal
 
-`blocks()` is for truly large scans. Given a database handle, it internally
-manages transactions for each planned block/window. Use it when a single
-transaction may get too old or block-at-a-time processing is preferable.
+`blocks()` is for truly large scans. Given a database handle, libfdb internally
+plans the range work and manages transactions for each block/window. Use it
+when a single transaction may get too old, or when the application naturally
+wants to process bounded groups of rows.
 
 ```cpp
 for (const auto& block : lfdb::blocks(dbh, q::prefix("object/metadata/"))) {
@@ -845,8 +846,38 @@ for (const auto& block : lfdb::blocks(dbh, q::prefix("object/metadata/"))) {
 }
 ```
 
+For example, a cache maintenance pass might walk a large object-metadata
+keyspace block-at-a-time and only keep one planned block in memory:
+
+```cpp
+for (const auto& block : lfdb::blocks<object_metadata>(
+       dbh, q::prefix("cache/object/head/"))) {
+  for (const auto& [key, metadata] : block) {
+    if (metadata.expired(cutoff)) {
+      schedule_eviction(key);
+    }
+  }
+}
+```
+
+The same pattern works for export or auditing jobs where progress can be
+recorded between blocks:
+
+```cpp
+std::uint64_t exported = 0;
+
+for (const auto& block : lfdb::blocks<object_metadata>(
+       dbh, q::prefix("tenant/acme/object/"))) {
+  write_export_batch(block);
+  exported += std::size(block);
+  lfdb::set(dbh, "export/acme/progress", exported);
+}
+```
+
 It may also be useful to group flat `scan()` output into discrete groups of N
-items. One way to do that is with a chunk view:
+items. That is different from `blocks()`: the scan has already chosen its
+transaction behavior, and `std::views::chunk()` only changes the shape seen by
+the caller.
 
 ```cpp
 // Stream groups of 100:

--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -723,6 +723,48 @@ The explicit selector is half-open: the begin key is included and the end key is
 excluded. Use `lfdb::inclusive()` or `lfdb::exclusive()` when the boundary shape
 needs to be different.
 
+### Navigating Stored Keys
+
+Key selectors navigate among keys that actually exist in FoundationDB. They do
+not compute byte-string successors or predecessors. See the FoundationDB
+[key selector guide](https://apple.github.io/foundationdb/developer-guide.html#key-selectors)
+for the underlying model.
+
+Assume the database contains these keys:
+
+`0 1 2 3 4`
+
+| Selector | Meaning | Result for anchor `2` | Result for anchor `2.5` |
+|---|---|---:|---:|
+| `lfdb::lower(key)` | greatest stored key `< key` | `1` | `2` |
+| `lfdb::floor(key)` | greatest stored key `<= key` | `2` | `2` |
+| `lfdb::ceiling(key)` | least stored key `>= key` | `2` | `3` |
+| `lfdb::higher(key)` | least stored key `> key` | `3` | `3` |
+
+```cpp
+auto txn = lfdb::make_transaction(dbh);
+
+auto previous = lfdb::get_key(txn, lfdb::lower("2"));
+auto current_or_previous = lfdb::get_key(txn, lfdb::floor("2"));
+auto current_or_next = lfdb::get_key(txn, lfdb::ceiling("2"));
+auto next = lfdb::get_key(txn, lfdb::higher("2"));
+```
+
+Selectors compose with content keys because content keys compile to ordinary
+FoundationDB keys. The resolved key is still just a key, so use the query
+algebra when you need to test whether it belongs to a content prefix:
+
+```cpp
+const auto objects = fdbc::keyspace("object-cache") / "object" / bucket_id;
+const auto object_b = objects / "b";
+
+const auto candidate = lfdb::get_key(dbh, lfdb::ceiling(object_b));
+
+if (q::contains(fdbc::prefix(objects), candidate)) {
+  load_object(candidate);
+}
+```
+
 ### Scanning A Selection
 
 `scan()` is the ordinary flat key/value traversal interface. With a transaction

--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -211,6 +211,45 @@ auto dbh = lfdb::create_database(
   lfdb::connection_source{"description:id@127.0.0.1:4500"});
 ```
 
+## API Namespace
+
+`lfdb::api` reports facts about the FoundationDB client API available to this
+process. These calls do not require a database handle. See the FoundationDB C API
+documentation:
+<https://apple.github.io/foundationdb/api-c.html>.
+
+```cpp
+const auto client = lfdb::api::client_version();
+const auto max_api = lfdb::api::max_version();
+```
+
+## System Namespace
+
+`lfdb::system` contains FoundationDB system-level observations and operational
+surface. Read-only functions report live database/client state. Sharp
+operational functions belong here too, rather than in the core key/value API,
+but they should only be called by code that is explicitly managing a
+FoundationDB deployment. See the FoundationDB C API entries for these database
+functions:
+<https://apple.github.io/foundationdb/api-c.html#c.fdb_database_get_client_status>
+and
+<https://apple.github.io/foundationdb/api-c.html#c.fdb_database_get_main_thread_busyness>.
+
+```cpp
+const auto busyness = lfdb::system::main_thread_busyness(dbh);
+const auto protocol = lfdb::system::server_protocol(dbh);
+const auto status_json = lfdb::system::client_status_json(dbh);
+```
+
+The remaining functions are operational controls, not ordinary application data
+operations:
+
+```cpp
+lfdb::system::reboot_worker(dbh, "127.0.0.1:4500", false, 60);
+lfdb::system::force_recovery_with_data_loss(dbh, "dc1");
+lfdb::system::create_snapshot(dbh, "snapshot-id", "snapshot-command");
+```
+
 ## Single-Key Operations
 
 Single-key `get()` returns whether the key was found.

--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -1204,6 +1204,28 @@ if (!lfdb::commit(txn)) {
 }
 ```
 
+`prepare_replay()` is the lower-level hook for application-managed replay. Most
+callers should use a transactor instead; use this when the application needs to
+keep its own progress marker before re-running part of a larger operation.
+`commit()` already prepares replay before returning `false`; call
+`prepare_replay()` only for retryable errors that escape before commit.
+
+```cpp
+auto txn = lfdb::make_transaction(dbh);
+
+try {
+  rebuild_cache_index(txn, marker);
+
+  if (!lfdb::commit(txn)) {
+    retry_from(marker);
+  }
+}
+catch (const lfdb::libfdb_exception& e) {
+  lfdb::prepare_replay(txn, e.fdb_error_value);
+  retry_from(marker);
+}
+```
+
 ## Transactors: Replayable Transactions
 
 Transactors are function objects created with `make_transactor()`. Creating a

--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -273,9 +273,11 @@ explicit open/closed boundaries.
 | Store one key/value pair | `lfdb::set(dbh, key, value)` | `void` | One logical write with automatic transaction handling. |
 | Store many key/value pairs already in a container | `lfdb::set(dbh, kvs)` | `void` | Writes the whole range in one managed transaction without spelling out iterators. |
 | Read one exact key | `lfdb::get(dbh, key, value)` | `bool` | Returns `true` only when the key exists and decodes into `value`. |
+| Read one exact key without adding a read conflict | `lfdb::get(dbh, key, value, lfdb::read_mode::snapshot)` | `bool` | Useful for advisory reads where the value is not part of the transaction's correctness condition. |
 | Read one exact key as bytes | `lfdb::get(dbh, key, callback)` | `bool` | Lets the callback copy or decode the raw value while the FDB buffer is valid. |
 | Read a small range into an existing output | `lfdb::get(dbh, query, out)` | `std::size_t` | Materializes decoded string pairs, publishes them after a successful managed read, and reports how many records were found. |
 | Read a flat stream in an existing transaction | `lfdb::scan(txn, query)` | generator of key/value pairs | Keeps transaction lifetime under caller control. |
+| Read a flat stream without adding read conflicts | `lfdb::scan(txn, query, lfdb::read_mode::snapshot)` | generator of key/value pairs | Leaves specialized read-then-write policy visible at the call site. |
 | Read a flat stream with managed transactions | `lfdb::scan(dbh, query)` | generator of key/value pairs | Hides transaction-window management while preserving streaming syntax. |
 | Read directly into a new container | `lfdb::collect<T>(dbh, query)` | vector of key/value pairs | Best when the caller really wants a fully materialized result. |
 | Read directly into a chosen container type | `lfdb::collect<T, AssocT>(dbh, query)` | `AssocT` | Keeps materialization explicit when the caller wants a map or custom container. |
@@ -304,6 +306,40 @@ const auto nread = lfdb::get(dbh, q::prefix("person/"), people);
 
 For very large reads, prefer `lfdb::blocks()` so work stays block-at-a-time
 instead of collecting one large result before publishing it.
+
+### Snapshot Reads
+
+Snapshot reads do not add read conflict ranges. The FoundationDB developer guide
+describes them here: <https://apple.github.io/foundationdb/developer-guide.html#snapshot-reads>.
+Use them for advisory reads, background maintenance, cleanup discovery, or other
+places where another transaction changing the read keys should not by itself make
+this transaction fail.
+
+```cpp
+object_metadata metadata;
+if (lfdb::get(dbh, "object/catalog/project-a/report.pdf", metadata,
+              lfdb::read_mode::snapshot) &&
+    metadata.expired(cutoff)) {
+  schedule_metadata_refresh(metadata);
+}
+```
+
+The same mode works for range-shaped reads. This is useful when discovering
+best-effort cleanup candidates where stale discoveries are acceptable:
+
+```cpp
+for (const auto& [key, metadata] :
+     lfdb::scan<object_metadata>(txn, q::prefix("object/catalog/project-a/"),
+                                 lfdb::read_mode::snapshot)) {
+  if (metadata.expired(cutoff)) {
+    schedule_metadata_refresh(metadata);
+  }
+}
+```
+
+Snapshot reads are a lower-isolation tool. If a later mutation depends on what
+was read, keep that choice explicit in an ordinary transaction rather than
+hiding it behind a convenience helper.
 
 ### Prefix Selection
 

--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -169,6 +169,17 @@ if (lfdb::commit(write_txn)) {
 auto dbh = lfdb::create_database();
 ```
 
+FoundationDB clients can connect through a default cluster file, an explicit
+cluster file path, or the connection string normally stored inside a cluster
+file. libfdb keeps caller-supplied sources explicit: a
+`std::filesystem::path` source opens a cluster file, while a string-like source
+opens a FoundationDB connection string. Use `create_database()` for
+FoundationDB's default cluster-file resolution; explicit source wrappers require
+non-empty inputs. See the
+FoundationDB [cluster file documentation](https://apple.github.io/foundationdb/administration.html#cluster-files)
+and the C API database-opening documentation:
+<https://apple.github.io/foundationdb/api-c.html#database>.
+
 ```cpp
 // Open a database with explicit database and network options. Explicit database
 // options are used as passed. Flag-only options use
@@ -188,7 +199,16 @@ auto dbh = lfdb::create_database(dbopts, netopts);
 
 ```cpp
 // Open a database with an explicit cluster file plus database/network options.
-auto dbh = lfdb::create_database("/path/to/fdb.cluster", dbopts, netopts);
+auto dbh = lfdb::create_database(
+  lfdb::connection_source{std::filesystem::path{"/path/to/fdb.cluster"}},
+  dbopts,
+  netopts);
+```
+
+```cpp
+// Open a database from a FoundationDB connection string.
+auto dbh = lfdb::create_database(
+  lfdb::connection_source{"description:id@127.0.0.1:4500"});
 ```
 
 ## Single-Key Operations

--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -286,6 +286,7 @@ explicit open/closed boundaries.
 | Select everything under one key prefix | `q::prefix(prefix)` | `lfdb::select` | Handles FDB prefix successor rules without hand-built byte bounds. |
 | Select an explicit half-open key interval | `q::between(begin, end)` | `lfdb::select` | Matches the usual FoundationDB `[begin, end)` range shape. |
 | Combine or subtract selections | `q::intersection()`, `q::set_union()`, `q::difference()` | query expression or selector | Lets the query compiler normalize intervals before execution. |
+| Add an explicit conflict check | `lfdb::mark_conflict_read(txn, query)` | `void` | Records transaction correctness dependencies that ordinary operations did not express. |
 | Run several dependent operations atomically | `lfdb::make_transactor(dbh)` | callable transaction runner | Replays retryable transactions while keeping user code explicit. |
 
 ### Managed Range Reads
@@ -341,6 +342,37 @@ for (const auto& [key, metadata] :
 Snapshot reads are a lower-isolation tool. If a later mutation depends on what
 was read, keep that choice explicit in an ordinary transaction rather than
 hiding it behind a convenience helper.
+
+### Explicit Conflict Ranges
+
+Conflict ranges are key ranges FoundationDB checks to decide whether a
+transaction can still commit safely. Ordinary reads and writes add the usual
+conflict ranges for their keys, but applications sometimes need to express an
+additional dependency. Use `mark_conflict_read()` when this transaction must
+retry if another transaction later writes an overlapping key or range. Use
+`mark_conflict_write()` when this transaction must be treated as a writer for an
+overlapping reader, even if it does not write that exact key itself:
+
+```cpp
+auto txn = lfdb::make_transaction(dbh);
+
+lfdb::mark_conflict_read(txn, "object/index/marker");
+lfdb::set(txn, "object/index/update", "pending");
+
+if (not lfdb::commit(txn)) {
+  retry_update();
+}
+```
+
+The same functions accept exact keys, begin/end ranges, selectors, and query
+expressions. Empty conflict expressions are rejected:
+
+```cpp
+auto txn = lfdb::make_transaction(dbh);
+
+lfdb::mark_conflict_read(txn, "object/index/a", "object/index/z");
+lfdb::mark_conflict_write(txn, q::prefix("object/cache/tenant-a/"));
+```
 
 ### Prefix Selection
 

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -408,7 +408,7 @@ struct future_value final
 
  private:
  void destroy() noexcept { future_ptr.reset(nullptr); }
- 
+
  private:
  friend class ceph::libfdb::transaction;
 };
@@ -800,7 +800,7 @@ inline void initialize_fdb(const network_options& options)
  // of fdb_database_system accomplishes this:
  if (fdb_error_t r = fdb_select_api_version(FDB_API_VERSION); 0 != r)
   throw libfdb_exception(r);
- 
+
  // Zero or more calls to this may now be made:
  apply_options(options, fdb_network_set_option);
  
@@ -1057,7 +1057,7 @@ class transaction final
  }
 
  bool get_single_value_from_transaction(const std::span<const std::uint8_t>& key,
-                                        std::invocable<std::span<const std::uint8_t>> auto&& write_output_fn,
+                                        concepts::value_callback auto&& write_output_fn,
                                         read_mode mode);
 
  public:
@@ -1442,7 +1442,7 @@ inline future_value transaction_get_key(const transaction_handle& txn,
 } // namespace detail
 
 inline bool ceph::libfdb::transaction::get_single_value_from_transaction(const std::span<const std::uint8_t>& key,
-                                                                         std::invocable<std::span<const std::uint8_t>> auto&& write_output,
+                                                                         concepts::value_callback auto&& write_output,
                                                                          const read_mode mode)
 {
  const fdb_bool_t snapshot = read_mode::snapshot == mode;
@@ -1453,23 +1453,23 @@ inline bool ceph::libfdb::transaction::get_single_value_from_transaction(const s
                                     snapshot)));
  auto *future = fv.raw_ptr_or_throw();
  
-  fdb_bool_t key_was_found = false;
-  const uint8_t *out_buffer = nullptr;
-  int out_len = 0;
+ fdb_bool_t key_was_found = false;
+ const uint8_t *out_buffer = nullptr;
+ int out_len = 0;
 
-  if (fdb_error_t r = fdb_future_get_value(future, &key_was_found, &out_buffer, &out_len); 0 != r) {
-    throw libfdb_exception(r);
-  }
+ if (fdb_error_t r = fdb_future_get_value(future, &key_was_found, &out_buffer, &out_len); 0 != r) {
+  throw libfdb_exception(r);
+ }
 
-  // No errors, but no value was found:
-  if (0 == key_was_found) {
-    return false;
-  }
+ // No errors, but no value was found:
+ if (0 == key_was_found) {
+  return false;
+ }
  
-  write_output(std::span<const std::uint8_t>(out_buffer, out_len));
+ std::invoke(write_output, std::span<const std::uint8_t>(out_buffer, out_len));
  
-  // The happy path is the simple path:
-  return true; 
+ // The happy path is the simple path:
+ return true;
 }
 
 [[nodiscard]] inline bool ceph::libfdb::transaction::commit()
@@ -1898,29 +1898,25 @@ inline range_work_plan plan_range_work(ceph::libfdb::database_handle dbh,
  const auto begin = ceph::libfdb::detail::as_fdb_span(split_selector.begin_key);
  const auto end = ceph::libfdb::detail::as_fdb_span(split_selector.end_key);
 
- for (bool should_retry = true; should_retry;) {
+ for (;;) {
   auto result_owner = wait_until_ready(
    transaction_get_range_split_points(txn, begin, end, target_bytes));
 
   auto split_points = extract_split_points(std::move(result_owner));
 
-  should_retry = retry_after_error(txn, split_points.error);
-
-  if (not should_retry) {
-   auto ranges = as_select_seq(split_points.result_keys, split_selector);
-   if (ranges.empty()) {
-    ranges.push_back(std::move(selector));
-   }
-
-   return range_work_plan {
-    .ranges = std::move(ranges)
-   };
+  if (retry_after_error(txn, split_points.error)) {
+   continue;
   }
- }
 
- return range_work_plan {
-  .ranges = {std::move(selector)}
- };
+  auto ranges = as_select_seq(split_points.result_keys, split_selector);
+  if (ranges.empty()) {
+   ranges.push_back(std::move(selector));
+  }
+
+  return range_work_plan {
+   .ranges = std::move(ranges)
+  };
+ }
 }
 
 // Generators (internal guts):

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -994,6 +994,13 @@ class transaction final
             detail::future_value(fdb_transaction_get_read_version(raw_handle()))));
  }
 
+ [[nodiscard]] std::int64_t approximate_commit_bytes() const
+ {
+  return detail::extract_int64(
+           detail::block_until_ready(
+            detail::future_value(fdb_transaction_get_approximate_size(raw_handle()))));
+ }
+
  void set_read_version(const std::int64_t version)
  {
   fdb_transaction_set_read_version(raw_handle(), version);
@@ -1052,6 +1059,7 @@ class transaction final
  friend inline bool commit(transaction_handle& txn, const versionstamp& stamp);
  friend inline std::int64_t committed_version(const transaction_handle& txn);
  friend inline std::int64_t read_version(const transaction_handle& txn);
+ friend inline std::int64_t approximate_commit_bytes(const transaction_handle& txn);
  friend inline void set_read_version(const transaction_handle& txn, std::int64_t version);
  friend inline watch_handle make_watch(transaction_handle txn, std::string_view key);
  friend inline fdb_error_t ceph::libfdb::detail::do_commit(transaction_handle& txn);

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -917,6 +917,10 @@ class transaction final
    throw libfdb_exception(r);
   }
 
+  if (0 > version) {
+   throw std::invalid_argument("committed_version() requires committed transaction");
+  }
+
   return version;
  }
 

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -28,6 +28,7 @@
 #include <span>
 #include <array>
 #include <tuple>
+#include <string>
 #include <vector>
 #include <variant>
 #include <optional>
@@ -144,6 +145,9 @@ inline future_value get_range_future_from_transaction(ceph::libfdb::transaction&
                                                       int iteration,
                                                       ceph::libfdb::read_mode mode = ceph::libfdb::read_mode::serializable);
 [[nodiscard]] inline std::int64_t extract_int64(future_value result_owner);
+[[nodiscard]] inline std::uint64_t extract_uint64(future_value result_owner);
+[[nodiscard]] inline std::string extract_byte_string(future_value result_owner);
+[[nodiscard]] inline ceph::libfdb::database& database_or_throw(const ceph::libfdb::database_handle& dbh);
 inline bool retry_after_error(transaction_handle& txn, fdb_error_t r);
 
 // A generator that produces successive spans for a range:
@@ -949,10 +953,81 @@ class database final
  public:
  FDBDatabase *raw_handle() const noexcept { return db_handle.get(); }
 
+ [[nodiscard]] double main_thread_busyness() const
+ {
+  return fdb_database_get_main_thread_busyness(raw_handle());
+ }
+
+ [[nodiscard]] std::uint64_t server_protocol(const std::uint64_t expected_version = 0) const
+ {
+  return detail::extract_uint64(
+           detail::block_until_ready(
+            detail::future_value(
+             fdb_database_get_server_protocol(raw_handle(), expected_version))));
+ }
+
+ [[nodiscard]] std::string client_status_json() const
+ {
+  return detail::extract_byte_string(
+           detail::block_until_ready(
+            detail::future_value(fdb_database_get_client_status(raw_handle()))));
+ }
+
+ void reboot_worker(std::string_view address, const bool check, const int duration) const
+ {
+  const auto address_bytes = detail::as_fdb_span(address);
+
+  detail::block_until_ready(
+   detail::future_value(
+    fdb_database_reboot_worker(raw_handle(),
+                               address_bytes.data(),
+                               static_cast<int>(std::size(address_bytes)),
+                               true == check,
+                               duration)));
+ }
+
+ void force_recovery_with_data_loss(std::string_view dcid) const
+ {
+  const auto dcid_bytes = detail::as_fdb_span(dcid);
+
+  detail::block_until_ready(
+   detail::future_value(
+    fdb_database_force_recovery_with_data_loss(raw_handle(),
+                                               dcid_bytes.data(),
+                                               static_cast<int>(std::size(dcid_bytes)))));
+ }
+
+ void create_snapshot(std::string_view uid, std::string_view snap_command) const
+ {
+  const auto uid_bytes = detail::as_fdb_span(uid);
+  const auto snap_command_bytes = detail::as_fdb_span(snap_command);
+
+  detail::block_until_ready(
+   detail::future_value(
+    fdb_database_create_snapshot(raw_handle(),
+                                 uid_bytes.data(),
+                                 static_cast<int>(std::size(uid_bytes)),
+                                 snap_command_bytes.data(),
+                                 static_cast<int>(std::size(snap_command_bytes)))));
+ }
+
  private:
  friend transaction;
 
 };
+
+namespace detail {
+
+[[nodiscard]] inline ceph::libfdb::database& database_or_throw(const ceph::libfdb::database_handle& dbh)
+{
+ if (dbh and *dbh) {
+  return *dbh;
+ }
+
+ throw std::invalid_argument("invalid database handle");
+}
+
+} // namespace detail
 
 class transaction final
 {
@@ -1600,6 +1675,38 @@ inline split_point_result extract_split_points(future_value result_owner)
  }
 
  return value;
+}
+
+[[nodiscard]] inline std::uint64_t extract_uint64(future_value result_owner)
+{
+ std::uint64_t value = 0;
+
+ if (fdb_error_t r = fdb_future_get_uint64(result_owner.raw_ptr_or_throw(), &value); 0 != r) {
+  throw libfdb_exception(r);
+ }
+
+ return value;
+}
+
+[[nodiscard]] inline std::string extract_byte_string(future_value result_owner)
+{
+ const uint8_t *out = nullptr;
+ int out_size = 0;
+
+ if (fdb_error_t r = fdb_future_get_key(result_owner.raw_ptr_or_throw(), &out, &out_size); 0 != r) {
+  throw libfdb_exception(r);
+ }
+
+ if (0 == out_size) {
+  return {};
+ }
+
+ if (nullptr == out) {
+  throw libfdb_exception("invalid byte string result");
+ }
+
+ return std::string(reinterpret_cast<const char *>(out),
+                    static_cast<std::string::size_type>(out_size));
 }
 
 inline query_window read_query_window(transaction& txn,

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -79,6 +79,7 @@ struct with_result_t;
 struct versionstamp;
 struct watch_handle;
 struct commit_result;
+class key_selector;
 
 class database;
 class transaction;
@@ -129,6 +130,9 @@ inline future_value transaction_get_range_split_points(const transaction_handle&
                                                        std::span<const std::uint8_t> begin,
                                                        std::span<const std::uint8_t> end,
                                                        std::int64_t target_bytes);
+inline future_value transaction_get_key(const transaction_handle& txn,
+                                        const key_selector& selector,
+                                        read_mode mode);
 
 inline future_value block_until_ready(future_value&& fv);
 inline fdb_error_t get_future_error(const future_value& fv);
@@ -261,6 +265,69 @@ concept storable_invocation_result =
 // libfdb_exception represents libfdb operation failures.
 // Caller contract errors use standard exceptions such as std::invalid_argument.
 namespace ceph::libfdb {
+
+/* FoundationDB key selectors navigate among stored keys. Prefer the named
+ * factory functions below; arbitrary offsets are an advanced FDB feature. */
+class key_selector final
+{
+ std::string key;
+
+ bool or_equal;
+ int offset;
+
+ public:
+ key_selector(const key_selector&) = default;
+ key_selector& operator=(const key_selector&) = default;
+ key_selector(key_selector&&) noexcept = default;
+ key_selector& operator=(key_selector&&) noexcept = default;
+
+ private:
+ constexpr key_selector(std::string_view key_,
+                        const bool or_equal_,
+                        const int offset_)
+  : key(key_),
+    or_equal(or_equal_),
+    offset(offset_)
+ {}
+
+ template <concepts::libfdb_key KeyT>
+ friend constexpr key_selector lower(const KeyT& key);
+
+ template <concepts::libfdb_key KeyT>
+ friend constexpr key_selector floor(const KeyT& key);
+
+ template <concepts::libfdb_key KeyT>
+ friend constexpr key_selector ceiling(const KeyT& key);
+
+ template <concepts::libfdb_key KeyT>
+ friend constexpr key_selector higher(const KeyT& key);
+
+ friend class transaction;
+};
+
+template <concepts::libfdb_key KeyT>
+[[nodiscard]] constexpr key_selector lower(const KeyT& key)
+{
+ return key_selector(detail::as_libfdb_key_view(key), false, 0);
+}
+
+template <concepts::libfdb_key KeyT>
+[[nodiscard]] constexpr key_selector floor(const KeyT& key)
+{
+ return key_selector(detail::as_libfdb_key_view(key), true, 0);
+}
+
+template <concepts::libfdb_key KeyT>
+[[nodiscard]] constexpr key_selector ceiling(const KeyT& key)
+{
+ return key_selector(detail::as_libfdb_key_view(key), false, 1);
+}
+
+template <concepts::libfdb_key KeyT>
+[[nodiscard]] constexpr key_selector higher(const KeyT& key)
+{
+ return key_selector(detail::as_libfdb_key_view(key), true, 1);
+}
 
 // Should we commit after the (possibly) mutating operation?
 enum struct commit_after_op { commit, no_commit };
@@ -989,6 +1056,20 @@ class transaction final
   };
  }
 
+ detail::future_value get_key(const key_selector& selector,
+                              const read_mode mode)
+ {
+  const auto key = detail::as_fdb_span(selector.key);
+  const fdb_bool_t snapshot = read_mode::snapshot == mode;
+
+  return detail::future_value {
+   fdb_transaction_get_key(raw_handle(),
+                           key.data(), static_cast<int>(std::size(key)),
+                           selector.or_equal, selector.offset,
+                           snapshot)
+  };
+ }
+
  bool key_exists(std::string_view k, const read_mode mode)
  {
     return get_single_value_from_transaction(detail::as_fdb_span(k), [](auto) {}, mode);
@@ -1130,6 +1211,9 @@ class transaction final
  friend inline auto ceph::libfdb::detail::transaction_get_range_split_points(
   const transaction_handle&, std::span<const std::uint8_t>, std::span<const std::uint8_t>, std::int64_t)
   -> ceph::libfdb::detail::future_value;
+ friend inline auto ceph::libfdb::detail::transaction_get_key(
+  const transaction_handle&, const key_selector&, read_mode)
+  -> ceph::libfdb::detail::future_value;
 
 };
 
@@ -1176,6 +1260,13 @@ inline future_value transaction_get_range_split_points(const transaction_handle&
                                                        const std::int64_t target_bytes)
 {
  return txn->get_range_split_points(begin, end, target_bytes);
+}
+
+inline future_value transaction_get_key(const transaction_handle& txn,
+                                        const key_selector& selector,
+                                        const read_mode mode)
+{
+ return txn->get_key(selector, mode);
 }
 
 } // namespace detail
@@ -1560,6 +1651,7 @@ inline future_value get_range_future_from_transaction(ceph::libfdb::transaction&
   const bool continuing_forward = not options.reverse_order and 1 < iteration;
   const bool continuing_reverse = options.reverse_order and 1 < iteration;
 
+  // Range bounds lower to the same FDB selector semantics as ceiling()/higher().
   const int begin_or_eq = (continuing_forward or not selection.begin_inclusive) ? 1 : 0;
   const int begin_offset = 1;
   const int end_or_eq = (not continuing_reverse and selection.end_inclusive) ? 1 : 0;

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -228,6 +228,10 @@ concept supported_invocation_result =
   std::constructible_from<std::remove_cvref_t<T>, T> and
   std::move_constructible<std::remove_cvref_t<T>>);
 
+template <typename T>
+concept storable_invocation_result =
+ not std::is_void_v<T> and supported_invocation_result<T>;
+
 } // namespace ceph::libfdb::concepts
 
 // libfdb_exception represents libfdb operation failures.

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -114,6 +114,10 @@ inline fdb_error_t do_commit(transaction_handle& txn);
 inline void transaction_set_kv_bytes(const transaction_handle& txn,
                                      std::span<const std::uint8_t> k,
                                      std::span<const std::uint8_t> v);
+inline void transaction_atomic_op(const transaction_handle& txn,
+                                  std::span<const std::uint8_t> k,
+                                  std::span<const std::uint8_t> param,
+                                  FDBMutationType type);
 inline void transaction_clear_key_bytes(const transaction_handle& txn,
                                         std::span<const std::uint8_t> k);
 inline void transaction_clear_range(const transaction_handle& txn,
@@ -333,7 +337,9 @@ struct future_value final
 
 inline auto as_fdb_span(concepts::libfdb_key_view auto key)
 {
- return std::span<const std::uint8_t>((const std::uint8_t *)key.data(), key.size());
+ return std::span<const std::uint8_t>(
+  reinterpret_cast<const std::uint8_t *>(key.data()),
+  std::size(key));
 }
 
 } // namespace detail
@@ -618,8 +624,8 @@ using transaction_options = option_map<FDBTransactionOption>;
 namespace detail {
 
 // Note that these are specific to FDB's needs (see return type, casts):
-inline const std::uint8_t *data_of(const std::vector<std::uint8_t>& xs) { return (const std::uint8_t *)xs.data(); }
-inline const std::uint8_t *data_of(const std::string& xs) { return (const std::uint8_t *)xs.data(); }
+inline const std::uint8_t *data_of(const std::vector<std::uint8_t>& xs) { return xs.data(); }
+inline const std::uint8_t *data_of(const std::string& xs) { return reinterpret_cast<const std::uint8_t *>(xs.data()); }
 inline const std::uint8_t *data_of(const std::int64_t& x) { return reinterpret_cast<const std::uint8_t *>(&x); }
 inline const std::uint8_t *data_of(const option_flag_t&) { return nullptr; }
 
@@ -630,7 +636,7 @@ constexpr int size_of(const std::int64_t) { return sizeof(std::int64_t); }
 constexpr int size_of(const option_flag_t&) { return 0; }
 
 // ...also used:
-inline const std::uint8_t *data_of(std::string_view xs) { return (const std::uint8_t *)xs.data(); }
+inline const std::uint8_t *data_of(std::string_view xs) { return reinterpret_cast<const std::uint8_t *>(xs.data()); }
 constexpr int size_of(std::string_view xs) { return static_cast<int>(xs.size()); }
 
 inline auto as_fdb_option_args(const auto& option)
@@ -840,8 +846,18 @@ class transaction final
  private:
  void set(std::span<const std::uint8_t> k, std::span<const std::uint8_t> v) {
     fdb_transaction_set(raw_handle(),
-                        (const uint8_t*)k.data(), k.size(),
-                        (const uint8_t*)v.data(), v.size());
+                        k.data(), static_cast<int>(std::size(k)),
+                        v.data(), static_cast<int>(std::size(v)));
+ }
+
+ void atomic_op(std::span<const std::uint8_t> k,
+                std::span<const std::uint8_t> param,
+                const FDBMutationType type)
+ {
+  fdb_transaction_atomic_op(raw_handle(),
+                            k.data(), static_cast<int>(std::size(k)),
+                            param.data(), static_cast<int>(std::size(param)),
+                            type);
  }
 
  void mark_version(const versionstamp& stamp)
@@ -859,8 +875,8 @@ class transaction final
                          const versionstamp& stamp)
  {
   fdb_transaction_atomic_op(raw_handle(),
-                            (const std::uint8_t*)k.data(), k.size(),
-                            (const std::uint8_t*)v.data(), v.size(),
+                            k.data(), static_cast<int>(std::size(k)),
+                            v.data(), static_cast<int>(std::size(v)),
                             MutationKind);
 
   mark_version(stamp);
@@ -887,15 +903,17 @@ class transaction final
 
  void erase(std::span<const std::uint8_t> k) {
     fdb_transaction_clear(raw_handle(),
-                          (const std::uint8_t *)k.data(), k.size());
+                          k.data(), static_cast<int>(std::size(k)));
  }
 
  void erase(const ceph::libfdb::select& key_range) {
     const auto half_open_range = detail::as_half_open_select(key_range);
+    const auto begin = detail::as_fdb_span(half_open_range.begin_key);
+    const auto end = detail::as_fdb_span(half_open_range.end_key);
 
     fdb_transaction_clear_range(raw_handle(),
-        (const uint8_t *)half_open_range.begin_key.data(), half_open_range.begin_key.size(),
-        (const uint8_t *)half_open_range.end_key.data(), half_open_range.end_key.size());
+        begin.data(), static_cast<int>(std::size(begin)),
+        end.data(), static_cast<int>(std::size(end)));
  }
 
  void mark_conflict(const ceph::libfdb::select& key_range,
@@ -915,8 +933,8 @@ class transaction final
   const auto end = detail::as_fdb_span(half_open_range.end_key);
 
   const auto r = fdb_transaction_add_conflict_range(raw_handle(),
-                 begin.data(), std::size(begin),
-                 end.data(), std::size(end),
+                 begin.data(), static_cast<int>(std::size(begin)),
+                 end.data(), static_cast<int>(std::size(end)),
                  type);
 
   if (0 != r) {
@@ -928,7 +946,7 @@ class transaction final
  {
   return watch_handle {
    detail::future_value {
-    fdb_transaction_watch(raw_handle(), key.data(), key.size())
+    fdb_transaction_watch(raw_handle(), key.data(), static_cast<int>(std::size(key)))
    }
   };
  }
@@ -1024,6 +1042,10 @@ class transaction final
  friend inline void ceph::libfdb::detail::transaction_set_kv_bytes(const transaction_handle&,
                                                                    std::span<const std::uint8_t>,
                                                                    std::span<const std::uint8_t>);
+ friend inline void ceph::libfdb::detail::transaction_atomic_op(const transaction_handle&,
+                                                                std::span<const std::uint8_t>,
+                                                                std::span<const std::uint8_t>,
+                                                                FDBMutationType);
  friend inline void ceph::libfdb::detail::transaction_clear_key_bytes(const transaction_handle&,
                                                                       std::span<const std::uint8_t>);
  friend inline void ceph::libfdb::detail::transaction_clear_range(const transaction_handle&,
@@ -1042,6 +1064,14 @@ inline void transaction_set_kv_bytes(const transaction_handle& txn,
                                      std::span<const std::uint8_t> v)
 {
  txn->set(k, v);
+}
+
+inline void transaction_atomic_op(const transaction_handle& txn,
+                                  std::span<const std::uint8_t> k,
+                                  std::span<const std::uint8_t> param,
+                                  const FDBMutationType type)
+{
+ txn->atomic_op(k, param, type);
 }
 
 inline void transaction_clear_key_bytes(const transaction_handle& txn,
@@ -1073,7 +1103,7 @@ inline bool ceph::libfdb::transaction::get_single_value_from_transaction(const s
 
  auto fv = detail::block_until_ready(detail::future_value(fdb_transaction_get(
                                     raw_handle(),
-                                    (const uint8_t *)key.data(), key.size(),
+                                    key.data(), static_cast<int>(std::size(key)),
                                     snapshot)));
  auto *future = fv.raw_ptr_or_throw();
  
@@ -1313,7 +1343,8 @@ inline std::optional<select> next_range_after(select key_range, const query_wind
  }
 
  const auto& last_key = window.result_pairs.back();
- auto cursor = std::string_view((const char *)last_key.key, last_key.key_length);
+ auto cursor = std::string_view(reinterpret_cast<const char *>(last_key.key),
+                                last_key.key_length);
 
  if (key_range.options.reverse_order) {
   key_range.end_key = cursor;
@@ -1421,9 +1452,9 @@ inline std::vector<ceph::libfdb::select> as_select_seq(std::span<const FDBKey> x
         | std::views::transform([&parent, xs](const auto i) {
            const auto& fst = xs[i];
            const auto& snd = xs[i + 1];
-           const auto first_key = std::string_view((const char *)fst.key,
+           const auto first_key = std::string_view(reinterpret_cast<const char *>(fst.key),
                                                     static_cast<std::string::size_type>(fst.key_length));
-           const auto second_key = std::string_view((const char *)snd.key,
+           const auto second_key = std::string_view(reinterpret_cast<const char *>(snd.key),
                                                      static_cast<std::string::size_type>(snd.key_length));
 
            ceph::libfdb::select split(first_key, second_key);
@@ -1442,10 +1473,10 @@ inline future_value get_range_future_from_transaction(ceph::libfdb::transaction&
                                                       int iteration,
                                                       const read_mode mode)
 {
-  const auto& begin_key  = selection.begin_key;
-  const auto& end_key    = selection.end_key;
+  const auto begin = detail::as_fdb_span(selection.begin_key);
+  const auto end = detail::as_fdb_span(selection.end_key);
 
-  const auto& options    = selection.options;
+  const auto& options = selection.options;
 
   // The documentation makes this stuff about as clear as mud... read VERY carefully
   // when you fiddle with these:
@@ -1462,11 +1493,13 @@ inline future_value get_range_future_from_transaction(ceph::libfdb::transaction&
   // the meaning of some of these, it can be hard to deduce from the documentation; Returns an
   // FDBKeyValueArray in the future:
   return future_value(fdb_transaction_get_range(txn.raw_handle(),
-                      (const uint8_t *)begin_key.data(), begin_key.size(),      // the reference-point key
+                      begin.data(),
+                      static_cast<int>(std::size(begin)),                       // the reference-point key
                       begin_or_eq,                                              // begin or eq
                       begin_offset,                                             // begin offset
 
-                      (const uint8_t *)end_key.data(), end_key.size(),          // the end selector key
+                      end.data(),
+                      static_cast<int>(std::size(end)),                         // the end selector key
                       end_or_eq,                                                // end or eq
                       end_offset,                                               // end offset (a shift AFTER end is matched)
 
@@ -1491,12 +1524,14 @@ inline std::vector<ceph::libfdb::select> plan_split_ranges(
 
  auto txn = ceph::libfdb::make_transaction(dbh);
  auto split_selector = ceph::libfdb::detail::as_half_open_select(selector);
+ const auto begin = ceph::libfdb::detail::as_fdb_span(split_selector.begin_key);
+ const auto end = ceph::libfdb::detail::as_fdb_span(split_selector.end_key);
 
  for (bool should_retry = true; should_retry;) {
   auto result_owner = wait_until_ready(future_value(fdb_transaction_get_range_split_points(
                        txn->raw_handle(),
-                       (const std::uint8_t *)split_selector.begin_key.data(), static_cast<int>(split_selector.begin_key.length()),
-                       (const std::uint8_t *)split_selector.end_key.data(), static_cast<int>(split_selector.end_key.length()),
+                       begin.data(), static_cast<int>(std::size(begin)),
+                       end.data(), static_cast<int>(std::size(end)),
                        remote_chunk_size)));
 
   auto split_points = extract_split_points(std::move(result_owner));

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -695,6 +695,52 @@ using network_options = option_map<FDBNetworkOption>;
 using database_options = option_map<FDBDatabaseOption>;
 using transaction_options = option_map<FDBTransactionOption>;
 
+// Caller-supplied database sources are tagged so paths and connection strings
+// cannot be confused:
+class connection_source final
+{
+ private:
+ enum class source_kind {
+  cluster_file,
+  connection_string
+ };
+
+ source_kind kind;
+ std::string value;
+
+ public:
+ explicit connection_source(std::filesystem::path path)
+  : kind(source_kind::cluster_file),
+    value(path.string())
+ {
+  if (std::empty(value)) {
+   throw std::invalid_argument("connection_source requires non-empty cluster file path");
+  }
+ }
+
+ explicit connection_source(std::string value_)
+  : kind(source_kind::connection_string),
+    value(std::move(value_))
+ {
+  if (std::empty(value)) {
+   throw std::invalid_argument("connection_source requires non-empty connection string");
+  }
+ }
+
+ explicit connection_source(const std::string_view value_)
+  : connection_source(std::string(value_))
+ {}
+
+ explicit connection_source(const char *value_)
+  : connection_source(value_ ? std::string_view(value_) : std::string_view())
+ {}
+
+ connection_source(std::nullptr_t) = delete;
+
+ private:
+ friend class database;
+};
+
 namespace detail {
 
 // Note that these are specific to FDB's needs (see return type, casts):
@@ -803,6 +849,8 @@ inline void shutdown_fdb()
 class database final
 {
  private:
+ using open_fn_t = fdb_error_t (*)(const char *, FDBDatabase **);
+
  struct database_deleter final
  {
   void operator()(FDBDatabase *db) const noexcept
@@ -813,7 +861,16 @@ class database final
 
  std::unique_ptr<FDBDatabase, database_deleter> db_handle;
 
- static FDBDatabase *create_database_ptr(const std::filesystem::path& cluster_file_path,
+ void apply_database_options(const ceph::libfdb::database_options& db_opts)
+ {
+  detail::apply_options(db_opts,
+             [handle = raw_handle()](auto option_code, auto data, auto size) {
+               return fdb_database_set_option(handle, option_code, data, size);
+             });
+ }
+
+ static FDBDatabase *create_database_ptr(const char *source,
+                                         const open_fn_t open,
                                          const network_options& network_opts) {
     std::call_once(detail::database_system::fdb_was_initialized,
                    detail::database_system::initialize_fdb,
@@ -825,12 +882,28 @@ class database final
 
     FDBDatabase *fdbp = nullptr;
 
-    if (fdb_error_t r = fdb_create_database(cluster_file_path.c_str(), &fdbp); 0 != r) {
+    if (fdb_error_t r = open(source, &fdbp); 0 != r) {
       throw libfdb_exception(r);
     }
     
     return fdbp;
  }
+
+ database(const char *source,
+          const open_fn_t open,
+          const ceph::libfdb::database_options& db_opts,
+          const network_options& network_opts)
+  : db_handle(create_database_ptr(source, open, network_opts))
+ {
+  apply_database_options(db_opts);
+ }
+
+ database(std::string source,
+          const open_fn_t open,
+          const ceph::libfdb::database_options& db_opts,
+          const network_options& network_opts)
+  : database(source.c_str(), open, db_opts, network_opts)
+ {}
 
  FDBTransaction *create_transaction() {
     FDBTransaction *txn_p = nullptr;
@@ -843,33 +916,31 @@ class database final
  }
 
  public:
- database(const std::filesystem::path cluster_file_path, const ceph::libfdb::database_options& db_opts, const network_options& network_opts)
-  : db_handle(create_database_ptr(cluster_file_path, network_opts))
- {
-  detail::apply_options(db_opts,
-             [handle = raw_handle()](auto option_code, auto data, auto size) {
-               return fdb_database_set_option(handle, option_code, data, size);
-             });
- }
+ database(connection_source source,
+          const ceph::libfdb::database_options& db_opts,
+          const network_options& network_opts)
+  : database(std::move(source.value),
+             connection_source::source_kind::cluster_file == source.kind
+              ? fdb_create_database
+              : fdb_create_database_from_connection_string,
+             db_opts,
+             network_opts)
+ {}
 
- database(const std::filesystem::path cluster_file_path, const ceph::libfdb::database_options& db_opts)
-  : database(cluster_file_path, db_opts, {})
+ database(connection_source source, const ceph::libfdb::database_options& db_opts)
+  : database(std::move(source), db_opts, {})
  {}
 
  database(const ceph::libfdb::database_options& db_opts, const ceph::libfdb::network_options& net_opts)
-  : database("", db_opts, net_opts)
+  : database(nullptr, fdb_create_database, db_opts, net_opts)
  {}
 
  database(const ceph::libfdb::database_options& db_opts)
-  : database("", db_opts, {})
- {}
-
- database(const std::filesystem::path cluster_file_path)
-  : database(cluster_file_path, {}, {})
+  : database(db_opts, {})
  {}
 
  database()
-  : database(std::filesystem::path {}, {}, {})
+  : database(database_options {}, network_options {})
  {}
 
  public:

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -138,6 +138,7 @@ inline future_value get_range_future_from_transaction(ceph::libfdb::transaction&
                                                       int iteration,
                                                       ceph::libfdb::read_mode mode = ceph::libfdb::read_mode::serializable);
 [[nodiscard]] inline std::int64_t extract_int64(future_value result_owner);
+inline bool retry_after_error(transaction_handle& txn, fdb_error_t r);
 
 // A generator that produces successive spans for a range:
 inline std::generator<std::span<const FDBKeyValue>> generate_FDB_pairs(ceph::libfdb::transaction& txn,
@@ -815,13 +816,31 @@ class database final
 
 class transaction final
 {
+ enum struct state_t { active, committed };
+
  database_handle dbh;
 
  std::unique_ptr<FDBTransaction, decltype(&fdb_transaction_destroy)> txn_handle;
 
  std::vector<versionstamp> version_stamps;
 
+ state_t state = state_t::active;
+
  private:
+ void require_active(const std::string_view operation) const
+ {
+  if (state_t::active != state || nullptr == raw_handle()) {
+   throw std::invalid_argument(fmt::format("{} requires active transaction", operation));
+  }
+ }
+
+ void require_committed(const std::string_view operation) const
+ {
+  if (state_t::committed != state || nullptr == raw_handle()) {
+   throw std::invalid_argument(fmt::format("{} requires committed transaction", operation));
+  }
+ }
+
  bool get_single_value_from_transaction(const std::span<const std::uint8_t>& key,
                                         std::invocable<std::span<const std::uint8_t>> auto&& write_output_fn,
                                         read_mode mode);
@@ -842,7 +861,10 @@ class transaction final
  }
 
  public:
- explicit operator bool() const noexcept { return dbh and nullptr != raw_handle(); }
+ explicit operator bool() const noexcept
+ {
+  return dbh and nullptr != raw_handle();
+ }
 
  public:
  FDBTransaction *raw_handle() const noexcept { return txn_handle.get(); }
@@ -974,6 +996,8 @@ class transaction final
 
  [[nodiscard]] std::int64_t committed_version() const
  {
+  require_committed("committed_version()");
+
   std::int64_t version = 0;
 
   if (fdb_error_t r = fdb_transaction_get_committed_version(raw_handle(), &version); 0 != r) {
@@ -1001,6 +1025,28 @@ class transaction final
             detail::future_value(fdb_transaction_get_approximate_size(raw_handle()))));
  }
 
+ [[nodiscard]] bool prepare_replay(const fdb_error_t r)
+ {
+  require_active("prepare_replay()");
+
+  if (0 == r) {
+   return false;
+  }
+
+  if (not fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, r)) {
+   // Non-retryable errors cannot be repaired by on_error():
+   throw libfdb_exception(r);
+  }
+
+  auto on_error_result = detail::wait_for_on_error(raw_handle(), r);
+
+  if (fdb_error_t on_error_r = detail::get_future_error(on_error_result); 0 != on_error_r) {
+   throw libfdb_exception(on_error_r);
+  }
+
+  return true;
+ }
+
  void set_read_version(const std::int64_t version)
  {
   fdb_transaction_set_read_version(raw_handle(), version);
@@ -1008,7 +1054,10 @@ class transaction final
 
  bool commit();
  bool commit(fdb_error_t *replay_error);
- void destroy() noexcept { txn_handle.reset(); }
+ void destroy() noexcept
+ {
+  txn_handle.reset();
+ }
 
  // As you can see, friends are used extensively to implement the public interface; it would be nice to come up
  // with a strategy for making these "lists" a bit more managable, but for now it's what we have and it allows me ot
@@ -1060,6 +1109,7 @@ class transaction final
  friend inline std::int64_t committed_version(const transaction_handle& txn);
  friend inline std::int64_t read_version(const transaction_handle& txn);
  friend inline std::int64_t approximate_commit_bytes(const transaction_handle& txn);
+ friend inline bool ceph::libfdb::detail::retry_after_error(transaction_handle& txn, fdb_error_t r);
  friend inline void set_read_version(const transaction_handle& txn, std::int64_t version);
  friend inline watch_handle make_watch(transaction_handle txn, std::string_view key);
  friend inline fdb_error_t ceph::libfdb::detail::do_commit(transaction_handle& txn);
@@ -1172,9 +1222,7 @@ inline bool ceph::libfdb::transaction::get_single_value_from_transaction(const s
   *replay_error = 0;
  }
 
- // We don't want to try to vivify for an "empty" commit:
- if (!*this)
-  return false;
+ require_active("commit()");
 
  std::optional<detail::future_value> versionstamp_future;
 
@@ -1210,6 +1258,8 @@ inline bool ceph::libfdb::transaction::get_single_value_from_transaction(const s
   version_stamps.clear();
   return false;
  }
+
+ state = state_t::committed;
 
  if (versionstamp_future) {
   auto ready = detail::block_until_ready(std::move(*versionstamp_future));
@@ -1462,20 +1512,7 @@ inline std::size_t get_value_range_from_transaction(transaction& txn,
 
 inline bool retry_after_error(ceph::libfdb::transaction_handle& txn, const fdb_error_t r)
 {
- if (0 == r) {
-  return false;
- }
-
- if (not fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, r)) {
-  // Non-retryable errors cannot be repaired by on_error():
-  throw ceph::libfdb::libfdb_exception(r);
- }
-
- if (fdb_error_t on_error_r = get_future_error(wait_for_on_error(txn->raw_handle(), r)); 0 != on_error_r) {
-  throw ceph::libfdb::libfdb_exception(r);
- }
-
- return true;
+ return txn->prepare_replay(r);
 }
 
 // Convert FDBKey array into something useful:

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -118,6 +118,9 @@ inline void transaction_clear_key_bytes(const transaction_handle& txn,
                                         std::span<const std::uint8_t> k);
 inline void transaction_clear_range(const transaction_handle& txn,
                                     const ceph::libfdb::select& key_range);
+inline void transaction_mark_conflict_range(const transaction_handle& txn,
+                                            const ceph::libfdb::select& key_range,
+                                            FDBConflictRangeType type);
 
 inline future_value block_until_ready(future_value&& fv);
 inline fdb_error_t get_future_error(const future_value& fv);
@@ -895,6 +898,32 @@ class transaction final
         (const uint8_t *)half_open_range.end_key.data(), half_open_range.end_key.size());
  }
 
+ void mark_conflict(const ceph::libfdb::select& key_range,
+                    const FDBConflictRangeType type)
+ {
+  const auto half_open_range = detail::as_half_open_select(key_range);
+
+  if (not (half_open_range.begin_key < half_open_range.end_key)) {
+   throw std::invalid_argument("conflict range must be non-empty");
+  }
+
+  if (FDB_CONFLICT_RANGE_TYPE_READ == type) {
+   (void)read_version();
+  }
+
+  const auto begin = detail::as_fdb_span(half_open_range.begin_key);
+  const auto end = detail::as_fdb_span(half_open_range.end_key);
+
+  const auto r = fdb_transaction_add_conflict_range(raw_handle(),
+                 begin.data(), std::size(begin),
+                 end.data(), std::size(end),
+                 type);
+
+  if (0 != r) {
+   throw libfdb_exception(r);
+  }
+ }
+
  [[nodiscard]] watch_handle make_watch(std::span<const std::uint8_t> key)
  {
   return watch_handle {
@@ -998,7 +1027,10 @@ class transaction final
  friend inline void ceph::libfdb::detail::transaction_clear_key_bytes(const transaction_handle&,
                                                                       std::span<const std::uint8_t>);
  friend inline void ceph::libfdb::detail::transaction_clear_range(const transaction_handle&,
-                                                                 const ceph::libfdb::select&);
+                                                                  const ceph::libfdb::select&);
+ friend inline void ceph::libfdb::detail::transaction_mark_conflict_range(const transaction_handle&,
+                                                                          const ceph::libfdb::select&,
+                                                                          FDBConflictRangeType);
 
 };
 
@@ -1022,6 +1054,13 @@ inline void transaction_clear_range(const transaction_handle& txn,
                                     const ceph::libfdb::select& key_range)
 {
  txn->erase(key_range);
+}
+
+inline void transaction_mark_conflict_range(const transaction_handle& txn,
+                                            const ceph::libfdb::select& key_range,
+                                            const FDBConflictRangeType type)
+{
+ txn->mark_conflict(key_range, type);
 }
 
 } // namespace detail

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -125,6 +125,10 @@ inline void transaction_clear_range(const transaction_handle& txn,
 inline void transaction_mark_conflict_range(const transaction_handle& txn,
                                             const ceph::libfdb::select& key_range,
                                             FDBConflictRangeType type);
+inline future_value transaction_get_range_split_points(const transaction_handle& txn,
+                                                       std::span<const std::uint8_t> begin,
+                                                       std::span<const std::uint8_t> end,
+                                                       std::int64_t target_bytes);
 
 inline future_value block_until_ready(future_value&& fv);
 inline fdb_error_t get_future_error(const future_value& fv);
@@ -951,6 +955,18 @@ class transaction final
   };
  }
 
+ detail::future_value get_range_split_points(std::span<const std::uint8_t> begin,
+                                             std::span<const std::uint8_t> end,
+                                             const std::int64_t target_bytes)
+ {
+  return detail::future_value {
+   fdb_transaction_get_range_split_points(raw_handle(),
+                                          begin.data(), static_cast<int>(std::size(begin)),
+                                          end.data(), static_cast<int>(std::size(end)),
+                                          target_bytes)
+  };
+ }
+
  bool key_exists(std::string_view k, const read_mode mode)
  {
     return get_single_value_from_transaction(detail::as_fdb_span(k), [](auto) {}, mode);
@@ -1053,6 +1069,9 @@ class transaction final
  friend inline void ceph::libfdb::detail::transaction_mark_conflict_range(const transaction_handle&,
                                                                           const ceph::libfdb::select&,
                                                                           FDBConflictRangeType);
+ friend inline auto ceph::libfdb::detail::transaction_get_range_split_points(
+  const transaction_handle&, std::span<const std::uint8_t>, std::span<const std::uint8_t>, std::int64_t)
+  -> ceph::libfdb::detail::future_value;
 
 };
 
@@ -1091,6 +1110,14 @@ inline void transaction_mark_conflict_range(const transaction_handle& txn,
                                             const FDBConflictRangeType type)
 {
  txn->mark_conflict(key_range, type);
+}
+
+inline future_value transaction_get_range_split_points(const transaction_handle& txn,
+                                                       std::span<const std::uint8_t> begin,
+                                                       std::span<const std::uint8_t> end,
+                                                       const std::int64_t target_bytes)
+{
+ return txn->get_range_split_points(begin, end, target_bytes);
 }
 
 } // namespace detail
@@ -1278,6 +1305,11 @@ struct split_point_result final
  future_value result_owner;
  std::span<const FDBKey> result_keys;
  fdb_error_t error = 0;
+};
+
+struct range_work_plan final
+{
+ std::vector<ceph::libfdb::select> ranges;
 };
 
 inline query_window extract_result_pairs(future_value result_owner)
@@ -1515,10 +1547,10 @@ inline future_value get_range_future_from_transaction(ceph::libfdb::transaction&
                     ));
 }
 
-inline std::vector<ceph::libfdb::select> plan_split_ranges(
-          ceph::libfdb::database_handle dbh, 
-          ceph::libfdb::select selector, 
-          const std::int64_t remote_chunk_size)
+// Plan internal range work in terms of libfdb selections, not raw FDB split points:
+inline range_work_plan plan_range_work(ceph::libfdb::database_handle dbh,
+                                       ceph::libfdb::select selector,
+                                       const std::int64_t target_bytes)
 {
  using ceph::libfdb::detail::wait_until_ready;
 
@@ -1528,22 +1560,28 @@ inline std::vector<ceph::libfdb::select> plan_split_ranges(
  const auto end = ceph::libfdb::detail::as_fdb_span(split_selector.end_key);
 
  for (bool should_retry = true; should_retry;) {
-  auto result_owner = wait_until_ready(future_value(fdb_transaction_get_range_split_points(
-                       txn->raw_handle(),
-                       begin.data(), static_cast<int>(std::size(begin)),
-                       end.data(), static_cast<int>(std::size(end)),
-                       remote_chunk_size)));
+  auto result_owner = wait_until_ready(
+   transaction_get_range_split_points(txn, begin, end, target_bytes));
 
   auto split_points = extract_split_points(std::move(result_owner));
 
   should_retry = retry_after_error(txn, split_points.error);
 
   if (not should_retry) {
-   return as_select_seq(split_points.result_keys, split_selector);
+   auto ranges = as_select_seq(split_points.result_keys, split_selector);
+   if (ranges.empty()) {
+    ranges.push_back(std::move(selector));
+   }
+
+   return range_work_plan {
+    .ranges = std::move(ranges)
+   };
   }
  }
 
- return {};
+ return range_work_plan {
+  .ranges = {std::move(selector)}
+ };
 }
 
 // Generators (internal guts):

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -120,6 +120,7 @@ inline future_value block_until_ready(future_value&& fv);
 inline fdb_error_t get_future_error(const future_value& fv);
 inline future_value wait_for_on_error(FDBTransaction* txn, fdb_error_t original_error);
 inline future_value get_range_future_from_transaction(ceph::libfdb::transaction& txn, const ceph::libfdb::select& selection, int iteration);
+[[nodiscard]] inline std::int64_t extract_int64(future_value result_owner);
 
 // A generator that produces successive spans for a range:
 inline std::generator<std::span<const FDBKeyValue>> generate_FDB_pairs(ceph::libfdb::transaction& txn, ceph::libfdb::select key_range);
@@ -892,6 +893,29 @@ class transaction final
     return get_single_value_from_transaction(detail::as_fdb_span(k), [](auto) {});
  }
 
+ [[nodiscard]] std::int64_t committed_version() const
+ {
+  std::int64_t version = 0;
+
+  if (fdb_error_t r = fdb_transaction_get_committed_version(raw_handle(), &version); 0 != r) {
+   throw libfdb_exception(r);
+  }
+
+  return version;
+ }
+
+ [[nodiscard]] std::int64_t read_version() const
+ {
+  return detail::extract_int64(
+           detail::block_until_ready(
+            detail::future_value(fdb_transaction_get_read_version(raw_handle()))));
+ }
+
+ void set_read_version(const std::int64_t version)
+ {
+  fdb_transaction_set_read_version(raw_handle(), version);
+ }
+
  bool commit();
  bool commit(fdb_error_t *replay_error);
  void destroy() noexcept { txn_handle.reset(); }
@@ -933,6 +957,9 @@ class transaction final
  friend inline bool commit(transaction_handle& txn);
  friend inline commit_result commit(with_result_t, transaction_handle& txn);
  friend inline bool commit(transaction_handle& txn, const versionstamp& stamp);
+ friend inline std::int64_t committed_version(const transaction_handle& txn);
+ friend inline std::int64_t read_version(const transaction_handle& txn);
+ friend inline void set_read_version(const transaction_handle& txn, std::int64_t version);
  friend inline watch_handle make_watch(transaction_handle txn, std::string_view key);
  friend inline fdb_error_t ceph::libfdb::detail::do_commit(transaction_handle& txn);
  friend inline void ceph::libfdb::detail::transaction_set_kv_bytes(const transaction_handle&,
@@ -1185,6 +1212,17 @@ inline split_point_result extract_split_points(future_value result_owner)
                             : std::span<const FDBKey>(),
   .error = error
  };
+}
+
+[[nodiscard]] inline std::int64_t extract_int64(future_value result_owner)
+{
+ std::int64_t value = 0;
+
+ if (fdb_error_t r = fdb_future_get_int64(result_owner.raw_ptr_or_throw(), &value); 0 != r) {
+  throw libfdb_exception(r);
+ }
+
+ return value;
 }
 
 inline query_window read_query_window(transaction& txn, const select& key_range, const int iteration)

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -130,6 +130,8 @@ inline future_value transaction_get_range_split_points(const transaction_handle&
                                                        std::span<const std::uint8_t> begin,
                                                        std::span<const std::uint8_t> end,
                                                        std::int64_t target_bytes);
+inline future_value transaction_get_estimated_range_size(const transaction_handle& txn,
+                                                         const ceph::libfdb::select& selection);
 inline future_value transaction_get_key(const transaction_handle& txn,
                                         const key_selector& selector,
                                         read_mode mode);
@@ -1056,6 +1058,19 @@ class transaction final
   };
  }
 
+ detail::future_value get_estimated_range_size(const select& selection)
+ {
+  const auto half_open_range = detail::as_half_open_select(selection);
+  const auto begin = detail::as_fdb_span(half_open_range.begin_key);
+  const auto end = detail::as_fdb_span(half_open_range.end_key);
+
+  return detail::future_value {
+   fdb_transaction_get_estimated_range_size_bytes(raw_handle(),
+                                                  begin.data(), static_cast<int>(std::size(begin)),
+                                                  end.data(), static_cast<int>(std::size(end)))
+  };
+ }
+
  detail::future_value get_key(const key_selector& selector,
                               const read_mode mode)
  {
@@ -1211,6 +1226,9 @@ class transaction final
  friend inline auto ceph::libfdb::detail::transaction_get_range_split_points(
   const transaction_handle&, std::span<const std::uint8_t>, std::span<const std::uint8_t>, std::int64_t)
   -> ceph::libfdb::detail::future_value;
+ friend inline auto ceph::libfdb::detail::transaction_get_estimated_range_size(
+  const transaction_handle&, const ceph::libfdb::select&)
+  -> ceph::libfdb::detail::future_value;
  friend inline auto ceph::libfdb::detail::transaction_get_key(
   const transaction_handle&, const key_selector&, read_mode)
   -> ceph::libfdb::detail::future_value;
@@ -1260,6 +1278,12 @@ inline future_value transaction_get_range_split_points(const transaction_handle&
                                                        const std::int64_t target_bytes)
 {
  return txn->get_range_split_points(begin, end, target_bytes);
+}
+
+inline future_value transaction_get_estimated_range_size(const transaction_handle& txn,
+                                                         const ceph::libfdb::select& selection)
+{
+ return txn->get_estimated_range_size(selection);
 }
 
 inline future_value transaction_get_key(const transaction_handle& txn,

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -86,6 +86,9 @@ class transaction;
 using database_handle = std::shared_ptr<database>;
 using transaction_handle = std::shared_ptr<transaction>;
 
+// Serializable reads add FDB read conflicts; snapshot reads do not:
+enum struct read_mode { serializable, snapshot };
+
 extern transaction_handle make_transaction(database_handle dbh);
 [[nodiscard]] inline watch_handle make_watch(transaction_handle txn, std::string_view key);
 
@@ -119,17 +122,25 @@ inline void transaction_clear_range(const transaction_handle& txn,
 inline future_value block_until_ready(future_value&& fv);
 inline fdb_error_t get_future_error(const future_value& fv);
 inline future_value wait_for_on_error(FDBTransaction* txn, fdb_error_t original_error);
-inline future_value get_range_future_from_transaction(ceph::libfdb::transaction& txn, const ceph::libfdb::select& selection, int iteration);
+inline future_value get_range_future_from_transaction(ceph::libfdb::transaction& txn,
+                                                      const ceph::libfdb::select& selection,
+                                                      int iteration,
+                                                      ceph::libfdb::read_mode mode = ceph::libfdb::read_mode::serializable);
 [[nodiscard]] inline std::int64_t extract_int64(future_value result_owner);
 
 // A generator that produces successive spans for a range:
-inline std::generator<std::span<const FDBKeyValue>> generate_FDB_pairs(ceph::libfdb::transaction& txn, ceph::libfdb::select key_range);
+inline std::generator<std::span<const FDBKeyValue>> generate_FDB_pairs(ceph::libfdb::transaction& txn,
+                                                                       ceph::libfdb::select key_range,
+                                                                       ceph::libfdb::read_mode mode = ceph::libfdb::read_mode::serializable);
 
 // Stores generated key/value pair results to an iterator and returns the
 // number of pairs emitted:
 template <typename OutIterT>
 requires std::output_iterator<OutIterT, std::pair<std::string, std::string>>
-inline std::size_t get_value_range_from_transaction(ceph::libfdb::transaction& txn, const ceph::libfdb::select& key_range, OutIterT& out_iter);
+inline std::size_t get_value_range_from_transaction(ceph::libfdb::transaction& txn,
+                                                    const ceph::libfdb::select& key_range,
+                                                    ceph::libfdb::read_mode mode,
+                                                    OutIterT& out_iter);
 
 } // namespace ceph::libfdb::detail
 
@@ -799,7 +810,8 @@ class transaction final
 
  private:
  bool get_single_value_from_transaction(const std::span<const std::uint8_t>& key,
-                                        std::invocable<std::span<const std::uint8_t>> auto&& write_output_fn);
+                                        std::invocable<std::span<const std::uint8_t>> auto&& write_output_fn,
+                                        read_mode mode);
 
  public:
  transaction(database_handle dbh_)
@@ -863,8 +875,11 @@ class transaction final
     k, std::span<const std::uint8_t>(v.encoding_buffer), v.stamp);
  }
 
- bool get(const std::span<const std::uint8_t> k, concepts::value_callback auto&& val_collector) {
-    return get_single_value_from_transaction(k, val_collector);
+ bool get(const std::span<const std::uint8_t> k,
+          concepts::value_callback auto&& val_collector,
+          const read_mode mode)
+ {
+    return get_single_value_from_transaction(k, val_collector, mode);
  }
 
  void erase(std::span<const std::uint8_t> k) {
@@ -889,8 +904,9 @@ class transaction final
   };
  }
 
- bool key_exists(std::string_view k) {
-    return get_single_value_from_transaction(detail::as_fdb_span(k), [](auto) {});
+ bool key_exists(std::string_view k, const read_mode mode)
+ {
+    return get_single_value_from_transaction(detail::as_fdb_span(k), [](auto) {}, mode);
  }
 
  [[nodiscard]] std::int64_t committed_version() const
@@ -948,10 +964,20 @@ class transaction final
  friend inline bool get(ceph::libfdb::transaction_handle,
                         const concepts::libfdb_key auto&,
                         OutputTargetOrFnT&&,
+                        read_mode,
+                        const commit_after_op);
+
+ template <typename OutputTargetOrFnT>
+ requires concepts::value_callback<std::remove_reference_t<OutputTargetOrFnT>> or
+          concepts::decoded_value_sink<OutputTargetOrFnT&&>
+ friend inline bool get(ceph::libfdb::transaction_handle,
+                        const concepts::libfdb_key auto&,
+                        OutputTargetOrFnT&&,
                         const commit_after_op);
 
  friend inline bool key_exists(transaction_handle txn,
                                const concepts::libfdb_key auto& k,
+                               read_mode mode,
                                const commit_after_op commit_after);
 
  friend inline bool commit(transaction_handle& txn);
@@ -996,14 +1022,16 @@ inline void transaction_clear_range(const transaction_handle& txn,
 
 } // namespace detail
 
-inline bool ceph::libfdb::transaction::get_single_value_from_transaction(const std::span<const std::uint8_t>& key, std::invocable<std::span<const std::uint8_t>> auto&& write_output)
+inline bool ceph::libfdb::transaction::get_single_value_from_transaction(const std::span<const std::uint8_t>& key,
+                                                                         std::invocable<std::span<const std::uint8_t>> auto&& write_output,
+                                                                         const read_mode mode)
 {
- const fdb_bool_t is_snapshot = false; 
+ const fdb_bool_t snapshot = read_mode::snapshot == mode;
 
  auto fv = detail::block_until_ready(detail::future_value(fdb_transaction_get(
                                     raw_handle(),
                                     (const uint8_t *)key.data(), key.size(),
-                                    is_snapshot)));
+                                    snapshot)));
  auto *future = fv.raw_ptr_or_throw();
  
   fdb_bool_t key_was_found = false;
@@ -1225,10 +1253,13 @@ inline split_point_result extract_split_points(future_value result_owner)
  return value;
 }
 
-inline query_window read_query_window(transaction& txn, const select& key_range, const int iteration)
+inline query_window read_query_window(transaction& txn,
+                                      const select& key_range,
+                                      const int iteration,
+                                      const read_mode mode = read_mode::serializable)
 {
  return extract_result_pairs(await_future_of([&]() {
-  return get_range_future_from_transaction(txn, key_range, iteration);
+  return get_range_future_from_transaction(txn, key_range, iteration, mode);
  }));
 }
 
@@ -1253,18 +1284,6 @@ inline std::optional<select> next_range_after(select key_range, const query_wind
  return key_range;
 }
 
-template <typename ValueT = std::string>
-inline auto decode_pairs(std::span<const FDBKeyValue> pairs)
-{
- return pairs | std::views::transform(to_decoded_kv_pair<ValueT>);
-}
-
-template <typename ValueT, typename AssocT>
-inline AssocT collect_pairs(std::span<const FDBKeyValue> pairs)
-{
- return ceph::util::collect_as<AssocT>(decode_pairs<ValueT>(pairs));
-}
-
 template <typename AssocT>
 struct query_window_result final
 {
@@ -1273,23 +1292,29 @@ struct query_window_result final
 };
 
 template <typename ValueT, typename AssocT>
-inline query_window_result<AssocT> materialize_query_window(transaction& txn, select key_range, const int iteration = 1)
+inline query_window_result<AssocT> materialize_query_window(transaction& txn,
+                                                           select key_range,
+                                                           const int iteration,
+                                                           const read_mode mode)
 {
- auto window = read_query_window(txn, key_range, iteration);
+ auto window = read_query_window(txn, key_range, iteration, mode);
+ auto decoded_pairs =
+  window.result_pairs | std::views::transform(to_decoded_kv_pair<ValueT>);
 
  return {
-  .result_block = collect_pairs<ValueT, AssocT>(window.result_pairs),
+  .result_block = ceph::util::collect_as<AssocT>(decoded_pairs),
   .next_range = next_range_after(std::move(key_range), window)
  };
 }
 
 inline std::size_t for_each_decoded_kv_pair(transaction& txn,
                                             const select& key_range,
+                                            const read_mode mode,
                                             auto&& fn)
 {
  std::size_t nread = 0;
 
- for (const auto& kv : detail::generate_FDB_pairs(txn, key_range) | std::views::join) {
+ for (const auto& kv : detail::generate_FDB_pairs(txn, key_range, mode) | std::views::join) {
   std::invoke(fn, to_decoded_kv_pair<std::string>(kv));
   ++nread;
  }
@@ -1299,9 +1324,12 @@ inline std::size_t for_each_decoded_kv_pair(transaction& txn,
 
 template <typename OutIterT>
 requires std::output_iterator<OutIterT, std::pair<std::string, std::string>>
-inline std::size_t get_value_range_from_transaction(transaction& txn, const select& key_range, OutIterT& out_iter)
+inline std::size_t get_value_range_from_transaction(transaction& txn,
+                                                    const select& key_range,
+                                                    const read_mode mode,
+                                                    OutIterT& out_iter)
 {
- return for_each_decoded_kv_pair(txn, key_range,
+ return for_each_decoded_kv_pair(txn, key_range, mode,
           [&out_iter](auto&& kv) {
             *out_iter++ = std::forward<decltype(kv)>(kv);
           });
@@ -1309,9 +1337,10 @@ inline std::size_t get_value_range_from_transaction(transaction& txn, const sele
 
 inline std::size_t get_value_range_from_transaction(transaction& txn,
                                                     const select& key_range,
+                                                    const read_mode mode,
                                                     concepts::string_pair_output_range auto& out)
 {
- return for_each_decoded_kv_pair(txn, key_range,
+ return for_each_decoded_kv_pair(txn, key_range, mode,
           [&out](auto&& kv) {
             ceph::util::push_back(out, std::forward<decltype(kv)>(kv));
           });
@@ -1365,7 +1394,10 @@ inline std::vector<ceph::libfdb::select> as_select_seq(std::span<const FDBKey> x
 // Finding a clear example both in the samples and in the documentation is not very easy. The
 // statelessness of FDB requests bleeds into here with basically no hand-holding, but note for instance
 // that the call parameters have to change for subsequent reads.
-inline future_value get_range_future_from_transaction(ceph::libfdb::transaction& txn, const ceph::libfdb::select& selection, int iteration)
+inline future_value get_range_future_from_transaction(ceph::libfdb::transaction& txn,
+                                                      const ceph::libfdb::select& selection,
+                                                      int iteration,
+                                                      const read_mode mode)
 {
   const auto& begin_key  = selection.begin_key;
   const auto& end_key    = selection.end_key;
@@ -1381,6 +1413,7 @@ inline future_value get_range_future_from_transaction(ceph::libfdb::transaction&
   const int begin_offset = 1;
   const int end_or_eq = (not continuing_reverse and selection.end_inclusive) ? 1 : 0;
   const int end_offset = 1;
+  const fdb_bool_t snapshot = read_mode::snapshot == mode;
 
   // See validate_and_update_parameters() in fdb_c.cpp (FDB source) if greater clarity is needed on
   // the meaning of some of these, it can be hard to deduce from the documentation; Returns an
@@ -1401,7 +1434,7 @@ inline future_value get_range_future_from_transaction(ceph::libfdb::transaction&
                       iteration,                                                // iteration # (produced side effect)
 
                       // Other options:
-                      0,                                                        // 0 unless this IS a snapshot read
+                      snapshot,                                                 // snapshot reads avoid read-conflict ranges
                       options.reverse_order                                     // should items come in reverse order?
                     ));
 }
@@ -1439,7 +1472,9 @@ inline std::vector<ceph::libfdb::select> plan_split_ranges(
 // The returned memory should be copied immediately as its lifetime will end once the Future is destroyed:
 // (This is pretty much why this is in the "detail" namespace-- we use this to implement the user-facing
 // stuff, it shouldn't really be touched outside.)
-inline std::generator<std::span<const FDBKeyValue>> generate_FDB_pairs(transaction& txn, select key_range)
+inline std::generator<std::span<const FDBKeyValue>> generate_FDB_pairs(transaction& txn,
+                                                                       select key_range,
+                                                                       const read_mode mode)
 {
  // FDB uses iteration for FDB_STREAMING_MODE_ITERATOR (but, other streaming modes
  // just ignore it, per fdb_c's documentation. We do have to keep this state somewhere,
@@ -1447,7 +1482,7 @@ inline std::generator<std::span<const FDBKeyValue>> generate_FDB_pairs(transacti
  int iteration = 1;
 
  for (auto more_available = true; more_available; iteration++) {
-  auto window = read_query_window(txn, key_range, iteration);
+  auto window = read_query_window(txn, key_range, iteration, mode);
   auto next_range = next_range_after(key_range, window);
 
   more_available = next_range.has_value();

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -148,7 +148,7 @@ inline future_value get_range_future_from_transaction(ceph::libfdb::transaction&
 [[nodiscard]] inline std::uint64_t extract_uint64(future_value result_owner);
 [[nodiscard]] inline std::string extract_byte_string(future_value result_owner);
 [[nodiscard]] inline ceph::libfdb::database& database_or_throw(const ceph::libfdb::database_handle& dbh);
-inline bool retry_after_error(transaction_handle& txn, fdb_error_t r);
+[[nodiscard]] inline bool reset_for_replay_if_needed(transaction_handle& txn, fdb_error_t error);
 
 // A generator that produces successive spans for a range:
 inline std::generator<std::span<const FDBKeyValue>> generate_FDB_pairs(ceph::libfdb::transaction& txn,
@@ -296,6 +296,7 @@ class key_selector final
     offset(offset_)
  {}
 
+ private:
  template <concepts::libfdb_key KeyT>
  friend constexpr key_selector lower(const KeyT& key);
 
@@ -701,7 +702,7 @@ using transaction_options = option_map<FDBTransactionOption>;
 
 // Caller-supplied database sources are tagged so paths and connection strings
 // cannot be confused:
-class connection_source final
+struct connection_source final
 {
  private:
  enum class source_kind {
@@ -752,25 +753,19 @@ inline const std::uint8_t *data_of(const std::vector<std::uint8_t>& xs) { return
 inline const std::uint8_t *data_of(const std::string& xs) { return reinterpret_cast<const std::uint8_t *>(xs.data()); }
 inline const std::uint8_t *data_of(const std::int64_t& x) { return reinterpret_cast<const std::uint8_t *>(&x); }
 inline const std::uint8_t *data_of(const option_flag_t&) { return nullptr; }
+inline const std::uint8_t *data_of(std::string_view xs) { return reinterpret_cast<const std::uint8_t *>(xs.data()); }
 
-// Note that these are specific to FDB's needs (see return type, casts):
 constexpr int size_of(const std::vector<std::uint8_t>& xs) { return static_cast<int>(xs.size()); }
 constexpr int size_of(const std::string& xs) { return static_cast<int>(xs.size()); }
 constexpr int size_of(const std::int64_t) { return sizeof(std::int64_t); }
 constexpr int size_of(const option_flag_t&) { return 0; }
-
-// ...also used:
-inline const std::uint8_t *data_of(std::string_view xs) { return reinterpret_cast<const std::uint8_t *>(xs.data()); }
 constexpr int size_of(std::string_view xs) { return static_cast<int>(xs.size()); }
 
 inline auto as_fdb_option_args(const auto& option)
 {
- auto [data, size] = std::visit([](const auto& x) {
-                         return std::tuple { data_of(x), size_of(x) };
-                       },
-                       option.second);
-
- return std::tuple { option.first, data, size };
+ return std::visit([&option](const auto& value) {
+  return std::tuple { option.first, data_of(value), size_of(value) };
+ }, option.second);
 }
 
 inline void apply_options(const auto& option_map, auto&& set_option)
@@ -785,7 +780,6 @@ inline void apply_options(const auto& option_map, auto&& set_option)
 }
 
 // The global DB state and management thread:
-// JFW: more user hooks that go into FDB system possible here
 namespace database_system
 {
 inline bool was_initialized = false;
@@ -853,7 +847,7 @@ inline void shutdown_fdb()
 class database final
 {
  private:
- using open_fn_t = fdb_error_t (*)(const char *, FDBDatabase **);
+ using create_db_fn_t = decltype(&fdb_create_database);
 
  struct database_deleter final
  {
@@ -874,7 +868,7 @@ class database final
  }
 
  static FDBDatabase *create_database_ptr(const char *source,
-                                         const open_fn_t open,
+                                         const create_db_fn_t create_db_fn,
                                          const network_options& network_opts) {
     std::call_once(detail::database_system::fdb_was_initialized,
                    detail::database_system::initialize_fdb,
@@ -886,7 +880,7 @@ class database final
 
     FDBDatabase *fdbp = nullptr;
 
-    if (fdb_error_t r = open(source, &fdbp); 0 != r) {
+    if (fdb_error_t r = create_db_fn(source, &fdbp); 0 != r) {
       throw libfdb_exception(r);
     }
     
@@ -894,19 +888,19 @@ class database final
  }
 
  database(const char *source,
-          const open_fn_t open,
+          const create_db_fn_t create_db_fn,
           const ceph::libfdb::database_options& db_opts,
           const network_options& network_opts)
-  : db_handle(create_database_ptr(source, open, network_opts))
+  : db_handle(create_database_ptr(source, create_db_fn, network_opts))
  {
   apply_database_options(db_opts);
  }
 
  database(std::string source,
-          const open_fn_t open,
+          const create_db_fn_t create_db_fn,
           const ceph::libfdb::database_options& db_opts,
           const network_options& network_opts)
-  : database(source.c_str(), open, db_opts, network_opts)
+  : database(source.c_str(), create_db_fn, db_opts, network_opts)
  {}
 
  FDBTransaction *create_transaction() {
@@ -953,7 +947,8 @@ class database final
  public:
  FDBDatabase *raw_handle() const noexcept { return db_handle.get(); }
 
- [[nodiscard]] double main_thread_busyness() const
+ // FDB client-network load: zero is idle; one or greater is saturated.
+ [[nodiscard]] double client_network_load() const
  {
   return fdb_database_get_main_thread_busyness(raw_handle());
  }
@@ -1041,6 +1036,7 @@ class transaction final
 
  state_t state = state_t::active;
 
+ // State guards to save tedious code repetition and provide consistent handling:
  private:
  void require_active(const std::string_view operation) const
  {
@@ -1053,6 +1049,23 @@ class transaction final
  {
   if (state_t::committed != state || nullptr == raw_handle()) {
    throw std::invalid_argument(fmt::format("{} requires committed transaction", operation));
+  }
+ }
+
+ // Transaction recovery:
+ void reset_for_replay(const fdb_error_t error)
+ {
+  require_active("reset_for_replay()");
+
+  if (not fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, error)) {
+   // Non-retryable errors cannot be repaired by on_error():
+   throw libfdb_exception(error);
+  }
+
+  auto on_error_result = detail::wait_for_on_error(raw_handle(), error);
+
+  if (fdb_error_t on_error_r = detail::get_future_error(on_error_result); 0 != on_error_r) {
+   throw libfdb_exception(on_error_r);
   }
  }
 
@@ -1167,7 +1180,8 @@ class transaction final
   }
 
   if (FDB_CONFLICT_RANGE_TYPE_READ == type) {
-   (void)read_version();
+   // just anchor the transaction to a read version:
+   std::ignore = read_version();
   }
 
   const auto begin = detail::as_fdb_span(half_open_range.begin_key);
@@ -1267,31 +1281,9 @@ class transaction final
             detail::future_value(fdb_transaction_get_approximate_size(raw_handle()))));
  }
 
- [[nodiscard]] bool prepare_replay(const fdb_error_t r)
- {
-  require_active("prepare_replay()");
-
-  if (0 == r) {
-   return false;
-  }
-
-  if (not fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, r)) {
-   // Non-retryable errors cannot be repaired by on_error():
-   throw libfdb_exception(r);
-  }
-
-  auto on_error_result = detail::wait_for_on_error(raw_handle(), r);
-
-  if (fdb_error_t on_error_r = detail::get_future_error(on_error_result); 0 != on_error_r) {
-   throw libfdb_exception(on_error_r);
-  }
-
-  return true;
- }
-
  void set_read_version(const std::int64_t version)
  {
-  fdb_transaction_set_read_version(raw_handle(), version);
+  return fdb_transaction_set_read_version(raw_handle(), version);
  }
 
  bool commit();
@@ -1351,7 +1343,7 @@ class transaction final
  friend inline std::int64_t committed_version(const transaction_handle& txn);
  friend inline std::int64_t read_version(const transaction_handle& txn);
  friend inline std::int64_t approximate_commit_bytes(const transaction_handle& txn);
- friend inline bool ceph::libfdb::detail::retry_after_error(transaction_handle& txn, fdb_error_t r);
+ friend inline bool ceph::libfdb::detail::reset_for_replay_if_needed(transaction_handle&, fdb_error_t);
  friend inline void set_read_version(const transaction_handle& txn, std::int64_t version);
  friend inline watch_handle make_watch(transaction_handle txn, std::string_view key);
  friend inline fdb_error_t ceph::libfdb::detail::do_commit(transaction_handle& txn);
@@ -1803,9 +1795,16 @@ inline std::size_t get_value_range_from_transaction(transaction& txn,
           });
 }
 
-inline bool retry_after_error(ceph::libfdb::transaction_handle& txn, const fdb_error_t r)
+// Return true only after FDB has reset the transaction for replay:
+[[nodiscard]] inline bool reset_for_replay_if_needed(transaction_handle& txn, const fdb_error_t error)
 {
- return txn->prepare_replay(r);
+ if (0 == error) {
+  return false;
+ }
+
+ txn->reset_for_replay(error);
+
+ return true;
 }
 
 // Convert FDBKey array into something useful:
@@ -1904,7 +1903,7 @@ inline range_work_plan plan_range_work(ceph::libfdb::database_handle dbh,
 
   auto split_points = extract_split_points(std::move(result_owner));
 
-  if (retry_after_error(txn, split_points.error)) {
+  if (reset_for_replay_if_needed(txn, split_points.error)) {
    continue;
   }
 

--- a/src/rgw/fdb/conversion.h
+++ b/src/rgw/fdb/conversion.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include <cstdint>
 #include <concepts>
+#include <cstring>
 #include <functional>
 #include <string_view>
 #include <type_traits>
@@ -93,6 +94,26 @@ inline void convert(const std::span<const std::uint8_t>& in, OutputFunction& wri
 
 namespace ceph::libfdb::detail {
 
+inline std::string decode_zpp_string_value(const std::span<const std::uint8_t> from)
+{
+ constexpr auto size_prefix = sizeof(zpp::bits::default_size_type);
+
+ if (from.size() < size_prefix) {
+  throw ceph::libfdb::libfdb_exception("unable to decode string value");
+ }
+
+ zpp::bits::default_size_type size = 0;
+ std::memcpy(&size, from.data(), size_prefix);
+
+ if (from.size() - size_prefix != size) {
+  throw ceph::libfdb::libfdb_exception("unable to decode string value");
+ }
+
+ const auto data = reinterpret_cast<const char*>(from.data() + size_prefix);
+
+ return std::string(data, static_cast<std::string::size_type>(size));
+}
+
 template <typename ValueT>
 inline std::pair<std::string, ValueT> to_decoded_kv_pair(const FDBKeyValue& kv)
 {
@@ -110,6 +131,15 @@ inline std::pair<std::string, ValueT> to_decoded_kv_pair(const FDBKeyValue& kv)
   }
 
  return r;
+}
+
+template <>
+inline std::pair<std::string, std::string> to_decoded_kv_pair<std::string>(const FDBKeyValue& kv)
+{
+ return {
+  std::string((const char *)kv.key, static_cast<std::string::size_type>(kv.key_length)),
+  decode_zpp_string_value(std::span<const std::uint8_t>(kv.value, kv.value_length))
+ };
 }
 
 } // namespace ceph::libfdb::detail

--- a/src/rgw/fdb/conversion.h
+++ b/src/rgw/fdb/conversion.h
@@ -87,7 +87,7 @@ inline void convert(const std::span<const std::uint8_t>& from, auto& to)
 template <std::invocable<const char *, size_t> OutputFunction>
 inline void convert(const std::span<const std::uint8_t>& in, OutputFunction& write_output_fn)
 {
- write_output_fn((const char *)in.data(), in.size());
+ write_output_fn(reinterpret_cast<const char *>(in.data()), in.size());
 }
 
 } // namespace ceph::libfdb::from
@@ -109,7 +109,7 @@ inline std::string decode_zpp_string_value(const std::span<const std::uint8_t> f
   throw ceph::libfdb::libfdb_exception("unable to decode string value");
  }
 
- const auto data = reinterpret_cast<const char*>(from.data() + size_prefix);
+ const auto data = reinterpret_cast<const char *>(size_prefix + from.data());
 
  return std::string(data, static_cast<std::string::size_type>(size));
 }
@@ -119,7 +119,8 @@ inline std::pair<std::string, ValueT> to_decoded_kv_pair(const FDBKeyValue& kv)
 {
  std::pair<std::string, ValueT> r;
 
- r.first.assign((const char *)kv.key, static_cast<std::string::size_type>(kv.key_length));
+ r.first.assign(reinterpret_cast<const char *>(kv.key),
+                static_cast<std::string::size_type>(kv.key_length));
 
  try 
   {
@@ -137,7 +138,8 @@ template <>
 inline std::pair<std::string, std::string> to_decoded_kv_pair<std::string>(const FDBKeyValue& kv)
 {
  return {
-  std::string((const char *)kv.key, static_cast<std::string::size_type>(kv.key_length)),
+  std::string(reinterpret_cast<const char *>(kv.key),
+              static_cast<std::string::size_type>(kv.key_length)),
   decode_zpp_string_value(std::span<const std::uint8_t>(kv.value, kv.value_length))
  };
 }

--- a/src/rgw/fdb/conversion.h
+++ b/src/rgw/fdb/conversion.h
@@ -73,21 +73,34 @@ non-FDB input sources here (or any non-matching user output sources). Do NOT add
 non-owning targets, lest Antevorda be angered!: */
 namespace ceph::libfdb::from {
 
+namespace detail {
+
+template <typename OutputFunction>
+concept output_function =
+ requires(OutputFunction& write_output_fn, const char *data, std::size_t size) {
+  { std::invoke(write_output_fn, data, size) } -> std::same_as<void>;
+};
+
+} // namespace detail
+
 inline void convert(const std::span<const std::uint8_t>& from, versionstamp& to)
 {
  to.store_result(from);
 }
 
-inline void convert(const std::span<const std::uint8_t>& from, auto& to)
+template <typename ToT>
+requires (!std::invocable<ToT&, const char *, std::size_t>)
+inline void convert(const std::span<const std::uint8_t>& from, ToT& to)
 {
  zpp::bits::in zpp_in(from);
  zpp_in(to).or_throw();
 }
 
-template <std::invocable<const char *, size_t> OutputFunction>
+template <typename OutputFunction>
+requires detail::output_function<OutputFunction>
 inline void convert(const std::span<const std::uint8_t>& in, OutputFunction& write_output_fn)
 {
- write_output_fn(reinterpret_cast<const char *>(in.data()), in.size());
+ std::invoke(write_output_fn, reinterpret_cast<const char *>(in.data()), in.size());
 }
 
 } // namespace ceph::libfdb::from
@@ -122,14 +135,13 @@ inline std::pair<std::string, ValueT> to_decoded_kv_pair(const FDBKeyValue& kv)
  r.first.assign(reinterpret_cast<const char *>(kv.key),
                 static_cast<std::string::size_type>(kv.key_length));
 
- try 
-  {
-     ceph::libfdb::from::convert(std::span<const std::uint8_t>(kv.value, kv.value_length), r.second);
+ try {
+  ceph::libfdb::from::convert(std::span<const std::uint8_t>(kv.value, kv.value_length), r.second);
  }
  catch (const std::system_error& e) {
-     // Decode failures still surface as libfdb operation failures to callers.
-     throw ceph::libfdb::libfdb_exception(e.what());
-  }
+  // Decode failures still surface as libfdb operation failures to callers.
+  throw ceph::libfdb::libfdb_exception(e.what());
+ }
 
  return r;
 }

--- a/src/rgw/fdb/conversion.h
+++ b/src/rgw/fdb/conversion.h
@@ -122,7 +122,7 @@ inline std::string decode_zpp_string_value(const std::span<const std::uint8_t> f
   throw ceph::libfdb::libfdb_exception("unable to decode string value");
  }
 
- const auto data = reinterpret_cast<const char *>(size_prefix + from.data());
+ const auto data = reinterpret_cast<const char *>(from.data() + size_prefix);
 
  return std::string(data, static_cast<std::string::size_type>(size));
 }

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -100,7 +100,8 @@ inline transaction_handle make_transaction(database_handle dbh, const transactio
 
 // Note: only rarely is a direct call to this needed. You can use transactors or pass database_handles
 // to get automagic.
-// Note: after a transaction is committed, it cannot be used again.
+// Note: after a transaction is committed, it cannot be used for more database
+// work. Post-commit observation helpers such as committed_version() are okay.
 // On false, the client should retry the transaction:
 [[nodiscard]] inline bool commit(transaction_handle& txn)
 {
@@ -117,6 +118,21 @@ void prepare_replay(transaction_handle& txn, fdb_error_t error);
 {
  txn->mark_version(stamp);
  return commit(txn);
+}
+
+[[nodiscard]] inline std::int64_t committed_version(const transaction_handle& txn)
+{
+ return txn->committed_version();
+}
+
+[[nodiscard]] inline std::int64_t read_version(const transaction_handle& txn)
+{
+ return txn->read_version();
+}
+
+inline void set_read_version(const transaction_handle& txn, const std::int64_t version)
+{
+ txn->set_read_version(version);
 }
 
 [[nodiscard]] inline watch_handle make_watch(transaction_handle txn, std::string_view key)

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -1317,6 +1317,31 @@ inline auto flatten_blocks(BlockRangeT block_range)
 
 } // namespace detail
 
+template <query::expression SelectionT>
+[[nodiscard]] inline std::int64_t approximate_range_size(transaction_handle txn,
+                                                         SelectionT selection)
+{
+ std::int64_t out = 0;
+
+ for (auto& interval : detail::intervals(std::move(selection))) {
+  out += detail::extract_int64(
+          detail::block_until_ready(
+           detail::transaction_get_estimated_range_size(txn, interval)));
+ }
+
+ return out;
+}
+
+template <query::expression SelectionT>
+[[nodiscard]] inline std::int64_t approximate_range_size(database_handle dbh,
+                                                         SelectionT selection)
+{
+ return detail::in_transaction(dbh,
+          [selection = std::move(selection)](transaction_handle& txn) mutable {
+            return approximate_range_size(txn, std::move(selection));
+          });
+}
+
 // For ordinary range scans inside one explicit transaction, scan() is usually
 // the right default:
 template <typename ValueT = std::string,

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -18,6 +18,7 @@
 #include "conversion.h"
 
 #include <tuple>
+#include <limits>
 
 namespace ceph::libfdb {
 
@@ -838,10 +839,7 @@ inline auto intervals(const QueryT& query)
 template <typename AssocT, typename RangeT>
 inline AssocT collect_range(RangeT&& range)
 {
- AssocT out;
- std::ranges::copy(std::forward<RangeT>(range),
-                   std::inserter(out, std::end(out)));
- return out;
+ return ceph::util::collect_as<AssocT>(std::forward<RangeT>(range));
 }
 
 template <typename ValueT = std::string>
@@ -881,7 +879,7 @@ inline auto scan(ceph::libfdb::transaction_handle txn, SelectionT selection)
  }
 }
 
-// Legacy name retained for compatibility:
+// Compatibility name retained for existing callers:
 template <typename ValueT = std::string,
           query::expression SelectionT>
 inline auto pair_generator(ceph::libfdb::transaction_handle txn,
@@ -891,22 +889,263 @@ inline auto pair_generator(ceph::libfdb::transaction_handle txn,
  return scan<ValueT>(txn, std::move(selection));
 }
 
-// Note: blocks() uses split planning to tackle large sets; use scan(txn, ...)
-// for direct scans in a caller-owned transaction.
-//
-// What blocks() gives you:
-// - avoids one huge transaction getting too old
-// - gives caller block-at-a-time processing
-// - can bound memory and transaction duration better than a monolithic scan
-//
-// Note: blocks() was originally parallel, and could be again, but preliminary
-// benchmarking showed it to be a significant performance impediment. The
-// database must be truly large to see benefits.
-//
-// Note: This is meant to be straightforward and easy-to-understand-- hence, there's not
-// a recovery strategy or other things (you can replay the entire query)-- as new needs arise, this
-// can be made more flexible via selector options, dynamic range-splitting, etc., but so far there
-// has been no need:
+struct page final
+{
+ static constexpr uint64_t max_size =
+  static_cast<uint64_t>(std::numeric_limits<int>::max()) - 1;
+
+ // FDB range limit convention: 0 means unlimited.
+ uint64_t size = 0;
+
+ constexpr page() noexcept = default;
+
+ explicit constexpr page(uint64_t size_)
+  : size(size_)
+ {
+  if (max_size < size) {
+   throw libfdb_exception("page size exceeds FoundationDB range limit");
+  }
+ }
+};
+
+template <typename RowT>
+struct page_result final
+{
+ std::vector<RowT> rows;
+ bool has_more = false;
+
+ auto begin() noexcept { return std::begin(rows); }
+ auto begin() const noexcept { return std::begin(rows); }
+ auto end() noexcept { return std::end(rows); }
+ auto end() const noexcept { return std::end(rows); }
+
+ bool empty() const noexcept
+ {
+  return std::empty(rows);
+ }
+
+ std::size_t size() const noexcept
+ {
+  return std::size(rows);
+ }
+};
+
+namespace detail {
+
+inline int range_limit_for(page p)
+{
+ if (0 == p.size) {
+  return 0;
+ }
+
+ return static_cast<int>(p.size + 1);
+}
+
+template <typename ValueT>
+using row_t = std::pair<std::string, ValueT>;
+
+template <typename ValueT, typename FnT>
+using row_transform_result_t =
+ std::invoke_result_t<FnT&, row_t<ValueT>&&>;
+
+template <typename FnT, typename ValueT>
+concept row_invocable = std::invocable<FnT&, row_t<ValueT>&&>;
+
+template <typename PredT, typename ValueT>
+concept row_predicate = std::predicate<PredT&, const row_t<ValueT>&>;
+
+} // namespace detail
+
+template <typename ValueT = std::string, typename FnT, query::expression SelectionT>
+requires detail::row_invocable<FnT, ValueT>
+inline void for_each(ceph::libfdb::transaction_handle txn,
+                     SelectionT selection,
+                     FnT&& fn)
+{
+ for (auto&& row : scan<ValueT>(std::move(txn), std::move(selection))) {
+  std::invoke(fn, std::move(row));
+ }
+}
+
+// Database-handle functional helpers run inside the managed transaction loop.
+// Keep callbacks replay-safe; use an explicit transaction for side effects that
+// must not be repeated.
+template <typename ValueT = std::string, typename FnT, query::expression SelectionT>
+requires detail::row_invocable<FnT, ValueT>
+inline void for_each(ceph::libfdb::database_handle dbh,
+                     SelectionT selection,
+                     FnT&& fn)
+{
+ detail::in_transaction(dbh,
+  [selection = std::move(selection), fn = std::forward<FnT>(fn)](auto& txn) mutable {
+   for_each<ValueT>(txn, selection, fn);
+  });
+}
+
+template <typename ValueT = std::string,
+          typename FnT,
+          typename OutIterT,
+          query::expression SelectionT>
+requires detail::row_invocable<FnT, ValueT> &&
+         concepts::storable_invocation_result<detail::row_transform_result_t<ValueT, FnT>> &&
+         std::output_iterator<OutIterT, detail::row_transform_result_t<ValueT, FnT>>
+inline OutIterT transform(ceph::libfdb::transaction_handle txn,
+                          SelectionT selection,
+                          FnT&& fn,
+                          OutIterT out)
+{
+ for_each<ValueT>(std::move(txn), std::move(selection),
+                  [&fn, &out](auto&& row) mutable {
+                   *out++ = std::invoke(fn, std::move(row));
+                  });
+
+ return out;
+}
+
+template <typename ValueT = std::string, typename FnT, query::expression SelectionT>
+requires detail::row_invocable<FnT, ValueT> &&
+         concepts::storable_invocation_result<detail::row_transform_result_t<ValueT, FnT>>
+[[nodiscard]] auto transform(ceph::libfdb::transaction_handle txn,
+                             SelectionT selection,
+                             FnT&& fn)
+{
+ using result_t =
+  std::remove_cvref_t<detail::row_transform_result_t<ValueT, FnT>>;
+
+ std::vector<result_t> out;
+ transform<ValueT>(std::move(txn), std::move(selection),
+                   std::forward<FnT>(fn), std::back_inserter(out));
+
+ return out;
+}
+
+template <typename ValueT = std::string, typename FnT, query::expression SelectionT>
+requires detail::row_invocable<FnT, ValueT> &&
+         concepts::storable_invocation_result<detail::row_transform_result_t<ValueT, FnT>>
+[[nodiscard]] auto transform(ceph::libfdb::database_handle dbh,
+                             SelectionT selection,
+                             FnT&& fn)
+{
+ return detail::in_transaction(dbh,
+  [selection = std::move(selection), fn = std::forward<FnT>(fn)](auto& txn) mutable {
+   return transform<ValueT>(txn, selection, fn);
+  });
+}
+
+template <typename ValueT = std::string,
+          typename FnT,
+          typename OutIterT,
+          query::expression SelectionT>
+requires detail::row_invocable<FnT, ValueT> &&
+         concepts::storable_invocation_result<detail::row_transform_result_t<ValueT, FnT>> &&
+         std::output_iterator<OutIterT, detail::row_transform_result_t<ValueT, FnT>>
+inline OutIterT transform(ceph::libfdb::database_handle dbh,
+                          SelectionT selection,
+                          FnT&& fn,
+                          OutIterT out)
+{
+ auto transformed = transform<ValueT>(dbh, std::move(selection),
+                                      std::forward<FnT>(fn));
+
+ for (auto& value : transformed) {
+  *out++ = std::move(value);
+ }
+
+ return out;
+}
+
+template <typename ValueT = std::string, typename PredT, query::expression SelectionT>
+requires detail::row_predicate<PredT, ValueT>
+inline std::size_t erase_if(ceph::libfdb::transaction_handle txn,
+                            SelectionT selection,
+                            PredT&& pred)
+{
+ std::size_t removed = 0;
+
+ for (const auto& row : scan<ValueT>(txn, std::move(selection))) {
+  if (std::invoke(pred, row)) {
+   erase(txn, row.first);
+   ++removed;
+  }
+ }
+
+ return removed;
+}
+
+template <typename ValueT = std::string, typename PredT, query::expression SelectionT>
+requires detail::row_predicate<PredT, ValueT>
+inline std::size_t erase_if(ceph::libfdb::database_handle dbh,
+                            SelectionT selection,
+                            PredT&& pred)
+{
+ return detail::in_transaction(dbh,
+  [selection = std::move(selection), pred = std::forward<PredT>(pred)](auto& txn) mutable {
+   return erase_if<ValueT>(txn, selection, pred);
+  });
+}
+
+template <std::ranges::input_range RangeT>
+[[nodiscard]] auto collect(RangeT&& rows, page p)
+{
+ using row_type = std::ranges::range_value_t<RangeT>;
+
+ page_result<row_type> out;
+ if (p.size) {
+  out.rows.reserve(p.size);
+ }
+
+ for (auto&& row : rows) {
+  if (p.size && std::size(out.rows) == p.size) {
+   out.has_more = true;
+   break;
+  }
+
+  out.rows.emplace_back(std::forward<decltype(row)>(row));
+ }
+
+ return out;
+}
+
+template <typename ValueT = std::string>
+[[nodiscard]] auto scan(ceph::libfdb::transaction_handle txn,
+                        ceph::libfdb::select selector,
+                        page p)
+{
+ using row_type = std::pair<std::string, ValueT>;
+
+ if (0 == p.size) {
+  return collect(scan<ValueT>(std::move(txn), std::move(selector)), p);
+ }
+
+ selector.options.result_limit = detail::range_limit_for(p);
+ auto window = detail::read_query_window(*txn, selector, 1);
+
+ page_result<row_type> out;
+ out.rows.reserve(p.size);
+ out.has_more = p.size < std::size(window.result_pairs) ||
+                window.more_available;
+
+ for (const auto& raw_pair : window.result_pairs | std::views::take(p.size)) {
+  out.rows.emplace_back(detail::to_decoded_kv_pair<ValueT>(raw_pair));
+ }
+
+ return out;
+}
+
+template <typename ValueT = std::string>
+[[nodiscard]] auto scan(ceph::libfdb::database_handle dbh,
+                        ceph::libfdb::select selector,
+                        page p)
+{
+ return make_transactor(dbh)([selector = std::move(selector), p](auto& txn) {
+  return scan<ValueT>(txn, selector, p);
+ });
+}
+
+// blocks() is for truly large scans that benefit from split planning:
+// it trades direct streaming for block-at-a-time processing, bounded
+// transaction windows, and lower risk of one transaction getting too old.
+// Prefer scan(txn, ...) for ordinary caller-owned transaction scans.
 namespace detail {
 
 template <typename ValueT = std::string,
@@ -968,7 +1207,7 @@ auto blocks(ceph::libfdb::database_handle dbh, SelectionT selection)
  }
 }
 
-// Legacy name retained for compatibility:
+// Compatibility name retained for existing callers:
 template <typename ValueT = std::string,
           typename AssocT = std::vector<std::pair<std::string, ValueT>>,
           query::expression SelectionT>

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -106,9 +106,9 @@ namespace api {
 
 namespace system {
 
-[[nodiscard]] inline double main_thread_busyness(database_handle dbh)
+[[nodiscard]] inline double client_network_load(database_handle dbh)
 {
- return detail::database_or_throw(dbh).main_thread_busyness();
+ return detail::database_or_throw(dbh).client_network_load();
 }
 
 [[nodiscard]] inline std::string client_status_json(database_handle dbh)
@@ -168,8 +168,8 @@ inline transaction_handle make_transaction(database_handle dbh, const transactio
  return txn->commit();
 }
 
-// Prepare a transaction to replay after a retryable operation-body error:
-void prepare_replay(transaction_handle& txn, fdb_error_t error);
+// Reset a transaction after a retryable operation-body error so its complete body can be replayed:
+void reset_for_replay(transaction_handle& txn, fdb_error_t error);
 
 [[nodiscard]] commit_result commit(with_result_t, transaction_handle& txn);
 
@@ -1859,10 +1859,10 @@ inline bool commit_or_throw(transaction_handle& txn)
 
 namespace ceph::libfdb {
 
-inline void prepare_replay(transaction_handle& txn, const fdb_error_t error)
+inline void reset_for_replay(transaction_handle& txn, const fdb_error_t error)
 {
- if (not detail::retry_after_error(txn, error)) {
-  throw libfdb_exception(error);
+ if (not detail::reset_for_replay_if_needed(txn, error)) {
+  throw std::invalid_argument("reset_for_replay() requires a nonzero FoundationDB error");
  }
 }
 
@@ -1984,7 +1984,7 @@ auto attempt_invocation(transaction_handle& txn, FnT&& fn, CommitFnT&& commit_fn
    throw;
   }
 
-  prepare_replay(txn, e.fdb_error_value);
+  reset_for_replay(txn, e.fdb_error_value);
   return std::nullopt;
  }
 
@@ -2035,7 +2035,7 @@ transaction_result maybe_retry_with_result(transaction_handle txn, FnT&& fn)
     throw;
    }
 
-   prepare_replay(txn, e.fdb_error_value);
+   reset_for_replay(txn, e.fdb_error_value);
    record_transaction_replay(result, e.fdb_error_value, 1 < attempts_left);
 
    continue;

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -546,12 +546,13 @@ requires concepts::string_pair_output_iterator<OutT> ||
          concepts::string_pair_output_range<OutT>
 inline std::size_t get_value_selection_from_transaction(transaction& txn,
                                                         const SelectionT& selection,
+                                                        const read_mode mode,
                                                         OutT& out)
 {
  std::size_t nread = 0;
 
  query::for_each_interval(selection, [&](const ceph::libfdb::select& interval) {
-  nread += detail::get_value_range_from_transaction(txn, interval, out);
+  nread += detail::get_value_range_from_transaction(txn, interval, mode, out);
  });
 
  return nread;
@@ -560,11 +561,12 @@ inline std::size_t get_value_selection_from_transaction(transaction& txn,
 template <typename OutT, query::expression SelectionT>
 requires concepts::materializable_string_pair_output_range<OutT>
 inline auto materialize_string_pair_selection(transaction& txn,
-                                              const SelectionT& selection)
+                                              const SelectionT& selection,
+                                              const read_mode mode)
  -> materialized_string_pair_output<OutT>
 {
  OutT tmp;
- const auto nread = get_value_selection_from_transaction(txn, selection, tmp);
+ const auto nread = get_value_selection_from_transaction(txn, selection, mode, tmp);
 
  return {
   .values = std::move(tmp),
@@ -581,29 +583,40 @@ inline auto materialize_string_pair_selection(transaction& txn,
 inline std::size_t get(ceph::libfdb::transaction_handle txn,
                        const query::expression auto& selection,
                        concepts::string_pair_output_iterator auto out_iter,
+                       const read_mode mode,
                        const ceph::libfdb::commit_after_op commit_after)
 {
  return detail::commit_noreplay(txn, commit_after,
-          [&selection, out_iter](const transaction_handle& active_txn) mutable {
-            return detail::get_value_selection_from_transaction(*active_txn, selection, out_iter);
+          [&selection, out_iter, mode](const transaction_handle& active_txn) mutable {
+            return detail::get_value_selection_from_transaction(*active_txn, selection, mode, out_iter);
           });
 }
 
 inline std::size_t get(ceph::libfdb::transaction_handle txn,
                        const query::expression auto& selection,
-                       concepts::string_pair_output_iterator auto out_iter)
+                       concepts::string_pair_output_iterator auto out_iter,
+                       const ceph::libfdb::commit_after_op commit_after)
 {
- return get(txn, selection, out_iter, commit_after_op::no_commit);
+ return get(txn, selection, out_iter, read_mode::serializable, commit_after);
+}
+
+inline std::size_t get(ceph::libfdb::transaction_handle txn,
+                       const query::expression auto& selection,
+                       concepts::string_pair_output_iterator auto out_iter,
+                       const read_mode mode = read_mode::serializable)
+{
+ return get(txn, selection, out_iter, mode, commit_after_op::no_commit);
 }
 
 inline std::size_t get(ceph::libfdb::database_handle dbh,
                        const query::expression auto& selection,
-                       concepts::string_pair_output_iterator auto out_iter)
+                       concepts::string_pair_output_iterator auto out_iter,
+                       const read_mode mode = read_mode::serializable)
 {
  auto result = detail::in_transaction(dbh,
-          [&selection](transaction_handle& txn) {
+          [&selection, mode](transaction_handle& txn) {
             using out_t = std::vector<std::pair<std::string, std::string>>;
-            return detail::materialize_string_pair_selection<out_t>(*txn, selection);
+            return detail::materialize_string_pair_selection<out_t>(*txn, selection, mode);
           });
 
  std::ranges::move(result.values, out_iter);
@@ -613,30 +626,41 @@ inline std::size_t get(ceph::libfdb::database_handle dbh,
 inline std::size_t get(ceph::libfdb::transaction_handle txn,
                        const query::expression auto& selection,
                        concepts::string_pair_output_range auto& out,
+                       const read_mode mode,
                        const ceph::libfdb::commit_after_op commit_after)
 {
  return detail::commit_noreplay(txn, commit_after,
-          [&selection, &out](const transaction_handle& active_txn) {
-            return detail::get_value_selection_from_transaction(*active_txn, selection, out);
+          [&selection, &out, mode](const transaction_handle& active_txn) {
+            return detail::get_value_selection_from_transaction(*active_txn, selection, mode, out);
           });
 }
 
 inline std::size_t get(ceph::libfdb::transaction_handle txn,
                        const query::expression auto& selection,
-                       concepts::string_pair_output_range auto& out)
+                       concepts::string_pair_output_range auto& out,
+                       const ceph::libfdb::commit_after_op commit_after)
 {
- return get(txn, selection, out, commit_after_op::no_commit);
+ return get(txn, selection, out, read_mode::serializable, commit_after);
+}
+
+inline std::size_t get(ceph::libfdb::transaction_handle txn,
+                       const query::expression auto& selection,
+                       concepts::string_pair_output_range auto& out,
+                       const read_mode mode = read_mode::serializable)
+{
+ return get(txn, selection, out, mode, commit_after_op::no_commit);
 }
 
 inline std::size_t get(ceph::libfdb::database_handle dbh,
                        const query::expression auto& selection,
-                       concepts::materializable_string_pair_output_range auto& out)
+                       concepts::materializable_string_pair_output_range auto& out,
+                       const read_mode mode = read_mode::serializable)
 {
  using out_t = std::remove_cvref_t<decltype(out)>;
 
  auto result = detail::in_transaction(dbh,
-          [&selection](transaction_handle& txn) {
-            return detail::materialize_string_pair_selection<out_t>(*txn, selection);
+          [&selection, mode](transaction_handle& txn) {
+            return detail::materialize_string_pair_selection<out_t>(*txn, selection, mode);
           });
 
  detail::publish_string_pair_results(out, std::move(result.values));
@@ -646,23 +670,51 @@ inline std::size_t get(ceph::libfdb::database_handle dbh,
 inline std::size_t get(ceph::libfdb::transaction_handle txn,
                        std::initializer_list<std::string_view> keys,
                        concepts::string_pair_output_range auto& out,
+                       const read_mode mode,
                        const ceph::libfdb::commit_after_op commit_after)
 {
- return get(txn, detail::select_from_initializer_list(keys), out, commit_after);
+ return get(txn, detail::select_from_initializer_list(keys), out, mode, commit_after);
 }
 
 inline std::size_t get(ceph::libfdb::transaction_handle txn,
                        std::initializer_list<std::string_view> keys,
-                       concepts::string_pair_output_range auto& out)
+                       concepts::string_pair_output_range auto& out,
+                       const ceph::libfdb::commit_after_op commit_after)
 {
- return get(txn, keys, out, commit_after_op::no_commit);
+ return get(txn, keys, out, read_mode::serializable, commit_after);
+}
+
+inline std::size_t get(ceph::libfdb::transaction_handle txn,
+                       std::initializer_list<std::string_view> keys,
+                       concepts::string_pair_output_range auto& out,
+                       const read_mode mode = read_mode::serializable)
+{
+ return get(txn, keys, out, mode, commit_after_op::no_commit);
 }
 
 inline std::size_t get(ceph::libfdb::database_handle dbh,
                        std::initializer_list<std::string_view> keys,
-                       concepts::materializable_string_pair_output_range auto& out)
+                       concepts::materializable_string_pair_output_range auto& out,
+                       const read_mode mode = read_mode::serializable)
 {
- return get(dbh, detail::select_from_initializer_list(keys), out);
+ return get(dbh, detail::select_from_initializer_list(keys), out, mode);
+}
+
+template <typename OutputTargetOrFnT>
+requires concepts::value_callback<std::remove_reference_t<OutputTargetOrFnT>> or
+         concepts::decoded_value_sink<OutputTargetOrFnT&&>
+inline bool get(ceph::libfdb::transaction_handle txn,
+                const concepts::libfdb_key auto& key,
+                OutputTargetOrFnT&& output_target_or_fn,
+                const read_mode mode,
+                const commit_after_op commit_after)
+{
+ return detail::commit_noreplay(txn, commit_after,
+          [key = detail::as_fdb_span(key), &output_target_or_fn, mode](const transaction_handle& active_txn) {
+            return active_txn->get(key,
+                                   detail::get_output_for(output_target_or_fn),
+                                   mode);
+          });
 }
 
 template <typename OutputTargetOrFnT>
@@ -673,11 +725,8 @@ inline bool get(ceph::libfdb::transaction_handle txn,
                 OutputTargetOrFnT&& output_target_or_fn,
                 const commit_after_op commit_after)
 {
- return detail::commit_noreplay(txn, commit_after,
-          [key = detail::as_fdb_span(key), &output_target_or_fn](const transaction_handle& active_txn) {
-            return active_txn->get(key,
-                                   detail::get_output_for(output_target_or_fn));
-          });
+ return get(txn, key, std::forward<OutputTargetOrFnT>(output_target_or_fn),
+            read_mode::serializable, commit_after);
 }
 
 template <typename OutputTargetOrFnT>
@@ -685,9 +734,11 @@ requires concepts::value_callback<std::remove_reference_t<OutputTargetOrFnT>> or
          concepts::decoded_value_sink<OutputTargetOrFnT&&>
 inline bool get(ceph::libfdb::transaction_handle txn,
                 const concepts::libfdb_key auto& key,
-                OutputTargetOrFnT&& output_target_or_fn)
+                OutputTargetOrFnT&& output_target_or_fn,
+                const read_mode mode = read_mode::serializable)
 {
- return get(txn, key, std::forward<OutputTargetOrFnT>(output_target_or_fn), commit_after_op::no_commit);
+ return get(txn, key, std::forward<OutputTargetOrFnT>(output_target_or_fn),
+            mode, commit_after_op::no_commit);
 }
 
 template <typename OutputTargetOrFnT>
@@ -695,11 +746,12 @@ requires concepts::value_callback<std::remove_reference_t<OutputTargetOrFnT>> or
          concepts::decoded_value_sink<OutputTargetOrFnT&&>
 inline bool get(ceph::libfdb::database_handle dbh,
                 const concepts::libfdb_key auto& key,
-                OutputTargetOrFnT&& output_target_or_fn)
+                OutputTargetOrFnT&& output_target_or_fn,
+                const read_mode mode = read_mode::serializable)
 {
  return detail::in_transaction(dbh,
-          [key, &output_target_or_fn](transaction_handle& txn) {
-            return get(txn, key, output_target_or_fn, commit_after_op::no_commit);
+          [key, &output_target_or_fn, mode](transaction_handle& txn) {
+            return get(txn, key, output_target_or_fn, mode, commit_after_op::no_commit);
           });
 }
 
@@ -710,24 +762,36 @@ namespace ceph::libfdb {
 // Does a key exist?
 inline bool key_exists(transaction_handle txn,
                        const concepts::libfdb_key auto& k,
+                       const read_mode mode,
                        const commit_after_op commit_after)
 {
  return detail::commit_noreplay(txn, commit_after,
-          [key = detail::as_libfdb_key_view(k)](const transaction_handle& active_txn) {
-            return active_txn->key_exists(key);
+          [key = detail::as_libfdb_key_view(k), mode](const transaction_handle& active_txn) {
+            return active_txn->key_exists(key, mode);
           });
 }
 
-inline bool key_exists(transaction_handle txn, const concepts::libfdb_key auto& k)
+inline bool key_exists(transaction_handle txn,
+                       const concepts::libfdb_key auto& k,
+                       const commit_after_op commit_after)
 {
- return key_exists(txn, k, commit_after_op::no_commit);
+ return key_exists(txn, k, read_mode::serializable, commit_after);
 }
 
-inline bool key_exists(database_handle dbh, const concepts::libfdb_key auto& k)
+inline bool key_exists(transaction_handle txn,
+                       const concepts::libfdb_key auto& k,
+                       const read_mode mode = read_mode::serializable)
+{
+ return key_exists(txn, k, mode, commit_after_op::no_commit);
+}
+
+inline bool key_exists(database_handle dbh,
+                       const concepts::libfdb_key auto& k,
+                       const read_mode mode = read_mode::serializable)
 {
  return detail::in_transaction(dbh,
-          [k](transaction_handle& txn) {
-            return key_exists(txn, k, commit_after_op::no_commit);
+          [k, mode](transaction_handle& txn) {
+            return key_exists(txn, k, mode, commit_after_op::no_commit);
           });
 }
 
@@ -852,23 +916,6 @@ inline auto intervals(const QueryT& query)
  return out;
 }
 
-template <typename AssocT, typename RangeT>
-inline AssocT collect_range(RangeT&& range)
-{
- return ceph::util::collect_as<AssocT>(std::forward<RangeT>(range));
-}
-
-template <typename ValueT = std::string>
-inline auto scan_selector(ceph::libfdb::transaction_handle txn, ceph::libfdb::select key_range)
-  -> std::generator<std::pair<std::string, ValueT>>
-{
- auto decoded_pairs = ceph::libfdb::detail::generate_FDB_pairs(*txn, key_range)
-                    | std::views::join
-                    | std::views::transform(ceph::libfdb::detail::to_decoded_kv_pair<ValueT>);
-
- co_yield std::ranges::elements_of(decoded_pairs);
-}
-
 template <typename ValueT, typename BlockRangeT>
 inline auto flatten_blocks(BlockRangeT block_range)
   -> std::generator<std::pair<std::string, ValueT>>
@@ -886,12 +933,17 @@ inline auto flatten_blocks(BlockRangeT block_range)
 // the right default:
 template <typename ValueT = std::string,
           query::expression SelectionT>
-inline auto scan(ceph::libfdb::transaction_handle txn, SelectionT selection)
+inline auto scan(ceph::libfdb::transaction_handle txn,
+                 SelectionT selection,
+                 const read_mode mode = read_mode::serializable)
   -> std::generator<std::pair<std::string, ValueT>>
 {
  for (auto& interval : detail::intervals(selection)) {
-  co_yield std::ranges::elements_of(
-   detail::scan_selector<ValueT>(txn, std::move(interval)));
+  auto decoded_pairs = detail::generate_FDB_pairs(*txn, std::move(interval), mode)
+                     | std::views::join
+                     | std::views::transform(detail::to_decoded_kv_pair<ValueT>);
+
+  co_yield std::ranges::elements_of(decoded_pairs);
  }
 }
 
@@ -899,10 +951,11 @@ inline auto scan(ceph::libfdb::transaction_handle txn, SelectionT selection)
 template <typename ValueT = std::string,
           query::expression SelectionT>
 inline auto pair_generator(ceph::libfdb::transaction_handle txn,
-                           SelectionT selection)
+                           SelectionT selection,
+                           const read_mode mode = read_mode::serializable)
   -> std::generator<std::pair<std::string, ValueT>>
 {
- return scan<ValueT>(txn, std::move(selection));
+ return scan<ValueT>(txn, std::move(selection), mode);
 }
 
 struct page final
@@ -976,9 +1029,10 @@ template <typename ValueT = std::string, typename FnT, query::expression Selecti
 requires detail::row_invocable<FnT, ValueT>
 inline void for_each(ceph::libfdb::transaction_handle txn,
                      SelectionT selection,
-                     FnT&& fn)
+                     FnT&& fn,
+                     const read_mode mode = read_mode::serializable)
 {
- for (auto&& row : scan<ValueT>(std::move(txn), std::move(selection))) {
+ for (auto&& row : scan<ValueT>(std::move(txn), std::move(selection), mode)) {
   std::invoke(fn, std::move(row));
  }
 }
@@ -990,11 +1044,12 @@ template <typename ValueT = std::string, typename FnT, query::expression Selecti
 requires detail::row_invocable<FnT, ValueT>
 inline void for_each(ceph::libfdb::database_handle dbh,
                      SelectionT selection,
-                     FnT&& fn)
+                     FnT&& fn,
+                     const read_mode mode = read_mode::serializable)
 {
  detail::in_transaction(dbh,
-  [selection = std::move(selection), fn = std::forward<FnT>(fn)](auto& txn) mutable {
-   for_each<ValueT>(txn, selection, fn);
+  [selection = std::move(selection), fn = std::forward<FnT>(fn), mode](auto& txn) mutable {
+   for_each<ValueT>(txn, selection, fn, mode);
   });
 }
 
@@ -1008,12 +1063,14 @@ requires detail::row_invocable<FnT, ValueT> &&
 inline OutIterT transform(ceph::libfdb::transaction_handle txn,
                           SelectionT selection,
                           FnT&& fn,
-                          OutIterT out)
+                          OutIterT out,
+                          const read_mode mode = read_mode::serializable)
 {
  for_each<ValueT>(std::move(txn), std::move(selection),
                   [&fn, &out](auto&& row) mutable {
                    *out++ = std::invoke(fn, std::move(row));
-                  });
+                  },
+                  mode);
 
  return out;
 }
@@ -1023,14 +1080,15 @@ requires detail::row_invocable<FnT, ValueT> &&
          concepts::storable_invocation_result<detail::row_transform_result_t<ValueT, FnT>>
 [[nodiscard]] auto transform(ceph::libfdb::transaction_handle txn,
                              SelectionT selection,
-                             FnT&& fn)
+                             FnT&& fn,
+                             const read_mode mode = read_mode::serializable)
 {
  using result_t =
   std::remove_cvref_t<detail::row_transform_result_t<ValueT, FnT>>;
 
  std::vector<result_t> out;
  transform<ValueT>(std::move(txn), std::move(selection),
-                   std::forward<FnT>(fn), std::back_inserter(out));
+                   std::forward<FnT>(fn), std::back_inserter(out), mode);
 
  return out;
 }
@@ -1040,11 +1098,12 @@ requires detail::row_invocable<FnT, ValueT> &&
          concepts::storable_invocation_result<detail::row_transform_result_t<ValueT, FnT>>
 [[nodiscard]] auto transform(ceph::libfdb::database_handle dbh,
                              SelectionT selection,
-                             FnT&& fn)
+                             FnT&& fn,
+                             const read_mode mode = read_mode::serializable)
 {
  return detail::in_transaction(dbh,
-  [selection = std::move(selection), fn = std::forward<FnT>(fn)](auto& txn) mutable {
-   return transform<ValueT>(txn, selection, fn);
+  [selection = std::move(selection), fn = std::forward<FnT>(fn), mode](auto& txn) mutable {
+   return transform<ValueT>(txn, selection, fn, mode);
   });
 }
 
@@ -1058,10 +1117,11 @@ requires detail::row_invocable<FnT, ValueT> &&
 inline OutIterT transform(ceph::libfdb::database_handle dbh,
                           SelectionT selection,
                           FnT&& fn,
-                          OutIterT out)
+                          OutIterT out,
+                          const read_mode mode = read_mode::serializable)
 {
  auto transformed = transform<ValueT>(dbh, std::move(selection),
-                                      std::forward<FnT>(fn));
+                                      std::forward<FnT>(fn), mode);
 
  for (auto& value : transformed) {
   *out++ = std::move(value);
@@ -1125,16 +1185,17 @@ template <std::ranges::input_range RangeT>
 template <typename ValueT = std::string>
 [[nodiscard]] auto scan(ceph::libfdb::transaction_handle txn,
                         ceph::libfdb::select selector,
-                        page p)
+                        page p,
+                        const read_mode mode = read_mode::serializable)
 {
  using row_type = std::pair<std::string, ValueT>;
 
  if (0 == p.size) {
-  return collect(scan<ValueT>(std::move(txn), std::move(selector)), p);
+  return collect(scan<ValueT>(std::move(txn), std::move(selector), mode), p);
  }
 
  selector.options.result_limit = detail::range_limit_for(p);
- auto window = detail::read_query_window(*txn, selector, 1);
+ auto window = detail::read_query_window(*txn, selector, 1, mode);
 
  page_result<row_type> out;
  out.rows.reserve(p.size);
@@ -1151,10 +1212,11 @@ template <typename ValueT = std::string>
 template <typename ValueT = std::string>
 [[nodiscard]] auto scan(ceph::libfdb::database_handle dbh,
                         ceph::libfdb::select selector,
-                        page p)
+                        page p,
+                        const read_mode mode = read_mode::serializable)
 {
- return make_transactor(dbh)([selector = std::move(selector), p](auto& txn) {
-  return scan<ValueT>(txn, selector, p);
+ return make_transactor(dbh)([selector = std::move(selector), p, mode](auto& txn) {
+  return scan<ValueT>(txn, selector, p, mode);
  });
 }
 
@@ -1166,7 +1228,9 @@ namespace detail {
 
 template <typename ValueT = std::string,
           typename AssocT = std::vector<std::pair<std::string, ValueT>>>
-auto blocks_selector(ceph::libfdb::database_handle dbh, ceph::libfdb::select selector)
+auto blocks_selector(ceph::libfdb::database_handle dbh,
+                     ceph::libfdb::select selector,
+                     const read_mode mode)
  -> std::generator<AssocT>
 {
  if (0 == selector.options.result_limit) {
@@ -1181,11 +1245,13 @@ auto blocks_selector(ceph::libfdb::database_handle dbh, ceph::libfdb::select sel
 
  auto split_ranges = detail::plan_split_ranges(dbh, selector, chunk_size);
 
- auto read_blocks = [txr = make_transactor(dbh)](this auto& self, ceph::libfdb::select range, const int iteration)
+ auto read_blocks = [txr = make_transactor(dbh), mode](this auto& self, ceph::libfdb::select range, const int iteration)
  -> std::generator<AssocT> {
-  auto read_result = txr([](auto& txn, ceph::libfdb::select range, const int iteration) {
-   return detail::materialize_query_window<ValueT, AssocT>(*txn, std::move(range), iteration);
-  }, std::move(range), iteration);
+  auto read_result = txr([](auto& txn, ceph::libfdb::select range,
+                            const int iteration, const read_mode mode) {
+   return detail::materialize_query_window<ValueT, AssocT>(
+    *txn, std::move(range), iteration, mode);
+  }, std::move(range), iteration, mode);
 
   auto next_range = std::move(read_result.next_range);
 
@@ -1214,12 +1280,14 @@ auto blocks_selector(ceph::libfdb::database_handle dbh, ceph::libfdb::select sel
 template <typename ValueT = std::string,
           typename AssocT = std::vector<std::pair<std::string, ValueT>>,
           query::expression SelectionT>
-auto blocks(ceph::libfdb::database_handle dbh, SelectionT selection)
+auto blocks(ceph::libfdb::database_handle dbh,
+            SelectionT selection,
+            const read_mode mode = read_mode::serializable)
  -> std::generator<AssocT>
 {
  for (auto& interval : detail::intervals(selection)) {
   co_yield std::ranges::elements_of(
-   detail::blocks_selector<ValueT, AssocT>(dbh, std::move(interval)));
+   detail::blocks_selector<ValueT, AssocT>(dbh, std::move(interval), mode));
  }
 }
 
@@ -1227,35 +1295,43 @@ auto blocks(ceph::libfdb::database_handle dbh, SelectionT selection)
 template <typename ValueT = std::string,
           typename AssocT = std::vector<std::pair<std::string, ValueT>>,
           query::expression SelectionT>
-auto block_generator(ceph::libfdb::database_handle dbh, SelectionT selection)
+auto block_generator(ceph::libfdb::database_handle dbh,
+                     SelectionT selection,
+                     const read_mode mode = read_mode::serializable)
  -> std::generator<AssocT>
 {
- return blocks<ValueT, AssocT>(dbh, std::move(selection));
+ return blocks<ValueT, AssocT>(dbh, std::move(selection), mode);
 }
 
 // Managed scans flatten the blocks() stream into key/value pairs.
 template <typename ValueT = std::string,
           query::expression SelectionT>
-inline auto scan(ceph::libfdb::database_handle dbh, SelectionT selection)
+inline auto scan(ceph::libfdb::database_handle dbh,
+                 SelectionT selection,
+                 const read_mode mode = read_mode::serializable)
   -> std::generator<std::pair<std::string, ValueT>>
 {
- return detail::flatten_blocks<ValueT>(blocks<ValueT>(dbh, std::move(selection)));
+ return detail::flatten_blocks<ValueT>(blocks<ValueT>(dbh, std::move(selection), mode));
 }
 
 template <typename ValueT = std::string,
           typename AssocT = std::vector<std::pair<std::string, ValueT>>,
           query::expression SelectionT>
-inline AssocT collect(ceph::libfdb::transaction_handle txn, SelectionT selection)
+inline AssocT collect(ceph::libfdb::transaction_handle txn,
+                      SelectionT selection,
+                      const read_mode mode = read_mode::serializable)
 {
- return detail::collect_range<AssocT>(scan<ValueT>(txn, std::move(selection)));
+ return ceph::util::collect_as<AssocT>(scan<ValueT>(txn, std::move(selection), mode));
 }
 
 template <typename ValueT = std::string,
           typename AssocT = std::vector<std::pair<std::string, ValueT>>,
           query::expression SelectionT>
-inline AssocT collect(ceph::libfdb::database_handle dbh, SelectionT selection)
+inline AssocT collect(ceph::libfdb::database_handle dbh,
+                      SelectionT selection,
+                      const read_mode mode = read_mode::serializable)
 {
- return detail::collect_range<AssocT>(scan<ValueT>(dbh, std::move(selection)));
+ return ceph::util::collect_as<AssocT>(scan<ValueT>(dbh, std::move(selection), mode));
 }
 
 } // namespace ceph::libfdb

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -113,6 +113,32 @@ void prepare_replay(transaction_handle& txn, fdb_error_t error);
 
 [[nodiscard]] commit_result commit(with_result_t, transaction_handle& txn);
 
+[[nodiscard]] inline std::string get_key(transaction_handle txn,
+                                         const key_selector& selector,
+                                         const read_mode mode = read_mode::serializable)
+{
+ auto ready = detail::block_until_ready(
+              detail::transaction_get_key(txn, selector, mode));
+
+ const uint8_t *out_key = nullptr;
+ int out_key_size = 0;
+
+ if (fdb_error_t r = fdb_future_get_key(ready.raw_handle(), &out_key, &out_key_size); 0 != r) {
+  throw libfdb_exception(r);
+ }
+
+ if (0 == out_key_size) {
+  return {};
+ }
+
+ if (nullptr == out_key) {
+  throw libfdb_exception("invalid key selector result");
+ }
+
+ return std::string(reinterpret_cast<const char *>(out_key),
+                    static_cast<std::string::size_type>(out_key_size));
+}
+
 [[nodiscard]] inline bool commit(transaction_handle& txn,
                                  const versionstamp& stamp)
 {
@@ -224,6 +250,16 @@ namespace ceph::libfdb {
  return detail::in_transaction(dbh,
           [key](transaction_handle& txn) {
             return make_watch(txn, key);
+          });
+}
+
+[[nodiscard]] inline std::string get_key(database_handle dbh,
+                                         const key_selector& selector,
+                                         const read_mode mode = read_mode::serializable)
+{
+ return detail::in_transaction(dbh,
+          [selector, mode](transaction_handle& txn) {
+            return get_key(txn, selector, mode);
           });
 }
 

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -130,6 +130,11 @@ void prepare_replay(transaction_handle& txn, fdb_error_t error);
  return txn->read_version();
 }
 
+[[nodiscard]] inline std::int64_t approximate_commit_bytes(const transaction_handle& txn)
+{
+ return txn->approximate_commit_bytes();
+}
+
 inline void set_read_version(const transaction_handle& txn, const std::int64_t version)
 {
  txn->set_read_version(version);

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -55,16 +55,16 @@ inline database_handle create_database()
  return std::make_shared<database>();
 }
 
-inline database_handle create_database(const std::filesystem::path dbfile)
+inline database_handle create_database(connection_source source)
 {
- return std::make_shared<database>(dbfile);
+ return std::make_shared<database>(std::move(source), database_options {});
 }
 
-inline database_handle create_database(const std::filesystem::path dbfile,
+inline database_handle create_database(connection_source source,
                                        const database_options& dbopts,
                                        const network_options& netopts)
 {
- return std::make_shared<database>(dbfile, dbopts, netopts);
+ return std::make_shared<database>(std::move(source), dbopts, netopts);
 }
 
 inline database_handle create_database(const database_options& dbopts,
@@ -78,10 +78,10 @@ inline database_handle create_database(const database_options& opts)
  return create_database(opts, network_options{});
 }
 
-inline database_handle create_database(const std::filesystem::path dbfile,
+inline database_handle create_database(connection_source source,
                                        const database_options& dbopts)
 {
- return create_database(dbfile, dbopts, network_options{});
+ return create_database(std::move(source), dbopts, network_options{});
 }
 
 inline transaction_handle make_transaction(database_handle dbh)

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -493,6 +493,66 @@ namespace ceph::libfdb {
 
 namespace detail {
 
+inline void mark_conflict(transaction_handle txn,
+                          const query::expression auto& selection,
+                          const FDBConflictRangeType type)
+{
+ bool marked = false;
+
+ query::for_each_interval(selection, [&](const ceph::libfdb::select& interval) {
+  transaction_mark_conflict_range(txn, interval, type);
+  marked = true;
+ });
+
+ if (not marked) {
+  throw std::invalid_argument("conflict expression must contain a non-empty range");
+ }
+}
+
+} // namespace detail
+
+// Mark explicit conflict ranges when transaction correctness depends on data
+// that was not read or written through the ordinary libfdb operation path:
+inline void mark_conflict_read(transaction_handle txn,
+                               const query::expression auto& selection)
+{
+ return detail::mark_conflict(txn, selection, FDB_CONFLICT_RANGE_TYPE_READ);
+}
+
+inline void mark_conflict_write(transaction_handle txn,
+                                const query::expression auto& selection)
+{
+ return detail::mark_conflict(txn, selection, FDB_CONFLICT_RANGE_TYPE_WRITE);
+}
+
+inline void mark_conflict_read(transaction_handle txn,
+                               const concepts::libfdb_key auto& begin,
+                               const concepts::libfdb_key auto& end)
+{
+ return mark_conflict_read(txn, query::between(begin, end));
+}
+
+inline void mark_conflict_write(transaction_handle txn,
+                                const concepts::libfdb_key auto& begin,
+                                const concepts::libfdb_key auto& end)
+{
+ return mark_conflict_write(txn, query::between(begin, end));
+}
+
+inline void mark_conflict_read(transaction_handle txn,
+                               const concepts::libfdb_key auto& key)
+{
+ return mark_conflict_read(txn, query::singleton(key));
+}
+
+inline void mark_conflict_write(transaction_handle txn,
+                                const concepts::libfdb_key auto& key)
+{
+ return mark_conflict_write(txn, query::singleton(key));
+}
+
+namespace detail {
+
 inline select select_from_initializer_list(std::initializer_list<std::string_view> keys)
 {
  const auto first = std::begin(keys);

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -1584,13 +1584,11 @@ auto blocks_selector(ceph::libfdb::database_handle dbh,
   selector.options.result_limit = 4096;
  }
 
- // JFW: Although this is tunable, in my measurement it isn't a large factor so far-- likely 
- // these can move into the select instance itself (this is hard to measure in tests-- N
- // has to be pretty big; I've adjusted chunk_size to where I guesstimate it needs to be,
- // we need real-world experience to tweak this further):
- const auto chunk_size = 4 * 1024 * 1024;
+ // Initial range-work target: measurements so far suggest low sensitivity here,
+ // but large real workloads should drive future tuning.
+ constexpr auto target_bytes = 4 * 1024 * 1024;
 
- auto split_ranges = detail::plan_split_ranges(dbh, selector, chunk_size);
+ auto plan = detail::plan_range_work(dbh, selector, target_bytes);
 
  auto read_blocks = [txr = make_transactor(dbh), mode](this auto& self, ceph::libfdb::select range, const int iteration)
  -> std::generator<AssocT> {
@@ -1617,7 +1615,7 @@ auto blocks_selector(ceph::libfdb::database_handle dbh,
   return read_blocks(std::move(range), 1);
  };
 
- co_yield std::ranges::elements_of(split_ranges
+ co_yield std::ranges::elements_of(plan.ranges
                                  | std::views::transform(expand_range)
                                  | std::views::join);
 }

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -437,6 +437,293 @@ inline void set(database_handle dbh,
 
 namespace ceph::libfdb {
 
+// Atomic operations enqueue FoundationDB server-side value mutations:
+namespace atomic {
+
+namespace detail {
+
+template <typename ValueT>
+requires (std::integral<ValueT> && not std::same_as<ValueT, bool>)
+constexpr auto little_endian_bytes(const ValueT value) noexcept
+{
+ using unsigned_t = std::make_unsigned_t<ValueT>;
+
+ std::array<std::uint8_t, sizeof(ValueT)> out {};
+ auto bits = static_cast<unsigned_t>(value);
+
+ for (auto& byte : out) {
+  byte = static_cast<std::uint8_t>(bits);
+  bits >>= 8;
+ }
+
+ return out;
+}
+
+inline auto byte_span(const std::string_view bytes)
+{
+ return std::span<const std::uint8_t>(
+  reinterpret_cast<const std::uint8_t *>(bytes.data()),
+  std::size(bytes));
+}
+
+template <typename FDBBytesT>
+requires (not concepts::stringview_convertible<FDBBytesT>)
+inline auto byte_span(const FDBBytesT& bytes)
+{
+ return std::span<const std::uint8_t>(bytes);
+}
+
+inline constexpr auto integral_param =
+ []<typename ValueT>(const ValueT value)
+ requires requires(ValueT x) { little_endian_bytes(x); }
+ {
+  return little_endian_bytes(value);
+ };
+
+inline constexpr auto byte_param =
+ []<typename FDBBytesT>(const FDBBytesT& value)
+ requires requires(const FDBBytesT& x) { byte_span(x); }
+ {
+  return byte_span(value);
+ };
+
+template <FDBMutationType MutationKind, auto MaterializeParam, typename ParamT>
+requires requires(const ParamT& value) { MaterializeParam(value); }
+inline void atomic_op(transaction_handle txn,
+                      const concepts::libfdb_key auto& k,
+                      const ParamT& param,
+                      const commit_after_op commit_after)
+{
+ return ceph::libfdb::detail::commit_noreplay(txn, commit_after,
+          [key = ceph::libfdb::detail::as_fdb_span(k),
+           value = MaterializeParam(param)](const transaction_handle& active_txn) {
+            return ceph::libfdb::detail::transaction_atomic_op(
+             active_txn, key, std::span<const std::uint8_t>(value), MutationKind);
+          });
+}
+
+template <FDBMutationType MutationKind, auto MaterializeParam, typename ParamT>
+requires requires(const ParamT& value) { MaterializeParam(value); }
+inline void atomic_op(database_handle dbh,
+                      const concepts::libfdb_key auto& k,
+                      const ParamT& param)
+{
+ return ceph::libfdb::detail::in_transaction(dbh,
+          [k, &param](transaction_handle& txn) {
+            return atomic_op<MutationKind, MaterializeParam>(
+             txn, k, param, commit_after_op::no_commit);
+          });
+}
+
+} // namespace detail
+
+template <typename ValueT>
+requires requires(ValueT value) { detail::little_endian_bytes(value); }
+inline void add(transaction_handle txn,
+                const concepts::libfdb_key auto& k,
+                const ValueT value,
+                const commit_after_op commit_after = commit_after_op::no_commit)
+{
+ return detail::atomic_op<FDB_MUTATION_TYPE_ADD, detail::integral_param>(
+  txn, k, value, commit_after);
+}
+
+template <typename ValueT>
+requires requires(ValueT value) { detail::little_endian_bytes(value); }
+inline void add(database_handle dbh,
+                const concepts::libfdb_key auto& k,
+                const ValueT value)
+{
+ return detail::atomic_op<FDB_MUTATION_TYPE_ADD, detail::integral_param>(dbh, k, value);
+}
+
+template <typename ValueT>
+requires (std::unsigned_integral<ValueT> && not std::same_as<ValueT, bool>)
+inline void min(transaction_handle txn,
+                const concepts::libfdb_key auto& k,
+                const ValueT value,
+                const commit_after_op commit_after = commit_after_op::no_commit)
+{
+ return detail::atomic_op<FDB_MUTATION_TYPE_MIN, detail::integral_param>(
+  txn, k, value, commit_after);
+}
+
+template <typename ValueT>
+requires (std::unsigned_integral<ValueT> && not std::same_as<ValueT, bool>)
+inline void min(database_handle dbh,
+                const concepts::libfdb_key auto& k,
+                const ValueT value)
+{
+ return detail::atomic_op<FDB_MUTATION_TYPE_MIN, detail::integral_param>(dbh, k, value);
+}
+
+template <typename ValueT>
+requires (std::unsigned_integral<ValueT> && not std::same_as<ValueT, bool>)
+inline void max(transaction_handle txn,
+                const concepts::libfdb_key auto& k,
+                const ValueT value,
+                const commit_after_op commit_after = commit_after_op::no_commit)
+{
+ return detail::atomic_op<FDB_MUTATION_TYPE_MAX, detail::integral_param>(
+  txn, k, value, commit_after);
+}
+
+template <typename ValueT>
+requires (std::unsigned_integral<ValueT> && not std::same_as<ValueT, bool>)
+inline void max(database_handle dbh,
+                const concepts::libfdb_key auto& k,
+                const ValueT value)
+{
+ return detail::atomic_op<FDB_MUTATION_TYPE_MAX, detail::integral_param>(dbh, k, value);
+}
+
+template <typename ValueT>
+requires requires(ValueT value) { detail::little_endian_bytes(value); }
+inline void bit_and(transaction_handle txn,
+                    const concepts::libfdb_key auto& k,
+                    const ValueT value,
+                    const commit_after_op commit_after = commit_after_op::no_commit)
+{
+ return detail::atomic_op<FDB_MUTATION_TYPE_BIT_AND, detail::integral_param>(
+  txn, k, value, commit_after);
+}
+
+template <typename ValueT>
+requires requires(ValueT value) { detail::little_endian_bytes(value); }
+inline void bit_and(database_handle dbh,
+                    const concepts::libfdb_key auto& k,
+                    const ValueT value)
+{
+ return detail::atomic_op<FDB_MUTATION_TYPE_BIT_AND, detail::integral_param>(dbh, k, value);
+}
+
+template <typename ValueT>
+requires requires(ValueT value) { detail::little_endian_bytes(value); }
+inline void bit_or(transaction_handle txn,
+                   const concepts::libfdb_key auto& k,
+                   const ValueT value,
+                   const commit_after_op commit_after = commit_after_op::no_commit)
+{
+ return detail::atomic_op<FDB_MUTATION_TYPE_BIT_OR, detail::integral_param>(
+  txn, k, value, commit_after);
+}
+
+template <typename ValueT>
+requires requires(ValueT value) { detail::little_endian_bytes(value); }
+inline void bit_or(database_handle dbh,
+                   const concepts::libfdb_key auto& k,
+                   const ValueT value)
+{
+ return detail::atomic_op<FDB_MUTATION_TYPE_BIT_OR, detail::integral_param>(dbh, k, value);
+}
+
+template <typename ValueT>
+requires requires(ValueT value) { detail::little_endian_bytes(value); }
+inline void bit_xor(transaction_handle txn,
+                    const concepts::libfdb_key auto& k,
+                    const ValueT value,
+                    const commit_after_op commit_after = commit_after_op::no_commit)
+{
+ return detail::atomic_op<FDB_MUTATION_TYPE_BIT_XOR, detail::integral_param>(
+  txn, k, value, commit_after);
+}
+
+template <typename ValueT>
+requires requires(ValueT value) { detail::little_endian_bytes(value); }
+inline void bit_xor(database_handle dbh,
+                    const concepts::libfdb_key auto& k,
+                    const ValueT value)
+{
+ return detail::atomic_op<FDB_MUTATION_TYPE_BIT_XOR, detail::integral_param>(dbh, k, value);
+}
+
+template <typename FDBBytesT>
+requires requires(const FDBBytesT& value) { detail::byte_span(value); }
+inline void byte_min(transaction_handle txn,
+                     const concepts::libfdb_key auto& k,
+                     const FDBBytesT& value,
+                     const commit_after_op commit_after = commit_after_op::no_commit)
+{
+ return detail::atomic_op<FDB_MUTATION_TYPE_BYTE_MIN, detail::byte_param>(
+  txn, k, value, commit_after);
+}
+
+template <typename FDBBytesT>
+requires requires(const FDBBytesT& value) { detail::byte_span(value); }
+inline void byte_min(database_handle dbh,
+                     const concepts::libfdb_key auto& k,
+                     const FDBBytesT& value)
+{
+ return detail::atomic_op<FDB_MUTATION_TYPE_BYTE_MIN, detail::byte_param>(dbh, k, value);
+}
+
+template <typename FDBBytesT>
+requires requires(const FDBBytesT& value) { detail::byte_span(value); }
+inline void byte_max(transaction_handle txn,
+                     const concepts::libfdb_key auto& k,
+                     const FDBBytesT& value,
+                     const commit_after_op commit_after = commit_after_op::no_commit)
+{
+ return detail::atomic_op<FDB_MUTATION_TYPE_BYTE_MAX, detail::byte_param>(
+  txn, k, value, commit_after);
+}
+
+template <typename FDBBytesT>
+requires requires(const FDBBytesT& value) { detail::byte_span(value); }
+inline void byte_max(database_handle dbh,
+                     const concepts::libfdb_key auto& k,
+                     const FDBBytesT& value)
+{
+ return detail::atomic_op<FDB_MUTATION_TYPE_BYTE_MAX, detail::byte_param>(dbh, k, value);
+}
+
+template <typename FDBBytesT>
+requires requires(const FDBBytesT& value) { detail::byte_span(value); }
+inline void append_if_fits(transaction_handle txn,
+                           const concepts::libfdb_key auto& k,
+                           const FDBBytesT& value,
+                           const commit_after_op commit_after = commit_after_op::no_commit)
+{
+ return detail::atomic_op<FDB_MUTATION_TYPE_APPEND_IF_FITS, detail::byte_param>(
+  txn, k, value, commit_after);
+}
+
+template <typename FDBBytesT>
+requires requires(const FDBBytesT& value) { detail::byte_span(value); }
+inline void append_if_fits(database_handle dbh,
+                           const concepts::libfdb_key auto& k,
+                           const FDBBytesT& value)
+{
+ return detail::atomic_op<FDB_MUTATION_TYPE_APPEND_IF_FITS, detail::byte_param>(dbh, k, value);
+}
+
+template <typename FDBBytesT>
+requires requires(const FDBBytesT& value) { detail::byte_span(value); }
+inline void compare_and_clear(transaction_handle txn,
+                              const concepts::libfdb_key auto& k,
+                              const FDBBytesT& expected,
+                              const commit_after_op commit_after = commit_after_op::no_commit)
+{
+ return detail::atomic_op<FDB_MUTATION_TYPE_COMPARE_AND_CLEAR, detail::byte_param>(
+  txn, k, expected, commit_after);
+}
+
+template <typename FDBBytesT>
+requires requires(const FDBBytesT& value) { detail::byte_span(value); }
+inline void compare_and_clear(database_handle dbh,
+                              const concepts::libfdb_key auto& k,
+                              const FDBBytesT& expected)
+{
+ return detail::atomic_op<FDB_MUTATION_TYPE_COMPARE_AND_CLEAR, detail::byte_param>(
+  dbh, k, expected);
+}
+
+} // namespace atomic
+
+} // namespace ceph::libfdb
+
+namespace ceph::libfdb {
+
 // erase() in libfdb is clear() in FDB parlance:
 inline void erase(ceph::libfdb::transaction_handle txn,
                   const query::expression auto& selection,

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -1457,7 +1457,7 @@ struct page_result final
 
 namespace detail {
 
-inline int range_limit_for(page p)
+constexpr int range_limit_for(page p)
 {
  if (0 == p.size) {
   return 0;
@@ -1476,13 +1476,19 @@ using row_transform_result_t =
 template <typename FnT, typename ValueT>
 concept row_invocable = std::invocable<FnT&, row_t<ValueT>&&>;
 
+template <typename FnT, typename ValueT>
+concept row_consumer =
+ requires(FnT& fn, row_t<ValueT>&& row) {
+  { std::invoke(fn, std::move(row)) } -> std::same_as<void>;
+ };
+
 template <typename PredT, typename ValueT>
 concept row_predicate = std::predicate<PredT&, const row_t<ValueT>&>;
 
 } // namespace detail
 
 template <typename ValueT = std::string, typename FnT, query::expression SelectionT>
-requires detail::row_invocable<FnT, ValueT>
+requires detail::row_consumer<FnT, ValueT>
 inline void for_each(ceph::libfdb::transaction_handle txn,
                      SelectionT selection,
                      FnT&& fn,
@@ -1497,7 +1503,7 @@ inline void for_each(ceph::libfdb::transaction_handle txn,
 // Keep callbacks replay-safe; use an explicit transaction for side effects that
 // must not be repeated.
 template <typename ValueT = std::string, typename FnT, query::expression SelectionT>
-requires detail::row_invocable<FnT, ValueT>
+requires detail::row_consumer<FnT, ValueT>
 inline void for_each(ceph::libfdb::database_handle dbh,
                      SelectionT selection,
                      FnT&& fn,

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -519,15 +519,14 @@ inline void set(database_handle dbh,
 
 } // namespace ceph::libfdb
 
-namespace ceph::libfdb {
-
-// Atomic operations enqueue FoundationDB server-side value mutations:
-namespace atomic {
-
-namespace detail {
+namespace ceph::libfdb::detail {
 
 template <typename ValueT>
-requires (std::integral<ValueT> && not std::same_as<ValueT, bool>)
+concept fdb_integer_value =
+ std::integral<ValueT> and
+ not std::same_as<std::remove_cv_t<ValueT>, bool>;
+
+template <fdb_integer_value ValueT>
 constexpr auto little_endian_bytes(const ValueT value) noexcept
 {
  using unsigned_t = std::make_unsigned_t<ValueT>;
@@ -542,6 +541,34 @@ constexpr auto little_endian_bytes(const ValueT value) noexcept
 
  return out;
 }
+
+template <fdb_integer_value ValueT>
+constexpr auto little_endian_integer(const std::span<const std::uint8_t> bytes)
+{
+ if (sizeof(ValueT) < std::size(bytes)) {
+  throw std::invalid_argument {"FoundationDB integer value is too large"};
+ }
+
+ using unsigned_t = std::make_unsigned_t<ValueT>;
+
+ unsigned_t out = 0;
+
+ for (auto byte : bytes | std::views::reverse) {
+  out <<= 8;
+  out |= static_cast<unsigned_t>(byte);
+ }
+
+ return static_cast<ValueT>(out);
+}
+
+} // namespace ceph::libfdb::detail
+
+namespace ceph::libfdb {
+
+// Atomic operations enqueue FoundationDB server-side value mutations:
+namespace atomic {
+
+namespace detail {
 
 inline auto byte_span(const std::string_view bytes)
 {
@@ -559,9 +586,9 @@ inline auto byte_span(const FDBBytesT& bytes)
 
 inline constexpr auto integral_param =
  []<typename ValueT>(const ValueT value)
- requires requires(ValueT x) { little_endian_bytes(x); }
+ requires ceph::libfdb::detail::fdb_integer_value<ValueT>
  {
-  return little_endian_bytes(value);
+  return ceph::libfdb::detail::little_endian_bytes(value);
  };
 
 inline constexpr auto byte_param =
@@ -602,7 +629,7 @@ inline void atomic_op(database_handle dbh,
 } // namespace detail
 
 template <typename ValueT>
-requires requires(ValueT value) { detail::little_endian_bytes(value); }
+requires ceph::libfdb::detail::fdb_integer_value<ValueT>
 inline void add(transaction_handle txn,
                 const concepts::libfdb_key auto& k,
                 const ValueT value,
@@ -613,7 +640,7 @@ inline void add(transaction_handle txn,
 }
 
 template <typename ValueT>
-requires requires(ValueT value) { detail::little_endian_bytes(value); }
+requires ceph::libfdb::detail::fdb_integer_value<ValueT>
 inline void add(database_handle dbh,
                 const concepts::libfdb_key auto& k,
                 const ValueT value)
@@ -662,7 +689,7 @@ inline void max(database_handle dbh,
 }
 
 template <typename ValueT>
-requires requires(ValueT value) { detail::little_endian_bytes(value); }
+requires ceph::libfdb::detail::fdb_integer_value<ValueT>
 inline void bit_and(transaction_handle txn,
                     const concepts::libfdb_key auto& k,
                     const ValueT value,
@@ -673,7 +700,7 @@ inline void bit_and(transaction_handle txn,
 }
 
 template <typename ValueT>
-requires requires(ValueT value) { detail::little_endian_bytes(value); }
+requires ceph::libfdb::detail::fdb_integer_value<ValueT>
 inline void bit_and(database_handle dbh,
                     const concepts::libfdb_key auto& k,
                     const ValueT value)
@@ -682,7 +709,7 @@ inline void bit_and(database_handle dbh,
 }
 
 template <typename ValueT>
-requires requires(ValueT value) { detail::little_endian_bytes(value); }
+requires ceph::libfdb::detail::fdb_integer_value<ValueT>
 inline void bit_or(transaction_handle txn,
                    const concepts::libfdb_key auto& k,
                    const ValueT value,
@@ -693,7 +720,7 @@ inline void bit_or(transaction_handle txn,
 }
 
 template <typename ValueT>
-requires requires(ValueT value) { detail::little_endian_bytes(value); }
+requires ceph::libfdb::detail::fdb_integer_value<ValueT>
 inline void bit_or(database_handle dbh,
                    const concepts::libfdb_key auto& k,
                    const ValueT value)
@@ -702,7 +729,7 @@ inline void bit_or(database_handle dbh,
 }
 
 template <typename ValueT>
-requires requires(ValueT value) { detail::little_endian_bytes(value); }
+requires ceph::libfdb::detail::fdb_integer_value<ValueT>
 inline void bit_xor(transaction_handle txn,
                     const concepts::libfdb_key auto& k,
                     const ValueT value,
@@ -713,7 +740,7 @@ inline void bit_xor(transaction_handle txn,
 }
 
 template <typename ValueT>
-requires requires(ValueT value) { detail::little_endian_bytes(value); }
+requires ceph::libfdb::detail::fdb_integer_value<ValueT>
 inline void bit_xor(database_handle dbh,
                     const concepts::libfdb_key auto& k,
                     const ValueT value)
@@ -1184,6 +1211,17 @@ inline bool get(ceph::libfdb::database_handle dbh,
           [key, &output_target_or_fn, mode](transaction_handle& txn) {
             return get(txn, key, output_target_or_fn, mode, commit_after_op::no_commit);
           });
+}
+
+// Adapt "out" to FDB's raw little-endian representation used by numeric atomic
+// mutations, bypassing libfdb's ordinary decoding. With get(), a missing key
+// leaves "out" unchanged; a value wider than ValueT throws:
+template <detail::fdb_integer_value ValueT>
+[[nodiscard]] constexpr auto as_fdb_integer(ValueT& out) noexcept
+{
+ return [&out](const std::span<const std::uint8_t> bytes) {
+  out = detail::little_endian_integer<ValueT>(bytes);
+ };
 }
 
 } // namespace ceph::libfdb

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -84,6 +84,66 @@ inline database_handle create_database(connection_source source,
  return create_database(std::move(source), dbopts, network_options{});
 }
 
+namespace api {
+
+[[nodiscard]] inline std::string client_version()
+{
+ const auto *version = fdb_get_client_version();
+
+ if (nullptr == version) {
+  throw libfdb_exception("invalid FDB client version");
+ }
+
+ return std::string(version);
+}
+
+[[nodiscard]] inline int max_version() noexcept
+{
+ return fdb_get_max_api_version();
+}
+
+} // namespace api
+
+namespace system {
+
+[[nodiscard]] inline double main_thread_busyness(database_handle dbh)
+{
+ return detail::database_or_throw(dbh).main_thread_busyness();
+}
+
+[[nodiscard]] inline std::string client_status_json(database_handle dbh)
+{
+ return detail::database_or_throw(dbh).client_status_json();
+}
+
+[[nodiscard]] inline std::uint64_t server_protocol(database_handle dbh,
+                                                   const std::uint64_t expected_version = 0)
+{
+ return detail::database_or_throw(dbh).server_protocol(expected_version);
+}
+
+inline void reboot_worker(database_handle dbh,
+                          std::string_view address,
+                          const bool check,
+                          const int duration)
+{
+ detail::database_or_throw(dbh).reboot_worker(address, check, duration);
+}
+
+inline void force_recovery_with_data_loss(database_handle dbh, std::string_view dcid)
+{
+ detail::database_or_throw(dbh).force_recovery_with_data_loss(dcid);
+}
+
+inline void create_snapshot(database_handle dbh,
+                            std::string_view uid,
+                            std::string_view snap_command)
+{
+ detail::database_or_throw(dbh).create_snapshot(uid, snap_command);
+}
+
+} // namespace system
+
 inline transaction_handle make_transaction(database_handle dbh)
 {
  if (!dbh) {
@@ -117,26 +177,9 @@ void prepare_replay(transaction_handle& txn, fdb_error_t error);
                                          const key_selector& selector,
                                          const read_mode mode = read_mode::serializable)
 {
- auto ready = detail::block_until_ready(
-              detail::transaction_get_key(txn, selector, mode));
-
- const uint8_t *out_key = nullptr;
- int out_key_size = 0;
-
- if (fdb_error_t r = fdb_future_get_key(ready.raw_handle(), &out_key, &out_key_size); 0 != r) {
-  throw libfdb_exception(r);
- }
-
- if (0 == out_key_size) {
-  return {};
- }
-
- if (nullptr == out_key) {
-  throw libfdb_exception("invalid key selector result");
- }
-
- return std::string(reinterpret_cast<const char *>(out_key),
-                    static_cast<std::string::size_type>(out_key_size));
+ return detail::extract_byte_string(
+          detail::block_until_ready(
+           detail::transaction_get_key(txn, selector, mode)));
 }
 
 [[nodiscard]] inline bool commit(transaction_handle& txn,

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -809,6 +809,18 @@ TEST_CASE("transaction watches", "[rgw][fdb]") {
   CHECK(watch.ready());
  }
 
+ SECTION("throwing stop-token wait preserves cancellation as an exception") {
+  auto watch = lfdb::make_watch(dbh, watch_key);
+  std::stop_source stop;
+
+  REQUIRE_FALSE(watch.ready());
+
+  stop.request_stop();
+
+  CHECK_THROWS_AS(watch.wait(stop.get_token()), lfdb::libfdb_exception);
+  CHECK(watch.ready());
+ }
+
  SECTION("watch can be rearmed after each key change") {
   auto watch = lfdb::make_watch(dbh, watch_key);
 

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -845,7 +845,7 @@ TEST_CASE("api and system diagnostics", "[fdb]")
  }
 
  SECTION("system namespace rejects invalid database handles") {
-  CHECK_THROWS_AS(lfdb::system::main_thread_busyness({}), std::invalid_argument);
+  CHECK_THROWS_AS(lfdb::system::client_network_load({}), std::invalid_argument);
   CHECK_THROWS_AS(lfdb::system::client_status_json({}), std::invalid_argument);
   CHECK_THROWS_AS(lfdb::system::server_protocol({}), std::invalid_argument);
   CHECK_THROWS_AS(lfdb::system::reboot_worker({}, "127.0.0.1:4500", false, 0),
@@ -859,8 +859,8 @@ TEST_CASE("api and system diagnostics", "[fdb]")
  SECTION("system namespace reports live database diagnostics") {
   janitor dbh;
 
-  const auto busyness = lfdb::system::main_thread_busyness(dbh);
-  CHECK(0.0 <= busyness);
+  const auto client_load = lfdb::system::client_network_load(dbh);
+  CHECK(0.0 <= client_load);
 
   const auto protocol = lfdb::system::server_protocol(dbh);
   CHECK(0 < protocol);
@@ -2630,6 +2630,19 @@ TEST_CASE("explicit conflict ranges", "[fdb]") {
  }
 }
 
+TEST_CASE("FoundationDB integer encoding is little endian", "[fdb]") {
+ constexpr auto bytes = std::array<std::uint8_t, 4> {0x78, 0x56, 0x34, 0x12};
+ constexpr auto short_bytes = std::array<std::uint8_t, 2> {0x78, 0x56};
+ constexpr auto negative_one = std::array<std::uint8_t, 4> {0xff, 0xff, 0xff, 0xff};
+
+ STATIC_REQUIRE(bytes == lfdb::detail::little_endian_bytes(std::uint32_t {0x12345678}));
+ STATIC_REQUIRE(std::uint32_t {0x12345678} ==
+                lfdb::detail::little_endian_integer<std::uint32_t>(bytes));
+ STATIC_REQUIRE(std::uint32_t {0x5678} ==
+                lfdb::detail::little_endian_integer<std::uint32_t>(short_bytes));
+ STATIC_REQUIRE(negative_one == lfdb::detail::little_endian_bytes(std::int32_t {-1}));
+}
+
 TEST_CASE("atomic mutations", "[fdb]") {
  janitor j;
 
@@ -2931,22 +2944,34 @@ SCENARIO("transactor", "[fdb]")
   return 7;
  })>);
 
- SECTION("prepare_replay handles retryable errors") {
+ SECTION("reset_for_replay handles retryable errors") {
   constexpr fdb_error_t not_committed = 1020;
   REQUIRE(0 != fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, not_committed));
 
   auto txn = lfdb::make_transaction(j);
 
-  CHECK_NOTHROW(lfdb::prepare_replay(txn, not_committed));
+  CHECK_NOTHROW(lfdb::reset_for_replay(txn, not_committed));
+
+  const auto key = test_key("reset-for-replay");
+  lfdb::set(txn, key, "value");
+
+  CHECK(lfdb::commit(txn));
+  CHECK(lfdb::key_exists(j, key));
  }
 
- SECTION("prepare_replay rejects non-retryable errors") {
+ SECTION("reset_for_replay rejects non-retryable errors") {
   constexpr fdb_error_t operation_cancelled = 1101;
   REQUIRE_FALSE(fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, operation_cancelled));
 
   auto txn = lfdb::make_transaction(j);
 
-  CHECK_THROWS_AS(lfdb::prepare_replay(txn, operation_cancelled), lfdb::libfdb_exception);
+  CHECK_THROWS_AS(lfdb::reset_for_replay(txn, operation_cancelled), lfdb::libfdb_exception);
+ }
+
+ SECTION("reset_for_replay requires an error") {
+  auto txn = lfdb::make_transaction(j);
+
+  CHECK_THROWS_AS(lfdb::reset_for_replay(txn, 0), std::invalid_argument);
  }
 
  SECTION("successful commit ends ordinary transaction work") {
@@ -2956,7 +2981,7 @@ SCENARIO("transactor", "[fdb]")
   REQUIRE(lfdb::commit(txn));
 
   CHECK(0 < lfdb::committed_version(txn));
-  CHECK_THROWS_AS(lfdb::prepare_replay(txn, 1020), std::invalid_argument);
+  CHECK_THROWS_AS(lfdb::reset_for_replay(txn, 1020), std::invalid_argument);
  }
 
  SECTION("transaction function returns nothing") {

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -100,6 +100,12 @@ concept can_atomic_add =
  };
 
 template <typename ValueT>
+concept can_get_as_fdb_integer =
+ requires(lfdb::database_handle dbh, std::string key, ValueT& value) {
+  { lfdb::get(dbh, key, lfdb::as_fdb_integer(value)) } -> std::same_as<bool>;
+ };
+
+template <typename ValueT>
 concept can_atomic_min =
  requires(lfdb::database_handle dbh, std::string key, ValueT value) {
   lfdb::atomic::min(dbh, key, value);
@@ -251,6 +257,8 @@ TEST_CASE("libfdb concepts describe supported API shapes", "[fdb][concepts]")
 
  STATIC_REQUIRE(can_atomic_add<std::uint64_t>);
  STATIC_REQUIRE_FALSE(can_atomic_add<bool>);
+ STATIC_REQUIRE(can_get_as_fdb_integer<std::uint64_t>);
+ STATIC_REQUIRE_FALSE(can_get_as_fdb_integer<bool>);
  STATIC_REQUIRE_FALSE(can_atomic_min<std::int64_t>);
 
  STATIC_REQUIRE(can_lfdb_for_each<decltype([](string_pair&&) {})>);
@@ -2639,6 +2647,25 @@ TEST_CASE("atomic mutations", "[fdb]") {
 
   REQUIRE(sizeof(std::uint64_t) == std::size(value));
   CHECK(3 == decode_little_endian<std::uint64_t>(value));
+ }
+
+ SECTION("as_fdb_integer decodes FoundationDB integer values") {
+  const auto key = test_key("fdb-integer/get");
+  auto value = std::uint64_t {42};
+
+  CHECK_FALSE(lfdb::get(j, key, lfdb::as_fdb_integer(value)));
+  CHECK(42 == value);
+
+  lfdb::atomic::add(j, key, std::uint64_t{5});
+  CHECK(lfdb::get(j, key, lfdb::as_fdb_integer(value)));
+  CHECK(5 == value);
+
+  auto txn = lfdb::make_transaction(j);
+
+  lfdb::atomic::add(txn, key, std::uint64_t{7});
+  REQUIRE(lfdb::commit(txn));
+  CHECK(lfdb::get(j, key, lfdb::as_fdb_integer(value)));
+  CHECK(12 == value);
  }
 
  SECTION("add does not require a read conflict") {

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -229,6 +229,58 @@ TEST_CASE("query prefix handles byte-string keyspace edges", "[fdb][query]")
  CHECK(lq::is_empty(lq::prefix(max_keyspace_prefix + "metadata")));
 }
 
+TEST_CASE("key selectors navigate stored keys", "[fdb][query]")
+{
+ janitor j;
+ const auto prefix = make_key_prefix("selector");
+
+ const auto key0 = prefix + "0";
+ const auto key1 = prefix + "1";
+ const auto key2 = prefix + "2";
+ const auto key3 = prefix + "3";
+ const auto key4 = prefix + "4";
+ const auto key2_5 = prefix + "2.5";
+
+ lfdb::set(j, key0, "zero");
+ lfdb::set(j, key1, "one");
+ lfdb::set(j, key2, "two");
+ lfdb::set(j, key3, "three");
+ lfdb::set(j, key4, "four");
+
+ CHECK(key1 == lfdb::get_key(j, lfdb::lower(key2)));
+ CHECK(key2 == lfdb::get_key(j, lfdb::floor(key2)));
+ CHECK(key2 == lfdb::get_key(j, lfdb::ceiling(key2)));
+ CHECK(key3 == lfdb::get_key(j, lfdb::higher(key2)));
+ CHECK(key2 == lfdb::get_key(j, lfdb::ceiling(key2), lfdb::read_mode::snapshot));
+
+ CHECK(key2 == lfdb::get_key(j, lfdb::lower(key2_5)));
+ CHECK(key2 == lfdb::get_key(j, lfdb::floor(key2_5)));
+ CHECK(key3 == lfdb::get_key(j, lfdb::ceiling(key2_5)));
+ CHECK(key3 == lfdb::get_key(j, lfdb::higher(key2_5)));
+}
+
+TEST_CASE("key selectors compose with content keys and query algebra", "[fdb][query][content]")
+{
+ namespace fdbc = ceph::libfdb::layer::content;
+ namespace lq = ceph::libfdb::query;
+
+ janitor j;
+ const auto root = test_key("content-selector");
+ const auto objects = fdbc::keyspace(root) / "objects";
+ const auto object_a = objects / "a";
+ const auto object_c = objects / "c";
+ const auto object_b = objects / "b";
+
+ lfdb::set(j, object_a, "alpha");
+ lfdb::set(j, object_c, "charlie");
+
+ const auto object_range = fdbc::prefix(objects);
+ const auto next_object = lfdb::get_key(j, lfdb::ceiling(object_b));
+
+ CHECK(lq::contains(object_range, next_object));
+ CHECK(std::string(libfdb_key_view(object_c)) == next_object);
+}
+
 struct position_insert_iterator
 {
  using difference_type = std::ptrdiff_t;

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -611,6 +611,16 @@ TEST_CASE("transaction versions", "[fdb]") {
   CHECK(0 < lfdb::read_version(txn));
  }
 
+ SECTION("committed version is only available after commit") {
+  auto txn = lfdb::make_transaction(dbh);
+
+  CHECK_THROWS_MATCHES(lfdb::committed_version(txn),
+                       std::invalid_argument,
+                       Catch::Matchers::MessageMatches(
+                        Catch::Matchers::ContainsSubstring(
+                         "committed_version() requires committed transaction")));
+ }
+
  SECTION("committed version is available after commit") {
   const auto key = test_key("transaction-version/committed");
   auto txn = lfdb::make_transaction(dbh);

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -435,6 +435,44 @@ TEST_CASE("version stamps", "[fdb]") {
   CHECK(10 == stamp.resolved_bytes().size());
  }
 
+ SECTION("one versionstamp can resolve multiple operations in one transaction") {
+  const auto first_key = test_key("versionstamp/multi/first");
+  const auto second_key = test_key("versionstamp/multi/second");
+  lfdb::versionstamp stamp;
+
+  auto txn = lfdb::make_transaction(dbh);
+  lfdb::set(txn, first_key, lfdb::versioned("", stamp));
+  lfdb::set(txn, second_key, lfdb::versioned("", stamp));
+  REQUIRE(lfdb::commit(txn));
+
+  lfdb::versionstamp first;
+  lfdb::versionstamp second;
+  REQUIRE(lfdb::get(dbh, first_key, first));
+  REQUIRE(lfdb::get(dbh, second_key, second));
+
+  REQUIRE(stamp.is_resolved());
+  CHECK(first.resolved_bytes() == stamp.resolved_bytes());
+  CHECK(second.resolved_bytes() == stamp.resolved_bytes());
+ }
+
+ SECTION("retryable commit failure does not resolve versionstamp") {
+  const auto conflict_key = test_key("versionstamp/conflict/read");
+  const auto output_key = test_key("versionstamp/conflict/output");
+  lfdb::set(dbh, conflict_key, "old");
+
+  auto txn = lfdb::make_transaction(dbh);
+  std::string value;
+  REQUIRE(lfdb::get(txn, conflict_key, value));
+
+  lfdb::versionstamp stamp;
+  lfdb::set(txn, output_key, lfdb::versioned("", stamp));
+
+  lfdb::set(dbh, conflict_key, "new");
+
+  CHECK_FALSE(lfdb::commit(txn));
+  CHECK_FALSE(stamp.is_resolved());
+ }
+
  SECTION("resolved versionstamp cannot be reused for commit") {
   const auto first_key = test_key("versionstamp/reuse/first");
   const auto second_key = test_key("versionstamp/reuse/second");

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -770,6 +770,34 @@ TEST_CASE("transaction commit byte estimate", "[fdb]") {
  CHECK(empty_estimate < populated_estimate);
 }
 
+TEST_CASE("approximate range size composes with selections", "[fdb][query]")
+{
+ namespace fdbc = ceph::libfdb::layer::content;
+ namespace lq = ceph::libfdb::query;
+
+ janitor dbh;
+ const auto prefix = make_key_prefix("range-size");
+ const auto object_root = fdbc::keyspace(test_key("range-size-content")) / "objects";
+
+ for (const auto i : std::views::iota(0, 8)) {
+  lfdb::set(dbh, make_key(i, "range-size"), std::string(1024, 'x'));
+ }
+
+ lfdb::set(dbh, object_root / "a", "alpha");
+ lfdb::set(dbh, object_root / "b", "bravo");
+
+ auto txn = lfdb::make_transaction(dbh);
+ const auto range_estimate = lfdb::approximate_range_size(txn, lq::prefix(prefix));
+ const auto union_estimate =
+  lfdb::approximate_range_size(dbh,
+                               lq::set_union(lq::prefix(prefix),
+                                             fdbc::prefix(object_root)));
+
+ CHECK(0 <= range_estimate);
+ CHECK(0 <= union_estimate);
+ CHECK(0 == lfdb::approximate_range_size(dbh, lfdb::select { prefix, prefix }));
+}
+
 static_assert(not std::default_initializable<lfdb::watch_handle>);
 static_assert(not std::copy_constructible<lfdb::watch_handle>);
 static_assert(std::move_constructible<lfdb::watch_handle>);

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -2071,6 +2071,69 @@ TEST_CASE("paged scan", "[fdb]") {
  }
 }
 
+TEST_CASE("snapshot reads do not add read conflicts", "[fdb]") {
+ janitor j;
+
+ SECTION("single-key get") {
+  const auto read_key = make_key(0, "snapshot-single");
+  const auto write_key = make_key(1, "snapshot-single");
+
+  lfdb::set(j, read_key, "old");
+
+  auto serializable_txn = lfdb::make_transaction(j);
+  std::string out;
+  REQUIRE(lfdb::get(serializable_txn, read_key, out));
+  lfdb::set(j, read_key, "new");
+  lfdb::set(serializable_txn, write_key, "side-effect");
+  CHECK_FALSE(lfdb::commit(serializable_txn));
+  CHECK_FALSE(lfdb::key_exists(j, write_key));
+
+  auto snapshot_txn = lfdb::make_transaction(j);
+  REQUIRE(lfdb::get(snapshot_txn, read_key, out, lfdb::read_mode::snapshot));
+  lfdb::set(j, read_key, "newer");
+  lfdb::set(snapshot_txn, write_key, "snapshot-side-effect");
+  CHECK(lfdb::commit(snapshot_txn));
+  CHECK(lfdb::key_exists(j, write_key));
+ }
+
+ SECTION("range scan") {
+  constexpr auto prefix = "snapshot-range";
+  const auto conflict_key = make_key(0, prefix);
+  const auto write_key = make_key(99, prefix);
+  const auto selector = lfdb::select { make_key(0, prefix), make_key(2, prefix) };
+
+  lfdb::set(j, conflict_key, "old");
+
+  auto serializable_txn = lfdb::make_transaction(j);
+  REQUIRE_FALSE(lfdb::collect(serializable_txn, selector).empty());
+  lfdb::set(j, conflict_key, "new");
+  lfdb::set(serializable_txn, write_key, "side-effect");
+  CHECK_FALSE(lfdb::commit(serializable_txn));
+  CHECK_FALSE(lfdb::key_exists(j, write_key));
+
+  auto snapshot_txn = lfdb::make_transaction(j);
+  REQUIRE_FALSE(lfdb::collect(snapshot_txn, selector, lfdb::read_mode::snapshot).empty());
+  lfdb::set(j, conflict_key, "newer");
+  lfdb::set(snapshot_txn, write_key, "snapshot-side-effect");
+  CHECK(lfdb::commit(snapshot_txn));
+  CHECK(lfdb::key_exists(j, write_key));
+ }
+
+ SECTION("key existence") {
+  const auto read_key = make_key(0, "snapshot-exists");
+  const auto write_key = make_key(1, "snapshot-exists");
+
+  lfdb::set(j, read_key, "old");
+
+  auto snapshot_txn = lfdb::make_transaction(j);
+  REQUIRE(lfdb::key_exists(snapshot_txn, read_key, lfdb::read_mode::snapshot));
+  lfdb::set(j, read_key, "new");
+  lfdb::set(snapshot_txn, write_key, "snapshot-side-effect");
+  CHECK(lfdb::commit(snapshot_txn));
+  CHECK(lfdb::key_exists(j, write_key));
+ }
+}
+
 TEST_CASE("generators honor selector endpoints", "[fdb]") {
  janitor j;
 

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -782,8 +782,42 @@ TEST_CASE("transaction commit byte estimate", "[fdb]") {
 
  const auto populated_estimate = lfdb::approximate_commit_bytes(txn);
 
- CHECK(0 <= empty_estimate);
- CHECK(empty_estimate < populated_estimate);
+CHECK(0 <= empty_estimate);
+CHECK(empty_estimate < populated_estimate);
+}
+
+TEST_CASE("api and system diagnostics", "[fdb]")
+{
+ SECTION("api namespace reports FDB client facts") {
+  CHECK_FALSE(lfdb::api::client_version().empty());
+  CHECK(730 <= lfdb::api::max_version());
+ }
+
+ SECTION("system namespace rejects invalid database handles") {
+  CHECK_THROWS_AS(lfdb::system::main_thread_busyness({}), std::invalid_argument);
+  CHECK_THROWS_AS(lfdb::system::client_status_json({}), std::invalid_argument);
+  CHECK_THROWS_AS(lfdb::system::server_protocol({}), std::invalid_argument);
+  CHECK_THROWS_AS(lfdb::system::reboot_worker({}, "127.0.0.1:4500", false, 0),
+                  std::invalid_argument);
+  CHECK_THROWS_AS(lfdb::system::force_recovery_with_data_loss({}, "dc1"),
+                  std::invalid_argument);
+  CHECK_THROWS_AS(lfdb::system::create_snapshot({}, "snapshot-id", "snapshot-command"),
+                  std::invalid_argument);
+ }
+
+ SECTION("system namespace reports live database diagnostics") {
+  janitor dbh;
+
+  const auto busyness = lfdb::system::main_thread_busyness(dbh);
+  CHECK(0.0 <= busyness);
+
+  const auto protocol = lfdb::system::server_protocol(dbh);
+  CHECK(0 < protocol);
+
+  const auto status = lfdb::system::client_status_json(dbh);
+  CHECK_FALSE(status.empty());
+  CHECK(std::string::npos != status.find("Healthy"));
+ }
 }
 
 TEST_CASE("approximate range size composes with selections", "[fdb][query]")

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -77,6 +77,18 @@ concept can_lfdb_set = requires(Ts&& ...xs) {
  lfdb::set(std::forward<Ts>(xs)...);
 };
 
+template <typename ValueT>
+concept can_atomic_add =
+ requires(lfdb::database_handle dbh, std::string key, ValueT value) {
+  lfdb::atomic::add(dbh, key, value);
+ };
+
+template <typename ValueT>
+concept can_atomic_min =
+ requires(lfdb::database_handle dbh, std::string key, ValueT value) {
+  lfdb::atomic::min(dbh, key, value);
+ };
+
 struct pair_identity final
 {
  const string_pair& operator()(const string_pair& kv) const noexcept
@@ -196,6 +208,10 @@ TEST_CASE("libfdb concepts describe supported API shapes", "[fdb][concepts]")
  STATIC_REQUIRE_FALSE((lfdb::detail::bound_transaction_op<
                        transaction_with_move_only_argument,
                        move_only_transaction_argument&>));
+
+ STATIC_REQUIRE(can_atomic_add<std::uint64_t>);
+ STATIC_REQUIRE_FALSE(can_atomic_add<bool>);
+ STATIC_REQUIRE_FALSE(can_atomic_min<std::int64_t>);
 }
 
 TEST_CASE("query prefix handles byte-string keyspace edges", "[fdb][query]")
@@ -268,6 +284,39 @@ inline void write_raw_fdb_value(lfdb::database_handle dbh,
                      static_cast<int>(std::size(value)));
 
  REQUIRE(lfdb::commit(txn));
+}
+
+inline std::vector<std::uint8_t> read_raw_fdb_value(lfdb::database_handle dbh,
+                                                    std::string_view key)
+{
+ std::vector<std::uint8_t> out;
+
+ REQUIRE(lfdb::get(dbh, key, [&out](std::span<const std::uint8_t> value) {
+  out.assign(std::begin(value), std::end(value));
+ }));
+
+ return out;
+}
+
+inline std::span<const std::uint8_t> raw_bytes(std::string_view value)
+{
+ return {
+  reinterpret_cast<const std::uint8_t *>(value.data()),
+  std::size(value)
+ };
+}
+
+template <std::unsigned_integral ValueT>
+constexpr ValueT decode_little_endian(std::span<const std::uint8_t> bytes)
+{
+ ValueT out = 0;
+
+ for (auto byte : bytes | std::views::reverse) {
+  out <<= 8;
+  out |= static_cast<ValueT>(byte);
+ }
+
+ return out;
 }
 
 inline auto decode_raw_fdb_pairs(std::span<const FDBKeyValue> pairs)
@@ -2382,6 +2431,108 @@ TEST_CASE("explicit conflict ranges", "[fdb]") {
                        Catch::Matchers::MessageMatches(
                         Catch::Matchers::ContainsSubstring(
                          "conflict expression must contain a non-empty range")));
+ }
+}
+
+TEST_CASE("atomic mutations", "[fdb]") {
+ janitor j;
+
+ SECTION("add mutates little-endian integer values") {
+  const auto key = test_key("atomic/add");
+
+  lfdb::atomic::add(j, key, std::uint64_t{5});
+
+  auto txn = lfdb::make_transaction(j);
+
+  lfdb::atomic::add(txn, key, std::int64_t{-2});
+  REQUIRE(lfdb::commit(txn));
+
+  const auto value = read_raw_fdb_value(j, key);
+
+  REQUIRE(sizeof(std::uint64_t) == std::size(value));
+  CHECK(3 == decode_little_endian<std::uint64_t>(value));
+ }
+
+ SECTION("add does not require a read conflict") {
+  const auto key = test_key("atomic/add/concurrent");
+
+  auto first_txn = lfdb::make_transaction(j);
+  auto second_txn = lfdb::make_transaction(j);
+
+  lfdb::atomic::add(first_txn, key, std::uint64_t{1});
+  lfdb::atomic::add(second_txn, key, std::uint64_t{1});
+
+  CHECK(lfdb::commit(first_txn));
+  CHECK(lfdb::commit(second_txn));
+
+  const auto value = read_raw_fdb_value(j, key);
+
+  REQUIRE(sizeof(std::uint64_t) == std::size(value));
+  CHECK(2 == decode_little_endian<std::uint64_t>(value));
+ }
+
+ SECTION("min and max use unsigned little-endian parameters") {
+  const auto key = test_key("atomic/min-max");
+
+  lfdb::atomic::max(j, key, std::uint64_t{10});
+  lfdb::atomic::max(j, key, std::uint64_t{7});
+  lfdb::atomic::max(j, key, std::uint64_t{12});
+  lfdb::atomic::min(j, key, std::uint64_t{20});
+  lfdb::atomic::min(j, key, std::uint64_t{4});
+
+  const auto value = read_raw_fdb_value(j, key);
+
+  REQUIRE(sizeof(std::uint64_t) == std::size(value));
+  CHECK(4 == decode_little_endian<std::uint64_t>(value));
+ }
+
+ SECTION("bit operations mutate integer bytes") {
+  const auto key = test_key("atomic/bit");
+
+  lfdb::atomic::bit_or(j, key, std::uint64_t{0x0F});
+  lfdb::atomic::bit_xor(j, key, std::uint64_t{0x03});
+  lfdb::atomic::bit_and(j, key, std::uint64_t{0x0A});
+
+  const auto value = read_raw_fdb_value(j, key);
+
+  REQUIRE(sizeof(std::uint64_t) == std::size(value));
+  CHECK(0x08 == decode_little_endian<std::uint64_t>(value));
+ }
+
+ SECTION("byte operations use lexicographic raw values") {
+  const auto key = test_key("atomic/byte-min-max");
+
+  const auto minimum = std::array<std::uint8_t, 1>{'b'};
+  const auto maximum = std::vector<std::uint8_t>{'c'};
+
+  write_raw_fdb_value(j, key, raw_bytes("m"));
+
+  lfdb::atomic::byte_min(j, key, minimum);
+  CHECK(std::vector<std::uint8_t>{'b'} == read_raw_fdb_value(j, key));
+
+  lfdb::atomic::byte_max(j, key, maximum);
+  CHECK(std::vector<std::uint8_t>{'c'} == read_raw_fdb_value(j, key));
+ }
+
+ SECTION("append_if_fits appends raw bytes") {
+  const auto key = test_key("atomic/append-if-fits");
+
+  write_raw_fdb_value(j, key, raw_bytes("cache"));
+  lfdb::atomic::append_if_fits(j, key, "-block");
+
+  CHECK(std::vector<std::uint8_t>{'c', 'a', 'c', 'h', 'e', '-', 'b', 'l', 'o', 'c', 'k'} ==
+        read_raw_fdb_value(j, key));
+ }
+
+ SECTION("compare_and_clear clears only matching raw bytes") {
+  const auto key = test_key("atomic/compare-and-clear");
+
+  write_raw_fdb_value(j, key, raw_bytes("present"));
+  lfdb::atomic::compare_and_clear(j, key, "missing");
+  CHECK(lfdb::key_exists(j, key));
+
+  lfdb::atomic::compare_and_clear(j, key, "present");
+  CHECK_FALSE(lfdb::key_exists(j, key));
  }
 }
 

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -105,6 +105,30 @@ concept can_atomic_min =
   lfdb::atomic::min(dbh, key, value);
  };
 
+template <typename FnT>
+concept can_lfdb_for_each =
+ requires(lfdb::transaction_handle txn, lfdb::select selection, FnT fn) {
+  lfdb::for_each(txn, selection, fn);
+ };
+
+template <typename FnT>
+concept can_lfdb_get_raw_value =
+ requires(lfdb::database_handle dbh, std::string key, FnT fn) {
+  lfdb::get(dbh, key, fn);
+ };
+
+template <typename FnT>
+concept can_lfdb_from_convert_output =
+ requires(std::span<const std::uint8_t> bytes, FnT fn) {
+  lfdb::from::convert(bytes, fn);
+ };
+
+template <typename FnT>
+concept can_lfdb_watched_loop =
+ requires(lfdb::database_handle dbh, std::string key, FnT fn) {
+  lfdb::watched_loop(dbh, key, fn);
+ };
+
 struct pair_identity final
 {
  const string_pair& operator()(const string_pair& kv) const noexcept
@@ -228,6 +252,25 @@ TEST_CASE("libfdb concepts describe supported API shapes", "[fdb][concepts]")
  STATIC_REQUIRE(can_atomic_add<std::uint64_t>);
  STATIC_REQUIRE_FALSE(can_atomic_add<bool>);
  STATIC_REQUIRE_FALSE(can_atomic_min<std::int64_t>);
+
+ STATIC_REQUIRE(can_lfdb_for_each<decltype([](string_pair&&) {})>);
+ STATIC_REQUIRE_FALSE(can_lfdb_for_each<decltype([](string_pair&&) { return 1; })>);
+
+ STATIC_REQUIRE(lfdb::concepts::value_callback<decltype([](std::span<const std::uint8_t>) {})>);
+ STATIC_REQUIRE_FALSE(lfdb::concepts::value_callback<decltype([](std::span<const std::uint8_t>) {
+  return 1;
+ })>);
+ STATIC_REQUIRE(can_lfdb_get_raw_value<decltype([](std::span<const std::uint8_t>) {})>);
+ STATIC_REQUIRE_FALSE(can_lfdb_get_raw_value<decltype([](std::span<const std::uint8_t>) {
+  return 1;
+ })>);
+ STATIC_REQUIRE(can_lfdb_from_convert_output<decltype([](const char *, std::size_t) {})>);
+ STATIC_REQUIRE_FALSE(can_lfdb_from_convert_output<decltype([](const char *, std::size_t) {
+  return 1;
+ })>);
+
+ STATIC_REQUIRE(can_lfdb_watched_loop<decltype([](std::string_view) {})>);
+ STATIC_REQUIRE_FALSE(can_lfdb_watched_loop<decltype([](std::string_view) { return true; })>);
 }
 
 TEST_CASE("query prefix handles byte-string keyspace edges", "[fdb][query]")

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -2731,6 +2731,34 @@ SCENARIO("transactor", "[fdb]")
   return 7;
  })>);
 
+ SECTION("prepare_replay handles retryable errors") {
+  constexpr fdb_error_t not_committed = 1020;
+  REQUIRE(0 != fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, not_committed));
+
+  auto txn = lfdb::make_transaction(j);
+
+  CHECK_NOTHROW(lfdb::prepare_replay(txn, not_committed));
+ }
+
+ SECTION("prepare_replay rejects non-retryable errors") {
+  constexpr fdb_error_t operation_cancelled = 1101;
+  REQUIRE_FALSE(fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, operation_cancelled));
+
+  auto txn = lfdb::make_transaction(j);
+
+  CHECK_THROWS_AS(lfdb::prepare_replay(txn, operation_cancelled), lfdb::libfdb_exception);
+ }
+
+ SECTION("successful commit ends ordinary transaction work") {
+  auto txn = lfdb::make_transaction(j);
+
+  lfdb::set(txn, test_key("lifecycle"), "value");
+  REQUIRE(lfdb::commit(txn));
+
+  CHECK(0 < lfdb::committed_version(txn));
+  CHECK_THROWS_AS(lfdb::prepare_replay(txn, 1020), std::invalid_argument);
+ }
+
  SECTION("transaction function returns nothing") {
   auto txr = lfdb::make_transactor(j);
   const auto key = test_key("key");

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -39,6 +39,7 @@
 #include <concepts>
 #include <cstdint>
 #include <exception>
+#include <filesystem>
 #include <iterator>
 #include <limits>
 #include <list>
@@ -76,6 +77,21 @@ template <typename ...Ts>
 concept can_lfdb_set = requires(Ts&& ...xs) {
  lfdb::set(std::forward<Ts>(xs)...);
 };
+
+template <typename SourceT>
+concept can_create_database_from = requires(SourceT source) {
+ lfdb::create_database(source);
+};
+
+static_assert(std::constructible_from<lfdb::connection_source, std::filesystem::path>);
+static_assert(std::constructible_from<lfdb::connection_source, std::string_view>);
+static_assert(not std::is_convertible_v<std::filesystem::path, lfdb::connection_source>);
+static_assert(not std::is_convertible_v<std::string_view, lfdb::connection_source>);
+static_assert(not std::constructible_from<lfdb::connection_source, std::nullptr_t>);
+static_assert(not can_create_database_from<std::filesystem::path>);
+static_assert(not can_create_database_from<std::string_view>);
+static_assert(not can_create_database_from<std::string>);
+static_assert(not can_create_database_from<const char *>);
 
 template <typename ValueT>
 concept can_atomic_add =
@@ -3092,7 +3108,8 @@ SCENARIO("options", "[fdb]")
                 { { FDB_DB_OPTION_LOCATION_CACHE_SIZE, 200'000 } },  
                 { { FDB_NET_OPTION_TRACE_ENABLE, lfdb::option_flag } });         
 
-  auto dbh1 = lfdb::create_database("fishing for databass!",             // name
+  auto dbh1 = lfdb::create_database(
+                lfdb::connection_source{std::filesystem::path{"fishing for databass!"}},
                 { { FDB_DB_OPTION_LOCATION_CACHE_SIZE, 200'000 } },      // database options
                 { { FDB_NET_OPTION_TRACE_ENABLE, lfdb::option_flag } }); // network options
  
@@ -3101,9 +3118,12 @@ SCENARIO("options", "[fdb]")
 
  SECTION("create_database()") {
   lfdb::create_database();
-  lfdb::create_database("");
-  lfdb::create_database("", {}, {});
+  lfdb::create_database(lfdb::connection_source{std::filesystem::path{"/dev/null"}});
+  lfdb::create_database(lfdb::connection_source{std::filesystem::path{"/dev/null"}}, {}, {});
   lfdb::create_database(lfdb::database_options {}, lfdb::network_options {});
+
+  CHECK_THROWS_AS(lfdb::connection_source{std::filesystem::path{}}, std::invalid_argument);
+  CHECK_THROWS_AS(lfdb::connection_source{""}, std::invalid_argument);
  }
 
  SECTION("piecemeal construction") {
@@ -3115,7 +3135,7 @@ SCENARIO("options", "[fdb]")
   // The cluster file is in "/etc/foundationdb.fdb.cluster" normally, but we'll point to 
   // nowhere just for fun. The cluster file is the "approved" way to establish a list of
   // addressess, AFAIK, rather than setting the option:
-  lfdb::create_database("/dev/null", {}, netopts);
+  lfdb::create_database(lfdb::connection_source{std::filesystem::path{"/dev/null"}}, {}, netopts);
  }
 }
 

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -2179,6 +2179,91 @@ TEST_CASE("snapshot reads do not add read conflicts", "[fdb]") {
   CHECK(lfdb::key_exists(j, write_key));
  }
 
+ SECTION("selection get") {
+  constexpr auto prefix = "snapshot-get-selection";
+  const auto conflict_key = make_key(0, prefix);
+  const auto write_key = make_key(99, prefix);
+  const auto selector = lfdb::select { make_key(0, prefix), make_key(2, prefix) };
+
+  lfdb::set(j, conflict_key, "old");
+
+  auto snapshot_txn = lfdb::make_transaction(j);
+  std::vector<string_pair> out;
+  REQUIRE(1 == lfdb::get(snapshot_txn, selector, out, lfdb::read_mode::snapshot));
+
+  lfdb::set(j, conflict_key, "new");
+  lfdb::set(snapshot_txn, write_key, "snapshot-side-effect");
+
+  CHECK(lfdb::commit(snapshot_txn));
+  CHECK(lfdb::key_exists(j, write_key));
+ }
+
+ SECTION("functional helpers") {
+  constexpr auto prefix = "snapshot-functional";
+  const auto conflict_key = make_key(0, prefix);
+  const auto write_key = make_key(99, prefix);
+  const auto selector = lfdb::select { make_key(0, prefix), make_key(2, prefix) };
+
+  lfdb::set(j, conflict_key, "old");
+
+  auto snapshot_txn = lfdb::make_transaction(j);
+  int visited = 0;
+  lfdb::for_each(snapshot_txn, selector,
+                 [&visited](string_pair&&) {
+                  ++visited;
+                 },
+                 lfdb::read_mode::snapshot);
+  REQUIRE(1 == visited);
+
+  const auto values = lfdb::transform(snapshot_txn, selector,
+                                      [](string_pair&& row) {
+                                       return std::move(row.second);
+                                      },
+                                      lfdb::read_mode::snapshot);
+  REQUIRE_THAT(values, Catch::Matchers::Equals(std::vector<std::string>{ "old" }));
+
+  lfdb::set(j, conflict_key, "new");
+  lfdb::set(snapshot_txn, write_key, "snapshot-side-effect");
+
+  CHECK(lfdb::commit(snapshot_txn));
+  CHECK(lfdb::key_exists(j, write_key));
+ }
+
+ SECTION("paginated scan") {
+  constexpr auto prefix = "snapshot-page";
+  const auto conflict_key = make_key(0, prefix);
+  const auto write_key = make_key(99, prefix);
+  const auto selector = lfdb::select { make_key(0, prefix), make_key(2, prefix) };
+
+  lfdb::set(j, conflict_key, "old");
+
+  auto snapshot_txn = lfdb::make_transaction(j);
+  const auto page = lfdb::scan(snapshot_txn, selector, lfdb::page{1},
+                              lfdb::read_mode::snapshot);
+  REQUIRE(1 == page.size());
+
+  lfdb::set(j, conflict_key, "new");
+  lfdb::set(snapshot_txn, write_key, "snapshot-side-effect");
+
+  CHECK(lfdb::commit(snapshot_txn));
+  CHECK(lfdb::key_exists(j, write_key));
+ }
+
+ SECTION("managed block scan accepts snapshot mode") {
+  constexpr auto prefix = "snapshot-blocks";
+  const auto selector = lfdb::select { make_key(0, prefix), make_key(3, prefix) };
+
+  lfdb::set(j, make_key(0, prefix), "zero");
+  lfdb::set(j, make_key(1, prefix), "one");
+
+  std::vector<string_pair> rows;
+  for (const auto& block : lfdb::blocks(j, selector, lfdb::read_mode::snapshot)) {
+   std::ranges::copy(block, std::back_inserter(rows));
+  }
+
+  CHECK(2 == rows.size());
+ }
+
  SECTION("key existence") {
   const auto read_key = make_key(0, "snapshot-exists");
   const auto write_key = make_key(1, "snapshot-exists");

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -424,10 +424,11 @@ TEST_CASE("version stamps", "[fdb]") {
  }
 
  SECTION("commit resolves explicit version stamp") {
+  const auto key = test_key("versionstamp/explicit");
   auto txn = lfdb::make_transaction(dbh);
   lfdb::versionstamp stamp;
 
-  lfdb::set(txn, "versionstamp/explicit", "value");
+  lfdb::set(txn, key, "value");
   REQUIRE(lfdb::commit(txn, stamp));
 
   CHECK(stamp.is_resolved());
@@ -435,15 +436,17 @@ TEST_CASE("version stamps", "[fdb]") {
  }
 
  SECTION("resolved versionstamp cannot be reused for commit") {
+  const auto first_key = test_key("versionstamp/reuse/first");
+  const auto second_key = test_key("versionstamp/reuse/second");
   lfdb::versionstamp stamp;
 
   auto txn = lfdb::make_transaction(dbh);
-  lfdb::set(txn, "versionstamp/reuse/first", "value");
+  lfdb::set(txn, first_key, "value");
   REQUIRE(lfdb::commit(txn, stamp));
   REQUIRE(stamp.is_resolved());
 
   auto reuse_txn = lfdb::make_transaction(dbh);
-  lfdb::set(reuse_txn, "versionstamp/reuse/second", "value");
+  lfdb::set(reuse_txn, second_key, "value");
 
   CHECK_THROWS_MATCHES(lfdb::commit(reuse_txn, stamp),
                        std::invalid_argument,
@@ -496,34 +499,36 @@ TEST_CASE("version stamps", "[fdb]") {
  }
 
  SECTION("versionstamp key") {
-  lfdb::erase(dbh, lfdb::select { "versionstamp/key/" });
+  const auto prefix = test_key("versionstamp/key/");
+  lfdb::erase(dbh, lfdb::select { prefix });
 
   lfdb::versionstamp stamp;
 
   lfdb::set(dbh,
-            lfdb::versioned("versionstamp/key/", "/entry", stamp),
+            lfdb::versioned(prefix, "/entry", stamp),
             "value"s);
 
   REQUIRE(stamp.is_resolved());
 
   std::map<std::string, std::string> out;
-  lfdb::get(dbh, lfdb::select { "versionstamp/key/" }, std::inserter(out, out.end()));
+  lfdb::get(dbh, lfdb::select { prefix }, std::inserter(out, out.end()));
 
   REQUIRE(1 == out.size());
   CHECK("value" == out.begin()->second);
  }
 
  SECTION("versionstamp value") {
+  const auto key = test_key("versionstamp/value");
   lfdb::versionstamp stamp;
 
   lfdb::set(dbh,
-            "versionstamp/value",
+            key,
             lfdb::versioned("", stamp));
 
   REQUIRE(stamp.is_resolved());
 
   lfdb::versionstamp out;
-  REQUIRE(lfdb::get(dbh, "versionstamp/value", out));
+  REQUIRE(lfdb::get(dbh, key, out));
 
   REQUIRE(out.is_resolved());
   CHECK(stamp.resolved_bytes() == out.resolved_bytes());
@@ -532,11 +537,12 @@ TEST_CASE("version stamps", "[fdb]") {
  SECTION("versionstamp overloads compile and commit") {
   // As these overloads share call paths, just check that they compile and briefly check output:
   {
+    const auto key_prefix = test_key("versionstamp/overload/key/");
     auto txn = lfdb::make_transaction(dbh);
     lfdb::versionstamp stamp;
 
     lfdb::set(txn,
-              lfdb::versioned("versionstamp/overload/key/", stamp),
+              lfdb::versioned(key_prefix, stamp),
               "value",
               lfdb::commit_after_op::commit);
 
@@ -544,16 +550,59 @@ TEST_CASE("version stamps", "[fdb]") {
   }
 
   {
+    const auto key = test_key("versionstamp/overload/value");
     auto txn = lfdb::make_transaction(dbh);
     lfdb::versionstamp stamp;
 
     lfdb::set(txn,
-              "versionstamp/overload/value",
+              key,
               lfdb::versioned("value:", stamp),
               lfdb::commit_after_op::commit);
 
     CHECK(stamp.is_resolved());
   }
+ }
+}
+
+TEST_CASE("transaction versions", "[fdb]") {
+ janitor dbh;
+
+ SECTION("read version is available in an active transaction") {
+  auto txn = lfdb::make_transaction(dbh);
+
+  CHECK(0 < lfdb::read_version(txn));
+ }
+
+ SECTION("committed version is available after commit") {
+  const auto key = test_key("transaction-version/committed");
+  auto txn = lfdb::make_transaction(dbh);
+
+  lfdb::set(txn, key, "value");
+  REQUIRE(lfdb::commit(txn));
+
+  CHECK(0 < lfdb::committed_version(txn));
+ }
+
+ SECTION("explicit read version can read an earlier committed value") {
+  const auto key = test_key("transaction-version/read-at");
+
+  auto first_txn = lfdb::make_transaction(dbh);
+  lfdb::set(first_txn, key, "first");
+  REQUIRE(lfdb::commit(first_txn));
+  const auto first_version = lfdb::committed_version(first_txn);
+
+  auto second_txn = lfdb::make_transaction(dbh);
+  lfdb::set(second_txn, key, "second");
+  REQUIRE(lfdb::commit(second_txn));
+
+  auto read_txn = lfdb::make_transaction(dbh);
+  lfdb::set_read_version(read_txn, first_version);
+
+  std::string value;
+  REQUIRE(lfdb::get(read_txn, key, value));
+
+  CHECK(first_version == lfdb::read_version(read_txn));
+  CHECK("first" == value);
  }
 }
 

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -40,6 +40,7 @@
 #include <cstdint>
 #include <exception>
 #include <iterator>
+#include <limits>
 #include <list>
 #include <map>
 #include <ranges>
@@ -133,6 +134,14 @@ struct immovable_string_pair_output final
 
  void push_back(string_pair value) { values.push_back(std::move(value)); }
 };
+
+[[nodiscard]] bool contains_key(const std::vector<string_pair>& rows,
+                                const std::string& key)
+{
+ const auto found = std::ranges::find(rows, key, &string_pair::first);
+
+ return std::end(rows) != found;
+}
 
 TEST_CASE("libfdb concepts describe supported API shapes", "[fdb][concepts]")
 {
@@ -1327,13 +1336,13 @@ TEST_CASE("query algebra examples execute against fdb", "[fdb][query][example]")
  }
 }
 
-TEST_CASE("legacy generator names delegate to scan vocabulary", "[fdb]")
+TEST_CASE("compatibility generator names delegate to scan vocabulary", "[fdb]")
 {
  janitor dbh;
 
- const auto kvs_in = write_monotonic_kvs(dbh, 10, "legacy-generator");
- const auto selector = lfdb::select { make_key(0, "legacy-generator"),
-                                      make_key(10, "legacy-generator") };
+ const auto kvs_in = write_monotonic_kvs(dbh, 10, "compat-generator");
+ const auto selector = lfdb::select { make_key(0, "compat-generator"),
+                                      make_key(10, "compat-generator") };
 
  auto txn = lfdb::make_transaction(dbh);
 
@@ -1677,6 +1686,339 @@ TEST_CASE("basic generators", "[fdb]") {
       CHECK(out.contains(make_key(0)));
       CHECK(out.contains(make_key(nkeys - 1)));
     }
+ }
+
+ SECTION("for_each forward") {
+    std::vector<string_pair> out;
+    auto txn = lfdb::make_transaction(j);
+
+    lfdb::for_each(txn, lfdb::select { make_key(0), make_key(nkeys) },
+                   [&out](string_pair&& row) {
+                     out.emplace_back(std::move(row));
+                   });
+
+    CAPTURE(nkeys);
+    CAPTURE(out.size());
+    REQUIRE(nkeys == out.size());
+
+    if (0 < nkeys) {
+      CHECK(make_key(0) == out.front().first);
+      CHECK(make_key(nkeys - 1) == out.back().first);
+      CHECK(std::ranges::is_sorted(out, std::ranges::less {},
+                                   &std::pair<std::string, std::string>::first));
+    }
+ }
+
+ SECTION("for_each reverse") {
+    std::vector<string_pair> out;
+    auto selector = lfdb::select { make_key(0), make_key(nkeys) };
+    selector.options.reverse_order = true;
+
+    auto txn = lfdb::make_transaction(j);
+    lfdb::for_each(txn, selector, [&out](string_pair&& row) {
+      out.emplace_back(std::move(row));
+    });
+
+    CAPTURE(nkeys);
+    CAPTURE(out.size());
+    REQUIRE(nkeys == out.size());
+
+    if (0 < nkeys) {
+      CHECK(make_key(nkeys - 1) == out.front().first);
+      CHECK(make_key(0) == out.back().first);
+      CHECK(std::ranges::is_sorted(out, std::ranges::greater {},
+                                   &std::pair<std::string, std::string>::first));
+    }
+ }
+
+ SECTION("for_each with database handle") {
+    std::vector<string_pair> out;
+
+    lfdb::for_each(j, lfdb::select { make_key(0), make_key(nkeys) },
+                   [&out](string_pair&& row) {
+                    out.emplace_back(std::move(row));
+                   });
+
+    CAPTURE(nkeys);
+    CAPTURE(out.size());
+    REQUIRE(nkeys == out.size());
+
+    if (0 < nkeys) {
+      CHECK(make_key(0) == out.front().first);
+      CHECK(make_key(nkeys - 1) == out.back().first);
+    }
+ }
+
+ SECTION("transform to output iterator") {
+    std::vector<std::string> keys;
+    auto txn = lfdb::make_transaction(j);
+
+    lfdb::transform(txn, lfdb::select { make_key(0), make_key(nkeys) },
+                    [](string_pair&& row) {
+                     return std::move(row.first);
+                    },
+                    std::back_inserter(keys));
+
+    CAPTURE(nkeys);
+    CAPTURE(keys.size());
+    REQUIRE(nkeys == keys.size());
+
+    if (0 < nkeys) {
+      CHECK(make_key(0) == keys.front());
+      CHECK(make_key(nkeys - 1) == keys.back());
+      CHECK(std::ranges::is_sorted(keys));
+    }
+ }
+
+ SECTION("transform returns vector") {
+    auto selector = lfdb::select { make_key(0), make_key(nkeys) };
+    selector.options.reverse_order = true;
+
+    auto txn = lfdb::make_transaction(j);
+    const auto values = lfdb::transform(txn, selector, [](string_pair&& row) {
+      return std::move(row.second);
+    });
+
+    CAPTURE(nkeys);
+    CAPTURE(values.size());
+    REQUIRE(nkeys == values.size());
+
+    if (0 < nkeys) {
+      CHECK(make_value(nkeys - 1) == values.front());
+      CHECK(make_value(0) == values.back());
+    }
+ }
+
+ SECTION("transform with database handle returns vector") {
+    const auto values = lfdb::transform(j,
+                                        lfdb::select { make_key(0), make_key(nkeys) },
+                                        [](string_pair&& row) {
+                                         return std::move(row.second);
+                                        });
+
+    CAPTURE(nkeys);
+    CAPTURE(values.size());
+    REQUIRE(nkeys == values.size());
+
+    if (0 < nkeys) {
+      CHECK(make_value(0) == values.front());
+      CHECK(make_value(nkeys - 1) == values.back());
+    }
+ }
+
+ SECTION("transform with database handle writes to output iterator") {
+    std::vector<std::string> keys;
+
+    lfdb::transform(j, lfdb::select { make_key(0), make_key(nkeys) },
+                    [](string_pair&& row) {
+                     return std::move(row.first);
+                    },
+                    std::back_inserter(keys));
+
+    CAPTURE(nkeys);
+    CAPTURE(keys.size());
+    REQUIRE(nkeys == keys.size());
+
+    if (0 < nkeys) {
+      CHECK(make_key(0) == keys.front());
+      CHECK(make_key(nkeys - 1) == keys.back());
+    }
+ }
+
+ SECTION("erase_if in explicit transaction") {
+    const auto erase_first = 0 < nkeys;
+    const auto erase_third = 2 < nkeys;
+
+    auto txn = lfdb::make_transaction(j);
+    const auto removed = lfdb::erase_if(txn,
+                                        lfdb::select { make_key(0), make_key(nkeys) },
+                                        [](const string_pair& row) {
+                                         return make_key(0) == row.first ||
+                                                make_key(2) == row.first;
+                                        });
+    REQUIRE(lfdb::commit(txn));
+
+    CHECK(static_cast<std::size_t>(erase_first) +
+          static_cast<std::size_t>(erase_third) == removed);
+
+    const auto remaining = lfdb::collect(j, lfdb::select { make_key(0), make_key(nkeys) });
+
+    if (erase_first) {
+      CHECK_FALSE(contains_key(remaining, make_key(0)));
+    }
+    if (erase_third) {
+      CHECK_FALSE(contains_key(remaining, make_key(2)));
+    }
+    if (1 < nkeys) {
+      CHECK(contains_key(remaining, make_key(1)));
+    }
+ }
+
+ SECTION("erase_if with database handle") {
+    const auto erase_second = 1 < nkeys;
+    const auto erase_fourth = 3 < nkeys;
+
+    const auto removed = lfdb::erase_if(j,
+                                        lfdb::select { make_key(0), make_key(nkeys) },
+                                        [](const string_pair& row) {
+                                         return make_key(1) == row.first ||
+                                                make_key(3) == row.first;
+                                        });
+
+    CHECK(static_cast<std::size_t>(erase_second) +
+          static_cast<std::size_t>(erase_fourth) == removed);
+
+    const auto remaining = lfdb::collect(j, lfdb::select { make_key(0), make_key(nkeys) });
+
+    if (erase_second) {
+      CHECK_FALSE(contains_key(remaining, make_key(1)));
+    }
+    if (erase_fourth) {
+      CHECK_FALSE(contains_key(remaining, make_key(3)));
+    }
+    if (0 < nkeys) {
+      CHECK(contains_key(remaining, make_key(0)));
+    }
+ }
+}
+
+TEST_CASE("paged scan", "[fdb]") {
+ janitor j;
+
+ const unsigned nkeys = 10;
+ const auto kvs_in = write_monotonic_kvs(j, nkeys);
+
+ SECTION("collects one generic range page") {
+  auto source = std::views::iota(0, 6)
+              | std::views::transform([](const auto n) { return n * 2; });
+
+  const auto page = lfdb::collect(source, lfdb::page{3});
+
+  CHECK(page.has_more);
+  CHECK_THAT(page.rows, Catch::Matchers::RangeEquals(std::vector{0, 2, 4}));
+ }
+
+ SECTION("collects an unlimited generic range page") {
+  const auto page = lfdb::collect(std::views::iota(0, 3), lfdb::page{});
+
+  CHECK_FALSE(page.has_more);
+  CHECK_THAT(page.rows, Catch::Matchers::RangeEquals(std::vector{0, 1, 2}));
+ }
+
+ SECTION("collects one page from a scan range") {
+  auto txn = lfdb::make_transaction(j);
+  auto rows = lfdb::scan(txn, lfdb::select { make_key(0), make_key(nkeys) });
+
+  const auto page = lfdb::collect(std::move(rows), lfdb::page{4});
+
+  CHECK(page.has_more);
+  CHECK_THAT(page.rows, Catch::Matchers::RangeEquals(first_keys(kvs_in, 4)));
+ }
+
+ SECTION("scans one page in an explicit transaction") {
+  auto txn = lfdb::make_transaction(j);
+  const auto page = lfdb::scan(txn, lfdb::select { make_key(0), make_key(nkeys) },
+                               lfdb::page{3});
+
+  CHECK(page.has_more);
+  CHECK_THAT(page.rows, Catch::Matchers::RangeEquals(first_keys(kvs_in, 3)));
+ }
+
+ SECTION("scans one page in an implicit transaction") {
+  const auto page = lfdb::scan(j, lfdb::select { make_key(0), make_key(nkeys) },
+                               lfdb::page{3});
+
+  CHECK(page.has_more);
+  CHECK_THAT(page.rows, Catch::Matchers::RangeEquals(first_keys(kvs_in, 3)));
+ }
+
+ SECTION("scans an unlimited page") {
+  const auto page = lfdb::scan(j, lfdb::select { make_key(0), make_key(nkeys) },
+                               lfdb::page{});
+
+  CHECK_FALSE(page.has_more);
+  CHECK_THAT(page.rows, Catch::Matchers::RangeEquals(kvs_in));
+ }
+
+ SECTION("scans a terminal page") {
+  const auto page = lfdb::scan(j, lfdb::select { make_key(0), make_key(2) },
+                               lfdb::page{3});
+
+  CHECK_FALSE(page.has_more);
+  CHECK_THAT(page.rows, Catch::Matchers::RangeEquals(first_keys(kvs_in, 2)));
+ }
+
+ SECTION("scans one reverse page") {
+  auto selector = lfdb::select { make_key(0), make_key(nkeys) };
+  selector.options.reverse_order = true;
+
+  const auto page = lfdb::scan(j, selector, lfdb::page{3});
+
+  CHECK(page.has_more);
+  CHECK_THAT(page.rows, Catch::Matchers::RangeEquals(last_keys_reversed(kvs_in, 3)));
+ }
+
+ SECTION("does not decode the forward continuation sentinel") {
+  constexpr auto prefix = "paged-scan-forward-sentinel";
+
+  lfdb::make_transactor(j)([prefix](auto& txn) {
+   for (const auto n : std::views::iota(0, 3)) {
+    lfdb::set(txn, make_key(n, prefix), n);
+   }
+
+   std::span<const std::uint8_t> invalid_value;
+   ceph::libfdb::detail::transaction_set_kv_bytes(
+    txn,
+    ceph::libfdb::detail::as_fdb_span(make_key(3, prefix)),
+    invalid_value);
+  });
+
+  const auto page = lfdb::scan<int>(j, lfdb::select { make_key(0, prefix),
+                                                      make_key(4, prefix) },
+                                    lfdb::page{3});
+
+  CHECK(page.has_more);
+  CHECK(3 == std::size(page));
+ }
+
+ SECTION("does not decode the reverse continuation sentinel") {
+  constexpr auto prefix = "paged-scan-reverse-sentinel";
+
+  lfdb::make_transactor(j)([prefix](auto& txn) {
+   std::span<const std::uint8_t> invalid_value;
+   ceph::libfdb::detail::transaction_set_kv_bytes(
+    txn,
+    ceph::libfdb::detail::as_fdb_span(make_key(0, prefix)),
+    invalid_value);
+
+   for (const auto n : std::views::iota(1, 4)) {
+    lfdb::set(txn, make_key(n, prefix), n);
+   }
+  });
+
+  auto selector = lfdb::select { make_key(0, prefix), make_key(4, prefix) };
+  selector.options.reverse_order = true;
+
+  const auto page = lfdb::scan<int>(j, selector, lfdb::page{3});
+
+  CHECK(page.has_more);
+  CHECK(3 == std::size(page));
+ }
+
+ SECTION("scans an empty page") {
+  const auto page = lfdb::scan(j, lfdb::select { make_key(nkeys), make_key(nkeys + 1) },
+                               lfdb::page{3});
+
+  CHECK(page.empty());
+  CHECK_FALSE(page.has_more);
+ }
+
+ SECTION("rejects a page too large for an FDB range limit") {
+  CHECK_THROWS_AS([] {
+                   (void)lfdb::page{static_cast<uint64_t>(
+                     std::numeric_limits<int>::max())};
+                  }(),
+                  lfdb::libfdb_exception);
  }
 }
 

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -2261,7 +2261,7 @@ TEST_CASE("snapshot reads do not add read conflicts", "[fdb]") {
    std::ranges::copy(block, std::back_inserter(rows));
   }
 
-  CHECK(2 == rows.size());
+  CHECK(2 == std::size(rows));
  }
 
  SECTION("key existence") {
@@ -2276,6 +2276,112 @@ TEST_CASE("snapshot reads do not add read conflicts", "[fdb]") {
   lfdb::set(snapshot_txn, write_key, "snapshot-side-effect");
   CHECK(lfdb::commit(snapshot_txn));
   CHECK(lfdb::key_exists(j, write_key));
+ }
+}
+
+TEST_CASE("explicit conflict ranges", "[fdb]") {
+ janitor j;
+
+ SECTION("marked read conflict fails after concurrent write") {
+  const auto guard_key = make_key(0, "conflict-read-key");
+  const auto side_effect_key = make_key(1, "conflict-read-key");
+
+  lfdb::set(j, guard_key, "old");
+
+  auto txn = lfdb::make_transaction(j);
+
+  lfdb::mark_conflict_read(txn, guard_key);
+
+  lfdb::set(j, guard_key, "new");
+  lfdb::set(txn, side_effect_key, "side-effect");
+
+  CHECK_FALSE(lfdb::commit(txn));
+  CHECK_FALSE(lfdb::key_exists(j, side_effect_key));
+ }
+
+ SECTION("marked write conflict invalidates overlapping read transaction") {
+  const auto guard_key = make_key(0, "conflict-write-key");
+  const auto side_effect_key = make_key(1, "conflict-write-key");
+
+  lfdb::set(j, guard_key, "old");
+
+  auto read_txn = lfdb::make_transaction(j);
+  std::string value;
+
+  REQUIRE(lfdb::get(read_txn, guard_key, value));
+
+  auto write_txn = lfdb::make_transaction(j);
+
+  lfdb::mark_conflict_write(write_txn, guard_key);
+  REQUIRE(lfdb::commit(write_txn));
+
+  lfdb::set(read_txn, side_effect_key, "side-effect");
+
+  CHECK_FALSE(lfdb::commit(read_txn));
+  CHECK_FALSE(lfdb::key_exists(j, side_effect_key));
+ }
+
+ SECTION("selector and query overloads normalize to conflict ranges") {
+  constexpr auto prefix = "conflict-selector";
+  const auto begin = make_key(0, prefix);
+  const auto middle = make_key(1, prefix);
+  const auto end = make_key(2, prefix);
+  const auto side_effect_key = make_key(99, prefix);
+
+  lfdb::set(j, middle, "old");
+
+  auto selector_txn = lfdb::make_transaction(j);
+
+  lfdb::mark_conflict_read(selector_txn, lfdb::select { begin, end });
+  lfdb::set(j, middle, "new");
+  lfdb::set(selector_txn, side_effect_key, "side-effect");
+
+  CHECK_FALSE(lfdb::commit(selector_txn));
+  CHECK_FALSE(lfdb::key_exists(j, side_effect_key));
+
+  auto query_txn = lfdb::make_transaction(j);
+
+  lfdb::mark_conflict_read(query_txn, lfdb::query::prefix(make_key_prefix(prefix)));
+  lfdb::set(j, middle, "newer");
+  lfdb::set(query_txn, side_effect_key, "query-side-effect");
+
+  CHECK_FALSE(lfdb::commit(query_txn));
+  CHECK_FALSE(lfdb::key_exists(j, side_effect_key));
+ }
+
+ SECTION("content keys can mark exact-key conflicts") {
+  const auto object = content::keyspace(test_namespace_prefix()) / "conflict" / "object";
+  const auto side_effect_key = make_key(0, "conflict-content");
+
+  lfdb::set(j, object, "old");
+
+  auto txn = lfdb::make_transaction(j);
+
+  lfdb::mark_conflict_read(txn, object);
+
+  lfdb::set(j, object, "new");
+  lfdb::set(txn, side_effect_key, "side-effect");
+
+  CHECK_FALSE(lfdb::commit(txn));
+  CHECK_FALSE(lfdb::key_exists(j, side_effect_key));
+ }
+
+ SECTION("empty conflict ranges are rejected") {
+  const auto key = make_key(0, "conflict-empty");
+
+  auto txn = lfdb::make_transaction(j);
+
+  CHECK_THROWS_MATCHES(lfdb::mark_conflict_read(txn, lfdb::select { key, key }),
+                       std::invalid_argument,
+                       Catch::Matchers::MessageMatches(
+                        Catch::Matchers::ContainsSubstring(
+                         "conflict expression must contain a non-empty range")));
+
+  CHECK_THROWS_MATCHES(lfdb::mark_conflict_write(txn, lfdb::query::prefix(std::string("\xFF", 1))),
+                       std::invalid_argument,
+                       Catch::Matchers::MessageMatches(
+                        Catch::Matchers::ContainsSubstring(
+                         "conflict expression must contain a non-empty range")));
  }
 }
 

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -703,6 +703,21 @@ TEST_CASE("transaction versions", "[fdb]") {
  }
 }
 
+TEST_CASE("transaction commit byte estimate", "[fdb]") {
+ janitor dbh;
+ auto txn = lfdb::make_transaction(dbh);
+
+ const auto empty_estimate = lfdb::approximate_commit_bytes(txn);
+
+ lfdb::set(txn, test_key("commit-bytes/a"), "alpha");
+ lfdb::set(txn, test_key("commit-bytes/b"), "bravo");
+
+ const auto populated_estimate = lfdb::approximate_commit_bytes(txn);
+
+ CHECK(0 <= empty_estimate);
+ CHECK(empty_estimate < populated_estimate);
+}
+
 static_assert(not std::default_initializable<lfdb::watch_handle>);
 static_assert(not std::copy_constructible<lfdb::watch_handle>);
 static_assert(std::move_constructible<lfdb::watch_handle>);

--- a/src/test/rgw/test_fdb_ceph.cc
+++ b/src/test/rgw/test_fdb_ceph.cc
@@ -40,6 +40,7 @@
 #include <ranges>
 #include <algorithm>
 #include <execution>
+#include <functional>
 
 using Catch::Matchers::AllMatch;
 
@@ -336,7 +337,7 @@ auto tier_generator(ceph::libfdb::database_handle dbh, ceph::libfdb::select sele
                         auto txn = ceph::libfdb::make_transaction(dbh);
 
                         // ...my libstdc++ lacks std::from_range overloads; the Hard Way(TM) it is:
-                        for(auto&& kvp : ceph::libfdb::pair_generator(txn, selector)) {
+                        for(auto&& kvp : ceph::libfdb::scan(txn, selector)) {
                           out.emplace(kvp);
                         }
 
@@ -628,19 +629,95 @@ TEST_CASE("read path benchmarks", "[.benchmark][benchmark]") {
     require_expected(read_tally, expected_encoded_bytes);
   };
 
-  BENCHMARK_ADVANCED("pair generator read all")(Catch::Benchmark::Chronometer meter) {
+  BENCHMARK_ADVANCED("scan read all")(Catch::Benchmark::Chronometer meter) {
     meter.measure([&] {
       read_tally.reset();
 
       try {
         auto txn = lfdb::make_transaction(dbh);
-        std::ranges::for_each(lfdb::pair_generator(txn, selector), add_kv);
+        std::ranges::for_each(lfdb::scan(txn, selector), add_kv);
       } catch (const ceph::libfdb::libfdb_exception& e) {
         mark_failure(e);
       }
     });
 
     require_expected(read_tally, expected_decoded_bytes);
+  };
+
+  BENCHMARK_ADVANCED("for_each read all")(Catch::Benchmark::Chronometer meter) {
+    meter.measure([&] {
+      read_tally.reset();
+
+      try {
+        auto txn = lfdb::make_transaction(dbh);
+        lfdb::for_each(txn, selector, add_kv);
+      } catch (const ceph::libfdb::libfdb_exception& e) {
+        mark_failure(e);
+      }
+    });
+
+    require_expected(read_tally, expected_decoded_bytes);
+  };
+
+  auto should_erase = [](const auto&) {
+    return true;
+  };
+
+  auto erase_if_manual_loop = [](auto txn, const auto& selector, auto&& pred) {
+    std::size_t removed = 0;
+
+    for (const auto& row : lfdb::scan(txn, selector)) {
+      if (std::invoke(pred, row)) {
+        lfdb::erase(txn, row.first);
+        ++removed;
+      }
+    }
+
+    return removed;
+  };
+
+  BENCHMARK_ADVANCED("erase_if manual loop queues all")(Catch::Benchmark::Chronometer meter) {
+    std::size_t removed = 0;
+
+    meter.measure([&] {
+      read_tally.reset();
+
+      try {
+        auto txn = lfdb::make_transaction(dbh);
+        removed = erase_if_manual_loop(txn, selector, should_erase);
+      } catch (const ceph::libfdb::libfdb_exception& e) {
+        mark_failure(e);
+      }
+    });
+
+    if (not read_tally.ok) {
+      WARN(read_tally.error);
+    }
+
+    REQUIRE(read_tally.ok);
+    REQUIRE(nkeys == removed);
+  };
+
+  BENCHMARK_ADVANCED("erase_if helper queues all")(Catch::Benchmark::Chronometer meter) {
+    std::size_t removed = 0;
+
+    meter.measure([&] {
+      read_tally.reset();
+
+      try {
+        auto txn = lfdb::make_transaction(dbh);
+        removed = lfdb::erase_if(txn, selector, should_erase);
+      } catch (const ceph::libfdb::libfdb_exception& e) {
+        mark_failure(e);
+      }
+    });
+
+    if (not read_tally.ok) {
+      WARN(read_tally.error);
+    }
+
+    REQUIRE(read_tally.ok);
+    REQUIRE(nkeys == removed);
   };
 
   BENCHMARK_ADVANCED("block generator read all")(Catch::Benchmark::Chronometer meter) {

--- a/src/test/rgw/test_fdb_ceph.cc
+++ b/src/test/rgw/test_fdb_ceph.cc
@@ -321,11 +321,11 @@ template <typename AssocT = boost::container::flat_map<std::string, std::string>
 auto tier_generator(ceph::libfdb::database_handle dbh, ceph::libfdb::select selector)
 -> std::generator<AssocT>
 {
- auto split_ranges = plan_split_ranges(dbh, selector);
+ auto plan = detail::plan_range_work(dbh, selector, 4 * 1024 * 1024);
 
  const unsigned local_max_block = 2*2024; // vis-a-vis remote request max
 
- std::transform_reduce(std::begin(split_ranges), std::end(split_ranges),
+ std::transform_reduce(std::begin(plan.ranges), std::end(plan.ranges),
                       AssocT(),
 
                       [](auto&& lhs, auto&& rhs) {


### PR DESCRIPTION
- **rgw/fdb: add functional scan helpers**
- **libfdb: add transaction version helpers**
- **libfdb: Add read_mode support for serializable and snapshot reads.**
- **More test scenarios for version stamps.**
- **libfdb: added test scenario for watch/trigger stop tokens**
- **libfdb: committed_version() requires committed transaction**
- **libfdb: improve unit tets for snapshot reads**
- **libfdb: implements conflict ranges**
- **libfdb:: support for atomic mutations**
- **libfdb: improve blocks beef up split planning)**
- **libfdb: add support for approximate_commit_bytes()**
- **libfdb: transaction replay preparation**
- **libfdb: add key selector naviation**
- **libfdb: add approximate range-size estimates**
- **libfdb: make database connection sources explicit**
- **libfdb: add api and system database calls**

This essentially completes libfdb with respect to supporting FoundationDB's non-experimental features. Includes implementation, tests, examples. libfdb's core functionality is also "completed", with ranges-aware Functional extensions.

Note: despite having documentation, features like Tenants are still listed as experimental, and therefore not implemented in this PR.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
