### PR TITLE
cephadm/rgw: track frontend config in dependencies to fix stale rgw_frontends

### DIFF
--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1417,6 +1417,25 @@ class RgwService(CephService):
     def allow_colo(self) -> bool:
         return True
 
+    def choose_next_action(
+        self,
+        scheduled_action: utils.Action,
+        daemon_type: Optional[str],
+        spec: Optional[ServiceSpec],
+        curr_deps: List[str],
+        last_deps: List[str],
+        daemon: Optional[DaemonDescription] = None,
+    ) -> utils.NextDaemonStep:
+        step = super().choose_next_action(
+            scheduled_action, daemon_type, spec, curr_deps, last_deps
+        )
+        # rgw_frontends can't be changed at runtime, so a reconfig
+        # won't actually apply the new config. We need a full redeploy
+        # to restart the daemon with the updated frontend settings.
+        if step.action is utils.Action.RECONFIG:
+            return utils.NextDaemonStep(utils.Action.REDEPLOY)
+        return step
+
     @classmethod
     def get_dependencies(cls, mgr: "CephadmOrchestrator",
                          spec: Optional[ServiceSpec] = None,
@@ -1431,6 +1450,17 @@ class RgwService(CephService):
             if isinstance(ssl_cert, list):
                 ssl_cert = '\n'.join(ssl_cert)
             deps.append(f'ssl-cert:{utils.config_hash(ssl_cert)}')
+
+        # track frontend config so that changes to rgw_frontend_extra_args
+        # (ex: so_reuseport toggle) or frontend type trigger a reconfig
+        if rgw_spec:
+            frontend_parts = []
+            if rgw_spec.rgw_frontend_type:
+                frontend_parts.append(f'type={rgw_spec.rgw_frontend_type}')
+            if rgw_spec.rgw_frontend_extra_args:
+                frontend_parts.append(f'extra_args={rgw_spec.rgw_frontend_extra_args}')
+            if frontend_parts:
+                deps.append(f'frontend:{utils.config_hash(str(frontend_parts))}')
 
         parent_deps = super().get_dependencies(mgr, spec, daemon_type)
         return sorted(deps + parent_deps)

--- a/src/pybind/mgr/cephadm/tests/services/test_rgw.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_rgw.py
@@ -2,6 +2,7 @@
 import pytest
 from unittest.mock import patch, MagicMock
 
+from cephadm.services.cephadmservice import RgwService
 from cephadm.services.service_registry import service_registry
 from cephadm.module import CephadmOrchestrator
 from ceph.deployment.service_spec import RGWSpec, CertificateSource
@@ -532,3 +533,31 @@ class TestRGWService:
                         assert kwargs == {
                             'custom_sans': ['s3.example.com', '*.s3.example.com'],
                         }
+
+    def test_rgw_deps_change_on_frontend_extra_args(self, cephadm_module: CephadmOrchestrator):
+        mgr = cephadm_module
+        spec_no_reuse = RGWSpec(service_id="foo", rgw_frontend_port=8300)
+        spec_with_reuse = RGWSpec(service_id="foo", rgw_frontend_port=8300,
+                                  rgw_frontend_extra_args=['so_reuseport=1'])
+
+        deps_before = RgwService.get_dependencies(mgr, spec_no_reuse)
+        deps_after = RgwService.get_dependencies(mgr, spec_with_reuse)
+        assert deps_before != deps_after
+
+    def test_rgw_deps_change_on_frontend_type(self, cephadm_module: CephadmOrchestrator):
+        mgr = cephadm_module
+        spec_beast = RGWSpec(service_id="foo", rgw_frontend_type='beast')
+        spec_civetweb = RGWSpec(service_id="foo", rgw_frontend_type='civetweb')
+
+        deps_beast = RgwService.get_dependencies(mgr, spec_beast)
+        deps_civetweb = RgwService.get_dependencies(mgr, spec_civetweb)
+        assert deps_beast != deps_civetweb
+
+    def test_rgw_deps_stable_when_frontend_unchanged(self, cephadm_module: CephadmOrchestrator):
+        mgr = cephadm_module
+        spec = RGWSpec(service_id="foo", rgw_frontend_port=8300,
+                       rgw_frontend_extra_args=['so_reuseport=1'])
+
+        deps1 = RgwService.get_dependencies(mgr, spec)
+        deps2 = RgwService.get_dependencies(mgr, spec)
+        assert deps1 == deps2


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/79561

## Problem
When we toggle `rgw_frontend_extra_args` (e.x: `so_reuseport=1`) via `ceph orch apply`, only daemons whose port changes get reconfigured. Daemons that stay on the same port keep their old `rgw_frontends` config, so the `so_reuseport` flag remains stale. And this needs a manual `ceph orch redeploy` to fix.

## Root Cause
`RgwService.get_dependencies()` was only tracking SSL certificate changes. It wasn't including `rgw_frontend_extra_args` or `rgw_frontend_type` in its dependency hash, so the orchestrator didn't detect any config changes for daemons whose port stayed the same.

## Fix
Added a hash of `rgw_frontend_type` and `rgw_frontend_extra_args` to `get_dependencies()` and now any change to these fields triggers a reconfig for all RGW daemons.

## Testing
Deployed RGW without `so_reuseport` -> both daemons got `beast port=8300/8301`
Toggled to `so_reuseport=1` -> both daemons picked up `so_reuseport=1`
Toggled back (removed it) -> both daemons dropped `so_reuseport`
Toggled again -> both daemons picked it up again

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
