### PR TITLE
qa/tasks/cbt: select appropriate CBT branch based on Ceph version

### DIFF
--- a/qa/tasks/cbt.py
+++ b/qa/tasks/cbt.py
@@ -9,6 +9,12 @@ from teuthology.task import Task
 
 log = logging.getLogger(__name__)
 
+CBT_FIRST_RELEASE = 21
+CBT_RELEASE_MAP = {
+    21 : "umbrella",
+    # 22 : "vampire",
+    # 23 : "w_release" ...
+}
 
 class CBT(Task):
     """
@@ -141,10 +147,37 @@ class CBT(Task):
                 ]
             )
 
+    def extract_ceph_major_version(self):
+        ceph_version_str = self.first_mon.sh(['ceph', '-v'])
+        self.log.debug('ceph -v output: %s', ceph_version_str)
+        # ceph version 21.3.0 <sha1> umbrella (dev)
+        
+        full_version_num = ceph_version_str.split()[2]
+        major_version_num = int(full_version_num.split(".")[0])
+
+        self.log.debug('extracted ceph major version: %d', major_version_num)
+        return major_version_num
+
+    def cbt_branch_from_version(self):
+        try:
+            # Extract major version number
+            ceph_major_version = self.extract_ceph_major_version()
+        except Exception as e:
+            self.log.error('Failed to extract ceph version: %s', e)
+            raise
+        
+        # If older than CBT's first release use 'master' CBT branch
+        if ceph_major_version < CBT_FIRST_RELEASE:
+            self.log.debug('ceph major version is %d, so returning master', ceph_major_version)
+            return "master"
+
+        # Otherwise use corresponding or latest release CBT branch
+        return CBT_RELEASE_MAP.get(ceph_major_version, CBT_RELEASE_MAP[max(CBT_RELEASE_MAP)])
+
     def checkout_cbt(self):
         testdir = misc.get_testdir(self.ctx)
         repo = self.config.get('repo', 'https://github.com/ceph/cbt.git')
-        branch = self.config.get('branch', 'master')
+        branch = self.config.get('branch', self.cbt_branch)
         branch = self.config.get('force-branch', branch)
         sha1 = self.config.get('sha1')
         if sha1 is None:
@@ -172,6 +205,7 @@ class CBT(Task):
         super(CBT, self).setup()
         self.first_mon = next(iter(self.ctx.cluster.only(misc.get_first_mon(self.ctx, self.config)).remotes.keys()))
         self.cbt_config = self.generate_cbt_config()
+        self.cbt_branch = self.cbt_branch_from_version()
         self.log.info('cbt configuration is %s', self.cbt_config)
         self.cbt_dir = os.path.join(misc.get_archive_dir(self.ctx), 'cbt')
         self.ctx.cluster.run(args=['mkdir', '-p', '-m0755', '--', self.cbt_dir])


### PR DESCRIPTION
Add `CBT_RELEASE_MAP` to map Ceph major versions to corresponding CBT branch. Query `ceph -v` and extract the major version number. Use this number to identify the correct CBT branch to be cloned for CBT tests. Raise error and quit if extraction sequence fails somehow.

Ceph versions older than Umbrella (v21) use 'master' CBT branch. For Umbrella and newer, use the corresponding CBT release branch. During Dev Kickoff use the latest CBT release branch. Update `CBT_RELEASE_MAP` after the creation of each new CBT release.

Fixes: https://tracker.ceph.com/issues/79657

Allows future QA suites to use newer features of CBT.

### **Testing:**
**Teuthology Runs**
- [main (perf-basic)](https://pulpito-ng.ceph.com/runs/mohant-2026-08-17_15:46:43-perf-basic-main-distro-default-smithi)
- [main (rados/perf)](https://pulpito-ng.ceph.com/runs/mohant-2026-08-17_15:55:10-rados:perf-main-distro-default-smithi)
- [main (crimson-rados/perf)](https://pulpito-ng.ceph.com/runs/mohant-2026-09-02_12:47:15-crimson-rados:perf-main-distro-default-trial)
- [umbrella (perf-basic)](https://pulpito-ng.ceph.com/runs/mohant-2026-08-14_14:27:10-perf-basic-umbrella-distro-default-smithi)
- [squid (perf-basic)](https://pulpito-ng.ceph.com/runs/mohant-2026-08-17_10:35:56-perf-basic-squid-distro-default-smithi)

**Unit Tests** (`pytest`)
(Created with the aid of IBM Bob 2.0.3)
- Checks `extract_ceph_major_version()` returns correct major version number for a given ceph version string - _PASSED_
- Checks `cbt_branch_from_version()` returns correct CBT branch name given ceph major version - _PASSED_


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
