### PR TITLE
tentacle: win32_deps_bild: bump openssl version

### DIFF
--- a/win32_build.sh
+++ b/win32_build.sh
@@ -233,8 +233,8 @@ if [[ -z $SKIP_DLL_COPY ]]; then
     required_dlls=(
         $zlibDir/zlib1.dll
         $lz4Dir/lib/dll/liblz4-1.dll
-        $sslDir/bin/libcrypto-1_1-x64.dll
-        $sslDir/bin/libssl-1_1-x64.dll
+        $sslDir/bin/libcrypto-3-x64.dll
+        $sslDir/bin/libssl-3-x64.dll
         $mingwLibpthreadDir/libwinpthread-1.dll)
     if [[ $ENABLE_SHARED == "ON" ]]; then
         required_dlls+=(

--- a/win32_deps_build.sh
+++ b/win32_deps_build.sh
@@ -11,7 +11,7 @@ depsToolsetDir="$DEPS_DIR/mingw"
 lz4SrcDir="${depsSrcDir}/lz4"
 lz4Dir="${depsToolsetDir}/lz4"
 lz4Tag="v1.9.2"
-sslTag="OpenSSL_1_1_1c"
+sslTag="openssl-3.0.16"
 sslDir="${depsToolsetDir}/openssl"
 sslSrcDir="${depsSrcDir}/openssl"
 


### PR DESCRIPTION
Backport of #63606 (clean cherry-pick).

The CVE-2025-30156 cephx merge on `tentacle` made `src/auth/Crypto.cc` include `<openssl/core_names.h>` (OpenSSL 3.x API), but this branch's Windows cross-build still compiles OpenSSL 1.1.1c, so the `ceph windows tests` check fails on every `tentacle` PR:

```
src/auth/Crypto.cc:39:10: fatal error: 'openssl/core_names.h' file not found
```

(e.g. [ceph-windows-pull-requests #86129](https://jenkins.ceph.com/job/ceph-windows-pull-requests/86129/), [#86130](https://jenkins.ceph.com/job/ceph-windows-pull-requests/86130/)). main has built the Windows deps with openssl-3.0.16 since May 2025.

backport tracker: https://tracker.ceph.com/issues/79697

---
- [x] this backport is a clean cherry-pick from main

