### PR TITLE
rgw: add perf counters to bucket resharding

### DIFF
--- a/doc/radosgw/metrics.rst
+++ b/doc/radosgw/metrics.rst
@@ -550,6 +550,122 @@ Combined Examples
       /
       increase(rgw_lc_per_bucket_objects_scanned[24h])
 
+Bucket Reshard Metrics
+======================
+
+The following metrics related to bucket resharding are tracked across buckets by the Ceph Object Gateway.
+
+.. list-table:: Ceph Object Gateway Across-Bucket Bucket Reshard Metrics
+   :widths: 25 25 75
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+   * - ``active``
+     - Gauge
+     - Number of currently active bucket reshards
+   * - ``active_shard_count``
+     - Gauge
+     - Number of bucket shards currently being resharded
+   * - ``ok``
+     - Counter
+     - Number of successful bucket reshards
+   * - ``failed``
+     - Counter
+     - Number of failed bucket reshards
+   * - ``start_time``
+     - Gauge
+     - Most recent bucket reshard start timestamp (Unix epoch seconds)
+   * - ``ok_end_time``
+     - Gauge
+     - Most recent bucket reshard success end timestamp (Unix epoch seconds)
+   * - ``failed_end_time``
+     - Gauge
+     - Most recent bucket reshard failed end timestamp (Unix epoch seconds)
+   * - ``ok_time_avg``
+     - Gauge
+     - Average time successful reshards take
+
+Bucket reshard metrics across buckets are in the "rgw/counters" section and all have the prefix "rgw_reshard_".
+
+The following metrics related to bucket resharding are tracked per bucket by the Ceph Object Gateway.
+
+.. list-table:: Ceph Object Gateway Per-Bucket Bucket Reshard Metrics
+   :widths: 25 25 75
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+   * - ``active_shard_count``
+     - Gauge
+     - Number of bucket shards currently being resharded for this bucket
+   * - ``ok``
+     - Counter
+     - Number of successful bucket reshards for this bucket
+   * - ``failed``
+     - Counter
+     - Number of failed bucket reshards for this bucket
+   * - ``start_time``
+     - Gauge
+     - Most recent bucket reshard start timestamp (Unix epoch seconds) for this bucket
+   * - ``ok_end_time``
+     - Gauge
+     - Most recent bucket reshard success end timestamp (Unix epoch seconds) for this bucket
+   * - ``failed_end_time``
+     - Gauge
+     - Most recent bucket reshard failed end timestamp (Unix epoch seconds) for this bucket
+   * - ``ok_time_avg``
+     - Gauge
+     - Average time successful reshards take for this bucket
+
+Bucket reshard metrics are labeled per-bucket in the ``rgw_bucket_reshard_per_bucket`` section.
+
+Information about bucket reshard metrics can be seen in the ``rgw_bucket_reshard_per_bucket``
+section from the output of the ``counter schema`` command.
+
+To retrieve bucket reshard metrics from a ``radosgw`` daemon's admin socket, see the
+``rgw_bucket_reshard_per_bucket`` section in the output of the ``counter dump`` command::
+
+    "rgw_bucket_reshard_per_bucket": [
+        {
+            "labels": {
+                "bucket": "bkt1"
+            },
+            "counters": {
+                "bucket_reshard_per_bucket_ok": 2,
+                "bucket_reshard_per_bucket_failed": 0,
+                "bucket_reshard_per_bucket_start_time": 1788288849,
+                "bucket_reshard_per_bucket_ok_end_time": 1788288849,
+                "bucket_reshard_per_bucket_failed_end_time": 0,
+                "bucket_reshard_per_bucket_ok_time_avg": {
+                    "avgcount": 2,
+                    "sum": 0.220919428,
+                    "avgtime": 0.110459714
+                }
+            }
+        },
+	...
+    ],
+
+Bucket Reshard Counter Cache
+----------------------------
+
+To track bucket reshard events per bucket, set :confval:`rgw_bucket_reshard_counters_cache` to ``true``. The default value is ``false``.
+
+Bucket reshard metrics are stored as labeled performance counters in memory. All counters are lost when the Ceph Object Gateway restarts or crashes.
+
+Since ``ceph-mgr`` cannot expose labeled counters today; use the per-host ``ceph-exporter`` daemon to scrape these metrics.
+
+Bucket Reshard Counter Cache Size & Eviction
+--------------------------------------------
+
+The :confval:`rgw_bucket_reshard_counters_cache_size` option can be used to set number of entries in the cache.
+
+When the number of cached counters exceeds this value, the least recently used (LRU) counters are evicted.
+
+
 Sending Metrics to Prometheus
 =============================
 
