### PR TITLE
[DRAFT] mgr/cephadm: expand unit test coverage for cephadm/module.py

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import re
 
 from contextlib import contextmanager
 
@@ -32,12 +33,19 @@ from ceph.deployment.service_spec import (
     PlacementSpec,
     RGWSpec,
     ServiceSpec,
+    SMBSpec,
+    OAuth2ProxySpec,
+    SNMPGatewaySpec,
+    CephExporterSpec,
+    IngressSpec,
 )
 from ceph.deployment.drive_selection.selector import DriveSelection
 from ceph.deployment.inventory import Devices, Device
 from ceph.utils import datetime_to_str, datetime_now, str_to_datetime
 from orchestrator import DaemonDescription, InventoryHost, \
     HostSpec, OrchestratorError, DaemonDescriptionStatus, OrchestratorEvent
+from orchestrator._interface import GenericSpec
+from orchestrator.module import Format
 from tests import mock
 from .fixtures import wait, _run_cephadm, match_glob, with_host, \
     with_cephadm_module, with_service, make_daemons_running, async_side_effect
@@ -184,15 +192,51 @@ class TestCephadm(object):
                     DriveGroupSpec(service_type='osd', service_id=''),
                     replace_osd_ids=[]))
 
-    def test_get_unique_name(self, cephadm_module):
-        # type: (CephadmOrchestrator) -> None
-        existing = [
-            DaemonDescription(daemon_type='mon', daemon_id='a')
+    @pytest.mark.parametrize(
+        "daemon_type,hostname,existing,prefix,forcename,rank,rank_generation,expected_pattern",
+        [
+            ('mon', 'myhost', [DaemonDescription(daemon_type='mon', daemon_id='a')], None, None, None, None, 'myhost'),
+            ('mgr', 'myhost', [DaemonDescription(daemon_type='mgr', daemon_id='a')], None, None, None, None, 'myhost.*'),
+            ('mgr', 'myhost', [DaemonDescription(daemon_type='mgr', daemon_id='a')], 'foo', None, None, None, 'foo.myhost.*'),
+            ('mgr', 'myhost.us-east', [DaemonDescription(daemon_type='mgr', daemon_id='a')], None, None, None, None, 'myhost.*'),
+            ('mds', 'myhost', [], 'foo', None, 0, 1, 'foo.0.1.myhost.*'),
         ]
-        new_mon = cephadm_module.get_unique_name('mon', 'myhost', existing)
-        match_glob(new_mon, 'myhost')
-        new_mgr = cephadm_module.get_unique_name('mgr', 'myhost', existing)
-        match_glob(new_mgr, 'myhost.*')
+    )
+    def test_get_unique_name(
+        self, 
+        cephadm_module: CephadmOrchestrator, 
+        daemon_type: str, 
+        hostname: str, 
+        existing: list,
+        prefix: str, 
+        forcename: str,
+        rank: int,
+        rank_generation: int,
+        expected_pattern: str
+    ):
+        new_name = cephadm_module.get_unique_name(daemon_type, hostname, existing, prefix, forcename, rank, rank_generation)
+        match_glob(new_name, expected_pattern)
+
+    @pytest.mark.parametrize(
+        "daemon_type,hostname,existing,prefix,forcename,expected_message",
+        [
+            ('mon', 'test', [DaemonDescription(daemon_type='mon', daemon_id='a')], '', 'a', 'name mon.a already in use'),
+            ('mon', 'test', [DaemonDescription(daemon_type='mon', daemon_id='test')], '', '', 'name mon.test already in use'),
+        ]
+    )
+    def test_get_unique_name_fail(
+        self, 
+        cephadm_module: CephadmOrchestrator, 
+        daemon_type: str, 
+        hostname: str, 
+        prefix: str, 
+        existing: list,
+        forcename: str,
+        expected_message: str
+    ):
+        with pytest.raises(OrchestratorError, match=expected_message):
+            cephadm_module.get_unique_name(daemon_type, hostname, existing, prefix, forcename)
+
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
     def test_valid_url(self, cephadm_module):
@@ -2202,6 +2246,11 @@ class TestCephadm(object):
             (ServiceSpec('rbd-mirror'), CephadmOrchestrator.apply_rbd_mirror),
             (ServiceSpec('cephfs-mirror'), CephadmOrchestrator.apply_rbd_mirror),
             (ServiceSpec('mds', service_id='fsname'), CephadmOrchestrator.apply_mds),
+            (ServiceSpec('mgmt-gateway'),CephadmOrchestrator.apply_mgmt_gateway),
+            (ServiceSpec('loki'), CephadmOrchestrator.apply_loki),
+            (ServiceSpec('promtail'), CephadmOrchestrator.apply_promtail),
+            (ServiceSpec('alloy'), CephadmOrchestrator.apply_alloy),
+            (ServiceSpec("ceph-exporter"), CephadmOrchestrator.apply_ceph_exporter),
             (ServiceSpec(
                 'mds', service_id='fsname',
                 placement=PlacementSpec(
@@ -2255,6 +2304,34 @@ class TestCephadm(object):
                 envs=['SECRET=password'],
                 ports=[8080, 8443]
             ), CephadmOrchestrator.apply_container),
+            (SNMPGatewaySpec(
+                'snmp-gateway',
+                snmp_version='V2c',
+                snmp_destination='192.168.1.1:162',
+                credentials={
+                    'snmp_community': 'public'
+                },
+            ), CephadmOrchestrator.apply_snmp_gateway),
+            (SMBSpec(
+                'smb',
+                service_id='smb-service-1',
+                placement=PlacementSpec(
+                    hosts=[HostPlacementSpec(
+                        hostname='test',
+                        name='bar',
+                        network=''
+                    )]
+                ),
+                cluster_id='foxtrot', 
+                config_uri='rados://.smb/foxtrot/config.json',
+            ), CephadmOrchestrator.apply_smb),
+            (OAuth2ProxySpec(
+                'oauth2-proxy',
+                provider_display_name='my_idp_provider',
+                client_id='my_client_id',
+                client_secret='my_client_secret',
+                oidc_issuer_url='http://192.168.10.10:8888/dex',
+            ), CephadmOrchestrator.apply_oauth2_proxy),
         ]
     )
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
@@ -2265,6 +2342,29 @@ class TestCephadm(object):
         with with_host(cephadm_module, 'test'):
             with with_service(cephadm_module, spec, meth, 'test'):
                 pass
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_apply_ingress(self, cephadm_module: CephadmOrchestrator):
+            with with_host(cephadm_module, 'test', addr='1.2.3.7'):
+                s = RGWSpec(service_id="foo", placement=PlacementSpec(count=1),
+                            rgw_frontend_type='beast')
+
+                ispec = IngressSpec(service_type='ingress',
+                                    service_id='test',
+                                    backend_service='rgw.foo',
+                                    frontend_port=8089,
+                                    monitor_port=8999,
+                                    monitor_user='admin',
+                                    monitor_password='12345',
+                                    keepalived_password='12345',
+                                    virtual_interface_networks=['1.2.3.0/24'],
+                                    virtual_ip="1.2.3.4/32",
+                                    enable_stats=True)
+                
+                with with_service(cephadm_module, s) as _, \
+                        with_service(cephadm_module, ispec, CephadmOrchestrator.apply_ingress) as _:
+                    pass
+
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     def test_mds_config_purge(self, cephadm_module: CephadmOrchestrator):
@@ -2970,6 +3070,63 @@ Traceback (most recent call last):
                     assert wait(cephadm_module, cephadm_module.describe_service())[0].size == 1
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+    def test_remove_last_admin_label(self, cephadm_module: CephadmOrchestrator):
+        hostname = "host1"
+        label = SpecialHostLabels.ADMIN
+        with with_host(cephadm_module, hostname):
+            cephadm_module.inventory.add_label(hostname, label)
+            with pytest.raises(OrchestratorError, match=f"Host {hostname} is the last host with the '{SpecialHostLabels.ADMIN}' label."):
+                cephadm_module.remove_host_label(hostname, label, force=False)
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+    def test_remove_invalid_label(self, cephadm_module: CephadmOrchestrator):
+        hostname = "host1"
+        invalid_label = "invalid_label"
+        valid_label = SpecialHostLabels.ADMIN
+        with with_host(cephadm_module, hostname):
+            cephadm_module.inventory.add_label(hostname, valid_label)
+            retval = cephadm_module.remove_host_label(hostname, invalid_label, force=False)
+            assert retval.result_str().startswith(f"Host {hostname} does not have label '{invalid_label}'.")
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+    def test_host_ok_to_stop(self, cephadm_module: CephadmOrchestrator):
+        host_to_stop = 'host1'
+        with with_host(cephadm_module, 'host1'):
+            with with_host(cephadm_module, 'host2'):
+                mgr_service = ServiceSpec(
+                    'mgr', 
+                    placement=PlacementSpec(count_per_host=1, host_pattern='*')
+                )
+                with with_service(cephadm_module, mgr_service, status_running=True):
+                    retval = cephadm_module.host_ok_to_stop(host_to_stop)
+                    assert retval.result_str().startswith(f"It is presumed safe to stop host {host_to_stop}")
+
+    @pytest.mark.parametrize(
+        "hostname, host_to_stop, expected_failure",
+        [
+            ("host1", "host1", "ALERT: Cannot stop {d_name} in RGW service. Not enough remaining RGW daemons."),
+            ("host1", "invalidhost", "Cannot find host \"invalidhost\"")
+        ]
+    )
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+    def test_host_ok_to_stop_fail(
+        self, 
+        cephadm_module: CephadmOrchestrator, 
+        hostname: str, 
+        host_to_stop: str, 
+        expected_failure: str
+    ):
+        with with_host(cephadm_module, hostname):
+            with with_service(
+                cephadm_module, 
+                RGWSpec(service_id='myrgw.foobar'), 
+                host=hostname,
+            ) as d_name:
+                expected = expected_failure.format(d_name=d_name)
+                with pytest.raises(OrchestratorError, match=re.escape(expected)):
+                    cephadm_module.host_ok_to_stop(host_to_stop)
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
     def test_host_rm_last_admin(self, cephadm_module: CephadmOrchestrator):
         with pytest.raises(OrchestratorError):
             with with_host(cephadm_module, 'test', refresh_hosts=False, rm_with_force=False):
@@ -3491,7 +3648,293 @@ Traceback (most recent call last):
 
                 cephadm_module.set_osd_spec('osd.foo', ['1'])
 
+    @pytest.mark.parametrize(
+        "action,expected_msg",
+        [
+            ('start', "Scheduled to {action} {daemon_name} on host '{hostname}'"),
+            ('stop', "Stopping entire mgr service is prohibited."),
+            ('restart', "Scheduled to {action} {daemon_name} on host '{hostname}'"),
+            ('reconfig', "Scheduled to {action} {daemon_name} on host '{hostname}'"),
+            ('redeploy', "Scheduled to {action} {daemon_name} on host '{hostname}'"),
+        ]
+    )
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_service_action(
+        self,
+        cephadm_module: CephadmOrchestrator, 
+        action: str, 
+        expected_msg: str,
+    ):
+        hostname = "host1"
+        with with_host(cephadm_module, hostname):
+            spec = ServiceSpec('mgr', placement=PlacementSpec(hosts=[hostname]))
+            with with_service(cephadm_module, spec) as d_name:
+                c = cephadm_module.service_action(action, 'mgr')
+                formatted_msg = expected_msg.format(action=action, daemon_name=d_name[0], hostname=hostname)
+                assert wait(cephadm_module, c) == [formatted_msg]
 
+    @pytest.mark.parametrize(
+        "spec,service_to_remove,expected_msg",
+        [ 
+            (
+                ServiceSpec(service_type='mds',service_id='fsname',unmanaged=True),
+                "mds.fsname",
+                "No daemons exist under service name",
+            ),
+            (
+                ServiceSpec(service_type='mds',service_id='fsname',unmanaged=False),
+                "mgr",
+                "Invalid service name",
+            ),
+        ]
+    )
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_service_action_fail(
+        self, 
+        cephadm_module: CephadmOrchestrator, 
+        spec: ServiceSpec, 
+        service_to_remove: str, 
+        expected_msg: str,
+    ):
+        hostname = "host1"
+        with with_host(cephadm_module, hostname):
+            with with_service(cephadm_module, spec) as _:
+                with pytest.raises(OrchestratorError, match=expected_msg):
+                    cephadm_module.service_action('start', service_to_remove)
+
+    @pytest.mark.parametrize(
+        "spec,no_overwrite,continue_on_error",
+        [
+            (HostSpec(hostname='host1'),False,True),
+            (HostSpec(hostname='host1'),True,True),
+            (
+                ServiceSpec(service_type='mgr'),
+                False,
+                True,
+            ),
+            (
+                ServiceSpec(service_type='mgr'),
+                True,
+                True,
+            ),
+        ]
+    )
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+    def test_apply(
+        self, 
+        cephadm_module: CephadmOrchestrator, 
+        spec: GenericSpec, 
+        no_overwrite: bool, 
+        continue_on_error: bool,
+    ):
+        with with_host(cephadm_module, 'host1'):
+            if isinstance(spec, ServiceSpec):
+                cephadm_module.spec_store.save(spec)
+            ret = cephadm_module.apply([spec], no_overwrite=no_overwrite, continue_on_error=continue_on_error)
+            assert ret
+
+
+    @pytest.mark.parametrize(
+        "spec,no_overwrite,continue_on_error,expected_msg",
+        [
+            (
+                ServiceSpec('mgr', placement=PlacementSpec(count=6)),
+                False,
+                False,
+                "The maximum number of mgr daemons allowed with 1 hosts is 5.",
+            ),
+            (
+                ServiceSpec('rgw', service_id='foo', placement=PlacementSpec(count=11)),
+                False,
+                False,
+                "The maximum number of rgw daemons allowed with 1 hosts is 10 .",
+            ),
+            (
+                ServiceSpec('rgw', service_id='foo', placement=PlacementSpec(host_pattern='*',count_per_host=11)),
+                False,
+                False,
+                "The maximum count_per_host allowed is 10.",
+            ),
+        ]
+    )
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+    def test_apply_fail(
+        self, 
+        cephadm_module: CephadmOrchestrator, 
+        spec: GenericSpec, 
+        no_overwrite: bool, 
+        continue_on_error: bool,
+        expected_msg: str,
+    ):
+        with with_host(cephadm_module, 'host1'):
+            with pytest.raises(OrchestratorError, match=expected_msg):
+                cephadm_module.apply([spec], no_overwrite=no_overwrite, continue_on_error=continue_on_error)
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+    def test_prepare_host(self, cephadm_module: CephadmOrchestrator):
+        with with_host(cephadm_module, 'host1'):
+            rc, _, _ = cephadm_module._prepare_host('host1')
+            assert rc == 0
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+    def test_prepare_host_and_enable_sudo_hardening(self, cephadm_module: CephadmOrchestrator):
+        with mock.patch("cephadm.module.CephadmOrchestrator._get_cephadm_version_for_host_prep") as mock_get_version:
+            mock_get_version.return_value = 'v18.0.0'
+            with with_host(cephadm_module, 'host1'):
+                cephadm_module.ssh_pub = 'ssh-rsa AAAAB3NzaC1yc2E...'
+                cephadm_module.inventory.add_label('host1', SpecialHostLabels.ADMIN)
+                rc, _, _ = cephadm_module._prepare_host_and_enable_sudo_hardening(
+                    user='user', host_label=SpecialHostLabels.ADMIN
+                )
+                assert rc == 0
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+    def test_prepare_new_host_for_sudo_hardening(self, cephadm_module: CephadmOrchestrator):
+        with mock.patch("cephadm.module.CephadmOrchestrator._get_cephadm_version_for_host_prep") as mock_get_version:
+            mock_get_version.return_value = 'v18.0.0'
+            cephadm_module.ssh_pub = 'ssh-rsa AAAAB3NzaC1yc2E...'
+            cephadm_module.ssh_user = 'cephadm'
+            cephadm_module._prepare_new_host_for_sudo_hardening(hostname='host1', addr='8.8.8.8')
+
+    @pytest.mark.parametrize(
+        "format,expected_retval",
+        [
+            (Format.plain, 0),
+            (Format.json, 0),
+            (Format.json_pretty, 0),
+            (Format.yaml, 1)
+        ]
+    )
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+    def test_config_checks_list(
+        self, 
+        format: Format, 
+        expected_retval: int, 
+        cephadm_module: CephadmOrchestrator
+    ):
+        result = cephadm_module._config_checks_list(format=format)
+        assert result.retval == expected_retval
+
+    @pytest.mark.parametrize(
+        "check_name,expected_retval,expected_err_msg,mock_get_store_config_checks",
+        [
+            (
+                'kernel_security', 0, '',
+                '{"kernel_security": "enabled", "os_subscription": "enabled"}'
+            ),
+            (
+                'invalid_check_name', 1, 'Invalid check name',
+                '{"kernel_security": "enabled", "os_subscription": "enabled"}'
+            ),
+            (
+                'kernel_security', 1, 'Failed to enable check', ''
+            ),
+        ]
+    )
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+    def test_config_check_enable(
+        self,
+        check_name: str,
+        expected_retval: int,
+        expected_err_msg: str,
+        mock_get_store_config_checks: str,
+        cephadm_module: CephadmOrchestrator
+    ):
+        with mock.patch.object(cephadm_module, 'get_store') as mock_get_store:
+            mock_get_store.return_value = mock_get_store_config_checks
+            result = cephadm_module._config_check_enable(check_name=check_name)
+            assert result.retval == expected_retval
+            assert result.stderr.startswith(expected_err_msg)
+
+    @pytest.mark.parametrize(
+        "check_name,expected_retval,expected_err_msg,mock_get_store_config_checks",
+        [
+            (
+                'kernel_security', 0, '',
+                '{"kernel_security": "enabled", "os_subscription": "enabled"}'
+            ),
+            (
+                'invalid_check_name', 1, 'Invalid check name',
+                '{"kernel_security": "enabled", "os_subscription": "enabled"}'
+            ),
+            (
+                'kernel_security', 1, 'Failed to disable check', ''
+            ),
+        ]
+    )
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+    def test_config_check_disable(
+        self,
+        check_name: str,
+        expected_retval: int,
+        expected_err_msg: str,
+        mock_get_store_config_checks: str,
+        cephadm_module: CephadmOrchestrator
+    ):
+        with mock.patch.object(cephadm_module, 'get_store') as mock_get_store:
+            mock_get_store.return_value = mock_get_store_config_checks
+            result = cephadm_module._config_check_disable(check_name=check_name)
+            assert result.retval == expected_retval
+            assert result.stderr.startswith(expected_err_msg)
+
+    @pytest.mark.parametrize(
+        "format",
+        [
+            (Format.plain),
+            (Format.json),
+            (Format.yaml)
+        ]
+    )
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+    def test_client_keyring_ls(self, format, cephadm_module: CephadmOrchestrator):
+        cephadm_module.keys.update(
+            ClientKeyringSpec(
+                entity='client.cephfs', 
+                placement=PlacementSpec(hosts=['host1']),
+                mode=0o600,
+                uid=0,
+                gid=0,
+                include_ceph_conf=True,
+            )
+        )
+        with with_host(cephadm_module, 'host1'):
+            result = cephadm_module._client_keyring_ls(format=format)
+            print(f"result {result.stdout}")
+            assert result.retval == 0
+            
+    def test_client_keyring_set(self, cephadm_module: CephadmOrchestrator):
+        entity = 'client.cephfs'
+        placement = 'host1'
+        owner = '1000:1000'
+        mode = '0o600'
+        no_ceph_conf = False
+        result = cephadm_module._client_keyring_set(entity, placement, owner, mode, no_ceph_conf)
+        assert result.retval == 0
+
+    @pytest.mark.parametrize(
+        "entity,placement,owner,mode,no_ceph_conf,expected_msg",
+        [
+            ('invalid.cephfs', 'host1', '1000:1000', '0o600', False, 'entity must start with client.'),
+            ('client.cephfs', 'host1', ':1000', '0o600', True, 'owner must look like "<uid>:<gid>", e.g., "0:0"'),
+            ('client.cephfs', 'host1', '1000:1000', '66a', False, 'mode must be an octal mode, e.g. "600"'),
+            ('client.cephfs', 'host1', '1000:1000', '844', False, 'mode must be an octal mode, e.g. "600"'),
+        ]
+    )
+    def test_client_keyring_set_fail(
+        self, 
+        cephadm_module: CephadmOrchestrator, 
+        entity: str, 
+        placement: str, 
+        owner: str, 
+        mode: str, 
+        no_ceph_conf: bool, 
+        expected_msg: str
+    ):
+        
+        result = cephadm_module._client_keyring_set(entity, placement, owner, mode, no_ceph_conf)
+        assert result.retval != 0
+        assert result.stderr == expected_msg
+        
 class TestCephadmBinaryLoggingLevel:
     """Test that host-status / cephadm binary logs are suppressed based on
     mgr/cephadm/cephadm_binary_logging_level.


### PR DESCRIPTION
Add comprehensive test cases to improves test coverage for the cephadm module by testing edge cases like different daemon types, hostname patterns, placement configurations, and error conditions.

New tests use parametrize decorators to test multiple input/output combinations including daemon naming with ranks, service failures, and daemon placement limits.

Fixes: https://tracker.ceph.com/issues/76543





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
