### PR TITLE
rgw/dedup: fix stale cursor hang

### DIFF
--- a/src/rgw/driver/rados/rgw_dedup.cc
+++ b/src/rgw/driver/rados/rgw_dedup.cc
@@ -76,7 +76,6 @@ using namespace rgw::dedup;
 #include "rgw_dedup_epoch.h"
 #include "rgw_perf_counters.h"
 #include "include/ceph_assert.h"
-#include "include/scope_guard.h"
 
 static constexpr auto dout_subsys = ceph_subsys_rgw_dedup;
 
@@ -2664,54 +2663,55 @@ namespace rgw::dedup {
     int ret = 0;
     std::string section("bucket.instance");
     std::string marker;
-    void *handle = nullptr;
-    ret = driver->meta_list_keys_init(dpp, section, marker, &handle);
-    if (ret < 0) {
-      ldpp_dout(dpp, 1) << __func__ << "::ERR: Failed meta_list_keys_init: "
-                        << cpp_strerror(-ret) << dendl;
-      return ret;
-    }
-
-    auto keys_guard = make_scope_guard(
-      [this, handle] { driver->meta_list_keys_complete(handle); });
+    constexpr int max_keys = 1000;
 
     d_all_buckets_obj_count = 0;
     d_all_buckets_obj_size  = 0;
 
     bool has_more = true;
     while (has_more) {
+      void *handle = nullptr;
+      ret = driver->meta_list_keys_init(dpp, section, marker, &handle);
+      if (ret < 0) {
+        ldpp_dout(dpp, 1) << __func__ << "::ERR: Failed meta_list_keys_init: "
+                          << cpp_strerror(-ret) << dendl;
+        reset_bucket_counters(&d_all_buckets_obj_count, &d_all_buckets_obj_size);
+        return ret;
+      }
       std::list<std::string> entries;
-      constexpr int max_keys = 1000;
       ret = driver->meta_list_keys_next(dpp, handle, max_keys, entries, &has_more);
       if (ret == 0) {
-        for (auto& entry : entries) {
-          ldpp_dout(dpp, 20) <<__func__ << "::bucket_name=" << entry << dendl;
-          rgw_bucket bucket;
-          ret = rgw_bucket_parse_bucket_key(cct, entry, &bucket, nullptr);
-          if (unlikely(ret < 0)) {
-            ldpp_dout(dpp, 1) << __func__ << "::ERR: Failed rgw_bucket_parse_bucket_key: "
-                              << cpp_strerror(-ret) << dendl;
-            reset_bucket_counters(&d_all_buckets_obj_count, &d_all_buckets_obj_size);
-            return ret;
-          }
-          ldpp_dout(dpp, 20) <<__func__ << "::bucket=" << bucket << dendl;
-          if (!d_filter.allow_bucket(bucket.name)) {
-            ldpp_dout(dpp, 10) << __func__ << "::skip bucket (filter): "
-                               << bucket.name << dendl;
-            continue;
-          }
-          ret = read_bucket_stats(bucket, &d_all_buckets_obj_count,
-                                  &d_all_buckets_obj_size);
-          if (unlikely(ret != 0)) {
-            reset_bucket_counters(&d_all_buckets_obj_count, &d_all_buckets_obj_size);
-            return ret;
-          }
-        }
+        marker = driver->meta_get_marker(handle);
       }
-      else {
+      driver->meta_list_keys_complete(handle);
+
+      if (ret != 0) {
         ldpp_dout(dpp, 1) << __func__ << "::ERR: failed driver->meta_list_keys_next()" << dendl;
         reset_bucket_counters(&d_all_buckets_obj_count, &d_all_buckets_obj_size);
         return ret;
+      }
+      for (auto& entry : entries) {
+        ldpp_dout(dpp, 20) <<__func__ << "::bucket_name=" << entry << dendl;
+        rgw_bucket bucket;
+        ret = rgw_bucket_parse_bucket_key(cct, entry, &bucket, nullptr);
+        if (unlikely(ret < 0)) {
+          ldpp_dout(dpp, 1) << __func__ << "::ERR: Failed rgw_bucket_parse_bucket_key: "
+                            << cpp_strerror(-ret) << dendl;
+          reset_bucket_counters(&d_all_buckets_obj_count, &d_all_buckets_obj_size);
+          return ret;
+        }
+        ldpp_dout(dpp, 20) <<__func__ << "::bucket=" << bucket << dendl;
+        if (!d_filter.allow_bucket(bucket.name)) {
+          ldpp_dout(dpp, 10) << __func__ << "::skip bucket (filter): "
+                             << bucket.name << dendl;
+          continue;
+        }
+        ret = read_bucket_stats(bucket, &d_all_buckets_obj_count,
+                                &d_all_buckets_obj_size);
+        if (unlikely(ret != 0)) {
+          reset_bucket_counters(&d_all_buckets_obj_count, &d_all_buckets_obj_size);
+          return ret;
+        }
       }
     }
 
@@ -2733,61 +2733,66 @@ namespace rgw::dedup {
     int ret = 0;
     std::string section("bucket.instance");
     std::string marker;
-    void *handle = nullptr;
-    ret = driver->meta_list_keys_init(dpp, section, marker, &handle);
-    if (ret < 0) {
-      ldpp_dout(dpp, 1) << __func__ << "::ERR: Failed meta_list_keys_init: "
-                        << cpp_strerror(-ret) << dendl;
-      return ret;
-    }
-    auto keys_guard = make_scope_guard(
-      [this, handle] { driver->meta_list_keys_complete(handle); });
+    constexpr int max_keys = 1000;
 
     disk_block_array_t disk_arr(dpp, raw_mem, raw_mem_size, worker_id,
                                 p_worker_stats, num_md5_shards);
     bool has_more = true;
-    // iterate over all buckets
-    while (ret == 0 && has_more) {
-      std::list<std::string> entries;
-      constexpr int max_keys = 1000;
-      ret = driver->meta_list_keys_next(dpp, handle, max_keys, entries, &has_more);
-      if (ret == 0) {
-        ldpp_dout(dpp, 20) <<__func__ << "::entries.size()=" << entries.size() << dendl;
-        for (auto& entry : entries) {
-          ldpp_dout(dpp, 20) <<__func__ << "::bucket_name=" << entry << dendl;
-          rgw_bucket bucket;
-          ret = rgw_bucket_parse_bucket_key(cct, entry, &bucket, nullptr);
-          if (unlikely(ret < 0)) {
-            // bad bucket entry, skip to the next one
-            ldpp_dout(dpp, 1) << __func__ << "::ERR: Failed rgw_bucket_parse_bucket_key: "
-                              << cpp_strerror(-ret) << dendl;
-            continue;
-          }
-          ldpp_dout(dpp, 20) <<__func__ << "::bucket=" << bucket << dendl;
-          if (!d_filter.allow_bucket(bucket.name)) {
-            ldpp_dout(dpp, 10) << __func__ << "::worker_id=" << worker_id
-                               << "::skip bucket (filter): " << bucket.name << dendl;
-            p_worker_stats->ingress_skip_filtered_bucket++;
-            continue;
-          }
-          ret = ingress_bucket_objects_single_shard(disk_arr, bucket, worker_id,
-                                                    num_work_shards, p_worker_stats);
-          if (unlikely(ret != 0)) {
-            if (d_ctl.should_stop()) {
-              return -ECANCELED;
-            }
-            ldpp_dout(dpp, 1) << __func__ << "::Failed ingress_bucket_objects_single_shard()" << dendl;
-            // skip bad bucket and move on to the next one
-            continue;
-          }
-        }
-      }
-      else {
-        ldpp_dout(dpp, 1) << __func__ << "::failed driver->meta_list_keys_next()" << dendl;
-        // TBD: what can we do here?
+    while (has_more) {
+      if (unlikely(d_ctl.should_stop())) {
+        ret = -ECANCELED;
         break;
       }
+
+      void *handle = nullptr;
+      ret = driver->meta_list_keys_init(dpp, section, marker, &handle);
+      if (ret < 0) {
+        ldpp_dout(dpp, 1) << __func__ << "::ERR: Failed meta_list_keys_init: "
+                          << cpp_strerror(-ret) << dendl;
+        break;
+      }
+      std::list<std::string> entries;
+      ret = driver->meta_list_keys_next(dpp, handle, max_keys, entries, &has_more);
+      if (ret == 0) {
+        marker = driver->meta_get_marker(handle);
+      }
+      driver->meta_list_keys_complete(handle);
+
+      if (ret != 0) {
+        ldpp_dout(dpp, 1) << __func__ << "::failed driver->meta_list_keys_next()" << dendl;
+        break;
+      }
+      ldpp_dout(dpp, 20) <<__func__ << "::entries.size()=" << entries.size() << dendl;
+      for (auto& entry : entries) {
+        ldpp_dout(dpp, 20) <<__func__ << "::bucket_name=" << entry << dendl;
+        rgw_bucket bucket;
+        int parse_ret = rgw_bucket_parse_bucket_key(cct, entry, &bucket, nullptr);
+        if (unlikely(parse_ret < 0)) {
+          ldpp_dout(dpp, 1) << __func__ << "::ERR: Failed rgw_bucket_parse_bucket_key: "
+                            << cpp_strerror(-parse_ret) << dendl;
+          continue;
+        }
+        ldpp_dout(dpp, 20) <<__func__ << "::bucket=" << bucket << dendl;
+        if (!d_filter.allow_bucket(bucket.name)) {
+          ldpp_dout(dpp, 10) << __func__ << "::worker_id=" << worker_id
+                             << "::skip bucket (filter): " << bucket.name << dendl;
+          p_worker_stats->ingress_skip_filtered_bucket++;
+          continue;
+        }
+        int ingress_ret = ingress_bucket_objects_single_shard(disk_arr, bucket, worker_id,
+                                                              num_work_shards, p_worker_stats);
+        if (unlikely(ingress_ret != 0)) {
+          if (d_ctl.should_stop()) {
+            ret = -ECANCELED;
+            has_more = false;   // break from external loop
+            break; // internal loop
+          }
+          ldpp_dout(dpp, 1) << __func__ << "::Failed ingress_bucket_objects_single_shard()" << dendl;
+          continue;
+        }
+      }
     }
+
     ldpp_dout(dpp, 20) <<__func__ << "::flush_output_buffers() worker_id="
                        << worker_id << dendl;
     disk_arr.flush_output_buffers(dpp, d_dedup_cluster_ioctx);


### PR DESCRIPTION
Commits 31e6d25f678 ("rgw/dedup: Bug fix for listing all bucket.instance...")
  and ddb6e308001 ("rgw/dedup: refactor code to use RAII scope_guard...")
  introduced buckets-scan where the meta_list_keys handle stays open
  during heavy bucket processing, causing the RADOS/OMap cursor to go
  stale and meta_list_keys_next to hang indefinitely.

Solution:  Replace with marker-based pagination: open handle, fetch one page,
  save marker via meta_get_marker(), close handle immediately, then
  process.

Fixes: https://github.com/ceph/ceph/pull/70976

Tracker: https://tracker.ceph.com/issues/79630

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
