### PR TITLE
os/bluestore: reap data-bdev write completions in the kv sync thread

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -30,6 +30,20 @@
   a few times in random workloads.  ``mds_dir_prefetch_backend_max`` (default 1)
   limits the number of concurrent background fetches.  This reduces latency in
   large directories while retaining cache warmth for hot directories.
+* BlueStore: on Linux with libaio, the data device's write completions
+  are by default reaped by the ``bstore_kv_sync`` thread itself (woken
+  through the same eventfd submitters use); that device no longer runs
+  a ``bstore_aio`` thread and instead runs a ``bstore_aio_rd`` thread
+  serving a dedicated read-side aio context.  The data device therefore
+  holds one extra aio context of ``bdev_aio_max_queue_depth`` slots per
+  OSD, so deployments with many OSDs per host may need to raise
+  ``fs.aio-max-nr``.  Setting the new option
+  ``bluestore_kv_sync_reap_write_completions`` to false restores the
+  previous behavior: a single aio context served by one ``bstore_aio``
+  completion thread, with no extra read-side context.  BlueFS's
+  db/wal/slow devices and other backends (io_uring, posix-aio, SPDK,
+  pmem) keep the single ring and completion thread they had before and
+  are unchanged.
 
 * CephFS: The ``client_force_lazyio`` configuration option is now correctly marked
   as not supporting runtime updates. Previously, the configuration schema indicated

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -43,7 +43,8 @@
   completion thread, with no extra read-side context.  BlueFS's
   db/wal/slow devices and other backends (io_uring, posix-aio, SPDK,
   pmem) keep the single ring and completion thread they had before and
-  are unchanged.
+  are unchanged.  The default of ``bdev_aio_reap_max`` rises from 16 to
+  128 completions per pass.
 
 * CephFS: The ``client_force_lazyio`` configuration option is now correctly marked
   as not supporting runtime updates. Previously, the configuration schema indicated

--- a/src/blk/BlockDevice.cc
+++ b/src/blk/BlockDevice.cc
@@ -77,7 +77,7 @@ uint64_t IOContext::get_num_ios() const
   // that to the bytes value.
   uint64_t ios = 0;
 #if defined(HAVE_LIBAIO) || defined(HAVE_POSIXAIO)
-  ios += pending_aios.size();
+  ios += writes.pending.size() + reads.pending.size();
 #endif
 #ifdef HAVE_SPDK
   ios += total_nseg;
@@ -90,7 +90,8 @@ void IOContext::release_running_aios()
   ceph_assert(!num_running);
 #if defined(HAVE_LIBAIO) || defined(HAVE_POSIXAIO)
   // release aio contexts (including pinned buffers).
-  running_aios.clear();
+  writes.running.clear();
+  reads.running.clear();
 #endif
 }
 

--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -96,8 +96,11 @@ public:
 #endif
 
 #if defined(HAVE_LIBAIO) || defined(HAVE_POSIXAIO)
-  std::list<aio_t> pending_aios;    ///< not yet submitted
-  std::list<aio_t> running_aios;    ///< submitting or submitted
+  // Reads and writes are tracked on separate lanes so nothing ever
+  // has to inspect an aio's direction: aio_read()/aio_write() know it
+  // statically, and submission moves each lane wholesale.
+  aio_lane writes;
+  aio_lane reads;
 #endif
   std::atomic_int num_pending = {0};
   std::atomic_int num_running = {0};

--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -301,6 +301,30 @@ public:
     bool buffered,
     int write_hint = WRITE_LIFE_NOT_SET) = 0;
   virtual int flush() = 0;
+
+  // External completion reaping of WRITE aio (opt-in, per instance).
+  // When a caller-owned eventfd is installed with
+  // set_completion_eventfd() BEFORE open(), the device does not run a
+  // completion thread for writes for its whole open lifetime; every
+  // write completion signals that eventfd, and the owner must drain
+  // them by calling reap_completions() - the write aio callbacks then
+  // run in the caller's context.  Reads move to a dedicated ring with
+  // its own completion thread, so read completion latency never
+  // depends on the owner's schedule.  The device only borrows the fd:
+  // the caller owns its lifetime and must keep it valid while the
+  // device is open.  The owner's obligations: (a) the reaping thread
+  // must never submit write aio itself or wait on a write IOContext -
+  // it is that ring's only drain, so sleeping in the submit EAGAIN
+  // retry loop (or in aio_wait) would deadlock; (b) no write aio may
+  // be issued at all while nothing is reaping.  Reads are exempt.
+  // Default: unsupported.
+  virtual int set_completion_eventfd(int fd) { return -EOPNOTSUPP; }
+  // Nonblocking; processes up to min(max, REAP_BATCH_MAX) completed
+  // aios and returns the number processed.  Devices not in
+  // external-completion mode simply return 0, so callers need no mode
+  // check.
+  virtual int reap_completions(int max) { return 0; }
+
   virtual bool try_discard(interval_set<uint64_t> &to_release,
                            bool async=true,
                            bool force=false) { return false; }