@@ -567,6 +683,8 @@ The following Ceph Object Gateway op metrics related settings can be set via ``c
 .. confval:: rgw_user_counters_cache_size
 .. confval:: rgw_bucket_counters_cache
 .. confval:: rgw_bucket_counters_cache_size
+.. confval:: rgw_bucket_reshard_counters_cache
+.. confval:: rgw_bucket_reshard_counters_cache_size
 
 The following are notable ceph-exporter related settings can be set via ``ceph config set global CONFIG_VARIABLE VALUE``.
 

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3086,6 +3086,28 @@ options:
   - rgw
   - rgw
   min: 16
+- name: rgw_bucket_reshard_counters_cache
+  type: bool
+  level: advanced
+  default: false
+  desc: enable a rgw perf counters cache for counters with bucket reshard
+  long desc: If set to true, rgw creates perf counters labeled by bucket for
+    bucket resharding and stores them in a perf counters cache.
+  see_also:
+  - rgw_bucket_reshard_counters_cache_size
+  services:
+  - rgw
+  with_legacy: true
+- name: rgw_bucket_reshard_counters_cache_size
+  type: uint
+  level: advanced
+  desc: Number of labeled perf counters the bucket resharding counters cache can store
+  default: 10000
+  services:
+  - rgw
+  see_also:
+  - rgw_bucket_reshard_counters_cache
+  with_legacy: true
 - name: rgw_trust_forwarded_https
   type: bool
   level: advanced

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -11,6 +11,7 @@
 #include "rgw_reshard.h"
 #include "rgw_sal.h"
 #include "rgw_sal_rados.h"
+#include "rgw_perf_counters.h"
 #include "cls/rgw/cls_rgw_client.h"
 #include "cls/lock/cls_lock_client.h"
 #include "common/Clock.h" // for ceph_clock_now()
