### PR TITLE
umbrella: cephadm: Version Tracking

### DIFF
--- a/doc/cephadm/index.rst
+++ b/doc/cephadm/index.rst
@@ -49,3 +49,4 @@ support older versions of Ceph.
     Client Setup <client-setup>
     troubleshooting
     Cephadm Feature Planning <../dev/cephadm/index>
+    version-tracker

--- a/doc/cephadm/version-tracker.rst
+++ b/doc/cephadm/version-tracker.rst
@@ -1,0 +1,339 @@
+.. _cli-version-tracker:
+
+=========================
+Version Tracking for Ceph
+=========================
+
+Cephadm tracks the history of cluster versions and info about the
+current state of the Ceph cluster at time of upgrade. There are two CLI
+commands to manage this information. Version information from 
+before the introduction of this feature is not available.
+
+Viewing Version History
+=======================
+
+.. prompt:: bash #
+
+    ceph cephadm get-cluster-version-history [--show-config]
+
+This command displays stored version history stored in 
+chronological order. If ``--show-config`` is passed the
+recorded config dump is also displayed.
+
+.. code-block:: json
+
+    {
+        "2026-06-22 22:33:43": {
+            "version": "ceph version 18.2.8 (asdfac5eee07c13fa5048sd230242b866df) reef (stable)",
+            "upgrade_type": "bootstrap",
+            "status": "complete",
+            "command_options": null
+        },
+        "2026-06-23 00:51:29": {
+            "version": "quay.io/ceph/ceph:v19.2.3",
+            "upgrade_type": "full",
+            "status": "complete",
+            "command_options": {
+                "image": "quay.io/ceph/ceph:v19.2.3",
+                "version": null,
+                "daemon_types": null,
+                "hosts": null,
+                "services": null,
+                "limit": null
+            }
+        }
+    }
+     
+Option ``--show-config``:
+
+.. code-block:: json
+
+    {
+        "2026-06-22 22:33:43": {
+            "version": "ceph version 18.2.8 (asdfac5eee07c13fa5048sd230242b866df) reef (stable)",
+            "upgrade_type": "bootstrap",
+            "status": "complete",
+            "command_options": null,
+            "config_dump": [
+                {
+                    "section": "global",
+                    "name": "container_image",
+                    "value": "quay.io/ceph/ceph:v18.2.8",
+                    "level": "basic",
+                    "can_update_at_runtime": false,
+                    "mask": ""
+                },
+                {
+                    "section": "global",
+                    "name": "public_network",
+                    "value": "0.0.0.0/0",
+                    "level": "advanced",
+                    "can_update_at_runtime": false,
+                    "mask": ""
+                },
+                {
+                    "section": "mon",
+                    "name": "auth_allow_insecure_global_id_reclaim",
+                    "value": "false",
+                    "level": "advanced",
+                    "can_update_at_runtime": true,
+                    "mask": ""
+                },
+                {
+                    "section": "mgr",
+                    "name": "mgr/cephadm/container_init",
+                    "value": "True",
+                    "level": "advanced",
+                    "can_update_at_runtime": false,
+                    "mask": ""
+                },
+                {
+                    "section": "mgr",
+                    "name": "mgr/cephadm/migration_current",
+                    "value": "6",
+                    "level": "advanced",
+                    "can_update_at_runtime": false,
+                    "mask": ""
+                },
+                {
+                    "section": "mgr",
+                    "name": "mgr/dashboard/ssl_server_port",
+                    "value": "2000",
+                    "level": "advanced",
+                    "can_update_at_runtime": false,
+                    "mask": ""
+                },
+                {
+                    "section": "mgr",
+                    "name": "mgr/orchestrator/orchestrator",
+                    "value": "cephadm",
+                    "level": "advanced",
+                    "can_update_at_runtime": true,
+                    "mask": ""
+                },
+                {
+                    "section": "osd",
+                    "name": "osd_memory_target_autotune",
+                    "value": "true",
+                    "level": "advanced",
+                    "can_update_at_runtime": true,
+                    "mask": ""
+                }
+            ]
+        }
+    }
+
+
+Removing Version History (Not Recommended)
+==========================================
+
+.. prompt:: bash #
+
+    ceph cephadm remove-cluster-version-history [--all] [--before <datetime>] [--after <datetime>]
+
+This command will allow users to delete version history and requires
+at least one of the three provided options to be passed. If ``--all`` is
+passed all version history is deleted, this option is incompatible
+with ``--before`` and ``--after`` and returns an error if either are passed
+with it. Supply ``--before`` to specify deletion of version history before
+the <datetime> specified. Supply ``--after`` to specify deletion of version
+history after the <datetime> specified. The parameters ``--after`` and
+``--before`` can be used together to specify a range for version history
+deletion. The format of <datetime> should be "YYYY-MM-DD HH:MM:SS".
+
+Option ``--all``:
+
+.. code-block:: json
+
+    {
+        "2026-06-22 22:33:43": {
+            "version": "ceph version 18.2.8 (asdfac5eee07c13fa5048sd230242b866df) reef (stable)",
+            "upgrade_type": "bootstrap",
+            "status": "complete",
+            "command_options": null
+        },
+        "2026-06-23 00:51:29": {
+            "version": "quay.io/ceph/ceph:v19.2.3",
+            "upgrade_type": "full",
+            "status": "complete",
+            "command_options": {
+                "image": "quay.io/ceph/ceph:v19.2.3",
+                "version": null,
+                "daemon_types": null,
+                "hosts": null,
+                "services": null,
+                "limit": null
+            }
+        }
+    }
+
+.. prompt:: bash #
+
+    ceph cephadm remove-cluster-version-history --all
+
+::
+
+    {
+        No Cluster Version History Stored
+    }
+
+Option ``--before``:
+
+.. code-block:: json
+
+    {
+        "2026-06-22 22:33:43": {
+            "version": "ceph version 18.2.8 (asdfac5eee07c13fa5048sd230242b866df) reef (stable)",
+            "upgrade_type": "bootstrap",
+            "status": "complete",
+            "command_options": null,
+        },
+        "2026-06-23 00:51:29": {
+            "version": "quay.io/ceph/ceph:v19.2.3",
+            "upgrade_type": "full",
+            "status": "complete",
+            "command_options": {
+                "image": "quay.io/ceph/ceph:v19.2.3",
+                "version": null,
+                "daemon_types": null,
+                "hosts": null,
+                "services": null,
+                "limit": null
+            }
+        }
+    }
+
+.. prompt:: bash #
+
+    ceph cephadm remove-cluster-version-history --before "2026-06-23 00:00:00"
+
+.. code-block:: json
+
+    {
+        "2026-06-23 00:51:29": {
+            "version": "quay.io/ceph/ceph:v19.2.3",
+            "upgrade_type": "full",
+            "status": "complete",
+            "command_options": {
+                "image": "quay.io/ceph/ceph:v19.2.3",
+                "version": null,
+                "daemon_types": null,
+                "hosts": null,
+                "services": null,
+                "limit": null
+            }
+        }
+    }
+
+Option ``--after``:
+
+.. code-block:: json
+
+    {
+        "2026-06-22 22:33:43": {
+            "version": "ceph version 18.2.8 (asdfac5eee07c13fa5048sd230242b866df) reef (stable)",
+            "upgrade_type": "bootstrap",
+            "status": "complete",
+            "command_options": null
+        },
+        "2026-06-23 00:51:29": {
+            "version": "quay.io/ceph/ceph:v19.2.3",
+            "upgrade_type": "full",
+            "status": "complete",
+            "command_options": {
+                "image": "quay.io/ceph/ceph:v19.2.3",
+                "version": null,
+                "daemon_types": null,
+                "hosts": null,
+                "services": null,
+                "limit": null
+            }
+        }
+    }
+
+.. prompt:: bash #
+
+    ceph cephadm remove-cluster-version-history --after "2026-06-23 00:00:00"
+
+.. code-block:: json
+
+    {
+        "2026-06-22 22:33:43": {
+            "version": "ceph version 18.2.8 (asdfac5eee07c13fa5048sd230242b866df) reef (stable)",
+            "upgrade_type": "bootstrap",
+            "status": "complete",
+            "command_options": null
+        }
+    }
+
+Options ``--before`` and ``--after``:
+
+.. code-block:: json
+
+    {
+        "2026-06-22 22:33:43": {
+            "version": "ceph version 18.2.8 (asdfac5eee07c13fa5048sd230242b866df) reef (stable)",
+            "upgrade_type": "bootstrap",
+            "status": "complete",
+            "command_options": null
+        },
+        "2026-06-23 00:51:29": {
+            "version": "quay.io/ceph/ceph:v19.2.3",
+            "upgrade_type": "full",
+            "status": "complete",
+            "command_options": {
+                "image": "quay.io/ceph/ceph:v19.2.3",
+                "version": null,
+                "daemon_types": null,
+                "hosts": null,
+                "services": null,
+                "limit": null
+            }
+        },
+        "2026-06-24 00:10:01": {
+            "version": "quay.io/ceph/ceph:v20.2.1",
+            "upgrade_type": "full",
+            "status": "complete",
+            "command_options": {
+                "image": "quay.io/ceph/ceph:v20.2.1",
+                "version": null,
+                "daemon_types": null,
+                "hosts": null,
+                "services": null,
+                "limit": null
+            }
+        }
+    }
+
+.. prompt:: bash #
+
+    ceph cephadm remove-cluster-version-history --after "2026-06-22 23:00:00" --before "2026-06-24 00:00:00"
+
+.. code-block:: json
+
+    {
+        "2026-06-22 22:33:43": {
+            "version": "ceph version 18.2.8 (asdfac5eee07c13fa5048sd230242b866df) reef (stable)",
+            "upgrade_type": "bootstrap",
+            "status": "complete",
+            "command_options": null
+        },
+        "2026-06-24 00:10:01": {
+            "version": "quay.io/ceph/ceph:v20.2.1",
+            "upgrade_type": "full",
+            "status": "complete",
+            "command_options": {
+                "image": "quay.io/ceph/ceph:v20.2.1",
+                "version": null,
+                "daemon_types": null,
+                "hosts": null,
+                "services": null,
+                "limit": null
+            }
+        }
+    }
+    
+
+
+
+

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -230,6 +230,7 @@ from cephadmlib.listing_updaters import (
 )
 from cephadmlib.container_lookup import infer_local_ceph_image, identify
 from ceph.cephadm.d3n_types import D3NCache, D3NCacheError
