### PR TITLE
cephadm/tests: pre-import tracemalloc to avoid pyfakefs setup race

### DIFF
--- a/src/cephadm/tests/conftest.py
+++ b/src/cephadm/tests/conftest.py
@@ -1,0 +1,13 @@
+# Pre-import tracemalloc so that pytest's unraisable-exception hook
+# (_pytest.unraisableexception.unraisable_hook -> tracemalloc_message) does not
+# lazily import it from inside a garbage-collection pass.
+#
+# Some tests (e.g. TestBootstrap) leave NamedTemporaryFile objects created on
+# the pyfakefs fake filesystem to be garbage collected after the fake fs has
+# been torn down; their __del__ raises, pytest's hook runs during GC and, the
+# first time, imports tracemalloc.  If that GC happens while pyfakefs'
+# Patcher._find_modules() is iterating sys.modules, the `fs` fixture setup
+# fails with "RuntimeError: dictionary changed size during iteration" and,
+# because Patcher is a ref-counted singleton, every later fs-based test errors
+# with "'NoneType' object has no attribute 'add_real_directory'".
+import tracemalloc  # noqa: F401


### PR DESCRIPTION
Since 2026-08-18 `run_tox_cephadm` has been failing in roughly a quarter of arm64 `make check` runs (and ~8% of x86 runs) with one

```
RuntimeError: dictionary changed size during iteration
  .tox/py3/lib/python3.10/site-packages/pyfakefs/fake_filesystem_unittest.py:831: in _find_modules
```

during `fs` fixture setup, followed by 80+ cascading `AttributeError: 'NoneType' object has no attribute 'add_real_directory'` (pyfakefs' `Patcher` is a ref-counted singleton; a failed `setUp()` never gets its `tearDown()`, so every later `fs` test sees `fs=None`). Examples: [arm64 #102097](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/102097/testReport/), [x86 #191801](https://jenkins.ceph.com/job/ceph-pull-requests/191801/testReport/).

#### Root cause

Reproduced locally (arm64 jammy container, py3.10, pyfakefs 5.3.5, pytest 9.1) with `_find_modules` instrumented: no other threads exist; `sys.modules` gains `tracemalloc`/`_tracemalloc` during the iteration and a gen-2 GC runs inside it.

1. Several `TestBootstrap` tests run `command_bootstrap()` to completion, which leaves `NamedTemporaryFile` objects created on the pyfakefs fake filesystem to be garbage collected after the fake fs is torn down.
2. Their `__del__` raises (these show up as `PytestUnraisableExceptionWarning: Exception ignored in: <function _TemporaryFileCloser.__del__ ...>` in the run output already).
3. pytest ≥ 8.4's unraisable-exception hook runs inside the GC pass and, the first time, lazily imports `tracemalloc` (`_pytest.tracemalloc.tracemalloc_message`).
4. If that GC fires while pyfakefs 5.3.5 is doing `list(sys.modules.items())` in `Patcher._find_modules()`, the iteration fails.

#65592 didn't introduce the leaked temp files (the unraisable warnings exist before and after it); it shifted allocation/GC timing in exactly the tests preceding the victim, which is why the flake started with that merge (and its umbrella backport #71137 shows the same failure on x86). The arm64/x86 rate difference is GC-timing luck, not an arch-specific bug.

#### Fix

Pre-import `tracemalloc` in `src/cephadm/tests/conftest.py` so nothing new is added to `sys.modules` from within a finalizer. Verified with a pytest plugin that forces a `tracemalloc` import from a GC callback during `_find_modules`: pyfakefs 5.3.5 fails deterministically without this change and passes 195/195 with it.

Also measured with the real (non-forced) race, 40 full-suite runs each under `stress-ng --cpu 6` in an arm64 jammy container: parent of #65592 → 0 hits, `main` after #65592 → 8 hits (20%), `main` + this patch → 0 hits.

Alternatives considered: pyfakefs ≥ 5.10 snapshots `sys.modules` with `dict.copy()` and is immune, but 5.10.2 breaks 16 cephadm tests with `PermissionError` (stricter fake-fs permission checks), so it isn't a drop-in bump. A proper follow-up would be to close the bootstrap temp files so the unraisable exceptions disappear entirely.

cc @timqn22 @adk3798

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[ ]` becomes `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced (ff93b87b850, #65592)
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-integration-tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests


