### PR TITLE
mgr/cephadm: reschedule smb daemons from offline hosts

### DIFF
--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_ctdb_host_offline_reschedule.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_ctdb_host_offline_reschedule.yaml
@@ -1,0 +1,105 @@
+roles:
+- - host.a
+  - mon.a
+  - mgr.x
+  - osd.0
+  - osd.1
+- - host.b
+  - mon.b
+  - osd.2
+  - osd.3
+- - host.c
+  - mon.c
+  - osd.4
+  - osd.5
+overrides:
+  ceph:
+    conf:
+      global:
+        osd_pool_default_size: 2
+        osd_pool_default_min_size: 2
+    log-ignorelist:
+      - CEPHADM_STRAY_HOST
+      - CEPHADM_STRAY_DAEMON
+      - CEPHADM_FAILED_DAEMON
+      - OSD_DOWN
+      - OSD_HOST_DOWN
+      - MON_DOWN
+      - mons down
+      - mon down
+      - out of quorum
+      - \(REQUEST_STUCK\)
+    log-only-match:
+      - CEPHADM_
+tasks:
+- pexec:
+    all:
+      - sudo setsebool -P virt_sandbox_use_netlink 1 || true
+- cephadm:
+
+- cephadm.shell:
+    host.a:
+      - cmd: ceph config set mgr mgr/cephadm/host_check_interval 60
+      - cmd: ceph config set mgr mgr/cephadm/daemon_cache_timeout 60
+
+- cephadm.shell:
+    host.a:
+      - ceph fs volume create cephfs
+- cephadm.wait_for_service:
+    service: mds.cephfs
+
+- cephadm.shell:
+    host.a:
+      # add subvolgroup & subvolume for test
+      - cmd: ceph fs subvolumegroup create cephfs smb
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
+      # set up smb cluster and share. count:2 across 3 eligible hosts
+      # (a/b/c) leaves one host free for cephadm to reschedule onto.
+      - cmd: ceph mgr module enable smb
+      - cmd: sleep 30
+      - cmd: >
+          ceph smb cluster create hoffl1 user
+          --define-user-pass=user1%t3stP4ss1
+          --placement=count:2
+          --clustering=default
+      - cmd: ceph smb share create hoffl1 share1 cephfs / --subvolume=smb/sv1
+- cephadm.wait_for_service:
+    service: smb.hoffl1
+
+# verify CTDB is healthy, cluster well formed across both initial hosts.
+# Doesn't use smb.workunit's ctdb_healthy check here because that assumes
+# admin_role also runs the daemon, which count:2 across 3 hosts doesn't
+# guarantee.
+- smb.wait_for_ctdb_healthy:
+    admin_role: host.a
+    cluster_id: hoffl1
+    node_count: 2
+
+# power off whichever host is currently running an smb daemon for this
+# cluster except host.a and restored automatically once the job finishes,
+# even if a later check below fails first.
+- smb.power_off_smb_daemon_host:
+    admin_role: host.a
+    cluster_id: hoffl1
+
+# Wait for the smb service to redeploy the relocated rank
+- cephadm.wait_for_service:
+    service: smb.hoffl1
+
+# verify cephadm actually relocated the rank onto the spare host - that's
+# what this test is checking. Don't also require CTDB to report fully
+# healthy here: that depends on CTDB's own convergence, which is a
+# separate concern from whether cephadm rescheduled the daemon.
+- smb.wait_for_ctdb_healthy:
+    admin_role: host.a
+    cluster_id: hoffl1
+    node_count: 2
+    timeout: 900
+    require_ctdb_healthy: false
+
+- cephadm.shell:
+    host.a:
+      - cmd: ceph smb share rm hoffl1 share1
+      - cmd: ceph smb cluster rm hoffl1
+- cephadm.wait_for_service_not_present:
+    service: smb.hoffl1

--- a/qa/tasks/smb.py
+++ b/qa/tasks/smb.py
@@ -6,10 +6,12 @@ import contextlib
 import copy
 import json
 import logging
+import re
 import shlex
 import time
 import threading
 
+from teuthology import contextutil
 from teuthology.exceptions import ConfigError, CommandFailedError
 from teuthology.task import ssh_keys
 
@@ -655,6 +657,207 @@ def write_metadata_file(ctx, config, *, roles=None):
                 mfile,
             ],
         )
