### PR TITLE
qa/cephadm: add teuthology tests for NFS daemon colocation and QoS

### DIFF
--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-colocation.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-colocation.yaml
@@ -1,0 +1,146 @@
+tasks:
+
+# stop kernel nfs server, if running
+- exec:
+    all-hosts:
+      - systemctl stop nfs-server
+
+- cephadm.shell:
+    host.a:
+      - ceph fs volume create foofs
+
+# deploy 3 NFS daemons across 2 hosts -- forces colocation on one host
+# first daemon per host uses base ports, second uses auto-incremented ports
+- cephadm.apply:
+    specs:
+      - service_type: nfs
+        service_id: colo
+        placement:
+          count: 3
+        spec:
+          port: 12049
+          monitoring_port: 19587
+
+- cephadm.wait_for_service:
+    service: nfs.colo
+
+- cephadm.shell:
+    host.a:
+      - |
+        set -ex
+
+        # ---- Verify 3 NFS daemons are running ----
+        NFS_COUNT=$(ceph orch ps --service-name nfs.colo --format json | jq '[.[] | select(.status_desc == "running")] | length')
+        if [ "$NFS_COUNT" -ne 3 ]; then
+          echo "Expected 3 running NFS daemons, got: $NFS_COUNT"
+          ceph orch ps --service-name nfs.colo
+          exit 1
+        fi
+
+        # ---- Verify colocation: at least one host has 2 NFS daemons ----
+        HOSTS_JSON=$(ceph orch ps --service-name nfs.colo --format json)
+        HOST_COUNTS=$(echo "$HOSTS_JSON" | jq '[.[] | .hostname] | group_by(.) | map(length) | sort | reverse')
+        MAX_PER_HOST=$(echo "$HOST_COUNTS" | jq '.[0]')
+        if [ "$MAX_PER_HOST" -lt 2 ]; then
+          echo "Expected at least 2 NFS daemons colocated on one host, max per host: $MAX_PER_HOST"
+          ceph orch ps --service-name nfs.colo
+          exit 1
+        fi
+
+        # ---- Verify each daemon has unique ports ----
+        PORTS=$(echo "$HOSTS_JSON" | jq '[.[] | .ports[0]]')
+        UNIQUE_PORTS=$(echo "$PORTS" | jq 'unique | length')
+        TOTAL_PORTS=$(echo "$PORTS" | jq 'length')
+        if [ "$UNIQUE_PORTS" -ne "$TOTAL_PORTS" ]; then
+          echo "Port conflict detected among NFS daemons"
+          echo "Ports: $PORTS"
+          ceph orch ps --service-name nfs.colo
+          exit 1
+        fi
+
+        # ---- Verify auto-incremented ports ----
+        # The base port is 12049; colocated daemon should get 12050
+        EXPECTED_PORTS="12049 12050"
+        for port in $EXPECTED_PORTS; do
+          if ! echo "$PORTS" | jq -e "any(. == $port)" > /dev/null; then
+            echo "Expected port $port not found in daemon ports: $PORTS"
+            exit 1
+          fi
+        done
+
+        # ---- Create an NFS export and verify it works ----
+        ceph nfs export create cephfs --fsname foofs --cluster-id colo --pseudo-path /colotest
+
+        EXPORTS=$(ceph nfs export ls colo)
+        if ! echo "$EXPORTS" | grep -q "/colotest"; then
+          echo "NFS export /colotest not found"
+          echo "Exports: $EXPORTS"
+          exit 1
+        fi
+
+# ---- Test custom colocation_ports ----
+- cephadm.shell:
+    host.a:
+      - |
+        set -ex
+
+        # Remove the auto-port service
+        ceph orch rm nfs.colo
+        sleep 15
+
+        # Wait for daemons to be removed
+        while [ "$(ceph orch ps --service-name nfs.colo --format json | jq 'length')" -gt 0 ]; do
+          sleep 5
+        done
+
+- cephadm.apply:
+    specs:
+      - service_type: nfs
+        service_id: colocustom
+        placement:
+          count: 3
+        spec:
+          port: 12049
+          monitoring_port: 19587
+          colocation_ports:
+            - data_port: 13049
+              monitoring_port: 19588
+              cluster_qos_port: 31312
+            - data_port: 14049
+              monitoring_port: 19589
+              cluster_qos_port: 31313
+
+- cephadm.wait_for_service:
+    service: nfs.colocustom
+
+- cephadm.shell:
+    host.a:
+      - |
+        set -ex
+
+        # ---- Verify 3 NFS daemons with custom ports ----
+        NFS_COUNT=$(ceph orch ps --service-name nfs.colocustom --format json | jq '[.[] | select(.status_desc == "running")] | length')
+        if [ "$NFS_COUNT" -ne 3 ]; then
+          echo "Expected 3 running NFS daemons, got: $NFS_COUNT"
+          ceph orch ps --service-name nfs.colocustom
+          exit 1
+        fi
+
+        # ---- Verify custom ports are assigned ----
+        PORTS=$(ceph orch ps --service-name nfs.colocustom --format json | jq '[.[] | .ports[0]] | sort')
+        for port in 12049 13049 14049; do
+          if ! echo "$PORTS" | jq -e "any(. == $port)" > /dev/null; then
+            echo "Expected custom port $port not found in: $PORTS"
+            ceph orch ps --service-name nfs.colocustom
+            exit 1
+          fi
+        done
+
+        # ---- Create export on custom-port service ----
+        ceph nfs export create cephfs --fsname foofs --cluster-id colocustom --pseudo-path /customtest
+
+        EXPORTS=$(ceph nfs export ls colocustom)
+        if ! echo "$EXPORTS" | grep -q "/customtest"; then
+          echo "NFS export /customtest not found"
+          exit 1
+        fi

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-qos.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-qos.yaml
@@ -1,0 +1,262 @@
+tasks:
+
+# stop kernel nfs server, if running
+- exec:
+    all-hosts:
+      - systemctl stop nfs-server
+
+- cephadm.shell:
+    host.a:
+      - ceph fs volume create foofs
+
+# deploy NFS service
+- cephadm.apply:
+    specs:
+      - service_type: nfs
+        service_id: qostest
+        placement:
+          count: 1
+        spec:
+          port: 12049
+
+- cephadm.wait_for_service:
+    service: nfs.qostest
+
+- cephadm.shell:
+    host.a:
+      - |
+        set -ex
+
+        # ---- Verify NFS service is running ----
+        NFS_COUNT=$(ceph orch ps --service-name nfs.qostest --format json | jq '[.[] | select(.status_desc == "running")] | length')
+        if [ "$NFS_COUNT" -lt 1 ]; then
+          echo "NFS daemon not running"
+          ceph orch ps --service-name nfs.qostest
+          exit 1
+        fi
+
+        # ---- Create a CephFS export for QoS testing ----
+        ceph nfs export create cephfs --fsname foofs --cluster-id qostest --pseudo-path /qostest
+
+        EXPORTS=$(ceph nfs export ls qostest)
+        if ! echo "$EXPORTS" | grep -q "/qostest"; then
+          echo "NFS export /qostest not found"
+          exit 1
+        fi
+
+        # ---- Save NFS daemon host IP for later mount ----
+        NFS_HOST=$(ceph orch ps --service-name nfs.qostest --format json | jq -r '.[0].hostname')
+        NFS_IP=$(ceph orch host ls --format json | jq -r --arg h "$NFS_HOST" '.[] | select(.hostname == $h) | .addr')
+        echo "NFS daemon on $NFS_HOST at $NFS_IP:12049"
+
+        # ============================================================
+        # Cluster-level bandwidth control (PerShare)
+        # ============================================================
+
+        # ---- Enable cluster BW control with PerShare type ----
+        ceph nfs cluster qos enable bandwidth_control qostest PerShare \
+          --max_export_write_bw 1M \
+          --max_export_read_bw 2M
+
+        # ---- Verify cluster QoS config ----
+        CLUSTER_QOS=$(ceph nfs cluster qos get qostest)
+        echo "$CLUSTER_QOS"
+
+        if ! echo "$CLUSTER_QOS" | jq -e '.enable_qos == true' > /dev/null; then
+          echo "Expected enable_qos to be true"
+          exit 1
+        fi
+        if ! echo "$CLUSTER_QOS" | jq -e '.enable_bw_control == true' > /dev/null; then
+          echo "Expected enable_bw_control to be true"
+          exit 1
+        fi
+
+        # ============================================================
+        # Export-level bandwidth control
+        # ============================================================
+
+        # ---- Enable export BW control ----
+        ceph nfs export qos enable bandwidth_control qostest /qostest \
+          --max_export_write_bw 512K \
+          --max_export_read_bw 512K
+
+        # ---- Verify export QoS config ----
+        EXPORT_QOS=$(ceph nfs export qos get qostest /qostest)
+        echo "$EXPORT_QOS"
+
+        if ! echo "$EXPORT_QOS" | jq -e '.enable_bw_control == true' > /dev/null; then
+          echo "Expected export enable_bw_control to be true"
+          exit 1
+        fi
+
+        # ---- Disable export BW control ----
+        ceph nfs export qos disable bandwidth_control qostest /qostest
+
+        EXPORT_QOS=$(ceph nfs export qos get qostest /qostest)
+        if echo "$EXPORT_QOS" | jq -e '.enable_bw_control == true' > /dev/null 2>&1; then
+          echo "Expected export enable_bw_control to be false after disable"
+          exit 1
+        fi
+
+        # ---- Disable cluster BW control ----
+        ceph nfs cluster qos disable bandwidth_control qostest
+
+        CLUSTER_QOS=$(ceph nfs cluster qos get qostest)
+        if echo "$CLUSTER_QOS" | jq -e '.enable_bw_control == true' > /dev/null 2>&1; then
+          echo "Expected cluster enable_bw_control to be false after disable"
+          exit 1
+        fi
+
+        # ============================================================
+        # Cluster-level IOPS control (PerShare)
+        # ============================================================
+
+        # ---- Enable cluster IOPS control ----
+        ceph nfs cluster qos enable ops_control qostest PerShare \
+          --max_export_iops 1000
+
+        CLUSTER_QOS=$(ceph nfs cluster qos get qostest)
+        if ! echo "$CLUSTER_QOS" | jq -e '.enable_iops_control == true' > /dev/null; then
+          echo "Expected enable_iops_control to be true"
+          exit 1
+        fi
+
+        # ---- Enable export IOPS control ----
+        ceph nfs export qos enable ops_control qostest /qostest \
+          --max_export_iops 500
+
+        EXPORT_QOS=$(ceph nfs export qos get qostest /qostest)
+        if ! echo "$EXPORT_QOS" | jq -e '.enable_iops_control == true' > /dev/null; then
+          echo "Expected export enable_iops_control to be true"
+          exit 1
+        fi
+
+        # ---- Disable export IOPS control ----
+        ceph nfs export qos disable ops_control qostest /qostest
+
+        # ---- Disable cluster IOPS control ----
+        ceph nfs cluster qos disable ops_control qostest
+
+        CLUSTER_QOS=$(ceph nfs cluster qos get qostest)
+        if echo "$CLUSTER_QOS" | jq -e '.enable_iops_control == true' > /dev/null 2>&1; then
+          echo "Expected cluster enable_iops_control to be false after disable"
+          exit 1
+        fi
+
+        # ============================================================
+        # Combined BW + IOPS control (PerShare_PerClient)
+        # ============================================================
+
+        # ---- Enable both BW and IOPS with PerShare_PerClient ----
+        ceph nfs cluster qos enable bandwidth_control qostest PerShare_PerClient \
+          --max_export_write_bw 1M \
+          --max_export_read_bw 1M \
+          --max_client_write_bw 512K \
+          --max_client_read_bw 512K
+
+        ceph nfs cluster qos enable ops_control qostest PerShare_PerClient \
+          --max_export_iops 1000 \
+          --max_client_iops 500
+
+        CLUSTER_QOS=$(ceph nfs cluster qos get qostest)
+        if ! echo "$CLUSTER_QOS" | jq -e '.enable_bw_control == true and .enable_iops_control == true' > /dev/null; then
+          echo "Expected both BW and IOPS control enabled"
+          exit 1
+        fi
+
+        # ---- Set QoS message interval ----
+        ceph nfs cluster qos set qostest --msg_interval 200
+
+        # ---- Cleanup: disable both controls ----
+        ceph nfs cluster qos disable ops_control qostest
+        ceph nfs cluster qos disable bandwidth_control qostest
+
+        # ---- Final verification: QoS fully disabled ----
+        # After disabling all controls, enable_qos should be false or the
+        # config may be an empty object
+        CLUSTER_QOS=$(ceph nfs cluster qos get qostest)
+        if echo "$CLUSTER_QOS" | jq -e '.enable_qos == true' > /dev/null 2>&1; then
+          echo "Expected QoS to be fully disabled, got:"
+          echo "$CLUSTER_QOS"
+          exit 1
+        fi
+
+# ============================================================
+# I/O-based bandwidth verification
+# Mount the NFS export and measure actual write throughput
+# with and without QoS to confirm throttling is effective
+# ============================================================
+
+- exec:
+    host.a:
+      - |
+        set -ex
+        mkdir -p /mnt/qostest
+
+        # Get the NFS daemon's host IP
+        NFS_IP=$(sudo cephadm shell -- ceph orch ps --service-name nfs.qostest --format json 2>/dev/null \
+          | jq -r '.[0].ip')
+
+        # If .ip is not available, fall back to host addr
+        if [ -z "$NFS_IP" ] || [ "$NFS_IP" = "null" ]; then
+          NFS_HOST=$(sudo cephadm shell -- ceph orch ps --service-name nfs.qostest --format json 2>/dev/null \
+            | jq -r '.[0].hostname')
+          NFS_IP=$(sudo cephadm shell -- ceph orch host ls --format json 2>/dev/null \
+            | jq -r --arg h "$NFS_HOST" '.[] | select(.hostname == $h) | .addr')
+        fi
+
+        echo "Mounting NFS from $NFS_IP:12049"
+        mount -t nfs -o port=12049,vers=4.1 ${NFS_IP}:/qostest /mnt/qostest
+        echo "Mount successful"
+
+        # ---- Baseline: unthrottled write ----
+        # Write 2MiB without QoS to establish a baseline timing
+        SECONDS=0
+        dd if=/dev/zero of=/mnt/qostest/baseline.dat bs=256K count=8 oflag=direct 2>&1
+        sync
+        BASELINE_TIME=$SECONDS
+        echo "Baseline write (2MiB, no QoS): ${BASELINE_TIME}s"
+        rm -f /mnt/qostest/baseline.dat
+
+        # ---- Enable a tight bandwidth limit: 256KiB/s ----
+        sudo cephadm shell -- ceph nfs cluster qos enable bandwidth_control \
+          qostest PerShare --max_export_write_bw 256K --max_export_read_bw 256K
+
+        # Allow time for QoS config to propagate to ganesha
+        sleep 10
+
+        # ---- Throttled write ----
+        # Write 1MiB -- at 256KiB/s this should take ~4 seconds
+        SECONDS=0
+        dd if=/dev/zero of=/mnt/qostest/throttled.dat bs=256K count=4 oflag=direct 2>&1
+        sync
+        THROTTLED_TIME=$SECONDS
+        echo "Throttled write (1MiB, 256KiB/s limit): ${THROTTLED_TIME}s"
+        rm -f /mnt/qostest/throttled.dat
+
+        # ---- Verify throttling had an effect ----
+        # The throttled write of 1MiB at 256KiB/s should take at least 2 seconds
+        # (generous margin -- theoretically ~4s, we just check it's > 2s)
+        if [ "$THROTTLED_TIME" -lt 2 ]; then
+          echo "FAIL: Throttled write completed too fast (${THROTTLED_TIME}s)."
+          echo "Expected at least 2s for 1MiB at 256KiB/s limit."
+          echo "QoS bandwidth throttling may not be effective."
+          sudo cephadm shell -- ceph nfs cluster qos get qostest
+          exit 1
+        fi
+        echo "PASS: QoS throttling is effective (baseline=${BASELINE_TIME}s, throttled=${THROTTLED_TIME}s)"
+
+        # ---- Disable QoS and verify write speed recovers ----
+        sudo cephadm shell -- ceph nfs cluster qos disable bandwidth_control qostest
+        sleep 5
+
+        SECONDS=0
+        dd if=/dev/zero of=/mnt/qostest/recovered.dat bs=256K count=8 oflag=direct 2>&1
+        sync
+        RECOVERED_TIME=$SECONDS
+        echo "Post-disable write (2MiB, QoS off): ${RECOVERED_TIME}s"
+        rm -f /mnt/qostest/recovered.dat
+
+        # Cleanup
+        umount /mnt/qostest
+        rmdir /mnt/qostest


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/77931

Signed-off-by: Shweta Bhosale <Shweta.Bhosale1@ibm.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
