### PR TITLE
doc: replace tracker ticket links with inline explanations

### DIFF
--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -230,9 +230,13 @@ command ``ceph orch upgrade status`` if the orchestrator has crashed:
 
    Error ENOENT: Module not found
 
-This is possibly caused by invalid JSON in a mgr config-key.
-See `Redmine tracker Issue #67329 <https://tracker.ceph.com/issues/67329>`_
-and `this discussion on the ceph-users mailing list <https://www.spinics.net/lists/ceph-users/msg83667.html>`_.
+This is possibly caused by invalid JSON in a mgr config-key. One known
+cause on releases before the fix: the OSD removal queue stored under
+the ``mgr/cephadm/osd_remove_queue`` config-key could contain a field
+(``original_weight``) that the cephadm module was unable to load back,
+which crashed the module whenever the Manager restarted. The
+workaround was to edit the stored JSON to remove the offending field
+and then restart ``ceph-mgr``.
 
 
 ``UPGRADE_NO_STANDBY_MGR``

--- a/doc/cephfs/cephfs-mirroring.rst
+++ b/doc/cephfs/cephfs-mirroring.rst
@@ -1427,7 +1427,10 @@ manages snapshot crawl and a data synchronization thread pool, which handles con
 transfers. Users can fine-tune these operations using configuration parameters:
 - ``cephfs_mirror_max_concurrent_directory_syncs``: controls the number of concurrent snapshots being crawled.
 - ``cephfs_mirror_max_datasync_threads``: controls the total threads available for data sync.
-For more information, see https://tracker.ceph.com/issues/73452
+
+Separating crawling from data transfer allows snapshot discovery and
+progress reporting to continue even while large file transfers are in
+flight.
 
 
 Snapshot Mirroring Checkpoints

--- a/doc/cephfs/disaster-recovery-experts.rst
+++ b/doc/cephfs/disaster-recovery-experts.rst
@@ -362,15 +362,17 @@ are confident that you can meet these challenges, study this list of
 limitations and pitfalls before attempting disaster recovery:
 
 #. The data-scan commands provide no way of estimating the time to completion
-   of their operation. A feature that will provide such an estimate is under
-   development. See https://tracker.ceph.com/issues/63191 for details.
+   of their operation. The ``scan_extents`` and ``scan_inodes`` steps scale
+   with the number of objects in the data pool, and ``scan_links`` iterates
+   over the metadata pool twice, so these steps can run for a very long time
+   on large file systems without giving any progress indication.
 #. It is important to perform a file system scrub after recovery before CephFS
    clients start using the file system.
 #. In general, we do not recommend that you change any MDS-related settings
    (for example, ``max_mds``) while things are broken.
-#. Disaster recovery is currently a manual process. There is a plan to automate
-   the recovery via the Disaster Recovery Super Tool. See
-   https://tracker.ceph.com/issues/71804 for details.
+#. Disaster recovery is a manual process. Each step must be chosen and run
+   by the operator according to the kind of metadata damage present; no tool
+   currently automates the sequence.
 #. A well-known trick (used by some community users) is to use the disaster
    recovery procedure (especially the ``recover_dentries`` step) when the MDS
    is somewhat stuck in the ``up_replay`` state due to a long journal. Before
@@ -510,9 +512,7 @@ at recovery since the existing metadata pool would not be modified.
 
    .. note::
 
-      The `Symbolic link recovery <https://tracker.ceph.com/issues/46166>`_ is
-      supported starting in the Quincy release.
-
+      Symbolic link recovery is supported starting in the Quincy release.
       Symbolic links were recovered as empty regular files before.
 
    It is recommended that you migrate any data from the recovery file system as
@@ -527,4 +527,3 @@ at recovery since the existing metadata pool would not be modified.
        data pool), the recovered files will contain holes in place of the
        missing data.
 
-.. _Symbolic link recovery: https://tracker.ceph.com/issues/46166

--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -119,8 +119,9 @@ tries to remove MDS daemons using the enabled Ceph Manager orchestrator module.
 
 .. note:: After volume deletion, we recommend restarting `ceph-mgr` if a new
    file system is created on the same cluster and the subvolume interface is
-   being used. See https://tracker.ceph.com/issues/49605#note-5 for more
-   details.
+   being used. The restart clears state that Manager modules may still hold
+   for the deleted volume, which can otherwise interfere with subvolume
+   operations on the new file system.
 
 .. note:: If the snap-schedule Ceph Manager module is being used for a volume
    and the volume is deleted, then the snap-schedule Ceph Manager module will
@@ -1172,9 +1173,8 @@ following command.
 Controlling Subvolume Snapshot Visibility
 -----------------------------------------
 
-.. note:: This functionality is currently supported only for FUSE/libcephfs clients.
-          Kernel client support is planned: progress can be tracked at
-          https://tracker.ceph.com/issues/72589.
+.. note:: This functionality is currently supported only for FUSE/libcephfs
+          clients. The kernel client does not yet support it.
 
 Snapshots of a subvolume can be hidden from compatible clients by
 performing two actions:

