### PR TITLE
mgr/volumes: add namespace isolation configuration for clones

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,12 @@
+* CephFS: The `fs subvolume snapshot clone` command now accepts two new optional
+  flags: `--namespace-isolated`, which places the cloned subvolume in its own
+  separate RADOS namespace (derived from the clone's group and name), and
+  `--preserve-namespace`, which retains the source snapshot's pool namespace
+  when `--pool_layout` is also specified (by default `--pool_layout` clears
+  the namespace). The two flags are mutually exclusive. Default behavior is
+  unchanged. In addition, `fs subvolume snapshot info` now reports the
+  snapshot's `pool_namespace`.
+
 * ``src/script/ceph-backport.sh`` now runs on macOS in addition to Linux: it
   re-execs under GNU bash >= 4 when the system bash is too old, and honors a
   ``$GETOPT`` environment override so GNU getopt can be selected

--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -795,6 +795,8 @@ The output format is JSON and contains the following fields.
 * ``created_at``: creation time of the snapshot in the format ``YYYY-MM-DD
   HH:MM:SS:ffffff``
 * ``data_pool``: data pool to which the snapshot belongs
+* ``pool_namespace``: RADOS namespace of the snapshot's data, empty if the
+  source subvolume was not namespace-isolated
 * ``has_pending_clones``: ``yes`` if snapshot clone is in progress, otherwise
   ``no``
 * ``pending_clones``: list of in-progress or pending clones and their target
@@ -954,6 +956,38 @@ the following form to create a cloned subvolume with a specific pool layout:
 .. prompt:: bash #
 
    ceph fs subvolume snapshot clone <vol_name> <subvol_name> <snap_name> <target_subvol_name> --pool_layout <pool_layout>
+
+A clone can be placed in its own separate RADOS namespace, regardless of
+whether the source subvolume was namespace-isolated, by passing
+``--namespace-isolated``. This uses the same namespace naming convention as
+``ceph fs subvolume create --namespace-isolated`` (see the note on pool
+namespace naming below), and can be combined with ``--pool_layout``:
+
+.. prompt:: bash #
+
+   ceph fs subvolume snapshot clone <vol_name> <subvol_name> <snap_name> <target_subvol_name> --namespace-isolated
+
+By default, ``--pool_layout`` clears the RADOS namespace on the clone. Pass
+``--preserve-namespace`` along with ``--pool_layout`` to keep the source
+snapshot's pool namespace on the clone instead:
+
+.. prompt:: bash #
+
+   ceph fs subvolume snapshot clone <vol_name> <subvol_name> <snap_name> <target_subvol_name> --pool_layout <pool_layout> --preserve-namespace
+
+Without ``--pool_layout``, ``--preserve-namespace`` has no effect, since the
+namespace is already inherited from the source snapshot by default. Since a
+RADOS namespace only has meaning within the pool it was created in,
+``--preserve-namespace`` is only accepted when the ``--pool_layout`` target
+is the same pool the source snapshot is already in; passing it along with a
+``--pool_layout`` that names a different pool results in an error.
+``--namespace-isolated`` and ``--preserve-namespace`` are mutually exclusive
+and passing both results in an error.
+
+.. note:: Client caps authorized against the source subvolume's namespace do
+   not automatically grant access to a ``--namespace-isolated`` clone, since
+   the clone gets its own separate namespace. Re-run ``ceph fs subvolume
+   authorize`` on the clone to grant access to it.
 
 Run a command of the following form to check the status of a clone operation:
 

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -158,7 +158,7 @@ class TestVolumesHelper(CephFSTestCase):
             cval = int(self.mount_a.run_shell(['stat', '-c' '%Y', sink_path]).stdout.getvalue().strip())
             self.assertEqual(sval, cval)
 
-    def _verify_clone_root(self, source_path, clone_path, clone, clone_group, clone_pool):
+    def _verify_clone_root(self, source_path, clone_path, clone, clone_group, clone_pool, clone_pool_namespace=None):
         # verifies following clone root attrs quota, data_pool and pool_namespace
         # remaining attributes of clone root are validated in _verify_clone_attrs
 
@@ -174,15 +174,21 @@ class TestVolumesHelper(CephFSTestCase):
             # verify pool is set as per request
             self.assertEqual(clone_info["data_pool"], clone_pool)
         else:
-            # verify pool and pool namespace are inherited from snapshot
+            # verify pool is inherited from snapshot
             self.assertEqual(clone_info["data_pool"],
                              self.mount_a.getfattr(source_path, "ceph.dir.layout.pool"))
+
+        if clone_pool_namespace is not None:
+            # verify pool namespace matches the caller's explicit expectation
+            self.assertEqual(clone_info["pool_namespace"], clone_pool_namespace)
+        elif not clone_pool:
+            # verify pool namespace is inherited from snapshot
             self.assertEqual(clone_info["pool_namespace"],
                              self.mount_a.getfattr(source_path, "ceph.dir.layout.pool_namespace"))
 
     def _verify_clone(self, subvolume, snapshot, clone,
                       source_group=None, clone_group=None, clone_pool=None,
-                      subvol_path=None, source_version=2, timo=120):
+                      clone_pool_namespace=None, subvol_path=None, source_version=2, timo=120):
         # pass in subvol_path (subvolume path when snapshot was taken) when subvolume is removed
         # but snapshots are retained for clone verification
         path1 = self._get_subvolume_snapshot_path(subvolume, snapshot, source_group)
