### PR TITLE
mgr/diskprediction_local: fix sklearn compatibility for disk predicti…

### DIFF
--- a/src/pybind/mgr/diskprediction_local/predictor.py
+++ b/src/pybind/mgr/diskprediction_local/predictor.py
@@ -23,12 +23,51 @@ An example code is as follows:
 'Unknown'
 """
 import os
+import sys
 import json
 import pickle
 import logging
 from typing import Any, Dict, List, Optional, Sequence, Tuple, no_type_check
 
 import numpy as np
+
+try:
+    import sklearn
+    import sklearn.svm
+    import sklearn.ensemble
+    import sklearn.preprocessing
+    import sklearn.tree
+
+    # Compatibility aliases for models pickled with older scikit-learn versions
+    sys.modules['sklearn.svm.classes'] = sklearn.svm
+    sys.modules['sklearn.ensemble.forest'] = sklearn.ensemble
+    sys.modules['sklearn.ensemble.weight_boosting'] = sklearn.ensemble
+    sys.modules['sklearn.preprocessing.data'] = sklearn.preprocessing
+    sys.modules['sklearn.tree.tree'] = sklearn.tree
+except ImportError:
+    pass
+
+
+def _patch_estimator(clf: Any) -> Any:
+    if clf is None:
+        return clf
+    d = getattr(clf, '__dict__', None)
+    if d is not None:
+        if 'n_support_' in d and '_n_support' not in d:
+            d['_n_support'] = np.array(d['n_support_'], dtype=np.int32)
+        if 'dual_coef_' in d and '_dual_coef_' not in d:
+            d['_dual_coef_'] = d['dual_coef_']
+        if 'intercept_' in d and '_intercept_' not in d:
+            d['_intercept_'] = d['intercept_']
+        if '_probA' not in d:
+            d['_probA'] = d.get('probA_', np.empty(0, dtype=np.float64))
+        if '_probB' not in d:
+            d['_probB'] = d.get('probB_', np.empty(0, dtype=np.float64))
+        if 'break_ties' not in d:
+            d['break_ties'] = False
+        if '_gamma' not in d:
+            d['_gamma'] = d.get('gamma', 0.0)
+    return clf
 
 
 def get_diskfailurepredictor_path() -> str:
@@ -190,7 +229,7 @@ class RHDiskFailurePredictor(Predictor):
         # scale features
         scaler_path = os.path.join(self.model_dirpath, manufacturer + "_scaler.pkl")
         with open(scaler_path, 'rb') as f:
-            scaler = pickle.load(f)
+            scaler = _patch_estimator(pickle.load(f, encoding='latin1'))
         featurized = scaler.transform(featurized)
         return featurized
 
@@ -228,8 +267,8 @@ class RHDiskFailurePredictor(Predictor):
             RHDiskFailurePredictor.LOGGER.debug(
                 "Manufacturer could not be determiend. This may be because \
                 DiskPredictor has never encountered this manufacturer before, \
-                    or the model name is not according to the manufacturer's \
-                        naming conventions known to DiskPredictor"
+                or the model name is not according to the manufacturer's \
+                naming conventions known to DiskPredictor"
             )
             return RHDiskFailurePredictor.PREDICTION_CLASSES[-1]
 
@@ -243,7 +282,7 @@ class RHDiskFailurePredictor(Predictor):
             self.model_dirpath, manufacturer + "_predictor.pkl"
         )
         with open(model_path, 'rb') as f:
-            model = pickle.load(f)
+            model = _patch_estimator(pickle.load(f, encoding='latin1'))
 
         # use prediction for most recent day
         # TODO: ensure that most recent day is last element and most previous day
@@ -466,12 +505,10 @@ class PSDiskFailurePredictor(Predictor):
 
             try:
                 with open(modelpath, "rb") as f_model:
-                    clf = pickle.load(f_model)
-
-            except UnicodeDecodeError:
-                # Compatibility for python3
+                    clf = _patch_estimator(pickle.load(f_model, encoding="latin1"))
+            except Exception:
                 with open(modelpath, "rb") as f_model:
-                    clf = pickle.load(f_model, encoding="latin1")
+                    clf = _patch_estimator(pickle.load(f_model, encoding="latin1"))
 
             pred = clf.predict(ordered_data)
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/72123

## Description
Pretrained models serialized with older versions of `scikit-learn` (0.19/0.22) fail to deserialize and execute under modern `scikit-learn` versions (1.4+), resulting in MGR crashes:
`HEALTH_ERR Module 'diskprediction_local' has failed: No module named 'sklearn.svm.classes'` or `'SVC' object has no attribute 'break_ties'`.

## Summary of Changes
- Add backward-compatibility aliases in `sys.modules` for relocated submodules (`sklearn.svm.classes`, `sklearn.ensemble.forest`, `sklearn.ensemble.weight_boosting`, `sklearn.preprocessing.data`, `sklearn.tree.tree`).
- Implement `_patch_estimator()` helper to set missing internal attributes on unpickled legacy `SVC` objects (`_n_support`, `_dual_coef_`, `_intercept_`, `break_ties`, `_probA`, `_probB`, `_gamma`).
- Use `encoding='latin1'` during `.pkl` unpickling in Python 3.

Fixes: https://tracker.ceph.com/issues/72123

## Description
Pretrained models serialized with older versions of `scikit-learn` (0.19/0.22) fail to deserialize and execute under modern `scikit-learn` versions (1.4+), resulting in MGR crashes:
`HEALTH_ERR Module 'diskprediction_local' has failed: No module named 'sklearn.svm.classes'` or `'SVC' object has no attribute 'break_ties'`.

## Summary of Changes
- Add backward-compatibility aliases in `sys.modules` for relocated submodules (`sklearn.svm.classes`, `sklearn.ensemble.forest`, `sklearn.ensemble.weight_boosting`, `sklearn.preprocessing.data`, `sklearn.tree.tree`).
- Implement `_patch_estimator()` helper to set missing internal attributes on unpickled legacy `SVC` objects (`_n_support`, `_dual_coef_`, `_intercept_`, `break_ties`, `_probA`, `_probB`, `_gamma`).
- Use `encoding='latin1'` during `.pkl` unpickling in Python 3.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI. When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`. Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

