### PR TITLE
mclock_common, mClockScheduler: Bound high_priority drain to prevent starvation

### DIFF
--- a/doc/rados/configuration/mclock-config-ref.rst
+++ b/doc/rados/configuration/mclock-config-ref.rst
@@ -218,6 +218,62 @@ change to the default HDD OSD shard configuration is made:
 | :confval:`osd_op_num_threads_per_shard_hdd` | 1                | 5              |
 +---------------------------------------------+------------------+----------------+
 
+.. index:: mclock; queue starvation
+
+.. _mclock-starvation-fix:
+
+mClock Queue Starvation Prevention
+==================================
+The mClock scheduler dequeues certain items -- ``immediate``-class traffic
+(for example, EC subop reads/writes/replies between shards of an
+erasure-coded PG, and scrub's own wire messages) along with any item at or
+above the scheduler's raw priority cutoff (for example, peering) -- ahead of,
+and independently from, the reservation/weight-governed queue that enforces
+the mClock parameters described above for the *client*, *background
+recovery*, and *background best-effort* client types.
+
+Under sustained high-priority load, this queue could previously stay
+continuously non-empty, meaning the mClock-managed queue was never even
+consulted regardless of the reservation or weight configured for the three
+client types above. On an erasure-coded pool under heavy client I/O, ordinary
+EC chunk fan-out is itself classified ``immediate``, which could result in
+indefinite starvation of *background best-effort* operations -- most visibly
+deep-scrub, whose own chunk-by-chunk progress events belong to that class.
+See https://tracker.ceph.com/issues/69078 for the original report.
+
+To bound this, the OSD tracks how long the mClock-managed queue has gone
+unserviced while the high-priority queue keeps refilling. Once that exceeds a
+device-aware threshold, the scheduler forces one dequeue attempt from the
+mClock-managed queue before resuming the high-priority drain. Whenever the
+mClock-managed queue is empty -- the common case -- this has no effect on
+scheduling behavior.
+
+The threshold is device-aware because the same absolute value does not make
+sense across device types: a rotational op's own natural per-op service time
+is multi-millisecond, so a several-hundred-millisecond threshold is a modest
+relative multiple of that, whereas flash completes a normal op in well under
+a millisecond, so the same absolute threshold would represent a much larger
+relative delay there -- and flash has far more IOPS headroom to spare for a
+tighter forced-check cadence in any case. On solid-state and NVMe media, this
+value (50ms) is fixed internally, validated by hardware testing. On
+rotational media, hardware validation of the equivalent default has not yet
+been possible, so instead of a hardcoded constant, the value is exposed as
+the tunable :confval:`osd_mclock_max_starve_time_hdd`.
+
+The option is bounded to a narrow range (100ms to 500ms) around its default
+(250ms), so that even without a way to automatically validate a given value
+against real hardware, it cannot be tuned into a state that erodes the
+low-latency treatment ``immediate``-class and other high-priority traffic
+depend on (i.e., too low) or silently re-opens the starvation this mechanism
+exists to prevent (i.e., too high). The option is configurable: a change made
+with ``ceph config set`` takes effect immediately (no OSD restart).
+For example, to raise the threshold to 400ms on all OSDs:
+
+  .. prompt:: bash #
+
+    ceph config set osd osd_mclock_max_starve_time_hdd 0.4
+
+
 .. index:: mclock; built-in profiles
 
 mClock Built-in Profiles -  Locked Config Options
@@ -825,5 +881,6 @@ mClock Config Options
 .. confval:: osd_mclock_iops_capacity_low_threshold_hdd
 .. confval:: osd_mclock_iops_capacity_threshold_ssd
 .. confval:: osd_mclock_iops_capacity_low_threshold_ssd
+.. confval:: osd_mclock_max_starve_time_hdd
 
 .. _the dmClock algorithm: https://www.usenix.org/legacy/event/osdi10/tech/full_papers/Gulati.pdf

--- a/src/common/mclock_common.cc
+++ b/src/common/mclock_common.cc
@@ -201,6 +201,10 @@ void MclockConfig::set_from_config()
           << osd_bandwidth_capacity_per_shard << " bytes/second"
           << dendl;
 
+  scheduler_max_starve_time = is_rotational
+    ? cct->_conf.get_val<double>("osd_mclock_max_starve_time_hdd")
+    : scheduler_max_starve_time_ssd;
+
   auto mclock_profile = cct->_conf.get_val<std::string>("osd_mclock_profile");
   if (mclock_profile == "high_client_ops") {
     current_profile = HIGH_CLIENT_OPS;
@@ -428,6 +432,10 @@ uint32_t MclockConfig::calc_scaled_cost(int item_cost)
   auto cost_per_io = static_cast<uint32_t>(osd_bandwidth_cost_per_io);
 
   return std::max<uint32_t>(cost, cost_per_io);
+}
+
+double MclockConfig::get_scheduler_max_starve_time() const {
+    return scheduler_max_starve_time;
 }
 
 void MclockConfig::handle_conf_change(const ConfigProxy& conf,

--- a/src/common/mclock_common.h
+++ b/src/common/mclock_common.h
@@ -234,6 +234,29 @@ private:
   // currently active profile, will be overridden from config on startup
   // and upon config change
   profile_t current_profile = BALANCED;
+
+  /**
+   * scheduler_max_starve_time / scheduler_max_starve_time_ssd
+   *
+   * Upper bound (secs) on how long the mClock managed queue may go unserviced
+   * while high_priority drain keeps being refilled, before yielding it one
+   * forced dequeue attempt. Without this, a sustained stream of high_priority
+   * traffic can starve the various mClock managed classes.
+   *
+   * Device-specific starve times: A HDD's own natural service time is multi-
+   * millisecond, and so the default 250ms bound is a modest multiple of that.
+   * See 'osd_mclock_max_starve_time_hdd' for more details. Flash devices
+   * complete a normal op much faster (sub millisecond), so the bound is
+   * tightened to a much shorter window of 50ms. This has been validated by
+   * real hardware testing and stays as an internal constant.
+   *
+   * But validation is not done on HDD test hardware and therefore it's exposed
+   * as a config option mentioned above with a default of 250ms and bound to
+   * [100ms, 500ms] rather than hardcode it. Thus is to allow an operator some
+   * flexibility in case a given HDD fleet needs a different value.
+   */
+  double scheduler_max_starve_time = 0.0;
+  static constexpr double scheduler_max_starve_time_ssd = 0.05; // 50 msec
 public:
   MclockConfig(CephContext *cct, ClientRegistry& creg,
                uint32_t num_shards, bool is_rotational, int shard_id,
@@ -259,6 +282,7 @@ public:
                           utime_t time_queued);
   double get_cost_per_io() const;
   double get_capacity_per_shard() const;
+  double get_scheduler_max_starve_time() const;
   void handle_conf_change(const ConfigProxy& conf,
 			  const std::set<std::string> &changed) final;
   std::vector<std::string> get_tracked_keys() const noexcept final {
@@ -277,7 +301,8 @@ public:
       "osd_mclock_max_capacity_iops_ssd"s,
       "osd_mclock_max_sequential_bandwidth_hdd"s,
       "osd_mclock_max_sequential_bandwidth_ssd"s,
-      "osd_mclock_profile"s
+      "osd_mclock_profile"s,
+      "osd_mclock_max_starve_time_hdd"s
     };
   }
   uint32_t calc_scaled_cost(int item_cost);

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -1425,6 +1425,29 @@ options:
   - osd_mclock_max_capacity_iops_ssd
   flags:
   - runtime
+- name: osd_mclock_max_starve_time_hdd
+  type: float
+  level: advanced
+  desc: Maximum time (seconds) the mclock-managed queue is allowed to be
+    starved by the immediate-class queue and other high-priority traffic (raw
+    priority at or above the scheduler's cutoff) before a forced dequeue
+    attempt yields it one turn, on rotational media. Bounds worst-case
+    starvation of mclock-managed classes under sustained high-priority load.
+  long_desc: The default (0.25s) is a starting-point value reasoned from
+    rotational media's own multi-millisecond natural per-op service time.
+    Bounded to a narrow range around that default. Too low erodes the
+    low-latency treatment immediate-class and other high-priority traffic (e.g.
+    client-driven EC subop I/O, peering) depends on; too high silently
+    re-opens the starvation this bound exists to prevent.
+  fmt_desc: Maximum time (seconds) the mclock-managed queue may be starved
+    by the immediate-class and high-priority queues before a forced
+    dequeue attempt, on rotational media.
+  default: 0.25
+  min: 0.1
+  max: 0.5
+  see_also:
+  - osd_op_queue
+  - osd_mclock_profile
 # Set to true for testing.  Users should NOT set this.
 # If set to true even after reading enough shards to
 # decode the object, any error will be reported.

--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -200,6 +200,44 @@ void mClockScheduler::enqueue_high(unsigned priority,
 
 WorkItem mClockScheduler::dequeue()
 {
+  if (!high_priority.empty() && mclock_queue_is_starved()) {
+    // The mclock-managed queue has pending work that has gone unserviced
+    // for at least high_priority_max_starve_time because high_priority
+    // keeps being refilled. Give it one guaranteed try so classes like
+    // background_best_effort (e.g. scrub, backfill etc.) make forward
+    // progress instead of being starved indefinitely -- see tracker 69078.
+    auto fmt_prio = [this](priority_t p) -> std::string {
+      return (p == immediate_class_priority) ? "MAX" : std::to_string(p);
+    };
+    dout(10) << __func__ << " mclock queue starved for at least "
+             << mclock_conf.get_scheduler_max_starve_time()
+             << "s behind high_priority backlog (priority queues: "
+             << high_priority.size();
+    for (const auto& [prio, queue] : high_priority) {
+      *_dout << ", priority " << fmt_prio(prio) << ": " << queue.size();
+    }
+    *_dout << "), forcing a dequeue attempt" << dendl;
+
+    mclock_queue_t::PullReq result = scheduler.pull_request();
+    if (result.is_retn()) {
+      auto &retn = result.get_retn();
+
+      scheduler_op_type_t op_type = scheduler_op_type_t::unknown;
+      utime_t time_queued = utime_t();
+      if (retn.request) {
+        op_type = get_scheduler_op_type(*retn.request);
+        time_queued = retn.request->get_time_queued();
+      }
+      mclock_conf.put_mclock_counter(retn.client, op_type, time_queued);
+      last_mclock_service_time = crimson::dmclock::get_time();
+
+      return std::move(*retn.request);
+    }
+    // Nothing was actually ready as per mclock's own reservation/limit tags
+    // -- fall through and serve high_priority as usual; the starvation check
+    // will retry on the next call.
+  }
+
   if (!high_priority.empty()) {
     auto iter = high_priority.begin();
     // invariant: high_priority entries are never empty
@@ -241,6 +279,7 @@ WorkItem mClockScheduler::dequeue()
         time_queued = retn.request->get_time_queued();
       }
       mclock_conf.put_mclock_counter(retn.client, op_type, time_queued);
+      last_mclock_service_time = crimson::dmclock::get_time();
 
       return std::move(*retn.request);
     }

--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -171,9 +171,22 @@ void mClockScheduler::enqueue_front(OpSchedulerItem&& item)
     enqueue_high(immediate_class_priority, std::move(item), true);
   } else if (priority >= cutoff_priority) {
     enqueue_high(priority, std::move(item), true);
+  } else if (SchedulerClass::client == id.class_id) {
+    // mClock does not support enqueue at front, so we redirect into the
+    // reserved requeued_class_priority bucket instead. dequeue() must
+    // never pull from the mclock-managed queue via the starvation-bound
+    // forced yield while this bucket is non-empty.
+    dout(10) << __func__ << " " << item
+             << " redirected into requeued_class_priority queue."
+             << dendl;
+    enqueue_high(requeued_class_priority, std::move(item), true);
   } else {
-    // mClock does not support enqueue at front, so we use
-    // the high queue with priority 0
+    // Non-client, non-immediate, lower than cutoff items redirected via
+    // enqueue_front() (background_recovery/background_best_effort) --
+    // no per-client tid-ordering invariant applies, so this keeps the
+    // original behavior: still ahead of the mclock-managed queue, same
+    // as always, but not exempted from the starvation-bound forced
+    // yield the way requeued_class_priority is.
     enqueue_high(0, std::move(item), true);
   }
 }
@@ -200,7 +213,16 @@ void mClockScheduler::enqueue_high(unsigned priority,
 
 WorkItem mClockScheduler::dequeue()
 {
-  if (!high_priority.empty() && mclock_queue_is_starved()) {
+  // True iff a client-class item that was pulled out of its normal queue
+  // position via enqueue_front() is currently waiting in high_priority.
+  // mClock has no insert-at-front, so the starvation-bound forced
+  // yield below must not pull anything from mClock managd queue while one
+  // of these is pending
+  const bool requeued_item_pending =
+    high_priority.count(requeued_class_priority) > 0;
+
+  if (!high_priority.empty() && !requeued_item_pending &&
+      mclock_queue_is_starved()) {
     // The mclock-managed queue has pending work that has gone unserviced
     // for at least high_priority_max_starve_time because high_priority
     // keeps being refilled. Give it one guaranteed try so classes like
@@ -242,9 +264,15 @@ WorkItem mClockScheduler::dequeue()
     auto iter = high_priority.begin();
     // invariant: high_priority entries are never empty
     ceph_assert(!iter->second.empty());
+    const priority_t popped_priority = iter->first;
     WorkItem ret{std::move(iter->second.back())};
     iter->second.pop_back();
-    if (iter->second.empty()) {
+    // Capture queue size BEFORE the possible erase() below. This is to
+    // ensure we don't violate the "entries are never empty" invariant,
+    // which could happen if we read later on using operator[] - as it
+    // would silently create a fresh empty entry.
+    const size_t remaining_in_queue = iter->second.size();
+    if (remaining_in_queue == 0) {
       // maintain invariant, high priority entries are never empty
       high_priority.erase(iter);
     }
@@ -257,6 +285,15 @@ WorkItem mClockScheduler::dequeue()
     };
     scheduler_op_type_t op_type = get_scheduler_op_type(*item_ptr);
     mclock_conf.put_mclock_counter(id, op_type, item_ptr->get_time_queued());
+
+    // Log when a requeued_class_priority item is released.
+    if (popped_priority == requeued_class_priority) {
+      dout(10) << __func__ << " " << *item_ptr
+               << " released from requeued_class_priority, "
+               << remaining_in_queue << " item(s) still pending"
+               << dendl;
+    }
+
     return ret;
   } else {
     mclock_queue_t::PullReq result = scheduler.pull_request();

--- a/src/osd/scheduler/mClockScheduler.h
+++ b/src/osd/scheduler/mClockScheduler.h
@@ -67,6 +67,25 @@ class mClockScheduler : public OpScheduler {
   priority_t immediate_class_priority = std::numeric_limits<priority_t>::max();
 
   /**
+   * requeued_class_priority
+   *
+   * Reserved high_priority bucket for SchedulerClass::client items
+   * pulled out of their normal queue position via enqueue_front() (e.g.
+   * PG::requeue_map_waiters()/requeue_op(), OSDShard::_wake_pg_slot()).
+   * mClock does not support inserting at the front of its own
+   * reservation/weight/limit-managed queue, so a redirected item cannot
+   * keep its position relative to other same-client items still sitting
+   * in that queue.
+   *
+   * Kept well below every real high_priority value (cutoff_priority >= 64).
+   * The starvation-bound forced yield must never pull from the mclock-managed
+   * queue while this bucket is non-empty.Set to SchedulerClass::client's own
+   * integer value purely so it self-documents in dumps/logs.
+   */
+  priority_t requeued_class_priority =
+    static_cast<priority_t>(SchedulerClass::client);
+
+  /**
    * last_mclock_service_time
    *
    * Time (per crimson::dmclock::get_time()) at which an item was last

--- a/src/osd/scheduler/mClockScheduler.h
+++ b/src/osd/scheduler/mClockScheduler.h
@@ -66,6 +66,23 @@ class mClockScheduler : public OpScheduler {
   SubQueue high_priority;
   priority_t immediate_class_priority = std::numeric_limits<priority_t>::max();
 
+  /**
+   * last_mclock_service_time
+   *
+   * Time (per crimson::dmclock::get_time()) at which an item was last
+   * successfully pulled from the mclock-managed queue (scheduler).
+   * TimeZero means "never" and is treated as already-expired.
+   */
+  crimson::dmclock::Time last_mclock_service_time = crimson::dmclock::TimeZero;
+
+  /// True if the mclock-managed queue has pending work that has gone
+  /// unserviced for at least high_priority_max_starve_time.
+  bool mclock_queue_is_starved() const {
+    return !scheduler.empty() &&
+      (crimson::dmclock::get_time() - last_mclock_service_time) >=
+        mclock_conf.get_scheduler_max_starve_time();
+  }
+
   static scheduler_id_t get_scheduler_id(const OpSchedulerItem &item) {
     return scheduler_id_t{
       item.get_scheduler_class(),

--- a/src/test/osd/TestMClockScheduler.cc
+++ b/src/test/osd/TestMClockScheduler.cc
@@ -225,6 +225,17 @@ TEST_F(mClockSchedulerTest, TestHighPriorityQueueEnqueueDequeue) {
 TEST_F(mClockSchedulerTest, TestAllQueuesEnqueueDequeue) {
   ASSERT_TRUE(q.empty());
 
+  // Prime last_mclock_service_time with a real, recent timestamp before
+  // the priority-ordering assertions below. last_mclock_service_time
+  // starts at TimeZero (treated as already-expired), so without this, the
+  // very first dequeue() from a queue with both high_priority and the
+  // mclock queue populated would force an mclock-queue pull ahead of
+  // high_priority, which is not what this test is checking -- that
+  // behavior gets its own dedicated tests below.
+  q.enqueue(create_item(0, client1, SchedulerClass::client));
+  get_item(q.dequeue());
+  ASSERT_TRUE(q.empty());
+
   // Insert ops into the mClock queue
   for (unsigned i = 100; i < 102; ++i) {
     q.enqueue(create_item(i, client1, SchedulerClass::client));
@@ -293,4 +304,118 @@ TEST_F(mClockSchedulerTest, TestSlowDequeue) {
     ASSERT_TRUE(wqi);
   }
   ASSERT_TRUE(q.empty());
+}
+
+// Tests for tracker 69078's starvation-bound fix: dequeue() forces one
+// mclock-managed-queue pull once it has gone unserviced for at least
+// mclock_conf's scheduler_max_starve_time while high_priority keeps
+// refilling. The fixture is non-rotational (SSD/NVMe), so the bound is
+// the fixed internal constant (50ms);
+TEST_F(mClockSchedulerTest, TestNoForcedYieldBeforeThreshold) {
+  ASSERT_TRUE(q.empty());
+
+  // Set up last_mclock_service_time (see TestAllQueuesEnqueueDequeue).
+  q.enqueue(create_item(0, client1, SchedulerClass::client));
+  get_item(q.dequeue());
+  ASSERT_TRUE(q.empty());
+
+  q.enqueue(create_item(1, client1, SchedulerClass::background_best_effort));
+  q.enqueue(create_high_prio_item(200, 200, client2, SchedulerClass::immediate));
+
+  // Well under the 50ms SSD/NVMe threshold -- ordinary priority order
+  // (high_priority before the mclock queue) is unaffected, confirming
+  // the fix is a no-op in the common, not-yet-starved case.
+  auto r = get_item(q.dequeue());
+  ASSERT_EQ(200u, r.get_map_epoch());
+}
+
+TEST_F(mClockSchedulerTest, TestStarvationForcesYield) {
+  ASSERT_TRUE(q.empty());
+
+  // Set up last_mclock_service_time.
+  q.enqueue(create_item(0, client1, SchedulerClass::client));
+  get_item(q.dequeue());
+  ASSERT_TRUE(q.empty());
+
+  // One item sits pending in the mclock-managed queue throughout.
+  q.enqueue(create_item(1, client1, SchedulerClass::background_best_effort));
+
+  // Keep high_priority continuously refilled for longer than the 50ms
+  // SSD/NVMe threshold, without calling dequeue() in between -- mirrors
+  // a sustained immediate-class backlog (e.g. EC subop traffic under
+  // heavy client I/O) that would otherwise starve the mclock queue
+  // indefinitely.
+  for (unsigned i = 0; i < 60; ++i) {
+    q.enqueue(create_high_prio_item(100 + i, 100 + i, client2,
+                                    SchedulerClass::immediate));
+  }
+  std::this_thread::sleep_for(60ms);
+
+  // high_priority still has pending items at this point -- the next
+  // dequeue() should force-pull the mclock-queue item instead of
+  // continuing to drain high_priority.
+  ASSERT_FALSE(q.empty());
+  auto r = get_item(q.dequeue());
+  ASSERT_EQ(1u, r.get_map_epoch());
+
+  // high_priority items are still there afterward -- confirms this was
+  // a forced yield, not high_priority having drained naturally.
+  ASSERT_FALSE(q.empty());
+}
+
+TEST(mClockSchedulerHDDTest, TestStarveTimeLiveReconfig) {
+  // Rotational path: osd_mclock_max_starve_time_hdd is read at
+  // construction (MclockConfig::set_from_config(), called from its own
+  // constructor) and re-read live via the existing handle_conf_change()
+  // observer on any subsequent config change -- the same path every
+  // other mclock scheduler option already uses. Uses a standalone
+  // scheduler instance (not the shared fixture, which is fixed
+  // non-rotational) so it can exercise the HDD-specific option.
+  g_ceph_context->_conf.rm_val("osd_mclock_max_starve_time_hdd");
+  g_ceph_context->_conf.apply_changes(nullptr);
+
+  mClockScheduler q(g_ceph_context, /*whoami=*/0, /*num_shards=*/1,
+                     /*shard_id=*/0, /*is_rotational=*/true,
+                     /*cutoff_priority=*/12,
+                     2ms, 2ms, 1ms, /*init_perfcounter=*/true);
+  uint64_t client1 = 1001;
+  uint64_t client2 = 9999;
+
+  q.enqueue(create_item(0, client1, SchedulerClass::client));
+  get_item(q.dequeue());
+  ASSERT_TRUE(q.empty());
+
+  q.enqueue(create_item(1, client1, SchedulerClass::background_best_effort));
+
+  // At the 250ms default, ~150ms of continuous high_priority refill is
+  // not enough to force a yield -- confirms the option's initial,
+  // construction-time value.
+  for (unsigned i = 0; i < 150; ++i) {
+    q.enqueue(create_high_prio_item(100 + i, 100 + i, client2,
+                                     SchedulerClass::immediate));
+  }
+  std::this_thread::sleep_for(150ms);
+  auto r = get_item(q.dequeue());
+  ASSERT_NE(1u, r.get_map_epoch());
+
+  // Live-reconfigure to the 100ms floor without rebuilding the
+  // scheduler.
+  g_ceph_context->_conf.set_val("osd_mclock_max_starve_time_hdd", "0.1");
+  g_ceph_context->_conf.apply_changes(nullptr);
+
+  // Continue refilling high_priority under the new, shorter threshold --
+  // this time the forced yield should engage well before 250ms, proving
+  // the live reconfiguration actually took effect rather than the
+  // unmodified default.
+  for (unsigned i = 0; i < 150; ++i) {
+    q.enqueue(create_high_prio_item(300 + i, 300 + i, client2,
+                                     SchedulerClass::immediate));
+  }
+  std::this_thread::sleep_for(150ms);
+  ASSERT_FALSE(q.empty());
+  r = get_item(q.dequeue());
+  ASSERT_EQ(1u, r.get_map_epoch());
+
+  g_ceph_context->_conf.rm_val("osd_mclock_max_starve_time_hdd");
+  g_ceph_context->_conf.apply_changes(nullptr);
 }

--- a/src/test/osd/TestMClockScheduler.cc
+++ b/src/test/osd/TestMClockScheduler.cc
@@ -419,3 +419,156 @@ TEST(mClockSchedulerHDDTest, TestStarveTimeLiveReconfig) {
   g_ceph_context->_conf.rm_val("osd_mclock_max_starve_time_hdd");
   g_ceph_context->_conf.apply_changes(nullptr);
 }
+
+// Tests for out-of-order-abort scenario:
+//
+// enqueue_front() cannot preserve a redirected item's position relative
+// to other same-client items still sitting in the mclock-managed queue
+// (mClock has no insert-at-front), so a client-class item pulled out of
+// its normal queue position is instead routed to a reserved
+// high_priority bucket (requeued_class_priority), and dequeue()'s
+// starvation-bound forced yield is guarded to never pull from the
+// mclock-managed queue while that bucket is non-empty.
+
+// Scenario 1:
+// What this verifies: Op order preservation of two consecutive ops from
+// the same client when one op is requeued and the other remains in the
+// mclock managed queue.
+// 1. Enqueue two ops from the same client with consecutive tids
+// 2. Pull the first op out of the mclock queue and requeue into the
+//    requeued_class_priority queue using enqueue_front()
+// 3. Attempt pulling using dequeue() - This should result in the
+//    requeued item to be dequeued first, which preserves the client op order.
+TEST_F(mClockSchedulerTest, TestEnqueueFrontPreservesClientOrder) {
+  ASSERT_TRUE(q.empty());
+
+  // Step 1: Two ops from the same client, both sub-cutoff (client class) -
+  // simulates tids 10 and 11 arriving in order.
+  q.enqueue(create_item(10, client1, SchedulerClass::client));
+  q.enqueue(create_item(11, client1, SchedulerClass::client));
+
+  // Step 2: The first op is pulled from the mclock-managed queue for
+  // processing, then requeued via enqueue_front() -- simulates a PG-level
+  // requeue that happens before it actually applies.
+  auto a = get_item(q.dequeue());
+  ASSERT_EQ(10u, a.get_map_epoch());
+  q.enqueue_front(std::move(a));
+
+  // Step 3: The second item (epoch 11) is still sitting, untouched, in the
+  // mclock-managed queue. The requeued item (epoch 10) must come out first -
+  // if 11 came out first instead, this is exactly the out-of-order abort.
+  ASSERT_FALSE(q.empty());
+  auto next = get_item(q.dequeue());
+  ASSERT_EQ(10u, next.get_map_epoch());
+
+  ASSERT_FALSE(q.empty());
+  next = get_item(q.dequeue());
+  ASSERT_EQ(11u, next.get_map_epoch());
+
+  ASSERT_TRUE(q.empty());
+}
+
+// Scenario 2:
+// What this verifies: The dequeue() guard added for out-of-order-abort.
+// Once a client-class item is sitting in the reserved requeued_class_priority
+// bucket (i.e. it was pulled out of its normal position via enqueue_front(),
+// simulating a PG-level requeue), the starvation-bound forced yield must not
+// fire -- even once a completely unrelated item in the mclock-managed queue
+// has aged well past the starvation threshold and would otherwise be
+// scheduled (see TestStarvationForcesYield).
+//
+// Steps:
+//   1. Enqueue one client-class item and immediately redirect it via
+//      enqueue_front(), landing it in requeued_class_priority.
+//   2. Enqueue a second, unrelated item into the mclock-managed queue
+//      and let it sit past the 50ms SSD/NVMe starvation threshold.
+//   3. Assert the redirected item comes out first, and only then does
+//      the aged mclock-queue item follow -- proving the guard controlled
+//      the order. If the guard were missing, the aged item would be
+//      force-pulled ahead of the redirected one instead.
+TEST_F(mClockSchedulerTest, TestRequeuedItemBlocksForcedYield) {
+  ASSERT_TRUE(q.empty());
+
+  // Step 1. Enqueued and redirected in isolation, before anything else
+  // exists in the scheduler. This dequeue() also sets up
+  // last_mclock_service_time (see TestAllQueuesEnqueueDequeue).
+  q.enqueue(create_item(50, client2, SchedulerClass::client));
+  auto redirected = get_item(q.dequeue());
+  ASSERT_EQ(50u, redirected.get_map_epoch());
+  q.enqueue_front(std::move(redirected));
+
+  // Step 2: A different client's item now sits pending in the mclock-managed
+  // queue -- this is the one the starvation-bound forced yield would
+  // normally rescue once enough time has elapsed (see
+  // TestStarvationForcesYield).
+  q.enqueue(create_item(1, client1, SchedulerClass::background_best_effort));
+
+  // Let the mclock-queue item age past the 50ms SSD/NVMe starvation
+  // threshold -- ordinarily this alone is enough to force a yield (see
+  // TestStarvationForcesYield), but the redirected item pending in
+  // requeued_class_priority must suppress it, or this is exactly the
+  // out-of-order abort scenario: the starved mclock item would cut ahead
+  // of its redirected same-client sibling (without the fix).
+  std::this_thread::sleep_for(60ms);
+
+  // Step 3. The redirected item must come out first...
+  ASSERT_FALSE(q.empty());
+  auto r = get_item(q.dequeue());
+  ASSERT_EQ(50u, r.get_map_epoch());
+
+  // With the redirected item now cleared, the mclock-queue item is no
+  // longer artificially blocked and comes out next.
+  ASSERT_FALSE(q.empty());
+  r = get_item(q.dequeue());
+  ASSERT_EQ(1u, r.get_map_epoch());
+}
+
+// Scenario 3:
+// What this verifies: A non-client item not blocking the forced yield.
+// A non-client item (e.g. a requeued low-priority EC recovery-read
+// subOp gets redirected via enqueue_front(). The tid-ordering invariant
+// never applies to non-client-sourced ops, so this must land in the plain,
+// ungated priority 0 queue rather than requeued_class_priority.
+//
+// Steps:
+// 1. Enqueue a background_best_effort item from a client and redirect it to
+//    the requeued_class_priority queue.
+// 2. Enqueue another background_best_effort item from a  different client
+//    which sits in the mclock queue.
+// 3. Let the item in the mclock queue age past the starvation time (50ms).
+// 4. A dequeue() here should result in the item sitting in the mclock queue
+//    to be returned ahead of the non-client item sitting in the
+//    requeued_class_priority queue thus validating the requeue gate logic.
+TEST_F(mClockSchedulerTest, TestNonClientRequeueDoesNotBlockForcedYield) {
+  ASSERT_TRUE(q.empty());
+
+  // Step 1: Enqueue a non-client background_best_effort item, dequeue it and
+  // redirect it to the requeued_class_priority queue. The dequeue()
+  // also sets up last_mclock_service_time.
+  q.enqueue(create_item(50, client2, SchedulerClass::background_best_effort));
+  auto redirected = get_item(q.dequeue());
+  ASSERT_EQ(50u, redirected.get_map_epoch());
+  q.enqueue_front(std::move(redirected));
+
+  // Step 2: A different client's item now sits pending in the mclock-managed
+  // queue.
+  q.enqueue(create_item(1, client1, SchedulerClass::background_best_effort));
+
+  // Step 3: Age the mclock item past the 50ms starvation threshold.
+  std::this_thread::sleep_for(60ms);
+
+ // Step 4: A dequeue() now results in a forced yield and result in the mclock
+ // item to be scheduled ahead of the priority 0 item - its presence must not
+ // withhold scheduling of the starved mclock-queue item.
+  ASSERT_FALSE(q.empty());
+  auto r = get_item(q.dequeue());
+  ASSERT_EQ(1u, r.get_map_epoch());
+
+  // The non-client redirected item is still sitting in the plain
+  // priority 0 queue and drains normally afterward.
+  ASSERT_FALSE(q.empty());
+  r = get_item(q.dequeue());
+  ASSERT_EQ(50u, r.get_map_epoch());
+
+  ASSERT_TRUE(q.empty());
+}


### PR DESCRIPTION
Background & Changes:

1. Under sustained client I/O on EC pools, mClockScheduler::dequeue() drains the strict-priority high_priority queue (immediate class, e.g. client-driven EC subop reads/writes/replies) unconditionally before ever calling scheduler.pull_request(), the entry point that services mClock managed queue items. Since high_priority can stay continuously non-empty under heavy load, this can starve mClock managed queue items -- in the trackers case most visibly deep-scrub's chunk-continuation events (PGScrubGetNextChunk, PGScrubChunkIsFree, PGScrubResched, etc.) -- for tens of seconds at a time, regardless of their configured mclock reservation.

- Add a bounded check: once the mclock-managed queue has gone unserviced for osd_mclock_max_starve_time while high_priority keeps refilling, force one dequeue attempt from it before resuming the high_priority drain. No-op when the mclock queue is empty, so normal operation is unaffected.
- Bound the starvation window on flash to 50ms via an internal constant -- scheduler_max_starve_time_ssd, and not a configuration option as this was tested on real hardware.
- But since no HDD test hardware has been available for this investigation, rather than ship an unvalidated hardcoded constant with no adjustment path, a configurable called osd_mclock_max_starve_time_hdd is introduced. Default 0.25s, bounded to [0.1s, 0.5s]. A modern 7200 RPM HDD's average random-access time is roughly 10-15ms, so the configurable range remains a real, meaningful multiple of that even at the tightest allowed setting. This allows an operator some flexibility in case a given HDD fleet needs a different value.

2. Give client class items enqueued via enqueue_front() a reserved high_priority queue (requeued_class_priority, set to SchedulerClass::client's own value purely so it documents itself) instead of priority 0, and gate the starvation-bound forced yield so it never pulls from the mclock-managed queue while requeued class priority queue is non-empty. The other high_priority queues(MAX, >=cutoff_priority) and their drain remain unchanged.

Tests (src/test/osd/TestMClockScheduler.cc):
- Add Unit Tests to exercise the starvation logic for SSD and HDD.
- Add unit tests to exercise the `requeued_class_priority` queue mechanics and maintaining op order invariant.

Documentation (doc/rados/configuration/mclock-config-ref.rst): Add a new "mClock Queue Starvation Prevention" section explaining the immediate/high-priority-vs-mclock-managed-queue starvation mechanism, the bounded forced-yield fix, the device-aware threshold split and add osd_mclock_max_starve_time_hdd to the list of config options.

[Test Report ](https://github.com/user-attachments/files/31279646/deep-scrub-starvation-fix-under-mclock-final-report.pdf) - Discusses results from more in-depth testing on a node with NVMe hardware.

Fixes: https://tracker.ceph.com/issues/69078
Signed-off-by: Sridhar Seshasayee <sridhar.seshasayee@ibm.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
