### PR TITLE
cephadm/nfs: support log_to_file for Ganesha daemons

### DIFF
--- a/src/cephadm/cephadmlib/daemons/nfs.py
+++ b/src/cephadm/cephadmlib/daemons/nfs.py
@@ -5,7 +5,7 @@ import re
 from typing import Dict, List, Optional, Tuple, Union
 
 from ..call_wrappers import call, CallVerbosity
-from ..constants import DEFAULT_IMAGE, CEPH_DEFAULT_CONF
+from ..constants import DEFAULT_IMAGE, CEPH_DEFAULT_CONF, LOG_DIR, LOG_DIR_MODE
 from ..container_daemon_form import ContainerDaemonForm, daemon_to_container
 from ..container_types import CephContainer, extract_uid_gid
 from ..context import CephadmContext
@@ -31,7 +31,7 @@ class NFSGanesha(ContainerDaemonForm):
     entrypoint = '/usr/local/scripts/ganesha-entrypoint.sh'
     ganesha_binary = '/usr/bin/ganesha.nfsd'
     entrypoint_script_name = 'ganesha-entrypoint.sh'
-    daemon_args = ['-F', '-L', 'STDERR']
+    daemon_args_base = ['-F', '-L', 'STDERR']
 
     required_files = ['ganesha.conf', 'idmap.conf']
 
@@ -64,6 +64,7 @@ class NFSGanesha(ContainerDaemonForm):
         self.files = dict_get(config_json, 'files', {})
         self.rgw = dict_get(config_json, 'rgw', {})
         self.enable_rdma = dict_get(config_json, 'enable_rdma', False)
+        self.log_to_file = dict_get(config_json, 'log_to_file', False)
 
         # validate the supplied args
         self.validate()
@@ -84,8 +85,8 @@ class NFSGanesha(ContainerDaemonForm):
     def identity(self) -> DaemonIdentity:
         return DaemonIdentity(self.fsid, self.daemon_type, self.daemon_id)
 
-    def _get_container_mounts(self, data_dir):
-        # type: (str) -> Dict[str, str]
+    def _get_container_mounts(self, data_dir, log_dir):
+        # type: (str, str) -> Dict[str, str]
         mounts = dict()
         mounts[os.path.join(data_dir, 'config')] = '/etc/ceph/ceph.conf:z'
         mounts[os.path.join(data_dir, 'keyring')] = '/etc/ceph/keyring:z'
@@ -93,6 +94,7 @@ class NFSGanesha(ContainerDaemonForm):
         mounts[
             os.path.join(data_dir, self.entrypoint_script_name)
         ] = self.entrypoint
+        mounts[log_dir] = '/var/log/ceph:z'
         if self.rgw:
             cluster = self.rgw.get('cluster', 'ceph')
             rgw_user = self.rgw.get('user', 'admin')
@@ -105,7 +107,10 @@ class NFSGanesha(ContainerDaemonForm):
         self, ctx: CephadmContext, mounts: Dict[str, str]
     ) -> None:
         data_dir = self.identity.data_dir(ctx.data_dir)
-        mounts.update(self._get_container_mounts(data_dir))
+        log_dir = os.path.join(
+            ctx.log_dir, self.fsid, self.get_daemon_name()
+        )
+        mounts.update(self._get_container_mounts(data_dir, log_dir))
 
     @staticmethod
     def get_container_envs():
@@ -171,7 +176,12 @@ class NFSGanesha(ContainerDaemonForm):
 
     def get_daemon_args(self):
         # type: () -> List[str]
-        return self.daemon_args + self.extra_args
+        if self.log_to_file:
+            log_file = '/var/log/ceph/ganesha.log'
+            args = ['-F', '-L', log_file]
+        else:
+            args = list(self.daemon_args_base)
+        return args + self.extra_args
 
     @staticmethod
     def ganesha_conf_text(conf: Union[str, List[str]]) -> str:
@@ -216,6 +226,12 @@ set -e
             raise OSError('data_dir is not a directory: %s' % (data_dir))
 
         logger.info('Creating ganesha config...')
