### PR TITLE
crimson/osd: quiesce the scrub machine in PG::stop()

### DIFF
--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -684,6 +684,10 @@ void PG::initiate_snap_trim()
 
 void PG::kick_snap_trim()
 {
+  // Scrub completion may try to resume snaptrim during PG shutdown.
+  if (stopping) {
+    return;
+  }
   if (peering_state.is_active() && peering_state.is_clean()
       && !snap_trimq.empty()
       && !peering_state.state_test(PG_STATE_SNAPTRIM)) {
@@ -1701,6 +1705,7 @@ seastar::future<> PG::stop()
   co_await osdmap_gate.stop();
   co_await wait_for_active_blocker.stop();
   client_request_orderer.clear_and_cancel(*this);
+  scrubber.stop();
   co_await recovery_handler->stop();
   co_await recovery_backend->stop();
   co_await backend->stop();

--- a/src/crimson/osd/scrub/pg_scrubber.cc
+++ b/src/crimson/osd/scrub/pg_scrubber.cc
@@ -35,6 +35,13 @@ void PGScrubber::on_replica_activate()
   handle_event(events::replica_activate_t{});
 }
 
+void PGScrubber::stop()
+{
+  LOG_PREFIX(PGScrubber::stop);
+  DEBUGDPP("", pg);
+  on_interval_change();
+}
+
 void PGScrubber::on_interval_change()
 {
   LOG_PREFIX(PGScrubber::on_interval_change);

--- a/src/crimson/osd/scrub/pg_scrubber.h
+++ b/src/crimson/osd/scrub/pg_scrubber.h
@@ -79,6 +79,9 @@ public:
   /// notify machine on replica that PG is active
   void on_replica_activate();
 
+  /// stop the scrubber on PG shutdown
+  void stop();
+
   /// notify machine of interval change
   void on_interval_change();
 

--- a/src/test/crimson/test_crimson_scrub.cc
+++ b/src/test/crimson/test_crimson_scrub.cc
@@ -1206,3 +1206,100 @@ TEST(TestSnapSet, Stats) {
 
   EXPECT_EQ(ret.stats, expected_stats);
 }
+
+namespace {
+
+class FakeScrubContext : public crimson::osd::scrub::ScrubContext {
+  DoutPrefix dpp{nullptr, ceph_subsys_test, "test_crimson_scrub"};
+  std::set<pg_shard_t> ids{pg_shard_t{0, shard_id_t::NO_SHARD}};
+
+public:
+  bool stopping = false;
+  bool snaptrim_started = false;
+  int notify_end = 0;
+
+  const std::set<pg_shard_t> &get_ids_to_scrub() const final {
+    return ids;
+  }
+  crimson::osd::scrub::chunk_validation_policy_t get_policy() const final {
+    return {
+      *ids.begin(),
+      TEST_MAX_OBJECT_SIZE,
+      std::string{TEST_INTERNAL_NAMESPACE},
+      TEST_OMAP_KEY_LIMIT,
+      TEST_OMAP_BYTES_LIMIT
+    };
+  }
+  void notify_scrub_start(bool) final {}
+  void notify_scrub_end(bool) final {
+    ++notify_end;
+    // same rule as PG::kick_snap_trim(): no new op while stopping
+    if (!stopping) {
+      snaptrim_started = true;
+    }
+  }
+  void request_range(const hobject_t &) final {}
+  void reserve_range(const hobject_t &, const hobject_t &) final {}
+  void release_range() final {}
+  void scan_range(
+    pg_shard_t, eversion_t, bool,
+    const hobject_t &, const hobject_t &) final {}
+  bool await_update(const eversion_t &) final { return true; }
+  void generate_and_submit_chunk_result(
+    const hobject_t &, const hobject_t &, bool) final {}
+  void emit_chunk_result(
+    const request_range_result_t &,
+    crimson::osd::scrub::chunk_result_t &&) final {}
+  void emit_scrub_result(bool, object_stat_sum_t) final {}
+  DoutPrefixProvider &get_dpp() final { return dpp; }
+};
+
+using crimson::osd::scrub::Inactive;
+using crimson::osd::scrub::PrimaryActive;
+using crimson::osd::scrub::ScrubMachine;
+using crimson::osd::scrub::Scrubbing;
+namespace events = crimson::osd::scrub::events;
+
+} // namespace
+
+TEST(TestScrubMachine, StopFromAwaitScrub) {
+  FakeScrubContext ctx;
+  ScrubMachine machine(ctx);
+  machine.initiate();
+  machine.process_event(events::primary_activate_t{});
+  ASSERT_TRUE(machine.state_downcast<const PrimaryActive *>());
+
+  machine.process_event(events::reset_t{});
+  EXPECT_TRUE(machine.state_downcast<const Inactive *>());
+  EXPECT_EQ(ctx.notify_end, 0);
+  EXPECT_FALSE(ctx.snaptrim_started);
+}
+
+TEST(TestScrubMachine, StopDuringScrubDoesNotStartSnapTrim) {
+  FakeScrubContext ctx;
+  ScrubMachine machine(ctx);
+  machine.initiate();
+  machine.process_event(events::primary_activate_t{});
+  machine.process_event(events::start_scrub_t{false});
+  ASSERT_TRUE(machine.state_downcast<const Scrubbing *>());
+
+  ctx.stopping = true;
+  machine.process_event(events::reset_t{});
+  EXPECT_TRUE(machine.state_downcast<const Inactive *>());
+  EXPECT_EQ(ctx.notify_end, 1);
+  EXPECT_FALSE(ctx.snaptrim_started);
+}
+
+TEST(TestScrubMachine, ScrubEndStartsSnapTrimWhenNotStopping) {
+  FakeScrubContext ctx;
+  ScrubMachine machine(ctx);
+  machine.initiate();
+  machine.process_event(events::primary_activate_t{});
+  machine.process_event(events::start_scrub_t{false});
+  ASSERT_TRUE(machine.state_downcast<const Scrubbing *>());
+
+  machine.process_event(events::reset_t{});
+  EXPECT_TRUE(machine.state_downcast<const Inactive *>());
+  EXPECT_EQ(ctx.notify_end, 1);
+  EXPECT_TRUE(ctx.snaptrim_started);
+}


### PR DESCRIPTION
crimson/osd: stop the scrubber before PG shutdown

PG::stop() shut down the PG backend and other services, but it did not
stop the scrubber. On OSD shutdown that left the scrub state machine
alive until ~PG destroyed it, which can crash while the OSD is stopping.

Stop the scrubber from PG::stop() and do not restart snaptrim while the
PG is stopping.

Fixes: https://tracker.ceph.com/issues/79547
Signed-off-by: Kautilya Tripathi <kautilya.tripathi@ibm.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