@@ -1286,12 +1287,57 @@ int RGWBucketReshard::execute(int num_shards,
   if (ret < 0) {
     return ret;
   }
-  // TODO: release the lock when purging the old index shards or unsucessful new index shards
+
+  // TODO: release the lock when purging the old index shards or
+  // unsucessful new index shards
   auto unlock = make_scope_guard([this] { reshard_lock.unlock(); });
+
+  const utime_t start_time = ceph_clock_now();
+  const auto current_num_shards =
+    rgw::num_shards(bucket_info.layout.current_index);
+
+  // NB: if this reshard is a result of a radosgw-admin rather than
+  // initiated by a radosgw daemon, then the perf counters will not
+  // have been created, and these both will be nullptrs
+  auto counters =
+    rgw::bucket_reshard_counters::get(bucket_info.bucket.name,
+                                      bucket_info.bucket.tenant);
+
+  if (perfcounter) {
+    perfcounter->inc(l_rgw_bucket_reshard_active, 1);
+    perfcounter->inc(l_rgw_bucket_reshard_active_shard_count,
+                     current_num_shards);
+    perfcounter->set(l_rgw_bucket_reshard_start_time, start_time.sec());
+  }
+  if (counters) {
+    counters->inc(l_rgw_bucket_reshard_per_bucket_active_shard_count,
+                  current_num_shards);
+    counters->set(l_rgw_bucket_reshard_per_bucket_start_time,
+                  start_time.sec());
+  }
+
+  auto perf_counter_failure_complete = [counters, current_num_shards]() {
+    const auto fail_time = ceph_clock_now().sec();
+    if (perfcounter) {
+      perfcounter->dec(l_rgw_bucket_reshard_active, 1);
+      perfcounter->dec(l_rgw_bucket_reshard_active_shard_count,
+                       current_num_shards);
+      perfcounter->inc(l_rgw_bucket_reshard_failed, 1);
+      perfcounter->set(l_rgw_bucket_reshard_failed_end_time, fail_time);
+    }
+    if (counters) {
+      counters->dec(l_rgw_bucket_reshard_per_bucket_active_shard_count,
+                    current_num_shards);
+      counters->inc(l_rgw_bucket_reshard_per_bucket_failed, 1);
+      counters->set(l_rgw_bucket_reshard_per_bucket_failed_end_time,
+                    fail_time);
+    }
+  };
 
   if (reshard_log) {
     ret = reshard_log->update(dpp, bucket_info, initiator, y);
     if (ret < 0) {
+      perf_counter_failure_complete();
       return ret;
     }
   }
@@ -1301,6 +1347,7 @@ int RGWBucketReshard::execute(int num_shards,
   ret = init_reshard(store, bucket_info, bucket_attrs, fault, num_shards,
                      support_logrecord, dpp, y);
   if (ret < 0) {
+    perf_counter_failure_complete();
     return ret;
   }
 
@@ -1314,16 +1361,38 @@ int RGWBucketReshard::execute(int num_shards,
 
   if (ret < 0) {
     cancel_reshard(store, bucket_info, bucket_attrs, fault, dpp, y);
+    perf_counter_failure_complete();
 
     ldpp_dout(dpp, 1) << __func__ << " INFO: reshard of bucket \""
         << bucket_info.bucket.name << "\" canceled due to errors" << dendl;
     return ret;
   }
 
-  auto current_num_shards = rgw::num_shards(bucket_info.layout.current_index);
   ret = commit_reshard(store, bucket_info, bucket_attrs, fault, dpp, y);
   if (ret < 0) {
+    perf_counter_failure_complete();
     return ret;
+  }
+
+  const auto succeed_time = ceph_clock_now();
+  if (perfcounter) {
+    perfcounter->dec(l_rgw_bucket_reshard_active, 1);
+    perfcounter->dec(l_rgw_bucket_reshard_active_shard_count,
+                     current_num_shards);
+    perfcounter->inc(l_rgw_bucket_reshard_ok, 1);
+    perfcounter->set(l_rgw_bucket_reshard_ok_end_time,
+                     succeed_time.sec());
+    perfcounter->tinc(l_rgw_bucket_reshard_ok_time_avg,
+                      succeed_time - start_time);
+  }
+  if (counters) {
+    counters->dec(l_rgw_bucket_reshard_per_bucket_active_shard_count,
+                  current_num_shards);
+    counters->inc(l_rgw_bucket_reshard_per_bucket_ok, 1);
+    counters->set(l_rgw_bucket_reshard_per_bucket_ok_end_time,
+                  succeed_time.sec());
+    counters->tinc(l_rgw_bucket_reshard_per_bucket_ok_time_avg,
+                      succeed_time - start_time);
   }
 
   ldpp_dout(dpp, 1) << __func__ << " INFO: reshard of bucket \"" <<

--- a/src/rgw/rgw_perf_counters.cc
+++ b/src/rgw/rgw_perf_counters.cc
@@ -65,9 +65,9 @@ void add_rgw_frontend_counters(PerfCountersBuilder *pcb) {
   pcb->add_u64_counter(l_rgw_d4n_cache_evictions, "d4n_cache_evictions", "D4N cache evictions");
 
   pcb->add_time_avg(l_rgw_kms_fetch_lat, "kms_fetch_lat", "Uncached KMS secret fetch latency");
-  pcb->add_u64_counter(l_rgw_kms_error_permanent, "kms_error_permanent", "Permanent (e.g key not found) errors returned from KMS");
-  pcb->add_u64_counter(l_rgw_kms_error_transient, "kms_error_transient", "Transient (e.g timeout, overloaded) errors returned from KMS");
-  pcb->add_u64_counter(l_rgw_kms_error_secret_store, "kms_error_secret_store", "Secret store errors (e.g kernel keyring quota)");
+  pcb->add_u64_counter(l_rgw_kms_error_permanent, "kms_error_permanent", "Permanent (e.g., key not found) errors returned from KMS");
+  pcb->add_u64_counter(l_rgw_kms_error_transient, "kms_error_transient", "Transient (e.g., timeout, overloaded) errors returned from KMS");
+  pcb->add_u64_counter(l_rgw_kms_error_secret_store, "kms_error_secret_store", "Secret store errors (e.g., kernel keyring quota)");
 
   pcb->add_u64(l_rgw_bucket_reshard_active,
                "bucket_reshard_active",

--- a/src/rgw/rgw_perf_counters.cc
+++ b/src/rgw/rgw_perf_counters.cc
@@ -68,6 +68,31 @@ void add_rgw_frontend_counters(PerfCountersBuilder *pcb) {
   pcb->add_u64_counter(l_rgw_kms_error_permanent, "kms_error_permanent", "Permanent (e.g key not found) errors returned from KMS");
   pcb->add_u64_counter(l_rgw_kms_error_transient, "kms_error_transient", "Transient (e.g timeout, overloaded) errors returned from KMS");
   pcb->add_u64_counter(l_rgw_kms_error_secret_store, "kms_error_secret_store", "Secret store errors (e.g kernel keyring quota)");
+
+  pcb->add_u64(l_rgw_bucket_reshard_active,
+               "bucket_reshard_active",
+               "Number of active bucket reshards");
+  pcb->add_u64(l_rgw_bucket_reshard_active_shard_count,
+               "bucket_reshard_active_shard_count",
+               "Number of shards actively being resharded");
+  pcb->add_u64_counter(l_rgw_bucket_reshard_ok,
+                       "bucket_reshard_ok",
+                       "Number of successful bucket reshards");
+  pcb->add_u64_counter(l_rgw_bucket_reshard_failed,
+                       "bucket_reshard_failed",
+                       "Number of failed bucket reshards");
+  pcb->add_u64(l_rgw_bucket_reshard_start_time,
+               "bucket_reshard_start_time",
+               "Time of most recent bucket reshard initiation");
+  pcb->add_u64(l_rgw_bucket_reshard_ok_end_time,
+               "bucket_reshard_ok_end_time",
+               "Time of most recent bucket reshard successful completion");
+  pcb->add_u64(l_rgw_bucket_reshard_failed_end_time,
+               "bucket_reshard_failed_end_time",
+               "Time of most recent bucket reshard failed completion");
+  pcb->add_time_avg(l_rgw_bucket_reshard_ok_time_avg,
+                    "bucket_reshard_ok_time_avg",
+                    "Average time span to complete successful reshards");
 }
 
 void add_rgw_op_counters(PerfCountersBuilder *lpcb) {
@@ -300,6 +325,66 @@ std::shared_ptr<PerfCounters> get(const std::string& bucket_name,
 
 } // namespace rgw::lc_counters
 
+
+namespace rgw::bucket_reshard_counters {
+
+std::optional<ceph::perf_counters::PerfCountersCache> bucket_reshard_counters_cache;
+const std::string rgw_bucket_reshard_counters_key = "rgw_bucket_reshard_per_bucket";
+
+void add_bucket_reshard_counters(PerfCountersBuilder* pcb) {
+  pcb->set_prio_default(PerfCountersBuilder::PRIO_USEFUL);
+
+  pcb->add_u64(l_rgw_bucket_reshard_per_bucket_active_shard_count,
+               "bucket_reshard_per_bucket_active_shard_count",
+               "Number of shards actively being resharded for this bucket");
+  pcb->add_u64_counter(l_rgw_bucket_reshard_per_bucket_ok,
+                       "bucket_reshard_per_bucket_ok",
+                       "Counter of successful bucket reshards for this bucket");
+  pcb->add_u64_counter(l_rgw_bucket_reshard_per_bucket_failed,
+                       "bucket_reshard_per_bucket_failed",
+                       "Counter of failed bucket reshard attempts for this bucket");
+  pcb->add_u64(l_rgw_bucket_reshard_per_bucket_start_time,
+               "bucket_reshard_per_bucket_start_time",
+               "Time of most recent reshard initiation for this bucket");
+  pcb->add_u64(l_rgw_bucket_reshard_per_bucket_ok_end_time,
+               "bucket_reshard_per_bucket_ok_end_time",
+               "Time of most recent reshard successful completion for this bucket");
+  pcb->add_u64(l_rgw_bucket_reshard_per_bucket_failed_end_time,
+               "bucket_reshard_per_bucket_failed_end_time",
+               "Time of most recent reshard failed completion for this bucket");
+  pcb->add_time_avg(l_rgw_bucket_reshard_per_bucket_ok_time_avg,
+                    "bucket_reshard_per_bucket_ok_time_avg",
+                    "Average time span to complete successful reshard for this bucket");
+} // add_bucket_reshard_counters()
+
+std::shared_ptr<PerfCounters> create_bucket_reshard_counters(const std::string& name,
+                                                             CephContext *cct)
+{
+  PerfCountersBuilder pcb(cct, name,
+                          l_rgw_bucket_reshard_first, l_rgw_bucket_reshard_last);
+  add_bucket_reshard_counters(&pcb);
+  std::shared_ptr<PerfCounters> new_counters(pcb.create_perf_counters());
+  cct->get_perfcounters_collection()->add(new_counters.get());
+  return new_counters;
+}
+
+std::shared_ptr<PerfCounters> get(const std::string& bucket_name,
+                                  const std::string& tenant)
+{
+  if (!bucket_reshard_counters_cache) {
+    return nullptr;
+  }
+  std::string key = ceph::perf_counters::key_create(rgw_bucket_reshard_counters_key,
+                                                    {{"bucket", bucket_name}});
+  if (!tenant.empty()) {
+    key = ceph::perf_counters::key_insert(key, {{"tenant", tenant}});
+  }
+  return bucket_reshard_counters_cache->get(key);
+}
+
+}; // namespace rgw::bucket_reshard_counters
+
+
 int rgw_perf_start(CephContext *cct)
 {
   frontend_counters_init(cct);
@@ -322,6 +407,17 @@ int rgw_perf_start(CephContext *cct)
     rgw::lc_counters::lc_counters_cache = new PerfCountersCache(cct, target_size, rgw::lc_counters::create_lc_counters);
   }
 
+  const bool bucket_reshard_counters_cache_enabled =
+    cct->_conf.get_val<bool>("rgw_bucket_reshard_counters_cache");
+  if (bucket_reshard_counters_cache_enabled) {
+    const uint64_t target_size =
+      cct->_conf.get_val<uint64_t>("rgw_bucket_reshard_counters_cache_size");
+    rgw::bucket_reshard_counters::bucket_reshard_counters_cache.emplace(
+      cct,
+      target_size,
+      rgw::bucket_reshard_counters::create_bucket_reshard_counters);
+  }
+
   global_op_counters_init(cct);
   return 0;
 }
@@ -337,4 +433,5 @@ void rgw_perf_stop(CephContext *cct)
   delete user_counters_cache;
   delete bucket_counters_cache;
   delete rgw::lc_counters::lc_counters_cache;
+  rgw::bucket_reshard_counters::bucket_reshard_counters_cache.reset();
 }

--- a/src/rgw/rgw_perf_counters.h
+++ b/src/rgw/rgw_perf_counters.h
@@ -57,6 +57,16 @@ enum {
   l_rgw_kms_error_transient,
   l_rgw_kms_error_permanent,
   l_rgw_kms_error_secret_store,
+
+  l_rgw_bucket_reshard_active,
+  l_rgw_bucket_reshard_active_shard_count,
+  l_rgw_bucket_reshard_ok,
+  l_rgw_bucket_reshard_failed,
+  l_rgw_bucket_reshard_start_time,
+  l_rgw_bucket_reshard_ok_end_time,
+  l_rgw_bucket_reshard_failed_end_time,
+  l_rgw_bucket_reshard_ok_time_avg,
+
   l_rgw_last,
 };
 
@@ -119,6 +129,20 @@ enum {
   l_rgw_lc_per_bucket_last
 };
 
+enum {
+  l_rgw_bucket_reshard_first = 19000,
+
+  l_rgw_bucket_reshard_per_bucket_active_shard_count,
+  l_rgw_bucket_reshard_per_bucket_ok,
+  l_rgw_bucket_reshard_per_bucket_failed,
+  l_rgw_bucket_reshard_per_bucket_start_time,
+  l_rgw_bucket_reshard_per_bucket_ok_end_time,
+  l_rgw_bucket_reshard_per_bucket_failed_end_time,
+  l_rgw_bucket_reshard_per_bucket_ok_time_avg,
+
+  l_rgw_bucket_reshard_last,
+};
+
 namespace rgw::op_counters {
 
 struct CountersContainer {
@@ -159,3 +183,11 @@ std::shared_ptr<PerfCounters> get(const std::string& bucket_name,
                                   const std::string& tenant);
 
 } // namespace rgw::lc_counters
+
+
+namespace rgw::bucket_reshard_counters {
+
+std::shared_ptr<PerfCounters> get(const std::string& bucket_name,
+                                  const std::string& tenant);
+
+} // namespace rgw::bucket_reshard_counters


### PR DESCRIPTION
Adds a set of perf counters for bucket resharding. Some are global and count all resharding attempts. Others are "volatile" and per-bucket.

Corresponding dashboard tracker ticket: https://tracker.ceph.com/issues/80209

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
