### PR TITLE
rgw/user: allow clearing the default placement and the placement tags

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -71,6 +71,15 @@
   individual bucket without suspending its owner. S3 requests against a suspended
   bucket fail with ``403 BucketSuspended``. The ``suspended`` field is now included
   in ``radosgw-admin bucket stats`` output.
+* RGW: The default placement and the placement tags of a user can now be cleared.
+  On ``user modify``, both in the admin ops API and in ``radosgw-admin``, an
+  explicitly empty ``default-placement`` (``--placement-id ""``) clears the
+  default placement rule of the user together with its storage class, and an
+  explicitly empty ``placement-tags`` (``--tags ""``) clears the placement tags.
+  Omitting a parameter still leaves it unchanged. Previously an empty value was
+  indistinguishable from an absent one and was silently ignored. Relatedly,
+  ``default-storage-class`` (``--storage-class``) given without a placement on
+  ``user modify`` now fails with ``EINVAL`` instead of being silently ignored.
 * RGW: OpenSSL engine support is deprecated in favor of provider support.
   - Removed the `openssl_engine_opts` configuration option. OpenSSL engine configuration in string format is no longer supported.
   - Added the `openssl_conf` configuration option for loading specified providers as default providers.

--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -750,11 +750,18 @@ Options
 
 .. option:: --placement-id
 
-   Placement ID for the zonegroup placement commands.
+   Placement ID for the zonegroup placement commands, and the default
+   placement of a user for the user commands. On ``user modify`` an explicitly
+   empty value (``--placement-id ""``) clears the default placement of the
+   user, together with its storage class, so that the user falls back to the
+   placement of its zonegroup. Omitting the option leaves it unchanged.
 
 .. option:: --tags=<list>
 
-   The list of tags for zonegroup placement add and modify commands.
+   The list of tags for zonegroup placement add and modify commands, and the
+   placement tags of a user for the user commands. On ``user modify`` an
+   explicitly empty value (``--tags ""``) clears the placement tags of the
+   user. Omitting the option leaves them unchanged.
 
 .. option:: --tags-add=<list>
 

--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -1397,16 +1397,33 @@ Request Parameters
 
 ``default-placement``
 
-:Description: default placement for the user.
+:Description: default placement for the user. An explicitly empty value clears
+              it, together with the default storage class, so that the user
+              falls back to the placement of its zonegroup. Omitting the
+              parameter leaves it unchanged.
 :Type: string
 :Example: default-placement
 :Required: No
 
 ``default-storage-class``
 
-:Description: default storage class for the user, default-placement must be defined when setting this option.
+:Description: default storage class for the user, default-placement must be
+              given together with this option. A storage class cannot be
+              cleared on its own: send default-placement again without a
+              storage class to reset it to the default of that placement, or
+              send an empty default-placement to clear both.
 :Type: string
 :Example: STANDARD-1A
+:Required: No
+
+``placement-tags``
+
+:Description: comma-separated list of placement tags for the user. An
+              explicitly empty value clears the list, so that the user is no
+              longer restricted to tagged placement targets. Omitting the
+              parameter leaves it unchanged.
+:Type: string
+:Example: tag1,tag2
 :Required: No
 
 .. versionadded:: Squid

--- a/qa/tasks/radosgw_admin.py
+++ b/qa/tasks/radosgw_admin.py
@@ -411,6 +411,57 @@ def task(ctx, config):
     (err, out) = rgwadmin(ctx, client, ['user', 'info', '--uid', user1], check_status=True)
     assert not out['suspended']
 
