### PR TITLE
mgr/prometheus: Fix healthcheck history column alignment and sort order

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -242,7 +242,6 @@ class LRUCacheDict(OrderedDict[K, V]):
 
 class HealthHistory:
     kv_name = 'health_history'
-    titles = "{healthcheck_name:<24}  {first_seen:<20}  {last_seen:<20}  {count:>5}  {active:^6}"
     date_format = "%Y/%m/%d %H:%M:%S"
 
     def __init__(self, mgr: MgrModule):
@@ -343,16 +342,22 @@ class HealthHistory:
         if len(self.healthcheck.keys()) == 0:
             out.append("No healthchecks have been recorded")
         else:
-            out.append(self.titles.format(
+            col_width = max(len("Healthcheck Name"),
+                            max(len(k) for k in self.healthcheck.keys()))
+            fmt = (f"{{healthcheck_name:<{col_width}}}  {{first_seen:<20}}  "
+                   f"{{last_seen:<20}}  {{count:>5}}  {{active:^6}}")
+            out.append(fmt.format(
                 healthcheck_name="Healthcheck Name",
                 first_seen="First Seen (UTC)",
                 last_seen="Last seen (UTC)",
                 count="Count",
                 active="Active")
             )
-            for k in sorted(self.healthcheck.keys()):
+            for k in sorted(self.healthcheck.keys(),
+                            key=lambda k: self.healthcheck[k].last_seen,
+                            reverse=True):
                 check = self.healthcheck[k]
-                out.append(self.titles.format(
+                out.append(fmt.format(
                     healthcheck_name=check.name,
                     first_seen=time.strftime(self.date_format, time.localtime(check.first_seen)),
                     last_seen=time.strftime(self.date_format, time.localtime(check.last_seen)),


### PR DESCRIPTION
 Dynamically calculate the healthcheck name column width to prevent
 misalignment and sort entries by Last Seen in descending order,
 showing the most recently active checks first.

Fixes: https://tracker.ceph.com/issues/79527

Before Changes:
```
[root@ceph12 ~]# ceph healthcheck history ls
Healthcheck Name          First Seen (UTC)      Last seen (UTC)       Count  Active
BLUESTORE_SLOW_OP_ALERT   2025/11/07 16:01:59   2026/08/12 17:30:18      63    No  
CEPHADM_APPLY_SPEC_FAIL   2024/11/04 19:29:16   2024/11/04 19:54:46      28    No  
CEPHADM_DAEMON_PLACE_FAIL  2024/11/12 22:44:19   2025/11/08 10:08:03      15    No  
CEPHADM_FAILED_DAEMON     2024/10/04 00:53:37   2026/07/29 14:12:55      97    No  
CEPHADM_HOST_CHECK_FAILED  2024/10/03 15:15:51   2026/08/10 19:53:21     233    No  
CEPHADM_REFRESH_FAILED    2024/10/02 23:18:35   2026/08/10 19:44:51     111    No  
CEPHADM_STRAY_DAEMON      2024/11/13 16:51:36   2024/11/19 13:52:02       3    No  
DAEMON_OLD_VERSION        2024/11/29 04:38:11   2025/04/04 16:41:32       2    No  
DB_DEVICE_STALLED_READ_ALERT  2025/12/30 13:25:44   2026/07/27 23:39:46      27    No  
FS_DEGRADED               2024/10/23 13:36:06   2026/02/21 18:05:25      26    No  
FS_WITH_FAILED_MDS        2024/10/23 13:36:06   2026/02/07 12:14:20       7    No 

```

After Changes:
```
[ceph: root@test-prachicode-0 /]# ceph healthcheck history ls
Healthcheck Name                         First Seen (UTC)      Last seen (UTC)       Count  Active
RECENT_MGR_MODULE_CRASH                  2026/08/18 11:04:44   2026/08/18 12:05:44       1   Yes  
OSD_NO_DOWN_OUT_INTERVAL                 2026/08/18 12:02:44   2026/08/18 12:05:44       1   Yes  
AUTH_INSECURE_GLOBAL_ID_RECLAIM_ALLOWED  2026/08/18 11:55:14   2026/08/18 11:55:44       1    No  
PG_DEGRADED                              2026/08/18 11:04:14   2026/08/18 11:13:29       2    No  
OSD_HOST_DOWN                            2026/08/18 11:03:59   2026/08/18 11:13:14       1    No  
OSD_DOWN                                 2026/08/18 11:03:59   2026/08/18 11:13:14       1    No  
PG_AVAILABILITY                          2026/08/18 11:04:59   2026/08/18 11:12:29       1    No  
TOO_FEW_OSDS                             2026/08/18 10:51:14   2026/08/18 10:56:29       1    No  
8 health check(s) listed

```
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