+from ceph.cephadm.version_entry import UpgradeType, UpgradeStatus, CephVersionEntry
 
 FuncT = TypeVar('FuncT', bound=Callable)
 
@@ -3104,6 +3105,18 @@ def command_bootstrap(ctx):
     else:
         logger.info('Enabling the logrotate.timer service to perform daily log rotation.')
         enable_service(ctx, 'logrotate.timer')
+
+    # Stores bootstrap version in version tracker
+    bootstrap_time = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+    bootstrap_entry = CephVersionEntry(
+        version=image_ver,
+        upgrade_type=UpgradeType.BOOTSTRAP,
+        status=UpgradeStatus.COMPLETE,
+        command_options=None,
+        config_dump=json.loads(cli(['config', 'dump', '--format', 'json']))
+    ).to_json()
+    cli(['config-key', 'set', f'mgr/cephadm/version_history/{bootstrap_time}', json.dumps(bootstrap_entry)])
+
     return ctx.error_code
 
 ##################################

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -50,7 +50,8 @@ def _container_info(*args, **kwargs):
 def bootstrap_test_ctx(*args, **kwargs):
     with with_cephadm_ctx(*args, **kwargs) as ctx:
         ctx.no_cleanup_on_failure = True
-        yield ctx
+        with mock.patch('cephadm.CephContainer.run', return_value='[]'):
+            yield ctx
 
 
 class TestCephAdm(object):

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -106,6 +106,7 @@ from .configchecks import CephadmConfigChecks
 from .offline_watcher import OfflineHostWatcher
 from .tuned_profiles import TunedProfileUtils
 from .ceph_volume import CephVolume
