### PR TITLE
ceph-volume: reduce log verbosity

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -745,7 +745,7 @@ class VolumeGroup(Lvm):
             return b_to_ext
         elif b_to_ext / int(self.vg_free_count) - 1 < 0.01:
             # return vg_fre_count if its less then 1% off
-            logger.info(
+            logger.debug(
                 'bytes_to_extents results in {} but only {} '
                 'are available, adjusting the latter'.format(b_to_ext,
                                                              self.vg_free_count))

--- a/src/ceph-volume/ceph_volume/devices/simple/scan.py
+++ b/src/ceph-volume/ceph_volume/devices/simple/scan.py
@@ -103,7 +103,7 @@ class Scan(object):
             file_json_key = file_
             if file_.endswith('_dmcrypt'):
                 file_json_key = file_.rstrip('_dmcrypt')
-                logger.info(
+                logger.debug(
                     'reading file {}, stripping _dmcrypt suffix'.format(file_)
                 )
             if os.path.islink(file_path):
@@ -122,7 +122,7 @@ class Scan(object):
             # contents from actual files later
             try:
                 if system.is_binary(file_path):
-                    logger.info('skipping binary file: %s' % file_path)
+                    logger.debug('skipping binary file: %s' % file_path)
                     continue
             except IOError:
                 logger.exception('skipping due to IOError on file: %s' % file_path)
@@ -217,15 +217,15 @@ class Scan(object):
     def scan(self, args):
         osd_metadata = {'cluster_name': conf.cluster}
         osd_path = None
-        logger.info('detecting if argument is a device or a directory: %s', args.osd_path)
+        logger.debug('detecting if argument is a device or a directory: %s', args.osd_path)
         if os.path.isdir(args.osd_path):
-            logger.info('will scan directly, path is a directory')
+            logger.debug('will scan directly, path is a directory')
             osd_path = args.osd_path
         else:
             # assume this is a device, check if it is mounted and use that path
-            logger.info('path is not a directory, will check if mounted')
+            logger.debug('path is not a directory, will check if mounted')
             if system.device_is_mounted(args.osd_path):
-                logger.info('argument is a device, which is mounted')
+                logger.debug('argument is a device, which is mounted')
                 mounted_osd_paths = self.device_mounts.get(args.osd_path)
                 osd_path = mounted_osd_paths[0] if len(mounted_osd_paths) else None
 
@@ -242,7 +242,7 @@ class Scan(object):
                     )
                 osd_metadata = self.scan_encrypted()
             else:
-                logger.info('device is not mounted, will mount it temporarily to scan')
+                logger.debug('device is not mounted, will mount it temporarily to scan')
                 with system.tmp_mount(args.osd_path) as osd_path:
                     osd_metadata = self.scan_directory(osd_path)
         else:

--- a/src/ceph-volume/ceph_volume/log.py
+++ b/src/ceph-volume/ceph_volume/log.py
@@ -16,7 +16,7 @@ def setup(name='ceph-volume.log', log_path=None, log_level=None):
     root_logger = logging.getLogger()
     # The default path is where all ceph log files are, and will get rotated by
     # Ceph's logrotate rules.
-    log_level = log_level or "DEBUG"
+    log_level = log_level or "INFO"
     log_level = getattr(logging, log_level.upper())
     root_logger.setLevel(log_level)
 

--- a/src/ceph-volume/ceph_volume/main.py
+++ b/src/ceph-volume/ceph_volume/main.py
@@ -142,9 +142,9 @@ Ceph Conf: {ceph_path}
         )
         parser.add_argument(
             '--log-level',
-            default='debug',
+            default='info',
             choices=['debug', 'info', 'warning', 'error', 'critical'],
-            help='Change the file log level (defaults to debug)',
+            help='Change the file log level (defaults to info)',
         )
         parser.add_argument(
             '--log-path',

--- a/src/ceph-volume/ceph_volume/objectstore/raw.py
+++ b/src/ceph-volume/ceph_volume/objectstore/raw.py
@@ -138,7 +138,7 @@ class Raw(BaseObjectStore):
             try:
                 mappers.refresh()
             except RuntimeError as e:
-                mlogger.info(
+                mlogger.warning(
                     'Failed to refresh dmcrypt mappers for osd.%s uuid %s: %s (is the OSD already running?)',
                     self.osd_id,
                     self.osd_fsid,

--- a/src/ceph-volume/ceph_volume/process.py
+++ b/src/ceph-volume/ceph_volume/process.py
@@ -11,7 +11,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def log_output(descriptor, message, terminal_logging, logfile_logging):
+def log_output(descriptor, message, terminal_logging, logfile_logging, log_level=logging.DEBUG):
     """
     log output to both the logger and the terminal if terminal_logging is
     enabled
@@ -23,7 +23,7 @@ def log_output(descriptor, message, terminal_logging, logfile_logging):
     if terminal_logging:
         getattr(terminal, descriptor)(message)
     if logfile_logging:
-        logger.info(line)
+        logger.log(log_level, line)
 
 
 def log_descriptors(reads, process, terminal_logging):
@@ -111,7 +111,7 @@ def run(command, run_on_host=False, **kw):
     stop_on_error = kw.pop('stop_on_error', True)
     command_msg = obfuscate(command, kw.pop('obfuscate', None))
     fail_msg = kw.pop('fail_msg', None)
-    logger.info(command_msg)
+    logger.debug(command_msg)
     terminal.write(command_msg)
     terminal_logging = kw.pop('terminal_logging', True)
 
@@ -139,6 +139,7 @@ def run(command, run_on_host=False, **kw):
     returncode = process.wait()
     if returncode != 0:
         msg = "command returned non-zero exit status: %s" % returncode
+        logger.warning(command_msg)
         if fail_msg:
             logger.warning(fail_msg)
             if terminal_logging:
@@ -156,7 +157,8 @@ def call(command, run_on_host=False, **kw):
     Similar to ``subprocess.Popen`` with the following changes:
 
     * returns stdout, stderr, and exit code (vs. just the exit code)
-    * logs the full contents of stderr and stdout (separately) to the file log
+    * logs the command and the full contents of stderr/stdout to the file log
+      at DEBUG on success, and at WARNING on failure
 
     By default, no terminal output is given, not even the command that is going
     to run.
@@ -184,7 +186,7 @@ def call(command, run_on_host=False, **kw):
     show_command = kw.pop('show_command', False)
     command_msg = "Running command: %s" % ' '.join(command)
     stdin = kw.pop('stdin', None)
-    logger.info(command_msg)
+    logger.debug(command_msg)
     if show_command:
         terminal.write(command_msg)
 
@@ -210,6 +212,7 @@ def call(command, run_on_host=False, **kw):
     stdout = stdout_stream.splitlines()
     stderr = stderr_stream.splitlines()
 
+    log_level = logging.DEBUG
     if returncode != 0:
         # set to true so that we can log the stderr/stdout that callers would
         # do anyway as long as verbose_on_failure is set (defaults to True)
@@ -218,12 +221,14 @@ def call(command, run_on_host=False, **kw):
         # logfiles aren't disruptive visually, unlike the terminal, so this
         # should always be on when there is a failure
         logfile_verbose = True
+        log_level = logging.WARNING
+        logger.warning(command_msg)
 
     # the following can get a messed up order in the log if the system call
     # returns output with both stderr and stdout intermingled. This separates
     # that.
     for line in stdout:
-        log_output('stdout', line, terminal_verbose, logfile_verbose)
+        log_output('stdout', line, terminal_verbose, logfile_verbose, log_level)
     for line in stderr:
-        log_output('stderr', line, terminal_verbose, logfile_verbose)
+        log_output('stderr', line, terminal_verbose, logfile_verbose, log_level)
     return stdout, stderr, returncode

--- a/src/ceph-volume/ceph_volume/systemd/main.py
+++ b/src/ceph-volume/ceph_volume/systemd/main.py
@@ -88,8 +88,8 @@ def main(args=None):
         raise RuntimeError('no arguments supplied')
     sub_command = parse_subcommand(suffix)
     extra_data = parse_extra_data(suffix)
-    logger.info('raw systemd input received: %s', suffix)
-    logger.info('parsed sub-command: %s, extra data: %s', sub_command, extra_data)
+    logger.debug('raw systemd input received: %s', suffix)
+    logger.debug('parsed sub-command: %s, extra data: %s', sub_command, extra_data)
     command = ['ceph-volume', sub_command, 'trigger', extra_data]
 
     tries = int(os.environ.get('CEPH_VOLUME_SYSTEMD_TRIES', 30))

--- a/src/ceph-volume/ceph_volume/tests/test_main.py
+++ b/src/ceph-volume/ceph_volume/tests/test_main.py
@@ -31,6 +31,8 @@ class TestVolume(object):
         stdout, stderr = capsys.readouterr()
         assert '--cluster' in stdout
         assert '--log-path' in stdout
+        assert '--log-level' in stdout
+        assert 'defaults to info' in stdout
 
     def test_log_ignoring_missing_ceph_conf(self, caplog, fake_filesystem):
         with pytest.raises(SystemExit) as error:

--- a/src/ceph-volume/ceph_volume/tests/test_process.py
+++ b/src/ceph-volume/ceph_volume/tests/test_process.py
@@ -29,7 +29,7 @@ def mock_call(monkeypatch):
 class TestCall(object):
 
     def test_stderr_terminal_and_logfile(self, mock_call, caplog, capsys):
-        caplog.set_level(logging.INFO)
+        caplog.set_level(logging.DEBUG)
         mock_call(stdout='stdout\n', stderr='some stderr message\n')
         process.call(['ls'], terminal_verbose=True)
         out, err = capsys.readouterr()
@@ -40,7 +40,7 @@ class TestCall(object):
         assert 'some stderr message' in err
 
     def test_stderr_terminal_and_logfile_off(self, mock_call, caplog, capsys):
-        caplog.set_level(logging.INFO)
+        caplog.set_level(logging.DEBUG)
         mock_call(stdout='stdout\n', stderr='some stderr message\n')
         process.call(['ls'], terminal_verbose=False)
         out, err = capsys.readouterr()
@@ -49,6 +49,16 @@ class TestCall(object):
         assert 'ls' in log_lines[0]
         assert 'stderr some stderr message' in log_lines[-1]
         assert out == ''
+
+    def test_success_not_logged_at_info(self, mock_call, caplog):
+        caplog.set_level(logging.INFO)
+        mock_call(stdout='stdout\n', stderr='some stderr message\n')
+        process.call(['ls'], terminal_verbose=False)
+        process_records = [
+            r for r in caplog.records
+            if r.name == 'ceph_volume.process' and r.levelno >= logging.INFO
+        ]
+        assert not process_records
 
     def test_verbose_on_failure(self, mock_call, caplog, capsys):
         caplog.set_level(logging.INFO)

--- a/src/ceph-volume/ceph_volume/util/arg_validators.py
+++ b/src/ceph-volume/ceph_volume/util/arg_validators.py
@@ -80,7 +80,7 @@ class ValidClearReplaceHeaderDevice(ValidDevice):
 
     def _is_valid_device(self) -> Device:
         if not self._device.is_being_replaced:
-            mlogger.info(f'{self.dev_path} has no replacement header.')
+            mlogger.debug(f'{self.dev_path} has no replacement header.')
         return self._device
 
 

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -1026,7 +1026,7 @@ def get_devices(_sys_block_path='/sys/block', device=''):
     return device_facts
 
 def has_bluestore_label(device_path: str) -> bool:
-    logger.info("opening device {} to check for BlueStore label".format(device_path))
+    logger.debug("opening device {} to check for BlueStore label".format(device_path))
     sig_len = len(BLUESTORE_BDEV_LABEL_SIGNATURE)
     try:
         with open(device_path, "rb") as fd:
@@ -1047,7 +1047,7 @@ def has_bluestore_label(device_path: str) -> bool:
                 if signature == BLUESTORE_BDEV_LABEL_SIGNATURE:
                     return True
     except IsADirectoryError:
-        logger.info(f'{device_path} is a directory, skipping.')
+        logger.debug(f'{device_path} is a directory, skipping.')
 
     return False
 

--- a/src/ceph-volume/ceph_volume/util/encryption.py
+++ b/src/ceph-volume/ceph_volume/util/encryption.py
@@ -292,7 +292,7 @@ def get_dmcrypt_key(osd_id, osd_fsid, lockbox_keyring=None):
     name = 'client.osd-lockbox.%s' % osd_fsid
     config_key = 'dm-crypt/osd/%s/luks' % osd_fsid
 
-    mlogger.info(f'Running ceph config-key get {config_key}')
+    mlogger.debug(f'Running ceph config-key get {config_key}')
     stdout, stderr, returncode = process.call(
         [
             'ceph',

--- a/src/ceph-volume/ceph_volume/util/lsmdisk.py
+++ b/src/ceph-volume/ceph_volume/util/lsmdisk.py
@@ -51,7 +51,7 @@ class LSMDisk:
         else:
             self.lsm_available = False
             self.error_list.add("libstoragemgmt (lsm module) is unavailable")
-            logger.info("LSM information is unavailable: libstoragemgmt is not installed")
+            logger.debug("LSM information is unavailable: libstoragemgmt is not installed")
             self.disk = None
 
         self.led_bits = None

--- a/src/ceph-volume/ceph_volume/util/nvme.py
+++ b/src/ceph-volume/ceph_volume/util/nvme.py
@@ -30,7 +30,7 @@ def is_namespace(resolved_device: str) -> bool:
         return False
     if not disk.is_device(resolved_device):
         # disk.is_device() already excludes partitions
-        logger.info('Skipping NVMe format for non-whole-disk device %s', resolved_device)
+        logger.debug('Skipping NVMe format for non-whole-disk device %s', resolved_device)
         return False
     return True
 

--- a/src/ceph-volume/ceph_volume/util/system.py
+++ b/src/ceph-volume/ceph_volume/util/system.py
@@ -60,7 +60,7 @@ def find_executable_on_host(locations=[], executable='', binary_check='/bin/ls')
     stdout = as_string(process.stdout.read())
     if stdout:
         executable_on_host = stdout.split('\n')[0]
-        logger.info('Executable {} found on the host, will use {}'.format(executable, executable_on_host))
+        logger.debug('Executable {} found on the host, will use {}'.format(executable, executable_on_host))
         return executable_on_host
     else:
         logger.warning('Executable {} not found on the host, will return {} as-is'.format(executable, executable))
@@ -216,9 +216,9 @@ def unmount_tmpfs(path):
     """
     _out, _err, rc = process.call(['findmnt', '-t', 'tmpfs', '-M', path])
     if rc != 0:
-        logger.info('{} does not appear to be a tmpfs mount'.format(path))
+        logger.debug('{} does not appear to be a tmpfs mount'.format(path))
     else:
-        logger.info('Unmounting tmpfs path at {}'.format( path))
+        logger.debug('Unmounting tmpfs path at {}'.format( path))
         unmount(path)
 
 
@@ -275,14 +275,14 @@ def device_is_mounted(dev, destination=None):
         if mounts: # we have a matching mount
             if destination:
                 if destination in mounts:
-                    logger.info(
+                    logger.debug(
                         '%s detected as mounted, exists at destination: %s', dev, destination
                     )
                     return True
             else:
-                logger.info('%s was found as mounted', dev)
+                logger.debug('%s was found as mounted', dev)
                 return True
-    logger.info('%s was not found as mounted', dev)
+    logger.debug('%s was not found as mounted', dev)
     return False
 
 class Mounts(object):
@@ -395,7 +395,7 @@ def set_context(path, recursive=False):
     """
     skip = os.environ.get('CEPH_VOLUME_SKIP_RESTORECON', '')
     if skip.lower() in ['1', 'true', 'yes']:
-        logger.info(
+        logger.debug(
             'CEPH_VOLUME_SKIP_RESTORECON environ is set, will not call restorecon'
         )
         return
@@ -404,11 +404,11 @@ def set_context(path, recursive=False):
         stdout, stderr, code = process.call(['selinuxenabled'],
                                             verbose_on_failure=False)
     except FileNotFoundError:
-        logger.info('No SELinux found, skipping call to restorecon')
+        logger.debug('No SELinux found, skipping call to restorecon')
         return
 
     if code != 0:
-        logger.info('SELinux is not enabled, will not call restorecon')
+        logger.debug('SELinux is not enabled, will not call restorecon')
         return
 
     # restore selinux context to default policy values


### PR DESCRIPTION
inventory/list logs every lsblk/pvs/bluestore probe at info, that's why the ceph-volume log file gets huge.
Those traces are debug. info stays for actual OSD work (create/zap/activate). if a command fails we still dump it at warning so you don't need --log-level debug to see what broke.

default --log-level is info now.

Fixes: https://tracker.ceph.com/issues/73725


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
