### PR TITLE
rgw/radosgw-admin: add bucket list --access-key filter

### DIFF
--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -7190,8 +7190,17 @@ int main(int argc, const char **argv)
   if (!(rgw::sal::User::empty(user) && access_key.empty()) || !subuser.empty()) {
     ret = ruser.init(dpp(), driver, user_op, null_yield);
     if (ret < 0) {
+      if (!access_key.empty() && !user_op.found_by_key) {
+        cerr << "ERROR: could not find user for access-key: "
+             << access_key << std::endl;
+        return -ENOENT;
+      }
       cerr << "user.init failed: " << cpp_strerror(-ret) << std::endl;
       return -ret;
+    }
+    if (rgw::sal::User::empty(user) && !access_key.empty() &&
+        user_op.found_by_key) {
+      bucket_op.set_user_id(user_op.get_user_id());
     }
   }
 


### PR DESCRIPTION
 Add the --access-key filter for bucket list and
 improve the error message when no matching user is
 found.

Fixes: https://tracker.ceph.com/issues/79410

Before Change:
```
[root@prachi-1 ~]# sudo radosgw-admin bucket list
[
    "user1-bucket-a",
    "user2-bucket-a",
    "user2-bucket-b",
    "user1-bucket-b"
]
[root@prachi-1 ~]# sudo radosgw-admin bucket list --uid=testuser1
[
    "user1-bucket-a",
    "user1-bucket-b"
]
[root@prachi-1 ~]# sudo radosgw-admin bucket list --uid=testuser2
[
    "user2-bucket-a",
    "user2-bucket-b"
]
[root@prachi-1 ~]# sudo radosgw-admin bucket list --access-key=TESTKEY111
[
    "user1-bucket-a",
    "user2-bucket-a",
    "user2-bucket-b",
    "user1-bucket-b"
]
[root@prachi-1 ~]# sudo radosgw-admin bucket list --access-key=TESTKEY222
[
    "user1-bucket-a",
    "user2-bucket-a",
    "user2-bucket-b",
    "user1-bucket-b"
]
[root@prachi-1 ~]# sudo radosgw-admin bucket list --access-key=INVALIDKEY
user.init failed: (22) Invalid argument

```

After Changes:
```
[ceph: root@test-prachicode-0 /]# radosgw-admin bucket list
[
    "user1-bucket-a",
    "user2-bucket-a",
    "user1-bucket-c",
    "user2-bucket-b",
    "user1-bucket-b"
]
[ceph: root@test-prachicode-0 /]# radosgw-admin bucket list --uid=testuser1
[
    "user1-bucket-a",
    "user1-bucket-b",
    "user1-bucket-c"
]
[ceph: root@test-prachicode-0 /]# radosgw-admin bucket list --uid=testuser2
[
    "user2-bucket-a",
    "user2-bucket-b"
]
[ceph: root@test-prachicode-0 /]# radosgw-admin bucket list --access-key=TESTKEY111
[
    "user1-bucket-a",
    "user1-bucket-b",
    "user1-bucket-c"
]
[ceph: root@test-prachicode-0 /]# radosgw-admin bucket list --access-key=TESTKEY222
[
    "user2-bucket-a",
    "user2-bucket-b"
]
[ceph: root@test-prachicode-0 /]# radosgw-admin bucket list --access-key=xyz       
ERROR: could not find user for access-key: xyz
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
