### PR TITLE
squid: Unpin botocore

### DIFF
--- a/src/test/rgw/s3-tests/requirements.txt
+++ b/src/test/rgw/s3-tests/requirements.txt
@@ -1,7 +1,6 @@
 PyYAML
 boto3 >=1.0.0
-# botocore-1.28 broke v2 signatures, see https://tracker.ceph.com/issues/58059
-botocore <1.28.0
+botocore
 munch >=2.0.0
 # 0.14 switches to libev, that means bootstrap needs to change too
 gevent >=1.0

--- a/src/test/rgw/s3-tests/s3tests/functional/__init__.py
+++ b/src/test/rgw/s3-tests/s3tests/functional/__init__.py
@@ -413,25 +413,25 @@ def get_v2_client():
     return client
 
 def get_sts_client(**kwargs):
+    kwargs.setdefault('region_name', '')
     kwargs.setdefault('aws_access_key_id', config.alt_access_key)
     kwargs.setdefault('aws_secret_access_key', config.alt_secret_key)
     kwargs.setdefault('config', Config(signature_version='s3v4'))
 
     client = boto3.client(service_name='sts',
                           endpoint_url=config.default_endpoint,
-                          region_name='',
                           use_ssl=config.default_is_secure,
                           verify=config.default_ssl_verify,
                           **kwargs)
     return client
 
 def get_iam_client(**kwargs):
+    kwargs.setdefault('region_name', '')
     kwargs.setdefault('aws_access_key_id', config.iam_access_key)
     kwargs.setdefault('aws_secret_access_key', config.iam_secret_key)
 
     client = boto3.client(service_name='iam',
                         endpoint_url=config.default_endpoint,
-                        region_name='',
                         use_ssl=config.default_is_secure,
                         verify=config.default_ssl_verify,
                         **kwargs)
@@ -451,22 +451,22 @@ def get_iam_s3client(**kwargs):
 
 def get_iam_root_client(**kwargs):
     kwargs.setdefault('service_name', 'iam')
+    kwargs.setdefault('region_name', '')
     kwargs.setdefault('aws_access_key_id', config.iam_root_access_key)
     kwargs.setdefault('aws_secret_access_key', config.iam_root_secret_key)
 
     return boto3.client(endpoint_url=config.default_endpoint,
-                        region_name='',
                         use_ssl=config.default_is_secure,
                         verify=config.default_ssl_verify,
                         **kwargs)
 
 def get_iam_alt_root_client(**kwargs):
     kwargs.setdefault('service_name', 'iam')
+    kwargs.setdefault('region_name', '')
     kwargs.setdefault('aws_access_key_id', config.iam_alt_root_access_key)
     kwargs.setdefault('aws_secret_access_key', config.iam_alt_root_secret_key)
 
     return boto3.client(endpoint_url=config.default_endpoint,
-                        region_name='',
                         use_ssl=config.default_is_secure,
                         verify=config.default_ssl_verify,
                         **kwargs)

--- a/src/test/rgw/s3-tests/s3tests/functional/test_headers.py
+++ b/src/test/rgw/s3-tests/s3tests/functional/test_headers.py
@@ -504,12 +504,14 @@ def test_bucket_create_bad_authorization_invalid_aws2():
     assert error_code == 'InvalidArgument'
 
 @pytest.mark.auth_aws2
+@pytest.mark.fails_on_rgw
 def test_bucket_create_bad_ua_empty_aws2():
     v2_client = get_v2_client()
     headers = {'User-Agent': ''}
     _add_header_create_bucket(headers, v2_client)
 
 @pytest.mark.auth_aws2
+@pytest.mark.fails_on_rgw
 def test_bucket_create_bad_ua_none_aws2():
     v2_client = get_v2_client()
     remove = 'User-Agent'

--- a/src/test/rgw/s3-tests/s3tests/functional/test_headers.py
+++ b/src/test/rgw/s3-tests/s3tests/functional/test_headers.py
@@ -1,5 +1,6 @@
 import boto3
 import pytest
+import botocore.config
 from botocore.exceptions import ClientError
 from email.utils import formatdate
 
@@ -209,7 +210,10 @@ def test_object_create_bad_contentlength_empty():
 @pytest.mark.auth_common
 @pytest.mark.fails_on_mod_proxy_fcgi
 def test_object_create_bad_contentlength_negative():
-    client = get_client()
+    # to test Content-Length=-1, we have to prevent the checksum calculation
+    # from switching to STREAMING-UNSIGNED-PAYLOAD-TRAILER
+    config = botocore.config.Config(request_checksum_calculation = 'when_required')
+    client = get_client(config)
     bucket_name = get_new_bucket()
     key_name = 'foo'
     e = assert_raises(ClientError, client.put_object, Bucket=bucket_name, Key=key_name, ContentLength=-1)