--- a/doc/cephfs/quota.rst
+++ b/doc/cephfs/quota.rst
@@ -132,7 +132,14 @@ Limitations
 
      $ ceph auth get-or-create client.guest mds 'allow r path=/home/volumes, allow rw path=/home/volumes/group' mgr 'allow rw' osd 'allow rw tag cephfs metadata=*' mon 'allow r'
 
-   See also: https://tracker.ceph.com/issues/55090
+   A related known issue: when the kernel client mounts a subdirectory
+   below the directory on which the quota is set, tools such as ``df``
+   may report the size and usage of the entire file system rather than
+   of the quota, because the client cannot see the quota-bearing
+   ancestor directory. ``ceph-fuse`` is not affected.
 
 #. *Snapshot file data which has since been deleted or changed does not count
-   towards the quota.* See also: https://tracker.ceph.com/issues/24284
+   towards the quota.* As a consequence, snapshots can retain space beyond
+   the configured quota. If this is a concern, the creation of new
+   snapshots can be disabled with ``ceph fs set <fs_name> allow_new_snaps
+   false``.

--- a/doc/rados/configuration/mclock-config-ref.rst
+++ b/doc/rados/configuration/mclock-config-ref.rst
@@ -191,8 +191,9 @@ Based on tests performed at scale with small objects in the range
 150 Million objects), it was found that scheduling with mClock was not optimal
 with multiple OSD shards. For example, in this cluster with multiple OSD node
 failures, the client throughput was found to be inconsistent across test runs
-coupled with multiple reported slow requests. For more details
-see https://tracker.ceph.com/issues/66289. With multiple shards, the situation
+coupled with multiple reported slow requests. Small objects suffered
+throughput losses of as much as 79 percent during OSD failures, while
+large objects lost upwards of 20 percent. With multiple shards, the situation
 was exacerbated when MAX limit was allocated to both client and background
 recovery class of operations. During the OSD failure phase, since both client
 and recovery ops were in direct competition to utilize the full bandwidth of

--- a/doc/rados/operations/cache-tiering.rst
+++ b/doc/rados/operations/cache-tiering.rst
@@ -591,24 +591,16 @@ Here is an example of unfound objects appearing during an upgrade from Ceph
        ],
        "more": false
 
-Some tests in the field indicate that the unfound objects can be deleted with
-no adverse effects (see `Tracker Issue #44286, Note 3
-<https://tracker.ceph.com/issues/44286#note-3>`_). Pawel Stefanski suggests
-that deleting missing or unfound objects is safe as long as the objects are a
-part of ``.ceph-internal::hit_set_PGID_archive``.
+Field reports indicate that the unfound objects can be deleted with no
+adverse effects, provided that the objects belong to the
+``.ceph-internal`` namespace and have names of the form
+``hit_set_<PGID>_archive``. These are hit set archives maintained
+internally by cache tiering, not user data. Pawel Stefanski reported
+that deleting missing or unfound objects is safe as long as the objects
+are a part of ``.ceph-internal::hit_set_PGID_archive``.
 
-Various members of the upstream Ceph community have reported in `Tracker Issue
-#44286 <https://tracker.ceph.com/issues/44286>`_ that the following versions of
-Ceph have been affected by this issue:
-
-* 14.2.8
-* 14.2.16
-* 15.2.15
-* 16.2.5
-* 17.2.7
-
-See `Tracker Issue #44286 <https://tracker.ceph.com/issues/44286>`_ for the
-history of this issue.
+Members of the upstream Ceph community have reported this issue on
+releases ranging from 14.2.8 through 17.2.7.
 
 
 .. _Bloom Filter: https://en.wikipedia.org/wiki/Bloom_filter

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -1246,8 +1246,11 @@ One (or more) BlueStore OSDs detects read errors on the main device.
 BlueStore has recovered from these errors by retrying disk reads. This alert
 might indicate issues with underlying hardware, issues with the I/O subsystem,
 or something similar. Such issues can cause permanent data
-corruption. Some observations on the root cause of spurious read errors can be
-found here: https://tracker.ceph.com/issues/22464
+corruption. Root-cause investigations of such reports have generally
+pointed at the underlying hardware or kernel I/O path rather than at
+BlueStore itself. A telltale sign is a reported checksum of
+``0x6706be76``, which is the checksum of an all-zero block: it
+indicates that the read returned zeroes instead of the stored data.
 
 This alert does not require an immediate response, but the affected host might
 need additional attention: for example, upgrading the host to the latest
