### PR TITLE
mgr/dashboard: rgw role permission policies

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -1393,6 +1393,57 @@ class RgwUserRole(NamedTuple):
     AccountId: str
 
 
+@APIRouter('/rgw/accounts/{account_id}/roles/{role_name}/policy', Scope.RGW)
+@APIDoc("RGW Role Policy API", "RgwRolePolicy")
+class RgwRolePolicyController(RESTController):
+    @EndpointDoc("List RGW role policies",
+                 parameters={'role_name': (str, 'Role name'),
+                             'account_id': (str, 'Account id')})
+    def list(self, role_name: str, account_id: str):
+        """
+        List all permission policy names attached to the specified role.
+        """
+        rgw_client = RgwClient.admin_instance()
+        return rgw_client.list_role_policies(role_name, account_id)
+
+    @EndpointDoc("Get RGW role policy document",
+                 parameters={'role_name': (str, 'Role name'),
+                             'policy_name': (str, 'Policy name'),
+                             'account_id': (str, 'Account id')})
+    def get(self, role_name: str, policy_name: str, account_id: str):
+        """
+        Get policy document for the specified role policy.
+        """
+        rgw_client = RgwClient.admin_instance()
+        return rgw_client.get_role_policy(role_name, policy_name, account_id)
+
+    @EndpointDoc("Attach RGW role policy",
+                 parameters={'role_name': (str, 'Role name'),
+                             'policy_name': (str, 'Policy name'),
+                             'policy_doc': (str, 'Policy document JSON'),
+                             'account_id': (str, 'Account id')})
+    @allow_empty_body
+    def create(self, role_name: str, policy_name: str, policy_doc: str, account_id: str):
+        """
+        Attach a permission policy document to the specified role.
+        """
+        rgw_client = RgwClient.admin_instance()
+        rgw_client.put_role_policy(role_name, policy_name, policy_doc, account_id)
+        return f'Policy {policy_name} attached to role {role_name} successfully'
+
+    @EndpointDoc("Delete RGW role policy",
+                 parameters={'role_name': (str, 'Role name'),
+                             'policy_name': (str, 'Policy name'),
+                             'account_id': (str, 'Account id')})
+    def delete(self, role_name: str, policy_name: str, account_id: str):
+        """
+        Delete/Detach a permission policy from the specified role.
+        """
+        rgw_client = RgwClient.admin_instance()
+        rgw_client.delete_role_policy(role_name, policy_name, account_id)
+        return f'Policy {policy_name} deleted from role {role_name} successfully'
+
+
 @APIRouter('/rgw/realm', Scope.RGW)
 class RgwRealm(RESTController):
     @allow_empty_body

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-details/rgw-account-role-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-details/rgw-account-role-details.component.html
@@ -1,0 +1,33 @@
+<div class="role-details-container cds-p-4">
+  <h4
+    i18n
+    class="cds--type-heading-02 cds-mb-3"
+  >
+    Permission Policies
+  </h4>
+  <p
+    i18n
+    class="cds--type-body-compact-01 cds-mb-4"
+  >
+    List of IAM permission policies attached to role "{{ selection?.RoleName }}".
+  </p>
+
+  <cd-table
+    #table
+    [autoReload]="false"
+    [data]="policies$ | async"
+    [columns]="columns"
+    selectionType="single"
+    columnMode="flex"
+    (updateSelection)="updateSelection($event)"
+    identifier="name"
+  >
+    <cd-table-actions
+      class="table-actions"
+      [permission]="permission"
+      [selection]="policySelection"
+      [tableActions]="tableActions"
+    >
+    </cd-table-actions>
+  </cd-table>
+</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-details/rgw-account-role-details.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-details/rgw-account-role-details.component.scss
@@ -1,0 +1,4 @@
+.role-details-container {
+  background-color: var(--cds-layer-01);
+  border-top: 1px solid var(--cds-border-subtle-01);
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-details/rgw-account-role-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-details/rgw-account-role-details.component.spec.ts
@@ -1,0 +1,84 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+
+import { configureTestBed } from '~/testing/unit-test-helper';
+import { RgwAccountRoleDetailsComponent } from './rgw-account-role-details.component';
+import { RgwRoleService } from '~/app/shared/api/rgw-role.service';
+import { SharedModule } from '~/app/shared/shared.module';
+import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
+import { NotificationService } from '~/app/shared/services/notification.service';
+import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
+
+describe('RgwAccountRoleDetailsComponent', () => {
+  let component: RgwAccountRoleDetailsComponent;
+  let fixture: ComponentFixture<RgwAccountRoleDetailsComponent>;
+  let rgwRoleService: RgwRoleService;
+  let notificationService: NotificationService;
+
+  configureTestBed({
+    imports: [HttpClientTestingModule, RouterTestingModule, SharedModule],
+    declarations: [RgwAccountRoleDetailsComponent],
+    providers: [
+      {
+        provide: AuthStorageService,
+        useValue: {
+          getPermissions: () => ({ rgw: { create: true, update: true, delete: true } })
+        }
+      }
+    ]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RgwAccountRoleDetailsComponent);
+    component = fixture.componentInstance;
+    rgwRoleService = TestBed.inject(RgwRoleService);
+    notificationService = TestBed.inject(NotificationService);
+    spyOn(notificationService, 'show');
+    component.accountId = 'test-account';
+    component.selection = { RoleName: 'test-role' } as any;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load policies on init', () => {
+    const policies = ['policy1', 'policy2'];
+    spyOn(rgwRoleService, 'listPolicies').and.returnValue(of(policies));
+    component.loadPolicies();
+    expect(rgwRoleService.listPolicies).toHaveBeenCalledWith('test-role', 'test-account');
+    component.policies$.subscribe((res) => {
+      expect(res).toEqual([{ name: 'policy1' }, { name: 'policy2' }]);
+    });
+  });
+
+  it('should delete a policy and show notification', () => {
+    spyOn(rgwRoleService, 'deletePolicy').and.returnValue(of(null));
+    spyOn(component, 'loadPolicies');
+    component.policySelection.selected = [{ name: 'test-policy' }];
+    spyOn(TestBed.inject(ModalCdsService), 'show').and.callFake((_componentClass, config) => {
+      config.submitActionObservable().subscribe();
+      return null;
+    });
+
+    component.deletePolicy();
+    expect(rgwRoleService.deletePolicy).toHaveBeenCalledWith(
+      'test-role',
+      'test-policy',
+      'test-account'
+    );
+    expect(notificationService.show).toHaveBeenCalled();
+    expect(component.loadPolicies).toHaveBeenCalled();
+  });
+
+  it('should open edit policy modal', () => {
+    const modalService = TestBed.inject(ModalCdsService);
+    spyOn(modalService, 'show');
+    component.policySelection.selected = [{ name: 'test-policy' }];
+    component.openEditPolicyModal();
+    expect(modalService.show).toHaveBeenCalled();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-details/rgw-account-role-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-details/rgw-account-role-details.component.ts
@@ -1,0 +1,168 @@
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
+import { CdTableAction } from '~/app/shared/models/cd-table-action';
+import { CdTableColumn } from '~/app/shared/models/cd-table-column';
+import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
+import { Icons } from '~/app/shared/enum/icons.enum';
+import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
+import { RgwRoleService } from '~/app/shared/api/rgw-role.service';
+import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
+import { RgwAccountRolePolicyFormComponent } from '../rgw-account-role-policy-form/rgw-account-role-policy-form.component';
+import { NotificationService } from '~/app/shared/services/notification.service';
+import { NotificationType } from '~/app/shared/enum/notification-type.enum';
+import { Observable, Subscriber, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Permission } from '~/app/shared/models/permissions';
+import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
+import { RgwRole } from '../models/rgw-role';
+
+@Component({
+  selector: 'cd-rgw-account-role-details',
+  templateUrl: './rgw-account-role-details.component.html',
+  styleUrls: ['./rgw-account-role-details.component.scss'],
+  standalone: false
+})
+export class RgwAccountRoleDetailsComponent implements OnInit, OnChanges {
+  @Input()
+  selection: RgwRole;
+
+  @Input()
+  accountId: string;
+
+  columns: CdTableColumn[] = [];
+  policies$: Observable<any[]>;
+  tableActions: CdTableAction[] = [];
+  policySelection: CdTableSelection = new CdTableSelection();
+  permission: Permission;
+
+  constructor(
+    public actionLabels: ActionLabelsI18n,
+    private rgwRoleService: RgwRoleService,
+    private modalService: ModalCdsService,
+    private authStorageService: AuthStorageService,
+    private notificationService: NotificationService
+  ) {
+    this.permission = this.authStorageService.getPermissions().rgw;
+  }
+
+  ngOnInit(): void {
+    this.columns = [
+      {
+        name: $localize`Policy name`,
+        prop: 'name',
+        flexGrow: 1
+      }
+    ];
+
+    this.tableActions = [
+      {
+        permission: 'create',
+        icon: Icons.add,
+        click: () => this.openAttachPolicyModal(),
+        name: $localize`Attach policy`,
+        canBePrimary: () => true
+      },
+      {
+        permission: 'update',
+        icon: Icons.edit,
+        click: () => this.openEditPolicyModal(),
+        name: this.actionLabels.EDIT,
+        disable: () => !this.policySelection.hasSelection
+      },
+      {
+        permission: 'delete',
+        icon: Icons.destroy,
+        click: () => this.deletePolicy(),
+        name: this.actionLabels.DELETE,
+        disable: () => !this.policySelection.hasSelection
+      }
+    ];
+
+    this.loadPolicies();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.selection && this.selection) {
+      this.loadPolicies();
+    }
+  }
+
+  get roleName(): string {
+    if (!this.selection) {
+      return '';
+    }
+    return (
+      this.selection.RoleName ||
+      (this.selection as any).role_name ||
+      (this.selection as any).row?.RoleName ||
+      (this.selection as any).row?.role_name ||
+      ''
+    );
+  }
+
+  loadPolicies(): void {
+    const roleName = this.roleName;
+    if (!roleName || !this.accountId) {
+      this.policies$ = of([]);
+      return;
+    }
+
+    this.policies$ = this.rgwRoleService.listPolicies(roleName, this.accountId).pipe(
+      map((policies: string[]) => {
+        return (policies || []).map((name) => ({ name }));
+      })
+    );
+  }
+
+  updateSelection(selection: CdTableSelection): void {
+    this.policySelection = selection;
+  }
+
+  openAttachPolicyModal(): void {
+    const modalRef = this.modalService.show(RgwAccountRolePolicyFormComponent, {
+      accountId: this.accountId,
+      roleName: this.roleName
+    });
+    modalRef?.close?.subscribe(() => this.loadPolicies());
+  }
+
+  openEditPolicyModal(): void {
+    const policyName = this.policySelection.first().name;
+    const modalRef = this.modalService.show(RgwAccountRolePolicyFormComponent, {
+      accountId: this.accountId,
+      roleName: this.roleName,
+      policyName: policyName,
+      isEdit: true
+    });
+    modalRef?.close?.subscribe(() => this.loadPolicies());
+  }
+
+  deletePolicy(): void {
+    const policyName = this.policySelection.first().name;
+    const roleName = this.roleName;
+
+    this.modalService.show(DeleteConfirmationModalComponent, {
+      itemDescription: $localize`Permission policy`,
+      itemNames: [policyName],
+      submitActionObservable: () => {
+        return new Observable((observer: Subscriber<any>) => {
+          this.rgwRoleService.deletePolicy(roleName, policyName, this.accountId).subscribe({
+            next: () => {
+              this.notificationService.show(
+                NotificationType.success,
+                $localize`Policy detached successfully`,
+                $localize`Policy "${policyName}" detached from role "${roleName}".`
+              );
+              this.loadPolicies();
+              observer.next();
+              observer.complete();
+            },
+            error: (err) => {
+              observer.error(err);
+            }
+          });
+        });
+      }
+    });
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-policy-form/rgw-account-role-policy-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-policy-form/rgw-account-role-policy-form.component.html
@@ -1,0 +1,126 @@
+<cds-modal
+  size="md"
+  [open]="open"
+  [hasScrollingContent]="false"
+  (overlaySelected)="closeModal()"
+>
+  <cds-modal-header (closeSelect)="closeModal()">
+    <h4
+      cdsModalHeaderLabel
+      class="cds--type-label-01"
+      i18n
+    >
+      Role Policy
+    </h4>
+    <h3
+      cdsModalHeaderHeading
+      i18n
+    >
+      {{ action }} permission policy
+    </h3>
+    <p
+      class="cds--modal-header__description cds--type-body-01 cds-mt-3"
+      *ngIf="!isEdit"
+      i18n
+    >
+      Attach an IAM permission policy specifying allowed or denied S3 actions to role "{{
+        roleName
+      }}".
+    </p>
+    <p
+      class="cds--modal-header__description cds--type-body-01 cds-mt-3"
+      *ngIf="isEdit"
+      i18n
+    >
+      Edit permission policy "{{ policyName }}" for role "{{ roleName }}".
+    </p>
+  </cds-modal-header>
+
+  <form
+    class="form"
+    #formDir="ngForm"
+    [formGroup]="form"
+  >
+    <div cdsModalContent>
+      <!-- Policy Name -->
+      <div class="form-item">
+        <cds-text-label
+          label="Policy name"
+          for="policy_name"
+          [invalid]="policyNameRef.isInvalid"
+          [invalidText]="policyNameError"
+          helperText="Unique name to identify this permission policy (e.g. S3FullAccessPolicy)."
+          i18n-helperText
+        >
+          Policy name
+          <input
+            cdsText
+            cdValidate
+            #policyNameRef="cdValidate"
+            id="policy_name"
+            name="policy_name"
+            formControlName="policy_name"
+            placeholder="Enter policy name"
+            [readonly]="isEdit"
+            [autofocus]="!isEdit"
+            modal-primary-focus
+          />
+        </cds-text-label>
+        <ng-template #policyNameError>
+          <span
+            *ngIf="form.showError('policy_name', formDir, 'required')"
+            class="invalid-feedback"
+            i18n
+            >This field is required.</span
+          >
+        </ng-template>
+      </div>
+
+      <!-- Policy Document -->
+      <div class="form-item">
+        <cds-textarea-label
+          for="policy_doc"
+          [invalid]="policyDoc.isInvalid"
+          [invalidText]="policyError"
+          helperText="JSON document defining the permissions policy statement."
+          i18n-helperText
+        >
+          Policy document
+          <textarea
+            cdsTextArea
+            cdValidate
+            #policyDoc="cdValidate"
+            id="policy_doc"
+            name="policy_doc"
+            formControlName="policy_doc"
+            placeholder='{"Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"arn:aws:s3:::*"}]}'
+            rows="8"
+            cols="200"
+            cdRequiredField="Policy Document"
+          ></textarea>
+        </cds-textarea-label>
+        <ng-template #policyError>
+          <span
+            *ngIf="form.showError('policy_doc', formDir, 'required')"
+            class="invalid-feedback"
+            i18n
+            >This field is required.</span
+          >
+          <span
+            *ngIf="form.showError('policy_doc', formDir, 'invalidJson')"
+            class="invalid-feedback"
+            i18n
+            >Please enter a valid JSON policy document.</span
+          >
+        </ng-template>
+      </div>
+    </div>
+
+    <cd-form-button-panel
+      (submitActionEvent)="onSubmit()"
+      [form]="form"
+      [submitText]="action"
+      [modalForm]="true"
+    ></cd-form-button-panel>
+  </form>
+</cds-modal>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-policy-form/rgw-account-role-policy-form.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-policy-form/rgw-account-role-policy-form.component.scss
@@ -1,0 +1,3 @@
+.form-item {
+  margin-bottom: 1rem;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-policy-form/rgw-account-role-policy-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-policy-form/rgw-account-role-policy-form.component.spec.ts
@@ -1,0 +1,81 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+
+import { RgwAccountRolePolicyFormComponent } from './rgw-account-role-policy-form.component';
+import { RgwRoleService } from '~/app/shared/api/rgw-role.service';
+import { SharedModule } from '~/app/shared/shared.module';
+import { NotificationService } from '~/app/shared/services/notification.service';
+
+describe('RgwAccountRolePolicyFormComponent', () => {
+  let component: RgwAccountRolePolicyFormComponent;
+  let fixture: ComponentFixture<RgwAccountRolePolicyFormComponent>;
+  let rgwRoleService: RgwRoleService;
+  let notificationService: NotificationService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, RouterTestingModule, SharedModule, ReactiveFormsModule],
+      declarations: [RgwAccountRolePolicyFormComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RgwAccountRolePolicyFormComponent);
+    component = fixture.componentInstance;
+    rgwRoleService = TestBed.inject(RgwRoleService);
+    notificationService = TestBed.inject(NotificationService);
+    spyOn(notificationService, 'show');
+    component.accountId = 'test-account';
+    component.roleName = 'test-role';
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should attach policy when form is submitted', () => {
+    spyOn(rgwRoleService, 'putPolicy').and.returnValue(of(null));
+    spyOn(component, 'closeModal');
+
+    component.form.patchValue({
+      policy_name: 'test-policy',
+      policy_doc: '{"Statement":[]}'
+    });
+
+    component.onSubmit();
+
+    expect(rgwRoleService.putPolicy).toHaveBeenCalledWith(
+      'test-role',
+      'test-policy',
+      '{"Statement":[]}',
+      'test-account'
+    );
+    expect(notificationService.show).toHaveBeenCalled();
+    expect(component.closeModal).toHaveBeenCalled();
+  });
+
+  it('should load policy and update when in edit mode', () => {
+    component.isEdit = true;
+    component.policyName = 'test-policy';
+    spyOn(rgwRoleService, 'getPolicy').and.returnValue(of({ Statement: [] }));
+    spyOn(rgwRoleService, 'putPolicy').and.returnValue(of(null));
+    spyOn(component, 'closeModal');
+
+    component.ngOnInit();
+
+    expect(rgwRoleService.getPolicy).toHaveBeenCalledWith(
+      'test-role',
+      'test-policy',
+      'test-account'
+    );
+    expect(component.form.getRawValue().policy_name).toBe('test-policy');
+
+    component.onSubmit();
+
+    expect(rgwRoleService.putPolicy).toHaveBeenCalled();
+    expect(notificationService.show).toHaveBeenCalled();
+    expect(component.closeModal).toHaveBeenCalled();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-policy-form/rgw-account-role-policy-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-role-policy-form/rgw-account-role-policy-form.component.ts
@@ -1,0 +1,116 @@
+import { Component, Inject, OnInit, Optional } from '@angular/core';
+import { Validators } from '@angular/forms';
+import { BaseModal } from 'carbon-components-angular';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
+import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
+import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
+import { CdValidators } from '~/app/shared/forms/cd-validators';
+import { RgwRoleService } from '~/app/shared/api/rgw-role.service';
+import { NotificationService } from '~/app/shared/services/notification.service';
+import { NotificationType } from '~/app/shared/enum/notification-type.enum';
+
+@Component({
+  selector: 'cd-rgw-account-role-policy-form',
+  templateUrl: './rgw-account-role-policy-form.component.html',
+  styleUrls: ['./rgw-account-role-policy-form.component.scss'],
+  standalone: false
+})
+export class RgwAccountRolePolicyFormComponent extends BaseModal implements OnInit {
+  form: CdFormGroup;
+  action: string;
+
+  constructor(
+    @Optional() @Inject('accountId') public accountId: string,
+    @Optional() @Inject('roleName') public roleName: string,
+    @Optional() @Inject('policyName') public policyName: string,
+    @Optional() @Inject('isEdit') public isEdit = false,
+    public actionLabels: ActionLabelsI18n,
+    private formBuilder: CdFormBuilder,
+    private rgwRoleService: RgwRoleService,
+    private notificationService: NotificationService
+  ) {
+    super();
+  }
+
+  ngOnInit(): void {
+    this.action = this.isEdit ? this.actionLabels.EDIT : $localize`Attach`;
+    this.createForm();
+    if (this.isEdit && this.policyName) {
+      this.loadPolicy();
+    }
+  }
+
+  private createForm() {
+    this.form = this.formBuilder.group({
+      policy_name: [{ value: this.policyName || '', disabled: this.isEdit }, [Validators.required]],
+      policy_doc: ['', [Validators.required, CdValidators.json()]]
+    });
+  }
+
+  private loadPolicy() {
+    this.rgwRoleService
+      .getPolicy(this.roleName, this.policyName, this.accountId)
+      .subscribe((res: any) => {
+        let policyDoc = res;
+
+        if (typeof res === 'object' && res !== null) {
+          const keys = Object.keys(res);
+          const policyKey = keys.find(
+            (k) =>
+              /policy/i.test(k) ||
+              k === 'Permission policy' ||
+              k === 'Policy' ||
+              k === 'PolicyDocument'
+          );
+          if (policyKey && res[policyKey]) {
+            policyDoc = res[policyKey];
+          } else if (keys.length === 1) {
+            policyDoc = res[keys[0]];
+          }
+        }
+
+        if (typeof policyDoc === 'string') {
+          try {
+            policyDoc = JSON.parse(policyDoc);
+          } catch {
+            // Keep as string if not valid JSON
+          }
+        }
+
+        if (typeof policyDoc === 'object' && policyDoc !== null) {
+          policyDoc = JSON.stringify(policyDoc, null, 2);
+        }
+
+        this.form.patchValue({ policy_doc: policyDoc });
+      });
+  }
+
+  onSubmit() {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const { policy_name, policy_doc } = this.form.getRawValue();
+
+    this.rgwRoleService
+      .putPolicy(this.roleName, policy_name, policy_doc, this.accountId)
+      .subscribe({
+        next: () => {
+          this.notificationService.show(
+            NotificationType.success,
+            this.isEdit
+              ? $localize`Permission policy updated`
+              : $localize`Permission policy attached`,
+            this.isEdit
+              ? $localize`Policy "${policy_name}" updated for role "${this.roleName}" successfully.`
+              : $localize`Policy "${policy_name}" attached to role "${this.roleName}" successfully.`
+          );
+          this.closeModal();
+        },
+        error: () => {
+          this.form.setErrors({ cdSubmitButton: true });
+        }
+      });
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-roles-list/rgw-account-roles-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-roles-list/rgw-account-roles-list.component.html
@@ -5,7 +5,9 @@
   [columns]="columns"
   selectionType="single"
   columnMode="flex"
+  [hasDetails]="true"
   (updateSelection)="updateSelection($event)"
+  (setExpandedRow)="setExpandedRow($event)"
   identifier="RoleName"
 >
   <cd-table-actions
@@ -15,4 +17,11 @@
     [tableActions]="tableActions"
   >
   </cd-table-actions>
+
+  <cd-rgw-account-role-details
+    *cdTableDetail
+    [selection]="expandedRow"
+    [accountId]="accountId"
+  >
+  </cd-rgw-account-role-details>
 </cd-table>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-roles-list/rgw-account-roles-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-roles-list/rgw-account-roles-list.component.ts
@@ -123,8 +123,14 @@ export class RgwAccountRolesListComponent implements OnInit, OnChanges {
     this.data$ = this.rgwRoleService.list(this.accountId);
   }
 
+  expandedRow: RgwRole;
+
   updateSelection(selection: CdTableSelection): void {
     this.selection = selection;
+  }
+
+  setExpandedRow(event: any): void {
+    this.expandedRow = event?.row || event;
   }
 
   openRoleForm(isEdit: boolean): void {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
@@ -140,6 +140,8 @@ import { RgwNotificationFormComponent } from './rgw-notification-form/rgw-notifi
 import { ComponentsModule } from '~/app/shared/components/components.module';
 import { RgwAccountRolesListComponent } from './rgw-account-roles-list/rgw-account-roles-list.component';
 import { RgwAccountRoleFormComponent } from './rgw-account-role-form/rgw-account-role-form.component';
+import { RgwAccountRoleDetailsComponent } from './rgw-account-role-details/rgw-account-role-details.component';
+import { RgwAccountRolePolicyFormComponent } from './rgw-account-role-policy-form/rgw-account-role-policy-form.component';
 import { RgwBucketResourceSidebarComponent } from './rgw-bucket-resource-sidebar/rgw-bucket-resource-sidebar.component';
 import { RgwBucketResourcePageComponent } from './rgw-bucket-resource-page/rgw-bucket-resource-page.component';
 import { RgwBucketResourceBreadcrumbResolver } from './rgw-bucket-resource-page/rgw-bucket-resource-breadcrumb.resolver';
@@ -262,6 +264,8 @@ import { RgwBucketTagsTableComponent } from './rgw-bucket-tags-table/rgw-bucket-
     RgwNotificationFormComponent,
     RgwAccountRolesListComponent,
     RgwAccountRoleFormComponent,
+    RgwAccountRoleDetailsComponent,
+    RgwAccountRolePolicyFormComponent,
     RgwBucketResourceSidebarComponent,
     RgwBucketResourcePageComponent,
     RgwBucketTagsTableComponent

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-role.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-role.service.spec.ts
@@ -56,4 +56,37 @@ describe('RgwRoleService', () => {
     const req = httpTesting.expectOne('api/rgw/accounts/test-account/roles/test-role');
     expect(req.request.method).toBe('DELETE');
   });
+
+  it('should call listPolicies', () => {
+    service.listPolicies('test-role', 'test-account').subscribe();
+    const req = httpTesting.expectOne('api/rgw/accounts/test-account/roles/test-role/policy');
+    expect(req.request.method).toBe('GET');
+  });
+
+  it('should call getPolicy', () => {
+    service.getPolicy('test-role', 'test-policy', 'test-account').subscribe();
+    const req = httpTesting.expectOne(
+      'api/rgw/accounts/test-account/roles/test-role/policy/test-policy'
+    );
+    expect(req.request.method).toBe('GET');
+  });
+
+  it('should call putPolicy', () => {
+    service.putPolicy('test-role', 'test-policy', '{"Statement":[]}', 'test-account').subscribe();
+    const req = httpTesting.expectOne('api/rgw/accounts/test-account/roles/test-role/policy');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({
+      role_name: 'test-role',
+      policy_name: 'test-policy',
+      policy_doc: '{"Statement":[]}'
+    });
+  });
+
+  it('should call deletePolicy', () => {
+    service.deletePolicy('test-role', 'test-policy', 'test-account').subscribe();
+    const req = httpTesting.expectOne(
+      'api/rgw/accounts/test-account/roles/test-role/policy/test-policy'
+    );
+    expect(req.request.method).toBe('DELETE');
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-role.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-role.service.ts
@@ -38,4 +38,29 @@ export class RgwRoleService {
   delete(roleName: string, accountId: string): Observable<any> {
     return this.http.delete(`${this.getUrl(accountId)}/${roleName}`);
   }
+
+  listPolicies(roleName: string, accountId: string): Observable<string[]> {
+    return this.http.get<string[]>(`${this.getUrl(accountId)}/${roleName}/policy`);
+  }
+
+  getPolicy(roleName: string, policyName: string, accountId: string): Observable<any> {
+    return this.http.get<any>(`${this.getUrl(accountId)}/${roleName}/policy/${policyName}`);
+  }
+
+  putPolicy(
+    roleName: string,
+    policyName: string,
+    policyDoc: string,
+    accountId: string
+  ): Observable<any> {
+    return this.http.post<any>(`${this.getUrl(accountId)}/${roleName}/policy`, {
+      role_name: roleName,
+      policy_name: policyName,
+      policy_doc: policyDoc
+    });
+  }
+
+  deletePolicy(roleName: string, policyName: string, accountId: string): Observable<any> {
+    return this.http.delete(`${this.getUrl(accountId)}/${roleName}/policy/${policyName}`);
+  }
 }

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -1114,8 +1114,7 @@ class RgwClient(RestClient):
 
     def get_role(self, role_name: str, account_id: Optional[str] = None):
         rgw_get_role_command = ['role', 'get', '--role-name', role_name]
-        if account_id:
-            rgw_get_role_command += ['--account-id', account_id]
+        self._append_account_flag(rgw_get_role_command, account_id)
         code, role, _err = mgr.send_rgwadmin_command(rgw_get_role_command)
         if code != 0:
             raise DashboardException(msg=f'Error getting role with code {code}: {_err}',
@@ -1128,8 +1127,7 @@ class RgwClient(RestClient):
                     account_id: Optional[str] = None):
         rgw_update_role_command = ['role', 'update', '--role-name',
                                    role_name, '--max_session_duration', max_session_duration]
-        if account_id:
-            rgw_update_role_command += ['--account-id', account_id]
+        self._append_account_flag(rgw_update_role_command, account_id)
         code, _, _err = mgr.send_rgwadmin_command(rgw_update_role_command,
                                                   stdout_as_json=False)
         if code != 0:
@@ -1138,12 +1136,71 @@ class RgwClient(RestClient):
 
     def delete_role(self, role_name: str, account_id: Optional[str] = None) -> None:
         rgw_delete_role_command = ['role', 'delete', '--role-name', role_name]
-        if account_id:
-            rgw_delete_role_command += ['--account-id', account_id]
+        self._append_account_flag(rgw_delete_role_command, account_id)
         code, _, _err = mgr.send_rgwadmin_command(rgw_delete_role_command,
                                                   stdout_as_json=False)
         if code != 0:
             raise DashboardException(msg=f'Error deleting role with code {code}: {_err}',
+                                     component='rgw')
+
+    def _append_account_flag(self, cmd: list, account_id: Optional[str]):
+        if account_id:
+            if account_id.startswith('RGW'):
+                cmd.extend(['--account-id', account_id])
+            else:
+                cmd.extend(['--account-name', account_id])
+
+    def list_role_policies(self, role_name: str,
+                           account_id: Optional[str] = None) -> List[str]:
+        rgw_list_role_policies_command = ['role', 'policy', 'list', '--role-name', role_name]
+        self._append_account_flag(rgw_list_role_policies_command, account_id)
+        code, res, err = mgr.send_rgwadmin_command(rgw_list_role_policies_command)
+        if code != 0:
+            logger.warning('Error listing role policies with code %d: %s', code, err)
+            return []
+        if isinstance(res, list):
+            return res
+        if isinstance(res, dict) and 'PolicyNames' in res:
+            return res['PolicyNames']
+        return []
+
+    def get_role_policy(self, role_name: str, policy_name: str,
+                         account_id: Optional[str] = None) -> Dict[str, Any]:
+        rgw_get_role_policy_command = ['role', 'policy', 'get', '--role-name', role_name,
+                                       '--policy-name', policy_name]
+        self._append_account_flag(rgw_get_role_policy_command, account_id)
+        code, res, err = mgr.send_rgwadmin_command(rgw_get_role_policy_command)
+        if code != 0:
+            raise DashboardException(msg=f'Error getting role policy with code {code}: {err}',
+                                     component='rgw')
+        return res
+
+    def put_role_policy(self, role_name: str, policy_name: str, policy_doc: str,
+                         account_id: Optional[str] = None) -> None:
+        try:
+            json.loads(policy_doc)
+        except:  # noqa: E722
+            raise DashboardException('Policy document is not a valid json')
+
+        rgw_put_role_policy_command = ['role', 'policy', 'put', '--role-name', role_name,
+                                       '--policy-name', policy_name,
+                                       '--policy-doc', f"{policy_doc}"]
+        self._append_account_flag(rgw_put_role_policy_command, account_id)
+        code, _, err = mgr.send_rgwadmin_command(rgw_put_role_policy_command,
+                                                 stdout_as_json=False)
+        if code != 0:
+            raise DashboardException(msg=f'Error putting role policy with code {code}: {err}',
+                                     component='rgw')
+
+    def delete_role_policy(self, role_name: str, policy_name: str,
+                            account_id: Optional[str] = None) -> None:
+        rgw_delete_role_policy_command = ['role', 'policy', 'delete', '--role-name', role_name,
+                                          '--policy-name', policy_name]
+        self._append_account_flag(rgw_delete_role_policy_command, account_id)
+        code, _, err = mgr.send_rgwadmin_command(rgw_delete_role_policy_command,
+                                                 stdout_as_json=False)
+        if code != 0:
+            raise DashboardException(msg=f'Error deleting role policy with code {code}: {err}',
                                      component='rgw')
 
     @RestClient.api_get('/{bucket_name}?policy')


### PR DESCRIPTION
mgr/dashboard: add RGW role permission policies management
Add backend controllers, services, and frontend UI to list, attach, and detach RGW account role permission policies.

Signed-off-by: Sagar Gopale <sagar.gopale@ibm.com>

Screencast : 

https://github.com/user-attachments/assets/8239fe6c-82ca-474d-85b8-522d3a1e29d4




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