+from .version_tracker import VersionTracker
 
 try:
     import asyncssh
@@ -657,6 +658,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         self.ssh._reconfig_ssh()
 
         CephadmOrchestrator.instance = self
+
+        self.version_tracker = VersionTracker(self)
 
         self.upgrade = CephadmUpgrade(self)
 
@@ -4743,3 +4746,20 @@ Then run the following:
     def trigger_connect_dashboard_rgw(self) -> None:
         self.need_connect_dashboard_rgw = True
         self.event.set()
+
+    @CephadmCLICommand.Read('cephadm get-cluster-version-history')
+    def do_get_cluster_version_history(self, show_config: Optional[bool] = False) -> HandleCommandResult:
+        '''
+        Shows all previous and current cluster versions ordered chronologically
+        '''
+        out = self.version_tracker.get_cluster_version_history(show_config)
+        return HandleCommandResult(stdout=out)
+
+    @CephadmCLICommand.Write('cephadm remove-cluster-version-history')
+    def do_remove_cluster_version_history(self, all: Optional[bool] = False, before: Optional[str] = None, after: Optional[str] = None) -> HandleCommandResult:
+        '''
+        Delete cluster versions stored in history
+        '''
+        err, msg = self.version_tracker.remove_cluster_version_history(all, before, after)
+        kwargs = {'stderr': msg} if err else {'stdout': msg}
+        return HandleCommandResult(retval=err, **kwargs)

