### PR TITLE
qa/distros: ask for Rocky by major, not a point release

### DIFF
--- a/qa/distros/all/rocky_10.yaml
+++ b/qa/distros/all/rocky_10.yaml
@@ -3,7 +3,7 @@ install_rocky_packages:
     - print: "Install additional rocky10 dependencies"
     # postmerge appends to this
 os_type: rocky
-os_version: "10.1"
+os_version: "10"
 overrides:
   selinux:
     allowlist:

--- a/qa/distros/all/rocky_9.yaml
+++ b/qa/distros/all/rocky_9.yaml
@@ -1,5 +1,5 @@
 os_type: rocky
-os_version: "9.6"
+os_version: "9"
 tasks:
 - pexec:
     all:


### PR DESCRIPTION
Rocky only maintains its newest point release and the rocky/10 packages shaman builds are compiled on it — `ceph-osd-crimson` now needs `c-ares >= 1.28`, which only 10.2 ships — so the lab treats Rocky 10 like CentOS Stream: the FOG image is named by major (`trial_rocky_10`) and kept on the current minor, and jobs ask for `os_version: "10"` (and "9"). Pinning the suite to `"10.1"` either fails the deploy (no 10.1 image) or, as on 2026-08-19, fails every package install with `nothing provides c-ares(x86-64) >= 1.28.0`.

**Depends on** ceph/teuthology#2246 (accepts a major-only Rocky version in the codename map and in the post-deploy OS check) — do not merge before that lands, or every Rocky job fails at `check_packages`. Related: ceph/ceph-cm-ansible#873.

Scheduled as `wip-dgalloway-rocky-10-major` on ceph-ci for a teuthology run with `--teuthology-branch wip-rocky-major-os-version`.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests