### PR TITLE
osd: derive CRUSH weight from the data device, not statfs total

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12467,6 +12467,9 @@ void BlueStore::_get_statfs_overall(struct store_statfs_t *buf)
   int rc = bdev->get_ebd_state(ebd_state);
   if (rc == 0) {
     buf->total += ebd_state.get_physical_total();
+    // data device only: excludes any dedicated db/wal device folded into
+    // total above, so it can be used to derive the OSD's CRUSH weight.
+    buf->data_total = ebd_state.get_physical_total();
 
     // we are limited by both the size of the virtual device and the
     // underlying physical device.
@@ -12475,6 +12478,8 @@ void BlueStore::_get_statfs_overall(struct store_statfs_t *buf)
     buf->allocated = ebd_state.get_physical_total() - ebd_state.get_physical_avail();;
   } else {
     buf->total += bdev->get_size();
+    // data device only (see above).
+    buf->data_total = bdev->get_size();
   }
   buf->available = bfree;
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4906,9 +4906,15 @@ int OSD::update_crush_location()
       derr << "statfs: " << cpp_strerror(r) << dendl;
       return r;
     }
+    // Weight the OSD by its data device only.  store_statfs_t::total folds in
+    // any dedicated block.db/block.wal device, so weighting by total skews
+    // placement toward DB-heavy OSDs when DB:data ratios are non-uniform.
+    // data_total excludes the metadata device(s); fall back to total for
+    // stores that do not populate it.
+    uint64_t data_total = st.data_total ? st.data_total : st.total;
     snprintf(weight, sizeof(weight), "%.4lf",
 	     std::max(.00001,
-		      double(st.total) /
+		      double(data_total) /
 		      double(1ull << 40 /* TB */)));
   }
 

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -3409,6 +3409,7 @@ bool operator==(const pg_stat_t& l, const pg_stat_t& r)
 bool store_statfs_t::operator==(const store_statfs_t& other) const
 {
   return total == other.total
+    && data_total == other.data_total
     && available == other.available
     && allocated == other.allocated
     && internally_reserved == other.internally_reserved
@@ -3423,6 +3424,7 @@ bool store_statfs_t::operator==(const store_statfs_t& other) const
 void store_statfs_t::dump(Formatter *f) const
 {
   f->dump_int("total", total);
+  f->dump_int("data_total", data_total);
   f->dump_int("available", available);
   f->dump_int("internally_reserved", internally_reserved);
   f->dump_int("allocated", allocated);
@@ -3440,6 +3442,7 @@ ostream& operator<<(ostream& out, const store_statfs_t &s)
       << "store_statfs(0x" << s.available
       << "/0x"  << s.internally_reserved
       << "/0x"  << s.total
+      << ", data_total 0x" << s.data_total
       << ", data 0x" << s.data_stored
       << "/0x"  << s.allocated
       << ", compress 0x" << s.data_compressed
@@ -3458,6 +3461,7 @@ list<store_statfs_t> store_statfs_t::generate_test_instances()
   store_statfs_t a;
   o.push_back(store_statfs_t(a));
   a.total = 234;
+  a.data_total = 200;
   a.available = 123;
   a.internally_reserved = 33;
   a.allocated = 32;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2505,6 +2505,9 @@ bool operator==(const pg_stat_t& l, const pg_stat_t& r);
 struct store_statfs_t
 {
   uint64_t total = 0;                  ///< Total bytes
+  uint64_t data_total = 0;             ///< Total bytes of the data/block device only
+                                       ///< (excludes any dedicated db/wal device);
+                                       ///< used to derive the OSD's CRUSH weight
   uint64_t available = 0;              ///< Free bytes available
   uint64_t internally_reserved = 0;    ///< Bytes reserved for internal purposes
 
@@ -2524,6 +2527,7 @@ struct store_statfs_t
   void floor(int64_t f) {
 #define FLOOR(x) if (int64_t(x) < f) x = f
     FLOOR(total);
+    FLOOR(data_total);
     FLOOR(available);
     FLOOR(internally_reserved);
     FLOOR(allocated);
@@ -2586,6 +2590,7 @@ struct store_statfs_t
 
   void add(const store_statfs_t& o) {
     total += o.total;
+    data_total += o.data_total;
     available += o.available;
     internally_reserved += o.internally_reserved;
     allocated += o.allocated;
@@ -2598,6 +2603,7 @@ struct store_statfs_t
   }
   void sub(const store_statfs_t& o) {
     total -= o.total;
+    data_total -= o.data_total;
     available -= o.available;
     internally_reserved -= o.internally_reserved;
     allocated -= o.allocated;
@@ -2610,7 +2616,7 @@ struct store_statfs_t
   }
   void dump(ceph::Formatter *f) const;
   DENC(store_statfs_t, v, p) {
-    DENC_START(1, 1, p);
+    DENC_START(2, 1, p);
     denc(v.total, p);
     denc(v.available, p);
     denc(v.internally_reserved, p);
@@ -2621,6 +2627,13 @@ struct store_statfs_t
     denc(v.data_compressed_original, p);
     denc(v.omap_allocated, p);
     denc(v.internal_metadata, p);
+    if (struct_v >= 2) {
+      denc(v.data_total, p);
+    } else if constexpr (!std::is_const_v<std::remove_reference_t<decltype(v)>>) {
+      // decoding a pre-v2 struct: no dedicated data_total was recorded, so
+      // fall back to the total (matches the historical CRUSH-weight behavior).
+      v.data_total = v.total;
+    }
     DENC_FINISH(p);
   }
   static std::list<store_statfs_t> generate_test_instances();


### PR DESCRIPTION
## Problem

`OSD::update_crush_location()` derives an OSD's initial CRUSH weight from
`store_statfs_t::total`:

```cpp
snprintf(weight, ..., "%.4lf", std::max(.00001, double(st.total) / double(1ull << 40)));
```

For BlueStore, `statfs.total` = data device size **plus** any dedicated
`block.db` (and `block.wal`) device size (see `BlueStore::_get_statfs_overall()`,
which adds the dedicated BlueFS DB device size to `total`). So an OSD with a
dedicated DB is weighted `(data + db)`, not by its data capacity.

When DB:data ratios are non-uniform across the cluster, DB-heavy OSDs are
over-weighted: they attract more data than their data device can hold and hit
nearfull first, while under-weighted OSDs keep unreachable headroom. The weight
is also sticky — `CrushWrapper::create_or_move_item` ignores the passed weight
once the OSD is placed — so the skew persists for the OSD's lifetime, and pool
`MAX AVAIL` is understated.

## Fix

Weight the OSD by its **data** device only.

- Add `store_statfs_t::data_total` — the data/block device size, excluding any
  dedicated metadata (db/wal) device. Encode version bumped to 2; decoding a
  pre-v2 struct defaults `data_total` to `total` so it degrades gracefully.
- Populate `data_total` in `BlueStore::_get_statfs_overall()` from the data
  device size (the value folded into `total` there, minus the dedicated BlueFS
  DB device).
- Use `data_total` in `update_crush_location()`, falling back to `total` for
  object stores that don't populate it (e.g. MemStore).

`statfs::total` semantics are unchanged; it remains the display/fullness value.
This is a placement-weight-only correction.

## Notes

- Existing clusters: weights are sticky, so this changes only newly created /
  re-weighted OSDs; operators wanting to correct existing DB-heavy OSDs still
  reweight explicitly.
- `ceph-dencoder` `store_statfs_t` test instance updated for the v2 field.
- Not yet build-tested in CI.

Assisted by Claude Opus 4.8

Fixes: #78911
Fixes: https://tracker.ceph.com/issues/78911
Signed-off-by: Anthony D'Atri <anthonyeleven@users.noreply.github.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