+
+
+def _smb_daemon_hostnames(ctx, admin_remote, cluster_id, cluster_name='ceph'):
+    from .cephadm import _shell
+
+    out = StringIO()
+    _shell(
+        ctx,
+        cluster_name,
+        admin_remote,
+        args=[
+            'ceph',
+            'orch',
+            'ps',
+            '--daemon-type',
+            'smb',
+            '--format',
+            'json',
+        ],
+        stdout=out,
+    )
+    daemons = json.loads(out.getvalue())
+
+    return sorted({
+        d['hostname']
+        for d in daemons
+        if d.get('daemon_id', '').split('.')[0] == cluster_id
+    })
+
+
+def _remote_for_hostname(ctx, hostname):
+    for remote in ctx.cluster.remotes:
+        if hostname in (remote.shortname, remote.hostname):
+            return remote
+    return None
+
+
+@contextlib.contextmanager
+def power_off_smb_daemon_host(ctx, config):
+    """Power off an SMB daemon host other than the admin host, restoring
+    it once the wrapped tasks finish.
+    """
+    admin_role = config.get('admin_role', 'host.a')
+    cluster_id = config['cluster_id']
+    (admin_remote,) = ctx.cluster.only(admin_role).remotes.keys()
+    admin_hostnames = {
+        h
+        for r in ctx.cluster.only(admin_role).remotes.keys()
+        for h in (r.shortname, r.hostname)
+    }
+
+    hostnames = _smb_daemon_hostnames(
+        ctx,
+        admin_remote,
+        cluster_id,
+    )
+
+    target_hostname = next(
+        (
+            hostname
+            for hostname in hostnames
+            if hostname not in admin_hostnames
+        ),
+        None,
+    )
+
+    if not target_hostname:
+        raise RuntimeError(
+            f'could not find an smb daemon for cluster {cluster_id} '
+            'on a non-admin host'
+        )
+
+    target_remote = _remote_for_hostname(ctx, target_hostname)
+
+    if not target_remote:
+        raise RuntimeError(
+            f'no teuthology remote found for host {target_hostname}'
+        )
+
+    assert getattr(target_remote.console, 'has_ipmi_credentials', True), (
+        f'{target_hostname} has no console credentials configured; '
+        'cannot power it off'
+    )
+
+    log.info(
+        'powering off %s (running smb.%s) to simulate an unplanned outage',
+        target_hostname,
+        cluster_id,
+    )
+    setattr(ctx, 'smb_offline_host', target_remote)
+    try:
+        target_remote.console.power_off()
+        yield
+    finally:
+        log.info('powering %s back on', target_remote.shortname)
+        target_remote.console.power_on()
+        if not target_remote.console.check_status(300):
+            raise RuntimeError(
+                f'{target_remote.shortname} did not come back up '
+                'after power on'
+            )
+
+        from teuthology import misc as teuthology
+
+        teuthology.reconnect(ctx, 60, [target_remote])
+        setattr(ctx, 'smb_offline_host', None)
+
+
+def wait_for_ctdb_healthy(ctx, config):
+    """Poll until the orchestrator's smb daemon set settles on node_count
+    hosts, excluding the offline one. If require_ctdb_healthy,
+    also require CTDB to report all nodes OK before returning.
+    """
+    admin_role = config.get('admin_role', 'host.a')
+    cluster_id = config['cluster_id']
+    node_count = config['node_count']
+    timeout = config.get('timeout', 360)
+    sleep_s = config.get('sleep_s', 15)
+    require_ctdb_healthy = config.get('require_ctdb_healthy', True)
+
+    (admin_remote,) = ctx.cluster.only(admin_role).remotes.keys()
+
+    matchers = [
+        re.compile(rf'pnn:{i} .*OK')
+        for i in range(node_count)
+    ]
+    matchers.append(
+        re.compile(rf'Number of nodes:{node_count}\b')
+    )
+
+    last_status = ''
+    try:
+        with contextutil.safe_while(
+            sleep=sleep_s,
+            tries=timeout // sleep_s,
+        ) as proceed:
+            while proceed():
+                offline_remote = getattr(ctx, 'smb_offline_host', None)
+
+                hostnames = _smb_daemon_hostnames(
+                    ctx,
+                    admin_remote,
+                    cluster_id,
+                )
+
+                remotes = []
+                for hostname in hostnames:
+                    candidate = _remote_for_hostname(ctx, hostname)
+                    if candidate is None or candidate is offline_remote:
+                        continue
+                    remotes.append(candidate)
+
+                if len(remotes) != node_count:
+                    log.warning(
+                        'orch daemon set for smb.%s not settled yet '
+                        '(hosts=%s); waiting for rescheduling',
+                        cluster_id, sorted(hostnames),
+                    )
+                    continue
+
+                if not require_ctdb_healthy:
+                    log.info(
+                        'orch daemon set for smb.%s settled on %s',
+                        cluster_id, sorted(hostnames),
+                    )
+                    return
+
+                remote = remotes[0]
+                out = StringIO()
+
+                result = remote.run(
+                    args=[
+                        'sudo',
+                        ctx.cephadm,
+                        'enter',
+                        '-i',
+                        f'smb.{cluster_id}',
+                        'ctdb',
+                        'status',
+                    ],
+                    stdout=out,
+                    stderr=out,
+                    check_status=False,
+                )
+                last_status = out.getvalue()
+                if result.exitstatus == 0 and all(
+                    m.search(last_status)
+                    for m in matchers
+                ):
+                    log.info(
+                        'ctdb healthy for smb.%s',
+                        cluster_id,
+                    )
+                    return
+    except contextutil.MaxWhileTries:
+        log.error(
+            'ctdb status for smb.%s did not converge:\n%s',
+            cluster_id,
+            last_status,
+        )
+        raise
 
 
 _DEFAULT_META_FILE = '/var/tmp/ceph-smb-test-meta.json'

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -13,6 +13,7 @@ from ceph.deployment.service_spec import (
     NFSServiceSpec,
     PatternType,
     HostPattern,
+    SMBSpec,
 )
 from ceph.deployment.hostspec import SpecValidationError
 
