### PR TITLE
mgr/dashboard: fix cephfs mirroring cephx permissions

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -14,8 +14,8 @@ from ..exceptions import DashboardException
 from ..security import Scope
 from ..services.ceph_service import CephService
 from ..services.cephfs import CephFS as CephFS_
-from ..services.cephfs import get_subvolumegroup_path, \
-    is_unmanaged_volume_entry, unmanaged_volume_info
+from ..services.cephfs import ensure_mirroring_client_caps, \
+    get_subvolumegroup_path, is_unmanaged_volume_entry, unmanaged_volume_info
 from ..services.exception import handle_cephfs_error
 from ..tools import ViewCache, str_to_bool
 from . import APIDoc, APIRouter, CreatePermission, DeletePermission, Endpoint, \
@@ -1470,6 +1470,7 @@ class CephFSMirror(RESTController):
     @Endpoint('POST')
     @CreatePermission
     def token(self, fs_name: str, client_name: str, site_name: str):
+        ensure_mirroring_client_caps(client_name, fs_name)
         error_code, out, err = mgr.remote(
             'mirroring', 'snapshot_mirror_peer_bootstrap_create', fs_name, client_name, site_name)
         if error_code != 0:

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-generate-token/cephfs-generate-token.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-generate-token/cephfs-generate-token.component.html
@@ -85,10 +85,8 @@
           <div class="form-item cds-mb-5">
             <div class="cds-input-group">
               <div class="fit-content">
-                <cds-text-label
-                  cdRequiredField="Username"
-                  i18n
-                >
+                <cds-text-label i18n>
+                  Username
                   <input
                     cdsText
                     value="client."
@@ -136,13 +134,15 @@
               @if (tokenForm.controls['username'].hasError('invalidChars')) {
                 <span i18n>Only letters, numbers, underscores, and hyphens are allowed.</span>
               }
+              @if (tokenForm.controls['username'].hasError('invalidMdsCaps')) {
+                <span i18n>Invalid capabilities on the MDS.</span>
+              }
             </ng-template>
           </div>
 
           <div class="form-item cds-mb-5">
             <cds-text-label
               for="sitename"
-              cdRequiredField="Sitename"
               [helperText]="sitenameHelper"
               [invalid]="
                 tokenForm.controls['sitename'].invalid && tokenForm.controls['sitename'].touched

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-generate-token/cephfs-generate-token.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-generate-token/cephfs-generate-token.component.spec.ts
@@ -149,12 +149,13 @@ describe('CephfsGenerateTokenComponent', () => {
     expect(component.tokenGenerated.emit).not.toHaveBeenCalled();
   }));
 