--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -153,6 +153,8 @@ public:
 class BlockDevice {
 public:
   CephContext* cct;
+  /// upper bound on completions processed by one reap pass
+  static constexpr int REAP_BATCH_MAX = 1024;
   typedef void (*aio_callback_t)(void *handle, void *aio);
   virtual void collect_alerts(osd_alert_list_t& alerts, const std::string& device_name);
 

--- a/src/blk/aio/aio.cc
+++ b/src/blk/aio/aio.cc
@@ -35,6 +35,9 @@ int aio_queue_t::submit_batch(aio_iter begin, aio_iter end,
 #if defined(HAVE_LIBAIO)
     while (cur != end && pulled < max_iodepth) {
       cur->priv = priv;
+      if (notify_eventfd >= 0) {
+	io_set_eventfd(&cur->iocb, notify_eventfd);
+      }
       piocb[pulled] = &(*cur);
       ++pulled;
       ++cur;

--- a/src/blk/aio/aio.h
+++ b/src/blk/aio/aio.h
@@ -110,6 +110,8 @@ struct io_queue_t {
   virtual int submit_batch(aio_iter begin, aio_iter end,
 			   void *priv, int *retries, int submit_retries, int initial_delay_us) = 0;
   virtual int get_next_completed(int timeout_ms, aio_t **paio, int max) = 0;
+  /// route completion notifications to an eventfd (see aio_queue_t)
+  virtual int set_notify_eventfd(int fd) { return -EOPNOTSUPP; }
 };
 
 struct aio_queue_t final : public io_queue_t {
@@ -119,6 +121,20 @@ struct aio_queue_t final : public io_queue_t {
 #elif defined(HAVE_POSIXAIO)
   int ctx;
 #endif
+  // When >= 0, every completion also signals this eventfd
+  // (io_set_eventfd on each iocb; libaio only).  Lets an external
+  // reaper epoll for completions instead of blocking in
+  // get_next_completed.
+  int notify_eventfd = -1;
+
+  int set_notify_eventfd(int fd) override {
+#if defined(HAVE_LIBAIO)
+    notify_eventfd = fd;
+    return 0;
+#else
+    return -EOPNOTSUPP;
+#endif
+  }
 
   explicit aio_queue_t(unsigned max_iodepth)
     : max_iodepth(max_iodepth),

--- a/src/blk/aio/aio.h
+++ b/src/blk/aio/aio.h
@@ -94,6 +94,12 @@ typedef boost::intrusive::list<
     boost::intrusive::list_member_hook<>,
     &aio_t::queue_item> > aio_list_t;
 
+/// one direction's aios of an IOContext
+struct aio_lane {
+  std::list<aio_t> pending;  ///< not yet submitted
+  std::list<aio_t> running;  ///< submitting or submitted
+};
+
 struct io_queue_t {
   typedef std::list<aio_t>::iterator aio_iter;
 

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -686,6 +686,47 @@ static bool is_expected_ioerr(const int r)
 	  );
 }
 
+// Common error taxonomy for one finished aio: pass EIO through when the
+// caller allows it, record and abort on any other device error, abort on
+// short I/O.  Returns only if the result is fully accounted for.  Log
+// lines carry the caller's name so the error's origin stays visible.
+void KernelDevice::_aio_check_completion(const char *caller, aio_t *aio,
+					 IOContext *ioc, long r)
+{
+  if (r < 0) {
+    derr << caller << " got r=" << r << " (" << cpp_strerror(r) << ")"
+	 << dendl;
+    if (ioc->allow_eio && is_expected_ioerr(r)) {
+      derr << caller << " translating the error to EIO for upper layer"
+	   << dendl;
+      ioc->set_return_value(-EIO);
+      return;
+    }
+    if (is_expected_ioerr(r)) {
+      note_io_error_event(
+	devname.c_str(),
+	path.c_str(),
+	r,
+#if defined(HAVE_POSIXAIO)
+	aio->aio.aiocb.aio_lio_opcode,
+#else
+	aio->iocb.aio_lio_opcode,
+#endif
+	aio->offset,
+	aio->length);
+    }
+    ceph_abort_msg(
+      "Unexpected IO error. "
+      "This may suggest a hardware issue. "
+      "Please check your kernel log!");
+  } else if (aio->length != (uint64_t)r) {
+    derr << caller << " aio to 0x" << std::hex << aio->offset
+	 << "~" << aio->length << std::dec
+	 << " but returned: " << r << dendl;
+    ceph_abort_msg("unexpected aio return value: does not match length");
+  }
+}
+
 void KernelDevice::_aio_thread()
 {
   dout(10) << __func__ << " start" << dendl;
@@ -719,41 +760,7 @@ void KernelDevice::_aio_thread()
 	io_since_flush.store(true);
 
 	long r = aio[i]->get_return_value();
-        if (r < 0) {
-          derr << __func__ << " got r=" << r << " (" << cpp_strerror(r) << ")"
-	       << dendl;
-          if (ioc->allow_eio && is_expected_ioerr(r)) {
-            derr << __func__ << " translating the error to EIO for upper layer"
-		 << dendl;
-            ioc->set_return_value(-EIO);
-          } else {
-	    if (is_expected_ioerr(r)) {
-	      note_io_error_event(
-		devname.c_str(),
-		path.c_str(),
-		r,
-#if defined(HAVE_POSIXAIO)
-                aio[i]->aio.aiocb.aio_lio_opcode,
-#else
-                aio[i]->iocb.aio_lio_opcode,
-#endif
-		aio[i]->offset,
-		aio[i]->length);
-	      ceph_abort_msg(
-		"Unexpected IO error. "
-		"This may suggest a hardware issue. "
-		"Please check your kernel log!");
-	    }
-	    ceph_abort_msg(
-	      "Unexpected IO error. "
-	      "This may suggest HW issue. Please check your dmesg!");
-          }
-        } else if (aio[i]->length != (uint64_t)r) {
-          derr << "aio to 0x" << std::hex << aio[i]->offset
-	       << "~" << aio[i]->length << std::dec
-               << " but returned: " << r << dendl;
-          ceph_abort_msg("unexpected aio return value: does not match length");
-        }
+	_aio_check_completion(__func__, aio[i], ioc, r);
 
         dout(10) << __func__ << " finished aio " << aio[i] << " r " << r
                  << " ioc " << ioc

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -13,6 +13,7 @@
  *
  */
 
+#include <algorithm>
 #include <cerrno>
 #include <limits>
 #include <unistd.h>
@@ -727,58 +728,68 @@ void KernelDevice::_aio_check_completion(const char *caller, aio_t *aio,
   }
 }
 
+int KernelDevice::_reap_completions(int timeout_ms, int max)
+{
+  // max sizes the VLA below (and an io_event array of the same length
+  // inside get_next_completed), so bound it regardless of what the
+  // caller derived from configuration; the surplus is picked up by
+  // the caller's next pass
+  max = std::clamp(max, 1, REAP_BATCH_MAX);
+  aio_t *aio[max];
+  int r = io_queue->get_next_completed(timeout_ms, aio, max);
+  if (r < 0) {
+    derr << __func__ << " got " << cpp_strerror(r) << dendl;
+    ceph_abort_msg("got unexpected error from io_getevents");
+  }
+  if (r > 0) {
+    dout(30) << __func__ << " got " << r << " completed aios" << dendl;
+    for (int i = 0; i < r; ++i) {
+      IOContext *ioc = static_cast<IOContext*>(aio[i]->priv);
+      _aio_log_finish(ioc, aio[i]->offset, aio[i]->length);
+      if (aio[i]->queue_item.is_linked()) {
+	std::lock_guard l(debug_queue_lock);
+	debug_aio_unlink(*aio[i]);
+      }
+
+      // set flag indicating new ios have completed.  we do this *before*
+      // any completion or notifications so that any user flush() that
+      // follows the observed io completion will include this io.  Note
+      // that an earlier, racing flush() could observe and clear this
+      // flag, but that also ensures that the IO will be stable before the
+      // later flush() occurs.
+      io_since_flush.store(true);
+
+      long res = aio[i]->get_return_value();
+      _aio_check_completion(__func__, aio[i], ioc, res);
+
+      dout(10) << __func__ << " finished aio " << aio[i] << " r " << res
+	       << " ioc " << ioc
+	       << " with " << (ioc->num_running.load() - 1)
+	       << " aios left" << dendl;
+
+      // NOTE: once num_running and we either call the callback or
+      // call aio_wake we cannot touch ioc or aio[] as the caller
+      // may free it.
+      if (ioc->priv) {
+	if (--ioc->num_running == 0) {
+	  aio_callback(aio_callback_priv, ioc->priv);
+	}
+      } else {
+	ioc->try_aio_wake();
+      }
+    }
+  }
+  return r;
+}
+
 void KernelDevice::_aio_thread()
 {
   dout(10) << __func__ << " start" << dendl;
   int inject_crash_count = 0;
   while (!aio_stop) {
     dout(40) << __func__ << " polling" << dendl;
-    int max = cct->_conf->bdev_aio_reap_max;
-    aio_t *aio[max];
-    int r = io_queue->get_next_completed(cct->_conf->bdev_aio_poll_ms,
-					 aio, max);
-    if (r < 0) {
-      derr << __func__ << " got " << cpp_strerror(r) << dendl;
-      ceph_abort_msg("got unexpected error from io_getevents");
-    }
-    if (r > 0) {
-      dout(30) << __func__ << " got " << r << " completed aios" << dendl;
-      for (int i = 0; i < r; ++i) {
-	IOContext *ioc = static_cast<IOContext*>(aio[i]->priv);
-	_aio_log_finish(ioc, aio[i]->offset, aio[i]->length);
-	if (aio[i]->queue_item.is_linked()) {
-	  std::lock_guard l(debug_queue_lock);
-	  debug_aio_unlink(*aio[i]);
-	}
-
-	// set flag indicating new ios have completed.  we do this *before*
-	// any completion or notifications so that any user flush() that
-	// follows the observed io completion will include this io.  Note
-	// that an earlier, racing flush() could observe and clear this
-	// flag, but that also ensures that the IO will be stable before the
-	// later flush() occurs.
-	io_since_flush.store(true);
-
-	long r = aio[i]->get_return_value();
-	_aio_check_completion(__func__, aio[i], ioc, r);
-
-        dout(10) << __func__ << " finished aio " << aio[i] << " r " << r
-                 << " ioc " << ioc
-                 << " with " << (ioc->num_running.load() - 1)
-                 << " aios left" << dendl;
-
-	// NOTE: once num_running and we either call the callback or
-	// call aio_wake we cannot touch ioc or aio[] as the caller
-	// may free it.
-	if (ioc->priv) {
-	  if (--ioc->num_running == 0) {
-	    aio_callback(aio_callback_priv, ioc->priv);
-	  }
-	} else {
-          ioc->try_aio_wake();
-	}
-      }
-    }
+    _reap_completions(cct->_conf->bdev_aio_poll_ms,
+		      cct->_conf->bdev_aio_reap_max);
     if (cct->_conf->bdev_debug_aio) {
       utime_t now = ceph_clock_now();
       std::lock_guard l(debug_queue_lock);

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -279,7 +279,8 @@ int KernelDevice::open(const string& p)
     goto out_fail;
   }
 
-  if (size >= block_size) {
+  // the completion thread's stop wakeup reads two distinct blocks
+  if (size >= 2 * block_size) {
     r = _aio_start();
     if (r < 0) {
       goto out_fail;
@@ -575,7 +576,7 @@ int KernelDevice::_aio_start()
       }
       return r;
     }
-    aio_thread.create("bstore_aio");
+    aio_thread.create("bstore_aio", io_queue.get());
   }
   return 0;
 }
@@ -585,22 +586,33 @@ void KernelDevice::_aio_stop()
   if (aio) {
     dout(10) << __func__ << dendl;
     aio_stop = true;
-
-    IOContext wakeup_ctx(cct, nullptr, false);
-    bufferlist bl;
-    aio_read(0, block_size, &bl, &wakeup_ctx);
-    aio_submit(&wakeup_ctx);
-
-    aio_thread.join();
-
-    if (cct->_conf->bdev_debug_aio) {
-      for (auto& i: wakeup_ctx.reads.running) {
-	debug_aio_unlink(i);
-      }
-    }
-
+    _aio_thread_wake(io_queue.get(), aio_thread);
     aio_stop = false;
     io_queue->shutdown();
+  }
+}
+
+// Stop one completion thread: unblock it from get_next_completed() by
+// submitting harmless reads, then join it.  Two reads, on distinct
+// blocks, so the batch neither takes the single-aio sync fast path
+// nor overlaps itself in the bdev_debug_inflight_ios tracking;
+// aio_submit() routes them to the ring this thread serves.  The
+// thread can exit on its poll timeout without ever reaping the
+// wakeup, so drain the queue afterwards until it is accounted for -
+// only then may the buffers go out of scope, and no stale interval is
+// left to trip the inflight tracking on a later stop cycle.
+void KernelDevice::_aio_thread_wake(io_queue_t *q, AioCompletionThread &thread)
+{
+  IOContext ioc(cct, nullptr, false);
+  bufferlist bl;
+  aio_read(0, block_size, &bl, &ioc);
+  aio_read(block_size, block_size, &bl, &ioc);
+  aio_submit(&ioc);
+
+  thread.join();
+
+  while (ioc.num_running.load() > 0) {
+    _reap_completions(q, cct->_conf->bdev_aio_poll_ms, 1);
   }
 }
 
@@ -728,7 +740,7 @@ void KernelDevice::_aio_check_completion(const char *caller, aio_t *aio,
   }
 }
 
-int KernelDevice::_reap_completions(int timeout_ms, int max)
+int KernelDevice::_reap_completions(io_queue_t *q, int timeout_ms, int max)
 {
   // max sizes the VLA below (and an io_event array of the same length
   // inside get_next_completed), so bound it regardless of what the
@@ -736,7 +748,7 @@ int KernelDevice::_reap_completions(int timeout_ms, int max)
   // the caller's next pass
   max = std::clamp(max, 1, REAP_BATCH_MAX);
   aio_t *aio[max];
-  int r = io_queue->get_next_completed(timeout_ms, aio, max);
+  int r = q->get_next_completed(timeout_ms, aio, max);
   if (r < 0) {
     derr << __func__ << " got " << cpp_strerror(r) << dendl;
     ceph_abort_msg("got unexpected error from io_getevents");
@@ -782,13 +794,13 @@ int KernelDevice::_reap_completions(int timeout_ms, int max)
   return r;
 }
 
-void KernelDevice::_aio_thread()
+void KernelDevice::_aio_thread(io_queue_t *q)
 {
   dout(10) << __func__ << " start" << dendl;
   int inject_crash_count = 0;
   while (!aio_stop) {
     dout(40) << __func__ << " polling" << dendl;
-    _reap_completions(cct->_conf->bdev_aio_poll_ms,
+    _reap_completions(q, cct->_conf->bdev_aio_poll_ms,
 		      cct->_conf->bdev_aio_reap_max);
     if (cct->_conf->bdev_debug_aio) {
       utime_t now = ceph_clock_now();
@@ -1044,13 +1056,11 @@ void KernelDevice::_aio_log_finish(
 // Callback-style IOContexts (txc data writes, deferred batches) are
 // not eligible: their callers do not wait, the pipeline consumes
 // their completions asynchronously.  Returns true if the io was
-// executed here.  (Never during _aio_stop: its wakeup ctx is a
-// single read that must reach the ring to unblock the completion
-// thread.)
+// executed here.
 bool KernelDevice::_aio_lone_waiter_sync(IOContext *ioc)
 {
 #if defined(HAVE_LIBAIO)
-  if (!aio || aio_stop || ioc->priv != nullptr ||
+  if (!aio || ioc->priv != nullptr ||
       ioc->num_pending.load() != 1) {
     return false;
   }

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -1021,6 +1021,64 @@ void KernelDevice::_aio_log_finish(
   }
 }
 
+// Fast path: a lone aio on a waiter-style IOContext (priv == NULL,
+// i.e. the caller blocks in aio_wait() rather than consuming a
+// completion callback) is one contiguous preadv/pwritev whose
+// submitter is about to wait for it - asynchrony buys nothing, so
+// execute it synchronously in the caller and skip the whole aio
+// completion round trip (ring, completion-thread wakeup, waiter
+// wakeup); aio_wait() then falls straight through.  This covers the
+// common single-extent read from _do_read and every single-segment
+// BlueFS flush (the WAL append on the commit path most importantly).
+// Callback-style IOContexts (txc data writes, deferred batches) are
+// not eligible: their callers do not wait, the pipeline consumes
+// their completions asynchronously.  Returns true if the io was
+// executed here.  (Never during _aio_stop: its wakeup ctx is a
+// single read that must reach the ring to unblock the completion
+// thread.)
+bool KernelDevice::_aio_lone_waiter_sync(IOContext *ioc)
+{
+#if defined(HAVE_LIBAIO)
+  if (!aio || aio_stop || ioc->priv != nullptr ||
+      ioc->num_pending.load() != 1) {
+    return false;
+  }
+  const bool is_read = !ioc->reads.pending.empty();
+  aio_t& a = is_read ? ioc->reads.pending.back()
+		     : ioc->writes.pending.back();
+  dout(20) << __func__ << " sync " << (is_read ? "read" : "write")
+	   << " 0x" << std::hex << a.offset << "~"
+	   << a.length << std::dec << dendl;
+  ssize_t r;
+  if (is_read) {
+    r = ::preadv(a.fd, a.iov.data(), a.iov.size(), a.offset);
+  } else {
+    r = ::pwritev(a.fd, a.iov.data(), a.iov.size(), a.offset);
+    // as in _sync_write/reap: arm the next flush() BEFORE anything
+    // can observe the write as complete
+    io_since_flush.store(true);
+  }
+  if (r < 0) {
+    r = -errno;
+    derr << __func__ << " sync " << (is_read ? "preadv" : "pwritev")
+	 << " 0x" << std::hex << a.offset << "~" << a.length
+	 << std::dec << " got " << cpp_strerror(r) << dendl;
+  }
+  // same rules as the completion thread's
+  _aio_check_completion(__func__, &a, ioc, r);
+  _aio_log_finish(ioc, a.offset, a.length);
+  ioc->num_pending--;
+  if (is_read) {
+    ioc->reads.pending.clear();
+  } else {
+    ioc->writes.pending.clear();
+  }
+  return true;
+#else
+  return false;
+#endif
+}
+
 void KernelDevice::aio_submit(IOContext *ioc)
 {
   dout(20) << __func__ << " ioc " << ioc
@@ -1029,6 +1087,10 @@ void KernelDevice::aio_submit(IOContext *ioc)
 	   << dendl;
 
   if (ioc->num_pending.load() == 0) {
+    return;
+  }
+
+  if (_aio_lone_waiter_sync(ioc)) {
     return;
   }
 

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -593,7 +593,7 @@ void KernelDevice::_aio_stop()
     aio_thread.join();
 
     if (cct->_conf->bdev_debug_aio) {
-      for (auto& i: wakeup_ctx.running_aios) {
+      for (auto& i: wakeup_ctx.reads.running) {
 	debug_aio_unlink(i);
       }
     }
@@ -1032,24 +1032,31 @@ void KernelDevice::aio_submit(IOContext *ioc)
     return;
   }
 
-  // move these aside, and get our end iterator position now, as the
+  // move these aside, and get our end iterator positions now, as the
   // aios might complete as soon as they are submitted and queue more
   // wal aio's.
-  list<aio_t>::iterator e = ioc->running_aios.begin();
-  ioc->running_aios.splice(e, ioc->pending_aios);
+  list<aio_t>::iterator we = ioc->writes.running.begin();
+  ioc->writes.running.splice(we, ioc->writes.pending);
+  list<aio_t>::iterator re = ioc->reads.running.begin();
+  ioc->reads.running.splice(re, ioc->reads.pending);
 
   int pending = ioc->num_pending.load();
   ioc->num_running += pending;
   ioc->num_pending -= pending;
   ceph_assert(ioc->num_pending.load() == 0);  // we should be only thread doing this
-  ceph_assert(ioc->pending_aios.size() == 0);
+  ceph_assert(ioc->writes.pending.empty());
+  ceph_assert(ioc->reads.pending.empty());
 
   if (cct->_conf->bdev_debug_aio) {
-    list<aio_t>::iterator p = ioc->running_aios.begin();
-    while (p != e) {
+    for (auto p = ioc->writes.running.begin(); p != we; ++p) {
       dout(30) << __func__ << " " << *p << dendl;
       std::lock_guard l(debug_queue_lock);
-      debug_aio_link(*p++);
+      debug_aio_link(*p);
+    }
+    for (auto p = ioc->reads.running.begin(); p != re; ++p) {
+      dout(30) << __func__ << " " << *p << dendl;
+      std::lock_guard l(debug_queue_lock);
+      debug_aio_link(*p);
     }
   }
 
@@ -1060,9 +1067,15 @@ void KernelDevice::aio_submit(IOContext *ioc)
 	   << " bdev_aio_submit_retry_max " << retry_max
 	   << " bdev_aio_submit_retry_initial_delay_us " << initial_delay_us
 	   << dendl;
-  int r, retries = 0;
-  r = io_queue->submit_batch(ioc->running_aios.begin(), e,
-			     priv, &retries, retry_max, initial_delay_us);
+  int r = 0, retries = 0;
+  if (ioc->writes.running.begin() != we) {
+    r = io_queue->submit_batch(ioc->writes.running.begin(), we,
+			       priv, &retries, retry_max, initial_delay_us);
+  }
+  if (r >= 0 && ioc->reads.running.begin() != re) {
+    r = io_queue->submit_batch(ioc->reads.running.begin(), re,
+			       priv, &retries, retry_max, initial_delay_us);
+  }
 
   if (retries)
     derr << __func__ << " retries " << retries << dendl;
@@ -1200,9 +1213,9 @@ int KernelDevice::aio_write(
 	   << dendl;
       // generate a real io so that aio_wait behaves properly, but make it
       // a read instead of write, and toss the result.
-      ioc->pending_aios.push_back(aio_t(ioc, choose_fd(false, write_hint)));
+      ioc->reads.pending.push_back(aio_t(ioc, choose_fd(false, write_hint)));
       ++ioc->num_pending;
-      auto& aio = ioc->pending_aios.back();
+      auto& aio = ioc->reads.pending.back();
       aio.bl.push_back(
         ceph::buffer::ptr_node::create(ceph::buffer::create_small_page_aligned(len)));
       aio.bl.prepare_iov(&aio.iov);
@@ -1211,9 +1224,9 @@ int KernelDevice::aio_write(
     } else {
       if (bl.length() <= RW_IO_MAX) {
 	// fast path (non-huge write)
-	ioc->pending_aios.push_back(aio_t(ioc, choose_fd(false, write_hint)));
+	ioc->writes.pending.push_back(aio_t(ioc, choose_fd(false, write_hint)));
 	++ioc->num_pending;
-	auto& aio = ioc->pending_aios.back();
+	auto& aio = ioc->writes.pending.back();
 	bl.prepare_iov(&aio.iov);
 	aio.bl.claim_append(bl);
 	aio.pwritev(off, len);
@@ -1231,9 +1244,9 @@ int KernelDevice::aio_write(
 	    tmp.substr_of(bl, prev_len, bl.length() - prev_len);
 	  }
 	  auto len = tmp.length();
-	  ioc->pending_aios.push_back(aio_t(ioc, choose_fd(false, write_hint)));
+	  ioc->writes.pending.push_back(aio_t(ioc, choose_fd(false, write_hint)));
 	  ++ioc->num_pending;
-	  auto& aio = ioc->pending_aios.back();
+	  auto& aio = ioc->writes.pending.back();
 	  tmp.prepare_iov(&aio.iov);
 	  aio.bl.claim_append(tmp);
 	  aio.pwritev(off + prev_len, len);
@@ -1510,9 +1523,9 @@ int KernelDevice::aio_read(
   if (aio && dio) {
     ceph_assert(is_valid_io(off, len));
     _aio_log_start(ioc, off, len);
-    ioc->pending_aios.push_back(aio_t(ioc, fd_directs[WRITE_LIFE_NOT_SET]));
+    ioc->reads.pending.push_back(aio_t(ioc, fd_directs[WRITE_LIFE_NOT_SET]));
     ++ioc->num_pending;
-    aio_t& aio = ioc->pending_aios.back();
+    aio_t& aio = ioc->reads.pending.back();
     aio.bl.push_back(
       ceph::buffer::ptr_node::create(create_custom_aligned(len, ioc)));
     aio.bl.prepare_iov(&aio.iov);

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -73,6 +73,11 @@ using ceph::make_timespan;
 using ceph::mono_clock;
 using ceph::operator <<;
 
+// the device whose externally-completed (outer) queue this thread
+// reaps; such a thread must never submit write aio to THAT device.
+// Compared only, never dereferenced.
+static thread_local const void *tl_outer_reaper_dev = nullptr;
+
 KernelDevice::KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv, aio_callback_t d_cb, void *d_cbpriv, const char* dev_name)
   : BlockDevice(cct, cb, cbpriv),
     aio(false), dio(false),
@@ -92,7 +97,7 @@ KernelDevice::KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv, ai
   if (use_ioring && ioring_queue_t::supported()) {
     bool use_ioring_hipri = cct->_conf.get_val<bool>("bdev_ioring_hipri");
     bool use_ioring_sqthread_poll = cct->_conf.get_val<bool>("bdev_ioring_sqthread_poll");
-    io_queue = std::make_unique<ioring_queue_t>(iodepth, use_ioring_hipri, use_ioring_sqthread_poll);
+    inner_io_queue = std::make_unique<ioring_queue_t>(iodepth, use_ioring_hipri, use_ioring_sqthread_poll);
   } else {
     static bool once;
     if (use_ioring && !once) {
@@ -100,7 +105,8 @@ KernelDevice::KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv, ai
            << dendl;
       once = true;
     }
-    io_queue = std::make_unique<aio_queue_t>(iodepth);
+    inner_io_queue = std::make_unique<aio_queue_t>(iodepth);
+    inner_is_libaio = true;
   }
 
   char name[128];
@@ -392,6 +398,10 @@ void KernelDevice::close()
     VOID_TEMP_FAILURE_RETRY(::close(fd_buffereds[i]));
     fd_buffereds[i] = -1;
   }
+  // the eventfd is borrowed, not owned; dropping the outer queue also
+  // drops our reference to it, and a re-opened device is back in
+  // normal mode unless the owner installs an eventfd again
+  outer_io_queue.reset();
   path.clear();
 }
 
@@ -566,17 +576,27 @@ int KernelDevice::_aio_start()
 {
   if (aio) {
     dout(10) << __func__ << dendl;
-    int r = io_queue->init(fd_directs);
-    if (r < 0) {
-      if (r == -EAGAIN) {
-	derr << __func__ << " io_setup(2) failed with EAGAIN; "
-	     << "try increasing /proc/sys/fs/aio-max-nr" << dendl;
-      } else {
-	derr << __func__ << " io_setup(2) failed: " << cpp_strerror(r) << dendl;
+    for (auto q : {inner_io_queue.get(), outer_io_queue.get()}) {
+      if (!q) {
+	continue;
       }
-      return r;
+      int r = q->init(fd_directs);
+      if (r < 0) {
+	if (r == -EAGAIN) {
+	  derr << __func__ << " io_setup(2) failed with EAGAIN; "
+	       << "try increasing /proc/sys/fs/aio-max-nr" << dendl;
+	} else {
+	  derr << __func__ << " io_setup(2) failed: " << cpp_strerror(r) << dendl;
+	}
+	if (q != inner_io_queue.get()) {
+	  inner_io_queue->shutdown();
+	}
+	return r;
+      }
     }
-    aio_thread.create("bstore_aio", io_queue.get());
+    // inner queue processes reads only if external completions are enabled
+    aio_thread.create(outer_io_queue ? "bstore_aio_rd" : "bstore_aio",
+      inner_io_queue.get());
   }
   return 0;
 }
@@ -586,9 +606,20 @@ void KernelDevice::_aio_stop()
   if (aio) {
     dout(10) << __func__ << dendl;
     aio_stop = true;
-    _aio_thread_wake(io_queue.get(), aio_thread);
+    if (outer_io_queue) {
+      // the owner must have stopped submitting by now, but
+      // completions may still sit unreaped in the write ring - drain
+      // them here rather than letting io_destroy discard them (their
+      // callbacks would never run)
+      while (_reap_completions(outer_io_queue.get(), 0,
+			       cct->_conf->bdev_aio_reap_max) > 0) {}
+    }
+    _aio_thread_wake(inner_io_queue.get(), aio_thread);
     aio_stop = false;
-    io_queue->shutdown();
+    if (outer_io_queue) {
+      outer_io_queue->shutdown();
+    }
+    inner_io_queue->shutdown();
   }
 }
 
@@ -792,6 +823,52 @@ int KernelDevice::_reap_completions(io_queue_t *q, int timeout_ms, int max)
     }
   }
   return r;
+}
+
+// Must be called before open(); the fd is borrowed from the caller
+// (never closed here) and stays installed for the device's whole open
+// lifetime - there is no mode switching on an open device.  Writes
+// only: reads move to a dedicated ring whose completion thread this
+// device keeps, so read completion latency never couples to the
+// owner's schedule.
+int KernelDevice::set_completion_eventfd(int fd)
+{
+#if defined(HAVE_LIBAIO)
+  ceph_assert(!aio_thread.is_started());
+  ceph_assert(fd >= 0);
+  ceph_assert(!outer_io_queue);
+  if (!inner_is_libaio) {
+    // bdev_ioring: keep the whole device on io_uring rather than
+    // silently moving writes to a libaio ring - the mode is libaio only
+    return -EOPNOTSUPP;
+  }
+  // eventfd support implies libaio, so the outer ring is plain aio
+  outer_io_queue = std::make_unique<aio_queue_t>(
+    cct->_conf->bdev_aio_max_queue_depth);
+
+  int r = outer_io_queue->set_notify_eventfd(fd);
+  if (r < 0) {
+    outer_io_queue.reset();
+    return r;
+  }
+  dout(5) << __func__ << " efd " << fd << dendl;
+  return 0;
+#else
+  return -EOPNOTSUPP;
+#endif
+}
+
+// drain the WRITE ring; a no-op unless in external-completion mode
+int KernelDevice::reap_completions(int max)
+{
+  if (!aio || !outer_io_queue) {
+    return 0;
+  }
+  // the calling thread is this device's outer-queue owner and only
+  // drain, for good; internal teardown drains do not mark their
+  // caller, so a thread that merely closed a device stays free
+  tl_outer_reaper_dev = this;
+  return _reap_completions(outer_io_queue.get(), 0, max);
 }
 
 void KernelDevice::_aio_thread(io_queue_t *q)
@@ -1102,6 +1179,13 @@ bool KernelDevice::_aio_lone_waiter_sync(IOContext *ioc)
 
 void KernelDevice::aio_submit(IOContext *ioc)
 {
+  // A thread that reaps this device's outer queue is that queue's
+  // only drain: if it submitted write aio here and slept in the
+  // submit EAGAIN retry, nobody would free the ring slots it is
+  // waiting for.  Reads are exempt (the device's own thread serves
+  // them), as are its submissions to other devices (BlueFS flushes
+  // from the kv sync thread land on BlueFS's own devices).
+  ceph_assert(tl_outer_reaper_dev != this || ioc->writes.pending.empty());
   dout(20) << __func__ << " ioc " << ioc
 	   << " pending " << ioc->num_pending.load()
 	   << " running " << ioc->num_running.load()
@@ -1150,14 +1234,19 @@ void KernelDevice::aio_submit(IOContext *ioc)
 	   << " bdev_aio_submit_retry_max " << retry_max
 	   << " bdev_aio_submit_retry_initial_delay_us " << initial_delay_us
 	   << dendl;
+  // reads ride the inner queue unless this device runs in
+  // external-completion mode, where they have their own ring
+  io_queue_t *wq = outer_io_queue ? outer_io_queue.get()
+				  : inner_io_queue.get();
   int r = 0, retries = 0;
   if (ioc->writes.running.begin() != we) {
-    r = io_queue->submit_batch(ioc->writes.running.begin(), we,
-			       priv, &retries, retry_max, initial_delay_us);
+    r = wq->submit_batch(ioc->writes.running.begin(), we,
+				     priv, &retries, retry_max,
+				     initial_delay_us);
   }
   if (r >= 0 && ioc->reads.running.begin() != re) {
-    r = io_queue->submit_batch(ioc->reads.running.begin(), re,
-			       priv, &retries, retry_max, initial_delay_us);
+    r = inner_io_queue->submit_batch(ioc->reads.running.begin(), re,
+      priv, &retries, retry_max, initial_delay_us);
   }
 
   if (retries)

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -95,6 +95,10 @@ private:
   virtual void  _pre_close() { }  // hook for child implementations
 
   void _aio_thread();
+  // one reap pass: get_next_completed(timeout_ms) + full completion
+  // processing (shared by the completion thread and any other caller
+  // driving completions)
+  int _reap_completions(int timeout_ms, int max);
   void _discard_thread(DiscardThread* thr);
   bool _queue_discard(interval_set<uint64_t> &to_release);
   int _discard(uint64_t offset, uint64_t len);

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -56,7 +56,17 @@ private:
   std::atomic<bool> io_since_flush = {false};
   ceph::mutex flush_mutex = ceph::make_mutex("KernelDevice::flush_mutex");
 
-  std::unique_ptr<io_queue_t> io_queue;
+  // The inner queue is served by the device's own completion thread
+  // and always exists; it carries everything in normal mode, and only
+  // reads when the owner installed a completion eventfd.  The outer
+  // queue exists only in that external-completion mode: it carries
+  // the writes, its completions signal the owner's eventfd, and the
+  // owner drains it via reap_completions().  Either way at most one
+  // completion thread runs per device.
+  std::unique_ptr<io_queue_t> inner_io_queue;
+  bool inner_is_libaio = false;  ///< external completions need libaio
+  // write completions reaped externally via the owner's eventfd
+  std::unique_ptr<io_queue_t> outer_io_queue;
   aio_callback_t discard_callback;
   void *discard_callback_priv;
   bool aio_stop;
@@ -178,6 +188,8 @@ public:
 		bool buffered,
 		int write_hint = WRITE_LIFE_NOT_SET) override;
   int flush() override;
+  int set_completion_eventfd(int fd) override;
+  int reap_completions(int max) override;
 
   bool try_discard(interval_set<uint64_t> &to_release,
                    bool async = true,

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -112,6 +112,7 @@ private:
 			     IOContext *ioc, long r);
 
   int _sync_write(uint64_t off, ceph::buffer::list& bl, bool buffered, int write_hint);
+  bool _aio_lone_waiter_sync(IOContext *ioc);
 
   int _lock();
 

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -70,9 +70,15 @@ private:
 
   struct AioCompletionThread : public Thread {
     KernelDevice *bdev;
+    io_queue_t *queue = nullptr;  ///< the ring this thread reaps
     explicit AioCompletionThread(KernelDevice *b) : bdev(b) {}
+    // hides Thread::create(): the queue is bound with the name
+    void create(const char *name, io_queue_t *q) {
+      queue = q;
+      Thread::create(name);
+    }
     void *entry() override {
-      bdev->_aio_thread();
+      bdev->_aio_thread(queue);
       return NULL;
     }
   } aio_thread;
@@ -94,11 +100,14 @@ private:
   virtual int _post_open() { return 0; }  // hook for child implementations
   virtual void  _pre_close() { }  // hook for child implementations
 
-  void _aio_thread();
+  void _aio_thread(io_queue_t *q);
+  // wake one completion thread out of get_next_completed(), join it,
+  // and drain whatever it left unreaped
+  void _aio_thread_wake(io_queue_t *q, AioCompletionThread &thread);
   // one reap pass: get_next_completed(timeout_ms) + full completion
   // processing (shared by the completion thread and any other caller
   // driving completions)
-  int _reap_completions(int timeout_ms, int max);
+  int _reap_completions(io_queue_t *q, int timeout_ms, int max);
   void _discard_thread(DiscardThread* thr);
   bool _queue_discard(interval_set<uint64_t> &to_release);
   int _discard(uint64_t offset, uint64_t len);

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -108,6 +108,8 @@ private:
 
   void _aio_log_start(IOContext *ioc, uint64_t offset, uint64_t length);
   void _aio_log_finish(IOContext *ioc, uint64_t offset, uint64_t length);
+  void _aio_check_completion(const char *caller, aio_t *aio,
+			     IOContext *ioc, long r);
 
   int _sync_write(uint64_t off, ceph::buffer::list& bl, bool buffered, int write_hint);
 

--- a/src/common/WakeupFd.h
+++ b/src/common/WakeupFd.h
@@ -1,0 +1,104 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2026 Ming Lei <ming.lei@clyso.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#ifndef CEPH_COMMON_WAKEUPFD_H
+#define CEPH_COMMON_WAKEUPFD_H
+
+#include <cerrno>
+#include <cstdint>
+#include <poll.h>
+#include <unistd.h>
+#include <sys/eventfd.h>
+
+#include "include/ceph_assert.h"
+#include "include/compat.h"
+
+/// A pollable wakeup primitive wrapping an eventfd: notify() makes
+/// fd() readable until the counter is consumed.  Semantics:
+///
+///  - notify() is thread-safe, cheap, and COALESCING: any number of
+///    notifies between two consumes yield one readable event.  The
+///    counter is incremented by the kernel at notify time,
+///    independently of any reader, so a notify can never be lost -
+///    an fd left unconsumed stays readable (sticky), which makes a
+///    "wake written before the waiter even started waiting" work.
+///  - consume() drains the counter; wait_and_consume() blocks first.
+///    Single consumer: concurrent consume()/wait_and_consume() from
+///    multiple threads is not supported (a wake could be swallowed
+///    by the wrong consumer).
+///    After consume() the caller must drain whatever queues the
+///    notifies advertised: the counter carries no payload.
+///  - fd() is a GENUINE eventfd, so beyond poll/epoll/select it may
+///    be handed to kernel-side signalling APIs that require one
+///    (io_set_eventfd()/IOCB_FLAG_RESFD for libaio,
+///    io_uring_register_eventfd()); the kernel then acts as another
+///    notifier of the same fd.
+///
+/// eventfd(2) is native on every platform this code builds for
+/// (linux; freebsd >= 13).  If an eventfd-less platform ever needs
+/// this, a self-pipe fallback belongs here and nowhere else - but
+/// note only userspace notification can be emulated that way; the
+/// kernel-side signalling APIs above require a real eventfd.
+class WakeupFd {
+public:
+  WakeupFd() {
+    fd_ = ::eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+    ceph_assert(fd_ >= 0);
+  }
+  ~WakeupFd() {
+    if (fd_ >= 0) {
+      VOID_TEMP_FAILURE_RETRY(::close(fd_));
+    }
+  }
+  WakeupFd(const WakeupFd&) = delete;
+  WakeupFd& operator=(const WakeupFd&) = delete;
+
+  int fd() const {
+    return fd_;
+  }
+
+  void notify() {
+    uint64_t one = 1;
+    ssize_t r = TEMP_FAILURE_RETRY(::write(fd_, &one, sizeof(one)));
+    // EAGAIN means the counter is at max, i.e. the fd is already
+    // readable - which is all a notify has to guarantee
+    ceph_assert(r == sizeof(one) || (r < 0 && errno == EAGAIN));
+  }
+
+  /// nonblocking drain; true if any notify was pending
+  bool consume() {
+    uint64_t v;
+    ssize_t r = TEMP_FAILURE_RETRY(::read(fd_, &v, sizeof(v)));
+    if (r < 0) {
+      ceph_assert(errno == EAGAIN);  // nothing pending (fd is nonblocking)
+      return false;
+    }
+    ceph_assert(r == sizeof(v));
+    return true;
+  }
+
+  /// block until notified (fd is nonblocking, so poll then drain)
+  void wait_and_consume() {
+    while (!consume()) {
+      struct pollfd pfd = { .fd = fd_, .events = POLLIN, .revents = 0 };
+      int r = TEMP_FAILURE_RETRY(::poll(&pfd, 1, -1));
+      ceph_assert(r >= 0);
+    }
+  }
+
+private:
+  int fd_ = -1;
+};
+
+#endif

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4101,7 +4101,8 @@ options:
 - name: bdev_aio_reap_max
   type: int
   level: advanced
-  default: 16
+  desc: Maximum number of aio completions reaped per pass
+  default: 128
   with_legacy: true
 - name: bdev_aio_submit_retry_max
   type: int

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5572,6 +5572,24 @@ options:
   desc: Try to submit metadata transaction to RocksDB in queuing thread context
   default: false
   with_legacy: true
+- name: bluestore_kv_sync_reap_write_completions
+  type: bool
+  level: advanced
+  desc: Reap data device write completions in the kv sync thread
+  long_desc: Selects how the data (block) device's write completions are
+    reaped.  When true, on linux/libaio the kv sync thread collects them
+    itself (signalled through an eventfd) and the device runs a dedicated
+    read-side aio context and completion thread instead of a write-side
+    one; this costs one extra aio context per OSD.  When false, the device
+    keeps a single aio context and completion thread as before.  BlueFS
+    devices are not affected.  Read at OSD start.
+  default: true
+  with_legacy: true
+  flags:
+  - startup
+  see_also:
+  - bdev_aio_max_queue_depth
+  - bdev_aio_reap_max
 - name: bluestore_fsck_read_bytes_cap
   type: size
   level: advanced

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -4259,7 +4259,8 @@ void BlueFS::_claim_completed_aios(FileWriter *h, list<aio_t> *ls)
 {
   for (auto p : h->iocv) {
     if (p) {
-      ls->splice(ls->end(), p->running_aios);
+      ls->splice(ls->end(), p->writes.running);
+      ls->splice(ls->end(), p->reads.running);
     }
   }
   dout(10) << __func__ << " got " << ls->size() << " aios" << dendl;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7261,6 +7261,23 @@ int BlueStore::_open_bdev(bool create)
   string p = path + "/block";
   bdev = BlockDevice::create(cct, p, aio_cb, static_cast<void*>(this), discard_cb, static_cast<void*>(this), "bluestore");
   int r = 0;
+  // Lend the kv sync thread's wakeup eventfd to the device before
+  // open(): where the backend supports it (libaio) the device then
+  // never starts the WRITE ring's completion thread - write
+  // completions signal the same fd the kv thread sleeps on, and it
+  // reaps them itself.  The read ring keeps its own thread in every
+  // mode, so read completion latency never couples to the commit
+  // cycle.  Where the backend does not support the eventfd
+  // (io_uring, posix-aio, SPDK, pmem), or the operator disabled the
+  // mode, the write thread stays and behaves exactly as before; its
+  // callbacks stage work and notify the same fd, so the kv thread is
+  // oblivious to the mode.
+  bdev_direct_completions =
+    cct->_conf->bluestore_kv_sync_reap_write_completions &&
+    bdev->set_completion_eventfd(kv_wake.fd()) == 0;
+  dout(5) << __func__ << " data bdev completions: "
+	  << (bdev_direct_completions ? "direct (kv sync thread reaps)"
+				      : "completion thread") << dendl;
   int plugin_preload_r = 0;
   if (cct->_conf->bluestore_use_ebd) {
     //load plugins
@@ -14834,7 +14851,7 @@ void BlueStore::_txc_state_proc(TransContext *txc)
 	kv_queue.push_back(txc);
 	if (!kv_sync_in_progress) {
 	  kv_sync_in_progress = true;
-	  kv_cond.notify_one();
+	  kv_wake.notify();
 	}
 	if (txc->get_state() != TransContext::STATE_KV_SUBMITTED) {
 	  kv_queue_unsubmitted.push_back(txc);
@@ -15277,7 +15294,7 @@ void BlueStore::_osr_drain_preceding(TransContext *txc)
     std::lock_guard l(kv_lock);
     if (!kv_sync_in_progress) {
       kv_sync_in_progress = true;
-      kv_cond.notify_one();
+      kv_wake.notify();
     }
   }
   osr->drain_preceding(txc);
@@ -15303,7 +15320,7 @@ void BlueStore::_osr_drain(OpSequencer *osr)
     std::lock_guard l(kv_lock);
     if (!kv_sync_in_progress) {
       kv_sync_in_progress = true;
-      kv_cond.notify_one();
+      kv_wake.notify();
     }
   }
   osr->drain();
@@ -15340,7 +15357,7 @@ void BlueStore::_osr_drain_all()
   {
     // wake up any previously finished deferred events
     std::lock_guard l(kv_lock);
-    kv_cond.notify_one();
+    kv_wake.notify();
   }
   {
     std::lock_guard l(kv_finalize_lock);
@@ -15386,13 +15403,12 @@ void BlueStore::_kv_stop()
 {
   dout(10) << __func__ << dendl;
   {
-    std::unique_lock l{kv_lock};
-    while (!kv_sync_started) {
-      kv_cond.wait(l);
-    }
+    // no started-handshake needed: the WakeupFd is sticky, so a stop
+    // notified before the thread even reaches its wait is still seen
+    std::lock_guard l(kv_lock);
     kv_stop = true;
-    kv_cond.notify_all();
   }
+  kv_wake.notify();
   {
     std::unique_lock l{kv_finalize_lock};
     while (!kv_finalize_started) {
@@ -15436,10 +15452,9 @@ void BlueStore::_kv_sync_thread()
 {
   dout(10) << __func__ << " start" << dendl;
   deque<DeferredBatch*> deferred_stable_queue; ///< deferred ios done + stable
+  // a prior mount's teardown drain may have left stale ticks on the fd
+  kv_wake.consume();
   std::unique_lock l{kv_lock};
-  ceph_assert(!kv_sync_started);
-  kv_sync_started = true;
-  kv_cond.notify_all();
 
   auto t0 = mono_clock::now();
   timespan twait = ceph::make_timespan(0);
@@ -15467,8 +15482,26 @@ void BlueStore::_kv_sync_thread()
       dout(20) << __func__ << " sleep" << dendl;
       auto t = mono_clock::now();
       kv_sync_in_progress = false;
-      kv_cond.wait(l);
+      l.unlock();
+      kv_wake.wait_and_consume();
       twait += mono_clock::now() - t;
+      // Drain the data bdev's WRITE completion ring (a no-op unless
+      // the device runs in external-completion mode); the callbacks
+      // (txc_aio_finish, deferred_aio_finish) run right here and
+      // stage work under kv_lock as they always did.  Reads are
+      // reaped by the device's own read-ring thread, never here.
+      // One batched reap keeps a sustained completion stream from
+      // starving the commit work below; a full batch means the ring
+      // may hold more, and the fd was consumed above, so self-notify
+      // to come straight back after this cycle.
+      {
+	const int reap_max = std::clamp(int(cct->_conf->bdev_aio_reap_max),
+					1, BlockDevice::REAP_BATCH_MAX);
+	if (bdev->reap_completions(reap_max) == reap_max) {
+	  kv_wake.notify();
+	}
+      }
+      l.lock();
 
       dout(20) << __func__ << " wake" << dendl;
     } else {
@@ -15680,8 +15713,12 @@ void BlueStore::_kv_sync_thread()
       deferred_stable_queue.swap(deferred_done);
     }
   }
+  l.unlock();
+  // nothing else drains the write ring after this thread exits; pick
+  // up any straggler completions before teardown discards them (the
+  // osr drains our callers run mean there normally are none)
+  while (bdev->reap_completions(BlockDevice::REAP_BATCH_MAX) > 0) {}
   dout(10) << __func__ << " finish" << dendl;
-  kv_sync_started = false;
 }
 
 void BlueStore::_kv_finalize_thread()
@@ -15962,7 +15999,7 @@ void BlueStore::_deferred_aio_finish(OpSequencer *osr)
     // catch us on the next commit anyway.
     if (deferred_aggressive && !kv_sync_in_progress) {
 	kv_sync_in_progress = true;
-	kv_cond.notify_one();
+	kv_wake.notify();
     }
   }
 }
@@ -16166,7 +16203,7 @@ int BlueStore::queue_transactions(
       std::lock_guard l(kv_lock);
       if (!kv_sync_in_progress) {
 	kv_sync_in_progress = true;
-	kv_cond.notify_one();
+	kv_wake.notify();
       }
     }
     throttle.finish_start_transaction(*db, *txc, tstart);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -15445,7 +15445,6 @@ void BlueStore::_kv_sync_thread()
       twait = ceph::make_timespan(0);
       kv_submitted = 0;
     }
-    ceph_assert(kv_committing.empty());
     if (kv_queue.empty() &&
 	((deferred_done_queue.empty() && deferred_stable_queue.empty()) ||
 	 !deferred_aggressive)) {
@@ -15459,6 +15458,7 @@ void BlueStore::_kv_sync_thread()
 
       dout(20) << __func__ << " wake" << dendl;
     } else {
+      deque<TransContext*> kv_committing;  ///< currently syncing
       deque<TransContext*> kv_submitting;
       deque<DeferredBatch*> deferred_done, deferred_stable;
       uint64_t aios = 0, costs = 0, txcs = 0;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -15418,6 +15418,20 @@ void BlueStore::_kv_stop()
   dout(10) << __func__ << " stopped" << dendl;
 }
 
+// Drain `from` into the tail of `to`, preserving order.  Steals the
+// whole deque O(1) when `to` is empty (the common case); appends when
+// the consumer is running behind.
+template <typename T>
+static void append_and_clear(std::deque<T>& to, std::deque<T>& from)
+{
+  if (to.empty()) {
+    to.swap(from);
+  } else {
+    to.insert(to.end(), from.begin(), from.end());
+    from.clear();
+  }
+}
+
 void BlueStore::_kv_sync_thread()
 {
   dout(10) << __func__ << " start" << dendl;
@@ -15516,13 +15530,7 @@ void BlueStore::_kv_sync_thread()
 	bdev->flush();
 
         // if we flush then deferred done are now deferred stable
-        if (deferred_stable.empty()) {
-          deferred_stable.swap(deferred_done);
-        } else {
-          deferred_stable.insert(deferred_stable.end(), deferred_done.begin(),
-                                 deferred_done.end());
-          deferred_done.clear();
-        }
+        append_and_clear(deferred_stable, deferred_done);
       }
       auto after_flush = mono_clock::now();
 
@@ -15625,24 +15633,8 @@ void BlueStore::_kv_sync_thread()
 
       {
 	std::unique_lock m{kv_finalize_lock};
-	if (kv_committing_to_finalize.empty()) {
-	  kv_committing_to_finalize.swap(kv_committing);
-	} else {
-	  kv_committing_to_finalize.insert(
-	      kv_committing_to_finalize.end(),
-	      kv_committing.begin(),
-	      kv_committing.end());
-	  kv_committing.clear();
-	}
-	if (deferred_stable_to_finalize.empty()) {
-	  deferred_stable_to_finalize.swap(deferred_stable);
-	} else {
-	  deferred_stable_to_finalize.insert(
-	      deferred_stable_to_finalize.end(),
-	      deferred_stable.begin(),
-	      deferred_stable.end());
-	  deferred_stable.clear();
-	}
+	append_and_clear(kv_committing_to_finalize, kv_committing);
+	append_and_clear(deferred_stable_to_finalize, deferred_stable);
 	if (!kv_finalize_in_progress) {
 	  kv_finalize_in_progress = true;
 	  kv_finalize_cond.notify_one();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2486,7 +2486,6 @@ private:
   bool kv_finalize_stop = false;
   std::deque<TransContext*> kv_queue;             ///< ready, already submitted
   std::deque<TransContext*> kv_queue_unsubmitted; ///< ready, need submit by kv thread
-  std::deque<TransContext*> kv_committing;        ///< currently syncing
   std::deque<DeferredBatch*> deferred_done_queue;   ///< deferred ios done
   bool kv_sync_in_progress = false;
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -23,6 +23,7 @@
 
 #include <atomic>
 #include <bit>
+#include <thread>
 #include <chrono>
 #include <ratio>
 #include <mutex>
@@ -49,6 +50,7 @@
 #include "common/bloom_filter.hpp"
 #include "common/Finisher.h"
 #include "common/ceph_mutex.h"
+#include "common/WakeupFd.h"
 #include "common/Throttle.h"
 #include "common/perf_counters.h"
 #include "common/PriorityCache.h"
@@ -2478,9 +2480,15 @@ private:
 
   KVSyncThread kv_sync_thread;
   ceph::mutex kv_lock = ceph::make_mutex("BlueStore::kv_lock");
-  ceph::condition_variable kv_cond;
+  /// wakes _kv_sync_thread: submitters (and, in direct-completion
+  /// mode, the kernel via IOCB_FLAG_RESFD) notify this fd
+  WakeupFd kv_wake;
+  // data bdev accepted kv_wake's eventfd (backend supports it and
+  // bluestore_kv_sync_reap_write_completions is on): no write-side
+  // completion thread, this thread reaps the write ring
+  bool bdev_direct_completions = false;
+
   bool _kv_only = false;
-  bool kv_sync_started = false;
   bool kv_stop = false;
   bool kv_finalize_started = false;
   bool kv_finalize_stop = false;

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -352,6 +352,14 @@ add_executable(unittest_dout_fmt test_dout_fmt.cc $<TARGET_OBJECTS:unit-main>)
 target_link_libraries(unittest_dout_fmt global)
 add_ceph_unittest(unittest_dout_fmt)
 
+# unittest_wakeup_fd
+if(LINUX OR FREEBSD)
+add_executable(unittest_wakeup_fd
+  test_wakeup_fd.cc)
+add_ceph_unittest(unittest_wakeup_fd)
+target_link_libraries(unittest_wakeup_fd ceph-common)
+endif()
+
 # We're getting an ICE when trying to compile this test using mingw-gcc and
 # recent Boost versions. Note that mingw-llvm works fine.
 if (NOT WIN32 OR (NOT(CMAKE_CXX_COMPILER_ID STREQUAL GNU)))

--- a/src/test/common/test_wakeup_fd.cc
+++ b/src/test/common/test_wakeup_fd.cc
@@ -1,0 +1,82 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include <poll.h>
+#include <thread>
+#include <vector>
+
+#include "common/WakeupFd.h"
+#include "gtest/gtest.h"
+
+static bool readable(int fd, int timeout_ms)
+{
+  struct pollfd pfd = { .fd = fd, .events = POLLIN, .revents = 0 };
+  int r = TEMP_FAILURE_RETRY(::poll(&pfd, 1, timeout_ms));
+  return r > 0 && (pfd.revents & POLLIN);
+}
+
+TEST(WakeupFd, Basic)
+{
+  WakeupFd w;
+  ASSERT_GE(w.fd(), 0);
+  ASSERT_FALSE(readable(w.fd(), 0));
+  ASSERT_FALSE(w.consume());
+
+  w.notify();
+  ASSERT_TRUE(readable(w.fd(), 0));
+  ASSERT_TRUE(w.consume());
+  ASSERT_FALSE(readable(w.fd(), 0));
+  ASSERT_FALSE(w.consume());
+}
+
+TEST(WakeupFd, Coalescing)
+{
+  WakeupFd w;
+  for (int i = 0; i < 1000; i++) {
+    w.notify();
+  }
+  // any number of notifies is one readable event, drained by one consume
+  ASSERT_TRUE(w.consume());
+  ASSERT_FALSE(w.consume());
+  ASSERT_FALSE(readable(w.fd(), 0));
+}
+
+TEST(WakeupFd, StickyBeforeWait)
+{
+  // a notify issued before anyone waits must still wake the waiter
+  WakeupFd w;
+  w.notify();
+  w.wait_and_consume();  // must not block
+  ASSERT_FALSE(w.consume());
+}
+
+TEST(WakeupFd, WakesBlockedWaiter)
+{
+  WakeupFd w;
+  std::thread waiter([&] {
+    w.wait_and_consume();
+  });
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  w.notify();
+  waiter.join();
+}
+
+TEST(WakeupFd, ManyNotifiers)
+{
+  WakeupFd w;
+  constexpr int nthreads = 8, per_thread = 10000;
+  std::vector<std::thread> ts;
+  for (int i = 0; i < nthreads; i++) {
+    ts.emplace_back([&] {
+      for (int j = 0; j < per_thread; j++) {
+	w.notify();
+      }
+    });
+  }
+  for (auto& t : ts) {
+    t.join();
+  }
+  // all notifies coalesce; the fd is readable exactly until consumed
+  ASSERT_TRUE(w.consume());
+  ASSERT_FALSE(w.consume());
+}


### PR DESCRIPTION
Let the kv sync thread reap the data device's write completions itself,
removing one thread and one handoff from every write's commit path on
linux/libaio.  The data device gets a dedicated read ring with its own
completion thread, so read completion latency never couples to the
commit cycle, and a lone waiter-style aio (the common single-extent
read, every single-segment BlueFS flush) is executed synchronously in
the submitter, skipping the aio machinery entirely.  Other devices and
backends keep the single ring and completion thread they have today.
The new startup option bluestore_kv_sync_reap_write_completions
(default true) falls back to the previous completion-thread mode.

Measured on a ramdisk OSD, RelWithDebInfo, single boot, counterbalanced
A/B against the base of this series:

```
4k randwrite qd1            +10.2% iops
4k randread  qd1            +12.9% iops
4k randwrite qd16, 2 jobs    +4.1%
mixed 70/30                  +3.2% both directions
4k randwrite qd16, 4 jobs    parity (~83k iops)
deferred-forced qd16         parity
```

Same binary, option on vs off: qd1 +4-7% iops, qd16 parity.

V2 changes:

- two new prep patches: factor the aio completion error taxonomy into
  a helper, and track read/write aios on separate lanes in IOContext
  (aio_lane), so submission routes by lane with O(1) splices and never
  scans a batch for direction
- the read ring is created only when the owner installs a completion
  eventfd; every other KernelDevice keeps one ring and one thread, and
  each device runs at most one completion thread in any mode (the
  stalled-aio watchdog and bdev_inject_crash always have a home)
- reap_completions() returns 0 outside external-completion mode, so
  callers need no mode check
- the kv sync drain is one batched reap; self-notify only when the
  batch comes back full
- _aio_thread_wake() owns the stop wakeup end to end (submit, join,
  drain), closing a buffer-lifetime window the previous version had
- AioCompletionThread::create() binds thread name and queue together;
  a redundant member is dropped

V3 changes:

- bluestore_kv_sync_reap_write_completions (default true, startup
  only) selects the reaping mode; false restores the single ring and
  bstore_aio thread
- the kv sync reap is bounded by bdev_aio_reap_max like every other
  reaper; its default rises from 16 to 128 in its own patch, and both
  sides clamp to a shared REAP_BATCH_MAX
- the stop wakeup submits two reads through aio_submit() instead of
  duplicating the submission logic (two, to stay out of the single-aio
  sync fast path); aio now needs a two-block device
- completion error logs name the originating function
- rebased onto current main

V4 changes:

- KernelDevice's two aio queues are named by completion ownership,
  inner_io_queue (the device's own thread reaps it) and
  outer_io_queue (reaped externally through the eventfd), instead of
  by direction; the external_completions bool goes away, the outer
  queue's existence is the mode (ifed01's suggestion)
- the "kv sync thread must not submit write aio in direct mode" rule
  is enforced inside KernelDevice: a thread that reaps a device's
  outer queue may not submit write aio to that device, asserted in
  aio_submit(); BlueStore no longer tracks the kv sync thread for
  this (ifed01's suggestion)
- an eventfd is refused on an io_uring device rather than silently
  moving its writes to a libaio queue

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
