### PR TITLE
rgw/multisite:  validate the cached version on metadata sync reads

### DIFF
--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -3619,10 +3619,9 @@ int RGWBucketCtl::link_bucket(librados::Rados& rados,
 
   if (update_entrypoint) {
     meta_key = RGWSI_Bucket::get_entrypoint_meta_key(bucket);
-    if (pinfo) {
-      ep = pinfo->ep;
-      pattrs = &pinfo->attrs;
-    } else {
+    /* store_bucket_entrypoint_info() below needs the current version, or
+     * the correspoding mdlog entry has an empty tag and zero version */
+    if (!pinfo || rot.read_version.tag.empty()) {
       ret = svc.bucket->read_bucket_entrypoint_info(meta_key,
                                                     &ep, &rot,
                                                     nullptr, &attrs,
@@ -3632,6 +3631,10 @@ int RGWBucketCtl::link_bucket(librados::Rados& rados,
                       << cpp_strerror(-ret) << dendl;
       }
       pattrs = &attrs;
+    }
+    if (pinfo) {
+      ep = pinfo->ep;
+      pattrs = &pinfo->attrs;
     }
   }
 

--- a/src/rgw/driver/rados/rgw_sync.cc
+++ b/src/rgw/driver/rados/rgw_sync.cc
@@ -1043,6 +1043,16 @@ public:
   }
 };
 
+/* version the entry left the object at. apply_write() moves write_version
+ * into read_version, so read_version is the one to use */
+static obj_version mdlog_entry_version(const RGWMetadataLogData& log_data)
+{
+  if (!log_data.read_version.empty()) {
+    return log_data.read_version;
+  }
+  return log_data.write_version;
+}
+
 static string full_sync_index_shard_oid(int shard_id)
 {
   return fmt::format("{}.{}", mdlog_sync_full_sync_index_prefix, shard_id);
@@ -1063,14 +1073,18 @@ class RGWReadRemoteMetadataCR : public RGWCoroutine {
   int tries{0};
   int op_ret{0};
 
+  obj_version expected_version;
+
 public:
   RGWReadRemoteMetadataCR(RGWMetaSyncEnv *_sync_env,
                                                       const string& _section, const string& _key, bufferlist *_pbl,
-                                                      const RGWSyncTraceNodeRef& _tn_parent) : RGWCoroutine(_sync_env->cct), sync_env(_sync_env),
+                                                      const RGWSyncTraceNodeRef& _tn_parent,
+                                                      const obj_version& _expected_version = obj_version{}) : RGWCoroutine(_sync_env->cct), sync_env(_sync_env),
                                                       http_op(NULL),
                                                       section(_section),
                                                       key(_key),
-                                                      pbl(_pbl) {
+                                                      pbl(_pbl),
+                                                      expected_version(_expected_version) {
     tn = sync_env->sync_tracer->add_node(_tn_parent, "read_remote_meta",
                                          section + ":" + key);
   }
@@ -1087,10 +1101,20 @@ public:
           url_encode(key, key_encode);
           rgw_http_param_pair pairs[] = { { "key" , key.c_str()},
                                           { NULL, NULL } };
+          param_vec_t params = make_param_list(pairs);
+
+          /* ask the remote for this version, so its stale cache is not
+           * replicated to us. older peers ignore these params */
+          if (!expected_version.tag.empty()) {
+            params.emplace_back(RGW_SYS_PARAM_PREFIX "expected-version-tag",
+                                expected_version.tag);
+            params.emplace_back(RGW_SYS_PARAM_PREFIX "expected-version-ver",
+                                std::to_string(expected_version.ver));
+          }
 
           string p = string("/admin/metadata/") + section + "/" + key_encode;
 
-          http_op = new RGWRESTReadResource(conn, p, pairs, NULL, sync_env->http_manager);
+          http_op = new RGWRESTReadResource(conn, p, params, NULL, sync_env->http_manager);
 
           init_new_io(http_op);
 
@@ -1298,12 +1322,14 @@ public:
 RGWMetaSyncSingleEntryCR::RGWMetaSyncSingleEntryCR(RGWMetaSyncEnv *_sync_env,
 		           const string& _raw_key, const string& _entry_marker,
                            const RGWMDLogStatus& _op_status,
-                           RGWMetaSyncShardMarkerTrack *_marker_tracker, const RGWSyncTraceNodeRef& _tn_parent) : RGWCoroutine(_sync_env->cct),
+                           RGWMetaSyncShardMarkerTrack *_marker_tracker, const RGWSyncTraceNodeRef& _tn_parent,
+                           const obj_version& _expected_version) : RGWCoroutine(_sync_env->cct),
                                                       sync_env(_sync_env),
 						      raw_key(_raw_key), entry_marker(_entry_marker),
                                                       op_status(_op_status),
                                                       pos(0), sync_status(0),
-                                                      marker_tracker(_marker_tracker), tries(0) {
+                                                      marker_tracker(_marker_tracker), tries(0),
+                                                      expected_version(_expected_version) {
   error_injection = (sync_env->cct->_conf->rgw_sync_meta_inject_err_probability > 0);
   tn = sync_env->sync_tracer->add_node(_tn_parent, "entry", raw_key);
 }
@@ -1332,7 +1358,8 @@ int RGWMetaSyncSingleEntryCR::operate(const DoutPrefixProvider *dpp) {
         section = raw_key.substr(0, pos);
         key = raw_key.substr(pos + 1);
         tn->log(10, SSTR("fetching remote metadata entry" << (tries == 0 ? "" : " (retry)")));
-        call(new RGWReadRemoteMetadataCR(sync_env, section, key, &md_bl, tn));
+        call(new RGWReadRemoteMetadataCR(sync_env, section, key, &md_bl, tn,
+                                         expected_version));
       }
 
       sync_status = retcode;
@@ -1920,7 +1947,8 @@ public:
             } else {
               raw_key = log_iter->section + ":" + log_iter->name;
               yield {
-                RGWCoroutinesStack *stack = spawn(new RGWMetaSyncSingleEntryCR(sync_env, raw_key, log_iter->id, mdlog_entry.log_data.status, marker_tracker, tn), false);
+                RGWCoroutinesStack *stack = spawn(new RGWMetaSyncSingleEntryCR(sync_env, raw_key, log_iter->id, mdlog_entry.log_data.status, marker_tracker, tn,
+                                                              mdlog_entry_version(mdlog_entry.log_data)), false);
                 ceph_assert(stack);
                 // stack_to_pos holds a reference to the stack
                 stack_to_pos[stack] = log_iter->id;

--- a/src/rgw/driver/rados/rgw_sync.h
+++ b/src/rgw/driver/rados/rgw_sync.h
@@ -504,11 +504,14 @@ class RGWMetaSyncSingleEntryCR : public RGWCoroutine {
 
   RGWSyncTraceNodeRef tn;
 
+  obj_version expected_version;
+
 public:
   RGWMetaSyncSingleEntryCR(RGWMetaSyncEnv *_sync_env,
                            const std::string& _raw_key, const std::string& _entry_marker,
                            const RGWMDLogStatus& _op_status,
-                           RGWMetaSyncShardMarkerTrack *_marker_tracker, const RGWSyncTraceNodeRef& _tn_parent);
+                           RGWMetaSyncShardMarkerTrack *_marker_tracker, const RGWSyncTraceNodeRef& _tn_parent,
+                           const obj_version& _expected_version = obj_version{});
 
   int operate(const DoutPrefixProvider *dpp) override;
 };

--- a/src/rgw/driver/rados/topic.cc
+++ b/src/rgw/driver/rados/topic.cc
@@ -56,15 +56,22 @@ int read(const DoutPrefixProvider* dpp, optional_yield y,
          rgw_pubsub_topic& info, RGWChainedCacheImpl<cache_entry>& cache,
          ceph::real_time* pmtime, RGWObjVersionTracker* pobjv)
 {
+  auto expected_version = rgw_expected_version(dpp);
   if (auto e = cache.find(topic_key)) {
-    if (pmtime) {
-      *pmtime = e->mtime;
+    /* check for expected version in chained cache entry */
+    if (expected_version &&
+        !e->objv.read_version.compare(&(*expected_version))) {
+      cache.invalidate(topic_key);
+    } else {
+      if (pmtime) {
+        *pmtime = e->mtime;
+      }
+      if (pobjv) {
+        *pobjv = std::move(e->objv);
+      }
+      info = std::move(e->info);
+      return 0;
     }
-    if (pobjv) {
-      *pobjv = std::move(e->objv);
-    }
-    info = std::move(e->info);
-    return 0;
   }
 
   const rgw_raw_obj obj = get_topic_obj(zone, topic_key);

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1422,6 +1422,9 @@ struct req_state : DoutPrefixProvider {
   /* Is the request made by an user marked as a system one?
    * Being system user means we also have the admin status. */
   bool system_request{false};
+  /* In multisite setup, secondary sends expected version of the metadata
+   * using the params: rgwx-expected-version-* on admin metadata GET */
+  boost::optional<obj_version> expected_version;
 
   std::string canned_acl;
   bool has_acl_header{false};
@@ -1481,6 +1484,14 @@ struct req_state : DoutPrefixProvider {
   CephContext* get_cct() const override { return cct; }
   unsigned get_subsys() const override { return ceph_subsys_rgw; }
 };
+
+/* check whether req_state (dpp) contains expected version */
+inline boost::optional<obj_version>
+rgw_expected_version(const DoutPrefixProvider *dpp)
+{
+  auto s = dynamic_cast<const req_state*>(dpp);
+  return s ? s->expected_version : boost::none;
+}
 
 void set_req_state_err(req_state*, int);
 void set_req_state_err(req_state*, int, const std::string&);

--- a/src/rgw/rgw_rest_metadata.cc
+++ b/src/rgw/rgw_rest_metadata.cc
@@ -61,6 +61,30 @@ void RGWOp_Metadata_Get::execute(optional_yield y) {
 #ifdef WITH_RADOSGW_RADOS
   auto meta_mgr = static_cast<rgw::sal::RadosStore*>(driver)->ctl()->meta.mgr;
 
+  /* a syncing peer sends the version it expects; a cache entry that is
+   * not at that version is re-read from rados */
+  if (s->system_request) {
+    bool ver_exists = false, tag_exists = false;
+    string ver_str = s->info.args.sys_get(RGW_SYS_PARAM_PREFIX "expected-version-ver", &ver_exists);
+    string tag_str = s->info.args.sys_get(RGW_SYS_PARAM_PREFIX "expected-version-tag", &tag_exists);
+    if (ver_exists && tag_exists && !tag_str.empty()) {
+      string err;
+      const uint64_t ver = strict_strtoll(ver_str.c_str(), 10, &err);
+      if (!err.empty()) {
+        ldpp_dout(s, 5) << "ERROR: invalid " << RGW_SYS_PARAM_PREFIX
+            << "expected-version-ver=" << ver_str << ": " << err << dendl;
+        op_ret = -EINVAL;
+        return;
+      }
+      obj_version v;
+      v.ver = ver;
+      v.tag = std::move(tag_str);
+      s->expected_version = v;
+      ldpp_dout(s, 20) << "metadata get: key=" << metadata_key
+          << " expected_version=" << v.tag << ":" << v.ver << dendl;
+    }
+  }
+
   /* Get keys */
   op_ret = meta_mgr->get(metadata_key, s->formatter, s->yield, s);
   if (op_ret < 0) {

--- a/src/rgw/services/svc_bucket_sobj.cc
+++ b/src/rgw/services/svc_bucket_sobj.cc
@@ -232,9 +232,12 @@ int RGWSI_Bucket_SObj::read_bucket_instance_info(const string& key,
   string cache_key("bi/");
   cache_key.append(key);
 
+  auto expected_version = rgw_expected_version(dpp);
   if (auto e = binfo_cache->find(cache_key)) {
-    if (refresh_version &&
-        e->info.objv_tracker.read_version.compare(&(*refresh_version))) {
+    if ((refresh_version &&
+         e->info.objv_tracker.read_version.compare(&(*refresh_version))) ||
+        (expected_version &&
+         !e->info.objv_tracker.read_version.compare(&(*expected_version)))) {
       ldpp_dout(dpp, -1) << "WARNING: The bucket info cache is inconsistent. This is "
         << "a failure that should be debugged. I am a nice machine, "
         << "so I will try to recover." << dendl;
@@ -340,13 +343,16 @@ int RGWSI_Bucket_SObj::read_bucket_info(const rgw_bucket& bucket,
   string cache_key("b/");
   cache_key.append(bucket_entry);
 
+  auto expected_version = rgw_expected_version(dpp);
   if (auto e = binfo_cache->find(cache_key)) {
     bool found_version = (bucket.bucket_id.empty() ||
                           bucket.bucket_id == e->info.bucket.bucket_id);
 
     if (!found_version ||
         (refresh_version &&
-         e->info.objv_tracker.read_version.compare(&(*refresh_version)))) {
+         e->info.objv_tracker.read_version.compare(&(*refresh_version))) ||
+        (expected_version &&
+         !e->info.objv_tracker.read_version.compare(&(*expected_version)))) {
       ldpp_dout(dpp, -1) << "WARNING: The bucket info cache is inconsistent. This is "
         << "a failure that should be debugged. I am a nice machine, "
         << "so I will try to recover." << dendl;

--- a/src/rgw/services/svc_sys_obj_cache.cc
+++ b/src/rgw/services/svc_sys_obj_cache.cc
@@ -146,9 +146,14 @@ int RGWSI_SysObj_Cache::read(const DoutPrefixProvider *dpp,
   if (attrs)
     flags |= CACHE_FLAG_XATTRS;
   
+  /* refresh_version is the version the caller already holds, so a match means
+   * the cache has nothing newer. expected_version is the version the caller
+   * requires, so a mismatch means the cache missed an update. */
+  auto expected_version = rgw_expected_version(dpp);
   int r = cache.get(dpp, name, info, flags, cache_info);
   if (r == 0 &&
-      (!refresh_version || !info.version.compare(&(*refresh_version)))) {
+      (!refresh_version || !info.version.compare(&(*refresh_version))) &&
+      (!expected_version || info.version.compare(&(*expected_version)))) {
     if (info.status < 0)
       return info.status;
 

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -7110,3 +7110,84 @@ def test_stale_bucket_owner_after_concurrent_chown():
         for uid in (uid_a, uid_b1, uid_b2):
             master.zone.cluster.admin(['user', 'rm', '--uid', uid, '--purge-data'],
                                       check_retcode=False)
+
+def _get_metadata(zone_conn, key):
+    """ read metadata via radosgw-admin, which sees rados rather than a
+    gateway cache """
+    out, _ = zone_conn.zone.cluster.admin(
+        ['metadata', 'get', key] + zone_conn.zone.zone_args(), read_only=True)
+    return json.loads(out)['data']
+
+def test_stale_bucket_owner_after_dropped_cache_notify():
+    """ Integration test for https://tracker.ceph.com/issues/77731
+
+    To simulate dropped notification, metadata is changed with the cache disabled, so the gateways get no
+    invalidation and keep serving the old values. A secondary syncing from
+    them must still get the new ones.
+    """
+    zonegroup = realm.master_zonegroup()
+    zonegroup_conns = ZonegroupConns(zonegroup)
+    if len(zonegroup_conns.rw_zones) < 2:
+        raise SkipTest('test_stale_bucket_owner_after_dropped_cache_notify requires at least 2 read-write zones')
+
+    master = zonegroup_conns.master_zone
+    secondary = next(z for z in zonegroup_conns.rw_zones if z != master)
+
+    owner = run_prefix + '-drop-a'
+    new_owner = run_prefix + '-drop-b'
+    new_display_name = owner + '-renamed'
+    creds = Credentials(owner + 'AK', owner + 'SK')
+
+    for uid in (owner, new_owner):
+        master.zone.cluster.admin(['user', 'create',
+                                   '--uid', uid, '--display-name', uid,
+                                   '--access-key', uid + 'AK',
+                                   '--secret-key', uid + 'SK'])
+    zonegroup_meta_checkpoint(zonegroup)
+
+    region = zonegroup.name
+    bucket_name = gen_bucket_name()
+    bucket_key = 'bucket:' + bucket_name
+    user_key = 'user:' + owner
+
+    try:
+        get_gateway_connection(master.zone.gateways[0], creds, region).create_bucket(Bucket=bucket_name)
+        zonegroup_meta_checkpoint(zonegroup)
+
+        # cache the pre-change values on every gateway that could serve the
+        # sync request
+        for gw in master.zone.gateways:
+            get_gateway_connection(gw, creds, region).head_bucket(Bucket=bucket_name)
+
+        # disable rgw cache, to simulate dropped notification. RGW cache will serve stale
+        # metadata
+        master.zone.cluster.admin(['bucket', 'link', '--bucket', bucket_name,
+                                   '--uid', new_owner, '--rgw-cache-enabled=false'])
+        master.zone.cluster.admin(['user', 'modify', '--uid', owner,
+                                   '--display-name', new_display_name,
+                                   '--rgw-cache-enabled=false'])
+
+        # catches a change that never landed, so a sync failure is not misread
+        master_owner = _get_metadata(master, bucket_key)['owner']
+        assert master_owner == new_owner, \
+            'chown did not take effect on master: %r expected %r' % (master_owner, new_owner)
+        master_name = _get_metadata(master, user_key)['display_name']
+        assert master_name == new_display_name, \
+            'user modify did not take effect on master: %r expected %r' % (master_name, new_display_name)
+
+        zonegroup_meta_checkpoint(zonegroup)
+
+        second_owner = _get_metadata(secondary, bucket_key)['owner']
+        log.info('master owner=%s secondary owner=%s', master_owner, second_owner)
+        assert second_owner == new_owner, \
+            'secondary replicated a stale owner %r, expected %r' % (second_owner, new_owner)
+
+        second_name = _get_metadata(secondary, user_key)['display_name']
+        log.info('master display_name=%s secondary display_name=%s', master_name, second_name)
+        assert second_name == new_display_name, \
+            'secondary replicated a stale display_name %r, expected %r' % (second_name, new_display_name)
+
+    finally:
+        for uid in (owner, new_owner):
+            master.zone.cluster.admin(['user', 'rm', '--uid', uid, '--purge-data'],
+                                      check_retcode=False)


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/77731

If a `distribute_cache()` notification is lost, RGW gateways keep serving stale metadata until `rgw_cache_expiry_interval`. PR #69748 guards against a late cache update overwriting a newer one, but a dropped notification leaves no update to reject.

In multisite this leads to durable wrong metadata on the secondary, typically a **_403 AccessDenied_** from an obsolete owner, while sync status reports no errors.

Every _mdlog entry_ in secondary sync already contains the _expected version_ of the metadata to be fetched from master. That version is now sent to the master as _rgwx-expected-version-*_ params on the **GET** request, and the master answers from its cache only when the entry is at that version, otherwise reading from RADOS. 

Fixed `link_bucket()`, which wrote the bucket _entrypoint_ and its _mdlog entry_ without a version **(empty tag, ver 0)**. Both `bucket link` and `bucket chown` were affected, from the CLI and the admin REST API.

Known gaps: full sync does not rely on mdlog entry and hence no expected-version is sent. Account and group changes are never written to the mdlog.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