-  it('should filter users by MDS capabilities when a filesystem is selected', fakeAsync(() => {
+  it('should filter users by sufficient MDS capabilities when a filesystem is selected', fakeAsync(() => {
     clusterServiceMock.listUser.mockReturnValue(
       of([
         { entity: 'client.admin', caps: { mds: 'allow *' } },
-        { entity: 'client.mirror-myfs', caps: { mds: 'allow r fsname=myfs' } },
-        { entity: 'client.mirror-other', caps: { mds: 'allow r fsname=otherfs' } }
+        { entity: 'client.mirror-myfs', caps: { mds: 'allow rwps fsname=myfs' } },
+        { entity: 'client.mirror-readonly', caps: { mds: 'allow r fsname=myfs' } },
+        { entity: 'client.mirror-other', caps: { mds: 'allow rwps fsname=otherfs' } }
       ])
     );
 
@@ -164,7 +165,7 @@ describe('CephfsGenerateTokenComponent', () => {
     component.tokenForm.controls['filesystem'].setValue('myfs');
     tick();
 
-    expect(component.filteredUsers).toEqual(['mirror-myfs']);
+    expect(component.filteredUsers).toEqual(['admin', 'mirror-myfs']);
   }));
 
   it('should show no users when no filesystem is selected', fakeAsync(() => {
@@ -182,6 +183,56 @@ describe('CephfsGenerateTokenComponent', () => {
     tick();
 
     expect(component.filteredUsers).toEqual([]);
+  }));
+
+  it('should allow an unknown username so the user can be created', fakeAsync(() => {
+    clusterServiceMock.listUser.mockReturnValue(of([]));
+    component.ngOnInit();
+    tick();
+
+    component.tokenForm.patchValue({
+      filesystem: 'myfs',
+      username: 'new-peer',
+      sitename: 'site-a'
+    });
+
+    expect(component.tokenForm.controls['username'].hasError('invalidMdsCaps')).toBe(false);
+    expect(component.tokenForm.valid).toBe(true);
+  }));
+
+  it('should accept an existing user with mirroring MDS caps', fakeAsync(() => {
+    clusterServiceMock.listUser.mockReturnValue(
+      of([{ entity: 'client.mirror-peer', caps: { mds: 'allow rwps fsname=myfs' } }])
+    );
+    component.ngOnInit();
+    tick();
+
+    component.tokenForm.patchValue({
+      filesystem: 'myfs',
+      username: 'mirror-peer',
+      sitename: 'site-a'
+    });
+
+    expect(component.tokenForm.controls['username'].hasError('invalidMdsCaps')).toBe(false);
+    expect(component.tokenForm.valid).toBe(true);
+  }));
+
+  it('should reject an existing user with insufficient MDS caps', fakeAsync(() => {
+    clusterServiceMock.listUser.mockReturnValue(
+      of([{ entity: 'client.readonly', caps: { mds: 'allow r fsname=myfs' } }])
+    );
+    component.ngOnInit();
+    tick();
+
+    component.tokenForm.patchValue({
+      filesystem: 'myfs',
+      username: 'readonly',
+      sitename: 'site-a'
+    });
+
+    expect(component.tokenForm.controls['username'].hasError('invalidMdsCaps')).toBe(true);
+    component.onGenerateToken();
+    expect(cephfsServiceMock.enableMirror).not.toHaveBeenCalled();
   }));
 
   it('should emit cancelled and reset state on cancel', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-generate-token/cephfs-generate-token.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-generate-token/cephfs-generate-token.component.ts
@@ -11,6 +11,7 @@ import { debounceTime, finalize, map, switchMap, takeUntil, tap } from 'rxjs/ope
 
 import { CephfsService } from '~/app/shared/api/cephfs.service';
 import { ClusterService } from '~/app/shared/api/cluster.service';
+import { CdValidators } from '~/app/shared/forms/cd-validators';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { FinishedTask } from '~/app/shared/models/finished-task';
 import {
@@ -21,6 +22,7 @@ import {
   VALID_USERNAME_PATTERN
 } from '~/app/shared/models/cephfs.model';
 import { CephAuthUser } from '~/app/shared/models/cluster.model';
+import { hasMirroringMdsCaps } from '../cephfs-utils';
 
 @Component({
   selector: 'cd-cephfs-generate-token',
@@ -62,7 +64,15 @@ export class CephfsGenerateTokenComponent implements OnInit, OnDestroy {
 
   tokenForm = this.fb.group({
     filesystem: ['', Validators.required],
-    username: ['', [Validators.required, this.noClientPrefix, this.validUsername]],
+    username: [
+      '',
+      [
+        Validators.required,
+        this.noClientPrefix,
+        this.validUsername,
+        CdValidators.mirroringMdsCaps(() => this.allClientUsers)
+      ]
+    ],
     sitename: ['', Validators.required]
   });
 
@@ -162,6 +172,7 @@ export class CephfsGenerateTokenComponent implements OnInit, OnDestroy {
           return entity.startsWith(CLIENT_PREFIX);
         });
         this.updateFilteredUsers();
+        this.tokenForm.controls['username'].updateValueAndValidity();
       },
       error: () => {
         this.allClientUsers = [];
@@ -177,10 +188,7 @@ export class CephfsGenerateTokenComponent implements OnInit, OnDestroy {
       return;
     }
     this.filteredUsers = this.allClientUsers
-      .filter((u) => {
-        const mdsCaps = u.caps?.mds || '';
-        return mdsCaps.includes(`fsname=${selectedFs}`);
-      })
+      .filter((u) => hasMirroringMdsCaps(u.caps?.mds, selectedFs))
       .map((u) => String(u.entity || u['user_entity'] || '').slice(CLIENT_PREFIX.length));
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-utils.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-utils.spec.ts
@@ -1,6 +1,7 @@
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import {
   getUnmanagedDisable,
+  hasMirroringMdsCaps,
   isUnmanagedSelection,
   unmanagedRecreateHint,
   UNMANAGED_STATE
@@ -38,6 +39,49 @@ describe('cephfs-utils', () => {
 
     it('should allow managed selections', () => {
       expect(getUnmanagedDisable(selectionWith('complete'), resource)).toBe(false);
+    });
+  });
+
+  describe('hasMirroringMdsCaps', () => {
+    it('accepts allow rwps fsname=<fs>', () => {
+      expect(hasMirroringMdsCaps('allow rwps fsname=myfs', 'myfs')).toBe(true);
+    });
+
+    it('accepts allow *', () => {
+      expect(hasMirroringMdsCaps('allow *', 'myfs')).toBe(true);
+    });
+
+    it('accepts unrestricted allow rwps', () => {
+      expect(hasMirroringMdsCaps('allow rwps', 'myfs')).toBe(true);
+    });
+
+    it('accepts path=/', () => {
+      expect(hasMirroringMdsCaps('allow rwps fsname=myfs path=/', 'myfs')).toBe(true);
+    });
+
+    it('accepts a matching grant among multiple grants', () => {
+      expect(hasMirroringMdsCaps('allow r fsname=otherfs, allow rwps fsname=myfs', 'myfs')).toBe(
+        true
+      );
+    });
+
+    it('rejects allow r fsname=<fs>', () => {
+      expect(hasMirroringMdsCaps('allow r fsname=myfs', 'myfs')).toBe(false);
+    });
+
+    it('rejects missing snapshot or pin flags', () => {
+      expect(hasMirroringMdsCaps('allow rwp fsname=myfs', 'myfs')).toBe(false);
+      expect(hasMirroringMdsCaps('allow rws fsname=myfs', 'myfs')).toBe(false);
+    });
+
+    it('rejects the wrong filesystem or a restricted path', () => {
+      expect(hasMirroringMdsCaps('allow rwps fsname=otherfs', 'myfs')).toBe(false);
+      expect(hasMirroringMdsCaps('allow rwps fsname=myfs path=/foo', 'myfs')).toBe(false);
+    });
+
+    it('rejects empty caps', () => {
+      expect(hasMirroringMdsCaps('', 'myfs')).toBe(false);
+      expect(hasMirroringMdsCaps(undefined, 'myfs')).toBe(false);
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-utils.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-utils.ts
@@ -43,3 +43,35 @@ export function createRecreateAction(
     visible: isUnmanagedSelection
   };
 }
+
+/**
+ * True when MDS caps match `ceph fs authorize <fs> <client> / rwps`
+ * (`allow rwps fsname=<fs>`). `allow *` and unrestricted `allow rwps` also pass.
+ */
+export function hasMirroringMdsCaps(mdsCaps?: string | null, fsName?: string | null): boolean {
+  if (!mdsCaps || !fsName) {
+    return false;
+  }
+  return mdsCaps.split(',').some((grant) => isMirroringMdsGrant(grant.trim(), fsName));
+}
+
+function isMirroringMdsGrant(grant: string, fsName: string): boolean {
+  if (!grant.startsWith('allow ')) {
+    return false;
+  }
+  const [perms, ...rest] = grant.slice(6).split(/\s+/).filter(Boolean);
+  if (!perms || (perms !== '*' && !['r', 'w', 'p', 's'].every((flag) => perms.includes(flag)))) {
+    return false;
+  }
+  const fs = capAttr(rest, 'fsname');
+  if (fs && fs !== fsName && fs !== '*' && fs !== 'all') {
+    return false;
+  }
+  const path = capAttr(rest, 'path');
+  return !path || path === '/';
+}
+
+function capAttr(tokens: string[], key: string): string | undefined {
+  const prefix = `${key}=`;
+  return tokens.find((token) => token.startsWith(prefix))?.slice(prefix.length);
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.spec.ts
@@ -426,6 +426,57 @@ describe('CdValidators', () => {
     });
   });
 
+  describe('mirroringMdsCaps', () => {
+    let users: { entity?: string; caps?: { mds?: string } }[];
+
+    beforeEach(() => {
+      users = [];
+      form = new CdFormGroup({
+        filesystem: new FormControl(''),
+        username: new FormControl(
+          '',
+          CdValidators.mirroringMdsCaps(() => users)
+        )
+      });
+      formHelper = new FormHelper(form);
+    });
+
+    it('should skip empty username', () => {
+      formHelper.setValue('filesystem', 'myfs');
+      formHelper.expectValid('username');
+    });
+
+    it('should allow unknown users', () => {
+      users = [{ entity: 'client.other', caps: { mds: 'allow r fsname=myfs' } }];
+      formHelper.setValue('filesystem', 'myfs');
+      formHelper.setValue('username', 'new-peer');
+      formHelper.expectValid('username');
+    });
+
+    it('should allow existing users with mirroring caps', () => {
+      users = [{ entity: 'client.mirror', caps: { mds: 'allow rwps fsname=myfs' } }];
+      formHelper.setValue('filesystem', 'myfs');
+      formHelper.setValue('username', 'mirror');
+      formHelper.expectValid('username');
+    });
+
+    it('should error when an existing user has invalid MDS caps', () => {
+      users = [{ entity: 'client.readonly', caps: { mds: 'allow r fsname=myfs' } }];
+      formHelper.setValue('filesystem', 'myfs');
+      formHelper.setValue('username', 'readonly');
+      formHelper.expectError('username', 'invalidMdsCaps');
+    });
+
+    it('should revalidate when the filesystem changes', () => {
+      users = [{ entity: 'client.mirror', caps: { mds: 'allow rwps fsname=myfs' } }];
+      formHelper.setValue('filesystem', 'myfs');
+      formHelper.setValue('username', 'mirror');
+      formHelper.expectValid('username');
+      formHelper.setValue('filesystem', 'otherfs');
+      formHelper.expectError('username', 'invalidMdsCaps');
+    });
+  });
+
   describe('validate if condition', () => {
     beforeEach(() => {
       form = new CdFormGroup({

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
@@ -10,7 +10,10 @@ import _ from 'lodash';
 import { Observable, of as observableOf, timer as observableTimer } from 'rxjs';
 import { map, switchMapTo, take } from 'rxjs/operators';
 
+import { hasMirroringMdsCaps } from '~/app/ceph/cephfs/cephfs-utils';
 import { RgwBucketService } from '~/app/shared/api/rgw-bucket.service';
+import { CLIENT_PREFIX } from '~/app/shared/models/cephfs.model';
+import { CephAuthUser } from '~/app/shared/models/cluster.model';
 import { DimlessBinaryPipe } from '~/app/shared/pipes/dimless-binary.pipe';
 import { FormatterService } from '~/app/shared/services/formatter.service';
 import validator from 'validator';
@@ -269,6 +272,49 @@ export class CdValidators {
         return { [error]: value };
       }
       return null;
+    };
+  }
+
+  /**
+   * Fails when an existing CephX user lacks MDS caps for CephFS mirroring.
+   * Missing users are valid (they will be created). Empty values are skipped.
+   * Revalidates when the filesystem control changes, same as {@link requiredIf}.
+   *
+   * @param getUsers Function returning the current CephX user list.
+   * @param fsControlName Name of the sibling form control with the filesystem name.
+   * @return {ValidatorFn} Error map with `invalidMdsCaps` when caps are insufficient.
+   */
+  static mirroringMdsCaps(
+    getUsers: () => CephAuthUser[],
+    fsControlName = 'filesystem'
+  ): ValidatorFn {
+    let isWatched = false;
+
+    return (control: AbstractControl): ValidationErrors | null => {
+      if (!isWatched && control.parent) {
+        const fsControl = control.parent.get(fsControlName);
+        if (fsControl) {
+          fsControl.valueChanges.subscribe(() => {
+            control.updateValueAndValidity({ emitEvent: false });
+          });
+        }
+        isWatched = true;
+      }
+
+      const username = (control.value ?? '').toString().trim();
+      const fsName = control.parent?.get(fsControlName)?.value;
+      if (isEmptyInputValue(username) || !fsName) {
+        return null;
+      }
+
+      const entity = `${CLIENT_PREFIX}${username}`;
+      const user = (getUsers() || []).find(
+        (u) => String(u.entity || u['user_entity'] || '') === entity
+      );
+      if (!user) {
+        return null;
+      }
+      return hasMirroringMdsCaps(user.caps?.mds, fsName) ? null : { invalidMdsCaps: true };
     };
   }
 

--- a/src/pybind/mgr/dashboard/services/cephfs.py
+++ b/src/pybind/mgr/dashboard/services/cephfs.py
@@ -5,12 +5,13 @@ import errno
 import logging
 import os
 from contextlib import contextmanager, suppress
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import cephfs
 
 from .. import mgr
 from ..exceptions import DashboardException
+from .ceph_service import CephService, SendCommandError
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +39,71 @@ def get_subvolumegroup_path(vol_name: str, group_name: str) -> str:
             f'Failed to get path for subvolume group {group_name}: {err}'
         )
     return out
+
+
+def has_mirroring_mds_caps(mds_caps: Optional[str], fs_name: str) -> bool:
+    """Return True if MDS caps allow CephFS snapshot mirroring for fs_name.
+
+    Mirroring requires the equivalent of ``fs authorize <fs> <entity> / rwps``,
+    stored as ``allow rwps fsname=<fs>`` (path ``/`` is omitted). ``allow *``
+    and unrestricted ``allow rwps`` are also sufficient.
+    """
+    if not mds_caps or not fs_name:
+        return False
+
+    for grant in mds_caps.split(','):
+        grant = grant.strip()
+        if not grant.startswith('allow '):
+            continue
+        parts = grant[6:].split()
+        if not parts:
+            continue
+
+        perms = parts[0]
+        attrs = {}
+        for part in parts[1:]:
+            if '=' in part:
+                key, value = part.split('=', 1)
+                attrs[key] = value
+
+        if perms != '*' and not all(flag in perms for flag in 'rwps'):
+            continue
+
+        grant_fs = attrs.get('fsname')
+        if grant_fs and grant_fs not in (fs_name, '*', 'all'):
+            continue
+
+        grant_path = attrs.get('path')
+        if grant_path and grant_path != '/':
+            continue
+
+        return True
+
+    return False
+
+
+def ensure_mirroring_client_caps(client_name: str, fs_name: str) -> None:
+    """Reject existing CephX users that lack MDS caps required for mirroring.
+
+    Missing users are left unchanged so bootstrap can create them. Existing
+    users with sufficient MDS caps are also left unchanged.
+    """
+    try:
+        user_data = CephService.send_command('mon', 'auth get', entity=client_name)
+    except SendCommandError as ex:
+        if ex.errno == -errno.ENOENT:
+            return
+        raise DashboardException(
+            msg=f'Failed to lookup CephX user {client_name}: {ex}',
+            component='cephfs.mirror') from ex
+
+    auth = user_data[0] if isinstance(user_data, list) else user_data
+    mds_caps = (auth.get('caps') or {}).get('mds', '')
+    if not has_mirroring_mds_caps(mds_caps, fs_name):
+        raise DashboardException(
+            msg='Invalid capabilities on the MDS',
+            code='invalid_mds_caps',
+            component='cephfs.mirror')
 
 
 class CephFS(object):

--- a/src/pybind/mgr/dashboard/tests/test_cephfs.py
+++ b/src/pybind/mgr/dashboard/tests/test_cephfs.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import errno
 import json
+import unittest
 import urllib.parse
 from collections import defaultdict
 
@@ -12,7 +13,10 @@ except ImportError:
 from .. import mgr
 from ..controllers.cephfs import CephFS, CephFSMirror, CephFSMirrorStatus, \
     CephFSSubvolume, CephFSSubvolumeGroups, CephFSSubvolumeSnapshots
-from ..services.cephfs import unmanaged_volume_info
+from ..exceptions import DashboardException
+from ..services.ceph_service import SendCommandError
+from ..services.cephfs import ensure_mirroring_client_caps, \
+    has_mirroring_mds_caps, unmanaged_volume_info
 from ..tests import ControllerTestCase
 
 UNMANAGED_VOLUME_ERROR = (-errno.EINVAL, '', 'failed to getxattr on subvolume metadata')
@@ -56,6 +60,72 @@ class CephFsTest(ControllerTestCase):
         self.assertEqual(mds_versions['bar'], ['foo'])
 
 
+class HasMirroringMdsCapsTest(unittest.TestCase):
+    def test_allow_rwps_fsname(self):
+        self.assertTrue(has_mirroring_mds_caps('allow rwps fsname=myfs', 'myfs'))
+
+    def test_allow_star(self):
+        self.assertTrue(has_mirroring_mds_caps('allow *', 'myfs'))
+
+    def test_allow_rwps_unrestricted(self):
+        self.assertTrue(has_mirroring_mds_caps('allow rwps', 'myfs'))
+
+    def test_allow_r_fsname(self):
+        self.assertFalse(has_mirroring_mds_caps('allow r fsname=myfs', 'myfs'))
+
+    def test_missing_snapshot_flag(self):
+        self.assertFalse(has_mirroring_mds_caps('allow rwp fsname=myfs', 'myfs'))
+
+    def test_missing_pin_flag(self):
+        self.assertFalse(has_mirroring_mds_caps('allow rws fsname=myfs', 'myfs'))
+
+    def test_wrong_fsname(self):
+        self.assertFalse(has_mirroring_mds_caps('allow rwps fsname=otherfs', 'myfs'))
+
+    def test_restricted_path(self):
+        self.assertFalse(has_mirroring_mds_caps('allow rwps fsname=myfs path=/foo',
+                                               'myfs'))
+
+    def test_root_path(self):
+        self.assertTrue(has_mirroring_mds_caps('allow rwps fsname=myfs path=/',
+                                              'myfs'))
+
+    def test_empty_caps(self):
+        self.assertFalse(has_mirroring_mds_caps('', 'myfs'))
+        self.assertFalse(has_mirroring_mds_caps(None, 'myfs'))
+
+    def test_multiple_grants_one_matches(self):
+        caps = 'allow r fsname=otherfs, allow rwps fsname=myfs'
+        self.assertTrue(has_mirroring_mds_caps(caps, 'myfs'))
+
+
+class EnsureMirroringClientCapsTest(unittest.TestCase):
+    @patch('dashboard.services.cephfs.CephService.send_command')
+    def test_missing_user_is_allowed(self, send_command):
+        send_command.side_effect = SendCommandError(
+            'failed to find client.mirror', 'auth get', {}, -errno.ENOENT)
+        ensure_mirroring_client_caps('client.mirror', 'myfs')
+
+    @patch('dashboard.services.cephfs.CephService.send_command')
+    def test_existing_user_with_valid_caps(self, send_command):
+        send_command.return_value = [{
+            'entity': 'client.mirror',
+            'caps': {'mds': 'allow rwps fsname=myfs'}
+        }]
+        ensure_mirroring_client_caps('client.mirror', 'myfs')
+
+    @patch('dashboard.services.cephfs.CephService.send_command')
+    def test_existing_user_with_invalid_caps(self, send_command):
+        send_command.return_value = [{
+            'entity': 'client.admin',
+            'caps': {'mds': 'allow r fsname=myfs'}
+        }]
+        with self.assertRaises(DashboardException) as ctx:
+            ensure_mirroring_client_caps('client.admin', 'myfs')
+        self.assertEqual(str(ctx.exception), 'Invalid capabilities on the MDS')
+        self.assertEqual(ctx.exception.code, 'invalid_mds_caps')
+
+
 class CephFSMirrorTest(ControllerTestCase):  # pylint: disable=too-many-public-methods
 
     @classmethod
@@ -93,7 +163,8 @@ class CephFSMirrorTest(ControllerTestCase):  # pylint: disable=too-many-public-m
         self.assertIn(error_message, response.get('detail', ''))
         mgr.remote.assert_called_once_with('mirroring', 'snapshot_mirror_peer_list', fs_name)
 
-    def test_token_success(self):
+    @patch('dashboard.controllers.cephfs.ensure_mirroring_client_caps')
+    def test_token_success(self, _ensure_caps):
         fs_name = 'test_fs'
         client_name = 'client.mirror'
         site_name = 'remote-site'
@@ -111,7 +182,8 @@ class CephFSMirrorTest(ControllerTestCase):  # pylint: disable=too-many-public-m
         mgr.remote.assert_called_once_with('mirroring', 'snapshot_mirror_peer_bootstrap_create',
                                            fs_name, client_name, site_name)
 
-    def test_token_error(self):
+    @patch('dashboard.controllers.cephfs.ensure_mirroring_client_caps')
+    def test_token_error(self, _ensure_caps):
         fs_name = 'test_fs'
         client_name = 'client.mirror'
         site_name = 'remote-site'
@@ -129,6 +201,24 @@ class CephFSMirrorTest(ControllerTestCase):  # pylint: disable=too-many-public-m
         self.assertIn(error_message, response.get('detail', ''))
         mgr.remote.assert_called_once_with('mirroring', 'snapshot_mirror_peer_bootstrap_create',
                                            fs_name, client_name, site_name)
+
+    @patch('dashboard.controllers.cephfs.ensure_mirroring_client_caps')
+    def test_token_invalid_mds_caps(self, ensure_caps):
+        ensure_caps.side_effect = DashboardException(
+            msg='Invalid capabilities on the MDS',
+            code='invalid_mds_caps',
+            component='cephfs.mirror')
+        mgr.remote = Mock()
+
+        self._post('/api/cephfs/mirror/token', {
+            'fs_name': 'test_fs',
+            'client_name': 'client.admin',
+            'site_name': 'remote-site'
+        })
+        self.assertStatus(400)
+        response = self.json_body()
+        self.assertIn('Invalid capabilities on the MDS', response.get('detail', ''))
+        mgr.remote.assert_not_called()
 
     def test_enable_success(self):
         fs_name = 'test_fs'


### PR DESCRIPTION
On prepare to recieve modal to create the cephfs mirroring token there was an issue with cephx users. The current implementation is updating the permisisons of any cephx user that is inputed, and if it does not exist it will create the cephx user with the needed cephx permisions.
This is a bit of a security issue since cephx user permissions are being updated without notice for all users.

Now the flow works as:
 - If cephx user exist check if it has appropiate permisisons to use cephfs mirroring which are: `ceph fs authorize <fs_name> client.mirror_remote / rwps`
 - If it has no appropiate permissins validation error is shown: Invalid capabilities on the MDS
- If cephx user inputed does not exist, it's created with the necesary capabilities for cephfs mirroring to work.

Using existing user

[screen-capture (42).webm](https://github.com/user-attachments/assets/695a90e5-25bb-440a-8223-5ce1dbea3670)


Creating new user

[screen-capture (43).webm](https://github.com/user-attachments/assets/65749286-2c44-4a23-b342-5f91683f3045)


Updated form without required labels (not on the video)

<img width="1147" height="732" alt="image" src="https://github.com/user-attachments/assets/46ffe10a-1e4b-4f9f-8746-ee272a4f7a99" />


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
