### PR TITLE
rgw: default MPU CRC32/CRC32C checksum-type to COMPOSITE

### DIFF
--- a/src/rgw/rgw_cksum.cc
+++ b/src/rgw/rgw_cksum.cc
@@ -147,9 +147,16 @@ namespace rgw::cksum {
   std::unique_ptr<Combiner> CombinerFactory(cksum::Type t, uint16_t flags)
   {
     switch(t) {
+    case cksum::Type::crc64nvme:
+      /* full-object only */
+      return std::unique_ptr<Combiner>(new CRCCombiner(t));
     case cksum::Type::crc32:
     case cksum::Type::crc32c:
-    case cksum::Type::crc64nvme:
+      /* Honor multipart checksum-type: COMPOSITE digests part checksums;
+       * FULL_OBJECT (or legacy callers with no type flag) CRC-combines. */
+      if (flags & Cksum::FLAG_COMPOSITE) {
+	return std::unique_ptr<Combiner>(new DigestCombiner(t));
+      }
       return std::unique_ptr<Combiner>(new CRCCombiner(t));
     default:
       return std::unique_ptr<Combiner>(new DigestCombiner(t));

--- a/src/rgw/rgw_cksum.h
+++ b/src/rgw/rgw_cksum.h
@@ -314,9 +314,15 @@ namespace rgw { namespace cksum {
       return Cksum::FLAG_CKSUM_NONE;
       break;
     case cksum::Type::crc64nvme:
+      /* AWS: CRC64NVME is full-object only for multipart. */
+      return Cksum::FLAG_FULL_OBJECT;
+      break;
     case cksum::Type::crc32:
     case cksum::Type::crc32c:
-      return Cksum::FLAG_FULL_OBJECT;
+      /* AWS CreateMultipartUpload defaults CRC32/CRC32C to COMPOSITE
+       * when x-amz-checksum-type is omitted. Match that so clients that
+       * send only x-amz-checksum-algorithm (e.g. minio-go) validate. */
+      return Cksum::FLAG_COMPOSITE;
       break;
     default:
       break;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4788,6 +4788,11 @@ void RGWInitMultipart_ObjStore_S3::send_response()
   }
   if (cksum_algo != rgw::cksum::Type::none) {
     dump_header(s, "x-amz-checksum-algorithm", to_uc_string(cksum_algo));
+    if (cksum_flags & rgw::cksum::Cksum::FLAG_COMPOSITE) {
+      dump_header(s, "x-amz-checksum-type", "COMPOSITE");
+    } else if (cksum_flags & rgw::cksum::Cksum::FLAG_FULL_OBJECT) {
+      dump_header(s, "x-amz-checksum-type", "FULL_OBJECT");
+    }
   }
   end_header(s, this, to_mime_type(s->format));
   if (op_ret == 0) {

--- a/src/test/rgw/test_rgw_cksum.cc
+++ b/src/test/rgw/test_rgw_cksum.cc
@@ -835,6 +835,73 @@ TEST(RGWCksum, Combiner1)
   }
 } /* Combiner1 */
 
+TEST(RGWCksum, FlagsOfDefaults)
+{
+  /* AWS CreateMultipartUpload: algorithm-only CRC32/CRC32C → COMPOSITE;
+   * CRC64NVME → FULL_OBJECT; cryptographic digests → COMPOSITE. */
+  ASSERT_EQ(cksum_flags_of(cksum::Type::crc32), Cksum::FLAG_COMPOSITE);
+  ASSERT_EQ(cksum_flags_of(cksum::Type::crc32c), Cksum::FLAG_COMPOSITE);
+  ASSERT_EQ(cksum_flags_of(cksum::Type::crc64nvme), Cksum::FLAG_FULL_OBJECT);
+  ASSERT_EQ(cksum_flags_of(cksum::Type::sha256), Cksum::FLAG_COMPOSITE);
+  ASSERT_EQ(cksum_flags_of(cksum::Type::none), Cksum::FLAG_CKSUM_NONE);
+}
+
+TEST(RGWCksum, CRC32C_CombinerComposite)
+{
+  using std::get;
+
+  auto t = cksum::Type::crc32c;
+  auto cksums = mpu_checksum_helper(t, 0);
+  auto& [cksum1, cksum2, cksum3] = cksums;
+
+  /* FULL_OBJECT (or no type flag): CRC-combine equals whole-object digest */
+  auto full = rgw::cksum::CombinerFactory(t, Cksum::FLAG_FULL_OBJECT);
+  ASSERT_TRUE(full);
+  full->append(cksum1, dolor.length());
+  full->append(cksum2, lorem.length());
+  auto cksum_full = full->final();
+  ASSERT_EQ(cksum3.to_armor(), cksum_full.to_armor());
+  ASSERT_TRUE(cksum_full.flags & Cksum::FLAG_FULL_OBJECT);
+
+  /* COMPOSITE: digest of part checksums — must differ from full-object */
+  auto composite = rgw::cksum::CombinerFactory(t, Cksum::FLAG_COMPOSITE);
+  ASSERT_TRUE(composite);
+  composite->append(cksum1, dolor.length());
+  composite->append(cksum2, lorem.length());
+  auto cksum_comp = composite->final();
+  ASSERT_NE(cksum3.to_armor(), cksum_comp.to_armor());
+  ASSERT_TRUE(cksum_comp.composite());
+
+  /* Default algorithm-only flags match COMPOSITE combiner */
+  auto def_flags = cksum_flags_of(t);
+  ASSERT_EQ(def_flags, Cksum::FLAG_COMPOSITE);
+  auto defcmb = rgw::cksum::CombinerFactory(t, def_flags);
+  defcmb->append(cksum1, dolor.length());
+  defcmb->append(cksum2, lorem.length());
+  ASSERT_EQ(cksum_comp.to_armor(), defcmb->final().to_armor());
+}
+
+TEST(RGWCksum, CRC32_CombinerComposite)
+{
+  using std::get;
+
+  auto t = cksum::Type::crc32;
+  auto cksums = mpu_checksum_helper(t, 0);
+  auto& [cksum1, cksum2, cksum3] = cksums;
+
+  auto full = rgw::cksum::CombinerFactory(t, Cksum::FLAG_FULL_OBJECT);
+  full->append(cksum1, dolor.length());
+  full->append(cksum2, lorem.length());
+  ASSERT_EQ(cksum3.to_armor(), full->final().to_armor());
+
+  auto composite = rgw::cksum::CombinerFactory(t, Cksum::FLAG_COMPOSITE);
+  composite->append(cksum1, dolor.length());
+  composite->append(cksum2, lorem.length());
+  auto cksum_comp = composite->final();
+  ASSERT_NE(cksum3.to_armor(), cksum_comp.to_armor());
+  ASSERT_TRUE(cksum_comp.composite());
+}
+
 using cksum_4tuple
     = std::tuple<rgw::cksum::Cksum, rgw::cksum::Cksum, rgw::cksum::Cksum,
 		 rgw::cksum::Cksum>;


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/main/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

## Summary

### Problem

After upgrading from Squid to Tentacle/main, multipart uploads that specify only
`x-amz-checksum-algorithm: CRC32` or `CRC32C` (without `x-amz-checksum-type`)
— for example minio-go clients — fail **CompleteMultipartUpload** with
`400 BadDigest`.

AWS S3 treats algorithm-only CRC32/CRC32C CreateMultipartUpload as checksum-type
**COMPOSITE** (aggregate of per-part checksums). CRC64NVME is full-object only.
Ceph incorrectly defaulted CRC32/CRC32C to **FULL_OBJECT**, `CombinerFactory`
always CRC-combined part checksums regardless of type, and CreateMultipartUpload
did not return `x-amz-checksum-type`.

Reproducer: https://github.com/KervyN/rgw-crc-issue

### Fix

- Default `cksum_flags_of(crc32/crc32c)` to **COMPOSITE** (CRC64NVME stays
  FULL_OBJECT).
- Honor COMPOSITE in `CombinerFactory` via `DigestCombiner`; keep CRC combine
  for explicit FULL_OBJECT.
- Emit `x-amz-checksum-type` on CreateMultipartUpload.

Introduced by: ee03b5054147

Fixes: https://tracker.ceph.com/issues/79572

## Testing
- `ninja unittest_rgw_cksum` + `./bin/unittest_rgw_cksum` on build host: **25 tests PASSED** (includes new `FlagsOfDefaults`, `CRC32C_CombinerComposite`, `CRC32_CombinerComposite`).

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins test ceph-volume all`
- `jenkins test windows`
- `jenkins test rook e2e`

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>