@@ -200,7 +206,7 @@ class TestVolumesHelper(CephFSTestCase):
             time.sleep(1)
         self.assertTrue(check < timo)
 
-        self._verify_clone_root(path1, path2, clone, clone_group, clone_pool)
+        self._verify_clone_root(path1, path2, clone, clone_group, clone_pool, clone_pool_namespace)
         self._verify_clone_attrs(path1, path2)
 
     def _gen_name(self, name, n):
@@ -5699,6 +5705,39 @@ class TestSubvolumeSnapshots(TestVolumesHelper):
         # verify trash dir is clean
         self._wait_for_trash_empty()
 
+    def test_subvolume_snapshot_info_pool_namespace(self):
+        """
+        tests that 'fs subvolume snapshot info' reports the snapshot's pool_namespace
+        """
+        subvolume = self._gen_subvol_name()
+        subvolume_iso = self._gen_subvol_name()
+        snapshot = self._gen_subvol_snap_name()
+
+        # create a plain subvolume and an isolated-namespace subvolume
+        self._fs_cmd("subvolume", "create", self.volname, subvolume, "--mode=777")
+        self._fs_cmd("subvolume", "create", self.volname, subvolume_iso, "--mode=777", "--namespace-isolated")
+
+        # snapshot both
+        self._fs_cmd("subvolume", "snapshot", "create", self.volname, subvolume, snapshot)
+        self._fs_cmd("subvolume", "snapshot", "create", self.volname, subvolume_iso, snapshot)
+
+        snap_info = json.loads(self._get_subvolume_snapshot_info(self.volname, subvolume, snapshot))
+        self.assertEqual(snap_info["pool_namespace"], "")
+
+        snap_info_iso = json.loads(self._get_subvolume_snapshot_info(self.volname, subvolume_iso, snapshot))
+        self.assertEqual(snap_info_iso["pool_namespace"], f'fsvolumens___nogroup_{subvolume_iso}')
+
+        # remove snapshots
+        self._fs_cmd("subvolume", "snapshot", "rm", self.volname, subvolume, snapshot)
+        self._fs_cmd("subvolume", "snapshot", "rm", self.volname, subvolume_iso, snapshot)
+
+        # remove subvolumes
+        self._fs_cmd("subvolume", "rm", self.volname, subvolume)
+        self._fs_cmd("subvolume", "rm", self.volname, subvolume_iso)
+
+        # verify trash dir is clean
+        self._wait_for_trash_empty()
+
     def test_subvolume_snapshot_in_group(self):
         subvolume = self._gen_subvol_name()
         group = self._gen_subvol_grp_name()
@@ -8883,6 +8922,363 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         # remove subvolumes
         self._fs_cmd("subvolume", "rm", self.volname, subvolume)
         self._fs_cmd("subvolume", "rm", self.volname, clone)
