### PR TITLE
tentacle: mgr/cephadm: drop orphaned noautoscale cleanup in _mark_upgrade_complete

### DIFF
--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -1414,10 +1414,6 @@ class CephadmUpgrade:
         if self.upgrade_state.health_warnings_muted:
             self._unmute_upgrade_related_health_warnings()
 
-        if getattr(self.upgrade_state, 'noautoscale_set', False):
-            self._unset_noautoscale()
-            self.upgrade_state.noautoscale_set = False
-
         logger.info('Upgrade: Complete!')
         if self.upgrade_state.progress_id:
             self.mgr.remote('progress', 'complete',


### PR DESCRIPTION
`run-tox-mgr` fails on every tentacle PR (first visible in [ceph-pull-requests #191945](https://jenkins.ceph.com/job/ceph-pull-requests/191945/), which is the first tentacle run to get past the compile break):

```
cephadm/upgrade.py: error: "CephadmUpgrade" has no attribute "_unset_noautoscale"  [attr-defined]
cephadm/upgrade.py: error: "UpgradeState" has no attribute "noautoscale_set"  [attr-defined]
```

5eaf4db5a88 ("mgr/cephadm: mute key rotation related health warnings during upgrade") brought a hunk of main's `_mark_upgrade_complete()` over to tentacle that belongs to the PG autoscaler feature main got in da4b361e63c ("mgr: Control PG autoscaler during upgrades with pg_autoscale_during_upgrade"), which was never backported. tentacle therefore calls `self._unset_noautoscale()` and assigns `self.upgrade_state.noautoscale_set`, neither of which exists on this branch.

Nothing on tentacle ever sets `noautoscale_set`, so the `getattr()` guard is always False and the block is dead code — dropping it is preferable to backporting a feature to a stable branch. Verified locally: `mypy --config-file=../../mypy.ini -m cephadm` goes from those 2 errors to "Success: no issues found".

This is a tentacle-only defect (main is fine, it has the whole feature), so there is no commit to cherry-pick and the commit is `tentacle:`-prefixed per SubmittingPatches-backports. The backport audit will flag **Missing Original PR(s)** for exactly that reason and needs `/audit override`.

@adk3798 FYI, since this came from your tentacle cephx series.

tracker: https://tracker.ceph.com/issues/79699
