### PR TITLE
mon: undefault MonConnection ctors

### DIFF
--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -66,10 +66,6 @@ public:
 		AuthRegistry *auth_registry,
                 ceph::mutex& m);
   ~MonConnection();
-  MonConnection(MonConnection&& rhs) = default;
-  MonConnection& operator=(MonConnection&&) = default;
-  MonConnection(const MonConnection& rhs) = delete;
-  MonConnection& operator=(const MonConnection&) = delete;
   int handle_auth(MAuthReply *m,
 		  const EntityName& entity_name,
 		  uint32_t want_keys,


### PR DESCRIPTION
a reference member variable was added to the class, so it's no longer moveable. instead of deleting/defaulting individual move/copy operations, just remove them and leave that to the compiler

Fixes: https://tracker.ceph.com/issues/79628

for reference:
```
FAILED: src/CMakeFiles/common-objs.dir/osdc/SplitOp.cc.o 
/usr/local/bin/sccache /usr/bin/clang++-19 -DBOOST_ASIO_DISABLE_THREAD_KEYWORD_EXTENSION -DBOOST_ASIO_NO_TS_EXECUTORS -DHAVE_CONFIG_H -DHAVE_WARN_IMPLICIT_CONST_INT_FLOAT_CONVERSION -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_REENTRANT -D_THREAD_SAFE -D__CEPH__ -D__STDC_FORMAT_MACROS -D__linux__ -I/ceph/build/src/include -I/ceph/src -I/ceph/build/src -isystem /opt/ceph/include -isystem /ceph/build/include -isystem /ceph/src/jaegertracing/opentelemetry-cpp/api/include -isystem /ceph/src/jaegertracing/opentelemetry-cpp/exporters/jaeger/include -isystem /ceph/src/jaegertracing/opentelemetry-cpp/ext/include -isystem /ceph/src/jaegertracing/opentelemetry-cpp/sdk/include -isystem /ceph/src/xxHash -isystem /ceph/src/fmt/include -g -Werror -fPIC -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -Wall -fno-strict-aliasing -fsigned-char -Wtype-limits -Wignored-qualifiers -Wpointer-arith -Werror=format-security -Winit-self -Wno-unknown-pragmas -Wnon-virtual-dtor -Wno-ignored-qualifiers -Wsign-compare -ftemplate-depth-1024 -DBOOST_ALLOW_DEPRECATED_HEADERS -Wpessimizing-move -Wredundant-move -Wno-inconsistent-missing-override -Wno-mismatched-tags -Wno-unused-private-field -Wno-address-of-packed-member -Wno-unknown-warning-option -Wno-unused-function -Wno-unused-local-typedef -Wno-varargs -Wno-gnu-designator -Wno-missing-braces -Wno-parentheses -Wno-deprecated-register -Wno-vla-cxx-extension -DCEPH_DEBUG_MUTEX -D_GLIBCXX_ASSERTIONS -fdiagnostics-color=auto -std=c++2b -MD -MT src/CMakeFiles/common-objs.dir/osdc/SplitOp.cc.o -MF src/CMakeFiles/common-objs.dir/osdc/SplitOp.cc.o.d -o src/CMakeFiles/common-objs.dir/osdc/SplitOp.cc.o -c /ceph/src/osdc/SplitOp.cc
In file included from /ceph/src/osdc/SplitOp.cc:12:
In file included from /ceph/src/osdc/SplitOp.h:39:
In file included from /ceph/src/osdc/Objecter.h:61:
/ceph/src/mon/MonClient.h:70:18: error: explicitly defaulted move assignment operator is implicitly deleted [-Werror,-Wdefaulted-function-deleted]
   70 |   MonConnection& operator=(MonConnection&&) = default;
      |                  ^
/ceph/src/mon/MonClient.h:151:16: note: move assignment operator of 'MonConnection' is implicitly deleted because field 'monc_lock' is of reference type 'ceph::mutex &' (aka 'mutex_debug_impl<false> &')
  151 |   ceph::mutex& monc_lock;
      |                ^
/ceph/src/mon/MonClient.h:70:47: note: replace 'default' with 'delete'
   70 |   MonConnection& operator=(MonConnection&&) = default;
      |                                               ^~~~~~~
      |                                               delete
1 error generated.
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
