### PR TITLE
mgr/dashboard: Storage class details view missing target_storage_class field

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-storage-class.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-storage-class.model.ts
@@ -50,6 +50,7 @@ export interface StorageClassDetails {
   glacier_restore_tier_type?: string;
   read_through_restore_days?: number;
   restore_storage_class?: string;
+  target_storage_class?: string;
   location_constraint?: string;
   retain_head_object?: boolean;
   acls?: ACL[];
@@ -194,6 +195,7 @@ export interface TextLabels {
   readthroughrestoreDaysText: string;
   restoreStorageClassText: string;
   locationConstraintText: string;
+  targetStorageClassText: string;
 }
 
 export const CLOUD_TIER_REQUIRED_FIELDS = [
@@ -238,8 +240,6 @@ export const TIER_TYPE_DISPLAY = {
   GLACIER: 'Cloud S3 Glacier'
 };
 
-export const GLACIER_TARGET_STORAGE_CLASS = $localize`GLACIER`;
-
 export const ALLOW_READ_THROUGH_TEXT = $localize`Enables fetching objects from remote cloud S3 if not found locally.`;
 
 export const MULTIPART_MIN_PART_TEXT = $localize`It specifies that objects this size or larger are transitioned to the cloud using multipart upload.`;
@@ -283,6 +283,8 @@ export const READTHROUGH_RESTORE_DAYS_TEXT = $localize`The days for which object
 export const RESTORE_STORAGE_CLASS_TEXT = $localize`The storage class to which object data is to be restored.`;
 
 export const LOCATION_CONSTRAINT_TEXT = $localize`The region constraint for the target bucket on the remote S3 endpoint. For AWS, set this only if the region is other than US East (us-east-1).`;
+
+export const TARGET_STORAGE_CLASS_TEXT = $localize`The storage class objects are placed into on the remote S3 endpoint (for example, STANDARD or STANDARD_IA). If empty, the remote endpoint's default is used.`;
 
 export const ZONEGROUP_TEXT = $localize`A Zonegroup is a logical grouping of one or more zones that share the same data
                   and metadata, allowing for multi-site replication and geographic distribution of

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.html
@@ -369,6 +369,23 @@
             </ng-template>
           </div>
           <div class="form-item">
+            <cds-text-label
+              labelInputID="target_storage_class"
+              i18n
+              [helperText]="helpTextLabels.targetStorageClassText"
+              cdOptionalField="Target storage class"
+              >Target storage class
+              <input
+                cdsText
+                type="text"
+                id="target_storage_class"
+                formControlName="target_storage_class"
+                placeholder="STANDARD, STANDARD_IA, GLACIER..."
+                i18n-placeholder
+              />
+            </cds-text-label>
+          </div>
+          <div class="form-item">
             <cds-checkbox
               id="allow_read_through"
               formControlName="allow_read_through"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.ts
@@ -31,6 +31,7 @@ import {
   TARGET_REGION_TEXT,
   TARGET_SECRET_KEY_TEXT,
   LOCATION_CONSTRAINT_TEXT,
+  TARGET_STORAGE_CLASS_TEXT,
   TierTarget,
   TIER_TYPE,
   ZoneGroup,
@@ -52,7 +53,6 @@ import {
   TextLabels,
   CLOUD_TIER_REQUIRED_FIELDS,
   GLACIER_REQUIRED_FIELDS,
-  GLACIER_TARGET_STORAGE_CLASS,
   AclHelperText,
   AclTypeLabel,
   AclFieldType,
@@ -162,7 +162,8 @@ export class RgwStorageClassFormComponent extends CdForm implements OnInit {
       restoreDaysText: RESTORE_DAYS_TEXT,
       readthroughrestoreDaysText: READTHROUGH_RESTORE_DAYS_TEXT,
       restoreStorageClassText: RESTORE_STORAGE_CLASS_TEXT,
-      locationConstraintText: LOCATION_CONSTRAINT_TEXT
+      locationConstraintText: LOCATION_CONSTRAINT_TEXT,
+      targetStorageClassText: TARGET_STORAGE_CLASS_TEXT
     };
     this.storageClassOptions = [
       { value: TIER_TYPE.LOCAL, label: TIER_TYPE_DISPLAY.LOCAL },
@@ -230,6 +231,7 @@ export class RgwStorageClassFormComponent extends CdForm implements OnInit {
               access_key: response?.access_key,
               secret_key: response?.secret,
               target_path: response?.target_path,
+              target_storage_class: response?.target_storage_class ?? '',
               retain_head_object: this.tierTargetInfo?.val?.retain_head_object || false,
               multipart_sync_threshold:
                 this.dimlessBinary.transform(response?.multipart_sync_threshold) || '',
@@ -473,6 +475,7 @@ export class RgwStorageClassFormComponent extends CdForm implements OnInit {
       target_path: new FormControl('', [
         CdValidators.composeIf({ storageClassType: TIER_TYPE.CLOUD_TIER }, [Validators.required])
       ]),
+      target_storage_class: new FormControl(''),
       retain_head_object: new FormControl(true),
       glacier_restore_tier_type: new FormControl(STORAGE_CLASS_CONSTANTS.DEFAULT_STORAGE_CLASS, [
         CdValidators.composeIf({ storageClassType: TIER_TYPE.GLACIER }, [Validators.required])
@@ -763,6 +766,7 @@ export class RgwStorageClassFormComponent extends CdForm implements OnInit {
       multipart_sync_threshold,
       multipart_min_part_size,
       restore_storage_class: rawFormValue.restore_storage_class,
+      target_storage_class: rawFormValue.target_storage_class || '',
       ...(rawFormValue.allow_read_through
         ? { read_through_restore_days: rawFormValue.read_through_restore_days }
         : {}),
@@ -796,8 +800,7 @@ export class RgwStorageClassFormComponent extends CdForm implements OnInit {
             tier_config: {
               ...tierConfig,
               glacier_restore_days: rawFormValue.glacier_restore_days,
-              glacier_restore_tier_type: rawFormValue.glacier_restore_tier_type,
-              target_storage_class: GLACIER_TARGET_STORAGE_CLASS
+              glacier_restore_tier_type: rawFormValue.glacier_restore_tier_type
             }
           }
         ]

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-resource-page/rgw-storage-class-resource-page.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-resource-page/rgw-storage-class-resource-page.component.spec.ts
@@ -94,13 +94,15 @@ describe('RgwStorageClassResourcePageComponent', () => {
     expect(component.details?.data_pool).toBe('my-local-pool');
   });
 
-  it('should include location_constraint in cloud-s3 overview fields', () => {
+  it('should include target_storage_class and location_constraint in cloud-s3 overview fields', () => {
     jest.spyOn(BucketTieringUtils, 'filterAndMapTierTargets').mockReturnValue([
       {
         zonegroup_name: 'zg-1',
         placement_target: 'pt-1',
         storage_class: 'sc-cloud',
         tier_type: TIER_TYPE_DISPLAY.CLOUD_TIER,
+        target_path: '/path',
+        target_storage_class: '',
         region: 'default',
         endpoint: 'http://s3.example.com',
         location_constraint: 'eu-north-1'
@@ -114,6 +116,16 @@ describe('RgwStorageClassResourcePageComponent', () => {
       placement_target: 'pt-1',
       storage_class: 'sc-cloud'
     });
+
+    const targetStorageClassField = component.overviewFields.find(
+      (field) => field.label === 'Target storage class'
+    );
+    expect(targetStorageClassField).toEqual(
+      expect.objectContaining({
+        value: '',
+        emptyText: '-'
+      })
+    );
 
     const locationConstraintField = component.overviewFields.find(
       (field) => field.label === 'Location constraint'

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-resource-page/rgw-storage-class-resource-page.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-resource-page/rgw-storage-class-resource-page.component.ts
@@ -19,6 +19,7 @@ import {
   TARGET_ACCESS_KEY_TEXT,
   TARGET_PATH_TEXT,
   LOCATION_CONSTRAINT_TEXT,
+  TARGET_STORAGE_CLASS_TEXT,
   TIER_TYPE,
   TIER_TYPE_DISPLAY,
   ZoneGroupDetails
@@ -219,6 +220,12 @@ export class RgwStorageClassResourcePageComponent implements OnInit, OnDestroy {
           label: $localize`Target Path`,
           value: details?.target_path,
           helperText: TARGET_PATH_TEXT
+        },
+        {
+          label: $localize`Target storage class`,
+          value: details?.target_storage_class,
+          helperText: TARGET_STORAGE_CLASS_TEXT,
+          emptyText: '-'
         },
         {
           label: $localize`Access key`,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/utils/rgw-bucket-tiering.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/utils/rgw-bucket-tiering.ts
@@ -77,6 +77,7 @@ export class BucketTieringUtils {
       read_through_restore_days: val.read_through_restore_days,
       acls: val.s3.acl_mappings,
       ...val.s3,
+      target_storage_class: val.s3?.target_storage_class ?? '',
       location_constraint: val.s3?.location_constraint ?? ''
     };
 


### PR DESCRIPTION


Fixes: https://tracker.ceph.com/issues/79658

<img width="1680" height="940" alt="Screenshot From 2026-08-20 18-17-45" src="https://github.com/user-attachments/assets/bdc9c798-3a3a-4457-b2ba-486e30aa2506" />
<img width="1680" height="862" alt="Screenshot From 2026-08-20 18-17-59" src="https://github.com/user-attachments/assets/bb391fc4-ce2b-4d28-a545-45b644797f55" />




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