+
+        # verify trash dir is clean
+        self._wait_for_trash_empty()
+
+    def test_subvolume_snapshot_clone_namespace_isolated(self):
+        subvolume = self._gen_subvol_name()
+        snapshot = self._gen_subvol_snap_name()
+        clone = self._gen_subvol_clone_name()
+
+        # create subvolume
+        self._fs_cmd("subvolume", "create", self.volname, subvolume, "--mode=777")
+
+        # do some IO
+        self._do_subvolume_io(subvolume, number_of_files=32)
+
+        # snapshot subvolume
+        self._fs_cmd("subvolume", "snapshot", "create", self.volname, subvolume, snapshot)
+
+        # schedule a clone with a fresh, isolated namespace
+        self._fs_cmd("subvolume", "snapshot", "clone", self.volname, subvolume, snapshot, clone, "--namespace-isolated")
+
+        # check clone status
+        self._wait_for_clone_to_complete(clone)
+
+        # verify clone
+        expected_namespace = f'fsvolumens___nogroup_{clone}'
+        self._verify_clone(subvolume, snapshot, clone, clone_pool_namespace=expected_namespace)
+
+        clone_info = json.loads(self._get_subvolume_info(self.volname, clone))
+        self.assertEqual(clone_info["pool_namespace"], expected_namespace)
+
+        # remove snapshot
+        self._fs_cmd("subvolume", "snapshot", "rm", self.volname, subvolume, snapshot)
+
+        # remove subvolumes
+        self._fs_cmd("subvolume", "rm", self.volname, subvolume)
+        self._fs_cmd("subvolume", "rm", self.volname, clone)
+
+        # verify trash dir is clean
+        self._wait_for_trash_empty()
+
+    def test_subvolume_snapshot_clone_namespace_isolated_from_isolated_source(self):
+        subvolume = self._gen_subvol_name()
+        snapshot = self._gen_subvol_snap_name()
+        clone = self._gen_subvol_clone_name()
+
+        # create an isolated-namespace source subvolume
+        self._fs_cmd("subvolume", "create", self.volname, subvolume, "--mode=777", "--namespace-isolated")
+
+        # do some IO
+        self._do_subvolume_io(subvolume, number_of_files=32)
+
+        # snapshot subvolume
+        self._fs_cmd("subvolume", "snapshot", "create", self.volname, subvolume, snapshot)
+
+        # schedule a clone with a fresh, isolated namespace
+        self._fs_cmd("subvolume", "snapshot", "clone", self.volname, subvolume, snapshot, clone, "--namespace-isolated")
+
+        # check clone status
+        self._wait_for_clone_to_complete(clone)
+
+        # verify the clone got its own fresh namespace, not the source's
+        source_namespace = f'fsvolumens___nogroup_{subvolume}'
+        expected_namespace = f'fsvolumens___nogroup_{clone}'
+        self._verify_clone(subvolume, snapshot, clone, clone_pool_namespace=expected_namespace)
+
+        clone_info = json.loads(self._get_subvolume_info(self.volname, clone))
+        self.assertEqual(clone_info["pool_namespace"], expected_namespace)
+        self.assertNotEqual(clone_info["pool_namespace"], source_namespace)
+
+        # remove snapshot
+        self._fs_cmd("subvolume", "snapshot", "rm", self.volname, subvolume, snapshot)
+
+        # remove subvolumes
+        self._fs_cmd("subvolume", "rm", self.volname, subvolume)
+        self._fs_cmd("subvolume", "rm", self.volname, clone)
+
+        # verify trash dir is clean
+        self._wait_for_trash_empty()
+
+    def test_subvolume_snapshot_clone_namespace_isolated_with_pool_layout(self):
+        subvolume = self._gen_subvol_name()
+        snapshot = self._gen_subvol_snap_name()
+        clone = self._gen_subvol_clone_name()
+
+        # add data pool
+        new_pool = "new_pool"
+        self.fs.add_data_pool(new_pool)
+
+        # create subvolume
+        self._fs_cmd("subvolume", "create", self.volname, subvolume, "--mode=777")
+
+        # do some IO
+        self._do_subvolume_io(subvolume, number_of_files=32)
+
+        # snapshot subvolume
+        self._fs_cmd("subvolume", "snapshot", "create", self.volname, subvolume, snapshot)
+
+        # schedule a clone into a new pool with a fresh, isolated namespace
+        self._fs_cmd("subvolume", "snapshot", "clone", self.volname, subvolume, snapshot, clone,
+                     "--pool_layout", new_pool, "--namespace-isolated")
+
+        # check clone status
+        self._wait_for_clone_to_complete(clone)
+
+        # verify clone
+        expected_namespace = f'fsvolumens___nogroup_{clone}'
+        self._verify_clone(subvolume, snapshot, clone, clone_pool=new_pool, clone_pool_namespace=expected_namespace)
+
+        clone_info = json.loads(self._get_subvolume_info(self.volname, clone))
+        self.assertEqual(clone_info["data_pool"], new_pool)
+        self.assertEqual(clone_info["pool_namespace"], expected_namespace)
+
+        # remove snapshot
+        self._fs_cmd("subvolume", "snapshot", "rm", self.volname, subvolume, snapshot)
+
+        # remove subvolumes
+        self._fs_cmd("subvolume", "rm", self.volname, subvolume)
+        self._fs_cmd("subvolume", "rm", self.volname, clone)
+
+        # verify trash dir is clean
+        self._wait_for_trash_empty()
+
+    def test_subvolume_snapshot_clone_namespace_isolated_to_target_group(self):
+        subvolume = self._gen_subvol_name()
+        snapshot = self._gen_subvol_snap_name()
+        clone = self._gen_subvol_clone_name()
+        group = self._gen_subvol_grp_name()
+
+        # create subvolume
+        self._fs_cmd("subvolume", "create", self.volname, subvolume, "--mode=777")
+
+        # do some IO
+        self._do_subvolume_io(subvolume, number_of_files=32)
+
+        # snapshot subvolume
+        self._fs_cmd("subvolume", "snapshot", "create", self.volname, subvolume, snapshot)
+
+        # create target group
+        self._fs_cmd("subvolumegroup", "create", self.volname, group)
+
+        # schedule a clone into the target group with a fresh, isolated namespace
+        self._fs_cmd("subvolume", "snapshot", "clone", self.volname, subvolume, snapshot, clone,
+                     "--target_group_name", group, "--namespace-isolated")
+
+        # check clone status
+        self._wait_for_clone_to_complete(clone, clone_group=group)
+
+        # verify clone
+        expected_namespace = f'fsvolumens__{group}_{clone}'
+        self._verify_clone(subvolume, snapshot, clone, clone_group=group, clone_pool_namespace=expected_namespace)
+
+        clone_info = json.loads(self._get_subvolume_info(self.volname, clone, group))
+        self.assertEqual(clone_info["pool_namespace"], expected_namespace)
+
+        # remove snapshot
+        self._fs_cmd("subvolume", "snapshot", "rm", self.volname, subvolume, snapshot)
+
+        # remove subvolumes
+        self._fs_cmd("subvolume", "rm", self.volname, subvolume)
+        self._fs_cmd("subvolume", "rm", self.volname, clone, group)
+
+        # remove group
+        self._fs_cmd("subvolumegroup", "rm", self.volname, group)
+
+        # verify trash dir is clean
+        self._wait_for_trash_empty()
+
+    def test_subvolume_snapshot_clone_pool_layout_preserve_namespace(self):
+        subvolume = self._gen_subvol_name()
+        snapshot = self._gen_subvol_snap_name()
+        clone = self._gen_subvol_clone_name()
+
+        # add data pool
+        new_pool = "new_pool"
+        self.fs.add_data_pool(new_pool)
+
+        # create an isolated-namespace source subvolume
+        self._fs_cmd("subvolume", "create", self.volname, subvolume, "--mode=777", "--namespace-isolated")
+
+        # do some IO
+        self._do_subvolume_io(subvolume, number_of_files=32)
+
+        # snapshot subvolume
+        self._fs_cmd("subvolume", "snapshot", "create", self.volname, subvolume, snapshot)
+
+        # a namespace only has meaning within the pool it was created in, so
+        # --preserve-namespace is rejected when --pool_layout names a
+        # different pool than the source subvolume's
+        self.negtest_ceph_cmd(
+            args=f'fs subvolume snapshot clone {self.volname} {subvolume} {snapshot} {clone} '
+                 f'--pool_layout {new_pool} --preserve-namespace',
+            retval=errno.EINVAL,
+            errmsgs=('differs from the source',))
+
+        # verify the clone subvolume was not created
+        try:
+            self._fs_cmd("subvolume", "getpath", self.volname, clone)
+        except CommandFailedError as ce:
+            self.assertEqual(ce.exitstatus, errno.ENOENT, "invalid error code on getpath of non-existent clone")
+        else:
+            self.fail("expected the 'fs subvolume getpath' command to fail for a rejected clone")
+
+        # schedule a clone into the same pool as the source, preserving the namespace
+        source_pool = json.loads(self._get_subvolume_info(self.volname, subvolume))["data_pool"]
+        self._fs_cmd("subvolume", "snapshot", "clone", self.volname, subvolume, snapshot, clone,
+                     "--pool_layout", source_pool, "--preserve-namespace")
+
+        # check clone status
+        self._wait_for_clone_to_complete(clone)
+
+        # verify clone
+        source_namespace = f'fsvolumens___nogroup_{subvolume}'
+        self._verify_clone(subvolume, snapshot, clone, clone_pool=source_pool, clone_pool_namespace=source_namespace)
+
+        clone_info = json.loads(self._get_subvolume_info(self.volname, clone))
+        self.assertEqual(clone_info["data_pool"], source_pool)
+        self.assertEqual(clone_info["pool_namespace"], source_namespace)
+
+        # remove snapshot
+        self._fs_cmd("subvolume", "snapshot", "rm", self.volname, subvolume, snapshot)
+
+        # remove subvolumes
+        self._fs_cmd("subvolume", "rm", self.volname, subvolume)
+        self._fs_cmd("subvolume", "rm", self.volname, clone)
+
+        # verify trash dir is clean
+        self._wait_for_trash_empty()
+
+    def test_subvolume_snapshot_clone_preserve_namespace_without_pool_layout(self):
+        subvolume = self._gen_subvol_name()
+        snapshot = self._gen_subvol_snap_name()
+        clone = self._gen_subvol_clone_name()
+
+        # create an isolated-namespace source subvolume
+        self._fs_cmd("subvolume", "create", self.volname, subvolume, "--mode=777", "--namespace-isolated")
+
+        # do some IO
+        self._do_subvolume_io(subvolume, number_of_files=32)
+
+        # snapshot subvolume
+        self._fs_cmd("subvolume", "snapshot", "create", self.volname, subvolume, snapshot)
+
+        # schedule a clone with --preserve-namespace alone; this is a no-op
+        # since the namespace is inherited by default when --pool_layout is absent
+        self._fs_cmd("subvolume", "snapshot", "clone", self.volname, subvolume, snapshot, clone, "--preserve-namespace")
+
+        # check clone status
+        self._wait_for_clone_to_complete(clone)
+
+        # verify clone matches the default inherit-from-snapshot behavior
+        self._verify_clone(subvolume, snapshot, clone)
+
+        # remove snapshot
+        self._fs_cmd("subvolume", "snapshot", "rm", self.volname, subvolume, snapshot)
+
+        # remove subvolumes
+        self._fs_cmd("subvolume", "rm", self.volname, subvolume)
+        self._fs_cmd("subvolume", "rm", self.volname, clone)
+
+        # verify trash dir is clean
+        self._wait_for_trash_empty()
+
+    def test_subvolume_snapshot_clone_preserve_namespace_from_non_isolated_source(self):
+        subvolume = self._gen_subvol_name()
+        snapshot = self._gen_subvol_snap_name()
+        clone = self._gen_subvol_clone_name()
+
+        # add data pool
+        new_pool = "new_pool"
+        self.fs.add_data_pool(new_pool)
+
+        # create a plain (non-isolated) source subvolume
+        self._fs_cmd("subvolume", "create", self.volname, subvolume, "--mode=777")
+
+        # do some IO
+        self._do_subvolume_io(subvolume, number_of_files=32)
+
+        # snapshot subvolume
+        self._fs_cmd("subvolume", "snapshot", "create", self.volname, subvolume, snapshot)
+
+        # --preserve-namespace with a --pool_layout naming a different pool is
+        # rejected regardless of whether the source subvolume is namespace-isolated
+        self.negtest_ceph_cmd(
+            args=f'fs subvolume snapshot clone {self.volname} {subvolume} {snapshot} {clone} '
+                 f'--pool_layout {new_pool} --preserve-namespace',
+            retval=errno.EINVAL,
+            errmsgs=('differs from the source',))
+
+        # verify the clone subvolume was not created
+        try:
+            self._fs_cmd("subvolume", "getpath", self.volname, clone)
+        except CommandFailedError as ce:
+            self.assertEqual(ce.exitstatus, errno.ENOENT, "invalid error code on getpath of non-existent clone")
+        else:
+            self.fail("expected the 'fs subvolume getpath' command to fail for a rejected clone")
+
+        # schedule a clone into the same pool as the source with --preserve-namespace;
+        # harmless no-op since the source never had a namespace to preserve
+        source_pool = json.loads(self._get_subvolume_info(self.volname, subvolume))["data_pool"]
+        self._fs_cmd("subvolume", "snapshot", "clone", self.volname, subvolume, snapshot, clone,
+                     "--pool_layout", source_pool, "--preserve-namespace")
+
+        # check clone status
+        self._wait_for_clone_to_complete(clone)
+
+        # verify clone
+        self._verify_clone(subvolume, snapshot, clone, clone_pool=source_pool, clone_pool_namespace="")
+
+        clone_info = json.loads(self._get_subvolume_info(self.volname, clone))
+        self.assertEqual(clone_info["data_pool"], source_pool)
+        self.assertEqual(clone_info["pool_namespace"], "")
+
+        # remove snapshot
+        self._fs_cmd("subvolume", "snapshot", "rm", self.volname, subvolume, snapshot)
+
+        # remove subvolumes
+        self._fs_cmd("subvolume", "rm", self.volname, subvolume)
+        self._fs_cmd("subvolume", "rm", self.volname, clone)
+
+        # verify trash dir is clean
+        self._wait_for_trash_empty()
+
+    def test_subvolume_snapshot_clone_namespace_flags_mutually_exclusive(self):
+        subvolume = self._gen_subvol_name()
+        snapshot = self._gen_subvol_snap_name()
+        clone = self._gen_subvol_clone_name()
+
+        # create subvolume
+        self._fs_cmd("subvolume", "create", self.volname, subvolume, "--mode=777")
+
+        # do some IO
+        self._do_subvolume_io(subvolume, number_of_files=1)
+
+        # snapshot subvolume
+        self._fs_cmd("subvolume", "snapshot", "create", self.volname, subvolume, snapshot)
+
+        # attempt a clone with both mutually exclusive namespace flags
+        self.negtest_ceph_cmd(
+            args=f'fs subvolume snapshot clone {self.volname} {subvolume} {snapshot} {clone} '
+                 f'--namespace-isolated --preserve-namespace',
+            retval=errno.EINVAL,
+            errmsgs=('mutually exclusive',))
+
+        # verify the clone subvolume was not created
+        try:
+            self._fs_cmd("subvolume", "getpath", self.volname, clone)
+        except CommandFailedError as ce:
+            self.assertEqual(ce.exitstatus, errno.ENOENT, "invalid error code on getpath of non-existent clone")
+        else:
+            self.fail("expected the 'fs subvolume getpath' command to fail for a rejected clone")
+
+        # remove snapshot
+        self._fs_cmd("subvolume", "snapshot", "rm", self.volname, subvolume, snapshot)
+
+        # remove subvolume
+        self._fs_cmd("subvolume", "rm", self.volname, subvolume)
 
         # verify trash dir is clean
         self._wait_for_trash_empty()