--- a/src/pybind/mgr/cephadm/tests/test_version_tracker.py
+++ b/src/pybind/mgr/cephadm/tests/test_version_tracker.py
@@ -1,0 +1,309 @@
+import pytest
+from tests import mock
+
+import json
+import errno
+
+from cephadm.version_tracker import VERSION_HISTORY_KEY_PREFIX, VersionTracker
+from ceph.cephadm.version_entry import UpgradeType, UpgradeStatus, CephVersionEntry
+from cephadm.module import CephadmOrchestrator
+from cephadm.upgrade import UpgradeState
+
+
+class TestCephVersionEntry(object):
+
+    @pytest.mark.parametrize(
+        "upgrade_type, status, command_options, config_dump",
+        [
+            # testing all possible enum values, command_options as None, and config_dump as None
+            (UpgradeType.FULL, UpgradeStatus.STARTED, {'image': 'quay.io/ceph/ceph:18.2.8', 'daemon_types': None}, [{'section': 'global'}, {'section': 'mon'}]),
+            (UpgradeType.STAGGERED, UpgradeStatus.STOPPED, {'image': 'quay.io/ceph/ceph:18.2.8', 'daemon_types': None}, None),
+            (UpgradeType.BOOTSTRAP, UpgradeStatus.COMPLETE, None, [{'section': 'global'}, {'section': 'mon'}])
+        ]
+    )
+    def test_version_entry_to_json_is_serializable(self, upgrade_type, status, command_options, config_dump):
+        entry = CephVersionEntry(
+            version='18.2.8',
+            upgrade_type=upgrade_type,
+            status=status,
+            command_options=command_options,
+            config_dump=config_dump
+        )
+        serialized = json.dumps(entry.to_json())
+        parsed = json.loads(serialized)
+        assert parsed['upgrade_type'] == upgrade_type.value
+        assert parsed['status'] == status.value
+        assert parsed['command_options'] == command_options
+        assert parsed['config_dump'] == config_dump
+
+
+class TestVersionTracker(object):
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    @mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command")
+    def test_add_cluster_version_full_upgrade(self, _check_mon_command, _set_store, cephadm_module: CephadmOrchestrator):
+        _check_mon_command.return_value = (0, json.dumps([{'section': 'global'}, {'section': 'mon'}]), '')
+        vt: VersionTracker = cephadm_module.version_tracker
+        params = {'image': 'quay.io/ceph/ceph:v18.2.8', 'version': '18.2.8', 'daemon_types': None}
+        vt.add_cluster_version('18.2.8', '2026-07-07 00:00:00', params, UpgradeStatus.STARTED)
+        expected_entry = CephVersionEntry(
+            version='18.2.8',
+            upgrade_type=UpgradeType.FULL,
+            command_options=params,
+            status=UpgradeStatus.STARTED,
+            config_dump=[{'section': 'global'}, {'section': 'mon'}]
+        ).to_json()
+        _set_store.assert_called_once_with(
+            f'{VERSION_HISTORY_KEY_PREFIX}2026-07-07 00:00:00',
+            json.dumps(expected_entry)
+        )
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    @mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command")
+    def test_add_cluster_version_staggered_upgrade(self, _check_mon_command, _set_store, cephadm_module: CephadmOrchestrator):
+        _check_mon_command.return_value = (0, json.dumps([{'section': 'global'}, {'section': 'mon'}]), '')
+        vt: VersionTracker = cephadm_module.version_tracker
+        params = {'image': 'quay.io/ceph/ceph:v18.2.8', 'version': '18.2.8', 'daemon_types': ['mgr']}
+        vt.add_cluster_version('18.2.8', '2026-07-07 00:00:00', params, UpgradeStatus.STARTED)
+        expected_entry = CephVersionEntry(
+            version='18.2.8',
+            upgrade_type=UpgradeType.STAGGERED,
+            command_options=params,
+            status=UpgradeStatus.STARTED,
+            config_dump=[{'section': 'global'}, {'section': 'mon'}]
+        ).to_json()
+        _set_store.assert_called_once_with(
+            f'{VERSION_HISTORY_KEY_PREFIX}2026-07-07 00:00:00',
+            json.dumps(expected_entry)
+        )
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    @mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command")
+    def test_add_cluster_version_check_mon_command_raises(self, _check_mon_command, _set_store, cephadm_module: CephadmOrchestrator):
+        _check_mon_command.side_effect = Exception('mon command failure')
+        vt: VersionTracker = cephadm_module.version_tracker
+        params = {'image': 'quay.io/ceph/ceph:v18.2.8', 'version': '18.2.8', 'daemon_types': ['mgr']}
+        with mock.patch.object(cephadm_module.log, 'error') as err_mock:
+            vt.add_cluster_version('18.2.8', '2026-07-07 00:00:00', params, UpgradeStatus.STARTED)
+            err_mock.assert_called_once()
+        expected_entry = CephVersionEntry(
+            version='18.2.8',
+            upgrade_type=UpgradeType.STAGGERED,
+            command_options=params,
+            status=UpgradeStatus.STARTED,
+            config_dump=None
+        ).to_json()
+        _set_store.assert_called_once_with(
+            f'{VERSION_HISTORY_KEY_PREFIX}2026-07-07 00:00:00',
+            json.dumps(expected_entry)
+        )
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    @mock.patch("cephadm.module.CephadmOrchestrator.check_mon_command")
+    def test_add_cluster_version_check_mon_command_empty_output(self, _check_mon_command, _set_store, cephadm_module: CephadmOrchestrator):
+        _check_mon_command.return_value = (0, '', '')
+        vt: VersionTracker = cephadm_module.version_tracker
+        params = {'image': 'quay.io/ceph/ceph:v18.2.8', 'version': '18.2.8', 'daemon_types': ['mgr']}
+        vt.add_cluster_version('18.2.8', '2026-07-07 00:00:00', params, UpgradeStatus.STARTED)
+        expected_entry = CephVersionEntry(
+            version='18.2.8',
+            upgrade_type=UpgradeType.STAGGERED,
+            command_options=params,
+            status=UpgradeStatus.STARTED,
+            config_dump=None
+        ).to_json()
+        _set_store.assert_called_once_with(
+            f'{VERSION_HISTORY_KEY_PREFIX}2026-07-07 00:00:00',
+            json.dumps(expected_entry)
+        )
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    @mock.patch("cephadm.module.CephadmOrchestrator.get_store_prefix")
+    def test_update_cluster_version_status_updates_for_one_entry(self, _get_store_prefix, _set_store, cephadm_module: CephadmOrchestrator):
+        entry = {'version': '18.2.8', 'status': UpgradeStatus.STARTED}
+        key = f'{VERSION_HISTORY_KEY_PREFIX}2026-01-01 00:00:00'
+        _get_store_prefix.return_value = {
+            key: json.dumps(entry)
+        }
+        vt: VersionTracker = cephadm_module.version_tracker
+        upgrade_state = mock.MagicMock(spec=UpgradeState)
+        vt.update_cluster_version_status(upgrade_state, UpgradeStatus.COMPLETE)
+        expected = dict(entry, status=UpgradeStatus.COMPLETE)
+        _set_store.assert_called_once_with(key, json.dumps(expected))
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    @mock.patch("cephadm.module.CephadmOrchestrator.get_store_prefix")
+    def test_update_cluster_version_status_updates_lastest_entry_for_multiple(self, _get_store_prefix, _set_store, cephadm_module: CephadmOrchestrator):
+        entry1 = {'version': '18.2.8', 'status': UpgradeStatus.COMPLETE}
+        entry2 = {'version': '19.2.3', 'status': UpgradeStatus.STARTED}
+        key1 = f'{VERSION_HISTORY_KEY_PREFIX}2026-01-01 00:00:00'
+        key2 = f'{VERSION_HISTORY_KEY_PREFIX}2027-01-01 00:00:00'
+        _get_store_prefix.return_value = {
+            key1: json.dumps(entry1),
+            key2: json.dumps(entry2)
+        }
+        vt: VersionTracker = cephadm_module.version_tracker
+        upgrade_state = mock.MagicMock(spec=UpgradeState)
+        vt.update_cluster_version_status(upgrade_state, UpgradeStatus.COMPLETE)
+        expected = dict(entry2, status=UpgradeStatus.COMPLETE)
+        _set_store.assert_called_once_with(key2, json.dumps(expected))
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    @mock.patch("cephadm.module.CephadmOrchestrator.get_store_prefix")
+    def test_update_cluster_version_status_adds_entry_when_no_entry_found(self, _get_store_prefix, _set_store, cephadm_module: CephadmOrchestrator):
+        _get_store_prefix.return_value = {}
+        vt: VersionTracker = cephadm_module.version_tracker
+        upgrade_state = mock.MagicMock(spec=UpgradeState)
+        upgrade_state._target_name = '19.2.3'
+        upgrade_state.daemon_types = None
+        upgrade_state.hosts = None
+        upgrade_state.services = None
+        upgrade_state.total_count = None
+        upgrade_state.crush_bucket_type = None
+        upgrade_state.crush_bucket_name = None
+        vt.update_cluster_version_status(upgrade_state, UpgradeStatus.COMPLETE)
+        _set_store.assert_called_once()
+        called_key, called_value = _set_store.call_args.args
+        assert called_key.startswith(VERSION_HISTORY_KEY_PREFIX)
+        stored_entry = json.loads(called_value)
+        assert stored_entry['version'] == '19.2.3'
+        assert stored_entry['status'] == UpgradeStatus.COMPLETE
+        assert stored_entry['upgrade_type'] == UpgradeType.FULL
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.get_store_prefix")
+    def test_get_cluster_version_history_empty(self, _get_store_prefix, cephadm_module: CephadmOrchestrator):
+        _get_store_prefix.return_value = {}
+        vt: VersionTracker = cephadm_module.version_tracker
+        out = vt.get_cluster_version_history()
+        assert out == 'No Cluster Version History Stored'
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.get_store_prefix")
+    def test_get_cluster_version_history_all_option_false(self, _get_store_prefix, cephadm_module: CephadmOrchestrator):
+        entry = {'version': '18.2.8', 'status': UpgradeStatus.STARTED, 'config_dump': [{'section': 'global'}, {'section': 'mon'}]}
+        key = f'{VERSION_HISTORY_KEY_PREFIX}2026-01-01 00:00:00'
+        _get_store_prefix.return_value = {
+            key: json.dumps(entry)
+        }
+        vt: VersionTracker = cephadm_module.version_tracker
+        out = vt.get_cluster_version_history(show_config=False)
+        parsed = json.loads(out)
+        assert 'config_dump' not in parsed[key[16:]]
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.get_store_prefix")
+    def test_get_cluster_version_history_all_option_true(self, _get_store_prefix, cephadm_module: CephadmOrchestrator):
+        entry = {'version': '18.2.8', 'status': UpgradeStatus.STARTED, 'config_dump': [{'section': 'global'}, {'section': 'mon'}]}
+        key = f'{VERSION_HISTORY_KEY_PREFIX}2026-01-01 00:00:00'
+        _get_store_prefix.return_value = {
+            key: json.dumps(entry)
+        }
+        vt: VersionTracker = cephadm_module.version_tracker
+        out = vt.get_cluster_version_history(show_config=True)
+        parsed = json.loads(out)
+        assert parsed[key[16:]]['config_dump'] == [{'section': 'global'}, {'section': 'mon'}]
+
+    def test_remove_cluster_version_history_no_options(self, cephadm_module: CephadmOrchestrator):
+        vt: VersionTracker = cephadm_module.version_tracker
+        err, msg = vt.remove_cluster_version_history()
+        assert err == -errno.EINVAL
+        assert msg == 'requires at least one of the options "all", "before", "after" to be set'
+
+    def test_remove_cluster_version_history_option_all_and_after_conflict(self, cephadm_module: CephadmOrchestrator):
+        vt: VersionTracker = cephadm_module.version_tracker
+        err, msg = vt.remove_cluster_version_history(all=True, after='2026-01-01 00:00:00')
+        assert err == -errno.EINVAL
+        assert msg == 'cannot have option "all" set while option "before" or option "after" are set'
+
+    def test_remove_cluster_version_history_option_all_and_before_conflict(self, cephadm_module: CephadmOrchestrator):
+        vt: VersionTracker = cephadm_module.version_tracker
+        err, msg = vt.remove_cluster_version_history(all=True, before='2026-01-01 00:00:00')
+        assert err == -errno.EINVAL
+        assert msg == 'cannot have option "all" set while option "before" or option "after" are set'
+
+    def test_remove_cluster_version_history_invalid_format(self, cephadm_module: CephadmOrchestrator):
+        vt: VersionTracker = cephadm_module.version_tracker
+        err, msg = vt.remove_cluster_version_history(before='00:00:00 2026-01-01')
+        assert err == -errno.EINVAL
+        assert msg == 'invalid datetime format for option "before", use "YYYY-MM-DD HH:MM:SS"'
+
+        err, msg = vt.remove_cluster_version_history(after='00:00:00 2026-01-01')
+        assert err == -errno.EINVAL
+        assert msg == 'invalid datetime format for option "after", use "YYYY-MM-DD HH:MM:SS"'
+
+    def test_remove_cluster_version_history_before_less_than_after_conflict(self, cephadm_module: CephadmOrchestrator):
+        vt: VersionTracker = cephadm_module.version_tracker
+        err, msg = vt.remove_cluster_version_history(before='2026-10-01 00:00:00', after='2027-10-01 00:00:00')
+        assert err == -errno.EINVAL
+        assert msg == 'option "before" cannot be a datetime less than option "after", command will remove entries in range (AFTER, BEFORE)'
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    @mock.patch("cephadm.module.CephadmOrchestrator.get_store_prefix")
+    def test_remove_cluster_version_history_all(self, _get_store_prefix, _set_store, cephadm_module: CephadmOrchestrator):
+        key1 = f'{VERSION_HISTORY_KEY_PREFIX}2026-01-01 00:00:00'
+        key2 = f'{VERSION_HISTORY_KEY_PREFIX}2027-01-01 00:00:00'
+        key3 = f'{VERSION_HISTORY_KEY_PREFIX}2027-10-01 00:00:00'
+        _get_store_prefix.return_value = {
+            key1: '{}',
+            key2: '{}',
+            key3: '{}',
+        }
+        vt: VersionTracker = cephadm_module.version_tracker
+        err, msg = vt.remove_cluster_version_history(all=True)
+        assert err == 0
+        assert msg == 'Cluster Version History Deletion Successful'
+        _set_store.assert_has_calls([
+            mock.call(key1, None),
+            mock.call(key2, None),
+            mock.call(key3, None)
+        ])
+        assert _set_store.call_count == 3
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    @mock.patch("cephadm.module.CephadmOrchestrator.get_store_prefix")
+    def test_remove_cluster_version_history_before_only(self, _get_store_prefix, _set_store, cephadm_module: CephadmOrchestrator):
+        key1 = f'{VERSION_HISTORY_KEY_PREFIX}2026-01-01 00:00:00'
+        key2 = f'{VERSION_HISTORY_KEY_PREFIX}2027-01-01 00:00:00'
+        key3 = f'{VERSION_HISTORY_KEY_PREFIX}2027-10-01 00:00:00'
+        _get_store_prefix.return_value = {
+            key1: '{}',
+            key2: '{}',
+            key3: '{}',
+        }
+        vt: VersionTracker = cephadm_module.version_tracker
+        err, msg = vt.remove_cluster_version_history(before='2027-01-01 00:00:00')
+        assert err == 0
+        assert msg == 'Cluster Version History Deletion Successful'
+        _set_store.assert_called_once_with(key1, None)
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    @mock.patch("cephadm.module.CephadmOrchestrator.get_store_prefix")
+    def test_remove_cluster_version_history_after_only(self, _get_store_prefix, _set_store, cephadm_module: CephadmOrchestrator):
+        key1 = f'{VERSION_HISTORY_KEY_PREFIX}2026-01-01 00:00:00'
+        key2 = f'{VERSION_HISTORY_KEY_PREFIX}2027-01-01 00:00:00'
+        key3 = f'{VERSION_HISTORY_KEY_PREFIX}2027-10-01 00:00:00'
+        _get_store_prefix.return_value = {
+            key1: '{}',
+            key2: '{}',
+            key3: '{}',
+        }
+        vt: VersionTracker = cephadm_module.version_tracker
+        err, msg = vt.remove_cluster_version_history(after='2027-01-01 00:00:00')
+        assert err == 0
+        assert msg == 'Cluster Version History Deletion Successful'
+        _set_store.assert_called_once_with(key3, None)
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    @mock.patch("cephadm.module.CephadmOrchestrator.get_store_prefix")
+    def test_remove_cluster_version_history_before_and_after_valid_range(self, _get_store_prefix, _set_store, cephadm_module: CephadmOrchestrator):
+        key1 = f'{VERSION_HISTORY_KEY_PREFIX}2026-01-01 00:00:00'
+        key2 = f'{VERSION_HISTORY_KEY_PREFIX}2027-01-01 00:00:00'
+        key3 = f'{VERSION_HISTORY_KEY_PREFIX}2027-10-01 00:00:00'
+        _get_store_prefix.return_value = {
+            key1: '{}',
+            key2: '{}',
+            key3: '{}',
+        }
+        vt: VersionTracker = cephadm_module.version_tracker
+        err, msg = vt.remove_cluster_version_history(before='2027-10-01 00:00:00', after='2026-01-01 00:00:00')
+        assert err == 0
+        assert msg == 'Cluster Version History Deletion Successful'
+        _set_store.assert_called_once_with(key2, None)

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -2,6 +2,7 @@ import errno
 import json
 import logging
 import time