@@ -1644,6 +1645,32 @@ class RescheduleFromOfflineTest(NamedTuple):
                                  [[]],
                              ),
                              RescheduleFromOfflineTest(
+                                 'smb',
+                                 PlacementSpec(count=2),
+                                 'host1 host2 host3'.split(),
+                                 [],
+                                 ['host2'],
+                                 [
+                                     DaemonDescription('smb', 'a', 'host1'),
+                                     DaemonDescription('smb', 'b', 'host2'),
+                                 ],
+                                 [['host3']],
+                                 [[]],
+                             ),
+                             RescheduleFromOfflineTest(
+                                 'smb',
+                                 PlacementSpec(count=2),
+                                 'host1 host2 host3'.split(),
+                                 ['host2'],
+                                 [],
+                                 [
+                                     DaemonDescription('smb', 'a', 'host1'),
+                                     DaemonDescription('smb', 'b', 'host2'),
+                                 ],
+                                 [[]],
+                                 [[]],
+                             ),
+                             RescheduleFromOfflineTest(
                                  'mon',
                                  PlacementSpec(count=2),
                                  'host1 host2 host3'.split(),
@@ -1681,6 +1708,14 @@ def test_remove_from_offline(service_type, placement, hosts, maintenance_hosts, 
                 monitor_port=8888,
                 virtual_ip='10.0.0.20/8',
                 backend_service='nfs-ha.foo',
+                placement=placement,
+            )
+    elif service_type == 'smb':
+        spec = \
+            SMBSpec(
+                service_id='test',
+                cluster_id='test',
+                config_uri='mem:test/config.json',
                 placement=placement,
             )
     else:

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -40,7 +40,7 @@ GATEWAY_TYPES = ['iscsi', 'nfs', 'nvmeof', 'smb']
 MONITORING_STACK_TYPES = ['node-exporter', 'prometheus',
                           'alertmanager', 'grafana', 'loki', 'promtail', 'alloy']
 MGMT_GATEWAY_STACK_TYPES = ['mgmt-gateway', 'oauth2-proxy']
-RESCHEDULE_FROM_OFFLINE_HOSTS_TYPES = ['haproxy', 'nfs', 'keepalived']
+RESCHEDULE_FROM_OFFLINE_HOSTS_TYPES = ['haproxy', 'nfs', 'keepalived', 'smb']
 
 CEPH_UPGRADE_ORDER = CEPH_TYPES + GATEWAY_TYPES + MONITORING_STACK_TYPES + MGMT_GATEWAY_STACK_TYPES
 


### PR DESCRIPTION
This PR includes fix about cephadm never rescheduling smb daemons when their host went offline, because `smb` was missing from `RESCHEDULE_FROM_OFFLINE_HOSTS_TYPES`. 

Fixes: https://tracker.ceph.com/issues/79601

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
