### PR TITLE
doc: fix the RST warnings failing -W and build with Sphinx >= 8

### DIFF
--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -1,5 +1,4 @@
-# capped below 9 until the RemovedInSphinx90Warning deprecations are cleared
-Sphinx >= 8, < 9
+Sphinx >= 8
 sphinx-ditaa@git+https://github.com/ceph/sphinx-ditaa.git@py3
 funcparserlib@git+https://github.com/vlasovskikh/funcparserlib.git
 breathe >= 4.20.0,!=4.33

--- a/doc/_ext/ceph_commands.py
+++ b/doc/_ext/ceph_commands.py
@@ -193,7 +193,7 @@ TEMPLATE = '''
 {{ command.prefix }}
 {{ command.prefix | length * punct_char }}
 
-{{ command.help | wordwrap(70) }}
+{{ command.help | trim | wordwrap(70) }}
 
 :Example command:
     .. code-block:: bash

--- a/doc/_themes/ceph/layout.html
+++ b/doc/_themes/ceph/layout.html
@@ -20,15 +20,11 @@
   {% endblock %}
 
   {# CSS #}
-  {%- for style in styles %}
-  <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
-  {%- endfor %}
-  <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
   {%- for css in css_files %}
-    {%- if css|attr("rel") %}
-  <link rel="{{ css.rel }}" href="{{ pathto(css.filename, 1) }}" type="text/css"{% if css.title is not none %} title="{{ css.title }}"{% endif %} />
+    {%- if css|attr("filename") %}
+  {{ css_tag(css) }}
     {%- else %}
-  <link rel="stylesheet" href="{{ pathto(css, 1) }}" type="text/css" />
+  <link rel="stylesheet" href="{{ pathto(css, 1)|e }}" type="text/css" />
     {%- endif %}
   {%- endfor %}
 

--- a/doc/dev/crimson/index.rst
+++ b/doc/dev/crimson/index.rst
@@ -422,3 +422,4 @@ Code Walkthroughs
    PoseidonStore <poseidonstore>
    PG Merge Synchronization <pgmerging>
    The Logical Address in SeaStore <seastore_laddr>
+   The Logical Bucket Cache in SeaStore <seastore_logical_bucket_cache>

--- a/doc/dev/release-checklists.rst
+++ b/doc/dev/release-checklists.rst
@@ -41,7 +41,7 @@ Make sure X (and, ideally, X+1) is defined:
 Github Actions
 ~~~~~~~~~~~~~~
 
-- [ ] `.github/workflows/*.yml' add release branch to pull_request_target trigger
+- [ ] ``.github/workflows/*.yml`` add release branch to pull_request_target trigger
 
 Scripts
 ~~~~~~~

--- a/doc/dev/release-process.rst
+++ b/doc/dev/release-process.rst
@@ -104,7 +104,7 @@ no longer match what was tested.
    <https://github.com/ceph/ceph-build/blob/main/ansible/roles/ceph-release/tasks/push.yml>`_
    steps need to be manually run by the "Build Lead" as close to the
    Announcement time as possible. The `ceph-setup
-   <https://jenkins.ceph.com/job/ceph-setup>`_ job will have already created
+   <https://jenkins.ceph.com/job/ceph-setup/>`_ job will have already created
    and pushed the tag to ceph-releases.git. Example using squid, pretending
    19.2.3 is the security release version:
 

--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -1596,7 +1596,7 @@ rgw_user
    - Mixed clusters: Configure both ``cephfs_user`` and ``rgw_user``
 
 Examples
-~~~~~~~~
+++++++++
 
 External cluster with CephFS support only:
 

--- a/doc/radosgw/s3_objects_dedup.rst
+++ b/doc/radosgw/s3_objects_dedup.rst
@@ -75,7 +75,7 @@ The dedup background thread must be enabled on at least one RGW daemon in each
 zone for dedup operations to function. Having the thread enabled on multiple
 RGW processes within the same zone spreads the dedup work between them.
 
-.. confval:: rgw_enable_dedup_threads
+:confval:`rgw_enable_dedup_threads`
 
 This setting is evaluated at RGW startup. Changing it requires a daemon
 restart.


### PR DESCRIPTION
as a follow-up of #71096, we go further by sweeping the warnings and allowing the doc build to use Sphinx 9


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