--- a/src/test/rgw/s3-tests/s3tests/functional/test_iam.py
+++ b/src/test/rgw/s3-tests/s3tests/functional/test_iam.py
@@ -507,7 +507,7 @@ def test_deny_bucket_actions_in_user_policy():
                                       UserName=get_alt_user_id())
     assert response['ResponseMetadata']['HTTPStatusCode'] == 200
 
-    e = assert_raises(ClientError, s3_client.list_buckets, Bucket=bucket)
+    e = assert_raises(ClientError, s3_client.list_buckets)
     status, error_code = _get_status_and_error_code(e.response)
     assert status == 403
     assert error_code == 'AccessDenied'

--- a/src/test/rgw/s3-tests/s3tests/functional/test_s3.py
+++ b/src/test/rgw/s3-tests/s3tests/functional/test_s3.py
@@ -11595,7 +11595,7 @@ def test_bucket_policy_put_obj_grant():
 @pytest.mark.encryption
 def test_put_obj_enc_conflict_c_s3():
     bucket_name = get_new_bucket()
-    client = get_v2_client()
+    client = get_client()
 
     # boto3.set_stream_logger(name='botocore')
 
@@ -11621,7 +11621,7 @@ def test_put_obj_enc_conflict_c_kms():
     if kms_keyid is None:
         kms_keyid = 'fool-me-once'
     bucket_name = get_new_bucket()
-    client = get_v2_client()
+    client = get_client()
 
     # boto3.set_stream_logger(name='botocore')
 
@@ -11648,7 +11648,7 @@ def test_put_obj_enc_conflict_s3_kms():
     if kms_keyid is None:
         kms_keyid = 'fool-me-once'
     bucket_name = get_new_bucket()
-    client = get_v2_client()
+    client = get_client()
 
     # boto3.set_stream_logger(name='botocore')
 
@@ -11672,7 +11672,7 @@ def test_put_obj_enc_conflict_bad_enc_kms():
     if kms_keyid is None:
         kms_keyid = 'fool-me-once'
     bucket_name = get_new_bucket()
-    client = get_v2_client()
+    client = get_client()
 
     # boto3.set_stream_logger(name='botocore')
 
@@ -11695,7 +11695,7 @@ def test_put_obj_enc_conflict_bad_enc_kms():
 @pytest.mark.fails_on_dbstore
 def test_bucket_policy_put_obj_s3_noenc():
     bucket_name = get_new_bucket()
-    client = get_v2_client()
+    client = get_client()
 
     deny_incorrect_algo = {
         "StringNotEquals": {
@@ -11751,7 +11751,7 @@ def test_bucket_policy_put_obj_s3_kms():
     if kms_keyid is None:
         kms_keyid = 'fool-me-twice'
     bucket_name = get_new_bucket()
-    client = get_v2_client()
+    client = get_client()
 
     deny_incorrect_algo = {
         "StringNotEquals": {
@@ -11797,7 +11797,7 @@ def test_bucket_policy_put_obj_kms_noenc():
     if kms_keyid is None:
         pytest.skip('[s3 main] section missing kms_keyid')
     bucket_name = get_new_bucket()
-    client = get_v2_client()
+    client = get_client()
 
     deny_incorrect_algo = {
         "StringNotEquals": {
@@ -11840,7 +11840,7 @@ def test_bucket_policy_put_obj_kms_noenc():
 @pytest.mark.bucket_policy
 def test_bucket_policy_put_obj_kms_s3():
     bucket_name = get_new_bucket()
-    client = get_v2_client()
+    client = get_client()
 
     deny_incorrect_algo = {
         "StringNotEquals": {

--- a/src/test/rgw/s3-tests/s3tests/functional/test_sns.py
+++ b/src/test/rgw/s3-tests/s3tests/functional/test_sns.py
@@ -41,13 +41,15 @@ def sns_alt(iam_alt_root):
 
 @pytest.fixture
 def s3(iam_root):
-    client = get_iam_root_client(service_name='s3')
+    # clear region_name to work around Invalid region: region was not a valid DNS name.
+    client = get_iam_root_client(service_name='s3', region_name=None)
     yield client
     nuke_prefixed_buckets(get_prefix(), client)
 
 @pytest.fixture
 def s3_alt(iam_alt_root):
-    client = get_iam_alt_root_client(service_name='s3')
+    # clear region_name to work around Invalid region: region was not a valid DNS name.
+    client = get_iam_alt_root_client(service_name='s3', region_name=None)
     yield client
     nuke_prefixed_buckets(get_prefix(), client)
 


### PR DESCRIPTION
Unpin Squid's s3-tests botocore dependency. The pinned version is interfering with the ability to backport some tests.

This is *not* a backport from Ceph. The fixes come from the s3-tests repository.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