@@ -1278,8 +1281,10 @@ evaluated and possibly removed and replaced.
    read stalled read 0x29f40370000~100000 (buffered) since 63410177.290546s, timeout is 5.000000s
 
 However, this is difficult to spot because there is no discernible warning (a
-health warning or info in ``ceph health detail`` for example). More observations
-can be found here: https://tracker.ceph.com/issues/62500
+health warning or info in ``ceph health detail`` for example). Other
+BlueStore log messages that point at a failing or overloaded drive
+include ``log_latency`` and ``log_latency_fn`` entries reporting slow
+operations with latencies of several seconds.
 
 Also because there can be false positive ``stalled read`` instances, a mechanism
 has been added to increase accuracy. If in the last :confval:`bdev_stalled_read_warn_lifetime`
@@ -2016,7 +2021,11 @@ The above procedure was developed by Eugen Block in September of 2024.
 
 See `Eugen Block's blog post <https://heiterbiswolkig.blogs.nde.ag/2024/09/06/pgs-not-deep-scrubbed-in-time/>`_ for much more detail.
 
-See `Redmine tracker issue #44959 <https://tracker.ceph.com/issues/44959>`_.
+This warning can appear even though every PG has been deep scrubbed
+within the configured interval. That happens when
+:confval:`osd_deep_scrub_interval` has been customized only for OSDs:
+the Monitors and Managers that raise the warning still evaluate it
+against the default interval, which the procedure above corrects.
 
 Second Method
 ~~~~~~~~~~~~~
@@ -2061,7 +2070,11 @@ The above procedure was developed by Eugen Block in September of 2024.
 
 See `Eugen Block's blog post <https://heiterbiswolkig.blogs.nde.ag/2024/09/06/pgs-not-deep-scrubbed-in-time/>`_ for much more detail.
 
-See `Redmine tracker issue #44959 <https://tracker.ceph.com/issues/44959>`_.
+This warning can appear even though every PG has been deep scrubbed
+within the configured interval. That happens when
+:confval:`osd_deep_scrub_interval` has been customized only for OSDs:
+the Monitors and Managers that raise the warning still evaluate it
+against the default interval, which the procedure above corrects.
 
 
 

--- a/doc/rados/operations/read-balancer.rst
+++ b/doc/rados/operations/read-balancer.rst
@@ -121,8 +121,12 @@ primary PG mappings and can impact read performance (this excludes any data move
 
 .. note::
 
-  Users affected by `#66867 <https://tracker.ceph.com/issues/66867>`_ or `#61948 <https://tracker.ceph.com/issues/61948>`_
-  may find these commands useful when dealing with unexpected ``pg-upmap-primary`` behavior.
+  These commands are useful for cleaning up unexpected
+  ``pg-upmap-primary`` state. For example, on some releases
+  ``pg-upmap-primary`` mappings were retained in the OSD map for pools
+  that had already been deleted, and such stale mappings could crash
+  Monitors with a ``pg_upmap_primaries.empty()`` assertion when an
+  older-format OSD map was encoded.
 
 To remove a specific ``pg-upmap-primary`` mapping, use:
 

--- a/doc/rados/operations/stretch-mode.rst
+++ b/doc/rados/operations/stretch-mode.rst
@@ -117,7 +117,12 @@ cascading failures and an impactful thundering herd of data movement. This can
 cause substantial client impact and long recovery times when OSDs return to
 service. If Ceph stops marking OSDs ``out``, some PGs may fail to
 rebalance to surviving OSDs, potentially leading to ``inactive`` PGs.
-See https://tracker.ceph.com/issues/68338 for more information.
+This is particularly relevant for three-availability-zone clusters,
+which are designed to survive the loss of a full zone (a third of the
+hosts): with the default ``mon_osd_min_in_ratio``, the down OSDs are
+never marked ``out``, so PGs stay ``peered`` and I/O stops even though
+the surviving zones have enough capacity to recover. Marking the down
+OSDs ``out`` manually restores service in that situation.
 
 .. _stretch_mode1:
 
@@ -228,8 +233,6 @@ with the CRUSH topology.
       The recommended approach is to use the ``stretch_replicated_rule`` definition shown
       above (with ``take default`` and ``choose firstn 0 type datacenter``), which correctly
       reports ``MAX AVAIL``.
-
-      See https://tracker.ceph.com/issues/56650 for more detail on this workaround.
 
    *The above procedure was developed in May and June of 2024 by Prashant Dhange.*
 


### PR DESCRIPTION
Eighteen citations across ten files pointed readers at tracker.ceph.com tickets as the only documentation of a limitation or workaround. Each is replaced with self-contained prose based on the ticket contents: for example, the zero-block checksum signature 0x6706be76 in BLUESTORE_SPURIOUS_READ_ERRORS, the osd_remove_queue original_weight crash workaround in the cephadm upgrade page, the deep-scrub interval evaluation gotcha behind PG_NOT_DEEP_SCRUBBED, and the quota bypass via snapshots with the allow_new_snaps mitigation. Forward-looking promises tied to open tickets were rewritten as plain statements of current behavior.

Fixes: https://tracker.ceph.com/issues/77199

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
