### PR TITLE
rgw/admin: add --access-key-file and --secret-key-file

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -554,6 +554,15 @@ Options
 
    S3 access key.
 
+.. option:: --access-key-file=<path>
+
+   Path to a file containing the S3 access key. Use this instead of
+   ``--access-key`` to keep the key out of the command line, which any local
+   user can read from ``/proc``. Trailing whitespace is ignored, so a file
+   ending in a newline works as expected. Restrict the file to mode 0600;
+   radosgw-admin warns if it is readable by group or others. This option cannot
+   be combined with ``--access-key``.
+
 .. option:: --email=email
 
    The e-mail address of the user.
@@ -561,6 +570,12 @@ Options
 .. option:: --secret/--secret-key=<key>
 
    The secret key.
+
+.. option:: --secret-file/--secret-key-file=<path>
+
+   Path to a file containing the secret key, with the same handling as
+   ``--access-key-file``. This option cannot be combined with ``--secret`` or
+   ``--secret-key``.
 
 .. option:: --gen-access-key
 

--- a/qa/suites/rgw/singleton/all/radosgw-admin.yaml
+++ b/qa/suites/rgw/singleton/all/radosgw-admin.yaml
@@ -24,5 +24,6 @@ tasks:
     clients:
       client.0:
         - rgw/test_account_migration.sh
+        - rgw/test_rgw_credential_file.sh
 - radosgw-admin:
 - radosgw-admin-rest:

--- a/qa/workunits/rgw/test_rgw_credential_file.sh
+++ b/qa/workunits/rgw/test_rgw_credential_file.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# test_rgw_credential_file.sh
+# Verify that radosgw-admin reads S3 credentials from the files named by
+# --access-key-file and --secret-key-file, so that they never appear in argv.
+
+set -e
+
+# Fallback to standard command if the variable isn't provided by the environment
+RGW_ADMIN=${RGW_ADMIN:-radosgw-admin}
+
+UID_UNDER_TEST="credfile-test-user"
+DISPLAY_NAME="credential file test user"
+ACCESS_KEY="CREDFILEACCESSKEY123"
+SECRET_KEY="credfileSecretKey0987654321abcdefghijklm"
+
+WORKDIR="$(mktemp -d)"
+
+cleanup() {
+    "$RGW_ADMIN" user rm --uid="$UID_UNDER_TEST" --purge-data > /dev/null 2>&1 || true
+    rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+# The trailing newline is deliberate: it is what a file written by an editor or
+# by "echo secret > file" looks like, and it must not end up in the key.
+printf '%s\n' "$ACCESS_KEY" > "$WORKDIR/access"
+printf '%s\n' "$SECRET_KEY" > "$WORKDIR/secret"
+chmod 0600 "$WORKDIR/access" "$WORKDIR/secret"
+
+expect_fail() {
+    local desc="$1"
+    shift
+    if "$@" > /dev/null 2>&1; then
+        echo "FAIL: ${desc}: expected a nonzero exit, but the command succeeded"
+        exit 1
+    fi
+    echo "ok: ${desc}"
+}
+
+echo "Creating a user whose credentials come from files..."
+"$RGW_ADMIN" user create \
+    --uid="$UID_UNDER_TEST" \
+    --display-name="$DISPLAY_NAME" \
+    --access-key-file="$WORKDIR/access" \
+    --secret-key-file="$WORKDIR/secret" > /dev/null
+
+echo "Checking that the stored credentials match the file contents..."
+USER_JSON="$("$RGW_ADMIN" user info --uid="$UID_UNDER_TEST" --format=json)"
+GOT_ACCESS="$(echo "$USER_JSON" | jq -r '.keys[0].access_key')"
+GOT_SECRET="$(echo "$USER_JSON" | jq -r '.keys[0].secret_key')"
+
+if [ "$GOT_ACCESS" != "$ACCESS_KEY" ]; then
+    echo "FAIL: expected access key '${ACCESS_KEY}', got '${GOT_ACCESS}'"
+    exit 1
+fi
+if [ "$GOT_SECRET" != "$SECRET_KEY" ]; then
+    echo "FAIL: expected secret key '${SECRET_KEY}', got '${GOT_SECRET}'"
+    exit 1
+fi
+echo "ok: credentials round-tripped with the trailing newline stripped"
+
+echo "Checking that a user can be looked up by a file-supplied access key..."
+LOOKUP_UID="$("$RGW_ADMIN" user info --access-key-file="$WORKDIR/access" --format=json | jq -r '.user_id')"
+if [ "$LOOKUP_UID" != "$UID_UNDER_TEST" ]; then
+    echo "FAIL: expected uid '${UID_UNDER_TEST}', got '${LOOKUP_UID}'"
+    exit 1
+fi
+echo "ok: user info accepts --access-key-file"
+
+echo "Checking the error cases..."
+expect_fail "missing access key file is rejected" \
+    "$RGW_ADMIN" user info --access-key-file="$WORKDIR/does-not-exist"
+
+: > "$WORKDIR/empty"
+chmod 0600 "$WORKDIR/empty"
+expect_fail "empty access key file is rejected" \
+    "$RGW_ADMIN" user info --access-key-file="$WORKDIR/empty"
+
+expect_fail "--access-key and --access-key-file together are rejected" \
+    "$RGW_ADMIN" user info --access-key="$ACCESS_KEY" --access-key-file="$WORKDIR/access"
+
+expect_fail "--secret and --secret-file together are rejected" \
+    "$RGW_ADMIN" user create --uid="${UID_UNDER_TEST}-2" --display-name=x \
+        --secret="$SECRET_KEY" --secret-file="$WORKDIR/secret"
+
+echo "Checking that a group-readable credential file still works..."
+"$RGW_ADMIN" user rm --uid="$UID_UNDER_TEST" --purge-data > /dev/null
+chmod 0644 "$WORKDIR/access" "$WORKDIR/secret"
+"$RGW_ADMIN" user create \
+    --uid="$UID_UNDER_TEST" \
+    --display-name="$DISPLAY_NAME" \
+    --access-key-file="$WORKDIR/access" \
+    --secret-key-file="$WORKDIR/secret" > /dev/null
+GOT_ACCESS="$("$RGW_ADMIN" user info --uid="$UID_UNDER_TEST" --format=json | jq -r '.keys[0].access_key')"
+if [ "$GOT_ACCESS" != "$ACCESS_KEY" ]; then
+    echo "FAIL: expected access key '${ACCESS_KEY}', got '${GOT_ACCESS}'"
+    exit 1
+fi
+echo "ok: a permissive mode warns but does not block"
+
+echo "SUCCESS: radosgw-admin credential files work correctly!"
+exit 0

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -5,6 +5,9 @@
  * Copyright (C) 2025 IBM
  */
 
+#include <sys/stat.h>
+
+#include <cctype>
 #include <cerrno>
 #include <string>
 #include <sstream>
@@ -35,10 +38,12 @@ extern "C" {
 #include "common/XMLFormatter.h"
 #include "common/errno.h"
 #include "common/safe_io.h"
+#include "common/ceph_crypto.h"
 #include "common/fault_injector.h"
 
 #include "common/async/blocked_completion.h"
 
+#include "include/compat.h"
 #include "include/util.h"
 
 #ifdef WITH_RADOSGW_RADOS
@@ -395,8 +400,11 @@ void usage()
   cout << "   --max-groups                      max number of groups for an account\n";
   cout << "   --max-access-keys                 max number of keys per user for an account\n";
   cout << "   --access-key=<key>                S3 access key\n";
+  cout << "   --access-key-file=<path>          file containing the S3 access key\n";
   cout << "   --email=<email>                   user's email address\n";
   cout << "   --secret/--secret-key=<key>       specify secret key\n";
+  cout << "   --secret-file/--secret-key-file=<path>\n";
+  cout << "                                     file containing the secret key\n";
   cout << "   --gen-access-key                  generate random access key (for S3)\n";
   cout << "   --gen-secret                      generate random secret key\n";
   cout << "   --generate-key                    create user with or without credentials\n";
@@ -1430,6 +1438,73 @@ static int init_bucket(const string& tenant_name,
 {
   rgw_bucket b{tenant_name, bucket_name, bucket_id};
   return init_bucket(b, bucket);
+}
+
+/*
+ * Read a credential from a file so that it never has to appear in argv, where
+ * any local user could read it out of /proc/<pid>/cmdline.
+ */
+static int read_credential_file(const string& path, string& credential)
+{
+  int fd = ::open(path.c_str(), O_RDONLY | O_CLOEXEC);
+  if (fd < 0) {
+    int err = -errno;
+    cerr << "ERROR: failed to open " << path << ": " << cpp_strerror(-err)
+         << std::endl;
+    return err;
+  }
+
+  struct stat st;
+  if (::fstat(fd, &st) < 0) {
+    int err = -errno;
+    cerr << "ERROR: failed to stat " << path << ": " << cpp_strerror(-err)
+         << std::endl;
+    VOID_TEMP_FAILURE_RETRY(::close(fd));
+    return err;
+  }
+
+  if (!S_ISREG(st.st_mode)) {
+    cerr << "ERROR: " << path << " is not a regular file" << std::endl;
+    VOID_TEMP_FAILURE_RETRY(::close(fd));
+    return -EINVAL;
+  }
+
+  if (st.st_mode & (S_IRWXG | S_IRWXO)) {
+    cerr << "WARNING: credential file " << path << " is accessible by group or "
+         << "others, recommended permissions are 0600" << std::endl;
+  }
+
+  constexpr int max_len = 4096;
+  char buf[max_len];
+  ssize_t len = safe_read(fd, buf, sizeof(buf));
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
+  if (len < 0) {
+    cerr << "ERROR: failed to read " << path << ": "
+         << cpp_strerror(static_cast<int>(-len)) << std::endl;
+    return static_cast<int>(len);
+  }
+
+  /* a full buffer means the file may be larger than it, so the read could have
+   * stopped mid-credential; refuse it rather than use a truncated key */
+  if (len == max_len) {
+    ::ceph::crypto::zeroize_for_security(buf, sizeof(buf));
+    cerr << "ERROR: " << path << " is too large to hold a credential"
+         << std::endl;
+    return -EINVAL;
+  }
+
+  while (len > 0 && std::isspace(static_cast<unsigned char>(buf[len - 1]))) {
+    --len;
+  }
+  credential.assign(buf, static_cast<size_t>(len));
+  ::ceph::crypto::zeroize_for_security(buf, sizeof(buf));
+
+  if (credential.empty()) {
+    cerr << "ERROR: " << path << " contains no credential" << std::endl;
+    return -EINVAL;
+  }
+
+  return 0;
 }
 
 static int read_input(const string& infile, bufferlist& bl)
@@ -3777,6 +3852,7 @@ int main(int argc, const char **argv)
   rgw_account_id account_id;
   rgw_user new_user_id;
   std::string access_key, secret_key, user_email, display_name;
+  std::string access_key_file, secret_key_file;
   std::string bucket_name, pool_name, object;
   rgw_pool pool;
   std::string date, subuser, access, format;
@@ -4109,10 +4185,14 @@ int main(int argc, const char **argv)
       }
     } else if (ceph_argparse_witharg(args, i, &val, "--access-key", (char*)NULL)) {
       access_key = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--access-key-file", (char*)NULL)) {
+      access_key_file = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--subuser", (char*)NULL)) {
       subuser = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--secret", "--secret-key", (char*)NULL)) {
       secret_key = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--secret-file", "--secret-key-file", (char*)NULL)) {
+      secret_key_file = val;
     } else if (ceph_argparse_witharg(args, i, &val, "-e", "--email", (char*)NULL)) {
       user_email = val;
     } else if (ceph_argparse_witharg(args, i, &val, "-n", "--display-name", (char*)NULL)) {
@@ -4700,6 +4780,32 @@ int main(int argc, const char **argv)
       return EINVAL;
     } else {
       ++i;
+    }
+  }
+
+  /* resolved here rather than in the parse loop so that the file and its
+   * inline counterpart can be given in either order */
+  if (!access_key_file.empty()) {
+    if (!access_key.empty()) {
+      cerr << "ERROR: --access-key and --access-key-file are mutually exclusive"
+           << std::endl;
+      return EINVAL;
+    }
+    int ret = read_credential_file(access_key_file, access_key);
+    if (ret < 0) {
+      return -ret;
+    }
+  }
+
+  if (!secret_key_file.empty()) {
+    if (!secret_key.empty()) {
+      cerr << "ERROR: --secret/--secret-key and --secret-file/--secret-key-file "
+           << "are mutually exclusive" << std::endl;
+      return EINVAL;
+    }
+    int ret = read_credential_file(secret_key_file, secret_key);
+    if (ret < 0) {
+      return -ret;
     }
   }
 

