### PR TITLE
Fix building isa-l with avx512 & vpclmul, and prevent /dev/null removal

### DIFF
--- a/cmake/modules/CheckNasm.cmake
+++ b/cmake/modules/CheckNasm.cmake
@@ -18,30 +18,40 @@ macro(check_nasm_support _object_format _support_x64 _support_x64_and_avx2 _supp
       " ${_support_x64})
       set(CMAKE_REQUIRED_QUIET ${save_quiet})
       if(${_support_x64})
+        # nasm removes the file on failure, and we expect failure, so use temp file
+        execute_process(COMMAND mktemp --suffix=.o
+          OUTPUT_VARIABLE nasm_tmp_obj
+          OUTPUT_STRIP_TRAILING_WHITESPACE)
         execute_process(COMMAND nasm -f ${object_format} -i
           ${CMAKE_SOURCE_DIR}/src/isa-l/include/
           ${CMAKE_SOURCE_DIR}/src/isa-l/erasure_code/gf_vect_dot_prod_avx2.asm
-          -o /dev/null
+          -o ${nasm_tmp_obj}
           RESULT_VARIABLE rc
           OUTPUT_QUIET
           ERROR_QUIET)
         if(NOT rc)
           set(${_support_x64_and_avx2} TRUE)
         endif()
+        execute_process(COMMAND mktemp --suffix=.o
+          OUTPUT_VARIABLE nasm_tmp_obj
+          OUTPUT_STRIP_TRAILING_WHITESPACE)
         execute_process(COMMAND nasm -D HAVE_AS_KNOWS_AVX512 -f ${object_format}
           -i ${CMAKE_SOURCE_DIR}/src/isa-l/include/
           ${CMAKE_SOURCE_DIR}/src/isa-l/erasure_code/gf_vect_dot_prod_avx512.asm
-          -o /dev/null
+          -o ${nasm_tmp_obj}
           RESULT_VARIABLE rt
           OUTPUT_QUIET
           ERROR_QUIET)
         if(NOT rt)
           set(${_support_x64_and_avx512} TRUE)
         endif()
-	execute_process(COMMAND nasm -D AS_FEATURE_LEVEL=10 -f ${object_format}
+        execute_process(COMMAND mktemp --suffix=.o
+          OUTPUT_VARIABLE nasm_tmp_obj
+          OUTPUT_STRIP_TRAILING_WHITESPACE)
+        execute_process(COMMAND nasm -D AS_FEATURE_LEVEL=10 -f ${object_format}
           -i ${CMAKE_SOURCE_DIR}/src/isa-l/include/
           ${CMAKE_SOURCE_DIR}/src/isa-l/crc/crc32_iscsi_by16_10.asm
-          -o /dev/null
+          -o ${nasm_tmp_obj}
           RESULT_VARIABLE rt
           OUTPUT_QUIET
           ERROR_QUIET)

--- a/cmake/modules/CheckNasm.cmake
+++ b/cmake/modules/CheckNasm.cmake
@@ -50,6 +50,7 @@ macro(check_nasm_support _object_format _support_x64 _support_x64_and_avx2 _supp
           OUTPUT_STRIP_TRAILING_WHITESPACE)
         execute_process(COMMAND nasm -D AS_FEATURE_LEVEL=10 -f ${object_format}
           -i ${CMAKE_SOURCE_DIR}/src/isa-l/include/
+          -i ${CMAKE_SOURCE_DIR}/src/isa-l/crc/
           ${CMAKE_SOURCE_DIR}/src/isa-l/crc/crc32_iscsi_by16_10.asm
           -o ${nasm_tmp_obj}
           RESULT_VARIABLE rt

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -238,8 +238,10 @@ if(HAVE_INTEL)
       crc32c_intel_fast_zero_asm.s)
   endif(HAVE_NASM_X64)
   if(HAVE_NASM_X64_AVX512_VPCLMUL)
-    set(CMAKE_ASM_FLAGS "-DAS_FEATURE_LEVEL=10 ${CMAKE_ASM_FLAGS}")
-    list(APPEND crc32_srcs ${PROJECT_SOURCE_DIR}/src/isa-l/crc/crc32_iscsi_by16_10.asm)
+    set(CMAKE_ASM_FLAGS "-DAS_FEATURE_LEVEL=10 -i ${PROJECT_SOURCE_DIR}/src/isa-l/crc/ ${CMAKE_ASM_FLAGS}")
+    list(APPEND crc32_srcs
+      ${PROJECT_SOURCE_DIR}/src/isa-l/crc/crc_const.asm
+      ${PROJECT_SOURCE_DIR}/src/isa-l/crc/crc32_iscsi_by16_10.asm)
   endif(HAVE_NASM_X64_AVX512_VPCLMUL)
 elseif(HAVE_POWER8)
   list(APPEND crc32_srcs


### PR DESCRIPTION
# Pull Request Description

[isa-l]: fix regression introduced by isa-l submodule version update that removes /dev/null, and stops compilation with _support_x64_and_avx512_vpclmul


## Description

This PR fixes a build regression introduced by a recent isa-l submodule version update, with two changes:

1. **`cmake: use mktemp temp files instead of /dev/null for nasm output`**
   When nasm fails to build, it deliberately unlinks the target. When built as root it can unlink `/dev/null`. Therefore use a proper temp file, to avoid breaking systems.

2. **`cmake: add crc include path when vpclmul enabled`**
   The updated isa-l `crc32_iscsi_by16_10.asm` now includes `crc_const.asm` (a new file added in the submodule update). This requires the `src/isa-l/crc/` directory to be added as a `-i` include path both during the `CheckNasm.cmake` capability probe and when building the actual CRC source. Also, `crc_const.asm` is added as a build source when `HAVE_NASM_X64_AVX512_VPCLMUL` is enabled.

   Regression introduced by: b160e2a9243aadb955f487dc2708bde1a625ccb5 isa-l: Update isa-l submodule from 2.32.0 to 2.32.1
Tracker https://github.com/ceph/ceph/pull/71121

First PR...be gentle :D 

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>