### PR TITLE
osd: Fix for write ordering issue caused by error injects with scrub blocked writes

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2256,7 +2256,7 @@ void PrimaryLogPG::do_op_impl(OpRequestRef op)
       return;
     }
 
-    if (m_scrubber->is_scrub_active() && m_scrubber->write_blocked_by_scrub(head)) {
+    if (m_scrubber->write_blocked_by_scrub(head)) {
       dout(20) << __func__ << ": waiting for scrub" << dendl;
       waiting_for_scrub.push_back(op);
       op->mark_delayed("waiting for scrub");

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -1107,6 +1107,10 @@ uint64_t PgScrubber::get_scrub_cost(uint64_t num_chunk_objects)
 
 bool PgScrubber::write_blocked_by_scrub(const hobject_t& soid)
 {
+  if (!is_queued_or_active()) {
+    return false;
+  }
+
   if (soid < m_start || soid >= m_end) {
     return false;
   }

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -763,7 +763,15 @@ ReplicaActive::ReplicaActive(my_context ctx)
 
 ReplicaActive::~ReplicaActive()
 {
+  DECLARE_LOCALS;
   clear_remote_reservation(false);
+
+  // Guard against replica_scrub_op() having set m_start/m_end/preemption
+  // state directly (ahead of the FSM) and an interval change then taking us
+  // out of ReplicaActive before ReplicaActiveOp was ever entered - in which
+  // case ~ReplicaActiveOp() (and its call to replica_handling_done()) would
+  // never run, leaving that state stale for the next interval.
+  scrbr->replica_handling_done();
 }
 
 void ReplicaActive::exit()


### PR DESCRIPTION
When running tests against Ceph, I ran into a data integrity issue. When analysing the logs for the root cause, I came across the following order of events that caused it, which I will also summarise afterwards.

* 50.59.785: replica_scrub sets m_scrubber’s m_start to 0 and m_end to MAX (Caused by scrub starting - priority set to highest because we have failed to run 5 times already due to writes).
* 50:59.896: ScrubMachine calls ReplicaActive::exit() due to new interval
* 50:59.896: ScrubMachine transitions to NotActive
* \~\~\~\~\~\~\~\~: ScrubMachine - several transitions between ReplicaActive/ReplicaIdle and NotActive. None call through to reset_internal_state.
* 51.14.558: Read 36354 dequeued
* 51.14.559: Write 36357 dequeued
* 51.14.560: Write 36357 is blocked because read 36354 holds the lock for reading.
* 51.14.563: Read 36354 completes
* 51.14.563: Write 36357 removed from the waiters list, but blocked by scrub due to soid being between m_start and m_end, so added to the waiting_for_scrub list.
* 51.14.565: Write 36358 dequeued. Doesn’t get blocked by scrub as scrub is not active (checks are different between the two places)
* 51.14.669: Write 36358 completes
* 51.15.277: ScrubMachine Destructs PrimaryActive as part of on_new_interval, which calls through to reset_internal_state which resets m_start and m_end
* 51.15.277: Scrub Machine transitions from PrimaryActive/PrimaryIdle to NotActive Scrub reset_internal_state caused by new epoch
* 51:16.293 Write 36357 dequeued
* 51:16.\~\~\~ Write 36357 completes
* 51:18.498: Read 36411 dequeued. Read covers the 2k which 36367 overwrote 36358. Detected as a miscompare.

To summarise what happened, scrub does not appear to be cleaning up correctly on non-primary replicas/shards. This matters specifically when cleaning up the scrubber because we have a new epoch in which that PG is transitioning from a non-primary to a primary replica/shard. When this happens, the non-cleaned up state is used as part of write_blocked_by_scrub(...) to decide if a write should be blocked, which allows writes to be re-queued even though scrub is in Non-Active state for that PG. Incoming writes have an extra layer of protection, querying write_blocked_by_scrub(...) only on PGs that are actively being scrubbed, allowing incoming IOs to progress when requeued IOs are delayed, resulting in requeued IOs being overtaken.

This commit addresses this in two ways:
* By making all calls to check if a write should be blocked by scrub consistent so they are scheduled fairly for all writes, whether requeued or straight from the client.
* It changes the exit process of ReplicaActive so it resets the scrubber state when it destructs so that we don't have stale data held in the scrubber for replica PGs after they transition out of ReplicaActive

I have created a tracker ticket for this PR to reference here: https://tracker.ceph.com/issues/79799

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