+    # TESTCASE 'set-placement','user','modify','default placement and tags','succeeds'
+    # the storage class is not asserted here: a STANDARD one is dropped when
+    # the placement rule is persisted, and 'user info' renders an empty
+    # storage class back as STANDARD, so the two states are indistinguishable
+    (err, out) = rgwadmin(ctx, client, [
+            'user', 'modify', '--uid', user1,
+            '--placement-id', 'default-placement',
+            '--tags', 'tag1,tag2',
+            ], check_status=True)
+
+    (err, out) = rgwadmin(ctx, client, ['user', 'info', '--uid', user1], check_status=True)
+    assert out['default_placement'] == 'default-placement'
+    assert out['placement_tags'] == ['tag1', 'tag2']
+
+    # TESTCASE 'keep-placement','user','modify','placement options omitted','left unchanged'
+    (err, out) = rgwadmin(ctx, client, [
+            'user', 'modify', '--uid', user1,
+            '--display-name', display_name1,
+            ], check_status=True)
+
+    (err, out) = rgwadmin(ctx, client, ['user', 'info', '--uid', user1], check_status=True)
+    assert out['default_placement'] == 'default-placement'
+    assert out['placement_tags'] == ['tag1', 'tag2']
+
+    # TESTCASE 'storage-class-without-placement','user','modify','storage class alone','fails'
+    (err, out) = rgwadmin(ctx, client, [
+            'user', 'modify', '--uid', user1,
+            '--storage-class', 'STANDARD',
+            ])
+    assert err
+
+    # TESTCASE 'clear-placement','user','modify','empty placement id','clears rule'
+    (err, out) = rgwadmin(ctx, client, [
+            'user', 'modify', '--uid', user1,
+            '--placement-id', '',
+            ], check_status=True)
+
+    (err, out) = rgwadmin(ctx, client, ['user', 'info', '--uid', user1], check_status=True)
+    assert out['default_placement'] == ''
+    assert out['placement_tags'] == ['tag1', 'tag2']
+
+    # TESTCASE 'clear-placement-tags','user','modify','empty tags','clears list'
+    (err, out) = rgwadmin(ctx, client, [
+            'user', 'modify', '--uid', user1,
+            '--tags', '',
+            ], check_status=True)
+
+    (err, out) = rgwadmin(ctx, client, ['user', 'info', '--uid', user1], check_status=True)
+    assert out['default_placement'] == ''
+    assert out['placement_tags'] == []
+
     # TESTCASE 'add-keys','key','create','w/valid info','succeeds'
     (err, out) = rgwadmin(ctx, client, [
             'key', 'create', '--uid', user1,

--- a/qa/tasks/radosgw_admin_rest.py
+++ b/qa/tasks/radosgw_admin_rest.py
@@ -437,6 +437,58 @@ def task(ctx, config):
     assert ret == 200
     assert not out['suspended']
 
+    # TESTCASE 'set-placement','user','modify','default placement and tags','succeeds'
+    # a STANDARD storage class is not stored as such: rgw_placement_rule is
+    # persisted through to_str(), which drops the storage class when it is the
+    # standard one, so only the placement itself can be asserted here
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'modify'],
+            {'uid' : user1,
+             'default-placement' : 'default-placement',
+             'placement-tags' : 'tag1,tag2'
+            })
+    assert ret == 200
+
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {'uid' : user1})
+    assert ret == 200
+    assert out['default_placement'] == 'default-placement'
+    assert out['placement_tags'] == ['tag1', 'tag2']
+
+    # TESTCASE 'keep-placement','user','modify','placement params omitted','left unchanged'
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'modify'],
+            {'uid' : user1, 'display-name' : display_name1})
+    assert ret == 200
+
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {'uid' : user1})
+    assert ret == 200
+    assert out['default_placement'] == 'default-placement'
+    assert out['placement_tags'] == ['tag1', 'tag2']
+
+    # TESTCASE 'storage-class-without-placement','user','modify','storage class alone','fails'
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'modify'],
+            {'uid' : user1, 'default-storage-class' : 'STANDARD'})
+    assert ret == 400
+
+    # TESTCASE 'clear-placement','user','modify','empty default placement','clears rule'
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'modify'],
+            {'uid' : user1, 'default-placement' : ''})
+    assert ret == 200
+
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {'uid' : user1})
+    assert ret == 200
+    assert out['default_placement'] == ''
+    assert out['default_storage_class'] == ''
+    assert out['placement_tags'] == ['tag1', 'tag2']
+
+    # TESTCASE 'clear-placement-tags','user','modify','empty placement tags','clears list'
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'modify'],
+            {'uid' : user1, 'placement-tags' : ''})
+    assert ret == 200
+
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {'uid' : user1})
+    assert ret == 200
+    assert out['default_placement'] == ''
+    assert out['placement_tags'] == []
+
     # TESTCASE 'add-keys','key','create','w/valid info','succeeds'
     (ret, out) = rgwadmin_rest(endpoint, admin_creds,
             [('user', 'key'), 'create'],

--- a/src/rgw/driver/rados/rgw_rest_user.cc
+++ b/src/rgw/driver/rados/rgw_rest_user.cc
@@ -412,21 +412,31 @@ void RGWOp_User_Modify::execute(optional_yield y)
   if (!default_placement_str.empty()) {
     rgw_placement_rule target_rule;
     target_rule.name = default_placement_str;
-    if (!default_storage_class_str.empty()){
-      target_rule.storage_class = default_storage_class_str;
-    }
+    target_rule.storage_class = default_storage_class_str;
     if (!driver->valid_placement(target_rule)) {
       ldpp_dout(this, 0) << "NOTICE: invalid dest placement: " << target_rule.to_str() << dendl;
       op_ret = -EINVAL;
       return;
     }
     op_state.set_default_placement(target_rule);
+  } else if (!default_storage_class_str.empty()) {
+    // a storage class is validated against its placement target, so it cannot
+    // be given on its own
+    ldpp_dout(this, 0) << "NOTICE: default-storage-class requires default-placement" << dendl;
+    op_ret = -EINVAL;
+    return;
+  } else if (s->info.args.exists("default-placement")) {
+    // explicitly empty: clear the rule, storage class included
+    op_state.set_default_placement(rgw_placement_rule());
   }
 
   if (!placement_tags_str.empty()) {
     list<string> placement_tags_list;
     get_str_list(placement_tags_str, ",", placement_tags_list);
     op_state.set_placement_tags(placement_tags_list);
+  } else if (s->info.args.exists("placement-tags")) {
+    // explicitly empty: clear the tag list
+    op_state.set_placement_tags(std::list<std::string>());
   }
   
   if (!s->penv.site->is_meta_master()) {

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -457,9 +457,13 @@ void usage()
   cout << "   --default                         set entity (realm, zonegroup, zone) as default\n";
   cout << "   --read-only                       set zone as read-only (when adding to zonegroup)\n";
   cout << "   --redirect-zone                   specify zone id to redirect when response is 404 (not found)\n";
-  cout << "   --placement-id                    placement id for zonegroup placement commands\n";
+  cout << "   --placement-id                    placement id for zonegroup placement commands, and the\n";
+  cout << "                                     default placement of a user for the user commands. on\n";
+  cout << "                                     user modify an empty value clears it\n";
   cout << "   --storage-class                   storage class for zonegroup placement commands\n";
-  cout << "   --tags=<list>                     list of tags for zonegroup placement add and modify commands\n";
+  cout << "   --tags=<list>                     list of tags for zonegroup placement add and modify commands,\n";
+  cout << "                                     and the placement tags of a user for the user commands. on\n";
+  cout << "                                     user modify an empty value clears them\n";
   cout << "   --tags-add=<list>                 list of tags to add for zonegroup placement modify command\n";
   cout << "   --tags-rm=<list>                  list of tags to remove for zonegroup placement modify command\n";
   cout << "   --endpoints=<list>                zone endpoints\n";
@@ -3881,8 +3885,10 @@ int main(int argc, const char **argv)
   std::string objects_file;
   string object_version;
   string placement_id;
+  bool placement_id_specified = false;
   std::optional<string> opt_storage_class;
   list<string> tags;
+  bool tags_specified = false;
   list<string> tags_add;
   list<string> tags_rm;
 #ifdef WITH_RADOSGW_RADOS
@@ -4490,10 +4496,12 @@ int main(int argc, const char **argv)
       zonegroup_new_name = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--placement-id", (char*)NULL)) {
       placement_id = val;
+      placement_id_specified = true;
     } else if (ceph_argparse_witharg(args, i, &val, "--storage-class", (char*)NULL)) {
       opt_storage_class = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--tags", (char*)NULL)) {
       get_str_list(val, ",", tags);
+      tags_specified = true;
     } else if (ceph_argparse_witharg(args, i, &val, "--tags-add", (char*)NULL)) {
       get_str_list(val, ",", tags_add);
     } else if (ceph_argparse_witharg(args, i, &val, "--tags-rm", (char*)NULL)) {
@@ -7182,10 +7190,22 @@ int main(int argc, const char **argv)
       return EINVAL;
     }
     user_op.set_default_placement(target_rule);
+  } else if (opt_cmd == OPT::USER_MODIFY && opt_storage_class &&
+             !opt_storage_class->empty()) {
+    // a storage class is validated against its placement target, so it cannot
+    // be given on its own
+    cerr << "ERROR: --storage-class requires --placement-id" << std::endl;
+    return EINVAL;
+  } else if (opt_cmd == OPT::USER_MODIFY && placement_id_specified) {
+    // explicitly empty: clear the rule, storage class included
+    user_op.set_default_placement(rgw_placement_rule());
   }
 
   if (!tags.empty()) {
     user_op.set_placement_tags(tags);
+  } else if (opt_cmd == OPT::USER_MODIFY && tags_specified) {
+    // explicitly empty: clear the tag list
+    user_op.set_placement_tags(list<string>());
   }
   user_op.path = path;
 

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -302,9 +302,13 @@
      --default                         set entity (realm, zonegroup, zone) as default
      --read-only                       set zone as read-only (when adding to zonegroup)
      --redirect-zone                   specify zone id to redirect when response is 404 (not found)
