### PR TITLE
squid: rgw: fix cap check for account get/delete APIs

### DIFF
--- a/src/rgw/rgw_rest_account.cc
+++ b/src/rgw/rgw_rest_account.cc
@@ -171,7 +171,7 @@ void RGWOp_Account_Modify::execute(optional_yield y)
 class RGWOp_Account_Get : public RGWRESTOp {
 public:
   int check_caps(const RGWUserCaps& caps) override {
-    return caps.check_cap("account", RGW_CAP_READ);
+    return caps.check_cap("accounts", RGW_CAP_READ);
   }
 
   void execute(optional_yield y) override;
@@ -193,7 +193,7 @@ void RGWOp_Account_Get::execute(optional_yield y)
 class RGWOp_Account_Delete : public RGWRESTOp {
 public:
   int check_caps(const RGWUserCaps& caps) override {
-    return caps.check_cap("account", RGW_CAP_WRITE);
+    return caps.check_cap("accounts", RGW_CAP_WRITE);
   }
 
   void execute(optional_yield y) override;


### PR DESCRIPTION
The get_account and delete_account APIs check the "account" cap, which
is not a valid cap type. Only "accounts" is accepted by
RGWUserCaps::is_valid_cap_type(), so these checks can never succeed and
users granted the "accounts" cap are always denied.

Backport of the rgw_rest_account.cc portion of
187573e9e7d4e151b7f99779450e29eaa004a0bb. The qa/tasks/radosgw_admin_rest.py
changes from that commit are omitted because they exercise the account
quota feature (e45368e97a3), which is not present in squid.

Original tracker: https://tracker.ceph.com/issues/72527
Backport tracker: https://tracker.ceph.com/issues/74395

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [x] No tests