### PR TITLE
cephadm: add deb support for sudo hardening and teuthology tests

### DIFF
--- a/debian/cephadm.install
+++ b/debian/cephadm.install
@@ -1,2 +1,3 @@
 usr/sbin/cephadm
+usr/libexec/cephadm_invoker.py
 usr/share/man/man8/cephadm.8

--- a/debian/cephadm.postinst
+++ b/debian/cephadm.postinst
@@ -47,6 +47,12 @@ case "$1" in
            usermod --home /var/lib/cephadm -m cephadm
        fi
 
+       # set invoker permissions to match RPM (0700, root:root)
+       if test -f /usr/libexec/cephadm_invoker.py; then
+           chown root:root /usr/libexec/cephadm_invoker.py
+           chmod 0700 /usr/libexec/cephadm_invoker.py
+       fi
+
        # set up (initially empty) .ssh/authorized_keys file
        if ! test -d ~cephadm/.ssh; then
            mkdir ~cephadm/.ssh

--- a/doc/cephadm/host-management.rst
+++ b/doc/cephadm/host-management.rst
@@ -708,7 +708,7 @@ To enable sudo hardening for the entire cluster, use the following command:
 This command performs a comprehensive sudo hardening setup:
 
 1. **Host Preparation**: Prepares all cluster hosts for sudo hardening by:
-   - Installing/upgrading cephadm RPM with the invoker script
+   - Installing/upgrading the cephadm package (RPM or DEB) with the invoker script
    - Configuring restricted sudo access for non-root users
    - Setting up SSH key authorization
 

--- a/doc/dev/cephadm/cephadm-invoker.rst
+++ b/doc/dev/cephadm/cephadm-invoker.rst
@@ -10,7 +10,7 @@ Overview
 
 The cephadm invoker validates the cephadm binary hash before execution and
 provides a secure way to run cephadm commands and deploy binaries. It is installed as
-part of the cephadm RPM at ``/usr/libexec/cephadm_invoker.py``.
+part of the cephadm package (RPM or DEB) at ``/usr/libexec/cephadm_invoker.py``.
 
 Commands
 --------

--- a/qa/suites/orch/cephadm/workunits/task/test_sudo_hardening.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_sudo_hardening.yaml
@@ -1,0 +1,105 @@
+roles:
+- - host.a
+  - mon.a
+  - mgr.a
+  - osd.0
+  - client.0
+- - host.b
+  - mon.b
+  - mgr.b
+  - osd.1
+  - client.1
+overrides:
+  cephadm:
+    cephadm_mode: cephadm-package
+  install:
+    extra_packages: [cephadm]
+  ceph:
+    log-ignorelist:
+      - CEPHADM_STRAY_DAEMON
+      - CEPHADM_FAILED_DAEMON
+    log-only-match:
+      - CEPHADM_
+tasks:
+- install:
+- cephadm:
+- cephadm.shell:
+    host.a:
+      - |
+        set -ex
+
+        # ---- Step 1: Verify cephadm_invoker.py is installed on all hosts ----
+        HOSTNAMES=$(ceph orch host ls --format json | jq -r '.[] | .hostname')
+        for host in $HOSTNAMES; do
+          # The invoker should be present from the cephadm package
+          ceph cephadm check-host ${host} 2> ${host}-check.txt
+          HOST_CHECK=$(cat ${host}-check.txt)
+          if ! grep -q "Host looks OK" <<< "$HOST_CHECK"; then
+            printf "check-host failed for ${host}:\n\n$HOST_CHECK"
+            exit 1
+          fi
+        done
+
+        # ---- Step 2: Verify sudo hardening is initially disabled ----
+        SUDO_HARDENING=$(ceph config get mgr mgr/cephadm/sudo_hardening)
+        if [ "$SUDO_HARDENING" != "false" ]; then
+          echo "Expected sudo_hardening to be false initially, got: $SUDO_HARDENING"
+          exit 1
+        fi
+
+        # ---- Step 3: Enable sudo hardening ----
+        ceph cephadm prepare-host-and-enable-sudo-hardening cephadm
+
+        # Wait for the orchestrator to settle after switching SSH user
+        sleep 30
+
+        # ---- Step 4: Verify sudo hardening is enabled ----
+        SUDO_HARDENING=$(ceph config get mgr mgr/cephadm/sudo_hardening)
+        if [ "$SUDO_HARDENING" != "true" ]; then
+          echo "Expected sudo_hardening to be true after enabling, got: $SUDO_HARDENING"
+          exit 1
+        fi
+
+        # ---- Step 5: Verify SSH user was changed to cephadm ----
+        SSH_USER=$(ceph cephadm get-user)
+        if [ "$SSH_USER" != "cephadm" ]; then
+          echo "Expected ssh_user to be 'cephadm', got: $SSH_USER"
+          exit 1
+        fi
+
+        # ---- Step 6: Verify cluster health after enabling sudo hardening ----
+        # Wait for services to stabilize under the new execution model
+        sleep 30
+
+        # Verify all hosts are reachable through the invoker
+        for host in $HOSTNAMES; do
+          ceph cephadm check-host ${host} 2> ${host}-hardened-check.txt
+          HOST_CHECK=$(cat ${host}-hardened-check.txt)
+          if ! grep -q "Host looks OK" <<< "$HOST_CHECK"; then
+            printf "check-host failed after hardening for ${host}:\n\n$HOST_CHECK"
+            exit 1
+          fi
+        done
+
+        # ---- Step 7: Verify orchestrator operations work through invoker ----
+        ceph orch ps
+        ceph orch ls
+        ceph orch host ls
+        ceph orch device ls
+
+        # Verify daemons are running
+        RUNNING_DAEMONS=$(ceph orch ps --format json | jq '[.[] | select(.status_desc == "running")] | length')
+        if [ "$RUNNING_DAEMONS" -lt 1 ]; then
+          echo "No running daemons found after enabling sudo hardening"
+          ceph orch ps
+          exit 1
+        fi
+
+        # ---- Step 8: Disable sudo hardening and verify ----
+        ceph config set mgr mgr/cephadm/sudo_hardening false
+        sleep 15
+        SUDO_HARDENING=$(ceph config get mgr mgr/cephadm/sudo_hardening)
+        if [ "$SUDO_HARDENING" != "false" ]; then
+          echo "Expected sudo_hardening to be false after disabling, got: $SUDO_HARDENING"
+          exit 1
+        fi


### PR DESCRIPTION
The cephadm_invoker.py script was not included in the Debian package, making sudo hardening RPM-only. Add it to debian/cephadm.install and set permissions (0700, root:root) in postinst to match the RPM spec. Update docs to reflect support for both RPM and DEB systems.

Fixes: https://tracker.ceph.com/issues/79568
Signed-off-by: Shweta Bhosale <Shweta.Bhosale1@ibm.com>




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
