### PR TITLE
tentacle: mon: surface data dir + db size as perf counters

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -7,6 +7,12 @@
   behavior is controlled by the new ``mgr_stats_period_autotune`` (default:
   ``true``) and ``mgr_stats_period_autotune_queue_threshold`` (default: ``100``)
   config options.
+* MON: Each monitor now reports four new perf counters covering its data
+  directory: ``data_disk_total_bytes``, ``data_disk_avail_bytes``,
+  ``data_disk_avail_percent``, and ``db_total_bytes`` (estimated on-disk size
+  of the key/value store). They surface automatically as ``ceph_mon_*``
+  Prometheus metrics via the ``prometheus`` mgr module and ``ceph-exporter``,
+  enabling trending of mon DB growth and filesystem free space.
 >=20.0.2
 
 * RGW: For `radosgw-admin account rm`, the `--purge-data` option previously applied only

--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -595,6 +595,13 @@ bool HealthMonitor::check_member_health()
 	   << ", used " << byte_u_t(stats.fs_stats.byte_used)
 	   << ", avail " << byte_u_t(stats.fs_stats.byte_avail) << dendl;
 
+  if (mon.logger) {
+    mon.logger->set(l_mon_data_disk_total_bytes, stats.fs_stats.byte_total);
+    mon.logger->set(l_mon_data_disk_avail_bytes, stats.fs_stats.byte_avail);
+    mon.logger->set(l_mon_data_disk_avail_percent, stats.fs_stats.avail_percent);
+    mon.logger->set(l_mon_db_total_bytes, stats.store_stats.bytes_total);
+  }
+
   // MON_DISK_{LOW,CRIT,BIG}
   health_check_map_t next;
   if (stats.fs_stats.avail_percent <= g_conf()->mon_data_avail_crit) {

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -779,6 +779,18 @@ int Monitor::preinit()
         "ewon", PerfCountersBuilder::PRIO_INTERESTING);
     pcb.add_u64_counter(l_mon_election_lose, "election_lose", "Elections lost",
         "elst", PerfCountersBuilder::PRIO_INTERESTING);
+    pcb.add_u64(l_mon_data_disk_total_bytes, "data_disk_total_bytes",
+        "Total size of the filesystem hosting the monitor data directory",
+        "dtot", PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
+    pcb.add_u64(l_mon_data_disk_avail_bytes, "data_disk_avail_bytes",
+        "Available space on the filesystem hosting the monitor data directory",
+        "davb", PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
+    pcb.add_u64(l_mon_data_disk_avail_percent, "data_disk_avail_percent",
+        "Available space on the filesystem hosting the monitor data directory, as a percentage",
+        "dpct", PerfCountersBuilder::PRIO_USEFUL);
+    pcb.add_u64(l_mon_db_total_bytes, "db_total_bytes",
+        "Estimated on-disk size of the monitor key/value store",
+        "dbsz", PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
     logger = pcb.create_perf_counters();
     cct->get_perfcounters_collection()->add(logger);
   }

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -98,6 +98,10 @@ enum {
   l_mon_election_call,
   l_mon_election_win,
   l_mon_election_lose,
+  l_mon_data_disk_total_bytes,
+  l_mon_data_disk_avail_bytes,
+  l_mon_data_disk_avail_percent,
+  l_mon_db_total_bytes,
   l_mon_last,
 };
 


### PR DESCRIPTION
Backport of #68916 to tentacle.

`HealthMonitor::check_member_health()` already collects filesystem stats for the
mon data directory and the estimated on-disk size of the mon key/value store on
every tick, and uses them to raise MON_DISK_LOW/CRIT/BIG. Nothing else exposes
those numbers, so there is no way to trend mon DB growth or free space on the
filesystem hosting mon_data.

Four PRIO_USEFUL gauges are added to the existing `mon` perf-counter group and
set from `check_member_health()` after the stats are populated:
`data_disk_total_bytes`, `data_disk_avail_bytes`, `data_disk_avail_percent` and
`db_total_bytes`. They surface automatically as `ceph_mon_*` metrics via the
`prometheus` mgr module and `ceph-exporter`. No new config option, no API change.

Conflicts:
- `src/mon/Monitor.cc`, `src/mon/Monitor.h`: main carries the mon backup perf
  counters, which are not on tentacle, so the four new counters attach after
  `election_lose` instead. The added lines themselves are unchanged from the
  commit merged on main (ab30aa816c0).
- `PendingReleaseNotes`: release note placed in this branch's pending section.

Verified by building `ceph-mon` on this branch with the patch applied: clean
build and link, no warnings introduced.

Tracker: https://tracker.ceph.com/issues/79614

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [x] No tests