-     --placement-id                    placement id for zonegroup placement commands
+     --placement-id                    placement id for zonegroup placement commands, and the
+                                       default placement of a user for the user commands. on
+                                       user modify an empty value clears it
      --storage-class                   storage class for zonegroup placement commands
-     --tags=<list>                     list of tags for zonegroup placement add and modify commands
+     --tags=<list>                     list of tags for zonegroup placement add and modify commands,
+                                       and the placement tags of a user for the user commands. on
+                                       user modify an empty value clears them
      --tags-add=<list>                 list of tags to add for zonegroup placement modify command
      --tags-rm=<list>                  list of tags to remove for zonegroup placement modify command
      --endpoints=<list>                zone endpoints


### PR DESCRIPTION
## Summary

`radosgw-admin user modify` and the admin ops user modify can set the default placement, the default storage class and the placement tags of a user, but not unset them. This makes an explicitly empty value clear the field, while an absent one still means no change.

## Problem

Both layers apply these parameters only when the value is not empty:

```cpp
if (!default_placement_str.empty()) {
  ...
  op_state.set_default_placement(target_rule);
}

if (!placement_tags_str.empty()) {
  ...
  op_state.set_placement_tags(placement_tags_list);
}
```

So `POST /admin/user?uid=x&default-placement=` is a silent no-op, indistinguishable from leaving the parameter out, and `--placement-id ""` behaves the same way on the CLI. The only way back to "inherit the zonegroup placement" was `metadata get` / edit JSON / `metadata put`, which skips validation and races with concurrent user modifications.

This blocks Rook, which needs it to reconcile removal of the per-user placement fields on its `CephObjectStoreUser` CRD back to the Ceph defaults. Without it a removed field leaves the RGW side permanently stale.

## Fix

On user modify, use the `exists()` idiom the same handler already uses for `suspended`, `system` and `account-root`:

- `default-placement` explicitly empty clears the whole rule, storage class included. A storage class is validated against its placement target, so a dangling one is not a state worth expressing.
- `placement-tags` explicitly empty clears the tag list, independently of the placement.
- an absent parameter is still a no-change.

The op state already supports this: `set_default_placement` and `set_placement_tags` raise `default_placement_specified` and `placement_tags_specified`, which `RGWUser::execute_modify` already honours. Only the parsing layers needed to change.

On the CLI, `placement_id` and `tags` are initialised empty, so absent and explicitly empty cannot be told apart after the fact. Added a `*_specified` bool set inside the `ceph_argparse_witharg` branch, which only runs when the flag is present. The clear paths are gated on `OPT::USER_MODIFY`, so the zonegroup and zone placement commands that share those two variables are unaffected.

`default-storage-class` given without `default-placement` was silently ignored, and now fails with `EINVAL`.

User create is deliberately left alone: an empty value there cannot be told apart from an absent one, and there is nothing to clear.

### Backwards compatibility

Redefining an explicitly empty value is safe in practice because no mainstream client can currently send one: go-ceph's URL encoder drops empty strings and empty lists client-side (ceph/go-ceph#1307 is the client half, which becomes actionable once this lands). The output format is unchanged. The release note covers the semantic change.

## Testing

Integration tests added to both admin task suites, 5 cases each: set, omit-leaves-unchanged, storage-class-without-placement fails, clear placement, clear tags.

Manually verified on vstart, radosgw-admin (18 checks) and the admin ops API (20 checks), all passing:

```
0. baseline: fresh user reports no placement                    ok
1. set placement + COLD storage class + tags                    ok
2. omitting the params leaves all three unchanged               ok
3. default-storage-class alone                              -> 400
4. default-placement=''  -> placement '', storage class ''      ok
                            tags untouched: ['tag1','tag2']     ok
5. placement-tags=''     -> []                                  ok
6. default-placement=no-such-placement                      -> 400
```

Step 4 is the interesting one: the storage class goes away with the rule, and the tags survive, which is the split the tracker asked for.

Note on why the suite tests do not assert on the storage class: `STANDARD` is not observable in either direction. `rgw_placement_rule::encode()` persists through `to_str()`, which drops the storage class when it is the standard one, and `RGWUserInfo::dump()` renders an empty storage class back as `STANDARD`. Setting `STANDARD` and clearing it therefore look identical. The manual run above uses a real non-standard class (`COLD`, added to the zone for the test) to show the clear actually happens. The suites assert on the placement name and the tags, which are observable everywhere.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