--- a/src/pybind/mgr/volumes/fs/operations/subvolume.py
+++ b/src/pybind/mgr/volumes/fs/operations/subvolume.py
@@ -28,7 +28,7 @@ def create_subvol(mgr, fs, vol_spec, group, subvolname, size, isolate_nspace, po
     subvolume.create(size, isolate_nspace, pool, mode, uid, gid, earmark, normalization, casesensitive, enctag)
 
 
-def create_clone(mgr, fs, vol_spec, group, subvolname, pool, source_volume, source_subvolume, snapname):
+def create_clone(mgr, fs, vol_spec, group, subvolname, pool, source_volume, source_subvolume, snapname, namespace_isolated=False, preserve_namespace=False):
     """
     create a cloned subvolume.
 
@@ -40,10 +40,13 @@ def create_clone(mgr, fs, vol_spec, group, subvolname, pool, source_volume, sour
     :param source_volume: source subvolumes volume name
     :param source_subvolume: source (parent) subvolume object
     :param snapname: source subvolume snapshot
+    :param namespace_isolated: If true, use separate RADOS namespace for this clone
+    :param preserve_namespace: If true, keep the source snapshot's RADOS namespace on the
+                                clone instead of clearing it when pool is also provided
     :return None
     """
     subvolume = loaded_subvolumes.get_subvolume_object_max(mgr, fs, vol_spec, group, subvolname)
-    subvolume.create_clone(pool, source_volume, source_subvolume, snapname)
+    subvolume.create_clone(pool, source_volume, source_subvolume, snapname, namespace_isolated, preserve_namespace)
 
 
 def remove_subvol(mgr, fs, vol_spec, group, subvolname, force=False, retainsnaps=False):

--- a/src/pybind/mgr/volumes/fs/operations/template.py
+++ b/src/pybind/mgr/volumes/fs/operations/template.py
@@ -110,7 +110,7 @@ class SubvolumeTemplate(object):
         """
         raise VolumeException(-errno.ENOTSUP, "operation not supported.")
 
-    def create_clone(self, pool, source_volname, source_subvolume, snapname):
+    def create_clone(self, pool, source_volname, source_subvolume, snapname, namespace_isolated=False, preserve_namespace=False):
         """
         prepare a subvolume to be cloned.
 
@@ -118,6 +118,9 @@ class SubvolumeTemplate(object):
         :param source_volname: source volume of snapshot
         :param source_subvolume: source subvolume of snapshot
         :param snapname: snapshot name to be cloned from
+        :param namespace_isolated: If true, use separate RADOS namespace for this clone
+        :param preserve_namespace: If true, keep the source snapshot's RADOS namespace on the
+                                    clone instead of clearing it when pool is also provided
         :return: None
         """
         raise VolumeException(-errno.ENOTSUP, "operation not supported.")

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v1.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v1.py
@@ -151,7 +151,7 @@ class SubvolumeV1(SubvolumeBase, SubvolumeTemplate):
             log.error(f"Failed to add clone failure status clone={self.subvol_name} group={self.group_name} "
                       f"reason={me.args[1]}, errno:{-me.args[0]}, {os.strerror(-me.args[0])}")
 
-    def create_clone(self, pool, source_volname, source_subvolume, snapname):
+    def create_clone(self, pool, source_volname, source_subvolume, snapname, namespace_isolated=False, preserve_namespace=False):
         subvolume_type = SubvolumeTypes.TYPE_CLONE
         try:
             initial_state = SubvolumeOpSm.get_init_state(subvolume_type)
@@ -173,8 +173,19 @@ class SubvolumeV1(SubvolumeBase, SubvolumeTemplate):
 
             # override snapshot pool setting, if one is provided for the clone
             if pool is not None:
+                source_pool = attrs["data_pool"]
+                if preserve_namespace and pool != source_pool:
+                    raise VolumeException(
+                        -errno.EINVAL,
+                        "--preserve-namespace cannot be used with --pool_layout when the "
+                        "target pool differs from the source subvolume's pool")
                 attrs["data_pool"] = pool
-                attrs["pool_namespace"] = None
+                # historical default: a pool override lands the clone in the new
+                # pool's default namespace unless the caller asks otherwise
+                if not preserve_namespace:
+                    attrs["pool_namespace"] = None
+            if namespace_isolated:
+                attrs["pool_namespace"] = self.namespace
 
             # create directory and set attributes
             self.fs.mkdirs(subvol_path, attrs.get("mode"))
@@ -832,9 +843,15 @@ class SubvolumeV1(SubvolumeBase, SubvolumeTemplate):
                           'data_pool':'ceph.dir.layout.pool'}
             for key, val in snap_attrs.items():
                 snap_info[key] = self.fs.getxattr(snappath, val)
+            try:
+                pool_namespace = self.fs.getxattr(
+                    snappath, 'ceph.dir.layout.pool_namespace').decode('utf-8')
+            except cephfs.NoData:
+                pool_namespace = ''
             pending_clones_info = self.get_pending_clones(snapname)
             info_dict = {'created_at': str(datetime.fromtimestamp(float(snap_info['created_at']))),
-                    'data_pool': snap_info['data_pool'].decode('utf-8')}
+                    'data_pool': snap_info['data_pool'].decode('utf-8'),
+                    'pool_namespace': pool_namespace}
             info_dict.update(pending_clones_info);
             return info_dict
         except cephfs.Error as e:

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
@@ -206,7 +206,7 @@ class SubvolumeV2(SubvolumeV1):
                 e = VolumeException(-e.args[0], e.args[1])
             raise e
 
-    def create_clone(self, pool, source_volname, source_subvolume, snapname):
+    def create_clone(self, pool, source_volname, source_subvolume, snapname, namespace_isolated=False, preserve_namespace=False):
         subvolume_type = SubvolumeTypes.TYPE_CLONE
         try:
             initial_state = SubvolumeOpSm.get_init_state(subvolume_type)
@@ -231,8 +231,19 @@ class SubvolumeV2(SubvolumeV1):
 
             # override snapshot pool setting, if one is provided for the clone
             if pool is not None:
+                source_pool = attrs["data_pool"]
+                if preserve_namespace and pool != source_pool:
+                    raise VolumeException(
+                        -errno.EINVAL,
+                        "--preserve-namespace cannot be used with --pool_layout when the "
+                        "target pool differs from the source subvolume's pool")
                 attrs["data_pool"] = pool
-                attrs["pool_namespace"] = None
+                # historical default: a pool override lands the clone in the new
+                # pool's default namespace unless the caller asks otherwise
+                if not preserve_namespace:
+                    attrs["pool_namespace"] = None
+            if namespace_isolated:
+                attrs["pool_namespace"] = self.namespace
 
             # create directory and set attributes
             self.fs.mkdirs(subvol_path, attrs.get("mode"))

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -1004,8 +1004,11 @@ class VolumeClient(CephfsClient["Module"]):
         s_subvolname        = kwargs['sub_name']
         s_groupname         = kwargs['group_name']
         t_groupname         = kwargs['target_group_name']
+        namespace_isolated  = kwargs.get('namespace_isolated', False)
+        preserve_namespace  = kwargs.get('preserve_namespace', False)
 
-        create_clone(self.mgr, fs_handle, self.volspec, t_group, t_subvolname, t_pool, volname, s_subvolume, s_snapname)
+        create_clone(self.mgr, fs_handle, self.volspec, t_group, t_subvolname, t_pool, volname, s_subvolume, s_snapname,
+                     namespace_isolated, preserve_namespace)
         with open_subvol(self.mgr, fs_handle, self.volspec, t_group, t_subvolname, SubvolumeOpType.CLONE_INTERNAL) as t_subvolume:
             try:
                 if t_groupname == s_groupname and t_subvolname == s_subvolname:
@@ -1049,10 +1052,14 @@ class VolumeClient(CephfsClient["Module"]):
         s_groupname  = kwargs['group_name']
 
         try:
+            if kwargs.get('namespace_isolated', False) and kwargs.get('preserve_namespace', False):
+                raise VolumeException(-errno.EINVAL,
+                                      "options --namespace-isolated and --preserve-namespace are mutually exclusive")
+
             if self.mgr.snapshot_clone_no_wait and \
                get_all_pending_clones_count(self, self.mgr, self.volspec) >= self.mgr.max_concurrent_clones:
                 raise(VolumeException(-errno.EAGAIN, "all cloner threads are busy, please try again later"))
-            
+
             with open_volume(self, volname) as fs_handle:
                 with open_group(fs_handle, self.volspec, s_groupname) as s_group:
                     with open_subvol(self.mgr, fs_handle, self.volspec, s_group, s_subvolname, SubvolumeOpType.CLONE_SOURCE) as s_subvolume:

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -585,7 +585,9 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                    'name=target_sub_name,type=CephString '
                    'name=pool_layout,type=CephString,req=false '
                    'name=group_name,type=CephString,req=false '
-                   'name=target_group_name,type=CephString,req=false ',
+                   'name=target_group_name,type=CephString,req=false '
+                   'name=namespace_isolated,type=CephBool,req=false '
+                   'name=preserve_namespace,type=CephBool,req=false ',
             'desc': "Clone a snapshot to target subvolume",
             'perm': 'rw'
         },
@@ -1136,7 +1138,9 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.vc.clone_subvolume_snapshot(
             vol_name=cmd['vol_name'], sub_name=cmd['sub_name'], snap_name=cmd['snap_name'],
             group_name=cmd.get('group_name', None), pool_layout=cmd.get('pool_layout', None),
-            target_sub_name=cmd['target_sub_name'], target_group_name=cmd.get('target_group_name', None))
+            target_sub_name=cmd['target_sub_name'], target_group_name=cmd.get('target_group_name', None),
+            namespace_isolated=cmd.get('namespace_isolated', False),
+            preserve_namespace=cmd.get('preserve_namespace', False))
 
     @mgr_cmd_wrap
     def _cmd_fs_clone_status(self, inbuf, cmd):


### PR DESCRIPTION
In this PR, I am proposing adding two new flags to the clone commands in the Manager pybind:

* `--namespace-isolated` - to create a new, unique, isolated pool namespace for the clone, exactly the same as it currently works for `ceph fs subvolume create` today
* `--preserve-namespace` - to preserve the existing pool namespace of the source subvolume when creating a clone, even when `--pool_layout` is specified, as long as the source and destination data pool are the same

The `--namespace-isolated` flag proposed here should behave identically to the existing one in the subvolume create flow, and it should not be impacted by the data pool specified in the request, whether or not the source/destination ones differ.

The `--preserve-namespace` flag is proposed here as an alternative to changing default behaviors, but I'm very much open to the idea of changing the default, should that be tolerable. Right now, [we explicitly unset the `pool_namespace` when `--pool_layout` is specified](https://github.com/ceph/ceph/blob/76df7a90b27dddcfb888d7008348f811a4ae50e7/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py#L232-L235), which is the default for Ceph CSI (and by extension, Rook) when a data pool is specified in the Kubernetes StorageClass. The current behavior makes perfect sense when the clone target is in a different data pool than the source subvolume/snapshot, but (imo) it results in a confusing end result for those who expect the clone to reside within the same namespace as the original source by default. If this new option is preferred to changing the default behavior, I will make a PR for the relevant change in Ceph CSI, allowing cluster admins who wish to use it to set the relevant flag in their k8s StorageClass.

Other than the discussion around whether the new flag is preferred to changing the default behavior, I would also like to note that I have made it error when the user passes in the new `--preserve-namespace` flag while also passing in a `--pool_layout` value that differs from the source data pool, as there's nothing to preserve there. I would be open to silently reverting to the current default behavior when source/destination data pools mismatch, but I did it this way to prevent the case where someone expecting that to remain the same might be surprised when it reverts to the default data pool.

Would love to hear thoughts and feedback from other contributors on the above.

Fixes: https://tracker.ceph.com/issues/79589

---

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