+
+        # create the per-daemon log directory so NFS can write logs when
+        # log_to_file is enabled; each daemon gets its own subdirectory to
+        # avoid mount conflicts when multiple NFS daemons run on the same host.
+        log_dir = os.path.join(LOG_DIR, self.fsid, self.get_daemon_name())
+        makedirs(log_dir, uid, gid, LOG_DIR_MODE)
 
         # create the ganesha conf dir
         config_dir = os.path.join(data_dir, 'etc/ganesha')

--- a/src/cephadm/tests/test_nfs.py
+++ b/src/cephadm/tests/test_nfs.py
@@ -111,6 +111,7 @@ def test_nfsganesha_init():
 
 
 def test_nfsganesha_container_mounts():
+    log_dir = "/var/log/ceph/" + SAMPLE_UUID + "/nfs.fred"
     with with_cephadm_ctx([]) as ctx:
         nfsg = _cephadm.NFSGanesha(
             ctx,
@@ -118,8 +119,8 @@ def test_nfsganesha_container_mounts():
             "fred",
             good_nfs_json(),
         )
-        cmounts = nfsg._get_container_mounts("/var/tmp")
-        assert len(cmounts) == 4
+        cmounts = nfsg._get_container_mounts("/var/tmp", log_dir)
+        assert len(cmounts) == 5
         assert cmounts["/var/tmp/config"] == "/etc/ceph/ceph.conf:z"
         assert cmounts["/var/tmp/keyring"] == "/etc/ceph/keyring:z"
         assert cmounts["/var/tmp/etc/ganesha"] == "/etc/ganesha:z"
@@ -127,6 +128,7 @@ def test_nfsganesha_container_mounts():
             cmounts["/var/tmp/ganesha-entrypoint.sh"]
             == "/usr/local/scripts/ganesha-entrypoint.sh"
         )
+        assert cmounts[log_dir] == "/var/log/ceph:z"
 
     with with_cephadm_ctx([]) as ctx:
         nfsg = _cephadm.NFSGanesha(
@@ -135,8 +137,8 @@ def test_nfsganesha_container_mounts():
             "fred",
             nfs_json(pool=True, files=True, rgw=True),
         )
-        cmounts = nfsg._get_container_mounts("/var/tmp")
-        assert len(cmounts) == 5
+        cmounts = nfsg._get_container_mounts("/var/tmp", log_dir)
+        assert len(cmounts) == 6
         assert cmounts["/var/tmp/config"] == "/etc/ceph/ceph.conf:z"
         assert cmounts["/var/tmp/keyring"] == "/etc/ceph/keyring:z"
         assert cmounts["/var/tmp/etc/ganesha"] == "/etc/ganesha:z"
@@ -144,6 +146,7 @@ def test_nfsganesha_container_mounts():
             cmounts["/var/tmp/keyring.rgw"]
             == "/var/lib/ceph/radosgw/ceph-jsmith/keyring:z"
         )
+        assert cmounts[log_dir] == "/var/log/ceph:z"
 
 
 def test_nfsganesha_container_envs():
@@ -214,6 +217,20 @@ def test_nfsganesha_get_daemon_args():
         )
         args = nfsg.get_daemon_args()
         assert args == ["-F", "-L", "STDERR"]
+
+
+def test_nfsganesha_get_daemon_args_log_to_file():
+    config = good_nfs_json()
+    config['log_to_file'] = True
+    with with_cephadm_ctx([]) as ctx:
+        nfsg = _cephadm.NFSGanesha(
+            ctx,
+            SAMPLE_UUID,
+            "fred",
+            config,
+        )
+        args = nfsg.get_daemon_args()
+        assert args == ["-F", "-L", "/var/log/ceph/ganesha.log"]
 
 
 @pytest.mark.parametrize(

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -185,7 +185,15 @@ class NFSService(CephService):
                     f'client_object_cache_max_dirty: '
                     f'{nfs_spec.client_object_cache_max_dirty}'
                 )
-
+        # log_to_file: query at the client.nfs section level to detect
+        # global or section-wide config changes
+        try:
+            log_to_file = mgr.get_foreign_ceph_option(
+                utils.name_to_config_section('nfs'), 'log_to_file')
+            if log_to_file:
+                deps.append(f'log_to_file: {bool(log_to_file)}')
+        except Exception:
+            pass
         parent_deps = super().get_dependencies(mgr, spec, daemon_type)
         return sorted(deps + parent_deps)
 
@@ -396,10 +404,25 @@ class NFSService(CephService):
                 'keyring': rgw_keyring,
             }
             config['enable_rdma'] = spec.enable_rdma
+            config['log_to_file'] = self._get_log_to_file(daemon_type, daemon_id)
             logger.debug('Generated cephadm config-json: %s' % config)
             return config
 
         return get_cephadm_config(), self.get_dependencies(self.mgr, spec)
+
+    def _get_log_to_file(self, daemon_type: str, daemon_id: str) -> bool:
+        """Check if log_to_file is enabled for NFS daemons.
+
+        Queries at the service section level (client.nfs) to stay consistent
+        with get_dependencies() and to pick up both section-wide and global
+        config settings.
+        """
+        entity = utils.name_to_config_section(daemon_type)
+        try:
+            log_to_file = self.mgr.get_foreign_ceph_option(entity, 'log_to_file')
+            return bool(log_to_file)
+        except Exception:
+            return False
 
     def pre_daemon_service_config(self, spec: ServiceSpec) -> None:
         nfs_spec = cast(NFSServiceSpec, spec)

--- a/src/pybind/mgr/cephadm/tests/services/test_ingress.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_ingress.py
@@ -1240,6 +1240,7 @@ class TestIngressService:
                 '[client.nfs.foo]\n'
                 'key = None\n'
             ),
+            'log_to_file': False,
             'namespace': 'foo',
             'pool': '.nfs',
             'rgw': {


### PR DESCRIPTION
**Summary**
This PR adds support for log_to_file for cephadm-managed NFS Ganesha daemons.

Previously, when log_to_file=true was configured, NFS Ganesha continued logging to stderr/journald and did not create log files under /var/log/ceph.

The change updates NFS deployment to:

- Create and mount the Ceph log directory
- Configure Ganesha to write logs to a file
- Respect the log_to_file configuration option
- Keep dependency calculation consistent between deployment and reconciliation paths

Additionally, this fixes an NFS redeploy loop caused by inconsistent dependency computation between generate_config() and get_dependencies().

Signed-off-by: Shubha Jain [SHUBHA.JAIN1@ibm.com]
Fixes: https://tracker.ceph.com/issues/79642

**Root Cause**

generate_config() appended:

`log_to_file: True
`
to the returned dependency list, while the cephadm reconciliation path used:

`get_dependencies()
`
which did not include the same dependency.

As a result:

```
stored deps = ['log_to_file: True']
computed deps = []
```

causing cephadm to continuously detect dependency drift and redeploy NFS daemons.

The fix moves log_to_file dependency generation into get_dependencies() so both code paths compute the same dependency set.

**Before Fix**

NFS did not create log files:

`/var/log/ceph/<fsid>/ceph-client.nfs.*   (missing)
`
cephadm continuously redeployed the NFS daemon:

Reconfigure wanted nfs.nfs-cluster1:
```
deps ['log_to_file: True'] -> []

Daemon nfs.nfs-cluster1.0.0.ceph-node-02.xjijnv
chose new action redeploy

Deploying daemon nfs.nfs-cluster1.0.0.ceph-node-02.xjijnv
```

Upgrade remained stuck while processing NFS:

**{
  "in_progress": true,
  "message": "Currently upgrading nfs daemons",
  "progress": "19/25 daemons upgraded"
}**

**After Fix**

NFS log file is created successfully:

**/var/log/ceph/<fsid>/ceph-client.nfs.nfs-cluster1.0.0.ceph-node-02.qemefd.log**

NFS daemon remains stable:

**NAME                                      STATUS
nfs.nfs-cluster1.0.0.ceph-node-02.qemefd  running**

No repeated redeploy activity is observed:

```
Creating key for client.nfs.nfs-cluster1.0.0.ceph-node-02.qemefd
Creating key for client.nfs.nfs-cluster1.0.0.ceph-node-02.qemefd-rgw
Deploying daemon nfs.nfs-cluster1.0.0.ceph-node-02.qemefd on ceph-node-02
```

No further:

```
Reconfigure wanted nfs ...
Daemon nfs ... chose new action redeploy
```
messages are generated.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