+import datetime
 import uuid
 from dataclasses import dataclass, field, asdict
 from typing import TYPE_CHECKING, Optional, Dict, List, Tuple, Any, cast, Set
@@ -15,6 +16,7 @@ from cephadm.utils import ceph_release_to_major, name_to_config_section, CEPH_UP
     CEPH_TYPES, CEPH_IMAGE_TYPES, NON_CEPH_IMAGE_TYPES, MONITORING_STACK_TYPES, GATEWAY_TYPES
 from cephadm.ssh import HostConnectionError
 from orchestrator import OrchestratorError, DaemonDescription, DaemonDescriptionStatus, daemon_type_to_service
+from ceph.cephadm.version_entry import UpgradeStatus
 
 from mgr_module import MonCommandFailed
 
@@ -554,6 +556,9 @@ class CephadmUpgrade:
     def upgrade_start(self, image: str, version: str, daemon_types: Optional[List[str]] = None,
                       hosts: Optional[List[str]] = None, services: Optional[List[str]] = None, limit: Optional[int] = None,
                       bucket_type: Optional[str] = None, bucket_name: Optional[str] = None) -> str:
+        # params variable needs to be at the top to only capture the parameters
+        params = locals()
+
         fail_fs_value = cast(bool, self.mgr.get_module_option_ex(
             'orchestrator', 'fail_fs', False))
         if self.mgr.mode != 'root':
