### PR TITLE
ceph-backport.sh: run on macOS as well as Linux

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,8 @@
+* ``src/script/ceph-backport.sh`` now runs on macOS in addition to Linux: it
+  re-execs under GNU bash >= 4 when the system bash is too old, and honors a
+  ``$GETOPT`` environment override so GNU getopt can be selected
+  (``brew install bash gnu-getopt``).
+
 * CephFS: The ``client_force_lazyio`` configuration option is now correctly marked
   as not supporting runtime updates. Previously, the configuration schema indicated
   this option could be changed at runtime, but changes had no effect on opened file

--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -52,6 +52,55 @@ if [[ $* == *--debug* ]]; then
     set -x
 fi
 
+# ---------------------------------------------------------------------------
+# Portability guard (Linux and macOS)
+#
+# ceph-backport.sh requires GNU bash >= 4 (associative arrays, ${var,,}) and
+# GNU getopt (--long options). Both are the default on Linux. macOS ships bash
+# 3.2 and BSD getopt, so install the GNU versions:
+#
+#     brew install bash gnu-getopt
+#
+# If they are not first in PATH, point this script at them with:
+#
+#     export BASH_OVERRIDE=/opt/homebrew/bin/bash
+#     export GETOPT=/opt/homebrew/opt/gnu-getopt/bin/getopt
+# ---------------------------------------------------------------------------
+
+# Re-exec under a bash >= 4 when the current interpreter is too old (e.g. the
+# bash 3.2 that macOS ships in /bin).
+if ((BASH_VERSINFO[0] < 4)) && [ -z "${_CEPH_BACKPORT_REEXEC:-}" ]; then
+    for _cand in "${BASH_OVERRIDE:-}" /opt/homebrew/bin/bash /usr/local/bin/bash "$(command -v bash 2>/dev/null || true)"; do
+        [ -n "$_cand" ] && [ -x "$_cand" ] || continue
+        _cand_major=$("$_cand" -c 'echo "${BASH_VERSINFO[0]}"' 2>/dev/null || true)
+        if [ -n "$_cand_major" ] && [ "$_cand_major" -ge 4 ] 2>/dev/null; then
+            exec env _CEPH_BACKPORT_REEXEC=1 "$_cand" "$0" "$@"
+        fi
+    done
+fi
+if ((BASH_VERSINFO[0] < 4)); then
+    echo "${0##*/}: requires GNU bash >= 4 (found ${BASH_VERSINFO[0]}.x)." >&2
+    echo "    On macOS: brew install bash   (or set BASH_OVERRIDE=/path/to/bash)" >&2
+    exit 1
+fi
+
+# Require GNU (enhanced) getopt; the BSD getopt on macOS has no --long. The
+# $GETOPT override lets callers select Homebrew's gnu-getopt.
+GETOPT="${GETOPT:-getopt}"
+if ! command -v "$GETOPT" >/dev/null 2>&1; then
+    echo "${0##*/}: cannot find getopt (\"$GETOPT\")." >&2
+    echo "    On macOS: brew install gnu-getopt" >&2
+    exit 1
+fi
+_getopt_rc=0
+"$GETOPT" --test >/dev/null 2>&1 || _getopt_rc=$?
+if [ "$_getopt_rc" -ne 4 ]; then
+    echo "${0##*/}: GNU (enhanced) getopt required; \"$GETOPT\" is not it." >&2
+    echo "    On macOS: brew install gnu-getopt, then" >&2
+    echo "    export GETOPT=/opt/homebrew/opt/gnu-getopt/bin/getopt" >&2
+    exit 1
+fi
+
 # associative array keyed on "component" strings from PR titles, mapping them to
 # GitHub PR labels that make sense in backports
 declare -A comp_hash=(
@@ -1408,7 +1457,7 @@ fi
 # process command-line arguments
 #
 
-munged_options=$(getopt -o c:dhsv --long "cherry-pick-only,component:,debug,existing-pr:,force,fork:,help,milestones,prepare,setup,setup-report,troubleshooting,update-version,usage,verbose,version" -n "$this_script" -- "$@")
+munged_options=$("$GETOPT" -o c:dhsv --long "cherry-pick-only,component:,debug,existing-pr:,force,fork:,help,milestones,prepare,setup,setup-report,troubleshooting,update-version,usage,verbose,version" -n "$this_script" -- "$@")
 eval set -- "$munged_options"
 
 ADVICE=""


### PR DESCRIPTION
The script needs GNU bash >= 4 (associative arrays, ${var,,}) and GNU getopt
(--long). macOS ships bash 3.2 and BSD getopt, so today it dies with a cryptic
"declare: -A: invalid option" before it can explain itself.

This adds a portability guard near the top that:

  * re-execs under a bash >= 4 when the running interpreter is too old,
    searching $BASH_OVERRIDE, the common Homebrew paths, and $PATH; and
  * resolves getopt through a $GETOPT override, verified as GNU/enhanced
    getopt via `getopt --test`.

When the tools are missing it prints `brew install bash gnu-getopt` instead of
a bash error. The Linux path is unchanged: bash there is already >= 4 and
getopt is GNU, so neither the re-exec nor any override triggers. Also adds a
PendingReleaseNotes entry.

Testing:

  * `bash -n` under bash 5.3 -- clean.
  * From system bash 3.2, `--version` and `--help` re-exec to bash 5 and parse
    `--long` options correctly.
  * Missing bash 4 / BSD getopt each produce the actionable hint.
  * Linux-equivalent (bash 5 + GNU getopt on PATH, no overrides) unchanged.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
