### PR TITLE
mgr/dashboard: fix subsystem change_key and subsystem del_key command decorators order so they appear in help

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -621,6 +621,9 @@ else:
 
         @Endpoint('PUT', '{nqn}/change_key')
         @UpdatePermission
+        @empty_response
+        @NvmeofCLICommand("nvmeof subsystem change_key", model.RequestStatus,
+                          success_message_template="Changing key for subsystem {nqn}: Successful")
         @EndpointDoc(
             "Change subsystem inband authentication key",
             parameters={
@@ -631,9 +634,6 @@ else:
                 "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
-        @empty_response
-        @NvmeofCLICommand("nvmeof subsystem change_key", model.RequestStatus,
-                          success_message_template="Changing key for subsystem {nqn}: Successful")
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def change_key(self, nqn: str, dhchap_key: str, gw_group: Optional[str] = None,
@@ -653,6 +653,9 @@ else:
                 )
             )
 
+        @empty_response
+        @NvmeofCLICommand("nvmeof subsystem del_key", model.RequestStatus,
+                          success_message_template="Deleting key for subsystem {nqn}: Successful")
         @EndpointDoc(
             "Delete subsystem inband authentication key",
             parameters={
@@ -662,9 +665,6 @@ else:
                 "traddr": Param(str, "NVMeoF gateway address (deprecated)", True, None),
             },
         )
-        @empty_response
-        @NvmeofCLICommand("nvmeof subsystem del_key", model.RequestStatus,
-                          success_message_template="Deleting key for subsystem {nqn}: Successful")
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def del_key(self, nqn: str, gw_group: Optional[str] = None,


### PR DESCRIPTION

changed the order of decorators to make the commands to be included in help.
Have some thoughts about how fragile this decorators setup is, but this is for another PR :)
before:
```
[xxx@xxx ~]# ceph nvmeof subsystem --help
........

 Monitor commands:
 =================
nvmeof subsystem add [<nqn>] [<max_namespaces:int>] [--no-group-append] [--serial_number <value>] [--dhchap_key <value>]   Create a new NVMeoF subsystem
 [--gw_group <value>] [--server_address <value>] [--network_mask <value>...] [--port <int>] [--secure-listeners] [--
 traddr <value>]
nvmeof subsystem add_kmip_server_endpoint <nqn> [<server_name>] [<address>] [<port:int>] [<gw_group>] [<server_address>]   Add a KMIP server endpoint to the subsystem
 [<traddr>]
nvmeof subsystem add_network <nqn> [<network_mask>] [<gw_group>] [<server_address>] [<traddr>]                             Add subsystem network mask
nvmeof subsystem del [<nqn>] [<force>] [<gw_group>] [<server_address>] [<traddr>]                                          Delete an existing NVMeoF subsystem
nvmeof subsystem del_kmip_server_endpoint <nqn> [<server_name>] [<address>] [<port:int>] [<gw_group>] [<server_address>]   Delete a KMIP server endpoint from the subsystem
 [<traddr>]
nvmeof subsystem del_network <nqn> [<network_mask>] [<gw_group>] [<server_address>] [<traddr>]                             Delete subsystem network mask
nvmeof subsystem get [<nqn>] [<gw_group>] [<server_address>] [<traddr>]                                                    Get information from a specific NVMeoF subsystem
nvmeof subsystem list [<nqn>] [<serial_number>] [<gw_group>] [<server_address>] [<traddr>]                                 List all NVMeoF subsystems
nvmeof subsystem list_kmip_server_endpoints [<nqn>] [<server_name>] [<gw_group>] [<server_address>] [<traddr>]             List KMIP server endpoints for a subsystem or all subsystems
```

after:
```
[xxx@xxx ~]# ceph nvmeof subsystem --help
............

 Monitor commands:
 =================
nvmeof subsystem add [<nqn>] [<max_namespaces:int>] [--no-group-append] [--serial_number <value>] [--dhchap_key <value>]   Create a new NVMeoF subsystem
 [--gw_group <value>] [--server_address <value>] [--network_mask <value>...] [--port <int>] [--secure-listeners] [--
 traddr <value>]
nvmeof subsystem add_kmip_server_endpoint <nqn> [<server_name>] [<address>] [<port:int>] [<gw_group>] [<server_address>]   Add a KMIP server endpoint to the subsystem
 [<traddr>]
nvmeof subsystem add_network <nqn> [<network_mask>] [<gw_group>] [<server_address>] [<traddr>]                             Add subsystem network mask
nvmeof subsystem change_key <nqn> [<dhchap_key>] [<gw_group>] [<server_address>] [<traddr>]                                Change subsystem inband authentication key
nvmeof subsystem del [<nqn>] [<force>] [<gw_group>] [<server_address>] [<traddr>]                                          Delete an existing NVMeoF subsystem
nvmeof subsystem del_key [<nqn>] [<gw_group>] [<server_address>] [<traddr>]                                                Delete subsystem inband authentication key
nvmeof subsystem del_kmip_server_endpoint <nqn> [<server_name>] [<address>] [<port:int>] [<gw_group>] [<server_address>]   Delete a KMIP server endpoint from the subsystem
 [<traddr>]
nvmeof subsystem del_network <nqn> [<network_mask>] [<gw_group>] [<server_address>] [<traddr>]                             Delete subsystem network mask
nvmeof subsystem get [<nqn>] [<gw_group>] [<server_address>] [<traddr>]                                                    Get information from a specific NVMeoF subsystem
nvmeof subsystem list [<nqn>] [<serial_number>] [<gw_group>] [<server_address>] [<traddr>]                                 List all NVMeoF subsystems
nvmeof subsystem list_kmip_server_endpoints [<nqn>] [<server_name>] [<gw_group>] [<server_address>] [<traddr>]             List KMIP server endpoints for a subsystem or all subsystems
```

notice it now includes `subsystem change_key` and `subsystem del_key`

fixes: https://tracker.ceph.com/issues/79634
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
