### PR TITLE
tentacle: qa/distros: ask for Rocky by major, not a point release

### DIFF
--- a/qa/distros/all/rocky_10.yaml
+++ b/qa/distros/all/rocky_10.yaml
@@ -3,7 +3,7 @@ install_rocky_packages:
     - print: "Install additional rocky10 dependencies"
     # postmerge appends to this
 os_type: rocky
-os_version: "10.1"
+os_version: "10"
 overrides:
   selinux:
     allowlist:

--- a/qa/distros/all/rocky_9.yaml
+++ b/qa/distros/all/rocky_9.yaml
@@ -1,5 +1,5 @@
 os_type: rocky
-os_version: "9.6"
+os_version: "9"
 teuthology:
   postmerge:
     - |


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79683

---

backport of https://github.com/ceph/ceph/pull/71169
parent tracker: https://tracker.ceph.com/issues/79682

**Do not merge** before the parent PR and ceph/teuthology#2246 (major-only Rocky version support in the codename map and post-deploy OS check) have merged, or every Rocky job fails at `check_packages`.

Note: tentacle's `rocky_9.yaml` still uses the postmerge-lua structure, so only the `os_version` lines were picked; the structural part of the conflict was resolved in favor of tentacle.
