### PR TITLE
rgw/posix: use mtime+inode for version-ids

### DIFF
--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -38,9 +38,11 @@ const std::string ATTR_PREFIX = "user.X-RGW-";
 #define RGW_POSIX_ATTR_OBJECT_TYPE "POSIX-Object-Type"
 #define RGW_POSIX_ATTR_MANIFEST "POSIX-Manifest"
 #define RGW_POSIX_ATTR_VERSION "POSIX-version"
+#define RGW_POSIX_ATTR_VERSION_ID "version_id"
 const std::string mp_ns = "multipart";
 const std::string MP_OBJ_PART_PFX = "part-";
 const std::string MP_OBJ_HEAD_NAME = MP_OBJ_PART_PFX + "00000";
+static const std::string NULL_VERSION_ID = "null";
 
 struct POSIXOwner {
   rgw_user user;
@@ -107,6 +109,99 @@ static inline std::string gen_rand_instance_name()
 
   return buf;
 }
+
+
+/* Versions */
+
+
+static std::string to_base36(uint64_t v)
+{
+  if (v == 0) return "0";
+  const char digits[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+  std::string result;
+  while (v > 0) {
+    result.insert(result.begin(), digits[v % 36]);
+    v /= 36;
+  }
+  return result;
+}
+
+static bool from_base36(const std::string& s, uint64_t& out)
+{
+  out = 0;
+  for (char c : s) {
+    uint64_t d;
+    if (c >= '0' && c <= '9') {
+      d = c - '0';
+    } else if (c >= 'a' && c <= 'z') {
+      d = 10 + (c - 'a');
+    } else {
+      return false;
+    }
+    out = out * 36 + d;
+  }
+  return true;
+}
+
+static uint64_t statx_mtime_ns(const struct statx& stx)
+{
+  return (uint64_t)stx.stx_mtime.tv_sec * 1000000000ULL
+       + stx.stx_mtime.tv_nsec;
+}
+
+static std::string posix_version_id_from_statx(const struct statx& stx)
+{
+  return "mtime-" + to_base36(statx_mtime_ns(stx))
+       + "-ino-" + to_base36(stx.stx_ino);
+}
+
+struct posix_version_info {
+  uint64_t mtime_ns{0};
+  uint64_t ino{0};
+};
+
+#if 0
+static bool posix_parse_version_id(const std::string& version_id,
+                                   posix_version_info& info)
+{
+  if (version_id == NULL_VERSION_ID) {
+    info = {};
+    return true;
+  }
+  static const std::string mtime_pfx = "mtime-";
+  static const std::string ino_pfx = "-ino-";
+  if (version_id.compare(0, mtime_pfx.size(), mtime_pfx) != 0) {
+    return false;
+  }
+  auto ino_pos = version_id.find(ino_pfx, mtime_pfx.size());
+  if (ino_pos == std::string::npos) {
+    return false;
+  }
+  std::string mtime_str = version_id.substr(mtime_pfx.size(),
+                                            ino_pos - mtime_pfx.size());
+  std::string ino_str = version_id.substr(ino_pos + ino_pfx.size());
+  return from_base36(mtime_str, info.mtime_ns) &&
+         from_base36(ino_str, info.ino);
+}
+
+static bool is_null_version_fd(int fd)
+{
+  char buf[256];
+  std::string vid_xattr = ATTR_PREFIX + RGW_POSIX_ATTR_VERSION_ID;
+  ssize_t len = ::fgetxattr(fd, vid_xattr.c_str(), buf, sizeof(buf));
+  if (len <= 0) {
+    return true;
+  }
+  return std::string_view(buf, len) == NULL_VERSION_ID;
+}
+#endif
+/* version entry name within .versions/: <leaf>_<version_id> */
+static inline std::string posix_ver_entry(const std::string& leaf,
+                                         const std::string& vid)
+{
+  return leaf + "_" + vid;
+}
+
 
 static inline std::string bucket_fname(std::string name, std::optional<std::string>& ns)
 {
@@ -532,6 +627,7 @@ int File::create(const DoutPrefixProvider *dpp, bool* existed, bool temp_file)
 
 int File::open(const DoutPrefixProvider* dpp)
 {
+  ldpp_dout(dpp, 0) << "NITHYA: File::open() " << get_name() << dendl;
   if (fd >= 0) {
     return 0;
   }
@@ -733,17 +829,22 @@ int File::remove(const DoutPrefixProvider* dpp, optional_yield y, bool delete_ch
   return 0;
 }
 
-int File::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y, std::string temp_fname)
+int File::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y, std::string tgt_fname)
 {
   if (fd < 0) {
     return 0;
   }
 
+/*
+  std::string tmp_name = ".tmp_link_" +
+  std::to_string(getpid()) + "_" + gen_rand_instance_name();
+
+*/
   char temp_file_path[PATH_MAX];
   // Only works on Linux - Non-portable
   snprintf(temp_file_path, PATH_MAX,  "/proc/self/fd/%d", fd);
 
-  int ret = linkat(AT_FDCWD, temp_file_path, parent->get_fd(), temp_fname.c_str(), AT_SYMLINK_FOLLOW);
+  int ret = linkat(AT_FDCWD, temp_file_path, parent->get_fd(), tgt_fname.c_str(), AT_SYMLINK_FOLLOW);
   if(ret < 0) {
     ret = errno;
     ldpp_dout(dpp, 0) << "ERROR: linkat for temp file could not finish: "
@@ -751,13 +852,15 @@ int File::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y, std::s
     return -ret;
   }
 
-  ret = renameat(parent->get_fd(), temp_fname.c_str(), parent->get_fd(), get_name().c_str());
+  ret = renameat(parent->get_fd(), tgt_fname.c_str(), parent->get_fd(), get_name().c_str());
   if(ret < 0) {
     ret = errno;
     ldpp_dout(dpp, 0) << "ERROR: renameat for object could not finish: "
 	<< cpp_strerror(ret) << dendl;
     return -ret;
   }
+
+//  fname = tgt_fname;
 
   /* note that open() and stat() return already sign-reversed result codes */
   ret = open(dpp);
@@ -766,7 +869,7 @@ int File::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y, std::s
     return ret;
   }
 
-  ret = stat(dpp);
+  ret = stat(dpp, true);
   if (ret < 0) {
     ldpp_dout(dpp, 20) << "ERROR: POSIXAtomicWriter failed closing file" << dendl;
     return ret;
@@ -774,6 +877,16 @@ int File::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y, std::s
 
   return 0;
 }
+
+/*
+int File::rename(const DoutPrefixProvider* dpp, Directory* dst_dir, const std::string& new_name)
+{
+  
+
+  return 0;
+}
+*/
+
 
 bool Directory::file_exists(std::string& name)
 {
@@ -1367,6 +1480,7 @@ int MPDirectory::fill_cache(const DoutPrefixProvider *dpp, optional_yield y,
 
 int VersionedDirectory::open(const DoutPrefixProvider* dpp)
 {
+  ldpp_dout(dpp, 0) << "NITHYA: VersionedDirectory::open() " << get_name() << dendl;
   if (fd > 0) {
     return 0;
   }
@@ -1391,6 +1505,7 @@ int VersionedDirectory::open(const DoutPrefixProvider* dpp)
 
 int VersionedDirectory::create(const DoutPrefixProvider* dpp, bool* existed, bool temp_file)
 {
+    ldpp_dout(dpp, 0) << "NITHYA: VersionedDirectory::create() " << get_name() << ", temp_file=" << temp_file << dendl;
   int ret = mkdirat(parent->get_fd(), fname.c_str(), S_IRWXU);
   if (ret < 0) {
     ret = errno;
@@ -1602,14 +1717,33 @@ int VersionedDirectory::read(int64_t ofs, int64_t left, bufferlist &bl,
 }
 
 int VersionedDirectory::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y,
-                              std::string temp_fname)
+                                       std::string temp_fname)
 {
+  ldpp_dout(dpp, 0) << "NITHYA: VersionedDirectory::link_temp_file() " << get_name() << dendl;
   if (!cur_version)
     return -EINVAL;
-  int ret = cur_version->link_temp_file(dpp, y, temp_fname);
+
+  // Get the mtime+inode info for the temp file via its fd
+
+  struct statx stx;
+  int ret = statx(cur_version->get_fd(), "", AT_SYMLINK_NOFOLLOW | AT_EMPTY_PATH,
+		  STATX_ALL, &stx);
+  if (ret == 0) {
+    std::string ver_id = posix_version_id_from_statx (stx);
+    rgw_obj_key key = decode_obj_key(get_name());
+    key.instance = ver_id;
+    std::string versioned_fname = get_key_fname(key, true);
+    cur_version->set_name(versioned_fname);
+  ldpp_dout(dpp, 0) << "NITHYA: VersionedDirectory::link_temp_file() updated_name :" << cur_version->get_name() << dendl;
+  } else {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not stat temp file for" << get_name() << ": "
+                      << cpp_strerror(ret) << dendl;
+    return ret;
+  }
+  ret = cur_version->link_temp_file(dpp, y, temp_fname);
   if (ret < 0)
     return ret;
-
   return set_cur_version_ent(dpp, cur_version.get());
 }
 
@@ -1691,7 +1825,7 @@ int VersionedDirectory::copy(const DoutPrefixProvider *dpp, optional_yield y,
 int VersionedDirectory::add_delete_marker(const DoutPrefixProvider* dpp,
                                           optional_yield y,
                                           std::unique_ptr<File>& marker,
-                                          const std::string &name)
+                                          std::string &name)
 {
   // Create as temporary file first
   int ret = marker->create(dpp, /*existed=*/nullptr, /*temp_file=*/true);
@@ -1727,7 +1861,19 @@ int VersionedDirectory::add_delete_marker(const DoutPrefixProvider* dpp,
     // removing the temporary files before returning failure
     marker->remove(dpp, y, /*delete_children=*/false, nullptr);
     return ret;
+  } 
+  struct statx stx;
+  ret = statx(marker->get_fd(), "", AT_SYMLINK_NOFOLLOW | AT_EMPTY_PATH,
+		  STATX_ALL, &stx);
+  if (ret < 0) {
+    return ret;
   }
+  std::string ver_id = posix_version_id_from_statx (stx);
+  rgw_obj_key key = decode_obj_key(get_name());
+  key.instance = ver_id;
+  std::string versioned_fname = get_key_fname(key, true);
+  marker->set_name(versioned_fname);
+  ldpp_dout(dpp, 0) << "NITHYA: VersionedDirectory::add_delete_marker() updated_name :" << marker->get_name() << dendl;
 
   // Link temp file to final name atomically
   ret = marker->link_temp_file(dpp, y, name);
@@ -1736,7 +1882,26 @@ int VersionedDirectory::add_delete_marker(const DoutPrefixProvider* dpp,
     marker->remove(dpp, y, /*delete_children=*/false, nullptr);
     return ret;
   }
+#if 0
+  // Hack
+  struct statx f_stx = marker->get_stx();
+  std::string ver_id = posix_version_id_from_statx (f_stx);
+  rgw_obj_key key = decode_obj_key(get_name());
+  key.instance = ver_id;
+  std::string versioned_fname = get_key_fname(key, true);
 
+  auto parent_fd = marker->get_parent()->get_fd();
+  ret = renameat2(parent_fd, marker->get_name().c_str(), parent_fd,
+                  versioned_fname.c_str(), 0);
+
+  if (ret < 0) {
+    return ret;
+  }
+#endif
+
+  if (instance_id.empty()){
+    instance_id = ver_id;
+  }
   return 0;
 }
 
@@ -1767,14 +1932,14 @@ int VersionedDirectory::remove(const DoutPrefixProvider* dpp, optional_yield y,
     key.instance = gen_rand_instance_name();
     tgtname = get_key_fname(key, /*use_version=*/true);
 
-    result->delete_marker = true;
-    result->version_id = key.instance;
 
     f = std::make_unique<File>(tgtname, this, ctx);
     ret = add_delete_marker(dpp, y, f, tgtname);
     if (ret < 0) {
       return ret;
     }
+    result->delete_marker = true;
+    result->version_id = instance_id;
 
     newlink = true;
     ret = set_cur_version_ent(dpp, f.get());
@@ -3773,6 +3938,7 @@ std::unique_ptr<Object::DeleteOp> POSIXObject::get_delete_op()
 
 int POSIXObject::open(const DoutPrefixProvider* dpp, bool create, bool temp_file)
 {
+  ldpp_dout(dpp, 0) << "NITHYA: POSIXObject::open() " << get_name() << dendl;
   int ret{0};
 
   if (!ent) {
@@ -3805,6 +3971,8 @@ int POSIXObject::open(const DoutPrefixProvider* dpp, bool create, bool temp_file
 
 int POSIXObject::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y)
 {
+  ldpp_dout(dpp, 0) << "NITHYA: POSIXObject::link_temp_file() " << get_name() << dendl;
+
   std::string temp_fname = gen_temp_fname();
   int ret = ent->link_temp_file(dpp, y, temp_fname);
   if (ret < 0)
@@ -4471,6 +4639,19 @@ int POSIXMultipartUpload::complete(const DoutPrefixProvider *dpp,
     }
   }
 
+  // If versioned, update the version id in the POSIXObject to the mtime+inode
+  // so the directory will be renamed to the correct name.
+
+  POSIXObject *to = static_cast<POSIXObject*>(target_obj);
+  POSIXBucket *sb = static_cast<POSIXBucket*>(target_obj->get_bucket());
+
+  if (sb->versioned()) {
+    auto *shadow_dir = shadow->get_dir();
+    ret = shadow_dir->stat(dpp, true);
+    struct statx f_stx = shadow_dir->get_stx();
+    std::string ver_id = posix_version_id_from_statx (f_stx);
+    to->set_instance_id(ver_id);
+  }
   // Rename to target_obj
   ret = shadow->rename(dpp, y, target_obj);
   if (ret < 0) {
@@ -4479,8 +4660,6 @@ int POSIXMultipartUpload::complete(const DoutPrefixProvider *dpp,
     return ret;
   }
 
-  POSIXObject *to = static_cast<POSIXObject*>(target_obj);
-  POSIXBucket *sb = static_cast<POSIXBucket*>(target_obj->get_bucket());
   if (sb->versioned()) {
     ret = to->set_cur_version(dpp);
     if (ret < 0) {
@@ -4693,6 +4872,7 @@ int POSIXAtomicWriter::complete(size_t accounted_size, const std::string& etag,
                        const req_context& rctx,
                        uint32_t flags)
 {
+  ldpp_dout(dpp, 0) << "NITHYA: POSIXAtomicWriter::complete " << obj->get_name() << dendl;
   int ret;
   uint64_t orig_size = 0;
   auto exists = obj->check_exists(dpp);
@@ -4751,6 +4931,7 @@ int POSIXAtomicWriter::complete(size_t accounted_size, const std::string& etag,
     return ret;
   }
 
+  ldpp_dout(dpp, 0) << "NITHYA: POSIXAtomicWriter::complete - calling link_temp_file" << dendl;
   ret = obj->link_temp_file(rctx.dpp, rctx.y);
   if (ret < 0) {
     ldpp_dout(dpp, 20) << "ERROR: POSIXAtomicWriter failed writing temp file" << dendl;

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -129,6 +129,7 @@ public:
 
   int get_fd() { return fd; };
   std::string& get_name() { return fname; }
+  void set_name(std::string& name) { fname = name; }
   Directory* get_parent() { return parent; }
   bool exists() { return exist; }
   struct statx& get_stx() { return stx; }
@@ -180,6 +181,7 @@ public:
   std::unique_ptr<File> clone() {
     return std::make_unique<File>(*this);
   }
+//  int rename(const DoutPrefixProvider* dpp, Directory* dst_dir, const std::string& new_name);
 };
 
 class Directory : public FSEnt {
@@ -339,7 +341,7 @@ public:
   std::string get_new_instance();
   int remove_symlink(const DoutPrefixProvider *dpp, optional_yield y, std::string match = "");
   int add_file(const DoutPrefixProvider *dpp, std::unique_ptr<FSEnt>&& file, bool* existed = nullptr, bool temp_file = false);
-  int add_delete_marker(const DoutPrefixProvider* dpp, optional_yield y, std::unique_ptr<File>& marker, const std::string &name);
+  int add_delete_marker(const DoutPrefixProvider* dpp, optional_yield y, std::unique_ptr<File>& marker, std::string &name);
   FSEnt* get_cur_version_ent() { return cur_version.get(); };
   int set_cur_version_ent(const DoutPrefixProvider *dpp, FSEnt* file);
   virtual std::unique_ptr<FSEnt> clone_base() override {
@@ -1162,6 +1164,7 @@ public:
   int make_ent(ObjectType type);
   bool versioned() { return bucket->versioned(); }
   DeleteResult get_result() {return del_result;}
+  void set_instance_id(const std::string& instance) { state.obj.key.set_instance(instance); };
 
 protected:
   int read(int64_t ofs, int64_t end, bufferlist& bl, const DoutPrefixProvider* dpp, optional_yield y);


### PR DESCRIPTION
Replace the counter based versioning scheme with one that uses the mtime and inode of the object file.

Credit: Matt Benjamin <mbenjamin@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
