### PR TITLE
client, mds: reset futuristic mtime on write under shared capabilities

### DIFF
--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -595,6 +595,74 @@ class TestMisc(CephFSTestCase):
             "The client stripped CEPH_SETATTR_ATIME from the mask, "
             "causing the MDS to skip advancing ctime during value-equality matches.")
 
+    def test_write_updates_futuristic_mtime(self):
+        """
+        Ensure a data write operation overwrites a user-set futuristic mtime/ctime
+        with the current system clock when the timestamp exceeds acceptable clock skew,
+        even in multi-client environments where CEPH_CAP_FILE_EXCL is revoked.
+        """
+        test_file = "test_futuristic_mtime.bin"
+
+        # Use Client 1 (mount_a) to create the file
+        self.mount_a.touch(test_file)
+
+        # Explicitly push the file's mtime 25 hours into the future
+        log.info("Setting file mtime 25 hours into the future")
+        self.mount_a.run_shell(["touch", "-m", "-d", "+25 hours", test_file])
+
+        # Verify the file is actually set in the future before continuing
+        future_mtime = int(self.mount_a.run_shell(["stat", "-c", "%Y",
+                                                   test_file]).stdout.getvalue().strip())
+        current_time = int(self.mount_a.run_shell(["date", "+%s"]).stdout.getvalue().strip())
+        self.assertTrue(future_mtime > current_time,
+                        "Setup error: File mtime is not in the future.")
+
+        # Keep file open on mount_b to ensure EXCL caps stay revoked on mount_a
+        log.info("Opening file on client_b to force cap downgrade (revoking EXCL) on client_a")
+        proc_b = self.mount_b.open_background(test_file, write=False)
+
+        # Wait briefly for cap transitions to settle across MDS/clients
+        time.sleep(2)
+
+        # Perform a data write operation via Client 1 (mount_a)
+        log.info("Executing write on client_a while working under shared capabilities")
+        self.mount_a.run_shell(["sh", "-c", f"echo 'payload' >> {test_file}"])
+
+        # Force mount_a to flush dirty caps (including updated mtime) to the MDS
+        self.mount_a.run_shell(["sync"])
+
+        # Release background handle on mount_b
+        self.mount_b.kill_background(proc_b)
+
+        # Remount client_b to clear its cache and force an MDS query
+        log.info("Remounting client_b to verify master MDS inode state")
+        self.mount_b.remount()
+
+        # Gather post-write metadata metrics from client_b (fresh from MDS)
+        log.info("Gathering post-write metadata metrics from client_b")
+        post_mtime = int(self.mount_b.run_shell(["stat", "-c", "%Y",
+                                                 test_file]).stdout.getvalue().strip())
+
+        # Refresh current time gauge
+        final_current_time = int(self.mount_a.run_shell(["date", "+%s"
+                                                         ]).stdout.getvalue().strip())
+
+        # Clean up test file while mount_a is still mounted
+        self.mount_a.run_shell(["rm", "-f", test_file])
+
+        # Final Assertion Checklist
+        log.info(f"Future mtime: {future_mtime} | Post-write mtime: {post_mtime}"
+                 f" | Current system time: {final_current_time}")
+
+        # The post-write mtime should no longer be stuck in the future
+        self.assertLessEqual(
+            post_mtime,
+            final_current_time + 10,
+            "REGRESSION DETECTED: The futuristic mtime remained stuck after a "
+            "write operation because metadata caps were not dirtied or accepted "
+            "by the MDS."
+        )
+
 @classhook('_add_session_client_evictions')
 class TestSessionClientEvict(CephFSTestCase):
     CLIENTS_REQUIRED = 3

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1057,11 +1057,15 @@ void Client::update_inode_file_time(Inode *in, int issued, uint64_t time_warp_se
       in->atime = atime;
       in->time_warp_seq = time_warp_seq;
     } else if (time_warp_seq == in->time_warp_seq) {
-      //take max times
-      if (mtime > in->mtime)
-	in->mtime = mtime;
-      if (atime > in->atime)
-	in->atime = atime;
+      // Do not overwrite local write timestamps if caps are dirty or actively flushing
+      bool local_time_dirty = (in->dirty_caps | in->flushing_caps) &
+                              (CEPH_CAP_FILE_WR | CEPH_CAP_FILE_EXCL);
+      if (!local_time_dirty) {
+        if (mtime > in->mtime)
+          in->mtime = mtime;
+        if (atime > in->atime)
+          in->atime = atime;
+      }
     } else if (issued & CEPH_CAP_FILE_EXCL) {
       //ignore mds values as we have a higher seq
     } else warn = true;

--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -1848,3 +1848,15 @@ options:
   - mds
   flags:
   - runtime
+- name: mds_max_clock_skew
+  type: float
+  level: advanced
+  desc: Maximum allowed clock skew before write operations reset futuristic mtime
+  long_desc: If a file's existing mtime exceeds the current MDS clock plus this threshold,
+    incoming write operations under shared capabilities will reset mtime and ctime
+    back to current real time.
+  default: 5
+  services:
+  - mds
+  flags:
+  - runtime

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -3989,8 +3989,17 @@ void Locker::_update_cap_fields(CInode *in, int dirty, const cref_t<MClientCaps>
     utime_t mtime = m->get_mtime();
     uint64_t size = m->get_size();
     version_t inline_version = m->inline_version;
-    
-    if (((dirty & CEPH_CAP_FILE_WR) && mtime > pi->mtime) ||
+
+    /* Allow writes to reset futuristic mtimes that exceed the clock skew threshold.
+     * This overrides stale future timestamps while preserving clock-skew safeguards
+     * against minor backward drift during concurrent writes.
+     */
+    double max_skew = g_conf().get_val<double>("mds_max_clock_skew");
+    utime_t skew_threshold = ceph_clock_now();
+    skew_threshold += max_skew;
+    bool mtime_is_far_future = pi->mtime > skew_threshold;
+
+    if (((dirty & CEPH_CAP_FILE_WR) && (mtime > pi->mtime || mtime_is_far_future)) ||
 	((dirty & CEPH_CAP_FILE_EXCL) && mtime != pi->mtime)) {
       dout(7) << "  mtime " << pi->mtime << " -> " << mtime
 	      << " for " << *in << dendl;


### PR DESCRIPTION
### Summary
When a file's `mtime` is explicitly set into the future (e.g. via `setattr` or `touch -d "+25 hours"`) and a second client opens the file, `CEPH_CAP_FILE_EXCL` is revoked from the writing client, forcing it to operate under shared write capabilities (`CEPH_CAP_FILE_WR`). 

Under shared write capabilities, data write operations need to reliably reset the file's modification timestamp back to real time. This PR updates both client and MDS logic to ensure incoming write operations properly reset futuristic timestamps.

### Key Changes
* **Client (`src/client/Client.cc`)**: Updated `Client::update_inode_file_time()` to preserve local real-time write timestamps by preventing incoming MDS cap grant messages from overwriting local values while `CEPH_CAP_FILE_WR` or `CEPH_CAP_FILE_EXCL` capabilities are dirty or actively flushing.
* **MDS Option (`src/common/options/mds.yaml.in`)**: Introduced the `mds_max_clock_skew` configuration option (default: `5` seconds).
* **MDS Locker (`src/mds/Locker.cc`)**: In `Locker::_update_cap_fields()`, added a clock-skew check (`mtime_is_far_future`). If the stored `pi->mtime` exceeds current MDS time plus `mds_max_clock_skew`, incoming write flushes under `CEPH_CAP_FILE_WR` are permitted to reset `mtime` and `ctime` back to current system time.
* **QA Test (`qa/tasks/cephfs/test_misc.py`)**: Added `test_write_updates_futuristic_mtime()` to validate that writes under shared capabilities reset futuristic timestamps in a multi-client environment.

### Testing
* **Teuthology Run**: Passed green across `fs:multiclient` suite
  * Pulpito: https://pulpito.ceph.com/jcollin-2026-08-20_03:17:55-fs:multiclient-wip-jcollin-testing-19082026-2-distro-default-trial/

Fixes: https://tracker.ceph.com/issues/71622

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