@@ -632,6 +637,13 @@ class CephadmUpgrade:
         self._save_upgrade_state()
         self._clear_upgrade_health_checks()
         self.mgr.event.set()
+        # Stores upgrade attempt in version tracker
+        self.mgr.version_tracker.add_cluster_version(
+            version=target_name,
+            time=datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S'),
+            status=UpgradeStatus.STARTED,
+            params={k: v for k, v in params.items() if k != 'self'}
+        )
         return 'Initiating upgrade to %s' % (target_name)
 
     def _validate_upgrade_filters(self, target_name: str, daemon_types: Optional[List[str]] = None, hosts: Optional[List[str]] = None, services: Optional[List[str]] = None) -> None:
@@ -763,6 +775,7 @@ class CephadmUpgrade:
                             self.upgrade_state.progress_id)
         target_image = self.target_image
         self.mgr.log.info('Upgrade: Stopped')
+        self.mgr.version_tracker.update_cluster_version_status(upgrade_state=self.upgrade_state, status=UpgradeStatus.STOPPED)
         self.upgrade_state = None
         self._ok_to_upgrade_osds_in_crush_bucket = None
         self._save_upgrade_state()
@@ -1700,6 +1713,7 @@ class CephadmUpgrade:
             self._unset_noautoscale()
             self.upgrade_state.noautoscale_set = False
         logger.info('Upgrade: Complete!')
+        self.mgr.version_tracker.update_cluster_version_status(upgrade_state=self.upgrade_state, status=UpgradeStatus.COMPLETE)
         if self.upgrade_state.progress_id:
             self.mgr.remote('progress', 'complete',
                             self.upgrade_state.progress_id)

--- a/src/pybind/mgr/cephadm/version_tracker.py
+++ b/src/pybind/mgr/cephadm/version_tracker.py
@@ -1,0 +1,123 @@
+import errno
+import json
+import datetime
+from typing import TYPE_CHECKING, Optional, Tuple
+from ceph.cephadm.version_entry import UpgradeType, UpgradeStatus, CephVersionEntry
+from cephadm.upgrade import UpgradeState
+
+if TYPE_CHECKING:
+    from .module import CephadmOrchestrator
+
+# on disk key prefix
+VERSION_HISTORY_KEY_PREFIX = "version_history/"
+
+
+class VersionTracker:
+
+    def __init__(self, mgr: "CephadmOrchestrator") -> None:
+        self.mgr = mgr
+
+    def add_cluster_version(self, version: str, time: str, params: dict, status: UpgradeStatus) -> None:
+        # Extracts config dump json and stores in config_dump variable
+        try:
+            ret, out, err = self.mgr.check_mon_command({
+                'prefix': 'config dump',
+                'format': 'json',
+            })
+            config_dump = json.loads(out) if out else None
+        except Exception as e:
+            self.mgr.log.error(f'Version Tracker: {e}')
+            config_dump = None
+
+        # Determines type of upgrade by seeing what options were set
+        upgrade_type = UpgradeType.FULL
+        for key in params.keys():
+            if key != 'image' and key != 'version' and params[key] is not None:
+                upgrade_type = UpgradeType.STAGGERED
+                break
+
+        # Information is stored as standardized json entries
+        new_entry = CephVersionEntry(
+            version=version,
+            upgrade_type=upgrade_type,
+            command_options=params,
+            status=status,
+            config_dump=config_dump
+        ).to_json()
+        self.mgr.set_store(f'{VERSION_HISTORY_KEY_PREFIX}{time}', json.dumps(new_entry))
+        self.mgr.log.info(f'Version Tracker: {VERSION_HISTORY_KEY_PREFIX}{time} entry added with version {version}')
+
+    def update_cluster_version_status(self, upgrade_state: UpgradeState, status: UpgradeStatus) -> None:
+        raw = self.mgr.get_store_prefix(VERSION_HISTORY_KEY_PREFIX)
+        if not raw:
+            # This condition exists for the edge case of upgrading from a version that didn't have
+            # version tracking, if raw is empty then no history is stored and use UpgradeState to
+            # obtain info for first entry
+            self.add_cluster_version(
+                version=upgrade_state._target_name,
+                time=datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S'),
+                params={
+                    'daemon_types': upgrade_state.daemon_types,
+                    'hosts': upgrade_state.hosts,
+                    'services': upgrade_state.services,
+                    'limit': upgrade_state.total_count,
+                    'bucket_type': upgrade_state.crush_bucket_type,
+                    'bucket_name': upgrade_state.crush_bucket_name,
+                },
+                status=status
+            )
+        else:
+            # Changes status field of last entry depending on if upgrade was completed or was stopped
+            latest_entry_key, latest_entry_value = next(reversed(raw.items()))
+            latest_entry_value = json.loads(latest_entry_value)
+            latest_entry_value['status'] = status
+            self.mgr.set_store(latest_entry_key, json.dumps(latest_entry_value))
+            self.mgr.log.info(f'Version Tracker: {latest_entry_key} entry updated with status {status}')
+
+    def get_cluster_version_history(self, show_config: Optional[bool] = False) -> str:
+        raw = self.mgr.get_store_prefix(VERSION_HISTORY_KEY_PREFIX)
+        prefix_len = len(VERSION_HISTORY_KEY_PREFIX)
+        res = {k[prefix_len:]: json.loads(v) for (k, v) in raw.items()}
+        if not res:
+            return 'No Cluster Version History Stored'
+        if show_config:
+            return json.dumps(res, indent=4)
+        else:
+            for entry in res.values():
+                del entry['config_dump']
+            return json.dumps(res, indent=4)
+
+    def remove_cluster_version_history(self, all: Optional[bool] = False, before: Optional[str] = None, after: Optional[str] = None) -> Tuple[int, str]:
+        # Validate option combinations and datetime formats
+        if not all and not before and not after:
+            return -errno.EINVAL, 'requires at least one of the options "all", "before", "after" to be set'
+        if all and (before or after):
+            return -errno.EINVAL, 'cannot have option "all" set while option "before" or option "after" are set'
+        if before:
+            try:
+                datetime.datetime.strptime(before, '%Y-%m-%d %H:%M:%S')
+            except ValueError:
+                return -errno.EINVAL, 'invalid datetime format for option "before", use "YYYY-MM-DD HH:MM:SS"'
+        if after:
+            try:
+                datetime.datetime.strptime(after, '%Y-%m-%d %H:%M:%S')
+            except ValueError:
+                return -errno.EINVAL, 'invalid datetime format for option "after", use "YYYY-MM-DD HH:MM:SS"'
+        if before and after and before < after:
+            return -errno.EINVAL, 'option "before" cannot be a datetime less than option "after", command will remove entries in range (AFTER, BEFORE)'
+
+        # Fetch existing entries and delete based on the requested range
+        raw = self.mgr.get_store_prefix(VERSION_HISTORY_KEY_PREFIX)
+        prefix_len = len(VERSION_HISTORY_KEY_PREFIX)
+        entry_dates = [key[prefix_len:] for key in raw.keys()]
+        if all:
+            for entry in entry_dates:
+                self.mgr.set_store(f'{VERSION_HISTORY_KEY_PREFIX}{entry}', None)
+        else:
+            for entry in entry_dates:
+                if before and entry >= before:
+                    continue
+                if after and entry <= after:
+                    continue
+                self.mgr.set_store(f'{VERSION_HISTORY_KEY_PREFIX}{entry}', None)
+        return 0, 'Cluster Version History Deletion Successful'

--- a/src/python-common/ceph/cephadm/version_entry.py
+++ b/src/python-common/ceph/cephadm/version_entry.py
@@ -1,0 +1,46 @@
+from enum import Enum
+from typing import Optional
+
+
+class UpgradeType(str, Enum):
+    FULL = 'full'
+    STAGGERED = 'staggered'
+    BOOTSTRAP = 'bootstrap'
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class UpgradeStatus(str, Enum):
+    STARTED = 'started'
+    STOPPED = 'stopped'
+    COMPLETE = 'complete'
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class CephVersionEntry:
+
+    def __init__(
+        self,
+        version: str,
+        upgrade_type: UpgradeType,
+        status: UpgradeStatus,
+        command_options: Optional[dict],
+        config_dump: Optional[list],
+    ):
+        self.version = version
+        self.upgrade_type = upgrade_type
+        self.status = status
+        self.command_options = command_options
+        self.config_dump = config_dump
+
+    def to_json(self) -> dict:
+        return {
+            'version': self.version,
+            'upgrade_type': self.upgrade_type,
+            'status': self.status,
+            'command_options': self.command_options,
+            'config_dump': self.config_dump,
+        }


### PR DESCRIPTION
Backport of: [65592](https://github.com/ceph/ceph/pull/65592)
Backport Tracker: https://tracker.ceph.com/issues/79573
Parent Tracker: https://tracker.ceph.com/issues/73124

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
