### PR TITLE
test/librados/split_op_cxx.cc: skip tests for crimson

### DIFF
--- a/src/test/librados/split_op_cxx.cc
+++ b/src/test/librados/split_op_cxx.cc
@@ -41,6 +41,7 @@ void RadosTestPPBase::ensure_log_committed(const char* oid, uint64_t offset, uin
 }
 
 TEST_P(LibRadosSplitOpPP, BigRead) {
+  SKIP_IF_CRIMSON();
   std::string min_split_size_str;
   ASSERT_EQ(0, cluster.conf_get("osd_min_split_replica_read_size", min_split_size_str));
   uint64_t min_split_size = std::stoull(min_split_size_str);
@@ -72,6 +73,7 @@ TEST_P(LibRadosSplitOpPP, BigRead) {
 }
 
 TEST_P(LibRadosSplitOpPP, ReadTwoShards) {
+  SKIP_IF_CRIMSON();
   // Read the osd_min_split_replica_read_size config value
   std::string min_split_size_str;
   ASSERT_EQ(0, cluster.conf_get("osd_min_split_replica_read_size", min_split_size_str));
@@ -141,6 +143,7 @@ TEST_P(LibRadosSplitOpPP, ReadTwoShards) {
 }
 
 TEST_P(LibRadosSplitOpPP, StatBeforeRead) {
+  SKIP_IF_CRIMSON();
   // Read the osd_min_split_replica_read_size config value
   std::string min_split_size_str;
   ASSERT_EQ(0, cluster.conf_get("osd_min_split_replica_read_size", min_split_size_str));
@@ -197,6 +200,7 @@ TEST_P(LibRadosSplitOpPP, StatBeforeRead) {
 }
 
 TEST_P(LibRadosSplitOpPP, GetXattrBeforeRead) {
+  SKIP_IF_CRIMSON();
   // Read the osd_min_split_replica_read_size config value
   std::string min_split_size_str;
   ASSERT_EQ(0, cluster.conf_get("osd_min_split_replica_read_size", min_split_size_str));


### PR DESCRIPTION
This commit skips running the following tests with crimson: BigRead, ReadTwoShards, StatBeforeRead, and GetXattrBeforeRead.

This is done as crimson does not support split reads.

Fixes: https://tracker.ceph.com/issues/79643

## Testing 

Before this fix: https://pulpito-ng.ceph.com/runs/shraddhaag-2026-08-20_06:31:58-crimson-rados-wip-shraddhaag-ec-delete-write-distro-debug-trial
After this fix: https://pulpito.ceph.com/shraddhaag-2026-08-20_10:27:38-crimson-rados-wip-shraddhaag-disable-split-read-tests-distro-debug-trial/


## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [X] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
