### PR TITLE
tentacle: cephadm/tests: pre-import tracemalloc to avoid pyfakefs setup race

### DIFF
--- a/src/cephadm/tests/conftest.py
+++ b/src/cephadm/tests/conftest.py
@@ -1,0 +1,13 @@
+# Pre-import tracemalloc so that pytest's unraisable-exception hook
+# (_pytest.unraisableexception.unraisable_hook -> tracemalloc_message) does not
+# lazily import it from inside a garbage-collection pass.
+#
+# Some tests (e.g. TestBootstrap) leave NamedTemporaryFile objects created on
+# the pyfakefs fake filesystem to be garbage collected after the fake fs has
+# been torn down; their __del__ raises, pytest's hook runs during GC and, the
+# first time, imports tracemalloc.  If that GC happens while pyfakefs'
+# Patcher._find_modules() is iterating sys.modules, the `fs` fixture setup
+# fails with "RuntimeError: dictionary changed size during iteration" and,
+# because Patcher is a ref-counted singleton, every later fs-based test errors
+# with "'NoneType' object has no attribute 'add_real_directory'".
+import tracemalloc  # noqa: F401


### PR DESCRIPTION
Backport of #71163 (clean cherry-pick).

`run_tox_cephadm` fails intermittently (~25% of arm64 `make check` runs, ~8% x86 on main; tentacle uses the same pyfakefs 5.3.5 pin and unpinned pytest, so it is equally exposed) with `RuntimeError: dictionary changed size during iteration` in pyfakefs `Patcher._find_modules` followed by ~80 cascading `'NoneType' object has no attribute 'add_real_directory'` errors. pytest ≥8.4's unraisable-exception hook lazily imports `tracemalloc` from inside a GC pass triggered by leaked `NamedTemporaryFile` finalizers; pre-importing it in conftest removes the sys.modules mutation.

backport tracker: https://tracker.ceph.com/issues/79677

---
- [x] this backport is a clean cherry-pick from main