--- a/src/test/cli/radosgw-admin/credential-file.t
+++ b/src/test/cli/radosgw-admin/credential-file.t
@@ -1,0 +1,71 @@
+Credentials can be read from a file so that they never appear in argv, where
+any local user could read them out of /proc/<pid>/cmdline.
+
+A file that cannot be opened is reported rather than silently ignored:
+
+  $ radosgw-admin --access-key-file=missing
+  ERROR: failed to open missing: (2)* (glob)
+  [2]
+
+  $ radosgw-admin --secret-key-file=missing
+  ERROR: failed to open missing: (2)* (glob)
+  [2]
+
+Only regular files hold credentials:
+
+  $ mkdir adir
+  $ radosgw-admin --access-key-file=adir
+  ERROR: adir is not a regular file
+  [22]
+
+An empty file holds no credential, and a mode that exposes it to other users
+is called out before the file is used:
+
+  $ : > empty
+  $ chmod 0644 empty
+  $ radosgw-admin --access-key-file=empty
+  WARNING: credential file empty is accessible by group or others, recommended permissions are 0600
+  ERROR: empty contains no credential
+  [22]
+
+A file holding only whitespace is empty once the trailing newline is stripped:
+
+  $ printf '\n' > blank
+  $ chmod 0600 blank
+  $ radosgw-admin --secret-file=blank
+  ERROR: blank contains no credential
+  [22]
+
+A well-formed file is accepted quietly, including its trailing newline. Here
+the access key is read successfully and the run proceeds far enough to fail on
+the secret instead:
+
+  $ printf 'AKIAIOSFODNN7EXAMPLE\n' > access
+  $ chmod 0600 access
+  $ radosgw-admin --access-key-file=access --secret-key-file=missing
+  ERROR: failed to open missing: (2)* (glob)
+  [2]
+
+A credential cannot be given both inline and in a file. The conflict is
+reported without the file being opened, so a path that does not exist is
+still enough to trigger it:
+
+  $ radosgw-admin --access-key=AKIAIOSFODNN7EXAMPLE --access-key-file=missing
+  ERROR: --access-key and --access-key-file are mutually exclusive
+  [22]
+
+  $ radosgw-admin --secret-key=wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY --secret-key-file=missing
+  ERROR: --secret/--secret-key and --secret-file/--secret-key-file are mutually exclusive
+  [22]
+
+The options may be given in either order:
+
+  $ radosgw-admin --access-key-file=missing --access-key=AKIAIOSFODNN7EXAMPLE
+  ERROR: --access-key and --access-key-file are mutually exclusive
+  [22]
+
+The aliases behave the same as the names they mirror:
+
+  $ radosgw-admin --secret=wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY --secret-file=missing
+  ERROR: --secret/--secret-key and --secret-file/--secret-key-file are mutually exclusive
+  [22]

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -240,8 +240,11 @@
      --max-groups                      max number of groups for an account
      --max-access-keys                 max number of keys per user for an account
      --access-key=<key>                S3 access key
+     --access-key-file=<path>          file containing the S3 access key
      --email=<email>                   user's email address
      --secret/--secret-key=<key>       specify secret key
+     --secret-file/--secret-key-file=<path>
+                                       file containing the secret key
      --gen-access-key                  generate random access key (for S3)
      --gen-secret                      generate random secret key
      --generate-key                    create user with or without credentials


### PR DESCRIPTION
## Motivation

Auditing Rook, I found it builds `radosgw-admin` command lines for realm operations with inline credentials, leaving them readable in `/proc/<pid>/cmdline`. Ceph already accepts this credential class from a file elsewhere (`ceph dashboard set-rgw-api-access-key -i`).

## What changed

`--access-key-file` and `--secret-key-file` (aliased `--secret-file`) read the credential from a file. Every subcommand taking `--access-key`/`--secret-key` accepts them, including `realm pull` and `period commit`.

## Notable decisions

A group- or world-readable file warns but still works, so a default-mode Kubernetes secret mount stays usable — unlike the Vault token check in `rgw_kms.cc`, which refuses.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
