### PR TITLE
umbrella: mgr/rbd_support: make schedule phase offset calculation FIPS compliant

### DIFF
--- a/src/pybind/mgr/rbd_support/schedule.py
+++ b/src/pybind/mgr/rbd_support/schedule.py
@@ -333,7 +333,7 @@ class Schedule:
     @staticmethod
     def _compute_phase_offset_minutes(entity_id: str, period_minutes: int) -> int:
         key = entity_id + "|" + str(period_minutes)
-        h = hashlib.md5(key.encode("utf-8")).hexdigest()
+        h = hashlib.md5(key.encode("utf-8"), usedforsecurity=False).hexdigest()
         val = int(h, 16)
         return (val % period_minutes)
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79575

---

backport of https://github.com/ceph/ceph/pull/71106
parent tracker: https://tracker.ceph.com/issues/79549

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh